### PR TITLE
util/strencodings: guard SAFE_CHARS index and pre-reserve result

### DIFF
--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -30,8 +30,16 @@ static const std::string SAFE_CHARS[] =
 std::string SanitizeString(std::string_view str, int rule)
 {
     std::string result;
+    // Validate rule index defensively and avoid out-of-bounds access.
+    const size_t safe_chars_count = sizeof(SAFE_CHARS) / sizeof(SAFE_CHARS[0]);
+    if (rule < 0 || static_cast<size_t>(rule) >= safe_chars_count) {
+        return result;
+    }
+
+    result.reserve(str.size());
+    const std::string& allowed = SAFE_CHARS[rule];
     for (char c : str) {
-        if (SAFE_CHARS[rule].find(c) != std::string::npos) {
+        if (allowed.find(c) != std::string::npos) {
             result.push_back(c);
         }
     }


### PR DESCRIPTION
- Add defensive bounds check for `rule` parameter in `SanitizeString` to prevent out-of-range access to `SAFE_CHARS` array
- Pre-reserve result capacity and cache reference to allowed charset to avoid repeated lookups  
- No behavior change for valid inputs; improves robustness and minor performance