### PR TITLE
guix: build `bitcoin-qt` with static libxcb & utils

### DIFF
--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -107,7 +107,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libxcb-icccm.so.4',
 'libxcb-image.so.0',
 'libxcb-shm.so.0',
-'libxcb-keysyms.so.1',
 'libxcb-randr.so.0',
 'libxcb-render.so.0',
 'libxcb-shape.so.0',

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -101,7 +101,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libfontconfig.so.1', # font support
 'libfreetype.so.6', # font parsing
 'libdl.so.2', # programming interface to dynamic linker
-'libxcb-image.so.0',
 'libxcb-shm.so.0',
 'libxcb-randr.so.0',
 'libxcb-render.so.0',

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -104,7 +104,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libfontconfig.so.1', # font support
 'libfreetype.so.6', # font parsing
 'libdl.so.2', # programming interface to dynamic linker
-'libxcb-icccm.so.4',
 'libxcb-image.so.0',
 'libxcb-shm.so.0',
 'libxcb-randr.so.0',

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -34,8 +34,7 @@ MAX_VERSIONS = {
     lief.ELF.ARCH.AARCH64:(2,31),
     lief.ELF.ARCH.PPC64:  (2,31),
     lief.ELF.ARCH.RISCV:  (2,31),
-},
-'V':         (0,5,0),  # xkb (bitcoin-qt only)
+    }
 }
 
 # Ignore symbols that are exported as part of every executable
