### PR TITLE
cluster mempool: control/optimize TxGraph memory usage

### DIFF
--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include <memusage.h>
 #include <random.h>
 #include <span.h>
 #include <util/feefrac.h>
@@ -331,6 +332,17 @@ public:
             }
         }
         return true;
+    }
+
+    /** Reduce memory usage if possible. No observable effect. */
+    void Compact() noexcept
+    {
+        entries.shrink_to_fit();
+    }
+
+    size_t DynamicMemoryUsage() const noexcept
+    {
+        return memusage::DynamicUsage(entries);
     }
 };
 

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -1012,6 +1012,21 @@ FUZZ_TARGET(txgraph)
                 }
                 assert(!top_sim.IsOversized());
                 break;
+            } else if (command-- == 0) {
+                // GetMainMemoryUsage().
+                auto usage = real->GetMainMemoryUsage();
+                // Test stability.
+                if (alt) {
+                    auto usage2 = real->GetMainMemoryUsage();
+                    assert(usage == usage2);
+                }
+                // Only empty graphs have 0 memory usage.
+                if (main_sim.GetTransactionCount() == 0) {
+                    assert(usage == 0);
+                } else {
+                    assert(usage > 0);
+                }
+                break;
             }
         }
     }

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -30,7 +30,7 @@ class TxGraphImpl;
 
 /** Position of a DepGraphIndex within a Cluster::m_linearization. */
 using LinearizationIndex = uint32_t;
-/** Position of a Cluster within Graph::ClusterSet::m_clusters. */
+/** Position of a Cluster within TxGraphImpl::ClusterSet::m_clusters. */
 using ClusterSetIndex = uint32_t;
 
 /** Quality levels for cached cluster linearizations. */
@@ -105,7 +105,7 @@ protected:
     using SetType = BitSet<MAX_CLUSTER_COUNT_LIMIT>;
     /** The quality level of m_linearization. */
     QualityLevel m_quality{QualityLevel::NONE};
-    /** Which position this Cluster has in Graph::ClusterSet::m_clusters[m_quality]. */
+    /** Which position this Cluster has in TxGraphImpl::ClusterSet::m_clusters[m_quality]. */
     ClusterSetIndex m_setindex{ClusterSetIndex(-1)};
     /** Sequence number for this Cluster (for tie-breaking comparison between equal-chunk-feerate
         transactions in distinct clusters). */
@@ -168,7 +168,7 @@ public:
     /** Figure out what level this Cluster exists at in the graph. In most cases this is known by
      *  the caller already (see all "int level" arguments below), but not always. */
     virtual int GetLevel(const TxGraphImpl& graph) const noexcept = 0;
-    /** Only called by Graph::SwapIndexes. */
+    /** Only called by TxGraphImpl::SwapIndexes. */
     virtual void UpdateMapping(DepGraphIndex cluster_idx, GraphIndex graph_idx) noexcept = 0;
     /** Push changes to Cluster and its linearization to the TxGraphImpl Entry objects. */
     virtual void Updated(TxGraphImpl& graph, int level) noexcept = 0;
@@ -553,7 +553,7 @@ public:
     Cluster* FindCluster(GraphIndex idx, int level) const noexcept { return FindClusterAndLevel(idx, level).first; }
     /** Like FindCluster, but also return what level the match was found in (-1 if not found). */
     std::pair<Cluster*, int> FindClusterAndLevel(GraphIndex idx, int level) const noexcept;
-    /** Extract a Cluster from its ClusterSet. */
+    /** Extract a Cluster from its ClusterSet, and set its quality to QualityLevel::NONE. */
     std::unique_ptr<Cluster> ExtractCluster(int level, QualityLevel quality, ClusterSetIndex setindex) noexcept;
     /** Delete a Cluster. */
     void DeleteCluster(Cluster& cluster, int level) noexcept;

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -12,6 +12,7 @@
 #include <util/vector.h>
 
 #include <compare>
+#include <functional>
 #include <memory>
 #include <set>
 #include <span>
@@ -120,9 +121,7 @@ class Cluster
 public:
     Cluster() noexcept = delete;
     /** Construct an empty Cluster. */
-    explicit Cluster(uint64_t sequence) noexcept;
-    /** Construct a singleton Cluster. */
-    explicit Cluster(uint64_t sequence, TxGraphImpl& graph, const FeePerWeight& feerate, GraphIndex graph_index) noexcept;
+    explicit Cluster(uint64_t sequence) noexcept : m_sequence(sequence) {}
 
     // Cannot move or copy (would invalidate Cluster* in Locator and ClusterSet). */
     Cluster(const Cluster&) = delete;
