### PR TITLE
test: Use unassigned p2p_port instead of hardcoded 60000 in p2p_i2p_ports.py

### DIFF
--- a/test/functional/p2p_i2p_ports.py
+++ b/test/functional/p2p_i2p_ports.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python3
-# Copyright (c) 2021-2021 The Bitcoin Core developers
+# Copyright (c) 2021-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """
 Test ports handling for I2P hosts
 """
 
-
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import p2p_port
 
-PROXY = "127.0.0.1:60000"
 
 class I2PPorts(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        # Use the p2p port of the non-existing next node as the proxy port
+        self.proxy = f"127.0.0.1:{p2p_port(self.num_nodes)}"
         # The test assumes that an I2P SAM proxy is not listening here.
-        self.extra_args = [[f"-i2psam={PROXY}"]]
+        self.extra_args = [[f"-i2psam={self.proxy}"]]
 
     def run_test(self):
         node = self.nodes[0]
@@ -27,7 +28,7 @@ class I2PPorts(BitcoinTestFramework):
 
         self.log.info("Ensure we try to connect if port=0 and get an error due to missing I2P proxy")
         addr = "h3r6bkn46qxftwja53pxiykntegfyfjqtnzbm6iv6r5mungmqgmq.b32.i2p:0"
-        with node.assert_debug_log(expected_msgs=[f"Error connecting to {addr}: Cannot connect to {PROXY}"]):
+        with node.assert_debug_log(expected_msgs=[f"Error connecting to {addr}: Cannot connect to {self.proxy}"]):
             node.addnode(node=addr, command="onetry")
 
 


### PR DESCRIPTION
The goal is to fix https://github.com/bitcoin/bitcoin/issues/30030.

The root cause it unclear. However, hard-coding the port to 60000 does not seem ideal anyway. This could break in an unlikely setting where so many functional tests are run, such that the port is occupied. Also, it could fail when `TEST_RUNNER_PORT_MIN` is set sufficiently high. (This is purely theoretical, as I don't think anyone would run a command like this, but on current master it fails, and on this pull it passes: `TEST_RUNNER_PORT_MIN=60000 ./bld-cmake/test/functional/p2p_i2p_ports.py --portseed=0`)

So fix those issues (and hopefully also 30030) by using an unoccupied p2p_port.

The logic is similar to the `extra_port()` logic in the `feature_bind_extra.py` test.