### PR TITLE
ci: gha: Set debug_pull_request_number_str annotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
     outputs:
       provider: ${{ steps.runners.outputs.provider }}
     steps:
+      - name: Annotate with pull request number
+        # This annotation is machine-readable and can be used to assign a check
+        # run to its corresponding pull request. Running in one check run is
+        # sufficient for each check suite.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "::notice title=debug_pull_request_number_str::${{ github.event.number }}"
+          fi
       - id: runners
         run: |
           if [[ "${REPO_USE_CIRRUS_RUNNERS}" == "${{ github.repository }}" ]]; then


### PR DESCRIPTION
GitHub Actions does not offer any way to determine the pull request number in a machine readable way from the checks API. See https://github.com/bitcoin/bitcoin/issues/27178#issuecomment-1503475232.

However, the pull request number can be useful for external tools to act on CI results.

Fix that by using a check run annotation for a single task named `debug_pull_request_number_str`.

This should re-enable the 'CI Failed' labelling mechanism via https://github.com/maflcko/DrahtBot/commit/1f24cc1ab9be8ad35fbb3a44aaa073bf669a7685.