### PR TITLE
refactor: C++20 operators

### DIFF
--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -29,10 +29,6 @@ struct FlatFilePos
         return (a.nFile == b.nFile && a.nPos == b.nPos);
     }
 
-    friend bool operator!=(const FlatFilePos &a, const FlatFilePos &b) {
-        return !(a == b);
-    }
-
     bool IsNull() const { return (nFile == -1); }
 
     std::string ToString() const;

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -210,7 +210,6 @@ public:
     bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
     friend bool operator==(const CNetAddr& a, const CNetAddr& b);
-    friend bool operator!=(const CNetAddr& a, const CNetAddr& b) { return !(a == b); }
     friend bool operator<(const CNetAddr& a, const CNetAddr& b);
 
     /**
@@ -523,7 +522,6 @@ public:
     bool IsValid() const;
 
     friend bool operator==(const CSubNet& a, const CSubNet& b);
-    friend bool operator!=(const CSubNet& a, const CSubNet& b) { return !(a == b); }
     friend bool operator<(const CSubNet& a, const CSubNet& b);
 };
 
@@ -554,7 +552,6 @@ public:
      */
     [[nodiscard]] sa_family_t GetSAFamily() const;
     friend bool operator==(const CService& a, const CService& b);
-    friend bool operator!=(const CService& a, const CService& b) { return !(a == b); }
     friend bool operator<(const CService& a, const CService& b);
     std::vector<unsigned char> GetKey() const;
     std::string ToStringAddrPort() const;

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -72,7 +72,6 @@ public:
         iterator operator-(size_type n) const { return iterator(ptr - n); }
         iterator& operator-=(size_type n) { ptr -= n; return *this; }
         bool operator==(iterator x) const { return ptr == x.ptr; }
-        bool operator!=(iterator x) const { return ptr != x.ptr; }
         bool operator>=(iterator x) const { return ptr >= x.ptr; }
         bool operator<=(iterator x) const { return ptr <= x.ptr; }
         bool operator>(iterator x) const { return ptr > x.ptr; }
@@ -104,7 +103,6 @@ public:
         const_iterator operator-(size_type n) const { return const_iterator(ptr - n); }
         const_iterator& operator-=(size_type n) { ptr -= n; return *this; }
         bool operator==(const_iterator x) const { return ptr == x.ptr; }
-        bool operator!=(const_iterator x) const { return ptr != x.ptr; }
         bool operator>=(const_iterator x) const { return ptr >= x.ptr; }
         bool operator<=(const_iterator x) const { return ptr <= x.ptr; }
         bool operator>(const_iterator x) const { return ptr > x.ptr; }
@@ -449,10 +447,6 @@ public:
             ++b2;
         }
         return true;
-    }
-
-    bool operator!=(const prevector<N, T, Size, Diff>& other) const {
-        return !(*this == other);
     }
 
     bool operator<(const prevector<N, T, Size, Diff>& other) const {

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -72,10 +72,7 @@ public:
         iterator operator-(size_type n) const { return iterator(ptr - n); }
         iterator& operator-=(size_type n) { ptr -= n; return *this; }
         bool operator==(iterator x) const { return ptr == x.ptr; }
-        bool operator>=(iterator x) const { return ptr >= x.ptr; }
-        bool operator<=(iterator x) const { return ptr <= x.ptr; }
-        bool operator>(iterator x) const { return ptr > x.ptr; }
-        bool operator<(iterator x) const { return ptr < x.ptr; }
+        auto operator<=>(iterator x) const { return ptr <=> x.ptr; }
     };
 
     class const_iterator {
@@ -103,10 +100,7 @@ public:
         const_iterator operator-(size_type n) const { return const_iterator(ptr - n); }
         const_iterator& operator-=(size_type n) { ptr -= n; return *this; }
         bool operator==(const_iterator x) const { return ptr == x.ptr; }
-        bool operator>=(const_iterator x) const { return ptr >= x.ptr; }
-        bool operator<=(const_iterator x) const { return ptr <= x.ptr; }
-        bool operator>(const_iterator x) const { return ptr > x.ptr; }
-        bool operator<(const_iterator x) const { return ptr < x.ptr; }
+        auto operator<=>(const_iterator x) const { return ptr <=> x.ptr; }
     };
 
 private:

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -51,11 +51,6 @@ public:
         return (a.hash == b.hash && a.n == b.n);
     }
 
