### PR TITLE
ci: Build ci_native_base image layer

### DIFF
--- a/ci/test/00_setup_env_mac_cross.sh
+++ b/ci/test/00_setup_env_mac_cross.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
 
 export CONTAINER_NAME=ci_macos_cross
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 export HOST=arm64-apple-darwin
 export PACKAGES="clang lld llvm zip"
 export XCODE_VERSION=15.0

--- a/ci/test/00_setup_env_mac_cross_intel.sh
+++ b/ci/test/00_setup_env_mac_cross_intel.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
 
 export CONTAINER_NAME=ci_macos_cross_intel
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 export HOST=x86_64-apple-darwin
 export PACKAGES="clang lld llvm zip"
 export XCODE_VERSION=15.0

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 
 # Only install BCC tracing packages in CI. Container has to match the host for BCC to work.
 if [[ "${INSTALL_BCC_TRACING_TOOLS}" == "true" ]]; then

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 export CONTAINER_NAME=ci_native_fuzz
 export APT_LLVM_V="21"
 export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} libclang-rt-${APT_LLVM_V}-dev libevent-dev libboost-dev libsqlite3-dev libcapnp-dev capnproto"

--- a/ci/test/00_setup_env_native_fuzz_with_msan.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_msan.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 export APT_LLVM_V="21"
 LIBCXX_DIR="/cxx_build/"
 export MSAN_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -g -O1 -fno-optimize-sibling-calls"

--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 export CONTAINER_NAME=ci_native_fuzz_valgrind
 export PACKAGES="libevent-dev libboost-dev libsqlite3-dev valgrind libcapnp-dev capnproto"
 export NO_DEPENDS=1

--- a/ci/test/00_setup_env_native_msan.sh
+++ b/ci/test/00_setup_env_native_msan.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 export APT_LLVM_V="21"
 LIBCXX_DIR="/cxx_build/"
 export MSAN_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -g -O1 -fno-optimize-sibling-calls"

