### PR TITLE
p2p: reduce false-positives in addr rate-limiting

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -372,9 +372,9 @@ struct Peer {
     std::atomic_bool m_wants_addrv2{false};
     /** Whether this peer has already sent us a getaddr message. */
     bool m_getaddr_recvd GUARDED_BY(NetEventsInterface::g_msgproc_mutex){false};
-    /** Number of addresses that can be processed from this peer. Start at 1 to
-     *  permit self-announcement. */
-    double m_addr_token_bucket GUARDED_BY(NetEventsInterface::g_msgproc_mutex){1.0};
+    /** Number of addresses that can be processed from this peer. Starts at 5 to
+     *  allow a few addresses to be processed when the connection is opened. */
+    double m_addr_token_bucket GUARDED_BY(NetEventsInterface::g_msgproc_mutex){5.0};
     /** When m_addr_token_bucket was last updated */
     std::chrono::microseconds m_addr_token_timestamp GUARDED_BY(NetEventsInterface::g_msgproc_mutex){GetTime<std::chrono::microseconds>()};
     /** Total number of addresses that were dropped due to rate limiting. */

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -38,7 +38,8 @@ ADDR_DESTINATIONS_THRESHOLD = 4
 class AddrReceiver(P2PInterface):
     num_ipv4_received = 0
     test_addr_contents = False
-    _tokens = 1
+    # Start with 5 tokens to match "m_addr_token_bucket"
+    _tokens = 5
     send_getaddr = True
 
     def __init__(self, test_addr_contents=False, send_getaddr=True):


### PR DESCRIPTION
Start the rate-limiter with 5 tokens instead of 1 token.

---

On some occasions, a peer will send us addresses a few seconds after the connection is established. As peers start with token=1 and only get an additional token only every 10 seconds, some of these addresses might be rate-limited. The following log snippet contains an example:

```
04:12:02 [net] Added connection to [redacted] peer=1234
...
04:12:03 [net] Received addr: 1 addresses (1 processed, 0 rate-limited) from peer=1234
04:12:34 [net] Received addr: 4 addresses (3 processed, 1 rate-limited) from peer=1234
04:13:09 [net] Received addr: 2 addresses (2 processed, 0 rate-limited) from peer=1234
```

The peer starts with token=1 and uses one for its self-announcement at 04:12:03. Until the next addr message arrives at 04:12:34, it re-gains 3 tokens and uses them, however, the fourth address in this addr message is rate-limited. At 04:13:09, the peer has token=3 and uses 2.

This change gives peers token=5 to start with. To choose this value, I looked at the address relay of freshly connected peers. The data was sampled from the debug.logs from different nodes. It appears, that only very few peers require more than 5 initial tokens.

<img width="1172" height="838" alt="image" src="https://github.com/user-attachments/assets/19fbe866-c604-4508-889c-d9600990726e" />


By increasing the initial tokens to 5, someone could connect, send 5 addresses, disconnect, and repeat to spam the node with addresses. Previously, the same was possible but only one address was processed. I don't think this is a problem anymore since #30568.

