### PR TITLE
argsman, cli: GNU-style command-line option parsing (allows options after non-option arguments)

### DIFF
--- a/doc/release-notes-33540.md
+++ b/doc/release-notes-33540.md
@@ -1,0 +1,8 @@
+### Tools and Utilities
+
+Command-line tools
+------------------
+
+- Command-line options may now be specified after non-option arguments. For example, `bitcoin-cli getblockchaininfo -rpcwait` now behaves the same as `bitcoin-cli -rpcwait getblockchaininfo`, matching common GNU-style option parsing behavior.
+
+- Options beginning with a double dash (`--`) that appear after the RPC method name are interpreted as RPC named parameters. Other option prefixes, such as single dashes (`-`) and Windows-style forward slashes (`/`), continue to be interpreted as command-line options.

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -166,6 +166,7 @@ static int AppInitRPC(int argc, char* argv[])
                 "\nIt can be used to query network information, manage wallets, create or broadcast transactions, and control the " CLIENT_NAME " server.\n"
                 "\nUse the \"help\" command to list all commands. Use \"help <command>\" to show help for that command.\n"
                 "The -named option allows you to specify parameters using the key=value format, eliminating the need to pass unused positional parameters.\n"
+                "[options] can be specified before or after the commands.\n"
                 "\n"
                 "Usage: bitcoin-cli [options] <command> [params]\n"
                 "or:    bitcoin-cli [options] -named <command> [name=value]...\n"
