### PR TITLE
doc: update Guix INSTALL.md

### DIFF
--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -64,14 +64,12 @@ Please refer to fanquake's instructions
 
 ## Option 4: Using a distribution-maintained package
 
-Note that this section is based on the distro packaging situation at the time of
-writing (July 2021). Guix is expected to be more widely packaged over time. For
-an up-to-date view on Guix's package status/version across distros, please see:
-https://repology.org/project/guix/versions
+For an up-to-date view on Guix's package status/version across
+distros, please see: https://repology.org/project/guix/versions
 
 ### Debian / Ubuntu
 
-Guix is available as a distribution package in [Debian
+Guix is available as a distribution package in various versions of [Debian
 ](https://packages.debian.org/search?keywords=guix) and [Ubuntu
 ](https://packages.ubuntu.com/search?keywords=guix).
 


### PR DESCRIPTION
It's somewhat annoying that Guix is falling out of being packaged by distros. For some more context, see https://lwn.net/Articles/1035491/.
> However, it is likely that the [Guix](https://guix.gnu.org/en/) package manager will soon be removed from the repositories for Debian 13 and Debian 12 ("bookworm", also called oldstable).

This seems to be happening. You can't `apt install guix` using the current release of Debian. https://packages.debian.org/search?keywords=guix. Guix is not going to be included in next release of Ubuntu (`25.10`): https://packages.ubuntu.com/search?keywords=guix.

Looking at https://aur.archlinux.org/packages/guix, comments over the last few months seem to indicate that the build is broken.

A 1.5.0 release is planned for sometime in January 2026: https://codeberg.org/guix/release-planning/wiki/release-1.5.0-project/. So hopefully the situation is going to improve in future.