### PR TITLE
net: Filter addrman during address selection via AddrPolicy to avoid underfill

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -12,6 +12,7 @@
 #include <logging/timer.h>
 #include <netaddress.h>
 #include <netgroup.h>
+#include <netbase.h>
 #include <protocol.h>
 #include <random.h>
 #include <serialize.h>
@@ -790,7 +791,7 @@ nid_type AddrManImpl::GetEntry(bool use_tried, size_t bucket, size_t position) c
     return -1;
 }
 
-std::vector<CAddress> AddrManImpl::GetAddr_(size_t max_addresses, size_t max_pct, std::optional<Network> network, const bool filtered) const
+std::vector<CAddress> AddrManImpl::GetAddr_(size_t max_addresses, size_t max_pct, std::optional<Network> network, const bool filtered, const AddrMan::AddrPolicy& policy) const
 {
     AssertLockHeld(cs);
     Assume(max_pct <= 100);
@@ -808,6 +809,7 @@ std::vector<CAddress> AddrManImpl::GetAddr_(size_t max_addresses, size_t max_pct
     const auto now{Now<NodeSeconds>()};
     std::vector<CAddress> addresses;
     addresses.reserve(nNodes);
+    size_t filtered_addr_net = 0, filtered_addr_quality = 0, filtered_addr_policy = 0;
     for (unsigned int n = 0; n < vRandom.size(); n++) {
         if (addresses.size() >= nNodes)
             break;
@@ -820,14 +822,31 @@ std::vector<CAddress> AddrManImpl::GetAddr_(size_t max_addresses, size_t max_pct
         const AddrInfo& ai{it->second};
 
         // Filter by network (optional)
-        if (network != std::nullopt && ai.GetNetClass() != network) continue;
+        if (network != std::nullopt && ai.GetNetClass() != network) {
+            ++filtered_addr_net;
+            continue;
+        }
 
         // Filter for quality
-        if (ai.IsTerrible(now) && filtered) continue;
+        if (ai.IsTerrible(now) && filtered) {
+            ++filtered_addr_quality;
+            continue;
+        }
+
+        // Filter by policy
+        if (policy && policy(ai)) {
+            ++filtered_addr_policy;
+            continue;
+        }
 
         addresses.push_back(ai);
     }
-    LogDebug(BCLog::ADDRMAN, "GetAddr returned %d random addresses\n", addresses.size());
+    LogDebug(BCLog::ADDRMAN, "GetAddr returned %zu random addresses from %s; %zu filtered "
+                             "(%zu network, %zu quality, %zu policy)\n",
+                             addresses.size(),
+                             network == std::nullopt ? "all networks" : GetNetworkName(network.value()),
+                             (filtered_addr_net+filtered_addr_quality+filtered_addr_policy),
+                             filtered_addr_net, filtered_addr_quality, filtered_addr_policy);
     return addresses;
 }
 
@@ -1207,11 +1226,11 @@ std::pair<CAddress, NodeSeconds> AddrManImpl::Select(bool new_only, const std::u
     return addrRet;
 }
 
-std::vector<CAddress> AddrManImpl::GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network, const bool filtered) const
+std::vector<CAddress> AddrManImpl::GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network, const bool filtered, const AddrMan::AddrPolicy& policy) const
 {
     LOCK(cs);
     Check();
-    auto addresses = GetAddr_(max_addresses, max_pct, network, filtered);
+    auto addresses = GetAddr_(max_addresses, max_pct, network, filtered, policy);
     Check();
     return addresses;
 }
@@ -1310,9 +1329,9 @@ std::pair<CAddress, NodeSeconds> AddrMan::Select(bool new_only, const std::unord
     return m_impl->Select(new_only, networks);
 }
 
-std::vector<CAddress> AddrMan::GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network, const bool filtered) const
+std::vector<CAddress> AddrMan::GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network, const bool filtered, const AddrPolicy& policy) const
 {
-    return m_impl->GetAddr(max_addresses, max_pct, network, filtered);
+    return m_impl->GetAddr(max_addresses, max_pct, network, filtered, policy);
 }
 
 std::vector<std::pair<AddrInfo, AddressPosition>> AddrMan::GetEntries(bool use_tried) const

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <ios>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -116,6 +117,15 @@ protected:
     const std::unique_ptr<AddrManImpl> m_impl;
 
 public:
+    /** Predicate used to exclude addresses during selection.
+     *  Return true to skip the given address.
+     *
+     *  Runs while holding AddrMan::cs, so it must be non-blocking, must not
+     *  attempt to reacquire AddrMan::cs, and must preserve lock ordering to
+     *  avoid deadlocks.
+     */
+    using AddrPolicy = std::function<bool(const CAddress&)>;
+
     explicit AddrMan(const NetGroupManager& netgroupman, bool deterministic, int32_t consistency_check_ratio);
 
     ~AddrMan();
@@ -194,10 +204,11 @@ public:
      * @param[in] max_pct        Maximum percentage of addresses to return (0 = all). Value must be from 0 to 100.
      * @param[in] network        Select only addresses of this network (nullopt = all).
      * @param[in] filtered       Select only addresses that are considered good quality (false = all).
+     * @param[in] policy         Optional predicate to exclude candidates during selection (return true to skip).
      *
      * @return                   A vector of randomly selected addresses from vRandom.
      */
-    std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network, bool filtered = true) const;
+    std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network, bool filtered = true, const AddrPolicy& policy = {}) const;
 
     /**
      * Returns an information-location pair for all addresses in the selected addrman table.

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -135,7 +135,7 @@ public:
     std::pair<CAddress, NodeSeconds> Select(bool new_only, const std::unordered_set<Network>& networks) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
-    std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network, bool filtered = true) const
+    std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network, bool filtered = true, const AddrMan::AddrPolicy& policy = {}) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
     std::vector<std::pair<AddrInfo, AddressPosition>> GetEntries(bool from_tried) const
@@ -267,7 +267,7 @@ private:
      * */
     nid_type GetEntry(bool use_tried, size_t bucket, size_t position) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    std::vector<CAddress> GetAddr_(size_t max_addresses, size_t max_pct, std::optional<Network> network, bool filtered = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    std::vector<CAddress> GetAddr_(size_t max_addresses, size_t max_pct, std::optional<Network> network, bool filtered = true, const AddrMan::AddrPolicy& policy = {}) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     std::vector<std::pair<AddrInfo, AddressPosition>> GetEntries_(bool from_tried) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3759,13 +3759,12 @@ CConnman::~CConnman()
 
 std::vector<CAddress> CConnman::GetAddressesUnsafe(size_t max_addresses, size_t max_pct, std::optional<Network> network, const bool filtered) const
 {
-    std::vector<CAddress> addresses = addrman.get().GetAddr(max_addresses, max_pct, network, filtered);
-    if (m_banman) {
-        addresses.erase(std::remove_if(addresses.begin(), addresses.end(),
-                        [this](const CAddress& addr){return m_banman->IsDiscouraged(addr) || m_banman->IsBanned(addr);}),
-                        addresses.end());
-    }
-    return addresses;
+    // This runs under AddrMan::cs, and BanMan checks take m_banned_mutex.
+    // The lock order here is AddrMan::cs -> m_banned_mutex.
+    const AddrMan::AddrPolicy policy = [this](const CAddress& addr) {
+        return m_banman && (m_banman->IsDiscouraged(addr) || m_banman->IsBanned(addr));
+    };
+    return addrman.get().GetAddr(max_addresses, max_pct, network, filtered, policy);
 }
 
 std::vector<CAddress> CConnman::GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct)

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -470,6 +470,27 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     // Net processing asks for 23% of addresses. 23% of 5 is 1 rounded down.
     BOOST_CHECK_EQUAL(addrman->GetAddr(/*max_addresses=*/2500, /*max_pct=*/23, /*network=*/std::nullopt).size(), 1U);
 
