### PR TITLE
ci: Use native platform for win-cross task

### DIFF
--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -8,7 +8,6 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_win64
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"  # Check that https://packages.ubuntu.com/noble/g++-mingw-w64-x86-64-posix (version 13.x, similar to guix) can cross-compile
-export CI_IMAGE_PLATFORM="linux/amd64"
 export HOST=x86_64-w64-mingw32
 export PACKAGES="g++-mingw-w64-x86-64-posix nsis"
 export RUN_UNIT_TESTS=false


### PR DESCRIPTION
Forcing the architecture to amd64 is no longer required. Dropping it should have some benefits:

* Faster CI speed on other arches (riscv64, arm, ...)
* Unlock the CI task to run on riscv64 at all