### PR TITLE
doc: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Guidance for Automated Agents
+
+## Commit attribution
+
+Include the following trailers on commits substantially generated with automated assistance:
+
+```
+Assisted-by: GitHub Copilot
+Assisted-by: OpenAI GPT-5-Codex
+```


### PR DESCRIPTION
Suggest disclosure via commit message:

```
Assisted-by: GitHub Copilot
Assisted-by: OpenAI GPT-5-Codex
```

This can be useful information for reviewers, especially when the PR is from a new contributor.

In my experience using Visual Studio Code in agent mode (e.g. on https://github.com/sjors/sv2-tp) it usually picks up and follows this instruction.

Of course anyone who wishes to hide the fact they're using an LLM can simply modify the commit message.

See https://agents.md