### PR TITLE
depends: remove xinerama extension from libxcb

### DIFF
--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -123,7 +123,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libxcb-shape.so.0',
 'libxcb-sync.so.1',
 'libxcb-xfixes.so.0',
-'libxcb-xinerama.so.0',
 'libxcb-xkb.so.1',
 }
 

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -16,7 +16,7 @@ $(package)_config_opts += --disable-dri2 --disable-dri3 --disable-glx
 $(package)_config_opts += --disable-present --disable-record --disable-resource
 $(package)_config_opts += --disable-screensaver --disable-xevie --disable-xfree86-dri
 $(package)_config_opts += --disable-xinput --disable-xprint --disable-selinux
-$(package)_config_opts += --disable-xtest --disable-xv --disable-xvmc
+$(package)_config_opts += --disable-xtest --disable-xv --disable-xvmc --disable-xinerama
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
This is listed on https://doc.qt.io/qt-5.15/linux-requirements.html as "recommended", and doesn't seem to be needed (only used for windowing over multiple screens support?) , and the fact that it's no-longer installed by default on modern linux distros (i.e Ubuntu), is annoying/confusing for users. See:

https://github.com/bitcoin/bitcoin/issues/30061
https://github.com/bitcoin/bitcoin/issues/32097
https://github.com/bitcoin/bitcoin/pull/33197
https://bitcoin.stackexchange.com/questions/122646/libxcb-xinerama0-library-required-by-bitcoin-qt

I haven't tested the GUI with these changes. Just opening an alternative to #33197. Note that we also already have `libxcb-cursor0` documented as a potentially missing runtime dependency (see `build-unix.md`).