### PR TITLE
node: add  `BlockTemplateCache`

### DIFF
--- a/src/bench/wallet_migration.cpp
+++ b/src/bench/wallet_migration.cpp
@@ -8,6 +8,7 @@
 #include <kernel/chain.h>
 #include <kernel/types.h>
 #include <node/context.h>
+#include <primitives/block.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <wallet/context.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -64,6 +64,7 @@
 #include <node/mempool_args.h>
 #include <node/mempool_persist.h>
 #include <node/mempool_persist_args.h>
+#include <node/miner.h>
 #include <node/mining_args.h>
 #include <node/mining_types.h>
 #include <node/peerman_args.h>
@@ -371,6 +372,11 @@ void Shutdown(NodeContext& node)
         }
     }
 
+    if (node.block_template_cache) {
+        Assert(node.validation_signals);
+        node.validation_signals->UnregisterValidationInterface(node.block_template_cache.get());
+    }
+
     // FlushStateToDisk generates a ChainStateFlushed callback, which we should avoid missing
     if (node.chainman) {
         LOCK(cs_main);
@@ -428,6 +434,7 @@ void Shutdown(NodeContext& node)
     }
     node.mempool.reset();
     node.fee_estimator.reset();
+    node.block_template_cache.reset();
     node.chainman.reset();
     node.validation_signals.reset();
     node.scheduler.reset();
@@ -1899,6 +1906,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     ChainstateManager& chainman = *Assert(node.chainman);
     auto& kernel_notifications{*Assert(node.notifications)};
+
+    node.block_template_cache = std::make_unique<node::BlockTemplateCache>(*node.mempool, chainman);
+    validation_signals.RegisterValidationInterface(node.block_template_cache.get());
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1335,9 +1335,6 @@ static ChainstateLoadResult InitAndLoadChainstate(
     if (!mempool_error.empty()) {
         return {ChainstateLoadStatus::FAILURE_FATAL, mempool_error};
     }
-    auto mining_args{node::ReadMiningArgs(args)};
-    Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
-    node.mining_args = std::move(*mining_args);
     LogInfo("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)",
             cache_sizes.coins / double(1_MiB),
             mempool_opts.max_size_bytes / double(1_MiB));
@@ -1906,8 +1903,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     ChainstateManager& chainman = *Assert(node.chainman);
     auto& kernel_notifications{*Assert(node.notifications)};
-
-    node.block_template_cache = std::make_unique<node::BlockTemplateCache>(*node.mempool, chainman);
+    auto mining_args{node::ReadMiningArgs(args)};
+    Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
+    node.block_template_cache = std::make_unique<node::BlockTemplateCache>(*node.mempool, chainman, std::move(*mining_args));
     validation_signals.RegisterValidationInterface(node.block_template_cache.get());
 
     assert(!node.peerman);

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -14,6 +14,7 @@
 #include <net_processing.h>
 #include <netgroup.h>
 #include <node/kernel_notifications.h>
+#include <node/miner.h>
 #include <node/warnings.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <scheduler.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_NODE_CONTEXT_H
 #define BITCOIN_NODE_CONTEXT_H
 
-#include <node/mining_types.h>
-
 #include <atomic>
 #include <cstdlib>
 #include <functional>
@@ -85,11 +83,6 @@ struct NodeContext {
     //! Reference to chain client that should used to load or create wallets
     //! opened by the gui.
     std::unique_ptr<interfaces::Mining> mining;
-    //! Mining options used to create block templates. This value member is an
-    //! exception to the dependency guidance above because BlockCreateOptions is
-    //! a minimal dependency. It could be moved to the BlockTemplateCache
-    //! proposed in bitcoin/bitcoin#33421.
-    BlockCreateOptions mining_args;
     interfaces::WalletLoader* wallet_loader{nullptr};
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -43,6 +43,7 @@ class SignalInterrupt;
 }
 
 namespace node {
+class BlockTemplateCache;
 class KernelNotifications;
 class Warnings;
 
@@ -74,6 +75,7 @@ struct NodeContext {
     std::unique_ptr<PeerManager> peerman;
     std::unique_ptr<TorController> tor_controller;
     std::unique_ptr<ChainstateManager> chainman;
+    std::unique_ptr<BlockTemplateCache> block_template_cache;
     std::unique_ptr<BanMan> banman;
     ArgsManager* args{nullptr}; // Currently a raw pointer because the memory is not managed by this struct
     std::vector<BaseIndex*> indexes; // raw pointers because memory is not managed by this struct

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -95,7 +95,6 @@ using interfaces::Node;
 using interfaces::Rpc;
 using interfaces::WalletLoader;
 using kernel::ChainstateRole;
-using node::BlockAssembler;
 using node::BlockCreateOptions;
 using node::BlockWaitOptions;
 using node::CoinbaseTx;
@@ -878,63 +877,58 @@ public:
 class BlockTemplateImpl : public BlockTemplate
 {
 public:
-    explicit BlockTemplateImpl(BlockCreateOptions create_options,
-                               std::unique_ptr<CBlockTemplate> block_template,
-                               const NodeContext& node) : m_create_options(std::move(create_options)),
-                                                          m_block_template(std::move(block_template)),
+    explicit BlockTemplateImpl(BlockCreateOptions assemble_options,
+                               BlockTemplateRef block_template_ref,
+                               const NodeContext& node) : m_assemble_options(std::move(assemble_options)),
+                                                          m_block_template_ref(std::move(block_template_ref)),
                                                           m_node(node)
     {
-        assert(m_block_template);
+        assert(m_block_template_ref);
     }
 
     CBlockHeader getBlockHeader() override
     {
-        return m_block_template->block;
+        return currentBlock();
     }
 
     CBlock getBlock() override
     {
-        return m_block_template->block;
+        return currentBlock();
     }
 
     std::vector<CAmount> getTxFees() override
     {
-        return m_block_template->vTxFees;
+        return m_block_template_ref->vTxFees;
     }
 
     std::vector<int64_t> getTxSigops() override
     {
-        return m_block_template->vTxSigOpsCost;
+        return m_block_template_ref->vTxSigOpsCost;
     }
 
     CoinbaseTx getCoinbaseTx() override
     {
-        return m_block_template->m_coinbase_tx;
+        return m_block_template_ref->m_coinbase_tx;
     }
 
     std::vector<uint256> getCoinbaseMerklePath() override
     {
-        return TransactionMerklePath(m_block_template->block, 0);
+        return TransactionMerklePath(currentBlock(), 0);
     }
 
     bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase) override
     {
-        AddMerkleRootAndCoinbase(m_block_template->block, std::move(coinbase), version, timestamp, nonce);
+        m_block = m_block_template_ref->block;
+        AddMerkleRootAndCoinbase(*m_block, std::move(coinbase), version, timestamp, nonce);
         std::string reason;
         std::string debug;
-        return SubmitBlock(chainman(), std::make_shared<const CBlock>(m_block_template->block), /*new_block=*/nullptr, reason, debug);
+        return SubmitBlock(chainman(), std::make_shared<const CBlock>(*m_block), /*new_block=*/nullptr, reason, debug);
     }
 
     std::unique_ptr<BlockTemplate> waitNext(BlockWaitOptions options) override
     {
-        auto new_template = WaitAndCreateNewBlock(chainman(),
-                                                  notifications(),
-                                                  m_node.mempool.get(),
-                                                  m_block_template,
-                                                  /*wait_options=*/options,
-                                                  /*create_options=*/m_create_options,
-                                                  /*interrupt_wait=*/m_interrupt_wait);
-        if (new_template) return std::make_unique<BlockTemplateImpl>(m_create_options, std::move(new_template), m_node);
+        BlockTemplateRef new_template_ref = WaitAndCreateNewBlock(*Assert(m_node.block_template_cache), chainman(), notifications(), *m_block_template_ref, options, m_assemble_options, m_interrupt_wait);
+        if (new_template_ref) return std::make_unique<BlockTemplateImpl>(m_assemble_options, new_template_ref, m_node);
         return nullptr;
     }
 
@@ -943,11 +937,16 @@ public:
         InterruptWait(notifications(), m_interrupt_wait);
     }
 
-    const BlockCreateOptions m_create_options;
-
-    const std::unique_ptr<CBlockTemplate> m_block_template;
-
+private:
+    const BlockCreateOptions m_assemble_options;
+    const BlockTemplateRef m_block_template_ref;
+    std::optional<CBlock> m_block;
     bool m_interrupt_wait{false};
+    // Returns m_block if a solution has been submitted, otherwise the template block.
+    const CBlock& currentBlock() const
+    {
+        return m_block ? *m_block : m_block_template_ref->block;
+    }
     ChainstateManager& chainman() { return *Assert(m_node.chainman); }
     KernelNotifications& notifications() { return *Assert(m_node.notifications); }
     const NodeContext& m_node;
@@ -1000,13 +999,8 @@ public:
             if (!CooldownIfHeadersAhead(chainman(), notifications(), *maybe_tip, m_interrupt_mining)) return {};
         }
         const BlockCreateOptions create_options{MergeMiningOptions(options, m_node.mining_args)};
-        return std::make_unique<BlockTemplateImpl>(create_options,
-                                                   BlockAssembler{
-                                                       chainman().ActiveChainstate(),
-                                                       m_node.mempool.get(),
-                                                       create_options,
-                                                   }.CreateNewBlock(),
-                                                   m_node);
+        auto new_template = Assert(m_node.block_template_cache)->GetBlockTemplate(create_options, std::nullopt);
+        return std::make_unique<BlockTemplateImpl>(create_options, std::move(new_template), m_node);
     }
 
     void interrupt() override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -998,8 +998,9 @@ public:
             // Also wait during the final catch-up moments after IBD.
             if (!CooldownIfHeadersAhead(chainman(), notifications(), *maybe_tip, m_interrupt_mining)) return {};
         }
