### PR TITLE
[28.x] More backports

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,6 +1,6 @@
-Bitcoin Core version 28.x is now available from:
+Bitcoin Core version 28.3rc1 is now available from:
 
-  <https://bitcoincore.org/bin/bitcoin-core-28.x/test.rc1/>
+  <https://bitcoincore.org/bin/bitcoin-core-28.3/test.rc1/>
 
 This release includes various bug fixes and performance
 improvements, as well as updated translations.
@@ -37,6 +37,10 @@ unsupported systems.
 Notable changes
 ===============
 
+### P2P
+
+- #33395 net: do not apply whitelist permissions to onion inbounds
+
 ### Test
 
 - #32765 test: Fix list index out of range error in feature_bip68_sequence.py
@@ -54,6 +58,11 @@ Notable changes
 - #32777 doc: fix Transifex 404s
 - #33070 doc/zmq: fix unix socket path example
 - #33133 rpc: fix getpeerinfo ping duration unit docs
+- #33236 doc: Remove wrong and redundant doxygen tag
+
+### Misc
+
+- #33340 Fix benchmark CSV output
 
 Credits
 =======
@@ -63,8 +72,11 @@ Thanks to everyone who directly contributed to this release:
 - fanquake
 - Hennadii Stepanov
 - MarcoFalke
+- Martin Zumsande
 - romanz
 - Sjors Provoost
+- theStack
+- Vasil Dimov
 - willcl-ark
 - zaidmstrr
 

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -627,7 +627,7 @@ std::string SHA256AutoDetect(sha256_implementation::UseImplementation use_implem
         Transform = sha256_x86_shani::Transform;
         TransformD64 = TransformD64Wrapper<sha256_x86_shani::Transform>;
         TransformD64_2way = sha256d64_x86_shani::Transform_2way;
-        ret = "x86_shani(1way,2way)";
+        ret = "x86_shani(1way;2way)";
         have_sse4 = false; // Disable SSE4/AVX2;
         have_avx2 = false;
     }
@@ -641,14 +641,14 @@ std::string SHA256AutoDetect(sha256_implementation::UseImplementation use_implem
 #endif
 #if defined(ENABLE_SSE41)
         TransformD64_4way = sha256d64_sse41::Transform_4way;
-        ret += ",sse41(4way)";
+        ret += ";sse41(4way)";
 #endif
     }
 
 #if defined(ENABLE_AVX2)
     if (have_avx2 && have_avx && enabled_avx) {
         TransformD64_8way = sha256d64_avx2::Transform_8way;
-        ret += ",avx2(8way)";
+        ret += ";avx2(8way)";
     }
 #endif
 #endif // defined(HAVE_GETCPUID)
@@ -682,7 +682,7 @@ std::string SHA256AutoDetect(sha256_implementation::UseImplementation use_implem
         Transform = sha256_arm_shani::Transform;
         TransformD64 = TransformD64Wrapper<sha256_arm_shani::Transform>;
         TransformD64_2way = sha256d64_arm_shani::Transform_2way;
-        ret = "arm_shani(1way,2way)";
+        ret = "arm_shani(1way;2way)";
     }
 #endif
 #endif // DISABLE_OPTIMIZED_SHA256

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -557,9 +557,9 @@ void CNode::CloseSocketDisconnect()
     m_i2p_sam_session.reset();
 }
 
