### PR TITLE
chore: compare against keys.size() in writeObject comma check

### DIFF
--- a/src/univalue/lib/univalue_write.cpp
+++ b/src/univalue/lib/univalue_write.cpp
@@ -104,7 +104,7 @@ void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, 
         if (prettyIndent)
             s += " ";
         s += values.at(i).write(prettyIndent, indentLevel + 1);
-        if (i != (values.size() - 1))
+        if (i != (keys.size() - 1))
             s += ",";
         if (prettyIndent)
             s += "\n";


### PR DESCRIPTION
Replace values.size() with keys.size() in the comma condition inside UniValue::writeObject. The loop iterates over keys.size(), and other UniValue methods consistently treat keys and values as parallel arrays. Using keys.size() here ensures internal consistency, avoids relying on the implicit invariant that keys.size() == values.size(
