### PR TITLE
txgraph: use enum Level instead of bool main_only

### DIFF
--- a/src/bench/txgraph.cpp
+++ b/src/bench/txgraph.cpp
@@ -114,9 +114,9 @@ void BenchTxGraphTrim(benchmark::Bench& bench)
         graph->GetBlockBuilder();
     });
 
-    assert(!graph->IsOversized());
+    assert(!graph->IsOversized(TxGraph::Level::TOP));
     // At least 99% of chains must survive.
-    assert(graph->GetTransactionCount() >= (NUM_TOP_CHAINS * NUM_TX_PER_TOP_CHAIN * 99) / 100);
+    assert(graph->GetTransactionCount(TxGraph::Level::TOP) >= (NUM_TOP_CHAINS * NUM_TX_PER_TOP_CHAIN * 99) / 100);
 }
 
 } // namespace

--- a/src/test/txgraph_tests.cpp
+++ b/src/test/txgraph_tests.cpp
@@ -64,19 +64,19 @@ BOOST_AUTO_TEST_CASE(txgraph_trim_zigzag)
     // Check that the graph is now oversized. This also forces the graph to
     // group clusters and compute the oversized status.
     graph->SanityCheck();
-    BOOST_CHECK_EQUAL(graph->GetTransactionCount(), NUM_TOTAL_TX);
-    BOOST_CHECK(graph->IsOversized(/*main_only=*/false));
+    BOOST_CHECK_EQUAL(graph->GetTransactionCount(TxGraph::Level::TOP), NUM_TOTAL_TX);
+    BOOST_CHECK(graph->IsOversized(TxGraph::Level::TOP));
 
     // Call Trim() to remove transactions and bring the cluster back within limits.
     auto removed_refs = graph->Trim();
     graph->SanityCheck();
-    BOOST_CHECK(!graph->IsOversized(/*main_only=*/false));
+    BOOST_CHECK(!graph->IsOversized(TxGraph::Level::TOP));
 
     // We only need to trim the middle bottom transaction to end up with 2 clusters each within cluster limits.
     BOOST_CHECK_EQUAL(removed_refs.size(), 1);
-    BOOST_CHECK_EQUAL(graph->GetTransactionCount(), MAX_CLUSTER_COUNT * 2 - 2);
+    BOOST_CHECK_EQUAL(graph->GetTransactionCount(TxGraph::Level::TOP), MAX_CLUSTER_COUNT * 2 - 2);
     for (unsigned int i = 0; i < refs.size(); ++i) {
-        BOOST_CHECK_EQUAL(graph->Exists(refs[i]), i != (NUM_BOTTOM_TX / 2));
+        BOOST_CHECK_EQUAL(graph->Exists(refs[i], TxGraph::Level::TOP), i != (NUM_BOTTOM_TX / 2));
     }
 }
 
@@ -123,19 +123,19 @@ BOOST_AUTO_TEST_CASE(txgraph_trim_flower)
 
     // Check that the graph is now oversized. This also forces the graph to
     // group clusters and compute the oversized status.
-    BOOST_CHECK(graph->IsOversized(/*main_only=*/false));
+    BOOST_CHECK(graph->IsOversized(TxGraph::Level::TOP));
 
     // Call Trim() to remove transactions and bring the cluster back within limits.
     auto removed_refs = graph->Trim();
     graph->SanityCheck();
-    BOOST_CHECK(!graph->IsOversized(/*main_only=*/false));
+    BOOST_CHECK(!graph->IsOversized(TxGraph::Level::TOP));
 
     // Since only the bottom transaction connects these clusters, we only need to remove it.
     BOOST_CHECK_EQUAL(removed_refs.size(), 1);
-    BOOST_CHECK_EQUAL(graph->GetTransactionCount(false), MAX_CLUSTER_COUNT * 2);
-    BOOST_CHECK(!graph->Exists(refs[0]));
+    BOOST_CHECK_EQUAL(graph->GetTransactionCount(TxGraph::Level::TOP), MAX_CLUSTER_COUNT * 2);
+    BOOST_CHECK(!graph->Exists(refs[0], TxGraph::Level::TOP));
     for (unsigned int i = 1; i < refs.size(); ++i) {
-        BOOST_CHECK(graph->Exists(refs[i]));
+        BOOST_CHECK(graph->Exists(refs[i], TxGraph::Level::TOP));
     }
 }
 
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(txgraph_trim_huge)
     graph->SanityCheck();
 
     // Not oversized so far (just 1000 clusters of 64).