-        const BlockCreateOptions create_options{MergeMiningOptions(options, m_node.mining_args)};
-        auto new_template = Assert(m_node.block_template_cache)->GetBlockTemplate(create_options, std::nullopt);
+        auto& cache = *Assert(m_node.block_template_cache);
+        const BlockCreateOptions create_options{MergeMiningOptions(options, cache.GetInitBlockCreateOptions())};
+        auto new_template = cache.GetBlockTemplate(create_options, std::nullopt);
         return std::make_unique<BlockTemplateImpl>(create_options, std::move(new_template), m_node);
     }
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -233,6 +233,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
             throw std::runtime_error(strprintf("TestBlockValidity failed: %s", state.ToString()));
         }
     }
+    pblocktemplate->m_creation_time = MockableSteadyClock::now();
     const auto time_2{SteadyClock::now()};
 
     LogDebug(BCLog::BENCH, "CreateNewBlock() chunks: %.2fms, validity: %.2fms (total %.2fms)\n",

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -15,6 +15,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <interfaces/types.h>
+#include <kernel/types.h>
 #include <node/blockstorage.h>
 #include <node/kernel_notifications.h>
 #include <node/mining_args.h>
@@ -338,6 +339,101 @@ void BlockAssembler::addChunks()
         selected_transactions.clear();
         chunk_feerate = m_mempool->GetBlockBuilderChunk(selected_transactions);
         chunk_feerate_vsize = ToFeePerVSize(chunk_feerate);
+    }
+}
+
+// Returns true if the template is not too old. Returns false if it is too old,
+// or if the clock moved backwards (should never happen except in tests).
+static bool AgeWithinLimit(
+    const MockableSteadyClock::time_point& creation_time,
+    MillisecondsDouble max_age)
+{
+    const auto now = MockableSteadyClock::now();
+    if (now - creation_time > max_age || now < creation_time) {
+        return false;
+    }
+    return true;
+}
+
+BlockTemplateCache::BlockTemplateCache(CTxMemPool& mempool, ChainstateManager& chainman, size_t block_template_cache_limit)
+    : m_mempool(mempool), m_chainman(chainman), m_block_template_cache_limit(block_template_cache_limit)
+{
+}
+
+void BlockTemplateCache::BlockConnected(
+    const ChainstateRole& role,
+    const std::shared_ptr<const CBlock>& /*unused*/,
+    const CBlockIndex* /*unused*/)
+{
+    // Ignore block being connected to historical chain, not current chain.
+    if (role.historical) return;
+    LOCK(m_mutex);
+    m_block_templates.clear();
+}
+
+void BlockTemplateCache::BlockDisconnected(
+    const std::shared_ptr<const CBlock>& /*unused*/,
+    const CBlockIndex* /*unused*/)
+{
+    LOCK(m_mutex);
+    m_block_templates.clear();
+}
+
+BlockTemplateRef BlockTemplateCache::GetBlockTemplate(
+    const BlockCreateOptions& options,
+    std::optional<MillisecondsDouble> template_max_age)
+{
+    if (!template_max_age.has_value()) {
+        return BlockAssembler{m_chainman.ActiveChainstate(), &m_mempool, options}.CreateNewBlock();
+    }
+
+    // Cache lookup requires an exact match on all block creation options.
+    // While some fields (e.g. test_block_validity, print_modified_fee, coinbase_output_script)
+    // could be ignored for cache reuse, differences in these fields mainly occur in
+    // tests and benchmarks. To keep the logic simple, we treat all fields as part of
+    // the cache key and accept cache misses in those cases.
+    {
+        LOCK(m_mutex);
+        auto cached_it = std::find_if(m_block_templates.begin(), m_block_templates.end(),
+                                      [&](const TemplateEntry& entry) { return entry.options == options; });
+        if (cached_it != m_block_templates.end() && AgeWithinLimit(cached_it->block_template->m_creation_time, *template_max_age)) {
+            return cached_it->block_template;
+        }
+    }
+
+    LOCK2(::cs_main, m_mutex);
+    // Search again with cs_main held. The search above avoided locking cs_main as an optimization,
+    // but new cached templates may have been created since then.
+    auto cached_it = std::find_if(m_block_templates.begin(), m_block_templates.end(),
+                                  [&](const TemplateEntry& entry) { return entry.options == options; });
+    if (cached_it != m_block_templates.end()) {
+        if (AgeWithinLimit(cached_it->block_template->m_creation_time, *template_max_age)) {
+            return cached_it->block_template;
+        }
+        m_block_templates.erase(cached_it);
+    }
+    BlockTemplateRef block_template = BlockAssembler{m_chainman.ActiveChainstate(), &m_mempool, options}.CreateNewBlock();
+    m_block_templates.emplace_back(options, block_template);
+    if (m_block_templates.size() > m_block_template_cache_limit) {
+        m_block_templates.pop_front();
+    }
+    return block_template;
+}
+
+void BlockTemplateCache::SanityCheck() const
+{
+    LOCK(m_mutex);
+    // Verify cache size does not exceed maximum
+    Assume(m_block_templates.size() <= m_block_template_cache_limit);
+    // Verify no duplicate options exist in cache
+    for (size_t i = 0; i < m_block_templates.size(); ++i) {
+        for (size_t j = i + 1; j < m_block_templates.size(); ++j) {
+            Assume(!(m_block_templates[i].options == m_block_templates[j].options));
+        }
+    }
+    // Verify that we don't have a nullptr in the block template.
+    for (const auto& [options, template_ref] : m_block_templates) {
+        Assume(template_ref != nullptr);
     }
 }
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -518,13 +518,13 @@ void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wa
     kernel_notifications.m_tip_block_cv.notify_all();
 }
 