+    // Test AddrMan::GetAddr filtering with various AddrPolicy rules.
+    const size_t addedAddresses = addrman->Size();
+    const AddrMan::AddrPolicy policyNoSkip = [](const CAddress&) { return false; };
+    const AddrMan::AddrPolicy policySkipAll = [](const CAddress&) { return true; };
+    const AddrMan::AddrPolicy policyPortPolicy = [](const CAddress& addr) { return addr.GetPort() != 8333; };
+
+    const std::vector<CAddress> vAddrNoPolicy = addrman->GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/std::nullopt, /*filtered=*/false);
+    const std::vector<CAddress> vAddrPolicyNoSkip = addrman->GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/std::nullopt, /*filtered=*/false, /*policy=*/policyNoSkip);
+    const std::vector<CAddress> vAddrPolicySkipAll = addrman->GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/std::nullopt, /*filtered=*/false, /*policy=*/policySkipAll);
+    const std::vector<CAddress> vAddrPolicyPort = addrman->GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/std::nullopt, /*filtered=*/false, /*policy=*/policyPortPolicy);
+    const std::set<CAddress> vExpectedAddresses = {addr1, addr3, addr4, addr5};
+
+    BOOST_CHECK_EQUAL(vAddrNoPolicy.size(), addedAddresses);
+    BOOST_CHECK_EQUAL(vAddrPolicyNoSkip.size(), vAddrNoPolicy.size());
+    BOOST_CHECK_EQUAL(vAddrPolicySkipAll.size(), 0);
+
+    // Check that vAddrPolicyPort contains exactly the same items as vExpectedAddresses
+    BOOST_CHECK_EQUAL(vAddrPolicyPort.size(), vExpectedAddresses.size());
+    BOOST_CHECK(std::all_of(vAddrPolicyPort.begin(), vAddrPolicyPort.end(), [&](const CAddress& a){ return vExpectedAddresses.contains(a); }));
+    BOOST_CHECK(std::none_of(vAddrPolicyPort.begin(), vAddrPolicyPort.end(), policyPortPolicy));
+
     // Test: Ensure GetAddr works with new and tried addresses.
     BOOST_CHECK(addrman->Good(CAddress(addr1, NODE_NONE)));
     BOOST_CHECK(addrman->Good(CAddress(addr2, NODE_NONE)));

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -180,6 +180,24 @@ FUZZ_TARGET(addrman, .init = initialize_addrman)
     auto filtered = fuzzed_data_provider.ConsumeBool();
     (void)const_addr_man.GetAddr(max_addresses, max_pct, network, filtered);
 
+    CallOneOf(
+        fuzzed_data_provider,
+        [&] {
+            const AddrMan::AddrPolicy policyNoSkip = [](const CAddress&) { return false; };
+            (void)const_addr_man.GetAddr(max_addresses, max_pct, network, filtered, policyNoSkip);
+        },
+        [&] {
+            const AddrMan::AddrPolicy policySkipAll = [](const CAddress&) { return true; };
+            (void)const_addr_man.GetAddr(max_addresses, max_pct, network, filtered, policySkipAll);
+        },
+        [&] {
+            const AddrMan::AddrPolicy policyPortPolicy = [](const CAddress& addr) {
+                return addr.GetPort() != 8333;
+            };
+            (void)const_addr_man.GetAddr(max_addresses, max_pct, network, filtered, policyPortPolicy);
+        }
+    );
+
     std::unordered_set<Network> nets;
     for (const auto& net : ALL_NETWORKS) {
         if (fuzzed_data_provider.ConsumeBool()) {


### PR DESCRIPTION
This PR introduces `AddrMan::AddrPolicy`, a predicate that allows callers to
exclude addresses during selection. The policy returns true to skip a given
entry and is evaluated while holding `AddrMan::cs`.

The mechanism is used in `CConnman::GetAddressesUnsafe()` to filter out
banned and discouraged peers during address selection instead of removing
them afterward. This prevents P2P responses (`GETADDR`) and RPCs (`getnodeaddresses)` from
returning fewer results than requested when large portions of the address space are filtered.

Additional improvements:
- Logs the number of filtered entries for diagnostics
- Avoids redundant filtering passes in higher-level callers
- Keeps locking behavior unchanged (the policy runs under `AddrMan::cs`)

**Testing**
- Repro: ban or discourage a large set of addresses, then call
  `getnodeaddresses 1`,  previously underfilled.
- After this change, the RPC returns up to the requested count as expected.

No behavior change for unaffected callers.
