### PR TITLE
doc: document fingerprinting risk when operating node on multiple networks

### DIFF
--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -166,3 +166,13 @@ In most cases, the default router settings should work fine.
 
 Please see the "General Guidance for Developers" section in https://geti2p.net/en/docs/api/samv3
 if you are developing a downstream application that may be bundling I2P with Bitcoin.
+
+## Privacy recommendations
+
+- Operating a node that listens on multiple networks (e.g. IPv4 and I2P) can help
+  strengthen the Bitcoin network, as nodes in this configuration (i.e. bridge nodes) increase
+  the cost and complexity of launching eclipse and partition attacks. However, under certain
+  conditions, an adversary that can connect to your node on multiple networks may be
+  able to correlate those identities by observing shared runtime characteristics. It
+  is not recommended to expose your node over multiple networks if you require
+  unlinkability across those identities.

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -238,9 +238,10 @@ for normal IPv4/IPv6 communication, use:
   Otherwise it is trivial to link them, which may reduce privacy. Onion
   services created automatically (as in section 2) always have only one port
   open.
-- Operating a node that listens on multiple networks (e.g. IPv4 and Tor) can increase
-  the cost and complexity of eclipse and partition attacks. However, under certain
+- Operating a node that listens on multiple networks (e.g. IPv4 and Tor) can help
+  strengthen the Bitcoin network, as nodes in this configuration (i.e. bridge nodes) increase
+  the cost and complexity of launching eclipse and partition attacks. However, under certain
   conditions, an adversary that can connect to your node on multiple networks may be
   able to correlate those identities by observing shared runtime characteristics. It
   is not recommended to expose your node over multiple networks if you require
-  unlinkability across those identities.   
+  unlinkability across those identities.

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -238,3 +238,9 @@ for normal IPv4/IPv6 communication, use:
   Otherwise it is trivial to link them, which may reduce privacy. Onion
   services created automatically (as in section 2) always have only one port
   open.
+- Operating a node that listens on multiple networks (e.g. IPv4 and Tor) can increase
+  the cost and complexity of eclipse and partition attacks. However, under certain
+  conditions, an adversary that can connect to your node on multiple networks may be
+  able to correlate those identities by observing shared runtime characteristics. It
+  is not recommended to expose your node over multiple networks if you require
+  unlinkability across those identities.   


### PR DESCRIPTION
Operating a Bitcoin node across multiple networks poses some fingerprinting risk. [0] Currently, this is not clear from the documentation and may be causing direct harm to users who are unaware of this. 

The included documentation change indicates this risk factor but also notes that operating a node across multiple networks does provide an important benefit (increases the cost of eclipse and partitioning attacks) and is thus not discouraged outright. 

The i2p documentation did not include a privacy recommendations section, so that is added as well.

[0] https://delvingbitcoin.org/t/fingerprinting-nodes-via-addr-requests/1786
