### PR TITLE
depends: strip when installing qt binaries

### DIFF
--- a/depends/packages/native_qt.mk
+++ b/depends/packages/native_qt.mk
@@ -147,7 +147,7 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  cmake --install . --prefix $($(package)_staging_prefix_dir)
+  cmake --install . --prefix $($(package)_staging_prefix_dir) --strip
 endef
 
 define $(package)_postprocess_cmds

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -278,7 +278,7 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  cmake --install . --prefix $($(package)_staging_prefix_dir)
+  cmake --install . --prefix $($(package)_staging_prefix_dir) --strip
 endef
 
 define $(package)_postprocess_cmds


### PR DESCRIPTION
Otherwise we end up with ~1.5GB of binaries (Linux) when `DEBUG=1`. This isn't great generally, but is worse in the CI, where disk may be limited (#33293).