### PR TITLE
randomenv: drop self define of 'environ'

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -57,10 +57,6 @@
 #include <sys/auxv.h>
 #endif
 
-#ifndef _MSC_VER
-extern char** environ; // NOLINT(readability-redundant-declaration): Necessary on some platforms
-#endif
-
 namespace {
 
 /** Helper to easily feed data into a CSHA512.


### PR DESCRIPTION
This variable/symbol/macro ought to be defined by the system includes, not us.

Alternative to #33570.