### PR TITLE
ci: Add macOS cross task for arm64-apple-darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,8 +408,7 @@ jobs:
           echo "PREVIOUS_RELEASES_DIR=${{ runner.temp }}/previous_releases" >> "$GITHUB_ENV"
 
       - name: Get previous releases
-        working-directory: test
-        run: ./get_previous_releases.py --target-dir $PREVIOUS_RELEASES_DIR
+        run: ./test/get_previous_releases.py --target-dir $PREVIOUS_RELEASES_DIR
 
       - name: Run functional tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,11 +446,17 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_asan.sh'
 
-          - name: 'macOS-cross, gui, no tests'
+          - name: 'macOS-cross to arm64'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_mac_cross.sh'
+
+          - name: 'macOS-cross to x86_64'
+            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
+            fallback-runner: 'ubuntu-24.04'
+            timeout-minutes: 120
+            file-env: './ci/test/00_setup_env_mac_cross_intel.sh'
 
           - name: 'No wallet, libbitcoinkernel'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'

--- a/ci/test/00_setup_env_mac_cross_intel.sh
+++ b/ci/test/00_setup_env_mac_cross_intel.sh
@@ -8,9 +8,9 @@ export LC_ALL=C.UTF-8
 
 export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
 
-export CONTAINER_NAME=ci_macos_cross
+export CONTAINER_NAME=ci_macos_cross_intel
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
-export HOST=arm64-apple-darwin
+export HOST=x86_64-apple-darwin
 export PACKAGES="clang lld llvm zip"
 export XCODE_VERSION=15.0
 export XCODE_BUILD_ID=15A240d

--- a/depends/README.md
+++ b/depends/README.md
@@ -123,7 +123,7 @@ Common `host-platform-triplet`s for cross compilation are:
 - `i686-pc-linux-gnu` for Linux x86 32 bit
 - `x86_64-pc-linux-gnu` for Linux x86 64 bit
 - `x86_64-w64-mingw32` for Win64
-- `x86_64-apple-darwin` for macOS
+- `x86_64-apple-darwin` for Intel macOS
 - `arm64-apple-darwin` for ARM macOS
 - `arm-linux-gnueabihf` for Linux ARM 32 bit
 - `aarch64-linux-gnu` for Linux ARM 64 bit


### PR DESCRIPTION
Cross compiling to Intel macOS seems fine, but it would be good to cross compile to arm64-apple-darwin as well.

Further reading:

* https://en.wikipedia.org/wiki/Mac_transition_to_Apple_silicon#Timeline.
* It is harder to find native Intel macOS hardware (E.g. GitHub is in the process of dropping it: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down)