### PR TITLE
rpc: deprecateboolverbose Boolean verbosity is deprecated

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -900,3 +900,10 @@ std::pair<int, char**> WinCmdLineArgs::get()
 }
 #endif
 } // namespace common
+
+bool IsDeprecatedRPCEnabled(const std::string& method)
+{
+    const std::vector<std::string> enabled_methods = gArgs.GetArgs("-deprecatedrpc");
+
+    return std::find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
+}

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -491,4 +491,12 @@ private:
 #endif
 } // namespace common
 
+/**
+ * Checks if a deprecated RPC method is enabled via -deprecatedrpc flag
+ *
+ * @param method The deprecated method name to check (e.g., "boolverbose")
+ * @return true if the method is enabled, false otherwise
+ */
+bool IsDeprecatedRPCEnabled(const std::string& method);
+
 #endif // BITCOIN_COMMON_ARGS_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -747,7 +747,7 @@ static RPCHelpMan getblock()
                 "If verbosity is 3, returns an Object with information about block <hash> and information about each transaction, including prevout information for inputs (only for unpruned blocks in the current best chain).\n",
                 {
                     {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash"},
-                    {"verbosity|verbose", RPCArg::Type::NUM, RPCArg::Default{1}, "0 for hex-encoded data, 1 for a JSON object, 2 for JSON object with transaction data, and 3 for JSON object with transaction data including prevout information for inputs",
+                    {"verbosity|verbose", RPCArg::Type::NUM, RPCArg::Default{1}, "0 for hex-encoded data, 1 for a JSON object, 2 for JSON object with transaction data, and 3 for JSON object with transaction data including prevout information for inputs (DEPRECATED: Boolean verbosity is deprecated, use -deprecatedrpc=boolverbose to re-enable)",
                      RPCArgOptions{.skip_type_check = true}},
                 },
                 {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -8,6 +8,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <common/args.h>
 #include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -8,6 +8,7 @@
 #include <addrman_impl.h>
 #include <banman.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <clientversion.h>
 #include <core_io.h>
 #include <net_permissions.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -270,7 +270,7 @@ static RPCHelpMan getrawtransaction()
                 "If verbosity is 2, returns a JSON Object with information about the transaction, including fee and prevout information.",
                 {
                     {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                    {"verbosity|verbose", RPCArg::Type::NUM, RPCArg::Default{0}, "0 for hex-encoded data, 1 for a JSON object, and 2 for JSON object with fee and prevout",
+                    {"verbosity|verbose", RPCArg::Type::NUM, RPCArg::Default{0}, "0 for hex-encoded data, 1 for a JSON object, and 2 for JSON object with fee and prevout (DEPRECATED: Boolean verbosity is deprecated, use -deprecatedrpc=boolverbose to re-enable)",
                      RPCArgOptions{.skip_type_check = true}},
                     {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "The block in which to look for the transaction"},
                 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -338,12 +338,6 @@ bool RPCIsInWarmup(std::string *outStatus)
     return fRPCInWarmup;
 }
 
-bool IsDeprecatedRPCEnabled(const std::string& method)
-{
-    const std::vector<std::string> enabled_methods = gArgs.GetArgs("-deprecatedrpc");
-
-    return find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
-}
 
 UniValue JSONRPCExec(const JSONRPCRequest& jreq, bool catch_errors)
 {

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -126,7 +126,6 @@ public:
     bool removeCommand(const std::string& name, const CRPCCommand* pcmd);
 };
 
-bool IsDeprecatedRPCEnabled(const std::string& method);
 
 extern CRPCTable tableRPC;
 

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -12,6 +12,7 @@
 #include <consensus/amount.h>
 #include <core_io.h>
 #include <key_io.h>
+#include <logging.h>
 #include <node/types.h>
 #include <outputtype.h>
 #include <pow.h>
@@ -90,6 +91,10 @@ int ParseVerbosity(const UniValue& arg, int default_verbosity, bool allow_bool)
             if (!allow_bool) {
                 throw JSONRPCError(RPC_TYPE_ERROR, "Verbosity was boolean but only integer allowed");
             }
+            if (!IsDeprecatedRPCEnabled("boolverbose")) {
+                throw JSONRPCError(RPC_TYPE_ERROR, "Boolean verbosity is deprecated. Use integer values (0=false, 1=true). To temporarily re-enable, use -deprecatedrpc=boolverbose");
+            }
+            LogDebug(BCLog::RPC, "WARNING: Boolean verbosity is deprecated and will be removed in a future release. Use integer values instead.\n");
             return arg.get_bool(); // true = 1
         } else {
             return arg.getInt<int>();

--- a/test/functional/rpc_boolverbose_deprecated.py
+++ b/test/functional/rpc_boolverbose_deprecated.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that deprecated boolean verbosity works with -deprecatedrpc=boolverbose flag."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class BoolVerboseDeprecatedTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        # Enable the deprecated boolean verbosity support
+        self.extra_args = [["-deprecatedrpc=boolverbose"]]
+
+    def run_test(self):
+        self.log.info(
+            "Test that boolean verbosity works with -deprecatedrpc=boolverbose"
+        )
+
+        # Generate a block to have transactions to test with
+        self.generate(self.nodes[0], 1)
+        blockhash = self.nodes[0].getbestblockhash()
+
+        # Test getblock with boolean verbosity - should work with deprecation flag
+        block_true = self.nodes[0].getblock(blockhash, True)
+        block_false = self.nodes[0].getblock(blockhash, False)
+        block_int_1 = self.nodes[0].getblock(blockhash, 1)
+        block_int_0 = self.nodes[0].getblock(blockhash, 0)
+
+        # Boolean True should be equivalent to integer 1
+        assert_equal(block_true, block_int_1)
+        # Boolean False should be equivalent to integer 0
+        assert_equal(block_false, block_int_0)
+
+        # Test getrawtransaction with boolean verbosity - should work with deprecation flag
+        block = self.nodes[0].getblock(blockhash, 1)
+        txid = block["tx"][0]
+
+        tx_true = self.nodes[0].getrawtransaction(txid, True)
+        tx_false = self.nodes[0].getrawtransaction(txid, False)
+        tx_int_1 = self.nodes[0].getrawtransaction(txid, 1)
+        tx_int_0 = self.nodes[0].getrawtransaction(txid, 0)
+
+        # Boolean True should be equivalent to integer 1
+        assert_equal(tx_true, tx_int_1)
+        # Boolean False should be equivalent to integer 0
+        assert_equal(tx_false, tx_int_0)
+
+
+if __name__ == "__main__":
+    BoolVerboseDeprecatedTest(__file__).main()

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -3,8 +3,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test deprecation of RPC calls."""
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_raises_rpc_error
+
 
 class DeprecatedRpcTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -28,11 +30,57 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         # Please don't delete nor modify this comment
         self.log.info("Tests for deprecated RPC methods (if any)")
 
+        self.log.info("Test boolean verbosity deprecation")
+        # Generate a block to have transactions to test with
+        self.generate(self.nodes[0], 1)
+        blockhash = self.nodes[0].getbestblockhash()
+
+        # Test getblock with boolean verbosity - should fail without deprecation flag
+        assert_raises_rpc_error(
+            -3,
+            "Boolean verbosity is deprecated",
+            self.nodes[0].getblock,
+            blockhash,
+            True,
+        )
+        assert_raises_rpc_error(
+            -3,
+            "Boolean verbosity is deprecated",
+            self.nodes[0].getblock,
+            blockhash,
+            False,
+        )
+
+        # Test getrawtransaction with boolean verbosity - should fail without deprecation flag
+        # Get a transaction from the block
+        block = self.nodes[0].getblock(blockhash, 1)
+        txid = block["tx"][0]
+        assert_raises_rpc_error(
+            -3,
+            "Boolean verbosity is deprecated",
+            self.nodes[0].getrawtransaction,
+            txid,
+            True,
+        )
+        assert_raises_rpc_error(
+            -3,
+            "Boolean verbosity is deprecated",
+            self.nodes[0].getrawtransaction,
+            txid,
+            False,
+        )
+
         if self.is_wallet_compiled():
             self.log.info("Tests for deprecated wallet-related RPC methods (if any)")
             self.log.info("Test settxfee RPC deprecation")
             self.nodes[0].createwallet("settxfeerpc")
-            assert_raises_rpc_error(-32, 'settxfee is deprecated and will be fully removed in v31.0.', self.nodes[0].settxfee, 0.01)
+            assert_raises_rpc_error(
+                -32,
+                "settxfee is deprecated and will be fully removed in v31.0.",
+                self.nodes[0].settxfee,
+                0.01,
+            )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     DeprecatedRpcTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -213,6 +213,7 @@ BASE_SCRIPTS = [
     'rpc_blockchain.py --v2transport',
     'mining_template_verification.py',
     'rpc_deprecated.py',
+    'rpc_boolverbose_deprecated.py',
     'wallet_disable.py',
     'wallet_change_address.py',
     'p2p_addr_relay.py',


### PR DESCRIPTION
  - Added a deprecation flag -deprecatedrpc=boolverbose
  - Modified ParseVerbosity to check this flag and warn when boolean is used
  - Boolean verbosity still works WITH the deprecation flag but shows warnings
  - WITHOUT the flag, it throws the deprecation error