### PR TITLE
index: Force database compaction in coinstatsindex

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -245,7 +245,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
 
     if (params.options.force_compact) {
         LogInfo("Starting database compaction of %s", fs::PathToString(params.path));
-        DBContext().pdb->CompactRange(nullptr, nullptr);
+        CompactFull();
         LogInfo("Finished database compaction of %s", fs::PathToString(params.path));
     }
 
@@ -345,6 +345,11 @@ bool CDBWrapper::IsEmpty()
     std::unique_ptr<CDBIterator> it(NewIterator());
     it->SeekToFirst();
     return !(it->Valid());
+}
+
+void CDBWrapper::CompactFull()
+{
+    DBContext().pdb->CompactRange(/*begin=*/nullptr, /*end=*/nullptr);
 }
 
 struct CDBIterator::IteratorImpl {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -270,6 +270,8 @@ public:
         ssKey2 << key_end;
         return EstimateSizeImpl(ssKey1, ssKey2);
     }
+
+    void CompactFull();
 };
 
 #endif // BITCOIN_DBWRAPPER_H

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -233,6 +233,7 @@ void BaseIndex::Sync()
                 pindex_next = NextSyncBlock(pindex, m_chainstate->m_chain);
                 if (!pindex_next) {
                     m_synced = true;
+                    OnSyncComplete();
                     break;
                 }
             }

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -143,6 +143,9 @@ protected:
     /// Update the internal best block index as well as the prune lock.
     void SetBestBlockIndex(const CBlockIndex* block);
 
+    /// Hook that is called once the index has synced
+    virtual void OnSyncComplete() {}
+
 public:
     BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name);
     /// Destructor interrupts sync thread if running and blocks until it exits.

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -402,3 +402,11 @@ bool CoinStatsIndex::RevertBlock(const interfaces::BlockInfo& block)
 
     return true;
 }
+
+void CoinStatsIndex::OnSyncComplete() {
+    // Force compaction of the database upon finishing synce since LevelDB
+    // doesn't seem to be handling this well itself at the speed coinstats
+    // index is syncing.
+    m_db->CompactFull();
+    LogDebug(BCLog::LEVELDB, "Compacted coinstatsindex database after sync");
+}

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -64,6 +64,7 @@ protected:
 
     BaseIndex::DB& GetDB() const override { return *m_db; }
 
+    void OnSyncComplete() override;
 public:
     // Constructs the index, which becomes available to be queried.
     explicit CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);


### PR DESCRIPTION
This PR forces full database compaction on coinstatsindex every 10,000 blocks. This does not seem to come with any considerable performance impact, though I did not test on many different systems.

Motivation: Currently, coinstatsindex ends up using a lot of 55kb files if this is not the case. This is likely related to very fast writes occurring during sync but so far I could not pin down where exactly the difference in behavior is coming from. It seems to be a LevelDB internal thing though, since I can not make out any difference in configuration between coinstatsindex and the other indexes.

This was first reported here: https://github.com/bitcoin/bitcoin/pull/30469#issuecomment-3235597424