### PR TITLE
refactor: throw `std::string_view` instead of `const char*` in constexpr/consteval functions

### DIFF
--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -305,7 +305,8 @@ class HasReason
 public:
     explicit HasReason(std::string_view reason) : m_reason(reason) {}
     bool operator()(std::string_view s) const { return s.find(m_reason) != std::string_view::npos; }
-    bool operator()(const std::exception& e) const { return (*this)(e.what()); }
+    bool operator()(const std::exception& e) const { return (*this)(std::string_view{e.what()}); }
+    bool operator()(const char* s) const = delete;
 
 private:
     const std::string m_reason;

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -37,7 +37,7 @@ void PassFmt(ConstevalFormatString<NumArgs> fmt)
 template <unsigned WrongNumArgs>
 void FailFmtWithError(const char* wrong_fmt, std::string_view error)
 {
-    BOOST_CHECK_EXCEPTION(CheckNumFormatSpecifiers<WrongNumArgs>(wrong_fmt), const char*, HasReason{error});
+    BOOST_CHECK_EXCEPTION(CheckNumFormatSpecifiers<WrongNumArgs>(wrong_fmt), std::string_view, HasReason{error});
 }
 
 BOOST_AUTO_TEST_CASE(ConstevalFormatString_NumSpec)

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -124,7 +124,7 @@ public:
 template <unsigned int BITS>
 consteval base_blob<BITS>::base_blob(std::string_view hex_str)
 {
-    if (hex_str.length() != m_data.size() * 2) throw "Hex string must fit exactly";
+    if (hex_str.length() != m_data.size() * 2) throw std::string_view("Hex string must fit exactly");
     auto str_it = hex_str.rbegin();
     for (auto& elem : m_data) {
         auto lo = util::ConstevalHexDigit(*(str_it++));

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -331,7 +331,7 @@ consteval uint8_t ConstevalHexDigit(const char c)
     if (c >= '0' && c <= '9') return c - '0';
     if (c >= 'a' && c <= 'f') return c - 'a' + 0xa;
 
-    throw "Only lowercase hex digits are allowed, for consistency";
+    throw std::string_view("Only lowercase hex digits are allowed, for consistency");
 }
 
 namespace detail {
@@ -342,7 +342,7 @@ struct Hex {
         // 2 hex digits required per byte + implicit null terminator
         requires(N % 2 == 1)
     {
-        if (hex_str[N - 1]) throw "null terminator required";
+        if (hex_str[N - 1]) throw std::string_view("null terminator required");
         for (std::size_t i = 0; i < bytes.size(); ++i) {
             bytes[i] = static_cast<std::byte>(
                 (ConstevalHexDigit(hex_str[2 * i]) << 4) |

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -37,7 +37,7 @@ constexpr static void CheckNumFormatSpecifiers(const char* str)
             if (*it == '$') {
                 ++it;
                 // Positional specifier, like %8$s
-                if (maybe_num == 0) throw "Positional format specifier must have position of at least 1";
+                if (maybe_num == 0) throw std::string_view{"Positional format specifier must have position of at least 1"};
                 count_pos = std::max(count_pos, maybe_num);
             } else {
                 // Non-positional specifier, like %s
@@ -69,14 +69,14 @@ constexpr static void CheckNumFormatSpecifiers(const char* str)
             parse_size();
         }
 
-        if (*it == '\0') throw "Format specifier incorrectly terminated by end of string";
+        if (*it == '\0') throw std::string_view{"Format specifier incorrectly terminated by end of string"};
 
         // Length and type in "[flags][width][.precision][length]type"
         // is not checked. Parsing continues with the next '%'.
     }
-    if (count_normal && count_pos) throw "Format specifiers must be all positional or all non-positional!";
+    if (count_normal && count_pos) throw std::string_view{"Format specifiers must be all positional or all non-positional!"};
     unsigned count{count_normal | count_pos};
-    if (num_params != count) throw "Format specifier count must match the argument count!";
+    if (num_params != count) throw std::string_view{"Format specifier count must match the argument count!"};
 }
 } // namespace detail
 


### PR DESCRIPTION
Related to https://github.com/bitcoin/bitcoin/pull/33550#issuecomment-3378978210

Works around Clang code generation bug when targeting Windows where where catching `const char*` exceptions by reference is broken, see https://github.com/mstorsjo/llvm-mingw/issues/522

Following [C++ Core Guidelines E.15](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#e15-throw-by-value-catch-exceptions-from-a-hierarchy-by-reference) "Throw by value, catch exceptions from a hierarchy by reference", we throw `std::string_view` instead of string literals.
Note that [clang-tidy](https://clang.llvm.org/extra/clang-tidy/checks/misc/throw-by-value-catch-by-reference.html) mentions string literals not being flagged, but it's still an `llvm-mingw` issue so we need to adjust anyway.
[Array-to-pointer conversion](https://en.cppreference.com/w/cpp/language/implicit_cast.html#Array-to-pointer_conversion) makes string literal exceptions particularly fragile across platforms.

Also deleted `HasReason::operator()(const char*)` to prevent future reliance on string literal exception handling.

----

The error was reproduced by adding a temporary [nightly build](https://github.com/l0rinc/bitcoin-core-nightly/pull/3) pointing to https://github.com/l0rinc/bitcoin/pull/44. On `master` the failure can be seen in https://github.com/l0rinc/bitcoin-core-nightly/pull/2