### PR TITLE
doc: follow-ups to "Add bitcoin-{node,gui} to release binaries for IPC"

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -122,7 +122,7 @@ User-Space, Statically Defined Tracing (USDT) dependencies:
 
 Cap'n Proto is needed for IPC functionality (see [multiprocess.md](multiprocess.md)):
 
-    sudo dnf install capnproto
+    sudo dnf install capnproto capnproto-devel
 
 Compile with `-DENABLE_IPC=OFF` if you do not need IPC functionality.
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -163,6 +163,12 @@ SQLite is required for the wallet:
 
 To build Bitcoin Core without the wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
+Cap'n Proto is needed for IPC functionality (see [multiprocess.md](multiprocess.md)):
+
+    apk add capnproto capnproto-dev
+
+Compile with `-DENABLE_IPC=OFF` if you do not need IPC functionality.
+
 ZMQ dependencies (provides ZMQ API):
 
     apk add zeromq-dev
@@ -205,7 +211,7 @@ Setup and Build Example: Arch Linux
 -----------------------------------
 This example lists the steps necessary to setup and build a command line only distribution of the latest changes on Arch Linux:
 
-    pacman --sync --needed cmake boost gcc git libevent make python sqlite
+    pacman --sync --needed capnproto cmake boost gcc git libevent make python sqlite
     git clone https://github.com/bitcoin/bitcoin.git
     cd bitcoin/
     cmake -B build

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -35,7 +35,7 @@ Bitcoin Core requires one of the following compilers.
 
 | Dependency | Releases | Minimum required |
 | --- | --- | --- |
-| [Cap'n Proto](../depends/packages/capnp.mk) | [link](https://capnproto.org) | [0.7.1](https://capnproto.org/install.html) |
+| [Cap'n Proto](../depends/packages/capnp.mk) | [link](https://capnproto.org) | [0.7.1](https://github.com/bitcoin/bitcoin/pull/28907) |
 | Python (scripts, tests) | [link](https://www.python.org) | [3.10](https://github.com/bitcoin/bitcoin/pull/30527) |
 | [Qt](../depends/packages/qt.mk) (gui) | [link](https://download.qt.io/archive/qt/) | [6.2](https://github.com/bitcoin/bitcoin/pull/30997) |
 | [qrencode](../depends/packages/qrencode.mk) (gui) | [link](https://fukuchi.org/works/qrencode/) | N/A |

--- a/doc/files.md
+++ b/doc/files.md
@@ -150,8 +150,8 @@ This table describes the files installed by Bitcoin Core across different platfo
 | *lib/pkgconfig/libbitcoinkernel.pc*                        | Pkg-config metadata for linking to `libbitcoinkernel`                       |
 | *libexec/bench_bitcoin*                                    | Benchmarking tool for measuring node performance                            |
 | *libexec/bitcoin-chainstate*                               | Tool to validate and connect blocks                                         |
-| *libexec/bitcoin-gui*                                      | IPC-enabled alternative to `bitcoin-qt`                                     |
-| *libexec/bitcoin-node*                                     | IPC-enabled alternative to `bitcoind`                                       |
+| libexec/bitcoin-gui                                        | IPC-enabled alternative to `bitcoin-qt`                                     |
+| libexec/bitcoin-node                                       | IPC-enabled alternative to `bitcoind`                                       |
 | libexec/test_bitcoin                                       | Unit test binary                                                            |
 | *libexec/test_bitcoin-qt*                                  | GUI-specific unit tests                                                     |
 | share/man/man1/                                            | Man pages for command-line tools like `bitcoin-cli`, `bitcoind`, and others |


### PR DESCRIPTION
- have `dependencies.md` link to the PR that updated the capnp version: https://github.com/bitcoin/bitcoin/pull/31802#discussion_r2290393840