-void CConnman::AddWhitelistPermissionFlags(NetPermissionFlags& flags, const CNetAddr &addr, const std::vector<NetWhitelistPermissions>& ranges) const {
+void CConnman::AddWhitelistPermissionFlags(NetPermissionFlags& flags, std::optional<CNetAddr> addr, const std::vector<NetWhitelistPermissions>& ranges) const {
     for (const auto& subnet : ranges) {
-        if (subnet.m_subnet.Match(addr)) {
+        if (addr.has_value() && subnet.m_subnet.Match(addr.value())) {
             NetPermissions::AddFlag(flags, subnet.m_flags);
         }
     }
@@ -1731,7 +1731,11 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
 {
     int nInbound = 0;
 
-    AddWhitelistPermissionFlags(permission_flags, addr, vWhitelistedRangeIncoming);
+    const bool inbound_onion = std::find(m_onion_binds.begin(), m_onion_binds.end(), addr_bind) != m_onion_binds.end();
+
+    // Tor inbound connections do not reveal the peer's actual network address.
+    // Therefore do not apply address-based whitelist permissions to them.
+    AddWhitelistPermissionFlags(permission_flags, inbound_onion ? std::optional<CNetAddr>{} : addr, vWhitelistedRangeIncoming);
 
     {
         LOCK(m_nodes_mutex);
@@ -1786,7 +1790,6 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
     NodeId id = GetNewNodeId();
     uint64_t nonce = GetDeterministicRandomizer(RANDOMIZER_ID_LOCALHOSTNONCE).Write(id).Finalize();
 
-    const bool inbound_onion = std::find(m_onion_binds.begin(), m_onion_binds.end(), addr_bind) != m_onion_binds.end();
     // The V2Transport transparently falls back to V1 behavior when an incoming V1 connection is
     // detected, so use it whenever we signal NODE_P2P_V2.
     ServiceFlags local_services = GetLocalServices();

--- a/src/net.h
+++ b/src/net.h
@@ -1345,7 +1345,7 @@ private:
 
     bool AttemptToEvictConnection();
     CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure, ConnectionType conn_type, bool use_v2transport) EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
-    void AddWhitelistPermissionFlags(NetPermissionFlags& flags, const CNetAddr &addr, const std::vector<NetWhitelistPermissions>& ranges) const;
+    void AddWhitelistPermissionFlags(NetPermissionFlags& flags, std::optional<CNetAddr> addr, const std::vector<NetWhitelistPermissions>& ranges) const;
 
     void DeleteNode(CNode* pnode);
 

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -45,8 +45,6 @@ public:
     /**
      * Construct a fee rate from a fee in satoshis and a vsize in vB.
      *
-     * param@[in]   nFeePaid    The fee paid by a transaction, in satoshis
-     * param@[in]   num_bytes   The vsize of a transaction, in vbytes
      */
     CFeeRate(const CAmount& nFeePaid, uint32_t num_bytes);
 

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -590,15 +590,15 @@ util::Result<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utx
 
 /** Find a subset of the OutputGroups that is at least as large as, but as close as possible to, the
  * target amount; solve subset sum.
- * param@[in]   groups          OutputGroups to choose from, sorted by value in descending order.
- * param@[in]   nTotalLower     Total (effective) value of the UTXOs in groups.
- * param@[in]   nTargetValue    Subset sum target, not including change.
- * param@[out]  vfBest          Boolean vector representing the subset chosen that is closest to
+ * @param[in]   groups          OutputGroups to choose from, sorted by value in descending order.
+ * @param[in]   nTotalLower     Total (effective) value of the UTXOs in groups.
+ * @param[in]   nTargetValue    Subset sum target, not including change.
+ * @param[out]  vfBest          Boolean vector representing the subset chosen that is closest to
  *                              nTargetValue, with indices corresponding to groups. If the ith
  *                              entry is true, that means the ith group in groups was selected.
- * param@[out]  nBest           Total amount of subset chosen that is closest to nTargetValue.
- * paramp[in]   max_selection_weight  The maximum allowed weight for a selection result to be valid.
- * param@[in]   iterations      Maximum number of tries.
+ * @param[out]  nBest           Total amount of subset chosen that is closest to nTargetValue.
+ * @param[in]   max_selection_weight  The maximum allowed weight for a selection result to be valid.
+ * @param[in]   iterations      Maximum number of tries.
  */
 static void ApproximateBestSubset(FastRandomContext& insecure_rand, const std::vector<OutputGroup>& groups,
                                   const CAmount& nTotalLower, const CAmount& nTargetValue,

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -123,14 +123,14 @@ FilteredOutputGroups GroupOutputs(const CWallet& wallet,
  * the solution (according to the waste metric) will be chosen. If a valid input cannot be found from any
  * single OutputType, fallback to running `ChooseSelectionResult()` over all available coins.
  *
- * param@[in]  chain                     The chain interface to get information on unconfirmed UTXOs bump fees
- * param@[in]  nTargetValue              The target value
- * param@[in]  groups                    The grouped outputs mapped by coin eligibility filters
- * param@[in]  coin_selection_params     Parameters for the coin selection
- * param@[in]  allow_mixed_output_types  Relax restriction that SelectionResults must be of the same OutputType
+ * @param[in]  chain                     The chain interface to get information on bump fees for unconfirmed UTXOs
+ * @param[in]  nTargetValue              The target value
+ * @param[in]  groups                    The grouped outputs mapped by coin eligibility filters
+ * @param[in]  coin_selection_params     Parameters for the coin selection
+ * @param[in]  allow_mixed_output_types  Relax restriction that SelectionResults must be of the same OutputType
  * returns                               If successful, a SelectionResult containing the input set
  *                                       If failed, returns (1) an empty error message if the target was not reached (general "Insufficient funds")
- *                                                  or (2) an specific error message if there was something particularly wrong (e.g. a selection
+ *                                                  or (2) a specific error message if there was something particularly wrong (e.g. a selection
  *                                                  result that surpassed the tx max weight size).
  */
 util::Result<SelectionResult> AttemptSelection(interfaces::Chain& chain, const CAmount& nTargetValue, OutputGroupTypeMap& groups,
@@ -141,13 +141,13 @@ util::Result<SelectionResult> AttemptSelection(interfaces::Chain& chain, const C
  * Multiple coin selection algorithms will be run and the input set that produces the least waste
  * (according to the waste metric) will be chosen.
  *
- * param@[in]  chain                     The chain interface to get information on unconfirmed UTXOs bump fees
- * param@[in]  nTargetValue              The target value
- * param@[in]  groups                    The struct containing the outputs grouped by script and divided by (1) positive only outputs and (2) all outputs (positive + negative).
- * param@[in]  coin_selection_params     Parameters for the coin selection
+ * @param[in]  chain                     The chain interface to get information on bump fees for unconfirmed UTXOs
+ * @param[in]  nTargetValue              The target value
+ * @param[in]  groups                    The struct containing the outputs grouped by script and divided by (1) positive only outputs and (2) all outputs (positive + negative).
+ * @param[in]  coin_selection_params     Parameters for the coin selection
  * returns                               If successful, a SelectionResult containing the input set
  *                                       If failed, returns (1) an empty error message if the target was not reached (general "Insufficient funds")
- *                                                  or (2) an specific error message if there was something particularly wrong (e.g. a selection
+ *                                                  or (2) a specific error message if there was something particularly wrong (e.g. a selection
  *                                                  result that surpassed the tx max weight size).
  */
 util::Result<SelectionResult> ChooseSelectionResult(interfaces::Chain& chain, const CAmount& nTargetValue, Groups& groups, const CoinSelectionParams& coin_selection_params);
@@ -181,10 +181,10 @@ util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const
 
 /**
  * Select a set of coins such that nTargetValue is met; never select unconfirmed coins if they are not ours
- * param@[in]   wallet                 The wallet which provides data necessary to spend the selected coins
- * param@[in]   available_coins        The struct of coins, organized by OutputType, available for selection prior to filtering
- * param@[in]   nTargetValue           The target value
- * param@[in]   coin_selection_params  Parameters for this coin selection such as feerates, whether to avoid partial spends,
+ * @param[in]   wallet                 The wallet which provides data necessary to spend the selected coins
+ * @param[in]   available_coins        The struct of coins, organized by OutputType, available for selection prior to filtering
+ * @param[in]   nTargetValue           The target value
+ * @param[in]   coin_selection_params  Parameters for this coin selection such as feerates, whether to avoid partial spends,
  *                                     and whether to subtract the fee from the outputs.
  * returns                             If successful, a SelectionResult containing the selected coins
  *                                     If failed, returns (1) an empty error message if the target was not reached (general "Insufficient funds")


### PR DESCRIPTION
Further backports for `28.x`:
* #33236
* #33340
* #33395