### PR TITLE
doc: Document valgrind aarch64 clang workaround

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -12,8 +12,10 @@
 #       --error-limit=no build/bin/test_bitcoin
 #
 # Note that suppressions may depend on OS and/or library versions.
-# Tested on aarch64 and x86_64 with Ubuntu Noble system libs, using clang-16
+# Tested on aarch64 and x86_64 with Ubuntu Noble system libs, using clang
 # and GCC, without gui.
+# When using clang on aarch64, -O1 may be required to work around
+# https://bugs.kde.org/show_bug.cgi?id=485276
 {
    Suppress uninitialized bytes warning in compat code
    Memcheck:Param


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/29635

The upstream bug will likely not be fixed any time soon, so it seems better to document the workaround and refer to the upstream bug.

This also allows to use any clang version (instead of requiring 16), going forward.