### PR TITLE
Datacarrier backwards compatibility and improved test coverage

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -659,11 +659,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-acceptstalefeeestimates", strprintf("Read fee estimates even if they are stale (%sdefault: %u) fee estimates are considered stale if they are %s hours old", "regtest only; ", DEFAULT_ACCEPT_STALE_FEE_ESTIMATES, Ticks<std::chrono::hours>(MAX_FILE_AGE)), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-bytespersigop", strprintf("Equivalent bytes per sigop in transactions for relay and mining (default: %u)", DEFAULT_BYTES_PER_SIGOP), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrier", strprintf("Relay and mine data carrier transactions (default: %u)", DEFAULT_ACCEPT_DATACARRIER), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-datacarriersize",
-                   strprintf("Relay and mine transactions whose data-carrying raw scriptPubKeys in aggregate "
-                             "are of this size or less, allowing multiple outputs (default: %u)",
-                             MAX_OP_RETURN_RELAY),
-                   ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-datacarriersize", strprintf("Relay and mine transactions whose any data-carrying raw scriptPubKey output is of this size or less. 0 = no limit (default: %u)", DEFAULT_OP_RETURN_SIZE_LIMIT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-permitbaremultisig", strprintf("Relay transactions creating non-P2SH multisig outputs (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -43,14 +43,23 @@ struct MemPoolOptions {
     /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
     CFeeRate min_relay_feerate{DEFAULT_MIN_RELAY_TX_FEE};
     CFeeRate dust_relay_feerate{DUST_RELAY_TX_FEE};
+    // TODO can be removed, no longer necessary
+    std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_DATACARRIER_RELAY} : std::nullopt};
     /**
      * A data carrying output is an unspendable output containing data. The script
      * type is designated as TxoutType::NULL_DATA.
-     *
-     * Maximum size of TxoutType::NULL_DATA scripts that this node considers standard.
+     */
+    bool datacarrier_accept{DEFAULT_ACCEPT_DATACARRIER};
+    /**
+     * Maximum size of a TxoutType::NULL_DATA script that this node considers standard (0 = no limit).
      * If nullopt, any size is nonstandard.
      */
-    std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_OP_RETURN_RELAY} : std::nullopt};
+    std::optional<unsigned> datacarrier_sizelimit{DEFAULT_ACCEPT_DATACARRIER ? std::optional{DEFAULT_OP_RETURN_SIZE_LIMIT} : std::nullopt};
+    /**
+     * Maximum count of TxoutType::NULL_DATA outputs that this node considers standard (0 = no limit).
+     * If nullopt, any count is nonstandard.
+     */
+    std::optional<unsigned> datacarrier_countlimit{DEFAULT_ACCEPT_DATACARRIER ? std::optional{DEFAULT_OP_RETURN_COUNT_LIMIT} : std::nullopt};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
     bool require_standard{true};
     bool persist_v1_dat{DEFAULT_PERSIST_V1_DAT};

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -91,10 +91,15 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
 
     mempool_opts.permit_bare_multisig = argsman.GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
 
