### PR TITLE
doc: Replace FIXME placeholders with correct libblkmaker version numbers

### DIFF
--- a/doc/release-notes/release-notes-0.10.4.md
+++ b/doc/release-notes/release-notes-0.10.4.md
@@ -79,10 +79,10 @@ found at the URLs below:
 - Block versions over the last 2,000 blocks showing the days to the
   earliest possible BIP65 consensus-enforced block: <http://bitcoin.sipa.be/ver-2k.png>
 
-**Notice to miners:** Bitcoin Core’s block templates are now for
+**Notice to miners:** Bitcoin Core's block templates are now for
 version 4 blocks only, and any mining software relying on its
 getblocktemplate must be updated in parallel to use libblkmaker either
-version FIXME or any version from FIXME onward.
+version 0.4.2 or any version from 0.5.1 onward.
 
 - If you are solo mining, this will affect you the moment you upgrade
   Bitcoin Core, which must be done prior to BIP65 achieving its 951/1001


### PR DESCRIPTION
## Summary

This PR replaces FIXME placeholders in the release notes with the correct libblkmaker version numbers.

## Changes

- Replace FIXME placeholders in release notes with correct version numbers:
  - `FIXME` → `0.4.2`
  - `FIXME` → `0.5.1`

## Context

The release notes for version 0.10.4 contained FIXME placeholders for libblkmaker version numbers. These same version numbers are correctly specified in other release notes (e.g., 0.9.5, 0.10.0, 0.11.2) as 0.4.2 and 0.5.1.

## Testing

- [x] Verified the change is correct by comparing with other release notes
- [x] No functional changes - this is purely documentation
- [x] Follows Bitcoin Core documentation style

## Why This Matters

Complete and accurate documentation helps users understand the correct version requirements for mining software when upgrading Bitcoin Core.

This is my second contribution to Bitcoin Core. I chose this TODO item because it's:
- Low risk (documentation only)
- Clearly actionable
- Improves documentation quality
- Easy to verify correctness 