### PR TITLE
ci: Turn CentOS config into Alpine musl config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
             file-env: './ci/test/00_setup_env_native_previous_releases.sh'
 
           - name: 'Alpine (musl), depends, gui'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
+            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_alpine_musl.sh'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,11 +477,11 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_previous_releases.sh'
 
-          - name: 'CentOS, depends, gui'
+          - name: 'Alpine (musl), depends, gui'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_native_centos.sh'
+            file-env: './ci/test/00_setup_env_native_alpine_musl.sh'
 
           - name: 'tidy'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'

--- a/ci/test/00_setup_env_native_alpine_musl.sh
+++ b/ci/test/00_setup_env_native_alpine_musl.sh
@@ -6,10 +6,10 @@
 
 export LC_ALL=C.UTF-8
 
-export CONTAINER_NAME=ci_native_centos
-export CI_IMAGE_NAME_TAG="quay.io/centos/centos:stream10"
-export CI_BASE_PACKAGES="gcc-c++ glibc-devel libstdc++-devel ccache make ninja-build git python3 python3-pip which patch xz procps-ng rsync coreutils bison e2fsprogs cmake dash"
-export PIP_PACKAGES="pyzmq pycapnp"
+export CONTAINER_NAME=ci_native_alpine_musl
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/alpine:3.22"
+export CI_BASE_PACKAGES="build-base musl-dev pkgconf curl ccache make ninja git python3 py3-pip which patch xz procps rsync util-linux bison e2fsprogs cmake dash linux-headers"
+export PIP_PACKAGES="--break-system-packages pyzmq pycapnp"
 export DEP_OPTS="DEBUG=1"
 export GOAL="install"
 export BITCOIN_CONFIG="\

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -32,16 +32,17 @@ if [ -n "${APT_LLVM_V}" ]; then
   )
 fi
 
-if [[ $CI_IMAGE_NAME_TAG == *centos* ]]; then
-  bash -c "dnf -y install epel-release"
-  # The ninja-build package is available in the CRB repository.
-  bash -c "dnf -y --allowerasing --enablerepo crb install $CI_BASE_PACKAGES $PACKAGES"
+if [[ $CI_IMAGE_NAME_TAG == *alpine* ]]; then
+  ${CI_RETRY_EXE} apk update
+  # shellcheck disable=SC2086
+  ${CI_RETRY_EXE} apk add --no-cache $CI_BASE_PACKAGES $PACKAGES
 elif [ "$CI_OS_NAME" != "macos" ]; then
   if [[ -n "${APPEND_APT_SOURCES_LIST}" ]]; then
     echo "${APPEND_APT_SOURCES_LIST}" >> /etc/apt/sources.list
   fi
   ${CI_RETRY_EXE} apt-get update
-  ${CI_RETRY_EXE} bash -c "apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $CI_BASE_PACKAGES"
+  # shellcheck disable=SC2086
+  ${CI_RETRY_EXE} apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $CI_BASE_PACKAGES
 fi
 
 if [ -n "${APT_LLVM_V}" ]; then

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -99,8 +99,8 @@ else
 fi
 
 if [ -z "$NO_DEPENDS" ]; then
-  if [[ $CI_IMAGE_NAME_TAG == *centos* ]]; then
-    SHELL_OPTS="CONFIG_SHELL=/bin/dash"
+  if [[ $CI_IMAGE_NAME_TAG == *alpine* ]]; then
+    SHELL_OPTS="CONFIG_SHELL=/usr/bin/dash"
   else
     SHELL_OPTS="CONFIG_SHELL="
   fi

--- a/ci/test_imagefile
+++ b/ci/test_imagefile
@@ -17,4 +17,7 @@ ENV BASE_ROOT_DIR=${BASE_ROOT_DIR}
 COPY ./ci/retry/retry /usr/bin/retry
 COPY ./ci/test/00_setup_env.sh ./${FILE_ENV} ./ci/test/01_base_install.sh /ci_container_base/ci/test/
 
+# Bash is required, so install it when missing
+RUN sh -c "bash -c 'true' || ( apk update && apk add --no-cache bash )"
+
 RUN ["bash", "-c", "cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh"]


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/33437

Historically, the centos task was added to add CI coverage for old packages and 32-bit depends builds, but both are now covered by different tasks.

The CentOS task aligns with Ubuntu/Debian CI tasks in terms of libc usage, but (slightly) differs in package naming and update philosophy. I am not aware of the task ever discovering a centos-related issue, so it seems fine to recycle it into an Alpine Linux task.

The main difference would be that musl libc is now used. Also, busybox is used in Alpine, so in theory the busybox install could be removed from the arm CI task in the future.

Packaging considerations: All packages should roughly be the same (gcc remains at version 14, python remains at version 3.12, etc). Also, all packages are from the Alpine main track, coming with 2 years of support. The only exception is the py3-pip package (https://pkgs.alpinelinux.org/packages?name=py3-pip&branch=v3.22&repo=&arch=riscv64) from the community track, however, I don't expect any issues arising from that.