@@ -1055,7 +1056,7 @@ static void ParseError(const UniValue& error, std::string& strPrint, int& nRet)
             strPrint += ("error message:\n" + err_msg.get_str());
         }
         if (err_code.isNum() && err_code.getInt<int>() == RPC_WALLET_NOT_SPECIFIED) {
-            strPrint += " Or for the CLI, specify the \"-rpcwallet=<walletname>\" option before the command";
+            strPrint += " Or for the CLI, specify the \"-rpcwallet=<walletname>\" option before or after the command";
             strPrint += " (run \"bitcoin-cli -h\" for help or \"bitcoin-cli listwallets\" to see which wallets are currently loaded).";
         }
     } else {

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -1262,16 +1262,21 @@ static void SetGenerateToAddressArgs(const std::string& address, std::vector<std
     args.emplace(args.begin() + 1, address);
 }
 
-static int CommandLineRPC(int argc, char *argv[])
+std::vector<std::string> GetCommandArgs() {
+    std::optional<const ArgsManager::Command> command = gArgs.GetCommand();
+
+    // Return command args if command is present, otherwise return an empty vector
+    if (command.has_value()) {
+        return command->args;
+    }
+    return {};
+}
+
+static int CommandLineRPC()
 {
     std::string strPrint;
     int nRet = 0;
     try {
-        // Skip switches
-        while (argc > 1 && IsSwitchChar(argv[1][0])) {
-            argc--;
-            argv++;
-        }
         std::string rpcPass;
         if (gArgs.GetBoolArg("-stdinrpcpass", false)) {
             NO_STDIN_ECHO();
@@ -1287,7 +1292,7 @@ static int CommandLineRPC(int argc, char *argv[])
             }
             gArgs.ForceSetArg("-rpcpassword", rpcPass);
         }
-        std::vector<std::string> args = std::vector<std::string>(&argv[1], &argv[argc]);
+        std::vector<std::string> args = GetCommandArgs();
         if (gArgs.GetBoolArg("-stdinwalletpassphrase", false)) {
             NO_STDIN_ECHO();
             std::string walletPass;
@@ -1405,7 +1410,7 @@ MAIN_FUNCTION
 
     int ret = EXIT_FAILURE;
     try {
-        ret = CommandLineRPC(argc, argv);
+        ret = CommandLineRPC();
     }
     catch (const std::exception& e) {
         PrintExceptionContinue(&e, "CommandLineRPC()");

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -797,35 +797,41 @@ static int CommandLineRawTx(int argc, char* argv[])
     std::string strPrint;
     int nRet = 0;
     try {
-        // Skip switches; Permit common stdin convention "-"
-        while (argc > 1 && IsSwitchChar(argv[1][0]) &&
-               (argv[1][1] != 0)) {
-            argc--;
-            argv++;
+        std::vector<std::string> args;
+        if (const auto command{gArgs.GetCommand()}) {
+            args = command->args;
+        } else {
+            // Skip switches; Permit common stdin convention "-"
+            while (argc > 1 && IsSwitchChar(argv[1][0]) &&
+                   (argv[1][1] != 0)) {
+                argc--;
+                argv++;
+            }
+            args.assign(argv + 1, argv + argc);
         }
 
         CMutableTransaction tx;
-        int startArg;
+        size_t startArg;
 
         if (!fCreateBlank) {
             // require at least one param
-            if (argc < 2)
+            if (args.empty())
                 throw std::runtime_error("too few parameters");
 
             // param: hex-encoded bitcoin transaction
-            std::string strHexTx(argv[1]);
+            std::string strHexTx(args[0]);
             if (strHexTx == "-")                 // "-" implies standard input
                 strHexTx = readStdin();
 
             if (!DecodeHexTx(tx, strHexTx, true))
                 throw std::runtime_error("invalid transaction encoding");
 
-            startArg = 2;
-        } else
             startArg = 1;
+        } else
+            startArg = 0;
 
-        for (int i = startArg; i < argc; i++) {
-            std::string arg = argv[i];
+        for (size_t i{startArg}; i < args.size(); ++i) {
+            const std::string& arg{args[i]};
             std::string key, value;
             size_t eqpos = arg.find('=');
             if (eqpos == std::string::npos)

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -274,82 +274,144 @@ bool ArgsManager::ProcessOptionKey(std::string& key,
     return HandleKnownOption(keyinfo, val, *flags, error);
 }
 
-bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::string& error)
+bool ArgsManager::ShouldSkipApplePlatformArg(const std::string& key)
 {
-    LOCK(cs_args);
-    m_settings.command_line_options.clear();
-
-    for (int i = 1; i < argc; i++) {
-        std::string key(argv[i]);
-
 #ifdef __APPLE__
-        // At the first time when a user gets the "App downloaded from the
-        // internet" warning, and clicks the Open button, macOS passes
-        // a unique process serial number (PSN) as -psn_... command-line
-        // argument, which we filter out.
-        if (key.starts_with("-psn_")) continue;
+    // At the first time when a user gets the "App downloaded from the
+    // internet" warning, and clicks the Open button, macOS passes
+    // a unique process serial number (PSN) as -psn_... command-line
+    // argument, which we filter out.
+    if (key.starts_with("-psn_")) return true;
 #endif
+    return false;
+}
 
-        if (key == "-") break; //bitcoin-tx using stdin
-        std::optional<std::string> val;
-        size_t is_index = key.find('=');
-        if (is_index != std::string::npos) {
-            val = key.substr(is_index + 1);
-            key.erase(is_index);
-        }
-#ifdef WIN32
-        key = ToLower(key);
-        if (key[0] == '/')
-            key[0] = '-';
-#endif
+void ArgsManager::SplitKeyValue(std::string& key, std::optional<std::string>& val)
+{
+    size_t eq = key.find('=');
+    if (eq == std::string::npos) return;
 
-        if (key[0] != '-') {
-            if (!m_accept_any_command && m_command.empty()) {
-                // The first non-dash arg is a registered command
-                std::optional<unsigned int> flags = GetArgFlags_(key);
-                if (!flags || !(*flags & ArgsManager::COMMAND)) {
-                    error = strprintf("Invalid command '%s'", argv[i]);
-                    return false;
-                }
-            }
-            m_command.push_back(key);
-            while (++i < argc) {
-                // The remaining args are command args
-                if (argv[i][0] == '-') {
-                    // except it starts with dash "-" then will check if it's a valid option
-                    // if not it will be passed to the command
-                    key = argv[i];
-                    val.reset();
-                    is_index = key.find('=');
-                    if (is_index != std::string::npos) {
-                        val = key.substr(is_index + 1);
-                        key.erase(is_index);
-                    }
-                    if (!ProcessOptionKey(key, val, error, true)) {
-                        return false;
-                    }
-                } else {
-                    m_command.emplace_back(argv[i]);
-                }
-            }
-            break;
-        }
+    val = key.substr(eq + 1);
+    key.erase(eq);
+}
 
-        if (!ProcessOptionKey(key, val, error)) {
+bool ArgsManager::HandleGlobalOption(std::string& key,
+                                     std::optional<std::string>& val,
+                                     std::string& error)
+{
+    AssertLockHeld(cs_args);
+    return ProcessOptionKey(key, val, error, /*found_after_non_option=*/false);
+}
+
+// ---------------- command handling ------------------
+
+bool ArgsManager::HandleCommandOption(const char* const arg, std::string& error)
+{
+    AssertLockHeld(cs_args);
+    std::string key(arg);
+    std::optional<std::string> val;
+
+    SplitKeyValue(key, val);
+
+    return ProcessOptionKey(key, val, error, /*found_after_non_option=*/true);
+}
+
+bool ArgsManager::HandleCommand(const char* const argv[], int& i, int argc, std::string& error)
+{
+    AssertLockHeld(cs_args);
+    // argv[i] is the command
+    std::string command(argv[i]);
+
+    // Validate command unless "accept-any" is enabled
+    if (!m_accept_any_command && m_command.empty()) {
+        auto flags = GetArgFlags_(command);
+        if (!flags || !(*flags & ArgsManager::COMMAND)) {
+            error = strprintf("Invalid command '%s'", argv[i]);
             return false;
         }
     }
 
-    // we do not allow -includeconf from command line, only -noincludeconf
-    if (auto* includes = common::FindKey(m_settings.command_line_options, "includeconf")) {
-        const common::SettingsSpan values{*includes};
-        // Range may be empty if -noincludeconf was passed
-        if (!values.empty()) {
-            error = "-includeconf cannot be used from commandline; -includeconf=" + values.begin()->write();
-            return false; // pick first value as example
+    m_command.push_back(command);
+
+    // Now consume all remaining items as command arguments or command options
+    while (++i < argc) {
+        const char* arg = argv[i];
+
+        if (arg[0] == '-') {
+            // dash → might be a command option
+            if (!HandleCommandOption(arg, error)) {
+                return false;
+            }
+        } else {
+            // positional arg to the command
+            m_command.emplace_back(arg);
         }
     }
+
     return true;
+}
+
+// ---------------- includeconf validation ------------------
+
+bool ArgsManager::HandleIncludeConfError(std::string& error)
+{
+    AssertLockHeld(cs_args);
+    // we do not allow -includeconf from command line, only -noincludeconf
+    auto* includes = common::FindKey(m_settings.command_line_options, "includeconf");
+    if (!includes) return true;
+
+    // Range may be empty if -noincludeconf was passed
+    const common::SettingsSpan values{*includes};
+    if (values.empty()) return true;
+
+    error = "-includeconf cannot be used from commandline; -includeconf=" + values.begin()->write();
+    return false;
+}
+
+// ---------------- main ParseParameters ------------------
+
+bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::string& error)
+{
+    LOCK(cs_args);
+    m_settings.command_line_options.clear();
+    m_command.clear();
+
+    for (int i = 1; i < argc; i++) {
+        std::string key(argv[i]);
+
+        if (ShouldSkipApplePlatformArg(key)) continue;
+
+        if (key == "-") break; // bitcoin-tx stdin special case
+
+        std::optional<std::string> val;
+        SplitKeyValue(key, val);
+
+#ifdef WIN32
+        key = ToLower(key);
+        if (!key.empty() && key[0] == '/')
+            key[0] = '-';
+#endif
+
+        if (key.empty()) continue;
+
+        // -----------------------------------------
+        // Case 1: Found a command (first non-dash)
+        // -----------------------------------------
+        if (key[0] != '-') {
+            return HandleCommand(argv, i, argc, error)
+                       ? HandleIncludeConfError(error)
+                       : false;
+        }
+
+        // -----------------------------------------
+        // Case 2: Global option
+        // -----------------------------------------
+        if (!HandleGlobalOption(key, val, error)) {
+            return false;
+        }
+    }
+
+    return HandleIncludeConfError(error);
 }
 
 std::optional<unsigned int> ArgsManager::GetArgFlags_(const std::string& name) const

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -174,8 +174,9 @@ void ArgsManager::SelectConfigNetwork(const std::string& network)
     m_network = network;
 }
 
-bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error) {
+bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error, const bool found_after_non_option) {
 
+    AssertLockHeld(cs_args);
     std::string original_input = key; // Capture the original key
     if (val) original_input += "=" + *val; // Append =value if it exists
 
@@ -191,7 +192,15 @@ bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>&
     // Unknown command line options and command line options with dot characters
     // (which are returned from InterpretKey with nonempty section strings)are not valid.
     if (!flags || !keyinfo.section.empty()) {
-        error = strprintf("Invalid parameter %s", original_input);
+        if (!found_after_non_option) {
+            error = strprintf("Invalid parameter %s", original_input);
+        } else {
+            // if the option is invalid but comes after a non-option (found_after_non_option)
+            // leave it up to the command if it accepts args that begin with "-"
+            m_command.emplace_back(original_input);
+            // returns true to continue processing the args of the command
+            return true;
+        }        
         return false;
     }
 
@@ -199,7 +208,6 @@ bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>&
     if (!value) return false;
 
     // Store the option
-    AssertLockHeld(cs_args);
     m_settings.command_line_options[keyinfo.name].push_back(*value);
 
     return true;
@@ -246,7 +254,22 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
             m_command.push_back(key);
             while (++i < argc) {
                 // The remaining args are command args
-                m_command.emplace_back(argv[i]);
+                if (argv[i][0] == '-') {
+                    // except it starts with dash "-" then will check if it's a valid option
+                    // if not it will be passed to the command
+                    key = argv[i];
+                    val.reset();
+                    is_index = key.find('=');
+                    if (is_index != std::string::npos) {
+                        val = key.substr(is_index + 1);
+                        key.erase(is_index);
+                    }
+                    if (!ProcessOptionKey(key, val, error, true)) {
+                        return false;
+                    }
+                } else {
+                    m_command.emplace_back(argv[i]);
+                }
             }
             break;
         }

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -177,12 +177,16 @@ void ArgsManager::SelectConfigNetwork(const std::string& network)
 bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error, const bool found_after_non_option) {
 
     AssertLockHeld(cs_args);
+    bool double_dash{false};
+    std::optional<std::string> original_val = val; // Capture the original val
     std::string original_input = key; // Capture the original key
     if (val) original_input += "=" + *val; // Append =value if it exists
 
     // Transform --foo to -foo
-    if (key.length() > 1 && key[1] == '-')
+    if (key.length() > 1 && key[1] == '-') {
         key.erase(0, 1);
+        double_dash = true;
+    }
 
     // Transform -foo to foo
     key.erase(0, 1);
@@ -192,16 +196,40 @@ bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>&
     // Unknown command line options and command line options with dot characters
     // (which are returned from InterpretKey with nonempty section strings)are not valid.
     if (!flags || !keyinfo.section.empty()) {
-        if (!found_after_non_option) {
-            error = strprintf("Invalid parameter %s", original_input);
-        } else {
-            // if the option is invalid but comes after a non-option (found_after_non_option)
-            // leave it up to the command if it accepts args that begin with "-"
-            m_command.emplace_back(original_input);
-            // returns true to continue processing the args of the command
+        // if it's a double dash --, means could be an RPC named param so remove them
+        if (!double_dash) {
+            if (!found_after_non_option) {
+                error = strprintf("Invalid parameter %s", original_input);
+            } else {
+                // if the option is invalid but comes after a non-option (found_after_non_option)
+                // leave it up to the command if it accepts args that begin with "-"
+                m_command.emplace_back(original_input);
+                // returns true to continue processing the args of the command
+                return true;
+            }
+            return false;
+        }
+    }
+
+    if (double_dash) {
+        // add "-named" option if the call have a double dash param intended for RPC
+        // only if CLI/ bitcoin-cli has the -named arg set (argsman.AddArg("-named", ...)
+        val.reset();
+        keyinfo = InterpretKey("named");
+        flags = GetArgFlags_('-' + keyinfo.name);
+        if (!flags || !keyinfo.section.empty()) {
+            // no "-named" needed, no bitcoin-cli
+            keyinfo = InterpretKey(key);
+            flags = GetArgFlags_('-' + keyinfo.name);
+
+            std::optional<common::SettingsValue> value = InterpretValue(keyinfo, original_val ? &*original_val : nullptr, *flags, error);
+            if (!value) return false;
+
+            m_settings.command_line_options[keyinfo.name].push_back(*value);
+            // when -named arg doesn't exist, e.g. not using bitcoin-cli
+            // just ignore it (returns true)
             return true;
-        }        
-        return false;
+        }
     }
 
     std::optional<common::SettingsValue> value = InterpretValue(keyinfo, val ? &*val : nullptr, *flags, error);
@@ -209,6 +237,10 @@ bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>&
 
     // Store the option
     m_settings.command_line_options[keyinfo.name].push_back(*value);
+
+    if (double_dash && keyinfo.name =="named") {
+        m_command.emplace_back(original_input.substr(2));
+    }
 
     return true;
 }

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -174,72 +174,104 @@ void ArgsManager::SelectConfigNetwork(const std::string& network)
     m_network = network;
 }
 
-bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error, const bool found_after_non_option)
+void ArgsManager::NormalizeKey(std::string& key, bool& double_dash)
+{
+    if (key.length() > 1 && key[1] == '-') {
+        key.erase(0, 1); // --foo -> -foo
+        double_dash = true;
+    }
+    key.erase(0, 1); // -foo -> foo
+}
+
+bool ArgsManager::TryHandleNamedRPC(const std::string& key,
+                                    const std::string& original_input,
+                                    std::string& error,
+                                    bool double_dash,
+                                    bool found_after_non_option)
+{
+    AssertLockHeld(cs_args);
+    if (!double_dash || !found_after_non_option) return false;
+
+    KeyInfo keyinfo = InterpretKey(key);
+    const auto flags = GetArgFlags_('-' + keyinfo.name);
+    const bool known = flags.has_value() && keyinfo.section.empty();
+
+    if (known) return false; // normal known option → don't apply special RPC logic
+
+    // Try -named
+    KeyInfo named_info = InterpretKey("named");
+    auto named_flags = GetArgFlags_('-' + named_info.name);
+
+    if (!named_flags || !named_info.section.empty()) {
+        return false; // binary does NOT support -named
+    }
+
+    // binary supports -named
+    auto named_value = InterpretValue(named_info, nullptr, *named_flags, error);
+    if (!named_value) return true; // error already set ----
+
+    m_settings.command_line_options[named_info.name].push_back(*named_value);
+    m_command.emplace_back(original_input.substr(2)); // strip '--'
+
+    return true; // handled
+}
+
+bool ArgsManager::HandleKnownOption(const KeyInfo& keyinfo,
+                                    const std::optional<std::string>& val,
+                                    const unsigned int flags,
+                                    std::string& error)
+{
+    AssertLockHeld(cs_args);
+    auto value = InterpretValue(keyinfo, val ? &*val : nullptr, flags, error);
+    if (!value) return false;
+
+    m_settings.command_line_options[keyinfo.name].push_back(*value);
+    return true;
+}
+
+bool ArgsManager::HandleUnknownOption(const std::string& original_input,
+                                      std::string& error,
+                                      bool found_after_non_option)
+{
+    AssertLockHeld(cs_args);
+    if (!found_after_non_option) {
+        error = strprintf("Invalid parameter %s", original_input);
+        return false;
+    }
+
+    // Unknown option after command: pass through to the command as an arg
+    m_command.emplace_back(original_input);
+    return true;
+}
+
+bool ArgsManager::ProcessOptionKey(std::string& key,
+                                   std::optional<std::string>& val,
+                                   std::string& error,
+                                   const bool found_after_non_option)
 {
     AssertLockHeld(cs_args);
     bool double_dash{false};
     std::string original_input{key};
     if (val) original_input += "=" + *val;
 
-    // Normalize leading dashes
-    if (key.length() > 1 && key[1] == '-') {
-        key.erase(0, 1);   // `--foo` -> `-foo`
-        double_dash = true;
+    NormalizeKey(key, double_dash);
+
+    // ---- 1. special named-RPC handling ----
+    if (TryHandleNamedRPC(key, original_input, error, double_dash, found_after_non_option)) {
+        return error.empty();
     }
-    key.erase(0, 1);       // `-foo`  -> `foo`
 
     KeyInfo keyinfo = InterpretKey(key);
-    std::optional<unsigned int> flags = GetArgFlags_('-' + keyinfo.name);
+    auto flags = GetArgFlags_('-' + keyinfo.name);
     const bool known_option = flags.has_value() && keyinfo.section.empty();
 
-    // Handle the special "named RPC" case early ---
-    if (double_dash && found_after_non_option && !known_option) {
-        // Try to map this to `-named`, if supported by the binary.
-        val.reset();
-        KeyInfo named_keyinfo = InterpretKey("named");
-        std::optional<unsigned int> named_flags = GetArgFlags_('-' + named_keyinfo.name);
-
-        if (named_flags && named_keyinfo.section.empty()) {
-            // Binary supports -named: enable it and append the stripped parameter.
-            std::optional<common::SettingsValue> named_value =
-                InterpretValue(named_keyinfo, /* val */ nullptr, *named_flags, error);
-            if (!named_value) return false;
-
-            {
-                m_settings.command_line_options[named_keyinfo.name].push_back(*named_value);
-                // Strip the leading "--" before passing to the command as a named param
-                m_command.emplace_back(original_input.substr(2));
-            }
-            return true;
-        }
-
-        // Binary doesn’t support -named: fall back and treat `--foo` as a
-        // normal option (or unknown option handled below).
-        keyinfo = InterpretKey(key);
-        flags = GetArgFlags_('-' + keyinfo.name);
+    // ---- 2. unknown option ----
+    if (!known_option) {
+        return HandleUnknownOption(original_input, error, found_after_non_option);
     }
 
-    // --- Normal option handling ---
-    if (!flags || !keyinfo.section.empty()) {
-        if (!found_after_non_option) {
-            // Unknown global option: keep legacy behaviour (error)
-            error = strprintf("Invalid parameter %s", original_input);
-            return false;
-        }
-
-        // Unknown option after command: pass through to the command as an arg
-        m_command.emplace_back(original_input);
-        return true;
-    }
-
-    // Known option (including `--datadir`, `--signet`, etc.)
-    std::optional<common::SettingsValue> value =
-        InterpretValue(keyinfo, val ? &*val : nullptr, *flags, error);
-    if (!value) return false;
-
-    // Store the option
-    m_settings.command_line_options[keyinfo.name].push_back(*value);
-    return true;
+    // ---- 3. known option ----
+    return HandleKnownOption(keyinfo, val, *flags, error);
 }
 
 bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::string& error)

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -174,74 +174,71 @@ void ArgsManager::SelectConfigNetwork(const std::string& network)
     m_network = network;
 }
 
-bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error, const bool found_after_non_option) {
-
+bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error, const bool found_after_non_option)
+{
     AssertLockHeld(cs_args);
     bool double_dash{false};
-    std::optional<std::string> original_val = val; // Capture the original val
-    std::string original_input = key; // Capture the original key
-    if (val) original_input += "=" + *val; // Append =value if it exists
+    std::string original_input{key};
+    if (val) original_input += "=" + *val;
 
-    // Transform --foo to -foo
+    // Normalize leading dashes
     if (key.length() > 1 && key[1] == '-') {
-        key.erase(0, 1);
+        key.erase(0, 1);   // `--foo` -> `-foo`
         double_dash = true;
     }
-
-    // Transform -foo to foo
-    key.erase(0, 1);
+    key.erase(0, 1);       // `-foo`  -> `foo`
 
     KeyInfo keyinfo = InterpretKey(key);
     std::optional<unsigned int> flags = GetArgFlags_('-' + keyinfo.name);
-    // Unknown command line options and command line options with dot characters
-    // (which are returned from InterpretKey with nonempty section strings)are not valid.
-    if (!flags || !keyinfo.section.empty()) {
-        // if it's a double dash --, means could be an RPC named param so remove them
-        if (!double_dash) {
-            if (!found_after_non_option) {
-                error = strprintf("Invalid parameter %s", original_input);
-            } else {
-                // if the option is invalid but comes after a non-option (found_after_non_option)
-                // leave it up to the command if it accepts args that begin with "-"
-                m_command.emplace_back(original_input);
-                // returns true to continue processing the args of the command
-                return true;
-            }
-            return false;
-        }
-    }
+    const bool known_option = flags.has_value() && keyinfo.section.empty();
 
-    if (double_dash) {
-        // add "-named" option if the call have a double dash param intended for RPC
-        // only if CLI/ bitcoin-cli has the -named arg set (argsman.AddArg("-named", ...)
+    // Handle the special "named RPC" case early ---
+    if (double_dash && found_after_non_option && !known_option) {
+        // Try to map this to `-named`, if supported by the binary.
         val.reset();
-        keyinfo = InterpretKey("named");
-        flags = GetArgFlags_('-' + keyinfo.name);
-        if (!flags || !keyinfo.section.empty()) {
-            // no "-named" needed, no bitcoin-cli
-            keyinfo = InterpretKey(key);
-            flags = GetArgFlags_('-' + keyinfo.name);
+        KeyInfo named_keyinfo = InterpretKey("named");
+        std::optional<unsigned int> named_flags = GetArgFlags_('-' + named_keyinfo.name);
 
-            std::optional<common::SettingsValue> value = InterpretValue(keyinfo, original_val ? &*original_val : nullptr, *flags, error);
-            if (!value) return false;
+        if (named_flags && named_keyinfo.section.empty()) {
+            // Binary supports -named: enable it and append the stripped parameter.
+            std::optional<common::SettingsValue> named_value =
+                InterpretValue(named_keyinfo, /* val */ nullptr, *named_flags, error);
+            if (!named_value) return false;
 
-            m_settings.command_line_options[keyinfo.name].push_back(*value);
-            // when -named arg doesn't exist, e.g. not using bitcoin-cli
-            // just ignore it (returns true)
+            {
+                m_settings.command_line_options[named_keyinfo.name].push_back(*named_value);
+                // Strip the leading "--" before passing to the command as a named param
+                m_command.emplace_back(original_input.substr(2));
+            }
             return true;
         }
+
+        // Binary doesn’t support -named: fall back and treat `--foo` as a
+        // normal option (or unknown option handled below).
+        keyinfo = InterpretKey(key);
+        flags = GetArgFlags_('-' + keyinfo.name);
     }
 
-    std::optional<common::SettingsValue> value = InterpretValue(keyinfo, val ? &*val : nullptr, *flags, error);
+    // --- Normal option handling ---
+    if (!flags || !keyinfo.section.empty()) {
+        if (!found_after_non_option) {
+            // Unknown global option: keep legacy behaviour (error)
+            error = strprintf("Invalid parameter %s", original_input);
+            return false;
+        }
+
+        // Unknown option after command: pass through to the command as an arg
+        m_command.emplace_back(original_input);
+        return true;
+    }
+
+    // Known option (including `--datadir`, `--signet`, etc.)
+    std::optional<common::SettingsValue> value =
+        InterpretValue(keyinfo, val ? &*val : nullptr, *flags, error);
     if (!value) return false;
 
     // Store the option
     m_settings.command_line_options[keyinfo.name].push_back(*value);
-
-    if (double_dash && keyinfo.name =="named") {
-        m_command.emplace_back(original_input.substr(2));
-    }
-
     return true;
 }
 

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -254,6 +254,11 @@ bool ArgsManager::ProcessOptionKey(std::string& key,
     std::string original_input{key};
     if (val) original_input += "=" + *val;
 
+#ifdef WIN32
+    key = ToLower(key);
+    if (!key.empty() && key[0] == '/') key[0] = '-';
+#endif
+
     NormalizeKey(key, double_dash);
 
     // ---- 1. special named-RPC handling ----
@@ -337,8 +342,8 @@ bool ArgsManager::HandleCommand(const char* const argv[], int& i, int argc, std:
     while (++i < argc) {
         const char* arg = argv[i];
 
-        if (arg[0] == '-') {
-            // dash → might be a command option
+        if (IsSwitchChar(arg[0])) {
+            // switch char → might be a command option
             if (!HandleCommandOption(arg, error)) {
                 return false;
             }

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -174,6 +174,37 @@ void ArgsManager::SelectConfigNetwork(const std::string& network)
     m_network = network;
 }
 
+bool ArgsManager::ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error) {
+
+    std::string original_input = key; // Capture the original key
+    if (val) original_input += "=" + *val; // Append =value if it exists
+
+    // Transform --foo to -foo
+    if (key.length() > 1 && key[1] == '-')
+        key.erase(0, 1);
+
+    // Transform -foo to foo
+    key.erase(0, 1);
+
+    KeyInfo keyinfo = InterpretKey(key);
+    std::optional<unsigned int> flags = GetArgFlags_('-' + keyinfo.name);
+    // Unknown command line options and command line options with dot characters
+    // (which are returned from InterpretKey with nonempty section strings)are not valid.
+    if (!flags || !keyinfo.section.empty()) {
+        error = strprintf("Invalid parameter %s", original_input);
+        return false;
+    }
+
+    std::optional<common::SettingsValue> value = InterpretValue(keyinfo, val ? &*val : nullptr, *flags, error);
+    if (!value) return false;
+
+    // Store the option
+    AssertLockHeld(cs_args);
+    m_settings.command_line_options[keyinfo.name].push_back(*value);
+
+    return true;
+}
+
 bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::string& error)
 {
     LOCK(cs_args);
@@ -220,27 +251,9 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
             break;
         }
 
-        // Transform --foo to -foo
-        if (key.length() > 1 && key[1] == '-')
-            key.erase(0, 1);
-
-        // Transform -foo to foo
-        key.erase(0, 1);
-        KeyInfo keyinfo = InterpretKey(key);
-        std::optional<unsigned int> flags = GetArgFlags_('-' + keyinfo.name);
-
-        // Unknown command line options and command line options with dot
-        // characters (which are returned from InterpretKey with nonempty
-        // section strings) are not valid.
-        if (!flags || !keyinfo.section.empty()) {
-            error = strprintf("Invalid parameter %s", argv[i]);
+        if (!ProcessOptionKey(key, val, error)) {
             return false;
         }
-
-        std::optional<common::SettingsValue> value = InterpretValue(keyinfo, val ? &*val : nullptr, *flags, error);
-        if (!value) return false;
-
-        m_settings.command_line_options[keyinfo.name].push_back(*value);
     }
 
     // we do not allow -includeconf from command line, only -noincludeconf

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -502,6 +502,23 @@ private:
         bool found_after_non_option) EXCLUSIVE_LOCKS_REQUIRED(cs_args);
 
     void NormalizeKey(std::string& key, bool& double_dash);
+
+    bool ShouldSkipApplePlatformArg(const std::string& key);
+
+    void SplitKeyValue(std::string& key, std::optional<std::string>& val);
+
+    bool HandleGlobalOption(std::string& key,
+                            std::optional<std::string>& val,
+                            std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_args);
+
+    bool HandleCommandOption(const char* arg, std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_args);
+
+    bool HandleCommand(const char* const argv[],
+                       int& i,
+                       int argc,
+                       std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_args);
+
+    bool HandleIncludeConfError(std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_args);
 };
 
 extern ArgsManager gArgs;

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -162,7 +162,7 @@ private:
      */
     bool UseDefaultSection(const std::string& arg) const EXCLUSIVE_LOCKS_REQUIRED(cs_args);
 
-    bool ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error)
+    bool ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error, bool found_after_non_option = false)
         EXCLUSIVE_LOCKS_REQUIRED(cs_args);
 
 protected:

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -482,6 +482,26 @@ private:
         const std::string& prefix,
         const std::string& section,
         const std::map<std::string, std::vector<common::SettingsValue>>& args) const EXCLUSIVE_LOCKS_REQUIRED(cs_args);
+
+    bool HandleUnknownOption(
+        const std::string& original_input,
+        std::string& error,
+        bool found_after_non_option) EXCLUSIVE_LOCKS_REQUIRED(cs_args);
+
+    bool HandleKnownOption(
+        const KeyInfo& keyinfo,
+        const std::optional<std::string>& val,
+        unsigned int flags,
+        std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_args);
+
+    bool TryHandleNamedRPC(
+        const std::string& key,
+        const std::string& original_input,
+        std::string& error,
+        bool double_dash,
+        bool found_after_non_option) EXCLUSIVE_LOCKS_REQUIRED(cs_args);
+
+    void NormalizeKey(std::string& key, bool& double_dash);
 };
 
 extern ArgsManager gArgs;

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -162,6 +162,9 @@ private:
      */
     bool UseDefaultSection(const std::string& arg) const EXCLUSIVE_LOCKS_REQUIRED(cs_args);
 
+    bool ProcessOptionKey(std::string& key, std::optional<std::string>& val, std::string& error)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_args);
+
 protected:
     [[nodiscard]] bool ReadConfigStream(std::istream& stream, const std::string& filepath, std::string& error, bool ignore_invalid_keys = false) EXCLUSIVE_LOCKS_REQUIRED(!cs_args);
     [[nodiscard]] bool ReadConfigString(const std::string& str_config) EXCLUSIVE_LOCKS_REQUIRED(!cs_args);

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -241,6 +241,13 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
         BOOST_CHECK(s.command_line_options.at("ccc").back().get_str() == "multiple");
     });
     BOOST_CHECK(testArgs.GetArgs("-ccc").size() == 2);
