### PR TITLE
DRAFT: add a freebsd job using systemlibs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,7 +517,7 @@ jobs:
 
       - name: Save ccache
         uses: cirruslabs/cache/save@v4
-        if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) }}
+        # if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) }}
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ github.job }}-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,85 @@ jobs:
           TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
         run: py -3 test/functional/test_runner.py --jobs $NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix="$RUNNER_TEMP" --combinedlogslen=99999999 --timeout-factor=$TEST_RUNNER_TIMEOUT_FACTOR $EXCLUDE $TEST_RUNNER_EXTRA
 
+  freebsd-syslibs:
+    name: 'FreeBSD: system libs, no GUI'
+    needs: runners
+    runs-on: ${{ needs.runners.outputs.use-cirrus-runners == 'true' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' || 'ubuntu-latest' }}
+    defaults:
+      run:
+        shell: freebsd {0}
+
+    steps:
+      - *CHECKOUT
+
+      - name: Setup Ccache directory
+        shell: bash
+        run: |
+          export CCACHE_DIR=${{ github.workspace }}/.ccache
+          echo "CCACHE_DIR=$CCACHE_DIR" >> "$GITHUB_ENV"
+          mkdir -p "$CCACHE_DIR"
+
+      - name: Restore ccache
+        uses: cirruslabs/cache/restore@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ github.job }}-${{ github.run_id }}
+          restore-keys: ccache-${{ github.job }}-
+
+      - name: Speed up VM install
+        shell: bash
+        run: |
+          # Updating man-db can be slow
+          echo "set man-db/auto-update false" | sudo debconf-communicate; sudo dpkg-reconfigure man-db
+
+      - name: Start FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          envs: 'CCACHE_DIR'
+          prepare: pkg install -y cmake-core ninja git pkgconf boost-libs libevent sqlite3 capnproto libzmq4 python3 net/py-pyzmq databases/py-sqlite3 ccache
+          run: git config --global --add safe.directory ${{ github.workspace }}
+          sync: 'nfs' # nfs is auto-synced and allows ccache save at the end of the run
+
+      - name: Generate buildsystem
+        env:
+          CMAKE_GENERATOR: 'Ninja'
+        run: |
+          cd ${{ github.workspace }}
+          cmake -B build -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWERROR=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        run: |
+          echo "CCACHE_DIR=$CCACHE_DIR"
+          ccache -s
+          ccache -z
+          cmake --build ${{ github.workspace }}/build -j$(nproc)
+          ccache -s
+
+      - name: Check 'bitcoind' executable
+        run: |
+          set -e
+          cd ${{ github.workspace }}
+          ls -l build/bin/bitcoind
+          file build/bin/bitcoind
+          ldd build/bin/bitcoind
+          ./build/bin/bitcoind -version
+
+      - name: Run test suite
+        run: |
+          cmake -E env ctest --test-dir ${{ github.workspace }}/build -j $(nproc) --output-on-failure
+
+      - name: Run functional tests
+        run: |
+          cd ${{ github.workspace }}
+          ./build/test/functional/test_runner.py --ci --extended -j $(nproc) --combinedlogslen=99999999 --quiet --timeout-factor=8 --tmpdirprefix=/tmp --cachedir=/tmp/test_cache
+
+      - name: Save ccache
+        uses: cirruslabs/cache/save@v4
+        if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ github.job }}-${{ github.run_id }}
+
   ci-matrix:
     name: ${{ matrix.name }}
     needs: runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,262 +186,262 @@ jobs:
           # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
           key: ${{ github.job }}-${{ matrix.job-type }}-ccache-${{ github.run_id }}
 