-std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainman,
-                                                      KernelNotifications& kernel_notifications,
-                                                      CTxMemPool* mempool,
-                                                      const std::unique_ptr<CBlockTemplate>& block_template,
-                                                      const BlockWaitOptions& wait_options,
-                                                      const BlockCreateOptions& create_options,
-                                                      bool& interrupt_wait)
+BlockTemplateRef WaitAndCreateNewBlock(BlockTemplateCache& block_template_cache,
+                                       ChainstateManager& chainman,
+                                       KernelNotifications& kernel_notifications,
+                                       const CBlockTemplate& block_template,
+                                       const BlockWaitOptions& options,
+                                       const BlockCreateOptions& assemble_options,
+                                       bool& interrupt_wait)
 {
     // Delay calculating the current template fees, just in case a new block
     // comes in before the next tick.
@@ -533,7 +533,7 @@ std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainma
     // Alternate waiting for a new tip and checking if fees have risen.
     // The latter check is expensive so we only run it once per second.
     auto now{NodeClock::now()};
-    const auto deadline = now + wait_options.timeout;
+    const auto deadline = now + options.timeout;
     const MillisecondsDouble tick{1000};
     const bool allow_min_difficulty{chainman.GetParams().GetConsensus().fPowAllowMinDifficultyBlocks};
 
@@ -548,7 +548,7 @@ std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainma
                 // We assume tip_block is set, because this is an instance
                 // method on BlockTemplate and no template could have been
                 // generated before a tip exists.
-                tip_changed = Assume(tip_block) && tip_block != block_template->block.hashPrevBlock;
+                tip_changed = Assume(tip_block) && tip_block != block_template.block.hashPrevBlock;
                 return tip_changed || chainman.m_interrupt || interrupt_wait;
             });
             if (interrupt_wait) {
@@ -580,25 +580,26 @@ std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainma
          *
          * We'll also create a new template if the tip changed during this iteration.
          */
-        if (wait_options.fee_threshold < MAX_MONEY || tip_changed) {
-            auto new_tmpl{BlockAssembler{
-                chainman.ActiveChainstate(),
-                mempool,
-                create_options
-                }.CreateNewBlock()};
+        if (options.fee_threshold < MAX_MONEY || tip_changed) {
+            // Passing std::nullopt as template_max_age bypasses the cache completely.
+            // We want a fresh template here because the cache currently returns a cached
+            // template regardless of mempool fee increases. In the future, when the cache
+            // can account for fee increases that affect the template, we can pass a desired
+            // fee increase threshold instead of std::nullopt.
+            auto new_tmpl{block_template_cache.GetBlockTemplate(assemble_options, std::nullopt)};
 
             // If the tip changed, return the new template regardless of its fees.
             if (tip_changed) return new_tmpl;
 
             // Calculate the original template total fees if we haven't already
             if (current_fees == -1) {
-                current_fees = std::accumulate(block_template->vTxFees.begin(), block_template->vTxFees.end(), CAmount{0});
+                current_fees = std::accumulate(block_template.vTxFees.begin(), block_template.vTxFees.end(), CAmount{0});
             }
 
             // Check if fees increased enough to return the new template
             const CAmount new_fees = std::accumulate(new_tmpl->vTxFees.begin(), new_tmpl->vTxFees.end(), CAmount{0});
-            Assume(wait_options.fee_threshold != MAX_MONEY);
-            if (new_fees >= current_fees + wait_options.fee_threshold) return new_tmpl;
+            Assume(options.fee_threshold != MAX_MONEY);
+            if (new_fees >= current_fees + options.fee_threshold) return new_tmpl;
         }
 
         now = NodeClock::now();

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -355,8 +355,12 @@ static bool AgeWithinLimit(
     return true;
 }
 
-BlockTemplateCache::BlockTemplateCache(CTxMemPool& mempool, ChainstateManager& chainman, size_t block_template_cache_limit)
-    : m_mempool(mempool), m_chainman(chainman), m_block_template_cache_limit(block_template_cache_limit)
+BlockTemplateCache::BlockTemplateCache(CTxMemPool& mempool, ChainstateManager& chainman,
+                                       BlockCreateOptions init_block_create_options,
+                                       size_t block_template_cache_limit)
+    : m_mempool(mempool), m_chainman(chainman),
+      m_init_block_create_options(std::move(init_block_create_options)),
+      m_block_template_cache_limit(block_template_cache_limit)
 {
 }
 

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -225,13 +225,13 @@ void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wa
  * Return a new block template when fees rise to a certain threshold or after a
  * new tip; return nullopt if timeout is reached.
  */
-std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainman,
-                                                      KernelNotifications& kernel_notifications,
-                                                      CTxMemPool* mempool,
-                                                      const std::unique_ptr<CBlockTemplate>& block_template,
-                                                      const BlockWaitOptions& wait_options,
-                                                      const BlockCreateOptions& create_options,
-                                                      bool& interrupt_wait);
+BlockTemplateRef WaitAndCreateNewBlock(BlockTemplateCache& block_template_cache,
+                                       ChainstateManager& chainman,
+                                       KernelNotifications& kernel_notifications,
+                                       const CBlockTemplate& block_template,
+                                       const BlockWaitOptions& options,
+                                       const BlockCreateOptions& assemble_options,
+                                       bool& interrupt_wait);
 
 /* Locks cs_main and returns the block hash and block height of the active chain if it exists; otherwise, returns nullopt.*/
 std::optional<BlockRef> GetTip(ChainstateManager& chainman);

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -10,12 +10,15 @@
 #include <node/mining_types.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
-#include <threadsafety.h>
+#include <sync.h>
 #include <txmempool.h>
 #include <util/feefrac.h>
 #include <util/time.h>
+#include <validationinterface.h>
 
+#include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <optional>
 #include <string>
@@ -35,9 +38,12 @@ struct BlockRef;
 } // namespace interfaces
 
 using interfaces::BlockRef;
