### PR TITLE
ci: disable cirrus cache in 32bit arm job

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -1,9 +1,12 @@
 name: 'Configure Docker'
 description: 'Set up Docker build driver and configure build cache args'
 inputs:
-  use-cirrus:
-    description: 'Use cirrus cache'
+  cache-provider:
+    description: 'gha or cirrus cache provider'
     required: true
+    options:
+    - gh
+    - cirrus
 runs:
   using: 'composite'
   steps:
@@ -32,7 +35,7 @@ runs:
         # which are set automatically when running on GitHub infra: https://docs.docker.com/build/cache/backends/gha/#synopsis
 
         # Use cirrus cache host
-        if [[ ${{ inputs.use-cirrus }} == 'true' ]]; then
+        if [[ ${{ inputs.cache-provider }} == 'cirrus' ]]; then
           url_args="url=${CIRRUS_CACHE_HOST},url_v2=${CIRRUS_CACHE_HOST}"
         else
           url_args=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,7 @@ jobs:
             fallback-runner: 'ubuntu-24.04-arm'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_arm.sh'
+            provider: 'gha'
 
           - name: 'ASan + LSan + UBSan + integer, no depends, USDT'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' # has to match container in ci/test/00_setup_env_native_asan.sh for tracing tools
@@ -513,7 +514,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          cache-provider: ${{ needs.runners.outputs.provider }}
+          cache-provider: ${{ matrix.provider || needs.runners.outputs.provider }}
 
       - name: Enable bpfcc script
         if: ${{ env.CONTAINER_NAME == 'ci_native_asan' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,15 @@ jobs:
     name: 'determine runners'
     runs-on: ubuntu-latest
     outputs:
-      use-cirrus-runners: ${{ steps.runners.outputs.use-cirrus-runners }}
+      provider: ${{ steps.runners.outputs.provider }}
     steps:
       - id: runners
         run: |
           if [[ "${REPO_USE_CIRRUS_RUNNERS}" == "${{ github.repository }}" ]]; then
-            echo "use-cirrus-runners=true" >> "$GITHUB_OUTPUT"
+            echo "provider=cirrus" >> "$GITHUB_OUTPUT"
             echo "::notice title=Runner Selection::Using Cirrus Runners"
           else
-            echo "use-cirrus-runners=false" >> "$GITHUB_OUTPUT"
+            echo "provider=gha" >> "$GITHUB_OUTPUT"
             echo "::notice title=Runner Selection::Using GitHub-hosted runners"
           fi
 
@@ -312,7 +312,7 @@ jobs:
   windows-cross:
     name: 'Linux->Windows cross, no tests'
     needs: runners
-    runs-on: ${{ needs.runners.outputs.use-cirrus-runners == 'true' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm' || 'ubuntu-24.04' }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
 
     env:
@@ -332,7 +332,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          use-cirrus: ${{ needs.runners.outputs.use-cirrus-runners }}
+          cache-provider: ${{ needs.runners.outputs.provider }}
 
       - name: CI script
         run: ./ci/test_run_all.sh
@@ -422,7 +422,7 @@ jobs:
   ci-matrix:
     name: ${{ matrix.name }}
     needs: runners
-    runs-on: ${{ needs.runners.outputs.use-cirrus-runners == 'true' && matrix.cirrus-runner || matrix.fallback-runner }}
+    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && matrix.cirrus-runner || matrix.fallback-runner }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
 
@@ -513,7 +513,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          use-cirrus: ${{ needs.runners.outputs.use-cirrus-runners }}
+          cache-provider: ${{ needs.runners.outputs.provider }}
 
       - name: Enable bpfcc script
         if: ${{ env.CONTAINER_NAME == 'ci_native_asan' }}
@@ -550,7 +550,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          use-cirrus: ${{ needs.runners.outputs.use-cirrus-runners }}
+          cache-provider: ${{ needs.runners.outputs.provider }}
 
       - name: CI script
         run: |


### PR DESCRIPTION
Add an optional matrix field allowing opt-out of configuring cirrus GHA cache when not using cirrus runners.

This is not needed for the cirruslabs/[save|restore]-cache actions, as they automatically fallback based on runner type.

Addresses https://github.com/bitcoin/bitcoin/issues/31965#issuecomment-3252638785