### PR TITLE
blocks: add resumable reobfuscation for existing block files

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -65,13 +65,12 @@ CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
     return locator;
 }
 
-BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom) :
+BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_bloom) :
     CDBWrapper{DBParams{
         .path = path,
         .cache_bytes = n_cache_size,
         .memory_only = f_memory,
         .wipe_data = f_wipe,
-        .obfuscate = f_obfuscate,
         .bloom_filter = f_bloom,
         .options = [] { DBOptions options; node::ReadDatabaseArgs(gArgs, options); return options; }()}}
 {}

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -65,7 +65,7 @@ protected:
     {
     public:
         DB(const fs::path& path, size_t n_cache_size,
-           bool f_memory = false, bool f_wipe = false, bool f_obfuscate = false, bool f_bloom = true);
+           bool f_memory = false, bool f_wipe = false, bool f_bloom = true);
 
         /// Read block locator of the chain that the index is in sync with.
         /// Note, the returned locator will be empty if no record exists.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -65,7 +65,7 @@ protected:
     {
     public:
         DB(const fs::path& path, size_t n_cache_size,
-           bool f_memory = false, bool f_wipe = false, bool f_obfuscate = false, bool f_bloom = true);
+           bool f_memory = false, bool f_wipe = false, bool f_bloom = true);
         virtual ~DB() = default;
 
         /// Read block locator of the chain that the index is in sync with.

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -88,7 +88,7 @@ TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
 {}
 
 TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool has_legacy) :
-    BaseIndex::DB(TxIndexDBPath(), n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/has_legacy),
+    BaseIndex::DB(TxIndexDBPath(), n_cache_size, f_memory, f_wipe, /*f_bloom=*/has_legacy),
     m_hasher{ReadOrCreateTxidHasher(*this)},
     m_has_legacy{has_legacy}
 {}

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -62,7 +62,7 @@ struct DBKey {
 };
 
 TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/false)}
