### PR TITLE
refactor: Add missing include in bitcoinkernel_wrapper.h

### DIFF
--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -8,6 +8,7 @@
 #include <kernel/bitcoinkernel.h>
 
 #include <array>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
Otherwise, the compilation may fail with:


```
/home/admin/actions-runner/_work/_temp/src/kernel/bitcoinkernel_wrapper.h:271:14: error: no type named 'exception_ptr' in namespace 'std'; did you mean 'exception'?
  271 |         std::exception_ptr exception;
      |         ~~~~~^~~~~~~~~~~~~
      |              exception
/cxx_build/include/c++/v1/__exception/exception.h:72:33: note: 'exception' declared here
   72 | class _LIBCPP_EXPORTED_FROM_ABI exception {
      |                                 ^
In file included from /home/admin/actions-runner/_work/_temp/src/bitcoin-chainstate.cpp:1:
/home/admin/actions-runner/_work/_temp/src/kernel/bitcoinkernel_wrapper.h:284:35: error: no member named 'current_exception' in namespace 'std'
  284 |             data.exception = std::current_exception();
      |                                   ^~~~~~~~~~~~~~~~~
/home/admin/actions-runner/_work/_temp/src/kernel/bitcoinkernel_wrapper.h:290:14: error: no member named 'rethrow_exception' in namespace 'std'
  290 |         std::rethrow_exception(user_data.exception);
      |              ^~~~~~~~~~~~~~~~~
/home/admin/actions-runner/_work/_temp/src/kernel/bitcoinkernel_wrapper.h:273:65: error: no viable conversion from 'std::nullptr_t' to 'std::exception'
  273 |     UserData user_data = UserData{.bytes = &bytes, .exception = nullptr};
      |                                                                 ^~~~~~~
/home/admin/actions-runner/_work/_temp/src/kernel/bitcoinkernel_wrapper.h:733:16: note: in instantiation of function template specialization 'btck::write_bytes<btck_Block>' requested here
  733 |         return write_bytes(get(), btck_block_to_bytes);
      |                ^
/cxx_build/include/c++/v1/__exception/exception.h:75:25: note: candidate constructor not viable: no known conversion from 'std::nullptr_t' to 'const exception &' for 1st argument
   75 |   _LIBCPP_HIDE_FROM_ABI exception(const exception&) _NOEXCEPT            = default;
      |                         ^         ~~~~~~~~~~~~~~~~
4 errors generated.