+using kernel::ChainstateRole;
 
 namespace node {
 class KernelNotifications;
+
+static constexpr size_t DEFAULT_BLOCK_TEMPLATE_CACHE_LIMIT{10};
 
 struct CBlockTemplate
 {
@@ -120,6 +126,78 @@ private:
       * This check should always succeed, and is here
       * only as an extra check in case of a bug */
     bool TestChunkTransactions(const std::vector<CTxMemPoolEntryRef>& txs) const;
+};
+
+using BlockTemplateRef = std::shared_ptr<const CBlockTemplate>;
+
+struct TemplateEntry {
+    BlockCreateOptions options;
+    BlockTemplateRef block_template;
+};
+
+/*
+ * BlockTemplateCache provides a thread-safe cache for block templates.
+ *
+ * Each cached entry is identified by its BlockCreateOptions. At most one
+ * template is stored per set of options, and the cache has a fixed maximum size.
+ *
+ * When requesting a block template:
+ * - If template_max_age is std::nullopt, a new block template is always
+ *   created and returned, and nothing is cached.
+ *
+ * - Otherwise, the cache is checked for a template with matching options.
+ *   If a cached template exists and its age (elapsed time since creation)
+ *   doesn't exceed template_max_age, it is reused.
+ *
+ * - If a cached template exists but it is too old, it is removed and replaced
+ *   with a newly created template.
+ *
+ * - If no matching template exists, a new template is created and cached.
+ *
+ * When adding a new entry causes the cache to exceed its size limit, the
+ * oldest cached template (by insertion order) is evicted.
+ *
+ * The cache inherits from CValidationInterface to receive notifications
+ * about connected and disconnected blocks, which triggers cache invalidation,
+ * ensuring stale templates are not returned.
+ */
+class BlockTemplateCache : public CValidationInterface
+{
+private:
+    CTxMemPool& m_mempool;
+    ChainstateManager& m_chainman;
+    const size_t m_block_template_cache_limit;
+    mutable Mutex m_mutex;
+    // FIFO cache; at most one template per BlockCreateOptions.
+    std::deque<TemplateEntry> m_block_templates GUARDED_BY(m_mutex);
+
+public:
+    explicit BlockTemplateCache(CTxMemPool& mempool,
+                                ChainstateManager& chainman,
+                                size_t block_template_cache_limit = DEFAULT_BLOCK_TEMPLATE_CACHE_LIMIT);
+    virtual ~BlockTemplateCache() = default;
+    /**
+     * Get a block template from the cache or create a new one.
+     *
+     * Cache lookup requires an exact match on all block creation options.
+     *
+     * @param options Block assembly options to match
+     * @param template_max_age Maximum age for cached templates in milliseconds.
+     *        If nullopt, bypasses cache entirely (doesn't insert into, read or delete from cache).
+     * @return A shared pointer to the block template
+     */
+    BlockTemplateRef GetBlockTemplate(const BlockCreateOptions& options,
+                                      std::optional<MillisecondsDouble> template_max_age = MillisecondsDouble::max())
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Test-only: verify cache invariants */
+    void SanityCheck() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Overridden from CValidationInterface. */
+    void BlockConnected(const ChainstateRole& role, const std::shared_ptr<const CBlock>& /*unused*/, const CBlockIndex* /*unused*/)
+        override EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& /*unused*/, const CBlockIndex* /*unused*/)
+        override EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 };
 
 /**

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -54,6 +54,13 @@ struct CBlockTemplate
      * miner code.
      */
     CoinbaseTx m_coinbase_tx;
+
+
+    /* Used to decide whether a cached template is eligible for reuse based on its age.
+     * Uses the steady clock because it is monotonic and unaffected by rare system clock changes.
+     * It uses the mockable version to allow for testing.
+     */
+    MockableSteadyClock::time_point m_creation_time;
 };
 
 /** Generate a new block, without valid proof-of-work */

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -166,6 +166,7 @@ class BlockTemplateCache : public CValidationInterface
 private:
     CTxMemPool& m_mempool;
     ChainstateManager& m_chainman;
+    const BlockCreateOptions m_init_block_create_options;
     const size_t m_block_template_cache_limit;
     mutable Mutex m_mutex;
     // FIFO cache; at most one template per BlockCreateOptions.
@@ -174,8 +175,12 @@ private:
 public:
     explicit BlockTemplateCache(CTxMemPool& mempool,
                                 ChainstateManager& chainman,
+                                BlockCreateOptions init_block_create_options = {},
                                 size_t block_template_cache_limit = DEFAULT_BLOCK_TEMPLATE_CACHE_LIMIT);
     virtual ~BlockTemplateCache() = default;
+    /** Return a copy of the block create options set during node init. */
+    BlockCreateOptions GetInitBlockCreateOptions() const { return m_init_block_create_options; }
+
     /**
      * Get a block template from the cache or create a new one.
      *

--- a/src/node/mining_types.h
+++ b/src/node/mining_types.h
@@ -89,6 +89,7 @@ struct BlockCreateOptions {
      * Should only be used for tests / benchmarks.
      */
     bool test_block_validity{true};