+    : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe, /*f_bloom=*/false)}
 {
     if (!m_db->Read("siphash_key", m_siphash_key)) {
         FastRandomContext rng(false);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1389,7 +1389,7 @@ static util::Result<void> ReobfuscateBlocksIfRequested(NodeContext& node, const 
     if (!args.GetBoolArg("-blocksxor", kernel::DEFAULT_XOR_BLOCKSDIR)) {
         return util::Error{_("Block reobfuscation cannot proceed with -blocksxor=0")};
     }
-    if (!node::ObfuscateBlocks(*Assert(node.shutdown_signal), blocks_dir, requested_key)) {
+    if (!node::ObfuscateBlocks(*Assert(node.shutdown_signal), *Assert(node.notifications), blocks_dir, requested_key)) {
         return util::Error{_("Block obfuscation failed")};
     }
     return {};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -93,6 +93,7 @@
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/moneystr.h>
+#include <util/obfuscation.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
@@ -551,6 +552,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
             "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >=%u = automatically prune block files to stay under the specified target size in MiB)", MIN_DISK_SPACE_FOR_BLOCK_FILES / 1_MiB), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex", "If enabled, wipe chain state and block index, and rebuild them from blk*.dat files on disk. Also wipe and rebuild other optional indexes that are active. If an assumeutxo snapshot was loaded, its chainstate will be wiped as well. The snapshot can then be reloaded via RPC.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex-chainstate", "If enabled, wipe chain state, and rebuild it from blk*.dat files on disk. If an assumeutxo snapshot was loaded, its chainstate will be wiped as well. The snapshot can then be reloaded via RPC.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-reobfuscate-blocks", "Reobfuscate existing blk*/rev* files. If a 16 character hexadecimal value is provided, it's used as the new XOR key; otherwise, the value is treated as a boolean and a random key is generated. This operation is resumable.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-settings=<file>", strprintf("Specify path to dynamic settings data file. Can be disabled with -nosettings. File is written at runtime and not meant to be edited by users (use %s instead for custom settings). Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME, BITCOIN_SETTINGS_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #if HAVE_SYSTEM
     argsman.AddArg("-startupnotify=<cmd>", "Execute command on startup.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -1369,6 +1371,30 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
     return std::nullopt;
 }
 
+static util::Result<void> ReobfuscateBlocksIfRequested(NodeContext& node, const ArgsManager& args)
+{
+    std::optional<Obfuscation::Key> requested_key;
+    bool reobfuscate_requested{false};
+    if (auto arg{args.GetArg("-reobfuscate-blocks")}) {
+        requested_key = Obfuscation::KeyFromHex(*arg);
+        reobfuscate_requested = requested_key || arg->empty() || *arg == "1";
+        if (!reobfuscate_requested && *arg != "0") {
+            return util::Error{strprintf(_("Invalid -reobfuscate-blocks value '%s'"), *arg)};
+        }
+    }
+
+    auto blocks_dir{args.GetBlocksDirPath()};
+    if (!reobfuscate_requested && !node::BlockReobfuscationPending(blocks_dir)) return {};
+
+    if (!args.GetBoolArg("-blocksxor", kernel::DEFAULT_XOR_BLOCKSDIR)) {
+        return util::Error{_("Block reobfuscation cannot proceed with -blocksxor=0")};
+    }
+    if (!node::ObfuscateBlocks(*Assert(node.shutdown_signal), blocks_dir, requested_key)) {
+        return util::Error{_("Block obfuscation failed")};
+    }
+    return {};
+}
+
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
 static ChainstateLoadResult InitAndLoadChainstate(
@@ -1885,6 +1911,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 #endif
 
     // ********************************************************* Step 7: load block chain
+
+    if (auto reobfuscation_result{ReobfuscateBlocksIfRequested(node, args)}; !reobfuscation_result) {
+        if (ShutdownRequested(node)) {
+            LogInfo("Shutdown requested. Exiting.");
+            return true;
+        }
+        return InitError(util::ErrorString(reobfuscation_result));
+    }
 
     // cache size calculations
     node::LogOversizedDbCache(args);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -91,6 +91,7 @@
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/moneystr.h>
+#include <util/obfuscation.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
@@ -551,6 +552,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
             "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >=%u = automatically prune block files to stay under the specified target size in MiB)", MIN_DISK_SPACE_FOR_BLOCK_FILES / 1_MiB), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex", "If enabled, wipe chain state and block index, and rebuild them from blk*.dat files on disk. Also wipe and rebuild other optional indexes that are active. If an assumeutxo snapshot was loaded, its chainstate will be wiped as well. The snapshot can then be reloaded via RPC.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex-chainstate", "If enabled, wipe chain state, and rebuild it from blk*.dat files on disk. If an assumeutxo snapshot was loaded, its chainstate will be wiped as well. The snapshot can then be reloaded via RPC.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-reobfuscate-blocks", "Reobfuscate existing blk*/rev* files. If a 16 character hexadecimal value is provided, it's used as the new XOR key; otherwise, the value is treated as a boolean and a random key is generated. This operation is resumable.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-settings=<file>", strprintf("Specify path to dynamic settings data file. Can be disabled with -nosettings. File is written at runtime and not meant to be edited by users (use %s instead for custom settings). Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME, BITCOIN_SETTINGS_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #if HAVE_SYSTEM
     argsman.AddArg("-startupnotify=<cmd>", "Execute command on startup.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -1320,6 +1322,30 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
     return std::nullopt;
 }
 
+static util::Result<void> ReobfuscateBlocksIfRequested(NodeContext& node, const ArgsManager& args)
+{
+    std::optional<Obfuscation::Key> requested_key;
+    bool reobfuscate_requested{false};
+    if (auto arg{args.GetArg("-reobfuscate-blocks")}) {
+        requested_key = Obfuscation::KeyFromHex(*arg);
+        reobfuscate_requested = requested_key || arg->empty() || *arg == "1";
+        if (!reobfuscate_requested && *arg != "0") {
+            return util::Error{strprintf(_("Invalid -reobfuscate-blocks value '%s'"), *arg)};
+        }
+    }
+
+    auto blocks_dir{args.GetBlocksDirPath()};
+    if (!reobfuscate_requested && !node::BlockReobfuscationPending(blocks_dir)) return {};
+
+    if (!args.GetBoolArg("-blocksxor", kernel::DEFAULT_XOR_BLOCKSDIR)) {
+        return util::Error{_("Block reobfuscation cannot proceed with -blocksxor=0")};
+    }
+    if (!node::ObfuscateBlocks(*Assert(node.shutdown_signal), blocks_dir, requested_key)) {
+        return util::Error{_("Block obfuscation failed")};
+    }
+    return {};
+}
+
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
 static ChainstateLoadResult InitAndLoadChainstate(
@@ -1852,6 +1878,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 #endif
 
     // ********************************************************* Step 7: load block chain
+
+    if (auto reobfuscation_result{ReobfuscateBlocksIfRequested(node, args)}; !reobfuscation_result) {
+        if (ShutdownRequested(node)) {
+            LogInfo("Shutdown requested. Exiting.");
+            return true;
+        }
+        return InitError(util::ErrorString(reobfuscation_result));
+    }
 
     // cache size calculations
     node::LogOversizedDbCache(args);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1340,7 +1340,7 @@ static util::Result<void> ReobfuscateBlocksIfRequested(NodeContext& node, const 
     if (!args.GetBoolArg("-blocksxor", kernel::DEFAULT_XOR_BLOCKSDIR)) {
         return util::Error{_("Block reobfuscation cannot proceed with -blocksxor=0")};
     }
-    if (!node::ObfuscateBlocks(*Assert(node.shutdown_signal), blocks_dir, requested_key)) {
+    if (!node::ObfuscateBlocks(*Assert(node.shutdown_signal), *Assert(node.notifications), blocks_dir, requested_key)) {
         return util::Error{_("Block obfuscation failed")};
     }
     return {};

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -171,6 +171,31 @@ std::string CBlockFileInfo::ToString() const
 
 namespace node {
 
+namespace {
+Obfuscation::Key ReadXorKeyFile(const fs::path& file)
+{
+    Obfuscation::Key obfuscation{};
+    AutoFile xor_key_file{fsbridge::fopen(file, "rb")};
+    xor_key_file >> obfuscation;
+    return obfuscation;
+}
+
+void WriteXorKeyFile(const fs::path& file, const Obfuscation::Key& obfuscation, bool overwrite)
+{
+#ifdef __MINGW64__
+    const char* mode{"wb"}; // Temporary workaround for https://github.com/bitcoin/bitcoin/issues/30210
+#else
+    const char* mode{overwrite ? "wb" : "wbx"};
+#endif
+    AutoFile xor_key_file{fsbridge::fopen(file, mode)};
+    xor_key_file << obfuscation;
+    if (xor_key_file.fclose() != 0) {
+        throw std::runtime_error{strprintf("Error closing XOR key file %s: %s", fs::PathToString(file), SysErrorString(errno))};
+    }
+}
+
+} // namespace
+
 bool CBlockIndexWorkComparator::operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
 {
     // First sort by most total work, ...
@@ -1206,23 +1231,10 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
     const fs::path xor_key_path{opts.blocks_dir / "xor.dat"};
     if (fs::exists(xor_key_path)) {
         // A pre-existing xor key file has priority.
-        AutoFile xor_key_file{fsbridge::fopen(xor_key_path, "rb")};
-        xor_key_file >> obfuscation;
+        obfuscation = ReadXorKeyFile(xor_key_path);
     } else {
         // Create initial or missing xor key file
-        AutoFile xor_key_file{fsbridge::fopen(xor_key_path,
-#ifdef __MINGW64__
-            "wb" // Temporary workaround for https://github.com/bitcoin/bitcoin/issues/30210
-#else
-            "wbx"
-#endif
-        )};
-        xor_key_file << obfuscation;
-        if (xor_key_file.fclose() != 0) {
-            throw std::runtime_error{strprintf("Error closing XOR key file %s: %s",
-                                               fs::PathToString(xor_key_path),
-                                               SysErrorString(errno))};
-        }
+        WriteXorKeyFile(xor_key_path, obfuscation, /*overwrite=*/false);
     }
     // If the user disabled the key, it must be zero.
     if (!opts.use_xor && obfuscation != decltype(obfuscation){}) {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1347,6 +1347,7 @@ bool BlockReobfuscationPending(const fs::path& blocks_dir)
 
 bool ObfuscateBlocks(
     const util::SignalInterrupt& interrupt,
+    kernel::Notifications& notifications,
     const fs::path& blocks_dir,
     const std::optional<Obfuscation::Key>& requested_key)
 {
@@ -1362,6 +1363,8 @@ bool ObfuscateBlocks(
         auto files{CollectBlockAndUndoFiles(blocks_dir)};
         std::ranges::sort(files, {}, &BlockFileEntry::file_num);
         LogInfo("[obfuscate] Reobfuscating %s block and undo files", files.size());
+        constexpr auto title{_("Reobfuscating blocks…")};
+        notifications.progress(title, /*progress_percent=*/0, /*resume_possible=*/true);
         std::vector<std::byte> buffer(REOBFUSCATION_BUFFER_SIZE);
         size_t done{0};
         int last_percent{0};
@@ -1371,9 +1374,11 @@ bool ObfuscateBlocks(
 
             if (int percent{static_cast<int>(100 * ++done / files.size())}; percent > last_percent) {
                 LogInfo("[obfuscate] Migrating %s - %s%% done", fs::PathToString(file.path.filename()), percent);
+                notifications.progress(title, percent, /*resume_possible=*/true);
                 last_percent = percent;
             }
         }
+        if (files.empty()) notifications.progress(title, /*progress_percent=*/100, /*resume_possible=*/true);
         fs::remove(xor_dat);
     }
     if (!DirectoryCommit(blocks_dir)) return false;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1258,8 +1258,15 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
                       HexStr(obfuscation), fs::PathToString(xor_key_path)),
         };
     }
-    LogInfo("Using obfuscation key for blocksdir *.dat files (%s): '%s'\n", fs::PathToString(opts.blocks_dir), HexStr(obfuscation));
-    return Obfuscation{obfuscation};
+    const Obfuscation result{obfuscation};
+    if (result) {
+        LogInfo("Using obfuscation key for blocksdir *.dat files (%s): '%s'\n", fs::PathToString(opts.blocks_dir), HexStr(obfuscation));
+    } else if (opts.use_xor) {
+        LogInfo("Obfuscation is not active for blocksdir *.dat files (%s). To obfuscate existing files, restart with the -reobfuscate-blocks option.",
+                fs::PathToString(opts.blocks_dir));
+    }
+
+    return result;
 }
 
 BlockManager::BlockManager(const util::SignalInterrupt& interrupt, Options opts)

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1183,7 +1183,7 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
 {
     // Bytes are serialized without length indicator, so this is also the exact
     // size of the XOR-key file.
-    std::array<std::byte, Obfuscation::KEY_SIZE> obfuscation{};
+    Obfuscation::Key obfuscation{};
 
     // Consider this to be the first run if the blocksdir contains only hidden
     // files (those which start with a .). Checking for a fully-empty dir would

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -172,6 +172,26 @@ std::string CBlockFileInfo::ToString() const
 namespace node {
 
 namespace {
+struct BlockFileEntry {
+    std::string file_num;
+    bool is_block;
+    fs::path path;
+};
+
+std::vector<BlockFileEntry> CollectBlockAndUndoFiles(const fs::path& blocks_dir)
+{
+    std::vector<BlockFileEntry> files;
+    for (auto& entry : fs::directory_iterator(blocks_dir)) {
+        auto filename{fs::PathToString(entry.path().filename())};
+        if (filename.length() == 12 && filename.ends_with(".dat") && entry.is_regular_file()) {
+            if (bool is_block{filename.starts_with("blk")}; is_block || filename.starts_with("rev")) {
+                files.emplace_back(filename.substr(3, 5), is_block, entry.path());
+            }
+        }
+    }
+    return files;
+}
+
 Obfuscation::Key ReadXorKeyFile(const fs::path& file)
 {
     Obfuscation::Key obfuscation{};
@@ -703,17 +723,11 @@ void BlockManager::CleanupBlockRevFiles() const
     // Remove the rev files immediately and insert the blk file paths into an
     // ordered map keyed by block file index.
     LogInfo("Removing unusable blk?????.dat and rev?????.dat files for -reindex with -prune");
-    for (fs::directory_iterator it(m_opts.blocks_dir); it != fs::directory_iterator(); it++) {
-        const std::string path = fs::PathToString(it->path().filename());
-        if (fs::is_regular_file(*it) &&
-            path.length() == 12 &&
-            path.ends_with(".dat"))
-        {
-            if (path.starts_with("blk")) {
-                mapBlockFiles[path.substr(3, 5)] = it->path();
-            } else if (path.starts_with("rev")) {
-                remove(it->path());
-            }
+    for (auto& file : CollectBlockAndUndoFiles(m_opts.blocks_dir)) {
+        if (file.is_block) {
+            mapBlockFiles.emplace(std::move(file.file_num), std::move(file.path));
+        } else {
+            remove(file.path);
         }
     }
 

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -30,12 +30,14 @@
 #include <util/check.h>
 #include <util/expected.h>
 #include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/log.h>
 #include <util/obfuscation.h>
 #include <util/overflow.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/syserror.h>
 #include <util/time.h>
 #include <util/translation.h>
@@ -172,6 +174,10 @@ std::string CBlockFileInfo::ToString() const
 namespace node {
 
 namespace {
+constexpr auto XOR_KEY_FILE_NAME{"xor.dat"};
+constexpr auto BLOCK_REOBFUSCATION_SUFFIX{".reobfuscated"};
+constexpr size_t REOBFUSCATION_BUFFER_SIZE{1_MiB}; // Independent of FlatFileSeq preallocation
+
 struct BlockFileEntry {
     std::string file_num;
     bool is_block;
@@ -209,11 +215,76 @@ void WriteXorKeyFile(const fs::path& file, const Obfuscation::Key& obfuscation, 
 #endif
     AutoFile xor_key_file{fsbridge::fopen(file, mode)};
     xor_key_file << obfuscation;
-    if (xor_key_file.fclose() != 0) {
-        throw std::runtime_error{strprintf("Error closing XOR key file %s: %s", fs::PathToString(file), SysErrorString(errno))};
-    }
+    if (bool success{xor_key_file.Commit()}; xor_key_file.fclose() || !success) throw std::runtime_error{strprintf("Error writing XOR key file %s", fs::PathToString(file))};
 }
 
+bool IsValidXorKeyFile(const fs::path& file)
+{
+    std::error_code ec;
+    return fs::file_size(file, ec) == Obfuscation::KEY_SIZE;
+}
+
+std::optional<Obfuscation> PrepareDeltaObfuscation(
+    const fs::path& xor_dat,
+    const fs::path& xor_new,
+    const std::optional<Obfuscation::Key>& requested_key,
+    const fs::path& blocks_dir)
+{
+    Obfuscation::Key old_key{};
+    if (IsValidXorKeyFile(xor_dat)) {
+        old_key = ReadXorKeyFile(xor_dat);
+    } else {
+        if (IsValidXorKeyFile(xor_new)) return std::nullopt; // only the renames remain
+        WriteXorKeyFile(xor_dat, old_key, /*overwrite=*/false);
+    }
+    if (!DirectoryCommit(blocks_dir)) throw std::runtime_error{"Failed to commit blocks directory"};
+
+    Obfuscation::Key new_key{};
+    if (IsValidXorKeyFile(xor_new)) {
+        AutoFile staged_key{fsbridge::fopen(xor_new, "rb+")};
+        staged_key >> new_key;
+        if (!staged_key.Commit()) throw std::runtime_error{strprintf("Error committing XOR key file %s", fs::PathToString(xor_new))};
+    } else {
+        new_key = requested_key ? *requested_key : FastRandomContext{}.randbytes<Obfuscation::KEY_SIZE>();
+        WriteXorKeyFile(xor_new, new_key, /*overwrite=*/true);
+    }
+    if (!DirectoryCommit(blocks_dir)) throw std::runtime_error{"Failed to commit blocks directory"};
+
+    Obfuscation old_obfuscation{old_key}, new_obfuscation{new_key};
+    LogInfo("[obfuscate] old key: %s", old_obfuscation.HexKey());
+    LogInfo("[obfuscate] new key: %s", new_obfuscation.HexKey());
+
+    if (auto delta{Obfuscation::Delta(old_obfuscation, new_obfuscation)}) return delta;
+    return std::nullopt; // Keys already match; only the renames remain
+}
+
+bool MigrateBlockFile(const BlockFileEntry& entry, const Obfuscation& delta_obfuscation, std::span<std::byte> buffer)
+{
+    const fs::path staged_path{entry.path + BLOCK_REOBFUSCATION_SUFFIX};
+
+    // Resume after deleting the original
+    if (fs::exists(staged_path) && !fs::exists(entry.path)) return true;
+
+    AutoFile old_blocks{fsbridge::fopen(entry.path, "rb"), delta_obfuscation}; // apply both keys in one pass
+    if (old_blocks.IsNull()) return false;
+    AutoFile new_blocks{fsbridge::fopen(staged_path, "wb")};
+    if (new_blocks.IsNull()) return false;
+
+    try {
+        while (auto n{old_blocks.detail_fread(buffer)}) {
+            new_blocks.write_buffer(buffer.first(n));
+        }
+    } catch (const std::ios_base::failure&) {
+        (void)new_blocks.fclose();
+        return false;
+    }
+    if (bool success{old_blocks.feof() && !old_blocks.fclose() && new_blocks.Commit()}; new_blocks.fclose() || !success) return false;
+    fs::last_write_time(staged_path, fs::last_write_time(entry.path)); // preserve timestamp
+    // Make the staged file durable before deletion. If a crash loses the deletion, resume copies the file again
+    if (!DirectoryCommit(staged_path.parent_path())) return false;
+    fs::remove(entry.path);
+    return true;
+}
 } // namespace
 
 bool CBlockIndexWorkComparator::operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
@@ -1242,7 +1313,7 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
         FastRandomContext{}.fillrand(obfuscation);
     }
 
-    const fs::path xor_key_path{opts.blocks_dir / "xor.dat"};
+    const fs::path xor_key_path{opts.blocks_dir / XOR_KEY_FILE_NAME};
     if (fs::exists(xor_key_path)) {
         // A pre-existing xor key file has priority.
         obfuscation = ReadXorKeyFile(xor_key_path);
@@ -1267,6 +1338,61 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
     }
 
     return result;
+}
+
+bool BlockReobfuscationPending(const fs::path& blocks_dir)
+{
+    return fs::exists((blocks_dir / XOR_KEY_FILE_NAME) + BLOCK_REOBFUSCATION_SUFFIX);
+}
+
+bool ObfuscateBlocks(
+    const util::SignalInterrupt& interrupt,
+    const fs::path& blocks_dir,
+    const std::optional<Obfuscation::Key>& requested_key)
+{
+    const auto start{SteadyClock::now()};
+    const fs::path xor_dat{blocks_dir / XOR_KEY_FILE_NAME};
+    const fs::path xor_new{xor_dat + BLOCK_REOBFUSCATION_SUFFIX};
+    if (requested_key && IsValidXorKeyFile(xor_new) && ReadXorKeyFile(xor_new) != *requested_key) {
+        LogError("[obfuscate] Requested XOR key does not match staged %s", fs::PathToString(xor_new.filename()));
+        return false;
+    }
+
+    if (auto delta_obfuscation{PrepareDeltaObfuscation(xor_dat, xor_new, requested_key, blocks_dir)}) {
+        auto files{CollectBlockAndUndoFiles(blocks_dir)};
+        std::ranges::sort(files, {}, &BlockFileEntry::file_num);
+        LogInfo("[obfuscate] Reobfuscating %s block and undo files", files.size());
+        std::vector<std::byte> buffer(REOBFUSCATION_BUFFER_SIZE);
+        size_t done{0};
+        int last_percent{0};
+        for (auto& file : files) {
+            if (interrupt) return false;
+            if (!MigrateBlockFile(file, *delta_obfuscation, buffer)) return false;
+
+            if (int percent{static_cast<int>(100 * ++done / files.size())}; percent > last_percent) {
+                LogInfo("[obfuscate] Migrating %s - %s%% done", fs::PathToString(file.path.filename()), percent);
+                last_percent = percent;
+            }
+        }
+        fs::remove(xor_dat);
+    }
+    if (!DirectoryCommit(blocks_dir)) return false;
+
+    // Activate staged data files before the new key. Renaming the key signals completion
+    for (auto& entry : fs::directory_iterator(blocks_dir)) {
+        auto filename{fs::PathToString(entry.path().filename())};
+        if (entry.path() != xor_new && entry.is_regular_file() && filename.ends_with(BLOCK_REOBFUSCATION_SUFFIX)) {
+            auto destination{entry.path().parent_path() / util::RemoveSuffixView(filename, BLOCK_REOBFUSCATION_SUFFIX)};
+            fs::rename(entry.path(), destination);
+        }
+    }
+    if (!DirectoryCommit(blocks_dir)) return false;
+    fs::rename(xor_new, xor_dat);
+    if (!DirectoryCommit(blocks_dir)) return false;
+
+    LogInfo("[obfuscate] Block and Undo file migration finished in %ss", Ticks<std::chrono::seconds>(SteadyClock::now() - start));
+
+    return true;
 }
 
 BlockManager::BlockManager(const util::SignalInterrupt& interrupt, Options opts)

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1342,6 +1342,7 @@ bool BlockReobfuscationPending(const fs::path& blocks_dir)
 
 bool ObfuscateBlocks(
     const util::SignalInterrupt& interrupt,
+    kernel::Notifications& notifications,
     const fs::path& blocks_dir,
     const std::optional<Obfuscation::Key>& requested_key)
 {
@@ -1357,6 +1358,8 @@ bool ObfuscateBlocks(
         auto files{CollectBlockAndUndoFiles(blocks_dir)};
         std::ranges::sort(files, {}, &BlockFileEntry::file_num);
         LogInfo("[obfuscate] Reobfuscating %s block and undo files", files.size());
+        constexpr auto title{_("Reobfuscating blocks…")};
+        notifications.progress(title, /*progress_percent=*/0, /*resume_possible=*/true);
         std::vector<std::byte> buffer(REOBFUSCATION_BUFFER_SIZE);
         size_t done{0};
         int last_percent{0};
@@ -1366,9 +1369,11 @@ bool ObfuscateBlocks(
 
             if (int percent{static_cast<int>(100 * ++done / files.size())}; percent > last_percent) {
                 LogInfo("[obfuscate] Migrating %s - %s%% done", fs::PathToString(file.path.filename()), percent);
+                notifications.progress(title, percent, /*resume_possible=*/true);
                 last_percent = percent;
             }
         }
+        if (files.empty()) notifications.progress(title, /*progress_percent=*/100, /*resume_possible=*/true);
         fs::remove(xor_dat);
         DirectoryCommit(blocks_dir);
     }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -30,12 +30,14 @@
 #include <util/check.h>
 #include <util/expected.h>
 #include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/log.h>
 #include <util/obfuscation.h>
 #include <util/overflow.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/syserror.h>
 #include <util/time.h>
 #include <util/translation.h>
@@ -172,6 +174,10 @@ std::string CBlockFileInfo::ToString() const
 namespace node {
 
 namespace {
+constexpr auto XOR_KEY_FILE_NAME{"xor.dat"};
+constexpr auto BLOCK_REOBFUSCATION_SUFFIX{".reobfuscated"};
+constexpr size_t REOBFUSCATION_BUFFER_SIZE{1_MiB}; // Independent of FlatFileSeq preallocation
+
 struct BlockFileEntry {
     std::string file_num;
     bool is_block;
@@ -214,6 +220,66 @@ void WriteXorKeyFile(const fs::path& file, const Obfuscation::Key& obfuscation, 
     }
 }
 
+bool IsValidXorKeyFile(const fs::path& file)
+{
+    std::error_code ec;
+    return fs::file_size(file, ec) == Obfuscation::KEY_SIZE;
+}
+
+std::optional<Obfuscation> PrepareDeltaObfuscation(
+    const fs::path& xor_dat,
+    const fs::path& xor_new,
+    const std::optional<Obfuscation::Key>& requested_key,
+    const fs::path& blocks_dir)
+{
+    Obfuscation::Key old_key{};
+    if (IsValidXorKeyFile(xor_dat)) {
+        old_key = ReadXorKeyFile(xor_dat);
+    } else {
+        if (IsValidXorKeyFile(xor_new)) return std::nullopt; // only the renames remain
+        WriteXorKeyFile(xor_dat, old_key, /*overwrite=*/false);
+        DirectoryCommit(blocks_dir);
+    }
+
+    Obfuscation::Key new_key{};
+    if (IsValidXorKeyFile(xor_new)) {
+        new_key = ReadXorKeyFile(xor_new);
+    } else {
+        new_key = requested_key ? *requested_key : FastRandomContext{}.randbytes<Obfuscation::KEY_SIZE>();
+        WriteXorKeyFile(xor_new, new_key, /*overwrite=*/true);
+        DirectoryCommit(blocks_dir);
+    }
+
+    Obfuscation old_obfuscation{old_key}, new_obfuscation{new_key};
+    LogInfo("[obfuscate] old key: %s", old_obfuscation.HexKey());
+    LogInfo("[obfuscate] new key: %s", new_obfuscation.HexKey());
+
+    if (auto delta{Obfuscation::Delta(old_obfuscation, new_obfuscation)}) return delta;
+    return std::nullopt; // Keys already match; only the renames remain
+}
+
+bool MigrateBlockFile(const BlockFileEntry& entry, const Obfuscation& delta_obfuscation, std::span<std::byte> buffer)
+{
+    const fs::path staged_path{entry.path + BLOCK_REOBFUSCATION_SUFFIX};
+
+    // Resume after deleting the original
+    if (fs::exists(staged_path) && !fs::exists(entry.path)) return true;
+
+    AutoFile old_blocks{fsbridge::fopen(entry.path, "rb"), delta_obfuscation}; // apply both keys in one pass
+    if (old_blocks.IsNull()) return false;
+    AutoFile new_blocks{fsbridge::fopen(staged_path, "wb")};
+    if (new_blocks.IsNull()) return false;
+
+    while (auto n{old_blocks.detail_fread(buffer)}) {
+        new_blocks.write_buffer(buffer.first(n));
+    }
+    if (!old_blocks.feof() || old_blocks.fclose() || !new_blocks.Commit() || new_blocks.fclose()) return false;
+    fs::last_write_time(staged_path, fs::last_write_time(entry.path)); // preserve timestamp
+    // Make the staged file durable before deletion. If a crash loses the deletion, resume copies the file again
+    DirectoryCommit(staged_path.parent_path());
+    fs::remove(entry.path);
+    return true;
+}
 } // namespace
 
 bool CBlockIndexWorkComparator::operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
@@ -1242,7 +1308,7 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
         FastRandomContext{}.fillrand(obfuscation);
     }
 
-    const fs::path xor_key_path{opts.blocks_dir / "xor.dat"};
+    const fs::path xor_key_path{opts.blocks_dir / XOR_KEY_FILE_NAME};
     if (fs::exists(xor_key_path)) {
         // A pre-existing xor key file has priority.
         obfuscation = ReadXorKeyFile(xor_key_path);
@@ -1267,6 +1333,60 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
     }
 
     return result;
+}
+
+bool BlockReobfuscationPending(const fs::path& blocks_dir)
+{
+    return fs::exists((blocks_dir / XOR_KEY_FILE_NAME) + BLOCK_REOBFUSCATION_SUFFIX);
+}
+
+bool ObfuscateBlocks(
+    const util::SignalInterrupt& interrupt,
+    const fs::path& blocks_dir,
+    const std::optional<Obfuscation::Key>& requested_key)
+{
+    const auto start{SteadyClock::now()};
+    const fs::path xor_dat{blocks_dir / XOR_KEY_FILE_NAME};
+    const fs::path xor_new{xor_dat + BLOCK_REOBFUSCATION_SUFFIX};
+    if (requested_key && IsValidXorKeyFile(xor_new) && ReadXorKeyFile(xor_new) != *requested_key) {
+        LogError("[obfuscate] Requested XOR key does not match staged %s", fs::PathToString(xor_new.filename()));
+        return false;
+    }
+
+    if (auto delta_obfuscation{PrepareDeltaObfuscation(xor_dat, xor_new, requested_key, blocks_dir)}) {
+        auto files{CollectBlockAndUndoFiles(blocks_dir)};
+        std::ranges::sort(files, {}, &BlockFileEntry::file_num);
+        LogInfo("[obfuscate] Reobfuscating %s block and undo files", files.size());
+        std::vector<std::byte> buffer(REOBFUSCATION_BUFFER_SIZE);
+        size_t done{0};
+        int last_percent{0};
+        for (auto& file : files) {
+            if (interrupt) return false;
+            if (!MigrateBlockFile(file, *delta_obfuscation, buffer)) return false;
+
+            if (int percent{static_cast<int>(100 * ++done / files.size())}; percent > last_percent) {
+                LogInfo("[obfuscate] Migrating %s - %s%% done", fs::PathToString(file.path.filename()), percent);
+                last_percent = percent;
+            }
+        }
+        fs::remove(xor_dat);
+        DirectoryCommit(blocks_dir);
+    }
+
+    // Activate staged data files before the new key. Renaming the key signals completion
+    for (auto& entry : fs::directory_iterator(blocks_dir)) {
+        auto filename{fs::PathToString(entry.path().filename())};
+        if (entry.path() != xor_new && entry.is_regular_file() && filename.ends_with(BLOCK_REOBFUSCATION_SUFFIX)) {
+            auto destination{entry.path().parent_path() / util::RemoveSuffixView(filename, BLOCK_REOBFUSCATION_SUFFIX)};
+            fs::rename(entry.path(), destination);
+        }
+    }
+    fs::rename(xor_new, xor_dat);
+    DirectoryCommit(blocks_dir);
+
+    LogInfo("[obfuscate] Block and Undo file migration finished in %ss", Ticks<std::chrono::seconds>(SteadyClock::now() - start));
+
+    return true;
 }
 
 BlockManager::BlockManager(const util::SignalInterrupt& interrupt, Options opts)

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -56,6 +56,8 @@ class SignalInterrupt;
 } // namespace util
 
 namespace kernel {
+class Notifications;
+
 class CBlockFileInfo
 {
 public:
@@ -491,6 +493,7 @@ bool BlockReobfuscationPending(const fs::path& blocks_dir);
 /** Rewrite block and undo files under a requested or random XOR key. Interrupted migrations resume on the next call. */
 bool ObfuscateBlocks(
     const util::SignalInterrupt& interrupt,
+    kernel::Notifications& notifications,
     const fs::path& blocks_dir,
     const std::optional<Obfuscation::Key>& requested_key);
 } // namespace node

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -484,6 +484,15 @@ public:
 
 // Calls ActivateBestChain() even if no blocks are imported.
 void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths);
+
+// Whether an interrupted reobfuscation left a staged key file behind and needs to be resumed.
+bool BlockReobfuscationPending(const fs::path& blocks_dir);
+
+/** Rewrite block and undo files under a requested or random XOR key. Interrupted migrations resume on the next call. */
+bool ObfuscateBlocks(
+    const util::SignalInterrupt& interrupt,
+    const fs::path& blocks_dir,
+    const std::optional<Obfuscation::Key>& requested_key);
 } // namespace node
 
 #endif // BITCOIN_NODE_BLOCKSTORAGE_H

--- a/src/streams.h
+++ b/src/streams.h
@@ -450,7 +450,7 @@ public:
     /** Continue with a different XOR key */
     void SetObfuscation(const Obfuscation& obfuscation) { m_obfuscation = obfuscation; }
 
-    /** Implementation detail, only used internally. */
+    /** Read up to dst.size() bytes and return the number read, without throwing on short reads. */
     std::size_t detail_fread(std::span<std::byte> dst);
 
     /** Wrapper around fseek(). Will throw if seeking is not possible. */

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -14,6 +14,17 @@
 
 BOOST_FIXTURE_TEST_SUITE(fs_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(directory_commit)
+{
+    const auto directory{m_args.GetDataDirBase() / "commit"};
+    fs::create_directory(directory);
+    BOOST_CHECK(DirectoryCommit(directory));
+#ifndef WIN32
+    fs::remove(directory);
+    BOOST_CHECK(!DirectoryCommit(directory));
+#endif
+}
+
 BOOST_AUTO_TEST_CASE(fsbridge_pathtostring)
 {
     std::string u8_str = "fs_tests_₿_🏃";

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(xor_random_chunks)
         const std::vector original{m_rng.randbytes<std::byte>(write_size)};
         std::vector roundtrip{original};
 
-        const auto key_bytes{m_rng.randbool() ? m_rng.randbytes<Obfuscation::KEY_SIZE>() : std::array<std::byte, Obfuscation::KEY_SIZE>{}};
+        auto key_bytes{m_rng.randbool() ? m_rng.randbytes<Obfuscation::KEY_SIZE>() : Obfuscation::Key{}};
         const Obfuscation obfuscation{key_bytes};
         apply_random_xor_chunks(roundtrip, obfuscation);
         BOOST_CHECK_EQUAL(roundtrip.size(), original.size());
@@ -55,6 +55,32 @@ BOOST_AUTO_TEST_CASE(obfuscation_hexkey)
 
     const Obfuscation obfuscation{key_bytes};
     BOOST_CHECK_EQUAL(obfuscation.HexKey(), HexStr(key_bytes));
+
+    auto parsed_key{Obfuscation::KeyFromHex(obfuscation.HexKey())};
+    BOOST_REQUIRE(parsed_key);
+    BOOST_CHECK(*parsed_key == key_bytes);
+
+    BOOST_CHECK(!Obfuscation::KeyFromHex(""));
+    BOOST_CHECK(!Obfuscation::KeyFromHex("00"));                                        // too short
+    BOOST_CHECK(!Obfuscation::KeyFromHex(obfuscation.HexKey() + "00"));                 // too long
+    BOOST_CHECK(!Obfuscation::KeyFromHex(std::string(2 * Obfuscation::KEY_SIZE, 'z'))); // not hex
+}
+
+BOOST_AUTO_TEST_CASE(obfuscation_delta)
+{
+    auto data{m_rng.randbytes<std::byte>(128)};
+    Obfuscation old_obfuscation{m_rng.randbytes<Obfuscation::KEY_SIZE>()};
+    Obfuscation new_obfuscation{m_rng.randbytes<Obfuscation::KEY_SIZE>()};
+
+    auto migrated{data};
+    old_obfuscation(migrated); // as stored under the old key
+    auto delta{Obfuscation::Delta(old_obfuscation, new_obfuscation)};
+    delta(migrated);
+
+    auto expected{data};
+    new_obfuscation(expected);
+
+    BOOST_CHECK(migrated == expected);
 }
 
 BOOST_AUTO_TEST_CASE(obfuscation_serialize)

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -136,14 +136,16 @@ bool FileCommit(FILE* file)
     return true;
 }
 
-void DirectoryCommit(const fs::path& dirname)
+bool DirectoryCommit(const fs::path& dirname)
 {
 #ifndef WIN32
-    FILE* file = fsbridge::fopen(dirname, "r");
-    if (file) {
-        fsync(fileno(file));
-        fclose(file);
+    if (FILE* file{fsbridge::fopen(dirname, "r")}) {
+        const bool success{!fsync(fileno(file))};
+        return !fclose(file) && success;
     }
+    return false;
+#else
+    return true;
 #endif
 }
 

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -41,8 +41,10 @@ bool FileCommit(FILE* file);
 /**
  * Sync directory contents. This is required on some environments to ensure that
  * newly created files are committed to disk.
+ * Returns false if opening, syncing, or closing the directory fails.
+ * On Windows this is a no-op that returns true.
  */
-void DirectoryCommit(const fs::path& dirname);
+bool DirectoryCommit(const fs::path& dirname);
 
 bool TruncateFile(FILE* file, unsigned int length);
 

--- a/src/util/obfuscation.h
+++ b/src/util/obfuscation.h
@@ -10,18 +10,22 @@
 #include <tinyformat.h>
 #include <util/strencodings.h>
 
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <climits>
 #include <cstdint>
 #include <ios>
 #include <memory>
+#include <optional>
+#include <string_view>
 
 class Obfuscation
 {
 public:
     using KeyType = uint64_t;
     static constexpr size_t KEY_SIZE{sizeof(KeyType)};
+    using Key = std::array<std::byte, KEY_SIZE>;
 
     Obfuscation() { SetRotations(0); }
     explicit Obfuscation(std::span<const std::byte, KEY_SIZE> key_bytes)
@@ -30,6 +34,14 @@ public:
     }
 
     operator bool() const { return m_rotations[0] != 0; }
+
+    static Obfuscation Delta(const Obfuscation& old_obfuscation, const Obfuscation& new_obfuscation)
+    {
+        Key delta_bytes{};
+        old_obfuscation(delta_bytes);
+        new_obfuscation(delta_bytes);
+        return Obfuscation{delta_bytes};
+    }
 
     void operator()(std::span<std::byte> target, size_t key_offset = 0) const
     {
@@ -63,6 +75,7 @@ public:
     void Serialize(Stream& s) const
     {
         // Use vector serialization for convenient compact size prefix.
+        // xor.dat uses array serialization instead
         std::vector<std::byte> bytes{KEY_SIZE};
         std::memcpy(bytes.data(), &m_rotations[0], KEY_SIZE);
         s << bytes;
@@ -80,6 +93,14 @@ public:
     std::string HexKey() const
     {
         return HexStr(std::as_bytes(std::span{&m_rotations[0], 1}));
+    }
+
+    static std::optional<Key> KeyFromHex(std::string_view hex)
+    {
+        if (hex.size() != 2 * KEY_SIZE || !IsHex(hex)) return std::nullopt;
+        Key key{};
+        std::ranges::copy(ParseHex<std::byte>(hex), key.begin());
+        return key;
     }
 
 private:

--- a/test/functional/feature_reobfuscation.py
+++ b/test/functional/feature_reobfuscation.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Reobfuscation coverage:
+
+- Node starts once (framework), which creates blk00000.dat / rev00000.dat.
+- Add many tiny blk*/rev* files so progress logging has milestones.
+- Restart with -reobfuscate-blocks=1 and check logs + xor.dat.
+- Rerunning with the already-active key skips the rewrite.
+- Restart without the flag; verify the active obfuscation key in logs matches xor.dat.
+- Simulate interrupted rename stage and ensure resume.
+- Invalid key values should fail fast.
+- Reobfuscation should fail before rewriting files when block XOR is disabled.
+- Do not suggest reobfuscation when block XOR is disabled.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import NULL_BLK_XOR_KEY, NUM_XOR_BYTES
+from test_framework.util import assert_equal, assert_not_equal
+
+
+class ReobfuscateBlocksSmokeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.uses_wallet = None
+        self.extra_args = [["-checkblocks=0"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        blocks_dir = node.blocks_path
+        blk0 = blocks_dir / "blk00000.dat"
+        rev0 = blocks_dir / "rev00000.dat"
+        xor_dat = node.blocks_key_path
+        xor_new = xor_dat.with_name(xor_dat.name + ".reobfuscated")
+
+        assert blk0.exists() and rev0.exists(), "Sanity: blk00000.dat and rev00000.dat should exist"
+
+        self.log.info("Snapshot initial contents")
+        before_blk = blk0.read_bytes()
+        before_rev = rev0.read_bytes()
+
+        self.log.info("Add many dummy block/undo files for progress logging (10 pairs in total)")
+        for i in range(1, 10):
+            (blocks_dir / f"blk{i:05d}.dat").write_bytes(b"\0")
+            (blocks_dir / f"rev{i:05d}.dat").write_bytes(b"\0")
+
+        self.log.info("Restarting with reobfuscation enabled")
+        with node.assert_debug_log(expected_msgs=[
+            "[obfuscate] Reobfuscating 20 block and undo files",
+            "% done",
+        ]):
+            self.restart_node(0, extra_args=self.extra_args[0] + ["-reobfuscate-blocks"])
+            self.stop_node(0)
+
+        assert xor_dat.exists(), "xor.dat not created"
+        assert_equal(xor_dat.stat().st_size, NUM_XOR_BYTES)
+
+        self.log.info("Files should have been rewritten")
+        assert_not_equal(before_blk, blk0.read_bytes(), error_message="blk00000.dat content did not change")
+        assert_not_equal(before_rev, rev0.read_bytes(), error_message="rev00000.dat content did not change")
+
+        self.log.info("Rerunning with the already-active key skips the rewrite")
+        with node.assert_debug_log(expected_msgs=["[obfuscate] Block and Undo file migration finished"], unexpected_msgs=["[obfuscate] Reobfuscating"]):
+            self.start_node(0, extra_args=self.extra_args[0] + [f"-reobfuscate-blocks={node.read_xor_key().hex()}"])
+            self.stop_node(0)
+
+        self.log.info("Start again without the flag; node should log the active obfuscation key matching xor.dat")
+        with node.assert_debug_log(expected_msgs=[
+            "Using obfuscation key for blocksdir *.dat files",
+            f"'{node.read_xor_key().hex()}'",
+        ]):
+            self.start_node(0, extra_args=self.extra_args[0])
+            self.generate(node, 1)
+            self.stop_node(0)
+
+        self.log.info("Simulate interrupted rename stage; ensure resume without flag")
+        dummy_reobfuscated = blocks_dir / "blk99999.dat.reobfuscated"
+        dummy_reobfuscated.write_bytes(b"\x00")
+        xor_new.write_bytes(node.read_xor_key())
+        xor_dat.unlink()
+
+        self.start_node(0, extra_args=self.extra_args[0])
+        self.stop_node(0)
+
+        assert (blocks_dir / "blk99999.dat").exists(), "resume did not rename staged block file"
+        assert not dummy_reobfuscated.exists(), "resume did not remove reobfuscated suffix"
+        assert xor_dat.exists(), "resume did not restore xor.dat"
+        assert not xor_new.exists(), "resume did not remove xor.dat.reobfuscated"
+
+        self.log.info("Invalid key values should fail early")
+        for invalid_key in ("z" * (2 * NUM_XOR_BYTES), "f" * (2 * NUM_XOR_BYTES - 1)):
+            node.assert_start_raises_init_error(
+                extra_args=self.extra_args[0] + [f"-reobfuscate-blocks={invalid_key}"],
+                expected_msg=f"Error: Invalid -reobfuscate-blocks value '{invalid_key}'",
+            )
+
+        self.log.info("Mismatched staged key should fail")
+        nonzero_key = "ff" * NUM_XOR_BYTES
+        xor_new.write_bytes(NULL_BLK_XOR_KEY)
+        node.assert_start_raises_init_error(
+            extra_args=self.extra_args[0] + [f"-reobfuscate-blocks={nonzero_key}"],
+            expected_msg="Error: Block obfuscation failed",
+        )
+        xor_new.unlink()
+
+        self.log.info("Reobfuscation should fail early when block XOR is disabled")
+        blk_before_disabled_xor = blk0.read_bytes()
+        xor_before_disabled_xor = node.read_xor_key()
+        node.assert_start_raises_init_error(
+            extra_args=self.extra_args[0] + ["-blocksxor=0", f"-reobfuscate-blocks={nonzero_key}"],
+            expected_msg="Error: Block reobfuscation cannot proceed with -blocksxor=0",
+        )
+        assert_equal(blk0.read_bytes(), blk_before_disabled_xor)
+        assert_equal(node.read_xor_key(), xor_before_disabled_xor)
+
+        self.log.info("Do not suggest reobfuscation when block XOR is disabled")
+        self.start_node(0, extra_args=self.extra_args[0] + [f"-reobfuscate-blocks={NULL_BLK_XOR_KEY.hex()}"])
+        self.stop_node(0)
+        assert_equal(node.read_xor_key(), NULL_BLK_XOR_KEY)
+        with node.assert_debug_log(expected_msgs=[], unexpected_msgs=["To obfuscate existing files"]):
+            self.start_node(0, extra_args=self.extra_args[0] + ["-blocksxor=0"])
+            self.stop_node(0)
+
+
+if __name__ == "__main__":
+    ReobfuscateBlocksSmokeTest(__file__).main()

--- a/test/functional/feature_reobfuscation.py
+++ b/test/functional/feature_reobfuscation.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Reobfuscation coverage:
+
+- Node starts once (framework), which creates blk00000.dat / rev00000.dat.
+- Add many tiny blk*/rev* files so progress logging has milestones.
+- Restart with -reobfuscate-blocks=1 and check logs + xor.dat.
+- Rerunning with the already-active key skips the rewrite.
+- Restart without the flag; verify the active obfuscation key in logs matches xor.dat.
+- Simulate interrupted rename stage and ensure resume.
+- Invalid key values should fail fast.
+- Reobfuscation should fail before rewriting files when block XOR is disabled.
+- Do not suggest reobfuscation when block XOR is disabled.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import NULL_BLK_XOR_KEY, NUM_XOR_BYTES
+from test_framework.util import assert_equal, assert_not_equal
+
+
+class ReobfuscateBlocksSmokeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.uses_wallet = None
+        self.extra_args = [["-checkblocks=0"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        blocks_dir = node.blocks_path
+        blk0 = blocks_dir / "blk00000.dat"
+        rev0 = blocks_dir / "rev00000.dat"
+        xor_dat = node.blocks_key_path
+        xor_new = xor_dat.with_name(xor_dat.name + ".reobfuscated")
+
+        assert blk0.exists() and rev0.exists(), "Sanity: blk00000.dat and rev00000.dat should exist"
+
+        self.log.info("Snapshot initial contents")
+        before_blk = blk0.read_bytes()
+        before_rev = rev0.read_bytes()
+
+        self.log.info("Add many dummy block/undo files for progress logging (10 pairs in total)")
+        for i in range(1, 10):
+            (blocks_dir / f"blk{i:05d}.dat").write_bytes(b"\0")
+            (blocks_dir / f"rev{i:05d}.dat").write_bytes(b"\0")
+
+        self.log.info("Restarting with reobfuscation enabled")
+        with node.assert_debug_log(expected_msgs=[
+            "[obfuscate] Reobfuscating 20 block and undo files",
+            "% done",
+        ]):
+            self.restart_node(0, extra_args=self.extra_args[0] + ["-reobfuscate-blocks"])
+            self.stop_node(0)
+
+        assert xor_dat.exists(), "xor.dat not created"
+        assert_equal(xor_dat.stat().st_size, NUM_XOR_BYTES)
+
+        self.log.info("Files should have been rewritten")
+        assert_not_equal(before_blk, blk0.read_bytes(), error_message="blk00000.dat content did not change")
+        assert_not_equal(before_rev, rev0.read_bytes(), error_message="rev00000.dat content did not change")
+
+        self.log.info("Rerunning with the already-active key skips the rewrite")
+        with node.assert_debug_log(expected_msgs=["[obfuscate] Block and Undo file migration finished"], unexpected_msgs=["[obfuscate] Reobfuscating"]):
+            self.start_node(0, extra_args=self.extra_args[0] + [f"-reobfuscate-blocks={node.read_xor_key().hex()}"])
+            self.stop_node(0)
+
+        self.log.info("Resume with a staged key before any files have been copied")
+        staged_key = bytes(byte ^ 0xff for byte in node.read_xor_key())
+        xor_new.write_bytes(staged_key)
+        self.start_node(0, extra_args=self.extra_args[0])
+        self.stop_node(0)
+        assert_equal(node.read_xor_key(), staged_key)
+        assert not xor_new.exists()
+
+        self.log.info("Start again without the flag; node should log the active obfuscation key matching xor.dat")
+        with node.assert_debug_log(expected_msgs=[
+            "Using obfuscation key for blocksdir *.dat files",
+            f"'{node.read_xor_key().hex()}'",
+        ]):
+            self.start_node(0, extra_args=self.extra_args[0])
+            self.generate(node, 1)
+            self.stop_node(0)
+
+        self.log.info("Simulate interrupted rename stage; ensure resume without flag")
+        dummy_reobfuscated = blocks_dir / "blk99999.dat.reobfuscated"
+        dummy_reobfuscated.write_bytes(b"\x00")
+        xor_new.write_bytes(node.read_xor_key())
+        xor_dat.unlink()
+
+        self.start_node(0, extra_args=self.extra_args[0])
+        self.stop_node(0)
+
+        assert (blocks_dir / "blk99999.dat").exists(), "resume did not rename staged block file"
+        assert not dummy_reobfuscated.exists(), "resume did not remove reobfuscated suffix"
+        assert xor_dat.exists(), "resume did not restore xor.dat"
+        assert not xor_new.exists(), "resume did not remove xor.dat.reobfuscated"
+
+        self.log.info("Invalid key values should fail early")
+        for invalid_key in ("z" * (2 * NUM_XOR_BYTES), "f" * (2 * NUM_XOR_BYTES - 1)):
+            node.assert_start_raises_init_error(
+                extra_args=self.extra_args[0] + [f"-reobfuscate-blocks={invalid_key}"],
+                expected_msg=f"Error: Invalid -reobfuscate-blocks value '{invalid_key}'",
+            )
+
+        self.log.info("Mismatched staged key should fail")
+        nonzero_key = "ff" * NUM_XOR_BYTES
+        xor_new.write_bytes(NULL_BLK_XOR_KEY)
+        node.assert_start_raises_init_error(
+            extra_args=self.extra_args[0] + [f"-reobfuscate-blocks={nonzero_key}"],
+            expected_msg="Error: Block obfuscation failed",
+        )
+        xor_new.unlink()
+
+        self.log.info("Reobfuscation should fail early when block XOR is disabled")
+        blk_before_disabled_xor = blk0.read_bytes()
+        xor_before_disabled_xor = node.read_xor_key()
+        node.assert_start_raises_init_error(
+            extra_args=self.extra_args[0] + ["-blocksxor=0", f"-reobfuscate-blocks={nonzero_key}"],
+            expected_msg="Error: Block reobfuscation cannot proceed with -blocksxor=0",
+        )
+        assert_equal(blk0.read_bytes(), blk_before_disabled_xor)
+        assert_equal(node.read_xor_key(), xor_before_disabled_xor)
+
+        self.log.info("Do not suggest reobfuscation when block XOR is disabled")
+        self.start_node(0, extra_args=self.extra_args[0] + [f"-reobfuscate-blocks={NULL_BLK_XOR_KEY.hex()}"])
+        self.stop_node(0)
+        assert_equal(node.read_xor_key(), NULL_BLK_XOR_KEY)
+        with node.assert_debug_log(expected_msgs=[], unexpected_msgs=["To obfuscate existing files"]):
+            self.start_node(0, extra_args=self.extra_args[0] + ["-blocksxor=0"])
+            self.stop_node(0)
+
+
+if __name__ == "__main__":
+    ReobfuscateBlocksSmokeTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -166,6 +166,7 @@ BASE_SCRIPTS = [
     'wallet_anchor.py',
     'feature_reindex.py',
     'feature_reindex_readonly.py',
+    'feature_reobfuscation.py',
     'wallet_labels.py',
     'p2p_compactblocks.py',
     'p2p_compactblocks_blocksonly.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -168,6 +168,7 @@ BASE_SCRIPTS = [
     'wallet_anchor.py',
     'feature_reindex.py',
     'feature_reindex_readonly.py',
+    'feature_reobfuscation.py',
     'wallet_labels.py',
     'p2p_compactblocks.py',
     'p2p_compactblocks_blocksonly.py',


### PR DESCRIPTION
**Problem:** Nodes that synced before v28 may store block and undo files effectively unobfuscated with a zero XOR key. There is no built-in way to obfuscate those existing files, rotate their key, or deliberately replace it with a zero key without resyncing.

**Fix:** Add `-reobfuscate-blocks[=<value>]` to rewrite existing `blk*.dat` and `rev*.dat` files before chainstate loading. With no value or `=1`, the option generates a random 8-byte key. A 16-character hexadecimal value selects an exact key, including all zeros to remove obfuscation, while malformed values fail during startup. If the selected key is already active, block and undo files are left unchanged.

Files are rewritten in fixed-size chunks, staged with a `.reobfuscated` suffix, committed before the originals are removed, and renamed to their original names after all rewrites finish. The target key is staged as `xor.dat.reobfuscated`, which is also used to resume an interrupted migration. File modification times are preserved, and progress is reported in the log and through kernel notifications marked as resumable.

**Benchmark:** The migration is single-threaded and processes one file at a time.

| CPU | Storage | Block count | Size | Files | Time (min) | Blocks/min |
|---|---|---:|---:|---:|---:|---:|
| Apple M4 Max laptop | SSD | ~955k | ~854 GB | 11,232 | 10.18 | 93,804 |
| Intel Core i9 | SSD | ~909k | ~725 GB | 10,238 | 23.1 | 39,351 |
| Raspberry Pi 5 | SSD | ~914k | ~728 GB | 10,276 | 72.78 | 12,558 |
| Intel Core i7 | HDD | ~909k | ~720 GB | 10,156 | 208.7 | 4,356 |
| Raspberry Pi 4B | HDD | ~915k | ~730 GB | 10,304 | 1467 | 624 |

**Similar work:**

- [contrib: add xor-blocks tool to obfuscate blocks directory #32451](https://github.com/bitcoin/bitcoin/pull/32451)
- [andrewtoth/blocks-xor](https://github.com/andrewtoth/blocks-xor)