### PR TITLE
clang-tidy: Disable `UndefinedBinaryOperatorResult` check in `src/ipc`

### DIFF
--- a/src/ipc/.clang-tidy.in
+++ b/src/ipc/.clang-tidy.in
@@ -1,0 +1,3 @@
+Checks: '
+-clang-analyzer-core.UndefinedBinaryOperatorResult,
+'

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -21,3 +21,5 @@ target_link_libraries(bitcoin_ipc
     core_interface
     univalue
 )
+
+configure_file(.clang-tidy.in .clang-tidy USE_SOURCE_PERMISSIONS COPYONLY)


### PR DESCRIPTION
The warnings are false positive and have been fixed upstream. See: https://github.com/capnproto/capnproto/pull/2334.

This PR:

1. Disables the `UndefinedBinaryOperatorResult` clang-tidy check for source files generated by the `mpgen` tool.

2. Is an alternative to the draft https://github.com/bitcoin/bitcoin/pull/33281.

3. Fixes https://github.com/bitcoin/bitcoin/issues/33256.