+    bool operator==(const BlockCreateOptions&) const = default;
 };
 
 struct BlockWaitOptions {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -502,7 +502,7 @@ static RPCMethod getmininginfo()
     obj.pushKV("target", GetTarget(tip, chainman.GetConsensus().powLimit).GetHex());
     obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
     obj.pushKV("pooledtx", mempool.size());
-    const auto mining_options{node::FlattenMiningOptions(node.mining_args)};
+    const auto mining_options{node::FlattenMiningOptions(CHECK_NONFATAL(node.block_template_cache)->GetInitBlockCreateOptions())};
     obj.pushKV("blockmintxfee", ValueFromAmount(CHECK_NONFATAL(mining_options.block_min_fee_rate)->GetFeePerK()));
     obj.pushKV("chain", chainman.GetParams().GetChainTypeString());
 

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(fuzz
   block_index.cpp
   block_index_tree.cpp
   blockfilter.cpp
+  blocktemplatecache.cpp
   bloom_filter.cpp
   buffered_file.cpp
   chain.cpp

--- a/src/test/fuzz/blocktemplatecache.cpp
+++ b/src/test/fuzz/blocktemplatecache.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/amount.h>
+#include <kernel/chain.h>
+#include <kernel/types.h>
+#include <node/miner.h>
+#include <policy/feerate.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/fuzz/util/mempool.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <test/util/time.h>
+#include <test/util/txmempool.h>
+#include <txmempool.h>
+#include <util/time.h>
+#include <validationinterface.h>
+
+#include <optional>
+
+using node::BlockCreateOptions;
+
+namespace {
+const TestingSetup* g_setup;
+
+void initialize_block_template_cache()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+}
+
+void PopulateRandTransactionsToMempool(FuzzedDataProvider& fuzzed_data_provider, CTxMemPool* mempool, int total_weight)
+{
+    // Populate mempool with varying transaction load to test cache under different conditions
+    while (total_weight > 0 && fuzzed_data_provider.remaining_bytes() > 0) {
+        const std::optional<CMutableTransaction> mutable_tx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS);
+        if (!mutable_tx) break;
+        auto tx = MakeTransactionRef(*mutable_tx);
+        CTxMemPoolEntry mempool_entry{ConsumeTxMemPoolEntry(fuzzed_data_provider, *tx)};
+        const Txid txid = tx->GetHash();
+        if (mempool->exists(txid)) continue;
+        const int32_t tx_weight = mempool_entry.GetTxWeight();
+        if (tx_weight > total_weight) break;
+        TryAddToMempool(*mempool, mempool_entry);
+        total_weight -= tx_weight;
+    }
+}
+} // namespace
+
+FUZZ_TARGET(block_template_cache, .init = initialize_block_template_cache)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    const auto& node = g_setup->m_node;
+    auto& template_cache = node.block_template_cache;
+    SteadyClockContext steady_clock{};
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    SetMockTime(WITH_LOCK(g_setup->m_node.chainman->GetMutex(),
+                          return g_setup->m_node.chainman->ActiveTip()->Time()));
+    node.validation_signals->BlockConnected(kernel::ChainstateRole{}, /*block=*/nullptr, /*pindex=*/nullptr);
+    int max_mempool_weight = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, DEFAULT_BLOCK_MAX_WEIGHT * 10);
+    PopulateRandTransactionsToMempool(fuzzed_data_provider, node.mempool.get(), max_mempool_weight);
+    // Establish baseline template
+    steady_clock += 1ms;
+    BlockCreateOptions base_options;
+    base_options.test_block_validity = false;
+    auto tmpl = template_cache->GetBlockTemplate(base_options, MillisecondsDouble{0});
+    assert(tmpl);
+    auto prev_time = tmpl->m_creation_time;
+    auto CheckCache = [&](bool expect_hit,
+                          const BlockCreateOptions& opts,
+                          std::optional<MillisecondsDouble> max_age = std::nullopt,
+                          std::chrono::milliseconds advance = 1ms) {
+        steady_clock += advance;
+        auto t = template_cache->GetBlockTemplate(opts, max_age);
+        assert(t);
+        if (expect_hit) {
+            assert(t->m_creation_time == prev_time);
+        } else {
+            assert(t->m_creation_time > prev_time);
+            if (max_age) prev_time = t->m_creation_time;
+        }
+    };
+    LIMITED_WHILE(fuzzed_data_provider.remaining_bytes(), 10)
+    {
+        // template age-based behavior
+        const auto advance_ms =
+            std::chrono::milliseconds{fuzzed_data_provider.ConsumeIntegralInRange<int>(1, 100000)};
+        const auto template_max_age_ms =
+            std::chrono::milliseconds{fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 100000)};
+        const auto max_age = MillisecondsDouble{template_max_age_ms};
+        // Expect a hit iff block template isn't older than max_age.
+        const bool expect_hit = advance_ms <= template_max_age_ms;
+        CheckCache(expect_hit, base_options, max_age, advance_ms);
+        // historical chainstate role should not clear cache
+        node.validation_signals->BlockConnected(kernel::ChainstateRole{.historical = true}, /*block=*/nullptr, /*pindex=*/nullptr);
+        CheckCache(true, base_options, MillisecondsDouble::max());
+        BlockCreateOptions modified = base_options;
+        modified.block_reserved_weight =
+            fuzzed_data_provider.ConsumeIntegralInRange<int>(
+                MINIMUM_BLOCK_RESERVED_WEIGHT, DEFAULT_BLOCK_RESERVED_WEIGHT - 1);
+        const CAmount fee_paid =
+            fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, COIN);
+        const int32_t tx_size =
+            fuzzed_data_provider.ConsumeIntegralInRange<int>(
+                1, MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR);
+        modified.block_min_fee_rate = CFeeRate(fee_paid, tx_size);
+        if (fuzzed_data_provider.ConsumeBool()) {
+            modified.block_max_weight =
+                fuzzed_data_provider.ConsumeIntegralInRange<int>(
+                    modified.block_reserved_weight.value(), DEFAULT_BLOCK_MAX_WEIGHT);
+        }
+        // Different options must miss cache
+        CheckCache(false, modified, MillisecondsDouble::max());
+        // std::nullopt max_template age should not hit a cache and not clear.
+        CheckCache(false, modified);
+        CheckCache(true, modified, MillisecondsDouble::max());
+        // Sanity check after all these insertions
+        template_cache->SanityCheck();
+        // non-historical chainstate role should clear cache
+        node.validation_signals->BlockConnected(kernel::ChainstateRole{}, /*block=*/nullptr, /*pindex=*/nullptr);
+        CheckCache(false, base_options, MillisecondsDouble::max());
+        // All block disconnection should clear cache
+        node.validation_signals->BlockDisconnected(/*block=*/nullptr, /*pindex=*/nullptr);
+        CheckCache(false, base_options, MillisecondsDouble::max());
+    }
+    template_cache->SanityCheck();
+}

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -14,6 +14,7 @@
 #include <net_processing.h>
 #include <netmessagemaker.h>
 #include <node/blockstorage.h>
+#include <node/miner.h>
 #include <node/mining_types.h>
 #include <policy/truc_policy.h>
 #include <primitives/block.h>
