### PR TITLE
rpc: require integer verbosity; remove boolean 'verbose'

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1294,11 +1294,11 @@ A few guidelines for introducing and reviewing new RPC interfaces:
     to a multi-value, or due to other historical reasons. **Always** have false map to 0 and
     true to 1 in this case.
 
-- For new RPC methods, if implementing a `verbosity` argument, use integer verbosity rather than boolean.
-  Disallow usage of boolean verbosity (see `ParseVerbosity()` in [util.h](/src/rpc/util.h)).
+- For RPC methods implementing a `verbosity` argument, use integer verbosity only.
+  Boolean verbosity is no longer supported (see `ParseVerbosity()` in [util.h](/src/rpc/util.h)).
 
-  - *Rationale*: Integer verbosity allows for multiple values. Undocumented boolean verbosity is deprecated
-    and new RPC methods should prevent its use.
+  - *Rationale*: Integer verbosity allows for multiple values and provides a cleaner, more consistent API.
+    Boolean verbosity has been removed to eliminate confusion and improve consistency across RPC methods.
 
 - Add every non-string RPC argument `(method, idx, name)` to the table `vRPCConvertParams` in `rpc/client.cpp`.
 

--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -50,6 +50,11 @@ P2P and network changes
 Updated RPCs
 ------------
 
+- The following RPC methods no longer accept boolean values for their verbosity parameters:
+  `getblock`, `getrawtransaction`, and `getorphantxs`. Boolean verbosity has been
+  completely removed. Use integer values instead: `false` → `0`, `true` → `1`.
+  This is a breaking change that improves consistency across RPC methods and enables
+  support for additional verbosity levels in the future.
 
 Changes to wallet related RPCs can be found in the Wallet section below.
 

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -59,9 +59,9 @@ void RPCNestedTests::rpcNestedTests()
     QVERIFY(filtered == "getblockchaininfo()[chain]");
 
     RPCConsole::RPCExecuteCommandLine(m_node, result, "getblock(getbestblockhash())"); //simple 2 level nesting
-    RPCConsole::RPCExecuteCommandLine(m_node, result, "getblock(getblock(getbestblockhash())[hash], true)");
+    RPCConsole::RPCExecuteCommandLine(m_node, result, "getblock(getblock(getbestblockhash())[hash], 1)");
 
