### PR TITLE
build: Enable -DCMAKE_EXPORT_COMPILE_COMMANDS=1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,9 @@ if (NOT DEFINED CMAKE_OPTIMIZE_DEPENDENCIES)
   set(CMAKE_OPTIMIZE_DEPENDENCIES TRUE)
 endif()
 
+# Enable export of `compile_commands.json` used by the clangd language server.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 #=============================
 # Configurable options
 #=============================


### PR DESCRIPTION
This was unintentionally disabled in the refactor commit https://github.com/bitcoin/bitcoin/pull/33101/commits/eb59a192d9ca3b1a27051cb5f2b3483186fe9928 from https://github.com/bitcoin/bitcoin/pull/33101.

This is useful for the `clangd` language server, and there is no harm in enabling it even for those that don't use it as far as I know, I assume that it is only temporarily disabled during secp256k1 compilation because this results in bad metadata being exported to `compile_commands.json`.