+
+#ifdef WIN32
+    const char* argv_windows_test[] = {"-ignored", "f", "/D=windows"};
+    BOOST_CHECK(testArgs.ParseParameters(3, argv_windows_test, error));
+    BOOST_CHECK(testArgs.IsArgSet("-d"));
+    BOOST_CHECK_EQUAL(testArgs.GetArg("-d", ""), "windows");
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(util_ParseInvalidParameters)

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -36,6 +36,17 @@ BOOST_AUTO_TEST_CASE(util_datadir)
     args.ClearPathCache();
     BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirBase());
 
+    {
+        ArgsManager parsed_args;
+        parsed_args.AddArg("-datadir=<dir>", "", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::OPTIONS);
+        const auto datadir_arg{"--datadir=" + fs::PathToString(dd_norm) + "/"};
+        const char* argv_datadir[]{"ignored", datadir_arg.c_str()};
+        std::string error;
+        BOOST_CHECK(parsed_args.ParseParameters(2, argv_datadir, error));
+        BOOST_CHECK_EQUAL(error, "");
+        BOOST_CHECK_EQUAL(dd_norm, parsed_args.GetDataDirBase());
+    }
+
     args.ForceSetArg("-datadir", fs::PathToString(dd_norm) + "/.");
     args.ClearPathCache();
     BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirBase());
