### PR TITLE
ci, iwyu: Treat warnings as errors for `src/init` and `src/policy`

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -215,7 +215,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
   fi
 
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(crypto|index|init)/.*\\.cpp"
+  FILES_WITH_ENFORCED_IWYU="/src/(crypto|index|init|policy|policy/fees)/.*\\.cpp"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -224,8 +224,10 @@ if [ "${RUN_TIDY}" = "true" ]; then
   run_iwyu() {
     mv "${BASE_BUILD_DIR}/$1" "${BASE_BUILD_DIR}/compile_commands.json"
     python3 "/include-what-you-use/iwyu_tool.py" \
-             -p "${BASE_BUILD_DIR}" "${MAKEJOBS}" \
-             -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
+             -p "${BASE_BUILD_DIR}" "${MAKEJOBS}" -- \
+             -Xiwyu --cxx17ns \
+             -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
+             -Xiwyu --mapping_file=/include-what-you-use/boost-1.75-all.imp \
              -Xiwyu --max_line_length=160 \
              2>&1 | tee /tmp/iwyu_ci.out
     python3 "/include-what-you-use/fix_includes.py" --nosafe_headers < /tmp/iwyu_ci.out

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -215,7 +215,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
   fi
 
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(crypto|index)/.*\\.cpp"
+  FILES_WITH_ENFORCED_IWYU="/src/(crypto|index|init)/.*\\.cpp"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -19,6 +19,7 @@
 #include <script/script.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/solver.h>
 #include <univalue.h>
 #include <util/exception.h>
 #include <util/fs.h>

--- a/src/crypto/hex_base.cpp
+++ b/src/crypto/hex_base.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cassert>
 #include <cstring>
+#include <span>
 #include <string>
 #include <tuple>
 

--- a/src/crypto/hex_base.h
+++ b/src/crypto/hex_base.h
@@ -9,7 +9,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <span>
 #include <string>
 
 /**

--- a/src/crypto/poly1305.h
+++ b/src/crypto/poly1305.h
@@ -10,7 +10,6 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <span>
 
 #define POLY1305_BLOCK_SIZE 16
 

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -7,6 +7,7 @@
 #include <interfaces/echo.h>
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
+#include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -4,6 +4,8 @@
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
+#include <init/common.h>
+
 #include <clientversion.h>
 #include <common/args.h>
 #include <logging.h>
@@ -17,8 +19,7 @@
 #include <util/translation.h>
 
 #include <algorithm>
-#include <filesystem>
-#include <string>
+#include <ranges>
 #include <vector>
 
 using util::SplitString;

--- a/src/policy/ephemeral_policy.cpp
+++ b/src/policy/ephemeral_policy.cpp
@@ -2,12 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <consensus/validation.h>
 #include <policy/ephemeral_policy.h>
+
+#include <consensus/amount.h>
+#include <consensus/validation.h>
 #include <policy/feerate.h>
 #include <policy/packages.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
+#include <tinyformat.h>
 #include <txmempool.h>
 #include <util/check.h>
 #include <util/hasher.h>
@@ -16,6 +19,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>

--- a/src/policy/ephemeral_policy.h
+++ b/src/policy/ephemeral_policy.h
@@ -9,8 +9,6 @@
 #include <policy/packages.h>
 #include <primitives/transaction.h>
 
-#include <optional>
-
 class CFeeRate;
 class CTxMemPool;
 class TxValidationState;

--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -3,9 +3,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <consensus/amount.h>
 #include <policy/feerate.h>
+
+#include <consensus/amount.h>
 #include <tinyformat.h>
+#include <util/check.h>
+#include <util/feefrac.h>
 
 
 CFeeRate::CFeeRate(const CAmount& nFeePaid, int32_t virtual_bytes)

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -10,10 +10,10 @@
 #include <serialize.h>
 #include <util/feefrac.h>
 
-
+#include <compare>
+#include <concepts>
 #include <cstdint>
 #include <string>
-#include <type_traits>
 
 const std::string CURRENCY_UNIT = "BTC"; // One formatted unit
 const std::string CURRENCY_ATOM = "sat"; // One indivisible minimum value unit

--- a/src/policy/fees/block_policy_estimator.cpp
+++ b/src/policy/fees/block_policy_estimator.cpp
@@ -5,7 +5,6 @@
 
 #include <policy/fees/block_policy_estimator.h>
 
-#include <common/system.h>
 #include <consensus/amount.h>
 #include <kernel/mempool_entry.h>
 #include <logging.h>
@@ -16,7 +15,6 @@
 #include <streams.h>
 #include <sync.h>
 #include <tinyformat.h>
-#include <uint256.h>
 #include <util/fs.h>
 #include <util/serfloat.h>
 #include <util/syserror.h>
@@ -24,10 +22,11 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <chrono>
 #include <cmath>
+#include <compare>
 #include <cstddef>
-#include <cstdint>
 #include <exception>
 #include <stdexcept>
 #include <utility>

--- a/src/policy/fees/block_policy_estimator.h
+++ b/src/policy/fees/block_policy_estimator.h
@@ -7,20 +7,21 @@
 
 #include <consensus/amount.h>
 #include <policy/feerate.h>
-#include <random.h>
+#include <primitives/transaction.h>
 #include <sync.h>
-#include <threadsafety.h>
-#include <uint256.h>
 #include <util/fs.h>
 #include <validationinterface.h>
 
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
 #include <vector>
+
+class FastRandomContext;
 
 
 // How often to flush fee estimates to fee_estimates.dat.

--- a/src/policy/fees/block_policy_estimator_args.cpp
+++ b/src/policy/fees/block_policy_estimator_args.cpp
@@ -5,6 +5,7 @@
 #include <policy/fees/block_policy_estimator_args.h>
 
 #include <common/args.h>
+#include <util/fs.h>
 
 namespace {
 const char* FEE_ESTIMATES_FILENAME = "fee_estimates.dat";

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -3,16 +3,21 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/packages.h>
-#include <policy/policy.h>
+
+#include <consensus/validation.h>
+#include <hash.h>
 #include <primitives/transaction.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/hasher.h>
 
 #include <algorithm>
-#include <cassert>
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <span>
+#include <string>
+#include <unordered_set>
 
 /** IsTopoSortedPackage where a set of txids has been pre-populated. The set is assumed to be correct and
  * is mutated within this function (even if return value is false). */

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -9,10 +9,9 @@
 #include <consensus/validation.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
-#include <util/hasher.h>
+#include <uint256.h>
 
 #include <cstdint>
-#include <unordered_set>
 #include <vector>
 
 /** Default maximum number of transactions in a package. */

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -18,6 +18,7 @@
 #include <script/solver.h>
 #include <serialize.h>
 #include <span.h>
+#include <util/check.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -10,14 +10,16 @@
 #include <consensus/consensus.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
-#include <script/solver.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
+#include <vector>
 
 class CCoinsViewCache;
 class CFeeRate;
 class CScript;
+enum class TxoutType;
 
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
 static constexpr unsigned int DEFAULT_BLOCK_MAX_WEIGHT{MAX_BLOCK_WEIGHT};

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -5,21 +5,22 @@
 #include <policy/rbf.h>
 
 #include <consensus/amount.h>
-#include <kernel/mempool_entry.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <txmempool.h>
-#include <uint256.h>
 #include <util/check.h>
+#include <util/feefrac.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
-
-#include <limits>
-#include <vector>
+#include <util/result.h>
+#include <util/translation.h>
 
 #include <compare>
+#include <span>
+#include <vector>
+
 
 RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
 {

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -9,17 +9,16 @@
 #include <primitives/transaction.h>
 #include <threadsafety.h>
 #include <txmempool.h>
-#include <util/feefrac.h>
 
-#include <compare>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <optional>
 #include <set>
 #include <string>
+#include <utility>
 
 class CFeeRate;
-class uint256;
 
 /** Maximum number of transactions that can be replaced by RBF (Rule #5). This includes all
  * mempool conflicts and their descendants. */

--- a/src/policy/truc_policy.cpp
+++ b/src/policy/truc_policy.cpp
@@ -4,14 +4,16 @@
 
 #include <policy/truc_policy.h>
 
-#include <coins.h>
-#include <consensus/amount.h>
-#include <logging.h>
+#include <policy/packages.h>
+#include <primitives/transaction.h>
 #include <tinyformat.h>
+#include <txmempool.h>
 #include <util/check.h>
 
 #include <algorithm>
-#include <numeric>
+#include <cstddef>
+#include <functional>
+#include <memory>
 #include <vector>
 
 /** Helper for PackageTRUCChecks: Returns a vector containing the indices of transactions (within

--- a/src/policy/truc_policy.h
+++ b/src/policy/truc_policy.h
@@ -5,15 +5,17 @@
 #ifndef BITCOIN_POLICY_TRUC_POLICY_H
 #define BITCOIN_POLICY_TRUC_POLICY_H
 
-#include <consensus/amount.h>
+#include <consensus/consensus.h>
 #include <policy/packages.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <txmempool.h>
-#include <util/result.h>
 
+#include <cstdint>
+#include <optional>
 #include <set>
 #include <string>
+#include <utility>
 
 // This module enforces rules for BIP 431 TRUC transactions which help make
 // RBF abilities more robust. A transaction with version=3 is treated as TRUC.

--- a/src/span.h
+++ b/src/span.h
@@ -7,7 +7,7 @@
 
 #include <cassert>
 #include <cstddef>
-#include <span>
+#include <span> // IWYU pragma: export
 #include <type_traits>
 #include <utility>
 

--- a/src/test/feerounder_tests.cpp
+++ b/src/test/feerounder_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <consensus/amount.h>
 #include <policy/fees/block_policy_estimator.h>
+#include <random.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/fuzz/fees.cpp
+++ b/src/test/fuzz/fees.cpp
@@ -5,6 +5,7 @@
 #include <common/messages.h>
 #include <consensus/amount.h>
 #include <policy/fees/block_policy_estimator.h>
+#include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -9,6 +9,7 @@
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/solver.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
 #include <tinyformat.h>

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -10,6 +10,7 @@
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/solver.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
 #include <validation.h>

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -24,7 +24,7 @@
 #include <util/hasher.h>
 #include <util/result.h>
 
-#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/hashed_index.hpp> // IWYU pragma: export
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/indexed_by.hpp>
 #include <boost/multi_index/ordered_index.hpp>


### PR DESCRIPTION
This PR continues the work from bitcoin/bitcoin#31308 by extending the treatment of IWYU warnings as errors to the `src/init` and `src/policy` directories.