### PR TITLE
Release: Prepare "Open Transifex translations for v30.0" step

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:bitcoin:p:bitcoin:r:qt-translation-029x]
+[o:bitcoin:p:bitcoin:r:qt-translation-030x]
 file_filter = src/qt/locale/bitcoin_<lang>.xlf
 source_file = src/qt/locale/bitcoin_en.xlf
 source_lang = en

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -11,9 +11,6 @@
 static const char UNUSED *bitcoin_strings[] = {
 QT_TRANSLATE_NOOP("bitcoin-core", "The %s developers"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring "
-"a backup."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
 "%s failed to validate the -assumeutxo snapshot state. This indicates a "
 "hardware problem, or a bug in the software, or a bad software modification "
 "that allowed an invalid snapshot to be loaded. As a result of this, the node "
@@ -30,15 +27,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for "
 "details and a full list."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Cannot downgrade wallet from version %i to version %i. Wallet version "
-"unchanged."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Cannot provide specific connections and have addrman find outgoing "
 "connections at the same time."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Cannot upgrade a non HD split wallet from version %i to version %i without "
-"upgrading to support pre-split keypool. Please use version %i or no version "
-"specified."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Disk space for %s may not accommodate the block files. Approximately %u GB "
 "of data will be stored in this directory."),
@@ -48,6 +38,9 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error loading %s: External signer wallet being loaded without external "
 "signer support compiled"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Error loading %s: Wallet is a legacy wallet. Please migrate to a descriptor "
+"wallet using the migration tool (migratewallet RPC)."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error loading wallet. Wallet requires blocks to be downloaded, and software "
 "does not currently support loading wallets while blocks are being downloaded "
@@ -69,14 +62,14 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error: Dumpfile identifier record is incorrect. Got \"%s\", expected \"%s\"."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Error: Dumpfile specifies an unsupported database format (%s). Only sqlite "
+"database dumps are supported"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error: Dumpfile version is not supported. This version of bitcoin-wallet "
 "only supports version 1 dumpfiles. Got dumpfile with version %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error: Duplicate descriptors created during migration. Your wallet may be "
 "corrupted."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Error: Legacy wallets only support the \"legacy\", \"p2sh-segwit\", and "
-"\"bech32\" address types"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error: Transaction %s in wallet cannot be identified to belong to migrated "
 "wallets"),
@@ -84,8 +77,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error: Unable to produce descriptors for this legacy wallet. Make sure to "
 "provide the wallet's passphrase if it is encrypted."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous "
-"cluster of unconfirmed transactions."),
+"Failed to calculate bump fees, because unconfirmed UTXOs depend on an "
+"enormous cluster of unconfirmed transactions."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Failed to remove snapshot chainstate dir (%s). Manually remove it before "
 "restarting.\n"),
@@ -129,21 +122,24 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "No dump file provided. To use dump, -dumpfile=<filename> must be provided."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"No wallet file format provided. To use createfromdump, -format=<format> must "
-"be provided."),
+"Option '-checkpoints' is set but checkpoints were removed. This option has "
+"no effect."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Option '-upnp' is set but UPnP support was dropped in version 29.0. Consider "
-"using '-natpmp' instead."),
+"Option '-maxorphantx' is set but no longer has any effect (see release "
+"notes). Please remove it from your configuration."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Outbound connections restricted to CJDNS (-onlynet=cjdns) but -"
-"cjdnsreachable is not provided"),
+"Options '-datacarrier' or '-datacarriersize' are set but are marked as "
+"deprecated. They will be removed in a future version."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Outbound connections restricted to CJDNS (-onlynet=cjdns) but "
+"-cjdnsreachable is not provided"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Outbound connections restricted to Tor (-onlynet=onion) but the proxy for "
 "reaching the Tor network is explicitly forbidden: -onion=0"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Outbound connections restricted to Tor (-onlynet=onion) but the proxy for "
-"reaching the Tor network is not provided: none of -proxy, -onion or -"
-"listenonion is given"),
+"reaching the Tor network is not provided: none of -proxy, -onion or "
+"-listenonion is given"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not "
 "provided"),
@@ -156,8 +152,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Prune mode is incompatible with -reindex-chainstate. Use full -reindex "
 "instead."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Prune: last wallet synchronisation goes beyond pruned data. You need to -"
-"reindex (download the whole blockchain again in case of pruned node)"),
+"Prune: last wallet synchronisation goes beyond pruned data. You need to "
+"-reindex (download the whole blockchain again in case of a pruned node)"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Rename of '%s' -> '%s' failed. Cannot clean up the background chainstate "
 "leveldb directory."),
@@ -195,10 +191,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "The transaction amount is too small to send after the fee has been deducted"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"This error could occur if this wallet was not shutdown cleanly and was last "
-"loaded using a build with a newer version of Berkeley DB. If so, please use "
-"the software that last loaded this wallet"),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
 "This is a pre-release test build - use at your own risk - do not use for "
 "mining or merchant applications"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
@@ -213,14 +205,14 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Total length of network version string (%i) exceeds maximum length (%i). "
 "Reduce the number or size of uacomments."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Transaction requires one destination of non-0 value, a non-0 feerate, or a "
-"pre-selected input"),
+"Transaction requires one destination of non-zero value, a non-zero feerate, "
+"or a pre-selected input"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "UTXO snapshot failed to validate. Restart to resume normal initial block "
 "download, or try loading a different snapshot."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Unable to replay blocks. You will need to rebuild the database using -"
-"reindex-chainstate."),
+"Unable to replay blocks. You will need to rebuild the database using "
+"-reindex-chainstate."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Unconfirmed UTXOs are available, but spending them creates a chain of "
 "transactions that will be rejected by the mempool"),
@@ -229,12 +221,9 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "\n"
 "The wallet might have been tampered with or created with malicious intent.\n"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Unknown wallet file format \"%s\" provided. Please provide one of \"bdb\" or "
-"\"sqlite\"."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Unrecognized descriptor found. Loading wallet %s\n"
 "\n"
-"The wallet might had been created on a newer version.\n"
+"The wallet might have been created on a newer version.\n"
 "Please try running the latest software version.\n"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Unsupported category-specific logging level %1$s=%2$s. Expected "
@@ -242,18 +231,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Unsupported chainstate database format found. Please restart with -reindex-"
 "chainstate. This will rebuild the chainstate database."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Wallet created successfully. The legacy wallet type is being deprecated and "
-"support for creating and opening legacy wallets will be removed in the "
-"future."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Wallet loaded successfully. The legacy wallet type is being deprecated and "
-"support for creating and opening legacy wallets will be removed in the "
-"future. Legacy wallets can be migrated to a descriptor wallet with "
-"migratewallet."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Warning: Dumpfile wallet format \"%s\" does not match command line specified "
-"format \"%s\"."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Warning: Private keys detected in wallet {%s} with disabled private keys"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
@@ -283,9 +260,11 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "whitebind may only be used for incoming connections (\"out\" was passed)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "%s is set very high!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "-maxmempool must be at least %d MB"),
+QT_TRANSLATE_NOOP("bitcoin-core", "-paytxfee is deprecated and will be fully removed in v31.0."),
 QT_TRANSLATE_NOOP("bitcoin-core", "A fatal internal error occurred, see debug.log for details: "),
 QT_TRANSLATE_NOOP("bitcoin-core", "Assumeutxo data not found for the given blockhash '%s'."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Block verification was interrupted"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Cannot add WalletDescriptor to a non-descriptor wallet"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot obtain a lock on directory %s. %s is probably already running."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot resolve -%s address: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot set -forcednsseed to true when setting -dnsseed to false."),
