### PR TITLE
ci: use pycapnp 2.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,11 +157,6 @@ jobs:
           brew install --quiet python@3 || brew link --overwrite python@3
           brew install --quiet coreutils ninja pkgconf gnu-getopt ccache boost libevent zeromq qt@6 qrencode capnp
 
-      - name: Install Python packages
-        run: |
-          git clone -b v2.1.0 https://github.com/capnproto/pycapnp
-          pip3 install ./pycapnp -C force-bundled-libcapnp=True --break-system-packages
-
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"
 

--- a/ci/test/00_setup_env_mac_native.sh
+++ b/ci/test/00_setup_env_mac_native.sh
@@ -6,8 +6,6 @@
 
 export LC_ALL=C.UTF-8
 
-# Homebrew's python@3.12 is marked as externally managed (PEP 668).
-# Therefore, `--break-system-packages` is needed.
 export CONTAINER_NAME="ci_mac_native"  # macos does not use a container, but the env var is needed for logging
 export PIP_PACKAGES="--break-system-packages zmq"
 export GOAL="install deploy"

--- a/ci/test/00_setup_env_mac_native.sh
+++ b/ci/test/00_setup_env_mac_native.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME="ci_mac_native"  # macos does not use a container, but the env var is needed for logging
-export PIP_PACKAGES="--break-system-packages zmq"
+export PIP_PACKAGES="--break-system-packages pycapnp zmq"
 export GOAL="install deploy"
 export CMAKE_GENERATOR="Ninja"
 export BITCOIN_CONFIG="-DBUILD_GUI=ON -DWITH_ZMQ=ON -DREDUCE_EXPORTS=ON -DCMAKE_EXE_LINKER_FLAGS='-Wl,-stack_size -Wl,0x80000'"

--- a/test/README.md
+++ b/test/README.md
@@ -37,7 +37,7 @@ The ZMQ functional test requires a python ZMQ library. To install it:
 The IPC functional test requires a python IPC library. `pip3 install pycapnp` may work, but if not, install it from source:
 
 ```sh
-git clone -b v2.1.0 https://github.com/capnproto/pycapnp
+git clone -b v2.2.1 https://github.com/capnproto/pycapnp
 pip3 install ./pycapnp
 ```
 
@@ -46,7 +46,7 @@ Depending on the system, it may be necessary to install and run in a venv:
 
 ```sh
 python -m venv venv
-git clone -b v2.1.0 https://github.com/capnproto/pycapnp
+git clone -b v2.2.1 https://github.com/capnproto/pycapnp
 venv/bin/pip3 install ./pycapnp -C force-bundled-libcapnp=True
 venv/bin/python3 build/test/functional/interface_ipc.py
 ```


### PR DESCRIPTION
Switch to using v2.2.1 in the mac native job. Remove the git clone & install step.