@@ -112,13 +113,16 @@ void ResetChainmanAndMempool(TestingSetup& setup)
     SetMockTime(Params().GenesisBlock().Time());
 
     bilingual_str error{};
-    setup.m_node.mempool.reset();
-    setup.m_node.mempool = std::make_unique<CTxMemPool>(MemPoolOptionsForTest(setup.m_node), error);
+    auto& node = setup.m_node;
+    node.mempool.reset();
+    node.mempool = std::make_unique<CTxMemPool>(MemPoolOptionsForTest(node), error);
     Assert(error.empty());
 
-    setup.m_node.chainman.reset();
+    setup.UnregisterAndResetBlockTemplateCache();
+    node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();
+    setup.CreateAndRegisterBlockTemplateCache();
 
     node::BlockCreateOptions options;
     options.coinbase_output_script = P2WSH_OP_TRUE;

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -155,6 +155,8 @@ void initialize_cmpctblock()
     g_nBits = Params().GenesisBlock().nBits;
     // Replace validation_signals before creating chainman and mempool so they use it.
     testing_setup->m_node.validation_signals = std::make_unique<ValidationSignals>(std::make_unique<ImmediateBackgroundTaskRunner>());
+    // Initialize mock steady clock for deterministic fuzzing
+    MockableSteadyClock::SetMockTime(MockableSteadyClock::INITIAL_MOCK_TIME);
     ResetChainmanAndMempool(*g_setup);
 }
 

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -23,6 +23,7 @@
 #include <test/util/random.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <util/check.h>
@@ -67,7 +68,8 @@ void initialize_tx_pool()
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
     SetMockTime(WITH_LOCK(g_setup->m_node.chainman->GetMutex(), return g_setup->m_node.chainman->ActiveTip()->Time()));
-
+    // Initialize mock steady clock for deterministic fuzzing
+    MockableSteadyClock::SetMockTime(MockableSteadyClock::INITIAL_MOCK_TIME);
     for (int i = 0; i < 2 * COINBASE_MATURITY; ++i) {
         COutPoint prevout{MineBlock(g_setup->m_node, {
             .coinbase_output_script = P2WSH_EMPTY,

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -8,6 +8,7 @@
 #include <kernel/chainparams.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/miner.h>
 #include <node/mining_types.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -47,9 +48,12 @@ std::string_view LIMIT_TO_MESSAGE_TYPE{};
 void ResetChainman(TestingSetup& setup)
 {
     SetMockTime(setup.m_node.chainman->GetParams().GenesisBlock().Time());
+    setup.UnregisterAndResetBlockTemplateCache();
     setup.m_node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();
+    setup.CreateAndRegisterBlockTemplateCache();
+
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
         node::BlockCreateOptions options;
         MineBlock(setup.m_node, options);

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -70,6 +70,8 @@ void initialize_process_message()
             {}),
     };
     g_setup = testing_setup.get();
+    // Initialize mock steady clock for deterministic fuzzing
+    MockableSteadyClock::SetMockTime(MockableSteadyClock::INITIAL_MOCK_TIME);
     ResetChainman(*g_setup);
 }
 

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -8,6 +8,7 @@
 #include <kernel/chainparams.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/miner.h>
 #include <node/mining_types.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -41,9 +42,12 @@ TestingSetup* g_setup;
 void ResetChainman(TestingSetup& setup)
 {
     SetMockTime(setup.m_node.chainman->GetParams().GenesisBlock().Time());
+    setup.UnregisterAndResetBlockTemplateCache();
     setup.m_node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();
+    setup.CreateAndRegisterBlockTemplateCache();
+
     node::BlockCreateOptions options;
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
         MineBlock(setup.m_node, options);

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -59,6 +59,8 @@ void initialize_process_messages()
             {}),
     };
     g_setup = testing_setup.get();
+    // Initialize mock steady clock for deterministic fuzzing
+    MockableSteadyClock::SetMockTime(MockableSteadyClock::INITIAL_MOCK_TIME);
     ResetChainman(*g_setup);
 }
 

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -25,6 +25,7 @@
 #include <test/util/random.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <util/check.h>
@@ -72,7 +73,8 @@ void initialize_tx_pool()
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
     SetMockTime(WITH_LOCK(g_setup->m_node.chainman->GetMutex(), return g_setup->m_node.chainman->ActiveTip()->Time()));
