### PR TITLE
build: Remove CMAKE_SKIP_BUILD_RPATH and SKIP_BUILD_RPATH settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,18 +621,6 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
   set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE)
 endif()
 
-# TODO: The `CMAKE_SKIP_BUILD_RPATH` variable setting can be deleted
-#       in the future after reordering Guix script commands to
-#       perform binary checks after the installation step.
-# Relevant discussions:
-# - https://github.com/hebasto/bitcoin/pull/236#issuecomment-2183120953
-# - https://github.com/bitcoin/bitcoin/pull/30312#issuecomment-2191235833
-# NetBSD always requires runtime paths to be set for executables.
-if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-else()
-  set(CMAKE_SKIP_BUILD_RPATH TRUE)
-endif()
 add_subdirectory(test)
 add_subdirectory(doc)
 
@@ -640,7 +628,6 @@ add_subdirectory(src)
 
 include(Maintenance)
 setup_split_debug_script()
-add_maintenance_targets()
 add_windows_deploy_target()
 add_macos_deploy_target()
 

--- a/cmake/module/Maintenance.cmake
+++ b/cmake/module/Maintenance.cmake
@@ -18,30 +18,6 @@ function(setup_split_debug_script)
   endif()
 endfunction()
 
-function(add_maintenance_targets)
-  if(NOT TARGET Python3::Interpreter)
-    return()
-  endif()
-
-  foreach(target IN ITEMS bitcoin bitcoind bitcoin-node bitcoin-qt bitcoin-gui bitcoin-cli bitcoin-tx bitcoin-util bitcoin-wallet test_bitcoin bench_bitcoin)
-    if(TARGET ${target})
-      list(APPEND executables $<TARGET_FILE:${target}>)
-    endif()
-  endforeach()
-
-  add_custom_target(check-symbols
-    COMMAND ${CMAKE_COMMAND} -E echo "Running symbol and dynamic library checks..."
-    COMMAND Python3::Interpreter ${PROJECT_SOURCE_DIR}/contrib/guix/symbol-check.py ${executables}
-    VERBATIM
-  )
-
-  add_custom_target(check-security
-    COMMAND ${CMAKE_COMMAND} -E echo "Checking binary security..."
-    COMMAND Python3::Interpreter ${PROJECT_SOURCE_DIR}/contrib/guix/security-check.py ${executables}
-    VERBATIM
-  )
-endfunction()
-
 function(add_windows_deploy_target)
   if(MINGW AND TARGET bitcoin AND TARGET bitcoin-qt AND TARGET bitcoind AND TARGET bitcoin-cli AND TARGET bitcoin-tx AND TARGET bitcoin-wallet AND TARGET bitcoin-util AND TARGET test_bitcoin)
     find_program(MAKENSIS_EXECUTABLE makensis)

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -248,11 +248,6 @@ mkdir -p "$DISTSRC"
     # Build Bitcoin Core
     cmake --build build -j "$JOBS" ${V:+--verbose}
 
-    # Perform basic security checks on a series of executables.
-    cmake --build build -j 1 --target check-security ${V:+--verbose}
-    # Check that executables only contain allowed version symbols.
-    cmake --build build -j 1 --target check-symbols ${V:+--verbose}
-
     mkdir -p "$OUTDIR"
 
     # Make the os-specific installers
@@ -281,6 +276,13 @@ mkdir -p "$DISTSRC"
             cmake --install build --prefix "${INSTALLPATH}" ${V:+--verbose}
             ;;
     esac
+
+    # Perform basic security checks on installed executables.
+    echo "Checking binary security on installed executables..."
+    python3 "${DISTSRC}/contrib/guix/security-check.py" "${INSTALLPATH}/bin/"* "${INSTALLPATH}/libexec/"*
+    # Check that executables only contain allowed version symbols.
+    echo "Running symbol and dynamic library checks on installed executables..."
+    python3 "${DISTSRC}/contrib/guix/symbol-check.py" "${INSTALLPATH}/bin/"* "${INSTALLPATH}/libexec/"*
 
     (
         cd installed

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -412,15 +412,6 @@ if(BUILD_KERNEL_LIB)
       bitcoin-chainstate.cpp
     )
     add_windows_application_manifest(bitcoin-chainstate)
-    # TODO: The `SKIP_BUILD_RPATH` property setting can be deleted
-    #       in the future after reordering Guix script commands to
-    #       perform binary checks after the installation step.
-    # Relevant discussions:
-    # - https://github.com/hebasto/bitcoin/pull/236#issuecomment-2183120953
-    # - https://github.com/bitcoin/bitcoin/pull/30312#issuecomment-2191235833
-    set_target_properties(bitcoin-chainstate PROPERTIES
-      SKIP_BUILD_RPATH OFF
-    )
     target_link_libraries(bitcoin-chainstate
       PRIVATE
         core_interface

--- a/src/test/kernel/CMakeLists.txt
+++ b/src/test/kernel/CMakeLists.txt
@@ -9,8 +9,4 @@ target_link_libraries(test_kernel
     Boost::headers
 )
 
-set_target_properties(test_kernel PROPERTIES
-  SKIP_BUILD_RPATH OFF
-)
-
 add_test(NAME test_kernel COMMAND test_kernel)


### PR DESCRIPTION
Remove CMAKE_SKIP_BUILD_RPATH and SKIP_BUILD_RPATH settings that are no longer needed after reordering the Guix build script to perform binary checks after installation.

This PR also removes the unused CMake maintenance targets (`check-security` and `check-symbols`) and updates the Guix security checks to include binaries in the `libexec/` directory (added in PR #31679).