@@ -214,14 +225,14 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
 
     BOOST_CHECK(testArgs.ParseParameters(7, argv_test, error));
     // expectation: -ignored is ignored (program name argument),
-    // -a, -b and -ccc end up in map, -d ignored because it is after
-    // a non-option argument (non-GNU option parsing)
+    // -a, -b and -ccc end up in map, also -d since the parser detects
+    // [options] after a non-option argument (GNU-style option parsing)
     BOOST_CHECK(testArgs.IsArgSet("-a") && testArgs.IsArgSet("-b") && testArgs.IsArgSet("-ccc")
-                && !testArgs.IsArgSet("f") && !testArgs.IsArgSet("-d"));
+                && !testArgs.IsArgSet("f") && testArgs.IsArgSet("-d"));
     testArgs.LockSettings([&](const common::Settings& s) {
-        BOOST_CHECK(s.command_line_options.size() == 3 && s.ro_config.empty());
+        BOOST_CHECK(s.command_line_options.size() == 4 && s.ro_config.empty());
         BOOST_CHECK(s.command_line_options.contains("a") && s.command_line_options.contains("b") && s.command_line_options.contains("ccc")
-                    && !s.command_line_options.contains("f") && !s.command_line_options.contains("d"));
+                    && !s.command_line_options.contains("f") && s.command_line_options.contains("d"));
 
         BOOST_CHECK(s.command_line_options.at("a").size() == 1);
         BOOST_CHECK(s.command_line_options.at("a").front().get_str() == "");
@@ -669,7 +680,13 @@ BOOST_AUTO_TEST_CASE(util_AddCommand)
     };
 
     BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "-opt1=foo", "cmd1"}));
