### PR TITLE
cmake: exclude secp256k1 from all

### DIFF
--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -45,8 +45,5 @@ function(add_secp256k1 subdir)
     deduplicate_flags(CMAKE_C_FLAGS)
   endif()
 
-  add_subdirectory(${subdir})
-  set_target_properties(secp256k1 PROPERTIES
-    EXCLUDE_FROM_ALL TRUE
-  )
+  add_subdirectory(${subdir} EXCLUDE_FROM_ALL)
 endfunction()


### PR DESCRIPTION
Instead of setting the EXCLUDE_FROM_ALL target property, pass EXCLUDE_FROM_ALL to `add_subdirectory()`.

This has the following advanteges:

* It is shorter (obviously).
* Target properties are set only in the `CMakeLists.txt` file that defines the target.
* Install rules defined in the subdirectory are excluded as well. This is what we want, because secp256k1 is linked statically.