-  windows-native-dll:
-    name: ${{ matrix.job-name }}
-    runs-on: windows-2022
-
-    if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
-
-    env:
-      PYTHONUTF8: 1
-      TEST_RUNNER_TIMEOUT_FACTOR: 40
-
-    strategy:
-      fail-fast: false
-      matrix:
-        job-type: [standard, fuzz]
-        include:
-          - job-type: standard
-            generate-options: '-DBUILD_GUI=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DWERROR=ON'
-            job-name: 'Windows native, VS 2022'
-          - job-type: fuzz
-            generate-options: '-DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet" -DBUILD_GUI=OFF -DBUILD_FOR_FUZZING=ON -DWERROR=ON'
-            job-name: 'Windows native, fuzz, VS 2022'
-
-    steps:
-      - *CHECKOUT
-
-      - &SET_UP_VS
-        name: Set up VS Developer Prompt
-        shell: pwsh -Command "$PSVersionTable; $PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
-        run: |
-          $vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $installationPath = & $vswherePath -latest -property installationPath
-          & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -arch=x64 -no_logo && set" | foreach-object {
-            $name, $value = $_ -split '=', 2
-            echo "$name=$value" >> $env:GITHUB_ENV
-          }
-
-      - name: Get tool information
-        shell: pwsh
-        run: |
-          cmake -version | Tee-Object -FilePath "cmake_version"
-          Write-Output "---"
-          msbuild -version | Tee-Object -FilePath "msbuild_version"
-          $env:VCToolsVersion | Tee-Object -FilePath "toolset_version"
-          py -3 --version
-          Write-Host "PowerShell version $($PSVersionTable.PSVersion.ToString())"
-          bash --version
-
-      - name: Using vcpkg with MSBuild
-        run: |
-          echo "set(VCPKG_BUILD_TYPE release)" >> "${VCPKG_INSTALLATION_ROOT}/triplets/x64-windows.cmake"
-          # Workaround for libevent, which requires CMake 3.1 but is incompatible with CMake >= 4.0.
-          sed -i '1s/^/set(ENV{CMAKE_POLICY_VERSION_MINIMUM} 3.5)\n/' "${VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake"
-
-      - name: vcpkg tools cache
-        uses: actions/cache@v4
-        with:
-          path: C:/vcpkg/downloads/tools
-          key: ${{ github.job }}-vcpkg-tools
-
-      - name: Restore vcpkg binary cache
-        uses: actions/cache/restore@v4
-        id: vcpkg-binary-cache
-        with:
-          path: ~/AppData/Local/vcpkg/archives
-          key: ${{ github.job }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
-
-      - name: Generate build system
-        run: |
-          cmake -B build -Werror=dev --preset vs2022 -DCMAKE_TOOLCHAIN_FILE="${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.generate-options }}
-
-      - name: Save vcpkg binary cache
-        uses: actions/cache/save@v4
-        if: github.event_name != 'pull_request' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' && matrix.job-type == 'standard'
-        with:
-          path: ~/AppData/Local/vcpkg/archives
-          key: ${{ github.job }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
-
-      - name: Build
-        working-directory: build
-        run: |
-          cmake --build . -j $NUMBER_OF_PROCESSORS --config Release
-
-      - name: Check executable manifests
-        if: matrix.job-type == 'standard'
-        working-directory: build
-        shell: pwsh -Command "$PSVersionTable; $PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
-        run: |
-          mt.exe -nologo -inputresource:bin\Release\bitcoind.exe -out:bitcoind.manifest
-          Get-Content bitcoind.manifest
-
-          Get-ChildItem -Filter "bin\Release\*.exe" | ForEach-Object {
-            $exeName = $_.Name
-
-            # Skip as they currently do not have manifests
-            if ($exeName -eq "fuzz.exe" -or $exeName -eq "bench_bitcoin.exe" -or $exeName -eq "test_bitcoin-qt.exe") {
-              Write-Host "Skipping $exeName (no manifest present)"
-              return
-            }
-
-            Write-Host "Checking $exeName"
-            & mt.exe -nologo -inputresource:$_.FullName -validate_manifest
-          }
-
-      - name: Run test suite
-        if: matrix.job-type == 'standard'
-        working-directory: build
-        env:
-          QT_PLUGIN_PATH: '${{ github.workspace }}\build\vcpkg_installed\x64-windows\Qt6\plugins'
-        run: |
-          ctest --output-on-failure --stop-on-failure -j $NUMBER_OF_PROCESSORS -C Release
-
-      - name: Run functional tests
-        if: matrix.job-type == 'standard'
-        working-directory: build
-        env:
-          BITCOIN_BIN: '${{ github.workspace }}\build\bin\Release\bitcoin.exe'
-          BITCOIND: '${{ github.workspace }}\build\bin\Release\bitcoind.exe'
-          BITCOINCLI: '${{ github.workspace }}\build\bin\Release\bitcoin-cli.exe'
-          BITCOINTX: '${{ github.workspace }}\build\bin\Release\bitcoin-tx.exe'
-          BITCOINUTIL: '${{ github.workspace }}\build\bin\Release\bitcoin-util.exe'
-          BITCOINWALLET: '${{ github.workspace }}\build\bin\Release\bitcoin-wallet.exe'
-          TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
-        run: py -3 test/functional/test_runner.py --jobs $NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix="${RUNNER_TEMP}" --combinedlogslen=99999999 --timeout-factor=${TEST_RUNNER_TIMEOUT_FACTOR} ${TEST_RUNNER_EXTRA}
-
-      - name: Clone corpora
-        if: matrix.job-type == 'fuzz'
-        run: |
-          git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${RUNNER_TEMP}/qa-assets"
-          cd "${RUNNER_TEMP}/qa-assets"
-          echo "Using qa-assets repo from commit ..."
-          git log -1
-
-      - name: Run fuzz tests
-        if: matrix.job-type == 'fuzz'
-        working-directory: build
-        env:
-          BITCOINFUZZ: '${{ github.workspace }}\build\bin\Release\fuzz.exe'
-        run: |
-          py -3 test/fuzz/test_runner.py --par $NUMBER_OF_PROCESSORS --loglevel DEBUG "${RUNNER_TEMP}/qa-assets/fuzz_corpora"
-
-  windows-cross:
-    name: 'Linux->Windows cross, no tests'
-    needs: runners
-    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm' || 'ubuntu-24.04' }}
-    if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
-
-    env:
-      FILE_ENV: './ci/test/00_setup_env_win64.sh'
-      DANGER_CI_ON_HOST_FOLDERS: 1
-
-    steps:
-      - *CHECKOUT
-
-      - name: Configure environment
-        uses: ./.github/actions/configure-environment
-
-      - name: Restore caches
-        id: restore-cache
-        uses: ./.github/actions/restore-caches
-
-      - name: Configure Docker
-        uses: ./.github/actions/configure-docker
-        with:
-          cache-provider: ${{ needs.runners.outputs.provider }}
-
-      - name: CI script
-        run: ./ci/test_run_all.sh
-
-      - name: Save caches
-        uses: ./.github/actions/save-caches
-
-      - name: Upload built executables
-        uses: actions/upload-artifact@v4
-        with:
-          name: x86_64-w64-mingw32-executables-${{ github.run_id }}
-          path: |
-            ${{ env.BASE_BUILD_DIR }}/bin/*.exe
-            ${{ env.BASE_BUILD_DIR }}/src/secp256k1/bin/*.exe
-            ${{ env.BASE_BUILD_DIR }}/src/univalue/*.exe
-            ${{ env.BASE_BUILD_DIR }}/test/config.ini
-
-  windows-native-test:
-    name: 'Windows, test cross-built'
-    runs-on: windows-2022
-    needs: windows-cross
-
-    env:
-      PYTHONUTF8: 1
-      TEST_RUNNER_TIMEOUT_FACTOR: 40
-
-    steps:
-      - *CHECKOUT
-
-      - name: Download built executables
-        uses: actions/download-artifact@v5
-        with:
-          name: x86_64-w64-mingw32-executables-${{ github.run_id }}
-
-      - name: Run bitcoind.exe
-        run: ./bin/bitcoind.exe -version
-
-      - *SET_UP_VS
-
-      - name: Check executable manifests
-        shell: pwsh -Command "$PSVersionTable; $PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
-        run: |
-          mt.exe -nologo -inputresource:bin\bitcoind.exe -out:bitcoind.manifest
-          Get-Content bitcoind.manifest
-
-          Get-ChildItem -Filter "bin\*.exe" | ForEach-Object {
-            $exeName = $_.Name
-
-            # Skip as they currently do not have manifests
-            if ($exeName -eq "fuzz.exe" -or $exeName -eq "bench_bitcoin.exe") {
-              Write-Host "Skipping $exeName (no manifest present)"
-              return
-            }
-
-            Write-Host "Checking $exeName"
-            & mt.exe -nologo -inputresource:$_.FullName -validate_manifest
-          }
-
-      - name: Run unit tests
-        # Can't use ctest here like other jobs as we don't have a CMake build tree.
-        run: |
-          ./bin/test_bitcoin.exe -l test_suite  # Intentionally run sequentially here, to catch test case failures caused by dirty global state from prior test cases.
-          ./src/secp256k1/bin/exhaustive_tests.exe
-          ./src/secp256k1/bin/noverify_tests.exe
-          ./src/secp256k1/bin/tests.exe
-          ./src/univalue/object.exe
-          ./src/univalue/unitester.exe
-
-      - name: Run benchmarks
-        run: ./bin/bench_bitcoin.exe -sanity-check
-
-      - name: Adjust paths in test/config.ini
-        shell: pwsh
-        run: |
-          (Get-Content "test/config.ini") -replace '(?<=^SRCDIR=).*', '${{ github.workspace }}' -replace '(?<=^BUILDDIR=).*', '${{ github.workspace }}' -replace '(?<=^RPCAUTH=).*', '${{ github.workspace }}/share/rpcauth/rpcauth.py' | Set-Content "test/config.ini"
-          Get-Content "test/config.ini"
-
-      - name: Set previous release directory
-        run: |
-          echo "PREVIOUS_RELEASES_DIR=${{ runner.temp }}/previous_releases" >> "$GITHUB_ENV"
-
-      - name: Get previous releases
-        working-directory: test
-        run: ./get_previous_releases.py --target-dir $PREVIOUS_RELEASES_DIR
-
-      - name: Run functional tests
-        env:
-          # TODO: Fix the excluded test and re-enable it.
-          # feature_unsupported_utxo_db.py fails on windows because of emojis in the test data directory
-          EXCLUDE: '--exclude wallet_multiwallet.py,feature_unsupported_utxo_db.py'
-          TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
-        run: py -3 test/functional/test_runner.py --jobs $NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix="$RUNNER_TEMP" --combinedlogslen=99999999 --timeout-factor=$TEST_RUNNER_TIMEOUT_FACTOR $EXCLUDE $TEST_RUNNER_EXTRA
+  # windows-native-dll:
+  #   name: ${{ matrix.job-name }}
+  #   runs-on: windows-2022
+  #
+  #   if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
+  #
+  #   env:
+  #     PYTHONUTF8: 1
+  #     TEST_RUNNER_TIMEOUT_FACTOR: 40
+  #
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       job-type: [standard, fuzz]
+  #       include:
+  #         - job-type: standard
+  #           generate-options: '-DBUILD_GUI=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DWERROR=ON'
+  #           job-name: 'Windows native, VS 2022'
+  #         - job-type: fuzz
+  #           generate-options: '-DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet" -DBUILD_GUI=OFF -DBUILD_FOR_FUZZING=ON -DWERROR=ON'
+  #           job-name: 'Windows native, fuzz, VS 2022'
+  #
+  #   steps:
+  #     - *CHECKOUT
+  #
+  #     - &SET_UP_VS
+  #       name: Set up VS Developer Prompt
+  #       shell: pwsh -Command "$PSVersionTable; $PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
+  #       run: |
+  #         $vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+  #         $installationPath = & $vswherePath -latest -property installationPath
+  #         & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -arch=x64 -no_logo && set" | foreach-object {
+  #           $name, $value = $_ -split '=', 2
+  #           echo "$name=$value" >> $env:GITHUB_ENV
+  #         }
+  #
+  #     - name: Get tool information
+  #       shell: pwsh
+  #       run: |
+  #         cmake -version | Tee-Object -FilePath "cmake_version"
+  #         Write-Output "---"
+  #         msbuild -version | Tee-Object -FilePath "msbuild_version"
+  #         $env:VCToolsVersion | Tee-Object -FilePath "toolset_version"
+  #         py -3 --version
+  #         Write-Host "PowerShell version $($PSVersionTable.PSVersion.ToString())"
+  #         bash --version
+  #
+  #     - name: Using vcpkg with MSBuild
+  #       run: |
+  #         echo "set(VCPKG_BUILD_TYPE release)" >> "${VCPKG_INSTALLATION_ROOT}/triplets/x64-windows.cmake"
+  #         # Workaround for libevent, which requires CMake 3.1 but is incompatible with CMake >= 4.0.
+  #         sed -i '1s/^/set(ENV{CMAKE_POLICY_VERSION_MINIMUM} 3.5)\n/' "${VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake"
+  #
+  #     - name: vcpkg tools cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: C:/vcpkg/downloads/tools
+  #         key: ${{ github.job }}-vcpkg-tools
+  #
+  #     - name: Restore vcpkg binary cache
+  #       uses: actions/cache/restore@v4
+  #       id: vcpkg-binary-cache
+  #       with:
+  #         path: ~/AppData/Local/vcpkg/archives
+  #         key: ${{ github.job }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
+  #
+  #     - name: Generate build system
+  #       run: |
+  #         cmake -B build -Werror=dev --preset vs2022 -DCMAKE_TOOLCHAIN_FILE="${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.generate-options }}
+  #
+  #     - name: Save vcpkg binary cache
+  #       uses: actions/cache/save@v4
+  #       if: github.event_name != 'pull_request' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' && matrix.job-type == 'standard'
+  #       with:
+  #         path: ~/AppData/Local/vcpkg/archives
+  #         key: ${{ github.job }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
+  #
+  #     - name: Build
+  #       working-directory: build
+  #       run: |
+  #         cmake --build . -j $NUMBER_OF_PROCESSORS --config Release
+  #
+  #     - name: Check executable manifests
+  #       if: matrix.job-type == 'standard'
+  #       working-directory: build
+  #       shell: pwsh -Command "$PSVersionTable; $PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
+  #       run: |
+  #         mt.exe -nologo -inputresource:bin\Release\bitcoind.exe -out:bitcoind.manifest
+  #         Get-Content bitcoind.manifest
+  #
+  #         Get-ChildItem -Filter "bin\Release\*.exe" | ForEach-Object {
+  #           $exeName = $_.Name
+  #
+  #           # Skip as they currently do not have manifests
+  #           if ($exeName -eq "fuzz.exe" -or $exeName -eq "bench_bitcoin.exe" -or $exeName -eq "test_bitcoin-qt.exe") {
+  #             Write-Host "Skipping $exeName (no manifest present)"
+  #             return
+  #           }
+  #
+  #           Write-Host "Checking $exeName"
+  #           & mt.exe -nologo -inputresource:$_.FullName -validate_manifest
+  #         }
+  #
+  #     - name: Run test suite
+  #       if: matrix.job-type == 'standard'
+  #       working-directory: build
+  #       env:
+  #         QT_PLUGIN_PATH: '${{ github.workspace }}\build\vcpkg_installed\x64-windows\Qt6\plugins'
+  #       run: |
+  #         ctest --output-on-failure --stop-on-failure -j $NUMBER_OF_PROCESSORS -C Release
+  #
+  #     - name: Run functional tests
+  #       if: matrix.job-type == 'standard'
+  #       working-directory: build
+  #       env:
+  #         BITCOIN_BIN: '${{ github.workspace }}\build\bin\Release\bitcoin.exe'
+  #         BITCOIND: '${{ github.workspace }}\build\bin\Release\bitcoind.exe'
+  #         BITCOINCLI: '${{ github.workspace }}\build\bin\Release\bitcoin-cli.exe'
+  #         BITCOINTX: '${{ github.workspace }}\build\bin\Release\bitcoin-tx.exe'
+  #         BITCOINUTIL: '${{ github.workspace }}\build\bin\Release\bitcoin-util.exe'
+  #         BITCOINWALLET: '${{ github.workspace }}\build\bin\Release\bitcoin-wallet.exe'
+  #         TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
+  #       run: py -3 test/functional/test_runner.py --jobs $NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix="${RUNNER_TEMP}" --combinedlogslen=99999999 --timeout-factor=${TEST_RUNNER_TIMEOUT_FACTOR} ${TEST_RUNNER_EXTRA}
+  #
+  #     - name: Clone corpora
+  #       if: matrix.job-type == 'fuzz'
+  #       run: |
+  #         git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${RUNNER_TEMP}/qa-assets"
+  #         cd "${RUNNER_TEMP}/qa-assets"
+  #         echo "Using qa-assets repo from commit ..."
+  #         git log -1
+  #
+  #     - name: Run fuzz tests
+  #       if: matrix.job-type == 'fuzz'
+  #       working-directory: build
+  #       env:
+  #         BITCOINFUZZ: '${{ github.workspace }}\build\bin\Release\fuzz.exe'
+  #       run: |
+  #         py -3 test/fuzz/test_runner.py --par $NUMBER_OF_PROCESSORS --loglevel DEBUG "${RUNNER_TEMP}/qa-assets/fuzz_corpora"
+  #
+  # windows-cross:
+  #   name: 'Linux->Windows cross, no tests'
+  #   needs: runners
+  #   runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm' || 'ubuntu-24.04' }}
+  #   if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
+  #
+  #   env:
+  #     FILE_ENV: './ci/test/00_setup_env_win64.sh'
+  #     DANGER_CI_ON_HOST_FOLDERS: 1
+  #
+  #   steps:
+  #     - *CHECKOUT
+  #
+  #     - name: Configure environment
+  #       uses: ./.github/actions/configure-environment
+  #
+  #     - name: Restore caches
+  #       id: restore-cache
+  #       uses: ./.github/actions/restore-caches
+  #
+  #     - name: Configure Docker
+  #       uses: ./.github/actions/configure-docker
+  #       with:
+  #         cache-provider: ${{ needs.runners.outputs.provider }}
+  #
+  #     - name: CI script
+  #       run: ./ci/test_run_all.sh
+  #
+  #     - name: Save caches
+  #       uses: ./.github/actions/save-caches
+  #
+  #     - name: Upload built executables
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: x86_64-w64-mingw32-executables-${{ github.run_id }}
+  #         path: |
+  #           ${{ env.BASE_BUILD_DIR }}/bin/*.exe
+  #           ${{ env.BASE_BUILD_DIR }}/src/secp256k1/bin/*.exe
+  #           ${{ env.BASE_BUILD_DIR }}/src/univalue/*.exe
+  #           ${{ env.BASE_BUILD_DIR }}/test/config.ini
+  #
+  # windows-native-test:
+  #   name: 'Windows, test cross-built'
+  #   runs-on: windows-2022
+  #   needs: windows-cross
+  #
+  #   env:
+  #     PYTHONUTF8: 1
+  #     TEST_RUNNER_TIMEOUT_FACTOR: 40
+  #
+  #   steps:
+  #     - *CHECKOUT
+  #
+  #     - name: Download built executables
+  #       uses: actions/download-artifact@v5
+  #       with:
+  #         name: x86_64-w64-mingw32-executables-${{ github.run_id }}
+  #
+  #     - name: Run bitcoind.exe
+  #       run: ./bin/bitcoind.exe -version
+  #
+  #     - *SET_UP_VS
+  #
+  #     - name: Check executable manifests
+  #       shell: pwsh -Command "$PSVersionTable; $PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
+  #       run: |
+  #         mt.exe -nologo -inputresource:bin\bitcoind.exe -out:bitcoind.manifest
+  #         Get-Content bitcoind.manifest
+  #
+  #         Get-ChildItem -Filter "bin\*.exe" | ForEach-Object {
+  #           $exeName = $_.Name
+  #
+  #           # Skip as they currently do not have manifests
+  #           if ($exeName -eq "fuzz.exe" -or $exeName -eq "bench_bitcoin.exe") {
+  #             Write-Host "Skipping $exeName (no manifest present)"
+  #             return
+  #           }
+  #
+  #           Write-Host "Checking $exeName"
+  #           & mt.exe -nologo -inputresource:$_.FullName -validate_manifest
+  #         }
+  #
+  #     - name: Run unit tests
+  #       # Can't use ctest here like other jobs as we don't have a CMake build tree.
+  #       run: |
+  #         ./bin/test_bitcoin.exe -l test_suite  # Intentionally run sequentially here, to catch test case failures caused by dirty global state from prior test cases.
+  #         ./src/secp256k1/bin/exhaustive_tests.exe
+  #         ./src/secp256k1/bin/noverify_tests.exe
+  #         ./src/secp256k1/bin/tests.exe
+  #         ./src/univalue/object.exe
+  #         ./src/univalue/unitester.exe
+  #
+  #     - name: Run benchmarks
+  #       run: ./bin/bench_bitcoin.exe -sanity-check
+  #
+  #     - name: Adjust paths in test/config.ini
+  #       shell: pwsh
+  #       run: |
+  #         (Get-Content "test/config.ini") -replace '(?<=^SRCDIR=).*', '${{ github.workspace }}' -replace '(?<=^BUILDDIR=).*', '${{ github.workspace }}' -replace '(?<=^RPCAUTH=).*', '${{ github.workspace }}/share/rpcauth/rpcauth.py' | Set-Content "test/config.ini"
+  #         Get-Content "test/config.ini"
+  #
+  #     - name: Set previous release directory
+  #       run: |
+  #         echo "PREVIOUS_RELEASES_DIR=${{ runner.temp }}/previous_releases" >> "$GITHUB_ENV"
+  #
+  #     - name: Get previous releases
+  #       working-directory: test
+  #       run: ./get_previous_releases.py --target-dir $PREVIOUS_RELEASES_DIR
+  #
+  #     - name: Run functional tests
+  #       env:
+  #         # TODO: Fix the excluded test and re-enable it.
+  #         # feature_unsupported_utxo_db.py fails on windows because of emojis in the test data directory
+  #         EXCLUDE: '--exclude wallet_multiwallet.py,feature_unsupported_utxo_db.py'
+  #         TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
+  #       run: py -3 test/functional/test_runner.py --jobs $NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix="$RUNNER_TEMP" --combinedlogslen=99999999 --timeout-factor=$TEST_RUNNER_TIMEOUT_FACTOR $EXCLUDE $TEST_RUNNER_EXTRA
 
   freebsd-syslibs:
     name: 'FreeBSD: system libs, no GUI'
@@ -522,146 +522,146 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ github.job }}-${{ github.run_id }}
 
-  ci-matrix:
-    name: ${{ matrix.name }}
-    needs: runners
-    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && matrix.cirrus-runner || matrix.fallback-runner }}
-    if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
-    timeout-minutes: ${{ matrix.timeout-minutes }}
-
-    env:
-      DANGER_CI_ON_HOST_FOLDERS: 1
-      FILE_ENV: ${{ matrix.file-env }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: '32 bit ARM, unit tests, no functional tests'
-            cirrus-runner: 'ubuntu-24.04-arm' # Cirrus' Arm runners are Apple (with virtual Linux aarch64), which doesn't support 32-bit mode
-            fallback-runner: 'ubuntu-24.04-arm'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_arm.sh'
-            provider: 'gha'
-
-          - name: 'ASan + LSan + UBSan + integer, no depends, USDT'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' # has to match container in ci/test/00_setup_env_native_asan.sh for tracing tools
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_native_asan.sh'
-
-          - name: 'macOS-cross, gui, no tests'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_mac_cross.sh'
-
-          - name: 'No wallet, libbitcoinkernel'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh'
-
-          - name: 'no IPC, i686, DEBUG'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_i686_no_ipc.sh'
-
-          - name: 'fuzzer,address,undefined,integer, no depends'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 240
-            file-env: './ci/test/00_setup_env_native_fuzz.sh'
-
-          - name: 'previous releases, depends DEBUG'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_native_previous_releases.sh'
-
-          - name: 'CentOS, depends, gui'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_native_centos.sh'
-
-          - name: 'tidy'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_native_tidy.sh'
-
-          - name: 'TSan, depends, no gui'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_native_tsan.sh'
-
-          - name: 'MSan, depends'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_native_msan.sh'
-
-    steps:
-      - *CHECKOUT
-
-      - name: Configure environment
-        uses: ./.github/actions/configure-environment
-
-      - name: Restore caches
-        id: restore-cache
-        uses: ./.github/actions/restore-caches
-
-      - name: Configure Docker
-        uses: ./.github/actions/configure-docker
-        with:
-          cache-provider: ${{ matrix.provider || needs.runners.outputs.provider }}
-
-      - name: Enable bpfcc script
-        if: ${{ env.CONTAINER_NAME == 'ci_native_asan' }}
-        # In the image build step, no external environment variables are available,
-        # so any settings will need to be written to the settings env file:
-        run: sed -i "s|\${INSTALL_BCC_TRACING_TOOLS}|true|g" ./ci/test/00_setup_env_native_asan.sh
-
-      - name: Set mmap_rnd_bits
-        if: ${{ env.CONTAINER_NAME == 'ci_native_tsan' || env.CONTAINER_NAME == 'ci_native_msan' }}
-        # Prevents crashes due to high ASLR entropy
-        run: sudo sysctl -w vm.mmap_rnd_bits=28
-
-      - name: CI script
-        run: ./ci/test_run_all.sh
-
-      - name: Save caches
-        uses: ./.github/actions/save-caches
-
-  lint:
-    name: 'lint'
-    needs: runners
-    runs-on: ${{ needs.runners.outputs.use-cirrus-runners == 'true' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xs' || 'ubuntu-24.04' }}
-    if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
-    timeout-minutes: 20
-    env:
-      CONTAINER_NAME: "bitcoin-linter"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          ref: *CHECKOUT_REF_TMPL
-          fetch-depth: 0
-
-      - name: Configure Docker
-        uses: ./.github/actions/configure-docker
-        with:
-          cache-provider: ${{ needs.runners.outputs.provider }}
-
-      - name: CI script
-        run: |
-          set -o xtrace
-          docker buildx build -t "$CONTAINER_NAME" $DOCKER_BUILD_CACHE_ARG --file "./ci/lint_imagefile" .
-          CIRRUS_PR_FLAG=""
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CIRRUS_PR_FLAG="-e CIRRUS_PR=1"
-          fi
-          docker run --rm $CIRRUS_PR_FLAG -v "$(pwd)":/bitcoin "$CONTAINER_NAME"
+  # ci-matrix:
+  #   name: ${{ matrix.name }}
+  #   needs: runners
+  #   runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && matrix.cirrus-runner || matrix.fallback-runner }}
+  #   if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
+  #   timeout-minutes: ${{ matrix.timeout-minutes }}
+  #
+  #   env:
+  #     DANGER_CI_ON_HOST_FOLDERS: 1
+  #     FILE_ENV: ${{ matrix.file-env }}
+  #
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - name: '32 bit ARM, unit tests, no functional tests'
+  #           cirrus-runner: 'ubuntu-24.04-arm' # Cirrus' Arm runners are Apple (with virtual Linux aarch64), which doesn't support 32-bit mode
+  #           fallback-runner: 'ubuntu-24.04-arm'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_arm.sh'
+  #           provider: 'gha'
+  #
+  #         - name: 'ASan + LSan + UBSan + integer, no depends, USDT'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' # has to match container in ci/test/00_setup_env_native_asan.sh for tracing tools
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_native_asan.sh'
+  #
+  #         - name: 'macOS-cross, gui, no tests'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_mac_cross.sh'
+  #
+  #         - name: 'No wallet, libbitcoinkernel'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh'
+  #
+  #         - name: 'no IPC, i686, DEBUG'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_i686_no_ipc.sh'
+  #
+  #         - name: 'fuzzer,address,undefined,integer, no depends'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 240
+  #           file-env: './ci/test/00_setup_env_native_fuzz.sh'
+  #
+  #         - name: 'previous releases, depends DEBUG'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_native_previous_releases.sh'
+  #
+  #         - name: 'CentOS, depends, gui'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_native_centos.sh'
+  #
+  #         - name: 'tidy'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_native_tidy.sh'
+  #
+  #         - name: 'TSan, depends, no gui'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_native_tsan.sh'
+  #
+  #         - name: 'MSan, depends'
+  #           cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
+  #           fallback-runner: 'ubuntu-24.04'
+  #           timeout-minutes: 120
+  #           file-env: './ci/test/00_setup_env_native_msan.sh'
+  #
+  #   steps:
+  #     - *CHECKOUT
+  #
+  #     - name: Configure environment
+  #       uses: ./.github/actions/configure-environment
+  #
+  #     - name: Restore caches
+  #       id: restore-cache
+  #       uses: ./.github/actions/restore-caches
+  #
+  #     - name: Configure Docker
+  #       uses: ./.github/actions/configure-docker
+  #       with:
+  #         cache-provider: ${{ matrix.provider || needs.runners.outputs.provider }}
+  #
+  #     - name: Enable bpfcc script
+  #       if: ${{ env.CONTAINER_NAME == 'ci_native_asan' }}
+  #       # In the image build step, no external environment variables are available,
+  #       # so any settings will need to be written to the settings env file:
+  #       run: sed -i "s|\${INSTALL_BCC_TRACING_TOOLS}|true|g" ./ci/test/00_setup_env_native_asan.sh
+  #
+  #     - name: Set mmap_rnd_bits
+  #       if: ${{ env.CONTAINER_NAME == 'ci_native_tsan' || env.CONTAINER_NAME == 'ci_native_msan' }}
+  #       # Prevents crashes due to high ASLR entropy
+  #       run: sudo sysctl -w vm.mmap_rnd_bits=28
+  #
+  #     - name: CI script
+  #       run: ./ci/test_run_all.sh
+  #
+  #     - name: Save caches
+  #       uses: ./.github/actions/save-caches
+  #
+  # lint:
+  #   name: 'lint'
+  #   needs: runners
+  #   runs-on: ${{ needs.runners.outputs.use-cirrus-runners == 'true' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xs' || 'ubuntu-24.04' }}
+  #   if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
+  #   timeout-minutes: 20
+  #   env:
+  #     CONTAINER_NAME: "bitcoin-linter"
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v5
+  #       with:
+  #         ref: *CHECKOUT_REF_TMPL
+  #         fetch-depth: 0
+  #
+  #     - name: Configure Docker
+  #       uses: ./.github/actions/configure-docker
+  #       with:
+  #         cache-provider: ${{ needs.runners.outputs.provider }}
+  #
+  #     - name: CI script
+  #       run: |
+  #         set -o xtrace
+  #         docker buildx build -t "$CONTAINER_NAME" $DOCKER_BUILD_CACHE_ARG --file "./ci/lint_imagefile" .
+  #         CIRRUS_PR_FLAG=""
+  #         if [ "${{ github.event_name }}" = "pull_request" ]; then
+  #           CIRRUS_PR_FLAG="-e CIRRUS_PR=1"
+  #         fi
+  #         docker run --rm $CIRRUS_PR_FLAG -v "$(pwd)":/bitcoin "$CONTAINER_NAME"


### PR DESCRIPTION
Re #33438

Test a basic freebsd job in this repo using cirrus runners to get some info on how long a run will take on Cirrus Runners.

A run on GHA (free) runners is clocking in at around 50 - 60 minutes: https://github.com/willcl-ark/bitcoin/actions/runs/18309856374/job/52135663056 

This will need permitting of the `vmactions/freebsd-vm@v1` action in this repo. This action seems well-maintained/used, including by [`rustup`](https://github.com/rust-lang/rustup/blob/061cf7830a61eaefaddddb8454232186d26fd2d1/ci/actions-templates/freebsd-builds-template.yaml#L19), python [`psutil`](https://github.com/giampaolo/psutil/blob/0217662c7e3381612e1a15181b02fe3d06894272/.github/workflows/bsd.yml#L19) and a few other notable repos.

This job could alternatively be run as a nightly job (but in this repo, rather than elsewhere), but that does not seem to address:

> BSDs are being tested in nightly repos, but merging code here, just to have it reported as broken after the fact, which then requires more changes to fix, isn't ideal. Issues should be caught in this repo, before merging.

Inspiration taken from https://github.com/hebasto/bitcoin-core-nightly/blob/main/.github/workflows/freebsd.yml