### PR TITLE
chainparams: remove dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us

### DIFF
--- a/contrib/seeds/README.md
+++ b/contrib/seeds/README.md
@@ -10,14 +10,13 @@ to addrman with).
 
 Update `MIN_BLOCKS` in  `makeseeds.py` and the `-m`/`--minblocks` arguments below, as needed.
 
-The seeds compiled into the release are created from sipa's, achow101's and luke-jr's
+The seeds compiled into the release are created from sipa's and achow101's
 DNS seed, virtu's crawler, and asmap community AS map data. Run the following commands
 from the `/contrib/seeds` directory:
 
 ```
 curl https://bitcoin.sipa.be/seeds.txt.gz | gzip -dc > seeds_main.txt
 curl https://21.ninja/seeds.txt.gz | gzip -dc >> seeds_main.txt
-curl https://luke.dashjr.org/programs/bitcoin/files/charts/seeds.txt >> seeds_main.txt
 curl https://mainnet.achownodes.xyz/seeds.txt.gz | gzip -dc >> seeds_main.txt
 curl https://signet.achownodes.xyz/seeds.txt.gz | gzip -dc > seeds_signet.txt
 curl https://testnet.achownodes.xyz/seeds.txt.gz | gzip -dc > seeds_test.txt

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -147,7 +147,6 @@ public:
         // release ASAP to avoid it where possible.
         vSeeds.emplace_back("seed.bitcoin.sipa.be."); // Pieter Wuille, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("dnsseed.bluematt.me."); // Matt Corallo, only supports x9
-        vSeeds.emplace_back("dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us."); // Luke Dashjr
         vSeeds.emplace_back("seed.bitcoin.jonasschnelli.ch."); // Jonas Schnelli, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("seed.btc.petertodd.net."); // Peter Todd, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("seed.bitcoin.sprovoost.nl."); // Sjors Provoost


### PR DESCRIPTION
The DNS seed `dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us.` is not returning a representative sample of bitcoin nodes. It currently returns nothing later than 28.1.0, breaching the policy.

This PR removes that seed from the list of DNS seeds

### Rationale

The [policy for seeds](https://github.com/bitcoin/bitcoin/blob/master/doc/dnsseed-policy.md) includes this:

> The DNS seed results must consist exclusively of fairly selected and functioning Bitcoin nodes from the public network

A number of comments below, in response to this PR, include apparent breaches of this policy: [1](https://github.com/bitcoin/bitcoin/pull/33723#issuecomment-3458071231) [2](https://github.com/bitcoin/bitcoin/pull/33723#issuecomment-3457655364), [3](https://github.com/bitcoin/bitcoin/pull/33723#issuecomment-3457712557), in particular the first linked comment ([1](https://github.com/bitcoin/bitcoin/pull/33723#issuecomment-3458071231)) comparing the distribution at this seed to other seeds. This seed is not including anything later than 28.2.0, breaching this policy.

To ensure the policy is followed, and the seeds include a representative sample of Bitcoin nodes, this PR removes this seed from the list

### Data

I ran this:
```
# Get some ip address from that seed:
# Repeated multiple times, to get many different IPs:
dig +short dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us >> dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us
# For each distinct ip gathered from the seed, get basic info about the node, including it's User Agent string:
cat dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us | sort -u | while read ip; do echo ===; echo $ip; nmap -p 8333 --script bitcoin-info "$ip"; done > seed_versions.txt
```

and then summarized the agents with `egrep 'User Agent' seed_versions.txt  | sort | uniq -c` and got:
```
      1   User Agent: /Satoshi:22.0.0/
      1   User Agent: /Satoshi:22.1.0/
      5   User Agent: /Satoshi:24.0.1/
      1   User Agent: /Satoshi:25.1.0/
     30  User Agent: /Satoshi:27.0.0/
      1   User Agent: /Satoshi:27.1.0/
      1   User Agent: /Satoshi:27.1.0/Knots:20240801/
      1   User Agent: /Satoshi:28.0.0/
      7   User Agent: /Satoshi:28.1.0/
      2   User Agent: /Satoshi:28.1.0/Knots:20250305/

```