-
+    // Initialize mock steady clock for deterministic fuzzing
+    MockableSteadyClock::SetMockTime(MockableSteadyClock::INITIAL_MOCK_TIME);
     for (int i = 0; i < 2 * COINBASE_MATURITY; ++i) {
         COutPoint prevout{MineBlock(g_setup->m_node, {
             .coinbase_output_script = P2WSH_OP_TRUE,

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -9,6 +9,7 @@
 #include <consensus/validation.h>
 #include <kernel/coinstats.h>
 #include <node/blockstorage.h>
+#include <node/miner.h>
 #include <node/utxo_snapshot.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -211,9 +212,11 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
         Assert(!dirty_chainman);
     }
     if (dirty_chainman) {
+        setup.UnregisterAndResetBlockTemplateCache();
         setup.m_node.chainman.reset();
         setup.m_make_chainman();
         setup.LoadVerifyActivateChainstate();
+        setup.CreateAndRegisterBlockTemplateCache();
     }
 }
 

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -36,6 +36,8 @@ FUZZ_TARGET(utxo_total_supply)
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider, /*min=*/1296688602)}; // regtest genesis block timestamp
+    // Initialize mock steady clock for deterministic fuzzing
+    MockableSteadyClock::SetMockTime(MockableSteadyClock::INITIAL_MOCK_TIME);
     /** The testing setup that creates a chainman only (no chainstate) */
     ChainTestingSetup test_setup{
         ChainType::REGTEST,

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -204,7 +204,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     const auto block_package_feerates = BlockAssembler{
         m_node.chainman->ActiveChainstate(),
         &tx_mempool,
-        m_node.mining_args,
+        m_node.block_template_cache->GetInitBlockCreateOptions(),
     }.CreateNewBlock()->m_package_feerates;
     BOOST_CHECK(block_package_feerates.size() == 2);
 
@@ -986,7 +986,7 @@ BOOST_AUTO_TEST_CASE(blocktemplate_cache)
     check_cache(/*expect_hit=*/false, opts_6, 2ms);
     template_cache->SanityCheck();
     // Exceeding the cache size limit evicts the oldest template.
-    node::BlockTemplateCache fifo_cache{*m_node.mempool, *m_node.chainman, /*block_template_cache_limit=*/2};
+    node::BlockTemplateCache fifo_cache{*m_node.mempool, *m_node.chainman, {}, /*block_template_cache_limit=*/2};
     const auto max_age{MillisecondsDouble::max()};
     const auto template_time = [](const node::BlockTemplateRef& block_template) {
         return block_template->m_creation_time;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -12,6 +12,7 @@
 #include <interfaces/mining.h>
 #include <interfaces/types.h>
 #include <kernel/chainparams.h>
+#include <kernel/types.h>
 #include <node/miner.h>
 #include <node/mining_types.h>
 #include <policy/feerate.h>
@@ -25,6 +26,7 @@
 #include <sync.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <test/util/transaction_utils.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
@@ -57,6 +59,7 @@ using node::BlockCreateOptions;
 
 namespace miner_tests {
 struct MinerTestingSetup : public TestingSetup {
+    SteadyClockContext m_steady_clock;
     void TestPackageSelection(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void TestBasicMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst, int baseheight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void TestPrioritisedMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
@@ -908,6 +911,96 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     SetMockTime(0);
 
     TestPrioritisedMining(scriptPubKey, txFirst);
+}
+
+BOOST_AUTO_TEST_CASE(blocktemplate_cache)
+{
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    m_steady_clock += 1ms;
+    auto& template_cache = m_node.block_template_cache;
+    BlockCreateOptions default_options;
+    default_options.test_block_validity = false;
+    // Establish baseline template creation time
+    auto block_template = template_cache->GetBlockTemplate(default_options, 0ms);
+    auto prev_time = block_template->m_creation_time;
+    auto check_cache = [&](bool expect_hit,
+                           const BlockCreateOptions& opts,
+                           std::optional<MillisecondsDouble> template_max_age) {
+        m_steady_clock += 1ms;
+        const auto tmpl = template_cache->GetBlockTemplate(opts, template_max_age);
+        BOOST_CHECK(tmpl != nullptr);
+        if (expect_hit) {
+            BOOST_CHECK(tmpl->m_creation_time == prev_time);
+        } else {
+            BOOST_CHECK(tmpl->m_creation_time > prev_time);
+            prev_time = tmpl->m_creation_time;
+        }
+    };
+    // std::nullopt will always create a new block template (bypass cache)
+    check_cache(/*expect_hit=*/false, default_options, std::nullopt);
+    // 0ms max_age creates new template (nothing can be <= 0ms old iff time advances)
+    check_cache(/*expect_hit=*/false, default_options, 0ms);
+    // Hit if age < max_age
+    check_cache(/*expect_hit=*/true, default_options, 2ms);
+    // Miss if age > max_age
+    check_cache(/*expect_hit=*/false, default_options, 1ms);
+    // Hit if age == max_age
+    check_cache(/*expect_hit=*/true, default_options, 1ms);
+    // BlockConnected signal with background chainstate role should not invalidate cache
+    auto chain_tip = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip());
+    auto block = std::make_shared<const CBlock>(block_template->block);
+    m_node.validation_signals->BlockConnected(ChainstateRole{.historical = true}, block, chain_tip);
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    check_cache(/*expect_hit=*/true, default_options, 2ms);
+    // BlockConnected signal with normal chainstate role should invalidate cache
+    m_node.validation_signals->BlockConnected(ChainstateRole{}, block, chain_tip);
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    check_cache(/*expect_hit=*/false, default_options, 2ms);
+    // BlockDisconnected signal should also invalidate cache
+    m_node.validation_signals->BlockDisconnected(block, chain_tip);
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    check_cache(/*expect_hit=*/false, default_options, 1ms);
+    // test_block_validity change makes us generate a new template
+    auto opts_1 = default_options;
+    opts_1.test_block_validity = true;
+    check_cache(/*expect_hit=*/false, opts_1, 2ms);
+    // Different coinbase script makes us generate a new template
+    auto opts_2 = default_options;
+    opts_2.coinbase_output_script = CScript() << OP_FALSE;
+    check_cache(/*expect_hit=*/false, opts_2, 2ms);
+    // Different block_max_weight triggers a new block
+    auto opts_3 = default_options;
+    opts_3.block_max_weight = DEFAULT_BLOCK_MAX_WEIGHT - 1;
+    check_cache(/*expect_hit=*/false, opts_3, 2ms);
+    // Different coinbase_output_max_additional_sigops triggers a new block
+    auto opts_4 = default_options;
+    opts_4.coinbase_output_max_additional_sigops -= 1;
+    check_cache(/*expect_hit=*/false, opts_4, 2ms);
+    // Different use_mempool triggers a new block
+    auto opts_5 = default_options;
+    opts_5.use_mempool = false;
+    check_cache(/*expect_hit=*/false, opts_5, 2ms);
+    // Different block_min_fee_rate triggers a new block
+    auto opts_6 = default_options;
+    opts_6.block_min_fee_rate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE + 1);
+    check_cache(/*expect_hit=*/false, opts_6, 2ms);
+    template_cache->SanityCheck();
+    // Exceeding the cache size limit evicts the oldest template.
+    node::BlockTemplateCache fifo_cache{*m_node.mempool, *m_node.chainman, /*block_template_cache_limit=*/2};
+    const auto max_age{MillisecondsDouble::max()};
+    const auto template_time = [](const node::BlockTemplateRef& block_template) {
+        return block_template->m_creation_time;
+    };
+    m_steady_clock += 1ms;
+    const auto template_1 = fifo_cache.GetBlockTemplate(default_options, max_age);
+    m_steady_clock += 1ms;
+    const auto template_2 = fifo_cache.GetBlockTemplate(opts_3, max_age);
+    m_steady_clock += 1ms;
+    const auto template_3 = fifo_cache.GetBlockTemplate(opts_6, max_age);
+    BOOST_CHECK(template_time(fifo_cache.GetBlockTemplate(opts_3, max_age)) == template_time(template_2));
+    BOOST_CHECK(template_time(fifo_cache.GetBlockTemplate(opts_6, max_age)) == template_time(template_3));
+    m_steady_clock += 1ms;
+    BOOST_CHECK(template_time(fifo_cache.GetBlockTemplate(default_options, max_age)) > template_time(template_1));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -72,6 +72,9 @@ struct MinerTestingSetup : public TestingSetup {
         // Delete the previous mempool to ensure with valgrind that the old
         // pointer is not accessed, when the new one should be accessed
         // instead.
+        // Because the validation interface registration takes a bare pointer and we will destroy the
+        // pointed-to object here; unregister the pointer to prevent nullptr access.
+        UnregisterAndResetBlockTemplateCache();
         m_node.mempool.reset();
         bilingual_str error;
         auto opts = MemPoolOptionsForTest(m_node);
@@ -81,6 +84,7 @@ struct MinerTestingSetup : public TestingSetup {
         opts.limits.cluster_size_vbytes = 1'200'000;
         m_node.mempool = std::make_unique<CTxMemPool>(opts, error);
         Assert(error.empty());
+        CreateAndRegisterBlockTemplateCache();
         return *m_node.mempool;
     }
     std::unique_ptr<Mining> MakeMining()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -329,12 +329,30 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
         m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
     };
     m_make_chainman();
+    CreateAndRegisterBlockTemplateCache();
+}
+
+void ChainTestingSetup::UnregisterAndResetBlockTemplateCache()
+{
+    if (m_node.validation_signals && m_node.block_template_cache) {
+        m_node.validation_signals->UnregisterValidationInterface(m_node.block_template_cache.get());
+    }
+    m_node.block_template_cache.reset();
+}
+
+void ChainTestingSetup::CreateAndRegisterBlockTemplateCache()
+{
+    Assert(!m_node.block_template_cache);
+    m_node.block_template_cache = std::make_unique<node::BlockTemplateCache>(*m_node.mempool, *m_node.chainman);
+    if (m_node.validation_signals) m_node.validation_signals->RegisterValidationInterface(m_node.block_template_cache.get());
 }
 
 ChainTestingSetup::~ChainTestingSetup()
 {
     if (m_node.scheduler) m_node.scheduler->stop();
+
     if (m_node.validation_signals) m_node.validation_signals->FlushBackgroundCallbacks();
+    UnregisterAndResetBlockTemplateCache();
     m_node.connman.reset();
     m_node.banman.reset();
     m_node.addrman.reset();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -31,7 +31,6 @@
 #include <node/context.h>
 #include <node/kernel_notifications.h>
 #include <node/miner.h>
-#include <node/mining_args.h>
 #include <node/mining_types.h>
 #include <node/peerman_args.h>
 #include <node/warnings.h>
@@ -411,9 +410,6 @@ TestingSetup::TestingSetup(
                                                m_node.args->GetIntArg("-checkaddrman", 0));
     m_node.banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     m_node.connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params()); // Deterministic randomness for tests.
-    auto mining_args{node::ReadMiningArgs(*m_node.args)};
-    Assert(mining_args);
-    m_node.mining_args = std::move(*mining_args);
     PeerManager::Options peerman_opts;
     ApplyArgsManOptions(*m_node.args, peerman_opts);
     peerman_opts.deterministic_rng = true;

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -104,6 +104,11 @@ struct ChainTestingSetup : public BasicTestingSetup {
     explicit ChainTestingSetup(ChainType chainType = ChainType::MAIN, TestOpts = {});
     ~ChainTestingSetup();
 
+    // Unregister block_template_cache from validation signals and reset it.
+    void UnregisterAndResetBlockTemplateCache();
+    // Create block_template_cache from current mempool and chainman, registering with validation signals.
+    void CreateAndRegisterBlockTemplateCache();
+
     // Supplies a chainstate, if one is needed
     void LoadVerifyActivateChainstate();
 };

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -7,6 +7,7 @@
 #include <kernel/disconnected_transactions.h>
 #include <node/chainstatemanager_args.h>
 #include <node/kernel_notifications.h>
+#include <node/miner.h>
 #include <node/utxo_snapshot.h>
 #include <random.h>
 #include <rpc/blockchain.h>
@@ -443,9 +444,12 @@ struct SnapshotTestSetup : TestChain100Setup {
                 },
             };
             // For robustness, ensure the old manager is destroyed before creating a
-            // new one.
+            // new one. Destroy block_template_cache first since it holds a reference
+            // to ChainstateManager.
+            UnregisterAndResetBlockTemplateCache();
             m_node.chainman.reset();
             m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
+            CreateAndRegisterBlockTemplateCache();
         }
         return *Assert(m_node.chainman);
     }


