### PR TITLE
test: Use extra_port() helper in feature_bind_extra.py

### DIFF
--- a/test/functional/feature_bind_extra.py
+++ b/test/functional/feature_bind_extra.py
@@ -37,37 +37,41 @@ class BindExtraTest(BitcoinTestFramework):
         loopback_ipv4 = addr_to_hex("127.0.0.1")
 
         # Start custom ports by reusing unused p2p ports
-        port = p2p_port(self.num_nodes)
+        def extra_port():
+            port = p2p_port(extra_port.index)
+            extra_port.index += 1
+            return port
+        extra_port.index = self.num_nodes
 
         # Array of tuples [command line arguments, expected bind addresses].
         self.expected = []
 
         # Node0, no normal -bind=... with -bind=...=onion, thus only the tor target.
+        port = extra_port()
         self.expected.append(
             [
                 [f"-bind=127.0.0.1:{port}=onion"],
-                [(loopback_ipv4, port)]
+                [(loopback_ipv4, port)],
             ],
         )
-        port += 1
 
         # Node1, both -bind=... and -bind=...=onion.
+        port = [extra_port(), extra_port()]
         self.expected.append(
             [
-                [f"-bind=127.0.0.1:{port}", f"-bind=127.0.0.1:{port + 1}=onion"],
-                [(loopback_ipv4, port), (loopback_ipv4, port + 1)]
+                [f"-bind=127.0.0.1:{port[0]}", f"-bind=127.0.0.1:{port[1]}=onion"],
+                [(loopback_ipv4, port[0]), (loopback_ipv4, port[1])],
             ],
         )
-        port += 2
 
         # Node2, no -bind=...=onion, thus no extra port for Tor target.
+        port = extra_port()
         self.expected.append(
             [
                 [f"-bind=127.0.0.1:{port}"],
-                [(loopback_ipv4, port)]
+                [(loopback_ipv4, port)],
             ],
         )
-        port += 1
 
         self.extra_args = list(map(lambda e: e[0], self.expected))
         self.setup_nodes()


### PR DESCRIPTION
This is a refactor for self-validating and self-documenting code.

Currently, the test assumes that extra ports are available and just increments them without checking. However, this may not be the case when the test is modified to use more ports. In this case, the tests may fail intermittently and the failure is hard to debug.

Fix this confusion, by calling `p2p_port` each time. This ensures the required `assert n <= MAX_NODES` is checked each time.

Closes https://github.com/bitcoin/bitcoin/issues/33250