-    friend bool operator!=(const COutPoint& a, const COutPoint& b)
-    {
-        return !(a == b);
-    }
-
     std::string ToString() const;
 };
 
@@ -135,11 +130,6 @@ public:
                 a.nSequence == b.nSequence);
     }
 
-    friend bool operator!=(const CTxIn& a, const CTxIn& b)
-    {
-        return !(a == b);
-    }
-
     std::string ToString() const;
 };
 
@@ -176,11 +166,6 @@ public:
     {
         return (a.nValue       == b.nValue &&
                 a.scriptPubKey == b.scriptPubKey);
-    }
-
-    friend bool operator!=(const CTxOut& a, const CTxOut& b)
-    {
-        return !(a == b);
     }
 
     std::string ToString() const;
@@ -361,11 +346,6 @@ public:
     friend bool operator==(const CTransaction& a, const CTransaction& b)
     {
         return a.GetWitnessHash() == b.GetWitnessHash();
-    }
-
-    friend bool operator!=(const CTransaction& a, const CTransaction& b)
-    {
-        return !operator==(a, b);
     }
 
     std::string ToString() const;

--- a/src/primitives/transaction_identifier.h
+++ b/src/primitives/transaction_identifier.h
@@ -38,8 +38,6 @@ public:
     template <typename Other>
     bool operator==(const Other& other) const { return Compare(other) == 0; }
     template <typename Other>
-    bool operator!=(const Other& other) const { return Compare(other) != 0; }
-    template <typename Other>
     bool operator<(const Other& other) const { return Compare(other) < 0; }
 
     const uint256& ToUint256() const LIFETIMEBOUND { return m_wrapped; }

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -121,10 +121,6 @@ public:
         return a.vch[0] == b.vch[0] &&
                memcmp(a.vch, b.vch, a.size()) == 0;
     }
-    friend bool operator!=(const CPubKey& a, const CPubKey& b)
-    {
-        return !(a == b);
-    }
     friend bool operator<(const CPubKey& a, const CPubKey& b)
     {
         return a.vch[0] < b.vch[0] ||
@@ -302,7 +298,6 @@ public:
     unsigned char* begin() { return m_keydata.begin(); }
     unsigned char* end() { return m_keydata.end(); }
     bool operator==(const XOnlyPubKey& other) const { return m_keydata == other.m_keydata; }
-    bool operator!=(const XOnlyPubKey& other) const { return m_keydata != other.m_keydata; }
     bool operator<(const XOnlyPubKey& other) const { return m_keydata < other.m_keydata; }
 
     //! Implement serialization without length prefixes since it is a fixed length
@@ -336,11 +331,6 @@ public:
     {
         return a.m_pubkey == b.m_pubkey;
     }
-
-    bool friend operator!=(const EllSwiftPubKey& a, const EllSwiftPubKey& b)
-    {
-        return a.m_pubkey != b.m_pubkey;
-    }
 };
 
 struct CExtPubKey {
@@ -358,11 +348,6 @@ struct CExtPubKey {
             a.nChild == b.nChild &&
             a.chaincode == b.chaincode &&
             a.pubkey == b.pubkey;
-    }
-
-    friend bool operator!=(const CExtPubKey &a, const CExtPubKey &b)
-    {
-        return !(a == b);
     }
 
     friend bool operator<(const CExtPubKey &a, const CExtPubKey &b)

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -270,16 +270,10 @@ public:
     }
 
     inline bool operator==(const int64_t& rhs) const    { return m_value == rhs; }
-    inline bool operator<=(const int64_t& rhs) const    { return m_value <= rhs; }
-    inline bool operator< (const int64_t& rhs) const    { return m_value <  rhs; }
-    inline bool operator>=(const int64_t& rhs) const    { return m_value >= rhs; }
-    inline bool operator> (const int64_t& rhs) const    { return m_value >  rhs; }
+    inline auto operator<=>(const int64_t& rhs) const    { return m_value <=> rhs; }
 
     inline bool operator==(const CScriptNum& rhs) const { return operator==(rhs.m_value); }
-    inline bool operator<=(const CScriptNum& rhs) const { return operator<=(rhs.m_value); }
-    inline bool operator< (const CScriptNum& rhs) const { return operator< (rhs.m_value); }
-    inline bool operator>=(const CScriptNum& rhs) const { return operator>=(rhs.m_value); }
-    inline bool operator> (const CScriptNum& rhs) const { return operator> (rhs.m_value); }
+    inline auto operator<=>(const CScriptNum& rhs) const { return operator<=>(rhs.m_value); }
 
     inline CScriptNum operator+(   const int64_t& rhs)    const { return CScriptNum(m_value + rhs);}
     inline CScriptNum operator-(   const int64_t& rhs)    const { return CScriptNum(m_value - rhs);}

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -270,14 +270,12 @@ public:
     }
 
     inline bool operator==(const int64_t& rhs) const    { return m_value == rhs; }
