### PR TITLE
build: Bump clang minimum supported version to 17

### DIFF
--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -7,10 +7,10 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_nowallet_libbitcoinkernel
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:bookworm"
-# Use minimum supported python3.10 (or best-effort 3.11) and clang-16, see doc/dependencies.md
-export PACKAGES="python3-zmq python3-pip clang-16 llvm-16 libc++abi-16-dev libc++-16-dev"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+# Use minimum supported python3.10 (or best-effort 3.12) and clang-17, see doc/dependencies.md
+export PACKAGES="python3-zmq python3-pip clang-17 llvm-17 libc++abi-17-dev libc++-17-dev"
 export PIP_PACKAGES="--break-system-packages pycapnp"
-export DEP_OPTS="NO_WALLET=1 CC=clang-16 CXX='clang++-16 -stdlib=libc++'"
+export DEP_OPTS="NO_WALLET=1 CC=clang-17 CXX='clang++-17 -stdlib=libc++'"
 export GOAL="install"
 export BITCOIN_CONFIG="-DREDUCE_EXPORTS=ON -DBUILD_UTIL_CHAINSTATE=ON -DBUILD_KERNEL_LIB=ON -DBUILD_SHARED_LIBS=ON"

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -10,7 +10,7 @@ Bitcoin Core requires one of the following compilers.
 
 | Dependency | Minimum required |
 | --- | --- |
-| [Clang](https://clang.llvm.org) | [16.0](https://github.com/bitcoin/bitcoin/pull/30263) |
+| [Clang](https://clang.llvm.org) | [17.0](https://github.com/bitcoin/bitcoin/pull/33555) |
 | [GCC](https://gcc.gnu.org) | [11.1](https://github.com/bitcoin/bitcoin/pull/29091) |
 
 ## Required

--- a/doc/release-notes-33555.md
+++ b/doc/release-notes-33555.md
@@ -1,0 +1,5 @@
+Build System
+------------
+
+- The minimum supported Clang compiler version has been raised to 17.0
+  (#33555).

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -580,20 +580,6 @@ BOOST_AUTO_TEST_CASE(conversion)
 
 BOOST_AUTO_TEST_CASE(operator_with_self)
 {
-    /* Clang 16 and earlier detects v -= v and v /= v as self-assignments
-       to 0 and 1 respectively.
-       See: https://github.com/llvm/llvm-project/issues/42469
-       and the fix in commit c5302325b2a62d77cf13dd16cd5c19141862fed0 .
-
-       This makes some sense for arithmetic classes, but could be considered a bug
-       elsewhere. Disable the warning here so that the code can be tested, but the
-       warning should remain on as there will likely always be a better way to
-       express this.
-    */
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wself-assign-overloaded"
-#endif
     arith_uint256 v{2};
     v *= v;
     BOOST_CHECK_EQUAL(v, arith_uint256{4});
@@ -603,9 +589,6 @@ BOOST_AUTO_TEST_CASE(operator_with_self)
     BOOST_CHECK_EQUAL(v, arith_uint256{2});
     v -= v;
     BOOST_CHECK_EQUAL(v, arith_uint256{0});
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/muhash.cpp
+++ b/src/test/fuzz/muhash.cpp
@@ -199,19 +199,7 @@ FUZZ_TARGET(muhash)
         },
         [&] {
             // Test that dividing a MuHash by itself brings it back to its initial state
-
-            // See note about clang + self-assignment in test/uint256_tests.cpp
-            #if defined(__clang__)
-            #    pragma clang diagnostic push
-            #    pragma clang diagnostic ignored "-Wself-assign-overloaded"
-            #endif
-
             muhash /= muhash;
-
-            #if defined(__clang__)
-            #    pragma clang diagnostic pop
-            #endif
-
             muhash.Finalize(out);
             out2 = initial_state_hash;
         },

--- a/src/util/overloaded.h
+++ b/src/util/overloaded.h
@@ -14,9 +14,6 @@ namespace util {
 //! Implementation comes from and example usage can be found at
 //! https://en.cppreference.com/w/cpp/utility/variant/visit#Example
 template<class... Ts> struct Overloaded : Ts... { using Ts::operator()...; };
-
-//! Explicit deduction guide (not needed after clang-17)
-template<class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
 } // namespace util
 
 #endif // BITCOIN_UTIL_OVERLOADED_H


### PR DESCRIPTION
Most supported operating systems ship with clang-17 (or later), so bump the minimum to that and allow new code to drop workarounds for previous clang bugs.

(Apart from dropping the small workaround, this bump allows the `ci_native_nowallet_libbitcoinkernel` CI to run on riscv64 without running into an ICE with clang-16.)

This patch will only be released in version 31.x, next year (2026).

For reference:

* https://packages.debian.org/bookworm/clang-19
* https://packages.ubuntu.com/noble/clang (clang-18)
* CentOS-like 8/9/10 ship clang-17 (and later) via Stream
* FreeBSD 12/13 ship clang-17 (and later) via packages
* OpenSuse Tumbleweed ships with https://software.opensuse.org/package/clang (clang21); No idea about OpenSuse Leap

On operating systems where the clang version is not shipped by default, the user would have to use GCC, or install clang in a different way. For example:

* https://packages.debian.org/bookworm/g++ (g++-12)
* https://packages.ubuntu.com/jammy/g++ (g++-11)
* https://apt.llvm.org/, or nix, or guix, or compile clang from source, ...

*Ubuntu 22.04 LTS does not ship with clang-16 (the previous minimum required), nor with clang-17, so one of the above workarounds is needed there.*

macOS 14 is unaffected, and the previous minimum requirement of Xcode15.0 remains, see also https://github.com/bitcoin/bitcoin/blob/919e6d01e93a57d991ed456bc67c43605583ada8/depends/hosts/darwin.mk#L3-L4. (Modulo compiling the fuzz tests, which requires https://github.com/bitcoin/bitcoin/blob/919e6d01e93a57d991ed456bc67c43605583ada8/.github/workflows/ci.yml#L149)