### PR TITLE
ci: Update Clang in "tidy" job

### DIFF
--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
 export CONTAINER_NAME=ci_native_tidy
-export TIDY_LLVM_V="20"
+export TIDY_LLVM_V="21"
 export APT_LLVM_V="${TIDY_LLVM_V}"
 export PACKAGES="clang-${TIDY_LLVM_V} libclang-${TIDY_LLVM_V}-dev llvm-${TIDY_LLVM_V}-dev libomp-${TIDY_LLVM_V}-dev clang-tidy-${TIDY_LLVM_V} jq libevent-dev libboost-dev libzmq3-dev systemtap-sdt-dev qt6-base-dev qt6-tools-dev qt6-l10n-tools libqrencode-dev libsqlite3-dev libcapnp-dev capnproto"
 export NO_DEPENDS=1

--- a/src/ipc/.clang-tidy.in
+++ b/src/ipc/.clang-tidy.in
@@ -1,3 +1,5 @@
-Checks: '
--clang-analyzer-core.UndefinedBinaryOperatorResult,
-'
+Checks:
+  # See: https://github.com/capnproto/capnproto/pull/2334.
+  - "-clang-analyzer-core.UndefinedBinaryOperatorResult"
+  # See: https://github.com/capnproto/capnproto/pull/2417.
+  - "-clang-analyzer-security.ArrayBound"

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -18,10 +18,10 @@ class WalletModel;
 class RecentRequestEntry
 {
 public:
-    RecentRequestEntry() : nVersion(RecentRequestEntry::CURRENT_VERSION) {}
+    RecentRequestEntry() = default;
 
     static const int CURRENT_VERSION = 1;
-    int nVersion;
+    int nVersion{RecentRequestEntry::CURRENT_VERSION};
     int64_t id{0};
     QDateTime date;
     SendCoinsRecipient recipient;

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -12,9 +12,7 @@
 #include <optional>
 
 TransactionFilterProxy::TransactionFilterProxy(QObject* parent)
-    : QSortFilterProxyModel(parent),
-      m_search_string(),
-      typeFilter(ALL_TYPES)
+    : QSortFilterProxyModel(parent)
 {
 }
 

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -44,7 +44,7 @@ private:
     std::optional<QDateTime> dateFrom;
     std::optional<QDateTime> dateTo;
     QString m_search_string;
-    quint32 typeFilter;
+    quint32 typeFilter{ALL_TYPES};
     CAmount minAmount{0};
     bool showInactive{true};
 };

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1254,8 +1254,12 @@ private:
     const CScript& scriptCode; //!< output script being consumed
     const unsigned int nIn;    //!< input index of txTo being signed
     const bool fAnyoneCanPay;  //!< whether the hashtype has the SIGHASH_ANYONECANPAY flag set
+    // Temporary workaround for a clang-tidy bug fixed in version 22.
+    // See: https://github.com/llvm/llvm-project/issues/160394.
+    // NOLINTBEGIN(modernize-use-default-member-init)
     const bool fHashSingle;    //!< whether the hashtype is SIGHASH_SINGLE
     const bool fHashNone;      //!< whether the hashtype is SIGHASH_NONE
+    // NOLINTEND(modernize-use-default-member-init)
 
 public:
     CTransactionSignatureSerializer(const T& txToIn, const CScript& scriptCodeIn, unsigned int nInIn, int nHashTypeIn) :

--- a/src/test/.clang-tidy.in
+++ b/src/test/.clang-tidy.in
@@ -1,0 +1,3 @@
+Checks:
+  # See: https://github.com/capnproto/capnproto/pull/2417.
+  - "-clang-analyzer-security.ArrayBound"

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -180,6 +180,8 @@ if(ENABLE_IPC)
       ipc_tests.cpp
   )
   target_link_libraries(test_bitcoin bitcoin_ipc_test bitcoin_ipc)
+
+  configure_file(.clang-tidy.in .clang-tidy USE_SOURCE_PERMISSIONS COPYONLY)
 endif()
 
 function(add_boost_test source_file)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -38,8 +38,8 @@ namespace {
 
 struct CoinEntry {
     COutPoint* outpoint;
-    uint8_t key;
-    explicit CoinEntry(const COutPoint* ptr) : outpoint(const_cast<COutPoint*>(ptr)), key(DB_COIN)  {}
+    uint8_t key{DB_COIN};
+    explicit CoinEntry(const COutPoint* ptr) : outpoint(const_cast<COutPoint*>(ptr)) {}
 
     SERIALIZE_METHODS(CoinEntry, obj) { READWRITE(obj.key, obj.outpoint->hash, VARINT(obj.outpoint->n)); }
 };

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -21,7 +21,6 @@ class CZMQAbstractNotifier
 public:
     static const int DEFAULT_ZMQ_SNDHWM {1000};
 
-    CZMQAbstractNotifier() : outbound_message_high_water_mark(DEFAULT_ZMQ_SNDHWM) {}
     virtual ~CZMQAbstractNotifier();
 
     template <typename T>
@@ -61,7 +60,7 @@ protected:
     void* psocket{nullptr};
     std::string type;
     std::string address;
-    int outbound_message_high_water_mark; // aka SNDHWM
+    int outbound_message_high_water_mark{DEFAULT_ZMQ_SNDHWM}; // aka SNDHWM
 };
 
 #endif // BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H


### PR DESCRIPTION
This PR:

1. Updates to [IWYU 0.25](https://github.com/include-what-you-use/include-what-you-use/releases/tag/0.25), which is compatible with Clang 21.

2. Fixes new "modernize-use-default-member-init" warnings. The warning in `interpreter.cpp` is a [false positive](https://github.com/llvm/llvm-project/issues/160394), so it has been suppressed.