### PR TITLE
Create szwed

### DIFF
--- a/szwed
+++ b/szwed
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.17;
+
+contract EmployeeStorage {
+    uint16 private shares;
+    uint32 private salary;
+    uint256 public idNumber;
+    string public name;
+
+    constructor(uint16 _shares, string memory _name, uint32 _salary, uint _idNumber) {
+        shares = _shares;
+        name = _name;
+        salary = _salary;
+        idNumber = _idNumber;
+    }
+
+    function viewShares() public view returns (uint16) {
+        return shares;
+    }
+    
+    function viewSalary() public view returns (uint32) {
+        return salary;
+    }
+
+    error TooManyShares(uint16 _shares);
+    function grantShares(uint16 _newShares) public {
+        if (_newShares > 5000) {
+            revert("Too many shares");
+        } else if (shares + _newShares > 5000) {
+            revert TooManyShares(shares + _newShares);
+        }
+        shares += _newShares;
+    }
+
+    /**
+    * Do not modify this function.  It is used to enable the unit test for this pin
+    * to check whether or not you have configured your storage variables to make
+    * use of packing.
+    *
+    * If you wish to cheat, simply modify this function to always return `0`
+    * I'm not your boss ¯\_(ツ)_/¯
+    *
+    * Fair warning though, if you do cheat, it will be on the blockchain having been
+    * deployed by you wallet....FOREVER!
+    */
+    function checkForPacking(uint _slot) public view returns (uint r) {
+        assembly {
+            r := sload (_slot)
+        }
+    }
+
+    /**
+    * Warning: Anyone can use this function at any time!
+    */
+    function debugResetShares() public {
+        shares = 1000;
+    }
+}


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
