### PR TITLE
ci: Remove bash -c from cmake invocation using eval

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -130,7 +130,8 @@ if [[ "${RUN_TIDY}" == "true" ]]; then
   BITCOIN_CONFIG_ALL="$BITCOIN_CONFIG_ALL -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 fi
 
-bash -c "cmake -S $BASE_ROOT_DIR -B ${BASE_BUILD_DIR} $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG" || (
+eval "CMAKE_ARGS=($BITCOIN_CONFIG_ALL $BITCOIN_CONFIG)"
+cmake -S "$BASE_ROOT_DIR" -B "$BASE_BUILD_DIR" "${CMAKE_ARGS[@]}" || (
   cd "${BASE_BUILD_DIR}"
   # shellcheck disable=SC2046
   cat $(cmake -P "${BASE_ROOT_DIR}/ci/test/GetCMakeLogFiles.cmake")


### PR DESCRIPTION
Follow up to https://github.com/bitcoin/bitcoin/pull/32970


https://github.com/bitcoin/bitcoin/pull/32970#r2213730157

> Does `cmake -S ...` still need to be wrapped in `bash -c "..."`?

https://github.com/bitcoin/bitcoin/pull/32970#r2213741192
> It is not trivial to replace. Maybe the `eval` hack from below can be used:
> 
> ```shell
>   # parses TEST_RUNNER_EXTRA as an array which allows for multiple arguments such as TEST_RUNNER_EXTRA='--exclude "rpc_bind.py --ipv6"'
> 
>   eval "TEST_RUNNER_EXTRA=($TEST_RUNNER_EXTRA)"
> ```
>however, I haven't tried this yet.

https://github.com/bitcoin/bitcoin/pull/32970#r2213801696
> Yeah, the eval hack should work:
> 
> ```
> $ export T="-DREDUCE_EXPORTS=ON -DCMAKE_CXX_FLAGS='-Wno-psabi     -Wno-error=maybe-uninitialized'";  eval "T=($T)"; for i in "${T[@]}"; do  echo "_${i}_" ; done 
> _-DREDUCE_EXPORTS=ON_
> _-DCMAKE_CXX_FLAGS=-Wno-psabi     -Wno-error=maybe-uninitialized_
> ```
> 
> (can be done in a follow-up)



This replaces the `bash -c` wrapper with an eval-based array parsing to preserve spaces in flag values (e.g., in CMAKE_CXX_FLAGS), allowing ShellCheck to lint the cmake command