-    BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "cmd1", "-opt1=foo"})); // things after the command are "args" and left unparsed, not options
+
+    // options/ command-options can be passsed before or after commands (GNU-Style)
+    BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "cmd1", "-opt3=foo"}));
+    BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "cmd2"}));
+    BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "cmd2", "-opt1"}));
+    BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "cmd2", "-opt1", "-opt3"}));
+    BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "cmd2", "-opt2"}));
 
     BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "-opt1=foo", "cmd2"}));
     BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "-opt1=foo", "cmd3"}));

--- a/test/functional/data/util/bitcoin-util-test.json
+++ b/test/functional/data/util/bitcoin-util-test.json
@@ -51,6 +51,11 @@
     "description": "Creates a blank transaction (output in json)"
   },
   { "exec": "./bitcoin-tx",
+    "args": ["01000000000000000000", "-json"],
+    "output_cmp": "blanktxv1.json",
+    "description": "Parses an option after a transaction hex"
+  },
+  { "exec": "./bitcoin-tx",
     "args": ["-json","-"],
     "input": "blanktxv2.hex",
     "output_cmp": "blanktxv2.json",

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -569,6 +569,12 @@ class ConfArgsTest(BitcoinTestFramework):
         self.nodes[0].datadir_path = new_data_dir_2
         self.start_node(0, [f'-datadir={new_data_dir_2}', f'-conf={conf_file}'])
         assert (new_data_dir_2 / self.chain / 'blocks').exists()
+        self.nodes[0].stop_node()
+
+        # Check that double dash'ed datadir (or any other option) works fine as well
+        self.nodes[0].datadir_path = new_data_dir_2
+        self.start_node(0, ["--regtest", f'--datadir={new_data_dir_2}', f'-conf={conf_file}'])
+        assert (new_data_dir_2 / self.chain / 'blocks').exists()
 
 
 if __name__ == '__main__':

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -427,6 +427,11 @@ class TestBitcoinCli(BitcoinTestFramework):
             self.nodes[0].cli('-regtest', 'createwallet', '-regtest', '-xyz', '-regtest').send_cli()
             wallet_name_begin_with_dash = self.nodes[0].get_wallet_rpc('-xyz').getwalletinfo()["walletname"]
             assert_equal(wallet_name_begin_with_dash, '-xyz')
+
+            self.log.info("Test double dash option is treated as RPC named parameter")
+            self.nodes[0].cli('createwallet', 'someWalletName', '--load_on_startup=true').send_cli()
+            self.restart_node(0)
+            assert_equal("someWalletName" in self.nodes[0].listwallets(), True)
         else:
             self.log.info("*** Wallet not compiled; cli getwalletinfo and -getinfo wallet tests skipped")
             self.generate(self.nodes[0], 30)  # maintain block parity with the wallet_compiled conditional branch

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -381,6 +381,7 @@ class TestBitcoinCli(BitcoinTestFramework):
             self.nodes[0].loadwallet(wallets[2])
             n3 = 4
             n4 = 10
+            n5 = 5
             blocks = self.nodes[0].getblockcount()
 
             self.log.info('Test -generate -rpcwallet=<filename> raise RPC error')
@@ -415,9 +416,20 @@ class TestBitcoinCli(BitcoinTestFramework):
             assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 'foo').echo)
             assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 0).echo)
             assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 1, 2, 3).echo)
