### PR TITLE
ci: Skip Centos job on GHA runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,7 @@ jobs:
             file-env: './ci/test/00_setup_env_native_previous_releases.sh'
 
           - name: 'CentOS, depends, gui'
+            if: ${{ needs.runners.outputs.use-cirrus-runners == 'true' }} # Skip this on non-Cirrus runners as it runs out of space
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120


### PR DESCRIPTION
Currently when running on GH free runners, this jobs runs out of space. This does not happen on Cirrus runners in the main repo (bitcoin/bitcoin) but does happen on forks.

Rather than include code to free up space on the runner image, disable this job on forks.

Fixes #33293