### PR TITLE
wallet, rpc: add UTXO set check and incremental rescan to importdescriptors

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -176,6 +176,10 @@ public:
     //! populates the values.
     virtual void findCoins(std::map<COutPoint, Coin>& coins) = 0;
 
+    //! Scan UTXO set from coins belonging to the output_scripts
+    virtual void findCoinsByScript(std::set<CScript>& output_scripts, std::map<COutPoint, Coin>& coins) = 0;
+
+
     //! Estimate fraction of total transactions verified if blocks up to
     //! the specified block hash are verified.
     virtual double guessVerificationProgress(const uint256& block_hash) = 0;

--- a/src/node/coin.cpp
+++ b/src/node/coin.cpp
@@ -24,4 +24,33 @@ void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins)
         }
     }
 }
+
+void FindCoinsByScript(const NodeContext& node, std::set<CScript>& output_scripts, std::map<COutPoint, Coin>& coins)
+{
+    assert(node.chainman);
+    std::unique_ptr<CCoinsViewCursor> cursor;
+    {
+        LOCK(cs_main);
+        Chainstate& active_chainstate = node.chainman->ActiveChainstate();
+        // Ensure on-disk coins DB is up-to-date so the cursor will see recent coins.
+        active_chainstate.ForceFlushStateToDisk();
+        cursor = active_chainstate.CoinsDB().Cursor();
+    }
+
+    if (!cursor) {
+        return;
+    }
+
+    // Iterate the cursor.
+    while (cursor->Valid()) {
+        COutPoint key;
+        Coin coin;
+        if (cursor->GetKey(key) && cursor->GetValue(coin)) {
+            if (output_scripts.count(coin.out.scriptPubKey)) {
+                coins.emplace(key, coin);
+            }
+        }
+        cursor->Next();
+    }
+}
 } // namespace node

--- a/src/node/coin.cpp
+++ b/src/node/coin.cpp
@@ -46,7 +46,7 @@ void FindCoinsByScript(const NodeContext& node, std::set<CScript>& output_script
         COutPoint key;
         Coin coin;
         if (cursor->GetKey(key) && cursor->GetValue(coin)) {
-            if (output_scripts.count(coin.out.scriptPubKey)) {
+            if (output_scripts.contains(coin.out.scriptPubKey)) {
                 coins.emplace(key, coin);
             }
         }

--- a/src/node/coin.h
+++ b/src/node/coin.h
@@ -6,9 +6,11 @@
 #define BITCOIN_NODE_COIN_H
 
 #include <map>
+#include <set>
 
 class COutPoint;
 class Coin;
+class CScript;
 
 namespace node {
 struct NodeContext;
@@ -22,6 +24,15 @@ struct NodeContext;
  * @param[in,out] coins map to fill
  */
 void FindCoins(const node::NodeContext& node, std::map<COutPoint, Coin>& coins);
+
+/**
+* Scans the UTXO set for coins belonging to output_scripts.
+*
+* @param[in] node The node context to use for lookup
+* @param[in] output_scripts The scripts to scan for coins
+* @param[in,out] coins map to fill
+*/
+void FindCoinsByScript(const NodeContext& node, std::set<CScript>& output_scripts, std::map<COutPoint, Coin>& coins);
 } // namespace node
 
 #endif // BITCOIN_NODE_COIN_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -642,6 +642,10 @@ public:
                int{FillBlock(block2, block2_out, lock, active, chainman().m_blockman)};
     }
     void findCoins(std::map<COutPoint, Coin>& coins) override { return FindCoins(m_node, coins); }
+    void findCoinsByScript(std::set<CScript>& output_scripts, std::map<COutPoint, Coin>& coins) override
+    {
+        return FindCoinsByScript(m_node, output_scripts, coins);
+    }
     double guessVerificationProgress(const uint256& block_hash) override
     {
         LOCK(chainman().GetMutex());

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -294,6 +294,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importmempool", 1, "use_current_time" },
     { "importmempool", 1, "apply_unbroadcast_set" },
     { "importdescriptors", 0, "requests" },
+    { "importdescriptors", 1, "verify_balance" },
     { "listdescriptors", 0, "private" },
     { "verifychain", 0, "checklevel" },
     { "verifychain", 1, "nblocks" },

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <coins.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <util/check.h>
@@ -292,6 +293,45 @@ Balance GetBalance(const CWallet& wallet, const int min_depth, bool avoid_reuse,
         }
     }
     return ret;
+}
+
+CAmount GetWalletUTXOSetBalance(const CWallet& wallet)
+{
+    // Collect unique scriptPubKeys owned by the wallet.
+    std::set<CScript> output_scripts;
+    {
+        LOCK(wallet.cs_wallet);
+        for (const auto spkm : wallet.GetAllScriptPubKeyMans()) {
+            for (const auto& script : spkm->GetScriptPubKeys()) {
+                output_scripts.emplace(script);
+            }
+        }
+    }
+
+    // Query chainstate for coins matching these scripts.
+    std::map<COutPoint, Coin> coins;
+    if (!output_scripts.empty()) {
+        wallet.chain().findCoinsByScript(output_scripts, coins);
+    }
+
+    const auto current_height = wallet.chain().getHeight();
+
+    auto TallyCoins = [&](const std::map<COutPoint, Coin>& coins_map) -> CAmount {
+        CAmount balance_out = 0;
+        for (const auto& it : coins_map) {
+            const Coin& coin = it.second;
+
+            // Skip immature coinbase outputs.
+            if (coin.IsCoinBase() && coin.nHeight + COINBASE_MATURITY > current_height) {
+                continue;
+            }
+
+            balance_out += coin.out.nValue;
+        }
+        return balance_out;
+    };
+
+    return TallyCoins(coins);
 }
 
 std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet)

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -51,6 +51,7 @@ struct Balance {
     CAmount m_mine_nonmempool{0};        //!< Coins spent by wallet txs that are not in the mempool
 };
 Balance GetBalance(const CWallet& wallet, int min_depth = 0, bool avoid_reuse = true, bool include_nonmempool = false);