@@ -99,8 +98,6 @@ ELF_ALLOWED_LIBRARIES = {
 'ld-linux-riscv64-lp64d.so.1', # 64-bit RISC-V dynamic linker
 # bitcoin-qt only
 'libxcb.so.1', # part of X11
-'libxkbcommon.so.0', # keyboard keymapping
-'libxkbcommon-x11.so.0', # keyboard keymapping
 'libfontconfig.so.1', # font support
 'libfreetype.so.6', # font parsing
 'libdl.so.2', # programming interface to dynamic linker

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -109,7 +109,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libxcb-shm.so.0',
 'libxcb-keysyms.so.1',
 'libxcb-randr.so.0',
-'libxcb-render-util.so.0',
 'libxcb-render.so.0',
 'libxcb-shape.so.0',
 'libxcb-sync.so.1',

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -97,17 +97,9 @@ ELF_ALLOWED_LIBRARIES = {
 'ld64.so.2', # POWER64 ABIv2 dynamic linker
 'ld-linux-riscv64-lp64d.so.1', # 64-bit RISC-V dynamic linker
 # bitcoin-qt only
-'libxcb.so.1', # part of X11
 'libfontconfig.so.1', # font support
 'libfreetype.so.6', # font parsing
 'libdl.so.2', # programming interface to dynamic linker
-'libxcb-shm.so.0',
-'libxcb-randr.so.0',
-'libxcb-render.so.0',
-'libxcb-shape.so.0',
-'libxcb-sync.so.1',
-'libxcb-xfixes.so.0',
-'libxcb-xkb.so.1',
 }
 
 MACHO_ALLOWED_LIBRARIES = {

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -7,7 +7,7 @@ $(package)_dependencies=xcb_proto libXau
 $(package)_patches = remove_pthread_stubs.patch
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen --without-launchd
+$(package)_config_opts=--disable-shared --disable-devel-docs --without-doxygen --without-launchd
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 # Disable unneeded extensions.
 # More info is available from: https://doc.qt.io/qt-5.15/linux-requirements.html

--- a/depends/packages/libxcb_util_image.mk
+++ b/depends/packages/libxcb_util_image.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=cb2c86190cf6216260b7357a57d9100811bb6f78c24576a3a5bfef6ad
 $(package)_dependencies=libxcb libxcb_util
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
+$(package)_config_opts=--disable-shared --disable-devel-docs --without-doxygen
 $(package)_config_opts+= --disable-dependency-tracking --enable-option-checking
 endef
 
@@ -19,11 +19,11 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $(MAKE)
+  $(MAKE) -C image
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+  $(MAKE) DESTDIR=$($(package)_staging_dir) -C image install
 endef
 
 define $(package)_postprocess_cmds

--- a/depends/packages/libxcb_util_keysyms.mk
+++ b/depends/packages/libxcb_util_keysyms.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=0807cf078fbe38489a41d755095c58239e1b67299f14460dec2ec811e
 $(package)_dependencies=libxcb xproto
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
+$(package)_config_opts=--disable-shared --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/depends/packages/libxcb_util_render.mk
+++ b/depends/packages/libxcb_util_render.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=55eee797e3214fe39d0f3f4d9448cc53cffe06706d108824ea37bb79f
 $(package)_dependencies=libxcb
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
+$(package)_config_opts=--disable-shared --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/depends/packages/libxcb_util_wm.mk
+++ b/depends/packages/libxcb_util_wm.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=038b39c4bdc04a792d62d163ba7908f4bb3373057208c07110be73c1b
 $(package)_dependencies=libxcb
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
+$(package)_config_opts=--disable-shared --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/depends/packages/libxkbcommon.mk
+++ b/depends/packages/libxkbcommon.mk
@@ -11,7 +11,7 @@ $(package)_dependencies=libxcb
 # a different build system (Meson)
 define $(package)_set_vars
 $(package)_config_opts = --enable-option-checking --disable-dependency-tracking
-$(package)_config_opts += --disable-static --disable-docs
+$(package)_config_opts += --disable-shared --disable-docs
 $(package)_cflags += -Wno-error=array-bounds
 endef
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -18,6 +18,7 @@ $(package)_patches += qtbase_plugins_cocoa.patch
 $(package)_patches += qtbase_skip_tools.patch
 $(package)_patches += rcc_hardcode_timestamp.patch
 $(package)_patches += qttools_skip_dependencies.patch
+$(package)_patches += static_fixes.patch
 
 $(package)_qttranslations_file_name=$(qt_details_qttranslations_file_name)
 $(package)_qttranslations_sha256_hash=$(qt_details_qttranslations_sha256_hash)
@@ -259,6 +260,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/qtbase_avoid_qmain.patch && \
   patch -p1 -i $($(package)_patch_dir)/qtbase_platformsupport.patch && \
   patch -p1 -i $($(package)_patch_dir)/qtbase_plugins_cocoa.patch && \
+  patch -p1 -i $($(package)_patch_dir)/static_fixes.patch && \
   patch -p1 -i $($(package)_patch_dir)/qtbase_skip_tools.patch && \
   patch -p1 -i $($(package)_patch_dir)/rcc_hardcode_timestamp.patch
 endef

--- a/depends/patches/qt/qttools_skip_dependencies.patch
+++ b/depends/patches/qt/qttools_skip_dependencies.patch
@@ -34,3 +34,12 @@ QtTools: Skip unnecessary dependencies:
  
  # Create a fake module that would emulate the Qt5::LinguistTools CMake Config package
  qt_internal_add_module(Linguist
+--- a/qttools/src/qdbus/CMakeLists.txt
++++ b/qttools/src/qdbus/CMakeLists.txt
+@@ -7,6 +7,3 @@ endif()
+ if(QT_FEATURE_dom)
+     add_subdirectory(qdbus)
+ endif()
+-if(QT_FEATURE_dialogbuttonbox AND QT_FEATURE_inputdialog AND QT_FEATURE_menu AND QT_FEATURE_messagebox AND TARGET Qt::Widgets)
+-    add_subdirectory(qdbusviewer)
+-endif()

--- a/depends/patches/qt/static_fixes.patch
+++ b/depends/patches/qt/static_fixes.patch
@@ -1,0 +1,80 @@
+commit 203148b1ed6d8f4bad8030ef64f0bc4083309010
+Author: fanquake <fanquake@gmail.com>
+Date:   Sat Oct 4 01:00:25 2025 +0100
+
+    static fixes
+
+    See: https://bugreports.qt.io/browse/QTBUG-86287
+    See: https://bugreports.qt.io/browse/QTBUG-137004
+
+diff --git a/cmake/3rdparty/extra-cmake-modules/find-modules/FindXCB.cmake b/cmake/3rdparty/extra-cmake-modules/find-modules/FindXCB.cmake
+index 26b9bf89633..0c546d09a8b 100644
+--- a/qtbase/cmake/3rdparty/extra-cmake-modules/find-modules/FindXCB.cmake
++++ b/qtbase/cmake/3rdparty/extra-cmake-modules/find-modules/FindXCB.cmake
+@@ -145,7 +145,7 @@ endforeach()
+ set(XCB_XCB_component_deps)
+ set(XCB_COMPOSITE_component_deps XCB XFIXES)
+ set(XCB_DAMAGE_component_deps XCB XFIXES)
+-set(XCB_IMAGE_component_deps XCB SHM)
++set(XCB_IMAGE_component_deps XCB SHM AUX)
+ set(XCB_RENDERUTIL_component_deps XCB RENDER)
+ set(XCB_XFIXES_component_deps XCB RENDER SHAPE)
+ set(XCB_XVMC_component_deps XCB XV)
+diff --git a/src/gui/configure.cmake b/src/gui/configure.cmake
+index 99c517e3581..a2e644f77d9 100644
+--- a/qtbase/src/gui/configure.cmake
++++ b/qtbase/src/gui/configure.cmake
+@@ -80,10 +80,14 @@ if((X11_SUPPORTED) OR QT_FIND_ALL_PACKAGES_ALWAYS)
+     qt_find_package(XCB 0.3.9 COMPONENTS ICCCM PROVIDED_TARGETS XCB::ICCCM MODULE_NAME gui QMAKE_LIB xcb_icccm)
+ endif()
+ qt_add_qmake_lib_dependency(xcb_icccm xcb)
++if((X11_SUPPORTED) OR QT_FIND_ALL_PACKAGES_ALWAYS)
++    qt_find_package(XCB 0.3.8 COMPONENTS UTIL PROVIDED_TARGETS XCB::UTIL MODULE_NAME gui QMAKE_LIB xcb_util)
++endif()
++qt_add_qmake_lib_dependency(xcb_util xcb)
+ if((X11_SUPPORTED) OR QT_FIND_ALL_PACKAGES_ALWAYS)
+     qt_find_package(XCB 0.3.9 COMPONENTS IMAGE PROVIDED_TARGETS XCB::IMAGE MODULE_NAME gui QMAKE_LIB xcb_image)
+ endif()
+-qt_add_qmake_lib_dependency(xcb_image xcb_shm xcb)
++qt_add_qmake_lib_dependency(xcb_image xcb_shm xcb_util xcb)
+ if((X11_SUPPORTED) OR QT_FIND_ALL_PACKAGES_ALWAYS)
+     qt_find_package(XCB 0.3.9 COMPONENTS KEYSYMS PROVIDED_TARGETS XCB::KEYSYMS MODULE_NAME gui QMAKE_LIB xcb_keysyms)
+ endif()
+@@ -488,6 +492,7 @@ qt_config_compile_test(xcb_syslibs
+     LIBRARIES
+         XCB::CURSOR
+         XCB::ICCCM
++        XCB::UTIL
+         XCB::IMAGE
+         XCB::KEYSYMS
+         XCB::RANDR
+@@ -503,6 +508,7 @@ qt_config_compile_test(xcb_syslibs
+ "// xkb.h is using a variable called 'explicit', which is a reserved keyword in C++
+ #define explicit dont_use_cxx_explicit
+ #include <xcb/xcb.h>
++#include <xcb/xcb_util.h>
+ #include <xcb/xcb_image.h>
+ #include <xcb/xcb_keysyms.h>
+ #include <xcb/xcb_cursor.h>
+diff --git a/src/plugins/platforms/xcb/CMakeLists.txt b/src/plugins/platforms/xcb/CMakeLists.txt
+index e8fb442dd43..e964138115c 100644
+--- a/qtbase/src/plugins/platforms/xcb/CMakeLists.txt
++++ b/qtbase/src/plugins/platforms/xcb/CMakeLists.txt
+@@ -52,6 +52,7 @@ qt_internal_add_module(XcbQpaPrivate
+         Qt::GuiPrivate
+         XCB::CURSOR
+         XCB::ICCCM
++        XCB::UTIL
+         XCB::IMAGE
+         XCB::KEYSYMS
+         XCB::RANDR
+--- a/qtbase/src/gui/configure.cmake
++++ b/qtbase/src/gui/configure.cmake
+@@ -504,6 +504,7 @@ qt_config_compile_test(xcb_syslibs
+         XCB::XFIXES
+         XCB::XKB
+         XCB::XCB
++        X11::Xau
+     CODE
+ "// xkb.h is using a variable called 'explicit', which is a reserved keyword in C++
+ #define explicit dont_use_cxx_explicit


### PR DESCRIPTION
Related to https://github.com/bitcoin/bitcoin/pull/33434.
Tested on:
* Fedora 42: https://github.com/bitcoin/bitcoin/pull/33537#pullrequestreview-3455373185.
* Ubuntu 24.04: https://github.com/bitcoin/bitcoin/pull/33537#issuecomment-3533276038.
* Debian 13.x: https://github.com/bitcoin/bitcoin/pull/33537#issuecomment-3540923567.