### PR TITLE
cmake: fatal error when PIE not supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,9 +187,6 @@ string(APPEND CMAKE_CXX_LINK_EXECUTABLE " ${APPEND_LDFLAGS}")
 
 set(configure_warnings)
 
-include(CheckLinkerSupportsPIE)
-check_linker_supports_pie(configure_warnings)
-
 # The core_interface library aims to encapsulate common build flags.
 # It is a usage requirement for all targets except for secp256k1, which
 # gets its flags by other means.
@@ -200,6 +197,14 @@ target_link_libraries(core_interface INTERFACE
   $<$<CONFIG:RelWithDebInfo>:core_interface_relwithdebinfo>
   $<$<CONFIG:Debug>:core_interface_debug>
 )
+
+include(CheckLinkerSupportsPIE)
+check_linker_supports_pie()
+if (PIE_REQUIRED)
+  set_target_properties(core_interface PROPERTIES
+    INTERFACE_POSITION_INDEPENDENT_CODE TRUE
+  )
+endif()
 
 if(BUILD_FOR_FUZZING)
   message(WARNING "BUILD_FOR_FUZZING=ON will disable all other targets and force BUILD_FUZZ_BINARY=ON.")

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -44,8 +44,13 @@ function(add_secp256k1 subdir)
     deduplicate_flags(CMAKE_C_FLAGS)
   endif()
 
+if(NOT DEFINED PIE_REQUIRED)
+  message(FATAL_ERROR "PIE_REQUIRED is not defined. The call order is incorrect.")
+endif()
+
   add_subdirectory(${subdir})
   set_target_properties(secp256k1 PROPERTIES
     EXCLUDE_FROM_ALL TRUE
+    POSITION_INDEPENDENT_CODE ${PIE_REQUIRED}
   )
 endfunction()


### PR DESCRIPTION
This simultaneously avoids silently overriding user preferences while making it harder to accidentally build without PIE support by requiring an explicit setting.

This introduces two behaviour changes:
1. a user-defined `CMAKE_POSITION_INDEPENDENT_CODE=OFF` will now be respected by our build system, instead of silently overriding it like before
2. when not explicitly disabled, lack of PIE support will raise a `FATAL_ERROR` instead of a `WARNING`, with a help instruction that this can be overridden with `-DCMAKE_POSITION_INDEPENDENT_CODE=0`

Removes a dependency on our custom `configure_warnings` system.
