### PR TITLE
More comprehensive datacarrier configuration

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -659,11 +659,8 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-acceptstalefeeestimates", strprintf("Read fee estimates even if they are stale (%sdefault: %u) fee estimates are considered stale if they are %s hours old", "regtest only; ", DEFAULT_ACCEPT_STALE_FEE_ESTIMATES, Ticks<std::chrono::hours>(MAX_FILE_AGE)), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-bytespersigop", strprintf("Equivalent bytes per sigop in transactions for relay and mining (default: %u)", DEFAULT_BYTES_PER_SIGOP), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrier", strprintf("Relay and mine data carrier transactions (default: %u)", DEFAULT_ACCEPT_DATACARRIER), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-datacarriersize",
-                   strprintf("Relay and mine transactions whose data-carrying raw scriptPubKeys in aggregate "
-                             "are of this size or less, allowing multiple outputs (default: %u)",
-                             MAX_OP_RETURN_RELAY),
-                   ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-datacarriersize", strprintf("Relay and mine transactions whose any data-carrying raw scriptPubKey output is of this size or less. 0 = no limit (default: %u)", DEFAULT_OP_RETURN_SIZE_LIMIT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-datacarriercount", strprintf("The maximum number of data carrier outputs per transaction to relay and mine. 0 = no limit (default: %u)", DEFAULT_OP_RETURN_COUNT_LIMIT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-permitbaremultisig", strprintf("Relay transactions creating non-P2SH multisig outputs (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -43,14 +43,23 @@ struct MemPoolOptions {
     /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
     CFeeRate min_relay_feerate{DEFAULT_MIN_RELAY_TX_FEE};
     CFeeRate dust_relay_feerate{DUST_RELAY_TX_FEE};
+    // TODO can be removed, no longer necessary
+    std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_DATACARRIER_RELAY} : std::nullopt};
     /**
      * A data carrying output is an unspendable output containing data. The script
      * type is designated as TxoutType::NULL_DATA.
-     *
-     * Maximum size of TxoutType::NULL_DATA scripts that this node considers standard.
+     */
+    bool datacarrier_accept{DEFAULT_ACCEPT_DATACARRIER};
+    /**
+     * Maximum size of a TxoutType::NULL_DATA script that this node considers standard (0 = no limit).
      * If nullopt, any size is nonstandard.
      */
-    std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_OP_RETURN_RELAY} : std::nullopt};
+    std::optional<unsigned> datacarrier_sizelimit{DEFAULT_ACCEPT_DATACARRIER ? std::optional{DEFAULT_OP_RETURN_SIZE_LIMIT} : std::nullopt};
+    /**
+     * Maximum count of TxoutType::NULL_DATA outputs that this node considers standard (0 = no limit).
+     * If nullopt, any count is nonstandard.
+     */
+    std::optional<unsigned> datacarrier_countlimit{DEFAULT_ACCEPT_DATACARRIER ? std::optional{DEFAULT_OP_RETURN_COUNT_LIMIT} : std::nullopt};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
     bool require_standard{true};
     bool persist_v1_dat{DEFAULT_PERSIST_V1_DAT};

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -91,10 +91,15 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
 
     mempool_opts.permit_bare_multisig = argsman.GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
 
