### PR TITLE
Relax standardness rules regarding CHECKMULTISIG

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -61,26 +61,12 @@ static inline void popstack(std::vector<valtype>& stack)
     stack.pop_back();
 }
 
-bool static IsCompressedOrUncompressedPubKey(const valtype &vchPubKey) {
-    if (vchPubKey.size() < CPubKey::COMPRESSED_SIZE) {
-        //  Non-canonical public key: too short
-        return false;
+bool static IsEmptyOrHybridPubKey(const valtype &vchPubKey) {
+    if (vchPubKey.size() == 0) return true;
+    if (vchPubKey.size() == CPubKey::SIZE) {
+        if (vchPubKey[0] == 0x06 || vchPubKey[0] == 0x07) return true;
     }
-    if (vchPubKey[0] == 0x04) {
-        if (vchPubKey.size() != CPubKey::SIZE) {
-            //  Non-canonical public key: invalid length for uncompressed key
-            return false;
-        }
-    } else if (vchPubKey[0] == 0x02 || vchPubKey[0] == 0x03) {
-        if (vchPubKey.size() != CPubKey::COMPRESSED_SIZE) {
-            //  Non-canonical public key: invalid length for compressed key
-            return false;
-        }
-    } else {
-        //  Non-canonical public key: neither compressed nor uncompressed
-        return false;
-    }
-    return true;
+    return false;
 }
 
 bool static IsCompressedPubKey(const valtype &vchPubKey) {
@@ -216,7 +202,7 @@ bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, script_ver
 }
 
 bool static CheckPubKeyEncoding(const valtype &vchPubKey, script_verify_flags flags, const SigVersion &sigversion, ScriptError* serror) {
-    if ((flags & SCRIPT_VERIFY_STRICTENC) != 0 && !IsCompressedOrUncompressedPubKey(vchPubKey)) {
+    if ((flags & SCRIPT_VERIFY_STRICTENC) != 0 && IsEmptyOrHybridPubKey(vchPubKey)) {
         return set_error(serror, SCRIPT_ERR_PUBKEYTYPE);
     }
     // Only compressed keys are accepted in segwit


### PR DESCRIPTION
In PR #5247, the STRICTENC standardness rules were tightened with regards to CHECKMULTISIG so that unparsable public keys fail the script when they are encountered. The overall purpose here was to disallow the use of confusing hybrid public keys by policy while keeping policy compatible (i.e., strictly stronger) with consensus rules.

Comments in PR #5247 note that "I don't believe it should affect any system in production"; however, this belief is/was false. Counterparty was stuffing data blobs into multisig pubkey lists, but these UTXOs were meant to be spendable because, although some pubkeys were unparsable, other keys were parsable, and the UTXOs were meant to be spent by those valid keys.

But in tackling the hybrid key issue, PR #5247 disallowed any unparsable keys in multisigs, whether or not they were hybrid, and whether or not the signature was meant to satisfy a hybrid key.

In production, Counterparty UTXOs were inadvertently caught up in this standardness rule change and became "soft confiscated."  That is, they were no longer spendable by policy but still recoverable if users are able to somehow bypass standardness by mining their transactions themselves, or getting out-of-band assistance from some other miner.

I understand that Bitcoin Core never intended to "soft confiscate" any UTXOs by policy changes.  This change addresses the problem.

With this change, only hybrid formatted keys and empty keys will cause early abort in CHECKMULTISIG operations. Otherwise, failing signature checks revert to their consensus behaviour of testing subsequent public keys.

Counterparty UTXOs were never intended to make use of hybrid keys and thus shouldn't have any passing signatures using hybrid keys.