+CAmount GetWalletUTXOSetBalance(const CWallet& wallet);
 
 std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet);
 std::set<std::set<CTxDestination>> GetAddressGroupings(const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -22,6 +22,7 @@
 #include <util/time.h>
 #include <util/translation.h>
 #include <wallet/export.h>
+#include <wallet/receive.h>
 #include <wallet/rpc/util.h>
 #include <wallet/wallet.h>
 
@@ -37,6 +38,94 @@
 using interfaces::FoundBlock;
 
 namespace wallet {
+struct IncrementalRescanResult {
+    bool matched{false};          // Wallet balance matches UTXO-set balance
+    int chunks_scanned{0};        // Number of incremental chunks scanned
+    int64_t matched_from_time{0}; // Timestamp where match occurred
+    int blocks_scanned{0};       // Number of blocks scanned across all chunks
+};
+
+static std::optional<IncrementalRescanResult> IncrementalRescan(CWallet& wallet, const CAmount utxo_target, WalletRescanReserver& reserver)
+{
+    constexpr int BLOCKS_PER_CHUNK = 1000;
+    constexpr int64_t AVG_BLOCK_TIME_SEC = 600; // seconds per block (~10 minutes)
+
+    // Get current chain tip
+    int64_t tip_time{0};
+    int tip_height{0};
+    {
+        LOCK(wallet.cs_wallet);
+        CHECK_NONFATAL(wallet.chain().findBlock(wallet.GetLastBlockHash(),interfaces::FoundBlock().time(tip_time).height(tip_height)));
+    }
+
+    // Compute earliest safe rescan time if node is pruned
+    bool has_prune_boundary = false;
+    int64_t earliest_safe_time = 0;
+
+    if (auto prune_height_opt = wallet.chain().getPruneHeight()) {
+        int64_t difference = tip_height - *prune_height_opt;
+        int64_t blocks_available = std::max(difference, int64_t(0));
+        earliest_safe_time = std::max(tip_time - blocks_available * AVG_BLOCK_TIME_SEC, int64_t(0));
+        has_prune_boundary = true;
+    }
+
+    int64_t next_chunk_end_time = tip_time; // upper boundary of next chunk
+    int chunk_index = 1;
+
+    IncrementalRescanResult result;
+
+    while (true) {
+        result.chunks_scanned++;
+
+        result.blocks_scanned += BLOCKS_PER_CHUNK;
+        // Compute start time of this chunk
+        int64_t chunk_start_time = tip_time > int64_t(chunk_index) * BLOCKS_PER_CHUNK * AVG_BLOCK_TIME_SEC ? tip_time - int64_t(chunk_index) * BLOCKS_PER_CHUNK * AVG_BLOCK_TIME_SEC : 0;
+
+        int64_t chunk_end_time = next_chunk_end_time;
+
+        // Check prune boundary
+        if (has_prune_boundary && chunk_start_time < earliest_safe_time) {
+            chunk_start_time = earliest_safe_time;
+        }
+
+        // No more chunks left to scan
+        if (chunk_index > 1 && chunk_start_time == next_chunk_end_time) {
+            break;
+        }
+
+        // Perform rescan for this chunk [chunk_start_time, chunk_end_time)
+        int64_t scanned_up_to_time = wallet.RescanFromTime(chunk_start_time, reserver, /*endTime=*/std::optional<int64_t>(chunk_end_time));
+
+        if (wallet.IsAbortingRescan()) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Rescan aborted by user.");
+        }
+
+        // If some blocks in the chunk failed to scan, return nullopt for fallback
+        if (scanned_up_to_time > chunk_start_time) {
+            return std::nullopt;
+        }
+
+        // Check if wallet balance matches target after this chunk
+        const auto bal = GetBalance(wallet);
+        if (bal.m_mine_trusted == utxo_target) {
+            result.matched = true;
+            result.matched_from_time = chunk_start_time;
+            return result;
+        }
+
+        next_chunk_end_time = chunk_start_time;
+
+        // Stop if we've reached genesis or prune boundary
+        if (chunk_start_time == 0 || (has_prune_boundary && chunk_start_time == earliest_safe_time)) {
+            break;
+        }
+
+        ++chunk_index;
+    }
+
+    return std::nullopt;
+}
+
 RPCMethod importprunedfunds()
 {
     return RPCMethod{
@@ -407,6 +496,12 @@ RPCMethod importdescriptors()
     const int64_t minimum_timestamp = 1;
     int64_t now = 0;
     int64_t lowest_timestamp = 0;
+
+    bool do_scan_utxoset = false;
+    if (main_request.params.size() > 1 && !main_request.params[1].isNull()) {
+        do_scan_utxoset = main_request.params[1].get_bool();
+    }
+
     bool rescan = false;
     UniValue response(UniValue::VARR);
     {
@@ -431,12 +526,40 @@ RPCMethod importdescriptors()
                 rescan = true;
             }
         }
+
         pwallet->ConnectScriptPubKeyManNotifiers();
         pwallet->RefreshAllTXOs();
     }
 
+    if (!rescan) {
+        return response;
+    }
+
+    UniValue info(UniValue::VOBJ);
+    std::optional<IncrementalRescanResult> incremental_rescan_result;
+    bool incremental_rescan = false;
+    //Incremental rescan if requested
+    if (do_scan_utxoset && rescan) {
+        const auto wallet_balance = GetBalance(wallet);
+        const CAmount utxo_scanned_balance = GetWalletUTXOSetBalance(wallet);
+
+        if (utxo_scanned_balance != wallet_balance.m_mine_trusted) {
+            incremental_rescan_result = IncrementalRescan(wallet, utxo_scanned_balance, reserver);
+
+            if (incremental_rescan_result) {
+                incremental_rescan = true;
+                info.pushKV("utxo_check", incremental_rescan_result->matched);
+                info.pushKV("scanned_chunks", incremental_rescan_result->chunks_scanned);
+                info.pushKV("scanned_blocks", incremental_rescan_result->blocks_scanned);
+            }
+        } else {
+            // No discrepancy found
+            incremental_rescan = false;
+        }
+    }
+
     // Rescan the blockchain using the lowest timestamp
-    if (rescan) {
+    if (rescan && !incremental_rescan) {
         int64_t scanned_time = pwallet->RescanFromTime(lowest_timestamp, reserver);
         pwallet->ResubmitWalletTransactions(node::TxBroadcast::MEMPOOL_NO_BROADCAST, /*force=*/true);
 
@@ -485,8 +608,19 @@ RPCMethod importdescriptors()
                 }
             }
         }