-    if (argsman.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER)) {
-        mempool_opts.max_datacarrier_bytes = argsman.GetIntArg("-datacarriersize", MAX_OP_RETURN_RELAY);
+    mempool_opts.datacarrier_accept = argsman.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
+    if (mempool_opts.datacarrier_accept) {
+        mempool_opts.max_datacarrier_bytes = MAX_DATACARRIER_RELAY;
+        mempool_opts.datacarrier_sizelimit = argsman.GetIntArg("-datacarriersize", DEFAULT_OP_RETURN_SIZE_LIMIT);
+        mempool_opts.datacarrier_countlimit = argsman.GetIntArg("-datacarriercount", DEFAULT_OP_RETURN_COUNT_LIMIT);
     } else {
         mempool_opts.max_datacarrier_bytes = std::nullopt;
+        mempool_opts.datacarrier_sizelimit = std::nullopt;
+        mempool_opts.datacarrier_countlimit = std::nullopt;
     }
 
     mempool_opts.require_standard = !argsman.GetBoolArg("-acceptnonstdtxn", DEFAULT_ACCEPT_NON_STD_TXN);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -74,10 +74,12 @@ static constexpr unsigned int DEFAULT_DESCENDANT_LIMIT{25};
 static constexpr unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT_KVB{101};
 /** Default for -datacarrier */
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
-/**
- * Default setting for -datacarriersize in vbytes.
- */
-static const unsigned int MAX_OP_RETURN_RELAY = MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR;
+/** Default setting for -datacarriersize. 80 bytes of data, +1 for OP_RETURN, +2 for the pushdata opcodes. 0 = no limit */
+static const unsigned int DEFAULT_OP_RETURN_SIZE_LIMIT = 83;
+/** Default setting for -datacarriercount. 1 max number of OP_RETURN outputs per transaction. 0 = no limit */
+static const unsigned int DEFAULT_OP_RETURN_COUNT_LIMIT = 1;
+/** Maximum total datacarrier bytes cap (100_000) */
+static const unsigned int MAX_DATACARRIER_RELAY = MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR;
 /**
  * An extra transaction can be added to a package, as long as it only has one
  * ancestor and is no larger than this. Not really any reason to make this
@@ -152,7 +154,7 @@ static constexpr decltype(CTransaction::version) TX_MAX_STANDARD_VERSION{3};
 * Check for standard transaction types
 * @return True if all outputs (scriptPubKeys) use only standard transaction forms
 */
-bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason);
+bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_op_return_size, const std::optional<unsigned>& max_op_return_count, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason);
 /**
 * Check for standard transaction types
 * @param[in] mapInputs       Map of previous transactions that have outputs we're spending

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -691,6 +691,9 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("fullrbf", true);
     ret.pushKV("permitbaremultisig", pool.m_opts.permit_bare_multisig);
     ret.pushKV("maxdatacarriersize", pool.m_opts.max_datacarrier_bytes.value_or(0));
+    ret.pushKV("datacarrieraccept", pool.m_opts.datacarrier_accept);
+    ret.pushKV("datacarriersizelimit", pool.m_opts.datacarrier_sizelimit.value_or(0));
+    ret.pushKV("datacarriercountlimit", pool.m_opts.datacarrier_countlimit.value_or(0));
     return ret;
 }
 
@@ -715,6 +718,9 @@ static RPCHelpMan getmempoolinfo()
                 {RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts RBF without replaceability signaling inspection (DEPRECATED)"},
                 {RPCResult::Type::BOOL, "permitbaremultisig", "True if the mempool accepts transactions with bare multisig outputs"},
                 {RPCResult::Type::NUM, "maxdatacarriersize", "Maximum number of bytes that can be used by OP_RETURN outputs in the mempool"},
+                {RPCResult::Type::BOOL, "datacarrieraccept", "True if the mempool accepts transactions with OP_RETURN outputs"},
+                {RPCResult::Type::NUM, "datacarriersizelimit", "Maximum number of bytes that can be used by an OP_RETURN output in a transaction (0 = no limit only if datacarrieraccept=true)"},
+                {RPCResult::Type::NUM, "datacarriercountlimit", "Maximum number of OP_RETURN outputs in a transaction (0 = no limit only if datacarrieraccept=true)"},
             }},
         RPCExamples{
             HelpExampleCli("getmempoolinfo", "")

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -61,8 +61,8 @@ FUZZ_TARGET(transaction, .init = initialize_transaction)
 
     const CFeeRate dust_relay_fee{DUST_RELAY_TX_FEE};
     std::string reason;
-    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
-    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
+    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
+    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
     if (is_standard_without_permit_bare_multisig) {
         assert(is_standard_with_permit_bare_multisig);
     }

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -21,13 +21,13 @@
 // Helpers:
 static bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, std::string& reason)
 {
-    return IsStandardTx(tx, std::nullopt, permit_bare_multisig, CFeeRate{DUST_RELAY_TX_FEE}, reason);
+    return IsStandardTx(tx, std::nullopt, std::nullopt, permit_bare_multisig, CFeeRate{DUST_RELAY_TX_FEE}, reason);
 }
 
 static bool IsStandardTx(const CTransaction& tx, std::string& reason)
 {
-    return IsStandardTx(tx, std::nullopt, /*permit_bare_multisig=*/true, CFeeRate{DUST_RELAY_TX_FEE}, reason) &&
-           IsStandardTx(tx, std::nullopt, /*permit_bare_multisig=*/false, CFeeRate{DUST_RELAY_TX_FEE}, reason);
+    return IsStandardTx(tx, std::nullopt, std::nullopt, /*permit_bare_multisig=*/true, CFeeRate{DUST_RELAY_TX_FEE}, reason) &&
+           IsStandardTx(tx, std::nullopt, std::nullopt, /*permit_bare_multisig=*/false, CFeeRate{DUST_RELAY_TX_FEE}, reason);
 }
 
 static std::vector<unsigned char> Serialize(const CScript& s)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -798,14 +798,14 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CKey key = GenerateRandomKey();
     t.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
 
