### PR TITLE
util: Address various issues in AllocateFileRange

### DIFF
--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -195,7 +195,7 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
     nFileSize.u.HighPart = nEndPos >> 32;
     SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
     SetEndOfFile(hFile);
-#elif defined(__APPLE__)
+#elif 0
     // OSX specific version
     // NOTE: Contrary to other OS versions, the OSX version assumes that
     // NOTE: offset is the size of the file.

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -213,8 +213,7 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
 #else
 #if defined(HAVE_POSIX_FALLOCATE)
     // Version using posix_fallocate
-    off_t nEndPos = (off_t)offset + length;
-    if (0 == posix_fallocate(fileno(file), 0, nEndPos)) return;
+    if (0 == posix_fallocate(fileno(file), offset, length)) return;
 #endif
     // Fallback version
     // TODO: just write one byte per block

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -193,8 +193,9 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
     int64_t nEndPos = (int64_t)offset + length;
     nFileSize.u.LowPart = nEndPos & 0xFFFFFFFF;
     nFileSize.u.HighPart = nEndPos >> 32;
-    SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
-    SetEndOfFile(hFile);
+    if (SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN)) {
+        SetEndOfFile(hFile);
+    }
 #elif 0
     // OSX specific version
     // NOTE: Contrary to other OS versions, the OSX version assumes that

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -191,10 +191,12 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
     HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
     LARGE_INTEGER nFileSize;
     int64_t nEndPos = (int64_t)offset + length;
-    nFileSize.u.LowPart = nEndPos & 0xFFFFFFFF;
-    nFileSize.u.HighPart = nEndPos >> 32;
-    if (SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN)) {
-        SetEndOfFile(hFile);
+    if (GetFileSizeEx(hFile, &nFileSize) && (int64_t{nFileSize.u.HighPart} << 32 | nFileSize.u.LowPart) <= nEndPos) {
+        nFileSize.u.LowPart = nEndPos & 0xFFFFFFFF;
+        nFileSize.u.HighPart = nEndPos >> 32;
+        if (SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN)) {
+            SetEndOfFile(hFile);
+        }
     }
 #elif 0
     // OSX specific version


### PR DESCRIPTION
Fixes several bugs in AllocateFileRange.

Not a real fix for #33128, but a workaround for the issue.

Potentially might fix #28552 too, but I don't have a way to reproduce that. (After digging into Apple's XNU code, it looks too buggy to try to use `F_PREALLOCATE` at all IMO; for reference: [XNU kernel code](https://github.com/apple-oss-distributions/xnu/blob/e3723e1f17661b24996789d8afc084c0c3303b26/bsd/kern/kern_descrip.c#L3289) and [HFS driver code](https://github.com/apple-oss-distributions/hfs/blob/a4bba3ecca6d79d997caf27c9a388eb1c8edcd08/core/hfs_readwrite.c#L4390) - notice the truncation risk from comparing to block-allocated size rather than file size and reachable code paths the comments assume to be dead code)