### PR TITLE
contrib: Add zsh completion scripts

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -42,7 +42,7 @@ Command Line Tools
 ---------------------
 
 ### [Completions](/contrib/completions) ###
-Shell completions for bash and fish.
+Shell completions for bash, zsh and fish.
 
 UTXO Set Tools
 --------------

--- a/contrib/completions/zsh/_bitcoin-cli
+++ b/contrib/completions/zsh/_bitcoin-cli
@@ -1,0 +1,143 @@
+#compdef bitcoin-cli
+#- zsh completion for bitcoin-cli(1)
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# call bitcoin-cli for RPC
+_bitcoin_rpc() {
+    # determine already specified args necessary for RPC
+    local rpcargs=()
+    local -a words_array
+    words_array=(${(z)BUFFER})
+
+    for i in $words_array; do
+        case "$i" in
+            -conf=*|-datadir=*|-regtest|-rpc*|-testnet|-testnet4)
+                rpcargs+=("$i")
+                ;;
+        esac
+    done
+
+    $bitcoin_cli "${rpcargs[@]}" "$@"
+}
+
+_bitcoin-cli() {
+    local context state line
+    local bitcoin_cli="$words[1]"
+
+    # Handle specific argument positions for various commands
+    if (( CURRENT > 5 )); then
+        case ${words[CURRENT-4]} in
+            sendtoaddress)
+                _values 'subtractfeefromamount' 'true' 'false'
+                return 0
+                ;;
+        esac
+    fi
+
+    if (( CURRENT > 4 )); then
+        case ${words[CURRENT-3]} in
+            importaddress|listtransactions|setban)
+                _values 'boolean' 'true' 'false'
+                return 0
+                ;;
+            signrawtransactionwithkey|signrawtransactionwithwallet)
+                _values 'sighashtype' 'ALL' 'NONE' 'SINGLE' 'ALL|ANYONECANPAY' 'NONE|ANYONECANPAY' 'SINGLE|ANYONECANPAY'
+                return 0
+                ;;
+        esac
+    fi
+
+    if (( CURRENT > 3 )); then
+        case ${words[CURRENT-2]} in
+            addmultisigaddress)
+                return 0
+                ;;
+            getbalance|gettxout|importaddress|importpubkey|importprivkey|listreceivedbyaddress|listsinceblock)
+                _values 'boolean' 'true' 'false'
+                return 0
+                ;;
+        esac
+    fi
+
+    if (( CURRENT > 2 )); then
+        case ${words[CURRENT-1]} in
+            addnode)
+                _values 'command' 'add' 'remove' 'onetry'
+                return 0
+                ;;
+            setban)
+                _values 'command' 'add' 'remove'
+                return 0
+                ;;
+            fundrawtransaction|getblock|getblockheader|getmempoolancestors|getmempooldescendants|getrawtransaction|gettransaction|listreceivedbyaddress|sendrawtransaction)
+                _values 'verbose' 'true' 'false'
+                return 0
+                ;;
+        esac
+    fi
+
+    # Handle previous word completions
+    case "${words[CURRENT-1]}" in
+        backupwallet|dumpwallet|importwallet)
+            _files
+            return 0
+            ;;
+        getaddednodeinfo|getrawmempool|lockunspent)
+            _values 'boolean' 'true' 'false'
+            return 0
+            ;;
+        getbalance|getnewaddress|listtransactions|sendmany)
+            return 0
+            ;;
+    esac
+
+    # Handle current word completions
+    case "$words[CURRENT]" in
+        -conf=*)
+            local conf_path=${words[CURRENT]#-conf=}
+            _files -W ${conf_path:h} -g "*"
+            return 0
+            ;;
+        -datadir=*)
+            local datadir_path=${words[CURRENT]#-datadir=}
+            _files -/ -W ${datadir_path:h}
+            return 0
+            ;;
+        -*=*)
+            # prevent nonsense completions
+            return 0
+            ;;
+        *)
+            local helpopts commands
+            local -a opts
+
+            # only parse -help if sensible (empty or starts with -)
+            if [[ -z "$words[CURRENT]" || "$words[CURRENT]" == -* ]]; then
+                helpopts="$($bitcoin_cli -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }')"
+                opts+=(${(f)helpopts})
+            fi
+
+            # only parse help if sensible (empty or starts with letter)
+            if [[ -z "$words[CURRENT]" || "$words[CURRENT]" == [a-z]* ]]; then
+                commands="$(_bitcoin_rpc help 2>/dev/null | awk '$1 ~ /^[a-z]/ { print $1; }')"
+                opts+=(${(f)commands})
+            fi
+
+            _describe 'bitcoin-cli options and commands' opts
+
+            return 0
+            ;;
+    esac
+}
+
+# Function is now defined and will be called by zsh completion system
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=sh

