### PR TITLE
fix: invalid plist format and update values to meet macOS 1.0 standard

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
-<plist version="0.9">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
 <dict>
   <key>LSMinimumSystemVersion</key>
-  <string>14</string>
+  <string>10.14.0</string>
 
   <key>LSArchitecturePriority</key>
   <array>
@@ -63,7 +63,7 @@
     <string>NSApplication</string>
 
   <key>NSHighResolutionCapable</key>
-    <string>True</string>
+    <true/>
 
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>


### PR DESCRIPTION
corrected the outdated and invalid parts of the plist file to comply with the current macOS property list 1.0 specification.

**changes:**

* replaced the old `SYSTEM` declaration and `version="0.9"` with the proper `PUBLIC` declaration and `version="1.0"`.
* updated `LSMinimumSystemVersion` from `14` to `10.14.0` (using the proper `X.Y.Z` format).
* changed `<string>True</string>` to `<true/>` to use a valid boolean value instead of a string.

now validates correctly with Apple’s DTD and works as expected on modern macOS versions.
