### PR TITLE
ci: Add Windows + UCRT jobs for cross-compiling and native testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,14 +343,26 @@ jobs:
         run: |
           py -3 test/fuzz/test_runner.py --par $NUMBER_OF_PROCESSORS --loglevel DEBUG "${RUNNER_TEMP}/qa-assets/fuzz_corpora"
 
-  windows-msvcrt-cross:
-    name: 'Windows-cross to x86_64, MSVCRT'
+  windows-cross:
+    name: 'Windows-cross to x86_64, ${{ matrix.crt }}'
     needs: runners
     runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm' || 'ubuntu-24.04' }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
 
+    strategy:
+      fail-fast: false
+      matrix:
+        crt: [msvcrt, ucrt]
+        include:
+          - crt: msvcrt
+            file-env: './ci/test/00_setup_env_win64_msvcrt.sh'
+            artifact-name: 'x86_64-w64-mingw32-executables'
+          - crt: ucrt
+            file-env: './ci/test/00_setup_env_win64.sh'
+            artifact-name: 'x86_64-w64-mingw32ucrt-executables'
+
     env:
-      FILE_ENV: './ci/test/00_setup_env_win64_msvcrt.sh'
+      FILE_ENV: ${{ matrix.file-env }}
       DANGER_CI_ON_HOST_FOLDERS: 1
 
     steps:
@@ -379,7 +391,7 @@ jobs:
       - name: Upload built executables
         uses: actions/upload-artifact@v4
         with:
-          name: x86_64-w64-mingw32-executables-${{ github.run_id }}
+          name: ${{ matrix.artifact-name }}-${{ github.run_id }}
           path: |
             ${{ env.BASE_BUILD_DIR }}/bin/*.dll
             ${{ env.BASE_BUILD_DIR }}/bin/*.exe
@@ -387,10 +399,20 @@ jobs:
             ${{ env.BASE_BUILD_DIR }}/src/univalue/*.exe
             ${{ env.BASE_BUILD_DIR }}/test/config.ini
 
-  windows-msvcrt-native-test:
-    name: 'Windows, MSVCRT, test cross-built'
+  windows-native-test:
+    name: 'Windows, ${{ matrix.crt }}, test cross-built'
     runs-on: windows-2022
-    needs: windows-msvcrt-cross
+    needs: windows-cross
+
+    strategy:
+      fail-fast: false
+      matrix:
+        crt: [msvcrt, ucrt]
+        include:
+          - crt: msvcrt
+            artifact-name: 'x86_64-w64-mingw32-executables'
+          - crt: ucrt
+            artifact-name: 'x86_64-w64-mingw32ucrt-executables'
 
     env:
       PYTHONUTF8: 1
@@ -404,7 +426,7 @@ jobs:
       - name: Download built executables
         uses: actions/download-artifact@v5
         with:
-          name: x86_64-w64-mingw32-executables-${{ github.run_id }}
+          name: ${{ matrix.artifact-name }}-${{ github.run_id }}
 
       - name: Run bitcoind.exe
         run: ./bin/bitcoind.exe -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,14 +343,14 @@ jobs:
         run: |
           py -3 test/fuzz/test_runner.py --par $NUMBER_OF_PROCESSORS --loglevel DEBUG "${RUNNER_TEMP}/qa-assets/fuzz_corpora"
 
-  windows-cross:
-    name: 'Windows-cross to x86_64'
+  windows-msvcrt-cross:
+    name: 'Windows-cross to x86_64, MSVCRT'
     needs: runners
     runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm' || 'ubuntu-24.04' }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
 
     env:
-      FILE_ENV: './ci/test/00_setup_env_win64.sh'
+      FILE_ENV: './ci/test/00_setup_env_win64_msvcrt.sh'
       DANGER_CI_ON_HOST_FOLDERS: 1
 
     steps:
@@ -387,10 +387,10 @@ jobs:
             ${{ env.BASE_BUILD_DIR }}/src/univalue/*.exe
             ${{ env.BASE_BUILD_DIR }}/test/config.ini
 
-  windows-native-test:
-    name: 'Windows, test cross-built'
+  windows-msvcrt-native-test:
+    name: 'Windows, MSVCRT, test cross-built'
     runs-on: windows-2022
-    needs: windows-cross
+    needs: windows-msvcrt-cross
 
     env:
       PYTHONUTF8: 1

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_win64
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"  # Check that https://packages.debian.org/trixie/g++-mingw-w64-ucrt64 can cross-compile
+export HOST=x86_64-w64-mingw32ucrt
+export DEP_OPTS="CC=${HOST}-gcc CXX=${HOST}-g++"
+export PACKAGES="g++-mingw-w64-ucrt64 nsis"
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false
+export GOAL="deploy"
+export BITCOIN_CONFIG="\
+  --preset=dev-mode \
+  -DENABLE_IPC=OFF \
+  -DWITH_USDT=OFF \
+  -DREDUCE_EXPORTS=ON \
+  -DCMAKE_CXX_FLAGS='-Wno-error=maybe-uninitialized' \
+"

--- a/ci/test/00_setup_env_win64_msvcrt.sh
+++ b/ci/test/00_setup_env_win64_msvcrt.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CONTAINER_NAME=ci_win64
+export CONTAINER_NAME=ci_win64_msvcrt
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"  # Check that https://packages.ubuntu.com/noble/g++-mingw-w64-x86-64-posix (version 13.x, similar to guix) can cross-compile
 export HOST=x86_64-w64-mingw32
 export PACKAGES="g++-mingw-w64-x86-64-posix nsis"


### PR DESCRIPTION
This PR is part of the ongoing effort to migrate to the modern UCRT runtime for cross-compiled Windows binaries, including release builds.

For more details about this migration, see:
- https://github.com/bitcoin/bitcoin/issues/30210
- https://github.com/bitcoin/bitcoin/pull/33593

MSVCRT-related CI jobs should be removed from the CI framework once the migration to UCRT is complete.