@@ -153,15 +152,25 @@ public:
         return m_quality == QualityLevel::NEEDS_SPLIT ||
                m_quality == QualityLevel::NEEDS_SPLIT_ACCEPTABLE;
     }
+
     /** Total memory usage currently for this Cluster, including all its dynamic memory, plus Cluster
      *  structure itself, and ClusterSet::m_clusters entry. */
     size_t TotalMemoryUsage() const noexcept;
+    /** Determine the range of DepGraphIndexes used by this Cluster. */
+    DepGraphIndex GetDepGraphIndexRange() const noexcept { return m_depgraph.PositionRange(); }
     /** Get the number of transactions in this Cluster. */
     LinearizationIndex GetTxCount() const noexcept { return m_linearization.size(); }
     /** Get the total size of the transactions in this Cluster. */
     uint64_t GetTotalTxSize() const noexcept;
     /** Given a DepGraphIndex into this Cluster, find the corresponding GraphIndex. */
     GraphIndex GetClusterEntry(DepGraphIndex index) const noexcept { return m_mapping[index]; }
+    /** Append a transaction with given GraphIndex at the end of this Cluster and its
+     *  linearization. Return the DepGraphIndex it was placed at. */
+    DepGraphIndex AppendTransaction(GraphIndex graph_idx, FeePerWeight feerate) noexcept;
+    /** Add dependencies to a given child in this cluster. */
+    void AddDependencies(SetType parents, DepGraphIndex child) noexcept;
+    /** Invoke visitor_fn for each transaction in the cluster, in linearization order, then wipe this Cluster. */
+    void ExtractTransactions(const std::function<void (DepGraphIndex, GraphIndex, FeePerWeight, SetType)>& visit_fn) noexcept;
     /** Figure out what level this Cluster exists at in the graph. In most cases this is known by
      *  the caller already (see all "int level" arguments below), but not always. */
     int GetLevel(const TxGraphImpl& graph) const noexcept;
@@ -186,7 +195,7 @@ public:
     // Functions that implement the Cluster-specific side of internal TxGraphImpl mutations.
 
     /** Apply all removals from the front of to_remove that apply to this Cluster, popping them
-     *  off. These must be at least one such entry. */
+     *  off. There must be at least one such entry. */
     void ApplyRemovals(TxGraphImpl& graph, int level, std::span<GraphIndex>& to_remove) noexcept;
     /** Split this cluster (must have a NEEDS_SPLIT* quality). Returns whether to delete this
      *  Cluster afterwards. */
@@ -732,6 +741,31 @@ uint64_t Cluster::GetTotalTxSize() const noexcept
     return ret;
 }
 
