### PR TITLE
test: Prevent disk space warning during node_init_tests

### DIFF
--- a/src/test/node_init_tests.cpp
+++ b/src/test/node_init_tests.cpp
@@ -11,7 +11,12 @@
 
 using node::NodeContext;
 
-BOOST_FIXTURE_TEST_SUITE(node_init_tests, BasicTestingSetup)
+//! Like BasicTestingSetup, but using regtest network instead of mainnet.
+struct InitTestSetup : BasicTestingSetup {
+    InitTestSetup() : BasicTestingSetup{ChainType::REGTEST} {}
+};
+
+BOOST_FIXTURE_TEST_SUITE(node_init_tests, InitTestSetup)
 
 //! Custom implementation of interfaces::Init for testing.
 class TestInit : public interfaces::Init


### PR DESCRIPTION
mzumsande pointed out https://github.com/bitcoin/bitcoin/pull/32345#issuecomment-3286964369 that this test was print a warning:

```
Warning: Disk space for "/tmp/test_common bitcoin/node_init_tests/init_test/bf78678cb7723a3e84b5/blocks" may not accommodate the block files. Approximately 810 GB of data will be stored in this directory.
```

Fix by setting regtest instead of mainnet network before running the test.