### PR TITLE
fuzz: don't pass (maybe) nullptr to memcpy()

### DIFF
--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -323,7 +323,9 @@ std::unique_ptr<Sock> FuzzedSock::Accept(sockaddr* addr, socklen_t* addr_len) co
                 auto addr4 = reinterpret_cast<sockaddr_in*>(addr);
                 addr4->sin_family = AF_INET;
                 const auto sin_addr_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(sizeof(addr4->sin_addr));
-                memcpy(&addr4->sin_addr, sin_addr_bytes.data(), sin_addr_bytes.size());
+                if (!sin_addr_bytes.empty()) {
+                    memcpy(&addr4->sin_addr, sin_addr_bytes.data(), sin_addr_bytes.size());
+                }
                 addr4->sin_port = m_fuzzed_data_provider.ConsumeIntegralInRange<uint16_t>(1, 65535);
             }
         } else {
@@ -334,7 +336,9 @@ std::unique_ptr<Sock> FuzzedSock::Accept(sockaddr* addr, socklen_t* addr_len) co
                 auto addr6 = reinterpret_cast<sockaddr_in6*>(addr);
                 addr6->sin6_family = AF_INET6;
                 const auto sin_addr_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(sizeof(addr6->sin6_addr));
-                memcpy(&addr6->sin6_addr, sin_addr_bytes.data(), sin_addr_bytes.size());
+                if (!sin_addr_bytes.empty()) {
+                    memcpy(&addr6->sin6_addr, sin_addr_bytes.data(), sin_addr_bytes.size());
+                }
                 addr6->sin6_port = m_fuzzed_data_provider.ConsumeIntegralInRange<uint16_t>(1, 65535);
             }
         }


### PR DESCRIPTION
If `ConsumeBytes()` returns an empty vector, then its `data()` method may or may not return a null pointer [1]. Its `size()` method will return 0 and `memcpy(dst, maybenull, 0)` will be called from `FuzzedSock::Accept()`.

Given that the `len` argument is 0, `memcpy()` should not try to dereference the maybenull argument, but nevertheless the sanitizer is upset:

```
./src/test/fuzz/util/net.cpp:337:43: runtime error: null pointer passed
as argument 2, which is declared to never be null
```

Fix this by avoiding the call to `memcpy()` if an empty vector is returned. The full target buffer is zeroed upfront.

[1] https://en.cppreference.com/w/cpp/container/vector/data

Resolves: https://github.com/bitcoin/bitcoin/issues/33643

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
