### PR TITLE
doc: add clarifying comment that creating the .bitcoin file is to avoid any mainnet datadir access

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -92,6 +92,7 @@ if [ "$USE_BUSY_BOX" = "true" ]; then
 fi
 
 # Make sure default datadir does not exist and is never read by creating a dummy file
+# Ensuring that no mainnet datadir access is happening from any of the tests
 if [ "$CI_OS_NAME" == "macos" ]; then
   echo > "${HOME}/Library/Application Support/Bitcoin"
 else


### PR DESCRIPTION
referenced from https://github.com/bitcoin/bitcoin/pull/33486#issuecomment-3347684298

This adds a clarifying comment to tell the reader that the creation of the `${HOME}/.bitcoin` file is to ensure that there is no mainnet datadir access happening from any of the tests