### PR TITLE
test: don't throw from the destructor of DebugLogHelper

### DIFF
--- a/src/test/util/logging.cpp
+++ b/src/test/util/logging.cpp
@@ -8,7 +8,8 @@
 #include <noui.h>
 #include <tinyformat.h>
 
-#include <stdexcept>
+#include <cstdlib>
+#include <iostream>
 
 DebugLogHelper::DebugLogHelper(std::string message, MatchFn match)
     : m_message{std::move(message)}, m_match(std::move(match))
@@ -21,11 +22,12 @@ DebugLogHelper::DebugLogHelper(std::string message, MatchFn match)
     noui_test_redirect();
 }
 
-void DebugLogHelper::check_found()
+DebugLogHelper::~DebugLogHelper()
 {
     noui_reconnect();
     LogInstance().DeleteCallback(m_print_connection);
     if (!m_found && m_match(nullptr)) {
-        throw std::runtime_error(strprintf("'%s' not found in debug log\n", m_message));
+        tfm::format(std::cerr, "Fatal error: expected message not found in the debug log: '%s'\n", m_message);
+        std::abort();
     }
 }

--- a/src/test/util/logging.h
+++ b/src/test/util/logging.h
@@ -27,6 +27,9 @@ public:
 
     explicit DebugLogHelper(std::string message, MatchFn match = [](const std::string*){ return true; });
 
+    DebugLogHelper(const DebugLogHelper&) = delete;
+    DebugLogHelper& operator=(const DebugLogHelper&) = delete;
+
     ~DebugLogHelper();
 
 private:

--- a/src/test/util/logging.h
+++ b/src/test/util/logging.h
@@ -13,10 +13,7 @@
 
 class DebugLogHelper
 {
-    const std::string m_message;
-    bool m_found{false};
-    std::list<std::function<void(const std::string&)>>::iterator m_print_connection;
-
+public:
     //! Custom match checking function.
     //!
     //! Invoked with pointers to lines containing matching strings, and with
@@ -27,13 +24,16 @@ class DebugLogHelper
     //! (2) raising an error in check_found if no match was found
     //! Can return false to do the opposite in either case.
     using MatchFn = std::function<bool(const std::string* line)>;
-    MatchFn m_match;
 
-    void check_found();
-
-public:
     explicit DebugLogHelper(std::string message, MatchFn match = [](const std::string*){ return true; });
-    ~DebugLogHelper() noexcept(false) { check_found(); }
+
+    ~DebugLogHelper();
+
+private:
+    const std::string m_message;
+    bool m_found{false};
+    std::list<std::function<void(const std::string&)>>::iterator m_print_connection;
+    MatchFn m_match;
 };
 
 #define ASSERT_DEBUG_LOG(message) DebugLogHelper UNIQUE_NAME(debugloghelper)(message)


### PR DESCRIPTION
Throwing an exception from the destructor of a class is a bad practice because the destructor will be called when an object of that type is alive on the stack and another exception is thrown, which will result in "exception during the exception". This would terminate the program without any messages.

Instead print the message to the standard error output and call `std::abort()`.

---

This change is part of https://github.com/bitcoin/bitcoin/pull/26812. It is an improvement on its own, so creating a separate PR for it following the discussion at https://github.com/bitcoin/bitcoin/pull/32604#discussion_r2345091587. Getting it in will reduce the size of #26812.