### PR TITLE
rpc: require integer verbosity; remove boolean 'verbose'

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1294,11 +1294,11 @@ A few guidelines for introducing and reviewing new RPC interfaces:
     to a multi-value, or due to other historical reasons. **Always** have false map to 0 and
     true to 1 in this case.
 
-- For new RPC methods, if implementing a `verbosity` argument, use integer verbosity rather than boolean.
-  Disallow usage of boolean verbosity (see `ParseVerbosity()` in [util.h](/src/rpc/util.h)).
+- For RPC methods implementing a `verbosity` argument, use integer verbosity only.
+  Boolean verbosity is no longer supported (see `ParseVerbosity()` in [util.h](/src/rpc/util.h)).
 
-  - *Rationale*: Integer verbosity allows for multiple values. Undocumented boolean verbosity is deprecated
-    and new RPC methods should prevent its use.
+  - *Rationale*: Integer verbosity allows for multiple values and provides a cleaner, more consistent API.
+    Boolean verbosity has been removed to eliminate confusion and improve consistency across RPC methods.
 
 - Add every non-string RPC argument `(method, idx, name)` to the table `vRPCConvertParams` in `rpc/client.cpp`.
 

--- a/doc/release-notes/release-notes-remove-boolean-verbosity.md
+++ b/doc/release-notes/release-notes-remove-boolean-verbosity.md
@@ -1,0 +1,35 @@
+# RPC Changes
+
+## Boolean verbosity parameters removed
+
+The following RPC methods no longer accept boolean values for their verbosity parameters:
+
+- `getblock`
+- `getrawtransaction` 
+- `getrawmempool`
+
+**Before (deprecated, now removed):**
+```bash
+bitcoin-cli getblock <blockhash> true   # Error
+bitcoin-cli getblock <blockhash> false  # Error
+bitcoin-cli getrawtransaction <txid> true   # Error
+bitcoin-cli getrawtransaction <txid> false  # Error  
+bitcoin-cli getrawmempool true   # Error
+bitcoin-cli getrawmempool false  # Error
+```
+
+**Use integers instead:**
+```bash
+bitcoin-cli getblock <blockhash> 1   # Verbose JSON format
+bitcoin-cli getblock <blockhash> 0   # Raw hex format
+bitcoin-cli getrawtransaction <txid> 1   # Verbose JSON format
+bitcoin-cli getrawtransaction <txid> 0   # Raw hex format
+bitcoin-cli getrawmempool 1   # Verbose JSON format  
+bitcoin-cli getrawmempool 0   # List of transaction IDs
+```
+
+**Breaking Change:** Any scripts or applications using boolean verbosity parameters will need to be updated to use integer values:
+- `false` → `0`
+- `true` → `1`
+
+This change improves consistency across RPC methods and enables support for additional verbosity levels in the future.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -812,7 +812,7 @@ static RPCHelpMan getblock()
 {
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
 
-    int verbosity{ParseVerbosity(request.params[1], /*default_verbosity=*/1, /*allow_bool=*/true)};
+    int verbosity{ParseVerbosity(request.params[1], /*default_verbosity=*/1)};
 
     const CBlockIndex* pblockindex;
     const CBlockIndex* tip;

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -899,7 +899,7 @@ static RPCHelpMan getorphantxs()
             PeerManager& peerman = EnsurePeerman(node);
             std::vector<node::TxOrphanage::OrphanInfo> orphanage = peerman.GetOrphanTransactions();
 
-            int verbosity{ParseVerbosity(request.params[0], /*default_verbosity=*/0, /*allow_bool*/false)};
+            int verbosity{ParseVerbosity(request.params[0], /*default_verbosity=*/0)};
 
             UniValue ret(UniValue::VARR);
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -330,7 +330,7 @@ static RPCHelpMan getrawtransaction()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "The genesis block coinbase is not considered an ordinary transaction and cannot be retrieved");
     }
 