+
+            self.log.info('Test -generate passing -rpcwallet after the nblocks arg')
+            generate = self.nodes[0].cli('-generate', n5, rpcwallet2).send_cli()
+            assert_equal(set(generate.keys()), {'address', 'blocks'})
+            assert_equal(len(generate["blocks"]), n5)
+            assert_equal(self.nodes[0].getblockcount(), blocks + 1 + n3 + n4 + n5)
+
+            self.log.info("Test options before and after using an RPC parameter startig with '-'")
+            self.nodes[0].cli('-regtest', 'createwallet', '-regtest', '-xyz', '-regtest').send_cli()
+            wallet_name_begin_with_dash = self.nodes[0].get_wallet_rpc('-xyz').getwalletinfo()["walletname"]
+            assert_equal(wallet_name_begin_with_dash, '-xyz')
         else:
             self.log.info("*** Wallet not compiled; cli getwalletinfo and -getinfo wallet tests skipped")
-            self.generate(self.nodes[0], 25)  # maintain block parity with the wallet_compiled conditional branch
+            self.generate(self.nodes[0], 30)  # maintain block parity with the wallet_compiled conditional branch
 
         self.test_netinfo()
 
@@ -443,7 +455,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         self.nodes[0].wait_for_cookie_credentials()  # ensure cookie file is available to avoid race condition
         blocks = self.nodes[0].cli('-rpcwait').send_cli('getblockcount')
         self.nodes[0].wait_for_rpc_connection()