-    inline bool operator!=(const int64_t& rhs) const    { return m_value != rhs; }
     inline bool operator<=(const int64_t& rhs) const    { return m_value <= rhs; }
     inline bool operator< (const int64_t& rhs) const    { return m_value <  rhs; }
     inline bool operator>=(const int64_t& rhs) const    { return m_value >= rhs; }
     inline bool operator> (const int64_t& rhs) const    { return m_value >  rhs; }
 
     inline bool operator==(const CScriptNum& rhs) const { return operator==(rhs.m_value); }
-    inline bool operator!=(const CScriptNum& rhs) const { return operator!=(rhs.m_value); }
     inline bool operator<=(const CScriptNum& rhs) const { return operator<=(rhs.m_value); }
     inline bool operator< (const CScriptNum& rhs) const { return operator< (rhs.m_value); }
     inline bool operator>=(const CScriptNum& rhs) const { return operator>=(rhs.m_value); }

--- a/src/support/allocators/pool.h
+++ b/src/support/allocators/pool.h
@@ -352,11 +352,4 @@ bool operator==(const PoolAllocator<T1, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& a,
     return a.resource() == b.resource();
 }
 
-template <class T1, class T2, std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
-bool operator!=(const PoolAllocator<T1, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& a,
-                const PoolAllocator<T2, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& b) noexcept
-{
-    return !(a == b);
-}
-
 #endif // BITCOIN_SUPPORT_ALLOCATORS_POOL_H

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -46,11 +46,6 @@ struct secure_allocator {
     {
         return true;
     }
-    template <typename U>
-    friend bool operator!=(const secure_allocator&, const secure_allocator<U>&) noexcept
-    {
-        return false;
-    }
 };
 
 // This is exactly like std::string, but with a custom allocator.

--- a/src/support/allocators/zeroafterfree.h
+++ b/src/support/allocators/zeroafterfree.h
@@ -38,11 +38,6 @@ struct zero_after_free_allocator {
     {
         return true;
     }
-    template <typename U>
-    friend bool operator!=(const zero_after_free_allocator&, const zero_after_free_allocator<U>&) noexcept
-    {
-        return false;
-    }
 };
 
 /** Byte-vector that clears its contents before deletion. */

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -61,14 +61,12 @@ public:
     }
 
     inline bool operator==(const int64_t& rhs) const    { return m_value == rhs; }
-    inline bool operator!=(const int64_t& rhs) const    { return m_value != rhs; }
     inline bool operator<=(const int64_t& rhs) const    { return m_value <= rhs; }
     inline bool operator< (const int64_t& rhs) const    { return m_value <  rhs; }
     inline bool operator>=(const int64_t& rhs) const    { return m_value >= rhs; }
     inline bool operator> (const int64_t& rhs) const    { return m_value >  rhs; }
 
     inline bool operator==(const CScriptNum10& rhs) const { return operator==(rhs.m_value); }
-    inline bool operator!=(const CScriptNum10& rhs) const { return operator!=(rhs.m_value); }
     inline bool operator<=(const CScriptNum10& rhs) const { return operator<=(rhs.m_value); }
     inline bool operator< (const CScriptNum10& rhs) const { return operator< (rhs.m_value); }
     inline bool operator>=(const CScriptNum10& rhs) const { return operator>=(rhs.m_value); }

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -61,16 +61,10 @@ public:
     }
 
     inline bool operator==(const int64_t& rhs) const    { return m_value == rhs; }
-    inline bool operator<=(const int64_t& rhs) const    { return m_value <= rhs; }
-    inline bool operator< (const int64_t& rhs) const    { return m_value <  rhs; }
-    inline bool operator>=(const int64_t& rhs) const    { return m_value >= rhs; }
-    inline bool operator> (const int64_t& rhs) const    { return m_value >  rhs; }
+    inline auto operator<=>(const int64_t& rhs) const    { return m_value <=> rhs; }
 
     inline bool operator==(const CScriptNum10& rhs) const { return operator==(rhs.m_value); }