-    constexpr auto CheckIsStandard = [](const auto& t, const unsigned int max_op_return_relay = MAX_OP_RETURN_RELAY) {
+    constexpr auto CheckIsStandard = [](const auto& t, const unsigned int max_op_return_size = DEFAULT_OP_RETURN_SIZE_LIMIT, const unsigned int max_op_return_count = DEFAULT_OP_RETURN_COUNT_LIMIT) {
         std::string reason;
-        BOOST_CHECK(IsStandardTx(CTransaction{t}, max_op_return_relay, g_bare_multi, g_dust, reason));
+        BOOST_CHECK(IsStandardTx(CTransaction{t}, max_op_return_size, max_op_return_count, g_bare_multi, g_dust, reason));
         BOOST_CHECK(reason.empty());
     };
-    constexpr auto CheckIsNotStandard = [](const auto& t, const std::string& reason_in, const unsigned int max_op_return_relay = MAX_OP_RETURN_RELAY) {
+    constexpr auto CheckIsNotStandard = [](const auto& t, const std::string& reason_in, const unsigned int max_op_return_size = DEFAULT_OP_RETURN_SIZE_LIMIT, const unsigned int max_op_return_count = DEFAULT_OP_RETURN_COUNT_LIMIT) {
         std::string reason;
-        BOOST_CHECK(!IsStandardTx(CTransaction{t}, max_op_return_relay, g_bare_multi, g_dust, reason));
+        BOOST_CHECK(!IsStandardTx(CTransaction{t}, max_op_return_size, max_op_return_count, g_bare_multi, g_dust, reason));
         BOOST_CHECK_EQUAL(reason_in, reason);
     };
 
@@ -859,13 +859,15 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_1;
     CheckIsNotStandard(t, "scriptpubkey");
 
-    // Custom 83-byte TxoutType::NULL_DATA (standard with max_op_return_relay of 83)
+    // DEFAULT_OP_RETURN_SIZE_LIMIT-byte TxoutType::NULL_DATA (standard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
-    BOOST_CHECK_EQUAL(83, t.vout[0].scriptPubKey.size());
-    CheckIsStandard(t, /*max_op_return_relay=*/83);
+    BOOST_CHECK_EQUAL(DEFAULT_OP_RETURN_SIZE_LIMIT, t.vout[0].scriptPubKey.size());
+    CheckIsStandard(t);
 
-    // Non-standard if max_op_return_relay datacarrier arg is one less
-    CheckIsNotStandard(t, "datacarrier", /*max_op_return_relay=*/82);
+    // DEFAULT_OP_RETURN_SIZE_LIMIT+1-byte TxoutType::NULL_DATA (non-standard)
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3800"_hex;
+    BOOST_CHECK_EQUAL(DEFAULT_OP_RETURN_SIZE_LIMIT + 1, t.vout[0].scriptPubKey.size());
+    CheckIsNotStandard(t, "datacarrier");
 
     // Data payload can be encoded in any way...
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ""_hex;
@@ -887,28 +889,40 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     CheckIsStandard(t);
 
-    // Multiple TxoutType::NULL_DATA are permitted
+    // TODO testing null vs 0
+    // // TxoutType::NULL_DATA with datacarrier = false
+    // // max_op_return_size=null and max_op_return_count=null
+    // CheckIsNotStandard(t, "datacarrier", std::nullopt, std::nullopt);
+
+    // Multiple TxoutType::NULL_DATA
     t.vout.resize(2);
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
     t.vout[0].nValue = 0;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
     t.vout[1].nValue = 0;
-    CheckIsStandard(t);
-
+    CheckIsStandard(t, DEFAULT_OP_RETURN_SIZE_LIMIT, t.vout.size() + 1);
+    CheckIsNotStandard(t, "datacarrier");
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    CheckIsStandard(t);
-
+    CheckIsStandard(t, DEFAULT_OP_RETURN_SIZE_LIMIT, t.vout.size());
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    CheckIsStandard(t);
+    CheckIsStandard(t, DEFAULT_OP_RETURN_SIZE_LIMIT, t.vout.size());
+    CheckIsNotStandard(t, "datacarrier", DEFAULT_OP_RETURN_SIZE_LIMIT, 1);
 
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
-    t.vout[1].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
-    const auto datacarrier_size = t.vout[0].scriptPubKey.size() + t.vout[1].scriptPubKey.size();
-    CheckIsStandard(t); // Default max relay should never trigger
-    CheckIsStandard(t, /*max_op_return_relay=*/datacarrier_size);
-    CheckIsNotStandard(t, "datacarrier", /*max_op_return_relay=*/datacarrier_size-1);
+    // Unlimited (0) max_op_return_size, max_op_return_count
+    t.vout.resize(3);
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
+    t.vout[0].nValue = 0;
+    t.vout[1].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
+    t.vout[1].nValue = 0;
+    t.vout[2].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
+    t.vout[2].nValue = 0;
+    CheckIsStandard(t, 0, 0);
+    CheckIsNotStandard(t, "datacarrier", t.vout[0].scriptPubKey.size() - 1, 0);
+    CheckIsNotStandard(t, "datacarrier", 0, t.vout.size() - 1);
+    CheckIsStandard(t, t.vout[0].scriptPubKey.size(), 0);
+    CheckIsStandard(t, 0, t.vout.size());
 
     // Check large scriptSig (non-standard if size is >1650 bytes)
     t.vout.resize(1);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -809,7 +809,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     std::string reason;
-    if (m_pool.m_opts.require_standard && !IsStandardTx(tx, m_pool.m_opts.max_datacarrier_bytes, m_pool.m_opts.permit_bare_multisig, m_pool.m_opts.dust_relay_feerate, reason)) {
+    if (m_pool.m_opts.require_standard && !IsStandardTx(tx, m_pool.m_opts.datacarrier_sizelimit, m_pool.m_opts.datacarrier_countlimit, m_pool.m_opts.permit_bare_multisig, m_pool.m_opts.dust_relay_feerate, reason)) {
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, reason);
     }
 

--- a/test/functional/feature_blocksxor.py
+++ b/test/functional/feature_blocksxor.py
@@ -23,6 +23,8 @@ class BlocksXORTest(BitcoinTestFramework):
         self.extra_args = [[
             '-blocksxor=1',
             '-fastprune=1',             # use smaller block files
+            '-datacarrier=1',
+            '-datacarriersize=0',       # needed to pad transaction with MiniWallet
         ]]
 
     def run_test(self):

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -50,6 +50,8 @@ class MaxUploadTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             f"-maxuploadtarget={UPLOAD_TARGET_MB}M",
+            "-datacarrier=1",
+            "-datacarriersize=0",
         ]]
 
     def assert_uploadtarget_state(self, *, target_reached, serve_historical_blocks):

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -594,7 +594,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         for incremental_setting in (0, 5, 10, 50, 100, 234, 1000, 5000, 21000):
             incremental_setting_decimal = incremental_setting / Decimal(COIN)
             self.log.info(f"-> Test -incrementalrelayfee={incremental_setting:.8f}sat/kvB...")
