### PR TITLE
chore(ci): bump artifact actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
         uses: ./.github/actions/save-caches
 
       - name: Upload built executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: x86_64-w64-mingw32-executables-${{ github.run_id }}
           path: |


### PR DESCRIPTION
switch the artifact upload/download steps to the v5 Actions release so we pick up the Node 24 compatibility and latest fixes; proof:[ actions/upload-artifact v5.0.0 release](https://github.com/actions/upload-artifact/releases/tag/v5.0.0)
