### PR TITLE
guix: build glibc with `--enable-static-pie`

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -476,6 +476,7 @@ inspecting signatures in Mach-O binaries.")
             (list "--enable-stack-protector=all",
                   "--enable-cet",
                   "--enable-bind-now",
+                  "--enable-static-pie",
                   "--disable-werror",
                   "--disable-timezone-tools",
                   "--disable-profile",


### PR DESCRIPTION
From the glibc `2.27` release notes:

> Major new features:
> The GNU C Library can now be compiled with support for building static
> PIE executables (See --enable-static-pie in INSTALL).
> These static PIE executables are like static executables but can be
> loaded at any address and provide additional security hardening benefits
> at the cost of some memory and performance.  When the library is built with
> --enable-static-pic the resulting libc.a is usable with GCC 8 and above to
> create static PIE executables using the GCC option '-static-pie'. This
> feature is currently supported on i386, x86_64 and x32 with binutils
> 2.29 or later, and on aarch64 with binutils 2.30 or later.

Note that from glibc 2.35 onwards, this option is replaced with a `--disable-*` variant, as glibc started defaulting to this behaviour.

This not give us `-static-pie` release binaries, that requires further changes, see #25573. This change makes it easier to experiment with the current release glibc, by being able to just use `-static-pie`, and not rebuild the toolchain.