### PR TITLE
doc: add cmake help option in Windows build docs

### DIFF
--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -50,6 +50,8 @@ CMake will put the resulting object files, libraries, and executables into a ded
 
 In the following instructions, the "Debug" configuration can be specified instead of the "Release" one.
 
+Run `cmake -B build -LH` to see the full list of available options.
+
 ### 4. Building with Static Linking with GUI
 
 ```

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -49,6 +49,9 @@ Build using:
 
     gmake -C depends HOST=x86_64-w64-mingw32  # Append "-j N" for N parallel jobs.
     cmake -B build --toolchain depends/x86_64-w64-mingw32/toolchain.cmake
+
+Run `cmake -B build -LH` to see the full list of available options.
+
     cmake --build build     # Append "-j N" for N parallel jobs.
 
 ## Depends system


### PR DESCRIPTION
Follow-up to #33088.

Adds `cmake -B build -LH` documentation to Windows build guides, similar to Unix build documentation.

Based on the suggestion and example provided by stickies-v in #33088, with minor adjustment to match existing indented code block format in `build-windows.md`.

Tested for:
- WSL Ubuntu with mingw-w64 cross-compilation  
- Windows 11 with Visual Studio 2022 (MSVC)