### PR TITLE
random: scope environ extern to macOS, BSDs and Illumos

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -57,8 +57,12 @@
 #include <sys/auxv.h>
 #endif
 
-#ifndef WIN32
-extern char** environ; // NOLINT(readability-redundant-declaration): Necessary on some platforms
+#if defined(__APPLE__) || \
+    defined(__FreeBSD__) || \
+    defined(__NetBSD__) || \
+    defined(__OpenBSD__) || \
+    defined(__illumos__)
+extern char** environ; // NOLINT(readability-redundant-declaration): Necessary on the above platforms
 #endif
 
 namespace {


### PR DESCRIPTION
These platforms fail to compile with it removed.
macOS: #33675
BSDs / Illumos: https://github.com/hebasto/bitcoin-core-nightly/pull/79.