### PR TITLE
ci(lint): Harden curl usage in 01_install.sh with fail-safe flags

### DIFF
--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -47,13 +47,13 @@ ${CI_RETRY_EXE} pip3 install \
   vulture==2.6
 
 SHELLCHECK_VERSION=v0.11.0
-curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | \
+url --fail --location --proto '=https' --tlsv1.2 --silent --show-error "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | \
     tar --xz -xf - --directory /tmp/
 mv "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/
 
 MLC_VERSION=v1
 MLC_BIN=mlc-x86_64-linux
-curl -sL "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/${MLC_BIN}" -o "/usr/bin/mlc"
+curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/${MLC_BIN}" -o "/usr/bin/mlc"
 chmod +x /usr/bin/mlc
 
 popd || exit


### PR DESCRIPTION


- **Description**:
  - **What**: Use stricter curl flags when fetching ShellCheck and MLC in `ci/lint/01_install.sh`.
  - **Why**: Prevent silent installs on HTTP errors and disallow non-HTTPS protocols, improving supply-chain safety.
  - **Changes**:
    - Replace `-sL` with `--fail --location --proto '=https' --tlsv1.2 --silent --show-error` for both downloads.
  - **Impact**: CI now fails explicitly on 4xx/5xx and protocol downgrades; no behavioral changes otherwise.
  