### PR TITLE
cmake: make missing Python interpreter behaviour more explicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ option(BUILD_GUI "Build bitcoin-qt executable." OFF)
 option(BUILD_CLI "Build bitcoin-cli executable." ON)
 
 option(BUILD_TESTS "Build test_bitcoin and other unit test executables." ON)
+option(BUILD_FUNCTIONAL_TESTS "Build functional tests." ON)
 option(BUILD_TX "Build bitcoin-tx executable." ${BUILD_TESTS})
 option(BUILD_UTIL "Build bitcoin-util executable." ${BUILD_TESTS})
 
@@ -631,7 +632,9 @@ else()
   set(CMAKE_SKIP_BUILD_RPATH TRUE)
   set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 endif()
-add_subdirectory(test)
+if (BUILD_FUNCTIONAL_TESTS)
+  add_subdirectory(test)
+endif()
 add_subdirectory(doc)
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,11 +591,6 @@ set(Python3_FIND_FRAMEWORK LAST CACHE STRING "")
 set(Python3_FIND_UNVERSIONED_NAMES FIRST CACHE STRING "")
 mark_as_advanced(Python3_FIND_FRAMEWORK Python3_FIND_UNVERSIONED_NAMES)
 find_package(Python3 3.10 COMPONENTS Interpreter)
-if(NOT TARGET Python3::Interpreter)
-  list(APPEND configure_warnings
-    "Minimum required Python not found."
-  )
-endif()
 
 target_compile_definitions(core_interface INTERFACE ${DEPENDS_COMPILE_DEFINITIONS})
 target_compile_definitions(core_interface_relwithdebinfo INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_RELWITHDEBINFO})

--- a/cmake/module/Maintenance.cmake
+++ b/cmake/module/Maintenance.cmake
@@ -77,6 +77,10 @@ endfunction()
 
 function(add_macos_deploy_target)
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND TARGET bitcoin-qt)
+    if(NOT TARGET Python3::Interpreter)
+      message(WARNING "Deploy target skipped, minimum required Python not found")
+      return()
+    endif()
     set(macos_app "Bitcoin-Qt.app")
     # Populate Contents subdirectory.
     configure_file(${PROJECT_SOURCE_DIR}/share/qt/Info.plist.in ${macos_app}/Contents/Info.plist NO_SOURCE_PERMISSIONS)

--- a/cmake/module/Maintenance.cmake
+++ b/cmake/module/Maintenance.cmake
@@ -20,6 +20,7 @@ endfunction()
 
 function(add_maintenance_targets)
   if(NOT TARGET Python3::Interpreter)
+    message(WARNING "Maintenance targets skipped, minimum required Python not found")
     return()
   endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,10 @@ function(create_test_config)
   configure_file(config.ini.in config.ini USE_SOURCE_PERMISSIONS @ONLY)
 endfunction()
 
+if(NOT TARGET Python3::Interpreter)
+  message(FATAL_ERROR "Minimum required Python not found. Consider configuring with -DBUILD_FUNCTIONAL_TESTS=0.")
+endif()
+
 create_test_config()
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/functional)


### PR DESCRIPTION
We require Python 3.10 for multiple targets, and currently raise a general warning if it is missing, leading to:
1. functional test suite: runtime failure if python missing (as e.g. described in #31476)
2. maintenance targets: targets skipped if python missing
3. macos deploy target: target created, but build fails if python missing

This PR:
- adds a `BUILD_FUNCTIONAL_TESTS` option (default `ON`) and raises `FATAL_ERROR` if Python is missing and we're building the functional tests
- raises explicit warnings (in-line, not at the end of the configure summary) for maintenance and macos deploy targets, and skips the macos deploy target instead of letting the build fail
- removes the general missing python warning at the end of the configure summary
- removes a dependency on our custom `configure_warnings` system (but requires further work to be completely removed)

Behaviour changes:
- `cmake -B build` now throws a `FATAL_ERROR` if minimum Python could not be found (overridden with `cmake -B build -DBUILD_FUNCTIONAL_TESTS=0`)
- `deploy` target no longer created if minimum Python could not be found
- warnings are raised on a usage basis, and no longer generically mentioned at the end of configure

Alternative to #31669 and partially to #33144 and #32865, partially addresses #31476.