### PR TITLE
build: suggest -DENABLE_IPC=OFF when missing capnp

### DIFF
--- a/cmake/libmultiprocess.cmake
+++ b/cmake/libmultiprocess.cmake
@@ -3,6 +3,16 @@
 # file COPYING or https://opensource.org/license/mit/.
 
 function(add_libmultiprocess subdir)
+  # Provide a more helpful message without pulling in CapnProtoConfig.cmake,
+  # which is included again by libmultiprocess. Skip the check when using the
+  # depends toolchain.
+  if(NOT (DEFINED CMAKE_TOOLCHAIN_FILE))
+    find_program(_CAPNP capnp)
+    if(NOT _CAPNP)
+      message(WARNING "Cap'n Proto (capnp) not found. Compile with -DENABLE_IPC=OFF if you do not need IPC functionality.")
+    endif()
+  endif()
+
   # Set BUILD_TESTING to match BUILD_TESTS. BUILD_TESTING is a standard cmake
   # option that controls whether enable_testing() is called, but in the bitcoin
   # build a BUILD_TESTS option is used instead.


### PR DESCRIPTION
Since #31802, when existing users upgrade to a recent version of master, or the upcoming v30 release, they'll be treated by an error that CapnProto is missing. Unless they read the release notes :-)

This error is generated by `src/ipc/libmultiprocess/CMakeLists.txt` which is a git subtree and so it doesn't have context of our project, and doesn't know about the `-DENABLE_IPC` option.

This pull request adds a simple pre-check in own CMake file to see if Cap'n Proto is missing. For ease of maintenance it doesn't check the version.

The new warning is shown in yellow, the (unchanged) error in red:

<img width="566" height="456" alt="Scherm­afbeelding 2025-09-03 om 14 30 03" src="https://github.com/user-attachments/assets/54542995-2181-4407-a620-fd4616eb28c9" />

