### PR TITLE
[29.x] depends: remove xinerama extension from libxcb

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -122,7 +122,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libxcb-shape.so.0',
 'libxcb-sync.so.1',
 'libxcb-xfixes.so.0',
-'libxcb-xinerama.so.0',
 'libxcb-xkb.so.1',
 }
 

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -16,7 +16,7 @@ $(package)_config_opts += --disable-dri2 --disable-dri3 --disable-glx
 $(package)_config_opts += --disable-present --disable-record --disable-resource
 $(package)_config_opts += --disable-screensaver --disable-xevie --disable-xfree86-dri
 $(package)_config_opts += --disable-xinput --disable-xprint --disable-selinux
-$(package)_config_opts += --disable-xtest --disable-xv --disable-xvmc
+$(package)_config_opts += --disable-xtest --disable-xv --disable-xvmc --disable-xinerama
 endef
 
 define $(package)_preprocess_cmds

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -136,6 +136,7 @@ function signature instead of just the function name. (#32604)
 - #32943 depends: Force CMAKE_EXPORT_NO_PACKAGE_REGISTRY=TRUE
 - #32954 cmake: Drop no longer necessary "cmakeMinimumRequired" object
 - #33073 guix: warn SOURCE_DATE_EPOCH set in guix-codesign
+- #33217 depends: remove xinerama extension from libxcb
 
 ### Gui
 


### PR DESCRIPTION
Backports #33217 to the `29.x` branch. 
Same rationale as #33217. `xinerama` was obseleted well before it's removal in Qt6.