### PR TITLE
qt: Increase tooltip wrap threshold from 80 to 100 characters

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -41,7 +41,7 @@ static const bool DEFAULT_SPLASHSCREEN = true;
 /* Tooltips longer than this (in characters) are converted into rich text,
    so that they can be word-wrapped.
  */
-static const int TOOLTIP_WRAP_THRESHOLD = 80;
+static const int TOOLTIP_WRAP_THRESHOLD = 100;
 
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 36


### PR DESCRIPTION
## Summary
This PR increases the tooltip wrap threshold from 80 to 100 characters to improve user experience.

## Changes
- Modified `TOOLTIP_WRAP_THRESHOLD` constant in `src/qt/guiconstants.h`
- Changed value from 80 to 100 characters

## Rationale
The previous threshold of 80 characters was too restrictive for modern displays and longer descriptive tooltips. This change allows more content to be displayed before tooltips are converted to rich text format.

## Testing
- No linter errors introduced
- Change is minimal and low-risk
- Improves UI/UX for longer tooltips

## Type of Change
- [x] UI/UX improvement
- [x] Low-risk change
- [x] No breaking changes