### PR TITLE
doc: update wallet build instruction

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -13,6 +13,14 @@ Run the following as root to install the base dependencies for building.
 pkg install boost-libs cmake git libevent pkgconf
 ```
 
+SQLite is required for the wallet:
+
+```bash
+pkg install sqlite3
+```
+
+To build Bitcoin Core without the wallet, use `-DENABLE_WALLET=OFF`.
+
 See [dependencies.md](dependencies.md) for a complete overview.
 
 ### 2. Clone Bitcoin Repo
@@ -22,17 +30,6 @@ git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 ### 3. Install Optional Dependencies
-
-#### Wallet Dependencies
-It is not necessary to build wallet functionality to run either `bitcoind` or `bitcoin-qt`.
-
-###### Descriptor Wallet Support
-
-`sqlite3` is required to support [descriptor wallets](descriptors.md).
-Skip if you don't intend to use descriptor wallets.
-```bash
-pkg install sqlite3
-```
 
 #### GUI Dependencies
 ###### Qt6
@@ -79,7 +76,7 @@ pkg install python3 databases/py-sqlite3 net/py-pyzmq
 
 There are many ways to configure Bitcoin Core, here are a few common examples:
 
-##### Descriptor Wallet and GUI:
+##### Wallet and GUI:
 This enables the GUI, assuming `sqlite` and `qt` are installed.
 ```bash
 cmake -B build -DBUILD_GUI=ON

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -31,6 +31,14 @@ cmake -B build
     ...
 ```
 
+SQLite is required for the wallet:
+
+```bash
+pkgin sqlite3
+```
+
+To build Bitcoin Core without the wallet, use `-DENABLE_WALLET=OFF`.
+
 See [dependencies.md](dependencies.md) for a complete overview.
 
 ### 2. Clone Bitcoin Repo
@@ -42,18 +50,6 @@ git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 ### 3. Install Optional Dependencies
-
-#### Wallet Dependencies
-
-It is not necessary to build wallet functionality to run bitcoind or the GUI.
-
-###### Descriptor Wallet Support
-
-`sqlite3` is required to enable support for [descriptor wallets](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).
-
-```bash
-pkgin install sqlite3
-```
 
 #### GUI Dependencies
 ###### Qt6

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -13,6 +13,14 @@ Run the following as root to install the base dependencies for building.
 pkg_add git cmake boost libevent
 ```
 
+SQLite is required for the wallet:
+
+```bash
+pkg_add sqlite3
+```
+
+To build Bitcoin Core without the wallet, use `-DENABLE_WALLET=OFF`.
+
 See [dependencies.md](dependencies.md) for a complete overview.
 
 ### 2. Clone Bitcoin Repo
@@ -22,16 +30,6 @@ git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 ### 3. Install Optional Dependencies
-
-#### Wallet Dependencies
-
-It is not necessary to build wallet functionality to run either `bitcoind` or `bitcoin-qt`.
-SQLite is required to build the wallet.
-
-
-``` bash
-pkg_add sqlite3
-```
 
 #### GUI Dependencies
 ###### Qt6
@@ -77,8 +75,8 @@ pkg_add python py3-zmq  # Select the newest version of the python package if nec
 
 There are many ways to configure Bitcoin Core, here are a few common examples:
 
-##### Descriptor Wallet and GUI:
-This enables descriptor wallet support and the GUI, assuming SQLite and Qt 6 are installed.
+##### Wallet and GUI:
+This enables wallet support and the GUI, assuming SQLite and Qt 6 are installed.
 
 ```bash
 cmake -B build -DBUILD_GUI=ON

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -51,6 +51,14 @@ To install, run the following from your terminal:
 brew install cmake boost pkgconf libevent
 ```
 
+#### Wallet Dependencies
+
+If you do not need wallet functionality, you can use `-DENABLE_WALLET=OFF` in
+the `cmake -B` step below.
+
+SQLite is required, but since macOS ships with a useable `sqlite` package, you don't need to
+install anything.
+
 ### 4. Clone Bitcoin repository
 
 `git` should already be installed by default on your system.
@@ -62,19 +70,6 @@ git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 ### 5. Install Optional Dependencies
-
-#### Wallet Dependencies
-
-It is not necessary to build wallet functionality to run `bitcoind` or  `bitcoin-qt`.
-
-###### Descriptor Wallet Support
-
-`sqlite` is required to support for descriptor wallets.
-
-macOS ships with a useable `sqlite` package, meaning you don't need to
-install anything.
-
----
 
 #### GUI Dependencies
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -54,11 +54,11 @@ Now, you can either build from self-compiled [depends](#dependencies) or install
 
     sudo apt-get install libevent-dev libboost-dev
 
-SQLite is required for the descriptor wallet:
+SQLite is required for the wallet:
 
     sudo apt install libsqlite3-dev
 
-To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
+To build Bitcoin Core without the wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
 ZMQ-enabled binaries are compiled with `-DWITH_ZMQ=ON` and require the following dependency:
 
@@ -105,11 +105,11 @@ Now, you can either build from self-compiled [depends](#dependencies) or install
 
     sudo dnf install libevent-devel boost-devel
 
-SQLite is required for the descriptor wallet:
+SQLite is required for the wallet:
 
     sudo dnf install sqlite-devel
 
-To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
+To build Bitcoin Core without the wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
 ZMQ-enabled binaries are compiled with `-DWITH_ZMQ=ON` and require the following dependency:
 
@@ -155,11 +155,11 @@ Now, you can either build from self-compiled [depends](#dependencies) or install
 
     apk add libevent-dev boost-dev
 
-SQLite is required for the descriptor wallet:
+SQLite is required for the wallet:
 
     apk add sqlite-dev
 
-To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
+To build Bitcoin Core without the wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
 ZMQ dependencies (provides ZMQ API):
 


### PR DESCRIPTION
Sqlite and the wallet are no longer optional, but they can still be opted out of. This PR updates the build instructions accordingly.

Updating this text now reduces churn in #31802.