-            self.restart_node(0, extra_args=[f"-incrementalrelayfee={incremental_setting_decimal:.8f}", "-persistmempool=0"])
+            self.restart_node(0, extra_args=[f"-incrementalrelayfee={incremental_setting_decimal:.8f}", "-persistmempool=0", "-datacarrier=1", "-datacarriersize=0"])
 
             # When incremental relay feerate is higher than min relay feerate, min relay feerate is automatically increased.
             min_relay_feerate = node.getmempoolinfo()["minrelaytxfee"]

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -61,6 +61,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             '-txindex','-permitbaremultisig=0',
+            '-datacarrier=1','-datacarriersize=0','-datacarriercount=0',
         ]] * self.num_nodes
         self.supports_cli = False
 

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -5,7 +5,7 @@
 """Test datacarrier functionality"""
 from test_framework.messages import (
     CTxOut,
-    MAX_OP_RETURN_RELAY,
+    MAX_DATACARRIER_RELAY,
 )
 from test_framework.script import (
     CScript,
@@ -21,32 +21,36 @@ from test_framework.wallet import MiniWallet
 
 from random import randbytes
 
-# The historical maximum, now used to test coverage
-CUSTOM_DATACARRIER_ARG = 83
+# Historical defaults for test coverage
+CUSTOM_OP_RETURN_SIZE = 83
+CUSTOM_OP_RETURN_COUNT = 1
 
 class DataCarrierTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 4
+        self.num_nodes = 6
         self.extra_args = [
-            [], # default is uncapped
+            [], # default
             ["-datacarrier=0"], # no relay of datacarrier
-            ["-datacarrier=1", f"-datacarriersize={CUSTOM_DATACARRIER_ARG}"],
+            ["-datacarrier=1", f"-datacarriersize={CUSTOM_OP_RETURN_SIZE - 1}"],
             ["-datacarrier=1", "-datacarriersize=2"],
+            ["-datacarrier=1", "-datacarriersize=0"], # uncapped size
+            ["-datacarrier=1", "-datacarriercount=0"], # uncapped count
         ]
 
-    def test_null_data_transaction(self, node: TestNode, data, success: bool) -> None:
+    def test_null_data_transaction(self, node: TestNode, data, outputs: int, success: bool, expected_error = "datacarrier") -> None:
         tx = self.wallet.create_self_transfer(fee_rate=0)["tx"]
         data = [] if data is None else [data]
-        tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN] + data)))
+        for i in range(outputs): # repeated data in each output
+            tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN] + data)))
+        
         tx.vout[0].nValue -= tx.get_vsize()  # simply pay 1sat/vbyte fee
-
         tx_hex = tx.serialize().hex()
 
         if success:
             self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_hex)
             assert tx.txid_hex in node.getrawmempool(True), f'{tx_hex} not in mempool'
         else:
