### PR TITLE
rest: Query predecessor headers using negative count param

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -52,6 +52,7 @@ With the /notxdetails/ option JSON response will only contain the transaction ha
 
 Given a block hash: returns <COUNT> amount of blockheaders in upward direction.
 Returns empty if the block doesn't exist or it isn't in the active chain.
+If <COUNT> is negative, returns |<COUNT>| amount of headers in downward direction.
 
 *Deprecated (but not removed) since 24.0:*
 `GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -213,9 +213,9 @@ static bool rest_headers(const std::any& context,
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid URI format. Expected /rest/headers/<hash>.<ext>?count=<count>");
     }
 
-    const auto parsed_count{ToIntegral<size_t>(raw_count)};
-    if (!parsed_count.has_value() || *parsed_count < 1 || *parsed_count > MAX_REST_HEADERS_RESULTS) {
-        return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Header count is invalid or out of acceptable range (1-%u): %s", MAX_REST_HEADERS_RESULTS, raw_count));
+    const auto parsed_count{ToIntegral<int>(raw_count)};
+    if (!parsed_count.has_value() || *parsed_count == 0 || *parsed_count > int(MAX_REST_HEADERS_RESULTS) || *parsed_count <  -int(MAX_REST_HEADERS_RESULTS)) {
+        return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Header count is invalid or out of acceptable range (1 <= |header_count| <= %u): %s", MAX_REST_HEADERS_RESULTS, raw_count));
     }
 
     auto hash{uint256::FromHex(hashStr)};
@@ -225,7 +225,7 @@ static bool rest_headers(const std::any& context,
 
     const CBlockIndex* tip = nullptr;
     std::vector<const CBlockIndex*> headers;
-    headers.reserve(*parsed_count);
+    headers.reserve(std::abs(*parsed_count));
     ChainstateManager* maybe_chainman = GetChainman(context, req);
     if (!maybe_chainman) return false;
     ChainstateManager& chainman = *maybe_chainman;
@@ -234,12 +234,19 @@ static bool rest_headers(const std::any& context,
         CChain& active_chain = chainman.ActiveChain();
         tip = active_chain.Tip();
         const CBlockIndex* pindex{chainman.m_blockman.LookupBlockIndex(*hash)};
-        while (pindex != nullptr && active_chain.Contains(pindex)) {
+        if (pindex != nullptr && *parsed_count < 0 && !active_chain.Contains(pindex)) {
+            tip = pindex;
+        }
+        while (pindex != nullptr && (*parsed_count < 0 || active_chain.Contains(pindex))) {
             headers.push_back(pindex);
-            if (headers.size() == *parsed_count) {
+            if (headers.size() == size_t(std::abs(*parsed_count))) {
                 break;
             }
-            pindex = active_chain.Next(pindex);
+            if (*parsed_count >= 0) {
+                pindex = active_chain.Next(pindex);
+            } else {
+                pindex = pindex->pprev;
+            }
         }
     }
 

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -304,6 +304,8 @@ class RESTTest (BitcoinTestFramework):
         self.wait_until(lambda: self.nodes[0].getindexinfo() == expected_filter)
         json_obj = self.test_rest_request(f"/headers/{bb_hash}", query_params={"count": 5})
         assert_equal(len(json_obj), 5)  # now we should have 5 header objects
+        json_obj = self.test_rest_request(f"/headers/{bb_hash}", query_params={"count": -204})
+        assert_equal(len(json_obj), 204)  # now we should have 204 header objects
         json_obj = self.test_rest_request(f"/blockfilterheaders/basic/{bb_hash}", query_params={"count": 5})
         first_filter_header = json_obj[0]
         assert_equal(len(json_obj), 5)  # now we should have 5 filter header objects
@@ -321,9 +323,9 @@ class RESTTest (BitcoinTestFramework):
         assert_equal(resp.read().decode('utf-8').rstrip(), f"Invalid hash: {INVALID_PARAM}")
 
         # Test number parsing
-        for num in ['5a', '-5', '0', '2001', '99999999999999999999999999999999999']:
+        for num in ['5a', '0', '2001', '-2001', '99999999999999999999999999999999999']:
             assert_equal(
-                bytes(f'Header count is invalid or out of acceptable range (1-2000): {num}\r\n', 'ascii'),
+                bytes(f'Header count is invalid or out of acceptable range (1 <= |header_count| <= 2000): {num}\r\n', 'ascii'),
                 self.test_rest_request(f"/headers/{bb_hash}", ret_type=RetType.BYTES, status=400, query_params={"count": num}),
             )
 


### PR DESCRIPTION
There is currently no mechanism by which to batch-query headers from tip, backwards towards genesis.
This PR extends the REST Blockheaders API to support batch-querying predecessor headers, by providing a negative count parameter.