### PR TITLE
doc: Remove wrong and redundant doxygen tag

### DIFF
--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -46,9 +46,6 @@ public:
     /**
      * Construct a fee rate from a fee in satoshis and a vsize in vB.
      *
-     * param@[in]   nFeePaid    The fee paid by a transaction, in satoshis
-     * param@[in]   virtual_bytes   The vsize of a transaction, in vbytes
-     *
      * Passing any virtual_bytes less than or equal to 0 will result in 0 fee rate per 0 size.
      */
     CFeeRate(const CAmount& nFeePaid, int32_t virtual_bytes);

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -589,15 +589,15 @@ util::Result<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utx
 
 /** Find a subset of the OutputGroups that is at least as large as, but as close as possible to, the
  * target amount; solve subset sum.
- * param@[in]   groups          OutputGroups to choose from, sorted by value in descending order.
- * param@[in]   nTotalLower     Total (effective) value of the UTXOs in groups.
- * param@[in]   nTargetValue    Subset sum target, not including change.
- * param@[out]  vfBest          Boolean vector representing the subset chosen that is closest to
+ * @param[in]   groups          OutputGroups to choose from, sorted by value in descending order.
+ * @param[in]   nTotalLower     Total (effective) value of the UTXOs in groups.
+ * @param[in]   nTargetValue    Subset sum target, not including change.
+ * @param[out]  vfBest          Boolean vector representing the subset chosen that is closest to
  *                              nTargetValue, with indices corresponding to groups. If the ith
  *                              entry is true, that means the ith group in groups was selected.
- * param@[out]  nBest           Total amount of subset chosen that is closest to nTargetValue.
- * paramp[in]   max_selection_weight  The maximum allowed weight for a selection result to be valid.
- * param@[in]   iterations      Maximum number of tries.
+ * @param[out]  nBest           Total amount of subset chosen that is closest to nTargetValue.
+ * @param[in]   max_selection_weight  The maximum allowed weight for a selection result to be valid.
+ * @param[in]   iterations      Maximum number of tries.
  */
 static void ApproximateBestSubset(FastRandomContext& insecure_rand, const std::vector<OutputGroup>& groups,
                                   const CAmount& nTotalLower, const CAmount& nTargetValue,

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -131,14 +131,14 @@ FilteredOutputGroups GroupOutputs(const CWallet& wallet,
  * the solution (according to the waste metric) will be chosen. If a valid input cannot be found from any
  * single OutputType, fallback to running `ChooseSelectionResult()` over all available coins.
  *
- * param@[in]  chain                     The chain interface to get information on unconfirmed UTXOs bump fees
- * param@[in]  nTargetValue              The target value
- * param@[in]  groups                    The grouped outputs mapped by coin eligibility filters
- * param@[in]  coin_selection_params     Parameters for the coin selection
- * param@[in]  allow_mixed_output_types  Relax restriction that SelectionResults must be of the same OutputType
+ * @param[in]  chain                     The chain interface to get information on bump fees for unconfirmed UTXOs
+ * @param[in]  nTargetValue              The target value
+ * @param[in]  groups                    The grouped outputs mapped by coin eligibility filters
+ * @param[in]  coin_selection_params     Parameters for the coin selection
+ * @param[in]  allow_mixed_output_types  Relax restriction that SelectionResults must be of the same OutputType
  * returns                               If successful, a SelectionResult containing the input set
  *                                       If failed, returns (1) an empty error message if the target was not reached (general "Insufficient funds")
- *                                                  or (2) an specific error message if there was something particularly wrong (e.g. a selection
+ *                                                  or (2) a specific error message if there was something particularly wrong (e.g. a selection
  *                                                  result that surpassed the tx max weight size).
  */
 util::Result<SelectionResult> AttemptSelection(interfaces::Chain& chain, const CAmount& nTargetValue, OutputGroupTypeMap& groups,
@@ -149,13 +149,13 @@ util::Result<SelectionResult> AttemptSelection(interfaces::Chain& chain, const C
  * Multiple coin selection algorithms will be run and the input set that produces the least waste
  * (according to the waste metric) will be chosen.
  *
- * param@[in]  chain                     The chain interface to get information on unconfirmed UTXOs bump fees
- * param@[in]  nTargetValue              The target value
- * param@[in]  groups                    The struct containing the outputs grouped by script and divided by (1) positive only outputs and (2) all outputs (positive + negative).
- * param@[in]  coin_selection_params     Parameters for the coin selection
+ * @param[in]  chain                     The chain interface to get information on bump fees for unconfirmed UTXOs
+ * @param[in]  nTargetValue              The target value
+ * @param[in]  groups                    The struct containing the outputs grouped by script and divided by (1) positive only outputs and (2) all outputs (positive + negative).
+ * @param[in]  coin_selection_params     Parameters for the coin selection
  * returns                               If successful, a SelectionResult containing the input set
  *                                       If failed, returns (1) an empty error message if the target was not reached (general "Insufficient funds")
- *                                                  or (2) an specific error message if there was something particularly wrong (e.g. a selection
+ *                                                  or (2) a specific error message if there was something particularly wrong (e.g. a selection
  *                                                  result that surpassed the tx max weight size).
  */
 util::Result<SelectionResult> ChooseSelectionResult(interfaces::Chain& chain, const CAmount& nTargetValue, Groups& groups, const CoinSelectionParams& coin_selection_params);
@@ -189,10 +189,10 @@ util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const
 
 /**
  * Select a set of coins such that nTargetValue is met; never select unconfirmed coins if they are not ours
- * param@[in]   wallet                 The wallet which provides data necessary to spend the selected coins
- * param@[in]   available_coins        The struct of coins, organized by OutputType, available for selection prior to filtering
- * param@[in]   nTargetValue           The target value
- * param@[in]   coin_selection_params  Parameters for this coin selection such as feerates, whether to avoid partial spends,
+ * @param[in]   wallet                 The wallet which provides data necessary to spend the selected coins
+ * @param[in]   available_coins        The struct of coins, organized by OutputType, available for selection prior to filtering
+ * @param[in]   nTargetValue           The target value
+ * @param[in]   coin_selection_params  Parameters for this coin selection such as feerates, whether to avoid partial spends,
  *                                     and whether to subtract the fee from the outputs.
  * returns                             If successful, a SelectionResult containing the selected coins
  *                                     If failed, returns (1) an empty error message if the target was not reached (general "Insufficient funds")


### PR DESCRIPTION
`param@[in]` is not a valid doxygen tag. Also, no other function in this file uses the annotations, and they are redundant with the line above, so just remove them in `feerate` to fix all issues.

In other places, fix them.