-            assert_raises_rpc_error(-26, "datacarrier", self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
+            assert_raises_rpc_error(-26, expected_error, self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
@@ -54,51 +58,86 @@ class DataCarrierTest(BitcoinTestFramework):
         # Test that bare multisig is allowed by default. Do it here rather than create a new test for it.
         assert_equal(self.nodes[0].getmempoolinfo()["permitbaremultisig"], True)
 
-        assert_equal(self.nodes[0].getmempoolinfo()["maxdatacarriersize"], MAX_OP_RETURN_RELAY)
-        assert_equal(self.nodes[1].getmempoolinfo()["maxdatacarriersize"], 0)
-        assert_equal(self.nodes[2].getmempoolinfo()["maxdatacarriersize"], CUSTOM_DATACARRIER_ARG)
-        assert_equal(self.nodes[3].getmempoolinfo()["maxdatacarriersize"], 2)
+        # By default, only 80 bytes are used for data (+1 for OP_RETURN, +2 for the pushdata opcodes).
+        default_size_data = randbytes(CUSTOM_OP_RETURN_SIZE - 3)
+        too_long_data = randbytes(CUSTOM_OP_RETURN_SIZE - 2)
+        small_data = randbytes(CUSTOM_OP_RETURN_SIZE - 4)
 
-        # By default, any size is allowed.
+        extremely_long_data = randbytes(MAX_DATACARRIER_RELAY - 200)
+        over_maximum_data = randbytes(MAX_DATACARRIER_RELAY)
 
-        # If it is custom set to 83, the historical value,
-        # only 80 bytes are used for data (+1 for OP_RETURN, +2 for the pushdata opcodes).
-        custom_size_data = randbytes(CUSTOM_DATACARRIER_ARG - 3)
-        too_long_data = randbytes(CUSTOM_DATACARRIER_ARG - 2)
-        extremely_long_data = randbytes(MAX_OP_RETURN_RELAY - 200)
         one_byte = randbytes(1)
         zero_bytes = randbytes(0)
 
-        self.log.info("Testing a null data transaction succeeds for default arg regardless of size.")
-        self.test_null_data_transaction(node=self.nodes[0], data=too_long_data, success=True)
-        self.test_null_data_transaction(node=self.nodes[0], data=extremely_long_data, success=True)
+        assert_equal(self.nodes[0].getmempoolinfo()["datacarrieraccept"], 1)
+        assert_equal(self.nodes[0].getmempoolinfo()["datacarriersizelimit"], CUSTOM_OP_RETURN_SIZE)
+        assert_equal(self.nodes[0].getmempoolinfo()["datacarriercountlimit"], CUSTOM_OP_RETURN_COUNT)
 
-        self.log.info("Testing a null data transaction with -datacarrier=false.")
-        self.test_null_data_transaction(node=self.nodes[1], data=custom_size_data, success=False)
+        assert_equal(self.nodes[1].getmempoolinfo()["datacarrieraccept"], 0)
+        assert_equal(self.nodes[1].getmempoolinfo()["datacarriersizelimit"], 0)
+        assert_equal(self.nodes[1].getmempoolinfo()["datacarriercountlimit"], 0)
 
-        self.log.info("Testing a null data transaction with a size larger than accepted by -datacarriersize.")
-        self.test_null_data_transaction(node=self.nodes[2], data=too_long_data, success=False)
+        assert_equal(self.nodes[2].getmempoolinfo()["datacarrieraccept"], 1)
+        assert_equal(self.nodes[2].getmempoolinfo()["datacarriersizelimit"], CUSTOM_OP_RETURN_SIZE - 1)
+        assert_equal(self.nodes[2].getmempoolinfo()["datacarriercountlimit"], CUSTOM_OP_RETURN_COUNT)
+
+        assert_equal(self.nodes[3].getmempoolinfo()["datacarrieraccept"], 1)
+        assert_equal(self.nodes[3].getmempoolinfo()["datacarriersizelimit"], 2)
+        assert_equal(self.nodes[3].getmempoolinfo()["datacarriercountlimit"], CUSTOM_OP_RETURN_COUNT)
+
+        assert_equal(self.nodes[4].getmempoolinfo()["datacarrieraccept"], 1)
+        assert_equal(self.nodes[4].getmempoolinfo()["datacarriersizelimit"], 0)
+        assert_equal(self.nodes[4].getmempoolinfo()["datacarriercountlimit"], CUSTOM_OP_RETURN_COUNT)
+
+        assert_equal(self.nodes[5].getmempoolinfo()["datacarrieraccept"], 1)
+        assert_equal(self.nodes[5].getmempoolinfo()["datacarriersizelimit"], CUSTOM_OP_RETURN_SIZE)
+        assert_equal(self.nodes[5].getmempoolinfo()["datacarriercountlimit"], 0)
 
         self.log.info("Testing a null data transaction with a size equal to -datacarriersize.")
-        self.test_null_data_transaction(node=self.nodes[2], data=custom_size_data, success=True)
+        self.test_null_data_transaction(node=self.nodes[0], data=default_size_data, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=default_size_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=default_size_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[3], data=default_size_data, outputs=1, success=False)
+
+        self.log.info("Testing a null data transaction with a size larger than accepted by -datacarriersize.")
+        self.test_null_data_transaction(node=self.nodes[0], data=too_long_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[1], data=too_long_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=too_long_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[3], data=too_long_data, outputs=1, success=False)
+
+        self.log.info("Testing a null data transaction with a smaller size than -datacarriersize.")
+        self.test_null_data_transaction(node=self.nodes[0], data=small_data, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=small_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=small_data, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[3], data=small_data, outputs=1, success=False)
 
         self.log.info("Testing a null data transaction with no data.")
-        self.test_null_data_transaction(node=self.nodes[0], data=None, success=True)
-        self.test_null_data_transaction(node=self.nodes[1], data=None, success=False)
-        self.test_null_data_transaction(node=self.nodes[2], data=None, success=True)
-        self.test_null_data_transaction(node=self.nodes[3], data=None, success=True)
+        self.test_null_data_transaction(node=self.nodes[0], data=None, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=None, outputs=1, success=False)
+        # TODO
+        # self.test_null_data_transaction(node=self.nodes[2], data=None, outputs=1, success=True)
+        # self.test_null_data_transaction(node=self.nodes[3], data=None, outputs=1, success=True)
 
         self.log.info("Testing a null data transaction with zero bytes of data.")
-        self.test_null_data_transaction(node=self.nodes[0], data=zero_bytes, success=True)
-        self.test_null_data_transaction(node=self.nodes[1], data=zero_bytes, success=False)
-        self.test_null_data_transaction(node=self.nodes[2], data=zero_bytes, success=True)
-        self.test_null_data_transaction(node=self.nodes[3], data=zero_bytes, success=True)
+        self.test_null_data_transaction(node=self.nodes[0], data=zero_bytes, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=zero_bytes, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=zero_bytes, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[3], data=zero_bytes, outputs=1, success=True)
 
         self.log.info("Testing a null data transaction with one byte of data.")
-        self.test_null_data_transaction(node=self.nodes[0], data=one_byte, success=True)
-        self.test_null_data_transaction(node=self.nodes[1], data=one_byte, success=False)
-        self.test_null_data_transaction(node=self.nodes[2], data=one_byte, success=True)
-        self.test_null_data_transaction(node=self.nodes[3], data=one_byte, success=False)
+        self.test_null_data_transaction(node=self.nodes[0], data=one_byte, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=one_byte, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=one_byte, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[3], data=one_byte, outputs=1, success=False)
+
+        self.log.info("Testing a null data transaction succeeds regardless of size.")
+        self.test_null_data_transaction(node=self.nodes[4], data=extremely_long_data, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[4], data=over_maximum_data, outputs=1, success=False, expected_error="tx-size")
+
+        # TODO
+        self.log.info("Testing limits for null data outputs in a transaction.")
+        self.test_null_data_transaction(node=self.nodes[5], data=None, outputs=int(MAX_DATACARRIER_RELAY/100), success=True)
+        self.test_null_data_transaction(node=self.nodes[5], data=None, outputs=int(MAX_DATACARRIER_RELAY/10), success=False, expected_error="tx-size")
 
 if __name__ == '__main__':
     DataCarrierTest(__file__).main()

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -29,6 +29,8 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [[
+            "-datacarrier=1",
+            "-datacarriersize=0",
             "-maxmempool=5",
         ]]
 

--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -51,6 +51,9 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         self.test_anc_count_limits()
         self.test_anc_count_limits_2()
         self.test_anc_count_limits_bushy()
+
+        # The node will accept (nonstandard) extra large OP_RETURN outputs
+        self.restart_node(0, extra_args=["-datacarrier=1", "-datacarriersize=0"])
         self.test_anc_size_limits()
         self.test_desc_size_limits()
 

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -33,6 +33,8 @@ class PackageRBFTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         # Required for fill_mempool()
         self.extra_args = [[
+            "-datacarrier=1",
+            "-datacarriersize=0",
             "-maxmempool=5",
         ]] * self.num_nodes
 

--- a/test/functional/mempool_sigoplimit.py
+++ b/test/functional/mempool_sigoplimit.py
@@ -52,6 +52,8 @@ MAX_PUBKEYS_PER_MULTISIG = 20
 class BytesPerSigOpTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        # allow large datacarrier output to pad transactions
+        self.extra_args = [['-datacarrier=1', '-datacarriersize=0']]
 
     def create_p2wsh_spending_tx(self, witness_script, output_script):
         """Create a 1-input-1-output P2WSH spending transaction with only the
@@ -145,7 +147,7 @@ class BytesPerSigOpTest(BitcoinTestFramework):
         self.log.info("Test a overly-large sigops-vbyte hits package limits")
         # Make a 2-transaction package which fails vbyte checks even though
         # separately they would work.
-        self.restart_node(0, extra_args=["-bytespersigop=5000","-permitbaremultisig=1"])
+        self.restart_node(0, extra_args=["-bytespersigop=5000","-permitbaremultisig=1"] + self.extra_args[0])
 
         def create_bare_multisig_tx(utxo_to_spend=None):
             _, pubkey = generate_keypair()
@@ -227,7 +229,7 @@ class BytesPerSigOpTest(BitcoinTestFramework):
             else:
                 bytespersigop_parameter = f"-bytespersigop={bytes_per_sigop}"
                 self.log.info(f"Test sigops limit setting {bytespersigop_parameter}...")
-                self.restart_node(0, extra_args=[bytespersigop_parameter])
+                self.restart_node(0, extra_args=[bytespersigop_parameter] + self.extra_args[0])
 
             for num_sigops in (69, 101, 142, 183, 222):
                 self.test_sigops_limit(bytes_per_sigop, num_sigops)

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -50,7 +50,7 @@ class MempoolTRUC(BitcoinTestFramework):
         assert_equal(len(txids), len(mempool_contents))
         assert all([txid in txids for txid in mempool_contents])
 
-    @cleanup()
+    @cleanup(extra_args=["-datacarriersize=20000"])
     def test_truc_max_vsize(self):
         node = self.nodes[0]
         self.log.info("Test TRUC-specific maximum transaction vsize")
@@ -64,7 +64,7 @@ class MempoolTRUC(BitcoinTestFramework):
         tx_v2_heavy = self.wallet.send_self_transfer(from_node=node, target_vsize=TRUC_MAX_VSIZE + 1, version=2)
         self.check_mempool([tx_v2_heavy["txid"]])
 
-    @cleanup()
+    @cleanup(extra_args=["-datacarriersize=1000"])
     def test_truc_acceptance(self):
         node = self.nodes[0]
         self.log.info("Test a child of a TRUC transaction cannot be more than 1000vB")
@@ -161,7 +161,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([tx_v3_bip125_rbf_v2["txid"], tx_v3_parent["txid"], tx_v3_child["txid"]])
 
 
-    @cleanup()
+    @cleanup(extra_args=["-datacarriersize=40000"])
     def test_truc_reorg(self):
         node = self.nodes[0]
         self.log.info("Test that, during a reorg, TRUC rules are not enforced")
@@ -196,7 +196,7 @@ class MempoolTRUC(BitcoinTestFramework):
         node.invalidateblock(block["hash"])
         self.check_mempool([tx_v3_block["txid"], tx_v2_block["txid"], tx_v3_block2["txid"], tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"], tx_chain_1["txid"], tx_chain_2["txid"], tx_chain_3["txid"], tx_chain_4["txid"]])
 
-    @cleanup(extra_args=["-limitdescendantsize=10"])
+    @cleanup(extra_args=["-limitdescendantsize=10", "-datacarriersize=40000"])
     def test_nondefault_package_limits(self):
         """
         Max standard tx size + TRUC rules imply the ancestor/descendant rules (at their default
@@ -229,7 +229,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.generate(node, 1)
 
         self.log.info("Test that a decreased limitancestorsize also applies to v3 parent")
-        self.restart_node(0, extra_args=["-limitancestorsize=10"])
+        self.restart_node(0, extra_args=["-limitancestorsize=10", "-datacarriersize=40000"])
         tx_v3_parent_large2 = self.wallet.send_self_transfer(
             from_node=node,
             target_vsize=parent_target_vsize,
@@ -249,7 +249,7 @@ class MempoolTRUC(BitcoinTestFramework):
         assert_raises_rpc_error(-26, "too-long-mempool-chain, exceeds ancestor size limit", node.sendrawtransaction, tx_v3_child_large2["hex"])
         self.check_mempool([tx_v3_parent_large2["txid"]])
 
-    @cleanup()
+    @cleanup(extra_args=["-datacarriersize=1000"])
     def test_truc_ancestors_package(self):
         self.log.info("Test that TRUC ancestor limits are checked within the package")
         node = self.nodes[0]
@@ -398,7 +398,7 @@ class MempoolTRUC(BitcoinTestFramework):
         assert_equal(result_package_cpfp["tx-results"][tx_sibling_3['wtxid']]['error'], expected_error_cpfp)
 
 
-    @cleanup()
+    @cleanup(extra_args=["-datacarriersize=1000"])
     def test_truc_package_inheritance(self):
         self.log.info("Test that TRUC inheritance is checked within package")
         node = self.nodes[0]

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -28,7 +28,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         # Ancestor and descendant limits depend on transaction_graph_test requirements
-        self.extra_args = [['-limitdescendantsize=1000', '-limitancestorsize=1000', f'-limitancestorcount={CUSTOM_ANCESTOR_COUNT}', f'-limitdescendantcount={CUSTOM_DESCENDANT_COUNT}']]
+        self.extra_args = [['-limitdescendantsize=1000', '-limitancestorsize=1000', f'-limitancestorcount={CUSTOM_ANCESTOR_COUNT}', f'-limitdescendantcount={CUSTOM_DESCENDANT_COUNT}', '-datacarrier=1', '-datacarriersize=0']]
 
     def create_empty_fork(self, fork_length):
         '''

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -288,9 +288,11 @@ class MiningTest(BitcoinTestFramework):
     def test_block_max_weight(self):
         self.log.info("Testing default and custom -blockmaxweight startup options.")
 
+        # Restart the node to allow large transactions
         LARGE_TXS_COUNT = 10
         LARGE_VSIZE = int(((MAX_BLOCK_WEIGHT - DEFAULT_BLOCK_RESERVED_WEIGHT) / WITNESS_SCALE_FACTOR) / LARGE_TXS_COUNT)
         HIGH_FEERATE = Decimal("0.0003")
+        self.restart_node(0, extra_args=[f"-datacarriersize={LARGE_VSIZE}"])
 
         # Ensure the mempool is empty
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
@@ -318,7 +320,7 @@ class MiningTest(BitcoinTestFramework):
         # Test block template creation with custom -blockmaxweight
         custom_block_weight = MAX_BLOCK_WEIGHT - 2000
         # Reducing the weight by 2000 units will prevent 1 large transaction from fitting into the block.
-        self.restart_node(0, extra_args=[f"-blockmaxweight={custom_block_weight}"])
+        self.restart_node(0, extra_args=[f"-datacarriersize={LARGE_VSIZE}", f"-blockmaxweight={custom_block_weight}"])        
 
         self.log.info("Testing the block template with custom -blockmaxweight to include 9 large and 2 normal transactions.")
         self.verify_block_template(
@@ -328,7 +330,7 @@ class MiningTest(BitcoinTestFramework):
 
         # Ensure the block weight does not exceed the maximum
         self.log.info(f"Testing that the block weight will never exceed {MAX_BLOCK_WEIGHT - DEFAULT_BLOCK_RESERVED_WEIGHT}.")
-        self.restart_node(0, extra_args=[f"-blockmaxweight={MAX_BLOCK_WEIGHT}"])
+        self.restart_node(0, extra_args=[f"-datacarriersize={LARGE_VSIZE}", f"-blockmaxweight={MAX_BLOCK_WEIGHT}"])
         self.log.info("Sending 2 additional normal transactions to fill the mempool to the maximum block weight.")
         self.send_transactions(utxos[LARGE_TXS_COUNT + 2:], NORMAL_FEERATE, NORMAL_VSIZE)
         self.log.info(f"Testing that the mempool's weight matches the maximum block weight: {MAX_BLOCK_WEIGHT}.")
@@ -342,7 +344,7 @@ class MiningTest(BitcoinTestFramework):
 
         self.log.info("Test -blockreservedweight startup option.")
         # Lowering the -blockreservedweight by 4000 will allow for two more transactions.
-        self.restart_node(0, extra_args=["-blockreservedweight=4000"])
+        self.restart_node(0, extra_args=[f"-datacarriersize={LARGE_VSIZE}", "-blockreservedweight=4000"])
         self.verify_block_template(
             expected_tx_count=12,
             expected_weight=MAX_BLOCK_WEIGHT - 4000,

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -27,6 +27,8 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             "-printpriority=1",
+            "-datacarrier=1",
+            "-datacarriersize=0",
         ]] * self.num_nodes
         self.supports_cli = False
 

--- a/test/functional/p2p_1p1c_network.py
+++ b/test/functional/p2p_1p1c_network.py
@@ -40,6 +40,8 @@ class PackageRelayTest(BitcoinTestFramework):
         # hugely speeds up the test, as it involves multiple hops of tx relay.
         self.noban_tx_relay = True
         self.extra_args = [[
+            "-datacarrier=1",
+            "-datacarriersize=0",
             "-maxmempool=5",
         ]] * self.num_nodes
 

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -77,6 +77,8 @@ class PackageRelayTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [[
+            "-datacarrier=1",
+            "-datacarriersize=0",
             "-maxmempool=5",
         ]]
 

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -59,7 +59,7 @@ def cleanup(func):
             self.wait_until(lambda: len(self.nodes[0].getorphantxs()) == 0)
             assert_equal(0, len(self.nodes[0].getrawmempool()))
 
-            self.restart_node(0, extra_args=["-persistmempool=0"])
+            self.restart_node(0, extra_args=["-persistmempool=0", "-datacarrier=1", "-datacarriersize=0"])
             # Allow use of bumpmocktime again
             self.nodes[0].setmocktime(int(time.time()))
             self.wallet.rescan_utxos(include_mempool=True)

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -68,7 +68,7 @@ class ConnectionType(Enum):
 class TxDownloadTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args= [['-maxmempool=5', '-persistmempool=0']] * self.num_nodes
+        self.extra_args= [['-datacarrier=1', '-datacarriersize=0', '-maxmempool=5', '-persistmempool=0']] * self.num_nodes
 
     def test_tx_requests(self):
         self.log.info("Test that we request transactions from all our peers, eventually")

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -441,6 +441,8 @@ class RPCPackagesTest(BitcoinTestFramework):
         # but child is too high fee
         # Lower mempool limit to make it easier to fill_mempool
         self.restart_node(0, extra_args=[
+            "-datacarrier=1",
+            "-datacarriersize=0",
             "-maxmempool=5",
             "-persistmempool=0",
         ])
@@ -469,7 +471,7 @@ class RPCPackagesTest(BitcoinTestFramework):
         assert parent["txid"] not in node.getrawmempool()
         assert child["txid"] not in node.getrawmempool()
 
-        # Reset maxmempool, reset dynamic mempool minimum feerate, and empty mempool.
+        # Reset maxmempool, datacarriersize, reset dynamic mempool minimum feerate, and empty mempool.
         self.restart_node(0)
         self.wallet.rescan_utxos()
 

--- a/test/functional/test_framework/mempool_util.py
+++ b/test/functional/test_framework/mempool_util.py
@@ -57,7 +57,7 @@ def fill_mempool(test_framework, node, *, tx_sync_fun=None):
     """Fill mempool until eviction.
 
     Allows for simpler testing of scenarios with floating mempoolminfee > minrelay
-    Requires -maxmempool=5.
+    Requires unlimited -datacarriersize=0 and -maxmempool=5.
     To avoid unintentional tx dependencies, the mempool filling txs are created with a
     tagged ephemeral miniwallet instance.
     """

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -73,10 +73,7 @@ WITNESS_SCALE_FACTOR = 4
 DEFAULT_ANCESTOR_LIMIT = 25    # default max number of in-mempool ancestors
 DEFAULT_DESCENDANT_LIMIT = 25  # default max number of in-mempool descendants
 
-
-# Default setting for -datacarriersize.
-MAX_OP_RETURN_RELAY = 100_000
-
+MAX_DATACARRIER_RELAY = 100_000
 
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 


### PR DESCRIPTION
This PR expands the control and testing of datacarrier transactions by decoupling the total bytes limit from the policy configuration.

---

While doing this, the historical **money-first** defaults for OP_RETURN outputs were reverted.

The [motivation](https://github.com/bitcoin/bitcoin/issues/33595) for this PR is to continue allowing each node to decide/signal their mempool relay (and mining) policy. However, the open-data relaying capacity of v30.0 is acknowledged and build upon.

The unlimited datacarrier policy is possible with the following configuration:

```conf
# open-data policy
datacarrier=1 # not required
datacarriersize=0
datacarriercount=0
```

---

**But even without the reversion of defaults, the main scope of this PR still applies.**

First, for more robust and complete testing. And second, to allow full backwards compatibility of datacarrier policy. Specifically, to allow limiting the amount of OP_RETURN outputs to just 1.

```conf
# money-first policy
datacarriersize=83
datacarriercount=1 # used to be hardcoded
```

This configuration mimics the exact historical (default) datacarrier policy, which is **not possible in v30.0**.

https://github.com/bitcoin/bitcoin/blob/52ede28a8adb2c2d44d7f800bbfbef8aed86070e/src/policy/policy.cpp#L140-L166

Note that `nDataOut`, which counted the number of OP_RETURN outputs, was removed in [#32406](https://github.com/bitcoin/bitcoin/pull/32406/files#diff-ea6d307faa4ec9dfa5abcf6858bc19603079f2b8e110e1d62da4df98f4bdb9c0L162). Without a count check, v30.0 nodes with `-datacarriersize=83` are still relaying transactions with multiple OP_RETURN outputs, transactions which all nodes prior to v30.0 will reject...