### PR TITLE
ci: Fix lint runner selection (and docker cache)

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -4,12 +4,21 @@ inputs:
   cache-provider:
     description: 'gha or cirrus cache provider'
     required: true
-    options:
-    - gh
-    - cirrus
 runs:
   using: 'composite'
   steps:
+    - name: Check inputs
+      shell: bash
+      run: |
+        # We expect only gha or cirrus as inputs to cache-provider
+        case "${{ inputs.cache-provider }}" in
+          gha|cirrus)
+            ;;
+          *)
+            echo "::warning title=Unknown input to configure docker action::Provided value was ${{ inputs.cache-provider }}"
+            ;;
+        esac
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,7 +566,7 @@ jobs:
   lint:
     name: 'lint'
     needs: runners
-    runs-on: ${{ needs.runners.outputs.use-cirrus-runners == 'true' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xs' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xs' || 'ubuntu-24.04' }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
     timeout-minutes: 20
     env:


### PR DESCRIPTION
Fixes: #33735

Correct runner type selection for the lint job.

This was erroneously left-out during refactor of the runner selection mechanism in #33302 causing the lint job to run on GH hosts (and therefore not be able to acces local cirrus caches).