### PR TITLE
mining: add applySolution() to interface

### DIFF
--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -61,6 +61,11 @@ public:
     virtual bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase) = 0;
 
     /**
+     * Re-construct and return the block. Does not validate or submit.
+     */
+    virtual CBlock applySolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase) = 0;
+
+    /**
      * Waits for fees in the next block to rise, a new tip or the timeout.
      *
      * @param[in] options   Control the timeout (default forever) and by how much total fees

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -56,12 +56,22 @@ public:
     /**
      * Construct and broadcast the block.
      *
+     * @param[in] version version block header field
+     * @param[in] timestamp time block header field (unix timestamp)
+     * @param[in] nonce nonce block header field
+     * @param[in] coinbase complete coinbase transaction (including witness)
+     *
+     * @note unlike the submitsolution RPC, this method and applySolution do
+     *       NOT add the coinbase witness automatically.
+     *
      * @returns if the block was processed, independent of block validity
      */
     virtual bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase) = 0;
 
     /**
      * Re-construct and return the block. Does not validate or submit.
+     *
+     * See submitSolution() for expected params.
      */
     virtual CBlock applySolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase) = 0;
 

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -32,6 +32,7 @@ interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {
     getWitnessCommitmentIndex @7 (context: Proxy.Context) -> (result: Int32);
     getCoinbaseMerklePath @8 (context: Proxy.Context) -> (result: List(Data));
     submitSolution @9 (context: Proxy.Context, version: UInt32, timestamp: UInt32, nonce: UInt32, coinbase :Data) -> (result: Bool);
+    applySolution @11 (context: Proxy.Context, version: UInt32, timestamp: UInt32, nonce: UInt32, coinbase :Data) -> (result: Data);
     waitNext @10 (context: Proxy.Context, options: BlockWaitOptions) -> (result: BlockTemplate);
 }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -916,6 +916,12 @@ public:
         return chainman().ProcessNewBlock(std::make_shared<const CBlock>(m_block_template->block), /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/nullptr);
     }
 
+    CBlock applySolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase) override
+    {
+        AddMerkleRootAndCoinbase(m_block_template->block, std::move(coinbase), version, timestamp, nonce);
+        return m_block_template->block;
+    }
+
     std::unique_ptr<BlockTemplate> waitNext(BlockWaitOptions options) override
     {
         auto new_template = WaitAndCreateNewBlock(chainman(), notifications(), m_node.mempool.get(), m_block_template, options, m_assemble_options);


### PR DESCRIPTION
Unlike the `submitblock` RPC which takes a fully serialized block, when a block solution is received via IPC the client only provides the nonce, coinbase and a few other fields. It may not have all the information it needs to reconstruct the block. This makes debugging difficult when the block is invalid.

This PR adds `applySolution()` which returns the reconstructed block and can be used by the client for debugging. It's assigned `@11` in the `.cap` file, and will not break existing client software.

It can also be used by the client for an alternative broadcast mechanism.

The tests cover both mainnet (unit tests) and regtest (functional tests), because the latter has SegWit active.

The second commit documents the fact that `applySolution()` as well as the (already existing) `submitSolution` are slightly different from the `submitsolution` RPC in that they expect a complete coinbase transaction and will not automatically add a witness. This behavior is also covered in the functional test of the first commit.

This is alternative or complimentary approach to:
- #33372 