### PR TITLE
ASAN: turn on more not-enabled-by-default options

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 set -ex
 
-export ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
+export ASAN_OPTIONS="strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
 export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan"
 export TSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/tsan:halt_on_error=1:second_deadlock_stack=1"
 export UBSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 set -ex
 
-export ASAN_OPTIONS="strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
+export ASAN_OPTIONS="strict_string_checks=1:detect_invalid_pointer_pairs=2:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
 export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan"
 export TSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/tsan:halt_on_error=1:second_deadlock_stack=1"
 export UBSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -23,7 +23,7 @@ def get_fuzz_env(*, target, source_dir):
         'UBSAN_OPTIONS':
         f'suppressions={source_dir}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1',
         'UBSAN_SYMBOLIZER_PATH': symbolizer,
-        "ASAN_OPTIONS": "strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
+        "ASAN_OPTIONS": "strict_string_checks=1:detect_invalid_pointer_pairs=2:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
         'ASAN_SYMBOLIZER_PATH': symbolizer,
         'MSAN_SYMBOLIZER_PATH': symbolizer,
     }

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -23,7 +23,7 @@ def get_fuzz_env(*, target, source_dir):
         'UBSAN_OPTIONS':
         f'suppressions={source_dir}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1',
         'UBSAN_SYMBOLIZER_PATH': symbolizer,
-        "ASAN_OPTIONS": "detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
+        "ASAN_OPTIONS": "strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
         'ASAN_SYMBOLIZER_PATH': symbolizer,
         'MSAN_SYMBOLIZER_PATH': symbolizer,
     }


### PR DESCRIPTION
`strict_string_checks=1`:
> If true, check that string arguments are properly null-terminated.

`detect_invalid_pointer_pairs=2`:
> If non-zero, try to detect operations like <, <=, >, >= and - on invalid pointer pairs (e.g. when pointers belong to different objects).

See https://github.com/google/sanitizers/wiki/AddressSanitizerFlags.