### PR TITLE
node: optimize CBlockIndexWorkComparator

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -158,20 +158,18 @@ namespace node {
 bool CBlockIndexWorkComparator::operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
 {
     // First sort by most total work, ...
-    if (pa->nChainWork > pb->nChainWork) return false;
-    if (pa->nChainWork < pb->nChainWork) return true;
+    if (pa->nChainWork != pb->nChainWork) {
+        return pa->nChainWork < pb->nChainWork;
+    }
 
     // ... then by earliest time received, ...
-    if (pa->nSequenceId < pb->nSequenceId) return false;
-    if (pa->nSequenceId > pb->nSequenceId) return true;
+    if (pa->nSequenceId != pb->nSequenceId) {
+        return pa->nSequenceId > pb->nSequenceId;
+    }
 
     // Use pointer address as tie breaker (should only happen with blocks
     // loaded from disk, as those all have id 0).
-    if (pa < pb) return false;
-    if (pa > pb) return true;
-
-    // Identical blocks.
-    return false;
+    return pa > pb;
 }
 
 bool CBlockIndexHeightOnlyComparator::operator()(const CBlockIndex* pa, const CBlockIndex* pb) const


### PR DESCRIPTION
## Summary

This PR optimizes `CBlockIndexWorkComparator::operator()` by removing 4 redundant branches.

The previous implementation used multiple separate comparisons with explicit branches for greater-than and less-than cases, resulting in unnecessary code paths.

The new implementation consolidates comparisons into single inequality checks and reduces complexity while preserving its original behavior. This change is particularly beneficial for loading blocks from files and reindexing.

## Benchmarks

```shell
taskset -c 1 ./bin/bench_bitcoin --filter="(CheckBlockIndex|LoadExternalBlockFile)" -output-csv=bench_old.csv --min-time=30000
```

> Before:

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|          129,988.82 |            7,692.97 |    0.0% |     33.02 | `CheckBlockIndex`
|       21,661,396.96 |               46.17 |    0.5% |     32.37 | `LoadExternalBlockFile`

> After:

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|          115,346.65 |            8,669.52 |    0.0% |     33.00 | `CheckBlockIndex`
|       20,389,679.85 |               49.04 |    0.4% |     31.76 | `LoadExternalBlockFile`

Compared to master:

* `CheckBlockIndex` **+12.7%** faster
* `LoadExternalBlockFile` **+6.2%** faster
