### PR TITLE
ci: Use cmake --preset=dev-mode in test-each-commit task

### DIFF
--- a/.github/ci-test-each-commit-exec.py
+++ b/.github/ci-test-each-commit-exec.py
@@ -37,13 +37,8 @@ def main():
         "-DAPPEND_CFLAGS='-O3 -g2'",
         "-DCMAKE_BUILD_TYPE=Debug",
         "-DWERROR=ON",
-        "-DWITH_ZMQ=ON",
-        "-DBUILD_GUI=ON",
-        "-DBUILD_BENCH=ON",
-        "-DBUILD_FUZZ_BINARY=ON",
-        "-DWITH_USDT=ON",
-        "-DBUILD_KERNEL_LIB=ON",
-        "-DBUILD_KERNEL_TEST=ON",
+        "--preset=dev-mode",
+        # Tolerate unused member functions in intermediate commits in a pull request
         "-DCMAKE_CXX_FLAGS=-Wno-error=unused-member-function",
     ])
     run(["cmake", "--build", "build", "-j", str(num_procs)])

--- a/.github/ci-test-each-commit-exec.py
+++ b/.github/ci-test-each-commit-exec.py
@@ -21,11 +21,12 @@ def main():
     run(["git", "log", "-1"])
 
     num_procs = int(run(["nproc"], stdout=subprocess.PIPE).stdout)
+    build_dir = "ci_build"
 
     run([
         "cmake",
         "-B",
-        "build",
+        build_dir,
         "-Werror=dev",
         # Use clang++, because it is a bit faster and uses less memory than g++
         "-DCMAKE_C_COMPILER=clang",
@@ -41,19 +42,19 @@ def main():
         # Tolerate unused member functions in intermediate commits in a pull request
         "-DCMAKE_CXX_FLAGS=-Wno-error=unused-member-function",
     ])
-    run(["cmake", "--build", "build", "-j", str(num_procs)])
+    run(["cmake", "--build", build_dir, "-j", str(num_procs)])
     run([
         "ctest",
         "--output-on-failure",
         "--stop-on-failure",
         "--test-dir",
-        "build",
+        build_dir,
         "-j",
         str(num_procs),
     ])
     run([
         sys.executable,
-        "./build/test/functional/test_runner.py",
+        f"./{build_dir}/test/functional/test_runner.py",
         "-j",
         str(num_procs * 2),
         "--combinedlogslen=99999999",


### PR DESCRIPTION
Using the preset should reduce the bloat and need to maintain several places to list the same cmake cache variables.

The only difference should be that `bitcoin-chainstate (experimental)` will be enabled, which seems fast and in line with the goal of the CI task.

* Before: https://github.com/bitcoin/bitcoin/actions/runs/19174075826/job/54814118651#step:8:315
* After: (this pull) https://github.com/bitcoin/bitcoin/actions/runs/19190748069/job/54864837086#step:7:324

```diff
   bitcoin-tx .......................... ON
   bitcoin-util ........................ ON
   bitcoin-wallet ...................... ON
-  bitcoin-chainstate (experimental) ... OFF
+  bitcoin-chainstate (experimental) ... ON
   libbitcoinkernel (experimental) ..... ON
   kernel-test (experimental) .......... ON
 Optional features:
