### PR TITLE
refactor: rename `fees.{h,cpp}` to `fees/block_policy_estimator.{h,cpp}`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,7 +239,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   noui.cpp
   policy/ephemeral_policy.cpp
   policy/fees/block_policy_estimator.cpp
-  policy/fees_args.cpp
+  policy/fees/block_policy_estimator_args.cpp
   policy/packages.cpp
   policy/rbf.cpp
   policy/settings.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -238,7 +238,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/warnings.cpp
   noui.cpp
   policy/ephemeral_policy.cpp
-  policy/fees.cpp
+  policy/fees/block_policy_estimator.cpp
   policy/fees_args.cpp
   policy/packages.cpp
   policy/rbf.cpp

--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -6,7 +6,7 @@
 #include <common/messages.h>
 
 #include <common/types.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <node/types.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -59,7 +59,7 @@
 #include <node/peerman_args.h>
 #include <policy/feerate.h>
 #include <policy/fees/block_policy_estimator.h>
-#include <policy/fees_args.h>
+#include <policy/fees/block_policy_estimator_args.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
 #include <protocol.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -58,7 +58,7 @@
 #include <node/miner.h>
 #include <node/peerman_args.h>
 #include <policy/feerate.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <policy/fees_args.h>
 #include <policy/policy.h>
 #include <policy/settings.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -39,7 +39,7 @@
 #include <node/txreconciliation.h>
 #include <node/warnings.h>
 #include <policy/feerate.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <policy/packages.h>
 #include <policy/policy.h>
 #include <primitives/block.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -15,7 +15,7 @@
 #include <netgroup.h>
 #include <node/kernel_notifications.h>
 #include <node/warnings.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <scheduler.h>
 #include <txmempool.h>
 #include <validation.h>

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -40,7 +40,7 @@
 #include <node/types.h>
 #include <node/warnings.h>
 #include <policy/feerate.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
 #include <policy/settings.h>

--- a/src/policy/fees/block_policy_estimator.cpp
+++ b/src/policy/fees/block_policy_estimator.cpp
@@ -875,6 +875,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
     if (feeCalc) {
         feeCalc->desiredTarget = confTarget;
         feeCalc->returnedTarget = confTarget;
+        feeCalc->best_height = nBestSeenHeight;
     }
 
     double median = -1;

--- a/src/policy/fees/block_policy_estimator.cpp
+++ b/src/policy/fees/block_policy_estimator.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 
 #include <common/system.h>
 #include <consensus/amount.h>

--- a/src/policy/fees/block_policy_estimator.h
+++ b/src/policy/fees/block_policy_estimator.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2009-2022 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef BITCOIN_POLICY_FEES_H
-#define BITCOIN_POLICY_FEES_H
+#ifndef BITCOIN_POLICY_FEES_BLOCK_POLICY_ESTIMATOR_H
+#define BITCOIN_POLICY_FEES_BLOCK_POLICY_ESTIMATOR_H
 
 #include <consensus/amount.h>
 #include <policy/feerate.h>
@@ -342,4 +342,4 @@ private:
     FastRandomContext& insecure_rand GUARDED_BY(m_insecure_rand_mutex);
 };
 
-#endif // BITCOIN_POLICY_FEES_H
+#endif // BITCOIN_POLICY_FEES_BLOCK_POLICY_ESTIMATOR_H

--- a/src/policy/fees/block_policy_estimator.h
+++ b/src/policy/fees/block_policy_estimator.h
@@ -95,6 +95,7 @@ struct FeeCalculation
     FeeReason reason = FeeReason::NONE;
     int desiredTarget = 0;
     int returnedTarget = 0;
+    unsigned int best_height{0};
 };
 
 /** \class CBlockPolicyEstimator

--- a/src/policy/fees/block_policy_estimator_args.cpp
+++ b/src/policy/fees/block_policy_estimator_args.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <policy/fees_args.h>
+#include <policy/fees/block_policy_estimator_args.h>
 
 #include <common/args.h>
 

--- a/src/policy/fees/block_policy_estimator_args.h
+++ b/src/policy/fees/block_policy_estimator_args.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_POLICY_FEES_ARGS_H
-#define BITCOIN_POLICY_FEES_ARGS_H
+#ifndef BITCOIN_POLICY_FEES_BLOCK_POLICY_ESTIMATOR_ARGS_H
+#define BITCOIN_POLICY_FEES_BLOCK_POLICY_ESTIMATOR_ARGS_H
 
 #include <util/fs.h>
 
@@ -12,4 +12,4 @@ class ArgsManager;
 /** @return The fee estimates data file path. */
 fs::path FeeestPath(const ArgsManager& argsman);
 
-#endif // BITCOIN_POLICY_FEES_ARGS_H
+#endif // BITCOIN_POLICY_FEES_BLOCK_POLICY_ESTIMATOR_ARGS_H

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -21,7 +21,7 @@
 #include <key_io.h>
 #include <node/interface_ui.h>
 #include <node/types.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <txmempool.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>

