### PR TITLE
fuzz: refactor memcpy to std::ranges::copy to work around ubsan warn

### DIFF
--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <ranges>
 #include <thread>
 #include <vector>
 
@@ -322,8 +323,8 @@ std::unique_ptr<Sock> FuzzedSock::Accept(sockaddr* addr, socklen_t* addr_len) co
                 *addr_len = write_len;
                 auto addr4 = reinterpret_cast<sockaddr_in*>(addr);
                 addr4->sin_family = AF_INET;
-                const auto sin_addr_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(sizeof(addr4->sin_addr));
-                memcpy(&addr4->sin_addr, sin_addr_bytes.data(), sin_addr_bytes.size());
+                const auto sin_addr_bytes{m_fuzzed_data_provider.ConsumeBytes<std::byte>(sizeof(addr4->sin_addr))};
+                std::ranges::copy(sin_addr_bytes, reinterpret_cast<std::byte*>(&addr4->sin_addr));
                 addr4->sin_port = m_fuzzed_data_provider.ConsumeIntegralInRange<uint16_t>(1, 65535);
             }
         } else {
@@ -333,8 +334,8 @@ std::unique_ptr<Sock> FuzzedSock::Accept(sockaddr* addr, socklen_t* addr_len) co
                 *addr_len = write_len;
                 auto addr6 = reinterpret_cast<sockaddr_in6*>(addr);
                 addr6->sin6_family = AF_INET6;
-                const auto sin_addr_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(sizeof(addr6->sin6_addr));
-                memcpy(&addr6->sin6_addr, sin_addr_bytes.data(), sin_addr_bytes.size());
+                const auto sin_addr_bytes{m_fuzzed_data_provider.ConsumeBytes<std::byte>(sizeof(addr6->sin6_addr))};
+                std::ranges::copy(sin_addr_bytes, reinterpret_cast<std::byte*>(&addr6->sin6_addr));
                 addr6->sin6_port = m_fuzzed_data_provider.ConsumeIntegralInRange<uint16_t>(1, 65535);
             }
         }


### PR DESCRIPTION
Using std::ranges::copy from the C++ standard library has a few benefits here:

* It has the additional benefit of being a bit more type safe and document the byte cast explicitly.
* The compiler will likely optimize it to the same asm, but performance doesn't really matter here anyway.
* It has defined semantics for empty source ranges.

Fixes https://github.com/bitcoin/bitcoin/issues/33643