### PR TITLE
depends: add zeromq patch to fix mingw CMake file install location

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -11,6 +11,7 @@ $(package)_patches += openbsd_kqueue_headers.patch
 $(package)_patches += cmake_minimum.patch
 $(package)_patches += cacheline_undefined.patch
 $(package)_patches += no_librt.patch
+$(package)_patches += mingw_cmake_files.patch
 
 define $(package)_set_vars
   $(package)_config_opts := -DCMAKE_BUILD_TYPE=None -DWITH_DOCS=OFF -DWITH_LIBSODIUM=OFF
@@ -26,6 +27,7 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/builtin_sha1.patch && \
   patch -p1 < $($(package)_patch_dir)/cacheline_undefined.patch && \
   patch -p1 < $($(package)_patch_dir)/fix_have_windows.patch && \
+  patch -p1 < $($(package)_patch_dir)/mingw_cmake_files.patch && \
   patch -p1 < $($(package)_patch_dir)/openbsd_kqueue_headers.patch && \
   patch -p1 < $($(package)_patch_dir)/cmake_minimum.patch && \
   patch -p1 < $($(package)_patch_dir)/no_librt.patch

--- a/depends/patches/zeromq/mingw_cmake_files.patch
+++ b/depends/patches/zeromq/mingw_cmake_files.patch
@@ -1,0 +1,16 @@
+Fix mingw CMake files install location.
+See https://github.com/zeromq/libzmq/pull/4814.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 03462271..e63b94b4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1724,7 +1724,7 @@ if(WITH_DOC)
+   endif()
+ endif()
+ 
+-if(WIN32)
++if(WIN32 AND NOT MINGW)
+   set(ZEROMQ_CMAKECONFIG_INSTALL_DIR
+       "CMake"
+       CACHE STRING "install path for ZeroMQConfig.cmake")


### PR DESCRIPTION
Currently the zeromq CMake files for mingw are installed to `x86_64-w64-mingw32/CMake`, when they should be in `x86_64-w64-mingw32/lib/cmake`, so take the patch from upstream that puts them in the right place. Noticed this while looking at other depends changes, that might cleanup / remove dirs.