### PR TITLE
refactor: remove dead branches in `SingletonClusterImpl`

### DIFF
--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -1437,16 +1437,9 @@ bool GenericClusterImpl::Split(TxGraphImpl& graph, int level) noexcept
 bool SingletonClusterImpl::Split(TxGraphImpl& graph, int level) noexcept
 {
     Assume(NeedsSplitting());
-    if (GetTxCount() == 0) {
-        // The cluster is now empty.
-        graph.GetClusterSet(level).m_cluster_usage -= TotalMemoryUsage();
-        return true;
-    } else {
-        // Nothing changed.
-        graph.SetClusterQuality(level, m_quality, m_setindex, QualityLevel::OPTIMAL);
-        Updated(graph, level);
-        return false;
-    }
+    Assume(!GetTxCount());
+    graph.GetClusterSet(level).m_cluster_usage -= TotalMemoryUsage();
+    return true;
 }
 
 void GenericClusterImpl::Merge(TxGraphImpl& graph, int level, Cluster& other) noexcept
@@ -1482,10 +1475,9 @@ void GenericClusterImpl::Merge(TxGraphImpl& graph, int level, Cluster& other) no
     });
 }
 
-void SingletonClusterImpl::Merge(TxGraphImpl& graph, int level, Cluster& other_abstract) noexcept
+void SingletonClusterImpl::Merge(TxGraphImpl&, int, Cluster&) noexcept
 {
-    // Nothing can be merged into a singleton; it should have been converted to GenericClusterImpl
-    // first.
+    // Nothing can be merged into a singleton; it should have been converted to GenericClusterImpl first.
     Assume(false);
 }
 
@@ -1537,13 +1529,10 @@ void GenericClusterImpl::ApplyDependencies(TxGraphImpl& graph, int level, std::s
     Updated(graph, level);
 }
 
-void SingletonClusterImpl::ApplyDependencies(TxGraphImpl& graph, int level, std::span<std::pair<GraphIndex, GraphIndex>> to_apply) noexcept
+void SingletonClusterImpl::ApplyDependencies(TxGraphImpl&, int, std::span<std::pair<GraphIndex, GraphIndex>>) noexcept
 {
     // Nothing can actually be applied.
-    for (auto& [par, chl] : to_apply) {
-        Assume(par == m_graph_index);
-        Assume(chl == m_graph_index);
-    }
+    Assume(false);
 }
 
 TxGraphImpl::~TxGraphImpl() noexcept


### PR DESCRIPTION
Found during review: [cluster mempool: control/optimize TxGraph memory usage](https://github.com/bitcoin/bitcoin/pull/33157#discussion_r2423058928)

### Fixes
`SplitAll()` always calls `ApplyRemovals()` first, for a singleton, it empties the cluster, therefore any `SingletonClusterImpl` passed to `Split()` must be empty.

`TxGraphImpl::ApplyDependencies()` first merges each dependency group and asserts the group has at least one dependency. Since `parent` != `child`, `TxGraphImpl::Merge()` upgrades the merge target to `GenericClusterImpl`, therefore the `ApplyDependencies()` is never dispatched to `SingletonClusterImpl`.

### Coverage proof:
* https://maflcko.github.io/b-c-cov/fuzz.coverage/src/txgraph.cpp.gcov.html#L1446
* https://storage.googleapis.com/oss-fuzz-coverage/bitcoin-core/reports/20251103/linux/src/bitcoin-core/src/txgraph.cpp.html#L1446