### PR TITLE
depends: systemtap 5.3

### DIFF
--- a/depends/packages/systemtap.mk
+++ b/depends/packages/systemtap.mk
@@ -1,8 +1,8 @@
 package=systemtap
-$(package)_version=4.8
+$(package)_version=5.3
 $(package)_download_path=https://sourceware.org/ftp/systemtap/releases/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=cbd50a4eba5b261394dc454c12448ddec73e55e6742fda7f508f9fbc1331c223
+$(package)_sha256_hash=966a360fb73a4b65a8d0b51b389577b3c4f92a327e84aae58682103e8c65a69a
 $(package)_patches=remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
The diff in the copied header is:
```diff
< #if __STDC_VERSION__ >= 199901L
---
> #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
```

From
https://sourceware.org/git/?p=systemtap.git;a=commit;h=b8345d8e07b725a943a97b19aa4866e74baadd98.