### PR DESCRIPTION
This PR implements the first step of #33758, adding a cache layer for node block templates.

### Motivation


i) Encapsulate block template creation logic in an abstraction layer where all requests go through a block template manager; globals and other mining-related variables will live here (e.g. see b016fc4f07c0983c1fdb024b0f40161bc863e971, `nTransactionsUpdatedLast`, etc., as mentioned in #33758).

ii) Allow reuse of block templates when options match and the time since creation is not stale.

iii) Prevent redundant block template builds in the mining interface when there is no inflow of transactions in the mempool.
This can be done after cluster mempool in two approaches discussed in https://delvingbitcoin.org/t/determining-blocktemplate-fee-increase-using-fee-rate-diagram/


This PR achieves i and ii. Note this PR does not yet achieve iii) because it depends on #34803 and a small modification to `createAssembler` to return the index at which we start skipping, due to the block template tail-end bin packaging issue. Using that, the linearization is deterministic and each chunk removal/addition can be maintained in a hot cache, giving a rough estimate of inflow that warrants a new block template build.

If we are doing the other approach then it depends on the modification to txgraph proposed by sipa and discussed here https://delvingbitcoin.org/t/determining-blocktemplate-fee-increase-using-fee-rate-diagram/2052/2

I have a slight preference for the former approach.
Either way, this PR is unaffected; both approaches can be compared and evaluated when that PR is under review.


### Changes

This PR creates a block template cache in the miner. The cache holds mining options and is planned to store additional options over time.

Block template requests can be routed through the cache, and globals such as `mining_options` can be accessed directly (as done in b016fc4f07c0983c1fdb024b0f40161bc863e971).

To request a block template, callers pass the block creation configuration options and an optional maximum age parameter in `MillisecondsDouble`:

- If the age limit is `nullopt`, a new template is created and returned without being added to the cache.
- If a matching template (one with identical `BlockCreateOptions`) exists in the cache and has not exceeded the age limit, the cached version is returned.
- If no matching template exists or the age limit has been exceeded, a new template is generated, cached, and returned. When evicting stale templates, duplicates are assumed not to exist since templates are evicted as soon as their age limit is reached or exceeded.

The cache has a configurable maximum size (default: 10 templates). When this limit is exceeded, the oldest template is evicted after each insertion.

Cache lookup requires an exact match on all `BlockCreateOptions` fields. While some fields (e.g., `test_block_validity`, `print_modified_fee`, `coinbase_output_script`) could theoretically be ignored for cache reuse, they differ primarily in tests and benchmarks, so the logic is kept simple and cache misses in those cases are accepted.

The cache enforces at most one template per set of options. A `SanityCheck()` method verifies this invariant in tests by scanning all cached entries for duplicates.

The cache subscribes to the validation interface and clears itself when blocks are connected to (non-historical chainstate, to avoid clearing during assumeutxo background validation) or disconnected from the active chain (during reorgs), preventing stale or invalid templates from being served.

`GetBlockTemplate()` uses double-checked locking: it first checks the cache holding only `m_mutex`, then on a miss acquires both `cs_main` and `m_mutex` to create the template. It checks the cache once more before creating, since another thread may have inserted a template while locks were released.

---

Next steps are documented at https://github.com/bitcoin/bitcoin/issues/33758