### PR TITLE
doc: Fix spelling mistakes in release notes

### DIFF
--- a/doc/release-notes/release-notes-0.18.0.md
+++ b/doc/release-notes/release-notes-0.18.0.md
@@ -419,7 +419,7 @@ Planned changes
 This section describes planned changes to Bitcoin Core that may affect
 other Bitcoin software and services.
 
-- Since version 0.16.0, Bitcoin Core’s built-in wallet has defaulted to
+- Since version 0.16.0, Bitcoin Core's built-in wallet has defaulted to
   generating P2SH-wrapped segwit addresses when users want to receive
   payments. These addresses are backwards compatible with all
   widely-used software.  Starting with Bitcoin Core 0.20 (expected about
@@ -430,7 +430,7 @@ other Bitcoin software and services.
   additional adoption, it will instead default to bech32 receiving
   addresses in Bitcoin Core 0.19 (approximately November 2019).
   P2SH-wrapped segwit addresses will continue to be provided if the user
-  requests them in the GUI or by RPC, and anyone who doesn’t want the
+  requests them in the GUI or by RPC, and anyone who doesn't want the
   update will be able to configure their default address type.
   (Similarly, pioneering users who want to change their default now may
   set the `addresstype=bech32` configuration option in any Bitcoin Core
@@ -924,7 +924,7 @@ Changes for particular platforms
 - #14958 Remove race between connecting and shutdown on separate connections (promag)
 - #15166 Pin shellcheck version (practicalswift)
 - #15196 Update all `subprocess.check_output` functions to be Python 3.4 compatible (gkrizek)
-- #15043 Build fuzz targets into seperate executables (MarcoFalke)
+- #15043 Build fuzz targets into separate executables (MarcoFalke)
 - #15276 travis: Compile once on trusty (MarcoFalke)
 - #15246 Add tests for invalid message headers (MarcoFalke)
 - #15301 When testing with --usecli, unify RPC arg to cli arg conversion and handle dicts and lists (achow101)

--- a/doc/release-notes/release-notes-0.20.0.md
+++ b/doc/release-notes/release-notes-0.20.0.md
@@ -698,7 +698,7 @@ Build system
 - #18224 Make AnalyzePSBT next role calculation simple, correct (instagibbs)
 - #18228 Add missing syncwithvalidationinterfacequeue (MarcoFalke)
 - #18247 Wait for both veracks in `add_p2p_connection` (MarcoFalke)
-- #18249 Bump timeouts to accomodate really slow disks (MarcoFalke)
+- #18249 Bump timeouts to accommodate really slow disks (MarcoFalke)
 - #18255 Add `bad-txns-*-toolarge` test cases to `invalid_txs` (MarcoFalke)
 - #18263 rpc: change setmocktime check to use IsMockableChain (gzhao408)
 - #18285 Check that `wait_until` returns if time point is in the past (MarcoFalke)

--- a/doc/release-notes/release-notes-28.2.md
+++ b/doc/release-notes/release-notes-28.2.md
@@ -43,7 +43,7 @@ Notable changes
 - #31500 depends: Fix compiling libevent package on NetBSD
 - #31627 depends: Fix spacing issue
 - #32070 build: use make < 3.82 syntax for define directive
-- #32439 guix: accomodate migration to codeberg
+- #32439 guix: accommodate migration to codeberg
 - #32568 depends: use "mkdir -p" when installing xproto
 - #32693 depends: fix cmake compatibility error for freetype
 


### PR DESCRIPTION
- Fix 'seperate' -> 'separate' in release-notes-0.18.0.md
- Fix 'accomodate' -> 'accommodate' in release-notes-0.20.0.md
- Fix 'accomodate' -> 'accommodate' in release-notes-28.2.md