-        assert_equal(blocks, BLOCKS + 25)
+        assert_equal(blocks, BLOCKS + 30)
 
         self.log.info("Test -rpcwait option waits at most -rpcwaittimeout seconds for startup")
         self.stop_node(0)  # stop the node so we time out

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -34,7 +34,7 @@ WALLET_NOT_LOADED = 'Requested wallet does not exist or is not loaded'
 WALLET_NOT_SPECIFIED = (
     "Multiple wallets are loaded. Please select which wallet to use by requesting the RPC "
     "through the /wallet/<walletname> URI path. Or for the CLI, specify the \"-rpcwallet=<walletname>\" "
-    "option before the command (run \"bitcoin-cli -h\" for help or \"bitcoin-cli listwallets\" to see "
+    "option before or after the command (run \"bitcoin-cli -h\" for help or \"bitcoin-cli listwallets\" to see "
     "which wallets are currently loaded)."
 )
 


### PR DESCRIPTION
This PR simplifies the argument parsing logic and resolves practical issues for `bitcoin-cli` and similar binaries (e.g. `bitcoin-wallet`) making their usage more consistent and predictable, enabling valid patterns such as mixing commands with wallet- or RPC-specific options—without relying on argument ordering quirks.

<details>
<summary>What's changed in ArgsManager that allows the above.</summary>

- Previously, `ArgsManager` stopped interpreting options once a non-option argument was encountered (non-GNU parsing). For example:

        bitcoind -a -b param -c

  would ignore `-c` because it followed the non-option argument `param`. In some cases '-c' is interpreted as an argument for 'param', producing unexpected behavior (eg empty arrays for listtransactions command).

- This PR changes the behavior so that options following non-option argument are recognized and processed (GNU parsing). This is needed for workflows for tools like CLI where command arguments may be followed by wallet- or RPC-specific
options, e.g.:

        bitcoin-cli -rpcwallet="" listtransactions -rpcwallet=mywallet
    
        bitcoin-cli getaddressinfo <address> -rpcwallet=mywallet

