### PR TITLE
randomenv: Fix MinGW dllimport warning for `environ`

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -57,7 +57,7 @@
 #include <sys/auxv.h>
 #endif
 
-#ifndef _MSC_VER
+#ifndef WIN32
 extern char** environ; // NOLINT(readability-redundant-declaration): Necessary on some platforms
 #endif
 


### PR DESCRIPTION
Related to https://github.com/bitcoin/bitcoin/pull/33550#issuecomment-3378978210

Extends 7703884 to guard environ declaration on all Windows builds, not just MSVC.

In the `mingw-w64` headers (used by `llvm-mingw`), `environ` is defined as a macro which  expands through [`_environ`](https://github.com/msys2-contrib/mingw-w64/blob/cdb052f1d4056cd510cb83197b55868427b87476/mingw-w64-headers/crt/stdlib.h#L262-L264) to `(* __p__environ())`, a call to a `dllimport` function, causing the same inconsistent linkage warning as MSVC.

Use `WIN32` instead of `_MSC_VER` to match the platform-specific guards already used throughout the file.

The warning occurs with `llvm-mingw` (both `UCRT` and `MSVCRT` variants as tested by Hebasto), but not with the `mingw-w64` toolchain currently used in CI (as mentioned by fanquake).

----

The error was reproduced by adding a temporary [nightly build](https://github.com/l0rinc/bitcoin-core-nightly/pull/4) pointing to https://github.com/l0rinc/bitcoin/pull/45. On `master` the failure can be seen in https://github.com/l0rinc/bitcoin-core-nightly/pull/2


before:
https://github.com/l0rinc/bitcoin-core-nightly/actions/runs/18327936488/job/52196728885?pr=2

<details>
<summary>Details</summary>

```
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src/randomenv.cpp:61:15: warning: '__p__environ' redeclared without 'dllimport' attribute: previous 'dllimport' ignored [-Winconsistent-dllimport]
   61 | extern char** environ; // NOLINT(readability-redundant-declaration): Necessary on some platforms
      |               ^
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/llvm_mingw_toolchain/aarch64-w64-mingw32/include/stdlib.h:656:17: note: expanded from macro 'environ'
  656 | #define environ _environ
      |                 ^
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/llvm_mingw_toolchain/aarch64-w64-mingw32/include/stdlib.h:225:21: note: expanded from macro '_environ'
  225 | #define _environ (* __p__environ())
      |                     ^
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/llvm_mingw_toolchain/aarch64-w64-mingw32/include/stdlib.h:221:27: note: previous declaration is here
  221 |   _CRTIMP char ***__cdecl __p__environ(void);
      |                           ^
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/llvm_mingw_toolchain/aarch64-w64-mingw32/include/stdlib.h:221:3: note: previous attribute is here
  221 |   _CRTIMP char ***__cdecl __p__environ(void);
      |   ^
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/llvm_mingw_toolchain/aarch64-w64-mingw32/include/_mingw.h:52:40: note: expanded from macro '_CRTIMP'
   52 | #      define _CRTIMP  __attribute__ ((__dllimport__))
      |                                        ^
1 warning generated.
```

</details>

after:
https://github.com/l0rinc/bitcoin-core-nightly/actions/runs/18329616268/job/52201940831?pr=4

<details>
<summary>Details</summary>

```
[ 28%] Building CXX object src/util/CMakeFiles/bitcoin_util.dir/__/randomenv.cpp.obj
```

</details>


Note that there are some other remaining warnings in the logs that will be fixed in separate PRs