-    }
+    } else {
+        std::vector<UniValue> results = response.getValues();
+        response.clear();
+        response.setArray();
 
+        if (incremental_rescan_result->matched) {
+            for (unsigned int i = 0; i < results.size(); ++i) {
+                UniValue res = results[i];
+                res.pushKV("info", info);
+                response.push_back(res);
+            }
+        }
+    }
     return response;
 },
     };

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -351,6 +351,7 @@ RPCMethod importdescriptors()
                             },
                         },
                         RPCArgOptions{.oneline_description="requests"}},
+                        {"verify_balance", RPCArg::Type::BOOL, RPCArg::Default{false}, "If true, scans the UTXO set balance and compare with wallet balance and triggers incremental rescan if discrepancy is found."}
                 },
                 RPCResult{
                     RPCResult::Type::ARR, "", "Response is an array with the same size as the input that has the execution result",
@@ -367,13 +368,21 @@ RPCMethod importdescriptors()
                                 {RPCResult::Type::NUM, "code", "JSONRPC error code"},
                                 {RPCResult::Type::STR, "message", "JSONRPC error message"},
                             }},
+                            {RPCResult::Type::OBJ, "info", /*optional=*/true, "Optional informational fields. When present, this object will contain details about incremental rescans (examples below).",
+                            {
+                                {RPCResult::Type::BOOL, "utxo_check", /*optional=*/true, "Status of the UTXO check. Example values: 'matched' (wallet DB matches UTXO set)."},
+                                {RPCResult::Type::NUM, "scanned_chunks", "If incremental rescans were performed, the number of chunks scanned before a match was found."},
+                                {RPCResult::Type::NUM, "scanned_blocks", "If incremental rescans were performed, the approximate number of blocks scanned (scanned_chunks * chunk_size)."},
+                            }},
                         }},
                     }
                 },
                 RPCExamples{
                     HelpExampleCli("importdescriptors", "'[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"internal\": true }, "
                                           "{ \"desc\": \"<my descriptor 2>\", \"label\": \"example 2\", \"timestamp\": 1455191480 }]'") +
-                    HelpExampleCli("importdescriptors", "'[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"active\": true, \"range\": [0,100], \"label\": \"<my bech32 wallet>\" }]'")
+                    HelpExampleCli("importdescriptors", "'[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"active\": true, \"range\": [0,100], \"label\": \"<my bech32 wallet>\" }]'") +
+                    HelpExampleCli("importdescriptors", "'[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"active\": true, " "\"range\": [0,100], \"label\": \"<my bech32 wallet>\", \"verify_balance\": true }]'") +
+                    HelpExampleRpc("importdescriptors", "[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"active\": true, " "\"range\": [0,100], \"label\": \"<my bech32 wallet>\", \"verify_balance\": true }]")
                 },
         [](const RPCMethod& self, const JSONRPCRequest& main_request) -> UniValue
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1837,7 +1837,7 @@ void CWallet::MaybeUpdateBirthTime(int64_t time)
  * @return Earliest timestamp that could be successfully scanned from. Timestamp
  * returned will be higher than startTime if relevant blocks could not be read.
  */