- (other binaries could also benefit from this change,  e.g. `bitcoin-wallet`)

        bitcoin-wallet create -wallet=newname

- Invalid options passed after non-options will be treated as RPC arguments that begin with a `-` character (so no
behavioural change against `master`), e.g.:

        bitcoin-cli -regtest -datadir=/tmp/btc createwallet -mywallet
        {
            "name": "-mywallet"
        }

</details>

<details><summary>Before and after outputs running RPC commands from <code>CLI</code>/ <code>bitcoin-cli</code>.</summary><ul>
     <li><details><summary>wallet commands using <code>CLI</code>:</summary><ul> 
           <li><details><summary><code>getaddressinfo</code></summary><ul>
           <li>before/ <code>master</code>

```
./build_master/bin/bitcoin-cli -regtest -datadir=/tmp/btc getaddressinfo bcrt1qrnz5xlcwz5d85n3fag6v0vc4lryjc90jhqtpsh -rpcwallet=nonExistent
error message:
getaddressinfo "address"
...
```
</li>
           <li>after

```
./build/bin/bitcoin-cli -regtest -datadir=/tmp/btc getaddressinfo bcrt1qrnz5xlcwz5d85n3fag6v0vc4lryjc90jhqtpsh -rpcwallet=nonExistent
error code: -18
error message:
Requested wallet does not exist or is not loaded
```

</li>
           </ul></details></li>
           <li><details><summary><code>listtransactions</code></summary><ul>
           <li>before/ <code>master</code>

```
./build_master/bin/bitcoin-cli -regtest -datadir=/tmp/btc listtransactions -rpcwallet=nonExistent
[
]
```

</li>
           <li>after


```
./build/bin/bitcoin-cli -regtest -datadir=/tmp/btc listtransactions -rpcwallet=nonExistent
error code: -18
error message:
Requested wallet does not exist or is not loaded
```

</li>
           </ul></details></li>
           <li><details><summary>any command that needs an option to be specifed, it can be added at the end directly instead of before the command</summary><ul>
           <li>before/ <code>master</code>

```
./build_master/bin/bitcoin-cli -regtest -datadir=/tmp/btc listtransactions
error code: -19
error message:
Multiple wallets are loaded. Please select which wallet to use by requesting the RPC through the /wallet/<walletname> URI path. Or for the CLI, specify the "-rpcwallet=<walletname>" option before the command (run "bitcoin-cli -h" for help or "bitcoin-cli listwallets" to see which wallets are currently loaded).
```

```
./build_master/bin/bitcoin-cli -regtest -datadir=/tmp/btc listtransactions -rpcwallet=""
error code: -19
error message:
Multiple wallets are loaded. Please select which wallet to use by requesting the RPC through the /wallet/<walletname> URI path. Or for the CLI, specify the "-rpcwallet=<walletname>" option before the command (run "bitcoin-cli -h" for help or "bitcoin-cli listwallets" to see which wallets are currently loaded).
```

</li>
           <li>after

```
/build/bin/bitcoin-cli -regtest -datadir=/tmp/btc listtransactions -rpcwallet=""
[
  {
    "address": "bcrt1q5pqkrlfrp9rvsg43sxxagrees7r7ul6uyskhs4",
    "parent_descs": [
      "wpkh([76a11ab0/84h/1h/0h]tpubDCDCuyC1Rtm1weZ5kfBYtdchcmqa2t8db7M68wsPHbWhUrYnzFTrHu7ufVVRydt3FdWQy8iNmKbZYbgpWWcEKPAj896x53UbS6i2xRD1qct/0/*)#kuff3m9t"
    ],
    "category": "immature",
    "amount": 50.00000000,
    "label": "",
...
```

</li>
           </ul></details></li>
     </ul></details></li>
     <li><details><summary>other binaries could benefit from it, e.g. <code>bitcoin-wallet:</code></summary><ul> 
           <li><details><summary><code>create</code> command</summary><ul>
           <li>before/ <code>master</code>

```
./build_master/bin/bitcoin-wallet -regtest -datadir=/tmp/btc create
Wallet name must be provided when creating a new wallet.
```
_(`-wallet` option has to be passed before the `create` command in order to work)_
```
./build_master/bin/bitcoin-wallet -regtest -datadir=/tmp/btc create -wallet=newWalletName
Error: Additional arguments provided (-wallet=newWalletName). Methods do not take arguments. Please refer to `-help`.
```

</li>
           <li>after

```
./build/bin/bitcoin-wallet -regtest -datadir=/tmp/btc create -wallet=newWallet
Topping up keypool...
Wallet info
===========
Name: newWallet
Format: sqlite
Descriptors: yes
Encrypted: no
HD (hd seed available): yes
Keypool Size: 8000
Transactions: 0
Address Book: 0
```
</li>
           </ul></details></li>
     </ul></details></li>
     </ul> <!-- End -->
</details>

-<ins>_**Notes**_</ins>:

- <ins>Backwards compatibility</ins>:
This PR is backward compatible in the sense that it allows new valid invocations that were previously rejected (failed or somehow ignored).
In `master`, any valid option following a command is treated as a positional argument. This can lead to unexpected RPC errors or help messages due to mismatched argument types. With this PR, those cases are parsed as proper options when applicable.

- `bitcoin-cli` continues to accept RPC arguments that begin with a `-` character as currently in `master` (check `createwallet` example in _"What's change in ArgsManager"_ section above).

- `bitcoin-cli` could distinguish between options that begin with single and double dashes, and treat options after the RPC method name that begin with double dashes as RPC named parameters (check example in 4th [commit](https://github.com/bitcoin/bitcoin/pull/33540/commits/a101bbb61fdf5563337334d63a10432432ee3625) message body).

- Refactored both `ArgsManager::ProcessOptionKey` (new function added in this PR) and `ArgsManager::ParseParameters` in separated commits making the code clearer and the PR much easier to follow and review.

- On Windows, command-specific options using the '/' prefix are now handled correctly when specified after a command.

- Updated `bitcoin-tx` to consume the command arguments already parsed by `ArgsManager`, avoiding re-processing raw `argv` in `CommandLineRawTx()`.

Additionally, this PR includes release notes documenting the GNU-style option parsing behaviour and the distinction between command-line options and RPC named parameters.