### PR TITLE
guix: update time-machine to 5cb84f2013c5b1e48a7d0e617032266f1e6059e2

### DIFF
--- a/ci/test/00_setup_env_mac_cross.sh
+++ b/ci/test/00_setup_env_mac_cross.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
 
 export CONTAINER_NAME=ci_macos_cross
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie" # Check that https://packages.debian.org/trixie/clang (version 19, similar to guix) can cross-compile
 export HOST=arm64-apple-darwin
 export PACKAGES="clang lld llvm zip"
 export XCODE_VERSION=15.0

--- a/ci/test/00_setup_env_mac_cross_intel.sh
+++ b/ci/test/00_setup_env_mac_cross_intel.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
 
 export CONTAINER_NAME=ci_macos_cross_intel
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie" # Check that https://packages.debian.org/trixie/clang (version 19, similar to guix) can cross-compile
 export HOST=x86_64-apple-darwin
 export PACKAGES="clang lld llvm zip"
 export XCODE_VERSION=15.0

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -71,7 +71,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://codeberg.org/guix/guix.git \
-                      --commit=53396a22afc04536ddf75d8f82ad2eafa5082725 \
+                      --commit=5cb84f2013c5b1e48a7d0e617032266f1e6059e2 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -455,7 +455,7 @@ inspecting signatures in Mach-O binaries.")
 (define-public glibc-2.31
   (let ((commit "7b27c450c34563a28e634cccb399cd415e71ebfe"))
   (package
-    (inherit glibc) ;; 2.35
+    (inherit glibc) ;; 2.39
     (version "2.31")
     (source (origin
               (method git-fetch)

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -18,7 +18,7 @@
              ((gnu packages python-build) #:select (python-poetry-core))
              ((gnu packages python-crypto) #:select (python-asn1crypto))
              ((gnu packages python-science) #:select (python-scikit-build-core))
-             ((gnu packages python-xyz) #:select (python-pydantic-2 python-pydantic-core))
+             ((gnu packages python-xyz) #:select (python-pydantic-2))
              ((gnu packages tls) #:select (openssl))
              ((gnu packages version-control) #:select (git-minimal))
              (guix build-system cmake)
@@ -175,7 +175,6 @@ chain for " target " development."))
     (native-inputs (list cmake-minimal
                          ninja
                          python-scikit-build-core
-                         python-pydantic-core
                          python-pydantic-2))
     (arguments
      (list

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -466,7 +466,8 @@ inspecting signatures in Mach-O binaries.")
               (sha256
                (base32
                 "017qdpr5id7ddb4lpkzj2li1abvw916m3fc6n7nw28z4h5qbv2n0"))
-              (patches (search-our-patches "glibc-guix-prefix.patch"))))
+              (patches (search-our-patches "glibc-guix-prefix.patch"
+                                           "glibc-riscv-jumptarget.patch"))))
     (arguments
       (substitute-keyword-arguments (package-arguments glibc)
         ((#:configure-flags flags)

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -567,9 +567,9 @@ inspecting signatures in Mach-O binaries.")
                  (list gcc-toolchain-13 "static")
                  (make-bitcoin-cross-toolchain target)))
           ((string-contains target "darwin")
-           (list clang-toolchain-18
-                 lld-18
-                 (make-lld-wrapper lld-18 #:lld-as-ld? #t)
+           (list clang-toolchain-19
+                 lld-19
+                 (make-lld-wrapper lld-19 #:lld-as-ld? #t)
                  python-signapple
                  zip))
           (else '())))))

--- a/contrib/guix/patches/glibc-riscv-jumptarget.patch
+++ b/contrib/guix/patches/glibc-riscv-jumptarget.patch
@@ -1,0 +1,57 @@
+commit 68389203832ab39dd0dbaabbc4059e7fff51c29b
+Author: Fangrui Song <maskray@google.com>
+Date:   Thu Oct 28 11:39:49 2021 -0700
+
+    riscv: Fix incorrect jal with HIDDEN_JUMPTARGET
+    
+    A non-local STV_DEFAULT defined symbol is by default preemptible in a
+    shared object. j/jal cannot target a preemptible symbol. On other
+    architectures, such a jump instruction either causes PLT [BZ #18822], or
+    if short-ranged, sometimes rejected by the linker (but not by GNU ld's
+    riscv port [ld PR/28509]).
+    
+    Use HIDDEN_JUMPTARGET to target a non-preemptible symbol instead.
+    
+    With this patch, ld.so and libc.so can be linked with LLD if source
+    files are compiled/assembled with -mno-relax/-Wa,-mno-relax.
+    
+    Acked-by: Palmer Dabbelt <palmer@dabbelt.com>
+    Reviewed-by: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+
+Can be dropped when we are using glibc 2.35 or later.
+
+diff --git a/sysdeps/riscv/setjmp.S b/sysdeps/riscv/setjmp.S
+index 0b92016b31..bec7ff80f4 100644
+--- a/sysdeps/riscv/setjmp.S
++++ b/sysdeps/riscv/setjmp.S
+@@ -21,7 +21,7 @@
+ 
+ ENTRY (_setjmp)
+   li	a1, 0
+-  j	__sigsetjmp
++  j	HIDDEN_JUMPTARGET (__sigsetjmp)
+ END (_setjmp)
+ ENTRY (setjmp)
+   li	a1, 1
+diff --git a/sysdeps/unix/sysv/linux/riscv/setcontext.S b/sysdeps/unix/sysv/linux/riscv/setcontext.S
+index 9510518750..e44a68aad4 100644
+--- a/sysdeps/unix/sysv/linux/riscv/setcontext.S
++++ b/sysdeps/unix/sysv/linux/riscv/setcontext.S
+@@ -95,6 +95,7 @@ LEAF (__setcontext)
+ 99:	j	__syscall_error
+ 
+ END (__setcontext)
++libc_hidden_def (__setcontext)
+ weak_alias (__setcontext, setcontext)
+ 
+ LEAF (__start_context)
+@@ -108,7 +109,7 @@ LEAF (__start_context)
+ 	/* Invoke subsequent context if present, else exit(0).  */
+ 	mv	a0, s2
+ 	beqz	s2, 1f
+-	jal	__setcontext
+-1:	j	exit
++	jal	HIDDEN_JUMPTARGET (__setcontext)
++1:	j	HIDDEN_JUMPTARGET (exit)
+ 
+ END (__start_context)

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -258,7 +258,7 @@ def check_MACHO_sdk(binary) -> bool:
     return False
 
 def check_MACHO_lld(binary) -> bool:
-    if binary.build_version.tools[0].version == [18, 1, 8]:
+    if binary.build_version.tools[0].version == [19, 1, 4]:
         return True
     return False
 


### PR DESCRIPTION
https://codeberg.org/guix/guix/commit/5cb84f2013c5b1e48a7d0e617032266f1e6059e2 isn't super recent, but it's enough to get access to some newer packages, such as LLVM 19, and avoids having to add any further work arounds for things that we know are fixed later (i.e nsis). Once things upstream have stabilized a bit more (the `core-updates` branch was fairly recently merged), we could look at bumping to something newer.

Package updates:
(base) glibc 2.35 -> 2.39
binutils 2.38 -> 2.41
diffutils 3.8 -> 3.10
gawk 5.2.1 -> 5.3.0
git-minimal 2.45.2 -> 2.46.0
grep 3.8 -> 3.11
gzip 1.12 -> 1.13
linux-headers 6.1.106 -> 6.1.119
make 4.3 -> 4.4.1
xz 5.2.8 -> 5.4.5

CMake 3.30 becomes available.
Clang/LLVM 19 becomes available.

Could be used for #32764.