### PR TITLE
doc: use new block_to_connect parameter name

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3103,7 +3103,7 @@ public:
 };
 
 /**
- * Connect a new block to m_chain. pblock is either nullptr or a pointer to a CBlock
+ * Connect a new block to m_chain. block_to_connect is either nullptr or a pointer to a CBlock
  * corresponding to pindexNew, to bypass loading it again from disk.
  *
  * The block is added to connectTrace if connection succeeds.


### PR DESCRIPTION
The parameter name was previously changed from `pblock` to `block_to_connect` in 9ba1fff29e4794615c599e59ef453848a9bdb880, without updating the documentation.

Addresses https://github.com/bitcoin/bitcoin/pull/33078#discussion_r2279914775.