### PR TITLE
test: Ignore error message give from python because of PYTHON_GIL

### DIFF
--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -6,6 +6,7 @@
 import asyncio
 
 from contextlib import ExitStack
+import warnings
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 from test_framework.ipc_util import (
@@ -15,7 +16,15 @@ from test_framework.ipc_util import (
 
 # Test may be skipped and not have capnp installed
 try:
-    import capnp  # type: ignore[import] # noqa: F401
+    # TODO: Remove this warning catch once capnp can run safely without the GIL
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"The global interpreter lock \(GIL\) has been enabled to load module \'capnp.lib.capnp\', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled \(at your own risk\)\, run with PYTHON_GIL\=0 or \-Xgil\=0\.",
+            category=RuntimeWarning,
+            module=r"importlib\._bootstrap",
+        )
+        import capnp  # type: ignore[import] # noqa: F401
 except ModuleNotFoundError:
     pass
 


### PR DESCRIPTION
## Description
I was able to reproduce this issue https://github.com/bitcoin/bitcoin/issues/33582

Currently, if a user is running Python version `3.14.0t` they will get this error message and the test suite will halt.

```
stderr:
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'capnp.lib.capnp', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
```

Instead of halting, we should ignore and suppress the warning message because, regardless of `PYTHON_GIL` being set, our tests should pass.

In this change, we are avoiding setting `PYTHON_GIL=1` in case it is deprecated in the future, so that newer tests would avoid having thread safety bugs. It makes sense not to have our test suite depend on `PYTHON_GIL=1`

---

## Before and after applying this patch

### Before: Warning message when using Python version `3.14.0t` and `PYTHON_GIL` unset on master branch
```
./build/test/functional/test_runner.py interface_ipc.py
Temporary test directory at /var/folders/sq/z88fhjzj0b19ftsd2_bjrmjm0000gn/T/test_runner_₿_🏃_20251009_094704
Remaining jobs: [interface_ipc.py]
1/1 - interface_ipc.py failed, Duration: 7 s

stdout:
2025-10-09T08:47:05.067786Z TestFramework (INFO): PRNG seed is: 8793929945784019901
2025-10-09T08:47:05.069073Z TestFramework (INFO): Initializing test directory /var/folders/sq/z88fhjzj0b19ftsd2_bjrmjm0000gn/T/test_runner_₿_🏃_20251009_094704/interface_ipc_0
2025-10-09T08:47:05.880408Z TestFramework (INFO): Running echo test
2025-10-09T08:47:05.883429Z TestFramework (INFO): Running mining test
2025-10-09T08:47:12.059233Z TestFramework (INFO): Stopping nodes
2025-10-09T08:47:12.173668Z TestFramework (INFO): Cleaning up /var/folders/sq/z88fhjzj0b19ftsd2_bjrmjm0000gn/T/test_runner_₿_🏃_20251009_094704/interface_ipc_0 on exit
2025-10-09T08:47:12.173842Z TestFramework (INFO): Tests successful
[node 0] Cleaning up ipc directory '/var/folders/sq/z88fhjzj0b19ftsd2_bjrmjm0000gn/T/test-ipc-s5k_0gog'


stderr:
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'capnp.lib.capnp', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.



TEST             | STATUS    | DURATION

interface_ipc.py | ✖ Failed  | 7 s

ALL              | ✖ Failed  | 7 s (accumulated) 
Runtime: 7 s
```

---

### After: Applying this patch, when `PYTHON_GIL` is `0` or `1` or not set
```
PYTHON_GIL=1 ./build_dev_mode/test/functional/test_runner.py interface_ipc.py
or 
PYTHON_GIL=0 ./build_dev_mode/test/functional/test_runner.py interface_ipc.py
or
./build_dev_mode/test/functional/test_runner.py interface_ipc.py

Temporary test directory at /tmp/test_runner_₿_🏃_20251105_180523
Remaining jobs: [interface_ipc.py]
1/1 - interface_ipc.py passed, Duration: 13 s

TEST             | STATUS    | DURATION

interface_ipc.py | ✓ Passed  | 13 s

ALL              | ✓ Passed  | 13 s (accumulated)
Runtime: 13 s
```