### PR TITLE
test: rpc_bind: Skip nonloopback test if no such address is found

### DIFF
--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -84,7 +84,10 @@ class RPCBindTest(BitcoinTestFramework):
         if not self.options.run_nonloopback:
             self._run_loopback_tests()
         if not self.options.run_ipv4 and not self.options.run_ipv6:
-            self._run_nonloopback_tests()
+            if self.non_loopback_ip:
+                self._run_nonloopback_tests()
+            else:
+                self.log.info('Non-loopback IP address not found, skipping non-loopback tests')
 
     def _run_loopback_tests(self):
         if self.options.run_ipv4:


### PR DESCRIPTION
Without this, I get:

```
2025-09-19T03:14:05.157000Z TestFramework (INFO): PRNG seed is: 3218602557639511064
2025-09-19T03:14:05.158000Z TestFramework (INFO): Initializing test directory /tmp/bitcoin-test/a
2025-09-19T03:14:05.158000Z TestFramework (INFO): Check for ipv6
2025-09-19T03:14:05.158000Z TestFramework (INFO): Check for non-loopback interface
2025-09-19T03:14:05.158000Z TestFramework (INFO): Bind test for []
2025-09-19T03:14:05.516000Z TestFramework (INFO): Bind test for []
2025-09-19T03:14:05.871000Z TestFramework (INFO): Bind test for ['[::1]']
2025-09-19T03:14:06.227000Z TestFramework (INFO): Bind test for ['127.0.0.1', '[::1]']
2025-09-19T03:14:06.583000Z TestFramework (INFO): Using interface None for testing
2025-09-19T03:14:06.583000Z TestFramework (INFO): Bind test for [None]
2025-09-19T03:14:06.583000Z TestFramework (ERROR): Unexpected exception
Traceback (most recent call last):
  File "/Bitcoin/bitcoin/workingtree/test/functional/test_framework/test_framework.py", line 135, in main
    self.run_test()
    ~~~~~~~~~~~~~^^
  File "/Bitcoin/bitcoin/workingtree/test/functional/rpc_bind.py", line 126, in run_test
    self._run_nonloopback_tests()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Bitcoin/bitcoin/workingtree/test/functional/rpc_bind.py", line 157, in _run_nonloopback_tests
    self.run_bind_test([self.non_loopback_ip], self.non_loopback_ip, [self.non_loopback_ip],
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        [(self.non_loopback_ip, self.defaultport)])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Bitcoin/bitcoin/workingtree/test/functional/rpc_bind.py", line 38, in run_bind_test
    expected = [(addr_to_hex(addr), port) for (addr, port) in expected]
                 ~~~~~~~~~~~^^^^^^
  File "/Bitcoin/bitcoin/workingtree/test/functional/test_framework/netutil.py", line 132, in addr_to_hex
    if '.' in addr: # IPv4
       ^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```