### PR TITLE
ci: re-add Valgrind job to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,6 +512,12 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_alpine_musl.sh'
 
+          - name: 'Valgrind'
+            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
+            fallback-runner: 'ubuntu-24.04'
+            timeout-minutes: 120
+            file-env: './ci/test/00_setup_env_native_valgrind.sh'
+
           - name: 'tidy'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
             fallback-runner: 'ubuntu-24.04'


### PR DESCRIPTION
Now that we've migrated to the new CI setup, and runtimes are looking decent, we could re-add some of the nightly/jobs runs in other repos, back to the main CI. This also came up in https://github.com/bitcoin/bitcoin/pull/33201#discussion_r2325069692.