-    inline bool operator<=(const CScriptNum10& rhs) const { return operator<=(rhs.m_value); }
-    inline bool operator< (const CScriptNum10& rhs) const { return operator< (rhs.m_value); }
-    inline bool operator>=(const CScriptNum10& rhs) const { return operator>=(rhs.m_value); }
-    inline bool operator> (const CScriptNum10& rhs) const { return operator> (rhs.m_value); }
+    inline auto operator<=>(const CScriptNum10& rhs) const { return operator<=>(rhs.m_value); }
 
     inline CScriptNum10 operator+(   const int64_t& rhs)    const { return CScriptNum10(m_value + rhs);}
     inline CScriptNum10 operator-(   const int64_t& rhs)    const { return CScriptNum10(m_value - rhs);}

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -64,7 +64,6 @@ public:
     constexpr int Compare(const base_blob& other) const { return std::memcmp(m_data.data(), other.m_data.data(), WIDTH); }
 
     friend constexpr bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
-    friend constexpr bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }
     friend constexpr bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
 
     /** @name Hex representation

--- a/src/util/bitdeque.h
+++ b/src/util/bitdeque.h
@@ -99,10 +99,7 @@ class bitdeque
         friend Iterator operator+(Iterator x, difference_type dist) { x += dist; return x; }
         friend Iterator operator+(difference_type dist, Iterator x) { x += dist; return x; }
         friend Iterator operator-(Iterator x, difference_type dist) { x -= dist; return x; }
-        friend bool operator<(const Iterator& x, const Iterator& y) { return std::tie(x.m_it, x.m_bitpos) < std::tie(y.m_it, y.m_bitpos); }
-        friend bool operator>(const Iterator& x, const Iterator& y) { return std::tie(x.m_it, x.m_bitpos) > std::tie(y.m_it, y.m_bitpos); }
-        friend bool operator<=(const Iterator& x, const Iterator& y) { return std::tie(x.m_it, x.m_bitpos) <= std::tie(y.m_it, y.m_bitpos); }
-        friend bool operator>=(const Iterator& x, const Iterator& y) { return std::tie(x.m_it, x.m_bitpos) >= std::tie(y.m_it, y.m_bitpos); }
+        friend auto operator<=>(const Iterator& x, const Iterator& y) { return std::tie(x.m_it, x.m_bitpos) <=> std::tie(y.m_it, y.m_bitpos); }
         friend bool operator==(const Iterator& x, const Iterator& y) { return x.m_it == y.m_it && x.m_bitpos == y.m_bitpos; }
         reference operator*() const { return (*m_it)[m_bitpos]; }
         reference operator[](difference_type pos) const { return *(*this + pos); }

--- a/src/util/bitdeque.h
+++ b/src/util/bitdeque.h
@@ -104,7 +104,6 @@ class bitdeque
         friend bool operator<=(const Iterator& x, const Iterator& y) { return std::tie(x.m_it, x.m_bitpos) <= std::tie(y.m_it, y.m_bitpos); }
         friend bool operator>=(const Iterator& x, const Iterator& y) { return std::tie(x.m_it, x.m_bitpos) >= std::tie(y.m_it, y.m_bitpos); }
         friend bool operator==(const Iterator& x, const Iterator& y) { return x.m_it == y.m_it && x.m_bitpos == y.m_bitpos; }
-        friend bool operator!=(const Iterator& x, const Iterator& y) { return x.m_it != y.m_it || x.m_bitpos != y.m_bitpos; }
         reference operator*() const { return (*m_it)[m_bitpos]; }
         reference operator[](difference_type pos) const { return *(*this + pos); }
     };

--- a/src/util/hash_type.h
+++ b/src/util/hash_type.h
@@ -50,11 +50,6 @@ public:
         return m_hash == other.m_hash;
     }
 
-    bool operator!=(const BaseHash<HashType>& other) const noexcept
-    {
-        return !(m_hash == other.m_hash);
-    }
-
     bool operator<(const BaseHash<HashType>& other) const noexcept
     {
         return m_hash < other.m_hash;


### PR DESCRIPTION
Remove all `operator!=` definitions and provide `operator<=>` as a replacement where all relational comparison operators were defined before.

The compiler is able to deduce missing comparison operators from `operator!=` and `operator<=>`. The compiler provided operators have the following advantages:

1. less code
2. guaranteed consistency

Refactoring that changes the implementation, or replaces it with `= default` is left for a separate PR.