### PR TITLE
test: ipc: resolve symlinks in `which capnp`

### DIFF
--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -27,7 +27,7 @@ class IPCInterfaceTest(BitcoinTestFramework):
     def load_capnp_modules(self):
         if capnp_bin := shutil.which("capnp"):
             # Add the system cap'nproto path so include/capnp/c++.capnp can be found.
-            capnp_dir = Path(capnp_bin).parent.parent / "include"
+            capnp_dir = Path(capnp_bin).resolve().parent.parent / "include"
         else:
             # If there is no system cap'nproto, the pycapnp module should have its own "bundled"
             # includes at this location. If pycapnp was installed with bundled capnp,


### PR DESCRIPTION
On Fedora, `/bin/` and `/usr/bin` are symlinked, and on one of my boxes (although I could not reproduce this behavior in a docker container), `/bin` comes before `/usr/bin` in `$PATH`, so `which capnp` reports `/bin/capnp`, and `capnp_dir` is set to `/include`, and the test fails:

```console
$ ./build/test/functional/interface_ipc.py
2025-10-30T20:43:43.753812Z TestFramework (INFO): PRNG seed is: 8370468257027235753
2025-10-30T20:43:43.754163Z TestFramework (INFO): Initializing test directory /tmp/bitcoin_func_test_b9kjzj2a
terminate called after throwing an instance of 'kj::ExceptionImpl'
  what():  mp/proxy.capnp:6: failed: Import failed: /capnp/c++.capnp
Aborted (core dumped)
```

This changes the functional test to resolve any symlinks in the `capnp` binary path reported by `which`.