-    RPCConsole::RPCExecuteCommandLine(m_node, result, "getblock( getblock( getblock(getbestblockhash())[hash] )[hash], true)"); //4 level nesting with whitespace, filtering path and boolean parameter
+    RPCConsole::RPCExecuteCommandLine(m_node, result, "getblock( getblock( getblock(getbestblockhash())[hash] )[hash], 1)"); //4 level nesting with whitespace, filtering path and integer parameter
 
     RPCConsole::RPCExecuteCommandLine(m_node, result, "getblockchaininfo");
     QVERIFY(result.starts_with("{"));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -812,7 +812,7 @@ static RPCHelpMan getblock()
 {
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
 
-    int verbosity{ParseVerbosity(request.params[1], /*default_verbosity=*/1, /*allow_bool=*/true)};
+    int verbosity{ParseVerbosity(request.params[1], /*default_verbosity=*/1)};
 
     const CBlockIndex* pblockindex;
     const CBlockIndex* tip;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -747,7 +747,7 @@ static RPCHelpMan getblock()
                 "If verbosity is 3, returns an Object with information about block <hash> and information about each transaction, including prevout information for inputs (only for unpruned blocks in the current best chain).\n",
                 {
                     {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash"},
-                    {"verbosity|verbose", RPCArg::Type::NUM, RPCArg::Default{1}, "0 for hex-encoded data, 1 for a JSON object, 2 for JSON object with transaction data, and 3 for JSON object with transaction data including prevout information for inputs",
+                    {"verbosity|verbose", RPCArg::Type::NUM, RPCArg::Default{1}, "0 for hex-encoded data, 1 for a JSON object, 2 for JSON object with transaction data, and 3 for JSON object with transaction data including prevout information for inputs (DEPRECATED: Boolean verbosity is deprecated, use -deprecatedrpc=boolverbose to re-enable)",
                      RPCArgOptions{.skip_type_check = true}},
                 },
                 {

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -899,7 +899,7 @@ static RPCHelpMan getorphantxs()
             PeerManager& peerman = EnsurePeerman(node);
             std::vector<node::TxOrphanage::OrphanInfo> orphanage = peerman.GetOrphanTransactions();
 
-            int verbosity{ParseVerbosity(request.params[0], /*default_verbosity=*/0, /*allow_bool*/false)};
+            int verbosity{ParseVerbosity(request.params[0], /*default_verbosity=*/0)};
 
             UniValue ret(UniValue::VARR);
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -333,7 +333,7 @@ static RPCHelpMan getrawtransaction()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "The genesis block coinbase is not considered an ordinary transaction and cannot be retrieved");
     }
 
-    int verbosity{ParseVerbosity(request.params[1], /*default_verbosity=*/0, /*allow_bool=*/true)};
+    int verbosity{ParseVerbosity(request.params[1], /*default_verbosity=*/0)};
 
     if (!request.params[2].isNull()) {
         LOCK(cs_main);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -270,7 +270,7 @@ static RPCHelpMan getrawtransaction()
                 "If verbosity is 2, returns a JSON Object with information about the transaction, including fee and prevout information.",
                 {
                     {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                    {"verbosity|verbose", RPCArg::Type::NUM, RPCArg::Default{0}, "0 for hex-encoded data, 1 for a JSON object, and 2 for JSON object with fee and prevout",
+                    {"verbosity|verbose", RPCArg::Type::NUM, RPCArg::Default{0}, "0 for hex-encoded data, 1 for a JSON object, and 2 for JSON object with fee and prevout (DEPRECATED: Boolean verbosity is deprecated, use -deprecatedrpc=boolverbose to re-enable)",
                      RPCArgOptions{.skip_type_check = true}},
                     {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "The block in which to look for the transaction"},
                 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -338,12 +338,6 @@ bool RPCIsInWarmup(std::string *outStatus)
     return fRPCInWarmup;
 }
 
-bool IsDeprecatedRPCEnabled(const std::string& method)
-{
-    const std::vector<std::string> enabled_methods = gArgs.GetArgs("-deprecatedrpc");
-
-    return find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
-}
 
 UniValue JSONRPCExec(const JSONRPCRequest& jreq, bool catch_errors)
 {

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -126,8 +126,6 @@ public:
     bool removeCommand(const std::string& name, const CRPCCommand* pcmd);
 };
 
-bool IsDeprecatedRPCEnabled(const std::string& method);
-
 extern CRPCTable tableRPC;
 
 void StartRPC();

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -83,14 +83,11 @@ void RPCTypeCheckObj(const UniValue& o,
     }
 }
 
-int ParseVerbosity(const UniValue& arg, int default_verbosity, bool allow_bool)
+int ParseVerbosity(const UniValue& arg, int default_verbosity)
 {
     if (!arg.isNull()) {
         if (arg.isBool()) {
-            if (!allow_bool) {
-                throw JSONRPCError(RPC_TYPE_ERROR, "Verbosity was boolean but only integer allowed");
-            }
-            return arg.get_bool(); // true = 1
+            throw JSONRPCError(RPC_TYPE_ERROR, "Verbosity was boolean but only integer allowed");
         } else {
             return arg.getInt<int>();
         }

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -107,13 +107,12 @@ std::vector<unsigned char> ParseHexO(const UniValue& o, std::string_view strKey)
 /**
  * Parses verbosity from provided UniValue.
  *
- * @param[in] arg The verbosity argument as an int (0, 1, 2,...) or bool if allow_bool is set to true
+ * @param[in] arg The verbosity argument as an int (0, 1, 2,...)
  * @param[in] default_verbosity The value to return if verbosity argument is null
- * @param[in] allow_bool If true, allows arg to be a bool and parses it
  * @returns An integer describing the verbosity level (e.g. 0, 1, 2, etc.)
- * @throws JSONRPCError if allow_bool is false but arg provided is boolean
+ * @throws JSONRPCError if arg provided is boolean
  */
-int ParseVerbosity(const UniValue& arg, int default_verbosity, bool allow_bool);
+int ParseVerbosity(const UniValue& arg, int default_verbosity);
 
 /**
  * Validate and return a CAmount from a UniValue number or string.

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -105,14 +105,23 @@ std::vector<unsigned char> ParseHexV(const UniValue& v, std::string_view name);
 std::vector<unsigned char> ParseHexO(const UniValue& o, std::string_view strKey);
 
 /**
+ * Checks if a deprecated RPC method is enabled via -deprecatedrpc flag
+ *
+ * @param method The deprecated method name to check (e.g., "boolverbose")
+ * @return true if the method is enabled, false otherwise
+ */
+bool IsDeprecatedRPCEnabled(const std::string& method);
+
+/**
  * Parses verbosity from provided UniValue.
  *
- * @param[in] arg The verbosity argument as an int (0, 1, 2,...)
+ * @param[in] arg The verbosity argument as an int (0, 1, 2,...) or boolean (deprecated)
  * @param[in] default_verbosity The value to return if verbosity argument is null
+ * @param[in] allow_bool Unused parameter (kept for API compatibility)
  * @returns An integer describing the verbosity level (e.g. 0, 1, 2, etc.)
- * @throws JSONRPCError if arg provided is boolean
+ * @throws JSONRPCError if arg provided is boolean and -deprecatedrpc=boolverbose is not enabled
  */
-int ParseVerbosity(const UniValue& arg, int default_verbosity);
+int ParseVerbosity(const UniValue& arg, int default_verbosity, bool allow_bool = false);
 
 /**
  * Validate and return a CAmount from a UniValue number or string.

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -238,7 +238,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.tip = int(inputblockhash, 16)
         self.tipheight += 1
         self.last_block_time += 600
-        assert_equal(len(self.nodes[0].getblock(inputblockhash, True)["tx"]), TESTING_TX_COUNT + 1)
+        assert_equal(len(self.nodes[0].getblock(inputblockhash, 1)["tx"]), TESTING_TX_COUNT + 1)
 
         # 2 more version 4 blocks
         test_blocks = self.generate_blocks(2)

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -189,7 +189,7 @@ class EstimateFeeTest(BitcoinTestFramework):
             for node in self.nodes:
                 node.batch(batch_sendtx_reqs)
             self.sync_mempools(wait=0.1)
-            mined = mining_node.getblock(self.generate(mining_node, 1)[0], True)["tx"]
+            mined = mining_node.getblock(self.generate(mining_node, 1)[0], 1)["tx"]
             # update which txouts are confirmed
             newmem = []
             for utx in self.memutxo:

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -86,7 +86,7 @@ class MaxUploadTest(BitcoinTestFramework):
 
         # Store the hash; we'll request this later
         big_old_block = self.nodes[0].getbestblockhash()
-        old_block_size = self.nodes[0].getblock(big_old_block, True)['size']
+        old_block_size = self.nodes[0].getblock(big_old_block, 1)['size']
         big_old_block = int(big_old_block, 16)
 
         # Advance to two days ago

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -227,7 +227,7 @@ class SegWitTest(BitcoinTestFramework):
 
         self.log.info("Verify sigops are counted in GBT with BIP141 rules after the fork")
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
-        raw_tx = self.nodes[0].getrawtransaction(txid, True)
+        raw_tx = self.nodes[0].getrawtransaction(txid, 1)
         tmpl = self.nodes[0].getblocktemplate({'rules': ['segwit']})
         assert_greater_than_or_equal(tmpl['sizelimit'], 3999577)  # actual maximum size is lower due to minimum mandatory non-witness data
         assert_equal(tmpl['weightlimit'], 4000000)

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -30,13 +30,13 @@ class UTXOSetHashTest(BitcoinTestFramework):
         # Generate 100 blocks and remove the first since we plan to spend its
         # coinbase
         block_hashes = self.generate(wallet, 1) + self.generate(node, 99)
-        blocks = list(map(lambda block: from_hex(CBlock(), node.getblock(block, False)), block_hashes))
+        blocks = list(map(lambda block: from_hex(CBlock(), node.getblock(block, 0)), block_hashes))
         blocks.pop(0)
 
         # Create a spending transaction and mine a block which includes it
         txid = wallet.send_self_transfer(from_node=node)['txid']
         tx_block = self.generateblock(node, output=wallet.get_address(), transactions=[txid])
-        blocks.append(from_hex(CBlock(), node.getblock(tx_block['hash'], False)))
+        blocks.append(from_hex(CBlock(), node.getblock(tx_block['hash'], 0)))
 
         # Serialize the outputs that should be in the UTXO set and add them to
         # a MuHash object

--- a/test/functional/interface_usdt_utxocache.py
+++ b/test/functional/interface_usdt_utxocache.py
@@ -292,7 +292,7 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
             for vin in tx["vin"]:
                 if "coinbase" not in vin:
                     prevout_tx = self.nodes[0].getrawtransaction(
-                        vin["txid"], True)
+                        vin["txid"], 1)
                     prevout_tx_block = self.nodes[0].getblockheader(
                         prevout_tx["blockhash"])
                     spends_coinbase = "coinbase" in prevout_tx["vin"][0]

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -44,7 +44,7 @@ class DataCarrierTest(BitcoinTestFramework):
 
         if success:
             self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_hex)
-            assert tx.txid_hex in node.getrawmempool(True), f'{tx_hex} not in mempool'
+            assert tx.txid_hex in node.getrawmempool(verbose=True), f'{tx_hex} not in mempool'
         else:
             assert_raises_rpc_error(-26, "datacarrier", self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
 

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -61,7 +61,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
         # Check mempool has DEFAULT_ANCESTOR_LIMIT transactions in it, and descendant and ancestor
         # count and fees should look correct
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(verbose=True)
         assert_equal(len(mempool), DEFAULT_ANCESTOR_LIMIT)
         descendant_count = 1
         descendant_fees = 0
@@ -84,7 +84,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(entry, mempool[x])
 
             # Check that gettxspendingprevout is consistent with getrawmempool
-            witnesstx = self.nodes[0].getrawtransaction(txid=x, verbose=True)
+            witnesstx = self.nodes[0].getrawtransaction(txid=x, verbose=1)
             for tx_in in witnesstx["vin"]:
                 spending_result = self.nodes[0].gettxspendingprevout([ {'txid' : tx_in["txid"], 'vout' : tx_in["vout"]} ])
                 assert_equal(spending_result, [ {'txid' : tx_in["txid"], 'vout' : tx_in["vout"], 'spendingtxid' : x} ])
@@ -191,8 +191,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(entry['fees']['descendant'], descendant_fees + Decimal("0.00002"))
 
         # Check that node1's mempool is as expected (-> custom ancestor limit)
-        mempool0 = self.nodes[0].getrawmempool(False)
-        mempool1 = self.nodes[1].getrawmempool(False)
+        mempool0 = self.nodes[0].getrawmempool(verbose=False)
+        mempool1 = self.nodes[1].getrawmempool(verbose=False)
         assert_equal(len(mempool1), CUSTOM_ANCESTOR_LIMIT)
         assert set(mempool1).issubset(set(mempool0))
         for tx in chain[:CUSTOM_ANCESTOR_LIMIT]:
@@ -224,7 +224,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
                 tx_children.append(txid)
             transaction_package.extend(new_tx["new_utxos"])
 
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(verbose=True)
         assert_equal(mempool[parent_transaction]['descendantcount'], DEFAULT_DESCENDANT_LIMIT)
         assert_equal(sorted(mempool[parent_transaction]['spentby']), sorted(tx_children))
 
@@ -241,8 +241,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # - txs chained off parent tx (-> custom descendant limit)
         self.wait_until(lambda: len(self.nodes[1].getrawmempool()) ==
                                 CUSTOM_ANCESTOR_LIMIT + 1 + CUSTOM_DESCENDANT_LIMIT, timeout=10)
-        mempool0 = self.nodes[0].getrawmempool(False)
-        mempool1 = self.nodes[1].getrawmempool(False)
+        mempool0 = self.nodes[0].getrawmempool(verbose=False)
+        mempool1 = self.nodes[1].getrawmempool(verbose=False)
         assert set(mempool1).issubset(set(mempool0))
         assert parent_transaction in mempool1
         for tx in chain[:CUSTOM_DESCENDANT_LIMIT]:

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -49,7 +49,7 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
         if self.is_wallet_compiled():
             unbroadcast_count += 1
         assert_equal(mempoolinfo['unbroadcastcount'], unbroadcast_count)
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(verbose=True)
         for tx in mempool:
             assert_equal(mempool[tx]['unbroadcast'], True)
 
@@ -74,7 +74,7 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
             assert wallet_tx_hsh in mempool
 
         # check that transactions are no longer in first node's unbroadcast set
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(verbose=True)
         for tx in mempool:
             assert_equal(mempool[tx]['unbroadcast'], False)
 

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -199,7 +199,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # Make sure that the size of each group of transactions exceeds
         # MAX_BLOCK_WEIGHT // 4 -- otherwise the test needs to be revised to
         # create more transactions.
-        mempool = self.nodes[0].getrawmempool(True)
+        mempool = self.nodes[0].getrawmempool(verbose=True)
         sizes = [0, 0, 0]
         for i in range(3):
             for j in txids[i]:

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -306,7 +306,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         block_hash = int(self.generate(node, 1)[0], 16)
 
         # Store the raw block in our internal format.
-        block = from_hex(CBlock(), node.getblock("%064x" % block_hash, False))
+        block = from_hex(CBlock(), node.getblock("%064x" % block_hash, 0))
 
         # Wait until the block was announced (via compact blocks)
         test_node.wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30)
@@ -567,7 +567,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         current_height = chain_height
         while (current_height >= chain_height - MAX_GETBLOCKTXN_DEPTH):
             block_hash = node.getblockhash(current_height)
-            block = from_hex(CBlock(), node.getblock(block_hash, False))
+            block = from_hex(CBlock(), node.getblock(block_hash, 0))
 
             msg = msg_getblocktxn()
             msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [])
@@ -602,7 +602,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Request with out-of-bounds tx index results in disconnect
         bad_peer = self.nodes[0].add_p2p_connection(TestP2PConn())
         block_hash = node.getblockhash(chain_height)
-        block = from_hex(CBlock(), node.getblock(block_hash, False))
+        block = from_hex(CBlock(), node.getblock(block_hash, 0))
         msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [len(block.vtx)])
         with node.assert_debug_log(['getblocktxn with out-of-bounds tx indices']):
             bad_peer.send_without_ping(msg)

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -396,7 +396,7 @@ class SegWitTest(BitcoinTestFramework):
             all_heights = all_heights[0:10]
             for height in all_heights:
                 block_hash = self.nodes[0].getblockhash(height)
-                rpc_block = self.nodes[0].getblock(block_hash, False)
+                rpc_block = self.nodes[0].getblock(block_hash, 0)
                 block_hash = int(block_hash, 16)
                 block = self.test_node.request_block(block_hash, 2)
                 wit_block = self.test_node.request_block(block_hash, 2 | MSG_WITNESS_FLAG)
@@ -413,7 +413,7 @@ class SegWitTest(BitcoinTestFramework):
             assert len(block.vtx[0].wit.vtxinwit[0].scriptWitness.stack) == 1
             test_witness_block(self.nodes[0], self.test_node, block, accepted=True)
             # Now try to retrieve it...
-            rpc_block = self.nodes[0].getblock(block.hash_hex, False)
+            rpc_block = self.nodes[0].getblock(block.hash_hex, 0)
             non_wit_block = self.test_node.request_block(block.hash_int, 2)
             wit_block = self.test_node.request_block(block.hash_int, 2 | MSG_WITNESS_FLAG)
             assert_equal(wit_block.serialize(), bytes.fromhex(rpc_block))
@@ -421,7 +421,7 @@ class SegWitTest(BitcoinTestFramework):
             assert_equal(wit_block.serialize(), block.serialize())
 
             # Test size, vsize, weight
-            rpc_details = self.nodes[0].getblock(block.hash_hex, True)
+            rpc_details = self.nodes[0].getblock(block.hash_hex, 1)
             assert_equal(rpc_details["size"], len(block.serialize()))
             assert_equal(rpc_details["strippedsize"], len(block.serialize(False)))
             assert_equal(rpc_details["weight"], block.get_weight())

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -685,11 +685,9 @@ class BlockchainTest(BitcoinTestFramework):
 
         self.log.info("Test that getblock with verbosity 0 hashes to expected value")
         assert_hexblock_hashes(0)
-        assert_hexblock_hashes(False)
 
         self.log.info("Test that getblock with verbosity 1 doesn't include fee")
         assert_fee_not_in_block(blockhash, 1)
-        assert_fee_not_in_block(blockhash, True)
 
         self.log.info('Test that getblock with verbosity 2 and 3 includes expected fee')
         assert_fee_in_block(blockhash, 2)

--- a/test/functional/rpc_boolverbose_deprecated.py
+++ b/test/functional/rpc_boolverbose_deprecated.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that deprecated boolean verbosity works with -deprecatedrpc=boolverbose flag."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class BoolVerboseDeprecatedTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        # Enable the deprecated boolean verbosity support
+        self.extra_args = [["-deprecatedrpc=boolverbose"]]
+
+    def run_test(self):
+        self.log.info(
+            "Test that boolean verbosity works with -deprecatedrpc=boolverbose"
+        )
+
+        # Generate a block to have transactions to test with
+        self.generate(self.nodes[0], 1)
+        blockhash = self.nodes[0].getbestblockhash()
+
+        # Test getblock with boolean verbosity - should work with deprecation flag
+        block_true = self.nodes[0].getblock(blockhash, True)
+        block_false = self.nodes[0].getblock(blockhash, False)
+        block_int_1 = self.nodes[0].getblock(blockhash, 1)
+        block_int_0 = self.nodes[0].getblock(blockhash, 0)
+
+        # Boolean True should be equivalent to integer 1
+        assert_equal(block_true, block_int_1)
+        # Boolean False should be equivalent to integer 0
+        assert_equal(block_false, block_int_0)
+
+        # Test getrawtransaction with boolean verbosity - should work with deprecation flag
+        block = self.nodes[0].getblock(blockhash, 1)
+        txid = block["tx"][0]
+
+        tx_true = self.nodes[0].getrawtransaction(txid, True, blockhash)
+        tx_false = self.nodes[0].getrawtransaction(txid, False, blockhash)
+        tx_int_1 = self.nodes[0].getrawtransaction(txid, 1, blockhash)
+        tx_int_0 = self.nodes[0].getrawtransaction(txid, 0, blockhash)
+
+        # Boolean True should be equivalent to integer 1
+        assert_equal(tx_true, tx_int_1)
+        # Boolean False should be equivalent to integer 0
+        assert_equal(tx_false, tx_int_0)
+
+
+if __name__ == "__main__":
+    BoolVerboseDeprecatedTest(__file__).main()

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -156,7 +156,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-25, "Input not found or already spent", node2.combinerawtransaction, [rawtx2['hex'], rawtx3['hex']])
 
-        txinfo = node0.getrawtransaction(tx, True, blk)
+        txinfo = node0.getrawtransaction(tx, 1, blk)
         self.log.info("n/m=%d/%d %s size=%d vsize=%d weight=%d" % (nsigs, nkeys, output_type, txinfo["size"], txinfo["vsize"], txinfo["weight"]))
 
     def test_mixing_uncompressed_and_compressed_keys(self, node):

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -28,6 +28,48 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         # Please don't delete nor modify this comment
         self.log.info("Tests for deprecated RPC methods (if any)")
 
+        self.log.info("Test boolean verbosity deprecation")
+        # Generate a block to have transactions to test with
+        self.generate(self.nodes[0], 1)
+        blockhash = self.nodes[0].getbestblockhash()
+
+        # Test getblock with boolean verbosity - should fail without deprecation flag
+        assert_raises_rpc_error(
+            -3,
+            "Boolean verbosity is deprecated",
+            self.nodes[0].getblock,
+            blockhash,
+            True,
+        )
+        assert_raises_rpc_error(
+            -3,
+            "Boolean verbosity is deprecated",
+            self.nodes[0].getblock,
+            blockhash,
+            False,
+        )
+
+        # Test getrawtransaction with boolean verbosity - should fail without deprecation flag
+        # Get a transaction from the block
+        block = self.nodes[0].getblock(blockhash, 1)
+        txid = block["tx"][0]
+        assert_raises_rpc_error(
+            -3,
+            "Boolean verbosity is deprecated",
+            self.nodes[0].getrawtransaction,
+            txid,
+            True,
+            blockhash,
+        )
+        assert_raises_rpc_error(
+            -3,
+            "Boolean verbosity is deprecated",
+            self.nodes[0].getrawtransaction,
+            txid,
+            False,
+            blockhash,
+        )
+
         if self.is_wallet_compiled():
             self.log.info("Tests for deprecated wallet-related RPC methods (if any)")
             self.log.info("Test settxfee RPC deprecation")

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -45,7 +45,7 @@ class RPCGenerateTest(BitcoinTestFramework):
 
         self.log.info('Generate an empty block to a descriptor')
         hash = self.generateblock(node, 'addr(' + address + ')', [])['hash']
-        block = node.getblock(blockhash=hash, verbosity=2)
+        block = node.getblock(blockhash=hash, verbose=2)
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
 
@@ -83,7 +83,7 @@ class RPCGenerateTest(BitcoinTestFramework):
         block = node.getblock(hash, 1)
         assert_equal(len(block['tx']), 2)
         txid = block['tx'][1]
-        assert_equal(node.getrawtransaction(txid=txid, verbose=False, blockhash=hash), rawtx)
+        assert_equal(node.getrawtransaction(txid=txid, verbose=0, blockhash=hash), rawtx)
 
         # Ensure that generateblock can be called concurrently by many threads.
         self.log.info('Generate blocks in parallel')

--- a/test/functional/rpc_orphans.py
+++ b/test/functional/rpc_orphans.py
@@ -145,8 +145,8 @@ class OrphanRPCsTest(BitcoinTestFramework):
 
     def test_misc(self):
         node = self.nodes[0]
-        assert_raises_rpc_error(-3, "Verbosity was boolean but only integer allowed", node.getorphantxs, verbosity=True)
-        assert_raises_rpc_error(-3, "Verbosity was boolean but only integer allowed", node.getorphantxs, verbosity=False)
+        assert_raises_rpc_error(-3, "Boolean verbosity is deprecated", node.getorphantxs, verbosity=True)
+        assert_raises_rpc_error(-3, "Boolean verbosity is deprecated", node.getorphantxs, verbosity=False)
         help_output = node.help()
         self.log.info("Check that getorphantxs is a hidden RPC")
         assert "getorphantxs" not in help_output

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -15,14 +15,14 @@ def unidirectional_node_sync_via_rpc(node_src, node_dest):
     blockhash = node_src.getbestblockhash()
     while True:
         try:
-            assert len(node_dest.getblock(blockhash, False)) > 0
+            assert len(node_dest.getblock(blockhash, 0)) > 0
             break
         except Exception:
             blocks_to_copy.append(blockhash)
             blockhash = node_src.getblockheader(blockhash, True)['previousblockhash']
     blocks_to_copy.reverse()
     for blockhash in blocks_to_copy:
-        blockdata = node_src.getblock(blockhash, False)
+        blockdata = node_src.getblock(blockhash, 0)
         assert node_dest.submitblock(blockdata) in (None, 'inconclusive')
 
 def node_sync_via_rpc(nodes):

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -130,7 +130,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
             # 6. invalid parameters - supply txid and invalid boolean values
             for value in [True, False]:
-                assert_raises_rpc_error(-3, "only integer allowed", self.nodes[n].getrawtransaction, txId, value)
+                assert_raises_rpc_error(-3, "Boolean verbosity is deprecated", self.nodes[n].getrawtransaction, txId, value)
             for value in ["True", "False"]:
                 assert_raises_rpc_error(-3, "not of expected type number", self.nodes[n].getrawtransaction, txid=txId, verbose=value)
                 assert_raises_rpc_error(-3, "not of expected type number", self.nodes[n].getrawtransaction, txid=txId, verbosity=value)

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -40,7 +40,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         blockhash = self.nodes[0].getblockhash(chain_height + 1)
 
         txlist = []
-        blocktxn = self.nodes[0].getblock(blockhash, True)["tx"]
+        blocktxn = self.nodes[0].getblock(blockhash, 1)["tx"]
         txlist.append(blocktxn[1])
         txlist.append(blocktxn[2])
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -597,7 +597,7 @@ def find_vout_for_address(node, txid, addr):
     Locate the vout index of the given transaction sending to the
     given address. Raises runtime error exception if not found.
     """
-    tx = node.getrawtransaction(txid, True)
+    tx = node.getrawtransaction(txid, 1)
     for i in range(len(tx["vout"])):
         if addr == tx["vout"][i]["scriptPubKey"]["address"]:
             return i

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -145,7 +145,7 @@ class MiniWallet:
             # Sort tx by ancestor count. See BlockAssembler::SortForBlock in src/node/miner.cpp
             sorted_mempool = sorted(mempool.items(), key=lambda item: (item[1]["ancestorcount"], int(item[0], 16)))
             for txid, _ in sorted_mempool:
-                self.scan_tx(self._test_node.getrawtransaction(txid=txid, verbose=True))
+                self.scan_tx(self._test_node.getrawtransaction(txid=txid, verbose=1))
 
     def scan_tx(self, tx):
         """Scan the tx and adjust the internal list of owned utxos"""

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -213,6 +213,7 @@ BASE_SCRIPTS = [
     'rpc_blockchain.py --v2transport',
     'mining_template_verification.py',
     'rpc_deprecated.py',
+    'rpc_boolverbose_deprecated.py',
     'wallet_disable.py',
     'wallet_change_address.py',
     'p2p_addr_relay.py',

--- a/test/functional/wallet_avoid_mixing_output_types.py
+++ b/test/functional/wallet_avoid_mixing_output_types.py
@@ -69,14 +69,14 @@ def is_legacy_address(node, addr):
 
 def is_same_type(node, tx):
     """Check that all inputs are of the same OutputType"""
-    vins = node.getrawtransaction(tx, True)['vin']
+    vins = node.getrawtransaction(tx, 1)['vin']
     inputs = []
     for vin in vins:
         prev_tx, n = vin['txid'], vin['vout']
         inputs.append(
             node.getrawtransaction(
                 prev_tx,
-                True,
+                1,
             )['vout'][n]['scriptPubKey']['address']
         )
     has_legacy = False

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -542,7 +542,7 @@ def test_settxfee(self, rbf_node, dest_address):
     requested_feerate = Decimal("0.00025000")
     rbf_node.settxfee(requested_feerate)
     bumped_tx = rbf_node.bumpfee(rbfid)
-    actual_feerate = bumped_tx["fee"] * 1000 / rbf_node.getrawtransaction(bumped_tx["txid"], True)["vsize"]
+    actual_feerate = bumped_tx["fee"] * 1000 / rbf_node.getrawtransaction(bumped_tx["txid"], 1)["vsize"]
     # Assert that the difference between the requested feerate and the actual
     # feerate of the bumped transaction is small.
     assert_greater_than(Decimal("0.00001000"), abs(requested_feerate - actual_feerate))

--- a/test/functional/wallet_change_address.py
+++ b/test/functional/wallet_change_address.py
@@ -64,7 +64,7 @@ class WalletChangeAddressTest(BitcoinTestFramework):
             for n in [1, 2]:
                 self.log.debug(f"Send transaction from node {n}: expected change index {i}")
                 txid = self.nodes[n].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
-                tx = self.nodes[n].getrawtransaction(txid, True)
+                tx = self.nodes[n].getrawtransaction(txid, 1)
                 # find the change output and ensure that expected change index was used
                 self.assert_change_index(self.nodes[n], tx, i)
 
@@ -88,7 +88,7 @@ class WalletChangeAddressTest(BitcoinTestFramework):
         # The avoid partial spends wallet will always create a change output
         node = self.nodes[2]
         res = w2.send({sendTo1: "1.0", sendTo2: "1.0", sendTo3: "0.9999"}, options={"change_position": 0})
-        tx = node.getrawtransaction(res["txid"], True)
+        tx = node.getrawtransaction(res["txid"], 1)
         self.assert_change_pos(w2, tx, 0)
 
         # The default wallet will internally create a tx without change first,
@@ -96,7 +96,7 @@ class WalletChangeAddressTest(BitcoinTestFramework):
         # Ensure that the user-configured change position is kept
         node = self.nodes[1]
         res = w1.send({sendTo1: "1.0", sendTo2: "1.0", sendTo3: "0.9999"}, options={"change_position": 0})
-        tx = node.getrawtransaction(res["txid"], True)
+        tx = node.getrawtransaction(res["txid"], 1)
         # If the wallet ignores the user's change_position there is still a 25%
         # that the random change position passes the test
         self.assert_change_pos(w1, tx, 0)

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -59,7 +59,7 @@ class WalletGroupTest(BitcoinTestFramework):
         #   given address, and leave the rest
         self.log.info("Test sending transactions picks one UTXO group and leaves the rest")
         txid1 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
-        tx1 = self.nodes[1].getrawtransaction(txid1, True)
+        tx1 = self.nodes[1].getrawtransaction(txid1, 1)
         # txid1 should have 1 input and 2 outputs
         assert_equal(1, len(tx1["vin"]))
         assert_equal(2, len(tx1["vout"]))
@@ -70,7 +70,7 @@ class WalletGroupTest(BitcoinTestFramework):
         assert_approx(v[1], vexp=0.3, vspan=0.0001)
 
         txid2 = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
-        tx2 = self.nodes[2].getrawtransaction(txid2, True)
+        tx2 = self.nodes[2].getrawtransaction(txid2, 1)
         # txid2 should have 2 inputs and 2 outputs
         assert_equal(2, len(tx2["vin"]))
         assert_equal(2, len(tx2["vout"]))
@@ -98,7 +98,7 @@ class WalletGroupTest(BitcoinTestFramework):
         # B0 + B1 or C0 + C1, because this avoids partial spends while not being
         # detrimental to transaction cost
         txid3 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.4)
-        tx3 = self.nodes[1].getrawtransaction(txid3, True)
+        tx3 = self.nodes[1].getrawtransaction(txid3, 1)
         # tx3 should have 2 inputs and 2 outputs
         assert_equal(2, len(tx3["vin"]))
         assert_equal(2, len(tx3["vout"]))
@@ -126,7 +126,7 @@ class WalletGroupTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         with self.nodes[3].assert_debug_log([f'Fee non-grouped = {tx4_ungrouped_fee}, grouped = {tx4_grouped_fee}, using grouped']):
             txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
-        tx4 = self.nodes[3].getrawtransaction(txid4, True)
+        tx4 = self.nodes[3].getrawtransaction(txid4, 1)
         # tx4 should have 2 inputs and 2 outputs although one output would
         # have been enough and the transaction caused higher fees
         assert_equal(2, len(tx4["vin"]))
@@ -137,7 +137,7 @@ class WalletGroupTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         with self.nodes[3].assert_debug_log([f'Fee non-grouped = {tx5_6_ungrouped_fee}, grouped = {tx5_6_grouped_fee}, using non-grouped']):
             txid5 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
-        tx5 = self.nodes[3].getrawtransaction(txid5, True)
+        tx5 = self.nodes[3].getrawtransaction(txid5, 1)
         # tx5 should have 3 inputs (1.0, 1.0, 1.0) and 2 outputs
         assert_equal(3, len(tx5["vin"]))
         assert_equal(2, len(tx5["vout"]))
@@ -150,7 +150,7 @@ class WalletGroupTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         with self.nodes[4].assert_debug_log([f'Fee non-grouped = {tx5_6_ungrouped_fee}, grouped = {tx5_6_grouped_fee}, using grouped']):
             txid6 = self.nodes[4].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
-        tx6 = self.nodes[4].getrawtransaction(txid6, True)
+        tx6 = self.nodes[4].getrawtransaction(txid6, 1)
         # tx6 should have 5 inputs and 2 outputs
         assert_equal(5, len(tx6["vin"]))
         assert_equal(2, len(tx6["vout"]))

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -497,7 +497,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         assert_equal(addr, 'bcrt1qp8s25ckjl7gr6x2q3dx3tn2pytwp05upkjztk6ey857tt50r5aeqn6mvr9') # Derived at m/84'/0'/0'/1
         change_addr = wmulti_pub.getrawchangeaddress('bech32') # uses change 2
         assert_equal(change_addr, 'bcrt1qp6j3jw8yetefte7kw6v5pc89rkgakzy98p6gf7ayslaveaxqyjusnw580c') # Derived at m/84'/1'/0'/2
-        assert send_txid in self.nodes[0].getrawmempool(True)
+        assert send_txid in self.nodes[0].getrawmempool(verbose=True)
         assert send_txid in (x['txid'] for x in wmulti_pub.listunspent(0))
         assert_equal(wmulti_pub.getwalletinfo()['keypoolsize'], 999)
 

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -48,7 +48,7 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         self.nodes[0].createwallet(wallet_name="w0", load_on_startup=True)
         wallet0 = self.nodes[0].get_wallet_rpc("w0")
         self.generatetoaddress(self.nodes[0], 1, wallet0.getnewaddress(), sync_fun=self.no_op)
-        node0_coinbase_tx_hash = wallet0.getblock(wallet0.getbestblockhash(), verbose=1)['tx'][0]
+        node0_coinbase_tx_hash = wallet0.getblock(wallet0.getbestblockhash(), verbosity=1)['tx'][0]
 
         # Mine 100 blocks on top to mature the coinbase and create a descendant
         self.generate(self.nodes[0], 101, sync_fun=self.no_op)
@@ -110,7 +110,7 @@ class ReorgsRestoreTest(BitcoinTestFramework):
 
         # Tip was disconnected, ensure coinbase has been abandoned
         assert_equal(wallet.getbalances()["mine"]["immature"], 0)
-        coinbase_tx_id = wallet.getblock(tip, verbose=1)["tx"][0]
+        coinbase_tx_id = wallet.getblock(tip, verbosity=1)["tx"][0]
         assert_equal(wallet.gettransaction(coinbase_tx_id)['details'][0]['abandoned'], True)
 
         # Abort process abruptly to mimic an unclean shutdown (no chain state flush to disk)

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -172,7 +172,7 @@ class WalletSendTest(BitcoinTestFramework):
             assert tx
             assert_equal(tx["bip125-replaceable"], "yes" if replaceable else "no")
             # Ensure transaction exists in the mempool:
-            tx = from_wallet.getrawtransaction(res["txid"], True)
+            tx = from_wallet.getrawtransaction(res["txid"], 1)
             assert tx
             if amount:
                 if subtract_fee_from_outputs:


### PR DESCRIPTION
### Summary

Standardize RPC verbosity to integers only and remove boolean handling for clarity, consistency, and future extensibility.

### Rationale

 - **Legacy cleanup**: Boolean verbosity has been discouraged/deprecated in docs since 2017 and continues to create tech debt (special-case parsing, inconsistent tests, user confusion).
- **Consistency**: Integers enable multi-level output without overloading a boolean.

### User-visible changes
- getblock, getrawtransaction, getorphantxs no longer accept booleans.
- Passing true/false now errors with: Verbosity was boolean but only integer allowed.
- Migration: false → 0, true → 1.

### Code / Docs
- ParseVerbosity(arg, default) now rejects booleans (removed allow_bool).
- Call sites and functional tests updated to use integer levels. 
- Developer notes updated; release notes added.

**Breaking change:** scripts/tools using boolean verbosity must switch to integers.