### PR TITLE
cmake: Do not require Python to build GUI

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -35,7 +35,7 @@ Bitcoin Core requires one of the following compilers.
 
 | Dependency | Releases | Minimum required |
 | --- | --- | --- |
-| Python (scripts, tests) | [link](https://www.python.org) | [3.10](https://github.com/bitcoin/bitcoin/pull/30527) |
+| Python (scripts, tests, translations) | [link](https://www.python.org) | [3.10](https://github.com/bitcoin/bitcoin/pull/30527) |
 | [Qt](../depends/packages/qt.mk) (gui) | [link](https://download.qt.io/archive/qt/) | [6.2](https://github.com/bitcoin/bitcoin/pull/30997) |
 | [qrencode](../depends/packages/qrencode.mk) (gui) | [link](https://fukuchi.org/works/qrencode/) | N/A |
 | [SQLite](../depends/packages/sqlite.mk) (wallet) | [link](https://sqlite.org) | [3.7.17](https://github.com/bitcoin/bitcoin/pull/19077) |

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -337,6 +337,10 @@ elseif(NOT SED_EXECUTABLE)
   add_custom_target(translate
     COMMAND ${CMAKE_COMMAND} -E echo "Error: GNU sed not found"
   )
+elseif(NOT TARGET Python3::Interpreter)
+  add_custom_target(translate
+    COMMAND ${CMAKE_COMMAND} -E echo "Error: Python not found"
+  )
 else()
   set(translatable_sources_directories src src/qt src/util)
   if(ENABLE_WALLET)


### PR DESCRIPTION
This PR fixes https://github.com/bitcoin/bitcoin/issues/33146, which may be considered a regression introduced in https://github.com/bitcoin/bitcoin/pull/31233.

This approach was chosen for its minimal diff.

An alternative approach would be to convert the `translate` build target into a CMake script. This could be justified, as the goal is to update files in the source tree and then commit them to the repository, which is something regular build targets are not intended to do.

On a related note, the [`share/qt/extract_strings_qt.py`](https://github.com/bitcoin/bitcoin/blob/master/share/qt/extract_strings_qt.py) looks simple enough to be rewritten in pure CMake code.