### PR TITLE
rpc, test: fix "internal" label check in importdescriptors and extend test

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -207,7 +207,7 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
         }
 
         // Internal addresses should not have a label either
-        if (internal && data.exists("label")) {
+        if (internal == true && data.exists("label")) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Internal addresses should not have a label");
         }
 

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -100,6 +100,8 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                      solvable=True,
                      ismine=True,
                      labels=["Descriptor import test"])
+        self.log.info("Test can import a p2pkh descriptor with internal explicitly set to false")
+        self.test_importdesc({**import_request, "internal": False}, success=True)
         assert_equal(w1.getwalletinfo()['keypoolsize'], 0)
 
         self.log.info("Test can import same descriptor with public key twice")


### PR DESCRIPTION
Fixes a logic issue in `ProcessDescriptorImport()` where descriptors with `"internal": false` and a label were incorrectly rejected.
The check now uses `internal == true` so labels are only disallowed when `internal` is `true`.

Tests updated to cover both cases