### PR TITLE
cmake: Install `bitcoin` manpage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -293,7 +293,7 @@ if(BUILD_BITCOIN_BIN)
   add_windows_resources(bitcoin bitcoin-res.rc)
   add_windows_application_manifest(bitcoin)
   target_link_libraries(bitcoin core_interface bitcoin_util)
-  install_binary_component(bitcoin)
+  install_binary_component(bitcoin HAS_MANPAGE)
 endif()
 
 # Bitcoin Core bitcoind.


### PR DESCRIPTION
This PR is an amendment to https://github.com/bitcoin/bitcoin/pull/31375.