-int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver)
+int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, std::optional<int64_t> endTime)
 {
     // Find starting block. May be null if nCreateTime is greater than the
     // highest blockchain timestamp, in which case there is nothing that needs
@@ -1847,9 +1847,20 @@ int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& r
     bool start = chain().findFirstBlockWithTimeAndHeight(startTime - TIMESTAMP_WINDOW, 0, FoundBlock().hash(start_block).height(start_height));
     WalletLogPrintf("%s: Rescanning last %i blocks\n", __func__, start ? WITH_LOCK(cs_wallet, return GetLastBlockHeight()) - start_height + 1 : 0);
 
+    // If an endTime was provided, find an approximate end height to limit the scan.
+    std::optional<int> max_height;
+    if (endTime.has_value()) {
+        int end_height = 0;
+        uint256 end_block;
+        bool end_found = chain().findFirstBlockWithTimeAndHeight(endTime.value() - TIMESTAMP_WINDOW, 0, FoundBlock().hash(end_block).height(end_height));
+        if (end_found) {
+            max_height = end_height;
+        }
+    }
+
     if (start) {
         // TODO: this should take into account failure by ScanResult::USER_ABORT
-        ScanResult result = ScanForWalletTransactions(start_block, start_height, /*max_height=*/{}, reserver, /*save_progress=*/false);
+        ScanResult result = ScanForWalletTransactions(start_block, start_height, max_height, reserver, /*save_progress=*/false);
         if (result.status == ScanResult::FAILURE) {
             int64_t time_max;
             CHECK_NONFATAL(chain().findBlock(result.last_failed_block, FoundBlock().maxTime(time_max)));

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -635,7 +635,7 @@ public:
     void blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) override;
     void blockDisconnected(const interfaces::BlockInfo& block) override;
     void updatedBlockTip() override;
-    int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver);
+    int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, std::optional<int64_t> endTime = std::nullopt);
 
     struct ScanResult {
         enum { SUCCESS, FAILURE, USER_ABORT } status = SUCCESS;

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -36,6 +36,8 @@ from test_framework.wallet_util import (
     test_address,
 )
 
+BLOCK_TIME = 60 * 10 # 10 minutes
+
 class ImportDescriptorsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
@@ -49,6 +51,11 @@ class ImportDescriptorsTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+
+    def advance_time(self, node, secs):
+        """Advance mocktime on node safely."""
+        self.node_time += secs
+        node.setmocktime(self.node_time)
 
     def test_importdesc(self, req, success, error_code=None, error_message=None, warnings=None, wallet=None):
         """Run importdescriptors and assert success"""
@@ -68,6 +75,119 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         if error_code is not None:
             assert_equal(result[0]['error']['code'], error_code)
             assert_equal(result[0]['error']['message'], error_message)
+
+    def import_descriptor_verify_balance_flag_test(self, node, miner_wallet):
+        self.log.info("Test import descriptor with verify_balance flag")
+        receive_address = miner_wallet.getnewaddress()
+
+        # Mine up to block 500, then send the first tx
+        for _ in range(500):
+            self.generate(node, 1, sync_fun=lambda: None)
+            self.advance_time(node, BLOCK_TIME)
+        txid_first = miner_wallet.sendtoaddress(receive_address, 2)
+        self.log.info(f"Sent first tx {txid_first} after 500 blocks")
+
+        # Mine 1000 total 1000 more blocksthen send the second tx
+        for _ in range(1000):
+            self.generate(node, 1, sync_fun=lambda: None)
+            self.advance_time(node, BLOCK_TIME)
+        txid_second = miner_wallet.sendtoaddress(receive_address, 2)
+        self.log.info(f"Sent second tx {txid_second} after 1000 blocks")
+
+        # Mine a few extra blocks so both txs are safely confirmed
+        for _ in range(50):
+            self.generate(node, 1, sync_fun=lambda: None)
+            self.advance_time(node, BLOCK_TIME)
+
+        # Create two watch-only wallets and import using timestamp="now"
+        node.createwallet(wallet_name='watch_only_no_scan', disable_private_keys=True, load_on_startup=True)
+        node.createwallet(wallet_name='watch_only_with_scan', disable_private_keys=True, load_on_startup=True)
+        wallet_no_scan = node.get_wallet_rpc('watch_only_no_scan')
+        wallet_with_scan = node.get_wallet_rpc('watch_only_with_scan')
+
+        # Blank wallets don't have a birth time
+        assert 'birthtime' not in wallet_no_scan.getwalletinfo()
+        assert 'birthtime' not in wallet_with_scan.getwalletinfo()
+
+        # Import address with timestamp=now. The second import uses scan_utxoset=True.
+        desc = miner_wallet.getaddressinfo(receive_address)["desc"]
+        wallet_no_scan.importdescriptors([{"desc": desc, "timestamp": "now"}])
+        import_result_now_scan = wallet_with_scan.importdescriptors([{"desc": desc, "timestamp": "now"}], True)
+
+        # Assert importdescriptors(...) returned the expected structure & values for the scan=True case
+        assert isinstance(import_result_now_scan, list) and len(import_result_now_scan) == 1, f"unexpected import result: {import_result_now_scan}"
+        import_res_now_scan = import_result_now_scan[0]
+        assert_equal(import_res_now_scan.get('success'), True)
+        assert 'info' in import_res_now_scan and isinstance(import_res_now_scan['info'], dict), f"missing/invalid info field: {import_res_now_scan}"
+        info_now_scan = import_res_now_scan['info']
+        assert_equal(info_now_scan.get('utxo_check'), True)
+        assert_equal(info_now_scan.get('scanned_chunks'), 2)
+        assert_equal(info_now_scan.get('scanned_blocks'), 2000)
+
+        # With two txs of 2 each: watch_only_no_scan (no scan) should see 0, watch_only_with_scan should see 2 txs, balance 4
+        assert_equal(len(wallet_no_scan.listtransactions()), 0)
+        assert_equal(len(wallet_with_scan.listtransactions()), 2)
+        assert_equal(wallet_no_scan.getbalance(), 0)
+        assert_equal(wallet_with_scan.getbalance(), 4)
+
+        # Timestamp-based import: use the block time of the first tx as timestamp.
+        # If we import using that accurate block time (or an earlier time), BOTH imports
+        # (scan_utxoset False and True) should discover both txs.
+        tx_raw_first = miner_wallet.gettransaction(txid_first)
+        tx_raw_second = miner_wallet.gettransaction(txid_second)
+        assert 'blockhash' in tx_raw_first and tx_raw_first['blockhash'] is not None, "first tx not confirmed as expected"
+        assert 'blockhash' in tx_raw_second and tx_raw_second['blockhash'] is not None, "second tx not confirmed as expected"
+
+        blockhash_first = tx_raw_first['blockhash']
+        blockhash_second = tx_raw_second['blockhash']
+
+        # get accurate block times from the headers (fall back to tx blocktime/time fields)
+        block_time_first = node.getblockheader(blockhash_first).get('time', tx_raw_first.get('blocktime', tx_raw_first.get('time', None)))
+        block_time_second = node.getblockheader(blockhash_second).get('time', tx_raw_second.get('blocktime', tx_raw_second.get('time', None)))
+        assert block_time_first is not None and block_time_second is not None, "Unable to determine tx block times for timestamp test"
+
+        # Use the earliest tx block time so the rescan will cover both transactions
+        earliest_tx_time = min(block_time_first, block_time_second)
+        self.log.info(f"tx1 time={block_time_first}, tx2 time={block_time_second}, earliest={earliest_tx_time}")
+
+        # Create two fresh watch-only wallets for the timestamp-based import test
+        node.createwallet(wallet_name='watch_only_ts_no_scan', disable_private_keys=True, load_on_startup=True)
+        node.createwallet(wallet_name='watch_only_ts_with_scan', disable_private_keys=True, load_on_startup=True)
+        wallet_ts_no_scan = node.get_wallet_rpc('watch_only_ts_no_scan')
+        wallet_ts_with_scan = node.get_wallet_rpc('watch_only_ts_with_scan')
+
+        # Blank wallets don't have a birth time
+        assert 'birthtime' not in wallet_ts_no_scan.getwalletinfo()
+        assert 'birthtime' not in wallet_ts_with_scan.getwalletinfo()
+
+        # Import using the earliest tx block time as timestamp
+        wallet_ts_no_scan.importdescriptors([{"desc": desc, "timestamp": earliest_tx_time}])
+        import_result_ts_scan = wallet_ts_with_scan.importdescriptors([{"desc": desc, "timestamp": earliest_tx_time}], True)
+        self.log.info(import_result_ts_scan)
+
+        # Assert importdescriptors(...) returned the expected structure & values for the timestamp scan=True case
+        assert isinstance(import_result_ts_scan, list) and len(import_result_ts_scan) == 1, f"unexpected import result: {import_result_ts_scan}"
+        import_res_ts_scan = import_result_ts_scan[0]
+        assert_equal(import_res_ts_scan.get('success'), True)
+        assert 'info' in import_res_ts_scan and isinstance(import_res_ts_scan['info'], dict), f"missing/invalid info field: {import_res_ts_scan}"
+        info_ts_scan = import_res_ts_scan['info']
+        assert_equal(info_ts_scan.get('utxo_check'), True)
+        assert_equal(info_ts_scan.get('scanned_chunks'), 2)
+        assert_equal(info_ts_scan.get('scanned_blocks'), 2000)
+
+        # Both wallets should discover both transactions because the timestamp is <= the earliest tx block time
+        assert_equal(len(wallet_ts_no_scan.listtransactions()), 2)
+        assert_equal(len(wallet_ts_with_scan.listtransactions()), 2)
+        assert_equal(wallet_ts_no_scan.getbalance(), 4)
+        assert_equal(wallet_ts_with_scan.getbalance(), 4)
+
+        # Cleanup: unload the timestamp test wallets
+        wallet_ts_no_scan.unloadwallet()
+        wallet_ts_with_scan.unloadwallet()
+
+        # Unload the initial watch-only wallets as well
+        wallet_no_scan.unloadwallet()
+        wallet_with_scan.unloadwallet()
 
     def test_import_unused_key(self):
         self.log.info("Test import of unused(KEY)")
@@ -956,6 +1076,17 @@ class ImportDescriptorsTest(BitcoinTestFramework):
             assert_equal(w_multipath.getrawchangeaddress(address_type="bech32"), w_multisplit.getrawchangeaddress(address_type="bech32"))
         assert_equal(sorted(w_multipath.listdescriptors()["descriptors"], key=lambda x: x["desc"]), sorted(w_multisplit.listdescriptors()["descriptors"], key=lambda x: x["desc"]))
 
+        self.node_time = int(time.time())
+        self.nodes[1].setmocktime(self.node_time)
+
+        # Create a miner wallet and fund it
+        self.nodes[1].createwallet(wallet_name='miner', load_on_startup=True)
+
+        miner_wallet = self.nodes[1].get_wallet_rpc('miner')
+
+        # Ensure miner has blocks/UTXOs
+        self.generatetoaddress(self.nodes[1], COINBASE_MATURITY + 10, miner_wallet.getnewaddress())
+
         self.log.info("Test older() safety")
 
         for flag in [0, SEQUENCE_LOCKTIME_TYPE_FLAG]:
@@ -995,6 +1126,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.test_import_unused_key_existing()
         self.test_import_unused_noprivs()
         self.test_rescan_fails_import()
+        self.import_descriptor_verify_balance_flag_test(self.nodes[1], miner_wallet)
 
 if __name__ == '__main__':
     ImportDescriptorsTest(__file__).main()


### PR DESCRIPTION
Fixes [#28898](https://github.com/bitcoin/bitcoin/issues/28898)

When importing descriptors, users may accidentally provide an incorrect birthdate (timestamp). This can cause the wallet to miss relevant historical transactions, leading to incorrect or incomplete balances. Currently, the wallet only relies on rescans starting from the provided timestamp.

This PR extends the importdescriptors RPC with a new optional argument:

`verify_balance` a `bool` which is `false` by defualt.

If enabled, the wallet will compare its calculated trusted balance against UTXO set balance (by generating the `scriptpukeys` of the wallet and comparing it with the chains UTXO set `scriptpubkeys` to get the accurate balance belonging to the wallet and comparing it with the wallet trusted balance).

If the balances match, import continues as normal.
If a discrepancy is detected, the wallet will attempt incremental rescans in chunks of recent blocks until the missing history is found. If the wallet is pruned, incremental rescans will not go earlier than the prune boundary.

Additional information is returned in the RPC response under an `"info" ` object when `verify_balance` is used, they are:

`utxo_check`: whether the UTXO set matched the wallet balance
`scanned_chunks:` number of incremental rescan chunks attempted
`scanned_blocks`: approximate number of blocks scanned during incremental rescans

This helps detect and fix balance mismatches caused by wrong descriptor timestamps.

**Implementation:**
- Add `FindCoinsByScript()` for scanning UTXO set for coins belonging to output_scripts and expose it to node interface through `findCoinsByScript()`.
- Add `GetWalletUTXOSetBalance()` which calculates the wallet’s total spendable balance by summing all UTXOs in the blockchain’s UTXO set that belong to the wallet’s scriptPubKeys, ignoring immature coinbase outputs.
- Add `std::optional<int64_t> endTime` to `RescanFromTime()` which lets the rescan stop at a specific block height, limiting the scan to a defined time range instead of scanning from startTime all the way to the blockchain tip.
- Add `IncrementalRescan()` this function scans the wallet’s transaction history in chunks of blocks from tip backwards to try and reconcile the wallet’s trusted balance with the actual UTXO-set balance, stopping early if a chunk produces a balance that matches the target. It is used only when there’s a discrepancy between the wallet’s trusted balance and the UTXO-set balance, performing an incremental rescan to identify when the balances align and recording how many chunks were scanned. 

**`importescriptors` with incremental example**
```
bitcoin-cli importdescriptors '[{
    "desc": "wpkh([f5b1c3d7/84h/0h/0h]xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKpJrZT4S9vPz4ZZ6f4a1V4f3ChFy8hRk4M6mh4J4LR6WcJbNf2oyMFGmQH6Eo1QvLKMjR18q3fTq5/0/*)#abcd1234",
    "timestamp": "now"
}]' true
```

Example Output
```
[
  {
    "info": {
      "utxo_check": true,
      "scanned_blocks": 2000,
      "scanned_chunks": 2
    }
  }
]
```

**Benchmarks**
Here's a benchmark result for normal rescan and incremental rescan as suggested by **fjahr**. 

| ns/op        | op/s       | err% | total | benchmark                   |
|-------------:|-----------:|-----:|------:|:----------------------------|
| 13,481.56    | 74,175.41  | 0.9% | 0.01  | BenchmarkIncrementalRescans |
| 13,450.49    | 74,346.72  | 1.4% | 0.01  | BenchmarkIncrementalRescans |
| 13,468.04    | 74,249.85  | 1.5% | 0.01  | BenchmarkIncrementalRescans |
| 2,274,875.00 | 439.58     | 1.7% | 0.03  | BenchmarkRescanFull         |
| 2,301,375.00 | 434.52     | 1.4% | 0.03  | BenchmarkRescanFull         |
| 2,306,334.00 | 433.59     | 3.0% | 0.03  | BenchmarkRescanFull         |


Here's the [code](https://github.com/bitcoin/bitcoin/commit/15982b5cdef97d89c5ac68fe4b075abad1f65228)  for the benchmark. Not 100 percent sure if I wrote it correctly. It's my first time writting benchmark, took inspiration from how [src/bench/wallet_balance.cpp](https://github.com/bitcoin/bitcoin/blob/master/src/bench/wallet_balance.cpp) was written.


A big thanks to **fjahr** for suggesting this approach [comment](https://github.com/bitcoin/bitcoin/pull/33392#issuecomment-3300319224)