### PR TITLE
depends: static libxcb-cursor

### DIFF
--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -112,7 +112,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libfontconfig.so.1', # font support
 'libfreetype.so.6', # font parsing
 'libdl.so.2', # programming interface to dynamic linker
-'libxcb-cursor.so.0',
 'libxcb-icccm.so.4',
 'libxcb-image.so.0',
 'libxcb-shm.so.0',

--- a/depends/packages/libxcb_util_cursor.mk
+++ b/depends/packages/libxcb_util_cursor.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=0e9c5446dc6f3beb8af6ebfcc9e27bcc6da6fe2860f7fc07b99144dfa
 $(package)_dependencies=libxcb libxcb_util_render libxcb_util_image
 
 define $(package)_set_vars
-$(package)_config_opts = --disable-static
+$(package)_config_opts = --disable-shared
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -81,8 +81,6 @@ the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if yo
 
     sudo apt-get install qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libgl-dev
 
-For Qt 6.5 and later, the `libxcb-cursor0` package must be installed at runtime.
-
 Additionally, to support Wayland protocol for modern desktop environments:
 
     sudo apt install qt6-wayland
@@ -133,8 +131,6 @@ the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if yo
 
     sudo dnf install qt6-qtbase-devel qt6-qttools-devel
 
-For Qt 6.5 and later, the `xcb-util-cursor` package must be installed at runtime.
-
 Additionally, to support Wayland protocol for modern desktop environments:
 
     sudo dnf install qt6-qtwayland
@@ -181,8 +177,6 @@ Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compi
 the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
     apk add qt6-qtbase-dev  qt6-qttools-dev
-
-For Qt 6.5 and later, the `xcb-util-cursor` package must be installed at runtime.
 
 The GUI will be able to encode addresses in QR codes unless this feature is explicitly disabled. To install libqrencode, run:
 


### PR DESCRIPTION
Remove the runtime requirement of `libxcb-cursor`. This library is no-longer present on modern Ubuntu.
Fixes #33432.
Also related to #32097.