### PR TITLE
ci: Checkout latest merged pulls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,12 @@ jobs:
       BASE_ROOT_DIR: ${{ github.workspace }}
 
     steps:
-      - name: Checkout
+      - &CHECKOUT
+        name: Checkout
         uses: actions/checkout@v5
+        with:
+          # Ensure the latest merged pull request state is used, even on re-runs.
+          ref: &CHECKOUT_REF_TMPL ${{ github.event_name == 'pull_request' && github.ref || '' }}
 
       - name: Clang version
         run: |
@@ -199,8 +203,7 @@ jobs:
             job-name: 'Windows native, fuzz, VS 2022'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - *CHECKOUT
 
       - name: Configure Developer Command Prompt for Microsoft Visual C++
         # Using microsoft/setup-msbuild is not enough.
@@ -310,8 +313,7 @@ jobs:
       DANGER_CI_ON_HOST_FOLDERS: 1
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - *CHECKOUT
 
       - name: Configure environment
         uses: ./.github/actions/configure-environment
@@ -351,8 +353,7 @@ jobs:
       TEST_RUNNER_TIMEOUT_FACTOR: 40
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - *CHECKOUT
 
       - name: Download built executables
         uses: actions/download-artifact@v4
@@ -493,8 +494,7 @@ jobs:
             file-env: './ci/test/00_setup_env_native_msan.sh'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - *CHECKOUT
 
       - name: Configure environment
         uses: ./.github/actions/configure-environment
@@ -537,6 +537,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: *CHECKOUT_REF_TMPL
           fetch-depth: 0
 
       - name: Configure Docker


### PR DESCRIPTION
Currently, the `actions/checkout@v5` checks out pull requests merged against master, which is what we want.

However, it checks out ancient/stale merge commits on a re-run. This is documented (https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs):

>  Re-run workflows [...] will also use the same GITHUB_SHA (commit SHA) and GITHUB_REF (git ref) of the original event that triggered the workflow run.

For example:

* https://github.com/bitcoin/bitcoin/actions/runs/17458152407/job/49579638898?pr=29641#step:9:914 compiles with IPC=ON, even though latest master is at ed2ff3c63d83e275b0785a695fa4db38870abf1a
* https://github.com/bitcoin/bitcoin/pull/32989#issuecomment-3133536724 (example explained in comment)

This is problematic, because:

* Unrelated CI failures and intermittent issues, which are fixed or worked around in latest master can not be cleaned by re-running the task. The author has to actively go out and (force-)push the branch, invalidating review.
* It is odd to have a recent CI run, but it uses code and config from the past.
* Detecting silent merge conflicts by re-running the CI task is impossible.

Fix all issues by checking out the latest merged state of the pull request. The behavior is unchanged for non-pull-request actions. This patch changes the "re-run" default behaviour. Forcing it to use the new state instead of running the old state again.
