### PR TITLE
guix: disable libsanitizer in Linux GCC build

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -438,6 +438,7 @@ inspecting signatures in Mach-O binaries.")
                   "--enable-standard-branch-protection=yes",
                   "--enable-cet=yes",
                   "--disable-gcov",
+                  "--disable-libsanitizer",
                   building-on)))
         ((#:phases phases)
           `(modify-phases ,phases


### PR DESCRIPTION
This causes issues when building against newer glibcs (i.e 2.42), and isn't needed in any case.

```bash
../../../../gcc-14.3.0/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:483:31: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
  483 |   unsigned struct_termio_sz = sizeof(struct termio);
      |                               ^~~~~~~~~~~~~~~~~~~~~
```

Extracted from #25573.