-    if (argsman.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER)) {
-        mempool_opts.max_datacarrier_bytes = argsman.GetIntArg("-datacarriersize", MAX_OP_RETURN_RELAY);
+    mempool_opts.datacarrier_accept = argsman.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
+    if (mempool_opts.datacarrier_accept) {
+        mempool_opts.max_datacarrier_bytes = MAX_DATACARRIER_RELAY;
+        mempool_opts.datacarrier_sizelimit = argsman.GetIntArg("-datacarriersize", DEFAULT_OP_RETURN_SIZE_LIMIT);
+        mempool_opts.datacarrier_countlimit = DEFAULT_OP_RETURN_COUNT_LIMIT;
     } else {
         mempool_opts.max_datacarrier_bytes = std::nullopt;
+        mempool_opts.datacarrier_sizelimit = std::nullopt;
+        mempool_opts.datacarrier_countlimit = std::nullopt;
     }
 
     mempool_opts.require_standard = !argsman.GetBoolArg("-acceptnonstdtxn", DEFAULT_ACCEPT_NON_STD_TXN);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -74,10 +74,12 @@ static constexpr unsigned int DEFAULT_DESCENDANT_LIMIT{25};
 static constexpr unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT_KVB{101};
 /** Default for -datacarrier */
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
-/**
- * Default setting for -datacarriersize in vbytes.
- */
-static const unsigned int MAX_OP_RETURN_RELAY = MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR;
+/** Default setting for -datacarriersize. e.g. 80 bytes of data, +1 for OP_RETURN, +2 for the pushdata opcodes. 0 = no limit */
+static const unsigned int DEFAULT_OP_RETURN_SIZE_LIMIT = 0;
+/** Default setting for -datacarriercount. e.g. 1 max number of OP_RETURN outputs per transaction. 0 = no limit */
+static const unsigned int DEFAULT_OP_RETURN_COUNT_LIMIT = 0;
+/** Maximum total datacarrier bytes cap (100_000) */
+static const unsigned int MAX_DATACARRIER_RELAY = MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR;
 /**
  * An extra transaction can be added to a package, as long as it only has one
  * ancestor and is no larger than this. Not really any reason to make this
@@ -152,7 +154,7 @@ static constexpr decltype(CTransaction::version) TX_MAX_STANDARD_VERSION{3};
 * Check for standard transaction types
 * @return True if all outputs (scriptPubKeys) use only standard transaction forms
 */
-bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason);
+bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_op_return_size, const std::optional<unsigned>& max_op_return_count, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason);
 /**
 * Check for standard transaction types
 * @param[in] mapInputs       Map of previous transactions that have outputs we're spending

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -691,6 +691,9 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("fullrbf", true);
     ret.pushKV("permitbaremultisig", pool.m_opts.permit_bare_multisig);
     ret.pushKV("maxdatacarriersize", pool.m_opts.max_datacarrier_bytes.value_or(0));
+    ret.pushKV("datacarrieraccept", pool.m_opts.datacarrier_accept);
+    ret.pushKV("datacarriersizelimit", pool.m_opts.datacarrier_sizelimit.value_or(0));
+    ret.pushKV("datacarriercountlimit", pool.m_opts.datacarrier_countlimit.value_or(0));
     return ret;
 }
 
@@ -715,6 +718,9 @@ static RPCHelpMan getmempoolinfo()
                 {RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts RBF without replaceability signaling inspection (DEPRECATED)"},
                 {RPCResult::Type::BOOL, "permitbaremultisig", "True if the mempool accepts transactions with bare multisig outputs"},
                 {RPCResult::Type::NUM, "maxdatacarriersize", "Maximum number of bytes that can be used by OP_RETURN outputs in the mempool"},
+                {RPCResult::Type::BOOL, "datacarrieraccept", "True if the mempool accepts transactions with OP_RETURN outputs"},
+                {RPCResult::Type::NUM, "datacarriersizelimit", "Maximum number of bytes that can be used by an OP_RETURN output in a transaction (0 = no limit only if datacarrieraccept=true)"},
+                {RPCResult::Type::NUM, "datacarriercountlimit", "Maximum number of OP_RETURN outputs in a transaction (0 = no limit only if datacarrieraccept=true)"},
             }},
         RPCExamples{
             HelpExampleCli("getmempoolinfo", "")

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -61,8 +61,8 @@ FUZZ_TARGET(transaction, .init = initialize_transaction)
 
     const CFeeRate dust_relay_fee{DUST_RELAY_TX_FEE};
     std::string reason;
-    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
-    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
+    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
+    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
     if (is_standard_without_permit_bare_multisig) {
         assert(is_standard_with_permit_bare_multisig);
     }

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -21,13 +21,13 @@
 // Helpers:
 static bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, std::string& reason)
 {
-    return IsStandardTx(tx, std::nullopt, permit_bare_multisig, CFeeRate{DUST_RELAY_TX_FEE}, reason);
+    return IsStandardTx(tx, std::nullopt, std::nullopt, permit_bare_multisig, CFeeRate{DUST_RELAY_TX_FEE}, reason);
 }
 
 static bool IsStandardTx(const CTransaction& tx, std::string& reason)
 {
-    return IsStandardTx(tx, std::nullopt, /*permit_bare_multisig=*/true, CFeeRate{DUST_RELAY_TX_FEE}, reason) &&
-           IsStandardTx(tx, std::nullopt, /*permit_bare_multisig=*/false, CFeeRate{DUST_RELAY_TX_FEE}, reason);
+    return IsStandardTx(tx, std::nullopt, std::nullopt, /*permit_bare_multisig=*/true, CFeeRate{DUST_RELAY_TX_FEE}, reason) &&
+           IsStandardTx(tx, std::nullopt, std::nullopt, /*permit_bare_multisig=*/false, CFeeRate{DUST_RELAY_TX_FEE}, reason);
 }
 
 static std::vector<unsigned char> Serialize(const CScript& s)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -809,7 +809,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     std::string reason;
