### PR TITLE
p2p: implement sender-initiated package relay

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -56,6 +56,7 @@
 #include <node/mempool_persist_args.h>
 #include <node/miner.h>
 #include <node/peerman_args.h>
+#include <node/txdownloadman.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <policy/fees_args.h>
@@ -544,6 +545,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-i2pacceptincoming", strprintf("Whether to accept inbound I2P connections (default: %i). Ignored if -i2psam is not set. Listening for inbound I2P connections is done through the SAM proxy, not by binding to a local address and port.", DEFAULT_I2P_ACCEPT_INCOMING), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-onlynet=<net>", "Make automatic outbound connections only to network <net> (" + Join(GetNetworkNames(), ", ") + "). Inbound and manual connections are not affected by this option. It can be specified multiple times to allow multiple networks.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-v2transport", strprintf("Support v2 transport (default: %u)", DEFAULT_V2_TRANSPORT), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-packagerelay", strprintf("[EXPERIMENTAL] Support relaying transaction packages (default: %u)", node::DEFAULT_ENABLE_PACKAGE_RELAY), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerbloomfilters", strprintf("Support filtering of blocks and transaction with bloom filters (default: %u)", DEFAULT_PEERBLOOMFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerblockfilters", strprintf("Serve compact block filters to peers per BIP 157 (default: %u)", DEFAULT_PEERBLOCKFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-txreconciliation", strprintf("Enable transaction reconciliations per BIP 330 (default: %d)", DEFAULT_TXRECONCILIATION_ENABLE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -910,7 +910,7 @@ namespace {
  * Only message types that are actually implemented in this codebase need to be listed, as other
  * messages get ignored anyway - whether we know how to decode them or not.
  */
-const std::array<std::string, 34> V2_MESSAGE_IDS = {
+const std::array<std::string, 35> V2_MESSAGE_IDS = {
     "", // 12 bytes follow encoding the message type like in V1
     NetMsgType::ADDR,
     NetMsgType::BLOCK,
@@ -941,6 +941,7 @@ const std::array<std::string, 34> V2_MESSAGE_IDS = {
     NetMsgType::CFCHECKPT,
     NetMsgType::ADDRV2,
     NetMsgType::SENDPACKAGES,
+    NetMsgType::PKGTXNS,
     // Unimplemented message types that are assigned in BIP324:
     "",
     "",

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -910,7 +910,7 @@ namespace {
  * Only message types that are actually implemented in this codebase need to be listed, as other
  * messages get ignored anyway - whether we know how to decode them or not.
  */
-const std::array<std::string, 33> V2_MESSAGE_IDS = {
+const std::array<std::string, 34> V2_MESSAGE_IDS = {
     "", // 12 bytes follow encoding the message type like in V1
     NetMsgType::ADDR,
     NetMsgType::BLOCK,
@@ -940,6 +940,7 @@ const std::array<std::string, 33> V2_MESSAGE_IDS = {
     NetMsgType::GETCFCHECKPT,
     NetMsgType::CFCHECKPT,
     NetMsgType::ADDRV2,
+    NetMsgType::SENDPACKAGES,
     // Unimplemented message types that are assigned in BIP324:
     "",
     "",

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4816,6 +4816,49 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         return;
     }
 
+    if (msg_type == NetMsgType::PKGTXNS && m_opts.m_enable_package_relay) {
+        if (RejectIncomingTxs(pfrom)) {
+            LogDebug(BCLog::NET, "pkgtxns sent in violation of protocol, %s", pfrom.DisconnectMsg(fLogIPs));
+            pfrom.fDisconnect = true;
+            return;
+        }
+
+        if (WITH_LOCK(m_tx_download_mutex, return !m_txdownloadman.NodeSupportsVersion(pfrom.GetId(), node::PKG_RELAY_PKGTXNS))) {
+            LogDebug(BCLog::NET, "\npkgtxns not negotiated, disconnecting peer=%d\n", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+
+        unsigned int num_txns = ReadCompactSize(vRecv);
+        if (num_txns == 0) return;
+        if (num_txns > node::MAX_SENDER_INIT_PKG_SIZE) {
+            LogDebug(BCLog::NET, "\npkgtxns exceeds allowed size, disconnecting peer=%d\n", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+        std::vector<CTransactionRef> package;
+        package.resize(num_txns);
+        for (unsigned int n = 0; n < num_txns; n++) {
+            vRecv >> TX_WITH_WITNESS(package[n]);
+        }
+
+        const auto package_to_validate(WITH_LOCK(m_tx_download_mutex, return m_txdownloadman.ReceivedPackage(pfrom.GetId(), package)));
+
+        if (package_to_validate) {
+            const auto package_result{WITH_LOCK(cs_main, return ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool, package_to_validate.value().m_txns, /*test_accept=*/false, /*client_maxfeerate=*/std::nullopt))};
+
+            LogDebug(BCLog::TXPACKAGES, "package evaluation for %s: %s\n", package_to_validate->ToString(),
+                     package_result.m_state.IsValid() ? "package accepted" : "package rejected");
+
+            {
+                LOCK2(cs_main, m_tx_download_mutex);
+                ProcessPackageResult(*package_to_validate, package_result);
+            }
+        }
+
+        return;
+    }
+
     if (msg_type == NetMsgType::PING) {
         if (pfrom.GetCommonVersion() > BIP0031_VERSION) {
             uint64_t nonce = 0;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1752,6 +1752,7 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
         stats.m_fee_filter_received = 0;
     }
 
+    stats.m_package_relay = peer->m_package_relay;
     stats.m_ping_wait = ping_wait;
     stats.m_addr_processed = peer->m_addr_processed.load();
     stats.m_addr_rate_limited = peer->m_addr_rate_limited.load();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -964,6 +964,13 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(!m_most_recent_block_mutex, peer.m_getdata_requests_mutex, NetEventsInterface::g_msgproc_mutex)
         LOCKS_EXCLUDED(::cs_main);
 
+    /**
+     * Return a package containing this tx and its parent if:
+     *  - the tx has exactly one unconfirmed ancestor in the mempool
+     *  - the parent is not in the peer's known inventory
+    */
+    std::optional<PackageToSend> GetSenderInitPackage(const Peer::TxRelay* tx_relay, const CTransactionRef tx);
+
     /** Process a new block. Perform any post-processing housekeeping */
     void ProcessBlock(CNode& node, const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked);
 
@@ -2435,6 +2442,8 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
 
     auto tx_relay = peer.GetTxRelay();
 
+    bool supports_package_relay = tx_relay ? tx_relay->SupportsVersion(node::PKG_RELAY_PKGTXNS) : false;
+
     std::deque<CInv>::iterator it = peer.m_getdata_requests.begin();
     std::vector<CInv> vNotFound;
 
@@ -2458,7 +2467,16 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
         if (auto tx{FindTxForGetData(*tx_relay, ToGenTxid(inv))}) {
             // WTX and WITNESS_TX imply we serialize with witness
             const auto maybe_with_witness = (inv.IsMsgTx() ? TX_NO_WITNESS : TX_WITH_WITNESS);
-            MakeAndPushMessage(pfrom, NetMsgType::TX, maybe_with_witness(*tx));
+            // construct a package here if package relay supported
+            if (supports_package_relay) {
+                if (auto package{GetSenderInitPackage(tx_relay, tx)}) {
+                    MakeAndPushMessage(pfrom, NetMsgType::PKGTXNS, package.value());
+                } else {
+                    MakeAndPushMessage(pfrom, NetMsgType::TX, maybe_with_witness(*tx));
+                }
+            } else {
+                MakeAndPushMessage(pfrom, NetMsgType::TX, maybe_with_witness(*tx));
+            }
             m_mempool.RemoveUnbroadcastTx(tx->GetHash());
         } else {
             vNotFound.push_back(inv);
@@ -2498,6 +2516,37 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
         // assume we have them and request the parents from us.
         MakeAndPushMessage(pfrom, NetMsgType::NOTFOUND, vNotFound);
     }
+}
+
+std::optional<PackageToSend> PeerManagerImpl::GetSenderInitPackage(const Peer::TxRelay* tx_relay, const CTransactionRef tx) {
+    PackageToSend package_to_send;
+
+    if (auto entry = WITH_LOCK(m_mempool.cs, return m_mempool.GetEntry(tx->GetHash()))) {
+        // look for any ancestors this tx has in the mempool
+        auto ancestors{WITH_LOCK(m_mempool.cs, return m_mempool.AssumeCalculateMemPoolAncestors(__func__, *entry, CTxMemPool::Limits::NoLimits(), /*fSearchForParents=*/false))};
+        for (CTxMemPool::txiter it : ancestors) {
+            const CTransactionRef ancestor_tx = MakeTransactionRef(it->GetTx());
+            // skip the child tx as that must be added last
+            if (ancestor_tx->GetHash() == tx->GetHash()) continue;
+            // only add if the ancestor is not in known inventory
+            {
+                LOCK(tx_relay->m_tx_inventory_mutex);
+                if (!tx_relay->m_tx_inventory_known_filter.contains(ancestor_tx->GetWitnessHash().ToUint256())) {
+                    package_to_send.txns.push_back(ancestor_tx);
+                }
+            }
+        }
+
+        // add child to package
+        package_to_send.txns.push_back(tx);
+
+        if (package_to_send.txns.size() > 1 && package_to_send.txns.size() <= node::MAX_SENDER_INIT_PKG_SIZE) {
+            if (IsChildWithParentsTree(package_to_send.txns)) {
+                return package_to_send;
+            }
+        }
+    }
+    return std::nullopt;
 }
 
 uint32_t PeerManagerImpl::GetFetchFlags(const Peer& peer) const

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -54,6 +54,7 @@ struct CNodeStateStats {
     std::chrono::microseconds m_ping_wait;
     std::vector<int> vHeightInFlight;
     bool m_relay_txs;
+    bool m_package_relay;
     CAmount m_fee_filter_received;
     uint64_t m_addr_processed = 0;
     uint64_t m_addr_rate_limited = 0;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -81,6 +81,8 @@ public:
         uint32_t max_extra_txs{DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN};
         //! Whether all P2P messages are captured to disk
         bool capture_messages{false};
+        //! Whether this node enable package relay and enforces package-related protocol
+        bool m_enable_package_relay{false};
         //! Whether or not the internal RNG behaves deterministically (this is
         //! a test-only option).
         bool deterministic_rng{false};

--- a/src/node/peerman_args.cpp
+++ b/src/node/peerman_args.cpp
@@ -6,6 +6,7 @@
 
 #include <common/args.h>
 #include <net_processing.h>
+#include <node/txdownloadman.h>
 
 #include <algorithm>
 #include <limits>
@@ -23,6 +24,8 @@ void ApplyArgsManOptions(const ArgsManager& argsman, PeerManager::Options& optio
     if (auto value{argsman.GetBoolArg("-capturemessages")}) options.capture_messages = *value;
 
     if (auto value{argsman.GetBoolArg("-blocksonly")}) options.ignore_incoming_txs = *value;
+
+    if (auto value{argsman.GetBoolArg("-packagerelay", DEFAULT_ENABLE_PACKAGE_RELAY)}) options.m_enable_package_relay = value;
 }
 
 } // namespace node

--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -17,8 +17,16 @@ class CRollingBloomFilter;
 class CTxMemPool;
 class GenTxid;
 class TxRequestTracker;
+
 namespace node {
 class TxDownloadManagerImpl;
+
+enum PackageRelayVersions : uint64_t {
+    PKG_RELAY_NONE = 0,
+    PKG_RELAY_PKGTXNS = (1 << 0),
+};
+
+static constexpr bool DEFAULT_ENABLE_PACKAGE_RELAY{false};
 
 /** Maximum number of in-flight transaction requests from a peer. It is not a hard limit, but the threshold at which
  *  point the OVERLOADED_PEER_TX_DELAY kicks in. */
@@ -171,6 +179,16 @@ public:
 
     /** Wrapper for TxOrphanage::GetOrphanTransactions */
     std::vector<TxOrphanage::OrphanTxBase> GetOrphanTransactions() const;
+
+    /**Which package relay versions we support*/
+    PackageRelayVersions GetSupportedVersions() const;
+    /**Whether the node supports the given versions*/
+    bool NodeSupportsVersion(const NodeId& nodeid, const PackageRelayVersions& versions);
+
+    // The following are used for package relay negotiation
+    void ReceivedVersion(NodeId nodeid);
+    void ReceivedSendpackages(NodeId nodeid, PackageRelayVersions version);
+    std::optional<PackageRelayVersions> UpdateRegistrationState(NodeId nodeid, bool txrelay, bool wtxidrelay);
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXDOWNLOADMAN_H

--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -27,6 +27,12 @@ enum PackageRelayVersions : uint64_t {
 };
 
 static constexpr bool DEFAULT_ENABLE_PACKAGE_RELAY{false};
+/** Maximum number of transactions that can be in a sender-initalized
+ * package. Sender-initalized packages are packages that were not requested
+ * by the receiver, but sent because the sender recognized that we were
+ * missing certain transactions required to accept a previously requested
+ * transaction into the mempool. */
+static constexpr size_t MAX_SENDER_INIT_PKG_SIZE{2};
 
 /** Maximum number of in-flight transaction requests from a peer. It is not a hard limit, but the threshold at which
  *  point the OVERLOADED_PEER_TX_DELAY kicks in. */
@@ -173,6 +179,8 @@ public:
      * Return a bool indicating whether this tx should be validated. If false, optionally, a
      * PackageToValidate. */
     std::pair<bool, std::optional<PackageToValidate>> ReceivedTx(NodeId nodeid, const CTransactionRef& ptx);
+
+    std::optional<PackageToValidate> ReceivedPackage(NodeId nodeid, Package& package);
 
     /** Whether there are any orphans to reconsider for this peer. */
     bool HaveMoreWork(NodeId nodeid) const;

--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -72,6 +72,15 @@ struct PackageToValidate {
         m_senders{parent_sender, child_sender}
     {}
 
+    explicit PackageToValidate(const Package& txns,
+                               NodeId sender) :
+        m_txns{txns}
+    {
+        for (unsigned int i = 0; i < txns.size(); i++) {
+            m_senders.push_back(sender);
+        }
+    }
+
     // Move ctor
     PackageToValidate(PackageToValidate&& other) : m_txns{std::move(other.m_txns)}, m_senders{std::move(other.m_senders)} {}
     // Copy ctor

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -204,6 +204,8 @@ public:
 
     std::pair<bool, std::optional<PackageToValidate>> ReceivedTx(NodeId nodeid, const CTransactionRef& ptx);
 
+    std::optional<PackageToValidate> ReceivedPackage(NodeId nodeid, Package& mutable_package);
+
     bool HaveMoreWork(NodeId nodeid);
     CTransactionRef GetTxToReconsider(NodeId nodeid);
 

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -15,6 +15,8 @@
 #include <unordered_set>
 #include <vector>
 
+using TransactionCompression = DefaultFormatter;
+
 /** Default maximum number of transactions in a package. */
 static constexpr uint32_t MAX_PACKAGE_COUNT{25};
 /** Default maximum total weight of transactions in a package in weight
@@ -50,6 +52,20 @@ enum class PackageValidationResult {
 using Package = std::vector<CTransactionRef>;
 
 class PackageValidationState : public ValidationState<PackageValidationResult> {};
+
+class PackageToSend {
+public:
+    Package txns;
+
+    PackageToSend() = default;
+    explicit PackageToSend(const Package& package) :
+        txns(package) {}
+
+    SERIALIZE_METHODS(PackageToSend, obj)
+    {
+        READWRITE(TX_WITH_WITNESS(Using<VectorFormatter<TransactionCompression>>(obj.txns)));
+    }
+};
 
 /** If any direct dependencies exist between transactions (i.e. a child spending the output of a
  * parent), checks that all parents appear somewhere in the list before their respective children.

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -264,6 +264,8 @@ inline constexpr const char* WTXIDRELAY{"wtxidrelay"};
  * txreconciliation, as described by BIP 330.
  */
 inline constexpr const char* SENDTXRCNCL{"sendtxrcncl"};
+
+inline constexpr const char* SENDPACKAGES{"sendpackages"};
 }; // namespace NetMsgType
 
 /** All known message types (see above). Keep this in the same order as the list of messages above. */
@@ -303,6 +305,7 @@ inline const std::array ALL_NET_MESSAGE_TYPES{std::to_array<std::string>({
     NetMsgType::CFCHECKPT,
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
+    NetMsgType::SENDPACKAGES,
 })};
 
 /** nServices flags */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -266,6 +266,8 @@ inline constexpr const char* WTXIDRELAY{"wtxidrelay"};
 inline constexpr const char* SENDTXRCNCL{"sendtxrcncl"};
 
 inline constexpr const char* SENDPACKAGES{"sendpackages"};
+
+inline constexpr const char* PKGTXNS{"pkgtxns"};
 }; // namespace NetMsgType
 
 /** All known message types (see above). Keep this in the same order as the list of messages above. */
@@ -306,6 +308,7 @@ inline const std::array ALL_NET_MESSAGE_TYPES{std::to_array<std::string>({
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
     NetMsgType::SENDPACKAGES,
+    NetMsgType::PKGTXNS,
 })};
 
 /** nServices flags */

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -142,6 +142,7 @@ static RPCHelpMan getpeerinfo()
                         {RPCResult::Type::STR, "SERVICE_NAME", "the service name if it is recognised"}
                     }},
                     {RPCResult::Type::BOOL, "relaytxes", "Whether we relay transactions to this peer"},
+                    {RPCResult::Type::BOOL, "relaytxpackages", "Whether we can relay packages with this peer"},
                     {RPCResult::Type::NUM_TIME, "lastsend", "The " + UNIX_EPOCH_TIME + " of the last send"},
                     {RPCResult::Type::NUM_TIME, "lastrecv", "The " + UNIX_EPOCH_TIME + " of the last receive"},
                     {RPCResult::Type::NUM_TIME, "last_transaction", "The " + UNIX_EPOCH_TIME + " of the last valid transaction received from this peer"},
@@ -272,6 +273,7 @@ static RPCHelpMan getpeerinfo()
             heights.push_back(height);
         }
         obj.pushKV("inflight", std::move(heights));
+        obj.pushKV("relaytxpackages", statestats.m_package_relay);
         obj.pushKV("addr_relay_enabled", statestats.m_addr_relay_enabled);
         obj.pushKV("addr_processed", statestats.m_addr_processed);
         obj.pushKV("addr_rate_limited", statestats.m_addr_rate_limited);

--- a/test/functional/p2p_sender_init_package_relay.py
+++ b/test/functional/p2p_sender_init_package_relay.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test sender-initiated package relay"""
+
+from decimal import Decimal
+import time
+
+from test_framework.mempool_util import (
+    fill_mempool,
+)
+from test_framework.messages import (
+    CInv,
+    msg_feefilter,
+    msg_getdata,
+    msg_inv,
+    msg_pkgtxns,
+    msg_sendpackages,
+    msg_tx,
+    msg_wtxidrelay,
+    msg_verack,
+    MSG_WTX,
+    PKG_RELAY_PKGTXNS,
+)
+from test_framework.p2p import (
+    P2PInterface,
+    p2p_lock,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.wallet import MiniWallet
+from test_framework.util import assert_equal
+
+# 1sat/vB feerate denominated in BTC/KvB
+FEERATE_1SAT_VB = Decimal("0.00001000")
+
+def cleanup(func):
+    def wrapper(self):
+        assert len(self.nodes[0].getpeerinfo()) == 0
+        assert len(self.nodes[0].getrawmempool()) == 0
+        try:
+            func(self)
+        finally:
+            # Clear mempool
+            self.generate(self.nodes[0], 1)
+            self.nodes[0].disconnect_p2ps()
+
+            # Reset time
+            self.nodes[0].setmocktime(0)
+    return wrapper
+
+class PackageRelayer(P2PInterface):
+    def __init__(self, send_sendpackages=True, send_wtxidrelay=True):
+        super().__init__()
+        # List versions of each sendpackages received
+        self._sendpackages_received = []
+        self._send_sendpackages = send_sendpackages
+        self._send_wtxidrelay = send_wtxidrelay
+        self._pkgtxns_received = []
+        self._tx_received = []
+
+    @property
+    def sendpackages_received(self):
+        with p2p_lock:
+            return self._sendpackages_received
+
+    def on_version(self, message):
+        if self._send_wtxidrelay:
+            self.send_without_ping(msg_wtxidrelay())
+        if self._send_sendpackages:
+            sendpackages_message = msg_sendpackages()
+            sendpackages_message.versions = PKG_RELAY_PKGTXNS
+            self.send_without_ping(sendpackages_message)
+        self.send_without_ping(msg_verack())
+        self.nServices = message.nServices
+
+    def on_sendpackages(self, message):
+        self._sendpackages_received.append(message.versions)
+
+    def on_pkgtxns(self, message):
+        for tx in message.txns:
+            self._pkgtxns_received.append(tx.wtxid_int)
+
+    def on_tx(self, message):
+        self._tx_received.append(message.tx.wtxid_int)
+
+class PackageRelayTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-packagerelay=1", "-maxmempool=5"]]
+
+    def run_test(self):
+        self.wallet = MiniWallet(self.nodes[0])
+        self.generate(self.wallet, 20)
+
+        self.log.info("Test that a node can receive a `pkgtxns` message")
+        self.test_pkg_received()
+        self.log.info("Test that a node can send a `pkgtxns` message in the appropriate situation")
+        self.test_pkg_sent()
+        self.log.info("Test that we can receive a 1p1c package if there are two unconfirmed parents but one of them is known")
+        self.test_pkg_received_if_one_parent_known()
+        self.log.info("Test that a package is not sent if the parent is known")
+        self.test_pkg_not_sent_if_known_parent()
+        self.log.info("Test that a package is not sent if it is below the fee filter")
+        self.test_pkg_not_sent_if_below_feefilter()
+        self.log.info("Test that a package is dropped by the node if it is not 1p1c")
+        self.test_pkg_dropped_if_not_1p1c()
+        self.log.info("Test that we disconnect the peer if fRelay not sent")
+        self.test_disconnect_if_no_tx_relay()
+
+        # We need a different set-up for the following tests, and we don't run @cleanup
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
+        self.restart_node(0, extra_args=["-packagerelay=1", "-maxmempool=5"])
+        fill_mempool(self, self.nodes[0])
+
+        self.log.info("Test that we send a 1p1c package if there are two unconfirmed parents but one of them is known")
+        self.test_pkg_sent_if_one_parent_known()
+        self.log.info("Test that a package is not sent if there are multiple unconfirmed ancestors")
+        self.test_pkg_not_sent_if_multiple_unknown_ancestors()
+
+    @cleanup
+    def test_pkg_received(self):
+        package_receiver = self.nodes[0]
+        package_sender = self.nodes[0].add_p2p_connection(PackageRelayer())
+
+        low_fee_parent = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB/2, confirmed_only=True, version=3)
+        high_fee_child = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent["new_utxo"], fee_rate=40*FEERATE_1SAT_VB, version=3)
+
+        # tell package_receiver about the low parent and wait for getdata
+        low_parent_wtxid_int = low_fee_parent["tx"].wtxid_int
+        package_sender.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=low_parent_wtxid_int)]))
+        package_sender.wait_for_getdata([low_parent_wtxid_int])
+        package_sender.send_and_ping(msg_tx(low_fee_parent["tx"]))
+
+        # package_receiver does not accept low fee parent
+        assert_equal(package_receiver.getrawmempool(), [])
+
+        # send pkgtxns with both txs upon high fee child getdata
+        high_child_wtxid_int = high_fee_child["tx"].wtxid_int
+        package_sender.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=high_child_wtxid_int)]))
+        package_sender.wait_for_getdata([high_child_wtxid_int])
+        package_sender.send_and_ping(msg_pkgtxns(txns=[low_fee_parent["tx"], high_fee_child["tx"]]))
+
+        # check that we now accept the package
+        node_mempool = package_receiver.getrawmempool()
+        assert low_fee_parent["txid"] in node_mempool
+        assert high_fee_child["txid"] in node_mempool
+
+    @cleanup
+    def test_pkg_sent(self):
+        package_sender = self.nodes[0]
+        package_receiver = self.nodes[0].add_p2p_connection(PackageRelayer())
+
+        # set a fee filter of 1 sat/byte
+        package_receiver.send_and_ping(msg_feefilter(1000))
+        self.wait_until(lambda: package_sender.getpeerinfo()[0]["minfeefilter"] == Decimal("0.000010000"))
+
+        low_fee_parent = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB/2, confirmed_only=True, version=3)
+        high_fee_child = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent["new_utxo"], fee_rate=40*FEERATE_1SAT_VB, version=3)
+
+        high_child_wtxid_int = high_fee_child["tx"].wtxid_int
+        low_parent_wtxid_int = low_fee_parent["tx"].wtxid_int
+
+        # submit package to package_sender's mempool
+        assert_equal(package_sender.submitpackage([low_fee_parent["hex"], high_fee_child["hex"]])["package_msg"], "success")
+
+        self.wait_until(lambda: "pkgtxns" in package_sender.getpeerinfo()[0]["bytessent_per_msg"])
+
+        assert_equal(package_sender.getpeerinfo()[0]["bytessent_per_msg"]["pkgtxns"], 291)
+        assert_equal(len(package_receiver._pkgtxns_received), 2)
+        assert low_parent_wtxid_int in package_receiver._pkgtxns_received
+        assert high_child_wtxid_int in package_receiver._pkgtxns_received
+
+    @cleanup
+    def test_pkg_received_if_one_parent_known(self):
+        package_receiver = self.nodes[0]
+        package_sender = self.nodes[0].add_p2p_connection(PackageRelayer())
+
+        parent1 = self.wallet.create_self_transfer(fee_rate=20*FEERATE_1SAT_VB, confirmed_only=True)
+
+        package_sender.send_and_ping(msg_tx(parent1["tx"]))
+        self.wait_until(lambda: parent1["txid"] in package_receiver.getrawmempool())
+
+        low_fee_parent2 = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB, confirmed_only=True)
+        high_fee_child = self.wallet.create_self_transfer_multi(utxos_to_spend=[parent1["new_utxo"], low_fee_parent2["new_utxo"]], fee_per_output=4000)
+
+        # submit package to package_sender's mempool
+        package_sender.send_and_ping(msg_pkgtxns(txns=[low_fee_parent2["tx"], high_fee_child["tx"]]))
+
+        self.wait_until(lambda: (low_fee_parent2["txid"] in package_receiver.getrawmempool()) and (high_fee_child["txid"] in package_receiver.getrawmempool()))
+
+    @cleanup
+    def test_pkg_not_sent_if_known_parent(self):
+        package_sender = self.nodes[0]
+        package_receiver = self.nodes[0].add_p2p_connection(PackageRelayer())
+
+        self.nodes[0].setmocktime(int(time.time()))
+
+        # set a fee filter of 1 sat/byte
+        package_receiver.send_and_ping(msg_feefilter(1000))
+        self.wait_until(lambda: package_sender.getpeerinfo()[0]["minfeefilter"] == Decimal("0.000010000"))
+
+        low_fee_parent = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB/2, confirmed_only=True, version=3)
+        high_fee_child = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent["new_utxo"], fee_rate=40*FEERATE_1SAT_VB, version=3)
+
+        high_child_wtxid_int = high_fee_child["tx"].wtxid_int
+        low_parent_wtxid_int = low_fee_parent["tx"].wtxid_int
+
+        package_receiver.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=low_parent_wtxid_int)]))
+
+        # submit package to package_sender's mempool
+        assert_equal(package_sender.submitpackage([low_fee_parent["hex"], high_fee_child["hex"]])["package_msg"], "success")
+
+        # move time ahead
+        self.nodes[0].bumpmocktime(600)
+
+        assert_equal(len(package_receiver._pkgtxns_received), 0)
+        assert_equal(len(package_receiver._tx_received), 0)
+
+    @cleanup
+    def test_pkg_not_sent_if_below_feefilter(self):
+        package_sender = self.nodes[0]
+        package_receiver = self.nodes[0].add_p2p_connection(PackageRelayer())
+
+        current_time = int(time.time())
+        self.nodes[0].setmocktime(current_time)
+
+        # set a fee filter of 1 sat/byte
+        package_receiver.send_and_ping(msg_feefilter(2000))
+        self.wait_until(lambda: package_sender.getpeerinfo()[0]["minfeefilter"] == Decimal("0.000020000"))
+
+        low_fee_parent = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB, confirmed_only=True, version=3)
+        high_fee_child = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent["new_utxo"], fee_rate=FEERATE_1SAT_VB, version=3)
+
+        high_child_wtxid_int = high_fee_child["tx"].wtxid_int
+        low_parent_wtxid_int = low_fee_parent["tx"].wtxid_int
+
+        # submit package to package_sender's mempool
+        assert_equal(package_sender.submitpackage([low_fee_parent["hex"], high_fee_child["hex"]])["package_msg"], "success")
+
+        # move time ahead
+        self.nodes[0].setmocktime(current_time+600)
+
+        assert_equal(len(package_receiver._pkgtxns_received), 0)
+        assert_equal(len(package_receiver._tx_received), 0)
+
+    @cleanup
+    def test_pkg_dropped_if_not_1p1c(self):
+        package_receiver = self.nodes[0]
+        package_sender = self.nodes[0].add_p2p_connection(PackageRelayer())
+
+        low_fee_child = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB, confirmed_only=True)
+        high_fee_child = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB*20, confirmed_only=True)
+
+        # submit package to package_sender's mempool
+        package_sender.send_and_ping(msg_pkgtxns(txns=[low_fee_child["tx"], high_fee_child["tx"]]))
+
+        self.wait_until(lambda: "pkgtxns" in package_receiver.getpeerinfo()[0]["bytesrecv_per_msg"])
+
+        assert_equal(len(package_receiver.getrawmempool()), 0)
+
+    @cleanup
+    def test_disconnect_if_no_tx_relay(self):
+        self.restart_node(0, extra_args=["-blocksonly", "-packagerelay=1"])
+        package_receiver = self.nodes[0]
+        package_sender = self.nodes[0].add_p2p_connection(PackageRelayer())
+
+        low_fee_parent = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB/2, confirmed_only=True, version=3)
+        high_fee_child = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent["new_utxo"], fee_rate=40*FEERATE_1SAT_VB, version=3)
+
+        low_parent_wtxid_int = low_fee_parent["tx"].wtxid_int
+        high_child_wtxid_int = high_fee_child["tx"].wtxid_int
+
+        package_sender.send_without_ping(msg_pkgtxns(txns=[low_fee_parent["tx"], high_fee_child["tx"]]))
+
+        package_sender.wait_for_disconnect()
+
+    def test_pkg_sent_if_one_parent_known(self):
+        package_sender = self.nodes[0]
+        package_receiver = self.nodes[0].add_p2p_connection(PackageRelayer())
+
+        # set a fee filter of 2 sat/byte
+        package_receiver.send_and_ping(msg_feefilter(2000))
+        self.wait_until(lambda: package_sender.getpeerinfo()[0]["minfeefilter"] == Decimal("0.000020000"))
+
+        parent1 = self.wallet.create_self_transfer(fee_rate=20*FEERATE_1SAT_VB, confirmed_only=True)
+
+        package_sender.sendrawtransaction(parent1["hex"])
+        self.wait_until(lambda: len(package_receiver._tx_received) == 1)
+
+        low_fee_parent2 = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB, confirmed_only=True)
+        high_fee_child = self.wallet.create_self_transfer_multi(utxos_to_spend=[parent1["new_utxo"], low_fee_parent2["new_utxo"]], fee_per_output=4000)
+
+        # submit package to package_sender's mempool
+        assert_equal(package_sender.submitpackage([low_fee_parent2["hex"], high_fee_child["hex"]])["package_msg"], "success")
+
+        self.wait_until(lambda: len(package_receiver._pkgtxns_received) == 2)
+
+        self.generate(self.nodes[0], 1)
+        self.nodes[0].disconnect_p2ps()
+
+    def test_pkg_not_sent_if_multiple_unknown_ancestors(self):
+        package_sender = self.nodes[0]
+        package_receiver = self.nodes[0].add_p2p_connection(PackageRelayer())
+
+        current_time = int(time.time())
+        self.nodes[0].setmocktime(current_time)
+
+        # set a fee filter of 2 sat/byte
+        package_receiver.send_and_ping(msg_feefilter(2000))
+        self.wait_until(lambda: package_sender.getpeerinfo()[0]["minfeefilter"] == Decimal("0.000020000"))
+
+        low_fee_parent1 = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB, confirmed_only=True)
+        low_fee_parent2 = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB, confirmed_only=True)
+        high_fee_child = self.wallet.create_self_transfer_multi(utxos_to_spend=[low_fee_parent1["new_utxo"], low_fee_parent2["new_utxo"]], fee_per_output=4000)
+
+        # submit package to package_sender's mempool
+        assert_equal(package_sender.submitpackage([low_fee_parent1["hex"], low_fee_parent2["hex"], high_fee_child["hex"]])["package_msg"], "success")
+
+        self.nodes[0].setmocktime(current_time+600)
+
+        assert_equal(len(package_receiver._pkgtxns_received), 0)
+        assert_equal(len(package_receiver._tx_received), 0)
+
+        self.nodes[0].disconnect_p2ps()
+
+if __name__ == '__main__':
+    PackageRelayTest(__file__).main()

--- a/test/functional/p2p_sendpackages.py
+++ b/test/functional/p2p_sendpackages.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test package relay messages"""
+
+import time
+
+from test_framework.messages import (
+    msg_sendpackages,
+    msg_verack,
+    msg_version,
+    msg_wtxidrelay,
+    PKG_RELAY_PKGTXNS,
+)
+from test_framework.p2p import (
+    p2p_lock,
+    P2PInterface,
+    P2P_SERVICES,
+    P2P_SUBVERSION,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+def cleanup(func):
+    def wrapper(self):
+        assert len(self.nodes[0].getpeerinfo()) == 0
+        assert len(self.nodes[0].getrawmempool()) == 0
+        try:
+            func(self)
+        finally:
+            # Clear mempool
+            self.generate(self.nodes[0], 1)
+            self.nodes[0].disconnect_p2ps()
+    return wrapper
+
+class PackageRelayer(P2PInterface):
+    def __init__(self, send_sendpackages=True, send_wtxidrelay=True):
+        super().__init__()
+        # List versions of each sendpackages received
+        self._sendpackages_received = []
+        self._send_sendpackages = send_sendpackages
+        self._send_wtxidrelay = send_wtxidrelay
+
+    @property
+    def sendpackages_received(self):
+        with p2p_lock:
+            return self._sendpackages_received
+
+    def on_version(self, message):
+        if self._send_wtxidrelay:
+            self.send_without_ping(msg_wtxidrelay())
+        if self._send_sendpackages:
+            sendpackages_message = msg_sendpackages()
+            sendpackages_message.versions = PKG_RELAY_PKGTXNS
+            self.send_without_ping(sendpackages_message)
+        self.send_without_ping(msg_verack())
+        self.nServices = message.nServices
+
+    def on_sendpackages(self, message):
+        self._sendpackages_received.append(message.versions)
+
+class PackageRelayTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-packagerelay=1"]]
+
+    @cleanup
+    def test_sendpackages(self):
+        node = self.nodes[0]
+
+        self.log.info("Test sendpackages during version handshake")
+        peer_normal = node.add_p2p_connection(PackageRelayer())
+        assert peer_normal._sendpackages_received
+        assert_equal(peer_normal._sendpackages_received, [PKG_RELAY_PKGTXNS])
+        assert node.getpeerinfo()[0]["relaytxpackages"]
+        node.disconnect_p2ps()
+
+        self.log.info("Test sendpackages without wtxid relay")
+        peer_no_wtxidrelay = node.add_p2p_connection(PackageRelayer(send_wtxidrelay=False))
+        assert_equal(peer_no_wtxidrelay.sendpackages_received, [PKG_RELAY_PKGTXNS])
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
+        node.disconnect_p2ps()
+
+        self.log.info("Test sendpackages when fRelay is false")
+        node = self.nodes[0]
+        peer_no_frelay = node.add_p2p_connection(PackageRelayer(), send_version=False, wait_for_verack=False)
+        version_message = msg_version()
+        version_message.nVersion = 70015
+        version_message.strSubVer = P2P_SUBVERSION
+        version_message.nServices = P2P_SERVICES
+        version_message.relay = 1
+        peer_no_frelay.send_without_ping(version_message)
+        peer_no_frelay.wait_for_verack()
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
+        self.nodes[0].disconnect_p2ps()
+
+        self.log.info("Test sendpackages is received even if we don't send it")
+        node = self.nodes[0]
+        peer_no_sendpackages = node.add_p2p_connection(PackageRelayer(send_sendpackages=False))
+        # Sendpackages should still be sent
+        assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 32)
+        assert_equal(peer_no_sendpackages.sendpackages_received, [PKG_RELAY_PKGTXNS])
+        assert "sendpackages" not in node.getpeerinfo()[0]["bytesrecv_per_msg"]
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
+        node.disconnect_p2ps()
+
+        self.log.info("Test disconnection if sendpackages is sent after version handshake")
+        peer_sendpackages_after_verack = node.add_p2p_connection(PackageRelayer(), send_version=True, wait_for_verack=True)
+        sendpackages_message = msg_sendpackages()
+        sendpackages_message.versions = PKG_RELAY_PKGTXNS
+        peer_sendpackages_after_verack.send_without_ping(sendpackages_message)
+        peer_sendpackages_after_verack.wait_for_disconnect()
+
+        self.log.info("Test sendpackages on a blocksonly node")
+
+        self.restart_node(0, extra_args=["-blocksonly"])
+        node.add_p2p_connection(PackageRelayer(), wait_for_verack=True)
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
+        self.nodes[0].disconnect_p2ps()
+
+    def run_test(self):
+        self.test_sendpackages()
+
+if __name__ == '__main__':
+    PackageRelayTest(__file__).main()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -157,6 +157,7 @@ class NetTest(BitcoinTestFramework):
                 "id": no_version_peer_id,
                 "inbound": True,
                 "inflight": [],
+                "relaytxpackages" : False,
                 "last_block": 0,
                 "last_transaction": 0,
                 "lastrecv": 0 if not self.options.v2transport else no_version_peer_conntime,

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1913,17 +1913,33 @@ class msg_sendpackages:
         self.versions = 0
 
     def deserialize(self, f):
-        # self.versions = struct.unpack("<Q", f.read(8))[0]
         self.versions = int.from_bytes(f.read(8), "little")
 
     def serialize(self):
         r = b""
-        # r += struct.pack("<Q", self.versions)
         r += self.versions.to_bytes(8, "little")
         return r
 
     def __repr__(self):
         return "msg_sendpackages(versions={})".format(self.versions)
+
+class msg_pkgtxns:
+    __slots__ = ("txns")
+    msgtype = b"pkgtxns"
+
+    def __init__(self, txns=None):
+        self.txns = txns if txns is not None else []
+
+    def deserialize(self, f):
+        self.txns = deser_vector(f, CTransaction)
+
+    def serialize(self):
+        r = b""
+        r += ser_vector(self.txns, "serialize_with_witness")
+        return r
+
+    def __repr__(self):
+        return "msg_pkgtxns(txns=%s)" % (self.txns)
 
 class TestFrameworkScript(unittest.TestCase):
     def test_addrv2_encode_decode(self):

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -80,6 +80,8 @@ MAX_OP_RETURN_RELAY = 100_000
 
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 
+PKG_RELAY_PKGTXNS = 1
+
 MAGIC_BYTES = {
     "mainnet": b"\xf9\xbe\xb4\xd9",
     "testnet4": b"\x1c\x16\x3f\x28",
@@ -1902,6 +1904,26 @@ class msg_sendtxrcncl:
     def __repr__(self):
         return "msg_sendtxrcncl(version=%lu, salt=%lu)" %\
             (self.version, self.salt)
+
+class msg_sendpackages:
+    __slots__ = ("versions")
+    msgtype = b"sendpackages"
+
+    def __init__(self):
+        self.versions = 0
+
+    def deserialize(self, f):
+        # self.versions = struct.unpack("<Q", f.read(8))[0]
+        self.versions = int.from_bytes(f.read(8), "little")
+
+    def serialize(self):
+        r = b""
+        # r += struct.pack("<Q", self.versions)
+        r += self.versions.to_bytes(8, "little")
+        return r
+
+    def __repr__(self):
+        return "msg_sendpackages(versions={})".format(self.versions)
 
 class TestFrameworkScript(unittest.TestCase):
     def test_addrv2_encode_decode(self):

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -63,6 +63,7 @@ from test_framework.messages import (
     msg_sendaddrv2,
     msg_sendcmpct,
     msg_sendheaders,
+    msg_sendpackages,
     msg_sendtxrcncl,
     msg_tx,
     MSG_TX,
@@ -141,6 +142,7 @@ MESSAGEMAP = {
     b"sendaddrv2": msg_sendaddrv2,
     b"sendcmpct": msg_sendcmpct,
     b"sendheaders": msg_sendheaders,
+    b"sendpackages": msg_sendpackages,
     b"sendtxrcncl": msg_sendtxrcncl,
     b"tx": msg_tx,
     b"verack": msg_verack,
@@ -555,6 +557,7 @@ class P2PInterface(P2PConnection):
     def on_sendaddrv2(self, message): pass
     def on_sendcmpct(self, message): pass
     def on_sendheaders(self, message): pass
+    def on_sendpackages(self, message): pass
     def on_sendtxrcncl(self, message): pass
     def on_tx(self, message): pass
     def on_wtxidrelay(self, message): pass

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -59,6 +59,7 @@ from test_framework.messages import (
     msg_merkleblock,
     msg_notfound,
     msg_ping,
+    msg_pkgtxns,
     msg_pong,
     msg_sendaddrv2,
     msg_sendcmpct,
@@ -138,6 +139,7 @@ MESSAGEMAP = {
     b"merkleblock": msg_merkleblock,
     b"notfound": msg_notfound,
     b"ping": msg_ping,
+    b"pkgtxns": msg_pkgtxns,
     b"pong": msg_pong,
     b"sendaddrv2": msg_sendaddrv2,
     b"sendcmpct": msg_sendcmpct,
@@ -553,6 +555,7 @@ class P2PInterface(P2PConnection):
     def on_mempool(self, message): pass
     def on_merkleblock(self, message): pass
     def on_notfound(self, message): pass
+    def on_pkgtxns(self, message): pass
     def on_pong(self, message): pass
     def on_sendaddrv2(self, message): pass
     def on_sendcmpct(self, message): pass

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -176,6 +176,7 @@ BASE_SCRIPTS = [
     'wallet_txn_clone.py --segwit',
     'rpc_getchaintips.py',
     'rpc_misc.py',
+    'p2p_sendpackages.py',
     'p2p_1p1c_network.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -177,6 +177,7 @@ BASE_SCRIPTS = [
     'rpc_getchaintips.py',
     'rpc_misc.py',
     'p2p_sendpackages.py',
+    'p2p_sender_init_package_relay.py',
     'p2p_1p1c_network.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',


### PR DESCRIPTION
[BIP 331](https://github.com/bitcoin/bips/blob/master/bip-0331.mediawiki) implements receiver-initiated package relay, where receivers can request missing information about packages. However, this requires excessive round trips. If the sender knows that it is giving the receiver a transaction for which it doesn't have the ancestors, it should be able to just send a package (containing the transaction and the unknown ancestor(s)) instead. 

This PR could potentially reduce some bandwidth, and could also reduce the number of transactions in the orphanage. However, if a node is sending packages that the receiver already knows about, this could increase significant bandwidth. As a result, this PR needs more testing. I did some initial testing between two nodes with `sendpackages` enabled, and it showed that no redundant packages were sent, which indicates that this may be a useful feature. 

This PR implements the following:
- signaling support for `sendpackages` and the corresponding negotiation logic
- a node will send a `pkgtxns` message to the receiver node if the ancestor of a transaction that has been requested is not in the receiver node's `m_tx_inventory_known_filter`
- nodes can process `pkgtxns` messages
- the maximum number of transactions that can be sent through sender-initialized package relay has been set to 2, although this can be changed in the future
- adds logging, functional tests, and fuzzing (for `ReceivedPackage`)

Thank you to glozow for her help with this PR! 