--- a/contrib/completions/zsh/_bitcoin-tx
+++ b/contrib/completions/zsh/_bitcoin-tx
@@ -1,0 +1,56 @@
+#compdef bitcoin-tx
+# zsh completion for bitcoin-tx(1)
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+_bitcoin-tx() {
+    local context state line
+    local bitcoin_tx="$words[1]"
+
+    # Handle current word completions
+    case "$words[CURRENT]" in
+        load=*:*)
+            local load_path=${words[CURRENT]#load=*:}
+            _files -W ${load_path:h}
+            return 0
+            ;;
+        *=*)
+            # prevent attempts to complete other arguments
+            return 0
+            ;;
+    esac
+
+    # Check if we should show options or commands
+    if (( CURRENT == 2 )) || [[ "$words[CURRENT-1]" != "-create" && "$words[CURRENT-1]" == -* ]]; then
+        # only options (or an uncompletable hex-string) allowed
+        # parse bitcoin-tx -help for options
+        local helpopts
+        helpopts="$($bitcoin_tx -help | awk '/^  -/ { gsub(/^  /, ""); print $1 }')"
+        local -a opts
+        opts=(${(f)helpopts})
+
+        _describe 'bitcoin-tx options' opts
+    else
+        # only commands are allowed
+        # parse -help for commands
+        local helpcmds
+        helpcmds="$($bitcoin_tx -help | awk '/Commands:/,0 { if (/^  [a-z]/) { gsub(/^  /, ""); gsub(/=.*/, "="); print $1 } }')"
+        local -a cmds
+        cmds=(${(f)helpcmds})
+
+        _describe 'bitcoin-tx commands' cmds
+    fi
+
+    return 0
+}
+
+# Function is now defined and will be called by zsh completion system
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=sh

--- a/contrib/completions/zsh/_bitcoind
+++ b/contrib/completions/zsh/_bitcoind
@@ -1,0 +1,50 @@
+#compdef bitcoind bitcoin-qt
+# zsh completion for bitcoind(1) and bitcoin-qt(1)
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+_bitcoind() {
+    local context state line
+    local bitcoind="$words[1]"
+
+    # Handle current word completions
+    case "$words[CURRENT]" in
+        -conf=*|-pid=*|-loadblock=*|-rpccookiefile=*|-wallet=*)
+            local file_path=${words[CURRENT]#*=}
+            _files -W ${file_path:h}
+            return 0
+            ;;
+        -datadir=*)
+            local dir_path=${words[CURRENT]#-datadir=}
+            _files -/ -W ${dir_path:h}
+            return 0
+            ;;
+        -*=*)
+            # prevent nonsense completions
+            return 0
+            ;;
+        *)
+            # only parse -help if sensible (empty or starts with -)
+            if [[ -z "$words[CURRENT]" || "$words[CURRENT]" == -* ]]; then
+                local helpopts
+                helpopts="$($bitcoind -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }')"
+                local -a opts
+                opts=(${(f)helpopts})
+
+                _describe 'bitcoind options' opts -S ''
+            fi
+            return 0
+            ;;
+    esac
+}
+
+# Function is now defined and will be called by zsh completion system
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=sh


### PR DESCRIPTION
  Adds zsh completion support using the compdef system for:
  - bitcoin-cli with RPC command completion and context-sensitive arguments
  - bitcoin-tx with option/command completion and file path handling
  - bitcoind with configuration option completion

  These complement the existing bash completion scripts and provide
  the same functionality for zsh users.
