### PR TITLE
coinselection: Tiebreak SRD eviction by weight

### DIFF
--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -529,7 +529,7 @@ class MinOutputGroupComparator
 public:
     int operator() (const OutputGroup& group1, const OutputGroup& group2) const
     {
-        return group1.GetSelectionAmount() > group2.GetSelectionAmount();
+        return descending_effval_weight(group1, group2);
     }
 };
 

--- a/src/wallet/test/coinselection_tests.cpp
+++ b/src/wallet/test/coinselection_tests.cpp
@@ -283,6 +283,13 @@ BOOST_AUTO_TEST_CASE(srd_test)
         AddDuplicateCoins(utxo_pool, /*count=*/3, /*amount=*/7 * CENT, cs_params);
         TestSRDSuccess("Select most valuable UTXOs for acceptable weight", utxo_pool, /*selection_target=*/20 * CENT, cs_params, /*max_selection_weight=*/4 * 4 * (P2WPKH_INPUT_VSIZE - 1 ));
         TestSRDFail("No acceptable weight possible", utxo_pool, /*selection_target=*/25 * CENT, cs_params, /*max_selection_weight=*/4 * 3 * P2WPKH_INPUT_VSIZE, /*expect_max_weight_exceeded=*/true);
+
+        // Create UTXO pool with UTXOs of same effective value but different weights
+        std::vector<OutputGroup> mixed_weight_pool;
+        AddDuplicateCoins(mixed_weight_pool, /*count=*/100, /*amount=*/5 * CENT, cs_params);
+        mixed_weight_pool.push_back(MakeCoin(5 * CENT, true, cs_params, /*custom_spending_vsize=*/P2WPKH_INPUT_VSIZE - 1));
+        TestSRDSuccess("Tie-break same effective value with lower weight", utxo_pool, /*selection_target=*/9 * CENT, cs_params,
+        /*max_selection_weight=*/4 * 3 * (P2WPKH_INPUT_VSIZE - 1));
     }
 }
 


### PR DESCRIPTION
yancyribbens [pointed out](https://github.com/p2pderivatives/rust-bitcoin-coin-selection/pull/108#issuecomment-3202107069) that SRD would fail to find a possible solution if there are multiple UTXOs of the same effective value with diverse weight.

This adds a tiebreaker that will make SRD succeed in such a scenario.