### PR TITLE
ci: upgrade GitHub Action to download-artifact@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
       - *CHECKOUT
 
       - name: Download built executables
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: x86_64-w64-mingw32-executables-${{ github.run_id }}
 


### PR DESCRIPTION
Release notes:https://github.com/actions/download-artifact/releases/tag/v5.0.0

Change:
uses: actions/download-artifact@v4 -> uses: actions/download-artifact@v5