-    if (m_pool.m_opts.require_standard && !IsStandardTx(tx, m_pool.m_opts.max_datacarrier_bytes, m_pool.m_opts.permit_bare_multisig, m_pool.m_opts.dust_relay_feerate, reason)) {
+    if (m_pool.m_opts.require_standard && !IsStandardTx(tx, m_pool.m_opts.datacarrier_sizelimit, m_pool.m_opts.datacarrier_countlimit, m_pool.m_opts.permit_bare_multisig, m_pool.m_opts.dust_relay_feerate, reason)) {
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, reason);
     }
 

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -5,7 +5,7 @@
 """Test datacarrier functionality"""
 from test_framework.messages import (
     CTxOut,
-    MAX_OP_RETURN_RELAY,
+    MAX_DATACARRIER_RELAY,
 )
 from test_framework.script import (
     CScript,
@@ -21,32 +21,34 @@ from test_framework.wallet import MiniWallet
 
 from random import randbytes
 
-# The historical maximum, now used to test coverage
-CUSTOM_DATACARRIER_ARG = 83
+# Historical defaults for test coverage
+CUSTOM_OP_RETURN_SIZE = 83
+CUSTOM_OP_RETURN_COUNT = 1
 
 class DataCarrierTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
         self.extra_args = [
-            [], # default is uncapped
+            [], # default is uncapped (since v30)
             ["-datacarrier=0"], # no relay of datacarrier
-            ["-datacarrier=1", f"-datacarriersize={CUSTOM_DATACARRIER_ARG}"],
+            ["-datacarrier=1", f"-datacarriersize={CUSTOM_OP_RETURN_SIZE - 1}"],
             ["-datacarrier=1", "-datacarriersize=2"],
         ]
 
-    def test_null_data_transaction(self, node: TestNode, data, success: bool) -> None:
+    def test_null_data_transaction(self, node: TestNode, data, outputs: int, success: bool, expected_error = "datacarrier") -> None:
         tx = self.wallet.create_self_transfer(fee_rate=0)["tx"]
         data = [] if data is None else [data]
-        tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN] + data)))
+        for i in range(outputs): # repeated data in each output
+            tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN] + data)))
+        
         tx.vout[0].nValue -= tx.get_vsize()  # simply pay 1sat/vbyte fee
-
         tx_hex = tx.serialize().hex()
 
         if success:
             self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_hex)
             assert tx.txid_hex in node.getrawmempool(True), f'{tx_hex} not in mempool'
         else:
