### PR TITLE
msvc: Update vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
-  "$comment": "The builtin-baseline corresponds to 2025.03.19 Release",
+  "$comment": "The builtin-baseline corresponds to 2025.08.27 Release",
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-  "builtin-baseline": "b02e341c927f16d991edbd915d8ea43eac52096c",
+  "builtin-baseline": "120deac3062162151622ca4860575a33844ba10b",
   "dependencies": [
     "boost-multi-index",
     "boost-signals2",


### PR DESCRIPTION
This PR updates the vcpkg manifest baseline from the ["2025.03.19 Release"](https://github.com/microsoft/vcpkg/releases/tag/2025.03.19) to the ["2025.08.27 Release"](https://github.com/microsoft/vcpkg/releases/tag/2025.08.27), with the following package
changes:
 - `boost`: 1.87.0 --> 1.88.0
 - `qtbase`: 6.8.2#1 -> 6.9.1
 - `qttools`: 6.8.2 -> 6.9.1
 - `sqlite3`: 3.49.1 --> 3.50.4

The previous update was made in https://github.com/bitcoin/bitcoin/pull/32213.