@@ -296,7 +275,9 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Copyright (C) %i-%i"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Corrupt block found indicating potential hardware failure."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Corrupted block database detected"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Could not find asmap file %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Could not generate scriptPubKeys (cache is empty)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Could not parse asmap file %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Could not top up scriptPubKeys"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Disk space is too low!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Do you want to rebuild the databases now?"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Done loading"),
@@ -304,7 +285,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Dump file %s does not exist."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Elliptic curve cryptography sanity check failure. %s is shutting down."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error creating %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error initializing block database"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Error initializing wallet database environment %s!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error loading %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error loading %s: Private keys can only be disabled during creation"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error loading %s: Wallet corrupted"),
@@ -328,6 +308,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Error: Got value that was not hex: %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Keypool ran out, please call keypoolrefill first"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Missing checksum"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: No %s addresses available."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Not all address book records were migrated"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Not all transaction records were migrated"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: This wallet already uses SQLite"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: This wallet is already a descriptor wallet"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Unable to begin reading all records in the database"),
@@ -343,12 +325,15 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Error: Unable to write watchonly wallet best 
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Wallet does not exist"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: cannot remove legacy wallet records"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: database transaction cannot be executed for wallet %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to acquire rescan reserver during wallet initialization"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to close block undo file."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to close file when writing block."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to connect best block (%s)."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to disconnect block."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to listen on any port. Use -listen=0 if you want this."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to read block."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to rescan the wallet during initialization"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Failed to start indexes, shutting down.."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Failed to start indexes, shutting down…"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to verify database"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to write block."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to write to block index database."),
@@ -357,7 +342,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Failed to write undo data."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failure removing transaction: %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Fee rate (%s) is lower than the minimum fee rate setting (%s)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Ignoring duplicate -wallet %s."),
-QT_TRANSLATE_NOOP("bitcoin-core", "Importing…"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Incorrect or no genesis block found. Wrong datadir for network?"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Initialization sanity check failed. %s is shutting down."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Input not found or already spent"),
@@ -365,6 +349,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Insufficient dbcache for block verification")
 QT_TRANSLATE_NOOP("bitcoin-core", "Insufficient funds"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid -i2psam address or hostname: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid -onion address or hostname: '%s'"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Invalid -proxy address or hostname, ends with '=': '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid -proxy address or hostname: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid P2P permission: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount for %s=<amount>: '%s' (must be at least %s)"),
@@ -372,7 +357,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount for %s=<amount>: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount for -%s=<amount>: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid netmask specified in -whitelist: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid port specified in %s: '%s'"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Invalid pre-selected input %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Listening for incoming connections failed (listen returned error %s)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading P2P addresses…"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading banlist…"),
@@ -433,18 +417,16 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Unable to bind to %s on this computer (bind r
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to bind to %s on this computer. %s is probably already running."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to create the PID file '%s': %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to find UTXO for external input"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Unable to generate initial keys"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Unable to generate keys"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to open %s for writing"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to parse -maxuploadtarget: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to start HTTP server. See debug log for details."),
-QT_TRANSLATE_NOOP("bitcoin-core", "Unable to unload the wallet before migrating"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown -blockfilterindex value %s."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown address type '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown change type '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown network specified in -onlynet: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown new rules activated (versionbit %i)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unrecognised option \"%s\" provided in -test=<option>."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Unrecognized network in -proxy='%s': '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unsupported global logging level %s=%s. Valid values: %s."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unsupported logging category %s=%s."),
 QT_TRANSLATE_NOOP("bitcoin-core", "User Agent comment (%s) contains unsafe characters."),

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -19,12 +19,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Copy the currently selected address to the system clipboard</translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="+17"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -44,7 +39,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
+        <location line="+54"/>
+        <source>Copy the currently selected address to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+47"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Export the data in the current tab to a file</translation>
     </message>
@@ -55,7 +55,7 @@
     </message>
     <message>
         <location line="-30"/>
-        <location filename="../addressbookpage.cpp" line="+113"/>
+        <location filename="../addressbookpage.cpp" line="+105"/>
         <source>&amp;Delete</source>
         <translation>&amp;Delete</translation>
     </message>
@@ -340,7 +340,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+260"/>
+        <location filename="../bitcoin.cpp" line="+251"/>
         <source>Settings file %1 might be corrupt or invalid.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -428,7 +428,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+184"/>
+        <location line="+188"/>
         <source>&amp;Minimize</source>
         <translation type="unfinished"></translation>
     </message>
@@ -444,12 +444,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+451"/>
+        <location line="+446"/>
         <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1221"/>
+        <location line="-1220"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Send coins to a Bitcoin address</translation>
     </message>
@@ -544,7 +544,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
+        <location line="+146"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
@@ -589,7 +589,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-879"/>
+        <location line="-883"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,7 +609,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+790"/>
+        <location line="+794"/>
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
             <numerusform>Processed %n block of transaction history.</numerusform>
@@ -637,7 +637,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Transactions after this will not yet be visible.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <location line="+35"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
@@ -652,12 +652,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-93"/>
+        <location line="-88"/>
         <source>Up to date</source>
         <translation>Up to date</translation>
     </message>
     <message>
-        <location line="-864"/>
+        <location line="-868"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
@@ -759,7 +759,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
+        <location line="+55"/>
         <location line="+59"/>
         <source>No wallets available</source>
         <translation type="unfinished"></translation>
@@ -862,17 +862,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
-        <source>Error creating wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+0"/>
-        <source>Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+159"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1317,7 +1307,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../freespacechecker.cpp" line="+21"/>
         <source>A new data directory will be created.</source>
         <translation>A new data directory will be created.</translation>
     </message>
@@ -1418,7 +1408,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Use a custom data directory:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+30"/>
+        <location filename="../intro.cpp" line="+54"/>
         <source>Bitcoin</source>
         <translation type="unfinished">Bitcoin</translation>
     </message>
@@ -2062,7 +2052,7 @@ The migration process will create a backup of the wallet before migrating. This 
         <translation>default</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <location line="+77"/>
         <source>none</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2137,7 +2127,7 @@ The migration process will create a backup of the wallet before migrating. This 
 <context>
     <name>OptionsModel</name>
     <message>
-        <location filename="../optionsmodel.cpp" line="+227"/>
+        <location filename="../optionsmodel.cpp" line="+226"/>
         <source>Could not read setting &quot;%1&quot;, %2.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2151,17 +2141,12 @@ The migration process will create a backup of the wallet before migrating. This 
     </message>
     <message>
         <location line="+62"/>
-        <location line="+335"/>
+        <location line="+220"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</translation>
     </message>
     <message>
-        <location line="-127"/>
-        <source>Watch-only:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="-88"/>
         <source>Available:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2171,17 +2156,17 @@ The migration process will create a backup of the wallet before migrating. This 
         <translation>Your current spendable balance</translation>
     </message>
     <message>
-        <location line="+35"/>
+        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-200"/>
+        <location line="-114"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+62"/>
         <source>Immature:</source>
         <translation>Immature:</translation>
     </message>
@@ -2191,12 +2176,12 @@ The migration process will create a backup of the wallet before migrating. This 
         <translation>Mined balance that has not yet matured</translation>
     </message>
     <message>
-        <location line="-150"/>
+        <location line="-93"/>
         <source>Balances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+83"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
@@ -2206,37 +2191,12 @@ The migration process will create a backup of the wallet before migrating. This 
         <translation>Your current total balance</translation>
     </message>
     <message>
-        <location line="+74"/>
-        <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <source>Spendable:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+49"/>
+        <location line="+88"/>
         <source>Recent transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
-        <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+38"/>
-        <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+110"/>
-        <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../overviewpage.cpp" line="+184"/>
+        <location filename="../overviewpage.cpp" line="+176"/>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2729,7 +2689,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <location line="+2"/>
-        <location filename="../rpcconsole.cpp" line="+1023"/>
+        <location filename="../rpcconsole.cpp" line="+979"/>
         <source>%1 kB</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2746,7 +2706,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
+        <location line="+159"/>
         <source>default wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2763,7 +2723,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
+        <location line="+422"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2778,7 +2738,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="-389"/>
+        <location filename="../optionsdialog.cpp" line="-385"/>
         <source>Embedded &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2821,7 +2781,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+34"/>
         <source>Save QR Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2874,7 +2834,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <location line="+26"/>
         <location line="+26"/>
         <location line="+26"/>
-        <location filename="../rpcconsole.h" line="+145"/>
+        <location filename="../rpcconsole.h" line="+144"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
@@ -3311,12 +3271,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
+        <location line="+41"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-477"/>
+        <location filename="../rpcconsole.cpp" line="-469"/>
         <source>Inbound: initiated by peer</source>
         <extracomment>Explanatory text for an inbound peer connection.</extracomment>
         <translation type="unfinished"></translation>
@@ -3409,7 +3369,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+146"/>
         <source>&amp;Copy address</source>
         <extracomment>Context menu action to copy the address of a peer.</extracomment>
         <translation type="unfinished"></translation>
@@ -3524,7 +3484,7 @@ For more information on using this console, type %6.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../rpcconsole.h" line="-42"/>
+        <location filename="../rpcconsole.h" line="-41"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3836,7 +3796,7 @@ For more information on using this console, type %6.
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+763"/>
+        <location filename="../sendcoinsdialog.cpp" line="+764"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
     </message>
@@ -4018,7 +3978,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation>S&amp;end</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-668"/>
+        <location filename="../sendcoinsdialog.cpp" line="-665"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4217,12 +4177,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
-        <source>Watch-only balance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+24"/>
+        <location line="+248"/>
         <source>The recipient address is not valid. Please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4257,8 +4212,8 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+35"/>
+        <location line="+76"/>
+        <location line="+37"/>
         <source>%1/kvB</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4271,7 +4226,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         </translation>
     </message>
     <message>
-        <location line="+95"/>
+        <location line="+99"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4383,7 +4338,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>SendConfirmationDialog</name>
     <message>
-        <location filename="../sendcoinsdialog.h" line="+146"/>
+        <location filename="../sendcoinsdialog.h" line="+151"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4463,8 +4418,8 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
     </message>
     <message>
         <location line="+30"/>
-        <source>Copy the current signature to the system clipboard</source>
-        <translation>Copy the current signature to the system clipboard</translation>
+        <source>Copy the current signature to the clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+21"/>
@@ -4535,7 +4490,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+120"/>
+        <location filename="../signverifymessagedialog.cpp" line="+122"/>
         <location line="+99"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
@@ -4628,7 +4583,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+40"/>
+        <location filename="../transactiondesc.cpp" line="+39"/>
         <source>conflicted with a transaction with %1 confirmations</source>
         <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished"></translation>
@@ -4686,51 +4641,43 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
     <message>
         <location line="+5"/>
         <location line="+14"/>
-        <location line="+72"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="+0"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
         <location line="+20"/>
-        <location line="+70"/>
+        <location line="+66"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+95"/>
+        <location line="-84"/>
+        <location line="+91"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-95"/>
-        <location line="+69"/>
-        <location line="+28"/>
-        <source>watch-only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-95"/>
+        <location line="-89"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+36"/>
         <location line="+12"/>
-        <location line="+54"/>
+        <location line="+48"/>
         <location line="+30"/>
         <location line="+60"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-154"/>
+        <location line="-148"/>
         <source>matures in %n more block(s)</source>
         <translation>
             <numerusform>matures in %n more block</numerusform>
@@ -4743,7 +4690,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
+        <location line="+54"/>
         <location line="+26"/>
         <location line="+63"/>
         <source>Debit</source>
@@ -4837,13 +4784,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
     </message>
     <message>
         <location line="+1"/>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+1"/>
+        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4864,7 +4809,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+258"/>
+        <location filename="../transactiontablemodel.cpp" line="+257"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
@@ -4879,7 +4824,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
+        <location line="+59"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4934,17 +4879,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <source>watch-only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
+        <location line="+36"/>
         <source>(n/a)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+205"/>
+        <location line="+188"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4965,11 +4905,6 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
     </message>
     <message>
         <location line="+2"/>
-        <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>User-defined intent/purpose of the transaction.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4982,7 +4917,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+73"/>
+        <location filename="../transactionview.cpp" line="+66"/>
         <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"></translation>
@@ -5048,7 +4983,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+89"/>
+        <location line="+88"/>
         <source>&amp;Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5104,7 +5039,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
+        <location line="+96"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5118,11 +5053,6 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished">Confirmed</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Watch-only</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -5170,7 +5100,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
+        <location line="+175"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5266,13 +5196,13 @@ Go to File &gt; Open Wallet to load a wallet.
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+224"/>
+        <location filename="../walletmodel.cpp" line="+218"/>
         <location line="+13"/>
         <source>Send Coins</source>
         <translation type="unfinished">Send Coins</translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+245"/>
         <location line="+49"/>
         <location line="+20"/>
         <location line="+5"/>
@@ -5409,11 +5339,6 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+1"/>
-        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5423,17 +5348,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
+        <location line="+7"/>
         <source>Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5443,7 +5358,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+9"/>
         <source>Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5468,17 +5383,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+5"/>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>Error: Legacy wallets only support the &quot;legacy&quot;, &quot;p2sh-segwit&quot;, and &quot;bech32&quot; address types</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
+        <location line="+9"/>
         <source>Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet&apos;s passphrase if it is encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5513,17 +5423,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Option &apos;-upnp&apos; is set but UPnP support was dropped in version 29.0. Consider using &apos;-natpmp&apos; instead.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
+        <location line="+24"/>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5538,12 +5438,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
+        <location line="+9"/>
         <source>Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5564,11 +5459,6 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+2"/>
-        <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,33 +5488,13 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
+        <location line="+15"/>
         <source>Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5658,7 +5528,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+6"/>
         <source>Cannot obtain a lock on directory %s. %s is probably already running.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5678,22 +5548,22 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-266"/>
+        <location line="-248"/>
         <source>%s is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+6"/>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+9"/>
         <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+11"/>
         <source>Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5703,22 +5573,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+13"/>
         <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+3"/>
         <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="+9"/>
         <source>Failed to remove snapshot chainstate dir (%s). Manually remove it before restarting.
 </source>
         <translation type="unfinished"></translation>
@@ -5764,7 +5629,22 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+10"/>
+        <source>Option &apos;-checkpoints&apos; is set but checkpoints were removed. This option has no effect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Option &apos;-maxorphantx&apos; is set but no longer has any effect (see release notes). Please remove it from your configuration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Options &apos;-datacarrier&apos; or &apos;-datacarriersize&apos; are set but are marked as deprecated. They will be removed in a future version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5784,7 +5664,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+11"/>
+        <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. Cannot clean up the background chainstate leveldb directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5819,12 +5704,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <source>Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5842,16 +5722,7 @@ The wallet might have been tampered with or created with malicious intent.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Unrecognized descriptor found. Loading wallet %s
-
-The wallet might had been created on a newer version.
-Please try running the latest software version.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+26"/>
         <source>Your computer&apos;s date and time appear to be more than %d minutes out of sync with the network, this may lead to consensus failure. After you&apos;ve confirmed your computer&apos;s clock, this message should no longer appear when you restart your node. Without a restart, it should stop showing automatically after you&apos;ve connected to a sufficient number of new outbound peers, which may take some time. You can inspect the `timeoffset` field of the `getpeerinfo` and `getnetworkinfo` RPC methods to get more info.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5874,6 +5745,11 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+4"/>
+        <source>-paytxfee is deprecated and will be fully removed in v31.0.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A fatal internal error occurred, see debug.log for details: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -5885,6 +5761,11 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Block verification was interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Cannot add WalletDescriptor to a non-descriptor wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5919,7 +5800,17 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
+        <source>Could not generate scriptPubKeys (cache is empty)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Could not parse asmap file %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Could not top up scriptPubKeys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5950,11 +5841,6 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Error initializing block database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6064,6 +5950,16 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
+        <source>Error: Not all address book records were migrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Not all transaction records were migrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Error: This wallet already uses SQLite</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6129,6 +6025,21 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
+        <source>Failed to acquire rescan reserver during wallet initialization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to close block undo file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to close file when writing block.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Failed to connect best block (%s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6153,12 +6064,7 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to start indexes, shutting down..</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Failed to verify database</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6199,11 +6105,6 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Importing…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6238,7 +6139,7 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Invalid -proxy address or hostname: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6270,11 +6171,6 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Invalid port specified in %s: &apos;%s&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Invalid pre-selected input %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6564,16 +6460,6 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Unable to generate initial keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Unable to generate keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Unable to open %s for writing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6585,11 +6471,6 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Unable to start HTTP server. See debug log for details.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Unable to unload the wallet before migrating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6623,7 +6504,7 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Unsupported global logging level %s=%s. Valid values: %s.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6643,12 +6524,41 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-148"/>
+        <location line="-390"/>
+        <source>Error loading %s: Wallet is a legacy wallet. Please migrate to a descriptor wallet using the migration tool (migratewallet RPC).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Error: Dumpfile specifies an unsupported database format (%s). Only sqlite database dumps are supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+128"/>
+        <source>Transaction requires one destination of non-zero value, a non-zero feerate, or a pre-selected input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might have been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+59"/>
         <source>Do you want to rebuild the databases now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+18"/>
         <source>Error: Could not add watchonly tx %s to watchonly wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6658,7 +6568,7 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+24"/>
         <source>Error: Wallet does not exist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6668,12 +6578,27 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
+        <location line="+10"/>
+        <source>Failed to start indexes, shutting down…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Invalid -proxy address or hostname, ends with &apos;=&apos;: &apos;%s&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
         <source>Not enough file descriptors available. %d available, %d required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
+        <location line="+59"/>
+        <source>Unrecognized network in -proxy=&apos;%s&apos;: &apos;%s&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6693,7 +6618,7 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-53"/>
+        <location line="-51"/>
         <source>Settings file could not be read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qt/locale/bitcoin_en.xlf
+++ b/src/qt/locale/bitcoin_en.xlf
@@ -15,24 +15,24 @@
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
       <trans-unit id="_msg4">
-        <source xml:space="preserve">Copy the currently selected address to the system clipboard</source>
-        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg5">
         <source xml:space="preserve">&amp;Copy</source>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg6">
+      <trans-unit id="_msg5">
         <source xml:space="preserve">C&amp;lose</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg7">
+      <trans-unit id="_msg6">
         <source xml:space="preserve">Delete the currently selected address from the list</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg8">
+      <trans-unit id="_msg7">
         <source xml:space="preserve">Enter address or label to search</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg8">
+        <source xml:space="preserve">Copy the currently selected address to the clipboard</source>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
       <trans-unit id="_msg9">
         <source xml:space="preserve">Export the data in the current tab to a file</source>
@@ -45,7 +45,7 @@
       <trans-unit id="_msg11">
         <source xml:space="preserve">&amp;Delete</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../addressbookpage.cpp</context><context context-type="linenumber">113</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../addressbookpage.cpp</context><context context-type="linenumber">105</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -53,62 +53,62 @@
     <group restype="x-trolltech-linguist-context" resname="AddressBookPage">
       <trans-unit id="_msg12">
         <source xml:space="preserve">Choose the address to send coins to</source>
-        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
       </trans-unit>
       <trans-unit id="_msg13">
         <source xml:space="preserve">Choose the address to receive coins with</source>
-        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
       <trans-unit id="_msg14">
         <source xml:space="preserve">C&amp;hoose</source>
-        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
       <trans-unit id="_msg15">
         <source xml:space="preserve">These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
       <trans-unit id="_msg16">
         <source xml:space="preserve">These are your Bitcoin addresses for receiving payments. Use the &apos;Create new receiving address&apos; button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
-        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
       <trans-unit id="_msg17">
         <source xml:space="preserve">&amp;Copy Address</source>
-        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
       <trans-unit id="_msg18">
         <source xml:space="preserve">Copy &amp;Label</source>
-        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
       <trans-unit id="_msg19">
         <source xml:space="preserve">&amp;Edit</source>
-        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
       <trans-unit id="_msg20">
         <source xml:space="preserve">Export Address List</source>
-        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
       <trans-unit id="_msg21">
         <source xml:space="preserve">Comma separated file</source>
-        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</note>
       </trans-unit>
       <trans-unit id="_msg22">
         <source xml:space="preserve">There was an error trying to save the address list to %1. Please try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
         <note annotates="source" from="developer">An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</note>
       </trans-unit>
       <trans-unit id="_msg23">
         <source xml:space="preserve">Sending addresses - %1</source>
-        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
       <trans-unit id="_msg24">
         <source xml:space="preserve">Receiving addresses - %1</source>
-        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
       <trans-unit id="_msg25">
         <source xml:space="preserve">Exporting Failed</source>
-        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -290,43 +290,43 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     <group restype="x-trolltech-linguist-context" resname="BitcoinApplication">
       <trans-unit id="_msg63">
         <source xml:space="preserve">Settings file %1 might be corrupt or invalid.</source>
-        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
       <trans-unit id="_msg64">
         <source xml:space="preserve">Runaway exception</source>
-        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
       </trans-unit>
       <trans-unit id="_msg65">
         <source xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <context-group purpose="location"><context context-type="linenumber">445</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
       </trans-unit>
       <trans-unit id="_msg66">
         <source xml:space="preserve">Internal error</source>
-        <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">445</context></context-group>
       </trans-unit>
       <trans-unit id="_msg67">
         <source xml:space="preserve">An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">446</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
       <trans-unit id="_msg68">
         <source xml:space="preserve">Do you want to reset settings to default values, or to abort without making changes?</source>
-        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
         <note annotates="source" from="developer">Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</note>
       </trans-unit>
       <trans-unit id="_msg69">
         <source xml:space="preserve">A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
-        <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
         <note annotates="source" from="developer">Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</note>
       </trans-unit>
       <trans-unit id="_msg70">
         <source xml:space="preserve">Error: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">616</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">601</context></context-group>
       </trans-unit>
       <trans-unit id="_msg71">
         <source xml:space="preserve">%1 didn&apos;t yet exit safely…</source>
-        <context-group purpose="location"><context context-type="linenumber">689</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">674</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -382,20 +382,20 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
       </trans-unit>
       <trans-unit id="_msg84">
         <source xml:space="preserve">&amp;Minimize</source>
-        <context-group purpose="location"><context context-type="linenumber">533</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">537</context></context-group>
       </trans-unit>
       <trans-unit id="_msg85">
         <source xml:space="preserve">Wallet:</source>
-        <context-group purpose="location"><context context-type="linenumber">612</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">616</context></context-group>
       </trans-unit>
       <trans-unit id="_msg86">
         <source xml:space="preserve">Network activity disabled.</source>
-        <context-group purpose="location"><context context-type="linenumber">1030</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1034</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip.</note>
       </trans-unit>
       <trans-unit id="_msg87">
         <source xml:space="preserve">Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1481</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1480</context></context-group>
       </trans-unit>
       <trans-unit id="_msg88">
         <source xml:space="preserve">Send coins to a Bitcoin address</source>
@@ -475,39 +475,39 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
       </trans-unit>
       <trans-unit id="_msg107">
         <source xml:space="preserve">&amp;File</source>
-        <context-group purpose="location"><context context-type="linenumber">499</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
       </trans-unit>
       <trans-unit id="_msg108">
         <source xml:space="preserve">&amp;Settings</source>
-        <context-group purpose="location"><context context-type="linenumber">520</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">524</context></context-group>
       </trans-unit>
       <trans-unit id="_msg109">
         <source xml:space="preserve">&amp;Help</source>
-        <context-group purpose="location"><context context-type="linenumber">581</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">585</context></context-group>
       </trans-unit>
       <trans-unit id="_msg110">
         <source xml:space="preserve">Tabs toolbar</source>
-        <context-group purpose="location"><context context-type="linenumber">592</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">596</context></context-group>
       </trans-unit>
       <trans-unit id="_msg111">
         <source xml:space="preserve">Syncing Headers (%1%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">1074</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1078</context></context-group>
       </trans-unit>
       <trans-unit id="_msg112">
         <source xml:space="preserve">Synchronizing with network…</source>
-        <context-group purpose="location"><context context-type="linenumber">1132</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1136</context></context-group>
       </trans-unit>
       <trans-unit id="_msg113">
         <source xml:space="preserve">Indexing blocks on disk…</source>
-        <context-group purpose="location"><context context-type="linenumber">1137</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1141</context></context-group>
       </trans-unit>
       <trans-unit id="_msg114">
         <source xml:space="preserve">Processing blocks on disk…</source>
-        <context-group purpose="location"><context context-type="linenumber">1139</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1143</context></context-group>
       </trans-unit>
       <trans-unit id="_msg115">
         <source xml:space="preserve">Connecting to peers…</source>
-        <context-group purpose="location"><context context-type="linenumber">1146</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1150</context></context-group>
       </trans-unit>
       <trans-unit id="_msg116">
         <source xml:space="preserve">Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -526,7 +526,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1155</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1159</context></context-group>
         <trans-unit id="_msg120[0]">
           <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
         </trans-unit>
@@ -536,35 +536,35 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
       </group>
       <trans-unit id="_msg121">
         <source xml:space="preserve">%1 behind</source>
-        <context-group purpose="location"><context context-type="linenumber">1178</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1182</context></context-group>
       </trans-unit>
       <trans-unit id="_msg122">
         <source xml:space="preserve">Catching up…</source>
-        <context-group purpose="location"><context context-type="linenumber">1183</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1187</context></context-group>
       </trans-unit>
       <trans-unit id="_msg123">
         <source xml:space="preserve">Last received block was generated %1 ago.</source>
-        <context-group purpose="location"><context context-type="linenumber">1202</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1206</context></context-group>
       </trans-unit>
       <trans-unit id="_msg124">
         <source xml:space="preserve">Transactions after this will not yet be visible.</source>
-        <context-group purpose="location"><context context-type="linenumber">1204</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1208</context></context-group>
       </trans-unit>
       <trans-unit id="_msg125">
         <source xml:space="preserve">Error</source>
-        <context-group purpose="location"><context context-type="linenumber">1244</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1243</context></context-group>
       </trans-unit>
       <trans-unit id="_msg126">
         <source xml:space="preserve">Warning</source>
-        <context-group purpose="location"><context context-type="linenumber">1248</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1247</context></context-group>
       </trans-unit>
       <trans-unit id="_msg127">
         <source xml:space="preserve">Information</source>
-        <context-group purpose="location"><context context-type="linenumber">1252</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1251</context></context-group>
       </trans-unit>
       <trans-unit id="_msg128">
         <source xml:space="preserve">Up to date</source>
-        <context-group purpose="location"><context context-type="linenumber">1159</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1163</context></context-group>
       </trans-unit>
       <trans-unit id="_msg129">
         <source xml:space="preserve">Ctrl+Q</source>
@@ -650,59 +650,59 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
       </trans-unit>
       <trans-unit id="_msg149">
         <source xml:space="preserve">No wallets available</source>
-        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">481</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">485</context></context-group>
       </trans-unit>
       <trans-unit id="_msg150">
         <source xml:space="preserve">Wallet Data</source>
-        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
         <note annotates="source" from="developer">Name of the wallet data file format.</note>
       </trans-unit>
       <trans-unit id="_msg151">
         <source xml:space="preserve">Load Wallet Backup</source>
-        <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
         <note annotates="source" from="developer">The title for Restore Wallet File Windows</note>
       </trans-unit>
       <trans-unit id="_msg152">
         <source xml:space="preserve">Restore Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">439</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
         <note annotates="source" from="developer">Title of pop-up window shown when the user is attempting to restore a wallet.</note>
       </trans-unit>
       <trans-unit id="_msg153">
         <source xml:space="preserve">Wallet Name</source>
-        <context-group purpose="location"><context context-type="linenumber">441</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">445</context></context-group>
         <note annotates="source" from="developer">Label of the input field where the name of the wallet is entered.</note>
       </trans-unit>
       <trans-unit id="_msg154">
         <source xml:space="preserve">&amp;Window</source>
-        <context-group purpose="location"><context context-type="linenumber">531</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">535</context></context-group>
       </trans-unit>
       <trans-unit id="_msg155">
         <source xml:space="preserve">Ctrl+M</source>
-        <context-group purpose="location"><context context-type="linenumber">534</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">538</context></context-group>
       </trans-unit>
       <trans-unit id="_msg156">
         <source xml:space="preserve">Zoom</source>
-        <context-group purpose="location"><context context-type="linenumber">543</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
       </trans-unit>
       <trans-unit id="_msg157">
         <source xml:space="preserve">Main Window</source>
-        <context-group purpose="location"><context context-type="linenumber">561</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">565</context></context-group>
       </trans-unit>
       <trans-unit id="_msg158">
         <source xml:space="preserve">%1 client</source>
-        <context-group purpose="location"><context context-type="linenumber">840</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">844</context></context-group>
       </trans-unit>
       <trans-unit id="_msg159">
         <source xml:space="preserve">&amp;Hide</source>
-        <context-group purpose="location"><context context-type="linenumber">908</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">912</context></context-group>
       </trans-unit>
       <trans-unit id="_msg160">
         <source xml:space="preserve">S&amp;how</source>
-        <context-group purpose="location"><context context-type="linenumber">909</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">913</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1027</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1031</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip.</note>
         <trans-unit id="_msg161[0]">
           <source xml:space="preserve">%n active connection(s) to Bitcoin network.</source>
@@ -713,177 +713,169 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
       </group>
       <trans-unit id="_msg162">
         <source xml:space="preserve">Click for more actions.</source>
-        <context-group purpose="location"><context context-type="linenumber">1037</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1041</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip. &quot;More actions&quot; are available via the context menu.</note>
       </trans-unit>
       <trans-unit id="_msg163">
         <source xml:space="preserve">Show Peers tab</source>
-        <context-group purpose="location"><context context-type="linenumber">1054</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1058</context></context-group>
         <note annotates="source" from="developer">A context menu item. The &quot;Peers tab&quot; is an element of the &quot;Node window&quot;.</note>
       </trans-unit>
       <trans-unit id="_msg164">
         <source xml:space="preserve">Disable network activity</source>
-        <context-group purpose="location"><context context-type="linenumber">1062</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1066</context></context-group>
         <note annotates="source" from="developer">A context menu item.</note>
       </trans-unit>
       <trans-unit id="_msg165">
         <source xml:space="preserve">Enable network activity</source>
-        <context-group purpose="location"><context context-type="linenumber">1064</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1068</context></context-group>
         <note annotates="source" from="developer">A context menu item. The network activity was disabled previously.</note>
       </trans-unit>
       <trans-unit id="_msg166">
         <source xml:space="preserve">Pre-syncing Headers (%1%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">1081</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1085</context></context-group>
       </trans-unit>
       <trans-unit id="_msg167">
-        <source xml:space="preserve">Error creating wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">1220</context></context-group>
+        <source xml:space="preserve">Error: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">1244</context></context-group>
       </trans-unit>
       <trans-unit id="_msg168">
-        <source xml:space="preserve">Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)</source>
-        <context-group purpose="location"><context context-type="linenumber">1220</context></context-group>
+        <source xml:space="preserve">Warning: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">1248</context></context-group>
       </trans-unit>
       <trans-unit id="_msg169">
-        <source xml:space="preserve">Error: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1245</context></context-group>
+        <source xml:space="preserve">Date: %1
+</source>
+        <context-group purpose="location"><context context-type="linenumber">1356</context></context-group>
       </trans-unit>
       <trans-unit id="_msg170">
-        <source xml:space="preserve">Warning: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1249</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg171">
-        <source xml:space="preserve">Date: %1
+        <source xml:space="preserve">Amount: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1357</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg172">
-        <source xml:space="preserve">Amount: %1
-</source>
-        <context-group purpose="location"><context context-type="linenumber">1358</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg173">
+      <trans-unit id="_msg171">
         <source xml:space="preserve">Wallet: %1
 </source>
-        <context-group purpose="location"><context context-type="linenumber">1360</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1359</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg174">
+      <trans-unit id="_msg172">
         <source xml:space="preserve">Type: %1
 </source>
-        <context-group purpose="location"><context context-type="linenumber">1362</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1361</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg175">
+      <trans-unit id="_msg173">
         <source xml:space="preserve">Label: %1
 </source>
-        <context-group purpose="location"><context context-type="linenumber">1364</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1363</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg176">
+      <trans-unit id="_msg174">
         <source xml:space="preserve">Address: %1
 </source>
+        <context-group purpose="location"><context context-type="linenumber">1365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg175">
+        <source xml:space="preserve">Sent transaction</source>
+        <context-group purpose="location"><context context-type="linenumber">1366</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg176">
+        <source xml:space="preserve">Incoming transaction</source>
         <context-group purpose="location"><context context-type="linenumber">1366</context></context-group>
       </trans-unit>
       <trans-unit id="_msg177">
-        <source xml:space="preserve">Sent transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">1367</context></context-group>
+        <source xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1418</context></context-group>
       </trans-unit>
       <trans-unit id="_msg178">
-        <source xml:space="preserve">Incoming transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">1367</context></context-group>
+        <source xml:space="preserve">HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1418</context></context-group>
       </trans-unit>
       <trans-unit id="_msg179">
-        <source xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1419</context></context-group>
+        <source xml:space="preserve">Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1418</context></context-group>
       </trans-unit>
       <trans-unit id="_msg180">
-        <source xml:space="preserve">HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1419</context></context-group>
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1441</context></context-group>
       </trans-unit>
       <trans-unit id="_msg181">
-        <source xml:space="preserve">Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1419</context></context-group>
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1449</context></context-group>
       </trans-unit>
       <trans-unit id="_msg182">
-        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1442</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg183">
-        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1450</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg184">
         <source xml:space="preserve">Original message:</source>
-        <context-group purpose="location"><context context-type="linenumber">1569</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1568</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="UnitDisplayStatusBarControl">
-      <trans-unit id="_msg185">
+      <trans-unit id="_msg183">
         <source xml:space="preserve">Unit to show amounts in. Click to select another unit.</source>
-        <context-group purpose="location"><context context-type="linenumber">1608</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1607</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/coincontroldialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg186">
+      <trans-unit id="_msg184">
         <source xml:space="preserve">Coin Selection</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg187">
+      <trans-unit id="_msg185">
         <source xml:space="preserve">Quantity:</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg188">
+      <trans-unit id="_msg186">
         <source xml:space="preserve">Bytes:</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg189">
+      <trans-unit id="_msg187">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg190">
+      <trans-unit id="_msg188">
         <source xml:space="preserve">Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg191">
+      <trans-unit id="_msg189">
         <source xml:space="preserve">After Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg192">
+      <trans-unit id="_msg190">
         <source xml:space="preserve">Change:</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg193">
+      <trans-unit id="_msg191">
         <source xml:space="preserve">(un)select all</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg194">
+      <trans-unit id="_msg192">
         <source xml:space="preserve">Tree mode</source>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg195">
+      <trans-unit id="_msg193">
         <source xml:space="preserve">List mode</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg196">
+      <trans-unit id="_msg194">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg197">
+      <trans-unit id="_msg195">
         <source xml:space="preserve">Received with label</source>
         <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg198">
+      <trans-unit id="_msg196">
         <source xml:space="preserve">Received with address</source>
         <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg199">
+      <trans-unit id="_msg197">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg200">
+      <trans-unit id="_msg198">
         <source xml:space="preserve">Confirmations</source>
         <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg201">
+      <trans-unit id="_msg199">
         <source xml:space="preserve">Confirmed</source>
         <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
       </trans-unit>
@@ -891,72 +883,72 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../coincontroldialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg202">
+      <trans-unit id="_msg200">
         <source xml:space="preserve">Copy amount</source>
         <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg203">
+      <trans-unit id="_msg201">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg204">
+      <trans-unit id="_msg202">
         <source xml:space="preserve">Copy &amp;label</source>
         <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg205">
+      <trans-unit id="_msg203">
         <source xml:space="preserve">Copy &amp;amount</source>
         <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg206">
+      <trans-unit id="_msg204">
         <source xml:space="preserve">Copy transaction &amp;ID and output index</source>
         <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg207">
+      <trans-unit id="_msg205">
         <source xml:space="preserve">L&amp;ock unspent</source>
         <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg208">
+      <trans-unit id="_msg206">
         <source xml:space="preserve">&amp;Unlock unspent</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg209">
+      <trans-unit id="_msg207">
         <source xml:space="preserve">Copy quantity</source>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg210">
+      <trans-unit id="_msg208">
         <source xml:space="preserve">Copy fee</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg211">
+      <trans-unit id="_msg209">
         <source xml:space="preserve">Copy after fee</source>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg212">
+      <trans-unit id="_msg210">
         <source xml:space="preserve">Copy bytes</source>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg213">
+      <trans-unit id="_msg211">
         <source xml:space="preserve">Copy change</source>
         <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg214">
+      <trans-unit id="_msg212">
         <source xml:space="preserve">(%1 locked)</source>
         <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg215">
+      <trans-unit id="_msg213">
         <source xml:space="preserve">Can vary +/- %1 satoshi(s) per input.</source>
         <context-group purpose="location"><context context-type="linenumber">528</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg216">
+      <trans-unit id="_msg214">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">573</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">627</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg217">
+      <trans-unit id="_msg215">
         <source xml:space="preserve">change from %1 (%2)</source>
         <context-group purpose="location"><context context-type="linenumber">620</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg218">
+      <trans-unit id="_msg216">
         <source xml:space="preserve">(change)</source>
         <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
       </trans-unit>
@@ -964,55 +956,55 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../walletcontroller.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletActivity">
-      <trans-unit id="_msg219">
+      <trans-unit id="_msg217">
         <source xml:space="preserve">Create Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
         <note annotates="source" from="developer">Title of window indicating the progress of creation of a new wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg220">
+      <trans-unit id="_msg218">
         <source xml:space="preserve">Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</note>
       </trans-unit>
-      <trans-unit id="_msg221">
+      <trans-unit id="_msg219">
         <source xml:space="preserve">Create wallet failed</source>
         <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg222">
+      <trans-unit id="_msg220">
         <source xml:space="preserve">Create wallet warning</source>
         <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg223">
+      <trans-unit id="_msg221">
         <source xml:space="preserve">Can&apos;t list signers</source>
         <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg224">
+      <trans-unit id="_msg222">
         <source xml:space="preserve">Too many external signers found</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="LoadWalletsActivity">
-      <trans-unit id="_msg225">
+      <trans-unit id="_msg223">
         <source xml:space="preserve">Load Wallets</source>
         <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
         <note annotates="source" from="developer">Title of progress window which is displayed when wallets are being loaded.</note>
       </trans-unit>
-      <trans-unit id="_msg226">
+      <trans-unit id="_msg224">
         <source xml:space="preserve">Loading wallets…</source>
         <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="MigrateWalletActivity">
-      <trans-unit id="_msg227">
+      <trans-unit id="_msg225">
         <source xml:space="preserve">Migrate wallet</source>
         <context-group purpose="location"><context context-type="linenumber">446</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg228">
+      <trans-unit id="_msg226">
         <source xml:space="preserve">Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg229">
+      <trans-unit id="_msg227">
         <source xml:space="preserve">Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.
 If this wallet contains any watchonly scripts, a new wallet will be created which contains those watchonly scripts.
 If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.
@@ -1020,100 +1012,100 @@ If this wallet contains any solvable but not watched scripts, a different and ne
 The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the &quot;Restore Wallet&quot; functionality.</source>
         <context-group purpose="location"><context context-type="linenumber">448</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg230">
+      <trans-unit id="_msg228">
         <source xml:space="preserve">Migrate Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg231">
+      <trans-unit id="_msg229">
         <source xml:space="preserve">Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg232">
+      <trans-unit id="_msg230">
         <source xml:space="preserve">The wallet &apos;%1&apos; was migrated successfully.</source>
         <context-group purpose="location"><context context-type="linenumber">471</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg233">
+      <trans-unit id="_msg231">
         <source xml:space="preserve">Watchonly scripts have been migrated to a new wallet named &apos;%1&apos;.</source>
         <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg234">
+      <trans-unit id="_msg232">
         <source xml:space="preserve">Solvable but not watched scripts have been migrated to a new wallet named &apos;%1&apos;.</source>
         <context-group purpose="location"><context context-type="linenumber">476</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg235">
+      <trans-unit id="_msg233">
         <source xml:space="preserve">Migration failed</source>
         <context-group purpose="location"><context context-type="linenumber">490</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg236">
+      <trans-unit id="_msg234">
         <source xml:space="preserve">Migration Successful</source>
         <context-group purpose="location"><context context-type="linenumber">492</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="OpenWalletActivity">
-      <trans-unit id="_msg237">
+      <trans-unit id="_msg235">
         <source xml:space="preserve">Open wallet failed</source>
         <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg238">
+      <trans-unit id="_msg236">
         <source xml:space="preserve">Open wallet warning</source>
         <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg239">
+      <trans-unit id="_msg237">
         <source xml:space="preserve">Open Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
         <note annotates="source" from="developer">Title of window indicating the progress of opening of a wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg240">
+      <trans-unit id="_msg238">
         <source xml:space="preserve">Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="RestoreWalletActivity">
-      <trans-unit id="_msg241">
+      <trans-unit id="_msg239">
         <source xml:space="preserve">Restore Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
         <note annotates="source" from="developer">Title of progress window which is displayed when wallets are being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg242">
+      <trans-unit id="_msg240">
         <source xml:space="preserve">Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg243">
+      <trans-unit id="_msg241">
         <source xml:space="preserve">Restore wallet failed</source>
         <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet could not be restored.</note>
       </trans-unit>
-      <trans-unit id="_msg244">
+      <trans-unit id="_msg242">
         <source xml:space="preserve">Restore wallet warning</source>
         <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet is restored with some warning.</note>
       </trans-unit>
-      <trans-unit id="_msg245">
+      <trans-unit id="_msg243">
         <source xml:space="preserve">Restore wallet message</source>
         <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet is successfully restored.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="WalletController">
-      <trans-unit id="_msg246">
+      <trans-unit id="_msg244">
         <source xml:space="preserve">Close wallet</source>
         <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg247">
+      <trans-unit id="_msg245">
         <source xml:space="preserve">Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg248">
+      <trans-unit id="_msg246">
         <source xml:space="preserve">Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg249">
+      <trans-unit id="_msg247">
         <source xml:space="preserve">Close all wallets</source>
         <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg250">
+      <trans-unit id="_msg248">
         <source xml:space="preserve">Are you sure you wish to close all wallets?</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
       </trans-unit>
@@ -1121,59 +1113,59 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/createwalletdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg251">
+      <trans-unit id="_msg249">
         <source xml:space="preserve">Create Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg252">
+      <trans-unit id="_msg250">
         <source xml:space="preserve">You are one step away from creating your new wallet!</source>
         <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg253">
+      <trans-unit id="_msg251">
         <source xml:space="preserve">Please provide a name and, if desired, enable any advanced options</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg254">
+      <trans-unit id="_msg252">
         <source xml:space="preserve">Wallet Name</source>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg255">
+      <trans-unit id="_msg253">
         <source xml:space="preserve">Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg256">
+      <trans-unit id="_msg254">
         <source xml:space="preserve">Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg257">
+      <trans-unit id="_msg255">
         <source xml:space="preserve">Encrypt Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg258">
+      <trans-unit id="_msg256">
         <source xml:space="preserve">Advanced Options</source>
         <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg259">
+      <trans-unit id="_msg257">
         <source xml:space="preserve">Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg260">
+      <trans-unit id="_msg258">
         <source xml:space="preserve">Disable Private Keys</source>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg261">
+      <trans-unit id="_msg259">
         <source xml:space="preserve">Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
         <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg262">
+      <trans-unit id="_msg260">
         <source xml:space="preserve">Make Blank Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg263">
+      <trans-unit id="_msg261">
         <source xml:space="preserve">Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
         <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg264">
+      <trans-unit id="_msg262">
         <source xml:space="preserve">External signer</source>
         <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
       </trans-unit>
@@ -1181,11 +1173,11 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../createwalletdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg265">
+      <trans-unit id="_msg263">
         <source xml:space="preserve">Create</source>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg266">
+      <trans-unit id="_msg264">
         <source xml:space="preserve">Compiled without external signing support (required for external signing)</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <note annotates="source" from="developer">&quot;External signing&quot; means using devices such as hardware wallets.</note>
@@ -1194,23 +1186,23 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/editaddressdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg267">
+      <trans-unit id="_msg265">
         <source xml:space="preserve">Edit Address</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg268">
+      <trans-unit id="_msg266">
         <source xml:space="preserve">&amp;Label</source>
         <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg269">
+      <trans-unit id="_msg267">
         <source xml:space="preserve">The label associated with this address list entry</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg270">
+      <trans-unit id="_msg268">
         <source xml:space="preserve">The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg271">
+      <trans-unit id="_msg269">
         <source xml:space="preserve">&amp;Address</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
@@ -1218,156 +1210,85 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../editaddressdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg272">
+      <trans-unit id="_msg270">
         <source xml:space="preserve">New sending address</source>
         <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg273">
+      <trans-unit id="_msg271">
         <source xml:space="preserve">Edit receiving address</source>
         <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg274">
+      <trans-unit id="_msg272">
         <source xml:space="preserve">Edit sending address</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg275">
+      <trans-unit id="_msg273">
         <source xml:space="preserve">The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg276">
+      <trans-unit id="_msg274">
         <source xml:space="preserve">Address &quot;%1&quot; already exists as a receiving address with label &quot;%2&quot; and so cannot be added as a sending address.</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg277">
+      <trans-unit id="_msg275">
         <source xml:space="preserve">The entered address &quot;%1&quot; is already in the address book with label &quot;%2&quot;.</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg278">
+      <trans-unit id="_msg276">
         <source xml:space="preserve">Could not unlock wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg279">
+      <trans-unit id="_msg277">
         <source xml:space="preserve">New key generation failed.</source>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
     </group>
   </body></file>
-  <file original="../intro.cpp" datatype="cpp" source-language="en"><body>
+  <file original="../freespacechecker.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="FreespaceChecker">
-      <trans-unit id="_msg280">
+      <trans-unit id="_msg278">
         <source xml:space="preserve">A new data directory will be created.</source>
-        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">21</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg279">
+        <source xml:space="preserve">name</source>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg280">
+        <source xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
       <trans-unit id="_msg281">
-        <source xml:space="preserve">name</source>
-        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+        <source xml:space="preserve">Path already exists, and is not a directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
       <trans-unit id="_msg282">
-        <source xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg283">
-        <source xml:space="preserve">Path already exists, and is not a directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg284">
         <source xml:space="preserve">Cannot create data directory here.</source>
-        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
-      </trans-unit>
-    </group>
-    <group restype="x-trolltech-linguist-context" resname="Intro">
-      <trans-unit id="_msg285">
-        <source xml:space="preserve">Bitcoin</source>
-        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
-      </trans-unit>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
-        <trans-unit id="_msg286[0]">
-          <source xml:space="preserve">%n GB of space available</source>
-        </trans-unit>
-        <trans-unit id="_msg286[1]">
-          <source xml:space="preserve">%n GB of space available</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
-        <trans-unit id="_msg287[0]">
-          <source xml:space="preserve">(of %n GB needed)</source>
-        </trans-unit>
-        <trans-unit id="_msg287[1]">
-          <source xml:space="preserve">(of %n GB needed)</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
-        <trans-unit id="_msg288[0]">
-          <source xml:space="preserve">(%n GB needed for full chain)</source>
-        </trans-unit>
-        <trans-unit id="_msg288[1]">
-          <source xml:space="preserve">(%n GB needed for full chain)</source>
-        </trans-unit>
-      </group>
-      <trans-unit id="_msg289">
-        <source xml:space="preserve">Choose data directory</source>
-        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg290">
-        <source xml:space="preserve">At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg291">
-        <source xml:space="preserve">Approximately %1 GB of data will be stored in this directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
-      </trans-unit>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
-        <note annotates="source" from="developer">Explanatory text on the capability of the current prune target.</note>
-        <trans-unit id="_msg292[0]">
-          <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
-        </trans-unit>
-        <trans-unit id="_msg292[1]">
-          <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
-        </trans-unit>
-      </group>
-      <trans-unit id="_msg293">
-        <source xml:space="preserve">%1 will download and store a copy of the Bitcoin block chain.</source>
-        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg294">
-        <source xml:space="preserve">The wallet will also be stored in this directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg295">
-        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
-        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg296">
-        <source xml:space="preserve">Error</source>
-        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../utilitydialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="HelpMessageDialog">
-      <trans-unit id="_msg297">
+      <trans-unit id="_msg283">
         <source xml:space="preserve">version</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg298">
+      <trans-unit id="_msg284">
         <source xml:space="preserve">About %1</source>
         <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg299">
+      <trans-unit id="_msg285">
         <source xml:space="preserve">Command-line options</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="ShutdownWindow">
-      <trans-unit id="_msg300">
+      <trans-unit id="_msg286">
         <source xml:space="preserve">%1 is shutting down…</source>
         <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg301">
+      <trans-unit id="_msg287">
         <source xml:space="preserve">Do not shut down the computer until this window disappears.</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
@@ -1375,102 +1296,175 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/intro.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="Intro">
-      <trans-unit id="_msg302">
+      <trans-unit id="_msg288">
         <source xml:space="preserve">Welcome</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg303">
+      <trans-unit id="_msg289">
         <source xml:space="preserve">Welcome to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg304">
+      <trans-unit id="_msg290">
         <source xml:space="preserve">As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg305">
+      <trans-unit id="_msg291">
         <source xml:space="preserve">Limit block chain storage to</source>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg306">
+      <trans-unit id="_msg292">
         <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg307">
+      <trans-unit id="_msg293">
         <source xml:space="preserve"> GB</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg308">
+      <trans-unit id="_msg294">
         <source xml:space="preserve">This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg309">
+      <trans-unit id="_msg295">
         <source xml:space="preserve">When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
         <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg310">
+      <trans-unit id="_msg296">
         <source xml:space="preserve">If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg311">
+      <trans-unit id="_msg297">
         <source xml:space="preserve">Use the default data directory</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg312">
+      <trans-unit id="_msg298">
         <source xml:space="preserve">Use a custom data directory:</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
     </group>
   </body></file>
+  <file original="../intro.cpp" datatype="cpp" source-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="Intro">
+      <trans-unit id="_msg299">
+        <source xml:space="preserve">Bitcoin</source>
+        <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+        <trans-unit id="_msg300[0]">
+          <source xml:space="preserve">%n GB of space available</source>
+        </trans-unit>
+        <trans-unit id="_msg300[1]">
+          <source xml:space="preserve">%n GB of space available</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+        <trans-unit id="_msg301[0]">
+          <source xml:space="preserve">(of %n GB needed)</source>
+        </trans-unit>
+        <trans-unit id="_msg301[1]">
+          <source xml:space="preserve">(of %n GB needed)</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+        <trans-unit id="_msg302[0]">
+          <source xml:space="preserve">(%n GB needed for full chain)</source>
+        </trans-unit>
+        <trans-unit id="_msg302[1]">
+          <source xml:space="preserve">(%n GB needed for full chain)</source>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg303">
+        <source xml:space="preserve">Choose data directory</source>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg304">
+        <source xml:space="preserve">At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg305">
+        <source xml:space="preserve">Approximately %1 GB of data will be stored in this directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
+        <note annotates="source" from="developer">Explanatory text on the capability of the current prune target.</note>
+        <trans-unit id="_msg306[0]">
+          <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
+        </trans-unit>
+        <trans-unit id="_msg306[1]">
+          <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg307">
+        <source xml:space="preserve">%1 will download and store a copy of the Bitcoin block chain.</source>
+        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg308">
+        <source xml:space="preserve">The wallet will also be stored in this directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg309">
+        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
+        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg310">
+        <source xml:space="preserve">Error</source>
+        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
   <file original="../forms/modaloverlay.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg313">
+      <trans-unit id="_msg311">
         <source xml:space="preserve">Form</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg314">
+      <trans-unit id="_msg312">
         <source xml:space="preserve">Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
         <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg315">
+      <trans-unit id="_msg313">
         <source xml:space="preserve">Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg316">
+      <trans-unit id="_msg314">
         <source xml:space="preserve">Number of blocks left</source>
         <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg317">
+      <trans-unit id="_msg315">
         <source xml:space="preserve">Unknown…</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../modaloverlay.cpp</context><context context-type="linenumber">160</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg318">
+      <trans-unit id="_msg316">
         <source xml:space="preserve">calculating…</source>
         <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg319">
+      <trans-unit id="_msg317">
         <source xml:space="preserve">Last block time</source>
         <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg320">
+      <trans-unit id="_msg318">
         <source xml:space="preserve">Progress</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg321">
+      <trans-unit id="_msg319">
         <source xml:space="preserve">Progress increase per hour</source>
         <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg322">
+      <trans-unit id="_msg320">
         <source xml:space="preserve">Estimated time left until synced</source>
         <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg323">
+      <trans-unit id="_msg321">
         <source xml:space="preserve">Hide</source>
         <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg324">
+      <trans-unit id="_msg322">
         <source xml:space="preserve">Esc</source>
         <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
@@ -1478,21 +1472,21 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../modaloverlay.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg325">
+      <trans-unit id="_msg323">
         <source xml:space="preserve">%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg326">
+      <trans-unit id="_msg324">
         <source xml:space="preserve">Unknown. Syncing Headers (%1, %2%)…</source>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg327">
+      <trans-unit id="_msg325">
         <source xml:space="preserve">Unknown. Pre-syncing Headers (%1, %2%)…</source>
         <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg328">
+      <trans-unit id="_msg326">
         <source xml:space="preserve">unknown</source>
         <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
       </trans-unit>
@@ -1500,15 +1494,15 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/openuridialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OpenURIDialog">
-      <trans-unit id="_msg329">
+      <trans-unit id="_msg327">
         <source xml:space="preserve">Open bitcoin URI</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg330">
+      <trans-unit id="_msg328">
         <source xml:space="preserve">URI:</source>
         <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg331">
+      <trans-unit id="_msg329">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
         <note annotates="source" from="developer">Tooltip text for button that allows you to paste an address that is in your clipboard.</note>
@@ -1517,294 +1511,294 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/optionsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg332">
+      <trans-unit id="_msg330">
         <source xml:space="preserve">Options</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg333">
+      <trans-unit id="_msg331">
         <source xml:space="preserve">&amp;Main</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg334">
+      <trans-unit id="_msg332">
         <source xml:space="preserve">Automatically start %1 after logging in to the system.</source>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg335">
+      <trans-unit id="_msg333">
         <source xml:space="preserve">&amp;Start %1 on system login</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg336">
+      <trans-unit id="_msg334">
         <source xml:space="preserve">Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg337">
+      <trans-unit id="_msg335">
         <source xml:space="preserve">Maximum database cache size. Make sure you have enough RAM. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</note>
       </trans-unit>
-      <trans-unit id="_msg338">
+      <trans-unit id="_msg336">
         <source xml:space="preserve">Size of &amp;database cache</source>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg339">
+      <trans-unit id="_msg337">
         <source xml:space="preserve">Number of script &amp;verification threads</source>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg340">
+      <trans-unit id="_msg338">
         <source xml:space="preserve">Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg341">
+      <trans-unit id="_msg339">
         <source xml:space="preserve">Automatically open the Bitcoin client port on the router. This only works when your router supports PCP or NAT-PMP and it is enabled. The external port could be random.</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg342">
+      <trans-unit id="_msg340">
         <source xml:space="preserve">Map port using PCP or NA&amp;T-PMP</source>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg343">
+      <trans-unit id="_msg341">
         <source xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">565</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg344">
+      <trans-unit id="_msg342">
         <source xml:space="preserve">Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
         <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">493</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg345">
+      <trans-unit id="_msg343">
         <source xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <context-group purpose="location"><context context-type="linenumber">662</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg346">
+      <trans-unit id="_msg344">
         <source xml:space="preserve">Font in the Overview tab: </source>
         <context-group purpose="location"><context context-type="linenumber">769</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg347">
+      <trans-unit id="_msg345">
         <source xml:space="preserve">Options set in this dialog are overridden by the command line:</source>
         <context-group purpose="location"><context context-type="linenumber">814</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg348">
+      <trans-unit id="_msg346">
         <source xml:space="preserve">Open the %1 configuration file from the working directory.</source>
         <context-group purpose="location"><context context-type="linenumber">859</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg349">
+      <trans-unit id="_msg347">
         <source xml:space="preserve">Open Configuration File</source>
         <context-group purpose="location"><context context-type="linenumber">862</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg350">
+      <trans-unit id="_msg348">
         <source xml:space="preserve">Reset all client options to default.</source>
         <context-group purpose="location"><context context-type="linenumber">872</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg351">
+      <trans-unit id="_msg349">
         <source xml:space="preserve">&amp;Reset Options</source>
         <context-group purpose="location"><context context-type="linenumber">875</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg352">
+      <trans-unit id="_msg350">
         <source xml:space="preserve">&amp;Network</source>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg353">
+      <trans-unit id="_msg351">
         <source xml:space="preserve">Prune &amp;block storage to</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg354">
+      <trans-unit id="_msg352">
         <source xml:space="preserve">GB</source>
         <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg355">
+      <trans-unit id="_msg353">
         <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg356">
+      <trans-unit id="_msg354">
         <source xml:space="preserve">MiB</source>
         <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg357">
+      <trans-unit id="_msg355">
         <source xml:space="preserve">Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</note>
       </trans-unit>
-      <trans-unit id="_msg358">
+      <trans-unit id="_msg356">
         <source xml:space="preserve">(0 = auto, &lt;0 = leave that many cores free)</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg359">
+      <trans-unit id="_msg357">
         <source xml:space="preserve">This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that enables the RPC server.</note>
       </trans-unit>
-      <trans-unit id="_msg360">
+      <trans-unit id="_msg358">
         <source xml:space="preserve">Enable R&amp;PC server</source>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
         <note annotates="source" from="developer">An Options window setting to enable the RPC server.</note>
       </trans-unit>
-      <trans-unit id="_msg361">
+      <trans-unit id="_msg359">
         <source xml:space="preserve">W&amp;allet</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg362">
+      <trans-unit id="_msg360">
         <source xml:space="preserve">Whether to set subtract fee from amount as default or not.</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</note>
       </trans-unit>
-      <trans-unit id="_msg363">
+      <trans-unit id="_msg361">
         <source xml:space="preserve">Subtract &amp;fee from amount by default</source>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
         <note annotates="source" from="developer">An Options window setting to set subtracting the fee from a sending amount as default.</note>
       </trans-unit>
-      <trans-unit id="_msg364">
+      <trans-unit id="_msg362">
         <source xml:space="preserve">Expert</source>
         <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg365">
+      <trans-unit id="_msg363">
         <source xml:space="preserve">Enable coin &amp;control features</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg366">
+      <trans-unit id="_msg364">
         <source xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg367">
+      <trans-unit id="_msg365">
         <source xml:space="preserve">&amp;Spend unconfirmed change</source>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg368">
+      <trans-unit id="_msg366">
         <source xml:space="preserve">Enable &amp;PSBT controls</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
         <note annotates="source" from="developer">An options window setting to enable PSBT controls.</note>
       </trans-unit>
-      <trans-unit id="_msg369">
+      <trans-unit id="_msg367">
         <source xml:space="preserve">Whether to show PSBT controls.</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
         <note annotates="source" from="developer">Tooltip text for options window setting that enables PSBT controls.</note>
       </trans-unit>
-      <trans-unit id="_msg370">
+      <trans-unit id="_msg368">
         <source xml:space="preserve">External Signer (e.g. hardware wallet)</source>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg371">
+      <trans-unit id="_msg369">
         <source xml:space="preserve">&amp;External signer script path</source>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg372">
+      <trans-unit id="_msg370">
         <source xml:space="preserve">Accept connections from outside.</source>
         <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg373">
+      <trans-unit id="_msg371">
         <source xml:space="preserve">Allow incomin&amp;g connections</source>
         <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg374">
+      <trans-unit id="_msg372">
         <source xml:space="preserve">Connect to the Bitcoin network through a SOCKS5 proxy.</source>
         <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg375">
+      <trans-unit id="_msg373">
         <source xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</source>
         <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg376">
+      <trans-unit id="_msg374">
         <source xml:space="preserve">Proxy &amp;IP:</source>
         <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">540</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg377">
+      <trans-unit id="_msg375">
         <source xml:space="preserve">&amp;Port:</source>
         <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">572</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg378">
+      <trans-unit id="_msg376">
         <source xml:space="preserve">Port of the proxy (e.g. 9050)</source>
         <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">597</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg379">
+      <trans-unit id="_msg377">
         <source xml:space="preserve">Used for reaching peers via:</source>
         <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg380">
+      <trans-unit id="_msg378">
         <source xml:space="preserve">IPv4</source>
         <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg381">
+      <trans-unit id="_msg379">
         <source xml:space="preserve">IPv6</source>
         <context-group purpose="location"><context context-type="linenumber">480</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg382">
+      <trans-unit id="_msg380">
         <source xml:space="preserve">Tor</source>
         <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg383">
+      <trans-unit id="_msg381">
         <source xml:space="preserve">&amp;Window</source>
         <context-group purpose="location"><context context-type="linenumber">633</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg384">
+      <trans-unit id="_msg382">
         <source xml:space="preserve">Show the icon in the system tray.</source>
         <context-group purpose="location"><context context-type="linenumber">639</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg385">
+      <trans-unit id="_msg383">
         <source xml:space="preserve">&amp;Show tray icon</source>
         <context-group purpose="location"><context context-type="linenumber">642</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg386">
+      <trans-unit id="_msg384">
         <source xml:space="preserve">Show only a tray icon after minimizing the window.</source>
         <context-group purpose="location"><context context-type="linenumber">652</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg387">
+      <trans-unit id="_msg385">
         <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
         <context-group purpose="location"><context context-type="linenumber">655</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg388">
+      <trans-unit id="_msg386">
         <source xml:space="preserve">M&amp;inimize on close</source>
         <context-group purpose="location"><context context-type="linenumber">665</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg389">
+      <trans-unit id="_msg387">
         <source xml:space="preserve">&amp;Display</source>
         <context-group purpose="location"><context context-type="linenumber">686</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg390">
+      <trans-unit id="_msg388">
         <source xml:space="preserve">User Interface &amp;language:</source>
         <context-group purpose="location"><context context-type="linenumber">694</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg391">
+      <trans-unit id="_msg389">
         <source xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <context-group purpose="location"><context context-type="linenumber">707</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg392">
+      <trans-unit id="_msg390">
         <source xml:space="preserve">&amp;Unit to show amounts in:</source>
         <context-group purpose="location"><context context-type="linenumber">718</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg393">
+      <trans-unit id="_msg391">
         <source xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <context-group purpose="location"><context context-type="linenumber">731</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg394">
+      <trans-unit id="_msg392">
         <source xml:space="preserve">Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
         <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">755</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg395">
+      <trans-unit id="_msg393">
         <source xml:space="preserve">&amp;Third-party transaction URLs</source>
         <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg396">
+      <trans-unit id="_msg394">
         <source xml:space="preserve">Whether to show coin control features or not.</source>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg397">
+      <trans-unit id="_msg395">
         <source xml:space="preserve">Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
         <context-group purpose="location"><context context-type="linenumber">528</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg398">
+      <trans-unit id="_msg396">
         <source xml:space="preserve">Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
         <context-group purpose="location"><context context-type="linenumber">531</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg399">
+      <trans-unit id="_msg397">
         <source xml:space="preserve">&amp;OK</source>
         <context-group purpose="location"><context context-type="linenumber">955</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg400">
+      <trans-unit id="_msg398">
         <source xml:space="preserve">&amp;Cancel</source>
         <context-group purpose="location"><context context-type="linenumber">968</context></context-group>
       </trans-unit>
@@ -1812,85 +1806,85 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../optionsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg401">
+      <trans-unit id="_msg399">
         <source xml:space="preserve">Compiled without external signing support (required for external signing)</source>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
         <note annotates="source" from="developer">&quot;External signing&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
-      <trans-unit id="_msg402">
+      <trans-unit id="_msg400">
         <source xml:space="preserve">default</source>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg403">
+      <trans-unit id="_msg401">
         <source xml:space="preserve">none</source>
-        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg404">
+      <trans-unit id="_msg402">
         <source xml:space="preserve">Confirm options reset</source>
-        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
         <note annotates="source" from="developer">Window title text of pop-up window shown when the user has chosen to reset options.</note>
       </trans-unit>
-      <trans-unit id="_msg405">
+      <trans-unit id="_msg403">
         <source xml:space="preserve">Client restart required to activate changes.</source>
-        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
         <note annotates="source" from="developer">Text explaining that the settings changed will not come into effect until the client is restarted.</note>
       </trans-unit>
-      <trans-unit id="_msg406">
+      <trans-unit id="_msg404">
         <source xml:space="preserve">Current settings will be backed up at &quot;%1&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
         <note annotates="source" from="developer">Text explaining to the user that the client&apos;s current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location&apos;s path.</note>
       </trans-unit>
-      <trans-unit id="_msg407">
+      <trans-unit id="_msg405">
         <source xml:space="preserve">Client will be shut down. Do you want to proceed?</source>
-        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
         <note annotates="source" from="developer">Text asking the user to confirm if they would like to proceed with a client shutdown.</note>
       </trans-unit>
-      <trans-unit id="_msg408">
+      <trans-unit id="_msg406">
         <source xml:space="preserve">Configuration options</source>
-        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
         <note annotates="source" from="developer">Window title text of pop-up box that allows opening up of configuration file.</note>
       </trans-unit>
-      <trans-unit id="_msg409">
+      <trans-unit id="_msg407">
         <source xml:space="preserve">The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
-        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
         <note annotates="source" from="developer">Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</note>
       </trans-unit>
-      <trans-unit id="_msg410">
+      <trans-unit id="_msg408">
         <source xml:space="preserve">Continue</source>
-        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg409">
+        <source xml:space="preserve">Cancel</source>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg410">
+        <source xml:space="preserve">Error</source>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
       <trans-unit id="_msg411">
-        <source xml:space="preserve">Cancel</source>
-        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+        <source xml:space="preserve">The configuration file could not be opened.</source>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
       <trans-unit id="_msg412">
-        <source xml:space="preserve">Error</source>
-        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+        <source xml:space="preserve">This change would require a client restart.</source>
+        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
       </trans-unit>
       <trans-unit id="_msg413">
-        <source xml:space="preserve">The configuration file could not be opened.</source>
-        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg414">
-        <source xml:space="preserve">This change would require a client restart.</source>
-        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg415">
         <source xml:space="preserve">The supplied proxy address is invalid.</source>
-        <context-group purpose="location"><context context-type="linenumber">450</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">446</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg416">
+      <trans-unit id="_msg414">
         <source xml:space="preserve">Embedded &quot;%1&quot;</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg417">
+      <trans-unit id="_msg415">
         <source xml:space="preserve">Default system font &quot;%1&quot;</source>
         <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg418">
+      <trans-unit id="_msg416">
         <source xml:space="preserve">Custom…</source>
         <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
       </trans-unit>
@@ -1898,120 +1892,96 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../optionsmodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsModel">
-      <trans-unit id="_msg419">
+      <trans-unit id="_msg417">
         <source xml:space="preserve">Could not read setting &quot;%1&quot;, %2.</source>
-        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/overviewpage.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg420">
+      <trans-unit id="_msg418">
         <source xml:space="preserve">Form</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg421">
+      <trans-unit id="_msg419">
         <source xml:space="preserve">The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg420">
+        <source xml:space="preserve">Available:</source>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg421">
+        <source xml:space="preserve">Your current spendable balance</source>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
       </trans-unit>
       <trans-unit id="_msg422">
-        <source xml:space="preserve">Watch-only:</source>
-        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+        <source xml:space="preserve">Pending:</source>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
       <trans-unit id="_msg423">
-        <source xml:space="preserve">Available:</source>
-        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+        <source xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
       <trans-unit id="_msg424">
-        <source xml:space="preserve">Your current spendable balance</source>
-        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+        <source xml:space="preserve">Immature:</source>
+        <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
       </trans-unit>
       <trans-unit id="_msg425">
-        <source xml:space="preserve">Pending:</source>
-        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+        <source xml:space="preserve">Mined balance that has not yet matured</source>
+        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
       <trans-unit id="_msg426">
-        <source xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg427">
-        <source xml:space="preserve">Immature:</source>
-        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg428">
-        <source xml:space="preserve">Mined balance that has not yet matured</source>
-        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg429">
         <source xml:space="preserve">Balances</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg430">
+      <trans-unit id="_msg427">
         <source xml:space="preserve">Total:</source>
-        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg431">
+      <trans-unit id="_msg428">
         <source xml:space="preserve">Your current total balance</source>
-        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg432">
-        <source xml:space="preserve">Your current balance in watch-only addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg433">
-        <source xml:space="preserve">Spendable:</source>
-        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg434">
+      <trans-unit id="_msg429">
         <source xml:space="preserve">Recent transactions</source>
-        <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg435">
-        <source xml:space="preserve">Unconfirmed transactions to watch-only addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg436">
-        <source xml:space="preserve">Mined balance in watch-only addresses that has not yet matured</source>
-        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg437">
-        <source xml:space="preserve">Current total balance in watch-only addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../overviewpage.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg438">
+      <trans-unit id="_msg430">
         <source xml:space="preserve">Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/psbtoperationsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg439">
+      <trans-unit id="_msg431">
         <source xml:space="preserve">PSBT Operations</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg440">
+      <trans-unit id="_msg432">
         <source xml:space="preserve">Sign Tx</source>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg441">
+      <trans-unit id="_msg433">
         <source xml:space="preserve">Broadcast Tx</source>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg442">
+      <trans-unit id="_msg434">
         <source xml:space="preserve">Copy to Clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg443">
+      <trans-unit id="_msg435">
         <source xml:space="preserve">Save…</source>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg444">
+      <trans-unit id="_msg436">
         <source xml:space="preserve">Close</source>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
       </trans-unit>
@@ -2019,112 +1989,112 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../psbtoperationsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg445">
+      <trans-unit id="_msg437">
         <source xml:space="preserve">Failed to load transaction: %1</source>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg446">
+      <trans-unit id="_msg438">
         <source xml:space="preserve">Failed to sign transaction: %1</source>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg447">
+      <trans-unit id="_msg439">
         <source xml:space="preserve">Cannot sign inputs while wallet is locked.</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg448">
+      <trans-unit id="_msg440">
         <source xml:space="preserve">Could not sign any more inputs.</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg449">
+      <trans-unit id="_msg441">
         <source xml:space="preserve">Signed %1 inputs, but more signatures are still required.</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg450">
+      <trans-unit id="_msg442">
         <source xml:space="preserve">Signed transaction successfully. Transaction is ready to broadcast.</source>
         <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg451">
+      <trans-unit id="_msg443">
         <source xml:space="preserve">Unknown error processing transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg452">
+      <trans-unit id="_msg444">
         <source xml:space="preserve">Transaction broadcast successfully! Transaction ID: %1</source>
         <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg453">
+      <trans-unit id="_msg445">
         <source xml:space="preserve">Transaction broadcast failed: %1</source>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg454">
+      <trans-unit id="_msg446">
         <source xml:space="preserve">PSBT copied to clipboard.</source>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg455">
+      <trans-unit id="_msg447">
         <source xml:space="preserve">Save Transaction Data</source>
         <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg456">
+      <trans-unit id="_msg448">
         <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
         <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
         <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
-      <trans-unit id="_msg457">
+      <trans-unit id="_msg449">
         <source xml:space="preserve">PSBT saved to disk.</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg458">
+      <trans-unit id="_msg450">
         <source xml:space="preserve">Sends %1 to %2</source>
         <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg459">
+      <trans-unit id="_msg451">
         <source xml:space="preserve">own address</source>
         <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg460">
+      <trans-unit id="_msg452">
         <source xml:space="preserve">Unable to calculate transaction fee or total transaction amount.</source>
         <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg461">
+      <trans-unit id="_msg453">
         <source xml:space="preserve">Pays transaction fee: </source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg462">
+      <trans-unit id="_msg454">
         <source xml:space="preserve">Total Amount</source>
         <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg463">
+      <trans-unit id="_msg455">
         <source xml:space="preserve">or</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg464">
+      <trans-unit id="_msg456">
         <source xml:space="preserve">Transaction has %1 unsigned inputs.</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg465">
+      <trans-unit id="_msg457">
         <source xml:space="preserve">Transaction is missing some information about inputs.</source>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg466">
+      <trans-unit id="_msg458">
         <source xml:space="preserve">Transaction still needs signature(s).</source>
         <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg467">
+      <trans-unit id="_msg459">
         <source xml:space="preserve">(But no wallet is loaded.)</source>
         <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg468">
+      <trans-unit id="_msg460">
         <source xml:space="preserve">(But this wallet cannot sign transactions.)</source>
         <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg469">
+      <trans-unit id="_msg461">
         <source xml:space="preserve">(But this wallet does not have the right keys.)</source>
         <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg470">
+      <trans-unit id="_msg462">
         <source xml:space="preserve">Transaction is fully signed and ready for broadcast.</source>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg471">
+      <trans-unit id="_msg463">
         <source xml:space="preserve">Transaction status is unknown.</source>
         <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
       </trans-unit>
@@ -2132,37 +2102,37 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../paymentserver.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PaymentServer">
-      <trans-unit id="_msg472">
+      <trans-unit id="_msg464">
         <source xml:space="preserve">Payment request error</source>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg473">
+      <trans-unit id="_msg465">
         <source xml:space="preserve">Cannot start bitcoin: click-to-pay handler</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg474">
+      <trans-unit id="_msg466">
         <source xml:space="preserve">URI handling</source>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg475">
+      <trans-unit id="_msg467">
         <source xml:space="preserve">&apos;bitcoin://&apos; is not a valid URI. Use &apos;bitcoin:&apos; instead.</source>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg476">
+      <trans-unit id="_msg468">
         <source xml:space="preserve">Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it&apos;s strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg477">
+      <trans-unit id="_msg469">
         <source xml:space="preserve">URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg478">
+      <trans-unit id="_msg470">
         <source xml:space="preserve">Payment request file handling</source>
         <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
       </trans-unit>
@@ -2170,52 +2140,52 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../peertablemodel.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
-      <trans-unit id="_msg479">
+      <trans-unit id="_msg471">
         <source xml:space="preserve">User Agent</source>
         <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains the peer&apos;s User Agent string.</note>
       </trans-unit>
-      <trans-unit id="_msg480">
+      <trans-unit id="_msg472">
         <source xml:space="preserve">Ping</source>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the current latency of the connection with the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg481">
+      <trans-unit id="_msg473">
         <source xml:space="preserve">Peer</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains a unique number used to identify a connection.</note>
       </trans-unit>
-      <trans-unit id="_msg482">
+      <trans-unit id="_msg474">
         <source xml:space="preserve">Age</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</note>
       </trans-unit>
-      <trans-unit id="_msg483">
+      <trans-unit id="_msg475">
         <source xml:space="preserve">Direction</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the direction the peer connection was initiated from.</note>
       </trans-unit>
-      <trans-unit id="_msg484">
+      <trans-unit id="_msg476">
         <source xml:space="preserve">Sent</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg485">
+      <trans-unit id="_msg477">
         <source xml:space="preserve">Received</source>
         <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have received from the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg486">
+      <trans-unit id="_msg478">
         <source xml:space="preserve">Address</source>
         <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</note>
       </trans-unit>
-      <trans-unit id="_msg487">
+      <trans-unit id="_msg479">
         <source xml:space="preserve">Type</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which describes the type of peer connection. The &quot;type&quot; describes why the connection exists.</note>
       </trans-unit>
-      <trans-unit id="_msg488">
+      <trans-unit id="_msg480">
         <source xml:space="preserve">Network</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which states the network the peer connected through.</note>
@@ -2224,12 +2194,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../peertablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
-      <trans-unit id="_msg489">
+      <trans-unit id="_msg481">
         <source xml:space="preserve">Inbound</source>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
         <note annotates="source" from="developer">An Inbound Connection from a Peer.</note>
       </trans-unit>
-      <trans-unit id="_msg490">
+      <trans-unit id="_msg482">
         <source xml:space="preserve">Outbound</source>
         <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
         <note annotates="source" from="developer">An Outbound Connection to a Peer.</note>
@@ -2238,7 +2208,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../bitcoinunits.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg491">
+      <trans-unit id="_msg483">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
       </trans-unit>
@@ -2246,236 +2216,236 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../guiutil.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg492">
+      <trans-unit id="_msg484">
         <source xml:space="preserve">Enter a Bitcoin address (e.g. %1)</source>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg493">
+      <trans-unit id="_msg485">
         <source xml:space="preserve">Ctrl+W</source>
         <context-group purpose="location"><context context-type="linenumber">433</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg494">
+      <trans-unit id="_msg486">
         <source xml:space="preserve">Unroutable</source>
         <context-group purpose="location"><context context-type="linenumber">690</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg495">
+      <trans-unit id="_msg487">
         <source xml:space="preserve">IPv4</source>
         <context-group purpose="location"><context context-type="linenumber">692</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of IPv4 network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg496">
+      <trans-unit id="_msg488">
         <source xml:space="preserve">IPv6</source>
         <context-group purpose="location"><context context-type="linenumber">694</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of IPv6 network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg497">
+      <trans-unit id="_msg489">
         <source xml:space="preserve">Onion</source>
         <context-group purpose="location"><context context-type="linenumber">696</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of Tor network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg498">
+      <trans-unit id="_msg490">
         <source xml:space="preserve">I2P</source>
         <context-group purpose="location"><context context-type="linenumber">698</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of I2P network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg499">
+      <trans-unit id="_msg491">
         <source xml:space="preserve">CJDNS</source>
         <context-group purpose="location"><context context-type="linenumber">700</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of CJDNS network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg500">
+      <trans-unit id="_msg492">
         <source xml:space="preserve">Inbound</source>
         <context-group purpose="location"><context context-type="linenumber">714</context></context-group>
         <note annotates="source" from="developer">An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg501">
+      <trans-unit id="_msg493">
         <source xml:space="preserve">Outbound</source>
         <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
         <note annotates="source" from="developer">An outbound connection to a peer. An outbound connection is a connection initiated by us.</note>
       </trans-unit>
-      <trans-unit id="_msg502">
+      <trans-unit id="_msg494">
         <source xml:space="preserve">Full Relay</source>
         <context-group purpose="location"><context context-type="linenumber">722</context></context-group>
         <note annotates="source" from="developer">Peer connection type that relays all network information.</note>
       </trans-unit>
-      <trans-unit id="_msg503">
+      <trans-unit id="_msg495">
         <source xml:space="preserve">Block Relay</source>
         <context-group purpose="location"><context context-type="linenumber">725</context></context-group>
         <note annotates="source" from="developer">Peer connection type that relays network information about blocks and not transactions or addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg504">
+      <trans-unit id="_msg496">
         <source xml:space="preserve">Manual</source>
         <context-group purpose="location"><context context-type="linenumber">727</context></context-group>
         <note annotates="source" from="developer">Peer connection type established manually through one of several methods.</note>
       </trans-unit>
-      <trans-unit id="_msg505">
+      <trans-unit id="_msg497">
         <source xml:space="preserve">Feeler</source>
         <context-group purpose="location"><context context-type="linenumber">729</context></context-group>
         <note annotates="source" from="developer">Short-lived peer connection type that tests the aliveness of known addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg506">
+      <trans-unit id="_msg498">
         <source xml:space="preserve">Address Fetch</source>
         <context-group purpose="location"><context context-type="linenumber">731</context></context-group>
         <note annotates="source" from="developer">Short-lived peer connection type that solicits known addresses from a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg507">
+      <trans-unit id="_msg499">
         <source xml:space="preserve">%1 d</source>
         <context-group purpose="location"><context context-type="linenumber">743</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">755</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg508">
+      <trans-unit id="_msg500">
         <source xml:space="preserve">%1 h</source>
         <context-group purpose="location"><context context-type="linenumber">744</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">756</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg509">
+      <trans-unit id="_msg501">
         <source xml:space="preserve">%1 m</source>
         <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">757</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg510">
+      <trans-unit id="_msg502">
         <source xml:space="preserve">%1 s</source>
         <context-group purpose="location"><context context-type="linenumber">747</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">758</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">784</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg511">
+      <trans-unit id="_msg503">
         <source xml:space="preserve">None</source>
         <context-group purpose="location"><context context-type="linenumber">772</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg512">
+      <trans-unit id="_msg504">
         <source xml:space="preserve">N/A</source>
         <context-group purpose="location"><context context-type="linenumber">778</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg513">
+      <trans-unit id="_msg505">
         <source xml:space="preserve">%1 ms</source>
         <context-group purpose="location"><context context-type="linenumber">779</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">797</context></context-group>
-        <trans-unit id="_msg514[0]">
+        <trans-unit id="_msg506[0]">
           <source xml:space="preserve">%n second(s)</source>
         </trans-unit>
-        <trans-unit id="_msg514[1]">
+        <trans-unit id="_msg506[1]">
           <source xml:space="preserve">%n second(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">801</context></context-group>
-        <trans-unit id="_msg515[0]">
+        <trans-unit id="_msg507[0]">
           <source xml:space="preserve">%n minute(s)</source>
         </trans-unit>
-        <trans-unit id="_msg515[1]">
+        <trans-unit id="_msg507[1]">
           <source xml:space="preserve">%n minute(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">805</context></context-group>
-        <trans-unit id="_msg516[0]">
+        <trans-unit id="_msg508[0]">
           <source xml:space="preserve">%n hour(s)</source>
         </trans-unit>
-        <trans-unit id="_msg516[1]">
+        <trans-unit id="_msg508[1]">
           <source xml:space="preserve">%n hour(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">809</context></context-group>
-        <trans-unit id="_msg517[0]">
+        <trans-unit id="_msg509[0]">
           <source xml:space="preserve">%n day(s)</source>
         </trans-unit>
-        <trans-unit id="_msg517[1]">
+        <trans-unit id="_msg509[1]">
           <source xml:space="preserve">%n day(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">813</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">819</context></context-group>
-        <trans-unit id="_msg518[0]">
+        <trans-unit id="_msg510[0]">
           <source xml:space="preserve">%n week(s)</source>
         </trans-unit>
-        <trans-unit id="_msg518[1]">
+        <trans-unit id="_msg510[1]">
           <source xml:space="preserve">%n week(s)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg519">
+      <trans-unit id="_msg511">
         <source xml:space="preserve">%1 and %2</source>
         <context-group purpose="location"><context context-type="linenumber">819</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">819</context></context-group>
-        <trans-unit id="_msg520[0]">
+        <trans-unit id="_msg512[0]">
           <source xml:space="preserve">%n year(s)</source>
         </trans-unit>
-        <trans-unit id="_msg520[1]">
+        <trans-unit id="_msg512[1]">
           <source xml:space="preserve">%n year(s)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg521">
+      <trans-unit id="_msg513">
         <source xml:space="preserve">%1 B</source>
         <context-group purpose="location"><context context-type="linenumber">827</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg522">
+      <trans-unit id="_msg514">
         <source xml:space="preserve">%1 kB</source>
         <context-group purpose="location"><context context-type="linenumber">829</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1023</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">979</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg523">
+      <trans-unit id="_msg515">
         <source xml:space="preserve">%1 MB</source>
         <context-group purpose="location"><context context-type="linenumber">831</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1024</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1025</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">980</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">981</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg524">
+      <trans-unit id="_msg516">
         <source xml:space="preserve">%1 GB</source>
         <context-group purpose="location"><context context-type="linenumber">833</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg525">
+      <trans-unit id="_msg517">
         <source xml:space="preserve">default wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">1013</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">992</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../qrimagewidget.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QRImageWidget">
-      <trans-unit id="_msg526">
+      <trans-unit id="_msg518">
         <source xml:space="preserve">&amp;Save Image…</source>
         <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg527">
+      <trans-unit id="_msg519">
         <source xml:space="preserve">&amp;Copy Image</source>
         <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg528">
+      <trans-unit id="_msg520">
         <source xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</source>
         <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg529">
+      <trans-unit id="_msg521">
         <source xml:space="preserve">Error encoding URI into QR Code.</source>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg530">
+      <trans-unit id="_msg522">
         <source xml:space="preserve">QR code support not available.</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg531">
+      <trans-unit id="_msg523">
         <source xml:space="preserve">Save QR Code</source>
-        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg532">
+      <trans-unit id="_msg524">
         <source xml:space="preserve">PNG Image</source>
-        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
         <note annotates="source" from="developer">Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</note>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/debugwindow.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg533">
+      <trans-unit id="_msg525">
         <source xml:space="preserve">N/A</source>
         <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
@@ -2516,325 +2486,325 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <context-group purpose="location"><context context-type="linenumber">1772</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1798</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1824</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.h</context><context context-type="linenumber">145</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.h</context><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg534">
+      <trans-unit id="_msg526">
         <source xml:space="preserve">Client version</source>
         <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg535">
+      <trans-unit id="_msg527">
         <source xml:space="preserve">&amp;Information</source>
         <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg536">
+      <trans-unit id="_msg528">
         <source xml:space="preserve">General</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg537">
+      <trans-unit id="_msg529">
         <source xml:space="preserve">Datadir</source>
         <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg538">
+      <trans-unit id="_msg530">
         <source xml:space="preserve">To specify a non-default location of the data directory use the &apos;%1&apos; option.</source>
         <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg539">
+      <trans-unit id="_msg531">
         <source xml:space="preserve">Blocksdir</source>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg540">
+      <trans-unit id="_msg532">
         <source xml:space="preserve">To specify a non-default location of the blocks directory use the &apos;%1&apos; option.</source>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg541">
+      <trans-unit id="_msg533">
         <source xml:space="preserve">Startup time</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg542">
+      <trans-unit id="_msg534">
         <source xml:space="preserve">Network</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1255</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg543">
+      <trans-unit id="_msg535">
         <source xml:space="preserve">Name</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg544">
+      <trans-unit id="_msg536">
         <source xml:space="preserve">Number of connections</source>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg545">
+      <trans-unit id="_msg537">
         <source xml:space="preserve">Local Addresses</source>
         <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg546">
+      <trans-unit id="_msg538">
         <source xml:space="preserve">Network addresses that your Bitcoin node is currently using to communicate with other nodes.</source>
         <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg547">
+      <trans-unit id="_msg539">
         <source xml:space="preserve">Block chain</source>
         <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg548">
+      <trans-unit id="_msg540">
         <source xml:space="preserve">Memory Pool</source>
         <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg549">
+      <trans-unit id="_msg541">
         <source xml:space="preserve">Current number of transactions</source>
         <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg550">
+      <trans-unit id="_msg542">
         <source xml:space="preserve">Memory usage</source>
         <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg551">
+      <trans-unit id="_msg543">
         <source xml:space="preserve">Wallet: </source>
         <context-group purpose="location"><context context-type="linenumber">478</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg552">
+      <trans-unit id="_msg544">
         <source xml:space="preserve">(none)</source>
         <context-group purpose="location"><context context-type="linenumber">489</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg553">
+      <trans-unit id="_msg545">
         <source xml:space="preserve">&amp;Reset</source>
         <context-group purpose="location"><context context-type="linenumber">700</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg554">
+      <trans-unit id="_msg546">
         <source xml:space="preserve">Received</source>
         <context-group purpose="location"><context context-type="linenumber">780</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1615</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg555">
+      <trans-unit id="_msg547">
         <source xml:space="preserve">Sent</source>
         <context-group purpose="location"><context context-type="linenumber">860</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1592</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg556">
+      <trans-unit id="_msg548">
         <source xml:space="preserve">&amp;Peers</source>
         <context-group purpose="location"><context context-type="linenumber">901</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg557">
+      <trans-unit id="_msg549">
         <source xml:space="preserve">Banned peers</source>
         <context-group purpose="location"><context context-type="linenumber">977</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg558">
+      <trans-unit id="_msg550">
         <source xml:space="preserve">Select a peer to view detailed information.</source>
         <context-group purpose="location"><context context-type="linenumber">1053</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1191</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg559">
+      <trans-unit id="_msg551">
         <source xml:space="preserve">Hide Peers Detail</source>
         <context-group purpose="location"><context context-type="linenumber">1105</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg560">
+      <trans-unit id="_msg552">
         <source xml:space="preserve">Ctrl+X</source>
         <context-group purpose="location"><context context-type="linenumber">1126</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg561">
+      <trans-unit id="_msg553">
         <source xml:space="preserve">The transport layer version: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1200</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg562">
+      <trans-unit id="_msg554">
         <source xml:space="preserve">Transport</source>
         <context-group purpose="location"><context context-type="linenumber">1203</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg563">
+      <trans-unit id="_msg555">
         <source xml:space="preserve">Session ID</source>
         <context-group purpose="location"><context context-type="linenumber">1229</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg564">
+      <trans-unit id="_msg556">
         <source xml:space="preserve">Version</source>
         <context-group purpose="location"><context context-type="linenumber">1278</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg565">
+      <trans-unit id="_msg557">
         <source xml:space="preserve">Whether we relay transactions to this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1350</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg566">
+      <trans-unit id="_msg558">
         <source xml:space="preserve">Transaction Relay</source>
         <context-group purpose="location"><context context-type="linenumber">1353</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg567">
+      <trans-unit id="_msg559">
         <source xml:space="preserve">Starting Block</source>
         <context-group purpose="location"><context context-type="linenumber">1402</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg568">
+      <trans-unit id="_msg560">
         <source xml:space="preserve">Synced Headers</source>
         <context-group purpose="location"><context context-type="linenumber">1425</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg569">
+      <trans-unit id="_msg561">
         <source xml:space="preserve">Synced Blocks</source>
         <context-group purpose="location"><context context-type="linenumber">1448</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg570">
+      <trans-unit id="_msg562">
         <source xml:space="preserve">Last Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">1523</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg571">
+      <trans-unit id="_msg563">
         <source xml:space="preserve">The mapped Autonomous System used for diversifying peer selection.</source>
         <context-group purpose="location"><context context-type="linenumber">1733</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg572">
+      <trans-unit id="_msg564">
         <source xml:space="preserve">Mapped AS</source>
         <context-group purpose="location"><context context-type="linenumber">1736</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg573">
+      <trans-unit id="_msg565">
         <source xml:space="preserve">Whether we relay addresses to this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1759</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</note>
       </trans-unit>
-      <trans-unit id="_msg574">
+      <trans-unit id="_msg566">
         <source xml:space="preserve">Address Relay</source>
         <context-group purpose="location"><context context-type="linenumber">1762</context></context-group>
         <note annotates="source" from="developer">Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</note>
       </trans-unit>
-      <trans-unit id="_msg575">
+      <trans-unit id="_msg567">
         <source xml:space="preserve">The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
         <context-group purpose="location"><context context-type="linenumber">1785</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</note>
       </trans-unit>
-      <trans-unit id="_msg576">
+      <trans-unit id="_msg568">
         <source xml:space="preserve">The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
         <context-group purpose="location"><context context-type="linenumber">1811</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</note>
       </trans-unit>
-      <trans-unit id="_msg577">
+      <trans-unit id="_msg569">
         <source xml:space="preserve">Addresses Processed</source>
         <context-group purpose="location"><context context-type="linenumber">1788</context></context-group>
         <note annotates="source" from="developer">Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</note>
       </trans-unit>
-      <trans-unit id="_msg578">
+      <trans-unit id="_msg570">
         <source xml:space="preserve">Addresses Rate-Limited</source>
         <context-group purpose="location"><context context-type="linenumber">1814</context></context-group>
         <note annotates="source" from="developer">Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</note>
       </trans-unit>
-      <trans-unit id="_msg579">
+      <trans-unit id="_msg571">
         <source xml:space="preserve">User Agent</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg580">
+      <trans-unit id="_msg572">
         <source xml:space="preserve">Node window</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg581">
+      <trans-unit id="_msg573">
         <source xml:space="preserve">Current block height</source>
         <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg582">
+      <trans-unit id="_msg574">
         <source xml:space="preserve">Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg583">
+      <trans-unit id="_msg575">
         <source xml:space="preserve">Decrease font size</source>
         <context-group purpose="location"><context context-type="linenumber">510</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg584">
+      <trans-unit id="_msg576">
         <source xml:space="preserve">Increase font size</source>
         <context-group purpose="location"><context context-type="linenumber">530</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg585">
+      <trans-unit id="_msg577">
         <source xml:space="preserve">Permissions</source>
         <context-group purpose="location"><context context-type="linenumber">1151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg586">
+      <trans-unit id="_msg578">
         <source xml:space="preserve">The direction and type of peer connection: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1174</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg587">
+      <trans-unit id="_msg579">
         <source xml:space="preserve">Direction/Type</source>
         <context-group purpose="location"><context context-type="linenumber">1177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg588">
+      <trans-unit id="_msg580">
         <source xml:space="preserve">The BIP324 session ID string in hex.</source>
         <context-group purpose="location"><context context-type="linenumber">1226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg589">
+      <trans-unit id="_msg581">
         <source xml:space="preserve">The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
         <context-group purpose="location"><context context-type="linenumber">1252</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg590">
+      <trans-unit id="_msg582">
         <source xml:space="preserve">Services</source>
         <context-group purpose="location"><context context-type="linenumber">1324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg591">
+      <trans-unit id="_msg583">
         <source xml:space="preserve">High bandwidth BIP152 compact block relay: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg592">
+      <trans-unit id="_msg584">
         <source xml:space="preserve">High Bandwidth</source>
         <context-group purpose="location"><context context-type="linenumber">1379</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg593">
+      <trans-unit id="_msg585">
         <source xml:space="preserve">Connection Time</source>
         <context-group purpose="location"><context context-type="linenumber">1471</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg594">
+      <trans-unit id="_msg586">
         <source xml:space="preserve">Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1494</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg595">
+      <trans-unit id="_msg587">
         <source xml:space="preserve">Last Block</source>
         <context-group purpose="location"><context context-type="linenumber">1497</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg596">
+      <trans-unit id="_msg588">
         <source xml:space="preserve">Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1520</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Last Transaction field in the peer details area.</note>
       </trans-unit>
-      <trans-unit id="_msg597">
+      <trans-unit id="_msg589">
         <source xml:space="preserve">Last Send</source>
         <context-group purpose="location"><context context-type="linenumber">1546</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg598">
+      <trans-unit id="_msg590">
         <source xml:space="preserve">Last Receive</source>
         <context-group purpose="location"><context context-type="linenumber">1569</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg599">
+      <trans-unit id="_msg591">
         <source xml:space="preserve">Ping Time</source>
         <context-group purpose="location"><context context-type="linenumber">1638</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg600">
+      <trans-unit id="_msg592">
         <source xml:space="preserve">The duration of a currently outstanding ping.</source>
         <context-group purpose="location"><context context-type="linenumber">1661</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg601">
+      <trans-unit id="_msg593">
         <source xml:space="preserve">Ping Wait</source>
         <context-group purpose="location"><context context-type="linenumber">1664</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg602">
+      <trans-unit id="_msg594">
         <source xml:space="preserve">Min Ping</source>
         <context-group purpose="location"><context context-type="linenumber">1687</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg603">
+      <trans-unit id="_msg595">
         <source xml:space="preserve">Time Offset</source>
         <context-group purpose="location"><context context-type="linenumber">1710</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg604">
+      <trans-unit id="_msg596">
         <source xml:space="preserve">Last block time</source>
         <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg605">
+      <trans-unit id="_msg597">
         <source xml:space="preserve">&amp;Open</source>
         <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg606">
+      <trans-unit id="_msg598">
         <source xml:space="preserve">&amp;Console</source>
         <context-group purpose="location"><context context-type="linenumber">461</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg607">
+      <trans-unit id="_msg599">
         <source xml:space="preserve">&amp;Network Traffic</source>
         <context-group purpose="location"><context context-type="linenumber">648</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg608">
+      <trans-unit id="_msg600">
         <source xml:space="preserve">Totals</source>
         <context-group purpose="location"><context context-type="linenumber">716</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg609">
+      <trans-unit id="_msg601">
         <source xml:space="preserve">Debug log file</source>
         <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg610">
+      <trans-unit id="_msg602">
         <source xml:space="preserve">Clear console</source>
         <context-group purpose="location"><context context-type="linenumber">550</context></context-group>
       </trans-unit>
@@ -2842,162 +2812,162 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../rpcconsole.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg611">
+      <trans-unit id="_msg603">
         <source xml:space="preserve">In:</source>
-        <context-group purpose="location"><context context-type="linenumber">975</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">931</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg612">
+      <trans-unit id="_msg604">
         <source xml:space="preserve">Out:</source>
-        <context-group purpose="location"><context context-type="linenumber">976</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">932</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg613">
+      <trans-unit id="_msg605">
         <source xml:space="preserve">Inbound: initiated by peer</source>
-        <context-group purpose="location"><context context-type="linenumber">499</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">463</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an inbound peer connection.</note>
       </trans-unit>
-      <trans-unit id="_msg614">
+      <trans-unit id="_msg606">
         <source xml:space="preserve">Outbound Full Relay: default</source>
-        <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</note>
       </trans-unit>
-      <trans-unit id="_msg615">
+      <trans-unit id="_msg607">
         <source xml:space="preserve">Outbound Block Relay: does not relay transactions or addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">506</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg616">
+      <trans-unit id="_msg608">
         <source xml:space="preserve">Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
-        <context-group purpose="location"><context context-type="linenumber">511</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">475</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</note>
       </trans-unit>
-      <trans-unit id="_msg617">
+      <trans-unit id="_msg609">
         <source xml:space="preserve">Outbound Feeler: short-lived, for testing addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">517</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">481</context></context-group>
         <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg618">
+      <trans-unit id="_msg610">
         <source xml:space="preserve">Outbound Address Fetch: short-lived, for soliciting addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">520</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">484</context></context-group>
         <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg619">
+      <trans-unit id="_msg611">
         <source xml:space="preserve">detecting: peer could be v1 or v2</source>
-        <context-group purpose="location"><context context-type="linenumber">525</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">489</context></context-group>
         <note annotates="source" from="developer">Explanatory text for &quot;detecting&quot; transport type.</note>
       </trans-unit>
-      <trans-unit id="_msg620">
+      <trans-unit id="_msg612">
         <source xml:space="preserve">v1: unencrypted, plaintext transport protocol</source>
-        <context-group purpose="location"><context context-type="linenumber">527</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">491</context></context-group>
         <note annotates="source" from="developer">Explanatory text for v1 transport type.</note>
       </trans-unit>
-      <trans-unit id="_msg621">
+      <trans-unit id="_msg613">
         <source xml:space="preserve">v2: BIP324 encrypted transport protocol</source>
-        <context-group purpose="location"><context context-type="linenumber">529</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">493</context></context-group>
         <note annotates="source" from="developer">Explanatory text for v2 transport type.</note>
       </trans-unit>
-      <trans-unit id="_msg622">
+      <trans-unit id="_msg614">
         <source xml:space="preserve">we selected the peer for high bandwidth relay</source>
-        <context-group purpose="location"><context context-type="linenumber">533</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">497</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg623">
+      <trans-unit id="_msg615">
         <source xml:space="preserve">the peer selected us for high bandwidth relay</source>
-        <context-group purpose="location"><context context-type="linenumber">534</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg624">
+      <trans-unit id="_msg616">
         <source xml:space="preserve">no high bandwidth relay selected</source>
-        <context-group purpose="location"><context context-type="linenumber">535</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">499</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg625">
+      <trans-unit id="_msg617">
         <source xml:space="preserve">Ctrl++</source>
-        <context-group purpose="location"><context context-type="linenumber">548</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">512</context></context-group>
         <note annotates="source" from="developer">Main shortcut to increase the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg626">
+      <trans-unit id="_msg618">
         <source xml:space="preserve">Ctrl+=</source>
-        <context-group purpose="location"><context context-type="linenumber">550</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">514</context></context-group>
         <note annotates="source" from="developer">Secondary shortcut to increase the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg627">
+      <trans-unit id="_msg619">
         <source xml:space="preserve">Ctrl+-</source>
-        <context-group purpose="location"><context context-type="linenumber">554</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
         <note annotates="source" from="developer">Main shortcut to decrease the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg628">
+      <trans-unit id="_msg620">
         <source xml:space="preserve">Ctrl+_</source>
-        <context-group purpose="location"><context context-type="linenumber">556</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">520</context></context-group>
         <note annotates="source" from="developer">Secondary shortcut to decrease the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg629">
+      <trans-unit id="_msg621">
         <source xml:space="preserve">&amp;Copy address</source>
-        <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">666</context></context-group>
         <note annotates="source" from="developer">Context menu action to copy the address of a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg630">
+      <trans-unit id="_msg622">
         <source xml:space="preserve">&amp;Disconnect</source>
-        <context-group purpose="location"><context context-type="linenumber">714</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">670</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg631">
+      <trans-unit id="_msg623">
         <source xml:space="preserve">1 &amp;hour</source>
-        <context-group purpose="location"><context context-type="linenumber">715</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">671</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg632">
+      <trans-unit id="_msg624">
         <source xml:space="preserve">1 d&amp;ay</source>
-        <context-group purpose="location"><context context-type="linenumber">716</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg633">
+      <trans-unit id="_msg625">
         <source xml:space="preserve">1 &amp;week</source>
-        <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">673</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg634">
+      <trans-unit id="_msg626">
         <source xml:space="preserve">1 &amp;year</source>
-        <context-group purpose="location"><context context-type="linenumber">718</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">674</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg635">
+      <trans-unit id="_msg627">
         <source xml:space="preserve">&amp;Copy IP/Netmask</source>
-        <context-group purpose="location"><context context-type="linenumber">744</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">700</context></context-group>
         <note annotates="source" from="developer">Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer&apos;s IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</note>
       </trans-unit>
-      <trans-unit id="_msg636">
+      <trans-unit id="_msg628">
         <source xml:space="preserve">&amp;Unban</source>
-        <context-group purpose="location"><context context-type="linenumber">748</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">704</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg629">
+        <source xml:space="preserve">Network activity disabled</source>
+        <context-group purpose="location"><context context-type="linenumber">935</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg630">
+        <source xml:space="preserve">None</source>
+        <context-group purpose="location"><context context-type="linenumber">948</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg631">
+        <source xml:space="preserve">Executing command without any wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">1027</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg632">
+        <source xml:space="preserve">Ctrl+I</source>
+        <context-group purpose="location"><context context-type="linenumber">1353</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg633">
+        <source xml:space="preserve">Ctrl+T</source>
+        <context-group purpose="location"><context context-type="linenumber">1354</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg634">
+        <source xml:space="preserve">Ctrl+N</source>
+        <context-group purpose="location"><context context-type="linenumber">1355</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg635">
+        <source xml:space="preserve">Ctrl+P</source>
+        <context-group purpose="location"><context context-type="linenumber">1356</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg636">
+        <source xml:space="preserve">Node window - [%1]</source>
+        <context-group purpose="location"><context context-type="linenumber">1374</context></context-group>
       </trans-unit>
       <trans-unit id="_msg637">
-        <source xml:space="preserve">Network activity disabled</source>
-        <context-group purpose="location"><context context-type="linenumber">979</context></context-group>
+        <source xml:space="preserve">Executing command using &quot;%1&quot; wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">1025</context></context-group>
       </trans-unit>
       <trans-unit id="_msg638">
-        <source xml:space="preserve">None</source>
-        <context-group purpose="location"><context context-type="linenumber">992</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg639">
-        <source xml:space="preserve">Executing command without any wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">1071</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg640">
-        <source xml:space="preserve">Ctrl+I</source>
-        <context-group purpose="location"><context context-type="linenumber">1397</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg641">
-        <source xml:space="preserve">Ctrl+T</source>
-        <context-group purpose="location"><context context-type="linenumber">1398</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg642">
-        <source xml:space="preserve">Ctrl+N</source>
-        <context-group purpose="location"><context context-type="linenumber">1399</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg643">
-        <source xml:space="preserve">Ctrl+P</source>
-        <context-group purpose="location"><context context-type="linenumber">1400</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg644">
-        <source xml:space="preserve">Node window - [%1]</source>
-        <context-group purpose="location"><context context-type="linenumber">1418</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg645">
-        <source xml:space="preserve">Executing command using &quot;%1&quot; wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">1069</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg646">
         <source xml:space="preserve">Welcome to the %1 RPC console.
 Use up and down arrows to navigate history, and %2 to clear screen.
 Use %3 and %4 to increase or decrease the font size.
@@ -3005,124 +2975,124 @@ Type %5 for an overview of available commands.
 For more information on using this console, type %6.
 
 %7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
-        <context-group purpose="location"><context context-type="linenumber">908</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">864</context></context-group>
         <note annotates="source" from="developer">RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</note>
       </trans-unit>
-      <trans-unit id="_msg647">
+      <trans-unit id="_msg639">
         <source xml:space="preserve">Executing…</source>
-        <context-group purpose="location"><context context-type="linenumber">1079</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1035</context></context-group>
         <note annotates="source" from="developer">A console message indicating an entered command is currently being executed.</note>
       </trans-unit>
-      <trans-unit id="_msg648">
+      <trans-unit id="_msg640">
         <source xml:space="preserve">(peer: %1)</source>
-        <context-group purpose="location"><context context-type="linenumber">1197</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg649">
+      <trans-unit id="_msg641">
         <source xml:space="preserve">via %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1199</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1155</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../rpcconsole.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg650">
+      <trans-unit id="_msg642">
         <source xml:space="preserve">Yes</source>
-        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg651">
+      <trans-unit id="_msg643">
         <source xml:space="preserve">No</source>
-        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg652">
+      <trans-unit id="_msg644">
         <source xml:space="preserve">To</source>
-        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg653">
+      <trans-unit id="_msg645">
         <source xml:space="preserve">From</source>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg646">
+        <source xml:space="preserve">Ban for</source>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg654">
-        <source xml:space="preserve">Ban for</source>
-        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg655">
+      <trans-unit id="_msg647">
         <source xml:space="preserve">Never</source>
-        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg656">
+      <trans-unit id="_msg648">
         <source xml:space="preserve">Unknown</source>
-        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/receivecoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg657">
+      <trans-unit id="_msg649">
         <source xml:space="preserve">&amp;Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg658">
+      <trans-unit id="_msg650">
         <source xml:space="preserve">&amp;Label:</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg659">
+      <trans-unit id="_msg651">
         <source xml:space="preserve">&amp;Message:</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg660">
+      <trans-unit id="_msg652">
         <source xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg661">
+      <trans-unit id="_msg653">
         <source xml:space="preserve">An optional label to associate with the new receiving address.</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg662">
+      <trans-unit id="_msg654">
         <source xml:space="preserve">Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg663">
+      <trans-unit id="_msg655">
         <source xml:space="preserve">An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg664">
+      <trans-unit id="_msg656">
         <source xml:space="preserve">An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg665">
+      <trans-unit id="_msg657">
         <source xml:space="preserve">An optional message that is attached to the payment request and may be displayed to the sender.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg666">
+      <trans-unit id="_msg658">
         <source xml:space="preserve">&amp;Create new receiving address</source>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg667">
+      <trans-unit id="_msg659">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg668">
+      <trans-unit id="_msg660">
         <source xml:space="preserve">Clear</source>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg669">
+      <trans-unit id="_msg661">
         <source xml:space="preserve">Requested payments history</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg670">
+      <trans-unit id="_msg662">
         <source xml:space="preserve">Show the selected request (does the same as double clicking an entry)</source>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg671">
+      <trans-unit id="_msg663">
         <source xml:space="preserve">Show</source>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg672">
+      <trans-unit id="_msg664">
         <source xml:space="preserve">Remove the selected entries from the list</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg673">
+      <trans-unit id="_msg665">
         <source xml:space="preserve">Remove</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
@@ -3130,63 +3100,63 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../receivecoinsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg674">
+      <trans-unit id="_msg666">
         <source xml:space="preserve">Copy &amp;URI</source>
         <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg675">
+      <trans-unit id="_msg667">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg676">
+      <trans-unit id="_msg668">
         <source xml:space="preserve">Copy &amp;label</source>
         <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg677">
+      <trans-unit id="_msg669">
         <source xml:space="preserve">Copy &amp;message</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg678">
+      <trans-unit id="_msg670">
         <source xml:space="preserve">Copy &amp;amount</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg679">
+      <trans-unit id="_msg671">
         <source xml:space="preserve">Base58 (Legacy)</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg680">
+      <trans-unit id="_msg672">
         <source xml:space="preserve">Not recommended due to higher fees and less protection against typos.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg681">
+      <trans-unit id="_msg673">
         <source xml:space="preserve">Base58 (P2SH-SegWit)</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg682">
+      <trans-unit id="_msg674">
         <source xml:space="preserve">Generates an address compatible with older wallets.</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg683">
+      <trans-unit id="_msg675">
         <source xml:space="preserve">Bech32 (SegWit)</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg684">
+      <trans-unit id="_msg676">
         <source xml:space="preserve">Generates a native segwit address (BIP-173). Some old wallets don&apos;t support it.</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg685">
+      <trans-unit id="_msg677">
         <source xml:space="preserve">Bech32m (Taproot)</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg686">
+      <trans-unit id="_msg678">
         <source xml:space="preserve">Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg687">
+      <trans-unit id="_msg679">
         <source xml:space="preserve">Could not unlock wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg688">
+      <trans-unit id="_msg680">
         <source xml:space="preserve">Could not generate new %1 address</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
@@ -3194,51 +3164,51 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../forms/receiverequestdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg689">
+      <trans-unit id="_msg681">
         <source xml:space="preserve">Request payment to …</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg690">
+      <trans-unit id="_msg682">
         <source xml:space="preserve">Address:</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg691">
+      <trans-unit id="_msg683">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg692">
+      <trans-unit id="_msg684">
         <source xml:space="preserve">Label:</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg693">
+      <trans-unit id="_msg685">
         <source xml:space="preserve">Message:</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg694">
+      <trans-unit id="_msg686">
         <source xml:space="preserve">Wallet:</source>
         <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg695">
+      <trans-unit id="_msg687">
         <source xml:space="preserve">Copy &amp;URI</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg696">
+      <trans-unit id="_msg688">
         <source xml:space="preserve">Copy &amp;Address</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg697">
+      <trans-unit id="_msg689">
         <source xml:space="preserve">&amp;Verify</source>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg698">
+      <trans-unit id="_msg690">
         <source xml:space="preserve">Verify this address on e.g. a hardware wallet screen</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg699">
+      <trans-unit id="_msg691">
         <source xml:space="preserve">&amp;Save Image…</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg700">
+      <trans-unit id="_msg692">
         <source xml:space="preserve">Payment information</source>
         <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
       </trans-unit>
@@ -3246,7 +3216,7 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../receiverequestdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg701">
+      <trans-unit id="_msg693">
         <source xml:space="preserve">Request payment to %1</source>
         <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
@@ -3254,31 +3224,31 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../recentrequeststablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RecentRequestsTableModel">
-      <trans-unit id="_msg702">
+      <trans-unit id="_msg694">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg703">
+      <trans-unit id="_msg695">
         <source xml:space="preserve">Label</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg704">
+      <trans-unit id="_msg696">
         <source xml:space="preserve">Message</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg705">
+      <trans-unit id="_msg697">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg706">
+      <trans-unit id="_msg698">
         <source xml:space="preserve">(no message)</source>
         <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg707">
+      <trans-unit id="_msg699">
         <source xml:space="preserve">(no amount requested)</source>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg708">
+      <trans-unit id="_msg700">
         <source xml:space="preserve">Requested</source>
         <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
       </trans-unit>
@@ -3286,150 +3256,150 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../forms/sendcoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg709">
+      <trans-unit id="_msg701">
         <source xml:space="preserve">Send Coins</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">763</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">764</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg710">
+      <trans-unit id="_msg702">
         <source xml:space="preserve">Coin Control Features</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg711">
+      <trans-unit id="_msg703">
         <source xml:space="preserve">automatically selected</source>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg712">
+      <trans-unit id="_msg704">
         <source xml:space="preserve">Insufficient funds!</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg713">
+      <trans-unit id="_msg705">
         <source xml:space="preserve">Quantity:</source>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg714">
+      <trans-unit id="_msg706">
         <source xml:space="preserve">Bytes:</source>
         <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg715">
+      <trans-unit id="_msg707">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg716">
+      <trans-unit id="_msg708">
         <source xml:space="preserve">Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg717">
+      <trans-unit id="_msg709">
         <source xml:space="preserve">After Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg718">
+      <trans-unit id="_msg710">
         <source xml:space="preserve">Change:</source>
         <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg719">
+      <trans-unit id="_msg711">
         <source xml:space="preserve">If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg720">
+      <trans-unit id="_msg712">
         <source xml:space="preserve">Custom change address</source>
         <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg721">
+      <trans-unit id="_msg713">
         <source xml:space="preserve">Transaction Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">704</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg722">
+      <trans-unit id="_msg714">
         <source xml:space="preserve">Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg723">
+      <trans-unit id="_msg715">
         <source xml:space="preserve">Warning: Fee estimation is currently not possible.</source>
         <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg724">
+      <trans-unit id="_msg716">
         <source xml:space="preserve">per kilobyte</source>
         <context-group purpose="location"><context context-type="linenumber">833</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg725">
+      <trans-unit id="_msg717">
         <source xml:space="preserve">Hide</source>
         <context-group purpose="location"><context context-type="linenumber">780</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg726">
+      <trans-unit id="_msg718">
         <source xml:space="preserve">Recommended:</source>
         <context-group purpose="location"><context context-type="linenumber">892</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg727">
+      <trans-unit id="_msg719">
         <source xml:space="preserve">Custom:</source>
         <context-group purpose="location"><context context-type="linenumber">922</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg728">
+      <trans-unit id="_msg720">
         <source xml:space="preserve">Send to multiple recipients at once</source>
         <context-group purpose="location"><context context-type="linenumber">1137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg729">
+      <trans-unit id="_msg721">
         <source xml:space="preserve">Add &amp;Recipient</source>
         <context-group purpose="location"><context context-type="linenumber">1140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg730">
+      <trans-unit id="_msg722">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <context-group purpose="location"><context context-type="linenumber">1120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg731">
+      <trans-unit id="_msg723">
         <source xml:space="preserve">Inputs…</source>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg732">
+      <trans-unit id="_msg724">
         <source xml:space="preserve">Choose…</source>
         <context-group purpose="location"><context context-type="linenumber">718</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg733">
+      <trans-unit id="_msg725">
         <source xml:space="preserve">Hide transaction fee settings</source>
         <context-group purpose="location"><context context-type="linenumber">777</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg734">
+      <trans-unit id="_msg726">
         <source xml:space="preserve">Specify a custom fee per kB (1,000 bytes) of the transaction&apos;s virtual size.
 
 Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 satoshis per kvB&quot; for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
         <context-group purpose="location"><context context-type="linenumber">828</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg735">
+      <trans-unit id="_msg727">
         <source xml:space="preserve">When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <context-group purpose="location"><context context-type="linenumber">863</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg736">
+      <trans-unit id="_msg728">
         <source xml:space="preserve">A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <context-group purpose="location"><context context-type="linenumber">866</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg737">
+      <trans-unit id="_msg729">
         <source xml:space="preserve">(Smart fee not initialized yet. This usually takes a few blocks…)</source>
         <context-group purpose="location"><context context-type="linenumber">971</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg738">
+      <trans-unit id="_msg730">
         <source xml:space="preserve">Confirmation time target:</source>
         <context-group purpose="location"><context context-type="linenumber">997</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg739">
+      <trans-unit id="_msg731">
         <source xml:space="preserve">Enable Replace-By-Fee</source>
         <context-group purpose="location"><context context-type="linenumber">1055</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg740">
+      <trans-unit id="_msg732">
         <source xml:space="preserve">With Replace-By-Fee (BIP-125) you can increase a transaction&apos;s fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
         <context-group purpose="location"><context context-type="linenumber">1058</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg741">
+      <trans-unit id="_msg733">
         <source xml:space="preserve">Clear &amp;All</source>
         <context-group purpose="location"><context context-type="linenumber">1123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg742">
+      <trans-unit id="_msg734">
         <source xml:space="preserve">Balance:</source>
         <context-group purpose="location"><context context-type="linenumber">1178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg743">
+      <trans-unit id="_msg735">
         <source xml:space="preserve">Confirm the send action</source>
         <context-group purpose="location"><context context-type="linenumber">1094</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg744">
+      <trans-unit id="_msg736">
         <source xml:space="preserve">S&amp;end</source>
         <context-group purpose="location"><context context-type="linenumber">1097</context></context-group>
       </trans-unit>
@@ -3437,300 +3407,296 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../sendcoinsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg745">
+      <trans-unit id="_msg737">
         <source xml:space="preserve">Copy quantity</source>
-        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg746">
-        <source xml:space="preserve">Copy amount</source>
-        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg747">
-        <source xml:space="preserve">Copy fee</source>
-        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg748">
-        <source xml:space="preserve">Copy after fee</source>
-        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg749">
-        <source xml:space="preserve">Copy bytes</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg750">
-        <source xml:space="preserve">Copy change</source>
+      <trans-unit id="_msg738">
+        <source xml:space="preserve">Copy amount</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg751">
-        <source xml:space="preserve">%1 (%2 blocks)</source>
-        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
+      <trans-unit id="_msg739">
+        <source xml:space="preserve">Copy fee</source>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg752">
+      <trans-unit id="_msg740">
+        <source xml:space="preserve">Copy after fee</source>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg741">
+        <source xml:space="preserve">Copy bytes</source>
+        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg742">
+        <source xml:space="preserve">Copy change</source>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg743">
+        <source xml:space="preserve">%1 (%2 blocks)</source>
+        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg744">
         <source xml:space="preserve">Sign on device</source>
-        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
         <note annotates="source" from="developer">&quot;device&quot; usually means a hardware wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg753">
+      <trans-unit id="_msg745">
         <source xml:space="preserve">Connect your hardware wallet first.</source>
-        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg746">
+        <source xml:space="preserve">Set external signer script path in Options -&gt; Wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
+        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
+      </trans-unit>
+      <trans-unit id="_msg747">
+        <source xml:space="preserve">Cr&amp;eate Unsigned</source>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg748">
+        <source xml:space="preserve">Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg749">
+        <source xml:space="preserve">%1 to &apos;%2&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg750">
+        <source xml:space="preserve">%1 to %2</source>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg751">
+        <source xml:space="preserve">To review recipient list click &quot;Show Details…&quot;</source>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg752">
+        <source xml:space="preserve">Sign failed</source>
+        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg753">
+        <source xml:space="preserve">External signer not found</source>
+        <context-group purpose="location"><context context-type="linenumber">460</context></context-group>
+        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
       <trans-unit id="_msg754">
-        <source xml:space="preserve">Set external signer script path in Options -&gt; Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
+        <source xml:space="preserve">External signer failure</source>
+        <context-group purpose="location"><context context-type="linenumber">466</context></context-group>
         <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
       <trans-unit id="_msg755">
-        <source xml:space="preserve">Cr&amp;eate Unsigned</source>
-        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+        <source xml:space="preserve">Save Transaction Data</source>
+        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
       </trans-unit>
       <trans-unit id="_msg756">
-        <source xml:space="preserve">Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
+        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
+        <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
+        <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
       <trans-unit id="_msg757">
-        <source xml:space="preserve">%1 to &apos;%2&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
+        <source xml:space="preserve">PSBT saved</source>
+        <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
+        <note annotates="source" from="developer">Popup message when a PSBT has been saved to a file</note>
       </trans-unit>
       <trans-unit id="_msg758">
-        <source xml:space="preserve">%1 to %2</source>
-        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+        <source xml:space="preserve">External balance:</source>
+        <context-group purpose="location"><context context-type="linenumber">713</context></context-group>
       </trans-unit>
       <trans-unit id="_msg759">
-        <source xml:space="preserve">To review recipient list click &quot;Show Details…&quot;</source>
+        <source xml:space="preserve">or</source>
         <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
       </trans-unit>
       <trans-unit id="_msg760">
-        <source xml:space="preserve">Sign failed</source>
-        <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
+        <source xml:space="preserve">You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
+        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
       </trans-unit>
       <trans-unit id="_msg761">
-        <source xml:space="preserve">External signer not found</source>
-        <context-group purpose="location"><context context-type="linenumber">456</context></context-group>
-        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
-      </trans-unit>
-      <trans-unit id="_msg762">
-        <source xml:space="preserve">External signer failure</source>
-        <context-group purpose="location"><context context-type="linenumber">462</context></context-group>
-        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
-      </trans-unit>
-      <trans-unit id="_msg763">
-        <source xml:space="preserve">Save Transaction Data</source>
-        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg764">
-        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
-        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
-        <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
-      </trans-unit>
-      <trans-unit id="_msg765">
-        <source xml:space="preserve">PSBT saved</source>
-        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
-        <note annotates="source" from="developer">Popup message when a PSBT has been saved to a file</note>
-      </trans-unit>
-      <trans-unit id="_msg766">
-        <source xml:space="preserve">External balance:</source>
-        <context-group purpose="location"><context context-type="linenumber">709</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg767">
-        <source xml:space="preserve">or</source>
-        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg768">
-        <source xml:space="preserve">You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg769">
         <source xml:space="preserve">Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
         <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</note>
       </trans-unit>
-      <trans-unit id="_msg770">
+      <trans-unit id="_msg762">
         <source xml:space="preserve">%1 from wallet &apos;%2&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg771">
+      <trans-unit id="_msg763">
         <source xml:space="preserve">Do you want to create this transaction?</source>
-        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
         <note annotates="source" from="developer">Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</note>
       </trans-unit>
-      <trans-unit id="_msg772">
+      <trans-unit id="_msg764">
         <source xml:space="preserve">Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
         <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</note>
       </trans-unit>
-      <trans-unit id="_msg773">
+      <trans-unit id="_msg765">
         <source xml:space="preserve">Please, review your transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
         <note annotates="source" from="developer">Text to prompt a user to review the details of the transaction they are attempting to send.</note>
       </trans-unit>
-      <trans-unit id="_msg774">
+      <trans-unit id="_msg766">
         <source xml:space="preserve">Transaction fee</source>
-        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg775">
+      <trans-unit id="_msg767">
         <source xml:space="preserve">%1 kvB</source>
-        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">PSBT transaction creation</context></context-group>
         <note annotates="source" from="developer">When reviewing a newly created PSBT (via Send flow), the transaction fee is shown, with &quot;virtual size&quot; of the transaction displayed for context</note>
       </trans-unit>
-      <trans-unit id="_msg776">
+      <trans-unit id="_msg768">
         <source xml:space="preserve">Not signalling Replace-By-Fee, BIP-125.</source>
-        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg777">
+      <trans-unit id="_msg769">
         <source xml:space="preserve">Total Amount</source>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg778">
+      <trans-unit id="_msg770">
         <source xml:space="preserve">Unsigned Transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">PSBT copied</context></context-group>
         <note annotates="source" from="developer">Caption of &quot;PSBT has been copied&quot; messagebox</note>
       </trans-unit>
-      <trans-unit id="_msg779">
+      <trans-unit id="_msg771">
         <source xml:space="preserve">The PSBT has been copied to the clipboard. You can also save it.</source>
-        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg772">
+        <source xml:space="preserve">PSBT saved to disk</source>
+        <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg773">
+        <source xml:space="preserve">Confirm send coins</source>
+        <context-group purpose="location"><context context-type="linenumber">489</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg774">
+        <source xml:space="preserve">The recipient address is not valid. Please recheck.</source>
+        <context-group purpose="location"><context context-type="linenumber">737</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg775">
+        <source xml:space="preserve">The amount to pay must be larger than 0.</source>
+        <context-group purpose="location"><context context-type="linenumber">740</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg776">
+        <source xml:space="preserve">The amount exceeds your balance.</source>
+        <context-group purpose="location"><context context-type="linenumber">743</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg777">
+        <source xml:space="preserve">The total exceeds your balance when the %1 transaction fee is included.</source>
+        <context-group purpose="location"><context context-type="linenumber">746</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg778">
+        <source xml:space="preserve">Duplicate address found: addresses should only be used once each.</source>
+        <context-group purpose="location"><context context-type="linenumber">749</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg779">
+        <source xml:space="preserve">Transaction creation failed!</source>
+        <context-group purpose="location"><context context-type="linenumber">752</context></context-group>
       </trans-unit>
       <trans-unit id="_msg780">
-        <source xml:space="preserve">PSBT saved to disk</source>
-        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+        <source xml:space="preserve">A fee higher than %1 is considered an absurdly high fee.</source>
+        <context-group purpose="location"><context context-type="linenumber">756</context></context-group>
       </trans-unit>
       <trans-unit id="_msg781">
-        <source xml:space="preserve">Confirm send coins</source>
-        <context-group purpose="location"><context context-type="linenumber">485</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg782">
-        <source xml:space="preserve">Watch-only balance:</source>
-        <context-group purpose="location"><context context-type="linenumber">712</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg783">
-        <source xml:space="preserve">The recipient address is not valid. Please recheck.</source>
-        <context-group purpose="location"><context context-type="linenumber">736</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg784">
-        <source xml:space="preserve">The amount to pay must be larger than 0.</source>
-        <context-group purpose="location"><context context-type="linenumber">739</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg785">
-        <source xml:space="preserve">The amount exceeds your balance.</source>
-        <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg786">
-        <source xml:space="preserve">The total exceeds your balance when the %1 transaction fee is included.</source>
-        <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg787">
-        <source xml:space="preserve">Duplicate address found: addresses should only be used once each.</source>
-        <context-group purpose="location"><context context-type="linenumber">748</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg788">
-        <source xml:space="preserve">Transaction creation failed!</source>
-        <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg789">
-        <source xml:space="preserve">A fee higher than %1 is considered an absurdly high fee.</source>
-        <context-group purpose="location"><context context-type="linenumber">755</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg790">
         <source xml:space="preserve">%1/kvB</source>
-        <context-group purpose="location"><context context-type="linenumber">834</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">832</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">869</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">883</context></context-group>
-        <trans-unit id="_msg791[0]">
+        <trans-unit id="_msg782[0]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
         </trans-unit>
-        <trans-unit id="_msg791[1]">
+        <trans-unit id="_msg782[1]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg792">
+      <trans-unit id="_msg783">
         <source xml:space="preserve">Warning: Invalid Bitcoin address</source>
-        <context-group purpose="location"><context context-type="linenumber">978</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">982</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg793">
+      <trans-unit id="_msg784">
         <source xml:space="preserve">Warning: Unknown change address</source>
-        <context-group purpose="location"><context context-type="linenumber">983</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">987</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg794">
+      <trans-unit id="_msg785">
         <source xml:space="preserve">Confirm custom change address</source>
-        <context-group purpose="location"><context context-type="linenumber">986</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">990</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg795">
+      <trans-unit id="_msg786">
         <source xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <context-group purpose="location"><context context-type="linenumber">986</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">990</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg796">
+      <trans-unit id="_msg787">
         <source xml:space="preserve">(no label)</source>
-        <context-group purpose="location"><context context-type="linenumber">1007</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1011</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/sendcoinsentry.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsEntry">
-      <trans-unit id="_msg797">
+      <trans-unit id="_msg788">
         <source xml:space="preserve">A&amp;mount:</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg798">
+      <trans-unit id="_msg789">
         <source xml:space="preserve">Pay &amp;To:</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg799">
+      <trans-unit id="_msg790">
         <source xml:space="preserve">&amp;Label:</source>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg800">
+      <trans-unit id="_msg791">
         <source xml:space="preserve">Choose previously used address</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg801">
+      <trans-unit id="_msg792">
         <source xml:space="preserve">The Bitcoin address to send the payment to</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg802">
+      <trans-unit id="_msg793">
         <source xml:space="preserve">Alt+A</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg803">
+      <trans-unit id="_msg794">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg804">
+      <trans-unit id="_msg795">
         <source xml:space="preserve">Alt+P</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg805">
+      <trans-unit id="_msg796">
         <source xml:space="preserve">Remove this entry</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg806">
+      <trans-unit id="_msg797">
         <source xml:space="preserve">The amount to send in the selected unit</source>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg807">
+      <trans-unit id="_msg798">
         <source xml:space="preserve">The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
         <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg808">
+      <trans-unit id="_msg799">
         <source xml:space="preserve">S&amp;ubtract fee from amount</source>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg809">
+      <trans-unit id="_msg800">
         <source xml:space="preserve">Use available balance</source>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg810">
+      <trans-unit id="_msg801">
         <source xml:space="preserve">Message:</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg811">
+      <trans-unit id="_msg802">
         <source xml:space="preserve">Enter a label for this address to add it to the list of used addresses</source>
         <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg812">
+      <trans-unit id="_msg803">
         <source xml:space="preserve">A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
       </trans-unit>
@@ -3738,117 +3704,117 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../sendcoinsdialog.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendConfirmationDialog">
-      <trans-unit id="_msg813">
+      <trans-unit id="_msg804">
         <source xml:space="preserve">Send</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg814">
+      <trans-unit id="_msg805">
         <source xml:space="preserve">Create Unsigned</source>
-        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/signverifymessagedialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg815">
+      <trans-unit id="_msg806">
         <source xml:space="preserve">Signatures - Sign / Verify a Message</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg816">
+      <trans-unit id="_msg807">
         <source xml:space="preserve">&amp;Sign Message</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg817">
+      <trans-unit id="_msg808">
         <source xml:space="preserve">You can sign messages/agreements with your legacy (P2PKH) addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg818">
+      <trans-unit id="_msg809">
         <source xml:space="preserve">The Bitcoin address to sign the message with</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg819">
+      <trans-unit id="_msg810">
         <source xml:space="preserve">Choose previously used address</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg820">
+      <trans-unit id="_msg811">
         <source xml:space="preserve">Alt+A</source>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg821">
+      <trans-unit id="_msg812">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg822">
+      <trans-unit id="_msg813">
         <source xml:space="preserve">Alt+P</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg823">
+      <trans-unit id="_msg814">
         <source xml:space="preserve">Enter the message you want to sign here</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg824">
+      <trans-unit id="_msg815">
         <source xml:space="preserve">Signature</source>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg825">
-        <source xml:space="preserve">Copy the current signature to the system clipboard</source>
+      <trans-unit id="_msg816">
+        <source xml:space="preserve">Copy the current signature to the clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg826">
+      <trans-unit id="_msg817">
         <source xml:space="preserve">Sign the message to prove you own this Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg827">
+      <trans-unit id="_msg818">
         <source xml:space="preserve">Sign &amp;Message</source>
         <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg828">
+      <trans-unit id="_msg819">
         <source xml:space="preserve">Reset all sign message fields</source>
         <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg829">
+      <trans-unit id="_msg820">
         <source xml:space="preserve">Clear &amp;All</source>
         <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg830">
+      <trans-unit id="_msg821">
         <source xml:space="preserve">&amp;Verify Message</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg831">
+      <trans-unit id="_msg822">
         <source xml:space="preserve">Enter the receiver&apos;s address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
         <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg832">
+      <trans-unit id="_msg823">
         <source xml:space="preserve">The Bitcoin address the message was signed with</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg833">
+      <trans-unit id="_msg824">
         <source xml:space="preserve">The signed message to verify</source>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg834">
+      <trans-unit id="_msg825">
         <source xml:space="preserve">The signature given when the message was signed</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg835">
+      <trans-unit id="_msg826">
         <source xml:space="preserve">Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg836">
+      <trans-unit id="_msg827">
         <source xml:space="preserve">Verify &amp;Message</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg837">
+      <trans-unit id="_msg828">
         <source xml:space="preserve">Reset all verify message fields</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg838">
+      <trans-unit id="_msg829">
         <source xml:space="preserve">Click &quot;Sign Message&quot; to generate signature</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
@@ -3856,71 +3822,71 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../signverifymessagedialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg839">
+      <trans-unit id="_msg830">
         <source xml:space="preserve">The entered address is invalid.</source>
-        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg831">
+        <source xml:space="preserve">Please check the address and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg832">
+        <source xml:space="preserve">The entered address does not refer to a legacy (P2PKH) key. Message signing for SegWit and other non-P2PKH address types is not supported in this version of %1. Please check the address and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg833">
+        <source xml:space="preserve">Wallet unlock was cancelled.</source>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg834">
+        <source xml:space="preserve">No error</source>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg835">
+        <source xml:space="preserve">Private key for the entered address is not available.</source>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg836">
+        <source xml:space="preserve">Message signing failed.</source>
+        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg837">
+        <source xml:space="preserve">Message signed.</source>
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg838">
+        <source xml:space="preserve">The signature could not be decoded.</source>
+        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg839">
+        <source xml:space="preserve">Please check the signature and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
       <trans-unit id="_msg840">
-        <source xml:space="preserve">Please check the address and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+        <source xml:space="preserve">The signature did not match the message digest.</source>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
       </trans-unit>
       <trans-unit id="_msg841">
-        <source xml:space="preserve">The entered address does not refer to a legacy (P2PKH) key. Message signing for SegWit and other non-P2PKH address types is not supported in this version of %1. Please check the address and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+        <source xml:space="preserve">Message verification failed.</source>
+        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
       </trans-unit>
       <trans-unit id="_msg842">
-        <source xml:space="preserve">Wallet unlock was cancelled.</source>
-        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg843">
-        <source xml:space="preserve">No error</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg844">
-        <source xml:space="preserve">Private key for the entered address is not available.</source>
-        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg845">
-        <source xml:space="preserve">Message signing failed.</source>
-        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg846">
-        <source xml:space="preserve">Message signed.</source>
-        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg847">
-        <source xml:space="preserve">The signature could not be decoded.</source>
-        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg848">
-        <source xml:space="preserve">Please check the signature and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg849">
-        <source xml:space="preserve">The signature did not match the message digest.</source>
-        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg850">
-        <source xml:space="preserve">Message verification failed.</source>
-        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg851">
         <source xml:space="preserve">Message verified.</source>
-        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../splashscreen.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SplashScreen">
-      <trans-unit id="_msg852">
+      <trans-unit id="_msg843">
         <source xml:space="preserve">(press q to shutdown and continue later)</source>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg853">
+      <trans-unit id="_msg844">
         <source xml:space="preserve">press q to shutdown</source>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
@@ -3928,7 +3894,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../trafficgraphwidget.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TrafficGraphWidget">
-      <trans-unit id="_msg854">
+      <trans-unit id="_msg845">
         <source xml:space="preserve">kB/s</source>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
@@ -3936,194 +3902,185 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiondesc.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDesc">
-      <trans-unit id="_msg855">
+      <trans-unit id="_msg846">
         <source xml:space="preserve">conflicted with a transaction with %1 confirmations</source>
-        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</note>
       </trans-unit>
-      <trans-unit id="_msg856">
+      <trans-unit id="_msg847">
         <source xml:space="preserve">0/unconfirmed, in memory pool</source>
-        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</note>
       </trans-unit>
-      <trans-unit id="_msg857">
+      <trans-unit id="_msg848">
         <source xml:space="preserve">0/unconfirmed, not in memory pool</source>
-        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</note>
       </trans-unit>
-      <trans-unit id="_msg858">
+      <trans-unit id="_msg849">
         <source xml:space="preserve">abandoned</source>
-        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</note>
       </trans-unit>
-      <trans-unit id="_msg859">
+      <trans-unit id="_msg850">
         <source xml:space="preserve">%1/unconfirmed</source>
-        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</note>
       </trans-unit>
-      <trans-unit id="_msg860">
+      <trans-unit id="_msg851">
         <source xml:space="preserve">%1 confirmations</source>
-        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</note>
       </trans-unit>
-      <trans-unit id="_msg861">
+      <trans-unit id="_msg852">
         <source xml:space="preserve">Status</source>
-        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg862">
+      <trans-unit id="_msg853">
         <source xml:space="preserve">Date</source>
-        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg863">
+      <trans-unit id="_msg854">
         <source xml:space="preserve">Source</source>
-        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg864">
+      <trans-unit id="_msg855">
         <source xml:space="preserve">Generated</source>
-        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg865">
+      <trans-unit id="_msg856">
         <source xml:space="preserve">From</source>
-        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg866">
+      <trans-unit id="_msg857">
         <source xml:space="preserve">unknown</source>
-        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg867">
+      <trans-unit id="_msg858">
         <source xml:space="preserve">To</source>
-        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg868">
+      <trans-unit id="_msg859">
         <source xml:space="preserve">own address</source>
-        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg869">
-        <source xml:space="preserve">watch-only</source>
-        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg870">
+      <trans-unit id="_msg860">
         <source xml:space="preserve">label</source>
-        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg871">
+      <trans-unit id="_msg861">
         <source xml:space="preserve">Credit</source>
-        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
-        <trans-unit id="_msg872[0]">
+        <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
+        <trans-unit id="_msg862[0]">
           <source xml:space="preserve">matures in %n more block(s)</source>
         </trans-unit>
-        <trans-unit id="_msg872[1]">
+        <trans-unit id="_msg862[1]">
           <source xml:space="preserve">matures in %n more block(s)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg873">
+      <trans-unit id="_msg863">
         <source xml:space="preserve">not accepted</source>
-        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg874">
+      <trans-unit id="_msg864">
         <source xml:space="preserve">Debit</source>
-        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg875">
+      <trans-unit id="_msg865">
         <source xml:space="preserve">Total debit</source>
-        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg876">
+      <trans-unit id="_msg866">
         <source xml:space="preserve">Total credit</source>
-        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg877">
+      <trans-unit id="_msg867">
         <source xml:space="preserve">Transaction fee</source>
-        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg878">
+      <trans-unit id="_msg868">
         <source xml:space="preserve">Net amount</source>
-        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg879">
+      <trans-unit id="_msg869">
         <source xml:space="preserve">Message</source>
-        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg880">
-        <source xml:space="preserve">Comment</source>
-        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg881">
-        <source xml:space="preserve">Transaction ID</source>
-        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg882">
-        <source xml:space="preserve">Transaction total size</source>
+        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg883">
+      <trans-unit id="_msg870">
+        <source xml:space="preserve">Comment</source>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg871">
+        <source xml:space="preserve">Transaction ID</source>
+        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg872">
+        <source xml:space="preserve">Transaction total size</source>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg873">
         <source xml:space="preserve">Transaction virtual size</source>
-        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg884">
+      <trans-unit id="_msg874">
         <source xml:space="preserve">Output index</source>
-        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg885">
+      <trans-unit id="_msg875">
         <source xml:space="preserve">%1 (Certificate was not verified)</source>
-        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg886">
+      <trans-unit id="_msg876">
         <source xml:space="preserve">Merchant</source>
-        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg887">
+      <trans-unit id="_msg877">
         <source xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg888">
+      <trans-unit id="_msg878">
         <source xml:space="preserve">Debug information</source>
-        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg889">
+      <trans-unit id="_msg879">
         <source xml:space="preserve">Transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg890">
+      <trans-unit id="_msg880">
         <source xml:space="preserve">Inputs</source>
-        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg891">
+      <trans-unit id="_msg881">
         <source xml:space="preserve">Amount</source>
-        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg892">
+      <trans-unit id="_msg882">
         <source xml:space="preserve">true</source>
-        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg893">
+      <trans-unit id="_msg883">
         <source xml:space="preserve">false</source>
-        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/transactiondescdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg894">
+      <trans-unit id="_msg884">
         <source xml:space="preserve">This pane shows a detailed description of the transaction</source>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
@@ -4131,7 +4088,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiondescdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg895">
+      <trans-unit id="_msg885">
         <source xml:space="preserve">Details for %1</source>
         <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
       </trans-unit>
@@ -4139,298 +4096,286 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiontablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionTableModel">
-      <trans-unit id="_msg896">
+      <trans-unit id="_msg886">
         <source xml:space="preserve">Date</source>
-        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg887">
+        <source xml:space="preserve">Type</source>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg888">
+        <source xml:space="preserve">Label</source>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg889">
+        <source xml:space="preserve">Unconfirmed</source>
+        <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg890">
+        <source xml:space="preserve">Abandoned</source>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg891">
+        <source xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</source>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg892">
+        <source xml:space="preserve">Confirmed (%1 confirmations)</source>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg893">
+        <source xml:space="preserve">Conflicted</source>
+        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg894">
+        <source xml:space="preserve">Immature (%1 confirmations, will be available after %2)</source>
+        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg895">
+        <source xml:space="preserve">Generated but not accepted</source>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg896">
+        <source xml:space="preserve">Received with</source>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
       </trans-unit>
       <trans-unit id="_msg897">
-        <source xml:space="preserve">Type</source>
-        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg898">
-        <source xml:space="preserve">Label</source>
-        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg899">
-        <source xml:space="preserve">Unconfirmed</source>
-        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg900">
-        <source xml:space="preserve">Abandoned</source>
-        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg901">
-        <source xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</source>
-        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg902">
-        <source xml:space="preserve">Confirmed (%1 confirmations)</source>
-        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg903">
-        <source xml:space="preserve">Conflicted</source>
-        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg904">
-        <source xml:space="preserve">Immature (%1 confirmations, will be available after %2)</source>
-        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg905">
-        <source xml:space="preserve">Generated but not accepted</source>
-        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg906">
-        <source xml:space="preserve">Received with</source>
+        <source xml:space="preserve">Received from</source>
         <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg907">
-        <source xml:space="preserve">Received from</source>
-        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg908">
+      <trans-unit id="_msg898">
         <source xml:space="preserve">Sent to</source>
+        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg899">
+        <source xml:space="preserve">Mined</source>
         <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg909">
-        <source xml:space="preserve">Mined</source>
-        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg910">
-        <source xml:space="preserve">watch-only</source>
-        <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg911">
+      <trans-unit id="_msg900">
         <source xml:space="preserve">(n/a)</source>
-        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg912">
+      <trans-unit id="_msg901">
         <source xml:space="preserve">(no label)</source>
-        <context-group purpose="location"><context context-type="linenumber">629</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">604</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg913">
+      <trans-unit id="_msg902">
         <source xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</source>
-        <context-group purpose="location"><context context-type="linenumber">668</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">643</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg914">
+      <trans-unit id="_msg903">
         <source xml:space="preserve">Date and time that the transaction was received.</source>
-        <context-group purpose="location"><context context-type="linenumber">670</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">645</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg915">
+      <trans-unit id="_msg904">
         <source xml:space="preserve">Type of transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">647</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg916">
-        <source xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">674</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg917">
+      <trans-unit id="_msg905">
         <source xml:space="preserve">User-defined intent/purpose of the transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">676</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">649</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg918">
+      <trans-unit id="_msg906">
         <source xml:space="preserve">Amount removed from or added to balance.</source>
-        <context-group purpose="location"><context context-type="linenumber">678</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">651</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../transactionview.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionView">
-      <trans-unit id="_msg919">
+      <trans-unit id="_msg907">
         <source xml:space="preserve">All</source>
-        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg908">
+        <source xml:space="preserve">Today</source>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg909">
+        <source xml:space="preserve">This week</source>
+        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg910">
+        <source xml:space="preserve">This month</source>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg911">
+        <source xml:space="preserve">Last month</source>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg912">
+        <source xml:space="preserve">This year</source>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg913">
+        <source xml:space="preserve">Received with</source>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg914">
+        <source xml:space="preserve">Sent to</source>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg915">
+        <source xml:space="preserve">Mined</source>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg916">
+        <source xml:space="preserve">Other</source>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg917">
+        <source xml:space="preserve">Enter address, transaction id, or label to search</source>
+        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg918">
+        <source xml:space="preserve">Min amount</source>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg919">
+        <source xml:space="preserve">Range…</source>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
       <trans-unit id="_msg920">
-        <source xml:space="preserve">Today</source>
-        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
+        <source xml:space="preserve">&amp;Copy address</source>
+        <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
       </trans-unit>
       <trans-unit id="_msg921">
-        <source xml:space="preserve">This week</source>
-        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
+        <source xml:space="preserve">Copy &amp;label</source>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
       <trans-unit id="_msg922">
-        <source xml:space="preserve">This month</source>
-        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
+        <source xml:space="preserve">Copy &amp;amount</source>
+        <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
       </trans-unit>
       <trans-unit id="_msg923">
-        <source xml:space="preserve">Last month</source>
-        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
+        <source xml:space="preserve">Copy transaction &amp;ID</source>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
       </trans-unit>
       <trans-unit id="_msg924">
-        <source xml:space="preserve">This year</source>
-        <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
+        <source xml:space="preserve">Copy &amp;raw transaction</source>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
       <trans-unit id="_msg925">
-        <source xml:space="preserve">Received with</source>
-        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+        <source xml:space="preserve">Copy full transaction &amp;details</source>
+        <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
       </trans-unit>
       <trans-unit id="_msg926">
-        <source xml:space="preserve">Sent to</source>
-        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+        <source xml:space="preserve">&amp;Show transaction details</source>
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
       <trans-unit id="_msg927">
-        <source xml:space="preserve">Mined</source>
-        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg928">
-        <source xml:space="preserve">Other</source>
-        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg929">
-        <source xml:space="preserve">Enter address, transaction id, or label to search</source>
-        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg930">
-        <source xml:space="preserve">Min amount</source>
-        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg931">
-        <source xml:space="preserve">Range…</source>
-        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg932">
-        <source xml:space="preserve">&amp;Copy address</source>
+        <source xml:space="preserve">Increase transaction &amp;fee</source>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg933">
-        <source xml:space="preserve">Copy &amp;label</source>
-        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg934">
-        <source xml:space="preserve">Copy &amp;amount</source>
-        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg935">
-        <source xml:space="preserve">Copy transaction &amp;ID</source>
+      <trans-unit id="_msg928">
+        <source xml:space="preserve">A&amp;bandon transaction</source>
         <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg936">
-        <source xml:space="preserve">Copy &amp;raw transaction</source>
+      <trans-unit id="_msg929">
+        <source xml:space="preserve">&amp;Edit address label</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg937">
-        <source xml:space="preserve">Copy full transaction &amp;details</source>
-        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg938">
-        <source xml:space="preserve">&amp;Show transaction details</source>
-        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg939">
-        <source xml:space="preserve">Increase transaction &amp;fee</source>
-        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg940">
-        <source xml:space="preserve">A&amp;bandon transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg941">
-        <source xml:space="preserve">&amp;Edit address label</source>
-        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg942">
+      <trans-unit id="_msg930">
         <source xml:space="preserve">Show in %1</source>
-        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
         <note annotates="source" from="developer">Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</note>
       </trans-unit>
-      <trans-unit id="_msg943">
+      <trans-unit id="_msg931">
         <source xml:space="preserve">Export Transaction History</source>
-        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg944">
+      <trans-unit id="_msg932">
         <source xml:space="preserve">Comma separated file</source>
-        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</note>
       </trans-unit>
-      <trans-unit id="_msg945">
+      <trans-unit id="_msg933">
         <source xml:space="preserve">Confirmed</source>
-        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg946">
-        <source xml:space="preserve">Watch-only</source>
-        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg947">
+      <trans-unit id="_msg934">
         <source xml:space="preserve">Date</source>
-        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg948">
+      <trans-unit id="_msg935">
         <source xml:space="preserve">Type</source>
-        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg949">
+      <trans-unit id="_msg936">
         <source xml:space="preserve">Label</source>
-        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg950">
+      <trans-unit id="_msg937">
         <source xml:space="preserve">Address</source>
-        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg951">
+      <trans-unit id="_msg938">
         <source xml:space="preserve">ID</source>
-        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg952">
+      <trans-unit id="_msg939">
         <source xml:space="preserve">Exporting Failed</source>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg953">
+      <trans-unit id="_msg940">
         <source xml:space="preserve">There was an error trying to save the transaction history to %1.</source>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg954">
+      <trans-unit id="_msg941">
         <source xml:space="preserve">Exporting Successful</source>
-        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg955">
+      <trans-unit id="_msg942">
         <source xml:space="preserve">The transaction history was successfully saved to %1.</source>
-        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg956">
+      <trans-unit id="_msg943">
         <source xml:space="preserve">Range:</source>
-        <context-group purpose="location"><context context-type="linenumber">558</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">527</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg957">
+      <trans-unit id="_msg944">
         <source xml:space="preserve">to</source>
-        <context-group purpose="location"><context context-type="linenumber">566</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">535</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../walletframe.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletFrame">
-      <trans-unit id="_msg958">
+      <trans-unit id="_msg945">
         <source xml:space="preserve">No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
         <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg959">
+      <trans-unit id="_msg946">
         <source xml:space="preserve">Create a new wallet</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg960">
+      <trans-unit id="_msg947">
         <source xml:space="preserve">Error</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg961">
+      <trans-unit id="_msg948">
         <source xml:space="preserve">Unable to decode PSBT from clipboard (invalid base64)</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg962">
+      <trans-unit id="_msg949">
         <source xml:space="preserve">Load Transaction Data</source>
         <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg963">
+      <trans-unit id="_msg950">
         <source xml:space="preserve">Partially Signed Transaction (*.psbt)</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg964">
+      <trans-unit id="_msg951">
         <source xml:space="preserve">PSBT file must be smaller than 100 MiB</source>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg965">
+      <trans-unit id="_msg952">
         <source xml:space="preserve">Unable to decode PSBT</source>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
@@ -4438,113 +4383,113 @@ Go to File &gt; Open Wallet to load a wallet.
   </body></file>
   <file original="../walletmodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletModel">
-      <trans-unit id="_msg966">
+      <trans-unit id="_msg953">
         <source xml:space="preserve">Send Coins</source>
-        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg967">
+      <trans-unit id="_msg954">
         <source xml:space="preserve">Fee bump error</source>
-        <context-group purpose="location"><context context-type="linenumber">491</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">540</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">560</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">565</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">476</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">525</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">545</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">550</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg968">
+      <trans-unit id="_msg955">
         <source xml:space="preserve">Increasing transaction fee failed</source>
-        <context-group purpose="location"><context context-type="linenumber">491</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">476</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg969">
+      <trans-unit id="_msg956">
         <source xml:space="preserve">Do you want to increase the fee?</source>
-        <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">483</context></context-group>
         <note annotates="source" from="developer">Asks a user if they would like to manually increase the fee of a transaction that has already been created.</note>
       </trans-unit>
-      <trans-unit id="_msg970">
+      <trans-unit id="_msg957">
         <source xml:space="preserve">Current fee:</source>
-        <context-group purpose="location"><context context-type="linenumber">502</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">487</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg971">
+      <trans-unit id="_msg958">
         <source xml:space="preserve">Increase:</source>
-        <context-group purpose="location"><context context-type="linenumber">506</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">491</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg972">
+      <trans-unit id="_msg959">
         <source xml:space="preserve">New fee:</source>
-        <context-group purpose="location"><context context-type="linenumber">510</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg973">
+      <trans-unit id="_msg960">
         <source xml:space="preserve">Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
-        <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg974">
+      <trans-unit id="_msg961">
         <source xml:space="preserve">Confirm fee bump</source>
-        <context-group purpose="location"><context context-type="linenumber">523</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">508</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg975">
+      <trans-unit id="_msg962">
         <source xml:space="preserve">Can&apos;t draft transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">540</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">525</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg976">
+      <trans-unit id="_msg963">
         <source xml:space="preserve">PSBT copied</source>
-        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">532</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg977">
+      <trans-unit id="_msg964">
         <source xml:space="preserve">Fee-bump PSBT copied to clipboard</source>
-        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">532</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg978">
+      <trans-unit id="_msg965">
         <source xml:space="preserve">Can&apos;t sign transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">560</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">545</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg979">
+      <trans-unit id="_msg966">
         <source xml:space="preserve">Could not commit transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">565</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">550</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg980">
+      <trans-unit id="_msg967">
         <source xml:space="preserve">Signer error</source>
-        <context-group purpose="location"><context context-type="linenumber">578</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">563</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg981">
+      <trans-unit id="_msg968">
         <source xml:space="preserve">Can&apos;t display address</source>
-        <context-group purpose="location"><context context-type="linenumber">581</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">566</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../walletview.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletView">
-      <trans-unit id="_msg982">
+      <trans-unit id="_msg969">
         <source xml:space="preserve">&amp;Export</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg983">
+      <trans-unit id="_msg970">
         <source xml:space="preserve">Export the data in the current tab to a file</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg984">
+      <trans-unit id="_msg971">
         <source xml:space="preserve">Backup Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg985">
+      <trans-unit id="_msg972">
         <source xml:space="preserve">Wallet Data</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
         <note annotates="source" from="developer">Name of the wallet data file format.</note>
       </trans-unit>
-      <trans-unit id="_msg986">
+      <trans-unit id="_msg973">
         <source xml:space="preserve">Backup Failed</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg987">
+      <trans-unit id="_msg974">
         <source xml:space="preserve">There was an error trying to save the wallet data to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg988">
+      <trans-unit id="_msg975">
         <source xml:space="preserve">Backup Successful</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg989">
+      <trans-unit id="_msg976">
         <source xml:space="preserve">The wallet data was successfully saved to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg990">
+      <trans-unit id="_msg977">
         <source xml:space="preserve">Cancel</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
@@ -4552,1047 +4497,1043 @@ Go to File &gt; Open Wallet to load a wallet.
   </body></file>
   <file original="../bitcoinstrings.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="bitcoin-core">
-      <trans-unit id="_msg991">
+      <trans-unit id="_msg978">
         <source xml:space="preserve">The %s developers</source>
         <context-group purpose="location"><context context-type="linenumber">12</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg992">
-        <source xml:space="preserve">%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
+      <trans-unit id="_msg979">
+        <source xml:space="preserve">%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
         <context-group purpose="location"><context context-type="linenumber">13</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg993">
-        <source xml:space="preserve">%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
-        <context-group purpose="location"><context context-type="linenumber">16</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg994">
+      <trans-unit id="_msg980">
         <source xml:space="preserve">%s request to listen on port %u. This port is considered &quot;bad&quot; and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
-        <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg995">
-        <source xml:space="preserve">Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+      <trans-unit id="_msg981">
+        <source xml:space="preserve">Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
         <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg996">
-        <source xml:space="preserve">Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
-        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg997">
-        <source xml:space="preserve">Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg998">
+      <trans-unit id="_msg982">
         <source xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg999">
-        <source xml:space="preserve">Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
-        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1000">
-        <source xml:space="preserve">Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1001">
-        <source xml:space="preserve">Error starting/committing db txn for wallet transactions removal process</source>
-        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1002">
-        <source xml:space="preserve">Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1003">
-        <source xml:space="preserve">Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1004">
-        <source xml:space="preserve">Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1005">
-        <source xml:space="preserve">Error: Legacy wallets only support the &quot;legacy&quot;, &quot;p2sh-segwit&quot;, and &quot;bech32&quot; address types</source>
-        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1006">
-        <source xml:space="preserve">Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet&apos;s passphrase if it is encrypted.</source>
-        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1007">
-        <source xml:space="preserve">File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
-        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1008">
-        <source xml:space="preserve">Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
-        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1009">
-        <source xml:space="preserve">Invalid value detected for &apos;-wallet&apos; or &apos;-nowallet&apos;. &apos;-wallet&apos; requires a string value, while &apos;-nowallet&apos; accepts only &apos;1&apos; to disable all wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1010">
-        <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1011">
-        <source xml:space="preserve">No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1012">
-        <source xml:space="preserve">No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1013">
-        <source xml:space="preserve">No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
-        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1014">
-        <source xml:space="preserve">Option &apos;-upnp&apos; is set but UPnP support was dropped in version 29.0. Consider using &apos;-natpmp&apos; instead.</source>
-        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1015">
-        <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1016">
-        <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1017">
-        <source xml:space="preserve">Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
-        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1018">
-        <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1019">
-        <source xml:space="preserve">Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
-        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1020">
-        <source xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
-        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1021">
-        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
-        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1022">
-        <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
-        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1023">
-        <source xml:space="preserve">This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1024">
-        <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1025">
-        <source xml:space="preserve">This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1026">
-        <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1027">
-        <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
-        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1028">
-        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1029">
-        <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1030">
-        <source xml:space="preserve">Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1031">
-        <source xml:space="preserve">Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
-        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1032">
-        <source xml:space="preserve">Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
-        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1033">
-        <source xml:space="preserve">Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
-        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1034">
-        <source xml:space="preserve">Wallet loaded successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future. Legacy wallets can be migrated to a descriptor wallet with migratewallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1035">
-        <source xml:space="preserve">Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1036">
-        <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1037">
-        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1038">
-        <source xml:space="preserve">Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
-        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1039">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1040">
-        <source xml:space="preserve">%s is set very high!</source>
-        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1041">
-        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
-        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1042">
-        <source xml:space="preserve">Cannot obtain a lock on directory %s. %s is probably already running.</source>
-        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1043">
-        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1044">
-        <source xml:space="preserve">Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
-        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1045">
-        <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
-        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1046">
-        <source xml:space="preserve">%s is set very high! Fees this large could be paid on a single transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">26</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1047">
-        <source xml:space="preserve">Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1048">
-        <source xml:space="preserve">Error loading %s: External signer wallet being loaded without external signer support compiled</source>
-        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      <trans-unit id="_msg983">
+        <source xml:space="preserve">Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1049">
-        <source xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
-        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
+      <trans-unit id="_msg984">
+        <source xml:space="preserve">Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1050">
-        <source xml:space="preserve">Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      <trans-unit id="_msg985">
+        <source xml:space="preserve">Error starting/committing db txn for wallet transactions removal process</source>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1051">
-        <source xml:space="preserve">Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
-        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
+      <trans-unit id="_msg986">
+        <source xml:space="preserve">Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1052">
-        <source xml:space="preserve">Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
+      <trans-unit id="_msg987">
+        <source xml:space="preserve">Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1053">
-        <source xml:space="preserve">Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.</source>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+      <trans-unit id="_msg988">
+        <source xml:space="preserve">Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1054">
-        <source xml:space="preserve">Failed to remove snapshot chainstate dir (%s). Manually remove it before restarting.
-</source>
-        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+      <trans-unit id="_msg989">
+        <source xml:space="preserve">Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet&apos;s passphrase if it is encrypted.</source>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1055">
-        <source xml:space="preserve">Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+      <trans-unit id="_msg990">
+        <source xml:space="preserve">File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1056">
-        <source xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+      <trans-unit id="_msg991">
+        <source xml:space="preserve">Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1057">
-        <source xml:space="preserve">Flushing block file to disk failed. This is likely the result of an I/O error.</source>
-        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1058">
-        <source xml:space="preserve">Flushing undo file to disk failed. This is likely the result of an I/O error.</source>
-        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1059">
-        <source xml:space="preserve">Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
-        <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1060">
-        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+      <trans-unit id="_msg992">
+        <source xml:space="preserve">Invalid value detected for &apos;-wallet&apos; or &apos;-nowallet&apos;. &apos;-wallet&apos; requires a string value, while &apos;-nowallet&apos; accepts only &apos;1&apos; to disable all wallets</source>
         <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1061">
-        <source xml:space="preserve">Maximum transaction weight is less than transaction weight without inputs</source>
+      <trans-unit id="_msg993">
+        <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
+        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg994">
+        <source xml:space="preserve">No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
         <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1062">
-        <source xml:space="preserve">Maximum transaction weight is too low, can not accommodate change output</source>
-        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+      <trans-unit id="_msg995">
+        <source xml:space="preserve">No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1063">
-        <source xml:space="preserve">Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
-        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
+      <trans-unit id="_msg996">
+        <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1064">
-        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
-        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      <trans-unit id="_msg997">
+        <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1065">
-        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
-        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      <trans-unit id="_msg998">
+        <source xml:space="preserve">Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1066">
-        <source xml:space="preserve">Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
-        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+      <trans-unit id="_msg999">
+        <source xml:space="preserve">Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
+        <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1067">
-        <source xml:space="preserve">Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. Cannot clean up the background chainstate leveldb directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+      <trans-unit id="_msg1000">
+        <source xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1068">
-        <source xml:space="preserve">Specified -blockmaxweight (%d) exceeds consensus maximum block weight (%d)</source>
-        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
+      <trans-unit id="_msg1001">
+        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
+        <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1069">
-        <source xml:space="preserve">Specified -blockreservedweight (%d) exceeds consensus maximum block weight (%d)</source>
-        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1070">
-        <source xml:space="preserve">Specified -blockreservedweight (%d) is lower than minimum safety value of (%d)</source>
-        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1071">
-        <source xml:space="preserve">The combination of the pre-selected inputs and the wallet automatic inputs selection exceeds the transaction maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
-        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1072">
-        <source xml:space="preserve">The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
-        <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1073">
-        <source xml:space="preserve">The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
+      <trans-unit id="_msg1002">
+        <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
         <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1074">
-        <source xml:space="preserve">Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input</source>
-        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      <trans-unit id="_msg1003">
+        <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1075">
+      <trans-unit id="_msg1004">
+        <source xml:space="preserve">This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1005">
+        <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
+        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1006">
+        <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
+        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1007">
+        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
+        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1008">
+        <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1009">
+        <source xml:space="preserve">Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1010">
+        <source xml:space="preserve">Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1011">
+        <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1012">
+        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1013">
+        <source xml:space="preserve">Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1014">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1015">
+        <source xml:space="preserve">%s is set very high!</source>
+        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1016">
+        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
+        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1017">
+        <source xml:space="preserve">Cannot obtain a lock on directory %s. %s is probably already running.</source>
+        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1018">
+        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1019">
+        <source xml:space="preserve">Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1020">
+        <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1021">
+        <source xml:space="preserve">%s is set very high! Fees this large could be paid on a single transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1022">
+        <source xml:space="preserve">Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1023">
+        <source xml:space="preserve">Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1024">
+        <source xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1025">
+        <source xml:space="preserve">Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1026">
+        <source xml:space="preserve">Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1027">
+        <source xml:space="preserve">Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1028">
+        <source xml:space="preserve">Failed to remove snapshot chainstate dir (%s). Manually remove it before restarting.
+</source>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1029">
+        <source xml:space="preserve">Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1030">
+        <source xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1031">
+        <source xml:space="preserve">Flushing block file to disk failed. This is likely the result of an I/O error.</source>
+        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1032">
+        <source xml:space="preserve">Flushing undo file to disk failed. This is likely the result of an I/O error.</source>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1033">
+        <source xml:space="preserve">Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1034">
+        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1035">
+        <source xml:space="preserve">Maximum transaction weight is less than transaction weight without inputs</source>
+        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1036">
+        <source xml:space="preserve">Maximum transaction weight is too low, can not accommodate change output</source>
+        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1037">
+        <source xml:space="preserve">Option &apos;-checkpoints&apos; is set but checkpoints were removed. This option has no effect.</source>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1038">
+        <source xml:space="preserve">Option &apos;-maxorphantx&apos; is set but no longer has any effect (see release notes). Please remove it from your configuration.</source>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1039">
+        <source xml:space="preserve">Options &apos;-datacarrier&apos; or &apos;-datacarriersize&apos; are set but are marked as deprecated. They will be removed in a future version.</source>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1040">
+        <source xml:space="preserve">Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
+        <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1041">
+        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1042">
+        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1043">
+        <source xml:space="preserve">Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1044">
+        <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)</source>
+        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1045">
+        <source xml:space="preserve">Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. Cannot clean up the background chainstate leveldb directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1046">
+        <source xml:space="preserve">Specified -blockmaxweight (%d) exceeds consensus maximum block weight (%d)</source>
+        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1047">
+        <source xml:space="preserve">Specified -blockreservedweight (%d) exceeds consensus maximum block weight (%d)</source>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1048">
+        <source xml:space="preserve">Specified -blockreservedweight (%d) is lower than minimum safety value of (%d)</source>
+        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1049">
+        <source xml:space="preserve">The combination of the pre-selected inputs and the wallet automatic inputs selection exceeds the transaction maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1050">
+        <source xml:space="preserve">The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
+        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1051">
+        <source xml:space="preserve">The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
+        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1052">
         <source xml:space="preserve">UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
-        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1076">
+      <trans-unit id="_msg1053">
         <source xml:space="preserve">Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
-        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1077">
+      <trans-unit id="_msg1054">
         <source xml:space="preserve">Unexpected legacy entry in descriptor wallet found. Loading wallet %s
 
 The wallet might have been tampered with or created with malicious intent.
 </source>
-        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1078">
-        <source xml:space="preserve">Unrecognized descriptor found. Loading wallet %s
-
-The wallet might had been created on a newer version.
-Please try running the latest software version.
-</source>
-        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1079">
+      <trans-unit id="_msg1055">
         <source xml:space="preserve">Your computer&apos;s date and time appear to be more than %d minutes out of sync with the network, this may lead to consensus failure. After you&apos;ve confirmed your computer&apos;s clock, this message should no longer appear when you restart your node. Without a restart, it should stop showing automatically after you&apos;ve connected to a sufficient number of new outbound peers, which may take some time. You can inspect the `timeoffset` field of the `getpeerinfo` and `getnetworkinfo` RPC methods to get more info.</source>
-        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1080">
+      <trans-unit id="_msg1056">
         <source xml:space="preserve">
 Unable to cleanup failed migration</source>
-        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1081">
+      <trans-unit id="_msg1057">
         <source xml:space="preserve">
 Unable to restore backup of wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1058">
+        <source xml:space="preserve">whitebind may only be used for incoming connections (&quot;out&quot; was passed)</source>
+        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1059">
+        <source xml:space="preserve">-paytxfee is deprecated and will be fully removed in v31.0.</source>
+        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1060">
+        <source xml:space="preserve">A fatal internal error occurred, see debug.log for details: </source>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1061">
+        <source xml:space="preserve">Assumeutxo data not found for the given blockhash &apos;%s&apos;.</source>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1062">
+        <source xml:space="preserve">Block verification was interrupted</source>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1063">
+        <source xml:space="preserve">Cannot add WalletDescriptor to a non-descriptor wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1064">
+        <source xml:space="preserve">Cannot write to directory &apos;%s&apos;; check permissions.</source>
+        <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1065">
+        <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
+        <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1066">
+        <source xml:space="preserve">Copyright (C) %i-%i</source>
+        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1067">
+        <source xml:space="preserve">Corrupt block found indicating potential hardware failure.</source>
+        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1068">
+        <source xml:space="preserve">Corrupted block database detected</source>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1069">
+        <source xml:space="preserve">Could not find asmap file %s</source>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1070">
+        <source xml:space="preserve">Could not generate scriptPubKeys (cache is empty)</source>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1071">
+        <source xml:space="preserve">Could not parse asmap file %s</source>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1082">
-        <source xml:space="preserve">whitebind may only be used for incoming connections (&quot;out&quot; was passed)</source>
-        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+      <trans-unit id="_msg1072">
+        <source xml:space="preserve">Could not top up scriptPubKeys</source>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1083">
-        <source xml:space="preserve">A fatal internal error occurred, see debug.log for details: </source>
+      <trans-unit id="_msg1073">
+        <source xml:space="preserve">Disk space is too low!</source>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1074">
+        <source xml:space="preserve">Done loading</source>
+        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1075">
+        <source xml:space="preserve">Dump file %s does not exist.</source>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1076">
+        <source xml:space="preserve">Elliptic curve cryptography sanity check failure. %s is shutting down.</source>
+        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1077">
+        <source xml:space="preserve">Error creating %s</source>
         <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1084">
-        <source xml:space="preserve">Assumeutxo data not found for the given blockhash &apos;%s&apos;.</source>
+      <trans-unit id="_msg1078">
+        <source xml:space="preserve">Error initializing block database</source>
         <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1085">
-        <source xml:space="preserve">Block verification was interrupted</source>
+      <trans-unit id="_msg1079">
+        <source xml:space="preserve">Error loading %s</source>
         <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1086">
-        <source xml:space="preserve">Cannot write to directory &apos;%s&apos;; check permissions.</source>
+      <trans-unit id="_msg1080">
+        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
+        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1081">
+        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1082">
+        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
+        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1083">
+        <source xml:space="preserve">Error loading block database</source>
+        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1084">
+        <source xml:space="preserve">Error loading databases</source>
         <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1087">
-        <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
+      <trans-unit id="_msg1085">
+        <source xml:space="preserve">Error opening block database</source>
         <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1088">
-        <source xml:space="preserve">Copyright (C) %i-%i</source>
+      <trans-unit id="_msg1086">
+        <source xml:space="preserve">Error opening coins database</source>
         <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1089">
-        <source xml:space="preserve">Corrupt block found indicating potential hardware failure.</source>
+      <trans-unit id="_msg1087">
+        <source xml:space="preserve">Error reading configuration file: %s</source>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1090">
-        <source xml:space="preserve">Corrupted block database detected</source>
+      <trans-unit id="_msg1088">
+        <source xml:space="preserve">Error reading from database, shutting down.</source>
         <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1091">
-        <source xml:space="preserve">Could not find asmap file %s</source>
+      <trans-unit id="_msg1089">
+        <source xml:space="preserve">Error reading next record from wallet database</source>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1092">
-        <source xml:space="preserve">Could not parse asmap file %s</source>
+      <trans-unit id="_msg1090">
+        <source xml:space="preserve">Error: Cannot extract destination from the generated scriptpubkey</source>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1093">
-        <source xml:space="preserve">Disk space is too low!</source>
-        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1094">
-        <source xml:space="preserve">Done loading</source>
+      <trans-unit id="_msg1091">
+        <source xml:space="preserve">Error: Couldn&apos;t create cursor into database</source>
         <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1095">
-        <source xml:space="preserve">Dump file %s does not exist.</source>
+      <trans-unit id="_msg1092">
+        <source xml:space="preserve">Error: Disk space is low for %s</source>
         <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1096">
-        <source xml:space="preserve">Elliptic curve cryptography sanity check failure. %s is shutting down.</source>
+      <trans-unit id="_msg1093">
+        <source xml:space="preserve">Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1097">
-        <source xml:space="preserve">Error creating %s</source>
+      <trans-unit id="_msg1094">
+        <source xml:space="preserve">Error: Failed to create new watchonly wallet</source>
         <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1098">
-        <source xml:space="preserve">Error initializing block database</source>
+      <trans-unit id="_msg1095">
+        <source xml:space="preserve">Error: Got key that was not hex: %s</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1099">
-        <source xml:space="preserve">Error initializing wallet database environment %s!</source>
+      <trans-unit id="_msg1096">
+        <source xml:space="preserve">Error: Got value that was not hex: %s</source>
         <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1100">
-        <source xml:space="preserve">Error loading %s</source>
+      <trans-unit id="_msg1097">
+        <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
         <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1101">
-        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
+      <trans-unit id="_msg1098">
+        <source xml:space="preserve">Error: Missing checksum</source>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1102">
-        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
+      <trans-unit id="_msg1099">
+        <source xml:space="preserve">Error: No %s addresses available.</source>
         <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1103">
-        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
+      <trans-unit id="_msg1100">
+        <source xml:space="preserve">Error: Not all address book records were migrated</source>
         <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1104">
-        <source xml:space="preserve">Error loading block database</source>
+      <trans-unit id="_msg1101">
+        <source xml:space="preserve">Error: Not all transaction records were migrated</source>
         <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1105">
-        <source xml:space="preserve">Error loading databases</source>
+      <trans-unit id="_msg1102">
+        <source xml:space="preserve">Error: This wallet already uses SQLite</source>
         <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1106">
-        <source xml:space="preserve">Error opening block database</source>
+      <trans-unit id="_msg1103">
+        <source xml:space="preserve">Error: This wallet is already a descriptor wallet</source>
         <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1107">
-        <source xml:space="preserve">Error opening coins database</source>
+      <trans-unit id="_msg1104">
+        <source xml:space="preserve">Error: Unable to begin reading all records in the database</source>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1108">
-        <source xml:space="preserve">Error reading configuration file: %s</source>
+      <trans-unit id="_msg1105">
+        <source xml:space="preserve">Error: Unable to make a backup of your wallet</source>
         <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1109">
-        <source xml:space="preserve">Error reading from database, shutting down.</source>
+      <trans-unit id="_msg1106">
+        <source xml:space="preserve">Error: Unable to parse version %u as a uint32_t</source>
         <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1110">
-        <source xml:space="preserve">Error reading next record from wallet database</source>
+      <trans-unit id="_msg1107">
+        <source xml:space="preserve">Error: Unable to read all records in the database</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1111">
-        <source xml:space="preserve">Error: Cannot extract destination from the generated scriptpubkey</source>
+      <trans-unit id="_msg1108">
+        <source xml:space="preserve">Error: Unable to read wallet&apos;s best block locator record</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1112">
-        <source xml:space="preserve">Error: Couldn&apos;t create cursor into database</source>
-        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1113">
-        <source xml:space="preserve">Error: Disk space is low for %s</source>
-        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1114">
-        <source xml:space="preserve">Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
-        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1115">
-        <source xml:space="preserve">Error: Failed to create new watchonly wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1116">
-        <source xml:space="preserve">Error: Got key that was not hex: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1117">
-        <source xml:space="preserve">Error: Got value that was not hex: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1118">
-        <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
-        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1119">
-        <source xml:space="preserve">Error: Missing checksum</source>
-        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1120">
-        <source xml:space="preserve">Error: No %s addresses available.</source>
-        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1121">
-        <source xml:space="preserve">Error: This wallet already uses SQLite</source>
-        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1122">
-        <source xml:space="preserve">Error: This wallet is already a descriptor wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1123">
-        <source xml:space="preserve">Error: Unable to begin reading all records in the database</source>
-        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1124">
-        <source xml:space="preserve">Error: Unable to make a backup of your wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1125">
-        <source xml:space="preserve">Error: Unable to parse version %u as a uint32_t</source>
-        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1126">
-        <source xml:space="preserve">Error: Unable to read all records in the database</source>
-        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1127">
-        <source xml:space="preserve">Error: Unable to read wallet&apos;s best block locator record</source>
-        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1128">
+      <trans-unit id="_msg1109">
         <source xml:space="preserve">Error: Unable to remove watchonly address book data</source>
-        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1129">
-        <source xml:space="preserve">Error: Unable to write data to disk for wallet %s</source>
-        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1130">
-        <source xml:space="preserve">Error: Unable to write record to new wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1131">
-        <source xml:space="preserve">Error: Unable to write solvable wallet best block locator record</source>
-        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1132">
-        <source xml:space="preserve">Error: Unable to write watchonly wallet best block locator record</source>
-        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1133">
-        <source xml:space="preserve">Error: database transaction cannot be executed for wallet %s</source>
-        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1134">
-        <source xml:space="preserve">Failed to connect best block (%s).</source>
-        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1135">
-        <source xml:space="preserve">Failed to disconnect block.</source>
-        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1136">
-        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1137">
-        <source xml:space="preserve">Failed to read block.</source>
-        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1138">
-        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
-        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1139">
-        <source xml:space="preserve">Failed to start indexes, shutting down..</source>
-        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1140">
-        <source xml:space="preserve">Failed to verify database</source>
-        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1141">
-        <source xml:space="preserve">Failed to write block.</source>
-        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1142">
-        <source xml:space="preserve">Failed to write to block index database.</source>
-        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1143">
-        <source xml:space="preserve">Failed to write to coin database.</source>
-        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1144">
-        <source xml:space="preserve">Failed to write undo data.</source>
-        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1145">
-        <source xml:space="preserve">Failure removing transaction: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1146">
-        <source xml:space="preserve">Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
-        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1147">
-        <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1148">
-        <source xml:space="preserve">Importing…</source>
-        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1149">
-        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1150">
-        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
-        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1151">
-        <source xml:space="preserve">Input not found or already spent</source>
-        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1152">
-        <source xml:space="preserve">Insufficient dbcache for block verification</source>
-        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1153">
-        <source xml:space="preserve">Insufficient funds</source>
-        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1154">
-        <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1155">
-        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1156">
-        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1157">
-        <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1158">
-        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
-        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1159">
-        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1160">
-        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1161">
-        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1162">
-        <source xml:space="preserve">Invalid port specified in %s: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1163">
-        <source xml:space="preserve">Invalid pre-selected input %s</source>
-        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1164">
-        <source xml:space="preserve">Listening for incoming connections failed (listen returned error %s)</source>
-        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1165">
-        <source xml:space="preserve">Loading P2P addresses…</source>
-        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1166">
-        <source xml:space="preserve">Loading banlist…</source>
-        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1167">
-        <source xml:space="preserve">Loading block index…</source>
-        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1168">
-        <source xml:space="preserve">Loading wallet…</source>
-        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1169">
-        <source xml:space="preserve">Maximum transaction weight must be between %d and %d</source>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1170">
-        <source xml:space="preserve">Missing amount</source>
-        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1171">
-        <source xml:space="preserve">Missing solving data for estimating transaction size</source>
-        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1172">
-        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1173">
-        <source xml:space="preserve">No addresses available</source>
-        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1174">
-        <source xml:space="preserve">Not found pre-selected input %s</source>
-        <context-group purpose="location"><context context-type="linenumber">387</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1175">
-        <source xml:space="preserve">Not solvable pre-selected input %s</source>
-        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1176">
-        <source xml:space="preserve">Only direction was set, no permissions: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1177">
-        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
-        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1178">
-        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
-        <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1179">
-        <source xml:space="preserve">Pruning blockstore…</source>
-        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1180">
-        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1181">
-        <source xml:space="preserve">Replaying blocks…</source>
-        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1182">
-        <source xml:space="preserve">Rescanning…</source>
-        <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1183">
-        <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1184">
-        <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">397</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1185">
-        <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1186">
-        <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <context-group purpose="location"><context context-type="linenumber">399</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1187">
-        <source xml:space="preserve">Section [%s] is not recognized.</source>
-        <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1188">
-        <source xml:space="preserve">Signer did not echo address</source>
-        <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1189">
-        <source xml:space="preserve">Signer echoed unexpected address %s</source>
-        <context-group purpose="location"><context context-type="linenumber">404</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1190">
-        <source xml:space="preserve">Signer returned error: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1191">
-        <source xml:space="preserve">Signing transaction failed</source>
-        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1192">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
-        <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1193">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
-        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1194">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
-        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1195">
-        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
-        <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1196">
-        <source xml:space="preserve">Specified data directory &quot;%s&quot; does not exist.</source>
-        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1197">
-        <source xml:space="preserve">Starting network threads…</source>
-        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1198">
-        <source xml:space="preserve">System error while flushing: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">413</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1199">
-        <source xml:space="preserve">System error while loading external block file: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1200">
-        <source xml:space="preserve">System error while saving block to disk: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1201">
-        <source xml:space="preserve">The source code is available from %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1202">
-        <source xml:space="preserve">The specified config file %s does not exist</source>
-        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1203">
-        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
-        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1204">
-        <source xml:space="preserve">The transactions removal process can only be executed within a db txn</source>
-        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1205">
-        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
-        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1206">
-        <source xml:space="preserve">There is no ScriptPubKeyManager for this address</source>
-        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1207">
-        <source xml:space="preserve">This is experimental software.</source>
-        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1208">
-        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1209">
-        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1210">
-        <source xml:space="preserve">Transaction %s does not belong to this wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1211">
-        <source xml:space="preserve">Transaction amount too small</source>
-        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1212">
-        <source xml:space="preserve">Transaction amounts must not be negative</source>
-        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1213">
-        <source xml:space="preserve">Transaction change output index out of range</source>
-        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1214">
-        <source xml:space="preserve">Transaction must have at least one recipient</source>
-        <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1215">
-        <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it.</source>
-        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1216">
-        <source xml:space="preserve">Transaction too large</source>
-        <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1217">
-        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
-        <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1218">
-        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
-        <context-group purpose="location"><context context-type="linenumber">433</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1219">
-        <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1220">
-        <source xml:space="preserve">Unable to find UTXO for external input</source>
-        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1221">
-        <source xml:space="preserve">Unable to generate initial keys</source>
-        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1222">
-        <source xml:space="preserve">Unable to generate keys</source>
-        <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1223">
-        <source xml:space="preserve">Unable to open %s for writing</source>
-        <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1224">
-        <source xml:space="preserve">Unable to parse -maxuploadtarget: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">439</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1225">
-        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
-        <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1226">
-        <source xml:space="preserve">Unable to unload the wallet before migrating</source>
-        <context-group purpose="location"><context context-type="linenumber">441</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1227">
-        <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1228">
-        <source xml:space="preserve">Unknown address type &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1229">
-        <source xml:space="preserve">Unknown change type &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1230">
-        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">445</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1231">
-        <source xml:space="preserve">Unknown new rules activated (versionbit %i)</source>
-        <context-group purpose="location"><context context-type="linenumber">446</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1232">
-        <source xml:space="preserve">Unrecognised option &quot;%s&quot; provided in -test=&lt;option&gt;.</source>
-        <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1233">
-        <source xml:space="preserve">Unsupported global logging level %s=%s. Valid values: %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">448</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1234">
-        <source xml:space="preserve">Wallet file creation failed: %s</source>
-        <context-group purpose="location"><context context-type="linenumber">453</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1235">
-        <source xml:space="preserve">acceptstalefeeestimates is not supported on %s chain.</source>
-        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1236">
-        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
-        <context-group purpose="location"><context context-type="linenumber">449</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1237">
-        <source xml:space="preserve">Do you want to rebuild the databases now?</source>
-        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1238">
-        <source xml:space="preserve">Error: Could not add watchonly tx %s to watchonly wallet</source>
         <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1239">
-        <source xml:space="preserve">Error: Could not delete watchonly transactions. </source>
+      <trans-unit id="_msg1110">
+        <source xml:space="preserve">Error: Unable to write data to disk for wallet %s</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1240">
-        <source xml:space="preserve">Error: Wallet does not exist</source>
+      <trans-unit id="_msg1111">
+        <source xml:space="preserve">Error: Unable to write record to new wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1112">
+        <source xml:space="preserve">Error: Unable to write solvable wallet best block locator record</source>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1113">
+        <source xml:space="preserve">Error: Unable to write watchonly wallet best block locator record</source>
+        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1114">
+        <source xml:space="preserve">Error: database transaction cannot be executed for wallet %s</source>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1115">
+        <source xml:space="preserve">Failed to acquire rescan reserver during wallet initialization</source>
+        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1116">
+        <source xml:space="preserve">Failed to close block undo file.</source>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1117">
+        <source xml:space="preserve">Failed to close file when writing block.</source>
+        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1118">
+        <source xml:space="preserve">Failed to connect best block (%s).</source>
+        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1119">
+        <source xml:space="preserve">Failed to disconnect block.</source>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1120">
+        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1121">
+        <source xml:space="preserve">Failed to read block.</source>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1122">
+        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1123">
+        <source xml:space="preserve">Failed to verify database</source>
+        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1124">
+        <source xml:space="preserve">Failed to write block.</source>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1125">
+        <source xml:space="preserve">Failed to write to block index database.</source>
+        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1126">
+        <source xml:space="preserve">Failed to write to coin database.</source>
+        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1127">
+        <source xml:space="preserve">Failed to write undo data.</source>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1128">
+        <source xml:space="preserve">Failure removing transaction: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1129">
+        <source xml:space="preserve">Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
         <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1241">
-        <source xml:space="preserve">Error: cannot remove legacy wallet records</source>
+      <trans-unit id="_msg1130">
+        <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
         <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1242">
-        <source xml:space="preserve">Not enough file descriptors available. %d available, %d required.</source>
-        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
+      <trans-unit id="_msg1131">
+        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
+        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1243">
-        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
-        <context-group purpose="location"><context context-type="linenumber">450</context></context-group>
+      <trans-unit id="_msg1132">
+        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1244">
-        <source xml:space="preserve">Verifying blocks…</source>
-        <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
+      <trans-unit id="_msg1133">
+        <source xml:space="preserve">Input not found or already spent</source>
+        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1245">
-        <source xml:space="preserve">Verifying wallet(s)…</source>
-        <context-group purpose="location"><context context-type="linenumber">452</context></context-group>
+      <trans-unit id="_msg1134">
+        <source xml:space="preserve">Insufficient dbcache for block verification</source>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1246">
-        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
-        <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
+      <trans-unit id="_msg1135">
+        <source xml:space="preserve">Insufficient funds</source>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1247">
-        <source xml:space="preserve">Settings file could not be read</source>
+      <trans-unit id="_msg1136">
+        <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1137">
+        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1138">
+        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1139">
+        <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1140">
+        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
+        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1141">
+        <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1142">
+        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1143">
+        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1144">
+        <source xml:space="preserve">Invalid port specified in %s: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1145">
+        <source xml:space="preserve">Listening for incoming connections failed (listen returned error %s)</source>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1146">
+        <source xml:space="preserve">Loading P2P addresses…</source>
+        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1147">
+        <source xml:space="preserve">Loading banlist…</source>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1148">
+        <source xml:space="preserve">Loading block index…</source>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1149">
+        <source xml:space="preserve">Loading wallet…</source>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1150">
+        <source xml:space="preserve">Maximum transaction weight must be between %d and %d</source>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1151">
+        <source xml:space="preserve">Missing amount</source>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1152">
+        <source xml:space="preserve">Missing solving data for estimating transaction size</source>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1153">
+        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1154">
+        <source xml:space="preserve">No addresses available</source>
+        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1155">
+        <source xml:space="preserve">Not found pre-selected input %s</source>
+        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1156">
+        <source xml:space="preserve">Not solvable pre-selected input %s</source>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1157">
+        <source xml:space="preserve">Only direction was set, no permissions: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1158">
+        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
+        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1159">
+        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
+        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1160">
+        <source xml:space="preserve">Pruning blockstore…</source>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1161">
+        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1162">
+        <source xml:space="preserve">Replaying blocks…</source>
+        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1163">
+        <source xml:space="preserve">Rescanning…</source>
+        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1164">
+        <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1165">
+        <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1166">
+        <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1167">
+        <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1168">
+        <source xml:space="preserve">Section [%s] is not recognized.</source>
+        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1169">
+        <source xml:space="preserve">Signer did not echo address</source>
+        <context-group purpose="location"><context context-type="linenumber">387</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1170">
+        <source xml:space="preserve">Signer echoed unexpected address %s</source>
+        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1171">
+        <source xml:space="preserve">Signer returned error: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1172">
+        <source xml:space="preserve">Signing transaction failed</source>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1173">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
+        <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1174">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1175">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
+        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1176">
+        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
+        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1177">
+        <source xml:space="preserve">Specified data directory &quot;%s&quot; does not exist.</source>
+        <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1178">
+        <source xml:space="preserve">Starting network threads…</source>
+        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1179">
+        <source xml:space="preserve">System error while flushing: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">397</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1180">
+        <source xml:space="preserve">System error while loading external block file: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1181">
+        <source xml:space="preserve">System error while saving block to disk: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">399</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1182">
+        <source xml:space="preserve">The source code is available from %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1183">
+        <source xml:space="preserve">The specified config file %s does not exist</source>
         <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1248">
-        <source xml:space="preserve">Settings file could not be written</source>
+      <trans-unit id="_msg1184">
+        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
         <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1185">
+        <source xml:space="preserve">The transactions removal process can only be executed within a db txn</source>
+        <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1186">
+        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
+        <context-group purpose="location"><context context-type="linenumber">404</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1187">
+        <source xml:space="preserve">There is no ScriptPubKeyManager for this address</source>
+        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1188">
+        <source xml:space="preserve">This is experimental software.</source>
+        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1189">
+        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1190">
+        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1191">
+        <source xml:space="preserve">Transaction %s does not belong to this wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1192">
+        <source xml:space="preserve">Transaction amount too small</source>
+        <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1193">
+        <source xml:space="preserve">Transaction amounts must not be negative</source>
+        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1194">
+        <source xml:space="preserve">Transaction change output index out of range</source>
+        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1195">
+        <source xml:space="preserve">Transaction must have at least one recipient</source>
+        <context-group purpose="location"><context context-type="linenumber">413</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1196">
+        <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it.</source>
+        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1197">
+        <source xml:space="preserve">Transaction too large</source>
+        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1198">
+        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
+        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1199">
+        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
+        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1200">
+        <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1201">
+        <source xml:space="preserve">Unable to find UTXO for external input</source>
+        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1202">
+        <source xml:space="preserve">Unable to open %s for writing</source>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1203">
+        <source xml:space="preserve">Unable to parse -maxuploadtarget: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1204">
+        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1205">
+        <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1206">
+        <source xml:space="preserve">Unknown address type &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1207">
+        <source xml:space="preserve">Unknown change type &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1208">
+        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1209">
+        <source xml:space="preserve">Unknown new rules activated (versionbit %i)</source>
+        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1210">
+        <source xml:space="preserve">Unrecognised option &quot;%s&quot; provided in -test=&lt;option&gt;.</source>
+        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1211">
+        <source xml:space="preserve">Unsupported global logging level %s=%s. Valid values: %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1212">
+        <source xml:space="preserve">Wallet file creation failed: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1213">
+        <source xml:space="preserve">acceptstalefeeestimates is not supported on %s chain.</source>
+        <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1214">
+        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
+        <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1215">
+        <source xml:space="preserve">Error loading %s: Wallet is a legacy wallet. Please migrate to a descriptor wallet using the migration tool (migratewallet RPC).</source>
+        <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1216">
+        <source xml:space="preserve">Error: Dumpfile specifies an unsupported database format (%s). Only sqlite database dumps are supported</source>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1217">
+        <source xml:space="preserve">Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.</source>
+        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1218">
+        <source xml:space="preserve">Transaction requires one destination of non-zero value, a non-zero feerate, or a pre-selected input</source>
+        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1219">
+        <source xml:space="preserve">Unrecognized descriptor found. Loading wallet %s
+
+The wallet might have been created on a newer version.
+Please try running the latest software version.
+</source>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1220">
+        <source xml:space="preserve">Do you want to rebuild the databases now?</source>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1221">
+        <source xml:space="preserve">Error: Could not add watchonly tx %s to watchonly wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1222">
+        <source xml:space="preserve">Error: Could not delete watchonly transactions. </source>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1223">
+        <source xml:space="preserve">Error: Wallet does not exist</source>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1224">
+        <source xml:space="preserve">Error: cannot remove legacy wallet records</source>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1225">
+        <source xml:space="preserve">Failed to start indexes, shutting down…</source>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1226">
+        <source xml:space="preserve">Invalid -proxy address or hostname, ends with &apos;=&apos;: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1227">
+        <source xml:space="preserve">Not enough file descriptors available. %d available, %d required.</source>
+        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1228">
+        <source xml:space="preserve">Unrecognized network in -proxy=&apos;%s&apos;: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1229">
+        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
+        <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1230">
+        <source xml:space="preserve">Verifying blocks…</source>
+        <context-group purpose="location"><context context-type="linenumber">433</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1231">
+        <source xml:space="preserve">Verifying wallet(s)…</source>
+        <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1232">
+        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1233">
+        <source xml:space="preserve">Settings file could not be read</source>
+        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1234">
+        <source xml:space="preserve">Settings file could not be written</source>
+        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
       </trans-unit>
     </group>
   </body></file>

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -84,7 +84,7 @@ static feebumper::Result CheckFeeRate(const CWallet& wallet, const CMutableTrans
 
     std::optional<CAmount> combined_bump_fee = wallet.chain().calculateCombinedBumpFee(reused_inputs, newFeerate);
     if (!combined_bump_fee.has_value()) {
-        errors.push_back(Untranslated(strprintf("Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.")));
+        errors.push_back(Untranslated(strprintf("Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.")));
     }
     CAmount new_total_fee = newFeerate.GetFee(maxTxSize) + combined_bump_fee.value();
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -762,7 +762,7 @@ util::Result<SelectionResult> ChooseSelectionResult(interfaces::Chain& chain, co
         }
         std::optional<CAmount> combined_bump_fee = chain.calculateCombinedBumpFee(outpoints, coin_selection_params.m_effective_feerate);
         if (!combined_bump_fee.has_value()) {
-            return util::Error{_("Failed to calculate bump fees, because unconfirmed UTXOs depend on enormous cluster of unconfirmed transactions.")};
+            return util::Error{_("Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.")};
         }
         CAmount bump_fee_overestimate = summed_bump_fees - combined_bump_fee.value();
         if (bump_fee_overestimate) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2847,7 +2847,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
             rescan_required = true;
         } else if (nLoadWalletRet == DBErrors::UNKNOWN_DESCRIPTOR) {
             error = strprintf(_("Unrecognized descriptor found. Loading wallet %s\n\n"
-                                "The wallet might had been created on a newer version.\n"
+                                "The wallet might have been created on a newer version.\n"
                                 "Please try running the latest software version.\n"), walletFile);
             return nullptr;
         } else if (nLoadWalletRet == DBErrors::UNEXPECTED_LEGACY_ENTRY) {
@@ -3149,7 +3149,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
                 // but fail the rescan with a generic error.
 
                 error = chain.havePruned() ?
-                     _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)") :
+                     _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)") :
                      strprintf(_(
                         "Error loading wallet. Wallet requires blocks to be downloaded, "
                         "and software does not currently support loading wallets while "

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -791,7 +791,7 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
             value >> desc;
         } catch (const std::ios_base::failure& e) {
             strErr = strprintf("Error: Unrecognized descriptor found in wallet %s. ", pwallet->GetName());
-            strErr += (last_client > CLIENT_VERSION) ? "The wallet might had been created on a newer version. " :
+            strErr += (last_client > CLIENT_VERSION) ? "The wallet might have been created on a newer version. " :
                     "The database might be corrupted or the software version is not compatible with one of your wallet descriptors. ";
             strErr += "Please try running the latest software version";
             // Also include error details


### PR DESCRIPTION
This PR follows our [Release Process](https://github.com/bitcoin/bitcoin/blob/53a996f122663e271efa52c45b173613b8ac635e/doc/release-process.md).

It is required to open Transifex translations for v30.0, as scheduled in https://github.com/bitcoin/bitcoin/issues/32275.

For reference, see the previous similar PR: https://github.com/bitcoin/bitcoin/pull/31809.

**Note for reviewers:**

To reproduce the diff in the last commit, run:
```
cmake --preset dev-mode
cmake --build build_dev_mode --target translate
```