--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -7,7 +7,7 @@
 #include <core_io.h>
 #include <node/context.h>
 #include <policy/feerate.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <rpc/server.h>

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -9,7 +9,7 @@
 #include <net_processing.h>
 #include <node/context.h>
 #include <node/miner.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <pow.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(test_bitcoin
   descriptor_tests.cpp
   disconnected_transactions.cpp
   feefrac_tests.cpp
+  feerounder_tests.cpp
   flatfile_tests.cpp
   fs_tests.cpp
   getarg_tests.cpp
@@ -72,7 +73,6 @@ add_executable(test_bitcoin
   pcp_tests.cpp
   peerman_tests.cpp
   pmt_tests.cpp
-  policy_fee_tests.cpp
   policyestimator_tests.cpp
   pool_tests.cpp
   pow_tests.cpp

--- a/src/test/feerounder_tests.cpp
+++ b/src/test/feerounder_tests.cpp
@@ -9,7 +9,7 @@
 
 #include <set>
 
-BOOST_AUTO_TEST_SUITE(policy_fee_tests)
+BOOST_AUTO_TEST_SUITE(fee_rounder_tests)
 
 BOOST_AUTO_TEST_CASE(FeeRounder)
 {

--- a/src/test/feerounder_tests.cpp
+++ b/src/test/feerounder_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/fuzz/fees.cpp
+++ b/src/test/fuzz/fees.cpp
@@ -4,7 +4,7 @@
 
 #include <common/messages.h>
 #include <consensus/amount.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/kitchen_sink.cpp
+++ b/src/test/fuzz/kitchen_sink.cpp
@@ -5,7 +5,7 @@
 #include <common/messages.h>
 #include <merkleblock.h>
 #include <node/types.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <rpc/util.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <kernel/mempool_entry.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <policy/fees_args.h>
 #include <primitives/transaction.h>
 #include <streams.h>

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -4,7 +4,7 @@
 
 #include <kernel/mempool_entry.h>
 #include <policy/fees/block_policy_estimator.h>
-#include <policy/fees_args.h>
+#include <policy/fees/block_policy_estimator_args.h>
 #include <primitives/transaction.h>
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/policy_estimator_io.cpp
+++ b/src/test/fuzz/policy_estimator_io.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <policy/fees_args.h>
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/policy_estimator_io.cpp
+++ b/src/test/fuzz/policy_estimator_io.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/fees/block_policy_estimator.h>
-#include <policy/fees_args.h>
+#include <policy/fees/block_policy_estimator_args.h>
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <policy/fees_args.h>
 #include <policy/policy.h>
 #include <test/util/txmempool.h>

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/fees/block_policy_estimator.h>
-#include <policy/fees_args.h>
+#include <policy/fees/block_policy_estimator_args.h>
 #include <policy/policy.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -28,7 +28,7 @@
 #include <node/peerman_args.h>
 #include <node/warnings.h>
 #include <noui.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <pow.h>
 #include <random.h>
 #include <rpc/blockchain.h>

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -7,7 +7,7 @@
 
 #include <outputtype.h>
 #include <policy/feerate.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <primitives/transaction.h>
 #include <script/keyorigin.h>
 #include <script/signingprovider.h>

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -5,7 +5,7 @@
 #include <common/system.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <policy/policy.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -9,7 +9,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <node/types.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <primitives/transaction.h>
 #include <rpc/server.h>
 #include <scheduler.h>

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -6,7 +6,7 @@
 #define BITCOIN_WALLET_SPEND_H
 
 #include <consensus/amount.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <util/result.h>
 #include <wallet/coinselection.h>
 #include <wallet/transaction.h>

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
-#include <policy/fees.h>
+#include <policy/fees/block_policy_estimator.h>
 #include <script/solver.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>


### PR DESCRIPTION
This PR is a simple refactoring that does four things:

1. Renames `test/policy_fee_tests.cpp` to `test/feerounder_tests.cpp`.
2. Renames `policy/fees.{h,cpp}` to `policy/fees/block_policy_estimator.{h,cpp}`.
3. Renames `policy/fees_args.cpp` to `policy/fees/block_policy_estimator_args.cpp`.
4. Modifies `estimateSmartFee` to return the block height at which the estimate was made by adding a `best_height` unsigned int value to the `FeeCalculation` struct.

**Motivation**

In preparation for adding a new fee estimator, the `fees` directory is created so we can organize code into `block_policy_estimator` and `mempool` because

a) It would be clunky to add more code directly under `fees`.
b) Having `policy/fees.{h,cpp}` and `policy/mempool.{h,cpp}` would also be undesirable. 

Therefore, it makes sense to structure the it as `policy/fees/block_policy_estimator`, `policy/fees/mempool`, etc.
Hence test file were also updated accordingly.

The current block height is also returned because later in #30157 we log the height at which each estimate is made (at the debug log category of  fee estimation :) ). This feature is particularly useful for empirical data analysis.
