### PR TITLE
RFC: bench: Add multi thread benchmarking

### DIFF
--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -49,6 +49,7 @@ struct Args {
     fs::path output_json;
     std::string regex_filter;
     std::vector<std::string> setup_args;
+    bool scale_threads;
 };
 
 class BenchRunner

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -33,6 +33,7 @@ static void SetupBenchArgs(ArgsManager& argsman)
     argsman.AddArg("-output-csv=<output.csv>", "Generate CSV file with the most important benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-output-json=<output.json>", "Generate JSON file with all benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-sanity-check", "Run benchmarks for only one iteration with no output", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-scale-threads", "Run benchmarks with worker threads from 1 to MAX_SCRIPTCHECK_THREADS (only works with -filter)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 }
 
 // parses a comma separated list like "10,20,30,50"
@@ -52,7 +53,7 @@ static std::vector<std::string> parseTestSetupArgs(const ArgsManager& argsman)
 {
     // Parses unit test framework arguments supported by the benchmark framework.
     std::vector<std::string> args;
-    static std::vector<std::string> AVAILABLE_ARGS = {"-testdatadir"};
+    static std::vector<std::string> AVAILABLE_ARGS = {"-testdatadir", "-worker-threads"};
     for (const std::string& arg_name : AVAILABLE_ARGS) {
         auto op_arg = argsman.GetArg(arg_name);
         if (op_arg) args.emplace_back(strprintf("%s=%s", arg_name, *op_arg));
@@ -131,6 +132,7 @@ int main(int argc, char** argv)
         args.regex_filter = argsman.GetArg("-filter", DEFAULT_BENCH_FILTER);
         args.sanity_check = argsman.GetBoolArg("-sanity-check", false);
         args.setup_args = parseTestSetupArgs(argsman);
+        args.scale_threads = argsman.GetBoolArg("-scale-threads", false);
 
         benchmark::BenchRunner::RunAll(args);
 


### PR DESCRIPTION
This adds a rough way to run specific benchmarks with different numbers of worker threads to see how these impact performance. This is useful for me in the batch validation context and for potential refactorings of checkqueue but I am not sure if this is useful in many other contexts so I am leaving this as a RFC draft for now to see if there is any interest in merging something like this.

Example output:

```
$ build/bin/bench_bitcoin -filter=ConnectBlockAllSchnorr -min-time=1000 -scale-threads
Running benchmarks with worker threads from 1 to 15

|            ns/block |             block/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|       43,118,187.50 |               23.19 |    0.1% |      0.99 | `ConnectBlockAllSchnorr_1_threads`
|       29,015,444.33 |               34.46 |    0.2% |      1.10 | `ConnectBlockAllSchnorr_2_threads`
|       22,241,437.50 |               44.96 |    0.1% |      1.09 | `ConnectBlockAllSchnorr_3_threads`
|       17,893,361.00 |               55.89 |    0.3% |      1.09 | `ConnectBlockAllSchnorr_4_threads`
|       15,105,819.50 |               66.20 |    0.2% |      1.09 | `ConnectBlockAllSchnorr_5_threads`
|       13,145,510.38 |               76.07 |    0.2% |      1.08 | `ConnectBlockAllSchnorr_6_threads`
|       11,646,614.62 |               85.86 |    0.2% |      1.06 | `ConnectBlockAllSchnorr_7_threads`
|       10,476,425.89 |               95.45 |    0.2% |      1.07 | `ConnectBlockAllSchnorr_8_threads`
|        9,547,125.00 |              104.74 |    0.2% |      1.08 | `ConnectBlockAllSchnorr_9_threads`
|        9,574,246.27 |              104.45 |    0.6% |      1.08 | `ConnectBlockAllSchnorr_10_threads`
|        9,557,633.40 |              104.63 |    1.1% |      1.08 | `ConnectBlockAllSchnorr_11_threads`
|        9,495,175.00 |              105.32 |    0.8% |      1.08 | `ConnectBlockAllSchnorr_12_threads`
|        9,297,012.50 |              107.56 |    0.3% |      1.07 | `ConnectBlockAllSchnorr_13_threads`
|        9,775,795.45 |              102.29 |    0.7% |      1.11 | `ConnectBlockAllSchnorr_14_threads`
|        9,776,140.18 |              102.29 |    0.9% |      1.06 | `ConnectBlockAllSchnorr_15_threads`
```
