### PR TITLE
policy: don't CheckEphemeralSpends on reorg

### DIFF
--- a/src/policy/ephemeral_policy.h
+++ b/src/policy/ephemeral_policy.h
@@ -41,13 +41,13 @@ class TxValidationState;
 
 /* All the following checks are only called if standardness rules are being applied. */
 
-/** Must be called for each transaction once transaction fees are known.
+/** Called for each transaction once transaction fees are known.
  * Does context-less checks about a single transaction.
  * @returns false if the fee is non-zero and dust exists, populating state. True otherwise.
  */
 bool PreCheckEphemeralTx(const CTransaction& tx, CFeeRate dust_relay_rate, CAmount base_fee, CAmount mod_fee, TxValidationState& state);
 
-/** Must be called for each transaction(package) if any dust is in the package.
+/** Called for each transaction(package) if any dust is in the package.
  *  Checks that each transaction's parents have their dust spent by the child,
  *  where parents are either in the mempool or in the package itself.
  *  Sets out_child_state and out_child_wtxid on failure.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1385,7 +1385,7 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransactionInternal(const CTransa
         return MempoolAcceptResult::Failure(ws.m_state);
     }
 
-    if (m_pool.m_opts.require_standard) {
+    if (!args.m_bypass_limits && m_pool.m_opts.require_standard) {
         Wtxid dummy_wtxid;
         if (!CheckEphemeralSpends(/*package=*/{ptx}, m_pool.m_opts.dust_relay_feerate, m_pool, ws.m_state, dummy_wtxid)) {
             return MempoolAcceptResult::Failure(ws.m_state);


### PR DESCRIPTION
Similar reasoning to https://github.com/bitcoin/bitcoin/pull/33504

During a deeper reorg it's possible that a long sequence of dust-having transactions that are connected in a linear fashion. On reorg, this could cause each subsequent "generation" to be rejected. These rejected transactions may contain a large amount of competitive fees via normal means.

PreCheck based `PreCheckEphemeralSpends` is left in place because we wouldn't have relayed them prior to the reorg.