### PR TITLE
net: Provide block templates to peers on request

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -599,6 +599,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
         "-whitebind. "
         "Additional flags \"in\" and \"out\" control whether permissions apply to incoming connections and/or manual (default: incoming only). "
         "Can be specified multiple times.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-sharetemplatecount", strprintf("Number of block templates to store and share to peers (default: %d). Set to 0 to disable sharing block templates.", DEFAULT_SHARETMPL_COUNT), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
 
     g_wallet_init_interface.AddWalletOptions(argsman);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1093,6 +1093,13 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         }
     }
 
+    if (args.GetBoolArg("-printpriority", DEFAULT_PRINT_MODIFIED_FEE)) {
+        if (!LogInstance().WillLogCategory(BCLog::MINER)) {
+            LogInstance().EnableCategory(BCLog::MINER);
+            LogInfo("parameter interaction: -printpriority -> setting -debug=miner\n");
+        }
+    }
+
     // Also report errors from parsing before daemonization
     {
         kernel::Notifications notifications{};

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -201,6 +201,7 @@ static const std::map<std::string, BCLog::LogFlags, std::less<>> LOG_CATEGORIES_
     {"txreconciliation", BCLog::TXRECONCILIATION},
     {"scan", BCLog::SCAN},
     {"txpackages", BCLog::TXPACKAGES},
+    {"miner", BCLog::MINER},
 };
 
 static const std::unordered_map<BCLog::LogFlags, std::string> LOG_CATEGORIES_BY_FLAG{

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -202,6 +202,7 @@ static const std::map<std::string, BCLog::LogFlags, std::less<>> LOG_CATEGORIES_
     {"scan", BCLog::SCAN},
     {"txpackages", BCLog::TXPACKAGES},
     {"miner", BCLog::MINER},
+    {"sharetmpl", BCLog::SHARETMPL},
 };
 
 static const std::unordered_map<BCLog::LogFlags, std::string> LOG_CATEGORIES_BY_FLAG{

--- a/src/logging.h
+++ b/src/logging.h
@@ -94,6 +94,7 @@ namespace BCLog {
         TXRECONCILIATION = (CategoryMask{1} << 26),
         SCAN        = (CategoryMask{1} << 27),
         TXPACKAGES  = (CategoryMask{1} << 28),
+        MINER       = (CategoryMask{1} << 29),
         ALL         = ~NONE,
     };
     enum class Level {

--- a/src/logging.h
+++ b/src/logging.h
@@ -95,6 +95,7 @@ namespace BCLog {
         SCAN        = (CategoryMask{1} << 27),
         TXPACKAGES  = (CategoryMask{1} << 28),
         MINER       = (CategoryMask{1} << 29),
+        SHARETMPL   = (CategoryMask{1} << 30),
         ALL         = ~NONE,
     };
     enum class Level {

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -46,6 +46,8 @@ static const unsigned int MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK = 3;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
  *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;
+/** Number of templates to keep around for sharing. */
+static constexpr uint32_t DEFAULT_SHARETMPL_COUNT = 10;
 
 struct CNodeStateStats {
     int nSyncHeight = -1;
@@ -89,6 +91,8 @@ public:
         //! Number of headers sent in one getheaders message result (this is
         //! a test-only option).
         uint32_t max_headers_result{MAX_HEADERS_RESULTS};
+        //! Number of block templates to keep for sharing.
+        uint32_t share_template_count{DEFAULT_SHARETMPL_COUNT};
     };
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -67,6 +67,15 @@ struct CNodeStateStats {
     std::chrono::seconds time_offset{0};
 };
 
+struct TemplateStats {
+    int num_templates{0};
+    int max_templates{0};
+    int num_transactions{0};
+    int latest_template_tx{0};
+    int latest_template_weight{0};
+    NodeClock::time_point next_update{NodeClock::time_point::max()};
+};
+
 struct PeerManagerInfo {
     std::chrono::seconds median_outbound_time_offset{0s};
     bool ignores_incoming_txs{false};
@@ -116,6 +125,9 @@ public:
     virtual bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const = 0;
 
     virtual std::vector<node::TxOrphanage::OrphanInfo> GetOrphanTransactions() = 0;
+
+    /** Get statistics/info about templates */
+    virtual TemplateStats GetTemplateStats() const = 0;
 
     /** Get peer manager info. */
     virtual PeerManagerInfo GetInfo() const = 0;

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -169,7 +169,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
     pblocktemplate->vchCoinbaseCommitment = m_chainstate.m_chainman.GenerateCoinbaseCommitment(*pblock, pindexPrev);
 
-    LogPrintf("CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
+    LogDebug(BCLog::MINER, "CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
 
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
@@ -240,7 +240,7 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
     inBlock.insert(iter->GetSharedTx()->GetHash());
 
     if (m_options.print_modified_fee) {
-        LogPrintf("fee rate %s txid %s\n",
+        LogDebug(BCLog::MINER, "fee rate %s txid %s\n",
                   CFeeRate(iter->GetModifiedFee(), iter->GetTxSize()).ToString(),
                   iter->GetTx().GetHash().ToString());
     }

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -16,7 +16,6 @@
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
 #include <logging.h>
-#include <node/context.h>
 #include <node/kernel_notifications.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -92,6 +92,14 @@ BlockAssembler::BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool
 {
 }
 
+BlockAssembler::BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool, const Options& options, AllowOversizedBlocks_tag)
+    : chainparams{chainstate.m_chainman.GetParams()},
+      m_mempool{options.use_mempool ? mempool : nullptr},
+      m_chainstate{chainstate},
+      m_options{options}
+{
+}
+
 void ApplyArgsManOptions(const ArgsManager& args, BlockAssembler::Options& options)
 {
     // Block resource limits

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -168,6 +168,8 @@ private:
     const CTxMemPool* const m_mempool;
     Chainstate& m_chainstate;
 
+    struct AllowOversizedBlocks_tag { explicit AllowOversizedBlocks_tag() = default; };
+
 public:
     struct Options : BlockCreateOptions {
         // Configuration parameters for the block size
@@ -179,6 +181,9 @@ public:
     };
 
     explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool, const Options& options);
+
+    static constexpr AllowOversizedBlocks_tag ALLOW_OVERSIZED_BLOCKS{};
+    explicit BlockAssembler(Chainstate& chainstate, const CTxMemPool* mempool, const Options& options, AllowOversizedBlocks_tag);
 
     /** Construct a new block template */
     std::unique_ptr<CBlockTemplate> CreateNewBlock();

--- a/src/node/peerman_args.cpp
+++ b/src/node/peerman_args.cpp
@@ -23,7 +23,11 @@ void ApplyArgsManOptions(const ArgsManager& argsman, PeerManager::Options& optio
     if (auto value{argsman.GetBoolArg("-capturemessages")}) options.capture_messages = *value;
 
     if (auto value{argsman.GetBoolArg("-blocksonly")}) options.ignore_incoming_txs = *value;
+
+    if (auto value{argsman.GetIntArg("-sharetemplatecount")}) {
+        // Arbitrary upper limit of 256 (equivalent to 2GB at 8MB per template, and a 2 hour backlog at 30s per update)
+        options.share_template_count = static_cast<uint32_t>(std::clamp<int64_t>(*value, 0, 256));
+    }
 }
 
 } // namespace node
-

--- a/src/node/protocol_version.h
+++ b/src/node/protocol_version.h
@@ -35,4 +35,7 @@ static const int INVALID_CB_NO_BAN_VERSION = 70015;
 //! "wtxidrelay" command for wtxid-based relay starts with this version
 static const int WTXID_RELAY_VERSION = 70016;
 
+//! sendtemplate support starts with this version
+static const int SENDTEMPLATE_VERSION = 70016;
+
 #endif // BITCOIN_NODE_PROTOCOL_VERSION_H

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -264,6 +264,11 @@ inline constexpr const char* WTXIDRELAY{"wtxidrelay"};
  * txreconciliation, as described by BIP 330.
  */
 inline constexpr const char* SENDTXRCNCL{"sendtxrcncl"};
+
+inline constexpr const char* SENDTEMPLATE{"sendtemplate"};
+inline constexpr const char* GETTEMPLATE{"gettemplate"};
+inline constexpr const char* TEMPLATE{"template"};
+
 }; // namespace NetMsgType
 
 /** All known message types (see above). Keep this in the same order as the list of messages above. */
@@ -303,6 +308,9 @@ inline const std::array ALL_NET_MESSAGE_TYPES{std::to_array<std::string>({
     NetMsgType::CFCHECKPT,
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
+    NetMsgType::SENDTEMPLATE,
+    NetMsgType::GETTEMPLATE,
+    NetMsgType::TEMPLATE,
 })};
 
 /** nServices flags */

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -149,6 +149,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getrawmempool",
     "getrawtransaction",
     "getrpcinfo",
+    "gettemplateinfo",
     "gettxout",
     "gettxoutsetinfo",
     "gettxspendingprevout",

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1734,6 +1734,58 @@ class msg_no_witness_blocktxn(msg_blocktxn):
         return self.block_transactions.serialize(with_witness=False)
 
 
+class msg_sendtemplate:
+    __slots__ = ()
+    msgtype = b"sendtemplate"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_sendtemplate()"
+
+class msg_gettemplate:
+    __slots__ = ()
+    msgtype = b"gettemplate"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_gettemplate()"
+
+class msg_template:
+    __slots__ = ("header_and_shortids",)
+    msgtype = b"template"
+
+    def __init__(self, header_and_shortids = None):
+        self.header_and_shortids = header_and_shortids
+
+    def deserialize(self, f):
+        self.header_and_shortids = P2PHeaderAndShortIDs()
+        self.header_and_shortids.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += self.header_and_shortids.serialize()
+        return r
+
+    def __repr__(self):
+        return "msg_template(HeaderAndShortIDs=%s)" % repr(self.header_and_shortids)
+
+
 class msg_getcfilters:
     __slots__ = ("filter_type", "start_height", "stop_hash")
     msgtype =  b"getcfilters"

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -53,6 +53,7 @@ from test_framework.messages import (
     msg_getcfilters,
     msg_getdata,
     msg_getheaders,
+    msg_gettemplate,
     msg_headers,
     msg_inv,
     msg_mempool,
@@ -63,7 +64,9 @@ from test_framework.messages import (
     msg_sendaddrv2,
     msg_sendcmpct,
     msg_sendheaders,
+    msg_sendtemplate,
     msg_sendtxrcncl,
+    msg_template,
     msg_tx,
     MSG_TX,
     MSG_TYPE_MASK,
@@ -131,6 +134,7 @@ MESSAGEMAP = {
     b"getcfilters": msg_getcfilters,
     b"getdata": msg_getdata,
     b"getheaders": msg_getheaders,
+    b"gettemplate": msg_gettemplate,
     b"headers": msg_headers,
     b"inv": msg_inv,
     b"mempool": msg_mempool,
@@ -141,7 +145,9 @@ MESSAGEMAP = {
     b"sendaddrv2": msg_sendaddrv2,
     b"sendcmpct": msg_sendcmpct,
     b"sendheaders": msg_sendheaders,
+    b"sendtemplate": msg_sendtemplate,
     b"sendtxrcncl": msg_sendtxrcncl,
+    b"template": msg_template,
     b"tx": msg_tx,
     b"verack": msg_verack,
     b"version": msg_version,
@@ -547,6 +553,7 @@ class P2PInterface(P2PConnection):
     def on_getblocktxn(self, message): pass
     def on_getdata(self, message): pass
     def on_getheaders(self, message): pass
+    def on_gettemplate(self, message): pass
     def on_headers(self, message): pass
     def on_mempool(self, message): pass
     def on_merkleblock(self, message): pass
@@ -555,7 +562,9 @@ class P2PInterface(P2PConnection):
     def on_sendaddrv2(self, message): pass
     def on_sendcmpct(self, message): pass
     def on_sendheaders(self, message): pass
+    def on_sendtemplate(self, message): pass
     def on_sendtxrcncl(self, message): pass
+    def on_template(self, message): pass
     def on_tx(self, message): pass
     def on_wtxidrelay(self, message): pass
 


### PR DESCRIPTION
Implements the sending side of `SENDTEMPLATE`, `GETTEMPLATE`, `TEMPLATE` message scheme for sharing block templates with peers via compact block encoding/reconstruction.