### PR TITLE
doc: bump the template macOS version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -78,7 +78,7 @@ body:
     id: os
     attributes:
       label: Operating system and version
-      placeholder: e.g. "MacOS Ventura 13.2" or "Ubuntu 22.04 LTS"
+      placeholder: e.g. "MacOS 26.0" or "Ubuntu 26.04 LTS"
     validations:
       required: true
   - type: textarea
@@ -90,4 +90,3 @@ body:
         e.g. OS/CPU and disk type, network connectivity
     validations:
       required: false
-


### PR DESCRIPTION
Motivated by https://github.com/bitcoin/bitcoin/pull/33489#issuecomment-3361601497

The minimum version of MacOS for this repo is now 14 and above so it makes sense to update the issue template to reflect that.
We are now using a higher version but since it is just a bug template, there is no need to put the lowest version we support.