### PR TITLE
stabilize translations by reverting old ids by text content

### DIFF
--- a/contrib/devtools/stabilize_xlf_ids.py
+++ b/contrib/devtools/stabilize_xlf_ids.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Stabilize XLF ids by replacing sequential ids with stable content hashes.
+
+The ID is derived from the Qt context ("resname") and the English source text.
+Plural forms keep the original "[N]" suffix.
+"""
+
+import hashlib
+import sys
+import os
+import re
+import xml.etree.ElementTree as ET
+
+PLURAL_SUFFIX = re.compile(r'(\[\d+])$')
+
+
+def source_text(tu):
+    source = tu.find('./{*}source')
+    assert source is not None, "trans-unit missing <source>"
+    return ''.join(source.itertext())
+
+
+def stable_id(resname, text):
+    return hashlib.sha256(f"{resname}\0{text}".encode('utf-8')).hexdigest()
+
+
+def build_id_mapping(path):
+    root = ET.parse(path).getroot()
+
+    mapping = {}
+    for g in root.findall('.//{*}group[@resname]'):
+        resname = g.get('resname')
+        for tu in g.findall('.//{*}trans-unit'):
+            old_id = tu.get('id')
+            assert old_id is not None, "trans-unit missing id attribute"
+            assert old_id not in mapping, f"duplicate input id detected: {old_id}"
+            plural = PLURAL_SUFFIX.search(old_id)
+            suffix = plural.group(1) if plural else ''
+            mapping[old_id] = f"{stable_id(resname, source_text(tu))}{suffix}"
+
+    if len(mapping) != len(root.findall('.//{*}trans-unit')):
+        raise SystemExit("trans-unit missing group resname")
+
+    if len(mapping) != len(set(mapping.values())):
+        raise SystemExit("duplicate output ids detected")
+    return mapping
+
+
+def stabilize_ids(old_path, new_path, mapping):
+    os.replace(new_path, old_path)  # we don't need the old translation units anymore
+    with open(old_path, 'r+', encoding='utf-8') as f:
+        content = re.sub(r'\bid="([^"]+)"', lambda m: f'id="{mapping.get(m.group(1), m.group(1))}"', f.read())
+        f.seek(0)
+        f.write(content)
+        f.truncate()
+
+
+def verify_unique_ids(path):
+    ids = [tu.get('id') for tu in ET.parse(path).getroot().findall('.//{*}trans-unit')]
+    if len(ids) != len(set(ids)):
+        raise SystemExit("duplicate id detected")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: stabilize_xlf_ids.py <old_xlf> <new_xlf>", file=sys.stderr)
+        sys.exit(1)
+
+    _, old_path, new_path = sys.argv
+    mapping = build_id_mapping(new_path)
+
+    stabilize_ids(old_path, new_path, mapping)
+    verify_unique_ids(old_path)
+
+    print(f"[stats] units={len(mapping)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/share/qt/translate.cmake
+++ b/share/qt/translate.cmake
@@ -115,8 +115,15 @@ execute_process(
 execute_process(
   COMMAND ${LCONVERT_EXECUTABLE}
     -drop-translations
-    -o ${PROJECT_SOURCE_DIR}/src/qt/locale/bitcoin_en.xlf
+    -o ${PROJECT_SOURCE_DIR}/src/qt/locale/bitcoin_en.new.xlf
     -i ${PROJECT_SOURCE_DIR}/src/qt/locale/bitcoin_en.ts
+  COMMAND_ERROR_IS_FATAL ANY
+)
+
+execute_process(
+  COMMAND python3 ${PROJECT_SOURCE_DIR}/contrib/devtools/stabilize_xlf_ids.py
+    ${PROJECT_SOURCE_DIR}/src/qt/locale/bitcoin_en.xlf
+    ${PROJECT_SOURCE_DIR}/src/qt/locale/bitcoin_en.new.xlf
   COMMAND_ERROR_IS_FATAL ANY
 )
 

--- a/src/qt/locale/bitcoin_en.xlf
+++ b/src/qt/locale/bitcoin_en.xlf
@@ -2,47 +2,47 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:trolltech="urn:trolltech:names:ts:document:1.0">
   <file original="../forms/addressbookpage.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="AddressBookPage">
-      <trans-unit id="_msg1">
+      <trans-unit id="92c897925509d32b5493a6f2ba789fd7c0993e8178cea3623919c0636b490c30">
         <source xml:space="preserve">Right-click to edit address or label</source>
         <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg2">
+      <trans-unit id="a5ddcbe3d0c6b4188a7d7d6b6b82e44d4ec01bc8054d437f947926e1b6ecddb0">
         <source xml:space="preserve">Create a new address</source>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg3">
+      <trans-unit id="68cdf0b4c579f83991464e5cfb9cdd2e8b16fffd20b846bb94b7755c81047344">
         <source xml:space="preserve">&amp;New</source>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg4">
+      <trans-unit id="558956e30ab553720b2c35ae42c4c093cde2ebc3658dcc1ad9e3f3e8c0c57789">
         <source xml:space="preserve">&amp;Copy</source>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg5">
+      <trans-unit id="9d0cd3c4a3a82bce398b41cb9a96487c4742e3433290baa2caf57e01547d0e7b">
         <source xml:space="preserve">C&amp;lose</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg6">
+      <trans-unit id="943155769cd6413078ad616b36af49e1aeab6ba4efbdbbc598e358e53f1a792a">
         <source xml:space="preserve">Delete the currently selected address from the list</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg7">
+      <trans-unit id="bc8eec287016c31d3db281acd74a36e0808e991dc7f920cecbcaa07284ec184d">
         <source xml:space="preserve">Enter address or label to search</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg8">
+      <trans-unit id="585a38d60afef652008592f2326917e7e4c725b8442d3b72dc5e99b91c6e917b">
         <source xml:space="preserve">Copy the currently selected address to the clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg9">
+      <trans-unit id="3f3b26987c59c3ccc6a5aebaadbc8aa0f3591d72fa74fc379b5a12175a52de4d">
         <source xml:space="preserve">Export the data in the current tab to a file</source>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg10">
+      <trans-unit id="aa9fe8f3e44c5c2b1d667d791cec6070ed3ba792e0c70b674f52c647598ae09c">
         <source xml:space="preserve">&amp;Export</source>
         <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg11">
+      <trans-unit id="28158199ecd048e6afe9589cdd09d2792dd542416b6a30e4aecc7d95aaded5c7">
         <source xml:space="preserve">&amp;Delete</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../addressbookpage.cpp</context><context context-type="linenumber">105</context></context-group>
@@ -51,62 +51,62 @@
   </body></file>
   <file original="../addressbookpage.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="AddressBookPage">
-      <trans-unit id="_msg12">
+      <trans-unit id="9a5a37587d5e319c408ef6be2890f39fd8617251ab17f0d1826d09072e389ba1">
         <source xml:space="preserve">Choose the address to send coins to</source>
         <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg13">
+      <trans-unit id="584407503b8e5861d9cc92e750166fab66d671d0c6e751aec10a3574882ce775">
         <source xml:space="preserve">Choose the address to receive coins with</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg14">
+      <trans-unit id="d3bfb61d70ec63f72e1c431dd524db32cf6acf9ebe0a879aa94b0ec12e7aade9">
         <source xml:space="preserve">C&amp;hoose</source>
         <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg15">
+      <trans-unit id="aae3a972cda691592051b313d769276bbe246dd5c9dad9b490f4bdc491503a7d">
         <source xml:space="preserve">These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg16">
+      <trans-unit id="bc04a49ffa06db14a0d0087804e7ff10265a3a014107607c62111735b35a9981">
         <source xml:space="preserve">These are your Bitcoin addresses for receiving payments. Use the &apos;Create new receiving address&apos; button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg17">
+      <trans-unit id="27801f57653fa2292fe4231ccdced099443ae9a159e5badc22efe9bf731ce613">
         <source xml:space="preserve">&amp;Copy Address</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg18">
+      <trans-unit id="746e5a8b28c992d65bac511f295709894f8dbadd5bfda0b8294543a82a621108">
         <source xml:space="preserve">Copy &amp;Label</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg19">
+      <trans-unit id="cab8fd6554ebd88b7d3463a7478a4e239ce76d9523b8fab12f792618a891bfa1">
         <source xml:space="preserve">&amp;Edit</source>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg20">
+      <trans-unit id="b79463db233c61fd0e459eacf7a69a18f8c84c70ff44884687bbfb5048732eef">
         <source xml:space="preserve">Export Address List</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg21">
+      <trans-unit id="8df2b5c1dce274b23ee7b8b2859258b9493859110a03df6e7e6a31f00752f87d">
         <source xml:space="preserve">Comma separated file</source>
         <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</note>
       </trans-unit>
-      <trans-unit id="_msg22">
+      <trans-unit id="320df4e80e974836cbce3db6a4e02fc6953e4fce088dce8ad4b8055207c66294">
         <source xml:space="preserve">There was an error trying to save the address list to %1. Please try again.</source>
         <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
         <note annotates="source" from="developer">An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</note>
       </trans-unit>
-      <trans-unit id="_msg23">
+      <trans-unit id="a8ed7bd86875a415c5ca2e02e3368c146aed752433740b2a1b74ae0af93c4b4e">
         <source xml:space="preserve">Sending addresses - %1</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg24">
+      <trans-unit id="6444a4ab4483182f7d6d2176aa3abaceada5b02249c55baa9127ba6653049530">
         <source xml:space="preserve">Receiving addresses - %1</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg25">
+      <trans-unit id="77e2f79b01cbb0d3da94ac2224c3baa11a445b9e0bbcf9e731198bae73177852">
         <source xml:space="preserve">Exporting Failed</source>
         <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
       </trans-unit>
@@ -114,15 +114,15 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../addresstablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="AddressTableModel">
-      <trans-unit id="_msg26">
+      <trans-unit id="32bd7139631d86ac9e0f5b924ce8ae5d9abf56c56104696076d219655bda7e15">
         <source xml:space="preserve">Label</source>
         <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg27">
+      <trans-unit id="c51d7e938df72d99540ad6c24dacc29da94bfea2851ba0e82a0f07568f9d81f7">
         <source xml:space="preserve">Address</source>
         <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg28">
+      <trans-unit id="f2435bb7e146000c7628a9b1acd83694890d953d45713bb2a7f3b1dc25052acd">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
       </trans-unit>
@@ -130,23 +130,23 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../forms/askpassphrasedialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="AskPassphraseDialog">
-      <trans-unit id="_msg29">
+      <trans-unit id="79f5f4bd2a4037c178eb64132f845b64c3870410fe3b4f37d702a817e27d3941">
         <source xml:space="preserve">Passphrase Dialog</source>
         <context-group purpose="location"><context context-type="linenumber">26</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg30">
+      <trans-unit id="f1ee55b572e8b824c030aafdde061d8da29245de457349d05d12649a2bdea597">
         <source xml:space="preserve">Enter passphrase</source>
         <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg31">
+      <trans-unit id="3c45562e25e1fff059a1d6436e3f590e3b267a32710b686b374f34d4676f495c">
         <source xml:space="preserve">New passphrase</source>
         <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg32">
+      <trans-unit id="440a4d544c9fa92e300cc617582d9f3c5860a7e8f280636af73025b0bf373508">
         <source xml:space="preserve">Repeat new passphrase</source>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg33">
+      <trans-unit id="2fef5efc8140eabbcf1d06a0b0fe2e1f90b5b6db86330b56627c45d2c96d8701">
         <source xml:space="preserve">Show passphrase</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
@@ -154,120 +154,120 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../askpassphrasedialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="AskPassphraseDialog">
-      <trans-unit id="_msg34">
+      <trans-unit id="00cadcc16189d1ea5c801b143065ccf9fa6292a90f334aeff5fef670e050cc80">
         <source xml:space="preserve">Encrypt wallet</source>
         <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg35">
+      <trans-unit id="3b4a9c0e216116bdaecaba9aff831b3cad0f915ef236bf029185ee8a2dd36e13">
         <source xml:space="preserve">This operation needs your wallet passphrase to unlock the wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg36">
+      <trans-unit id="4f270c49849aa5cfa7707cf5240bae3702a5465270ce4b5102021f853865466b">
         <source xml:space="preserve">Unlock wallet</source>
         <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg37">
+      <trans-unit id="13863768f29ab9176c3482a3e4c9f21db9358f2804453e5b76ba006d11aaed37">
         <source xml:space="preserve">Change passphrase</source>
         <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg38">
+      <trans-unit id="3ed1676f76c36e466e67e929642ac40963cde06500ac9a4f06377f59ff2cbe72">
         <source xml:space="preserve">Confirm wallet encryption</source>
         <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg39">
+      <trans-unit id="b2ca5fb7158dfef5a5f7d48e8a0935c9628c95cb5b0d8e7673606adad992a55f">
         <source xml:space="preserve">Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg40">
+      <trans-unit id="3ecc90ad06fda52810e2d91a91f076e5d9a9d7234550b172a82cdec2e1bf5c8d">
         <source xml:space="preserve">Are you sure you wish to encrypt your wallet?</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg41">
+      <trans-unit id="97ea4e415f0c4a5e49322921f79327cde940d4ed4b395a9e9050f38c880fe81e">
         <source xml:space="preserve">Wallet encrypted</source>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg42">
+      <trans-unit id="d109f98de2068f25beb50453d8ca4799e93674458981246a5c9c8a3e070ebdfd">
         <source xml:space="preserve">Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg43">
+      <trans-unit id="94ab06d269ababd469384b6ec14fe535920f81cfac81db903f9d463ca4333ff7">
         <source xml:space="preserve">Enter the old passphrase and new passphrase for the wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg44">
+      <trans-unit id="839734f85fd3f5de3dfb15b290a3ddf4640552be90f85040cf30ff72ddfee110">
         <source xml:space="preserve">Continue</source>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg45">
+      <trans-unit id="26da82b4da945441cc1a56449b880fd3fc0c62a30bbd4d7395f21f838bde2d27">
         <source xml:space="preserve">Back</source>
         <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg46">
+      <trans-unit id="e5228a2f63887124a9c1400e731d3310cf31465033c161adba4bb0cd215d774e">
         <source xml:space="preserve">Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg47">
+      <trans-unit id="c1e318ee6c2c9afde8fa092d8d20999615c9f562a99218b45163356b9b69acb8">
         <source xml:space="preserve">Wallet to be encrypted</source>
         <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg48">
+      <trans-unit id="b9b16457227662d7a2e7faf10ef7ec15ba61862cb6121ee35018c071b78003c9">
         <source xml:space="preserve">Your wallet is about to be encrypted. </source>
         <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg49">
+      <trans-unit id="ee1c425029fea51ece5a283c4764a42b7963cfb6c10b29c92b9f519212b83c4c">
         <source xml:space="preserve">Your wallet is now encrypted. </source>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg50">
+      <trans-unit id="f88969441faeb40174d23a01974f5e2bfde02e8e2b100b3096c178b08f9776ef">
         <source xml:space="preserve">IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg51">
+      <trans-unit id="bc42a5eb7f950ef0428b07d7c30c1e185d9bcf54068039de19b570462bc1e98c">
         <source xml:space="preserve">Wallet encryption failed</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg52">
+      <trans-unit id="6856072aafe846a630de156140faef6b4f0f7ff0f67f190739c265311c121c54">
         <source xml:space="preserve">Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg53">
+      <trans-unit id="85c02c267429aa05ea87c49b47eb2ccb36f1af531a1a0833f3c658794c85c667">
         <source xml:space="preserve">The supplied passphrases do not match.</source>
         <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg54">
+      <trans-unit id="f9c0cfc8d72b0e348af08effbb00bf044472692fbc45db2282a763d36b8b36b9">
         <source xml:space="preserve">Wallet unlock failed</source>
         <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg55">
+      <trans-unit id="964aeb0d9ea80b7ea9885a37a169c8baff54855712ebdd37e908f4ee1fded091">
         <source xml:space="preserve">The passphrase entered for the wallet decryption was incorrect.</source>
         <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg56">
+      <trans-unit id="f784eade52afaaa3924131ce02a793bc531337885c599c0a70dbec3cbe060f65">
         <source xml:space="preserve">The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg57">
+      <trans-unit id="df5ab88844b58e6bdfab81dc464093b545ef613bf9accaa388c960d00a0f458c">
         <source xml:space="preserve">Wallet passphrase was successfully changed.</source>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg58">
+      <trans-unit id="d5c59dc1dcd03e6ef65cd90ef462c340f5550160c69f54f89e77a4cf6e875fb3">
         <source xml:space="preserve">Passphrase change failed</source>
         <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg59">
+      <trans-unit id="9b2bd9e28370732015eaf192144cb69d4fc1d30966a7f9c344f6d7873aef1b22">
         <source xml:space="preserve">The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
         <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg60">
+      <trans-unit id="4ed1c9a3a1ba8fd05e84a1c984f9cba72ce76d57f697ad90e80d88889ec22d08">
         <source xml:space="preserve">Warning: The Caps Lock key is on!</source>
         <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
@@ -276,11 +276,11 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../bantablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="BanTableModel">
-      <trans-unit id="_msg61">
+      <trans-unit id="ca473b91b02b69165f7ebd1cc5388a7f1ee41f5aa4d8bcf43708d98c223913dc">
         <source xml:space="preserve">IP/Netmask</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg62">
+      <trans-unit id="67b4c05b3f3dca8082153a5519e60ee369dd8e6727a8959fa25e957e42fa8b96">
         <source xml:space="preserve">Banned Until</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
@@ -288,43 +288,43 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../bitcoin.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="BitcoinApplication">
-      <trans-unit id="_msg63">
+      <trans-unit id="1438fd1c5a07999bbac80e0fe2d0cd1ae42d7047b40367451450756529a63935">
         <source xml:space="preserve">Settings file %1 might be corrupt or invalid.</source>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg64">
+      <trans-unit id="7c71c70721bbb21391f4dc03fd6013d32b7836e64b1ba1de3b1794b3df31f8b2">
         <source xml:space="preserve">Runaway exception</source>
         <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg65">
+      <trans-unit id="827770649a0a269a29d92376242ef5fbb5d1801582e4615be3aca0b528452f83">
         <source xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg66">
+      <trans-unit id="9c01424e8d83e47ecebf43f2c83db5c5ed08ed018bc14a51f15e42f59fe11ffc">
         <source xml:space="preserve">Internal error</source>
         <context-group purpose="location"><context context-type="linenumber">446</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg67">
+      <trans-unit id="6ab0a4896e72d7ead2de655088bdbc73b550c2d61eae87ec49428c89c1107c22">
         <source xml:space="preserve">An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
         <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg68">
+      <trans-unit id="6ea4e17c917f2d62c6e7d032aebf1635575e4c6879e44394e0e996a55c80b837">
         <source xml:space="preserve">Do you want to reset settings to default values, or to abort without making changes?</source>
         <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
         <note annotates="source" from="developer">Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</note>
       </trans-unit>
-      <trans-unit id="_msg69">
+      <trans-unit id="b7f0c644bae538cca7364a589b924164e9eb2a3a80146179a5e05bc3805f8f29">
         <source xml:space="preserve">A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
         <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
         <note annotates="source" from="developer">Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</note>
       </trans-unit>
-      <trans-unit id="_msg70">
+      <trans-unit id="fc7ccc5b344c223805447dbb092bd477c5cb5ed6fc0cf1161f4253a159963c98">
         <source xml:space="preserve">Error: %1</source>
         <context-group purpose="location"><context context-type="linenumber">597</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg71">
+      <trans-unit id="3e179d00d24355d3d1d4186c2bbaa7ac6ffa5e9d0dac0c7d162a32c90bf8693f">
         <source xml:space="preserve">%1 didn&apos;t yet exit safely…</source>
         <context-group purpose="location"><context context-type="linenumber">670</context></context-group>
       </trans-unit>
@@ -332,505 +332,505 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../bitcoingui.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="BitcoinGUI">
-      <trans-unit id="_msg72">
+      <trans-unit id="a6d9cc73bcd7ccea35d48609748509b328bcdf8919bcfa3965b380e9c73f34a1">
         <source xml:space="preserve">&amp;Overview</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg73">
+      <trans-unit id="5efc583fb3991bb5875213dac1351996ce3ae5ceb9edb3236ee4c4b3b00ec320">
         <source xml:space="preserve">Show general overview of wallet</source>
         <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg74">
+      <trans-unit id="be96a304c5af6988f0d49df3bbcaf22f3c52147a3bfcb568f931e1257258f562">
         <source xml:space="preserve">&amp;Transactions</source>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg75">
+      <trans-unit id="164304c04586090a633572c085e612e9ea97713fd7c78d72309d5f61367a93c9">
         <source xml:space="preserve">Browse transaction history</source>
         <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg76">
+      <trans-unit id="3c570b94af0e19b9738e689c31b3df1fad27bf17be6f5c7ba0ca246ca2b343a3">
         <source xml:space="preserve">E&amp;xit</source>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg77">
+      <trans-unit id="adc2ded63d7d87c6d1ebffc5990be79c75b8ec91afec15c2e228be21811e9547">
         <source xml:space="preserve">Quit application</source>
         <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg78">
+      <trans-unit id="8ea948749733d3c80126e7dbdd247ca46212bc262debd6568f009f39ece81609">
         <source xml:space="preserve">&amp;About %1</source>
         <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg79">
+      <trans-unit id="d8917e1f8948fb034fc1414ab3f9b671b2f0347096724aa1181dc0d7df5dfbbe">
         <source xml:space="preserve">Show information about %1</source>
         <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg80">
+      <trans-unit id="0c8fcad57ad1f0908addb15b350eaf204bde0926f875f488cc93c0abf991a11c">
         <source xml:space="preserve">About &amp;Qt</source>
         <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg81">
+      <trans-unit id="2479c7947349c5e28300b241e5d0c3ea207bce03f074294198759588762f2173">
         <source xml:space="preserve">Show information about Qt</source>
         <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg82">
+      <trans-unit id="684e2dca377d35195b5466195264c3659d9e2759f1a66b6286163e29059e42af">
         <source xml:space="preserve">Modify configuration options for %1</source>
         <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg83">
+      <trans-unit id="7b629f386e4073175b5aa752cf6cf5c4a96f4f8588e916f3ee5514d24dfc4e14">
         <source xml:space="preserve">Create a new wallet</source>
         <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg84">
+      <trans-unit id="864a120502773c012c040b5a9517b4daa9be8738956cf5f91cddafeeaa30f577">
         <source xml:space="preserve">&amp;Minimize</source>
         <context-group purpose="location"><context context-type="linenumber">573</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg85">
+      <trans-unit id="1d2f7163d3266de2d3da225965243df3f53c60f4a293320149a9f793c357cdc2">
         <source xml:space="preserve">Wallet:</source>
         <context-group purpose="location"><context context-type="linenumber">652</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg86">
+      <trans-unit id="78babc34a1fbf3e01044b35cb84d2df178af3ea7ac145329dd53326b8d3bc0aa">
         <source xml:space="preserve">Network activity disabled.</source>
         <context-group purpose="location"><context context-type="linenumber">1070</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip.</note>
       </trans-unit>
-      <trans-unit id="_msg87">
+      <trans-unit id="cb0b402d7344248b635f1f9320684967e2a140dc13fb3dc0ee1065c3ed828c54">
         <source xml:space="preserve">Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1516</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg88">
+      <trans-unit id="a7960c6621cd657498c6e94b7ad48ae8535cc6f01e49a95e75cb7cff3c9caba9">
         <source xml:space="preserve">Send coins to a Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg89">
+      <trans-unit id="03ab8122443929a950785c1a9318f6e561d1fe5826f8ebb58dd84e51b6b0af47">
         <source xml:space="preserve">Backup wallet to another location</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg90">
+      <trans-unit id="1b67c238e51e6ba1df69384a5a7fc9b2b7569907c36acb393ed2290921b4e841">
         <source xml:space="preserve">Change the passphrase used for wallet encryption</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg91">
+      <trans-unit id="2d4de5f5ecc4b3ca6f1257d162a2f5496b1a3d02602587faf76dd6f520c916bf">
         <source xml:space="preserve">&amp;Send</source>
         <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg92">
+      <trans-unit id="6a83432dd6602dfedd588a199b690975a15191fbe912c97f370f86cb561093fd">
         <source xml:space="preserve">&amp;Receive</source>
         <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg93">
+      <trans-unit id="42e0f4844b9b969c2a3b41bee85b953967cd20b0f54d89d4ed680ead92da000e">
         <source xml:space="preserve">&amp;Options…</source>
         <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg94">
+      <trans-unit id="39bfdbb505c6dfe58166f1dde2af8003ce4ab532ccd3223f785b883dbcc893c6">
         <source xml:space="preserve">&amp;Encrypt Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg95">
+      <trans-unit id="1e46e36cb3afdd06da200f536d2325304d0e8604ee2ddebd7476a7a61e835e0d">
         <source xml:space="preserve">Encrypt the private keys that belong to your wallet</source>
         <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg96">
+      <trans-unit id="2b3e58b4fe1b16de2dd0259b6ff97afe1a920880967e4ed4ccaa07afb58caa40">
         <source xml:space="preserve">&amp;Backup Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg97">
+      <trans-unit id="3d35d0bc6200c9c7569b8377b60d28845b27554f4ea2f44480149584833d333f">
         <source xml:space="preserve">&amp;Change Passphrase…</source>
         <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg98">
+      <trans-unit id="c3b1f88d439ea2313540f49a528c248d72aa271b167cd46dacbed86341944222">
         <source xml:space="preserve">Sign &amp;message…</source>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg99">
+      <trans-unit id="931c5b7dbf5995ab13c5f2328b80286e14f54b5908589f834cbe87e69e067383">
         <source xml:space="preserve">Sign messages with your Bitcoin addresses to prove you own them</source>
         <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg100">
+      <trans-unit id="05a61e3f882c69099edafce765ed1ff51c396dd99e5cc9ff56e112469e8370ce">
         <source xml:space="preserve">&amp;Verify message…</source>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg101">
+      <trans-unit id="c6ba5e5a4ae73ad713b149e5d6f7744ae54b0d0549bf8f995a2468da3cc21a7b">
         <source xml:space="preserve">Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg102">
+      <trans-unit id="5c0d1f5c463f733423b3e03ecbe4d9c2a8933b95525434c26305ce374df0a5d4">
         <source xml:space="preserve">&amp;Load PSBT from file…</source>
         <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg103">
+      <trans-unit id="335e59008de7cadb4c5a52693fcab4716a31fd4556e2dbd36ee8794e8ff0ceff">
         <source xml:space="preserve">Open &amp;URI…</source>
         <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg104">
+      <trans-unit id="e89c711095344d5d0412a1f8fac01a622ba6b715b324cc2c9b362ebdeaf02444">
         <source xml:space="preserve">Close Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg105">
+      <trans-unit id="d4cd15679ee65bea7ea9b6127948be8d769de32aa242b19410449804c0877ad9">
         <source xml:space="preserve">Create Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg106">
+      <trans-unit id="a28b668579376a4452589b8c6ae2a71f39e050ba2f6c8e7c1640741f13249d4e">
         <source xml:space="preserve">Close All Wallets…</source>
         <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg107">
+      <trans-unit id="39d0e34462fbae2a815f0ce2e8675e912fc251711f450175aed615cbe7a643bf">
         <source xml:space="preserve">Restore and Migrate Wallet File…</source>
         <context-group purpose="location"><context context-type="linenumber">499</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg108">
+      <trans-unit id="dc2d8392f457759fbb2acb55142fccfacc91830cb791c2bdf7dc76514f7b0188">
         <source xml:space="preserve">&amp;File</source>
         <context-group purpose="location"><context context-type="linenumber">539</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg109">
+      <trans-unit id="64a8a39028c80dc923dcf923b876d0d29dbb6240488bfa54e4ea1495f31e582a">
         <source xml:space="preserve">&amp;Settings</source>
         <context-group purpose="location"><context context-type="linenumber">560</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg110">
+      <trans-unit id="9c0e2cb6e2df7fcb7e2494db4c4b639410e60f00b056ade9db41332bb6ffb36d">
         <source xml:space="preserve">&amp;Help</source>
         <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg111">
+      <trans-unit id="89f8ee3e4e2afbcb03a59772a8101767ab5435ec962690f829b6ed6c5aff750b">
         <source xml:space="preserve">Tabs toolbar</source>
         <context-group purpose="location"><context context-type="linenumber">632</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg112">
+      <trans-unit id="00bd4390b5b3991817c4af577501369e199a9f404bca71b66241b5dd3ceee61d">
         <source xml:space="preserve">Syncing Headers (%1%)…</source>
         <context-group purpose="location"><context context-type="linenumber">1114</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg113">
+      <trans-unit id="ba7c4525ccdd2b5c6a3480ac3ac8587137edce6734ff673c961aa9ade5f39412">
         <source xml:space="preserve">Synchronizing with network…</source>
         <context-group purpose="location"><context context-type="linenumber">1172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg114">
+      <trans-unit id="c7b26a78be2f3716b595d70f8b9e52498e90b2d1cd0ceae13489c60b16ed3a6b">
         <source xml:space="preserve">Indexing blocks on disk…</source>
         <context-group purpose="location"><context context-type="linenumber">1177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg115">
+      <trans-unit id="f5b9327f03ae7b8932c9257dfbcfc4e3996079647dba3be82c7ecf0cd898ce7e">
         <source xml:space="preserve">Processing blocks on disk…</source>
         <context-group purpose="location"><context context-type="linenumber">1179</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg116">
+      <trans-unit id="53b9f08935e2082801ebea719e3b7c8268d2f1b2df5e334ca2c4a320e149a3e3">
         <source xml:space="preserve">Connecting to peers…</source>
         <context-group purpose="location"><context context-type="linenumber">1186</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg117">
+      <trans-unit id="909d0f5602d33c77cdcff3d6bcc47d68ef0cd2d9ec311972c520d88ba179208a">
         <source xml:space="preserve">Request payments (generates QR codes and bitcoin: URIs)</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg118">
+      <trans-unit id="15d8ee8e81922f43a068c7421943f520b969a5566c4ec9829d42be59c4abcbfb">
         <source xml:space="preserve">Show the list of used sending addresses and labels</source>
         <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg119">
+      <trans-unit id="64bda7d2b10d566da3b3394316cd08f4f58acf569a1493c5a003d4e4c8bb69df">
         <source xml:space="preserve">Show the list of used receiving addresses and labels</source>
         <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg120">
+      <trans-unit id="5279ce1359482ad834178937c9366104c36baec86f8c71d7dfea54748a1b4a31">
         <source xml:space="preserve">&amp;Command-line options</source>
         <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">1195</context></context-group>
-        <trans-unit id="_msg121[0]">
+        <trans-unit id="8250a2bc5f116144d204db327fee92bc4ad4b6ad0243c99f7edf94ec9e180ff3[0]">
           <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
         </trans-unit>
-        <trans-unit id="_msg121[1]">
+        <trans-unit id="8250a2bc5f116144d204db327fee92bc4ad4b6ad0243c99f7edf94ec9e180ff3[1]">
           <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg122">
+      <trans-unit id="d4ba4d16549476f0ccb378e84a52d39af68614e0bd466b6c4293e8467c132b5e">
         <source xml:space="preserve">%1 behind</source>
         <context-group purpose="location"><context context-type="linenumber">1218</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg123">
+      <trans-unit id="32a16cc69486aa8bf41981cd5bbc303a64330990731d9144fe8f99a0a8ed6cfc">
         <source xml:space="preserve">Catching up…</source>
         <context-group purpose="location"><context context-type="linenumber">1223</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg124">
+      <trans-unit id="81624362afb024c7f7dedf679920726352800faff6b8fb83ac681d25225cee40">
         <source xml:space="preserve">Last received block was generated %1 ago.</source>
         <context-group purpose="location"><context context-type="linenumber">1242</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg125">
+      <trans-unit id="d54233400e10a4b00d83a7cddec3107a33595254d050a3ab94e44e3bf93aaee6">
         <source xml:space="preserve">Transactions after this will not yet be visible.</source>
         <context-group purpose="location"><context context-type="linenumber">1244</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg126">
+      <trans-unit id="c7d47ff01623f507633c3c73a107a3d2d24e183c7396e10b427d33c71f177c4a">
         <source xml:space="preserve">Error</source>
         <context-group purpose="location"><context context-type="linenumber">1279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg127">
+      <trans-unit id="1e34c7398a7aeedb16f4c2507ee6f4a4f2592220454158844f4c7709ba1f8c89">
         <source xml:space="preserve">Warning</source>
         <context-group purpose="location"><context context-type="linenumber">1283</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg128">
+      <trans-unit id="6960fce6acb0e724f38498b04dcbb9d77d995973185516d9dde421fa510beb8e">
         <source xml:space="preserve">Information</source>
         <context-group purpose="location"><context context-type="linenumber">1287</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg129">
+      <trans-unit id="4a71ae993c34b0817a5028fbdb964578fd41f7fdd6c597926ecd7a6df8cdf7cf">
         <source xml:space="preserve">Up to date</source>
         <context-group purpose="location"><context context-type="linenumber">1199</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg130">
+      <trans-unit id="012e3f051a9d348139f064a907281f0abd1d8f1a7e4bf271ef2899f19fb207f3">
         <source xml:space="preserve">Ctrl+Q</source>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg131">
+      <trans-unit id="d3e5381b227e3acb564f8584d0186427f5d1507ecaf7a86f95c11e924df87f86">
         <source xml:space="preserve">Load Partially Signed Bitcoin Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg132">
+      <trans-unit id="ac9bf57df77f875b097d635d7f22eceae750a211fc7dd798612192511eaa7660">
         <source xml:space="preserve">Load PSBT from &amp;clipboard…</source>
         <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg133">
+      <trans-unit id="fc59e22a90fb4d8dd876cde9289e717bfb178539b80970e2b713e85c453efda8">
         <source xml:space="preserve">Load Partially Signed Bitcoin Transaction from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg134">
+      <trans-unit id="8cc23c37a55940def92d239fdb463a244404e54eeb0f59eeb32808d6b424e980">
         <source xml:space="preserve">Node window</source>
         <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg135">
+      <trans-unit id="736fd63368b255a1b83342e54dac8dced1f94ab17dc4c8b39a76722b9018a118">
         <source xml:space="preserve">Open node debugging and diagnostic console</source>
         <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg136">
+      <trans-unit id="05da40601516701ff2cfbddf7d1d239538b116105fcadc61475f11d6e0ad9ed0">
         <source xml:space="preserve">&amp;Sending addresses</source>
         <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg137">
+      <trans-unit id="ad060bb0e5fd79372be0be62e616ce3c36094596d74ee72b872f0028f22e608b">
         <source xml:space="preserve">&amp;Receiving addresses</source>
         <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg138">
+      <trans-unit id="ad2134d10f5915916adef33838427963b8d2aaa0b60bd22975fa78d1b46c175c">
         <source xml:space="preserve">Open a bitcoin: URI</source>
         <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg139">
+      <trans-unit id="0cd8d67c06c9292bf94f78725bb18cfc3ce71c7109f7a35f6dca6aff5aa29088">
         <source xml:space="preserve">Open Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg140">
+      <trans-unit id="c5f6e9ee8ec4d985aff81935c1596bd569d87021e6d177b95b52abe9c910ca15">
         <source xml:space="preserve">Open a wallet</source>
         <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg141">
+      <trans-unit id="16b592f1b314971b09bcf09576382f9e4ea9fd9cd65ed03c224846f4b78a3483">
         <source xml:space="preserve">Close wallet</source>
         <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg142">
+      <trans-unit id="b2a2843772e6c296939bca5a6d25a1e86eb2a5b6a1f2875f7833d7ed4ca5ceee">
         <source xml:space="preserve">Restore Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
         <note annotates="source" from="developer">Name of the menu item that restores wallet from a backup file.</note>
       </trans-unit>
-      <trans-unit id="_msg143">
+      <trans-unit id="a087fab9c2172fd7a04e6f798659141181954c97ca1841cf7928dbdc2222259f">
         <source xml:space="preserve">Restore a wallet from a backup file</source>
         <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
         <note annotates="source" from="developer">Status tip for Restore Wallet menu item</note>
       </trans-unit>
-      <trans-unit id="_msg144">
+      <trans-unit id="b4c3929965b1687e58f186dfe8eac826e480172147d70bd13ee7e9e1e066885f">
         <source xml:space="preserve">Close all wallets</source>
         <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg145">
+      <trans-unit id="a1669408be2ea37ab1ba72c94f51b6b4517360ef60eed3e0135375a48fcae8c0">
         <source xml:space="preserve">Migrate Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg146">
+      <trans-unit id="d389735e6a142b0af3a775d67938008d0b526d1a330a3fb505409aa176bb3798">
         <source xml:space="preserve">Migrate a wallet</source>
         <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg147">
+      <trans-unit id="7f2cc1292ea770c07e2e8f36fc10339c0229d7ca017c1535e1d3a876faa8b54c">
         <source xml:space="preserve">Show the %1 help message to get a list with possible Bitcoin command-line options</source>
         <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg148">
+      <trans-unit id="166dc57e79c9a73a81c8525e2708181a86bf2cd20ee57fd824f2b54ffa5a055a">
         <source xml:space="preserve">&amp;Mask values</source>
         <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg149">
+      <trans-unit id="c0cb3ad8150774286d4e324993bde32a3f07c5f178fca8557096c8a42575fcdd">
         <source xml:space="preserve">Mask the values in the Overview tab</source>
         <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg150">
+      <trans-unit id="168fb5f5afa9d7c545fa4b0e4f13ca8bcdaa90a1263ee0b112ac12f3770b2e85">
         <source xml:space="preserve">No wallets available</source>
         <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg151">
+      <trans-unit id="05102c4eb27aad7901324c4ad6bc151ca2f8f590b419694b5cabc9bc99b4ad3c">
         <source xml:space="preserve">Wallet Data</source>
         <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
         <note annotates="source" from="developer">Name of the wallet data file format.</note>
       </trans-unit>
-      <trans-unit id="_msg152">
+      <trans-unit id="3df30cdc8dd59ab5725946f57debd81dced2ebb0e164928be5801843c3cf5a75">
         <source xml:space="preserve">Load Wallet Backup</source>
         <context-group purpose="location"><context context-type="linenumber">441</context></context-group>
         <note annotates="source" from="developer">The title for Restore Wallet File Windows</note>
       </trans-unit>
-      <trans-unit id="_msg153">
+      <trans-unit id="e8c5883daf5b3b620ee30bb96e3d43200b39f727745806f9e6b52fe9fcc8f6cd">
         <source xml:space="preserve">Restore Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">449</context></context-group>
         <note annotates="source" from="developer">Title of pop-up window shown when the user is attempting to restore a wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg154">
+      <trans-unit id="3811a06dc9bd7dce0dd2852d31e046de20a9fe99a10354b873d884a18078de8c">
         <source xml:space="preserve">Wallet Name</source>
         <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">514</context></context-group>
         <note annotates="source" from="developer">Label of the input field where the name of the wallet is entered.</note>
       </trans-unit>
-      <trans-unit id="_msg155">
+      <trans-unit id="1f91954946a087792b1cd6cd041f34fbe112737519daf537bee833a390706e98">
         <source xml:space="preserve">Invalid Wallet Name</source>
         <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg156">
+      <trans-unit id="82cca25c262b0aeb7387b89ab0b2cb13119f477489a92c465495e4152ae4e226">
         <source xml:space="preserve">Wallet name cannot be empty</source>
         <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg157">
+      <trans-unit id="dba766a6092abebc3a168c63a755ddc28b8329c0e24fa00edbbc30788f9eccc6">
         <source xml:space="preserve">Restore and Migrate Wallet Backup</source>
         <context-group purpose="location"><context context-type="linenumber">504</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg158">
+      <trans-unit id="f99f5f1b0cfeed86fa3a06054e3bc9d5fa2c6ab903d74dddf7538c23687ac016">
         <source xml:space="preserve">Restore and Migrate Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">512</context></context-group>
         <note annotates="source" from="developer">Title of pop-up window shown when the user is attempting to restore a wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg159">
+      <trans-unit id="82a6a1ed4c2c65fcf21ca809e954ae669f2c61621210ca1cd53194bfea2bc02c">
         <source xml:space="preserve">&amp;Window</source>
         <context-group purpose="location"><context context-type="linenumber">571</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg160">
+      <trans-unit id="ed4750596cfa8beac9364b4475d604681613a55b66974bd27e7b47189314a512">
         <source xml:space="preserve">Ctrl+M</source>
         <context-group purpose="location"><context context-type="linenumber">574</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg161">
+      <trans-unit id="45f1e8dd3f2da824f22cca8b5b19beab14cb82715f281a2bc1a949bfad3f0ab7">
         <source xml:space="preserve">Zoom</source>
         <context-group purpose="location"><context context-type="linenumber">583</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg162">
+      <trans-unit id="7f7adc5616777f63be420019793386b481f548325ac0d7bbb9bf5b1a4b4f4891">
         <source xml:space="preserve">Main Window</source>
         <context-group purpose="location"><context context-type="linenumber">601</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg163">
+      <trans-unit id="d3971858340d6241646227f1a22acefe160136b1b7aa4c3e81f490f7684629dd">
         <source xml:space="preserve">%1 client</source>
         <context-group purpose="location"><context context-type="linenumber">880</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg164">
+      <trans-unit id="54488078093901698e5f9ca568091c8042bdcc954b4a54fe035f17e8b91bdcb6">
         <source xml:space="preserve">&amp;Hide</source>
         <context-group purpose="location"><context context-type="linenumber">948</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg165">
+      <trans-unit id="1f05e0b51c2075ddb09150ec389837cdfeae1962b046c89e30132da45e394806">
         <source xml:space="preserve">S&amp;how</source>
         <context-group purpose="location"><context context-type="linenumber">949</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">1067</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip.</note>
-        <trans-unit id="_msg166[0]">
+        <trans-unit id="07373ec1ef305f95d81914103643fe9acdde72965034e821c1bb3f9af6fc4092[0]">
           <source xml:space="preserve">%n active connection(s) to Bitcoin network.</source>
         </trans-unit>
-        <trans-unit id="_msg166[1]">
+        <trans-unit id="07373ec1ef305f95d81914103643fe9acdde72965034e821c1bb3f9af6fc4092[1]">
           <source xml:space="preserve">%n active connection(s) to Bitcoin network.</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg167">
+      <trans-unit id="bb15392a28d199ba32679b388efed61628e7cb36aff3783d708a50a39da9f9c1">
         <source xml:space="preserve">Click for more actions.</source>
         <context-group purpose="location"><context context-type="linenumber">1077</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip. &quot;More actions&quot; are available via the context menu.</note>
       </trans-unit>
-      <trans-unit id="_msg168">
+      <trans-unit id="0fc2ed5d1521049c82a232a8729fb11e5d336d5374d4c5074bd6cd18ff097b7d">
         <source xml:space="preserve">Show Peers tab</source>
         <context-group purpose="location"><context context-type="linenumber">1094</context></context-group>
         <note annotates="source" from="developer">A context menu item. The &quot;Peers tab&quot; is an element of the &quot;Node window&quot;.</note>
       </trans-unit>
-      <trans-unit id="_msg169">
+      <trans-unit id="8af0fd5f68b7d51ac572da59a4fe5b4b5027429538ec7e56e159379367c9c2d6">
         <source xml:space="preserve">Disable network activity</source>
         <context-group purpose="location"><context context-type="linenumber">1102</context></context-group>
         <note annotates="source" from="developer">A context menu item.</note>
       </trans-unit>
-      <trans-unit id="_msg170">
+      <trans-unit id="f6bf9510cc81ae6191b3ce072b4b7cf1fe24d8f0f315590caa686280cf1f0fd7">
         <source xml:space="preserve">Enable network activity</source>
         <context-group purpose="location"><context context-type="linenumber">1104</context></context-group>
         <note annotates="source" from="developer">A context menu item. The network activity was disabled previously.</note>
       </trans-unit>
-      <trans-unit id="_msg171">
+      <trans-unit id="d56afca09e1b523f538a87280fe8d8b84222b3df33351e41aa2f574798f394a7">
         <source xml:space="preserve">Pre-syncing Headers (%1%)…</source>
         <context-group purpose="location"><context context-type="linenumber">1121</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg172">
+      <trans-unit id="22a066cbd7ea1c9ddee6095661a33ae2475a8950f1fc7ac3fb2505d6b42307ea">
         <source xml:space="preserve">Error: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1280</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg173">
+      <trans-unit id="a370397becbf5e3016ee4e14a177d50682ae29190ebf74a9c2d8b932b10dfa11">
         <source xml:space="preserve">Warning: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg174">
+      <trans-unit id="bd07caca1943638f89e2153fb77990681c75b4c59a610b8898e3d6a319a9c253">
         <source xml:space="preserve">Date: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1392</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg175">
+      <trans-unit id="e325d51d66a2f5085f28f0465388cced813db82902312763be9ed5c9c8af1bba">
         <source xml:space="preserve">Amount: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1393</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg176">
+      <trans-unit id="12eaee907629e0c02a907b54b0f4655d161786dfb4a9e95249ff9d4f8c363563">
         <source xml:space="preserve">Wallet: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1395</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg177">
+      <trans-unit id="62ecf4a366a4c33cb2985c502a05c70e9b09c26d6c75693ebf4bf95dc876530c">
         <source xml:space="preserve">Type: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1397</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg178">
+      <trans-unit id="7aee70705aece7b89429dadd84dc336869687a1d2183d8f3ba4bfdc08525a805">
         <source xml:space="preserve">Label: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1399</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg179">
+      <trans-unit id="45c6587971000111540230be049d3ece571465c35ce36203a4bdc59fbba81e9d">
         <source xml:space="preserve">Address: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1401</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg180">
+      <trans-unit id="00f0fad0923798a1731332df5b5baa38dfa54f3e152f41e9b7854a53a86cd607">
         <source xml:space="preserve">Sent transaction</source>
         <context-group purpose="location"><context context-type="linenumber">1402</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg181">
+      <trans-unit id="e0a5ec1301a63f701e54e71c8ff9cc2b5e145302569b513697d185321449e026">
         <source xml:space="preserve">Incoming transaction</source>
         <context-group purpose="location"><context context-type="linenumber">1402</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg182">
+      <trans-unit id="ed1b2fd44fb50d3b6b184f7854806f087646bfc376e6697a52ac327250c27fe4">
         <source xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
         <context-group purpose="location"><context context-type="linenumber">1454</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg183">
+      <trans-unit id="0d840db42f4576510e294709e1435708f885ba0be415788d498dac32ec0f24cd">
         <source xml:space="preserve">HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
         <context-group purpose="location"><context context-type="linenumber">1454</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg184">
+      <trans-unit id="cd0246f344fd717b81d04d933037d863d089ec79ab2ff7d296fc4d943acbc6b2">
         <source xml:space="preserve">Private key &lt;b&gt;disabled&lt;/b&gt;</source>
         <context-group purpose="location"><context context-type="linenumber">1454</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg185">
+      <trans-unit id="5083c9191912c56dda94072dd5bb31c9d9de993bf4cc09ffacdc1ff02d715150">
         <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <context-group purpose="location"><context context-type="linenumber">1477</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg186">
+      <trans-unit id="ec9fc9b45dcd7f33607d54f491a3d7bb0a76b0d5a56fd229868533645e61bb18">
         <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <context-group purpose="location"><context context-type="linenumber">1485</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg187">
+      <trans-unit id="610d8812559605c9b892b3c722cfc386f5003bc4b72f219bb5493cc828bdbf7d">
         <source xml:space="preserve">Original message:</source>
         <context-group purpose="location"><context context-type="linenumber">1604</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="UnitDisplayStatusBarControl">
-      <trans-unit id="_msg188">
+      <trans-unit id="d57f2fb8992561de7437fa501e1224de2f9fd6d6c181d7fee540686efa367d6e">
         <source xml:space="preserve">Unit to show amounts in. Click to select another unit.</source>
         <context-group purpose="location"><context context-type="linenumber">1650</context></context-group>
       </trans-unit>
@@ -838,67 +838,67 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../forms/coincontroldialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg189">
+      <trans-unit id="06da91cb095aedd9542f828fe0bb3c203a01200f646dc0689c406d0ce85c2d01">
         <source xml:space="preserve">Coin Selection</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg190">
+      <trans-unit id="6974650c2c777cc723c70854018e406ab7c610c7db0871b96126679058903718">
         <source xml:space="preserve">Quantity:</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg191">
+      <trans-unit id="6f14c5771245f8e62ab5c4874fe80697bf89677b6f8514aaf9e2212239846c4d">
         <source xml:space="preserve">Bytes:</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg192">
+      <trans-unit id="c0fb7b4bf383c78a0e38ed2dc5e29d2ff802eddac46fe0ca32ec5114f8786248">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg193">
+      <trans-unit id="588a659f39c485b6fcd67bb9472230dc60f256a1e5d59e05d4551c7f87aa965d">
         <source xml:space="preserve">Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg194">
+      <trans-unit id="f687af9579c20d1cc4e3fe18e86fa59772c5fb4ad65bfe14eac868b2f0a2ac47">
         <source xml:space="preserve">After Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg195">
+      <trans-unit id="ff2ff25c0afe3b06b7bbb0d105fab6805f48ec8275e9f106622293a11e0a1172">
         <source xml:space="preserve">Change:</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg196">
+      <trans-unit id="164236d15fc41f690fe40fac05c40641b05dd80e771e5395484a0a8cfffe2a57">
         <source xml:space="preserve">(un)select all</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg197">
+      <trans-unit id="32c77a8dc5201dd0b20abc26697cd6e68e48231888f37edbf5a3eb4d1b7ec396">
         <source xml:space="preserve">Tree mode</source>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg198">
+      <trans-unit id="018bc2cd3dfe8f000fbbc7763f9a14d08d5636bf8f79a4ca181a17b5f93ef9ca">
         <source xml:space="preserve">List mode</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg199">
+      <trans-unit id="11e46ccd13a2d3d0b433378ebe2d804d5b9721b2e0fc767876fcf78c922c5ea4">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg200">
+      <trans-unit id="de4ab9608d8dfcc579a875c86ed0f01bfa5d5387a63a731694061dffe5253dab">
         <source xml:space="preserve">Received with label</source>
         <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg201">
+      <trans-unit id="6916abcb6aef1a0e972d6569f4266e760f98d5a0d8e7c8d5407a37a34f9aa47e">
         <source xml:space="preserve">Received with address</source>
         <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg202">
+      <trans-unit id="d59647fc8955c122eea96362e2bb39602e744dec60ff6f11ca86216f91ddf56d">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg203">
+      <trans-unit id="363697fbefb9052e7829a718c52d59d82be398202d28532038065a89f172ba01">
         <source xml:space="preserve">Confirmations</source>
         <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg204">
+      <trans-unit id="827b8aeed87a2743d78bdeb4c8d520c0e0fc67324ff43231847dbad8439eca67">
         <source xml:space="preserve">Confirmed</source>
         <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
       </trans-unit>
@@ -906,72 +906,72 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../coincontroldialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg205">
+      <trans-unit id="4439c2b6cb8c78257c313845d47f84885917a5b2f90b12ff3d0b7dcaa0bd9f0c">
         <source xml:space="preserve">Copy amount</source>
         <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg206">
+      <trans-unit id="d2c9aad01b88f3f36f19d3ec9122ee268113bc893186254664079631e3b8a814">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg207">
+      <trans-unit id="35b8aa6a1e45e40786dc373690e8daaad94584cf208a892cd625cc50458ab9cc">
         <source xml:space="preserve">Copy &amp;label</source>
         <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg208">
+      <trans-unit id="8cebc9c9704ad043abdd6fb0c2effede3f90f0c39626d98fbe5b1de7749ad609">
         <source xml:space="preserve">Copy &amp;amount</source>
         <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg209">
+      <trans-unit id="63fd594878d813c465b57d1ea1571bc733286c617c57a0fd833535eeeafe9fb4">
         <source xml:space="preserve">Copy transaction &amp;ID and output index</source>
         <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg210">
+      <trans-unit id="cdc014c368f712501eb8c573c1ee544ef9ad11f19f7f9af83a7d856b80e66f3e">
         <source xml:space="preserve">L&amp;ock unspent</source>
         <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg211">
+      <trans-unit id="0a9b1b3ee948142a5008cc4b12bc849a7a23646d7943a5be739b324f96f8832c">
         <source xml:space="preserve">&amp;Unlock unspent</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg212">
+      <trans-unit id="886d6318749b9f9bc4fc5f279789e164b65a4822ff7b7a00dba88c5cf34f8ece">
         <source xml:space="preserve">Copy quantity</source>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg213">
+      <trans-unit id="1b88ad6d33b7e0d2351e5408d074de4562f369438bc6e48e54a3adf23f0634ba">
         <source xml:space="preserve">Copy fee</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg214">
+      <trans-unit id="73322ed316774161e99a0151ecf0efbdf3a1cc5e493fb0b00fc7bf93b21287e2">
         <source xml:space="preserve">Copy after fee</source>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg215">
+      <trans-unit id="0effdc658270922ed3ef790c7acd9e73bcbc8660a3b0db2fab81e2b5ce5c702d">
         <source xml:space="preserve">Copy bytes</source>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg216">
+      <trans-unit id="e1b0082a1c406f95b0d52e4d67c5bc3c224f4fcd5201755af7d1737f05d1dce6">
         <source xml:space="preserve">Copy change</source>
         <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg217">
+      <trans-unit id="20a6b731444fb9acb0264baaa7ba72f7873a42886ecbc818a31868d0c97d839f">
         <source xml:space="preserve">(%1 locked)</source>
         <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg218">
+      <trans-unit id="d3be91561b338f9dd5be68ac806e8644c402fb15963b23e367a3e7717d4caaf0">
         <source xml:space="preserve">Can vary +/- %1 satoshi(s) per input.</source>
         <context-group purpose="location"><context context-type="linenumber">528</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg219">
+      <trans-unit id="88f9b0bc276086574d56794262f195d1d5a6fb83b5672c9cabb28b92665d916e">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">573</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">627</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg220">
+      <trans-unit id="e5b1695b6405f3f06fb7f1968c7fd16ebec7c4663ff06b6cab1aab087300bca4">
         <source xml:space="preserve">change from %1 (%2)</source>
         <context-group purpose="location"><context context-type="linenumber">620</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg221">
+      <trans-unit id="71fed124db181b92667fcaedf6474860b4387f1920d8740b07a386bd89ff919d">
         <source xml:space="preserve">(change)</source>
         <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
       </trans-unit>
@@ -979,55 +979,55 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../walletcontroller.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletActivity">
-      <trans-unit id="_msg222">
+      <trans-unit id="f60f6718e0fea30289dae15234c052e7dd995fca34a0998e20a2f1f6dbc17a9f">
         <source xml:space="preserve">Create Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
         <note annotates="source" from="developer">Title of window indicating the progress of creation of a new wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg223">
+      <trans-unit id="881fd4986ee9b4d4de1fef04dec7b88ca16426f9760414466a27bb067c4be28f">
         <source xml:space="preserve">Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</note>
       </trans-unit>
-      <trans-unit id="_msg224">
+      <trans-unit id="7ab5dc0ccc1cb0bd27ec4d46854c7e13d5d16b3de490e247a999ac8dc475bde2">
         <source xml:space="preserve">Create wallet failed</source>
         <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg225">
+      <trans-unit id="f68af66758fe482ac6e69b429fce0e8677010eda7bea33b00563e99480edb68e">
         <source xml:space="preserve">Create wallet warning</source>
         <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg226">
+      <trans-unit id="5fbcef11766618a0c31486ed4dc9408494f05f3a70124c0a9708f971c6641a3d">
         <source xml:space="preserve">Can&apos;t list signers</source>
         <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg227">
+      <trans-unit id="c9f221b83b5a4ea8c0e34bdc0ee92c6687d7420b5a99383c2c1eec8aa7074d04">
         <source xml:space="preserve">Too many external signers found</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="LoadWalletsActivity">
-      <trans-unit id="_msg228">
+      <trans-unit id="e6d2196f5deb482f9c115eddcac03adbef54c9e0b4a2304ee557f475bf085060">
         <source xml:space="preserve">Load Wallets</source>
         <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
         <note annotates="source" from="developer">Title of progress window which is displayed when wallets are being loaded.</note>
       </trans-unit>
-      <trans-unit id="_msg229">
+      <trans-unit id="54e8856628c678f65409f33ccb9366762d51de427bc13653c5efbea18c91de32">
         <source xml:space="preserve">Loading wallets…</source>
         <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="MigrateWalletActivity">
-      <trans-unit id="_msg230">
+      <trans-unit id="0944f8125f955a1a63238afb995a266f42308bb7211ad8753efd611c72304b27">
         <source xml:space="preserve">Migrate wallet</source>
         <context-group purpose="location"><context context-type="linenumber">477</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg231">
+      <trans-unit id="ae8b5f766c0cc37d91df3453c673b8678fc157d901dff69c4fdb975b1dc80b8e">
         <source xml:space="preserve">Are you sure you wish to migrate the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <context-group purpose="location"><context context-type="linenumber">478</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg232">
+      <trans-unit id="3f0f45feffdbdf844c42a2327b422992927aa8c87e933c922f8350e461910267">
         <source xml:space="preserve">Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.
 If this wallet contains any watchonly scripts, a new wallet will be created which contains those watchonly scripts.
 If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.
@@ -1035,35 +1035,35 @@ If this wallet contains any solvable but not watched scripts, a different and ne
 The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the &quot;Restore Wallet&quot; functionality.</source>
         <context-group purpose="location"><context context-type="linenumber">479</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg233">
+      <trans-unit id="ed8d171efa37c3e1138f0daef10e4888470c2f48d68c37f367b5d70cf67bd66f">
         <source xml:space="preserve">Migrate Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg234">
+      <trans-unit id="aad093ad1658f0da0b5c8502f287a784652732329b53b6ddb94e3bea9979d4b7">
         <source xml:space="preserve">Migrating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg235">
+      <trans-unit id="bcf4bc5025c377e28ffc44ea2a25b8055023ff65a9b8ee31bc7a84b148585d1f">
         <source xml:space="preserve">The wallet &apos;%1&apos; was migrated successfully.</source>
         <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg236">
+      <trans-unit id="f23df4e633d36245890841ea1b2fe5b17b1831181172046c037b36296708c8ca">
         <source xml:space="preserve">Watchonly scripts have been migrated to a new wallet named &apos;%1&apos;.</source>
         <context-group purpose="location"><context context-type="linenumber">459</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg237">
+      <trans-unit id="dc8a195a8bfde85e5f59aedf8dba78de81180a4afaeb1425ab4eee68c09ce217">
         <source xml:space="preserve">Solvable but not watched scripts have been migrated to a new wallet named &apos;%1&apos;.</source>
         <context-group purpose="location"><context context-type="linenumber">462</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg238">
+      <trans-unit id="097d7ceb581b0386e9f21412c09ca12ffdc5ee17db1676a7bcf0482462473046">
         <source xml:space="preserve">Restore and Migrate wallet</source>
         <context-group purpose="location"><context context-type="linenumber">496</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg239">
+      <trans-unit id="14e7c510649a1301e86110f4a7e59b9f6ecd02c34655dbfbbd3844b2cd4b7c2e">
         <source xml:space="preserve">Are you sure you wish to restore the wallet file &lt;i&gt;%1&lt;/i&gt; to &lt;i&gt;%2&lt;/i&gt; and migrate it?</source>
         <context-group purpose="location"><context context-type="linenumber">497</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg240">
+      <trans-unit id="2c01564b19ec16bded787906ded4dfb15ba2e4237aed98560fb1e56948eff83a">
         <source xml:space="preserve">Restoring the wallet will copy the backup file to the wallets directory and place it in the standard wallet directory layout. The original file will not be modified.
 
 Migrating the wallet will convert the restored wallet to one or more descriptor wallets. A new wallet backup will need to be made.
@@ -1073,90 +1073,90 @@ If this wallet contains any solvable but not watched scripts, a different and ne
 The migration process will create a backup of the wallet before migrating. This backup file will be named &lt;wallet name&gt;-&lt;timestamp&gt;.legacy.bak and can be found in the directory for this wallet. In the event of an incorrect migration, the backup can be restored with the &quot;Restore Wallet&quot; functionality.</source>
         <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg241">
+      <trans-unit id="5aa1a06d4cb3f762f58dd0e92d6a7dc35ce43fb535ca4e1b6311b4a0359aa537">
         <source xml:space="preserve">Restore Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">512</context></context-group>
         <note annotates="source" from="developer">Title of progress window which is displayed when wallets are being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg242">
+      <trans-unit id="5e3bb186348d57f00f8843eb8fe5687f26b16f3c34c4a9cb501f44cff991c4d2">
         <source xml:space="preserve">Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">515</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg243">
+      <trans-unit id="3beace6d8ca28ad554037dd90e5edd3d78bc150237a55c481b7401948676f54a">
         <source xml:space="preserve">Migration failed</source>
         <context-group purpose="location"><context context-type="linenumber">534</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg244">
+      <trans-unit id="4b0aa022310c273a8a39eb11d5bd7b8dd8a5d36eafbe085314e5e19f896a8690">
         <source xml:space="preserve">Migration Successful</source>
         <context-group purpose="location"><context context-type="linenumber">536</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="OpenWalletActivity">
-      <trans-unit id="_msg245">
+      <trans-unit id="8ffaa4d50dce8a959a9613e5b8af0d5cc07db82a64f95617bfd798a8974177bd">
         <source xml:space="preserve">Open wallet failed</source>
         <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg246">
+      <trans-unit id="4a477014867608e3a618c83645c830d683b91d75a1c48bf561558655018f3ce7">
         <source xml:space="preserve">Open wallet warning</source>
         <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg247">
+      <trans-unit id="bb0b9716d04860c74a3e34efa16111b673e4ecc452287a01ac24a5d216275015">
         <source xml:space="preserve">Open Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
         <note annotates="source" from="developer">Title of window indicating the progress of opening of a wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg248">
+      <trans-unit id="d664866b419b707847fb3aa04c6a2be0525092fcf6a75b87d52a014d34fdbb75">
         <source xml:space="preserve">Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="RestoreWalletActivity">
-      <trans-unit id="_msg249">
+      <trans-unit id="5c7bd708e2200c1ead68165a57a9ee5590ad18b3a0b497ff56fa79be8223e7cd">
         <source xml:space="preserve">Restore Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
         <note annotates="source" from="developer">Title of progress window which is displayed when wallets are being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg250">
+      <trans-unit id="57b52dfb4b65cdcf687528d5f3424d8396dba2b477f5585607b4a76e94511b80">
         <source xml:space="preserve">Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg251">
+      <trans-unit id="c83b8f44d1aea7c4c9bccbae073bbe1c8d2b74999d932a678a4c4ecb2b6437a3">
         <source xml:space="preserve">Restore wallet failed</source>
         <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet could not be restored.</note>
       </trans-unit>
-      <trans-unit id="_msg252">
+      <trans-unit id="a1d001eccbcf68aa7d0dbff3015dc45c04f13464d245e72c559b4e4e83290b48">
         <source xml:space="preserve">Restore wallet warning</source>
         <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet is restored with some warning.</note>
       </trans-unit>
-      <trans-unit id="_msg253">
+      <trans-unit id="493b4b8c082ff5b5711d4e9edad18a8ab3e6b3dc7865708f2b7551306630c650">
         <source xml:space="preserve">Restore wallet message</source>
         <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet is successfully restored.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="WalletController">
-      <trans-unit id="_msg254">
+      <trans-unit id="dc10e1df22443a4734b09ca0293ce1c18e6defff9ba2c57cf8e8be2c6780596b">
         <source xml:space="preserve">Close wallet</source>
         <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg255">
+      <trans-unit id="6949a3627857616bf555bb06ddc20caa8de51c387a99d19f0da2b5d8db0dd0a6">
         <source xml:space="preserve">Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg256">
+      <trans-unit id="0a16b020044fbf1df886566e378b2cfa4b6c6595de0a4c38c7b94aecffbff913">
         <source xml:space="preserve">Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg257">
+      <trans-unit id="856f123f17b7c39af36d004a05e1771da6433987f8a7b0f9be5be5ea11a754a7">
         <source xml:space="preserve">Close all wallets</source>
         <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg258">
+      <trans-unit id="e1acce1d93c3e4a5fd58e8ae8c30c9158c66fc20c48d496e3830f93dbf221842">
         <source xml:space="preserve">Are you sure you wish to close all wallets?</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
       </trans-unit>
@@ -1164,59 +1164,59 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/createwalletdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg259">
+      <trans-unit id="d547a39bb874e2ea57bc4008bfa119876344a35e8e29c0c04a844be80b2f147b">
         <source xml:space="preserve">Create Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg260">
+      <trans-unit id="b09f647e776bd38d4ab79b3877e812371db93695d37e5b62b135ae9e77f22ea0">
         <source xml:space="preserve">You are one step away from creating your new wallet!</source>
         <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg261">
+      <trans-unit id="b571ec7a81210a7b725af798ac75a072499ee900e01454b8d327d51ba1866cdc">
         <source xml:space="preserve">Please provide a name and, if desired, enable any advanced options</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg262">
+      <trans-unit id="fff74c9d926f6b4c77d7a775ee46e32650bc01a728a25f7155010ab0bf357505">
         <source xml:space="preserve">Wallet Name</source>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg263">
+      <trans-unit id="660f0192d257e702373f2c9296d0d3c03f6767ac8599b593d2d8fd7086c3c63d">
         <source xml:space="preserve">Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg264">
+      <trans-unit id="abd9b51f250912edfbc711a0c152aaccfadac27f81d14a2e9704c342eac1c799">
         <source xml:space="preserve">Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg265">
+      <trans-unit id="8c3f5115496088554ec75c8baeb76fc4f2a81d2588d43fd6b426ecf784665a2e">
         <source xml:space="preserve">Encrypt Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg266">
+      <trans-unit id="ec7045172dbe667877538d2f5d65740c58c1d44ecfde403e184b0edf553ac020">
         <source xml:space="preserve">Advanced Options</source>
         <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg267">
+      <trans-unit id="5488cd0fc94b206555edb65e6dd11b8dc5a6520017fd9f08cc634fee43a8ead6">
         <source xml:space="preserve">Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg268">
+      <trans-unit id="ec17e2fc6c0506dcee459f8e9786588da722e60bfa47510929ff26d253dcc1c2">
         <source xml:space="preserve">Disable Private Keys</source>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg269">
+      <trans-unit id="23bdd06d7e9fbb0df20fe7720fd86cec4786997783b5bbea5cf893d9c5a42d80">
         <source xml:space="preserve">Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported using descriptors at a later time.</source>
         <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg270">
+      <trans-unit id="d7a7acd4bf42f3deec6a8c3888162b4d6d7f10053a3a1304802f7c51bbecf30c">
         <source xml:space="preserve">Make Blank Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg271">
+      <trans-unit id="0dc1b9e52254840400d178911525ced5b4155a91366303750d614776442e4811">
         <source xml:space="preserve">Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
         <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg272">
+      <trans-unit id="051edb97d2b58e723a9bf061619d90bc948bbe6dd0f5d1b6a60b91c8c532cd9d">
         <source xml:space="preserve">External signer</source>
         <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
       </trans-unit>
@@ -1224,11 +1224,11 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../createwalletdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg273">
+      <trans-unit id="f708ccbbd1c3d9d5ee33a2bceee805bd5e88936ca11d05dd9fe38df5bbd0ab98">
         <source xml:space="preserve">Create</source>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg274">
+      <trans-unit id="5efd8bf8d42a10b138cffe2857ceecfb739c05a1358d94141f0b90fd6cc5c3fe">
         <source xml:space="preserve">Compiled without external signing support (required for external signing)</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <note annotates="source" from="developer">&quot;External signing&quot; means using devices such as hardware wallets.</note>
@@ -1237,23 +1237,23 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/editaddressdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg275">
+      <trans-unit id="f0ece86fd2910993bd0abf7917990fa204b1509862110ec8f74f55db047d4edb">
         <source xml:space="preserve">Edit Address</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg276">
+      <trans-unit id="e98737217aa19991db5b4afdfe27b8e080df7abcf001b7ba351591f7bbd23ff6">
         <source xml:space="preserve">&amp;Label</source>
         <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg277">
+      <trans-unit id="5d4b4ce24a6f614a0e84d42b63d2830d0b20d746a5d149bb33e8ac7e53c83e51">
         <source xml:space="preserve">The label associated with this address list entry</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg278">
+      <trans-unit id="528667a035afaecf84ad35b9c3f266ddfcf0d246759b241b2010d1380a8b5a53">
         <source xml:space="preserve">The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg279">
+      <trans-unit id="2574833396b79f5ef228ddb35a55ff9bf1270d43aacade186f7a7f6350b0a0a9">
         <source xml:space="preserve">&amp;Address</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
@@ -1261,35 +1261,35 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../editaddressdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg280">
+      <trans-unit id="93d13f39cf0f012006efaa4d94572b04f50e0a49b93f5ab57076c040bff61094">
         <source xml:space="preserve">New sending address</source>
         <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg281">
+      <trans-unit id="4b0c6df3a78d4b5c5ba1f61252491775188cda7a7e8cf42a762da024bb59a9fa">
         <source xml:space="preserve">Edit receiving address</source>
         <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg282">
+      <trans-unit id="4c159c8fbe2646d5f88c12ac9e77870215e12d7cd9fc2f1158187cd8d06738b2">
         <source xml:space="preserve">Edit sending address</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg283">
+      <trans-unit id="3f0950245515a325f0c1b175ca2af14b9af2c0a2595462b33adc6cd1b7dcfe29">
         <source xml:space="preserve">The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg284">
+      <trans-unit id="81dde30fa359f4a8a5b27fcdc843f3075209cd055b08df6651b9140eb0b2ff69">
         <source xml:space="preserve">Address &quot;%1&quot; already exists as a receiving address with label &quot;%2&quot; and so cannot be added as a sending address.</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg285">
+      <trans-unit id="b1590f197e5dd7abb140bcfeb97b0a7752f05de34f34128e6b8086dd308c1648">
         <source xml:space="preserve">The entered address &quot;%1&quot; is already in the address book with label &quot;%2&quot;.</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg286">
+      <trans-unit id="5448fd7af74a03ebde8fb6c981482defa34ae2819cbba2c7c12c6c3b23af550d">
         <source xml:space="preserve">Could not unlock wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg287">
+      <trans-unit id="f8d088f80434a76a11da21790882875f7c8466e024bb54399223e621edad7f80">
         <source xml:space="preserve">New key generation failed.</source>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
@@ -1297,23 +1297,23 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../freespacechecker.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="FreespaceChecker">
-      <trans-unit id="_msg288">
+      <trans-unit id="80d1a806ec00b5a3ba0c9cf9906da65a3fc652c5b560712e92e11b11dd4cb2c3">
         <source xml:space="preserve">A new data directory will be created.</source>
         <context-group purpose="location"><context context-type="linenumber">21</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg289">
+      <trans-unit id="0d346c46c59d8be93c0c13dca44ec00d5bfc259dfc394d6fb4cf705d3d01b755">
         <source xml:space="preserve">name</source>
         <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg290">
+      <trans-unit id="10b2747cc669a87a775f345d1f274855db4375e12d248aa5474f05d53b3d9836">
         <source xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg291">
+      <trans-unit id="a8ab3e5aec6dd6f554b9ed7d19d13e66c9fdabd9453ce1f69597e22d7f2c133c">
         <source xml:space="preserve">Path already exists, and is not a directory.</source>
         <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg292">
+      <trans-unit id="af3c12f24fb1253e36c64497f99a518101c0c7b214c3ccfa4b31146bb15a8564">
         <source xml:space="preserve">Cannot create data directory here.</source>
         <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
       </trans-unit>
@@ -1321,25 +1321,25 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../utilitydialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="HelpMessageDialog">
-      <trans-unit id="_msg293">
+      <trans-unit id="e4b667073c0fb750d70f319589c552ad004f27609066db71498a030fffbb70cf">
         <source xml:space="preserve">version</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg294">
+      <trans-unit id="31235cd93e54107b70b0f33ddeca491b08b0dd3ed4ef705e815af30423b989e4">
         <source xml:space="preserve">About %1</source>
         <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg295">
+      <trans-unit id="661006a72953603c2f94ef5d7d433159ae9b5be0e8d64e44338ed51c664f02ac">
         <source xml:space="preserve">Command-line options</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="ShutdownWindow">
-      <trans-unit id="_msg296">
+      <trans-unit id="121b17f94d5e15490571101c07ac59c2977484027536d661b44d8d47e67ad096">
         <source xml:space="preserve">%1 is shutting down…</source>
         <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg297">
+      <trans-unit id="5fa4bed6565601fc4711dc2137b9672b8f35b6f2127be9027b4223dc2f6e7a5b">
         <source xml:space="preserve">Do not shut down the computer until this window disappears.</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
@@ -1347,47 +1347,47 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/intro.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="Intro">
-      <trans-unit id="_msg298">
+      <trans-unit id="f0228b2112a72c0c0f88460e9f7134248842e2a480305b7c10c65bb5af9d69af">
         <source xml:space="preserve">Welcome</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg299">
+      <trans-unit id="14996ba551590eb46de8273c403c30f554b768799c7c4b890abff40af7889529">
         <source xml:space="preserve">Welcome to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg300">
+      <trans-unit id="3972f54e3931415779c2270fe29f736a16179194d4e9d2ed1c4220717c8ba66c">
         <source xml:space="preserve">As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg301">
+      <trans-unit id="0fc1f2d1f8b8edbf45851d8bfa8bb48b45e63b2ccd68871e0c7cdf2f32664e26">
         <source xml:space="preserve">Limit block chain storage to</source>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg302">
+      <trans-unit id="a61995fa8f9d8e298a868857df38094b1ac1d20dd7c76f0776a20259b753d23b">
         <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg303">
+      <trans-unit id="781cd395603d273ba15f6b0a41e66e79fd9c12b2a35664808ed67313427362bb">
         <source xml:space="preserve"> GB</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg304">
+      <trans-unit id="45a82a9d6ed5559e6cc5a0d070e2dfbd9c9179220d95b8d1b2b5e63c18cf49e0">
         <source xml:space="preserve">This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg305">
+      <trans-unit id="770edde6fa8cab61cd8f837846c48f40eb9af9c6bd08a420b53e63525aa46f37">
         <source xml:space="preserve">When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
         <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg306">
+      <trans-unit id="0406fc6893e07c17d4b770e39c20190f082709e732e3089b5f25642bb1cf3720">
         <source xml:space="preserve">If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg307">
+      <trans-unit id="cabc8f28bea6985d3436ba49ac34901288dee3c474aa4cfa372360c8731bcc03">
         <source xml:space="preserve">Use the default data directory</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg308">
+      <trans-unit id="a1024a800ff5ae93b5e5799db5358d5d7d449c94c3768c7b1a5e5d4233f3cbb7">
         <source xml:space="preserve">Use a custom data directory:</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
@@ -1395,72 +1395,72 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../intro.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="Intro">
-      <trans-unit id="_msg309">
+      <trans-unit id="43af85e5f18c757ee565296d9d8855dba30d22864dc89fb391547b87907431ec">
         <source xml:space="preserve">Bitcoin</source>
         <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
-        <trans-unit id="_msg310[0]">
+        <trans-unit id="484288fc0ecb8d889508e42556545eef1b6a38d8da1ce206a7f811fc82f71992[0]">
           <source xml:space="preserve">%n GB of space available</source>
         </trans-unit>
-        <trans-unit id="_msg310[1]">
+        <trans-unit id="484288fc0ecb8d889508e42556545eef1b6a38d8da1ce206a7f811fc82f71992[1]">
           <source xml:space="preserve">%n GB of space available</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
-        <trans-unit id="_msg311[0]">
+        <trans-unit id="80ed4edf55eff8df0fef6ec6eee42759650942d60c61a3fa6442764d9bd6e61d[0]">
           <source xml:space="preserve">(of %n GB needed)</source>
         </trans-unit>
-        <trans-unit id="_msg311[1]">
+        <trans-unit id="80ed4edf55eff8df0fef6ec6eee42759650942d60c61a3fa6442764d9bd6e61d[1]">
           <source xml:space="preserve">(of %n GB needed)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
-        <trans-unit id="_msg312[0]">
+        <trans-unit id="aa1b881ad67363a694e05cabd7c650fd151a37d6e064cf28b004a9d38dc5ac4c[0]">
           <source xml:space="preserve">(%n GB needed for full chain)</source>
         </trans-unit>
-        <trans-unit id="_msg312[1]">
+        <trans-unit id="aa1b881ad67363a694e05cabd7c650fd151a37d6e064cf28b004a9d38dc5ac4c[1]">
           <source xml:space="preserve">(%n GB needed for full chain)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg313">
+      <trans-unit id="d0b8ca090cb94c6afce9d3b6f18203f51097e6726e2730c1ae113b872015fda5">
         <source xml:space="preserve">Choose data directory</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg314">
+      <trans-unit id="66f53315d1a0551215ed438cd02f4b62479609310b587c8dbc6cd8182acc178c">
         <source xml:space="preserve">At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg315">
+      <trans-unit id="a4264d57b84de5707dafe34b80276393607ddbce0daabc4fd28b94e1f6983002">
         <source xml:space="preserve">Approximately %1 GB of data will be stored in this directory.</source>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
         <note annotates="source" from="developer">Explanatory text on the capability of the current prune target.</note>
-        <trans-unit id="_msg316[0]">
+        <trans-unit id="46ec06e3d5e9fec67bb461e6fdf6fb596d4532641061dbcde535c9adc8d9fd86[0]">
           <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
         </trans-unit>
-        <trans-unit id="_msg316[1]">
+        <trans-unit id="46ec06e3d5e9fec67bb461e6fdf6fb596d4532641061dbcde535c9adc8d9fd86[1]">
           <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg317">
+      <trans-unit id="f08845c82a0742625b714dbce6ffdfeaaedc6a74193bed7f7318e135cc27ebd3">
         <source xml:space="preserve">%1 will download and store a copy of the Bitcoin block chain.</source>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg318">
+      <trans-unit id="d058dd0f007079cfbae2db5149725a92cd786329561103ac959ee17b9bdc98b4">
         <source xml:space="preserve">The wallet will also be stored in this directory.</source>
         <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg319">
+      <trans-unit id="be1e2bfd626b744b461b7d4fe4076a60791c95ef84793279cd51254623c29a8e">
         <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg320">
+      <trans-unit id="1bb6f33dd870454ccdebda21eca1a142966674381b8c86d5ef07b281cd817f84">
         <source xml:space="preserve">Error</source>
         <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
       </trans-unit>
@@ -1468,54 +1468,54 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/modaloverlay.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg321">
+      <trans-unit id="17c497fad21f39d75f71139e0fbc8abe877785e4e4839e5e4fb4bd6aec6c695f">
         <source xml:space="preserve">Form</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg322">
+      <trans-unit id="03897bf35c7cfbc502c3b127a1c37d4b0864c2625bb9018b7288b04fe92b3350">
         <source xml:space="preserve">Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
         <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg323">
+      <trans-unit id="945de43049e3dac5ed0e182d64375fa9522ca0c09d3cea1dd64737c72095dc25">
         <source xml:space="preserve">Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg324">
+      <trans-unit id="0659e7a3e3a69e03df12e8fcc7f65966a8d71078d4074467b1531adfc0420a62">
         <source xml:space="preserve">Number of blocks left</source>
         <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg325">
+      <trans-unit id="9f04ce9c20b78b385d9fd6653ec535b80681fb382e265b656a4497ff3024b4bd">
         <source xml:space="preserve">Unknown…</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../modaloverlay.cpp</context><context context-type="linenumber">160</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg326">
+      <trans-unit id="a5b9e9ca1bc3cbe3ab98f5e0bb32cc44d9a9149470d8370161c20b33c3223c0f">
         <source xml:space="preserve">calculating…</source>
         <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg327">
+      <trans-unit id="c36ab4e11bad97cafd2304f4113b9659138fa7a201dc099c27f712b97c294495">
         <source xml:space="preserve">Last block time</source>
         <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg328">
+      <trans-unit id="8035e2347144799747d1e75faf6501a6a5f01c763798fc6eb8c74ee431034b49">
         <source xml:space="preserve">Progress</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg329">
+      <trans-unit id="aced37f49c654e43a4166d3943a5ef80f6d44fcd5dd9a4241e0380b65e014a4a">
         <source xml:space="preserve">Progress increase per hour</source>
         <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg330">
+      <trans-unit id="60d60920c6ec81a8ae8e5c1532dc202a36cb7fb4ac4ab6d418e73d58f95c003b">
         <source xml:space="preserve">Estimated time left until synced</source>
         <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg331">
+      <trans-unit id="b154fccfae8292301b74f8dbe7a9b1b4ef78f05dcefd8cf3d81755959ce26ff9">
         <source xml:space="preserve">Hide</source>
         <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg332">
+      <trans-unit id="14182846686765d6e8a7ea05ef61b6f040835b5ece7fdb9992b0618d4e10f8f9">
         <source xml:space="preserve">Esc</source>
         <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
@@ -1523,21 +1523,21 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../modaloverlay.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg333">
+      <trans-unit id="562975dd49876616e19b2936df30f2ba98b37af19b87e297e0c2ac53208454a3">
         <source xml:space="preserve">%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg334">
+      <trans-unit id="9e6c5f3d030c3d4fa963c5d06a32c5e9d8dc2e26661f01828ceb9f2253ff011c">
         <source xml:space="preserve">Unknown. Syncing Headers (%1, %2%)…</source>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg335">
+      <trans-unit id="db4d83497d9dc2f535b213203585bcdaba358293be32894e86b7fad6093eeeaa">
         <source xml:space="preserve">Unknown. Pre-syncing Headers (%1, %2%)…</source>
         <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg336">
+      <trans-unit id="0107a96ddc3293ec464b656c907488758ad264c6979d9c9b9c27fd8dfc682a78">
         <source xml:space="preserve">unknown</source>
         <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
       </trans-unit>
@@ -1545,15 +1545,15 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/openuridialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OpenURIDialog">
-      <trans-unit id="_msg337">
+      <trans-unit id="bacb3bc3acce2a04c6b3a3cb9339e092e9f047de7da75c44330ff5bee0f11ff5">
         <source xml:space="preserve">Open bitcoin URI</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg338">
+      <trans-unit id="afa4819b2e713cc235373efef6597fa387b644f653f8bf671d3a7e35e488a37d">
         <source xml:space="preserve">URI:</source>
         <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg339">
+      <trans-unit id="ec5a7cb9f12eb1900338731d9eaad677c953204ae66eca9c68d725826485fe86">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
         <note annotates="source" from="developer">Tooltip text for button that allows you to paste an address that is in your clipboard.</note>
@@ -1562,294 +1562,294 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/optionsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg340">
+      <trans-unit id="094548fb0f98aa28a3f17490180ab6b599cbea27416cf2a8875cb66f046352f2">
         <source xml:space="preserve">Options</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg341">
+      <trans-unit id="2481987482adde549052bf40e85bcac7ec543a2bec81dae9c76803f6f53e05de">
         <source xml:space="preserve">&amp;Main</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg342">
+      <trans-unit id="769c7ddff5eb1101be7a71843f19fa63371ba3c3d527f867aa6ceee0bb6f3cb4">
         <source xml:space="preserve">Automatically start %1 after logging in to the system.</source>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg343">
+      <trans-unit id="ebd6daaea683f9193bfd82d219d6850b05400b79e0598fc9b58569063f60d28d">
         <source xml:space="preserve">&amp;Start %1 on system login</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg344">
+      <trans-unit id="0f16fbca99c3bf5be866ff7df333b54be46b1f7513b4ebf20336c2c952beed5b">
         <source xml:space="preserve">Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg345">
+      <trans-unit id="04d141d98ebac06ac02f645ec578571c150138be20881b89204deefd4752e7cb">
         <source xml:space="preserve">Maximum database cache size. Make sure you have enough RAM. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</note>
       </trans-unit>
-      <trans-unit id="_msg346">
+      <trans-unit id="48be962c3a3697b169b9f85757ed769e550c4715ff2f741d0dbb75bbe50859a7">
         <source xml:space="preserve">Size of &amp;database cache</source>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg347">
+      <trans-unit id="97993f8228a2432d28c38b5c69a9faef7287a65846dcf2cab53240faf50ca132">
         <source xml:space="preserve">Number of script &amp;verification threads</source>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg348">
+      <trans-unit id="975abb112238422ab354cad4053b61f5bc977f845fa19cd593ed71d4e3ffc576">
         <source xml:space="preserve">Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg349">
+      <trans-unit id="7c22551fd60027cb0600dbf866b457c27978fcc62151a7dc1cb161e4336bceb3">
         <source xml:space="preserve">Automatically open the Bitcoin client port on the router. This only works when your router supports PCP or NAT-PMP and it is enabled. The external port could be random.</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg350">
+      <trans-unit id="648be31376681d2c6370631bdb0c2daec7d50294b7d92cddf95b0500ec9da255">
         <source xml:space="preserve">Map port using PCP or NA&amp;T-PMP</source>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg351">
+      <trans-unit id="cd3e289af2c02633056a0ea524c5da72c2e8acc9d46bb921c54a18480e6c8c1c">
         <source xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">565</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg352">
+      <trans-unit id="676300598c97aaa67ec4009b46711dd4b3d3d9bafb0aeddb09b0c6d36f5f782e">
         <source xml:space="preserve">Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
         <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">493</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg353">
+      <trans-unit id="bbbe0d9eb40ffec46c7acef9adc64c4b8668ce57ebdf9171112d3da7dfeca14a">
         <source xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <context-group purpose="location"><context context-type="linenumber">662</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg354">
+      <trans-unit id="f2594835ad98e6267f2a5bd53a464d8d705977d97b62d4a9b5de6ca05c585394">
         <source xml:space="preserve">Font in the Overview tab: </source>
         <context-group purpose="location"><context context-type="linenumber">769</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg355">
+      <trans-unit id="ff682eab155e3f31c3626d33b55cee073d10c4daca55ca785a7487c5a07a8739">
         <source xml:space="preserve">Options set in this dialog are overridden by the command line:</source>
         <context-group purpose="location"><context context-type="linenumber">814</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg356">
+      <trans-unit id="0f9d93909310b6a93cc08f91c6faf09cc59e70b9a76cd83f64589c4aebf9d3d3">
         <source xml:space="preserve">Open the %1 configuration file from the working directory.</source>
         <context-group purpose="location"><context context-type="linenumber">859</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg357">
+      <trans-unit id="75a791defb49d520b86ea86fef1e0d7a538a803d2d261622a1a7718544421eb9">
         <source xml:space="preserve">Open Configuration File</source>
         <context-group purpose="location"><context context-type="linenumber">862</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg358">
+      <trans-unit id="963b5500d13f9484b28947a5c9e8b4de5e8160fd3ba6c0d1ee263e7c13d28a97">
         <source xml:space="preserve">Reset all client options to default.</source>
         <context-group purpose="location"><context context-type="linenumber">872</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg359">
+      <trans-unit id="93071832ab3bfd4b39f7597d0aa5847bd0ffad5b93d00154bf31e263ddb24f8b">
         <source xml:space="preserve">&amp;Reset Options</source>
         <context-group purpose="location"><context context-type="linenumber">875</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg360">
+      <trans-unit id="507efde8c0c7e12c20c6dd6994ea457e3af14d53c198f6aaa65b1d440fc15a32">
         <source xml:space="preserve">&amp;Network</source>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg361">
+      <trans-unit id="d348d638818545d1c032e77bed3d318ba8f88c3b5f4b921d62c027f0e7edb9e9">
         <source xml:space="preserve">Prune &amp;block storage to</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg362">
+      <trans-unit id="f82ebe68a22d9336720926d60b45a01c37294d9a601872d1c76c2bae58078d18">
         <source xml:space="preserve">GB</source>
         <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg363">
+      <trans-unit id="b08edccddd80f6f77b56727b2cf5ddb8f54b3506df53ed0eb09c8ed8631da197">
         <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg364">
+      <trans-unit id="231ea0db9c85f7f84754ae9db1e372f577abdeebefc69eae16c7e19b7bfc7eb1">
         <source xml:space="preserve">MiB</source>
         <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg365">
+      <trans-unit id="49c91f4cd3beee23fc8c8248dfc853ac6e602ce08785d2263469bfc57aa0276d">
         <source xml:space="preserve">Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</note>
       </trans-unit>
-      <trans-unit id="_msg366">
+      <trans-unit id="8fdc9fcb2aaa1fe48fecc27d902a645834e65a7f19016f0459c40450b3dd2860">
         <source xml:space="preserve">(0 = auto, &lt;0 = leave that many cores free)</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg367">
+      <trans-unit id="4b3597ef132dc92ccae8e8aac168adedbb133e24dac4e1d01729ace62ea738d0">
         <source xml:space="preserve">This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that enables the RPC server.</note>
       </trans-unit>
-      <trans-unit id="_msg368">
+      <trans-unit id="0b5dbdc0954cb2d2a229bfc04dba90ecb6cf0c63c3de5d7bf127f69c4edd56a6">
         <source xml:space="preserve">Enable R&amp;PC server</source>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
         <note annotates="source" from="developer">An Options window setting to enable the RPC server.</note>
       </trans-unit>
-      <trans-unit id="_msg369">
+      <trans-unit id="8fd819536d7bb84faa6e201f6f4c1bbf41a0ea6d4e63df7fbd5828ea303b4116">
         <source xml:space="preserve">W&amp;allet</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg370">
+      <trans-unit id="6e78bcefd813b8037a55bc028938827159df6cbffc39d96e6c23a6be5f441db4">
         <source xml:space="preserve">Whether to set subtract fee from amount as default or not.</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</note>
       </trans-unit>
-      <trans-unit id="_msg371">
+      <trans-unit id="93e06a4849a2c83e15a34a119358393e55a670296c6002d59c2ac264bf1a8afc">
         <source xml:space="preserve">Subtract &amp;fee from amount by default</source>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
         <note annotates="source" from="developer">An Options window setting to set subtracting the fee from a sending amount as default.</note>
       </trans-unit>
-      <trans-unit id="_msg372">
+      <trans-unit id="35511e1a4f17463318dc0f2aec893b07dab0ab866506e3a5f12066f04926ed0e">
         <source xml:space="preserve">Expert</source>
         <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg373">
+      <trans-unit id="17906a745243328427c7d2e43c030506761537c0a2ece86a6252947a73c967cb">
         <source xml:space="preserve">Enable coin &amp;control features</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg374">
+      <trans-unit id="001fc821a56b39a8a729dec3209d8d5bc8f7d353e09d4f993de7819f7107084b">
         <source xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg375">
+      <trans-unit id="6a73b1d37bd05158b814e588ea4c98824461e5611a2f67f2d57685ca10d0945d">
         <source xml:space="preserve">&amp;Spend unconfirmed change</source>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg376">
+      <trans-unit id="92c56a634a9c53b4cc6d453d7c4a0efb1b8de2b8447dd9f4d6d0be2b27217e85">
         <source xml:space="preserve">Enable &amp;PSBT controls</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
         <note annotates="source" from="developer">An options window setting to enable PSBT controls.</note>
       </trans-unit>
-      <trans-unit id="_msg377">
+      <trans-unit id="9e4513ab3f01f8d3b77b9d7ed02a070dd00020d884de4efae55966811ce2532b">
         <source xml:space="preserve">Whether to show PSBT controls.</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
         <note annotates="source" from="developer">Tooltip text for options window setting that enables PSBT controls.</note>
       </trans-unit>
-      <trans-unit id="_msg378">
+      <trans-unit id="bb7892e19e43d139550a35eb9e627ce717acd4514f8c6923b7836a8e8f08641b">
         <source xml:space="preserve">External Signer (e.g. hardware wallet)</source>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg379">
+      <trans-unit id="f7f6ef4e049b1d0a5b53a682c6fceec4ade1eba992306474d4d1f877316e357a">
         <source xml:space="preserve">&amp;External signer script path</source>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg380">
+      <trans-unit id="51c7992441f13d56c172bf200b8777bcdd01142fd6c0e39226f7fff58bbf9f9f">
         <source xml:space="preserve">Accept connections from outside.</source>
         <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg381">
+      <trans-unit id="9be259f72d34c51d3e53d36e19a305c034c7c7550c583bf4bf1caf15a462a14f">
         <source xml:space="preserve">Allow incomin&amp;g connections</source>
         <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg382">
+      <trans-unit id="d06d8d5e9460ace822c1ae85eb2c7d2a845cb2218d3cc0a475a69d390033b972">
         <source xml:space="preserve">Connect to the Bitcoin network through a SOCKS5 proxy.</source>
         <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg383">
+      <trans-unit id="c27d62dc4d92030ca811cd650023851d34d307b987329b2031a05cf57aa00392">
         <source xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</source>
         <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg384">
+      <trans-unit id="713d9cbc4174ca9a5be45c5129917fe002fc01d0af8312888baafce202e9608f">
         <source xml:space="preserve">Proxy &amp;IP:</source>
         <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">540</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg385">
+      <trans-unit id="96bb06e1428a7aa5d293229195cd82c64f319fd314db93b848786c5c28c787c7">
         <source xml:space="preserve">&amp;Port:</source>
         <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">572</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg386">
+      <trans-unit id="bef950f7ba93e3eaf44d98b5994ea5b97306b5e48525f36899d8e983a17955c6">
         <source xml:space="preserve">Port of the proxy (e.g. 9050)</source>
         <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">597</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg387">
+      <trans-unit id="a479e5b2e0549e3f09a477208839881dc21e195faf42b2bd37f0fa4e043257b1">
         <source xml:space="preserve">Used for reaching peers via:</source>
         <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg388">
+      <trans-unit id="dff8c773a600c5ec02d471e5b77452ed88d7ff1ab6f65a32a6184df3fdcf7ff6">
         <source xml:space="preserve">IPv4</source>
         <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg389">
+      <trans-unit id="982bd2947ab007bd34fcbbfe588f459a34a952c08755a8e34e90ae17f917db45">
         <source xml:space="preserve">IPv6</source>
         <context-group purpose="location"><context context-type="linenumber">480</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg390">
+      <trans-unit id="ad42ef253e0b394d33c3aece137ed04aa33fd7128329dc8f7c749e0050a5b33a">
         <source xml:space="preserve">Tor</source>
         <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg391">
+      <trans-unit id="07c398eab159e5493d4fda6c981e69de6a8bfe169a79a18d700b1cc9fdea0f16">
         <source xml:space="preserve">&amp;Window</source>
         <context-group purpose="location"><context context-type="linenumber">633</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg392">
+      <trans-unit id="99d855f00713a851e9ee99427cc3c2f76db1ac7ce67bb21a39ce86ddddabd426">
         <source xml:space="preserve">Show the icon in the system tray.</source>
         <context-group purpose="location"><context context-type="linenumber">639</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg393">
+      <trans-unit id="69f0dfe82f574e7395de8b6858544a2916ec5300f78f6fc9a83b81b97d548c5f">
         <source xml:space="preserve">&amp;Show tray icon</source>
         <context-group purpose="location"><context context-type="linenumber">642</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg394">
+      <trans-unit id="7c70fa0dfb7d72e826708fe6c055bdef53379a7adb334bcdffd2e7a760b0881b">
         <source xml:space="preserve">Show only a tray icon after minimizing the window.</source>
         <context-group purpose="location"><context context-type="linenumber">652</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg395">
+      <trans-unit id="8f98b7af2b43248fd8f661481dbf7d1a51bf4274a453dbc9a62b7f25bb9e5472">
         <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
         <context-group purpose="location"><context context-type="linenumber">655</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg396">
+      <trans-unit id="337c4a5954f4b0c2cc7f9f17415fd49e6b03258eb2cc88bd66415cd1e6a8b3dd">
         <source xml:space="preserve">M&amp;inimize on close</source>
         <context-group purpose="location"><context context-type="linenumber">665</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg397">
+      <trans-unit id="5c5e536bd82bcef85dd2a3c506c6fda50b1fdea1232d0305a996251d181ce748">
         <source xml:space="preserve">&amp;Display</source>
         <context-group purpose="location"><context context-type="linenumber">686</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg398">
+      <trans-unit id="475bdc4dee44bec16f2c67cb728cb7482ddb4d0401ad510c5e85aa2330ff3a00">
         <source xml:space="preserve">User Interface &amp;language:</source>
         <context-group purpose="location"><context context-type="linenumber">694</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg399">
+      <trans-unit id="57b56eb207c5d76ce2a8c49ffc4113862ea434cb7b47e436eb533d9271b6386a">
         <source xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <context-group purpose="location"><context context-type="linenumber">707</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg400">
+      <trans-unit id="293aeed14ed97abeb9ab7f034bc095e7449cd6138adc1a883c87e78f3253bf9c">
         <source xml:space="preserve">&amp;Unit to show amounts in:</source>
         <context-group purpose="location"><context context-type="linenumber">718</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg401">
+      <trans-unit id="0f7440b687042927e52e249af1ed89b1fa09e565a77603133ce7f95a697f07ae">
         <source xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <context-group purpose="location"><context context-type="linenumber">731</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg402">
+      <trans-unit id="b3e8fc922a16d971fab89fa4fc3fd1093dd535298b4b4111b51e959c64dc2833">
         <source xml:space="preserve">Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
         <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">755</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg403">
+      <trans-unit id="0acc0706b1be9ee63edf1633c7ad938fc14e34b5d2e1a98de76952e165717753">
         <source xml:space="preserve">&amp;Third-party transaction URLs</source>
         <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg404">
+      <trans-unit id="6f83d75a747b9db45b22b2b4d41bc40f984c0169d85cefc6ea41c082e73441c9">
         <source xml:space="preserve">Whether to show coin control features or not.</source>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg405">
+      <trans-unit id="267d2e9180e5680c0417aafdea19725ac482c0651656d789541f64f5e120742d">
         <source xml:space="preserve">Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
         <context-group purpose="location"><context context-type="linenumber">528</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg406">
+      <trans-unit id="3fc3cdbd31df0c20f141dc492e0a37a5aa01105bebd3205cdb4c2d2889fbbe71">
         <source xml:space="preserve">Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
         <context-group purpose="location"><context context-type="linenumber">531</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg407">
+      <trans-unit id="826727e1059954662f4aac7b561bc0eadb354f8748edd942bdfa0785c9435b3d">
         <source xml:space="preserve">&amp;OK</source>
         <context-group purpose="location"><context context-type="linenumber">955</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg408">
+      <trans-unit id="04116aa68669c093fe3f802d289a0bd84f1a64e539b9a1e2e63d7b196206a30d">
         <source xml:space="preserve">&amp;Cancel</source>
         <context-group purpose="location"><context context-type="linenumber">968</context></context-group>
       </trans-unit>
@@ -1857,85 +1857,85 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../optionsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg409">
+      <trans-unit id="11495c5fe981c39fe08cfec959887807d6dc09c4b0724fe5f05b3c63c0a48cd7">
         <source xml:space="preserve">Compiled without external signing support (required for external signing)</source>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
         <note annotates="source" from="developer">&quot;External signing&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
-      <trans-unit id="_msg410">
+      <trans-unit id="eed850de0c15cd900945f304b09fc837d9975c6e1212bc9b8de9712223e5729d">
         <source xml:space="preserve">default</source>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg411">
+      <trans-unit id="ff0b9cc474d7c1996130528e97c79c0564827bc92a4ed9efbac6fdac67c66c5e">
         <source xml:space="preserve">none</source>
         <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg412">
+      <trans-unit id="e8caaca0760bc088ec9511e5170d530bc0e256fc44d4571728e5a73c44a86e4d">
         <source xml:space="preserve">Confirm options reset</source>
         <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
         <note annotates="source" from="developer">Window title text of pop-up window shown when the user has chosen to reset options.</note>
       </trans-unit>
-      <trans-unit id="_msg413">
+      <trans-unit id="b9af31a4c68e9987b6c60e493f3833b243094cad2157488ebfbc0e000616efc3">
         <source xml:space="preserve">Client restart required to activate changes.</source>
         <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
         <note annotates="source" from="developer">Text explaining that the settings changed will not come into effect until the client is restarted.</note>
       </trans-unit>
-      <trans-unit id="_msg414">
+      <trans-unit id="5222482487bcb489c2ff535cf10d1b6135f10d6554d3bbdab5ffd2391882fbc4">
         <source xml:space="preserve">Current settings will be backed up at &quot;%1&quot;.</source>
         <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
         <note annotates="source" from="developer">Text explaining to the user that the client&apos;s current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location&apos;s path.</note>
       </trans-unit>
-      <trans-unit id="_msg415">
+      <trans-unit id="d2dc61a5e76c215185d574e9f119439b867784b24d30ccd46173240fa3c3334f">
         <source xml:space="preserve">Client will be shut down. Do you want to proceed?</source>
         <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
         <note annotates="source" from="developer">Text asking the user to confirm if they would like to proceed with a client shutdown.</note>
       </trans-unit>
-      <trans-unit id="_msg416">
+      <trans-unit id="7fe470ef57907733d055b8fa56a97ce822869b0867d2762af55a88a43703e9bd">
         <source xml:space="preserve">Configuration options</source>
         <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
         <note annotates="source" from="developer">Window title text of pop-up box that allows opening up of configuration file.</note>
       </trans-unit>
-      <trans-unit id="_msg417">
+      <trans-unit id="aa90481c00725de2df2ba372e51b53e117af81373dd8d161be472367e899e7f9">
         <source xml:space="preserve">The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
         <note annotates="source" from="developer">Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</note>
       </trans-unit>
-      <trans-unit id="_msg418">
+      <trans-unit id="4abd8f4f4102f7e0cf6c85f6ba472c6426d0bcbf0a90677add4880f92b70c569">
         <source xml:space="preserve">Continue</source>
         <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg419">
+      <trans-unit id="a265866da555331d88713fc29f08bffc6ce991421ad63acfc7bcd31836f5b5f2">
         <source xml:space="preserve">Cancel</source>
         <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg420">
+      <trans-unit id="81dffe3fddf7968016752f163173bf156f4a8526ddf6f8387335f29af7ade5f1">
         <source xml:space="preserve">Error</source>
         <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg421">
+      <trans-unit id="5fa6c7d7b14f11ca0dfb93839e2536bb6b0f6e5af6b858c4377fac7a4b4e1758">
         <source xml:space="preserve">The configuration file could not be opened.</source>
         <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg422">
+      <trans-unit id="96113a7f604d1be6910400f79e930b0480dfa6372f3f7746dee309bbaaaedbf3">
         <source xml:space="preserve">This change would require a client restart.</source>
         <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg423">
+      <trans-unit id="62165a9639b6a3020b1249e9da8c0814864bbcc49ef820cb1a5c27b8cab690de">
         <source xml:space="preserve">The supplied proxy address is invalid.</source>
         <context-group purpose="location"><context context-type="linenumber">446</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg424">
+      <trans-unit id="92e529f06fe959f8e4f929ca72600895926ad387d12cc107beba3f587619ce9b">
         <source xml:space="preserve">Embedded &quot;%1&quot;</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg425">
+      <trans-unit id="5d610a2deb3539b8fa6b392881fd57452d03924a855d6f5445835f7671220137">
         <source xml:space="preserve">Default system font &quot;%1&quot;</source>
         <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg426">
+      <trans-unit id="99ecd5005a19892320fc60d1efa6557a321f68fabd50b00ea73229b1419937d3">
         <source xml:space="preserve">Custom…</source>
         <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
       </trans-unit>
@@ -1943,7 +1943,7 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../optionsmodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsModel">
-      <trans-unit id="_msg427">
+      <trans-unit id="6da06f9575d7c37f16276699d37de1e74323a4339f0b80b2c911bed622b169e9">
         <source xml:space="preserve">Could not read setting &quot;%1&quot;, %2.</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
@@ -1951,52 +1951,52 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/overviewpage.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg428">
+      <trans-unit id="e26432f0963dd4f02cf0c6136aa06cfef97b0e4a564144885d9e2121dc4d47f0">
         <source xml:space="preserve">Form</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg429">
+      <trans-unit id="07e7d826bf45cbda758dfc84c71ddad6d69170266b7a0eedb419618339f0541a">
         <source xml:space="preserve">The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg430">
+      <trans-unit id="5ceadb75badf6143d6938e68fd520fab2ad033f4fb525af5ff0f3d342f622a93">
         <source xml:space="preserve">Available:</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg431">
+      <trans-unit id="0935faf2a2a46496fb965c2e30c7b36e3fb6c08e9049e5c835fb388b11045b0b">
         <source xml:space="preserve">Your current spendable balance</source>
         <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg432">
+      <trans-unit id="57ebc6f74ac1d8f87318b2c6f2b77f0a139d6c7b90459e7d7b59342db7afe2e5">
         <source xml:space="preserve">Pending:</source>
         <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg433">
+      <trans-unit id="b58464d199246d62dbc333c741e063e7eec7302c6a675674fb7cdeda5f153c78">
         <source xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg434">
+      <trans-unit id="c9fb212b1faec87dbc5d45c7703be6e30bba9b706accebfec3745864c9659642">
         <source xml:space="preserve">Immature:</source>
         <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg435">
+      <trans-unit id="1d8eb71c9dc962b60f5f4a8b5c1c35accb5b961c73ec0d5cebae144e93e76d5b">
         <source xml:space="preserve">Mined balance that has not yet matured</source>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg436">
+      <trans-unit id="707f1b162ff3a4f47fc20e78722a4b16a586a99eaae89153ecdc19f0edbdd86e">
         <source xml:space="preserve">Balances</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg437">
+      <trans-unit id="e051460d87d53bdd6089182d02a97c17883de5204902bb4a052d28da67c56b02">
         <source xml:space="preserve">Total:</source>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg438">
+      <trans-unit id="5a21b1fd79d8792e159b8c51a9336c8dc2cd859927384da01a8f90cebfbcba87">
         <source xml:space="preserve">Your current total balance</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg439">
+      <trans-unit id="fd335bbcd92d73bf822049652fbb6c1ab163c78f14f31c9f41f5a68d2cea9fc2">
         <source xml:space="preserve">Recent transactions</source>
         <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
       </trans-unit>
@@ -2004,7 +2004,7 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../overviewpage.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg440">
+      <trans-unit id="68432567bc19ab05774f2b197b2bf664a7578b4259816ba79fb125dd85b1ba55">
         <source xml:space="preserve">Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
@@ -2012,27 +2012,27 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../forms/psbtoperationsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg441">
+      <trans-unit id="35b0a8c1d01b3f0dd636c3db151b86190a692a378756a8051235439fffe7ddd6">
         <source xml:space="preserve">PSBT Operations</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg442">
+      <trans-unit id="94819af1639f10fb7d80a40d3d02141eb39075641cb424ace99e2697f4a1a751">
         <source xml:space="preserve">Sign Tx</source>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg443">
+      <trans-unit id="423962c3f822d2c5e69527039bf8c4108c0609610296e6f36161afff3ad2db1c">
         <source xml:space="preserve">Broadcast Tx</source>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg444">
+      <trans-unit id="264cfb99c192f4ff3767bad519a5f4bd6139247a5f218226ce76a91bed9ebe46">
         <source xml:space="preserve">Copy to Clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg445">
+      <trans-unit id="c4bdbb5b5c87b63d22bd7942b82050814f2375fbdd488af72cc5d64681a414ec">
         <source xml:space="preserve">Save…</source>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg446">
+      <trans-unit id="dde3921f648a4e408047ffee837a074683757806cab867328c9dc701e7c92074">
         <source xml:space="preserve">Close</source>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
       </trans-unit>
@@ -2040,122 +2040,122 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../psbtoperationsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg447">
+      <trans-unit id="98ca76e2c8080a85143b8ed4c5eda12cfe2c71ea8ad6e71fa9e8b58ec7bff1ed">
         <source xml:space="preserve">Failed to load transaction: %1</source>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg448">
+      <trans-unit id="a0500b58d003d995398b6d048879d0b1b9165584845fd6b1982a46e6fdb432f7">
         <source xml:space="preserve">Failed to sign transaction: %1</source>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg449">
+      <trans-unit id="63df3a9709cfd662d1c79949f4fa015b310e98031cd03a2cf7821c951232a71c">
         <source xml:space="preserve">Cannot sign inputs while wallet is locked.</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg450">
+      <trans-unit id="71694a53949a160daa8fab41897b8bb2c04e4602c6da3357b453328bcdee1a0d">
         <source xml:space="preserve">Could not sign any more inputs.</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
-        <trans-unit id="_msg451[0]">
+        <trans-unit id="1c39c8637734798cf6ade2010d4d6d9cb9f82f7c483924ac4da02376cb0d2723[0]">
           <source xml:space="preserve">Signed %n input(s), but more signatures are still required.</source>
         </trans-unit>
-        <trans-unit id="_msg451[1]">
+        <trans-unit id="1c39c8637734798cf6ade2010d4d6d9cb9f82f7c483924ac4da02376cb0d2723[1]">
           <source xml:space="preserve">Signed %n input(s), but more signatures are still required.</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg452">
+      <trans-unit id="f064b3db811b5c1e90bc2e048d90e36eace20ccd55a566d7dded75d5a84ca761">
         <source xml:space="preserve">Signed transaction successfully. Transaction is ready to broadcast.</source>
         <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg453">
+      <trans-unit id="a177e16260bf55f3c8b49ed34a7430c0d934190e4c4056cd40970f71b17957e3">
         <source xml:space="preserve">Unknown error processing transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg454">
+      <trans-unit id="7b006a96be41ac350195ee7860c5b22182f252275f3cc1ef7bb7ac6845da03ce">
         <source xml:space="preserve">Transaction broadcast successfully! Transaction ID: %1</source>
         <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg455">
+      <trans-unit id="5b33b6097e2da4698e8d3ab445e6274a4c4d2df9691064baa0aa691dea4e929d">
         <source xml:space="preserve">Transaction broadcast failed: %1</source>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg456">
+      <trans-unit id="afc62ad9d2eb81f986d395d68478117adb1bd205efe07a184c7d2e0d686869bc">
         <source xml:space="preserve">PSBT copied to clipboard.</source>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg457">
+      <trans-unit id="94cdb0621e9feb86d2c7916d1a00a04513439092c3f5bd1b6b2510bdc5f6eaaf">
         <source xml:space="preserve">Save Transaction Data</source>
         <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg458">
+      <trans-unit id="8453163888dbaae33ff2b54209b906e50e4926cd023047edeadb376b5aacba83">
         <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
         <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
         <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
-      <trans-unit id="_msg459">
+      <trans-unit id="f9def64c5ac642454e19d532ba35465baea4ffe99a1a2fbf065b9507d8ac0da1">
         <source xml:space="preserve">PSBT saved to disk.</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg460">
+      <trans-unit id="554a6cbbb832163465a2fc43a4fa4d4aae38d3c82c723379dd906640a3253ae0">
         <source xml:space="preserve">Sends %1 to %2</source>
         <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg461">
+      <trans-unit id="82a1dbcdc13c3e906e86f5a27cde1701b4a78d9b100244639541ae39f316a64f">
         <source xml:space="preserve">own address</source>
         <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg462">
+      <trans-unit id="596ec88f5e899b426e233f60beca6ee4c0175e5111253ecee0e44f54aa7accad">
         <source xml:space="preserve">Unable to calculate transaction fee or total transaction amount.</source>
         <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg463">
+      <trans-unit id="d13fdbdc59760b72d68bca778b0730ad742d27cac3b07ddb54715fc3a854ba22">
         <source xml:space="preserve">Pays transaction fee: </source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg464">
+      <trans-unit id="a817f85bcbbccd2d2ccafd00858975a22e7b09f2d67af9e727df693a102bcdd8">
         <source xml:space="preserve">Total Amount</source>
         <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg465">
+      <trans-unit id="3dea54fc60f7a6158025672790e9457dc552dd8802ac3947bad48655d0bc6deb">
         <source xml:space="preserve">or</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
-        <trans-unit id="_msg466[0]">
+        <trans-unit id="5146b80cb228394dbe9f158930e2233642895b42980c2a21e956ca981a0d5b01[0]">
           <source xml:space="preserve">Transaction has %n unsigned input(s).</source>
         </trans-unit>
-        <trans-unit id="_msg466[1]">
+        <trans-unit id="5146b80cb228394dbe9f158930e2233642895b42980c2a21e956ca981a0d5b01[1]">
           <source xml:space="preserve">Transaction has %n unsigned input(s).</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg467">
+      <trans-unit id="58bfc39f58aeb0b6a8311d039a1bb9fb2eac50e5d4eaa3eee92d3ce487228474">
         <source xml:space="preserve">Transaction is missing some information about inputs.</source>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg468">
+      <trans-unit id="cc8e784963a85255c66321ccd3768eac57f3cbe2156f14316f679cd6ef5dfc10">
         <source xml:space="preserve">Transaction still needs signature(s).</source>
         <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg469">
+      <trans-unit id="5bd6ed8e98237bec77c82d13c42ff0b3e2d71faa5a4547b935c60ee7fffa43fe">
         <source xml:space="preserve">(But no wallet is loaded.)</source>
         <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg470">
+      <trans-unit id="91bfd9515ea51ce4a16f0947ce2c346f39225f1baeb36e61774b5ea4765a3701">
         <source xml:space="preserve">(But this wallet cannot sign transactions.)</source>
         <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg471">
+      <trans-unit id="a8e0981e1d9e2431dbf5e9944c4b1679fb630eb0db2c3f83c5cdb063af764772">
         <source xml:space="preserve">(But this wallet does not have the right keys.)</source>
         <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg472">
+      <trans-unit id="d8af96bca5f0bb4e35a5f9f214b746a34759ce7bf812cd6efad7c29cb18064be">
         <source xml:space="preserve">Transaction is fully signed and ready for broadcast.</source>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg473">
+      <trans-unit id="3056abadf6fd0a164788e03906c6dac6f850f5a85e7f1595e483c703cd7a10ac">
         <source xml:space="preserve">Transaction status is unknown.</source>
         <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
       </trans-unit>
@@ -2163,37 +2163,37 @@ The migration process will create a backup of the wallet before migrating. This 
   </body></file>
   <file original="../paymentserver.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PaymentServer">
-      <trans-unit id="_msg474">
+      <trans-unit id="2312071a6cf1b8ed8cebfcbe2af315d588e60cbfe66e229fc9b27f94b80839ff">
         <source xml:space="preserve">Payment request error</source>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg475">
+      <trans-unit id="24c60892de34ad3ff4fc18f3957978d3bced11771b66db4498db544282ff34e6">
         <source xml:space="preserve">Cannot start bitcoin: click-to-pay handler</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg476">
+      <trans-unit id="2e7afe672a351840c85dcfda25b8b39b4251f9894deb5cd9aec4dde98d750f23">
         <source xml:space="preserve">URI handling</source>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg477">
+      <trans-unit id="8552674236a99c6ae9cf01bda9b306cac1794dff013e2c68d505a3c9fdd373b8">
         <source xml:space="preserve">&apos;bitcoin://&apos; is not a valid URI. Use &apos;bitcoin:&apos; instead.</source>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg478">
+      <trans-unit id="68a3690e03ad10d9374b155a40c60d3adb99fa8920aa5259f04d399a83721f7b">
         <source xml:space="preserve">Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it&apos;s strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg479">
+      <trans-unit id="75fb44a2ff3903438b890a047969b140e365e2681e64219f8c6e33e656dfd843">
         <source xml:space="preserve">URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg480">
+      <trans-unit id="a1bedd67db97ff4304842b73c08de15a453662e6074939eefefb0ec126e424b2">
         <source xml:space="preserve">Payment request file handling</source>
         <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
       </trans-unit>
@@ -2201,52 +2201,52 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../peertablemodel.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
-      <trans-unit id="_msg481">
+      <trans-unit id="2e0630b719a40d10f8c92b21544b9e2fc00635834fec3e2d7d9f97eabec93227">
         <source xml:space="preserve">User Agent</source>
         <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains the peer&apos;s User Agent string.</note>
       </trans-unit>
-      <trans-unit id="_msg482">
+      <trans-unit id="3eee2c7bd38dc9041671ebff9ea73682356702589937ca43b55a23dd40fcb2e3">
         <source xml:space="preserve">Ping</source>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the current latency of the connection with the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg483">
+      <trans-unit id="324740f22f38197047c32c4657fdf3bc44f4b0f42279e7ab66387451ad69ed81">
         <source xml:space="preserve">Peer</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains a unique number used to identify a connection.</note>
       </trans-unit>
-      <trans-unit id="_msg484">
+      <trans-unit id="ef7ec733eea0344e0def92f5c565eed4ae0a4276de9d27cad77af0b5af3c5e11">
         <source xml:space="preserve">Age</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</note>
       </trans-unit>
-      <trans-unit id="_msg485">
+      <trans-unit id="0ed289f885eab724a88bf6c4fa617e5b8c460f975f36b5d53adff8f2c31af6a3">
         <source xml:space="preserve">Direction</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the direction the peer connection was initiated from.</note>
       </trans-unit>
-      <trans-unit id="_msg486">
+      <trans-unit id="79d076115d043e0ff7515e5706c170dd4bf3e26b1a1b5b0d17e193bf44c380fd">
         <source xml:space="preserve">Sent</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg487">
+      <trans-unit id="6cf492f01d8cd87a461e83eaa0bcc4cfb0cf006f6b75c3619c5b5f057157efde">
         <source xml:space="preserve">Received</source>
         <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have received from the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg488">
+      <trans-unit id="ea867dba9e11cfa35b15617bc4a5fe1ae37499eb6f1784c3a218e74361d042c4">
         <source xml:space="preserve">Address</source>
         <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</note>
       </trans-unit>
-      <trans-unit id="_msg489">
+      <trans-unit id="5de5a28081651e702ab70e65534849ffd0ee8188570b5c39d4137b7d6ae78d05">
         <source xml:space="preserve">Type</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which describes the type of peer connection. The &quot;type&quot; describes why the connection exists.</note>
       </trans-unit>
-      <trans-unit id="_msg490">
+      <trans-unit id="57d48349532d367b7dc2810bad5776902309142fe6593fcf34106d019cd05e0f">
         <source xml:space="preserve">Network</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which states the network the peer connected through.</note>
@@ -2255,12 +2255,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../peertablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
-      <trans-unit id="_msg491">
+      <trans-unit id="80b737306f90e6eaf8142621427e895a9c4510a908c298db0c9ca9c2b26c5080">
         <source xml:space="preserve">Inbound</source>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
         <note annotates="source" from="developer">An Inbound Connection from a Peer.</note>
       </trans-unit>
-      <trans-unit id="_msg492">
+      <trans-unit id="71e89c404704a6351a3313df48ab39d904c445692800df420d0acd62b2d41254">
         <source xml:space="preserve">Outbound</source>
         <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
         <note annotates="source" from="developer">An Outbound Connection to a Peer.</note>
@@ -2269,7 +2269,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../bitcoinunits.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg493">
+      <trans-unit id="971792fc2d5505684ee5741ffff0888a16dc5b20769e30f50f53f6b7ee0c8386">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
       </trans-unit>
@@ -2277,200 +2277,200 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../guiutil.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg494">
+      <trans-unit id="c379fe163c543f16b39c8c46126c05499e03a44d5cf770d2889637dea391bf43">
         <source xml:space="preserve">Enter a Bitcoin address (e.g. %1)</source>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg495">
+      <trans-unit id="15abba87134e780222afca4eab641258493595d1ffd4bd6d7c4011c276a45884">
         <source xml:space="preserve">Ctrl+W</source>
         <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg496">
+      <trans-unit id="47e5a970abfa5e8ce0406db6eb97512a45ba6990ef1503fa516fa6b8b9a979c6">
         <source xml:space="preserve">Unroutable</source>
         <context-group purpose="location"><context context-type="linenumber">683</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg497">
+      <trans-unit id="3fa95542bc260875da0a4f83b8c5ab86e3675b2059025474f444ad3213c99f77">
         <source xml:space="preserve">IPv4</source>
         <context-group purpose="location"><context context-type="linenumber">685</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of IPv4 network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg498">
+      <trans-unit id="ee5a446a91afa2096b5a80f3588e8f900cd1f2c3ec6fee17769516867c9dfed9">
         <source xml:space="preserve">IPv6</source>
         <context-group purpose="location"><context context-type="linenumber">687</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of IPv6 network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg499">
+      <trans-unit id="7499552041e83d7c1719d478d289e3a7b4ce215148628a4f57c4e4aca6167a4d">
         <source xml:space="preserve">Onion</source>
         <context-group purpose="location"><context context-type="linenumber">689</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of Tor network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg500">
+      <trans-unit id="966833bfb36bb51e935b3b4cf6a92896593ce6fe6baa4b3f6066831c530ad06b">
         <source xml:space="preserve">I2P</source>
         <context-group purpose="location"><context context-type="linenumber">691</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of I2P network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg501">
+      <trans-unit id="702868fac93b7d7c86fcf8d8bf360c65cb9154ea12414184a2d84918441fff89">
         <source xml:space="preserve">CJDNS</source>
         <context-group purpose="location"><context context-type="linenumber">693</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">network name</context></context-group>
         <note annotates="source" from="developer">Name of CJDNS network in peer info</note>
       </trans-unit>
-      <trans-unit id="_msg502">
+      <trans-unit id="e1dd06dcc733664960d17214dcacc91f3fb488fa827417aff08072ecf710a9ad">
         <source xml:space="preserve">Inbound</source>
         <context-group purpose="location"><context context-type="linenumber">707</context></context-group>
         <note annotates="source" from="developer">An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg503">
+      <trans-unit id="3806cc0795b92ecd4cc96a655be62ab16817a5ba7a4a9c3841233419f46fffcf">
         <source xml:space="preserve">Outbound</source>
         <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
         <note annotates="source" from="developer">An outbound connection to a peer. An outbound connection is a connection initiated by us.</note>
       </trans-unit>
-      <trans-unit id="_msg504">
+      <trans-unit id="c993304d9e11b2bfd29d811c625c365b3a657545278831134d10b3516c6d3564">
         <source xml:space="preserve">Full Relay</source>
         <context-group purpose="location"><context context-type="linenumber">715</context></context-group>
         <note annotates="source" from="developer">Peer connection type that relays all network information.</note>
       </trans-unit>
-      <trans-unit id="_msg505">
+      <trans-unit id="94b9cab36c2ad3542a8b1bced29774a908fcd67090ff9f3234b2c125bc9ec48f">
         <source xml:space="preserve">Block Relay</source>
         <context-group purpose="location"><context context-type="linenumber">718</context></context-group>
         <note annotates="source" from="developer">Peer connection type that relays network information about blocks and not transactions or addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg506">
+      <trans-unit id="206b3269f93cf9d915f94c692bc189036fc43a8bd2311afb1b691a80f415f417">
         <source xml:space="preserve">Manual</source>
         <context-group purpose="location"><context context-type="linenumber">720</context></context-group>
         <note annotates="source" from="developer">Peer connection type established manually through one of several methods.</note>
       </trans-unit>
-      <trans-unit id="_msg507">
+      <trans-unit id="370303d41fe70396190f72bb715ad6615ea004f7c9d787c16fe95baa2bf9dfbd">
         <source xml:space="preserve">Feeler</source>
         <context-group purpose="location"><context context-type="linenumber">722</context></context-group>
         <note annotates="source" from="developer">Short-lived peer connection type that tests the aliveness of known addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg508">
+      <trans-unit id="c76c6e1ddfd037c6eb0cdea9ed1ebf6feb207c982c6447ce7709982218e2775c">
         <source xml:space="preserve">Address Fetch</source>
         <context-group purpose="location"><context context-type="linenumber">724</context></context-group>
         <note annotates="source" from="developer">Short-lived peer connection type that solicits known addresses from a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg509">
+      <trans-unit id="923187a98199062d6cc7da76217d9c93a66fa4a5c4129548168d18ceee0f312c">
         <source xml:space="preserve">Private Broadcast</source>
         <context-group purpose="location"><context context-type="linenumber">726</context></context-group>
         <note annotates="source" from="developer">Short-lived peer connection type that is used for broadcasting privacy-sensitive data.</note>
       </trans-unit>
-      <trans-unit id="_msg510">
+      <trans-unit id="0255638bd4b2d9f6cc89361965d56cbff100e62685c1fcf43a35d8653ebe487e">
         <source xml:space="preserve">%1 d</source>
         <context-group purpose="location"><context context-type="linenumber">738</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">750</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg511">
+      <trans-unit id="9c67bd5b433e3f9be01c48417fb0781cb1fecf64d8898d336410f9d3e3a9f8f3">
         <source xml:space="preserve">%1 h</source>
         <context-group purpose="location"><context context-type="linenumber">739</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg512">
+      <trans-unit id="f1308b396bdfeb76f87a049720216939b0442826f02ff1d357bb1081b66a0385">
         <source xml:space="preserve">%1 m</source>
         <context-group purpose="location"><context context-type="linenumber">740</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">752</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg513">
+      <trans-unit id="10392c1923aa6dd60516f41ef5c49bcba99375f6c28b9093d93fcf1334dcbfa3">
         <source xml:space="preserve">%1 s</source>
         <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">753</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">779</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg514">
+      <trans-unit id="c8f5e8ac1f131851bc43898d36b3e3ac2524ce08e7def1a95830f9721e6d7e20">
         <source xml:space="preserve">None</source>
         <context-group purpose="location"><context context-type="linenumber">767</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg515">
+      <trans-unit id="217f1fd7866d8c6840889005d82b7f8ed24d13f5115392034def324a104fe47d">
         <source xml:space="preserve">N/A</source>
         <context-group purpose="location"><context context-type="linenumber">773</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg516">
+      <trans-unit id="053b9c6bbbb1a4193d5ec7a30e6c9a4e2adb3448a13ee100e839dffefd4cc141">
         <source xml:space="preserve">%1 ms</source>
         <context-group purpose="location"><context context-type="linenumber">774</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">792</context></context-group>
-        <trans-unit id="_msg517[0]">
+        <trans-unit id="9da147340d8715433289d892c382a4050542acb2b68de2c53dee9ab85832adff[0]">
           <source xml:space="preserve">%n second(s)</source>
         </trans-unit>
-        <trans-unit id="_msg517[1]">
+        <trans-unit id="9da147340d8715433289d892c382a4050542acb2b68de2c53dee9ab85832adff[1]">
           <source xml:space="preserve">%n second(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">796</context></context-group>
-        <trans-unit id="_msg518[0]">
+        <trans-unit id="3e3abd9110386e2773c8c607d9091e0e9ad6f81eb32204eadfb9c96dae380d43[0]">
           <source xml:space="preserve">%n minute(s)</source>
         </trans-unit>
-        <trans-unit id="_msg518[1]">
+        <trans-unit id="3e3abd9110386e2773c8c607d9091e0e9ad6f81eb32204eadfb9c96dae380d43[1]">
           <source xml:space="preserve">%n minute(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">800</context></context-group>
-        <trans-unit id="_msg519[0]">
+        <trans-unit id="7641c5147bb0d1b1204b8e4143f7e501f3e62f1ebe94cf3b51355dbf85c05afc[0]">
           <source xml:space="preserve">%n hour(s)</source>
         </trans-unit>
-        <trans-unit id="_msg519[1]">
+        <trans-unit id="7641c5147bb0d1b1204b8e4143f7e501f3e62f1ebe94cf3b51355dbf85c05afc[1]">
           <source xml:space="preserve">%n hour(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">804</context></context-group>
-        <trans-unit id="_msg520[0]">
+        <trans-unit id="170c86ad6234641000e8786389ceb8b0832be2e0b4200fad970eebabae7c5304[0]">
           <source xml:space="preserve">%n day(s)</source>
         </trans-unit>
-        <trans-unit id="_msg520[1]">
+        <trans-unit id="170c86ad6234641000e8786389ceb8b0832be2e0b4200fad970eebabae7c5304[1]">
           <source xml:space="preserve">%n day(s)</source>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">808</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">814</context></context-group>
-        <trans-unit id="_msg521[0]">
+        <trans-unit id="4380b0174cc2278e3d89b645d446caab22db54f5d690852277be56f01c907fca[0]">
           <source xml:space="preserve">%n week(s)</source>
         </trans-unit>
-        <trans-unit id="_msg521[1]">
+        <trans-unit id="4380b0174cc2278e3d89b645d446caab22db54f5d690852277be56f01c907fca[1]">
           <source xml:space="preserve">%n week(s)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg522">
+      <trans-unit id="7b3608b5b3ba0051a0cc17076783219aff4bcf8d5ae9b2aeb8548e9769342497">
         <source xml:space="preserve">%1 and %2</source>
         <context-group purpose="location"><context context-type="linenumber">814</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">814</context></context-group>
-        <trans-unit id="_msg523[0]">
+        <trans-unit id="d7fbba65793624b8b371f86a055a1a02e3587a69b373391196f5e987e45de2a6[0]">
           <source xml:space="preserve">%n year(s)</source>
         </trans-unit>
-        <trans-unit id="_msg523[1]">
+        <trans-unit id="d7fbba65793624b8b371f86a055a1a02e3587a69b373391196f5e987e45de2a6[1]">
           <source xml:space="preserve">%n year(s)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg524">
+      <trans-unit id="05bd026a9b709ac9bf3e96718a082418987b5199ee188f5aaf7cc1a56aa597f3">
         <source xml:space="preserve">%1 B</source>
         <context-group purpose="location"><context context-type="linenumber">822</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg525">
+      <trans-unit id="f69c2c96c30d92aa06060ed87a1d8055c6b1ea1a3274f542c931445f6e7e4e00">
         <source xml:space="preserve">%1 kB</source>
         <context-group purpose="location"><context context-type="linenumber">824</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">985</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg526">
+      <trans-unit id="042267c99cda10d878653a6af952844d5dc16c9e3fa8ba651a4bd5317b4b04a3">
         <source xml:space="preserve">%1 MB</source>
         <context-group purpose="location"><context context-type="linenumber">826</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">986</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">987</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg527">
+      <trans-unit id="546707c907986b82724c362bdd9e5d2d0ce98c82fc73f8cd7dea1e6f136a07a2">
         <source xml:space="preserve">%1 GB</source>
         <context-group purpose="location"><context context-type="linenumber">828</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg528">
+      <trans-unit id="7a1690a1b420067b0977e66356b1e2d7e3dd7c9d5fa23e5c9e7727033c83e989">
         <source xml:space="preserve">default wallet</source>
         <context-group purpose="location"><context context-type="linenumber">987</context></context-group>
       </trans-unit>
@@ -2478,31 +2478,31 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../qrimagewidget.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QRImageWidget">
-      <trans-unit id="_msg529">
+      <trans-unit id="39f768a627f39039d72fe1cc92a394cef6b5f2012a0f651720c33217bb644046">
         <source xml:space="preserve">&amp;Save Image…</source>
         <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg530">
+      <trans-unit id="2c3d628bd8f5b98e9e76bccc7b46f4c04125f7abd0b1cb29ba223bdf8908370b">
         <source xml:space="preserve">&amp;Copy Image</source>
         <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg531">
+      <trans-unit id="e23917413db2045faa61e6d7c82dfe5adab095c6477a2ba682a47960e769294c">
         <source xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</source>
         <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg532">
+      <trans-unit id="56824bf56a0a89bd03af278c0a3d1b312f0ce78c23b7fe641e2b5a847082eabc">
         <source xml:space="preserve">Error encoding URI into QR Code.</source>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg533">
+      <trans-unit id="e4f73dfce656934efd1c6f7f6eb378ae7a2f7e6f77914e2503f6292626b354f5">
         <source xml:space="preserve">QR code support not available.</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg534">
+      <trans-unit id="900692d4242e8fa555c2e0816aa47c58007dd30e82eef45b88189be93542c9d5">
         <source xml:space="preserve">Save QR Code</source>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg535">
+      <trans-unit id="98fb3dba0c3cbae8733f29ee5aa4025f69d0fc2ab53262201256453cd2900cef">
         <source xml:space="preserve">PNG Image</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
         <note annotates="source" from="developer">Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</note>
@@ -2511,7 +2511,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../forms/debugwindow.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg536">
+      <trans-unit id="58f95d1a41c42215ef932a246aec1cb16f46e648b8964c113bb903d07b073d62">
         <source xml:space="preserve">N/A</source>
         <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
@@ -2553,319 +2553,319 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <context-group purpose="location"><context context-type="linenumber">1801</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.h</context><context context-type="linenumber">147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg537">
+      <trans-unit id="27f1eaa6821485b8665be14c5f9571eee42daa6cd90caa7cfee6e9ecfaea13f4">
         <source xml:space="preserve">Client version</source>
         <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg538">
+      <trans-unit id="9fdde01a73ba2a4b65105ac75b0d8d4999b0f183b5dcd9668caf54edcd66125a">
         <source xml:space="preserve">&amp;Information</source>
         <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg539">
+      <trans-unit id="184b87164f1d9d76fde64860576de08d1c4cdb3fc8a28d8071cb1df2366d56c7">
         <source xml:space="preserve">General</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg540">
+      <trans-unit id="f69d4ec6975b6caced182bddc0fba6fcf99d21b93366bb19dfc68915d709e218">
         <source xml:space="preserve">Datadir</source>
         <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg541">
+      <trans-unit id="684401fc943cda425be1f10416e3f83d673a89086d919ba658f166dc044d6e6e">
         <source xml:space="preserve">To specify a non-default location of the data directory use the &apos;%1&apos; option.</source>
         <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg542">
+      <trans-unit id="0a4274626e49be6be1cd65ad1d87deb974dc450199e16bce053809cad42e682b">
         <source xml:space="preserve">Blocksdir</source>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg543">
+      <trans-unit id="d945eaa0f77538d3ef05a56e05e3e88e1774c785998e1ef199f204ec40c8e403">
         <source xml:space="preserve">To specify a non-default location of the blocks directory use the &apos;%1&apos; option.</source>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg544">
+      <trans-unit id="4ab2e36de69cb1a1ef8949507a5d9851a8c6228ed76b909e714b8d3c660f3e34">
         <source xml:space="preserve">Startup time</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg545">
+      <trans-unit id="015b0138b7949d30ce110a5acd8085d3ca09f7441267f975667c7002e03c37d2">
         <source xml:space="preserve">Network</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1255</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg546">
+      <trans-unit id="7cd8eb965a48480f2b49fdd4b691b93a29a7a51745016b2a2d529a4e71c5313b">
         <source xml:space="preserve">Name</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg547">
+      <trans-unit id="db88cc6930d12da160b3769773450352ecdc7f7e8d10fbed5e7693bbbc38a180">
         <source xml:space="preserve">Number of connections</source>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg548">
+      <trans-unit id="ffd5ad45f3b7638c233a182c77246890fcb5793913a7e8bb48e7cc4ad3efd7bc">
         <source xml:space="preserve">Local Addresses</source>
         <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg549">
+      <trans-unit id="bf3538724ad256f05dca81d7185cf06d998e3c3b16c81c81392ee15339dea3c9">
         <source xml:space="preserve">Network addresses that your Bitcoin node is currently using to communicate with other nodes.</source>
         <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg550">
+      <trans-unit id="75a649f130eee5791e48f66fb99b1021c0e07dfd4e8729d137b85d24ff6b2c95">
         <source xml:space="preserve">Block chain</source>
         <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg551">
+      <trans-unit id="8205998cf457d350ab713d2ee343d761a83593a645af7db92d522de2bed6a538">
         <source xml:space="preserve">Memory Pool</source>
         <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg552">
+      <trans-unit id="a56c70708138f3aa9f4552f823dfa9e71b253fea81843ec2889c0021ecd089a1">
         <source xml:space="preserve">Current number of transactions</source>
         <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg553">
+      <trans-unit id="e9808862ba69c79f2a7ebb6284759e55fdcbce663bc5c6a09c29195c653c5d8a">
         <source xml:space="preserve">Memory usage</source>
         <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg554">
+      <trans-unit id="1553081a02a08ade900c68d28d9661c3b717dfaf75293ccee4c79c4896dfcadd">
         <source xml:space="preserve">Wallet: </source>
         <context-group purpose="location"><context context-type="linenumber">478</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg555">
+      <trans-unit id="3531e0584bdec29e3bdbaeb286764df2eeb21ea5875b0a6bb5dc16f3db4aa000">
         <source xml:space="preserve">(none)</source>
         <context-group purpose="location"><context context-type="linenumber">489</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg556">
+      <trans-unit id="7173f3fb12783be3267f8c056e2b2283463928202f7e62836a93fbae2b6b360f">
         <source xml:space="preserve">&amp;Reset</source>
         <context-group purpose="location"><context context-type="linenumber">700</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg557">
+      <trans-unit id="b18317361d2bde52fb96743a778223174d24ab16cf75b9fe2e4d075ff2fd8f69">
         <source xml:space="preserve">Received</source>
         <context-group purpose="location"><context context-type="linenumber">780</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1592</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg558">
+      <trans-unit id="19786d565e37c2a9845669c13dde853a5c81cc1f65302b145024c796171c4512">
         <source xml:space="preserve">Sent</source>
         <context-group purpose="location"><context context-type="linenumber">860</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1569</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg559">
+      <trans-unit id="b31be8a8de3716cb5562852bc9e59e9b5acdfd8b6d2db293caf39697cd6f4c7e">
         <source xml:space="preserve">&amp;Peers</source>
         <context-group purpose="location"><context context-type="linenumber">901</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg560">
+      <trans-unit id="8c134a592d028208eadebef4629e1dac6778a50859a39330596f9e14a208b9cf">
         <source xml:space="preserve">Banned peers</source>
         <context-group purpose="location"><context context-type="linenumber">977</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg561">
+      <trans-unit id="8c9ea8e3ad741955a721ed7415586037ed911a36f5597f5169692416ac87a364">
         <source xml:space="preserve">Select a peer to view detailed information.</source>
         <context-group purpose="location"><context context-type="linenumber">1053</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg562">
+      <trans-unit id="92c5c3c9dcaca4aa6afc34238232c430e2d9a3b28486e5c49993d6b6d850f347">
         <source xml:space="preserve">Hide Peers Detail</source>
         <context-group purpose="location"><context context-type="linenumber">1105</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg563">
+      <trans-unit id="b14ae08fa27c7e0d525baaea12a533b331e2accbcea02f50b598322cbb95b1fe">
         <source xml:space="preserve">Ctrl+X</source>
         <context-group purpose="location"><context context-type="linenumber">1126</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg564">
+      <trans-unit id="a8c6eca81054f41bf8b86b8bad88e2b6f23ab7fca0168de9adc00b69785adbe1">
         <source xml:space="preserve">The transport layer version: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1200</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg565">
+      <trans-unit id="e68842a8e2b2deb464e49929a9cea4a4c1651d5e07c01de62345d6f84eb35f01">
         <source xml:space="preserve">Transport</source>
         <context-group purpose="location"><context context-type="linenumber">1203</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg566">
+      <trans-unit id="fac9ec988e1ffcf563c686dbda434dbcb15ba81e348b6b2bfe8e4acbdeb7b2a0">
         <source xml:space="preserve">Session ID</source>
         <context-group purpose="location"><context context-type="linenumber">1229</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg567">
+      <trans-unit id="49ed3ccc43e58af009abdc950a78473058fac455052e8638df5cd2651ed87855">
         <source xml:space="preserve">Version</source>
         <context-group purpose="location"><context context-type="linenumber">1278</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg568">
+      <trans-unit id="0ffcba7a70c892f663052011b739ea657c24c4ef7955393a7839b97a0e9cd521">
         <source xml:space="preserve">Whether we relay transactions to this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1350</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg569">
+      <trans-unit id="8aaf24f3718a541f04491195a7cc9a0f198c93f5b0faab8aa28a3b56ffae5dff">
         <source xml:space="preserve">Transaction Relay</source>
         <context-group purpose="location"><context context-type="linenumber">1353</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg570">
+      <trans-unit id="b0bd92f08854179c6c972440b90ed9fb585e1cd7f8a00b041f63749e1e17b62a">
         <source xml:space="preserve">Synced Headers</source>
         <context-group purpose="location"><context context-type="linenumber">1402</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg571">
+      <trans-unit id="a2a5f619ac91cf6fc18ac67eade9c59f7a69b3f282906d0dd4c47e14f23e228d">
         <source xml:space="preserve">Synced Blocks</source>
         <context-group purpose="location"><context context-type="linenumber">1425</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg572">
+      <trans-unit id="f10863d3776ecad2351bcff879ba747dd8dd05726003ff60b512c1cd3e67072b">
         <source xml:space="preserve">Last Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">1500</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg573">
+      <trans-unit id="6be615f8e0822016f854bad64d5e2bd9437f32f49142e788af574eee2752391c">
         <source xml:space="preserve">The mapped Autonomous System used for diversifying peer selection.</source>
         <context-group purpose="location"><context context-type="linenumber">1710</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg574">
+      <trans-unit id="9d00e7a52346c9f0a67b3801c46691494c677d9dc4bb3e40f16747dcdbf6f115">
         <source xml:space="preserve">Mapped AS</source>
         <context-group purpose="location"><context context-type="linenumber">1713</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg575">
+      <trans-unit id="d0ce425402b3ce36126610db8a19250f1a56907fbc1560b8de4a7f85ae427536">
         <source xml:space="preserve">Whether we relay addresses to this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1736</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</note>
       </trans-unit>
-      <trans-unit id="_msg576">
+      <trans-unit id="e576f3d0b9f1576070e5a8dd68806a53c90d5b1f2377c181a3ea83f3679e670a">
         <source xml:space="preserve">Address Relay</source>
         <context-group purpose="location"><context context-type="linenumber">1739</context></context-group>
         <note annotates="source" from="developer">Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</note>
       </trans-unit>
-      <trans-unit id="_msg577">
+      <trans-unit id="8e8a45fec078daedb119775b3f19b443ebc92adf31f8f6626d6b6448d1c4c267">
         <source xml:space="preserve">The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
         <context-group purpose="location"><context context-type="linenumber">1762</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</note>
       </trans-unit>
-      <trans-unit id="_msg578">
+      <trans-unit id="bb566a4e964d546f6d4ceb8679fbd048484d5c0a45542a6fb997a6b56695def0">
         <source xml:space="preserve">The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
         <context-group purpose="location"><context context-type="linenumber">1788</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</note>
       </trans-unit>
-      <trans-unit id="_msg579">
+      <trans-unit id="04ed0d470681a79eb5b5d91026d87afca3cec9a186371cdc39b89291d2da7d0f">
         <source xml:space="preserve">Addresses Processed</source>
         <context-group purpose="location"><context context-type="linenumber">1765</context></context-group>
         <note annotates="source" from="developer">Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</note>
       </trans-unit>
-      <trans-unit id="_msg580">
+      <trans-unit id="46372632c1b1bd16a6e80f04a7ca4d74d51cfb2dc1f02a8eb0bf17e512f4978d">
         <source xml:space="preserve">Addresses Rate-Limited</source>
         <context-group purpose="location"><context context-type="linenumber">1791</context></context-group>
         <note annotates="source" from="developer">Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</note>
       </trans-unit>
-      <trans-unit id="_msg581">
+      <trans-unit id="5f6b3ceaebab5e76d6397ae57c594aa24764388975842d31f8eb3b93996980b5">
         <source xml:space="preserve">User Agent</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg582">
+      <trans-unit id="af46accc98a219b4ee6a9655786e8e1f01bf41350cff7ba18b92529b8983bdfe">
         <source xml:space="preserve">Node window</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg583">
+      <trans-unit id="0e9958f47dcf54cbf87677bf159173f98ee040c2bb78e78d67b9af0cc4fea24b">
         <source xml:space="preserve">Current block height</source>
         <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg584">
+      <trans-unit id="9610a73cd7612ccd55be5ac660b8902c26c217315437cf2477537ad70147b929">
         <source xml:space="preserve">Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg585">
+      <trans-unit id="d59e2cf99423b95275382cc81f3aad6a7dba0c867c20832995c96ccde5b825f4">
         <source xml:space="preserve">Decrease font size</source>
         <context-group purpose="location"><context context-type="linenumber">510</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg586">
+      <trans-unit id="cb8bc3b8ba73864da38b6cf6ff50093abc6c354ee6aa99118216c61050276077">
         <source xml:space="preserve">Increase font size</source>
         <context-group purpose="location"><context context-type="linenumber">530</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg587">
+      <trans-unit id="79f08fdcf0b7f143a38134386130ebf5e6a78861882f00a785188cf7be03c2ae">
         <source xml:space="preserve">Permissions</source>
         <context-group purpose="location"><context context-type="linenumber">1151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg588">
+      <trans-unit id="2125b7d4c877370ee49fac44aba02d06d18e1081abda22ebc1e05ad34873f6be">
         <source xml:space="preserve">The direction and type of peer connection: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1174</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg589">
+      <trans-unit id="ea3b981065f0ea6f5bda9caf939dbe2956081be4f6ccacdfeb770d19cb96dcec">
         <source xml:space="preserve">Direction/Type</source>
         <context-group purpose="location"><context context-type="linenumber">1177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg590">
+      <trans-unit id="16a285f81a651381f36a9547663afa49547cffc17a78a62c2d1ac0c2ae859faf">
         <source xml:space="preserve">The BIP324 session ID string in hex.</source>
         <context-group purpose="location"><context context-type="linenumber">1226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg591">
+      <trans-unit id="55323a91fafc3ca6c5bc1db5cd5c1229ab8d0b65b25aeb59a6213b1db61b8c35">
         <source xml:space="preserve">The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
         <context-group purpose="location"><context context-type="linenumber">1252</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg592">
+      <trans-unit id="7015ffc76c14ec98e24c35aee94258b87fa9134dba980d5fb10ee8cd1d4cb1e7">
         <source xml:space="preserve">Services</source>
         <context-group purpose="location"><context context-type="linenumber">1324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg593">
+      <trans-unit id="760b51645aa6fcaa9c54927000d0160c5133e01b6a199326be15f9627bd01cc5">
         <source xml:space="preserve">High bandwidth BIP152 compact block relay: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg594">
+      <trans-unit id="9387b869dc272ca96fd33ab282baceefce7f32330c09c227c751de1f31a4579f">
         <source xml:space="preserve">High Bandwidth</source>
         <context-group purpose="location"><context context-type="linenumber">1379</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg595">
+      <trans-unit id="d33dbd3071edae8878b73098cbdc42d8c3460ab381c542789b70bdd2b17b06bd">
         <source xml:space="preserve">Connection Time</source>
         <context-group purpose="location"><context context-type="linenumber">1448</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg596">
+      <trans-unit id="32c60fe8563ce7a6691dc056ad35484243e7bdba6c6877fd42c404c4f134b9f2">
         <source xml:space="preserve">Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1471</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg597">
+      <trans-unit id="1bfd4ef5c6e0e82d994999f684c850ebe05173dbdf8bbce1e40d3447a13b12fc">
         <source xml:space="preserve">Last Block</source>
         <context-group purpose="location"><context context-type="linenumber">1474</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg598">
+      <trans-unit id="559905038b48d08db5db573c5a0e0a9b456f09dfc710a4d94eabcdd18313abe2">
         <source xml:space="preserve">Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1497</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Last Transaction field in the peer details area.</note>
       </trans-unit>
-      <trans-unit id="_msg599">
+      <trans-unit id="a0004f3eed3ac45a21ba86c7f7eaf5b17d2a2128db1d22013fa5abc3a1f295cf">
         <source xml:space="preserve">Last Send</source>
         <context-group purpose="location"><context context-type="linenumber">1523</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg600">
+      <trans-unit id="b36bab256e8bfd824edae01972bf967ce2dc4d33df619c472f3a45f4866809c8">
         <source xml:space="preserve">Last Receive</source>
         <context-group purpose="location"><context context-type="linenumber">1546</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg601">
+      <trans-unit id="f46eb910b7d3022b38251bc9ccfc9c742fd361b6d8cc13b115e9601d579d55fe">
         <source xml:space="preserve">Ping Time</source>
         <context-group purpose="location"><context context-type="linenumber">1615</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg602">
+      <trans-unit id="cc383f7ed6f076862d92e621994e5a479c9543f91380a3890809aaae7713788b">
         <source xml:space="preserve">The duration of a currently outstanding ping.</source>
         <context-group purpose="location"><context context-type="linenumber">1638</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg603">
+      <trans-unit id="f4713614ea44680241044484697f1ddb6052cb598ef1db04fea33217fd2c0eff">
         <source xml:space="preserve">Ping Wait</source>
         <context-group purpose="location"><context context-type="linenumber">1641</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg604">
+      <trans-unit id="f9a7593a6c8cdd779af451209c0cb1484a9eba0cd00997c841657087291f8a7e">
         <source xml:space="preserve">Min Ping</source>
         <context-group purpose="location"><context context-type="linenumber">1664</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg605">
+      <trans-unit id="32932b2ed57a05fef9dfab0d2829bfba2d5aec34ea860be25c549f21a997001c">
         <source xml:space="preserve">Time Offset</source>
         <context-group purpose="location"><context context-type="linenumber">1687</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg606">
+      <trans-unit id="e94812d8e7fa9ae1d56d39ea016b641cf7e9100bd75dbf3244a24d5a46cf8ad2">
         <source xml:space="preserve">Last block time</source>
         <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg607">
+      <trans-unit id="4099de4cafc8a551a9f7cac5a4f166b54b44b218e00c0ab5e9c56ba88891a78e">
         <source xml:space="preserve">&amp;Open</source>
         <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg608">
+      <trans-unit id="09ec7bb9f6831f26c9757e2849852e46ad6422f698f4a91ca0542cc202bdb329">
         <source xml:space="preserve">&amp;Console</source>
         <context-group purpose="location"><context context-type="linenumber">461</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg609">
+      <trans-unit id="521b1cf4f29901c1f2ea1a321f7f00801ed8d48c75a2c3dd45c1dd35e9dd4c32">
         <source xml:space="preserve">&amp;Network Traffic</source>
         <context-group purpose="location"><context context-type="linenumber">648</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg610">
+      <trans-unit id="597db33991a26cb1562415886f0399db92060d51845f85d5673bde1a9fc82f8c">
         <source xml:space="preserve">Totals</source>
         <context-group purpose="location"><context context-type="linenumber">716</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg611">
+      <trans-unit id="3143ee2eff43cbc9a56b607ce8966e49885a4982f6f4476b4e5893be1ccd5fcb">
         <source xml:space="preserve">Debug log file</source>
         <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg612">
+      <trans-unit id="c0ffaffec6f4616b3f56c98fe0af21204867f47b19c0e83038d21ed861f5ccca">
         <source xml:space="preserve">Clear console</source>
         <context-group purpose="location"><context context-type="linenumber">550</context></context-group>
       </trans-unit>
@@ -2873,167 +2873,167 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../rpcconsole.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg613">
+      <trans-unit id="fdd29f13298fe9db45700ad6d52ebabdd7538f8a2cfa83cdf1306ce436f7a121">
         <source xml:space="preserve">In:</source>
         <context-group purpose="location"><context context-type="linenumber">937</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg614">
+      <trans-unit id="81efdddf791b5789508abe3198c21cbfcb09b8f1abf3fc9c9cde01ce46f3d732">
         <source xml:space="preserve">Out:</source>
         <context-group purpose="location"><context context-type="linenumber">938</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg615">
+      <trans-unit id="aae6f91f5cfe6382536b1916204adb7d141fed1c9a24c4690cc5cd9a85740fe5">
         <source xml:space="preserve">Inbound: initiated by peer</source>
         <context-group purpose="location"><context context-type="linenumber">466</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an inbound peer connection.</note>
       </trans-unit>
-      <trans-unit id="_msg616">
+      <trans-unit id="f175e520963a7ee409c85855201d0a187090726a2cec7aa4e8396f88544979be">
         <source xml:space="preserve">Outbound Full Relay: default</source>
         <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</note>
       </trans-unit>
-      <trans-unit id="_msg617">
+      <trans-unit id="f028cdffbcbf9ac72fa05d716dd906e7be5dea57f7ea52bee92c09bf91c83178">
         <source xml:space="preserve">Outbound Block Relay: does not relay transactions or addresses</source>
         <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg618">
+      <trans-unit id="c589fc9702c4c39593888bf311ca1f3d50d860368d1d8cb5a5d095960b4e9003">
         <source xml:space="preserve">Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
         <context-group purpose="location"><context context-type="linenumber">478</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</note>
       </trans-unit>
-      <trans-unit id="_msg619">
+      <trans-unit id="b63a24a890a5d0de23eac3ddb96b16646c3e9ec01fd6c1b981a93ed3029b4e6b">
         <source xml:space="preserve">Outbound Feeler: short-lived, for testing addresses</source>
         <context-group purpose="location"><context context-type="linenumber">484</context></context-group>
         <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg620">
+      <trans-unit id="8d05c5a0f895d60486cb572c74d728266c8668c959fb14f29cdb8dd327943f1d">
         <source xml:space="preserve">Outbound Address Fetch: short-lived, for soliciting addresses</source>
         <context-group purpose="location"><context context-type="linenumber">487</context></context-group>
         <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg621">
+      <trans-unit id="873090356290c7fecb837dd641665b038e6086d633d9fefbf45c9b04d448531e">
         <source xml:space="preserve">Private broadcast: short-lived, for broadcasting privacy-sensitive transactions</source>
         <context-group purpose="location"><context context-type="linenumber">490</context></context-group>
         <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to broadcast privacy-sensitive data (like our transactions).</note>
       </trans-unit>
-      <trans-unit id="_msg622">
+      <trans-unit id="421e91611f23695bf0707f8e77e26b8367a2902839a4cf6e6c6ccfc82c44b929">
         <source xml:space="preserve">detecting: peer could be v1 or v2</source>
         <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
         <note annotates="source" from="developer">Explanatory text for &quot;detecting&quot; transport type.</note>
       </trans-unit>
-      <trans-unit id="_msg623">
+      <trans-unit id="b30466c459ac20da10595e54874ebe84c04d1c1b5255cde217c8beb9b6eac85f">
         <source xml:space="preserve">v1: unencrypted, plaintext transport protocol</source>
         <context-group purpose="location"><context context-type="linenumber">497</context></context-group>
         <note annotates="source" from="developer">Explanatory text for v1 transport type.</note>
       </trans-unit>
-      <trans-unit id="_msg624">
+      <trans-unit id="96ce5fdb38f537e97a6a289c3b538a95e0810de101d11d172461c6fd174613c9">
         <source xml:space="preserve">v2: BIP324 encrypted transport protocol</source>
         <context-group purpose="location"><context context-type="linenumber">499</context></context-group>
         <note annotates="source" from="developer">Explanatory text for v2 transport type.</note>
       </trans-unit>
-      <trans-unit id="_msg625">
+      <trans-unit id="84736a1c9a8c158736996606e88451a35da97bdefec4773339ab8648c6e460a7">
         <source xml:space="preserve">we selected the peer for high bandwidth relay</source>
         <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg626">
+      <trans-unit id="35695a341047291213d71b9492c0b003f02b3695c376c98dfa25b25c0064dafd">
         <source xml:space="preserve">the peer selected us for high bandwidth relay</source>
         <context-group purpose="location"><context context-type="linenumber">504</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg627">
+      <trans-unit id="4a320de62282e0f4c5dc17e8f2095c89e4725a4a15df114ebb02bb07cee13c4b">
         <source xml:space="preserve">no high bandwidth relay selected</source>
         <context-group purpose="location"><context context-type="linenumber">505</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg628">
+      <trans-unit id="67a3938eb248db0e09a34d0c2f4a0a460f96bbcc7929f80bfba70b7acfdf9d34">
         <source xml:space="preserve">Ctrl++</source>
         <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
         <note annotates="source" from="developer">Main shortcut to increase the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg629">
+      <trans-unit id="59ab68f63cf03167eb3f526d30abbc91f4c85b00ef672937437f3d31a8c44d89">
         <source xml:space="preserve">Ctrl+=</source>
         <context-group purpose="location"><context context-type="linenumber">520</context></context-group>
         <note annotates="source" from="developer">Secondary shortcut to increase the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg630">
+      <trans-unit id="4b0d8d18ee9131206b25f1cd5b01aa648c134889650c9a8dc4ec7c4aac27ccdb">
         <source xml:space="preserve">Ctrl+-</source>
         <context-group purpose="location"><context context-type="linenumber">524</context></context-group>
         <note annotates="source" from="developer">Main shortcut to decrease the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg631">
+      <trans-unit id="583caead47bb0f7dd7dec7a27dab78dcb6ae1c54ae878a9fcaa5122846cc7cab">
         <source xml:space="preserve">Ctrl+_</source>
         <context-group purpose="location"><context context-type="linenumber">526</context></context-group>
         <note annotates="source" from="developer">Secondary shortcut to decrease the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg632">
+      <trans-unit id="9b6296be23a085bbeaf808fd7d32f9b894999c619485beb7b0651e8c63cf142d">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
         <note annotates="source" from="developer">Context menu action to copy the address of a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg633">
+      <trans-unit id="3f85d17b4bbacd769e21a32840693e2b776700ea9c47caa04cae724875f8a677">
         <source xml:space="preserve">&amp;Disconnect</source>
         <context-group purpose="location"><context context-type="linenumber">676</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg634">
+      <trans-unit id="fdc3580f89d5f1956c6c6a692c981c10aa924196a59bcade407846c29cf90b6d">
         <source xml:space="preserve">1 &amp;hour</source>
         <context-group purpose="location"><context context-type="linenumber">677</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg635">
+      <trans-unit id="4019318a0d57e86e3ea08038696ee29fb48923e9a47f92bf133a342239a596ab">
         <source xml:space="preserve">1 d&amp;ay</source>
         <context-group purpose="location"><context context-type="linenumber">678</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg636">
+      <trans-unit id="d75e82fd5201a9ab2c717650f8c8f1c5048121ae2f38996d6af542b284901d42">
         <source xml:space="preserve">1 &amp;week</source>
         <context-group purpose="location"><context context-type="linenumber">679</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg637">
+      <trans-unit id="998b9acc9311679cbb9ddc7c00826ae04965f11061b2d3ff9d6bc646e6d5b586">
         <source xml:space="preserve">1 &amp;year</source>
         <context-group purpose="location"><context context-type="linenumber">680</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg638">
+      <trans-unit id="ed25613dabe5abb9c4f35249652d267e6581a06490f40a52918fccf9a23f8a61">
         <source xml:space="preserve">&amp;Copy IP/Netmask</source>
         <context-group purpose="location"><context context-type="linenumber">706</context></context-group>
         <note annotates="source" from="developer">Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer&apos;s IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</note>
       </trans-unit>
-      <trans-unit id="_msg639">
+      <trans-unit id="efb834ffbeaaf4e19e47a78e1a889c0f2e5234c26ee7a42264d70188dbac508f">
         <source xml:space="preserve">&amp;Unban</source>
         <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg640">
+      <trans-unit id="36c726de7649250233f0053fb3c3a57b074cd365bfd3d513d5375ac37e65285b">
         <source xml:space="preserve">Network activity disabled</source>
         <context-group purpose="location"><context context-type="linenumber">941</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg641">
+      <trans-unit id="e9f6fff89af93f03c35407bfba6f26fc33269cc4093e86b462182bf9c77e9351">
         <source xml:space="preserve">None</source>
         <context-group purpose="location"><context context-type="linenumber">954</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg642">
+      <trans-unit id="f9b16d443424b1830d684a9fca6647693eafda94cedbdd5bcd2a0a4b82b05978">
         <source xml:space="preserve">Executing command without any wallet</source>
         <context-group purpose="location"><context context-type="linenumber">1033</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg643">
+      <trans-unit id="32eca197a284a64becec0eae0c8d0f5eb4aa9cbfcc1c8ed87b4194f4480c150b">
         <source xml:space="preserve">Ctrl+I</source>
         <context-group purpose="location"><context context-type="linenumber">1354</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg644">
+      <trans-unit id="9f388901c0dc9c7af4b306471d93f2aed0cd884cd9853f67e11765c39624c978">
         <source xml:space="preserve">Ctrl+T</source>
         <context-group purpose="location"><context context-type="linenumber">1355</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg645">
+      <trans-unit id="e95894a11887c8054ff803cbfdd60e6452916d2cd624936893834bbca950c13e">
         <source xml:space="preserve">Ctrl+N</source>
         <context-group purpose="location"><context context-type="linenumber">1356</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg646">
+      <trans-unit id="6946f1802675010c7477b80685690f81344747691231893afe0a95f2673a0376">
         <source xml:space="preserve">Ctrl+P</source>
         <context-group purpose="location"><context context-type="linenumber">1357</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg647">
+      <trans-unit id="02eea5b3777f88f388de9aa7bf1ad755f193cd9df639adb75de165f2866daf25">
         <source xml:space="preserve">Node window - [%1]</source>
         <context-group purpose="location"><context context-type="linenumber">1375</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg648">
+      <trans-unit id="dfe4e3d819a6da08528de414103360bdd11df21bfc878c76bb6ff459f1b57d5c">
         <source xml:space="preserve">Executing command using &quot;%1&quot; wallet</source>
         <context-group purpose="location"><context context-type="linenumber">1031</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg649">
+      <trans-unit id="87ffed2a1150bb01a22f7d34a680925cf4cbe49354d866f43f62cbe77c5e3e3f">
         <source xml:space="preserve">Welcome to the %1 RPC console.
 Use up and down arrows to navigate history, and %2 to clear screen.
 Use %3 and %4 to increase or decrease the font size.
@@ -3044,16 +3044,16 @@ For more information on using this console, type %6.
         <context-group purpose="location"><context context-type="linenumber">870</context></context-group>
         <note annotates="source" from="developer">RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</note>
       </trans-unit>
-      <trans-unit id="_msg650">
+      <trans-unit id="1073102505b7a2339dd098ac923dc0ac8e2f9b9c1f27c66105cd7bde3875d3b8">
         <source xml:space="preserve">Executing…</source>
         <context-group purpose="location"><context context-type="linenumber">1041</context></context-group>
         <note annotates="source" from="developer">A console message indicating an entered command is currently being executed.</note>
       </trans-unit>
-      <trans-unit id="_msg651">
+      <trans-unit id="38f9c57c06c05d729985cc5e360222630bd19f5d0fad856e4bf55418c8df881a">
         <source xml:space="preserve">(peer: %1)</source>
         <context-group purpose="location"><context context-type="linenumber">1159</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg652">
+      <trans-unit id="ac68c9c1bbafd77ea7cdd25430d5dc1a91660a84aa409945105c2e824e17eb05">
         <source xml:space="preserve">via %1</source>
         <context-group purpose="location"><context context-type="linenumber">1161</context></context-group>
       </trans-unit>
@@ -3061,31 +3061,31 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../rpcconsole.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg653">
+      <trans-unit id="c1311426d67d59bfd98f0eed75d7944cf30282bf6e7665ed5f996c43ab280d33">
         <source xml:space="preserve">Yes</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg654">
+      <trans-unit id="9bb84def60530682b06b9aa5ea9c730468bff9650fc978dfeb54e4303c3ca270">
         <source xml:space="preserve">No</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg655">
+      <trans-unit id="8d26c7e77890bed1e260e3f1fe7a28fd5f9b9d6d924dbdda94fca5d1102be081">
         <source xml:space="preserve">To</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg656">
+      <trans-unit id="4ba23d4308d0b00ecddeb949c6321feb797ab2a3cae0b28ec999b29b042c5024">
         <source xml:space="preserve">From</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg657">
+      <trans-unit id="eac5213fe430ef6da94e401faccaee111aebf3a1884da77ce173946b3b38618d">
         <source xml:space="preserve">Ban for</source>
         <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg658">
+      <trans-unit id="f05cdbfcdf96e304b04c6ac2d4687c48e8adc9dce5929171d5d3d999bf27f4f7">
         <source xml:space="preserve">Never</source>
         <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg659">
+      <trans-unit id="08a3bd372194edd13941b4858689046eafada438456e20f413b15e95522144b4">
         <source xml:space="preserve">Unknown</source>
         <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
@@ -3093,72 +3093,72 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../forms/receivecoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg660">
+      <trans-unit id="d43624fbf1f58a51bb0889a886d46c99e21eaf2e0e743c17af8d8daba5dfbad1">
         <source xml:space="preserve">&amp;Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg661">
+      <trans-unit id="fd970f64c3439282c1f8b5177c2413052a87c1a4f70a408c55ca0dcef68599e8">
         <source xml:space="preserve">&amp;Label:</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg662">
+      <trans-unit id="8a739414321f34699007a3126a7251cb9a06b01ca45a3eb981df09a4f9eecb02">
         <source xml:space="preserve">&amp;Message:</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg663">
+      <trans-unit id="66587a3a56bd7dcd9cf3e5ce04c0f43d0dbcb6a4932810cd00a63bea123b510b">
         <source xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg664">
+      <trans-unit id="6cde17afe7c0361e7208242a31d72b03a721cc1847f570162d38f93f2719d152">
         <source xml:space="preserve">An optional label to associate with the new receiving address.</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg665">
+      <trans-unit id="9bfa6fc32be1ae7ee6bce54e84216c170efb0bd7ed61fb9dfdbce7246febc4a5">
         <source xml:space="preserve">Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg666">
+      <trans-unit id="0ac4d365fef77ac948232132118689a255a34d2b2efff4b009ee091877afc752">
         <source xml:space="preserve">An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg667">
+      <trans-unit id="3556eec1c265e0611a8bd43965563cfd62fd47f9974ad29ae5fd3d3a941c38d4">
         <source xml:space="preserve">An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg668">
+      <trans-unit id="dd0b010013dd7e31b0cecf3be96791b13ea932d3938afd8ad4f4e45b5849a7e8">
         <source xml:space="preserve">An optional message that is attached to the payment request and may be displayed to the sender.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg669">
+      <trans-unit id="dc83fe8d976f64d9858dd078cb49c8abd6c975fe4b1598fa4991cb87cf92480e">
         <source xml:space="preserve">&amp;Create new receiving address</source>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg670">
+      <trans-unit id="767ca1d2f25855d02c16513872ecbb4f26511e1aae7082da3de02bf4aaf46aa9">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg671">
+      <trans-unit id="9f598e7c0d3ce26bc76ff0fef8986864be5474625ceebd6fea843d3f40953fdf">
         <source xml:space="preserve">Clear</source>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg672">
+      <trans-unit id="9043cade0ac3a0a42e2268685444d1c75dd797cd2103bdbc9c056c267be1c612">
         <source xml:space="preserve">Requested payments history</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg673">
+      <trans-unit id="d155e6166281adbbdae30a4963701bdc9b8efe11b75a3f8fdc58ba9390ef8763">
         <source xml:space="preserve">Show the selected request (does the same as double clicking an entry)</source>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg674">
+      <trans-unit id="8ba28484b82fd236f4abb188568c649839bef70e48564030e167904831a9e5f1">
         <source xml:space="preserve">Show</source>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg675">
+      <trans-unit id="665d11abaeb9d968b53a622c9347a51a6436ba9373b68759b26a9cf8233bf8dc">
         <source xml:space="preserve">Remove the selected entries from the list</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg676">
+      <trans-unit id="2fadc0388e13680f2c71811ca5150b77e49144885841ad71ab1c2a1f9a7bd968">
         <source xml:space="preserve">Remove</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
@@ -3166,63 +3166,63 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../receivecoinsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg677">
+      <trans-unit id="526f469308c0e50df1a277fc8edfeb87f286c339ea1c71ddc94a7712272783c4">
         <source xml:space="preserve">Copy &amp;URI</source>
         <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg678">
+      <trans-unit id="14877f5771a1463f3b5158fa23acaea7cd6a0852dde186ead3413c2acc8d490d">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg679">
+      <trans-unit id="9ce38f6b862f745e72adca4994c07f7489ac6963218177bc4f1ef5086c1a685d">
         <source xml:space="preserve">Copy &amp;label</source>
         <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg680">
+      <trans-unit id="f04724fad1066784c054e9cd25ab072488ad5b98f796257a4636c8f88ec7721c">
         <source xml:space="preserve">Copy &amp;message</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg681">
+      <trans-unit id="07c3a9731e2b9b1027e85ab19568e7c7c4e0fa0d957d8dd288f6e0bcc64dca81">
         <source xml:space="preserve">Copy &amp;amount</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg682">
+      <trans-unit id="f8195b4bc44f626b5985ec3af411c400c6d685cbea61b0aa6a414a540201987e">
         <source xml:space="preserve">Base58 (Legacy)</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg683">
+      <trans-unit id="e186db13879640e454823a83a181125d35d39a6ef1ce20827675862e6316e8b7">
         <source xml:space="preserve">Not recommended due to higher fees and less protection against typos.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg684">
+      <trans-unit id="9ae6baf50084cd662bd0ede0105d29535dd4a970bdd2ee32cae1f00577589103">
         <source xml:space="preserve">Base58 (P2SH-SegWit)</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg685">
+      <trans-unit id="878999ccc818cb15f9b1dc779ffa9e13c37d06b56d8de43f69c3097a9e76a815">
         <source xml:space="preserve">Generates an address compatible with older wallets.</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg686">
+      <trans-unit id="27f73802e9b02b75a3a79a8ed405081f9d825a18f7cce2e49469dedd4b262ad7">
         <source xml:space="preserve">Bech32 (SegWit)</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg687">
+      <trans-unit id="88791de145edf1b2513f4847b8995cf815199c54214bb12518d748b57ac979f6">
         <source xml:space="preserve">Generates a native segwit address (BIP-173). Some old wallets don&apos;t support it.</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg688">
+      <trans-unit id="8c489b15af8b4f723bc968ea050cd35f1bbe612a82f4c773f049432b8552b525">
         <source xml:space="preserve">Bech32m (Taproot)</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg689">
+      <trans-unit id="a3c276b2ebedfb37ad5be507eb5040c6b5e7e7d86a4e87e0a83f44a22cdee608">
         <source xml:space="preserve">Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg690">
+      <trans-unit id="c48f64735f96c93f06b70aa3e04d7bc0eb1d958ccfefbf327617c1b5f91dfc16">
         <source xml:space="preserve">Could not unlock wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg691">
+      <trans-unit id="ee1a75ecef2053b6bf6c4885c29b0433417125527e783b224618c8befb4ab7d4">
         <source xml:space="preserve">Could not generate new %1 address</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
@@ -3230,51 +3230,51 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../forms/receiverequestdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg692">
+      <trans-unit id="53a8c80b563b040f872ea3b23d1a8ec750176e9e01c4934bad5e666c0c5682f3">
         <source xml:space="preserve">Request payment to …</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg693">
+      <trans-unit id="de710fb3b4e64ddf9d9fec69347c6e21eded0c2b2fb6ecddb7bbf1cad67e7cbe">
         <source xml:space="preserve">Address:</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg694">
+      <trans-unit id="d222a201e0476cc3b2fd0a8bcc83b750b4140d1818877dc975164124915c169d">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg695">
+      <trans-unit id="3c1acffe8a40d349553d080f02343428e1c01df7f444451533aa171f791be318">
         <source xml:space="preserve">Label:</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg696">
+      <trans-unit id="a9eea4de33df2f8dffa6459e83d6c761c026976f52e348a797439147460d9c3a">
         <source xml:space="preserve">Message:</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg697">
+      <trans-unit id="cc214145603d0891383dd4bf07af0921c78d46ab5ae40b7e4d65a96116d5f1f5">
         <source xml:space="preserve">Wallet:</source>
         <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg698">
+      <trans-unit id="e82abea7aadd30419e5a6bb4bad5540cfd6176d309efe00beb31352cdaa2b3a3">
         <source xml:space="preserve">Copy &amp;URI</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg699">
+      <trans-unit id="d91eb8e3bb5200597007c4f31daf35364b60669d7573c38b5c7649cc585ee86e">
         <source xml:space="preserve">Copy &amp;Address</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg700">
+      <trans-unit id="074a5ff674b55b07cc3b62e42c3457fb8f735413ef12457e982d7ad1da9ed20c">
         <source xml:space="preserve">&amp;Verify</source>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg701">
+      <trans-unit id="7793b6d912a33abcbaefeedc327f1b3101edbeccc842a28414bf08a606f83acc">
         <source xml:space="preserve">Verify this address on e.g. a hardware wallet screen</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg702">
+      <trans-unit id="2d984d63cd6ec00134291e9c119e030a8bb6bd86c98a0fd227c70bdbd435e577">
         <source xml:space="preserve">&amp;Save Image…</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg703">
+      <trans-unit id="39391773df0dc370b70b3101ae80a210024581cd228d1103ad2af1b7b51bbdef">
         <source xml:space="preserve">Payment information</source>
         <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
       </trans-unit>
@@ -3282,7 +3282,7 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../receiverequestdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg704">
+      <trans-unit id="44797eb8a0b760ab18a87822f73a2fc20c725072b17cde732586e47adb46c381">
         <source xml:space="preserve">Request payment to %1</source>
         <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
@@ -3290,31 +3290,31 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../recentrequeststablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RecentRequestsTableModel">
-      <trans-unit id="_msg705">
+      <trans-unit id="ee8652d273e232f797b82db7fc923555aebf0d7d7acd98b4b297935a238dd514">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg706">
+      <trans-unit id="f7854fa2f5da0f4c04ca373c5b5b7809ef7afd0de9fb9a5994be09185836581e">
         <source xml:space="preserve">Label</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg707">
+      <trans-unit id="e93c5b4e92d771c910ad1f6a3e2e86fb6b8e0c53b793da822b586e12a7f48509">
         <source xml:space="preserve">Message</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg708">
+      <trans-unit id="fa7341aa526e9b461384270dabf04fcf8147930d6989428a858853916f54bd5d">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg709">
+      <trans-unit id="851a84e480ab1255411ef486d366dff5eec127e95e1e80497d8c4afcf1b45817">
         <source xml:space="preserve">(no message)</source>
         <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg710">
+      <trans-unit id="9904f84f7c45fadde09b131029f10d33e7f5a66731e7a60c644d609def50f388">
         <source xml:space="preserve">(no amount requested)</source>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg711">
+      <trans-unit id="29e099caa9c13bf2f151ff829b96fb640d51103bce7e4bb51c3746d166a90911">
         <source xml:space="preserve">Requested</source>
         <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
       </trans-unit>
@@ -3322,150 +3322,150 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../forms/sendcoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg712">
+      <trans-unit id="9fd18f08f8b0e693509d4843a6ebfd8fe814519755b830fa9935311acfcdc0fb">
         <source xml:space="preserve">Send Coins</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">758</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg713">
+      <trans-unit id="31a5f75b3dbdfc056120c496e54d04f60c2ae2210a64dc9520e4dffa9ff64208">
         <source xml:space="preserve">Coin Control Features</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg714">
+      <trans-unit id="deb5697ece20843beb28b730ca1357f6738969723cf03cac3da8f28d2b9aec66">
         <source xml:space="preserve">automatically selected</source>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg715">
+      <trans-unit id="b07bdbe8bab1b52f8f4fd28d9370acd8c9e5c66d4f25b9e28b5db1371d237190">
         <source xml:space="preserve">Insufficient funds!</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg716">
+      <trans-unit id="bcc2bd4f06380c55e014ca6bc2c260eb53bdb3676b094398f9d8be5c17ef7708">
         <source xml:space="preserve">Quantity:</source>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg717">
+      <trans-unit id="cafee1e15d65807df4040a92b449d1ecdf154f6ae5991e016f6472cbfed4dcfa">
         <source xml:space="preserve">Bytes:</source>
         <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg718">
+      <trans-unit id="36c811409b372c0265ea6abf7becd363c5cf0964fd7e4f55728405c26de710f9">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg719">
+      <trans-unit id="f4a222c4ff4c1a2c1e0e309acb917061457dedee36c8d46bbcd4694cbcf661e4">
         <source xml:space="preserve">Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg720">
+      <trans-unit id="2ec35a50573228b4c00cd01f098bd45598c73fa49a27fdfefb57be8d245d4ae8">
         <source xml:space="preserve">After Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg721">
+      <trans-unit id="8c5b1686767292ca7a0032c9319fb6a07e1ed39c088e472ec5b160f243192e25">
         <source xml:space="preserve">Change:</source>
         <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg722">
+      <trans-unit id="f594cf96fa0419a45e80762b120b160cc2ee4f936ed27fa5edf10da7c30d83d9">
         <source xml:space="preserve">If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg723">
+      <trans-unit id="1ada9c0a06d9d1d2753e846d87313a682e2b752acd954882429b57afd45188e8">
         <source xml:space="preserve">Custom change address</source>
         <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg724">
+      <trans-unit id="4b59844d283084c50f323ebfa13a0a4cb5440149a902af5dc1cb99791c0b6a0b">
         <source xml:space="preserve">Transaction Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">704</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg725">
+      <trans-unit id="c575986a6f1938822f67fa6af1a03e3fc7b8d42576b1e2c5c25f1e0269174a72">
         <source xml:space="preserve">Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg726">
+      <trans-unit id="6fe14b652c75228576b9fc4b733ac01398c0e62ded239ff41b9d0150b8aedb15">
         <source xml:space="preserve">Warning: Fee estimation is currently not possible.</source>
         <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg727">
+      <trans-unit id="b74b840585643b02994d769fdc56f72ba23609fe2376a81b4510cff55d656c62">
         <source xml:space="preserve">per kilobyte</source>
         <context-group purpose="location"><context context-type="linenumber">833</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg728">
+      <trans-unit id="6cbd819feeb20d056d1804fae7fb973ec4c4c1f22048191655d4c96075af86c4">
         <source xml:space="preserve">Hide</source>
         <context-group purpose="location"><context context-type="linenumber">780</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg729">
+      <trans-unit id="683b3fbf8720870dbe278343d8df3dd6b51ff8554b6d7c7f9b1fec44d98c50f1">
         <source xml:space="preserve">Recommended:</source>
         <context-group purpose="location"><context context-type="linenumber">892</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg730">
+      <trans-unit id="9cdd0fbf960e75a19ed4416d1a8651bc13892076a241f5aaf2252d7a0b99f576">
         <source xml:space="preserve">Custom:</source>
         <context-group purpose="location"><context context-type="linenumber">922</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg731">
+      <trans-unit id="2658682f4259de78cc20e529bda3df67aba681c9199d62f37090a547d98bd7f5">
         <source xml:space="preserve">Send to multiple recipients at once</source>
         <context-group purpose="location"><context context-type="linenumber">1137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg732">
+      <trans-unit id="e7906a32a27190e9c416371e8ead1de7c1a3b574a35107fa15af1643df4bd933">
         <source xml:space="preserve">Add &amp;Recipient</source>
         <context-group purpose="location"><context context-type="linenumber">1140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg733">
+      <trans-unit id="b500c4661bbbec1b8784f59a32a5a1742b2c0e66e5c9dc64d28412c614a1ef67">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <context-group purpose="location"><context context-type="linenumber">1120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg734">
+      <trans-unit id="d37b2e4e3ac57b070d14478318d7641dd7001dcd6a43a67450b2fbbccb4263f5">
         <source xml:space="preserve">Inputs…</source>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg735">
+      <trans-unit id="a48476a5976f2f47ea2fee844cad50448374ba27bb04b513b0f20fac326bf412">
         <source xml:space="preserve">Choose…</source>
         <context-group purpose="location"><context context-type="linenumber">718</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg736">
+      <trans-unit id="cae140ad4b0dba545fa69744bbdf18d40bb4bc33e2e5412e741047d7375a40a9">
         <source xml:space="preserve">Hide transaction fee settings</source>
         <context-group purpose="location"><context context-type="linenumber">777</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg737">
+      <trans-unit id="0fc8a4931b9c46d1b2bc30f834df964b5f4e43fc483599801f181d45db9aa727">
         <source xml:space="preserve">Specify a custom fee per kB (1,000 bytes) of the transaction&apos;s virtual size.
 
 Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 satoshis per kvB&quot; for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
         <context-group purpose="location"><context context-type="linenumber">828</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg738">
+      <trans-unit id="a5f887b6b6eb44c1c95ed5a0b726091586fd1390c7a016e24b8af4962ea399be">
         <source xml:space="preserve">When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <context-group purpose="location"><context context-type="linenumber">863</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg739">
+      <trans-unit id="4260f3ac62b4b3448f58b559da9ac05b14f82fb3abfcf1f50633a4dfacae3a2b">
         <source xml:space="preserve">A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <context-group purpose="location"><context context-type="linenumber">866</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg740">
+      <trans-unit id="e7473c1029508c9d3ac32d3aa1565ef4f46b5a7fede0504e96778e894fab8375">
         <source xml:space="preserve">(Smart fee not initialized yet. This usually takes a few blocks…)</source>
         <context-group purpose="location"><context context-type="linenumber">971</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg741">
+      <trans-unit id="9ae143688bd3c5a491014dea465c2e98f85318487a556e10d3297c28c4eee602">
         <source xml:space="preserve">Confirmation time target:</source>
         <context-group purpose="location"><context context-type="linenumber">997</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg742">
+      <trans-unit id="1c7787514960b3b750fe31bbce98518fc57de8edf192996104eb24b8f9ef01bd">
         <source xml:space="preserve">Enable Replace-By-Fee</source>
         <context-group purpose="location"><context context-type="linenumber">1055</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg743">
+      <trans-unit id="a1f4ea675bb73087009848db43e1337188684401e25562cf48667a8b6d65fb62">
         <source xml:space="preserve">With Replace-By-Fee (BIP-125) you can increase a transaction&apos;s fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
         <context-group purpose="location"><context context-type="linenumber">1058</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg744">
+      <trans-unit id="0a1493723c54c5927dafc0a7a4f82e13a65497a2cc9e0835f8e52fa9880f0bfd">
         <source xml:space="preserve">Clear &amp;All</source>
         <context-group purpose="location"><context context-type="linenumber">1123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg745">
+      <trans-unit id="c73009b356c857a36bac025affd3b8e4562add086c95269f81cba5d218975c4e">
         <source xml:space="preserve">Balance:</source>
         <context-group purpose="location"><context context-type="linenumber">1178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg746">
+      <trans-unit id="47b4fec426d39c7dc3e5aa6e371932974fc0c6b65d226615315d1e36ab50ebb1">
         <source xml:space="preserve">Confirm the send action</source>
         <context-group purpose="location"><context context-type="linenumber">1094</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg747">
+      <trans-unit id="4537be00b897c96d38f3f631fc7134c16363bd4a59e2911cb348918773eea454">
         <source xml:space="preserve">S&amp;end</source>
         <context-group purpose="location"><context context-type="linenumber">1097</context></context-group>
       </trans-unit>
@@ -3473,223 +3473,223 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../sendcoinsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg748">
+      <trans-unit id="3f966d571396c97cd2afee5690c6a17fbf2c2822256e31adfe2fd61885a5ec26">
         <source xml:space="preserve">Copy quantity</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg749">
+      <trans-unit id="194e70361ffe37aa04638c6da74644f5197e3733d7ecb013bd828e9ee7f825df">
         <source xml:space="preserve">Copy amount</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg750">
+      <trans-unit id="e6ffffda9b3517087b6af964353ee813ff95cac3ca1295124d26ea14aa2283f9">
         <source xml:space="preserve">Copy fee</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg751">
+      <trans-unit id="1510aff57fb204ccdcc9a5ce3f5e34cde5dba1677312313b213af8496f800db4">
         <source xml:space="preserve">Copy after fee</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg752">
+      <trans-unit id="722332f36fbd41dab7e088d0d89dffa6fe64a707a3a591bd70c875bf9e5c1e2f">
         <source xml:space="preserve">Copy bytes</source>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg753">
+      <trans-unit id="be7b03a3a92bc4587626a543c2295590f977274bf72051ef23194df938aa67a6">
         <source xml:space="preserve">Copy change</source>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg754">
+      <trans-unit id="b1ec927f37d569e6c0a680bf17b3811e297183bdd8cfe43033f8a30dc92ae105">
         <source xml:space="preserve">%1 (%2 blocks)</source>
         <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg755">
+      <trans-unit id="8c348e4e7a6a12c56aad972dde87f5eb3beb783bb7dd2fab2240c7a37427acde">
         <source xml:space="preserve">Sign on device</source>
         <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
         <note annotates="source" from="developer">&quot;device&quot; usually means a hardware wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg756">
+      <trans-unit id="a955fa94872d1d24d3c1193050033886787a4899f9f50cf4e08c1eb70888b36f">
         <source xml:space="preserve">Connect your hardware wallet first.</source>
         <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg757">
+      <trans-unit id="fbdb74005fd04af8b3c6cc26031dcb6f3c5b567a613cf27636ce5b2870f7c418">
         <source xml:space="preserve">Set external signer script path in Options -&gt; Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
         <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
-      <trans-unit id="_msg758">
+      <trans-unit id="5c9953361e1d076205d2e2818d83c9821f4c82a59631613378b45374fe5cbb7d">
         <source xml:space="preserve">Cr&amp;eate Unsigned</source>
         <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg759">
+      <trans-unit id="88cd0f2d8d794efde33063c7cf56cb013623c2de3aa56f8d1d2b16184785fec7">
         <source xml:space="preserve">Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg760">
+      <trans-unit id="1a9ff60e6ee5b4b188705a1d39942152ed9eba70e5c8b53bd14635e07df8e26d">
         <source xml:space="preserve">%1 to &apos;%2&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg761">
+      <trans-unit id="d147f8931b520808951743ffff8ca1544730e0173e8412fe8b0aece0bdf99a88">
         <source xml:space="preserve">%1 to %2</source>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg762">
+      <trans-unit id="c1048e9a5583ccde73b7d3705a45c54a3a02fd7b3f5b0cd2f99c0b1b196ff73a">
         <source xml:space="preserve">To review recipient list click &quot;Show Details…&quot;</source>
         <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg763">
+      <trans-unit id="7bad85eb1596326d76285814e43763c0bda5195b46a5c60651ff095a6f107d83">
         <source xml:space="preserve">Sign failed</source>
         <context-group purpose="location"><context context-type="linenumber">452</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg764">
+      <trans-unit id="474e0c86f9bff9e2cfbcd09ff6d057b6557dbfc580e6e28b4a15c10c4d429237">
         <source xml:space="preserve">External signer not found</source>
         <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
         <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
-      <trans-unit id="_msg765">
+      <trans-unit id="38d99862c871957597cb2bb00a604dba65ef6b08650897c2b9f6ad65b097fb45">
         <source xml:space="preserve">External signer failure</source>
         <context-group purpose="location"><context context-type="linenumber">463</context></context-group>
         <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
-      <trans-unit id="_msg766">
+      <trans-unit id="b4a74cef45cf25cd5ae024308e2cc00e550e9ffe3d06b95716653d3329e7f027">
         <source xml:space="preserve">Save Transaction Data</source>
         <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg767">
+      <trans-unit id="6b8debcc69514e06df62fcfd4511a21c01c4ce428c975ccec0baf5de5ebf9514">
         <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
         <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
         <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
-      <trans-unit id="_msg768">
+      <trans-unit id="0e99f0a661bee40173f3d5b704162f2bff1ea20d152352675298a671613ebbd3">
         <source xml:space="preserve">PSBT saved</source>
         <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
         <note annotates="source" from="developer">Popup message when a PSBT has been saved to a file</note>
       </trans-unit>
-      <trans-unit id="_msg769">
+      <trans-unit id="0ff914c70bdbf38e95a43d225238fcb23df76d3fd90779ca74d8dcc49d7c68f5">
         <source xml:space="preserve">External balance:</source>
         <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg770">
+      <trans-unit id="5f605a76da1166c912e1c401298d79db9b8e8a8184c088f637b88a108452bf53">
         <source xml:space="preserve">or</source>
         <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg771">
+      <trans-unit id="2e7961d9f0602870a087a6a5d0788672b9814f25e19b1b1c7435cdcc71f9e5cc">
         <source xml:space="preserve">You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
         <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg772">
+      <trans-unit id="e70d05aeb53c7ccb55e3867ab116fe780dd62ce607cf2e1d812638cb4d9a4ad4">
         <source xml:space="preserve">Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
         <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</note>
       </trans-unit>
-      <trans-unit id="_msg773">
+      <trans-unit id="8c6d6ec4528eb62da1a13846bfa3b663b0f9729bcb38cb844fd1b56bb48fd55b">
         <source xml:space="preserve">%1 from wallet &apos;%2&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg774">
+      <trans-unit id="07924b7441a258f51db827901d240dd201fe415bdceabc4dd4e8d9d811829adc">
         <source xml:space="preserve">Do you want to create this transaction?</source>
         <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
         <note annotates="source" from="developer">Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</note>
       </trans-unit>
-      <trans-unit id="_msg775">
+      <trans-unit id="ec038cd77d2aee0bc3e8d32da9bf3a20759403bed14cc4927bb292b86560228f">
         <source xml:space="preserve">Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
         <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</note>
       </trans-unit>
-      <trans-unit id="_msg776">
+      <trans-unit id="049360b1d7a1477941b8ae13fd670f6541cd20f207fb655078eb2ecf8987c0ce">
         <source xml:space="preserve">Please, review your transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
         <note annotates="source" from="developer">Text to prompt a user to review the details of the transaction they are attempting to send.</note>
       </trans-unit>
-      <trans-unit id="_msg777">
+      <trans-unit id="10d8095956108df7f7a24745b502ba569e675a3ca2221165c18d75175d91e525">
         <source xml:space="preserve">Transaction fee</source>
         <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg778">
+      <trans-unit id="eb356c8e62603611cbeb936326935d04eab127128471bbd0df797cca0fe01885">
         <source xml:space="preserve">%1 kvB</source>
         <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">PSBT transaction creation</context></context-group>
         <note annotates="source" from="developer">When reviewing a newly created PSBT (via Send flow), the transaction fee is shown, with &quot;virtual size&quot; of the transaction displayed for context</note>
       </trans-unit>
-      <trans-unit id="_msg779">
+      <trans-unit id="f893a132938567497f09bbbff66ec63d470322bc46c2a7ffb6b6e0b22ab943fb">
         <source xml:space="preserve">Not signalling Replace-By-Fee, BIP-125.</source>
         <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg780">
+      <trans-unit id="93b9e5d3396df2136e2ccde2b4e6db63de9003e0df9bede328db5d7b6c95b996">
         <source xml:space="preserve">Total Amount</source>
         <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg781">
+      <trans-unit id="40eb8d6272d32e734ede74cfe9f9250cbe9878592ef695b23116869b15f8ec04">
         <source xml:space="preserve">Unsigned Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
         <context-group><context context-type="x-gettext-msgctxt">PSBT copied</context></context-group>
         <note annotates="source" from="developer">Caption of &quot;PSBT has been copied&quot; messagebox</note>
       </trans-unit>
-      <trans-unit id="_msg782">
+      <trans-unit id="d4e0b026e16eb36501d23d4b67f63358805ab11164a59d026a3b6d35a04b3641">
         <source xml:space="preserve">The PSBT has been copied to the clipboard. You can also save it.</source>
         <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg783">
+      <trans-unit id="140cb64cb706b0701ea6d7920bb00023d4a0a02394db0bb67c37c01461477f41">
         <source xml:space="preserve">PSBT saved to disk</source>
         <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg784">
+      <trans-unit id="f63d181fc27cb840051b255a826c87cd75c96a17a51b8781e22545b6818f2644">
         <source xml:space="preserve">Confirm send coins</source>
         <context-group purpose="location"><context context-type="linenumber">486</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg785">
+      <trans-unit id="0d8d11b578394c8a7a600eb7243941e62f430688f50688542221840e50386878">
         <source xml:space="preserve">The recipient address is not valid. Please recheck.</source>
         <context-group purpose="location"><context context-type="linenumber">734</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg786">
+      <trans-unit id="32b0c9c388eb6b920eb7445cec6c455959330ebcae0ad3c61700184ffce0b47c">
         <source xml:space="preserve">The amount to pay must be larger than 0.</source>
         <context-group purpose="location"><context context-type="linenumber">737</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg787">
+      <trans-unit id="4d061db4d1e2bdf64822c7952e2d6627e4107f89262da510b7b2b8df782e57f0">
         <source xml:space="preserve">The amount exceeds your balance.</source>
         <context-group purpose="location"><context context-type="linenumber">740</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg788">
+      <trans-unit id="a270885ab81349c814edf43d9ec81128198d05ca456be9f6eb9ed3de753b4db7">
         <source xml:space="preserve">Duplicate address found: addresses should only be used once each.</source>
         <context-group purpose="location"><context context-type="linenumber">743</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg789">
+      <trans-unit id="9d41c26e2d27f7fa17f9aa66dccc46c0d5b14bb905342ba3d6396c370b6f8324">
         <source xml:space="preserve">Transaction creation failed!</source>
         <context-group purpose="location"><context context-type="linenumber">746</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg790">
+      <trans-unit id="7440caa0e7136c9533d87227e95a1ad0ff97cc3755301a3efe842e557003f452">
         <source xml:space="preserve">A fee higher than %1 is considered an absurdly high fee.</source>
         <context-group purpose="location"><context context-type="linenumber">750</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg791">
+      <trans-unit id="1783d1e8c22d84af3e3c1daec8ea4bfe4552a7a7ff02ad6da2ed3a58e37568f2">
         <source xml:space="preserve">%1/kvB</source>
         <context-group purpose="location"><context context-type="linenumber">826</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">863</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">877</context></context-group>
-        <trans-unit id="_msg792[0]">
+        <trans-unit id="82382fcc8ab57db7eda1838cf16789a7012fa9b26e2713a942db379b5ae51dcf[0]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
         </trans-unit>
-        <trans-unit id="_msg792[1]">
+        <trans-unit id="82382fcc8ab57db7eda1838cf16789a7012fa9b26e2713a942db379b5ae51dcf[1]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg793">
+      <trans-unit id="f140a14704bcfa3f8b1f86c81734b4c7ff057b8b41f9d9dc7c12d41d350f08e4">
         <source xml:space="preserve">Warning: Invalid Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">976</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg794">
+      <trans-unit id="62a577ce2157ad01d863b30e0fc176b354857c66772d656b1ea6259f42718ac0">
         <source xml:space="preserve">Warning: Unknown change address</source>
         <context-group purpose="location"><context context-type="linenumber">981</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg795">
+      <trans-unit id="8f429b8e1616ec35dac65af45b97f29b29073d7defdb0c30881a08a5b6b564ad">
         <source xml:space="preserve">Confirm custom change address</source>
         <context-group purpose="location"><context context-type="linenumber">984</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg796">
+      <trans-unit id="ab89cd775c8cfcc6fbced7092ebdf506dd52fc0739bf8e5b3a6f216813efa652">
         <source xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
         <context-group purpose="location"><context context-type="linenumber">984</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg797">
+      <trans-unit id="eef4f5bf9d69e4b2e216cf3661f92776ac059ba05f7af161c0cfb45577f7236e">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">1005</context></context-group>
       </trans-unit>
@@ -3697,68 +3697,68 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../forms/sendcoinsentry.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsEntry">
-      <trans-unit id="_msg798">
+      <trans-unit id="756eef35f72afcc548951c11c76754ee9fb70f5badca365a25f30cc59dd40228">
         <source xml:space="preserve">A&amp;mount:</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg799">
+      <trans-unit id="c5cf49b61a519df7c012c0014e73a257b14be2a506c4876f15ec0a732b14ad2e">
         <source xml:space="preserve">Pay &amp;To:</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg800">
+      <trans-unit id="561e5dd2b2cc755a1585036ed46677e5108f9ec9ce55ae9f0c32dd1a2476f176">
         <source xml:space="preserve">&amp;Label:</source>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg801">
+      <trans-unit id="e0a11a24d04c3e05a9de62f0af8a744ae7c552e832cc079ea05d1344f36bb8f9">
         <source xml:space="preserve">Choose previously used address</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg802">
+      <trans-unit id="aa51c17708a2b55720123121f322aea0369f322efc6d404c28ab493c6c3b6ade">
         <source xml:space="preserve">The Bitcoin address to send the payment to</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg803">
+      <trans-unit id="0c3dd095dc0c8cd460cb5ba70f5f590eeacd0bcb8982c56e0f3b17da56cb23c3">
         <source xml:space="preserve">Alt+A</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg804">
+      <trans-unit id="e4d764afd806f33081c910e6d075fe9e337389eadca31d392f66dfe543f95f45">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg805">
+      <trans-unit id="9aa4a60f71c959464f66564d731cdfe963df19ca9bbaf8fc92b6bf9d5ef410b3">
         <source xml:space="preserve">Alt+P</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg806">
+      <trans-unit id="c77896e4041e7f8dbaee6a41cbc280831ab9ce88568c750c71d70a7221ff1481">
         <source xml:space="preserve">Remove this entry</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg807">
+      <trans-unit id="b164b971a86a5f03b9aee0e42bc1dd802a26ef4a8aeac03765848d3d7a5f8e14">
         <source xml:space="preserve">The amount to send in the selected unit</source>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg808">
+      <trans-unit id="c42f94fc5bd3cee86b807155efa6fc67d37cc6e998ad9b3ff7334e529030920f">
         <source xml:space="preserve">The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
         <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg809">
+      <trans-unit id="799443ce02138b56cbc468efdd456865de2c509e8f4930fd9d12a23e13f25a99">
         <source xml:space="preserve">S&amp;ubtract fee from amount</source>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg810">
+      <trans-unit id="ee7aafcde31cacefcd5a4282fe04e81f68b91078dfd5a13f8bc63a595c664e10">
         <source xml:space="preserve">Use available balance</source>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg811">
+      <trans-unit id="5a3f4241e51da1706c7f21a7224ccede731735cad6ddf7fdde00eea41ae7f059">
         <source xml:space="preserve">Message:</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg812">
+      <trans-unit id="a3bf17270c196e089c898d175c04a9ca90830de1ef07f497ff74f2be4785e2da">
         <source xml:space="preserve">Enter a label for this address to add it to the list of used addresses</source>
         <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg813">
+      <trans-unit id="1c990ae3876f789794051370bb4991ad29aea02428e1099a111a2fd87cc7199f">
         <source xml:space="preserve">A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
       </trans-unit>
@@ -3766,11 +3766,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../sendcoinsdialog.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendConfirmationDialog">
-      <trans-unit id="_msg814">
+      <trans-unit id="389334f4e9d6f2408cee2fd46d50a1a35e998ba68e4f5a0fa50cfe0a5b2d167f">
         <source xml:space="preserve">Send</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg815">
+      <trans-unit id="e96a2587b3e4bab2c262c80b3a737c689ad65e8e26eb24dc02bfe8333cea9f51">
         <source xml:space="preserve">Create Unsigned</source>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
@@ -3778,105 +3778,105 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../forms/signverifymessagedialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg816">
+      <trans-unit id="6cbd13cfcb68d20f2b1dfa885b2ef8d62611500b0d0817babf44d0b2628bfc4c">
         <source xml:space="preserve">Signatures - Sign / Verify a Message</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg817">
+      <trans-unit id="08fd1385a72202b164dd6f9dcc64af474497eaf36ba386248ed90c79efc079be">
         <source xml:space="preserve">&amp;Sign Message</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg818">
+      <trans-unit id="930ad36f7b7da7e869b21c00488d57e5d1993299e795ed310762c547c4557420">
         <source xml:space="preserve">You can sign messages/agreements with your legacy (P2PKH) addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg819">
+      <trans-unit id="55f842e8538d406b4baaad00d65292d61323cc8e359e725cc7768e4c8e47b48a">
         <source xml:space="preserve">The Bitcoin address to sign the message with</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg820">
+      <trans-unit id="8d353e14c6cecc200f4a37c3bca79df05cd0d6d09d21b4c2222fe26dd08521be">
         <source xml:space="preserve">Choose previously used address</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg821">
+      <trans-unit id="da0df52eec52f80f6a0eeb3aaf5a38c8ec8b72eb7ae9f43b845b484cbd7f92a6">
         <source xml:space="preserve">Alt+A</source>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg822">
+      <trans-unit id="d3933d1783d17fd5e241144cff72c9d0061831c5fd044a2a588877f9478d194e">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg823">
+      <trans-unit id="6cf7e5afb20ba2dae617f31d9c81460c55ab7a296c9bf8961b899db76b6f0c17">
         <source xml:space="preserve">Alt+P</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg824">
+      <trans-unit id="5ec26d185b151552d22e2cd4dc5f10275bdb30a44fc9d3a05154450556c733b1">
         <source xml:space="preserve">Enter the message you want to sign here</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg825">
+      <trans-unit id="588b6b8b7d4f422d16fb11bb68af57dd87e5c3d212ef3f203dc3bb9b5f3ea163">
         <source xml:space="preserve">Signature</source>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg826">
+      <trans-unit id="db060ed7b9b0a911b8baedc52efa95c80a0f3183eb740daf1dcaaeb7eb72ad0d">
         <source xml:space="preserve">Copy the current signature to the clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg827">
+      <trans-unit id="e33fafd2361514fb620caad1873f948aff04e3c6f7e23e27f0abaa080997be6b">
         <source xml:space="preserve">Sign the message to prove you own this Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg828">
+      <trans-unit id="30f92c7bd40a9981f6698bc0269e85b2e8f422d79345f395c6a659505fb53fd6">
         <source xml:space="preserve">Sign &amp;Message</source>
         <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg829">
+      <trans-unit id="f7f6f7dc141196efb768ddfa5f9ccfbee89f9cb99564b11afb90d6ec2f518f2d">
         <source xml:space="preserve">Reset all sign message fields</source>
         <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg830">
+      <trans-unit id="3f41fd8ca95e539516f3b1eb493be28ef0ac38353ab96f96d708fb2e98aa80d5">
         <source xml:space="preserve">Clear &amp;All</source>
         <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg831">
+      <trans-unit id="5d7fba20e38cd1c789e09b3e0e3433549ce34f21dd8460dc563baa012d6c197a">
         <source xml:space="preserve">&amp;Verify Message</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg832">
+      <trans-unit id="a2152730df1331a65bf49abb07232869927f5a10ef7a8a81f52f978743cb8278">
         <source xml:space="preserve">Enter the receiver&apos;s address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
         <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg833">
+      <trans-unit id="b5f96a644ed2f319b7b5d26c3801061a35846a597fe9bd39de24839193224926">
         <source xml:space="preserve">The Bitcoin address the message was signed with</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg834">
+      <trans-unit id="2d5ab749075ed8347fc235e922012d5176c350740290b8b6043e4af485235395">
         <source xml:space="preserve">The signed message to verify</source>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg835">
+      <trans-unit id="1de795bc6a7dcc91016eef5ee44e27d8ad377764cdd79f99f45b792dfcb75d38">
         <source xml:space="preserve">The signature given when the message was signed</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg836">
+      <trans-unit id="8f6f1dd9b41c64a5de9abb5944bb45cb7cbef37a78e45816902c7fe59d08dbb2">
         <source xml:space="preserve">Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg837">
+      <trans-unit id="54e9cd944ce431ae8b2c25c9b81de1b283f4ba6b63f653dbbc7e9af6fcee1f9c">
         <source xml:space="preserve">Verify &amp;Message</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg838">
+      <trans-unit id="c173f342317379814c8ffddbf9e45f277594602ac0af8e055aa1a990317ef4d0">
         <source xml:space="preserve">Reset all verify message fields</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg839">
+      <trans-unit id="86c8a0646bf9ffec69b8b6ca80c8ed3067817e7370587e09496603e9aa6d01e8">
         <source xml:space="preserve">Click &quot;Sign Message&quot; to generate signature</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
@@ -3884,59 +3884,59 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../signverifymessagedialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg840">
+      <trans-unit id="a7f0087ecb8dd02df98c4710436c8fdbbe9471137168da7d14b2fae8e54b2d6f">
         <source xml:space="preserve">The entered address is invalid.</source>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg841">
+      <trans-unit id="c8d59cad6fe569b98b6a039e1a1db386e4b6ddf611ece8401ff2a4bbb350b7ba">
         <source xml:space="preserve">Please check the address and try again.</source>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg842">
+      <trans-unit id="5c04fdc183a206efbaf82ebdc8a89be98a1d9ce4e92bea9b8987864f5e757e4e">
         <source xml:space="preserve">The entered address does not refer to a legacy (P2PKH) key. Message signing for SegWit and other non-P2PKH address types is not supported in this version of %1. Please check the address and try again.</source>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg843">
+      <trans-unit id="5841449ae6efeed8acf6b9f404004c3cc2092e074cf0b4399c1668315ac0eb89">
         <source xml:space="preserve">Wallet unlock was cancelled.</source>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg844">
+      <trans-unit id="7f2f533c56915114b517c887e75a818300cefc9334a22c12fb7e27298de412b4">
         <source xml:space="preserve">No error</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg845">
+      <trans-unit id="b4b5932d428b243cd0433190719e5dc24deac161a9cc16df0a2a48f514aa44a7">
         <source xml:space="preserve">Private key for the entered address is not available.</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg846">
+      <trans-unit id="c638d2e7c4f8c2aa841dcab36903097084e1ee197096da461acc507456248923">
         <source xml:space="preserve">Message signing failed.</source>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg847">
+      <trans-unit id="60b6d5fff449b61f622be4155ef3b100ae681deab631cea3430bcf310a999e53">
         <source xml:space="preserve">Message signed.</source>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg848">
+      <trans-unit id="a8ee04b0ad413d52e1532a58c7b74ff7b81552cd1ebbf432c57c82213bcc6798">
         <source xml:space="preserve">The signature could not be decoded.</source>
         <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg849">
+      <trans-unit id="7e0c1cae2b3e44f8694f2bcd59257043007656619403f4ce4d17437ca568b4a9">
         <source xml:space="preserve">Please check the signature and try again.</source>
         <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg850">
+      <trans-unit id="5a5473a5469eb7286623ba64b7f8e8be055847689b06573c6423edb23c9de394">
         <source xml:space="preserve">The signature did not match the message digest.</source>
         <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg851">
+      <trans-unit id="e3d3086a5efbd30deb55d5cbf7b870d47177b6ecd707382b369a05be46b2dbcd">
         <source xml:space="preserve">Message verification failed.</source>
         <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg852">
+      <trans-unit id="001243f74e2a407178aac807ff8382888cebf08b0c4475ac7ba4a95add50ed1c">
         <source xml:space="preserve">Message verified.</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
@@ -3944,11 +3944,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../splashscreen.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SplashScreen">
-      <trans-unit id="_msg853">
+      <trans-unit id="5036258278239efcf546c3f419950c78c3505e34ca8bb00ee78047c84dbdd9ca">
         <source xml:space="preserve">(press q to shutdown and continue later)</source>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg854">
+      <trans-unit id="220a5e000daf4c9990d6d68e9876320a39240b9ff3255bd1f1cf5e6e6ccce83a">
         <source xml:space="preserve">press q to shutdown</source>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
@@ -3956,7 +3956,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../trafficgraphwidget.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TrafficGraphWidget">
-      <trans-unit id="_msg855">
+      <trans-unit id="a02dfc2f185e032314b3f32fff92eb16b13fca567e8ccec3d60e6b4144d63b65">
         <source xml:space="preserve">kB/s</source>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
@@ -3964,77 +3964,77 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiondesc.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDesc">
-      <trans-unit id="_msg856">
+      <trans-unit id="7b3a60d6397c39491dd0ba40bbe00f9ccf41e03c9e070e7d29f2acf1139f7718">
         <source xml:space="preserve">conflicted with a transaction with %1 confirmations</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</note>
       </trans-unit>
-      <trans-unit id="_msg857">
+      <trans-unit id="9fe496f30f264f16b4bd9e399294afad5c5ea224ef32cadf97f0bd40c4f7ae22">
         <source xml:space="preserve">0/unconfirmed, in memory pool</source>
         <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</note>
       </trans-unit>
-      <trans-unit id="_msg858">
+      <trans-unit id="c2b25828029fcc183adc12e8de4ea82fa4335e0b13df190a118b76c4d3902aed">
         <source xml:space="preserve">0/unconfirmed, not in memory pool</source>
         <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</note>
       </trans-unit>
-      <trans-unit id="_msg859">
+      <trans-unit id="80867aa77963ed5530f7e8527f3775f5a331e77b53191be6ba764b01a82fd091">
         <source xml:space="preserve">abandoned</source>
         <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</note>
       </trans-unit>
-      <trans-unit id="_msg860">
+      <trans-unit id="874cb10f36fe43cd2a863bc26254d31eedaed64f3ac37816ddf95aaca98e625a">
         <source xml:space="preserve">%1/unconfirmed</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</note>
       </trans-unit>
-      <trans-unit id="_msg861">
+      <trans-unit id="18f0b323ed7f141263e5f6c13863f2b0ff60e88f901b8067de9293853077b91c">
         <source xml:space="preserve">%1 confirmations</source>
         <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</note>
       </trans-unit>
-      <trans-unit id="_msg862">
+      <trans-unit id="0332fb5483117fce095363ef9baf9efe7e47f914aca7259129dc6ceceab25816">
         <source xml:space="preserve">Status</source>
         <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg863">
+      <trans-unit id="227bc1217948be81c34a825c71ab49eb2e05dbd8527dd1971188b0e9cffe3df7">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg864">
+      <trans-unit id="118ea82b07f3f84cf57ea24579d4e0eb09c3416451b4417e54649233c6f19bf8">
         <source xml:space="preserve">Source</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg865">
+      <trans-unit id="3eabe6bdd4d81ba14bd5566011e6513fff18679ead11f55daf21a550699900d1">
         <source xml:space="preserve">Generated</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg866">
+      <trans-unit id="02130cad18c440fb41ee3a4a78ea6b16741a4b516c7dc0ac6facdb7d15923976">
         <source xml:space="preserve">From</source>
         <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg867">
+      <trans-unit id="432ff8e6ee32eefc1c23a2c8d4492e9d689f496c8e715ca580d154cca21b995b">
         <source xml:space="preserve">unknown</source>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg868">
+      <trans-unit id="439d8635d7e29b36ee223336e02b777feb4ac755faab9152c125b44a0de50680">
         <source xml:space="preserve">To</source>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg869">
+      <trans-unit id="b2f4916e983f4206bbff6a0ad175e10e2720dc09948a736ce9d091a234914b80">
         <source xml:space="preserve">own address</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg870">
+      <trans-unit id="4cc51753084fcd62aa1d672646d832af3ca0ef9090500cd5f20a70efdd70977d">
         <source xml:space="preserve">label</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg871">
+      <trans-unit id="700fc8c2264556fbf239a255d1208444f3693a968a7198d45b2004fa4611f2e1">
         <source xml:space="preserve">Credit</source>
         <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
@@ -4044,97 +4044,97 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
-        <trans-unit id="_msg872[0]">
+        <trans-unit id="a198499436d73cc175a216935201b15a77aea0e8b001ad30322d434ff9df8536[0]">
           <source xml:space="preserve">matures in %n more block(s)</source>
         </trans-unit>
-        <trans-unit id="_msg872[1]">
+        <trans-unit id="a198499436d73cc175a216935201b15a77aea0e8b001ad30322d434ff9df8536[1]">
           <source xml:space="preserve">matures in %n more block(s)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg873">
+      <trans-unit id="7e5fbffda2f74e6f3e7da9e45a0e226c1d9c9356af91972316328365cc53d770">
         <source xml:space="preserve">not accepted</source>
         <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg874">
+      <trans-unit id="9857762efc8adb2746964f50ab071ea8be894a54eff22e2886cdf9ce305973e0">
         <source xml:space="preserve">Debit</source>
         <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg875">
+      <trans-unit id="2d14db22dbf8782aae7b5dd60475412ac2b79ad46ea15e7e596211c24348946f">
         <source xml:space="preserve">Total debit</source>
         <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg876">
+      <trans-unit id="9c0fb2e1da9f75c1ed8123fd603d1fe9d9591c321e4bd4980c2315ee3bba7d0e">
         <source xml:space="preserve">Total credit</source>
         <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg877">
+      <trans-unit id="335583fba5dc3ff0e53ea15ecb1e139731d7e2d2a2ad28490f6fc2bb08366a03">
         <source xml:space="preserve">Transaction fee</source>
         <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg878">
+      <trans-unit id="fe5f05110a5896079fb68791b85385a0ff6342a53a70e28dd1ad3ce4151a0439">
         <source xml:space="preserve">Net amount</source>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg879">
+      <trans-unit id="72d9af4ff1825b07478ad4b1fb516f3df43b2e17e04ed5a980ebf455ab01fd92">
         <source xml:space="preserve">Message</source>
         <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg880">
+      <trans-unit id="2775a67e9e875b86cac453b074ee256a7210933cbfdc3ebf048b048a50112bdb">
         <source xml:space="preserve">Comment</source>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg881">
+      <trans-unit id="62375deffb2b0bdfa6121d5e0dea2f02a592ecf37a6ecccb9adc32a79bcdd3d0">
         <source xml:space="preserve">Transaction ID</source>
         <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg882">
+      <trans-unit id="04a3a44189cdd1990a10ed16e04eb2f8ed98fc415fceb8b21d60f0fa14c319db">
         <source xml:space="preserve">Transaction total size</source>
         <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg883">
+      <trans-unit id="54cafde13b8572f39d9a7eeae330935a70ed07a9aad3e87259c9210acc2ea4b2">
         <source xml:space="preserve">Transaction virtual size</source>
         <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg884">
+      <trans-unit id="8fbaef87002449dd9e0fd493e29e1264698c76402d5a9e87a0f434b3928614d8">
         <source xml:space="preserve">Output index</source>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg885">
+      <trans-unit id="af50e9e517dc1be805727f0eb24d4aa02ed400cdd4b15f5444c4b574debd62f4">
         <source xml:space="preserve">%1 (Certificate was not verified)</source>
         <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg886">
+      <trans-unit id="b1c30fb0da0ff084a1882bcd16f4e56fddf3e66a8d95d4173e955d19388f40cf">
         <source xml:space="preserve">Merchant</source>
         <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg887">
+      <trans-unit id="97032618ca8b35e088730375129ceec81f4852ba5def31c5b2a789800114c75f">
         <source xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg888">
+      <trans-unit id="c225bdfc550ec426e1059579c53a5a3bba7d2e31363308278d6a5446f1bf6525">
         <source xml:space="preserve">Debug information</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg889">
+      <trans-unit id="46738996982e03ad70080c3d165c8fba5819bce04d78e8bfdff3308a723cecca">
         <source xml:space="preserve">Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg890">
+      <trans-unit id="1d34011a18a225b02d77b5dd212acf8088f0e0e3086dda700cd4b5e160b5c0a9">
         <source xml:space="preserve">Inputs</source>
         <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg891">
+      <trans-unit id="67318e3d0eb3e70cf2cbfbc1174077ba69119de1a6c3d2753c90fd1089b12e59">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg892">
+      <trans-unit id="62eabda3d4701db19fdc0e488ea6ffb9f6046bdd1773428add4de820a8b81a7d">
         <source xml:space="preserve">true</source>
         <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg893">
+      <trans-unit id="1f200ccfc606623fb23f13e69754ec2988cc870e477f2f78cadf39f2864c5651">
         <source xml:space="preserve">false</source>
         <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
       </trans-unit>
@@ -4142,7 +4142,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../forms/transactiondescdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg894">
+      <trans-unit id="c51455bc13939fe4728fa1336081f751fac6a839d6afb00fa586ee2cb6a0364a">
         <source xml:space="preserve">This pane shows a detailed description of the transaction</source>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
@@ -4150,7 +4150,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiondescdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg895">
+      <trans-unit id="e46869e43950f14c3cf3b34570e523e050d5e1017560bd2cbe240055cfc8e04a">
         <source xml:space="preserve">Details for %1</source>
         <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
       </trans-unit>
@@ -4158,87 +4158,87 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiontablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionTableModel">
-      <trans-unit id="_msg896">
+      <trans-unit id="8da31258d3d7b88ee0db03245048876ceaa09be2c7440c2fdb1125ba062fc8f5">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg897">
+      <trans-unit id="a479f3b28476f337861362461a23dacf6e9b97cbc6c1a81dce92b66b9adca51a">
         <source xml:space="preserve">Type</source>
         <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg898">
+      <trans-unit id="7811d32e0298ac5529039f316ea831d3bb833bd7bd0d40e02fd3723a1ca50bd4">
         <source xml:space="preserve">Label</source>
         <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg899">
+      <trans-unit id="de9df14288564d85c7c121c1da27be4da13f548de9cfb5ed14a0bb3065da0085">
         <source xml:space="preserve">Unconfirmed</source>
         <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg900">
+      <trans-unit id="91642c5fdc6e9c0af6f5be769e3f3229166d6777e8358d72b5497def3d22d3fd">
         <source xml:space="preserve">Abandoned</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg901">
+      <trans-unit id="47c76ac99faf7d1ac513b2a15d7a21ff10666022702797ecf1ea440d69fb03ac">
         <source xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</source>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg902">
+      <trans-unit id="475ade1763b585d779fbdd09077606d4d7b1d35e58d130a4e9568545c2f2810e">
         <source xml:space="preserve">Confirmed (%1 confirmations)</source>
         <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg903">
+      <trans-unit id="c6c6d9c8d59fb380b9ae3ab563206fc7d087ba07d4946806007e5d90ba06e376">
         <source xml:space="preserve">Conflicted</source>
         <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg904">
+      <trans-unit id="4b33e64bf7e48277e3998b2c41d440c410f58e7e5ea91d0ddde0d5267bb7e034">
         <source xml:space="preserve">Immature (%1 confirmations, will be available after %2)</source>
         <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg905">
+      <trans-unit id="3beea684806386cf362e0f124bc85c354fa406b3a893ed049895d593b287f13e">
         <source xml:space="preserve">Generated but not accepted</source>
         <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg906">
+      <trans-unit id="2d8ca80a0de45ba3a6a819b1b2f2242dec3758ae55438fa1ce9a8e1ce2a81a4c">
         <source xml:space="preserve">Received with</source>
         <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg907">
+      <trans-unit id="cad6e8178aa433bd14c096e20bd70ba146b0344bba00e1c914d55d25cd7ebd47">
         <source xml:space="preserve">Received from</source>
         <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg908">
+      <trans-unit id="09543f52330af9a5f4fdc9033e8c6287fbc9165a8cec40c845f44addb5e6982e">
         <source xml:space="preserve">Sent to</source>
         <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg909">
+      <trans-unit id="37ac9236a861cd8b821253d56be5b0c86d8bee41e56ea7f3748c36b3f03f0096">
         <source xml:space="preserve">Mined</source>
         <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg910">
+      <trans-unit id="7afb3e4587dbd602f1b8e658482437942cad55be5032bad302b73f2cdbc8eb8c">
         <source xml:space="preserve">(n/a)</source>
         <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg911">
+      <trans-unit id="e761a5318002f8fc1558c298ebb7889cc98ac829d0de5d4e34e9de7951e86765">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">604</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg912">
+      <trans-unit id="2d0cc973cafd4e15acbcdec4bb181bd37036881020077ed537a58870f988b79a">
         <source xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</source>
         <context-group purpose="location"><context context-type="linenumber">643</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg913">
+      <trans-unit id="065af34bc364de5ae69c2445436363e2db95368266f55805c266bb255a7b91c0">
         <source xml:space="preserve">Date and time that the transaction was received.</source>
         <context-group purpose="location"><context context-type="linenumber">645</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg914">
+      <trans-unit id="26d4311277ffb93726ec1e50d8bcf1e412eea2ce4fabecc593b731e99c94fdac">
         <source xml:space="preserve">Type of transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">647</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg915">
+      <trans-unit id="3979d52034c6aa0b12b48b69d59ab882640654f6ca25371afcb35ae3ac647a37">
         <source xml:space="preserve">User-defined intent/purpose of the transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">649</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg916">
+      <trans-unit id="a27adef1bc31528c513d2fdb4404fceffc47f132b52bf9a91e087d07ff674ae7">
         <source xml:space="preserve">Amount removed from or added to balance.</source>
         <context-group purpose="location"><context context-type="linenumber">651</context></context-group>
       </trans-unit>
@@ -4246,158 +4246,158 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactionview.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionView">
-      <trans-unit id="_msg917">
+      <trans-unit id="72ff396b1a35a0c9016ed51e8ff4ed4f3e7d8fde0b2c2a84337f4418ba7e8284">
         <source xml:space="preserve">All</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg918">
+      <trans-unit id="7e69a50e61bba56ae6a5704e2b63279e5f57491715f76a9f5239361c03877572">
         <source xml:space="preserve">Today</source>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg919">
+      <trans-unit id="14c75beed0e1d8ba932123aed38cc4e68798923bed774f86abce9e9cb12ffacf">
         <source xml:space="preserve">This week</source>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg920">
+      <trans-unit id="8d8691d0aa1b8314cd532fe16e6972451f43265e5d069a8b1e1584d4b4e093b0">
         <source xml:space="preserve">This month</source>
         <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg921">
+      <trans-unit id="0a2d9f95cf821cc86bc74f02c2bb9a9cc8b9725034c74cfc99d3b78ff69408b0">
         <source xml:space="preserve">Last month</source>
         <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg922">
+      <trans-unit id="4cc3f9c74fa51073226b55311ea03997ca69084d8fc430d6b8805e2b6fc2dc0f">
         <source xml:space="preserve">This year</source>
         <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg923">
+      <trans-unit id="7e8d3618746b7cd13ddf5f05ed608283f039d262fb0cb8d0ec6f1dd58bcec8cb">
         <source xml:space="preserve">Received with</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg924">
+      <trans-unit id="cd10f79f1f2acef59ee97efbf4711122377af53e5df351d5d480fc7448149735">
         <source xml:space="preserve">Sent to</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg925">
+      <trans-unit id="ba39225a7bd87ec63d6e569d2f8f5bd797f7c429380818994571a412505867f0">
         <source xml:space="preserve">Mined</source>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg926">
+      <trans-unit id="097a9b9357708ba27bf618a6a99a195910d61fceaa0487271b53ab9fc012ffca">
         <source xml:space="preserve">Other</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg927">
+      <trans-unit id="7008eaea3c5948cd0d07a37e7a6659c82d6fb0736e228e092f897e1fa246bcd0">
         <source xml:space="preserve">Enter address, transaction id, or label to search</source>
         <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg928">
+      <trans-unit id="27fa6a9528b06e089a1031b445c9bf1084e695b6b487d4bc20a2219c8451db7b">
         <source xml:space="preserve">Min amount</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg929">
+      <trans-unit id="5937b22a7f27756ccae7fde9bbe58dcc01ab667732e2f5dac6312598b0c8e250">
         <source xml:space="preserve">Range…</source>
         <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg930">
+      <trans-unit id="7f83c80b5dd8016bae0f58882c106ea3af5eb813a375df711e75b39145ce7f20">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg931">
+      <trans-unit id="9387ebbbcd159c3fdb529162953d5800f163c4322d1802d6f8e543ac61249a61">
         <source xml:space="preserve">Copy &amp;label</source>
         <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg932">
+      <trans-unit id="22a7cfce3e3fe9c256ddd7f90f217ef9bc14de1717c5de0cb89e9fe2a6b48876">
         <source xml:space="preserve">Copy &amp;amount</source>
         <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg933">
+      <trans-unit id="ec82c9bdf3ea80e14065ef6c8d3631e4e5743e50afc4d6b8df18ae007c38187e">
         <source xml:space="preserve">Copy transaction &amp;ID</source>
         <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg934">
+      <trans-unit id="8f684dcd6e66446fcd4402a4e9c7e7ea4f5db7f501c929843670ee0a4fe576ff">
         <source xml:space="preserve">Copy &amp;raw transaction</source>
         <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg935">
+      <trans-unit id="95ed59054463e89ad31b792f72058193ff1a2984a82e7793ccbb2919b8632f5e">
         <source xml:space="preserve">Copy full transaction &amp;details</source>
         <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg936">
+      <trans-unit id="c42b1d0c66b3a7f177f08968f6fe639952d693afd2293b46509a9944c718f438">
         <source xml:space="preserve">&amp;Show transaction details</source>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg937">
+      <trans-unit id="4f4dc3d22828c18caf36b15624076fcd8dce38ee3ec2ace21a86eff55ad0d27b">
         <source xml:space="preserve">Increase transaction &amp;fee</source>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg938">
+      <trans-unit id="04ebb9ff27aa729372d92e7036d5d3622dc842293afc840b1b2320b4d838262a">
         <source xml:space="preserve">A&amp;bandon transaction</source>
         <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg939">
+      <trans-unit id="b688371ede2fb2170dcb129907ee7be460400c3d336a27e060724981ee508b78">
         <source xml:space="preserve">&amp;Edit address label</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg940">
+      <trans-unit id="2192a5dd9e65cc240a70f2af77679e1ff247a295333054712b652b86e40373d3">
         <source xml:space="preserve">Show in %1</source>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
         <note annotates="source" from="developer">Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</note>
       </trans-unit>
-      <trans-unit id="_msg941">
+      <trans-unit id="a33236c9332697d42d5a24059d6908c9f73bc285ebb4a8aec27ec711b3dc8306">
         <source xml:space="preserve">Export Transaction History</source>
         <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg942">
+      <trans-unit id="45e5d11a5738b6a253a5b3d8219c68a7025bbf178a75aab9c4170b4c7239ba82">
         <source xml:space="preserve">Comma separated file</source>
         <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</note>
       </trans-unit>
-      <trans-unit id="_msg943">
+      <trans-unit id="894d457d93401f4f7c792c4593755e656c0a003cd2c3512e33d8c0eb62e581f1">
         <source xml:space="preserve">Confirmed</source>
         <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg944">
+      <trans-unit id="bc20f98cb659d126d34eec4dfce47e6bec12b14a8987ad1a3224dc0f50aceca4">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg945">
+      <trans-unit id="fe97a1a4e658284047835faf525d7fb0910dc6738522fc63e5e64f196cb601c6">
         <source xml:space="preserve">Type</source>
         <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg946">
+      <trans-unit id="1fb82887938b3ceaf4f70cd671a2327fd4d3f42050e4abd42b378885ab41397a">
         <source xml:space="preserve">Label</source>
         <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg947">
+      <trans-unit id="a72e37ad4bd844b56c5d113283d989cd77e78eab64151c60496056e085eff485">
         <source xml:space="preserve">Address</source>
         <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg948">
+      <trans-unit id="f2dfaebd3af353ca065df9987e3611568d6b5bb89baf5eb43d084f608036b9ab">
         <source xml:space="preserve">ID</source>
         <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg949">
+      <trans-unit id="0516247242e4eeb655ec5552b28f42e5fd737e71dfebccfdf3d6396cf52a7448">
         <source xml:space="preserve">Exporting Failed</source>
         <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg950">
+      <trans-unit id="8bfe69c2a494e5067671e54f200e4ff20834a09bbd91252d29381ffc0a03f85c">
         <source xml:space="preserve">There was an error trying to save the transaction history to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg951">
+      <trans-unit id="0a872df9efb87f4cbdd46a6ab64d65217765efddef562ad77ec439fa879d281c">
         <source xml:space="preserve">Exporting Successful</source>
         <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg952">
+      <trans-unit id="e1805b91aa37dd5733efb2fe4bcfbbe6fdb159daa37c58a47b619dc7b8767d80">
         <source xml:space="preserve">The transaction history was successfully saved to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg953">
+      <trans-unit id="8ea526e7cf83cad243d8dbdde3af9ec2fd3e534ae7193671a0537bdf4ad2c722">
         <source xml:space="preserve">Range:</source>
         <context-group purpose="location"><context context-type="linenumber">527</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg954">
+      <trans-unit id="a6b7c5715db28ce002a063261213464f33610c9c8e3e2cc83dd076df3be6ccf5">
         <source xml:space="preserve">to</source>
         <context-group purpose="location"><context context-type="linenumber">535</context></context-group>
       </trans-unit>
@@ -4405,39 +4405,39 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../walletframe.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletFrame">
-      <trans-unit id="_msg955">
+      <trans-unit id="df61aa97f1694de9de26523467f5949f6d00801e3e2dc6ef5580d6adf6ce4fed">
         <source xml:space="preserve">No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
         <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg956">
+      <trans-unit id="a16edadcb5990040521a2ad651714e0e1102d92efa00562c2417394870029a2f">
         <source xml:space="preserve">Create a new wallet</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg957">
+      <trans-unit id="6443490d871277748db3d8a16c9b965228691ed02396b82605909ff724b957f6">
         <source xml:space="preserve">Error</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg958">
+      <trans-unit id="d740dd39bfd7a4e1c1fe323c93ca40c94ab2729cc2e8359c685442b05a71b586">
         <source xml:space="preserve">Unable to decode PSBT from clipboard (invalid base64)</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg959">
+      <trans-unit id="15800c1ac2248a19365b27719551eefdce08e0024352cde496c28f8596476c05">
         <source xml:space="preserve">Load Transaction Data</source>
         <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg960">
+      <trans-unit id="1fa2c525b9c0af2c2e27ce5a4daca58a654d623c9ffe0a39322ada3b3f1290c3">
         <source xml:space="preserve">Partially Signed Transaction (*.psbt)</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg961">
+      <trans-unit id="3db2bdb22ebbdf9741a97d25b0dac58cb6b889b07d7684f3fb9f7033b43c14a3">
         <source xml:space="preserve">PSBT file must be smaller than 100 MiB</source>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg962">
+      <trans-unit id="560843c7d809eb294840eb6a139b6099128209594149eee0cf99bd585c896d02">
         <source xml:space="preserve">Unable to decode PSBT</source>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
@@ -4445,72 +4445,72 @@ Go to File &gt; Open Wallet to load a wallet.
   </body></file>
   <file original="../walletmodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletModel">
-      <trans-unit id="_msg963">
+      <trans-unit id="1e957552cb0492f71d88a45aa18963d466ca8d025965b9c18863e516ed3a2517">
         <source xml:space="preserve">Send Coins</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg964">
+      <trans-unit id="0df881e09062e6e5b80c937f84b78dd9117907e9b8456d0712c1998deaba4346">
         <source xml:space="preserve">Fee bump error</source>
         <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">522</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">542</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg965">
+      <trans-unit id="0c4a8e2659276150452297d749fefef1b59e59c996e5299a4f558e97723280ce">
         <source xml:space="preserve">Increasing transaction fee failed</source>
         <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg966">
+      <trans-unit id="76ac977f656655e8e05d2c8a9bf4cff3c692117363204dcacfa386a69000ad06">
         <source xml:space="preserve">Do you want to increase the fee?</source>
         <context-group purpose="location"><context context-type="linenumber">480</context></context-group>
         <note annotates="source" from="developer">Asks a user if they would like to manually increase the fee of a transaction that has already been created.</note>
       </trans-unit>
-      <trans-unit id="_msg967">
+      <trans-unit id="e844156b3a6fa8944462f16123ab7766fbbb05ae9510ab8b2a1759275e221da0">
         <source xml:space="preserve">Current fee:</source>
         <context-group purpose="location"><context context-type="linenumber">484</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg968">
+      <trans-unit id="d22a15ca2332cb95492ff8d1f9632c1b28710b3dbf08857daa59a7786182f374">
         <source xml:space="preserve">Increase:</source>
         <context-group purpose="location"><context context-type="linenumber">488</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg969">
+      <trans-unit id="8400f28346f14104146edfe46a4375726085ff265891d9f75483afc715d98b02">
         <source xml:space="preserve">New fee:</source>
         <context-group purpose="location"><context context-type="linenumber">492</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg970">
+      <trans-unit id="4f3efd87b7b3a3dc87e59b2fe9de2792d426d38e62a4f74cc0ca24d25400bc77">
         <source xml:space="preserve">Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
         <context-group purpose="location"><context context-type="linenumber">500</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg971">
+      <trans-unit id="86936b6ae4fe0bb5912841d9ccda9de22b4fb2d951e2f1e3e53cd28f59b2d998">
         <source xml:space="preserve">Confirm fee bump</source>
         <context-group purpose="location"><context context-type="linenumber">505</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg972">
+      <trans-unit id="1b00cbed66b49ade020446f5dd3b5f2f61235b3ac36f2aaa30c88090f8627b75">
         <source xml:space="preserve">Can&apos;t draft transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">522</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg973">
+      <trans-unit id="1c36cb083722952857fab981236aa7c85ebc0e19dd6aa0f44152758d9d45b336">
         <source xml:space="preserve">PSBT copied</source>
         <context-group purpose="location"><context context-type="linenumber">529</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg974">
+      <trans-unit id="4db3a8682cef01e2db30e7aba6d620e0736f29b67996d4fe6f751254bb1050b0">
         <source xml:space="preserve">Fee-bump PSBT copied to clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">529</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg975">
+      <trans-unit id="955a0c354c843582ebd91631f0f48e7d06e468d505018efcf5016d90188c71d3">
         <source xml:space="preserve">Can&apos;t sign transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">542</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg976">
+      <trans-unit id="286c2d8e0208e08da374149214c54f1d4c3687d8940b18b80c367767b2393bdf">
         <source xml:space="preserve">Could not commit transaction</source>
         <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg977">
+      <trans-unit id="479c3e1fa6a3069cb8c27ca721a2ef2cfbd5ad44717cdd6cc5edf03b945d9800">
         <source xml:space="preserve">Signer error</source>
         <context-group purpose="location"><context context-type="linenumber">560</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg978">
+      <trans-unit id="05c807bbd852728916b9bd03eeb08a0747852c78d8d2de839006e8e8411bb473">
         <source xml:space="preserve">Can&apos;t display address</source>
         <context-group purpose="location"><context context-type="linenumber">563</context></context-group>
       </trans-unit>
@@ -4518,40 +4518,40 @@ Go to File &gt; Open Wallet to load a wallet.
   </body></file>
   <file original="../walletview.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletView">
-      <trans-unit id="_msg979">
+      <trans-unit id="5e98cff38b24cabb4a492a43665df77120fe5d771c0632b3e7eb3fafcb9987ae">
         <source xml:space="preserve">&amp;Export</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg980">
+      <trans-unit id="da242cb3e79c3881d46416a9a22e0b55e69ecbb52a458b9252e3ef9d6dd12a6b">
         <source xml:space="preserve">Export the data in the current tab to a file</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg981">
+      <trans-unit id="9167e0d998e6fc09a029faa127813eb95175c9c1ad2e4a9ded7466084e24379f">
         <source xml:space="preserve">Backup Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg982">
+      <trans-unit id="95244616ed05f9f23924aec1d1777010d3e3eb1abadd571a15f8247377cb1917">
         <source xml:space="preserve">Wallet Data</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
         <note annotates="source" from="developer">Name of the wallet data file format.</note>
       </trans-unit>
-      <trans-unit id="_msg983">
+      <trans-unit id="d4c95176ecdc163a8ad5161db5fc3fb113d89d95459e5682d47234eec0594cf4">
         <source xml:space="preserve">Backup Failed</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg984">
+      <trans-unit id="b7d9f778c0609fc61038a4d635e49c5b18306f467c555c9f6f4dcc03a8f3c965">
         <source xml:space="preserve">There was an error trying to save the wallet data to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg985">
+      <trans-unit id="92829d554f9a7f3f5d3e1641cdefa4581f7a20f5fa1fc9391afb1302d2362fa7">
         <source xml:space="preserve">Backup Successful</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg986">
+      <trans-unit id="c086f78ea6f3d5063bda80c8247f519016dad765c924e73f0d187367b2d16ee2">
         <source xml:space="preserve">The wallet data was successfully saved to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg987">
+      <trans-unit id="d089d42c7bfe7daf6559370905f379900c7d82888d26b05a21d956d54d15d4e7">
         <source xml:space="preserve">Cancel</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
@@ -4559,1001 +4559,1001 @@ Go to File &gt; Open Wallet to load a wallet.
   </body></file>
   <file original="../bitcoinstrings.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="bitcoin-core">
-      <trans-unit id="_msg988">
+      <trans-unit id="2f3e169d06afcc7bb807b1bc61edf1e6f63ba7db6ddd832b92ee5dc4fe64908f">
         <source xml:space="preserve">The %s developers</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg989">
+      <trans-unit id="3ef1ebede72e0a3964a89d50bf2e46b88551291eeee81f1af7031492a3612a23">
         <source xml:space="preserve">%s failed to validate the -assumeutxo snapshot state. This indicates a hardware problem, or a bug in the software, or a bad software modification that allowed an invalid snapshot to be loaded. As a result of this, the node will shut down and stop using any state that was built on the snapshot, resetting the chain height from %d to %d. On the next restart, the node will resume syncing from %d without using any snapshot data. Please report this incident to %s, including how you obtained the snapshot. The invalid snapshot chainstate will be left on disk in case it is helpful in diagnosing the issue that caused this error.</source>
         <context-group purpose="location"><context context-type="linenumber">12</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg990">
+      <trans-unit id="a60bf5081048ee0456fd21456603cf38799c33f503ea29f0ef9817036f331983">
         <source xml:space="preserve">%s request to listen on port %u. This port is considered &quot;bad&quot; and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
         <context-group purpose="location"><context context-type="linenumber">15</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg991">
+      <trans-unit id="9e8687020911acf4a7df1610dc24353d36878247c1cb5e9fe20355d4c77ca703">
         <source xml:space="preserve">Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
         <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg992">
+      <trans-unit id="99ea7604851ed1c7d47c33ee473bd78d99572f283b772fd94970206df32cbde4">
         <source xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg993">
+      <trans-unit id="e27b4452f16b929e83f28372e9ba2fe996135bef35acabaa41c0505d693a074a">
         <source xml:space="preserve">Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
         <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg994">
+      <trans-unit id="84ec60926ae999f90b5f3095c6ffc91093dcd7120cb625bd1f21d36391e6a494">
         <source xml:space="preserve">Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg995">
+      <trans-unit id="0359e80023449f4c2c18185731467c762687698eadfbc6c61d3febadbef1a60e">
         <source xml:space="preserve">Error starting/committing db txn for wallet transactions removal process</source>
         <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg996">
+      <trans-unit id="ed68b81d39eb18c0131065355fb9845e892d5c5010c18ed597514580dbf01764">
         <source xml:space="preserve">Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg997">
+      <trans-unit id="a0a7b42942e369de765674338dcbf6255b8043201894b0173e3849ff3c298d8c">
         <source xml:space="preserve">Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg998">
+      <trans-unit id="461858da68e18eee70d441bd2188a655488f159a0b199280e91a0772f21ca8c7">
         <source xml:space="preserve">Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg999">
+      <trans-unit id="eaee6db5807ee121a4fd7779e9a9b01158b9650ba086ff474f9f16115373542b">
         <source xml:space="preserve">Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet&apos;s passphrase if it is encrypted.</source>
         <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1000">
+      <trans-unit id="31ad627ca3cd0e7965041fce173bb22c241678aa233a142c53f99e07a8443d67">
         <source xml:space="preserve">File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1001">
+      <trans-unit id="e6b3974b7b732af5ffa34a522254b38021f3c5d131504ebb8e4658e38fbec843">
         <source xml:space="preserve">Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1002">
+      <trans-unit id="8b0dd56343bbb12391a54a93cf94343c3e81f3daab72ad3692a78a8f339ba5a6">
         <source xml:space="preserve">Invalid value detected for &apos;-wallet&apos; or &apos;-nowallet&apos;. &apos;-wallet&apos; requires a string value, while &apos;-nowallet&apos; accepts only &apos;1&apos; to disable all wallets</source>
         <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1003">
+      <trans-unit id="8b80c92608b4ca762a73c620f789f960db6a9f88f6ffcd546c7132eee3c461cb">
         <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1004">
+      <trans-unit id="182420c2df81147348d83cbd3b8623087b27d36cd77c99d1d2f33c17b95e665e">
         <source xml:space="preserve">No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
         <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1005">
+      <trans-unit id="cfee7a820dad9d928572b3260530595d370d09e64148530e079e2cc9413a6a9f">
         <source xml:space="preserve">No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
         <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1006">
+      <trans-unit id="dadfa90bb7aedcdc681f5cbd3c6c459be846d0b6cc35919da07924777a3fc7a8">
         <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1007">
+      <trans-unit id="dd39d9e3c39a160e89bd934bfea075efd4a32ce30450b31490e8a65e09b4c8de">
         <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1008">
+      <trans-unit id="92a8240c340b7b717863375615d2d32d9cfe02322b6f4dc992d52d9cf4ea419b">
         <source xml:space="preserve">Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
         <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1009">
+      <trans-unit id="952dc91e21a4679bce374bac2e80e8fb98b46c1229b6904d0a79782d9574f537">
         <source xml:space="preserve">Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. You should resolve this by manually moving or deleting the invalid snapshot directory %s, otherwise you will encounter the same error again on the next startup.</source>
         <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1010">
+      <trans-unit id="a0497bf918e6f65106cd34b210a17f7e734d95049f67d74d2f55887dea0640b7">
         <source xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
         <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1011">
+      <trans-unit id="da180642b3c617d581c752833fa2912cf63a71030d6dc865d267ef4abaa8b54e">
         <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
         <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1012">
+      <trans-unit id="6ad2f58c4ff7f99f32d8a090733ae4ed4c61726613c32e3f1de8a1b6b6e12939">
         <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
         <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1013">
+      <trans-unit id="fe8a8b3638ebf81f710bec9290dedbb88127567f550c7667139979212be05349">
         <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1014">
+      <trans-unit id="1dfa7b16725250ccdd3cf7b97162a48e552093c95160afeecdbf724175588439">
         <source xml:space="preserve">This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
         <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1015">
+      <trans-unit id="aafefc4eff14a8ee1ff4aa6a2fbbd853fd2f86da7df92caee7312488e4505a5c">
         <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1016">
+      <trans-unit id="0afb9d36b822939a76d16156ef687079da9f655e2f0f06f2d139bf2b9dbb378c">
         <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
         <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1017">
+      <trans-unit id="feadbeea25a836e3b45a4c8e50f6b69c1085fed1ebefedb218844476b8888560">
         <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
         <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1018">
+      <trans-unit id="b7c6cb91063201c90201ab544346aa6573a363e64c76beaa78d6506e18bcf073">
         <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1019">
+      <trans-unit id="97691711e521ea08170bbcdc35b20504c0bbbc7fbe7ba48dbb72b98c94d98e5e">
         <source xml:space="preserve">Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %3$s. Valid loglevels: %4$s.</source>
         <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1020">
+      <trans-unit id="264e4c1cd622b9eb4442f0136644fcf5ebf0524e72ae6d145f55cb6dc2658933">
         <source xml:space="preserve">Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
         <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1021">
+      <trans-unit id="6059f002adfe2595b30cb2be4c576d261758c6874d2438eb7df85b415fb6e834">
         <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1022">
+      <trans-unit id="dc995b31c6f8dd56c07e33a25d4bcbb1a78a7c2b6703d2252a7d32a8a33bfc5a">
         <source xml:space="preserve">Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1023">
+      <trans-unit id="f054d08be72292185008237002b9226c6474903d6c4297ab20f77a95a29a48aa">
         <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1024">
+      <trans-unit id="68331bfff01f6555c30bddddc10f8d97e0ee63a0326a9e4a25221e7c280a8f56">
         <source xml:space="preserve">%s is set very high!</source>
         <context-group purpose="location"><context context-type="linenumber">13</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1025">
+      <trans-unit id="73c901f2ebe0b3970478b29dac7342883656de3e16d64be31d07a5c37a558470">
         <source xml:space="preserve">-maxmempool must be at least %d MB</source>
         <context-group purpose="location"><context context-type="linenumber">16</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1026">
+      <trans-unit id="94b1812417fc55980373f534aed60f0304c7bfd80257059e6d996c668db15e3b">
         <source xml:space="preserve">Cannot obtain a lock on directory %s. %s is probably already running.</source>
         <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1027">
+      <trans-unit id="be2671c6fff4bd0c6b177accd4ecc333e1aa9e42b49948e43dc43c7d94132b5f">
         <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1028">
+      <trans-unit id="d03c0b56e41ed6b39df2d8ca84e0984b6d83588aa5c20053b155ea2f74a44c6d">
         <source xml:space="preserve">Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
         <context-group purpose="location"><context context-type="linenumber">26</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1029">
+      <trans-unit id="d5ee61c2707f4fd1959c98f636364398fc914b2f7e8d0877b2546f086e8e3144">
         <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1030">
+      <trans-unit id="ab5729226e36a6177fe0d03dae30956aa313496d6c634d888d1501d390bc9356">
         <source xml:space="preserve">%s is set very high! Fees this large could be paid on a single transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1031">
+      <trans-unit id="8655eda5824cd2e22607baba2fa78bda744bd6e7e3d75803d093f1fc5cf62f7e">
         <source xml:space="preserve">Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
         <context-group purpose="location"><context context-type="linenumber">24</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1032">
+      <trans-unit id="c11cf3d2a72f56a0b32ed2c0604bd5dd55953e5651f243e4d30218cda0304562">
         <source xml:space="preserve">Error loading %s: External signer wallet being loaded without external signer support compiled</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1033">
+      <trans-unit id="00fa43f82aecb7b16057ad4754bcb157e544d128fec8d4d6e40759004f330386">
         <source xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address metadata may be missing or incorrect.</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1034">
+      <trans-unit id="8a30a529a6d7ba2aaa7e59add5ec24f43bdf71dc2302b6d0db03ea85f0c8ca7e">
         <source xml:space="preserve">Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1035">
+      <trans-unit id="5a3881dae870116973b4c05f672d6f5bf903834bb98c8d08a6661d9f94e6bb8b">
         <source xml:space="preserve">Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1036">
+      <trans-unit id="1ede3ec873801b9e932f1a87006389b28202a09dd1b8a299343ed08cdb16d8b9">
         <source xml:space="preserve">Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1037">
+      <trans-unit id="733e1549879e5652ce4502c115eaacb5ff604cf3e20a6c9f57ee20271cc72839">
         <source xml:space="preserve">Failed to remove snapshot chainstate dir (%s). Manually remove it before restarting.
 </source>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1038">
+      <trans-unit id="edb285f4ad2dc15c1fe02b93b8774a3bafb6de0c18a83d540f76934f80cbec6c">
         <source xml:space="preserve">Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1039">
+      <trans-unit id="62653a3f5c8132593748e121b43023d5e6fc44cf1fc19dcf12cbf63743c01841">
         <source xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s.</source>
         <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1040">
+      <trans-unit id="f826905b318eea0889d85a469c9f3b1a1b527a69d6ba0ef7b2e61fe9e7968131">
         <source xml:space="preserve">Flushing block file to disk failed. This is likely the result of an I/O error.</source>
         <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1041">
+      <trans-unit id="87b1827781fdf3530a7cf6cd45f5a0d619184ec4837338ce1638c04d9959f803">
         <source xml:space="preserve">Flushing undo file to disk failed. This is likely the result of an I/O error.</source>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1042">
+      <trans-unit id="a0ff7fab52a4771d8042b861219db93ff1f55f893410e064d976dc89f30b49be">
         <source xml:space="preserve">Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
         <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1043">
+      <trans-unit id="5eed9481d30c62887e099b7e4dafb6f590465c44ab6ccd6c5fcb1b6ae58096ca">
         <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1044">
+      <trans-unit id="1cad3947993b66ceda8f86740f99a7991a6579449476b7e95d1a3e0bf941fc0f">
         <source xml:space="preserve">Maximum transaction weight is less than transaction weight without inputs</source>
         <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1045">
+      <trans-unit id="bc4afe397e11a8b548454b4daeb065d20c714f85c82a1ff4cce3c6b896d614b9">
         <source xml:space="preserve">Maximum transaction weight is too low, can not accommodate change output</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1046">
+      <trans-unit id="cc2556f99290c46dfee9cca7a7bb943a9be3507467b1545ad330fa512a218a3d">
         <source xml:space="preserve">Option &apos;-checkpoints&apos; is set but checkpoints were removed. This option has no effect.</source>
         <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1047">
+      <trans-unit id="639e076eb226eef15095f2459c44b240e34198c9334b9884acbe592360198751">
         <source xml:space="preserve">Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
         <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1048">
+      <trans-unit id="c2cec7f72a652372986ed7cd9107048096de1a13d3963d2816600bd0ca6f4f1b">
         <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
         <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1049">
+      <trans-unit id="8b3a87d8f564ec30e279322c2840da69bd700abd234facd3acd251763abd4b91">
         <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1050">
+      <trans-unit id="8911a25f68b4cdb9942a6e9f6030e933e762bd2b941f4f37ecca63c3947a8be4">
         <source xml:space="preserve">Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
         <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1051">
+      <trans-unit id="731f04b674f953585466d16efd56f503c4c0b0bf8aa9f3c01af44d7b7e713422">
         <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)</source>
         <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1052">
+      <trans-unit id="214bd15bc461646f7259bdc82e27145486d8f8e72a261495a79ce3da0948bb38">
         <source xml:space="preserve">Rename of &apos;%s&apos; -&gt; &apos;%s&apos; failed. Cannot clean up the background chainstate leveldb directory.</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1053">
+      <trans-unit id="ac298b7cae67fb5a9d074dc0a577b8990706afefb90effca80a8fd65aa4631e4">
         <source xml:space="preserve">Specified -blockmaxweight (%d) exceeds consensus maximum block weight (%d)</source>
         <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1054">
+      <trans-unit id="d03779dcc331854e2937eccf5afa93a465364e33085ff07a839305243656e87e">
         <source xml:space="preserve">Specified -blockreservedweight (%d) exceeds consensus maximum block weight (%d)</source>
         <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1055">
+      <trans-unit id="12a0513567ac2e1b7b784193a736618980eecdf9427ff767d0d91a91fe7f59ef">
         <source xml:space="preserve">Specified -blockreservedweight (%d) is lower than minimum safety value of (%d)</source>
         <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1056">
+      <trans-unit id="346da2571d4d67c677e29589580a7ab3bf47bbf7a9a5226c3076e7731c9717fe">
         <source xml:space="preserve">The combination of the pre-selected inputs and the wallet automatic inputs selection exceeds the transaction maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1057">
+      <trans-unit id="e295ebc1265dfc26aa50f033af10cec4aa7d673ddd17a8bdef288c98cfc08c41">
         <source xml:space="preserve">The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
         <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1058">
+      <trans-unit id="768952210d9b53f6d68b6b3fbb4ad1c49c53bdd51ea6d3e71c9d5bc4913d8c9b">
         <source xml:space="preserve">The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
         <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1059">
+      <trans-unit id="f288c7589b4c6a416cdce7c0b946fcf42d6fcf2e2a2a8b2555442ea43f14d9c1">
         <source xml:space="preserve">UTXO snapshot failed to validate. Restart to resume normal initial block download, or try loading a different snapshot.</source>
         <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1060">
+      <trans-unit id="1a0492da7848795869b59dac9018a031b6f8e9c2fb84dc2b41176d162e8d8a4a">
         <source xml:space="preserve">Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool</source>
         <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1061">
+      <trans-unit id="8be4eddcb4c89115e5440bccc28efb5b9610016ee395c5607128a5b6fbfc1204">
         <source xml:space="preserve">Unexpected legacy entry in descriptor wallet found. Loading wallet %s
 
 The wallet might have been tampered with or created with malicious intent.
 </source>
         <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1062">
+      <trans-unit id="2ea3801cd6ce5dba1789319199e3de11f2281ada8f7bbde2e07655b3c925cb06">
         <source xml:space="preserve">Your computer&apos;s date and time appear to be more than %d minutes out of sync with the network, this may lead to consensus failure. After you&apos;ve confirmed your computer&apos;s clock, this message should no longer appear when you restart your node. Without a restart, it should stop showing automatically after you&apos;ve connected to a sufficient number of new outbound peers, which may take some time. You can inspect the `timeoffset` field of the `getpeerinfo` and `getnetworkinfo` RPC methods to get more info.</source>
         <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1063">
+      <trans-unit id="f9031a21fb896794e5a9825cea274d3e0d9dadc7aa4b461bb20d4ded55dc972f">
         <source xml:space="preserve">
 Unable to cleanup failed migration</source>
         <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1064">
+      <trans-unit id="e695e92406c20a06b3978cf36c7f329e270d078933113cf42e6c0c4e32c7e83d">
         <source xml:space="preserve">
 Unable to restore backup of wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1065">
+      <trans-unit id="02a2b88b41f263917e37f4dd8856ad719569ad1314a10fb4ade6362f079f4104">
         <source xml:space="preserve">default wallet</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1066">
+      <trans-unit id="88cb17c09f1dc66ee84a2fb0b81f344b745dc29842f016035a32564c4d5637f4">
         <source xml:space="preserve">whitebind may only be used for incoming connections (&quot;out&quot; was passed)</source>
         <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1067">
+      <trans-unit id="6c94a9855a5d3522a99dd59152b6d13831688cba2904475e42a935f699e3c7ab">
         <source xml:space="preserve">A fatal internal error occurred, see debug.log for details: </source>
         <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1068">
+      <trans-unit id="bc42af28af680c906fe4b7c82a00223b76880bc17a392c1f9966b8dd03ea0531">
         <source xml:space="preserve">Assumeutxo data not found for the given blockhash &apos;%s&apos;.</source>
         <context-group purpose="location"><context context-type="linenumber">19</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1069">
+      <trans-unit id="4ab1018a9d84c0c32a06d4c24c1454f629dbb86897b1b3ddefff6078cc4edd34">
         <source xml:space="preserve">Block verification was interrupted</source>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1070">
+      <trans-unit id="08fc42d504b77c9f9ebb8ef0075a9ee87ca24e5b762ce6cae670671a9f5902f0">
         <source xml:space="preserve">Can&apos;t spend unconfirmed version %d pre-selected input with a version 3 tx</source>
         <context-group purpose="location"><context context-type="linenumber">21</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1071">
+      <trans-unit id="08d9ea07a828bf4517737fc47394c0aa3a72679d04d6929deee239d31ba6caa6">
         <source xml:space="preserve">Can&apos;t spend unconfirmed version 3 pre-selected input with a version %d tx</source>
         <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1072">
+      <trans-unit id="cd79452d08360ab4cb577c63f75ca616c5c0e26d88eb9d473c3cfbb120d2f303">
         <source xml:space="preserve">Cannot write to directory &apos;%s&apos;; check permissions.</source>
         <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1073">
+      <trans-unit id="690a4f988aafa3cc37e24d7791232a93200c0b7c3b6cf09a4b70cb0865b617ee">
         <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
         <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1074">
+      <trans-unit id="ce062ca0be24b540d1371074bc55ee78d2c7de0895f95eeefa84a3157ac7bdec">
         <source xml:space="preserve">Copyright (C) %i-%i</source>
         <context-group purpose="location"><context context-type="linenumber">30</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1075">
+      <trans-unit id="977689ea648b7bf9e02ab2b974c9deab3398165777773491ee1c56593d9ec49f">
         <source xml:space="preserve">Corrupt block found indicating potential hardware failure.</source>
         <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1076">
+      <trans-unit id="372b6860569c60d854d2f290921866aeb5b3cd94f2fa18f854f6ceec6af73567">
         <source xml:space="preserve">Corrupted block database detected</source>
         <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1077">
+      <trans-unit id="daa687aad9bd262a5689f380c3f88929296374294bbc7a2f6b32db5d10bad302">
         <source xml:space="preserve">Could not find asmap file %s</source>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1078">
+      <trans-unit id="5082daa03d8140602786395cdfe6ac89a3c38ce710de6e5286145709445a956a">
         <source xml:space="preserve">Could not generate scriptPubKeys (cache is empty)</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1079">
+      <trans-unit id="30c0ce4e7d1a0dc04efc2613b0ecfc99269c08346568a288bdc14940875696d6">
         <source xml:space="preserve">Could not parse asmap file %s</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1080">
+      <trans-unit id="2946aae112873fd18fc0572c62bc7e6839f5ebe0708802b98d98f2539c74ba52">
         <source xml:space="preserve">Could not read embedded asmap data</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1081">
+      <trans-unit id="37cc3ef409bb8b1ccf907404596022c97b0a19f6b9df10d7313c0ac4bdf63395">
         <source xml:space="preserve">Could not top up scriptPubKeys</source>
         <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1082">
+      <trans-unit id="2129449a43bbef4dfac6514715e2774033b45e8527bf889a8de6e0f7fe1b6c82">
         <source xml:space="preserve">Disk space is too low!</source>
         <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1083">
+      <trans-unit id="b23393a11f1517e5f63a06d84aa3e08dfe12328e09a27a238f6188e475a6affc">
         <source xml:space="preserve">Done loading</source>
         <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1084">
+      <trans-unit id="c4bb49629468a2e25ae929fd846258d9adbf48b4efc53e6d62b53185fc7e6aa8">
         <source xml:space="preserve">Dump file %s does not exist.</source>
         <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1085">
+      <trans-unit id="762dd583b7eb5647779d8ef3cb515dccaa37086e1ef30fcc093db94199d9e5e1">
         <source xml:space="preserve">Elliptic curve cryptography sanity check failure. %s is shutting down.</source>
         <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1086">
+      <trans-unit id="8a382e7874f8b4d5c4e9a9507fac0752990a5b1ddf53a01383fec634b5dfa0b2">
         <source xml:space="preserve">Embedded asmap data not available</source>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1087">
+      <trans-unit id="d7390ecdabb9b3f105295cd45525d3c19ed240d344afce34dea2e6de4b009467">
         <source xml:space="preserve">Error initializing block database</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1088">
+      <trans-unit id="d35d1177a2f2cd1e366b0b9a6830c8630fba77a377d39106ae2c446bfd5bd278">
         <source xml:space="preserve">Error loading %s</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1089">
+      <trans-unit id="6cd80e5a60c93cff4a9dff159983cb542e4da679b425449b8356f4347d9ba5b6">
         <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
         <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1090">
+      <trans-unit id="50465dbff020f8db5af642bc2a72f8dc10b0fa7ec2edefa037d2543f0df1ac8d">
         <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
         <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1091">
+      <trans-unit id="cc645714e4d7b42b42522539681eb7c18b93cfd9755c847e2fd38f209b320f01">
         <source xml:space="preserve">Error loading block database</source>
         <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1092">
+      <trans-unit id="036c865c19bf418afa3bdc3d42578e3f00acd83de8b0f607f3247e44da4262a8">
         <source xml:space="preserve">Error loading databases</source>
         <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1093">
+      <trans-unit id="44a97cbfb4a38c4a1589c3ed5c9150df1427b3344e78e36be2d3c17cd0c9b1c8">
         <source xml:space="preserve">Error opening block database</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1094">
+      <trans-unit id="fcb3b7da9947394ea0437e3f290c203568c448365c58ed2557b6cf2e8602bead">
         <source xml:space="preserve">Error opening coins database</source>
         <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1095">
+      <trans-unit id="b35c24fca0385513d2926476852d9af8535415ab7eb59c54d7371bed4433f905">
         <source xml:space="preserve">Error reading configuration file: %s</source>
         <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1096">
+      <trans-unit id="5cb7742d377cbcfb376c3ce43e14607c8f8fb18e15450e9dca4cd7f5d5aff3f5">
         <source xml:space="preserve">Error reading from database, shutting down.</source>
         <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1097">
+      <trans-unit id="ba52d4af039fa2c138c9957ecb04f6e2bb4d2515858fd36a24c0278aa1445217">
         <source xml:space="preserve">Error reading next record from wallet database</source>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1098">
+      <trans-unit id="1dc607f0690f8f3a4f725a2295d32b1b18bfe6782a33837400db5d4f4fae7f3c">
         <source xml:space="preserve">Error: Cannot extract destination from the generated scriptpubkey</source>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1099">
+      <trans-unit id="cf44b0ec1a9e6fbee3566b316d707b8dc0f142e7a34fd13a8e1ff616bd0f10b1">
         <source xml:space="preserve">Error: Couldn&apos;t create cursor into database</source>
         <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1100">
+      <trans-unit id="0b6a371bf70c32abebf11545a85080772455ebd219de1ca07ec3c7b273d050ec">
         <source xml:space="preserve">Error: Disk space is low for %s</source>
         <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1101">
+      <trans-unit id="eef7c005b21a3a15761806a0fdb725df21f5f9e8e6a9b39a862e54df1306b171">
         <source xml:space="preserve">Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1102">
+      <trans-unit id="d45e1bb4606ac83825b213f3844561d0802c742cc0c55929e00b1c9f3ed67cd5">
         <source xml:space="preserve">Error: Failed to create new watchonly wallet</source>
         <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1103">
+      <trans-unit id="0627cddabab680b5e7502294caa34d2100f7b1913eee85964e648f35d6eb575a">
         <source xml:space="preserve">Error: Got key that was not hex: %s</source>
         <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1104">
+      <trans-unit id="72429ad3b625c84ec3d53442a79f5d96839dc0ce935a1ffb2c15b728daa419ca">
         <source xml:space="preserve">Error: Got value that was not hex: %s</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1105">
+      <trans-unit id="b450049f663714e2aad8128612fff96d103e10912e2465598c4391a95cf65ab0">
         <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
         <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1106">
+      <trans-unit id="0448f0d1bbefb2d5b2627dcbae58db42e6f2e2a2dae6dd9aed70a5b707e1400e">
         <source xml:space="preserve">Error: Missing checksum</source>
         <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1107">
+      <trans-unit id="a13d23e66eea85f559ee6b8186cf4bd4f230da7d3a420f8f098ebb9e91ac4064">
         <source xml:space="preserve">Error: No %s addresses available.</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1108">
+      <trans-unit id="6749bea9bd72caf72fbbc65a047ed7f62fb6a10a5cb81d84dbcad64f3b99af99">
         <source xml:space="preserve">Error: Not all address book records were migrated</source>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1109">
+      <trans-unit id="903061497ec09ba02b4e094b2014e031543a5ab09748c955b3ef24ec10ce0628">
         <source xml:space="preserve">Error: Not all transaction records were migrated</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1110">
+      <trans-unit id="77d93a20877e48e0965a58a68906ba547cb1d6cefe20748af0e3553311326899">
         <source xml:space="preserve">Error: This wallet already uses SQLite</source>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1111">
+      <trans-unit id="aaa9684d158dad4cc82889384a40a74d5703771d91754706a59e651d63ca900f">
         <source xml:space="preserve">Error: This wallet is already a descriptor wallet</source>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1112">
+      <trans-unit id="6982c5abd93a10ed5e609a47ffcdf3025a714b795bd29e548602a7758bd787e5">
         <source xml:space="preserve">Error: Unable to begin reading all records in the database</source>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1113">
+      <trans-unit id="9c4313dc2609c75aea1920f7532a3ee2b6d4c49741db0ca749f21ac209c1ca6c">
         <source xml:space="preserve">Error: Unable to make a backup of your wallet</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1114">
+      <trans-unit id="e29dbfa3072f2f4dcf3f9faecdd4864b31aafcb76bc1eaf22f891c8a39cdd02b">
         <source xml:space="preserve">Error: Unable to parse version %u as a uint32_t</source>
         <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1115">
+      <trans-unit id="cd252c4fdb6bf694725083792742001c38a0e9219ed329f5c089c5bd2b733e54">
         <source xml:space="preserve">Error: Unable to read all records in the database</source>
         <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1116">
+      <trans-unit id="fe07db692f82ff32c687e2d4224650316f8e43c51c6c979d0cd79ed8f8f2f6df">
         <source xml:space="preserve">Error: Unable to read wallet&apos;s best block locator record</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1117">
+      <trans-unit id="7030aa3d77743674425ef674c74ec960c1b5008ce8e9bb571002435673953c71">
         <source xml:space="preserve">Error: Unable to remove watchonly address book data</source>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1118">
+      <trans-unit id="90d11034e4cff48aa0772615cd8af54e505e9610c4290b34031415c62aae2367">
         <source xml:space="preserve">Error: Unable to write data to disk for wallet %s</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1119">
+      <trans-unit id="045f3b0a53dd60a01b5305443b243a634b28abbf3153a4003ef09ae5a1ebec2e">
         <source xml:space="preserve">Error: Unable to write record to new wallet</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1120">
+      <trans-unit id="7c2ff5a39e6e08eecbad82dbc8a8a79b8eed26353710d697829795b1c2b00a21">
         <source xml:space="preserve">Error: Unable to write solvable wallet best block locator record</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1121">
+      <trans-unit id="caf8b787251a7482d9fac3f7d1dd273ca55e16f4cb1dfec935c78377cd8a9fb6">
         <source xml:space="preserve">Error: Unable to write watchonly wallet best block locator record</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1122">
+      <trans-unit id="5192f6854806e909c1f0d69674251483da2da26cb6709cce24224234d0d6039e">
         <source xml:space="preserve">Error: database transaction cannot be executed for wallet %s</source>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1123">
+      <trans-unit id="5ebd71f9cd4350d66634768c55787346e4d82b5c72c8fd9391c8407ac9e91478">
         <source xml:space="preserve">Failed to acquire rescan reserver during wallet initialization</source>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1124">
+      <trans-unit id="ff58794d6b4216f7e8c05f24584ff5e320ef52db051ab0448f099e77352bc394">
         <source xml:space="preserve">Failed to close block undo file.</source>
         <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1125">
+      <trans-unit id="d5bdd0ce060bca6643e50faeb30130703aa2e4ee192741c0e2a0a978bcd616be">
         <source xml:space="preserve">Failed to close file when writing block.</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1126">
+      <trans-unit id="93b2110004d38cff8f58c02c26f95a32c849c037c0fcc8c6a1e5e96d981da4af">
         <source xml:space="preserve">Failed to disconnect block.</source>
         <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1127">
+      <trans-unit id="8d55d7f1583d6aaa4b01bf71c0448251468afcb42a28bf46cb096cd0155ea441">
         <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1128">
+      <trans-unit id="33df2adc9c4ac02ecf5acd0b26befcd23d7ba5be40b4f20948b1912a5fc7894a">
         <source xml:space="preserve">Failed to read block.</source>
         <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1129">
+      <trans-unit id="d098079a7a9bf3843a0f164e40c69c99891515fbc0336fbd031ad4edc11fa5ef">
         <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
         <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1130">
+      <trans-unit id="b7b536e2f8f9235ee34629eff64ab16b3c13335ddc603f0bd5b5d5ea60d2cea7">
         <source xml:space="preserve">Failed to verify database</source>
         <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1131">
+      <trans-unit id="a99c53ce0baf58341e4a822a6fc5dfade150a3b060738a12530985868776a64f">
         <source xml:space="preserve">Failed to write block.</source>
         <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1132">
+      <trans-unit id="534de53a7a2ee4102f2982d94932ee9cfacdad1584cdf6f8f9e09b80c00d7b76">
         <source xml:space="preserve">Failed to write undo data.</source>
         <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1133">
+      <trans-unit id="0ec01e5b3128b20b17fffa2c28791b5de23c9c075c73a16abd0777bbdbc88f98">
         <source xml:space="preserve">Failure removing transaction: %s</source>
         <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1134">
+      <trans-unit id="5f3ea29ba39dc7e056acfaa3c89fafc71342d2b31c3dc70b8c759f3cea7cf877">
         <source xml:space="preserve">Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
         <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1135">
+      <trans-unit id="dcb1d628d04e6c1e0b709034a5645886af2e820852aa3e191aa3d3b43a5df08e">
         <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
         <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1136">
+      <trans-unit id="0f25d2a556c4a5d0cea146c6834b3cbb4cc46a1a827811e9b79a1ce9604c51da">
         <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1137">
+      <trans-unit id="21ba472180ee8e20f57c667da3e3919c226f6881994c33e86dbaae8e0cc747c2">
         <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
         <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1138">
+      <trans-unit id="fd47b2bf5d3b1d7925a615527ac3cbe9d22f09377d4e3bbbfd82d421ee6075c7">
         <source xml:space="preserve">Input not found or already spent</source>
         <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1139">
+      <trans-unit id="0381138cf59c82de1605c5e9b0ce9bc6240f7b0df0e5b4b65b42ace20b83974b">
         <source xml:space="preserve">Insufficient dbcache for block verification</source>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1140">
+      <trans-unit id="efbc2bb9431ed57d5e9f2a8a6148750e54dfe8397068cc8e7b9411f5d1f6826e">
         <source xml:space="preserve">Insufficient funds</source>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1141">
+      <trans-unit id="a9b418e33592d0f221bfab65c725fc8612a3369780db0c8be5701a704273d68f">
         <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1142">
+      <trans-unit id="af0fc7fcd8791415e8724a9404e65efc9d1e860d6d2d697af3c171487b4259cc">
         <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1143">
+      <trans-unit id="799fdc1c34f2769c7ee42aa2c3f3c2a4c37fe63e6750bccc47637a98869196b1">
         <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1144">
+      <trans-unit id="132aed1a42a5f1adc8c102cc6fa5e09364ae4a29f32cf784004dd3ed95644af4">
         <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1145">
+      <trans-unit id="bdfa1b7c396f4d95bc9077869aa4430824ad43053d2b095d6ff15f9dc1be22d0">
         <source xml:space="preserve">Invalid amount for %s=&lt;amount&gt;: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1146">
+      <trans-unit id="c63b1270d6699e01011b1876820ee9963de716fbcf71a2393e52f2f679931695">
         <source xml:space="preserve">A %zu MiB dbcache may be too large for a system memory of only %zu MiB.</source>
         <context-group purpose="location"><context context-type="linenumber">17</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1147">
+      <trans-unit id="938b7425c02dfa9a0ff22c2036456b669c36b7a88f6008234c66cadb1225886f">
         <source xml:space="preserve">Creating wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1148">
+      <trans-unit id="ba9092fdb5467c9d83f2208fda607ab7b5998155d2e7de08fb5efd438da20412">
         <source xml:space="preserve">Duplicate binding configuration for address %s. Please check your -bind, -bind=...=onion and -whitebind settings.</source>
         <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1149">
+      <trans-unit id="76553ef9b4680dd4c8a73fa875b3cc3914b3714876c64bb67706b034246767de">
         <source xml:space="preserve">Error creating %s: Could not write version metadata.</source>
         <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1150">
+      <trans-unit id="e8c867b95269b2f16ae3e10a3a12bd0c885ee3af377effdbfc848c2b6242fb7f">
         <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1151">
+      <trans-unit id="44af3f66ece76c71d90a37d13b5ce3c76044f55b1098433709f04aedd52cdb83">
         <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1152">
+      <trans-unit id="9649503a93dcb52dd9fd534b04a08ad0a6265b5e8b09f76ebba8589de05269ca">
         <source xml:space="preserve">Invalid port specified in %s: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1153">
+      <trans-unit id="60d62b9514213b500431bd3781dbeb3e809a5b7d23edada53e1193324c6fe03e">
         <source xml:space="preserve">Listening for incoming connections failed (listen returned error %s)</source>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1154">
+      <trans-unit id="edb23808ebb1ff4f4d3421afa53ecf4dbae6c6e49aa26cc98249c771b08bbb96">
         <source xml:space="preserve">Loading P2P addresses…</source>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1155">
+      <trans-unit id="e5a5196731b285d2ec9ef16ffad497df4ca6b9bb7ce4b3dc0bf3a769f43dbc40">
         <source xml:space="preserve">Loading banlist…</source>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1156">
+      <trans-unit id="675bf96bc51af1078f172f14254dc358f8e70079a2012be0ef98dadd3f19c975">
         <source xml:space="preserve">Loading block index…</source>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1157">
+      <trans-unit id="decc1f0c4f559e27d51a280ef522d86e640a2f32948a4fec69697ff85cee408b">
         <source xml:space="preserve">Loading wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1158">
+      <trans-unit id="ac43be1026dc02ccbbb8444a27a8b64937e69c3cad3f07eb859de00afcb6e82d">
         <source xml:space="preserve">Maximum transaction weight must be between %d and %d</source>
         <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1159">
+      <trans-unit id="6fc6872a799c1ae35017a054872eacf1878cbc2d7a30aa3c06375c92338fbde0">
         <source xml:space="preserve">Missing amount</source>
         <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1160">
+      <trans-unit id="70090349e1bfabdcbf2b699362023fbd8999c20ce97b9c43aa42a4c827ac32f2">
         <source xml:space="preserve">Missing solving data for estimating transaction size</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1161">
+      <trans-unit id="273c63a6a1fd3c4eea528ea1fcab239f17962a9418df4b8b9cd089fb4b70932d">
         <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1162">
+      <trans-unit id="b5994d88544fb12fd05a1743bcdd6a9e4f3a2c2febd8bc592419d76188949d2a">
         <source xml:space="preserve">No addresses available</source>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1163">
+      <trans-unit id="57335eddc2ef8d85aa133cee3e90a1b9e309b0a8a4e2a675276de23bfc7c3820">
         <source xml:space="preserve">Not found pre-selected input %s</source>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1164">
+      <trans-unit id="718ac4bda5517cc65e85da69f01e25ef67593fe510879d5038a283e8728b0753">
         <source xml:space="preserve">Not solvable pre-selected input %s</source>
         <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1165">
+      <trans-unit id="c050e8418362f017e836c77b2b55101ce37c80e253d8f23cb8d652153fe92bed">
         <source xml:space="preserve">Only direction was set, no permissions: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1166">
+      <trans-unit id="5dc83033bbd342d0ba333511429ba715ae4da7b44f8b8da50ffc7960105bea28">
         <source xml:space="preserve">Option &apos;-limitancestorsize&apos; is given but ancestor size limits have been replaced with cluster size limits (see -limitclustersize). This option has no effect.</source>
         <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1167">
+      <trans-unit id="188b653110af584eeb24e8f41ae3ee6808b36a8f99f823ae71026a8381dc4951">
         <source xml:space="preserve">Option &apos;-limitdescendantsize&apos; is given but descendant size limits have been replaced with cluster size limits (see -limitclustersize). This option has no effect.</source>
         <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1168">
+      <trans-unit id="0caef2f739fb17ef1741426c6c6f01eaf20697389bda86b62218b41afbb34d20">
         <source xml:space="preserve">Private broadcast of own transactions requested (-privatebroadcast) and -proxyrandomize is disabled. Tor circuits for private broadcast connections may be correlated to other connections over Tor. For maximum privacy set -proxyrandomize=1.</source>
         <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1169">
+      <trans-unit id="51942980ea2e2b526d1e32a5e863310e34043cedb683539bc6fa94b3116e4f09">
         <source xml:space="preserve">Private broadcast of own transactions requested (-privatebroadcast), but -connect is also configured. They are incompatible because the private broadcast needs to open new connections to randomly chosen Tor or I2P peers. Consider using -maxconnections=0 -addnode=... instead</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1170">
+      <trans-unit id="d95b6dc2ea07eeb5bdf0fe81bfc4c5c5e7992fffc6c9813c88967dc298e90ab2">
         <source xml:space="preserve">Private broadcast of own transactions requested (-privatebroadcast), but none of Tor or I2P networks is reachable</source>
         <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1171">
+      <trans-unit id="dcab36a2c6c8b0b79a9124eeba893c9943637517d68d6777b31f61ef8795db0e">
         <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1172">
+      <trans-unit id="15dbc68660c5a7cc144d64a36276f8dc5f894867024173bfeb630d9152b805f6">
         <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1173">
+      <trans-unit id="13e95e90844b80879e7eaa002d580f17e4bf710c01b8944f2847ce41d1968f56">
         <source xml:space="preserve">Prune mode is incompatible with -txospenderindex.</source>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1174">
+      <trans-unit id="5113eabf32164b63725d030d4df39c8dc96bc1957d8f63d2939b8760aca0573b">
         <source xml:space="preserve">Pruning blockstore…</source>
         <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1175">
+      <trans-unit id="4ca71e773e2b113efd95bc3dfcd0f48b3a566c114ff4e3563a293ea2410a5046">
         <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1176">
+      <trans-unit id="88cd422c1254dc72d62b715ab97ac705e7890f3b46f34a2bbc0598a7eec0a035">
         <source xml:space="preserve">Replaying blocks…</source>
         <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1177">
+      <trans-unit id="4b3f98161b6530e7da7a7c1c6dea7b7d1eb3d1076645d32bd74445f7946f92fb">
         <source xml:space="preserve">Rescanning…</source>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1178">
+      <trans-unit id="b578e41748546fd99700c801db9552c95db9b2a5a493ac9794f76bc6195f40f3">
         <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
         <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1179">
+      <trans-unit id="a851dc689546aed7e67c6d9c8051a541df33d3fc1c4922332de9bcd89b3379e5">
         <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
         <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1180">
+      <trans-unit id="17db0a5562839183748c4a118922468f29b619ba60112f99591b2ec70d1b0590">
         <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
         <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1181">
+      <trans-unit id="d6ee24a4ac534b555a4b0d6382f5033846202e8ed6bcc902f14eeaabcca7fb0f">
         <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
         <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1182">
+      <trans-unit id="eb0b167811a1aa16fa761d4c36978c78fc352319cd00233672de3273644187b6">
         <source xml:space="preserve">Section [%s] is not recognized.</source>
         <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1183">
+      <trans-unit id="3f83aa4da7aa0e66a0f3f85935b13c0726f99e088cbc48c3b0ebec9eb6465c14">
         <source xml:space="preserve">Signer did not echo address</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1184">
+      <trans-unit id="ee559b0d2d25741edfa3acd6125310ccfed4e9c539f3af79f5c476ee98d38806">
         <source xml:space="preserve">Signer echoed unexpected address %s</source>
         <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1185">
+      <trans-unit id="df69aed491aff77a20c675b8a3fed29bf26434b4cd964646955cfec2947c3c1d">
         <source xml:space="preserve">Signer returned error: %s</source>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1186">
+      <trans-unit id="6edea129acb717507ac2a98ece8265913deea3931a6161942de331d3e359b3ec">
         <source xml:space="preserve">Signing transaction failed</source>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1187">
+      <trans-unit id="cc8f66d2795160bd611976fff1fd25b69ff57d4ac755a895b802b6e328a6ced3">
         <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
         <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1188">
+      <trans-unit id="4472afe40e13fa6ae5d6901ee30eb1255bf456ca4c89bab1f01fef9dd6d68f0c">
         <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
         <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1189">
+      <trans-unit id="063e33d8ac8506e27b27187d1f34a8a25fba801ad2b2a2b9305ef69fab3fbeaf">
         <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1190">
+      <trans-unit id="7c689c06f5ad44530e8fc8228d659f3917c78602903c793fba3ea5ecabc1c6ed">
         <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
         <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1191">
+      <trans-unit id="ad6a525c38d8c7409d55604709f3ee40b7c704b943071fa5b844d1ca80b561d5">
         <source xml:space="preserve">Specified data directory &quot;%s&quot; does not exist.</source>
         <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1192">
+      <trans-unit id="af0a2211fc297af695a6e050b8e1357c38653833b5d3c0b09212e59fb5c428d2">
         <source xml:space="preserve">Starting network threads…</source>
         <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1193">
+      <trans-unit id="eacd1b56ba6403ed554115fc810c22cc4e1dc3b45b18d0904b2f4aab56d8a477">
         <source xml:space="preserve">System error while flushing: %s</source>
         <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1194">
+      <trans-unit id="a4b4c0b2bbece237211130594e388025a7688b32acf9e980419aa825ab6e1270">
         <source xml:space="preserve">System error while loading external block file: %s</source>
         <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1195">
+      <trans-unit id="37f5fdc39ec1de84e0f9e017519d5092e88801fb18c80c788ea4e756f2825ac0">
         <source xml:space="preserve">System error while saving block to disk: %s</source>
         <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1196">
+      <trans-unit id="8ab6195dcda2219223915966ba288b0d66a82ed5ee2a6680eecd646d9bc64f9d">
         <source xml:space="preserve">The %s path uses exFAT, which is known to have intermittent corruption problems on macOS. Move this directory to a different filesystem to avoid data loss.</source>
         <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1197">
+      <trans-unit id="0ecf0d33f3df44bd35f39f243ed9b8917f26086e30a5bf57e4c95c06829e489a">
         <source xml:space="preserve">The source code is available from %s.</source>
         <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1198">
+      <trans-unit id="31cbe21aa515041e45cd05581ca0e7fd04338761d30dcb1263cb9bc7883dea3a">
         <source xml:space="preserve">The specified config file %s does not exist</source>
         <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1199">
+      <trans-unit id="581d1ad537ca398073216ae6973265d03339acf56f015c1e2c3c6bc92eccbce3">
         <source xml:space="preserve">The total exceeds your balance when the %s transaction fee is included.</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1200">
+      <trans-unit id="f6a1d9cd8f3ab16da5a5c01277ebd055d467c0bfa47a8fe788bb676a688cb12c">
         <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
         <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1201">
+      <trans-unit id="08b34dd6d8a35c633b3c74cf29b4c0b1d1c4e5ec2e4aad477706c24ae7a14514">
         <source xml:space="preserve">The transactions removal process can only be executed within a db txn</source>
         <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1202">
+      <trans-unit id="5b091967da3527415f0c2e9ad2c60d8eb995e562906580fa1d317be4b0325659">
         <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
         <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1203">
+      <trans-unit id="22c6c7f011cdb9eec000899da9c543ae4b2c52f3b1ce60d33a82e1ca0e5f12fd">
         <source xml:space="preserve">There is no ScriptPubKeyManager for this address</source>
         <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1204">
+      <trans-unit id="eb7ffecb0c2df2a86956f57f140c69fb002bce9cbcc000f0a16aac77fd78a84e">
         <source xml:space="preserve">This is experimental software.</source>
         <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1205">
+      <trans-unit id="d0fbdd2379be7623dbd478e0dc1095f9b33f66daee6324ab5d404374ab3453e2">
         <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1206">
+      <trans-unit id="c52fd38f9f252b27880cb523cae25393684e158dfb2dadcf1083b381e720551c">
         <source xml:space="preserve">Transaction %s does not belong to this wallet</source>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1207">
+      <trans-unit id="9cf81667b7f298b23eafd7eefe6f47640d2cc374fe1613f0f26e0cec0e831324">
         <source xml:space="preserve">Transaction amount too small</source>
         <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1208">
+      <trans-unit id="c0d171958624dda25a0e224fe70f9009ce08cbbf15ae9e8ecf6402fa7d9aa7c6">
         <source xml:space="preserve">Transaction amounts must not be negative</source>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1209">
+      <trans-unit id="3bd125dc841ef7ee009d1066d30817bbba578d5d6393e3e9866592a70df27f19">
         <source xml:space="preserve">Transaction change output index out of range</source>
         <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1210">
+      <trans-unit id="b6fcc5f3c8b967def9a2a1843a111f42fec5ae9902862cb63d031eba8201ccb7">
         <source xml:space="preserve">Transaction must have at least one recipient</source>
         <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1211">
+      <trans-unit id="e51365b39d675c706f2324d9ccb8d4e2a1da1afc413d9135495649b6d8d3ee52">
         <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it.</source>
         <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1212">
+      <trans-unit id="d6fcae660cab1f456917ae2ac2796e9fd63c2a8aaa6e52de962c1e949bf774a9">
         <source xml:space="preserve">Transaction too large</source>
         <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1213">
+      <trans-unit id="9110f1620541a4deb68367602515f6353bf96686c69b4cf1a3b74758610a02c9">
         <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1214">
+      <trans-unit id="8af01ee02ac782ae63f5aa2f0318dd0c504ed83d340af9f49e19834f87720fba">
         <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
         <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1215">
+      <trans-unit id="397236ea88ce016be5a15e0d68dc1c75c2422410c98f82597d946202cb7336a7">
         <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1216">
+      <trans-unit id="24ae9e9bc362fbaae4db407b3e9bebb854617e898573d697140d2173ea0f7612">
         <source xml:space="preserve">Unable to find UTXO for external input</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1217">
+      <trans-unit id="d258fbfc532a7fe5da89239a3beb143cd888d0e73dffe96f0effe5851a575453">
         <source xml:space="preserve">Unable to open %s for writing</source>
         <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1218">
+      <trans-unit id="a4257029acfaec72c6cb01ce16f6925a17ac936548353391dee18f61b5d63926">
         <source xml:space="preserve">Unable to parse -maxuploadtarget: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1219">
+      <trans-unit id="61c5444186ba410d02cad951f5ae515ac664ab7ab9fa4ad86e32543f3dac4419">
         <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
         <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1220">
+      <trans-unit id="32d9d8204d8018cc1678a080f7ae0f42745564908dd7d2d6297918b4ebc330f5">
         <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1221">
+      <trans-unit id="cfde9dd0af71b64e45ca2a9e96f23372f00620c4698b8a36ee8875daba63f8f0">
         <source xml:space="preserve">Unknown address type &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1222">
+      <trans-unit id="148659948e3f8e1aa633b8f19e7898449576e146c426a8278de34dea6111dd84">
         <source xml:space="preserve">Unknown change type &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1223">
+      <trans-unit id="44d6db21ef928fcd7a8510cead0dd7550c7e139bf6e45330a9b28c3ad325d10e">
         <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1224">
+      <trans-unit id="3043064f4afcc3a72c553011ccd5addf1d459af10cf118a3acd6d4d71d6cace4">
         <source xml:space="preserve">Unknown new rules activated (versionbit %i)</source>
         <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1225">
+      <trans-unit id="4ba12792aa080aa9f46843b8a37b4c5df1de71934d7041f5c02bc7391635a366">
         <source xml:space="preserve">Unrecognised option &quot;%s&quot; provided in -test=&lt;option&gt;.</source>
         <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1226">
+      <trans-unit id="b814d1dc4974e45941f3e158e893356b08b8751a8b049cb59ba477358781ecdf">
         <source xml:space="preserve">Unsupported global logging level %s=%s. Valid values: %s.</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1227">
+      <trans-unit id="8a4fd2b50286a1acbaab5045fea4c9792a7d07cefecf289214e58604a3d34920">
         <source xml:space="preserve">Wallet file creation failed: %s</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1228">
+      <trans-unit id="99bb263fdd8d9f898687e99f9fe2ca6432176e53a4f5e3ed4907f28cea4c4c5d">
         <source xml:space="preserve">Warning: Found invalid chain more than 6 blocks longer than our best chain. This could be due to database corruption or consensus incompatibility with peers.</source>
         <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1229">
+      <trans-unit id="0cddccb4764e14f0086e648efbeadf4e63f51ad982b730634c013212b0547c29">
         <source xml:space="preserve">acceptstalefeeestimates is not supported on %s chain.</source>
         <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1230">
+      <trans-unit id="1a891c0a0c843baf71b0c2603f7fce390abf3fb0586aa0d57f39e86a9b399f66">
         <source xml:space="preserve">Unsupported logging category %s=%s.</source>
         <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1231">
+      <trans-unit id="3e2ccd031ff09a54188df1271c5f0e9fd9f87efc08b386a85cfddede8aca7f04">
         <source xml:space="preserve">Error loading %s: Wallet is a legacy wallet. Please migrate to a descriptor wallet using the migration tool (migratewallet RPC).</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1232">
+      <trans-unit id="512ad6324000100b8f0c19419fc1c9a051af39f631659f45d5131f2a907cae80">
         <source xml:space="preserve">Error: Dumpfile specifies an unsupported database format (%s). Only sqlite database dumps are supported</source>
         <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1233">
+      <trans-unit id="bc3fd4d394c66f9cd404d2841b18e73e92c78177c65c918a80c363a5de962395">
         <source xml:space="preserve">Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.</source>
         <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1234">
+      <trans-unit id="dd50a7c2590f626459863d3a3900221e0090f8ee27b2ca758c1a8594481b3cd1">
         <source xml:space="preserve">Transaction requires one destination of non-zero value, a non-zero feerate, or a pre-selected input</source>
         <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1235">
+      <trans-unit id="e5bcc62c3bab83a005454d41164ebd1c9b91dec30d26309c96516675a3286a8c">
         <source xml:space="preserve">Unrecognized descriptor found. Loading wallet %s
 
 The wallet might have been created on a newer version.
@@ -5561,63 +5561,63 @@ Please try running the latest software version.
 </source>
         <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1236">
+      <trans-unit id="2701d41147c15de24a83621a4e6369382cbbdd514c9ff276922ea2c844b7b185">
         <source xml:space="preserve">Do you want to rebuild the databases now?</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1237">
+      <trans-unit id="ed36b63711fea0927c6627686c192705d16da8a3ae4c6fdcc071bdd7e8a15f51">
         <source xml:space="preserve">Error: Could not add watchonly tx %s to watchonly wallet</source>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1238">
+      <trans-unit id="7ecfbe36886fc19ebfa6802d6b22a0cb417deba2eb0b005f83ff18a7461c9397">
         <source xml:space="preserve">Error: Could not delete watchonly transactions. </source>
         <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1239">
+      <trans-unit id="1ba61057dde7c09d429530aef7985c9b42ae431a4fdec6aac1522fefe673f29d">
         <source xml:space="preserve">Error: Wallet does not exist</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1240">
+      <trans-unit id="729935a8e715275ec44adb10604048be327fa4dd73204751cdde5412d9de9a67">
         <source xml:space="preserve">Error: cannot remove legacy wallet records</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1241">
+      <trans-unit id="2dfd56338858af780c480f47cd1c978be81e30e40eedb6ff61f993e4fe3836c5">
         <source xml:space="preserve">Failed to start indexes, shutting down…</source>
         <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1242">
+      <trans-unit id="5120e79c517f46e447905f9a1948f6fa8cd458f4f03ae60d3e00048484c68ea6">
         <source xml:space="preserve">Invalid -proxy address or hostname, ends with &apos;=&apos;: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1243">
+      <trans-unit id="1d7291535a53a4612cbc4d916a8c82409a67d0748aa3fd0322b654efe764710c">
         <source xml:space="preserve">Not enough file descriptors available. %d available, %d required.</source>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1244">
+      <trans-unit id="1bfbc843eab6ec087f71a5c7f412555e392559d68026b5ef1606017adbe5feaf">
         <source xml:space="preserve">Unrecognized network in -proxy=&apos;%s&apos;: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1245">
+      <trans-unit id="5ddc2b11c24d9eb12ddbe48f96c0414fc01907cb09e885e5061d104eea9c7503">
         <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1246">
+      <trans-unit id="c42089bf882ea8bbb003a9f5bfe01842215a2066f876769107d01d4e6b96847d">
         <source xml:space="preserve">Verifying blocks…</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1247">
+      <trans-unit id="93dc164b0c7018324638030da915143dda9010d0979a0e645107d093cbafc4b7">
         <source xml:space="preserve">Verifying wallet(s)…</source>
         <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1248">
+      <trans-unit id="0c420335283b9dea8bd36e5797ed69e4a7990034198e63aae0f5d334eb80d160">
         <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
         <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1249">
+      <trans-unit id="ff729c01c9e1cc9c5b8d851dac652773b1d7f8ee4b63e6ff0025e59b8ceb5f40">
         <source xml:space="preserve">Settings file could not be read</source>
         <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1250">
+      <trans-unit id="180b0ec466b57af4115c90a34b06d3c2753e9f9813505f8de4f60e23c04f2516">
         <source xml:space="preserve">Settings file could not be written</source>
         <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
       </trans-unit>


### PR DESCRIPTION
### Summary

Regenerating the Qt translation template (`src/qt/locale/bitcoin_en.xlf`) previously used sequential `_msg<N>` IDs. When strings moved within the sorted message list, IDs shifted, creating large diffs and making translation platforms treat unchanged strings as new.

This PR switches XLF `<trans-unit id=...>` values to stable IDs derived from a SHA256 hash of the message context and source text.

### Details

As mentioned in https://github.com/bitcoin/bitcoin/pull/33224#issuecomment-3234820665, any change that moves a translatable string within the sorted messages can renumber subsequent entries when IDs are sequential.

Some English texts can appear in multiple places (e.g. “Clear”) with different meanings depending on the Qt context. To avoid collisions, the hash includes the `<group resname=...>` context.

### Fix

The `translate` target already runs `contrib/devtools/stabilize_xlf_ids.py`. Instead of trying to preserve/renumber `_msg<N>` IDs by matching old/new units, the script now rewrites every `<trans-unit id>` to:

- `sha256(resname + "\0" + source-text)` (hex)
- keeping the existing plural `[N]` suffix for plural forms

The script also checks for duplicate IDs and aborts if any are detected.

Note: this is a one-time mass change from `_msg<N>` IDs to hashes; after that, rerunning `translate` on an unchanged tree should not churn IDs.

With this PR applied, IDs become stable hashes so ordering changes no longer cause renumbering churn.

### Reproducer

You can test the replacer by changing any translatable text:
```patch
diff --git a/src/qt/bitcoingui.cpp b/src/qt/bitcoingui.cpp
--- a/src/qt/bitcoingui.cpp	(revision a38b8cf788922174538161cda81ce28f2ac462ec)
+++ b/src/qt/bitcoingui.cpp	(date 1767310724675)
@@ -258,7 +258,7 @@
     connect(modalOverlay, &ModalOverlay::triggered, tabGroup, &QActionGroup::setEnabled);
 
     overviewAction = new QAction(platformStyle->SingleColorIcon(":/icons/overview"), tr("&Overview"), this);
-    overviewAction->setStatusTip(tr("Show general overview of wallet"));
+    overviewAction->setStatusTip(tr("Show general overview of Wallet"));
     overviewAction->setToolTip(overviewAction->statusTip());
     overviewAction->setCheckable(true);
     overviewAction->setShortcut(QKeySequence(QStringLiteral("Alt+1")));
```
and regenerating the translations
```bash
cmake --preset dev-mode -DWITH_USDT=OFF && cmake --build build_dev_mode --target translate
```
You will notice that the new text moved to a different place with a different hash, but all other messages retained their IDs.