### PR TITLE
build: Remove lingering Windows registry & shortcuts (#32132 follow-up)

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -113,6 +113,19 @@ Section -post SEC0001
     WriteRegStr HKCR "@CLIENT_TARNAME@" "" "URL:Bitcoin"
     WriteRegStr HKCR "@CLIENT_TARNAME@\DefaultIcon" "" $INSTDIR\@BITCOIN_GUI_NAME@@EXEEXT@
     WriteRegStr HKCR "@CLIENT_TARNAME@\shell\open\command" "" '"$INSTDIR\@BITCOIN_GUI_NAME@@EXEEXT@" "%1"'
+
+    # Lingering since fb2b05b1259d3e69e6e675adfa30b429424c7625 which removed the suffix
+    DeleteRegValue HKCU "${REGKEY} (64-bit)\Components" Main
+    DeleteRegKey HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name) (64-bit)"
+    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name) (64-bit).lnk"
+    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\$(^Name) (64-bit).lnk"
+    DeleteRegValue HKCU "${REGKEY} (64-bit)" StartMenuGroup
+    DeleteRegValue HKCU "${REGKEY} (64-bit)" Path
+    DeleteRegKey /IfEmpty HKCU "${REGKEY} (64-bit)\Components"
+    DeleteRegKey /IfEmpty HKCU "${REGKEY} (64-bit)"
+
+    # Lingering since 77b2923f87131a407f7d4193c54db22375130403
+    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Bitcoin Core (testnet, 64-bit).lnk"
 SectionEnd
 
 # Macro for selecting uninstaller sections


### PR DESCRIPTION
### Problem

Prior to fb2b05b1259d3e69e6e675adfa30b429424c7625 / #32132 we installed using paths with an extra " (64-bit)"-suffix. Installing a version including that commit on top of a version that does not results in 2 entries in the "Installed apps" list. Both of them end up running the same `C:\Program Files\Bitcoin\uninstall.exe`. However, only one of the entries is removed by the uninstaller. The left over registry entry will now point to an executable that no longer exists and fail to work.

Removing the left over "Installed apps"  entry on master currently requires the user to manually remove the Windows Registry entries (or run the correct old/new installer to ensure the uninstaller exists again).

### Solution

This PR automates removal of old entries (& shortcuts) when installing the new version.

### Disclaimer

Not an NSIS expert - confirmed that added deletion commands work without causing any visible errors both when prior items exist and when they don't.

Post-merge edit: Issue was initially reported by @hebasto in https://github.com/bitcoin/bitcoin/pull/32132#issuecomment-3303467007