### PR TITLE
fuzz: reduce iterations in slow targets

### DIFF
--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -50,7 +50,7 @@ FUZZ_TARGET(mini_miner, .init = initialize_miner)
     std::deque<COutPoint> available_coins = g_available_coins;
     LOCK2(::cs_main, pool.cs);
     // Cluster size cannot exceed 500
-    LIMITED_WHILE(!available_coins.empty(), 500)
+    LIMITED_WHILE(!available_coins.empty(), 100)
     {
         CMutableTransaction mtx = CMutableTransaction();
         const size_t num_inputs = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, available_coins.size());

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -223,7 +223,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
         return coin.out.nValue;
     };
 
-    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 300)
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100)
     {
         {
             // Total supply is the mempool fee + all outpoints

--- a/src/test/fuzz/txdownloadman.cpp
+++ b/src/test/fuzz/txdownloadman.cpp
@@ -178,7 +178,7 @@ FUZZ_TARGET(txdownloadman, .init = initialize)
 
     std::chrono::microseconds time{244466666};
 
-    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000)
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 500)
     {
         NodeId rand_peer = fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, NUM_PEERS - 1);
 
@@ -303,7 +303,7 @@ FUZZ_TARGET(txdownloadman_impl, .init = initialize)
 
     std::chrono::microseconds time{244466666};
 
-    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000)
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 500)
     {
         NodeId rand_peer = fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, NUM_PEERS - 1);
 


### PR DESCRIPTION
The `mini_miner`, `txdownloadman`, `txdownloadman_impl`, and `tx_pool_standard` fuzz targets are all slow-running targets. Fix this by reducing the iteration count in the `LIMITED_WHILE` loops.

This should help decrease the run time of the fuzz CI jobs. See https://github.com/bitcoin/bitcoin/pull/33425.

Addresses https://github.com/bitcoin/bitcoin/issues/32870 as well.