### PR TITLE
doc: unify `datacarriersize` warning with release notes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -904,7 +904,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     }
 
     if (args.IsArgSet("-datacarriersize") || args.IsArgSet("-datacarrier")) {
-        InitWarning(_("Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated. They will be removed in a future version."));
+        InitWarning(_("Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated and are expected to be removed in a future version."));
     }
 
     // We no longer limit the orphanage based on number of transactions but keep the option to warn users who still have it in their config.

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -103,9 +103,9 @@ class DataCarrierTest(BitcoinTestFramework):
         # Clean shutdown boilerplate due to deprecation
         self.expected_stderr = [
             "",  # node 0 has no deprecated options
-            "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated. They will be removed in a future version.",
-            "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated. They will be removed in a future version.",
-            "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated. They will be removed in a future version.",
+            "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated and are expected to be removed in a future version.",
+            "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated and are expected to be removed in a future version.",
+            "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated and are expected to be removed in a future version.",
         ]
 
         for i in range(self.num_nodes):


### PR DESCRIPTION
Follow-up to https://github.com/bitcoin/bitcoin/pull/32406

---

The [release notes](https://github.com/bitcoin/bitcoin/blob/a189d636184b1c28fa4a325b56c1fab8f44527b1/doc/release-notes-32406.md#L1) claim

> [...] marked as deprecated and are expected to be removed in a future release

but the [warning itself](https://github.com/bitcoin/bitcoin/blob/2885bd0e1c4fc863a7f28ff0fd353f5cffb03442/src/init.cpp#L907) claims

> [...] marked as deprecated. They **will** be removed in a future version.

To be less aggressive (since some have objected against this version online) - and to unify the deprecation warning with the release notes - I have changed the warning to communicate our expectation in a friendlier way.