### PR TITLE
mini miner: enable `Linearize` return package feerates

### DIFF
--- a/src/node/mini_miner.cpp
+++ b/src/node/mini_miner.cpp
@@ -167,7 +167,8 @@ MiniMiner::MiniMiner(const std::vector<MiniMinerMempoolEntry>& manual_entries,
     Assume(m_to_be_replaced.empty());
     Assume(m_requested_outpoints_by_txid.empty());
     Assume(m_bump_fees.empty());
-    Assume(m_inclusion_order.empty());
+    Assume(m_linearize_result.inclusion_order.empty());
+    Assume(m_linearize_result.packages.empty());
     SanityCheck();
 }
 
@@ -261,6 +262,7 @@ void MiniMiner::BuildMockTemplate(std::optional<CFeeRate> target_feerate)
             break;
         }
 
+        m_linearize_result.packages.emplace_back(ancestor_package_fee, static_cast<int32_t>(ancestor_package_size));
         // Calculate ancestors on the fly. This lookup should be fairly cheap, and ancestor sets
         // change at every iteration, so this is more efficient than maintaining a cache.
         std::set<MockEntryMap::iterator, IteratorComparator> ancestors;
@@ -283,7 +285,7 @@ void MiniMiner::BuildMockTemplate(std::optional<CFeeRate> target_feerate)
         }
         // Track the order in which transactions were selected.
         for (const auto& ancestor : ancestors) {
-            m_inclusion_order.emplace(ancestor->first, sequence_num);
+            m_linearize_result.inclusion_order.emplace(ancestor->first, sequence_num);
         }
         DeleteAncestorPackage(ancestors);
         SanityCheck();
@@ -295,16 +297,16 @@ void MiniMiner::BuildMockTemplate(std::optional<CFeeRate> target_feerate)
         Assume(m_in_block.empty() || m_total_fees >= target_feerate->GetFee(m_total_vsize));
     }
     Assume(m_in_block.empty() || sequence_num > 0);
-    Assume(m_in_block.size() == m_inclusion_order.size());
+    Assume(m_in_block.size() == m_linearize_result.inclusion_order.size());
     // Do not try to continue building the block template with a different feerate.
     m_ready_to_calculate = false;
 }
 
 
-std::map<Txid, uint32_t> MiniMiner::Linearize()
+LinearizationResult MiniMiner::Linearize()
 {
     BuildMockTemplate(std::nullopt);
-    return m_inclusion_order;
+    return m_linearize_result;
 }
 
 std::map<COutPoint, CAmount> MiniMiner::CalculateBumpFees(const CFeeRate& target_feerate)

--- a/src/node/mini_miner.h
+++ b/src/node/mini_miner.h
@@ -21,6 +21,16 @@ class CTxMemPool;
 
 namespace node {
 
+struct LinearizationResult {
+    // Txid to a number representing the order in which this transaction was included (smaller
+    // number = included earlier).  Transactions included in an ancestor set together have the same
+    // sequence number.
+    std::map<Txid, uint32_t> inclusion_order;
+
+    // A vector of all selected package fee rates in the block template.
+    std::vector<CFeeRate> packages;
+};
+
 // Container for tracking updates to ancestor feerate as we include ancestors in the "block"
 class MiniMinerMempoolEntry
 {
@@ -90,10 +100,7 @@ class MiniMiner
     // the same tx will have the same bumpfee. Excludes non-mempool transactions.
     std::map<Txid, std::vector<COutPoint>> m_requested_outpoints_by_txid;
 
-    // Txid to a number representing the order in which this transaction was included (smaller
-    // number = included earlier).  Transactions included in an ancestor set together have the same
-    // sequence number.
-    std::map<Txid, uint32_t> m_inclusion_order;
+    LinearizationResult m_linearize_result;
     // What we're trying to calculate. Outpoint to the fee needed to bring the transaction to the target feerate.
     std::map<COutPoint, CAmount> m_bump_fees;
 
@@ -161,11 +168,10 @@ public:
      * if it cannot be calculated. */
     std::optional<CAmount> CalculateTotalBumpFees(const CFeeRate& target_feerate);
 
-    /** Construct a new block template with all of the transactions and calculate the order in which
-     * they are selected. Returns the sequence number (lower = selected earlier) with which each
-     * transaction was selected, indexed by txid, or an empty map if it cannot be calculated.
+    /** Construct a new block template with all of the transactions and calculate the order in
+     * which they are selected and their chunk fee rate.
      */
-    std::map<Txid, uint32_t> Linearize();
+    LinearizationResult Linearize();
 };
 } // namespace node
 

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -349,7 +349,7 @@ BOOST_FIXTURE_TEST_CASE(miniminer_1p1c, TestChain100Setup)
     node::MiniMiner miniminer_pool(pool, all_unspent_outpoints);
     BOOST_CHECK(miniminer_manual.IsReadyToCalculate());
     BOOST_CHECK(miniminer_pool.IsReadyToCalculate());
-    for (const auto& sequences : {miniminer_manual.Linearize(), miniminer_pool.Linearize()}) {
+    for (const auto& sequences : {miniminer_manual.Linearize().inclusion_order, miniminer_pool.Linearize().inclusion_order}) {
         // tx6 is selected first: high feerate with no parents to bump
         BOOST_CHECK_EQUAL(Find(sequences, tx6->GetHash()), 0);
 
@@ -567,7 +567,7 @@ BOOST_FIXTURE_TEST_CASE(miniminer_overlap, TestChain100Setup)
     node::MiniMiner miniminer_pool(pool, all_unspent_outpoints);
     BOOST_CHECK(miniminer_manual.IsReadyToCalculate());
     BOOST_CHECK(miniminer_pool.IsReadyToCalculate());
-    for (const auto& sequences : {miniminer_manual.Linearize(), miniminer_pool.Linearize()}) {
+    for (const auto& sequences : {miniminer_manual.Linearize().inclusion_order, miniminer_pool.Linearize().inclusion_order}) {
         // tx2 and tx4 selected first: high feerate with nothing to bump
         BOOST_CHECK_EQUAL(Find(sequences, tx4->GetHash()), 0);
         BOOST_CHECK_EQUAL(Find(sequences, tx2->GetHash()), 1);
@@ -682,7 +682,7 @@ BOOST_FIXTURE_TEST_CASE(manual_ctor, TestChain100Setup)
 
         node::MiniMiner miniminer_manual(miniminer_info, descendant_caches);
         BOOST_CHECK(miniminer_manual.IsReadyToCalculate());
-        const auto sequences{miniminer_manual.Linearize()};
+        const auto sequences{miniminer_manual.Linearize().inclusion_order};
 
         // CPFP zero + high
         BOOST_CHECK_EQUAL(sequences.at(grandparent_zero_fee->GetHash()), 0);


### PR DESCRIPTION
This PR adds supports for mini miner to return the package fee rates of the linearized transactions

The first step for #30079

It is motivated by https://github.com/bitcoin/bitcoin/pull/30079#issuecomment-3191510709