### PR TITLE
wallet: reduce unconditional logging during load

### DIFF
--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -51,6 +51,8 @@ bool VerifyWallets(WalletContext& context)
     }
 
     LogInfo("Using wallet directory %s", fs::PathToString(GetWalletDir()));
+    // Print general DB information
+    LogDBInfo();
 
     chain.initMessage(_("Verifying wallet(s)…"));
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -116,9 +116,6 @@ SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const fs::path& file_pa
 {
     {
         LOCK(g_sqlite_mutex);
-        LogInfo("Using SQLite Version %s", SQLiteDatabaseVersion());
-        LogInfo("Using wallet %s", fs::PathToString(m_dir_path));
-
         if (++g_sqlite_count == 1) {
             // Setup logging
             int ret = sqlite3_config(SQLITE_CONFIG_LOG, ErrorLogCallback, nullptr);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -63,6 +63,12 @@ const std::string WATCHS{"watchs"};
 const std::unordered_set<std::string> LEGACY_TYPES{CRYPTED_KEY, CSCRIPT, DEFAULTKEY, HDCHAIN, KEYMETA, KEY, OLD_KEY, POOL, WATCHMETA, WATCHS};
 } // namespace DBKeys
 
+void LogDBInfo()
+{
+    // Add useful DB information here. This will be printed during startup.
+    LogInfo("Using SQLite Version %s", SQLiteDatabaseVersion());
+}
+
 //
 // WalletBatch
 //

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -27,6 +27,9 @@ class CWallet;
 class CWalletTx;
 struct WalletContext;
 
+// Logs information about the database, including available engines, features, and other capabilities
+void LogDBInfo();
+
 /**
  * Overview of wallet database classes:
  *


### PR DESCRIPTION
Currently the unconditional log during init with a default wallet happens three times:
```
2025-09-03T19:57:16Z init message: Verifying wallet(s)…
2025-09-03T19:57:16Z Using SQLite Version 3.45.1
2025-09-03T19:57:16Z Using wallet XXX/.bitcoin/regtest
2025-09-03T19:57:16Z Using SQLite Version 3.45.1
2025-09-03T19:57:16Z Using wallet XXX/.bitcoin/regtest
(...)
2025-09-03T19:57:16Z Using SQLite Version 3.45.1
2025-09-03T19:57:16Z Using wallet XXX/.bitcoin/regtest
2025-09-03T19:57:16Z init message: Loading wallet…
```
For non-default wallets it's logged two times.

That seems a bit too much, so just log the SQLite version just one, and remove the log for the full path of the wallet, since it's already clear from other logs which wallet is being loaded.