+DepGraphIndex Cluster::AppendTransaction(GraphIndex graph_idx, FeePerWeight feerate) noexcept
+{
+    Assume(graph_idx != GraphIndex(-1));
+    auto ret = m_depgraph.AddTransaction(feerate);
+    m_mapping.push_back(graph_idx);
+    m_linearization.push_back(ret);
+    return ret;
+}
+
+void Cluster::AddDependencies(SetType parent, DepGraphIndex child) noexcept
+{
+    m_depgraph.AddDependencies(parent, child);
+}
+
+void Cluster::ExtractTransactions(const std::function<void (DepGraphIndex, GraphIndex, FeePerWeight, SetType)>& visit_fn) noexcept
+{
+    for (auto pos : m_linearization) {
+        visit_fn(pos, m_mapping[pos], FeePerWeight::FromFeeFrac(m_depgraph.FeeRate(pos)), m_depgraph.GetReducedParents(pos));
+    }
+    // Purge this Cluster, now that everything has been moved.
+    m_depgraph = DepGraph<SetType>{};
+    m_linearization.clear();
+    m_mapping.clear();
+}
+
 int Cluster::GetLevel(const TxGraphImpl& graph) const noexcept
 {
     // GetLevel() does not work for empty Clusters.
@@ -1072,12 +1106,7 @@ bool Cluster::Split(TxGraphImpl& graph, int level) noexcept
         /** The cluster which transaction originally in position i is moved to. */
         Cluster* new_cluster = remap[i].first;
         // Copy the transaction to the new cluster's depgraph, and remember the position.
-        remap[i].second = new_cluster->m_depgraph.AddTransaction(m_depgraph.FeeRate(i));
-        // Create new mapping entry.
-        new_cluster->m_mapping.push_back(m_mapping[i]);
-        // Create a new linearization entry. As we're only appending transactions, they equal the
-        // DepGraphIndex.
-        new_cluster->m_linearization.push_back(remap[i].second);
+        remap[i].second = new_cluster->AppendTransaction(m_mapping[i], FeePerWeight::FromFeeFrac(m_depgraph.FeeRate(i)));
     }
     // Redistribute the dependencies.
     for (auto i : m_linearization) {
@@ -1086,7 +1115,7 @@ bool Cluster::Split(TxGraphImpl& graph, int level) noexcept
         // Copy its parents, translating positions.
         SetType new_parents;
         for (auto par : m_depgraph.GetReducedParents(i)) new_parents.Set(remap[par].second);
-        new_cluster->m_depgraph.AddDependencies(new_parents, remap[i].second);
+        new_cluster->AddDependencies(new_parents, remap[i].second);
     }
     // Update all the Locators of moved transactions, and memory usage.
     for (Cluster* new_cluster : new_clusters) {
@@ -1104,12 +1133,11 @@ bool Cluster::Split(TxGraphImpl& graph, int level) noexcept
 void Cluster::Merge(TxGraphImpl& graph, int level, Cluster& other) noexcept
 {
     /** Vector to store the positions in this Cluster for each position in other. */
-    std::vector<DepGraphIndex> remap(other.m_depgraph.PositionRange());
+    std::vector<DepGraphIndex> remap(other.GetDepGraphIndexRange());
     // Iterate over all transactions in the other Cluster (the one being absorbed).
-    for (auto pos : other.m_linearization) {
-        auto idx = other.m_mapping[pos];
+    other.ExtractTransactions([&](DepGraphIndex pos, GraphIndex idx, FeePerWeight feerate, SetType other_parents) noexcept {
         // Copy the transaction into this Cluster, and remember its position.
-        auto new_pos = m_depgraph.AddTransaction(other.m_depgraph.FeeRate(pos));
+        auto new_pos = m_depgraph.AddTransaction(feerate);
         // Since this cluster must have been made hole-free before being merged into, all added
         // transactions should appear at the end.
         Assume(new_pos == m_mapping.size());
@@ -1117,26 +1145,22 @@ void Cluster::Merge(TxGraphImpl& graph, int level, Cluster& other) noexcept
         m_mapping.push_back(idx);
         m_linearization.push_back(new_pos);
         // Copy the transaction's dependencies, translating them using remap. Note that since
-        // pos iterates over other.m_linearization, which is in topological order, all parents
-        // of pos should already be in remap.
+        // pos iterates in linearization order, which is topological, all parents of pos should
+        // already be in remap.
         SetType parents;
-        for (auto par : other.m_depgraph.GetReducedParents(pos)) {
+        for (auto par : other_parents) {
             parents.Set(remap[par]);
         }
         m_depgraph.AddDependencies(parents, remap[pos]);
         // Update the transaction's Locator. There is no need to call Updated() to update chunk
         // feerates, as Updated() will be invoked by Cluster::ApplyDependencies on the resulting
-        // merged Cluster later anyway).
+        // merged Cluster later anyway.
         auto& entry = graph.m_entries[idx];
         // Discard any potential ChunkData prior to modifying the Cluster (as that could
         // invalidate its ordering).
         if (level == 0) graph.ClearChunkData(entry);
         entry.m_locator[level].SetPresent(this, new_pos);
-    }
-    // Purge the other Cluster, now that everything has been moved.
-    other.m_depgraph = DepGraph<SetType>{};
-    other.m_linearization.clear();
-    other.m_mapping.clear();
+    });
 }
 
 void Cluster::ApplyDependencies(TxGraphImpl& graph, int level, std::span<std::pair<GraphIndex, GraphIndex>> to_apply) noexcept
@@ -1766,17 +1790,6 @@ void TxGraphImpl::MakeAllAcceptable(int level) noexcept
     }
 }
 
-Cluster::Cluster(uint64_t sequence) noexcept : m_sequence{sequence} {}
-
-Cluster::Cluster(uint64_t sequence, TxGraphImpl& graph, const FeePerWeight& feerate, GraphIndex graph_index) noexcept :
-    m_sequence{sequence}
-{
-    // Create a new transaction in the DepGraph, and remember its position in m_mapping.
-    auto cluster_idx = m_depgraph.AddTransaction(feerate);
-    m_mapping.push_back(graph_index);
-    m_linearization.push_back(cluster_idx);
-}
-
 TxGraph::Ref TxGraphImpl::AddTransaction(const FeePerWeight& feerate) noexcept
 {
     Assume(m_main_chunkindex_observers == 0 || GetTopLevel() != 0);
@@ -1793,7 +1806,8 @@ TxGraph::Ref TxGraphImpl::AddTransaction(const FeePerWeight& feerate) noexcept
     GetRefIndex(ret) = idx;
     // Construct a new singleton Cluster (which is necessarily optimally linearized).
     bool oversized = uint64_t(feerate.size) > m_max_cluster_size;
-    auto cluster = std::make_unique<Cluster>(m_next_sequence_counter++, *this, feerate, idx);
+    auto cluster = std::make_unique<Cluster>(m_next_sequence_counter++);
+    cluster->AppendTransaction(idx, feerate);
     auto cluster_ptr = cluster.get();
     int level = GetTopLevel();
     auto& clusterset = GetClusterSet(level);

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -177,6 +177,8 @@ public:
     void Clear(TxGraphImpl& graph, int level) noexcept;
     /** Change a Cluster's level from 1 (staging) to 0 (main). */
     void MoveToMain(TxGraphImpl& graph) noexcept;
+    /** Minimize this Cluster's memory usage. */
+    void Compact() noexcept;
 
     // Functions that implement the Cluster-specific side of internal TxGraphImpl mutations.
 
@@ -910,6 +912,7 @@ void Cluster::ApplyRemovals(TxGraphImpl& graph, int level, std::span<GraphIndex>
             [&](auto pos) { return todo[pos]; }), m_linearization.end());
         quality = QualityLevel::NEEDS_SPLIT;
     }
