### PR TITLE
docs: clarify RPC credentials security boundary

### DIFF
--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -124,6 +124,22 @@ RPC interface will be abused.
   security-sensitive operations on a computer whose other programs you
   trust.
 
+- **RPC Credentials Security Boundary:** Any client with valid RPC credentials
+  should be treated as having significant control over both the Bitcoin Core node
+  and the filesystem resources accessible by the `bitcoind` process. RPC commands
+  can load wallet files from paths that the `bitcoind` process has permission to
+  access, specify file paths for operations, and potentially gain broader access
+  than intended. This means that someone with RPC access can potentially compromise
+  not only the Bitcoin Core node, but also the machine it is running on. Bitcoin Core
+  provides the `-rpcwhitelist` option to restrict which RPC commands specific users
+  can access, and `-rpcwhitelistdefault` to control the default behavior for users
+  without explicit whitelists. However, when using multiple wallets or sharing access
+  with different users, these should not be considered robust security boundaries, as
+  users with access to certain commands may still be able to exploit functionality in
+  unexpected ways. For security-sensitive operations, implement proper system-level
+  isolation (containers, virtualization, separate user accounts with restricted
+  permissions) rather than relying solely on RPC access controls.
+
 - **Securing remote network access:** You may optionally allow other
   computers to remotely control Bitcoin Core by setting the `rpcallowip`
   and `rpcbind` configuration parameters.  These settings are only meant


### PR DESCRIPTION
Explicitly states that RPC credentials grant full administrative access to the node and filesystem resources accessible by bitcoind. Adds a new section in JSON-RPC-interface.md to address issue https://github.com/bitcoin/bitcoin/issues/32274 by documenting that providing RPC credentials to untrusted clients

reopened #32424

P.S. I've tried to somehow squash all the commits from the previous pr but accidentally closed the pr and had no idea how to return back, therefore created a new pr, I'm really sorry for the inconvenience 