### PR TITLE
system: improve handling around GetTotalRAM()

### DIFF
--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -113,10 +113,15 @@ int GetNumCores()
 
 std::optional<size_t> GetTotalRAM()
 {
-    auto clamp{[](uint64_t v) { return size_t(std::min(v, uint64_t{std::numeric_limits<size_t>::max()})); }};
+    [[maybe_unused]] auto clamp{[](uint64_t v) { return size_t(std::min(v, uint64_t{std::numeric_limits<size_t>::max()})); }};
 #ifdef WIN32
     if (MEMORYSTATUSEX m{}; (m.dwLength = sizeof(m), GlobalMemoryStatusEx(&m))) return clamp(m.ullTotalPhys);
-#elif defined(__linux__) || defined(__APPLE__)
+#elif defined(__APPLE__) || \
+      defined(__FreeBSD__) || \
+      defined(__NetBSD__) || \
+      defined(__OpenBSD__) || \
+      defined(__illumos__) || \
+      defined(__linux__)
     if (long p{sysconf(_SC_PHYS_PAGES)}, s{sysconf(_SC_PAGESIZE)}; p > 0 && s > 0) return clamp(1ULL * p * s);
 #endif
     return std::nullopt;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -102,6 +102,7 @@ add_executable(test_bitcoin
   span_tests.cpp
   streams_tests.cpp
   sync_tests.cpp
+  system_ram_tests.cpp
   system_tests.cpp
   testnet4_miner_tests.cpp
   timeoffsets_tests.cpp
@@ -197,7 +198,10 @@ function(add_boost_test source_file)
       COMMAND test_bitcoin --run_test=${test_suite_name} --catch_system_error=no --log_level=test_suite -- DEBUG_LOG_OUT
     )
     set_property(TEST ${test_suite_name} PROPERTY
-      SKIP_REGULAR_EXPRESSION "no test cases matching filter" "skipping script_assets_test"
+      SKIP_REGULAR_EXPRESSION
+        "no test cases matching filter"
+        "skipping script_assets_test"
+        "skipping total_ram"
     )
   endforeach()
 endfunction()

--- a/src/test/system_ram_tests.cpp
+++ b/src/test/system_ram_tests.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <common/system.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <optional>
+
+BOOST_AUTO_TEST_SUITE(system_ram_tests)
+
+BOOST_AUTO_TEST_CASE(total_ram)
+{
+    const auto total{GetTotalRAM()};
+    if (!total) {
+        BOOST_WARN_MESSAGE(false, "skipping total_ram: total RAM unknown");
+        return;
+    }
+
+    BOOST_CHECK_GE(*total, 1000_MiB);
+
+    if constexpr (SIZE_MAX == UINT64_MAX) {
+        // Upper bound check only on 64-bit: 32-bit systems can reasonably have max memory,
+        // but extremely large values on 64-bit likely indicate detection errors
+        BOOST_CHECK_LT(*total, 10'000'000_MiB); // >10 TiB memory is unlikely
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -8,8 +8,6 @@
 #include <common/run_command.h>
 #include <univalue.h>
 
-#include <common/system.h>
-
 #ifdef ENABLE_EXTERNAL_SIGNER
 #include <util/subprocess.h>
 #endif // ENABLE_EXTERNAL_SIGNER
@@ -17,17 +15,6 @@
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(system_tests, BasicTestingSetup)
-
-BOOST_AUTO_TEST_CASE(total_ram)
-{
-    BOOST_CHECK_GE(GetTotalRAM(), 1000_MiB);
-
-    if constexpr (SIZE_MAX == UINT64_MAX) {
-        // Upper bound check only on 64-bit: 32-bit systems can reasonably have max memory,
-        // but extremely large values on 64-bit likely indicate detection errors
-        BOOST_CHECK_LT(GetTotalRAM(), 10'000'000_MiB); // >10 TiB memory is unlikely
-    }
-}
 
 #ifdef ENABLE_EXTERNAL_SIGNER
 


### PR DESCRIPTION
1. Fix unused variable warning (https://github.com/bitcoin/bitcoin/pull/33333#discussion_r2362493046)
2. Enable `GetTotalRAM()` on other platforms where it was tested to work.
3. Skip the `GetTotalRAM()` unit test on unsupported platforms.

Prior discussion: https://github.com/bitcoin/bitcoin/pull/33333#discussion_r2362493046