### PR TITLE
fix: AutoFile position bug

### DIFF
--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -88,7 +88,7 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
     CBlockHeader header;
     try {
         file >> header;
-        file.seek(postx.nTxOffset, SEEK_CUR);
+        file.SetPos(postx.nTxOffset);
         file >> TX_WITH_WITNESS(tx);
     } catch (const std::exception& e) {
         LogError("Deserialize or I/O error - %s", e.what());


### PR DESCRIPTION
`AutoFile` doesn’t have `seek`, so I swapped it for `SetPos()` like Bitcoin Core does.
now moving around the file works correctly.
