### PR TITLE
validation: make the "rolling forward" loop interruptible

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4913,6 +4913,7 @@ bool Chainstate::ReplayBlocks()
     // Roll forward from the forking point to the new tip.
     int nForkHeight = pindexFork ? pindexFork->nHeight : 0;
     for (int nHeight = nForkHeight + 1; nHeight <= pindexNew->nHeight; ++nHeight) {
+        if (m_blockman.m_interrupt) return false;
         const CBlockIndex& pindex{*Assert(pindexNew->GetAncestor(nHeight))};
 
         LogInfo("Rolling forward %s (%i)", pindex.GetBlockHash().ToString(), nHeight);


### PR DESCRIPTION
### Summary

Restarting an unsuccessful reindex can result in replay of previously indexed blocks. This process can take many hours and is currently not interruptible.

### Reproducer:
* start a normal ibd, stop after some progress
* do a reindex, stop before it finishes
* restart the node normally without specifying the reindex parameter It should start rolling the blocks forward.

After this change you should be able to interrupt the process:
```
2025-09-20T05:35:42Z Rolling forward 000000002f4f55aecfccc911076dc3f73ac0288c83dc1d79db0a026441031d40 (46245)
2025-09-20T05:35:42Z Rolling forward 0000000017ffcf34c8eac010c529670ba6745ea59cf1edf7b820928e3b40acf6 (46246)
^C2025-09-20T05:35:42Z Rolling forward 000000002857934511131e0800ac1dcbe3ae7873b715a9528747f29ae090b0d4 (46247)
2025-09-20T05:35:42Z [error] Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.
Error: Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.
2025-09-20T05:35:42Z Shutdown in progress...
2025-09-20T05:35:42Z scheduler thread exit
2025-09-20T05:35:42Z Shutdown done
```