--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 export CONTAINER_NAME=ci_native_tidy
 export TIDY_LLVM_V="20"
 export APT_LLVM_V="${TIDY_LLVM_V}"

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_tsan
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 export APT_LLVM_V="21"
 LIBCXX_DIR="/cxx_build/"
 LIBCXX_FLAGS="-fsanitize=thread -nostdinc++ -nostdlib++ -isystem ${LIBCXX_DIR}include/c++/v1 -L${LIBCXX_DIR}lib -Wl,-rpath,${LIBCXX_DIR}lib -lc++ -lc++abi -lpthread -Wno-unused-command-line-argument"

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="ci_native_base"
 export CONTAINER_NAME=ci_native_valgrind
 export PACKAGES="valgrind python3-zmq libevent-dev libboost-dev libzmq3-dev libsqlite3-dev libcapnp-dev capnproto python3-pip"
 export PIP_PACKAGES="--break-system-packages pycapnp"

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_win64
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"  # Check that https://packages.ubuntu.com/noble/g++-mingw-w64-x86-64-posix (version 13.x, similar to guix) can cross-compile
+export CI_IMAGE_NAME_TAG="ci_native_base"  # Check that https://packages.ubuntu.com/noble/g++-mingw-w64-x86-64-posix (version 13.x, similar to guix) can cross-compile
 export HOST=x86_64-w64-mingw32
 export PACKAGES="g++-mingw-w64-x86-64-posix nsis"
 export RUN_UNIT_TESTS=false

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -67,6 +67,19 @@ def main():
         # Using buildx is required to properly load the correct driver, for use with registry caching. Neither build, nor BUILDKIT=1 currently do this properly
         cmd_build = ["docker", "buildx", "build"]
         cmd_build += [
+            f"--file={os.getenv('BASE_READ_ONLY_DIR')}/ci/test_imagefile_base",
+            f"--platform=linux",  # Use native architecture
+            f"--label={CI_IMAGE_LABEL}",
+            f"--tag=ci_native_base",
+        ]
+        cmd_build += maybe_cache_arg
+        cmd_build += [os.getenv('BASE_READ_ONLY_DIR')]
+
+        print(f"Building ci_native_base image layer")
+        run(cmd_build)
+
+        cmd_build = ["docker", "buildx", "build"]
+        cmd_build += [
             f"--file={os.getenv('BASE_READ_ONLY_DIR')}/ci/test_imagefile",
             f"--build-arg=CI_IMAGE_NAME_TAG={os.getenv('CI_IMAGE_NAME_TAG')}",
             f"--build-arg=FILE_ENV={os.getenv('FILE_ENV')}",

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -69,18 +69,11 @@ def main():
         buildx_ls = run(
             ["docker", "buildx", "ls", "--format", "{{.DriverEndpoint}} {{.Name}}"],
             check=False,
-            text=True,
-            stdout=subprocess.PIPE,
         )
         if buildx_ls.returncode != 0:
             print("Could not find docker based buildx, assuming podman!")
             print("If you are not using podman, but docker, make sure to create the buildx driver:")
             print("For example, via 'docker buildx create --use --driver docker'")
-        for line in buildx_ls.stdout.splitlines():
-            drv, name = line.split(maxsplit=1)
-            if drv == "docker":
-                print(f"Using existing docker based buildx: {name}")
-                os.environ["BUILDX_BUILDER"] = name
 
         cmd_build = ["docker", "buildx", "build"]
         cmd_build += [

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -94,6 +94,7 @@ def main():
             f"--build-arg=CI_IMAGE_NAME_TAG={os.getenv('CI_IMAGE_NAME_TAG')}",
             f"--build-arg=FILE_ENV={os.getenv('FILE_ENV')}",
             f"--build-arg=BASE_ROOT_DIR={os.getenv('BASE_ROOT_DIR')}",
+            f"--build-context=ci_native_base=docker-image://ci_native_base:latest",
             f"--platform={os.getenv('CI_IMAGE_PLATFORM')}",
             f"--label={CI_IMAGE_LABEL}",
             f"--tag={os.getenv('CONTAINER_NAME')}",

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -12,8 +12,9 @@ import sys
 
 def run(cmd, **kwargs):
     print("+ " + shlex.join(cmd), flush=True)
+    kwargs.setdefault("check", True)
     try:
-        return subprocess.run(cmd, check=True, **kwargs)
+        return subprocess.run(cmd, **kwargs)
     except Exception as e:
         sys.exit(e)
 
@@ -65,6 +66,22 @@ def main():
 
         # Use buildx unconditionally
         # Using buildx is required to properly load the correct driver, for use with registry caching. Neither build, nor BUILDKIT=1 currently do this properly
+        buildx_ls = run(
+            ["docker", "buildx", "ls", "--format", "{{.DriverEndpoint}} {{.Name}}"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+        if buildx_ls.returncode != 0:
+            print("Could not find docker based buildx, assuming podman!")
+            print("If you are not using podman, but docker, make sure to create the buildx driver:")
+            print("For example, via 'docker buildx create --use --driver docker'")
+        for line in buildx_ls.stdout.splitlines():
+            drv, name = line.split(maxsplit=1)
+            if drv == "docker":
+                print(f"Using existing docker based buildx: {name}")
+                os.environ["BUILDX_BUILDER"] = name
+
         cmd_build = ["docker", "buildx", "build"]
         cmd_build += [
             f"--file={os.getenv('BASE_READ_ONLY_DIR')}/ci/test_imagefile_base",

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -4,6 +4,7 @@
 # file COPYING or https://opensource.org/license/mit/.
 
 import os
+import random
 import shlex
 import subprocess
 import sys
@@ -15,6 +16,18 @@ def run(cmd, **kwargs):
         return subprocess.run(cmd, check=True, **kwargs)
     except Exception as e:
         sys.exit(e)
+
+
+def maybe_cpuset():
+    # Env vars during the build can not be changed. For example, a modified
+    # $MAKEJOBS is ignored in the build process. Use --cpuset-cpus as an
+    # approximation to respect $MAKEJOBS somewhat, if cpuset is available.
+    if os.getenv("HAVE_CGROUP_CPUSET"):
+        P = int(run(['nproc'], stdout=subprocess.PIPE).stdout)
+        M = min(P, int(os.getenv("MAKEJOBS").lstrip("-j")))
+        cpus = sorted(random.sample(range(P), M))
+        return [f"--cpuset-cpus={','.join(map(str, cpus))}"]
+    return []
 
 
 def main():
@@ -44,6 +57,30 @@ def main():
             if k in settings:
                 file.write(f"{k}={v}\n")
     run(["cat", env_file])
+
+    if not os.getenv("DANGER_RUN_CI_ON_HOST"):
+        CI_IMAGE_LABEL = "bitcoin-ci-test"
+
+        maybe_cache_arg = shlex.split(os.getenv('DOCKER_BUILD_CACHE_ARG'))
+
+        # Use buildx unconditionally
+        # Using buildx is required to properly load the correct driver, for use with registry caching. Neither build, nor BUILDKIT=1 currently do this properly
+        cmd_build = ["docker", "buildx", "build"]
+        cmd_build += [
+            f"--file={os.getenv('BASE_READ_ONLY_DIR')}/ci/test_imagefile",
+            f"--build-arg=CI_IMAGE_NAME_TAG={os.getenv('CI_IMAGE_NAME_TAG')}",
+            f"--build-arg=FILE_ENV={os.getenv('FILE_ENV')}",
+            f"--build-arg=BASE_ROOT_DIR={os.getenv('BASE_ROOT_DIR')}",
+            f"--platform={os.getenv('CI_IMAGE_PLATFORM')}",
+            f"--label={CI_IMAGE_LABEL}",
+            f"--tag={os.getenv('CONTAINER_NAME')}",
+        ]
+        cmd_build += maybe_cpuset()
+        cmd_build += maybe_cache_arg
+        cmd_build += [os.getenv('BASE_READ_ONLY_DIR')]
+
+        print(f"Building {os.getenv('CI_IMAGE_NAME_TAG')} image to run in")
+        run(cmd_build)
 
     run(["./ci/test/02_run_container.sh"])  # run the remainder
 

--- a/ci/test_imagefile_base
+++ b/ci/test_imagefile_base
@@ -1,0 +1,15 @@
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+# See ci/README.md for usage.
+
+# This offers a CI base image, which can be used as a shared base layer for
+# individual CI images.
+
+FROM mirror.gcr.io/ubuntu:24.04
+
+COPY ./ci/retry/retry /usr/bin/retry
+COPY ./ci/test/00_setup_env.sh /ci_container_base/ci/test/
+
+RUN ["bash", "-c", "cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && apt-get update && apt-get install --no-install-recommends --no-upgrade -y $CI_BASE_PACKAGES"]


### PR DESCRIPTION
Storage is cheap, so there was little value in extracting build layers in the CI images.

However, the GHA cache is limited to 10GB, so extracting a shared base layer could help to reduce the overall footprint. Possibly, it could even speed up image building, because installation is only done once.