### PR TITLE
refactor: optimize block index comparisons (1.4-6.8x faster)

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -99,18 +99,6 @@ base_uint<BITS>& base_uint<BITS>::operator/=(const base_uint& b)
 }
 
 template <unsigned int BITS>
-int base_uint<BITS>::CompareTo(const base_uint<BITS>& b) const
-{
-    for (int i = WIDTH - 1; i >= 0; i--) {
-        if (pn[i] < b.pn[i])
-            return -1;
-        if (pn[i] > b.pn[i])
-            return 1;
-    }
-    return 0;
-}
-
-template <unsigned int BITS>
 bool base_uint<BITS>::EqualTo(uint64_t b) const
 {
     for (int i = WIDTH - 1; i >= 2; i--) {

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -100,18 +100,6 @@ base_uint<BITS>& base_uint<BITS>::operator/=(const base_uint& b)
 }
 
 template <unsigned int BITS>
-int base_uint<BITS>::CompareTo(const base_uint<BITS>& b) const
-{
-    for (int i = WIDTH - 1; i >= 0; i--) {
-        if (pn[i] < b.pn[i])
-            return -1;
-        if (pn[i] > b.pn[i])
-            return 1;
-    }
-    return 0;
-}
-
-template <unsigned int BITS>
 bool base_uint<BITS>::EqualTo(uint64_t b) const
 {
     for (int i = WIDTH - 1; i >= 2; i--) {

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -202,10 +202,9 @@ public:
     friend inline std::strong_ordering operator<=>(const base_uint& a, const base_uint& b) noexcept {
         /** Numeric ordering (unlike \ref base_blob::Compare) */
         for (int i{WIDTH - 1}; i >= 0; --i) {
-            if (a.pn[i] < b.pn[i])
-                return std::strong_ordering::less;
-            if (a.pn[i] > b.pn[i])
-                return std::strong_ordering::greater;
+            if (auto cmp{a.pn[i] <=> b.pn[i]}; std::is_neq(cmp)) {
+                return cmp;
+            }
         }
         return std::strong_ordering::equal;
     }

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -186,8 +186,6 @@ public:
         return ret;
     }
 
-    /** Numeric ordering (unlike \ref base_blob::Compare) */
-    int CompareTo(const base_uint& b) const;
     bool EqualTo(uint64_t b) const;
 
     friend inline base_uint operator+(const base_uint& a, const base_uint& b) { return base_uint(a) += b; }
@@ -201,7 +199,16 @@ public:
     friend inline base_uint operator<<(const base_uint& a, int shift) { return base_uint(a) <<= shift; }
     friend inline base_uint operator*(const base_uint& a, uint32_t b) { return base_uint(a) *= b; }
     friend inline bool operator==(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) == 0; }
-    friend inline std::strong_ordering operator<=>(const base_uint& a, const base_uint& b) { return a.CompareTo(b) <=> 0; }
+    friend inline std::strong_ordering operator<=>(const base_uint& a, const base_uint& b) noexcept {
+        /** Numeric ordering (unlike \ref base_blob::Compare) */
+        for (int i{WIDTH - 1}; i >= 0; --i) {
+            if (a.pn[i] < b.pn[i])
+                return std::strong_ordering::less;
+            if (a.pn[i] > b.pn[i])
+                return std::strong_ordering::greater;
+        }
+        return std::strong_ordering::equal;
+    }
     friend inline bool operator==(const base_uint& a, uint64_t b) { return a.EqualTo(b); }
 
     /** Hex encoding of the number (with the most significant digits first). */

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(bench_bitcoin
   bip324_ecdh.cpp
   block_assemble.cpp
   blockencodings.cpp
+  blockstorage.cpp
   ccoins_caching.cpp
   chacha20.cpp
   checkblock.cpp

--- a/src/bench/blockstorage.cpp
+++ b/src/bench/blockstorage.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <arith_uint256.h>
+#include <bench/bench.h>
+#include <chain.h>
+#include <node/blockstorage.h>
+#include <random.h>
+#include <uint256.h>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+static void CBlockIndexWorkComparator(benchmark::Bench& bench)
+{
+    FastRandomContext rng{/*fDeterministic=*/true};
+
+    constexpr size_t n{1'000};
+    std::vector<std::unique_ptr<CBlockIndex>> blocks;
+    blocks.reserve(n);
+    for (size_t i{0}; i < n; ++i) {
+        auto block{std::make_unique<CBlockIndex>()};
+
+        if (i % 10 == 1) {
+            // Have some duplicates
+            if (rng.randbool()) block->nChainWork = blocks.back()->nChainWork;
+            if (rng.randbool()) block->nSequenceId = blocks.back()->nSequenceId;
+        } else {
+            block->nChainWork = UintToArith256(rng.rand256());
+            block->nSequenceId = int32_t(rng.rand32());
+        }
+
+        blocks.push_back(std::move(block));
+    }
+    std::ranges::shuffle(blocks, rng);
+
+    bench.batch(n * n).unit("cmp").run([&] {
+        for (size_t i{0}; i < n; ++i) {
+            for (size_t j{0}; j < n; ++j) {
+                constexpr node::CBlockIndexWorkComparator comparator;
+                bool result{comparator(&*blocks[i], &*blocks[j])};
+                ankerl::nanobench::doNotOptimizeAway(result);
+            }
+        }
+    });
+}
+
+BENCHMARK(CBlockIndexWorkComparator);

--- a/src/bench/blockstorage.cpp
+++ b/src/bench/blockstorage.cpp
@@ -2,15 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <node/blockstorage.h>
+
 #include <arith_uint256.h>
 #include <bench/bench.h>
 #include <chain.h>
-#include <node/blockstorage.h>
 #include <random.h>
-#include <uint256.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 static void CBlockIndexWorkComparator(benchmark::Bench& bench)

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -171,31 +171,6 @@ std::string CBlockFileInfo::ToString() const
 
 namespace node {
 
-bool CBlockIndexWorkComparator::operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
-{
-    // First sort by most total work, ...
-    if (pa->nChainWork > pb->nChainWork) return false;
-    if (pa->nChainWork < pb->nChainWork) return true;
-
-    // ... then by earliest activatable time, ...
-    if (pa->nSequenceId < pb->nSequenceId) return false;
-    if (pa->nSequenceId > pb->nSequenceId) return true;
-
-    // Use pointer address as tie breaker (should only happen with blocks
-    // loaded from disk, as those share the same id: 0 for blocks on the
-    // best chain, 1 for all others).
-    if (pa < pb) return false;
-    if (pa > pb) return true;
-
-    // Identical blocks.
-    return false;
-}
-
-bool CBlockIndexHeightOnlyComparator::operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
-{
-    return pa->nHeight < pb->nHeight;
-}
-
 std::vector<CBlockIndex*> BlockManager::GetAllBlockIndices()
 {
     AssertLockHeld(cs_main);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -141,24 +141,12 @@ inline constexpr uint32_t UNDO_DATA_DISK_OVERHEAD{STORAGE_HEADER_BYTES + uint256
 using BlockMap = std::unordered_map<uint256, CBlockIndex, BlockHasher>;
 
 struct CBlockIndexWorkComparator {
-    bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
+    bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const noexcept
     {
-        // First sort by most total work, ...
-        if (pa->nChainWork > pb->nChainWork) return false;
-        if (pa->nChainWork < pb->nChainWork) return true;
-
-        // ... then by earliest activatable time, ...
-        if (pa->nSequenceId < pb->nSequenceId) return false;
-        if (pa->nSequenceId > pb->nSequenceId) return true;
-
-        // Use pointer address as tie breaker (should only happen with blocks
-        // loaded from disk, as those share the same id: 0 for blocks on the
-        // best chain, 1 for all others).
-        if (pa < pb) return false;
-        if (pa > pb) return true;
-
-        // Identical blocks.
-        return false;
+        // First sort by most total work (ascending), then by earliest activatable time (descending), then by pointer value (descending).
+        // Pointer tiebreak should only happen with blocks loaded from disk, as those share the same id: 0 for blocks on the best chain, 1 for all others.
+        return std::tie(pa->nChainWork, pb->nSequenceId, pb)
+             < std::tie(pb->nChainWork, pa->nSequenceId, pa);
     }
 
     using is_transparent = void;
@@ -166,7 +154,7 @@ struct CBlockIndexWorkComparator {
 
 struct CBlockIndexHeightOnlyComparator {
     // Only compares the height of two block indices, doesn't try to tie-break
-    bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
+    bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const noexcept
     {
         return pa->nHeight < pb->nHeight;
     }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_NODE_BLOCKSTORAGE_H
 #define BITCOIN_NODE_BLOCKSTORAGE_H
 
+#include <arith_uint256.h>
 #include <attributes.h>
 #include <chain.h>
 #include <dbwrapper.h>
@@ -29,6 +30,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <compare>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -40,6 +42,7 @@
 #include <set>
 #include <span>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -138,13 +141,35 @@ inline constexpr uint32_t UNDO_DATA_DISK_OVERHEAD{STORAGE_HEADER_BYTES + uint256
 using BlockMap = std::unordered_map<uint256, CBlockIndex, BlockHasher>;
 
 struct CBlockIndexWorkComparator {
-    bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const;
+    bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
+    {
+        // First sort by most total work, ...
+        if (pa->nChainWork > pb->nChainWork) return false;
+        if (pa->nChainWork < pb->nChainWork) return true;
+
+        // ... then by earliest activatable time, ...
+        if (pa->nSequenceId < pb->nSequenceId) return false;
+        if (pa->nSequenceId > pb->nSequenceId) return true;
+
+        // Use pointer address as tie breaker (should only happen with blocks
+        // loaded from disk, as those share the same id: 0 for blocks on the
+        // best chain, 1 for all others).
+        if (pa < pb) return false;
+        if (pa > pb) return true;
+
+        // Identical blocks.
+        return false;
+    }
+
     using is_transparent = void;
 };
 
 struct CBlockIndexHeightOnlyComparator {
-    /* Only compares the height of two block indices, doesn't try to tie-break */
-    bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const;
+    // Only compares the height of two block indices, doesn't try to tie-break
+    bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
+    {
+        return pa->nHeight < pb->nHeight;
+    }
 };
 
 struct PruneLockInfo {

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -8,6 +8,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <iomanip>
@@ -16,7 +18,7 @@
 #include <string>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(arith_uint256_tests)
+BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)
 
 /// Convert vector to arith_uint256, via uint256 blob
 static inline arith_uint256 arith_uint256V(const std::vector<unsigned char>& vch)
@@ -277,6 +279,21 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
 
     BOOST_CHECK_LT(ZeroL,
                    OneL);
+}
+
+BOOST_AUTO_TEST_CASE(comparison_sorting)
+{
+    const std::array expected{
+        arith_uint256{1},
+        arith_uint256{2},
+        arith_uint256{arith_uint256{1} << 32},
+        arith_uint256{arith_uint256{1} << 33},
+    };
+
+    auto values{expected};
+    std::ranges::shuffle(values, m_rng);
+    std::ranges::sort(values);
+    BOOST_CHECK(values == expected);
 }
 
 BOOST_AUTO_TEST_CASE( plusMinus )

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -3,11 +3,14 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <arith_uint256.h>
+#include <random.h>
 #include <test/util/common.h>
 #include <uint256.h>
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <iomanip>
@@ -283,6 +286,22 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
 
     BOOST_CHECK_LT(ZeroL,
                    OneL);
+}
+
+BOOST_AUTO_TEST_CASE(comparison_sorting)
+{
+    const std::array expected{
+        arith_uint256{1},
+        arith_uint256{2},
+        arith_uint256{arith_uint256{1} << 32},
+        arith_uint256{arith_uint256{1} << 33},
+    };
+
+    FastRandomContext rng{/*fDeterministic=*/false};
+    auto values{expected};
+    std::ranges::shuffle(values, rng);
+    std::ranges::sort(values);
+    BOOST_CHECK(values == expected);
 }
 
 BOOST_AUTO_TEST_CASE( plusMinus )

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -6,11 +6,14 @@
 #include <node/blockstorage.h>
 #include <rpc/blockchain.h>
 #include <sync.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/string.h>
 
 #include <boost/test/unit_test.hpp>
 
+#include <array>
+#include <algorithm>
 #include <cstdlib>
 
 using util::ToString;
@@ -115,6 +118,32 @@ BOOST_AUTO_TEST_CASE(num_chain_tx_max)
     CBlockIndex block_index{};
     block_index.m_chain_tx_count = std::numeric_limits<uint64_t>::max();
     BOOST_CHECK_EQUAL(block_index.m_chain_tx_count, std::numeric_limits<uint64_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(cblockindex_comparator_sorting)
+{
+    constexpr std::array<std::pair<uint64_t, int32_t>, 4> original{{
+        {1, 20},
+        {1, 10},
+        {2, 20},
+        {2, 10},
+    }};
+
+    std::array<CBlockIndex, original.size()> pointer_storage{};
+    std::array<CBlockIndex*, original.size()> indexes{};
+    for (size_t i{0}; i < pointer_storage.size(); ++i) {
+        pointer_storage[i].nChainWork = arith_uint256{original[i].first};
+        pointer_storage[i].nSequenceId = original[i].second;
+        indexes[i] = &pointer_storage[i];
+    }
+
+    std::ranges::shuffle(indexes, m_rng);
+    std::ranges::sort(indexes, node::CBlockIndexWorkComparator{});
+
+    for (size_t i{0}; i < indexes.size(); ++i) {
+        BOOST_CHECK_EQUAL(indexes[i]->nChainWork, original[i].first);
+        BOOST_CHECK_EQUAL(indexes[i]->nSequenceId, original[i].second);
+    }
 }
 
 BOOST_FIXTURE_TEST_CASE(invalidate_block, TestChain100Setup)

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(util)
 add_executable(fuzz
   addition_overflow.cpp
   addrman.cpp
+  arith_uint256_comparison_equivalence.cpp
   asmap.cpp
   asmap_direct.cpp
   autofile.cpp
@@ -20,6 +21,7 @@ add_executable(fuzz
   block_header.cpp
   block_index.cpp
   block_index_tree.cpp
+  block_index_work_comparator.cpp
   blockfilter.cpp
   bloom_filter.cpp
   buffered_file.cpp

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(util)
 add_executable(fuzz
   addition_overflow.cpp
   addrman.cpp
+  arith_uint256_comparison_equivalence.cpp
   asmap.cpp
   asmap_direct.cpp
   autofile.cpp
@@ -21,6 +22,7 @@ add_executable(fuzz
   block_index.cpp
   block_index_tree.cpp
   block_policy_estimator.cpp
+  block_index_work_comparator.cpp
   blockfilter.cpp
   bloom_filter.cpp
   buffered_file.cpp

--- a/src/test/fuzz/arith_uint256_comparison_equivalence.cpp
+++ b/src/test/fuzz/arith_uint256_comparison_equivalence.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <arith_uint256.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cassert>
+
+namespace {
+
+struct OriginalArithUint256 : arith_uint256 {
+    using arith_uint256::arith_uint256;
+
+    explicit OriginalArithUint256(const arith_uint256& v) : arith_uint256(v) {}
+
+    int CompareTo(const OriginalArithUint256& b) const
+    {
+        for (int i = WIDTH - 1; i >= 0; i--) {
+            if (pn[i] < b.pn[i])
+                return -1;
+            if (pn[i] > b.pn[i])
+                return 1;
+        }
+        return 0;
+    }
+};
+
+} // namespace
+
+FUZZ_TARGET(arith_uint256_comparison_equivalence)
+{
+    FuzzedDataProvider provider{buffer.data(), buffer.size()};
+    OriginalArithUint256 a{ConsumeArithUInt256(provider)};
+    const OriginalArithUint256 b{ConsumeArithUInt256(provider)};
+    if (provider.ConsumeBool()) {
+        // Exercise identical pointers.
+        a = b;
+    }
+
+    const int old_result{a.CompareTo(b)};
+
+    const auto comparison{a <=> b};
+    const int new_result{comparison < 0 ? -1 : comparison > 0 ? 1 : 0};
+    assert(old_result == new_result);
+
+    // Verify all comparison operators match old behavior
+    assert((a < b) == (old_result < 0));
+    assert((a > b) == (old_result > 0));
+    assert((a <= b) == (old_result <= 0));
+    assert((a >= b) == (old_result >= 0));
+    assert((a == b) == (old_result == 0));
+    assert((a != b) == (old_result != 0));
+}

--- a/src/test/fuzz/block_index_work_comparator.cpp
+++ b/src/test/fuzz/block_index_work_comparator.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chain.h>
+#include <node/blockstorage.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <array>
+
+namespace {
+
+struct OldCBlockIndexWorkComparator {
+    bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
+    {
+        // First sort by most total work, ...
+        if (pa->nChainWork > pb->nChainWork) return false;
+        if (pa->nChainWork < pb->nChainWork) return true;
+
+        // ... then by earliest activatable time, ...
+        if (pa->nSequenceId < pb->nSequenceId) return false;
+        if (pa->nSequenceId > pb->nSequenceId) return true;
+
+        // Use pointer address as tie breaker (should only happen with blocks
+        // loaded from disk, as those share the same id: 0 for blocks on the
+        // best chain, 1 for all others).
+        if (pa < pb) return false;
+        if (pa > pb) return true;
+
+        // Identical blocks.
+        return false;
+    }
+};
+
+} // namespace
+
+FUZZ_TARGET(block_index_work_comparator)
+{
+    FuzzedDataProvider provider{buffer.data(), buffer.size()};
+
+    std::array<CBlockIndex, 2> storage{}; // defined pointer ordering
+    CBlockIndex* a{&storage[0]}, *b{&storage[1]};
+
+    // Generate random chain work and sequence IDs
+    a->nChainWork = ConsumeArithUInt256(provider);
+    a->nSequenceId = provider.ConsumeIntegral<int32_t>();
+    // Add some duplicates to test self-equality and pointer tie break
+    if (provider.ConsumeBool()) {
+        b = a;
+    } else {
+        // Exercise both equal and unequal values.
+        b->nChainWork = provider.ConsumeBool() ? a->nChainWork : ConsumeArithUInt256(provider);
+        b->nSequenceId = provider.ConsumeBool() ? a->nSequenceId : provider.ConsumeIntegral<int32_t>();
+    }
+
+    constexpr node::CBlockIndexWorkComparator comparator;
+    assert(OldCBlockIndexWorkComparator{}(a, b) == comparator(a, b));
+    assert(OldCBlockIndexWorkComparator{}(b, a) == comparator(b, a));
+}

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -59,7 +59,7 @@ public:
 
     /** Lexicographic ordering
      * @note Does NOT match the ordering on the corresponding \ref
-     *       base_uint::CompareTo, which starts comparing from the end.
+     *       base_uint::operator<=>, which starts comparing from the end.
      */
     constexpr int Compare(const base_blob& other) const { return std::memcmp(m_data.data(), other.m_data.data(), WIDTH); }
 

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -63,7 +63,7 @@ public:
 
     /** Lexicographic ordering
      * @note Does NOT match the ordering on the corresponding \ref
-     *       base_uint::CompareTo, which starts comparing from the end.
+     *       base_uint::operator<=>, which starts comparing from the end.
      */
     constexpr std::strong_ordering operator<=>(const base_blob& other) const = default;
 


### PR DESCRIPTION
**Context:** The comparator is often called either directly or for the sorting of [`setBlockIndexCandidates`](https://github.com/bitcoin/bitcoin/blob/master/src/validation.h#L637), a red-black tree-set containing valid block headers where the comparator is invoked extensively.
Besides the sorted set usages, the comparator is used directly in `Chainstate` in `FindMostWorkChain`, `PruneBlockIndexCandidates`, `ActivateBestChain`, and `InvalidateBlock`; and in `ChainstateManager` in `LoadBlockIndex`, `CheckBlockIndex`, `ActivateSnapshot`, and `PopulateAndValidateSnapshot`.

It was profiled during the investigation of https://github.com/bitcoin/bitcoin/issues/33618#issuecomment-3402229976.

**Testing:** To ensure the optimized implementations are both fast and correct, the first commit adds a dedicated benchmark to measure `CBlockIndexWorkComparator` performance, and the second commit adds deterministic sorting tests comparing the new implementation with the original one. Later commits add fuzz targets for equivalence coverage.

**Results:**
> GCC 15.0.1:

* `CBlockIndexWorkComparator`: 100,772,511 cmp/s → 656,674,205 cmp/s = 6.51x faster
* `CheckBlockIndex`: 9,091 ops/s → 14,765 ops/s = 1.62x faster
> Clang 22.0.0:

* `CBlockIndexWorkComparator`: 100,451,893 cmp/s → 683,414,234 cmp/s = 6.8x faster
* `CheckBlockIndex`: 10,322 ops/s → 14,376 ops/s = 1.39x faster

See https://corecheck.dev/bitcoin/bitcoin/pulls/33637 for the CI's `CheckBlockIndex` performance.
<details>
<summary>gcc and clang measurements</summary>

> Compiler: gcc 15.0.1

b60450fae8 bench: add benchmark to measure `CBlockIndexWorkComparator` performance

|              ns/cmp |               cmp/s |    err% |         ins/cmp |         cyc/cmp |    IPC |        bra/cmp |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                9.92 |      100,772,511.62 |    0.0% |           63.98 |           35.64 |  1.795 |          14.17 |    1.9% |      5.50 | `CBlockIndexWorkComparator`

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          109,996.46 |            9,091.20 |    0.2% |    1,014,421.11 |      394,979.29 |  2.568 |     313,025.11 |    0.0% |      5.50 | `CheckBlockIndex`

e2e02177ba refactor: inline `arith_uint256` comparison operator

|              ns/cmp |               cmp/s |    err% |         ins/cmp |         cyc/cmp |    IPC |        bra/cmp |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                6.48 |      154,439,491.66 |    0.0% |           31.01 |           23.25 |  1.334 |           7.16 |    3.8% |      5.50 | `CBlockIndexWorkComparator`

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          105,754.86 |            9,455.83 |    0.1% |      913,130.11 |      379,588.20 |  2.406 |     276,692.11 |    0.0% |      5.50 | `CheckBlockIndex`

85b74b01de refactor: optimize `arith_uint256` comparison with spaceship operator

|              ns/cmp |               cmp/s |    err% |         ins/cmp |         cyc/cmp |    IPC |        bra/cmp |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                6.37 |      156,990,488.06 |    0.0% |           28.85 |           22.87 |  1.261 |           8.61 |    3.2% |      5.50 | `CBlockIndexWorkComparator`

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           83,803.10 |           11,932.73 |    0.0% |      743,565.09 |      300,824.84 |  2.472 |     232,646.08 |    0.0% |      5.56 | `CheckBlockIndex`

deb58eea2f refactor: optimize `CBlockIndexWorkComparator` with std::tie

|              ns/cmp |               cmp/s |    err% |         ins/cmp |         cyc/cmp |    IPC |        bra/cmp |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                1.52 |      656,674,205.98 |    0.0% |           13.18 |            5.47 |  2.410 |           3.06 |    0.1% |      5.50 | `CBlockIndexWorkComparator`

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           67,726.84 |           14,765.19 |    0.2% |      585,826.07 |      243,155.90 |  2.409 |     181,920.07 |    0.0% |      5.54 | `CheckBlockIndex`
> Compiler: clang 22.0.0

b60450fae8 bench: add benchmark to measure `CBlockIndexWorkComparator` performance

|              ns/cmp |               cmp/s |    err% |         ins/cmp |         cyc/cmp |    IPC |        bra/cmp |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                9.96 |      100,451,893.46 |    0.0% |           61.28 |           35.75 |  1.714 |          13.62 |    2.1% |      5.52 | `CBlockIndexWorkComparator`

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           96,878.70 |           10,322.19 |    0.1% |      802,827.10 |      347,679.01 |  2.309 |     234,823.10 |    0.0% |      5.50 | `CheckBlockIndex`

e2e02177ba refactor: inline `arith_uint256` comparison operator

|              ns/cmp |               cmp/s |    err% |         ins/cmp |         cyc/cmp |    IPC |        bra/cmp |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                6.13 |      163,183,693.10 |    0.0% |           25.74 |           22.01 |  1.170 |           6.10 |    4.6% |      5.50 | `CBlockIndexWorkComparator`

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           86,307.94 |           11,586.42 |    1.2% |      646,229.09 |      309,785.33 |  2.086 |     195,119.09 |    0.0% |      5.54 | `CheckBlockIndex`

85b74b01de refactor: optimize `arith_uint256` comparison with spaceship operator

|              ns/cmp |               cmp/s |    err% |         ins/cmp |         cyc/cmp |    IPC |        bra/cmp |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                6.36 |      157,330,900.16 |    1.0% |           26.20 |           22.61 |  1.159 |           6.55 |    4.4% |      5.53 | `CBlockIndexWorkComparator`

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           75,031.66 |           13,327.71 |    1.0% |      650,604.15 |      266,934.04 |  2.437 |     149,967.14 |    0.0% |      5.54 | `CheckBlockIndex`

deb58eea2f refactor: optimize `CBlockIndexWorkComparator` with std::tie

|              ns/cmp |               cmp/s |    err% |         ins/cmp |         cyc/cmp |    IPC |        bra/cmp |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                1.46 |      683,414,234.14 |    0.0% |           16.12 |            5.25 |  3.067 |           4.02 |    0.1% |      5.50 | `CBlockIndexWorkComparator`

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           69,559.70 |           14,376.14 |    0.1% |      559,208.07 |      249,654.28 |  2.240 |     132,342.07 |    0.0% |      5.51 | `CheckBlockIndex`
</details>
**Reproducer:** Run the equivalence tests with:
```bash
cmake -B build && cmake --build build && ./build/bin/test_bitcoin --run_test=arith_uint256_tests,blockchain_tests
```
Each commit shows how it changes the relevant benchmarks.
<details>
<summary>Benchmark script</summary>

```bash
for compiler in gcc clang; do \
  if [ "$compiler" = "gcc" ]; then CC=gcc; CXX=g++; COMP_VER=$(gcc -dumpfullversion); \
  else CC=clang; CXX=clang++; COMP_VER=$(clang -dumpversion); fi && \
  echo "> Compiler: $compiler $COMP_VER" && \
  for commit in 70c6244b709fcf6a853ea44b91b9ed219609ac90 \
                516e05cd7d8dbb61b05854c59f5393367e502284 \
                d053b27c06d06cccbc6395b0aa7dc1c4193a6fc3 \
                8ef4ce2cb3ac80cbe58b8cf76e183f9eca6fafe4 \
                703165e6d3b9fbd58b9c31ddce0e961047fc5e71; do \
    git fetch origin $commit >/dev/null 2>&1 && git checkout $commit >/dev/null 2>&1 && git log -1 --pretty='%h %s' && \
    rm -rf build && \
    cmake -B build -DBUILD_BENCH=ON -DENABLE_IPC=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo \
      -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX >/dev/null 2>&1 && \
    cmake --build build -j$(nproc) >/dev/null 2>&1 && \
    for i in 1; do \
      build/bin/bench_bitcoin -filter='CBlockIndexWorkComparator|CheckBlockIndex' -min-time=5000; \
    done; \
  done; \
done
```
</details>
Note: something similar was already started in #33334, but this is a broader optimization that doesn't use the same technique.