+    Compact();
     graph.SetClusterQuality(level, m_quality, m_setindex, quality);
     Updated(graph, level);
 }
@@ -935,6 +938,13 @@ void Cluster::MoveToMain(TxGraphImpl& graph) noexcept
     auto cluster = graph.ExtractCluster(1, quality, m_setindex);
     graph.InsertCluster(/*level=*/0, std::move(cluster), quality);
     Updated(graph, /*level=*/0);
+}
+
+void Cluster::Compact() noexcept
+{
+    m_linearization.shrink_to_fit();
+    m_mapping.shrink_to_fit();
+    m_depgraph.Compact();
 }
 
 void Cluster::AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept
@@ -1050,6 +1060,7 @@ bool Cluster::Split(TxGraphImpl& graph, int level) noexcept
     // Update all the Locators of moved transactions.
     for (Cluster* new_cluster : new_clusters) {
         new_cluster->Updated(graph, level);
+        new_cluster->Compact();
     }
     // Wipe this Cluster, and return that it needs to be deleted.
     m_depgraph = DepGraph<SetType>{};
@@ -1627,6 +1638,7 @@ void TxGraphImpl::Merge(std::span<Cluster*> to_merge, int level) noexcept
         to_merge[0]->Merge(*this, level, *to_merge[i]);
         DeleteCluster(*to_merge[i], level);
     }
+    to_merge[0]->Compact();
 }
 
 void TxGraphImpl::ApplyDependencies(int level) noexcept

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -202,6 +202,13 @@ public:
      *  graph must not be oversized. If the graph is empty, {{}, FeePerWeight{}} is returned. */
     virtual std::pair<std::vector<Ref*>, FeePerWeight> GetWorstMainChunk() noexcept = 0;
 
+    /** Get the approximate memory usage for this object, just counting the main graph. If a
+     *  staging graph is present, return a number corresponding to memory usage after
+     *  AbortStaging() would be called. BlockBuilders' memory usage, memory usage of internally
+     *  queued operations, and memory due to temporary caches, is not included here. Can always be
+     *  called. */
+    virtual size_t GetMainMemoryUsage() noexcept = 0;
+
     /** Perform an internal consistency check on this object. */
     virtual void SanityCheck() const = 0;
 


### PR DESCRIPTION
Part of #30289.

This adds a few optimizations to reduce `TxGraph`'s memory usage, and makes sure that dynamic memory it uses doesn't linger after shrinking clusters. Finally, it exposes a function `GetMainMemoryUsage()` to compute `TxGraph`'s approximate memory usage.

It makes the `Cluster` type abstract, with two instances (`SingletonClusterImpl` for 1-transaction clusters, and `GenericClusterImpl` for others).

On my 64-bit system, I obtain the following numbers:
* `SingletonClusterImpl`: 48 bytes, plus 16 bytes malloc overhead in its `unique_ptr`, plus 8-byte pointer in `m_clusters`
* `GenericClusterImpl`: 104 bytes, plus 16 bytes malloc overhead in its `unique_ptr`, plus 8-byte pointer in `m_clusters`, plus 72 bytes malloc overhead inside its vectors and `DepGraph`, plus 40 bytes per transaction in those.
* `TxGraphImpl::Entry`: 72 bytes per transaction
* `TxGraphImpl::ChunkData`: 8 bytes, plus 56 bytes in `std::set` overhead + malloc overhead, all per chunk.
* `TxGraph::Ref`: 16 bytes per transaction

This overall amounts to 200 bytes per cluster, plus 64 bytes per chunk, plus 128 bytes per transaction, but only 224 bytes overall per singleton cluster.