### PR TITLE
ci: check if file or directory already exists for ${HOME}/.bitcoin instead of failing

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -91,11 +91,18 @@ if [ "$USE_BUSY_BOX" = "true" ]; then
   patch --help
 fi
 
-# Make sure default datadir does not exist and is never read by creating a dummy file
+# Set DATADIR path based on CI_OS_NAME
 if [ "$CI_OS_NAME" == "macos" ]; then
-  echo > "${HOME}/Library/Application Support/Bitcoin"
+  DATADIR="${HOME}/Library/Application Support/Bitcoin"
 else
-  echo > "${HOME}/.bitcoin"
+  DATADIR="${HOME}/.bitcoin"
+fi
+
+# Check if DATADIR exists (file or directory), skip if it does
+if [ -e "$DATADIR" ]; then
+  echo "Skipping creation of $DATADIR; it already exists."
+else
+  echo > "$DATADIR"
 fi
 
 if [ -z "$NO_DEPENDS" ]; then


### PR DESCRIPTION
## Description
I was trying to run this script, but then it was giving me this error

```
/ci_container_base/ci/test/03_test_script.sh: line 90: /root/.bitcoin: Is a directory
Command '['./ci/test/02_run_container.sh']' returned non-zero exit status 1.
```
Since there is a directory there, we should skip this step. 

## Solution
I created a check to see if a directory or a file already exists, otherwise create one

### How to reproduce
I'm on Fedora 27
```
mkdir $HOME/.bitcoin
./ci/test/03_test_script.sh
```
This should be enough to run into the error, since the directory exists and the script thus cannot create a file