### PR TITLE
Bug Fix: invalid address error message and test

### DIFF
--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -87,10 +87,11 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
     uint160 hash;
     error_str = "";
 
+    bool is_bech32 = !(bech32::Decode(str).encoding == bech32::Encoding::INVALID);
     // Note this will be false if it is a valid Bech32 address for a different network
-    bool is_bech32 = (ToLower(str.substr(0, params.Bech32HRP().size())) == params.Bech32HRP());
+    bool is_bech32_hrp = (ToLower(str.substr(0, params.Bech32HRP().size())) == params.Bech32HRP());
 
-    if (!is_bech32 && DecodeBase58Check(str, data, 21)) {
+    if (!is_bech32 && !is_bech32_hrp && DecodeBase58Check(str, data, 21)) {
         // base58-encoded Bitcoin addresses.
         // Public-key-hash-addresses have version 0 (or 111 testnet).
         // The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
@@ -117,7 +118,7 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
             error_str = "Invalid or unsupported Base58-encoded address.";
         }
         return CNoDestination();
-    } else if (!is_bech32) {
+    } else if (!is_bech32 && !is_bech32_hrp) {
         // Try Base58 decoding without the checksum, using a much larger max length
         if (!DecodeBase58(str, data, 100)) {
             error_str = "Invalid or unsupported Segwit (Bech32) or Base58 encoding.";

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -63,7 +63,7 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
     def test_validateaddress(self):
         # Invalid Bech32
         self.check_invalid(BECH32_INVALID_SIZE, "Invalid Bech32 address program size (41 bytes)")
-        self.check_invalid(BECH32_INVALID_PREFIX, 'Invalid or unsupported Segwit (Bech32) or Base58 encoding.')
+        self.check_invalid(BECH32_INVALID_PREFIX, 'Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc).')
         self.check_invalid(BECH32_INVALID_BECH32, 'Version 1+ witness address must use Bech32m checksum')
         self.check_invalid(BECH32_INVALID_BECH32M, 'Version 0 witness address must use Bech32 checksum')
         self.check_invalid(BECH32_INVALID_VERSION, 'Invalid Bech32 address witness version')


### PR DESCRIPTION
Error message returned for an invalid HRP string for a correctly encoded bech32 addresses was incorrect. It was returning `'Not a valid Bech32 or Base58 encoding'.` but it should return "Invalid or unsupported prefix for Segwit (Bech32) address (expected ..., got ...)."

The check in the `DecodeDestination` function that returns `"Invalid or unsupported prefix for Segwit (Bech32) address (expected ..., got ...)."` was not reachable for any address, as the HRP was checked at the start of the `DecodeDestination` function, and if it didn't match, then the address was assumed to be base58 or an invalid encoding, even if it was valid bech32 but with incorrect HRP. 

This fix checks if the address is a valid bech32 encoding, and then only if an invalid encoding AND incorrect HRP, then attempts to verify a base58 encoding. 