### PR TITLE
doc: Correct typo 'implementes' to 'implements'

### DIFF
--- a/src/crc32c/.ycm_extra_conf.py
+++ b/src/crc32c/.ycm_extra_conf.py
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 """YouCompleteMe configuration that interprets a .clang_complete file.
 
-This module implementes the YouCompleteMe configuration API documented at:
+This module implements the YouCompleteMe configuration API documented at:
 https://github.com/ycm-core/ycmd#ycm_extra_confpy-specification
 
 The implementation loads and processes a .clang_complete file, documented at:


### PR DESCRIPTION
Fixes a typo in `src\crc32c\.ycm_extra_conf.py` where "implementes" was used instead of "implements". This change improves readability and ensures consistency in the documentation.

No functional changes or tests are required, as this is a trivial documentation fix.

