### PR TITLE
Revert "depends: Update URL for `qrencode` package source tarball"

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -108,7 +108,7 @@ $(1)_prefixbin:=$($($(1)_type)_prefix)/bin/
 $(1)_all_sources=$($(1)_file_name) $($(1)_extra_sources)
 
 #stamps
-$(1)_fetched=$(SOURCES_PATH)/download-stamps/.stamp_fetched-$(1)-$($(1)_version)-$($(1)_sha256_hash).hash
+$(1)_fetched=$(SOURCES_PATH)/download-stamps/.stamp_fetched-$(1)-$($(1)_file_name).hash
 $(1)_extracted=$$($(1)_extract_dir)/.stamp_extracted
 $(1)_preprocessed=$$($(1)_extract_dir)/.stamp_preprocessed
 $(1)_cleaned=$$($(1)_extract_dir)/.stamp_cleaned

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -1,9 +1,8 @@
 package=qrencode
 $(package)_version=4.1.1
-$(package)_download_path=https://github.com/fukuchi/libqrencode/archive/refs/tags/
-$(package)_download_file=v$($(package)_version).tar.gz
+$(package)_download_path=https://fukuchi.org/works/qrencode/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=5385bc1b8c2f20f3b91d258bf8ccc8cf62023935df2d2676b5b67049f31a049c
+$(package)_sha256_hash=da448ed4f52aba6bcb0cd48cac0dd51b8692bccc4cd127431402fca6f8171e8e
 $(package)_patches=cmake_fixups.patch
 
 define $(package)_set_vars


### PR DESCRIPTION
The new URL breaks CI on the current release branches, see https://github.com/bitcoin/bitcoin/pull/33494#issuecomment-3380802351.

The old URL also no longer exists so the tarball is fetched from the depends sources cache that we host, but the original tarball has already been overwritten on there. We will need to manually reinstate the original tarball.