### PR TITLE
ci: fix buildx gha cache authentication on forks

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -22,8 +22,12 @@ runs:
       uses: actions/github-script@v6
       with:
         script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env['ACTIONS_CACHE_URL'])
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
+          Object.keys(process.env).forEach(function (key) {
+            if (key.startsWith('ACTIONS_')) {
+              core.info(`Exporting ${key}`);
+              core.exportVariable(key, process.env[key]);
+            }
+          });
 
     - name: Construct docker build cache args
       shell: bash


### PR DESCRIPTION
When using `docker buildx build` in conjunction with the `gha` backend cache type (as we do in our CI) it's important to specify the URL and TOKEN needed to authenticate.

On Cirrus runners this is working with only `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN`, but this is not enough for the GitHub backend.

Fix this by exporting all `ACTIONS_*` variables.

This fixes docker build layer cache restore/save on forks or where GH-hosted runners are being used, and addresses https://github.com/bitcoin/bitcoin/issues/31965#issuecomment-3324707093