### PR TITLE
test: ensure logs are flushed before reading them

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -509,6 +509,14 @@ void BCLog::Logger::LogPrintStr_(std::string_view str, std::source_location&& so
     }
 }
 
+void BCLog::Logger::FlushDebugFile()
+{
+    StdLockGuard lock{m_cs};
+    if (m_fileout) {
+        fflush(m_fileout);
+    }
+}
+
 void BCLog::Logger::ShrinkDebugFile()
 {
     // Amount of debug.log to save at end when shrinking (must fit in memory)

--- a/src/logging.h
+++ b/src/logging.h
@@ -275,6 +275,7 @@ namespace BCLog {
          */
         void DisableLogging() EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
 
+        void FlushDebugFile() EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
         void ShrinkDebugFile();
 
         std::unordered_map<LogFlags, Level> CategoryLevels() const EXCLUSIVE_LOCKS_REQUIRED(!m_cs)

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -39,6 +39,7 @@ static void ResetLogger()
 
 static std::vector<std::string> ReadDebugLogLines()
 {
+    LogInstance().FlushDebugFile();
     std::vector<std::string> lines;
     std::ifstream ifs{LogInstance().m_file_path};
     for (std::string line; std::getline(ifs, line);) {


### PR DESCRIPTION
_Should fix https://github.com/bitcoin/bitcoin/issues/33195 (still testing, trying to reproduce locally, draft until then)_

Logging to file is unbuffered ([src](https://github.com/bitcoin/bitcoin/blob/7b4a1350dfd6b3892a9c314eeff28b22ef0c1a73/src/logging.cpp#L68)), but is not blocked by flushing. Generally, that seems desireable, but it can be problematic for tests.

https://github.com/bitcoin/bitcoin/issues/33195 observes intermittent failure of the `TestLogFromLocation()` function (see [comment](https://github.com/bitcoin/bitcoin/issues/33195#issuecomment-3191611727) for more details), where we [write and read to/from file in quick succession](https://github.com/bitcoin/bitcoin/blob/7b4a1350dfd6b3892a9c314eeff28b22ef0c1a73/src/test/logging_tests.cpp#L424-L425).

This PR introduces a `Logger::FlushDebugFile()` method, and uses it in the test-only `ReadDebugLogLines()` function. As such, this PR should not change any non-test behaviour or performance.