### PR TITLE
clang-tidy: Remove no longer needed NOLINT

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -62,7 +62,7 @@
     defined(__NetBSD__) || \
     defined(__OpenBSD__) || \
     defined(__illumos__)
-extern char** environ; // NOLINT(readability-redundant-declaration): Necessary on the above platforms
+extern char** environ; // Necessary on the above platforms
 #endif
 
 namespace {


### PR DESCRIPTION
From https://github.com/bitcoin/bitcoin/pull/33714/files#r2491476516:
> Actually, the `NOLINT` was fixed and can be removed? You've confirmed that it is undeclared on the listed platforms, so it can't be hit by `readability-redundant-declaration`