-    BOOST_CHECK(!graph->IsOversized());
+    BOOST_CHECK(!graph->IsOversized(TxGraph::Level::TOP));
 
     // Construct the bottom transactions, and dependencies to the top chains.
     while (top_components.size() > 1) {
@@ -237,19 +237,19 @@ BOOST_AUTO_TEST_CASE(txgraph_trim_huge)
     graph->SanityCheck();
 
     // Now we are oversized (one cluster of 64011).
-    BOOST_CHECK(graph->IsOversized());
-    const auto total_tx_count = graph->GetTransactionCount();
+    BOOST_CHECK(graph->IsOversized(TxGraph::Level::TOP));
+    const auto total_tx_count = graph->GetTransactionCount(TxGraph::Level::TOP);
     BOOST_CHECK(total_tx_count == top_refs.size() + bottom_refs.size());
     BOOST_CHECK(total_tx_count == NUM_TOTAL_TX);
 
     // Call Trim() to remove transactions and bring the cluster back within limits.
     auto removed_refs = graph->Trim();
-    BOOST_CHECK(!graph->IsOversized());
-    BOOST_CHECK(removed_refs.size() == total_tx_count - graph->GetTransactionCount());
+    BOOST_CHECK(!graph->IsOversized(TxGraph::Level::TOP));
+    BOOST_CHECK(removed_refs.size() == total_tx_count - graph->GetTransactionCount(TxGraph::Level::TOP));
     graph->SanityCheck();
 
     // At least 99% of chains must survive.
-    BOOST_CHECK(graph->GetTransactionCount() >= (NUM_TOP_CHAINS * NUM_TX_PER_TOP_CHAIN * 99) / 100);
+    BOOST_CHECK(graph->GetTransactionCount(TxGraph::Level::TOP) >= (NUM_TOP_CHAINS * NUM_TX_PER_TOP_CHAIN * 99) / 100);
 }
 
 BOOST_AUTO_TEST_CASE(txgraph_trim_big_singletons)
@@ -277,17 +277,17 @@ BOOST_AUTO_TEST_CASE(txgraph_trim_big_singletons)
 
     // Check that the graph is now oversized. This also forces the graph to
     // group clusters and compute the oversized status.
-    BOOST_CHECK(graph->IsOversized(/*main_only=*/false));
+    BOOST_CHECK(graph->IsOversized(TxGraph::Level::TOP));
 
     // Call Trim() to remove transactions and bring the cluster back within limits.
     auto removed_refs = graph->Trim();
     graph->SanityCheck();
-    BOOST_CHECK_EQUAL(graph->GetTransactionCount(), NUM_TOTAL_TX - 6);
-    BOOST_CHECK(!graph->IsOversized(/*main_only=*/false));
+    BOOST_CHECK_EQUAL(graph->GetTransactionCount(TxGraph::Level::TOP), NUM_TOTAL_TX - 6);
+    BOOST_CHECK(!graph->IsOversized(TxGraph::Level::TOP));
 
     // Check that all the oversized transactions were removed.
     for (unsigned int i = 0; i < refs.size(); ++i) {
-        BOOST_CHECK_EQUAL(graph->Exists(refs[i]), i != 88 && i % 20 != 0);
+        BOOST_CHECK_EQUAL(graph->Exists(refs[i], TxGraph::Level::TOP), i != 88 && i % 20 != 0);
     }
 }
 


### PR DESCRIPTION
Part of #30289. Inspired by https://github.com/bitcoin/bitcoin/pull/28676#discussion_r2331387778.

Since there has been more than one case in the development of #28676 of calling a `TxGraph` function without correctly setting the `bool main_only` argument that many of its interface functions have, make these mandatory and explicit, using an `enum class Level`:

```c++
enum class Level {
    TOP, //!< Refers to staging if it exists, main otherwise.
    MAIN //!< Always refers to the main graph, whether staging is present or not.
};
```