### PR TITLE
crypto: optimize SipHash Write() method with chunked processing

### DIFF
--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -51,8 +51,11 @@ CSipHasher& CSipHasher::Write(std::span<const unsigned char> data)
     uint64_t t = tmp;
     uint8_t c = count;
 
-    while (data.size() > 0) {
-        t |= uint64_t{data.front()} << (8 * (c % 8));
+    const unsigned char* ptr = data.data();
+    size_t size = data.size();
+
+    while (size > 0) {
+        t |= uint64_t{*ptr} << (8 * (c % 8));
         c++;
         if ((c & 7) == 0) {
             v3 ^= t;
@@ -61,7 +64,8 @@ CSipHasher& CSipHasher::Write(std::span<const unsigned char> data)
             v0 ^= t;
             t = 0;
         }
-        data = data.subspan(1);
+        ptr++;
+        size--;
     }
 
     v[0] = v0;


### PR DESCRIPTION
## Summary

The current default `Write()` implementation of Siphash uses a byte-by-byte approach to iterate the span. This results in significant overhead for large inputs due to repeated bounds checking and span manipulations, without any help from the compiler.

This PR aims at optimizing Siphash by replacing byte-by-byte processing in CSipHasher::Write() with an optimized
chunked approach that processes data in 8-byte aligned blocks when possible.

## Details

The new implementation is divided in 3 stages that process:

1. initial unaligned bytes to reach an 8-byte boundary
2. aligned 8-byte chunks directly using memcpy for efficiency
3. remaining bytes at the end

every change was thoroughly tested and benchmarked to avoid overfitting, but replicating is welcomed and encouraged.

## Benchmarks

```shell
taskset -c 1 ./bin/bench_bitcoin -filter="(WalletIsMineMigratedDescriptors|WalletIsMineDescriptors|GCSFilterConstruct|AddrManSelect)" -output-csv=bench_old.csv --min-time=60000
```

> Before:

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|       12,983,090.72 |               77.02 |    0.1% |     66.00 | `GCSFilterConstruct`

> After:

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|       11,155,751.42 |               89.64 |    0.1% |     65.99 | `GCSFilterConstruct`

compared to master:

- `GCSFilterConstruct` **+16%** faster