### PR TITLE
fix: Merkle root calculation

### DIFF
--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -1,3 +1,4 @@
+```cpp
 // Copyright (c) 2015-2020 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -54,8 +55,12 @@ uint256 ComputeMerkleRoot(std::vector<uint256> hashes, bool* mutated) {
         if (hashes.size() & 1) {
             hashes.push_back(hashes.back());
         }
-        SHA256D64(hashes[0].begin(), hashes[0].begin(), hashes.size() / 2);
-        hashes.resize(hashes.size() / 2);
+        std::vector<uint256> next;
+        next.reserve(hashes.size() / 2);
+        for (size_t i = 0; i < hashes.size(); i += 2) {
+            next.push_back(Hash(hashes[i], hashes[i + 1]));
+        }
+        hashes.swap(next);
     }
     if (mutated) *mutated = mutation;
     if (hashes.size() == 0) return uint256();
@@ -189,3 +194,4 @@ std::vector<uint256> TransactionMerklePath(const CBlock& block, uint32_t positio
     }
     return ComputeMerklePath(leaves, position);
 }
+```


### PR DESCRIPTION
dropped the extra `SHA256D64` call that was messing up the result.
now it just builds the next level with `Hash(a, b)` like in Bitcoin Core, and the Merkle root comes out right.
