### PR TITLE
guix: Added guix-shasums script for gathering and formatting build output checksums

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -90,6 +90,26 @@ An invocation with all default options would look like:
 env DETACHED_SIGS_REPO=<path/to/bitcoin-detached-sigs> ./contrib/guix/guix-codesign
 ```
 
+## Gathering shasums of build outputs
+
+After a successful build, the shasums of the build outputs are gathered
+into a file named `SHA256SUMS`. These files are located
+in each of the architecture-specific output directories.
+
+To gather all shasums and output them in a (markdown-friendly) formatted way,
+for e.g. inclusion in a Guix pull request comment, run:
+
+``` sh
+./contrib/guix/guix-shasums
+```
+
+or in a markdown-friendly format:
+
+``` sh
+./contrib/guix/guix-shasums --markdown
+```
+
+
 ## Cleaning intermediate work directories
 
 By default, `guix-build` leaves all intermediate files or "work directories"

--- a/contrib/guix/guix-shasums
+++ b/contrib/guix/guix-shasums
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Help message
+help_msg() {
+    cat << 'EOF'
+Usage: guix-build-output [OPTIONS]
+
+Options:
+    -m, --markdown [FILE]  Output in markdown format (optionally to FILE)
+    -c, --commit HASH      Use specific git commit hash instead of HEAD
+    -h, --help             Show this help message
+EOF
+}
+
+# Parse arguments
+output_file=""
+mode=""
+commit_hash="$(git rev-parse --short=12 HEAD)"
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -m|--markdown)
+            mode="markdown"
+            shift
+            if [[ $# -gt 0 && $1 != -* ]]; then
+                output_file="$1"
+                shift
+            fi
+            ;;
+        -c|--commit)
+            shift
+            if [[ $# -eq 0 ]]; then
+                echo "Error: -c/--commit requires a hash argument" >&2
+                exit 1
+            fi
+            commit_hash="$(git rev-parse --short=12 "$1")"
+            shift
+            ;;
+        -h|--help)
+            help_msg
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            help_msg >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Get build directory
+build_dir="guix-build-$commit_hash"
+if [[ ! -d "$build_dir" ]]; then
+    echo "Error: Directory $build_dir not found" >&2
+    exit 1
+fi
+
+# Get output directory
+output_dir="$build_dir/output"
+if [[ ! -d "$output_dir" ]]; then
+    echo "Error: Output directory $output_dir not found" >&2
+    exit 1
+fi
+
+generate_markdown() {
+    echo "## Guix Build Output"
+    echo ""
+    echo "**Host architecture:** \`$(uname -m)\`"
+    echo "**Commit:** \`$commit_hash\`"
+    echo ""
+    echo "### File Checksums"
+    echo ""
+    echo "|                             SHA256                                 |     FILE    |"
+    echo "|--------------------------------------------------------------------|-------------|"
+
+    find "$output_dir" -type f -print0 | env LC_ALL=C sort -z | \
+    xargs -r0 sha256sum | while IFS=' *' read -r checksum file; do
+        echo "| \`$checksum\` | \`$file\` |"
+    done
+}
+
+if [[ $mode == "markdown" ]]; then
+    if [[ -n "$output_file" ]]; then
+        generate_markdown > "$output_file"
+        echo "Markdown output written to: $output_file"
+    else
+        generate_markdown
+    fi
+else
+    guix describe
+    uname -m
+    find "$output_dir" -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
+fi


### PR DESCRIPTION
When a PR requires proof of Guix builds (sha256sums), the PR author or reviewer uses a not well documented command to collect the sha256sums of build outputs or manually gathers them from files:

```sh
guix describe
uname -m
find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
```

This PR introduces a guix-shasums script that gathers all the sha256sums from the output directories and either outputs them on the screen or formats them as Markdown formatted output (to the screen or a file) for easy inclusion in a PR or PR comment. The script is based on the commonly used command (as displayed above) 

Example of Markdown formatted output:
<details>

## Guix Build Output

**Host architecture:** `aarch64`
**Commit:** `7d846e5aeae6`

### File Checksums

|                             SHA256                                 |     FILE    |
|--------------------------------------------------------------------|-------------|
| `8f0e314bfcc701bd184eb93d6236dd5a115fa03f74a0702abd66e9b1ffc9f136` | `guix-build-7d846e5aeae6/output/aarch64-linux-gnu/SHA256SUMS.part` |
| `f9485defe7044cb02dffbdf49d95cf00631b8f314289376ea1aff54f595f0f8e` | `guix-build-7d846e5aeae6/output/aarch64-linux-gnu/bitcoin-7d846e5aeae6-aarch64-linux-gnu-debug.tar.gz` |
| `9eeb2e4c796b3cdee5267cd2a1ca91225b00e3035195a162f52380b45d6487db` | `guix-build-7d846e5aeae6/output/aarch64-linux-gnu/bitcoin-7d846e5aeae6-aarch64-linux-gnu.tar.gz` |
| `d88bc97752f27c618868fab92daa39cab265f4a00dd82837c77bc09e10fe3fe5` | `guix-build-7d846e5aeae6/output/dist-archive/bitcoin-7d846e5aeae6.tar.gz` |
| `2bc6e86d713efcb23a34aa679a1b45fc4fedbddefa656eeb6cc0bb442f6630e4` | `guix-build-7d846e5aeae6/output/riscv64-linux-gnu/SHA256SUMS.part` |
| `b995f2b23d3be189709931cd15a15746d0a05a4c4cdbc40674dfcd2fee157f92` | `guix-build-7d846e5aeae6/output/riscv64-linux-gnu/bitcoin-7d846e5aeae6-riscv64-linux-gnu-debug.tar.gz` |
| `c5f2b8f328a5559e3e604267f3e4dd329158d3f7fcb1111fe459c275864db3a8` | `guix-build-7d846e5aeae6/output/riscv64-linux-gnu/bitcoin-7d846e5aeae6-riscv64-linux-gnu.tar.gz` |


</details>
