### PR TITLE
ci, iwyu: Fix warnings in `src/kernel` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -215,7 +215,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_read.cpp|signet.cpp|kernel/chain.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_read.cpp|signet.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -8,13 +8,12 @@
 
 #include <chain.h>
 #include <coins.h>
-#include <consensus/amount.h>
 #include <consensus/validation.h>
+#include <dbwrapper.h>
 #include <kernel/caches.h>
 #include <kernel/chainparams.h>
 #include <kernel/checks.h>
 #include <kernel/context.h>
-#include <kernel/cs_main.h>
 #include <kernel/notifications_interface.h>
 #include <kernel/warning.h>
 #include <logging.h>
@@ -27,9 +26,9 @@
 #include <serialize.h>
 #include <streams.h>
 #include <sync.h>
-#include <tinyformat.h>
 #include <uint256.h>
 #include <undo.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
@@ -38,14 +37,15 @@
 #include <validation.h>
 #include <validationinterface.h>
 
-#include <cassert>
 #include <cstddef>
 #include <cstring>
 #include <exception>
 #include <functional>
+#include <iterator>
 #include <list>
 #include <memory>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -21,10 +21,14 @@
 #include <util/strencodings.h>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstdint>
 #include <cstring>
-#include <type_traits>
+#include <iterator>
+#include <map>
+#include <span>
+#include <utility>
 
 using namespace util::hex_literals;
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -14,13 +14,12 @@
 #include <util/hash_type.h>
 #include <util/vector.h>
 
+#include <cstddef>
 #include <cstdint>
-#include <iterator>
 #include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 struct AssumeutxoHash : public BaseHash<uint256> {

--- a/src/kernel/checks.cpp
+++ b/src/kernel/checks.cpp
@@ -8,7 +8,7 @@
 #include <util/result.h>
 #include <util/translation.h>
 
-#include <memory>
+#include <string>
 
 namespace kernel {
 

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -12,23 +12,19 @@
 #include <node/blockstorage.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
-#include <serialize.h>
 #include <span.h>
 #include <streams.h>
 #include <sync.h>
-#include <tinyformat.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/overflow.h>
 #include <validation.h>
 
-#include <cassert>
-#include <iosfwd>
-#include <iterator>
 #include <map>
 #include <memory>
-#include <string>
+#include <span>
 #include <utility>
+#include <version>
 
 namespace kernel {
 

--- a/src/kernel/coinstats.h
+++ b/src/kernel/coinstats.h
@@ -7,8 +7,6 @@
 
 #include <arith_uint256.h>
 #include <consensus/amount.h>
-#include <crypto/muhash.h>
-#include <streams.h>
 #include <uint256.h>
 
 #include <cstdint>
@@ -19,6 +17,7 @@ class CCoinsView;
 class Coin;
 class COutPoint;
 class CScript;
+class MuHash3072;
 namespace node {
 class BlockManager;
 } // namespace node

--- a/src/kernel/disconnected_transactions.h
+++ b/src/kernel/disconnected_transactions.h
@@ -8,6 +8,8 @@
 #include <primitives/transaction.h>
 #include <util/hasher.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <list>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
Now seems like a good time to update the includes in `src/kernel`.