-    int verbosity{ParseVerbosity(request.params[1], /*default_verbosity=*/0, /*allow_bool=*/true)};
+    int verbosity{ParseVerbosity(request.params[1], /*default_verbosity=*/0)};
 
     if (!request.params[2].isNull()) {
         LOCK(cs_main);

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -83,14 +83,11 @@ void RPCTypeCheckObj(const UniValue& o,
     }
 }
 
-int ParseVerbosity(const UniValue& arg, int default_verbosity, bool allow_bool)
+int ParseVerbosity(const UniValue& arg, int default_verbosity)
 {
     if (!arg.isNull()) {
         if (arg.isBool()) {
-            if (!allow_bool) {
-                throw JSONRPCError(RPC_TYPE_ERROR, "Verbosity was boolean but only integer allowed");
-            }
-            return arg.get_bool(); // true = 1
+            throw JSONRPCError(RPC_TYPE_ERROR, "Verbosity was boolean but only integer allowed");
         } else {
             return arg.getInt<int>();
         }

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -107,13 +107,12 @@ std::vector<unsigned char> ParseHexO(const UniValue& o, std::string_view strKey)
 /**
  * Parses verbosity from provided UniValue.
  *
- * @param[in] arg The verbosity argument as an int (0, 1, 2,...) or bool if allow_bool is set to true
+ * @param[in] arg The verbosity argument as an int (0, 1, 2,...)
  * @param[in] default_verbosity The value to return if verbosity argument is null
- * @param[in] allow_bool If true, allows arg to be a bool and parses it
  * @returns An integer describing the verbosity level (e.g. 0, 1, 2, etc.)
- * @throws JSONRPCError if allow_bool is false but arg provided is boolean
+ * @throws JSONRPCError if arg provided is boolean
  */
-int ParseVerbosity(const UniValue& arg, int default_verbosity, bool allow_bool);
+int ParseVerbosity(const UniValue& arg, int default_verbosity);
 
 /**
  * Validate and return a CAmount from a UniValue number or string.

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -238,7 +238,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.tip = int(inputblockhash, 16)
         self.tipheight += 1
         self.last_block_time += 600
-        assert_equal(len(self.nodes[0].getblock(inputblockhash, True)["tx"]), TESTING_TX_COUNT + 1)
+        assert_equal(len(self.nodes[0].getblock(inputblockhash, 1)["tx"]), TESTING_TX_COUNT + 1)
 
         # 2 more version 4 blocks
         test_blocks = self.generate_blocks(2)

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -189,7 +189,7 @@ class EstimateFeeTest(BitcoinTestFramework):
             for node in self.nodes:
                 node.batch(batch_sendtx_reqs)
             self.sync_mempools(wait=0.1)
-            mined = mining_node.getblock(self.generate(mining_node, 1)[0], True)["tx"]
+            mined = mining_node.getblock(self.generate(mining_node, 1)[0], 1)["tx"]
             # update which txouts are confirmed
             newmem = []
             for utx in self.memutxo:

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -86,7 +86,7 @@ class MaxUploadTest(BitcoinTestFramework):
 
         # Store the hash; we'll request this later
         big_old_block = self.nodes[0].getbestblockhash()
-        old_block_size = self.nodes[0].getblock(big_old_block, True)['size']
+        old_block_size = self.nodes[0].getblock(big_old_block, 1)['size']
         big_old_block = int(big_old_block, 16)
 
         # Advance to two days ago

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -227,7 +227,7 @@ class SegWitTest(BitcoinTestFramework):
 
         self.log.info("Verify sigops are counted in GBT with BIP141 rules after the fork")
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
-        raw_tx = self.nodes[0].getrawtransaction(txid, True)
+        raw_tx = self.nodes[0].getrawtransaction(txid, 1)
         tmpl = self.nodes[0].getblocktemplate({'rules': ['segwit']})
         assert_greater_than_or_equal(tmpl['sizelimit'], 3999577)  # actual maximum size is lower due to minimum mandatory non-witness data
         assert_equal(tmpl['weightlimit'], 4000000)

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -30,13 +30,13 @@ class UTXOSetHashTest(BitcoinTestFramework):
         # Generate 100 blocks and remove the first since we plan to spend its
         # coinbase
         block_hashes = self.generate(wallet, 1) + self.generate(node, 99)
-        blocks = list(map(lambda block: from_hex(CBlock(), node.getblock(block, False)), block_hashes))
+        blocks = list(map(lambda block: from_hex(CBlock(), node.getblock(block, 0)), block_hashes))
         blocks.pop(0)
 
         # Create a spending transaction and mine a block which includes it
         txid = wallet.send_self_transfer(from_node=node)['txid']
         tx_block = self.generateblock(node, output=wallet.get_address(), transactions=[txid])
-        blocks.append(from_hex(CBlock(), node.getblock(tx_block['hash'], False)))
+        blocks.append(from_hex(CBlock(), node.getblock(tx_block['hash'], 0)))
 
         # Serialize the outputs that should be in the UTXO set and add them to
         # a MuHash object

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -44,7 +44,7 @@ class DataCarrierTest(BitcoinTestFramework):
 
         if success:
             self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_hex)
-            assert tx.txid_hex in node.getrawmempool(True), f'{tx_hex} not in mempool'
+            assert tx.txid_hex in node.getrawmempool(1), f'{tx_hex} not in mempool'
         else:
             assert_raises_rpc_error(-26, "datacarrier", self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
 

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -61,7 +61,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
         # Check mempool has DEFAULT_ANCESTOR_LIMIT transactions in it, and descendant and ancestor
         # count and fees should look correct
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(1)
         assert_equal(len(mempool), DEFAULT_ANCESTOR_LIMIT)
         descendant_count = 1
         descendant_fees = 0
@@ -191,8 +191,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(entry['fees']['descendant'], descendant_fees + Decimal("0.00002"))
 
         # Check that node1's mempool is as expected (-> custom ancestor limit)
-        mempool0 = self.nodes[0].getrawmempool(False)
-        mempool1 = self.nodes[1].getrawmempool(False)
+        mempool0 = self.nodes[0].getrawmempool(0)
+        mempool1 = self.nodes[1].getrawmempool(0)
         assert_equal(len(mempool1), CUSTOM_ANCESTOR_LIMIT)
         assert set(mempool1).issubset(set(mempool0))
         for tx in chain[:CUSTOM_ANCESTOR_LIMIT]:
@@ -224,7 +224,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
                 tx_children.append(txid)
             transaction_package.extend(new_tx["new_utxos"])
 
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(1)
         assert_equal(mempool[parent_transaction]['descendantcount'], DEFAULT_DESCENDANT_LIMIT)
         assert_equal(sorted(mempool[parent_transaction]['spentby']), sorted(tx_children))
 
@@ -241,8 +241,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # - txs chained off parent tx (-> custom descendant limit)
         self.wait_until(lambda: len(self.nodes[1].getrawmempool()) ==
                                 CUSTOM_ANCESTOR_LIMIT + 1 + CUSTOM_DESCENDANT_LIMIT, timeout=10)
-        mempool0 = self.nodes[0].getrawmempool(False)
-        mempool1 = self.nodes[1].getrawmempool(False)
+        mempool0 = self.nodes[0].getrawmempool(0)
+        mempool1 = self.nodes[1].getrawmempool(0)
         assert set(mempool1).issubset(set(mempool0))
         assert parent_transaction in mempool1
         for tx in chain[:CUSTOM_DESCENDANT_LIMIT]:

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -49,7 +49,7 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
         if self.is_wallet_compiled():
             unbroadcast_count += 1
         assert_equal(mempoolinfo['unbroadcastcount'], unbroadcast_count)
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(1)
         for tx in mempool:
             assert_equal(mempool[tx]['unbroadcast'], True)
 
@@ -74,7 +74,7 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
             assert wallet_tx_hsh in mempool
 
         # check that transactions are no longer in first node's unbroadcast set
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(1)
         for tx in mempool:
             assert_equal(mempool[tx]['unbroadcast'], False)
 

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -199,7 +199,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # Make sure that the size of each group of transactions exceeds
         # MAX_BLOCK_WEIGHT // 4 -- otherwise the test needs to be revised to
         # create more transactions.
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(1)
         sizes = [0, 0, 0]
         for i in range(3):
             for j in txids[i]:

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -306,7 +306,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         block_hash = int(self.generate(node, 1)[0], 16)
 
         # Store the raw block in our internal format.
-        block = from_hex(CBlock(), node.getblock("%064x" % block_hash, False))
+        block = from_hex(CBlock(), node.getblock("%064x" % block_hash, 0))
 
         # Wait until the block was announced (via compact blocks)
         test_node.wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30)
@@ -567,7 +567,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         current_height = chain_height
         while (current_height >= chain_height - MAX_GETBLOCKTXN_DEPTH):
             block_hash = node.getblockhash(current_height)
-            block = from_hex(CBlock(), node.getblock(block_hash, False))
+            block = from_hex(CBlock(), node.getblock(block_hash, 0))
 
             msg = msg_getblocktxn()
             msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [])
@@ -602,7 +602,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Request with out-of-bounds tx index results in disconnect
         bad_peer = self.nodes[0].add_p2p_connection(TestP2PConn())
         block_hash = node.getblockhash(chain_height)
-        block = from_hex(CBlock(), node.getblock(block_hash, False))
+        block = from_hex(CBlock(), node.getblock(block_hash, 0))
         msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [len(block.vtx)])
         with node.assert_debug_log(['getblocktxn with out-of-bounds tx indices']):
             bad_peer.send_without_ping(msg)

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -396,7 +396,7 @@ class SegWitTest(BitcoinTestFramework):
             all_heights = all_heights[0:10]
             for height in all_heights:
                 block_hash = self.nodes[0].getblockhash(height)
-                rpc_block = self.nodes[0].getblock(block_hash, False)
+                rpc_block = self.nodes[0].getblock(block_hash, 0)
                 block_hash = int(block_hash, 16)
                 block = self.test_node.request_block(block_hash, 2)
                 wit_block = self.test_node.request_block(block_hash, 2 | MSG_WITNESS_FLAG)
@@ -413,7 +413,7 @@ class SegWitTest(BitcoinTestFramework):
             assert len(block.vtx[0].wit.vtxinwit[0].scriptWitness.stack) == 1
             test_witness_block(self.nodes[0], self.test_node, block, accepted=True)
             # Now try to retrieve it...
-            rpc_block = self.nodes[0].getblock(block.hash_hex, False)
+            rpc_block = self.nodes[0].getblock(block.hash_hex, 0)
             non_wit_block = self.test_node.request_block(block.hash_int, 2)
             wit_block = self.test_node.request_block(block.hash_int, 2 | MSG_WITNESS_FLAG)
             assert_equal(wit_block.serialize(), bytes.fromhex(rpc_block))
@@ -421,7 +421,7 @@ class SegWitTest(BitcoinTestFramework):
             assert_equal(wit_block.serialize(), block.serialize())
 
             # Test size, vsize, weight
-            rpc_details = self.nodes[0].getblock(block.hash_hex, True)
+            rpc_details = self.nodes[0].getblock(block.hash_hex, 1)
             assert_equal(rpc_details["size"], len(block.serialize()))
             assert_equal(rpc_details["strippedsize"], len(block.serialize(False)))
             assert_equal(rpc_details["weight"], block.get_weight())

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -156,7 +156,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-25, "Input not found or already spent", node2.combinerawtransaction, [rawtx2['hex'], rawtx3['hex']])
 
-        txinfo = node0.getrawtransaction(tx, True, blk)
+        txinfo = node0.getrawtransaction(tx, 1, blk)
         self.log.info("n/m=%d/%d %s size=%d vsize=%d weight=%d" % (nsigs, nkeys, output_type, txinfo["size"], txinfo["vsize"], txinfo["weight"]))
 
     def test_mixing_uncompressed_and_compressed_keys(self, node):

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -15,14 +15,14 @@ def unidirectional_node_sync_via_rpc(node_src, node_dest):
     blockhash = node_src.getbestblockhash()
     while True:
         try:
-            assert len(node_dest.getblock(blockhash, False)) > 0
+            assert len(node_dest.getblock(blockhash, 0)) > 0
             break
         except Exception:
             blocks_to_copy.append(blockhash)
             blockhash = node_src.getblockheader(blockhash, True)['previousblockhash']
     blocks_to_copy.reverse()
     for blockhash in blocks_to_copy:
-        blockdata = node_src.getblock(blockhash, False)
+        blockdata = node_src.getblock(blockhash, 0)
         assert node_dest.submitblock(blockdata) in (None, 'inconclusive')
 
 def node_sync_via_rpc(nodes):

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -112,7 +112,7 @@ class RawTransactionsTest(BitcoinTestFramework):
                 assert_equal(self.nodes[n].getrawtransaction(txId, 0), tx['hex'])
 
                 # 3. valid parameters - supply txid and False for non-verbose
-                assert_equal(self.nodes[n].getrawtransaction(txId, False), tx['hex'])
+                assert_equal(self.nodes[n].getrawtransaction(txId, 0), tx['hex'])
 
                 # 4. valid parameters - supply txid and 1 for verbose.
                 # We only check the "hex" field of the output so we don't need to update this test every time the output format changes.
@@ -120,7 +120,7 @@ class RawTransactionsTest(BitcoinTestFramework):
                 assert_equal(self.nodes[n].getrawtransaction(txId, 2)["hex"], tx['hex'])
 
                 # 5. valid parameters - supply txid and True for non-verbose
-                assert_equal(self.nodes[n].getrawtransaction(txId, True)["hex"], tx['hex'])
+                assert_equal(self.nodes[n].getrawtransaction(txId, 1)["hex"], tx['hex'])
             else:
                 # Without -txindex, expect to raise.
                 for verbose in [None, 0, False, 1, True]:

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -40,7 +40,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         blockhash = self.nodes[0].getblockhash(chain_height + 1)
 
         txlist = []
-        blocktxn = self.nodes[0].getblock(blockhash, True)["tx"]
+        blocktxn = self.nodes[0].getblock(blockhash, 1)["tx"]
         txlist.append(blocktxn[1])
         txlist.append(blocktxn[2])
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -597,7 +597,7 @@ def find_vout_for_address(node, txid, addr):
     Locate the vout index of the given transaction sending to the
     given address. Raises runtime error exception if not found.
     """
-    tx = node.getrawtransaction(txid, True)
+    tx = node.getrawtransaction(txid, 1)
     for i in range(len(tx["vout"])):
         if addr == tx["vout"][i]["scriptPubKey"]["address"]:
             return i

--- a/test/functional/wallet_avoid_mixing_output_types.py
+++ b/test/functional/wallet_avoid_mixing_output_types.py
@@ -69,7 +69,7 @@ def is_legacy_address(node, addr):
 
 def is_same_type(node, tx):
     """Check that all inputs are of the same OutputType"""
-    vins = node.getrawtransaction(tx, True)['vin']
+    vins = node.getrawtransaction(tx, 1)['vin']
     inputs = []
     for vin in vins:
         prev_tx, n = vin['txid'], vin['vout']

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -542,7 +542,7 @@ def test_settxfee(self, rbf_node, dest_address):
     requested_feerate = Decimal("0.00025000")
     rbf_node.settxfee(requested_feerate)
     bumped_tx = rbf_node.bumpfee(rbfid)
-    actual_feerate = bumped_tx["fee"] * 1000 / rbf_node.getrawtransaction(bumped_tx["txid"], True)["vsize"]
+    actual_feerate = bumped_tx["fee"] * 1000 / rbf_node.getrawtransaction(bumped_tx["txid"], 1)["vsize"]
     # Assert that the difference between the requested feerate and the actual
     # feerate of the bumped transaction is small.
     assert_greater_than(Decimal("0.00001000"), abs(requested_feerate - actual_feerate))

--- a/test/functional/wallet_change_address.py
+++ b/test/functional/wallet_change_address.py
@@ -64,7 +64,7 @@ class WalletChangeAddressTest(BitcoinTestFramework):
             for n in [1, 2]:
                 self.log.debug(f"Send transaction from node {n}: expected change index {i}")
                 txid = self.nodes[n].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
-                tx = self.nodes[n].getrawtransaction(txid, True)
+                tx = self.nodes[n].getrawtransaction(txid, 1)
                 # find the change output and ensure that expected change index was used
                 self.assert_change_index(self.nodes[n], tx, i)
 
@@ -88,7 +88,7 @@ class WalletChangeAddressTest(BitcoinTestFramework):
         # The avoid partial spends wallet will always create a change output
         node = self.nodes[2]
         res = w2.send({sendTo1: "1.0", sendTo2: "1.0", sendTo3: "0.9999"}, options={"change_position": 0})
-        tx = node.getrawtransaction(res["txid"], True)
+        tx = node.getrawtransaction(res["txid"], 1)
         self.assert_change_pos(w2, tx, 0)
 
         # The default wallet will internally create a tx without change first,
@@ -96,7 +96,7 @@ class WalletChangeAddressTest(BitcoinTestFramework):
         # Ensure that the user-configured change position is kept
         node = self.nodes[1]
         res = w1.send({sendTo1: "1.0", sendTo2: "1.0", sendTo3: "0.9999"}, options={"change_position": 0})
-        tx = node.getrawtransaction(res["txid"], True)
+        tx = node.getrawtransaction(res["txid"], 1)
         # If the wallet ignores the user's change_position there is still a 25%
         # that the random change position passes the test
         self.assert_change_pos(w1, tx, 0)

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -59,7 +59,7 @@ class WalletGroupTest(BitcoinTestFramework):
         #   given address, and leave the rest
         self.log.info("Test sending transactions picks one UTXO group and leaves the rest")
         txid1 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
-        tx1 = self.nodes[1].getrawtransaction(txid1, True)
+        tx1 = self.nodes[1].getrawtransaction(txid1, 1)
         # txid1 should have 1 input and 2 outputs
         assert_equal(1, len(tx1["vin"]))
         assert_equal(2, len(tx1["vout"]))
@@ -70,7 +70,7 @@ class WalletGroupTest(BitcoinTestFramework):
         assert_approx(v[1], vexp=0.3, vspan=0.0001)
 
         txid2 = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
-        tx2 = self.nodes[2].getrawtransaction(txid2, True)
+        tx2 = self.nodes[2].getrawtransaction(txid2, 1)
         # txid2 should have 2 inputs and 2 outputs
         assert_equal(2, len(tx2["vin"]))
         assert_equal(2, len(tx2["vout"]))
@@ -98,7 +98,7 @@ class WalletGroupTest(BitcoinTestFramework):
         # B0 + B1 or C0 + C1, because this avoids partial spends while not being
         # detrimental to transaction cost
         txid3 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.4)
-        tx3 = self.nodes[1].getrawtransaction(txid3, True)
+        tx3 = self.nodes[1].getrawtransaction(txid3, 1)
         # tx3 should have 2 inputs and 2 outputs
         assert_equal(2, len(tx3["vin"]))
         assert_equal(2, len(tx3["vout"]))
@@ -126,7 +126,7 @@ class WalletGroupTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         with self.nodes[3].assert_debug_log([f'Fee non-grouped = {tx4_ungrouped_fee}, grouped = {tx4_grouped_fee}, using grouped']):
             txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
-        tx4 = self.nodes[3].getrawtransaction(txid4, True)
+        tx4 = self.nodes[3].getrawtransaction(txid4, 1)
         # tx4 should have 2 inputs and 2 outputs although one output would
         # have been enough and the transaction caused higher fees
         assert_equal(2, len(tx4["vin"]))
@@ -137,7 +137,7 @@ class WalletGroupTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         with self.nodes[3].assert_debug_log([f'Fee non-grouped = {tx5_6_ungrouped_fee}, grouped = {tx5_6_grouped_fee}, using non-grouped']):
             txid5 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
-        tx5 = self.nodes[3].getrawtransaction(txid5, True)
+        tx5 = self.nodes[3].getrawtransaction(txid5, 1)
         # tx5 should have 3 inputs (1.0, 1.0, 1.0) and 2 outputs
         assert_equal(3, len(tx5["vin"]))
         assert_equal(2, len(tx5["vout"]))
@@ -150,7 +150,7 @@ class WalletGroupTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         with self.nodes[4].assert_debug_log([f'Fee non-grouped = {tx5_6_ungrouped_fee}, grouped = {tx5_6_grouped_fee}, using grouped']):
             txid6 = self.nodes[4].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
-        tx6 = self.nodes[4].getrawtransaction(txid6, True)
+        tx6 = self.nodes[4].getrawtransaction(txid6, 1)
         # tx6 should have 5 inputs and 2 outputs
         assert_equal(5, len(tx6["vin"]))
         assert_equal(2, len(tx6["vout"]))

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -497,7 +497,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         assert_equal(addr, 'bcrt1qp8s25ckjl7gr6x2q3dx3tn2pytwp05upkjztk6ey857tt50r5aeqn6mvr9') # Derived at m/84'/0'/0'/1
         change_addr = wmulti_pub.getrawchangeaddress('bech32') # uses change 2
         assert_equal(change_addr, 'bcrt1qp6j3jw8yetefte7kw6v5pc89rkgakzy98p6gf7ayslaveaxqyjusnw580c') # Derived at m/84'/1'/0'/2
-        assert send_txid in self.nodes[0].getrawmempool(True)
+        assert send_txid in self.nodes[0].getrawmempool(1)
         assert send_txid in (x['txid'] for x in wmulti_pub.listunspent(0))
         assert_equal(wmulti_pub.getwalletinfo()['keypoolsize'], 999)
 

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -172,7 +172,7 @@ class WalletSendTest(BitcoinTestFramework):
             assert tx
             assert_equal(tx["bip125-replaceable"], "yes" if replaceable else "no")
             # Ensure transaction exists in the mempool:
-            tx = from_wallet.getrawtransaction(res["txid"], True)
+            tx = from_wallet.getrawtransaction(res["txid"], 1)
             assert tx
             if amount:
                 if subtract_fee_from_outputs:


### PR DESCRIPTION
### Summary

Standardize RPC verbosity to integers only and remove boolean handling for clarity, consistency, and future extensibility.

### Rationale

 - **Legacy cleanup**: Boolean verbosity has been discouraged/deprecated in docs since 2017 and continues to create tech debt (special-case parsing, inconsistent tests, user confusion).
- **Consistency**: Integers enable multi-level output without overloading a boolean.

### User-visible changes
- getblock, getrawtransaction, getrawmempool no longer accept booleans.
- Passing true/false now errors with: Verbosity was boolean but only integer allowed.
- Migration: false → 0, true → 1.

### Code / Docs
- ParseVerbosity(arg, default) now rejects booleans (removed allow_bool).
- Call sites and functional tests updated to use integer levels. 
- Developer notes updated; release notes added.

**Breaking change:** scripts/tools using boolean verbosity must switch to integers.