-            assert_raises_rpc_error(-26, "datacarrier", self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
+            assert_raises_rpc_error(-26, expected_error, self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
@@ -54,51 +56,78 @@ class DataCarrierTest(BitcoinTestFramework):
         # Test that bare multisig is allowed by default. Do it here rather than create a new test for it.
         assert_equal(self.nodes[0].getmempoolinfo()["permitbaremultisig"], True)
 
-        assert_equal(self.nodes[0].getmempoolinfo()["maxdatacarriersize"], MAX_OP_RETURN_RELAY)
-        assert_equal(self.nodes[1].getmempoolinfo()["maxdatacarriersize"], 0)
-        assert_equal(self.nodes[2].getmempoolinfo()["maxdatacarriersize"], CUSTOM_DATACARRIER_ARG)
-        assert_equal(self.nodes[3].getmempoolinfo()["maxdatacarriersize"], 2)
+        # By default, only 80 bytes are used for data (+1 for OP_RETURN, +2 for the pushdata opcodes).
+        default_size_data = randbytes(CUSTOM_OP_RETURN_SIZE - 3)
+        too_long_data = randbytes(CUSTOM_OP_RETURN_SIZE - 2)
+        small_data = randbytes(CUSTOM_OP_RETURN_SIZE - 4)
 
-        # By default, any size is allowed.
+        extremely_long_data = randbytes(MAX_DATACARRIER_RELAY - 200)
+        over_maximum_data = randbytes(MAX_DATACARRIER_RELAY)
 
-        # If it is custom set to 83, the historical value,
-        # only 80 bytes are used for data (+1 for OP_RETURN, +2 for the pushdata opcodes).
-        custom_size_data = randbytes(CUSTOM_DATACARRIER_ARG - 3)
-        too_long_data = randbytes(CUSTOM_DATACARRIER_ARG - 2)
-        extremely_long_data = randbytes(MAX_OP_RETURN_RELAY - 200)
         one_byte = randbytes(1)
         zero_bytes = randbytes(0)
 
-        self.log.info("Testing a null data transaction succeeds for default arg regardless of size.")
-        self.test_null_data_transaction(node=self.nodes[0], data=too_long_data, success=True)
-        self.test_null_data_transaction(node=self.nodes[0], data=extremely_long_data, success=True)
+        assert_equal(self.nodes[0].getmempoolinfo()["datacarrieraccept"], 1)
+        assert_equal(self.nodes[0].getmempoolinfo()["datacarriersizelimit"], 0)
+        assert_equal(self.nodes[0].getmempoolinfo()["datacarriercountlimit"], 0)
 
-        self.log.info("Testing a null data transaction with -datacarrier=false.")
-        self.test_null_data_transaction(node=self.nodes[1], data=custom_size_data, success=False)
+        # uncapped limits tests
 
-        self.log.info("Testing a null data transaction with a size larger than accepted by -datacarriersize.")
-        self.test_null_data_transaction(node=self.nodes[2], data=too_long_data, success=False)
+        self.log.info("Testing a null data transaction succeeds regardless of size.")
+        self.test_null_data_transaction(node=self.nodes[0], data=extremely_long_data, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[0], data=over_maximum_data, outputs=1, success=False, expected_error="tx-size")
+
+        self.log.info("Testing limits for null data outputs in a transaction.")
+        self.test_null_data_transaction(node=self.nodes[0], data=None, outputs=int(MAX_DATACARRIER_RELAY/100), success=True)
+        self.test_null_data_transaction(node=self.nodes[0], data=None, outputs=int(MAX_DATACARRIER_RELAY/10), success=False, expected_error="tx-size")
+
+        assert_equal(self.nodes[1].getmempoolinfo()["datacarrieraccept"], 0)
+        assert_equal(self.nodes[1].getmempoolinfo()["datacarriersizelimit"], 0)
+        assert_equal(self.nodes[1].getmempoolinfo()["datacarriercountlimit"], 0)
+
+        assert_equal(self.nodes[2].getmempoolinfo()["datacarrieraccept"], 1)
+        assert_equal(self.nodes[2].getmempoolinfo()["datacarriersizelimit"], CUSTOM_OP_RETURN_SIZE - 1)
+        assert_equal(self.nodes[2].getmempoolinfo()["datacarriercountlimit"], 0)
+
+        assert_equal(self.nodes[3].getmempoolinfo()["datacarrieraccept"], 1)
+        assert_equal(self.nodes[3].getmempoolinfo()["datacarriersizelimit"], 2)
+        assert_equal(self.nodes[3].getmempoolinfo()["datacarriercountlimit"], 0)
 
         self.log.info("Testing a null data transaction with a size equal to -datacarriersize.")
-        self.test_null_data_transaction(node=self.nodes[2], data=custom_size_data, success=True)
+        self.test_null_data_transaction(node=self.nodes[0], data=default_size_data, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=default_size_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=default_size_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[3], data=default_size_data, outputs=1, success=False)
+
+        self.log.info("Testing a null data transaction with a size larger than accepted by -datacarriersize.")
+        self.test_null_data_transaction(node=self.nodes[0], data=too_long_data, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=too_long_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=too_long_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[3], data=too_long_data, outputs=1, success=False)
+
+        self.log.info("Testing a null data transaction with a smaller size than -datacarriersize.")
+        self.test_null_data_transaction(node=self.nodes[0], data=small_data, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=small_data, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=small_data, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[3], data=small_data, outputs=1, success=False)
 
         self.log.info("Testing a null data transaction with no data.")
-        self.test_null_data_transaction(node=self.nodes[0], data=None, success=True)
-        self.test_null_data_transaction(node=self.nodes[1], data=None, success=False)
-        self.test_null_data_transaction(node=self.nodes[2], data=None, success=True)
-        self.test_null_data_transaction(node=self.nodes[3], data=None, success=True)
+        self.test_null_data_transaction(node=self.nodes[0], data=None, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=None, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=None, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[3], data=None, outputs=1, success=True)
 
         self.log.info("Testing a null data transaction with zero bytes of data.")
-        self.test_null_data_transaction(node=self.nodes[0], data=zero_bytes, success=True)
-        self.test_null_data_transaction(node=self.nodes[1], data=zero_bytes, success=False)
-        self.test_null_data_transaction(node=self.nodes[2], data=zero_bytes, success=True)
-        self.test_null_data_transaction(node=self.nodes[3], data=zero_bytes, success=True)
+        self.test_null_data_transaction(node=self.nodes[0], data=zero_bytes, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=zero_bytes, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=zero_bytes, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[3], data=zero_bytes, outputs=1, success=True)
 
         self.log.info("Testing a null data transaction with one byte of data.")
-        self.test_null_data_transaction(node=self.nodes[0], data=one_byte, success=True)
-        self.test_null_data_transaction(node=self.nodes[1], data=one_byte, success=False)
-        self.test_null_data_transaction(node=self.nodes[2], data=one_byte, success=True)
-        self.test_null_data_transaction(node=self.nodes[3], data=one_byte, success=False)
+        self.test_null_data_transaction(node=self.nodes[0], data=one_byte, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=one_byte, outputs=1, success=False)
+        self.test_null_data_transaction(node=self.nodes[2], data=one_byte, outputs=1, success=True)
+        self.test_null_data_transaction(node=self.nodes[3], data=one_byte, outputs=1, success=False)
 
 if __name__ == '__main__':
     DataCarrierTest(__file__).main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -73,10 +73,7 @@ WITNESS_SCALE_FACTOR = 4
 DEFAULT_ANCESTOR_LIMIT = 25    # default max number of in-mempool ancestors
 DEFAULT_DESCENDANT_LIMIT = 25  # default max number of in-mempool descendants
 
-
-# Default setting for -datacarriersize.
-MAX_OP_RETURN_RELAY = 100_000
-
+MAX_DATACARRIER_RELAY = 100_000
 
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 


### PR DESCRIPTION
This PR addresses the *"misalignments"* of [#33682](https://github.com/bitcoin/bitcoin/pull/33682).

> Summing up: The change which was brought with v30 was broadly discussed and deliberately chosen. I think that reverting the defaults now would be a bad idea. And even if, the path to do this should not be this PR and changing defaults should not be bundled with introducing a new knob.

@cedwies, this new PR keeps v30 defaults AND also removes the "public knob". It must definitely keep the new count default constant, as that is the main new concept introduced. Specifically for:

1. Custom client's policy, including ones that wish full pre-v30 policy compatibility
2. More exhaustive testing
3. Consistency and specificity

@achow101, this new PR should not be "re-litigating" anything, but if there is, I'll be glad to discover how.

Constructive feedback is welcomed.