### PR TITLE
p2p: Allow block downloads from peers without snapshot block after assumeutxo validation

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1385,11 +1385,13 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
         return;
     }
 
-    // When we sync with AssumeUtxo and discover the snapshot is not in the peer's best chain, abort:
-    // We can't reorg to this chain due to missing undo data until the background sync has finished,
+    // When syncing with AssumeUtxo and the snapshot has not yet been validated,
+    // abort downloading blocks from peers that don't have the snapshot block in their best chain.
+    // We can't reorg to this chain due to missing undo data until validation completes,
     // so downloading blocks from it would be futile.
     const CBlockIndex* snap_base{m_chainman.CurrentChainstate().SnapshotBase()};
-    if (snap_base && state->pindexBestKnownBlock->GetAncestor(snap_base->nHeight) != snap_base) {
+    if (snap_base && m_chainman.CurrentChainstate().m_assumeutxo == Assumeutxo::UNVALIDATED &&
+        state->pindexBestKnownBlock->GetAncestor(snap_base->nHeight) != snap_base) {
         LogDebug(BCLog::NET, "Not downloading blocks from peer=%d, which doesn't have the snapshot block in its best chain.\n", peer.m_id);
         return;
     }


### PR DESCRIPTION
Currently, after assumeutxo background validation finishes, the node continues to skip peers that don't have the snapshot block in their best chain until restart. This unnecessarily excludes peers from block downloads even though the background sync has completed and undo data is available.

The restriction persists because `m_chainman.CurrentChainstate().SnapshotBase()` continues to return the snapshot base block until restart, even after validation completes. Added `m_chainman.CurrentChainstate().m_assumeutxo == Assumeutxo::UNVALIDATED` check to only apply the peer restriction while background validation is ongoing. 

Also added test coverage in `feature_assumeutxo.py` that verifies peers without the snapshot block can be used for block downloads after background validation completes. The test fails without this fix.