### PR TITLE
ci: Lint follow-ups

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -8,16 +8,11 @@ runs:
   using: 'composite'
   steps:
     - name: Check inputs
-      shell: bash
+      shell: python
       run: |
         # We expect only gha or cirrus as inputs to cache-provider
-        case "${{ inputs.cache-provider }}" in
-          gha|cirrus)
-            ;;
-          *)
-            echo "::warning title=Unknown input to configure docker action::Provided value was ${{ inputs.cache-provider }}"
-            ;;
-        esac
+        if "${{ inputs.cache-provider }}" not in ("gha", "cirrus"):
+          print("::warning title=Unknown input to configure docker action::Provided value was ${{ inputs.cache-provider }}")
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,7 +601,7 @@ jobs:
       - name: CI script
         shell: python
         run: |
-          import os, shlex, subprocess, sys
+          import os, shlex, subprocess, sys, time
 
           def run(cmd, **kwargs):
               print("+ " + shlex.join(cmd), flush=True)
@@ -621,7 +621,10 @@ jobs:
               "."
           ]
 
-          run(build_cmd)
+          if run(build_cmd, check=False).returncode != 0:
+              print("Retry building image tag after failure")
+              time.sleep(3)
+              run(build_cmd)
 
           CIRRUS_PR_FLAG = []
           if '${{ github.event_name }}' == "pull_request":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,11 +599,37 @@ jobs:
           cache-provider: ${{ needs.runners.outputs.provider }}
 
       - name: CI script
+        shell: python
         run: |
-          set -o xtrace
-          docker buildx build -t "$CONTAINER_NAME" $DOCKER_BUILD_CACHE_ARG --file "./ci/lint_imagefile" .
-          CIRRUS_PR_FLAG=""
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CIRRUS_PR_FLAG="-e CIRRUS_PR=1"
-          fi
-          docker run --rm $CIRRUS_PR_FLAG -v "$(pwd)":/bitcoin "$CONTAINER_NAME"
+          import os, shlex, subprocess, sys
+
+          def run(cmd, **kwargs):
+              print("+ " + shlex.join(cmd), flush=True)
+              kwargs.setdefault("check", True)
+              try:
+                  return subprocess.run(cmd, **kwargs)
+              except Exception as e:
+                  sys.exit(e)
+
+          CONTAINER_NAME = os.environ["CONTAINER_NAME"]
+
+          build_cmd = [
+              "docker", "buildx", "build",
+              f"--tag={CONTAINER_NAME}",
+              *shlex.split(os.getenv("DOCKER_BUILD_CACHE_ARG", "")),
+              "--file=./ci/lint_imagefile",
+              "."
+          ]
+
+          run(build_cmd)
+
+          CIRRUS_PR_FLAG = []
+          if '${{ github.event_name }}' == "pull_request":
+              CIRRUS_PR_FLAG = ["-e", "CIRRUS_PR=1"]
+
+          run([
+              "docker", "run", "--rm",
+              *CIRRUS_PR_FLAG,
+              f"--volume={os.getcwd()}:/bitcoin",
+              CONTAINER_NAME,
+          ])

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,12 @@ jobs:
     outputs:
       provider: ${{ steps.runners.outputs.provider }}
     steps:
-      - name: Annotate with pull request number
+      - &ANNOTATION_PR_NUMBER
+        name: Annotate with pull request number
         # This annotation is machine-readable and can be used to assign a check
-        # run to its corresponding pull request. Running in one check run is
-        # sufficient for each check suite.
+        # run to its corresponding pull request. Running in all check runs is
+        # required, because check re-runs discard the annotations of other
+        # tasks in the test suite.
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "::notice title=debug_pull_request_number_str::${{ github.event.number }}"
@@ -63,6 +65,7 @@ jobs:
     steps:
       - name: Determine fetch depth
         run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"
+      - *ANNOTATION_PR_NUMBER
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -141,6 +144,8 @@ jobs:
       BASE_ROOT_DIR: ${{ github.workspace }}
 
     steps:
+      - *ANNOTATION_PR_NUMBER
+
       - &CHECKOUT
         name: Checkout
         uses: actions/checkout@v5
@@ -212,6 +217,8 @@ jobs:
             job-name: 'Windows native, fuzz, VS 2022'
 
     steps:
+      - *ANNOTATION_PR_NUMBER
+
       - *CHECKOUT
 
       - &SET_UP_VS
@@ -341,6 +348,8 @@ jobs:
       DANGER_CI_ON_HOST_FOLDERS: 1
 
     steps:
+      - *ANNOTATION_PR_NUMBER
+
       - *CHECKOUT
 
       - name: Configure environment
@@ -381,6 +390,8 @@ jobs:
       TEST_RUNNER_TIMEOUT_FACTOR: 40
 
     steps:
+      - *ANNOTATION_PR_NUMBER
+
       - *CHECKOUT
 
       - name: Download built executables
@@ -547,6 +558,8 @@ jobs:
             file-env: './ci/test/00_setup_env_native_msan.sh'
 
     steps:
+      - *ANNOTATION_PR_NUMBER
+
       - *CHECKOUT
 
       - name: Configure environment
@@ -587,6 +600,8 @@ jobs:
     env:
       CONTAINER_NAME: "bitcoin-linter"
     steps:
+      - *ANNOTATION_PR_NUMBER
+
       - name: Checkout
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
This contains a few follow-ups to https://github.com/bitcoin/bitcoin/pull/33744:

* Rewrite the actions Bash snippet to Python. I've confirmed it still works in https://github.com/maflcko/bitcoin-core-with-ci/actions/runs/19067932430 (scroll down).
* Add a lint-build retry to avoid issues such as https://github.com/bitcoin/bitcoin/issues/33640 for the lint task as well.
* Finally, run the `debug_pull_request_number_str` annotation on all checks, to ensure they are present even when GitHub deletes annotations on a re-run. For example, the initial attempt https://github.com/bitcoin/bitcoin/actions/runs/19041534107/attempts/1?pr=33772 has the annotations, and the lint re-run has them removed: https://github.com/bitcoin/bitcoin/actions/runs/19041534107?pr=33772