### PR TITLE
interfaces, chain, refactor: Remove unused getTipLocator and incaccurate getActiveChainLocator

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -52,11 +52,6 @@ CBlockLocator GetLocator(const CBlockIndex* index)
     return CBlockLocator{LocatorEntries(index)};
 }
 
-CBlockLocator CChain::GetLocator() const
-{
-    return ::GetLocator(Tip());
-}
-
 const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
     if (pindex == nullptr) {
         return nullptr;

--- a/src/chain.h
+++ b/src/chain.h
@@ -467,9 +467,6 @@ public:
     /** Set/initialize a chain with a given tip. */
     void SetTip(CBlockIndex& block);
 
-    /** Return a CBlockLocator that refers to the tip in of this chain. */
-    CBlockLocator GetLocator() const;
-
     /** Find the last common block between this chain and a block index entry. */
     const CBlockIndex* FindFork(const CBlockIndex* pindex) const;
 

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -143,9 +143,6 @@ public:
     //! pruned), and contains transactions.
     virtual bool haveBlockOnDisk(int height) = 0;
 
-    //! Get locator for the current chain tip.
-    virtual CBlockLocator getTipLocator() = 0;
-
     //! Return a locator that refers to a block in the active chain.
     //! If specified block is not in the active chain, return locator for the latest ancestor that is in the chain.
     virtual CBlockLocator getActiveChainLocator(const uint256& block_hash) = 0;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -143,10 +143,6 @@ public:
     //! pruned), and contains transactions.
     virtual bool haveBlockOnDisk(int height) = 0;
 
-    //! Return a locator that refers to a block in the active chain.
-    //! If specified block is not in the active chain, return locator for the latest ancestor that is in the chain.
-    virtual CBlockLocator getActiveChainLocator(const uint256& block_hash) = 0;
-
     //! Return height of the highest block on chain in common with the locator,
     //! which will either be the original block used to create the locator,
     //! or one of its ancestors.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -559,11 +559,6 @@ public:
         const CBlockIndex* block{chainman().ActiveChain()[height]};
         return block && ((block->nStatus & BLOCK_HAVE_DATA) != 0) && block->nTx > 0;
     }
-    CBlockLocator getTipLocator() override
-    {
-        LOCK(::cs_main);
-        return chainman().ActiveChain().GetLocator();
-    }
     CBlockLocator getActiveChainLocator(const uint256& block_hash) override
     {
         LOCK(::cs_main);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -559,12 +559,6 @@ public:
         const CBlockIndex* block{chainman().ActiveChain()[height]};
         return block && ((block->nStatus & BLOCK_HAVE_DATA) != 0) && block->nTx > 0;
     }
-    CBlockLocator getActiveChainLocator(const uint256& block_hash) override
-    {
-        LOCK(::cs_main);
-        const CBlockIndex* index = chainman().m_blockman.LookupBlockIndex(block_hash);
-        return GetLocator(index);
-    }
     std::optional<int> findLocatorFork(const CBlockLocator& locator) override
     {
         LOCK(::cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2919,7 +2919,7 @@ bool Chainstate::FlushStateToDisk(
     }
     if (full_flush_completed && m_chainman.m_options.signals) {
         // Update best block in wallet (so we can detect restored wallets).
-        m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), m_chain.GetLocator());
+        m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), GetLocator(m_chain.Tip()));
     }
     } catch (const std::runtime_error& e) {
         return FatalError(m_chainman.GetNotifications(), state, strprintf(_("System error while flushing: %s"), e.what()));


### PR DESCRIPTION
Remove `Chain::getTipLocator`, `Chain::GetLocator()`, and `Chain::getActiveChainLocator`:
- `Chain::getTipLocator` is no longer used.
- `Chain::GetLocator`, replaced its call by `GetLocator()`, which uses `LocatorEntries`, avoiding direct access to the chain itself (change suggested by l0rinc while reviewing this PR to maintain consistency with the overall refactoring).
- `Chain::getActiveChainLocator`, whose name was misleading, has functionality redundant with Chain::findBlock.
  - Additionally, the comment for getActiveChainLocator became inaccurate following changes in commit https://github.com/bitcoin/bitcoin/commit/ed470940cddbeb40425960d51cefeec4948febe4 (from PR #25717).


This is a [follow-up](https://github.com/bitcoin/bitcoin/pull/29652#issuecomment-3151665095) to #29652.