### PR TITLE
ci: clear out space on CentOS, depends, gui GHA job

### DIFF
--- a/.github/actions/clear-files/action.yml
+++ b/.github/actions/clear-files/action.yml
@@ -1,0 +1,12 @@
+name: 'Clear unnecessary files'
+description: 'Clear out unnecessary files to make space on the VM'
+runs:
+  using: 'composite'
+  steps:
+    - name: Clear unnecessary files
+      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        set +o errexit
+        sudo bash -c '(ionice -c 3 nice -n 19 rm -rf /usr/share/dotnet/ /usr/local/graalvm/ /usr/local/.ghcup/ /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/android /usr/local/lib/node_modules)&'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,10 @@ jobs:
         with:
           cache-provider: ${{ matrix.provider || needs.runners.outputs.provider }}
 
+      - name: Clear unnecessary files
+        if: ${{ needs.runners.outputs.provider == 'gha' && true || false }} # Only needed on GHA runners
+        uses: ./.github/actions/clear-files
+
       - name: Enable bpfcc script
         if: ${{ env.CONTAINER_NAME == 'ci_native_asan' }}
         # In the image build step, no external environment variables are available,


### PR DESCRIPTION
Fixes #33293

Clear out space on jobs running on GHA by deleteing unnecessary files.

Raised in #33293 which pointed to a solution like https://github.com/google/oss-fuzz/commit/b7f04d782277638a67bc44865de445977eed4708 which is adapted slightly here.

Only runs when cache provider (runner) is `gha`.

A run on my fork can be seen here: https://github.com/willcl-ark/bitcoin/actions/runs/19703413734/job/56444984809