### PR TITLE
p2p: add `DifferenceFormatter` fuzz target and invariant check

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4135,6 +4135,11 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
     if (msg_type == NetMsgType::GETBLOCKTXN) {
         BlockTransactionsRequest req;
         vRecv >> req;
+        // Verify differential encoding invariant: indexes must be strictly increasing
+        // DifferenceFormatter should guarantee this property during deserialization
+        for (size_t i = 1; i < req.indexes.size(); ++i) {
+            Assume(req.indexes[i] > req.indexes[i-1]);
+        }
 
         std::shared_ptr<const CBlock> recent_block;
         {

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(fuzz
   decode_tx.cpp
   descriptor_parse.cpp
   deserialize.cpp
+  difference_formatter.cpp
   eval_script.cpp
   feefrac.cpp
   fee_rate.cpp

--- a/src/test/fuzz/difference_formatter.cpp
+++ b/src/test/fuzz/difference_formatter.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <blockencodings.h>
+#include <streams.h>
+#include <random.h>
+#include <test/fuzz/fuzz.h>
+
+#include <vector>
+
+FUZZ_TARGET(difference_formatter)
+{
+    const auto block_hash = InsecureRandomContext{{}}.rand256();
+    DataStream ss{};
+    ss << block_hash << std::span{buffer};
+
+    // Test deserialization
+    try {
+        BlockTransactionsRequest test_container;
+        ss >> test_container;
+        assert(test_container.blockhash == block_hash);
+
+        // Invariant: strictly monotonic increasing (no duplicates allowed)
+        for (size_t i = 1; i < test_container.indexes.size(); ++i) {
+            assert(test_container.indexes[i] > test_container.indexes[i-1]);
+        }
+
+    } catch (const std::ios_base::failure&) {
+        // Expected for malformed input
+    }
+}


### PR DESCRIPTION
Adds a fuzz test for the [`DifferenceFormatter`](https://github.com/bitcoin/bitcoin/blob/e3f416dbf7633b2fb19c933e5508bd231cc7e9cf/src/blockencodings.h#L22-L42) (used in [`BlockTransactionsRequest`](https://github.com/bitcoin/bitcoin/blob/master/src/blockencodings.h#L44-L54), [BIP 152](https://github.com/bitcoin/bips/blob/master/bip-0152.mediawiki)). The DifferenceFormatter class implements differential encoding for compact block transactions (BIP 152). This PR ensures that its strictly-monotonic property is maintained. It complements the tests in [`blocktransactionsrequest_deserialize`](https://github.com/bitcoin/bitcoin/blob/9703b7e6d563ea58f83a6eca819562365404f4ab/src/test/fuzz/deserialize.cpp#L314). 

Additionally, there's an added invariant check after GETBLOCKTXN deserialization in `net_processing.cpp`. 

