### PR TITLE
common: Make arith_uint256 trivially copyable

### DIFF
--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -37,20 +37,8 @@ public:
             pn[i] = 0;
     }
 
-    base_uint(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] = b.pn[i];
-    }
-
-    base_uint& operator=(const base_uint& b)
-    {
-        if (this != &b) {
-            for (int i = 0; i < WIDTH; i++)
-                pn[i] = b.pn[i];
-        }
-        return *this;
-    }
+    base_uint(const base_uint& b) = default;
+    base_uint& operator=(const base_uint& b) = default;
 
     base_uint(uint64_t b)
     {
@@ -271,6 +259,9 @@ public:
     friend uint256 ArithToUint256(const arith_uint256 &);
     friend arith_uint256 UintToArith256(const uint256 &);
 };
+
+// Keeping the trivially copyable property is beneficial for performance
+static_assert(std::is_trivially_copyable_v<arith_uint256>);
 
 uint256 ArithToUint256(const arith_uint256 &);
 arith_uint256 UintToArith256(const uint256 &);


### PR DESCRIPTION
Makes `arith_uint256`/`base_uint` trivially copyable by removing the custom copy constructor and copy assignment operators. Removing of the custom code should not result in a change of behavior since `base_uint` contains a simple array of `uint32_t` and compiler generated versions of the code could be better optimized.

This was suggested by maflcko here: https://github.com/bitcoin/bitcoin/pull/30469#pullrequestreview-3186533494