### PR TITLE
scripted-diff: Remove obsolete comment

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -101,5 +101,5 @@ cmake -B build -DENABLE_WALLET=OFF
 
 ```bash
 cmake --build build     # Append "-j N" for N parallel jobs.
-ctest --test-dir build  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+ctest --test-dir build  # Append "-j N" for N parallel tests.
 ```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -115,5 +115,5 @@ Build and run the tests:
 
 ```bash
 cmake --build build     # Append "-j N" for N parallel jobs.
-ctest --test-dir build  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+ctest --test-dir build  # Append "-j N" for N parallel tests.
 ```

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -93,7 +93,7 @@ Run `cmake -B build -LH` to see the full list of available options.
 
 ```bash
 cmake --build build     # Append "-j N" for N parallel jobs.
-ctest --test-dir build  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+ctest --test-dir build  # Append "-j N" for N parallel tests.
 ```
 
 ## Resource limits

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -170,7 +170,7 @@ Run the following in your terminal to compile Bitcoin Core:
 
 ``` bash
 cmake --build build     # Append "-j N" here for N parallel jobs.
-ctest --test-dir build  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+ctest --test-dir build  # Append "-j N" for N parallel tests.
 ```
 
 ### 3. Deploy (optional)

--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -57,7 +57,7 @@ Run `cmake -B build -LH` to see the full list of available options.
 ```
 cmake -B build --preset vs2022-static          # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
 cmake --build build --config Release           # Append "-j N" for N parallel jobs.
-ctest --test-dir build --build-config Release  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+ctest --test-dir build --build-config Release  # Append "-j N" for N parallel tests.
 cmake --install build --config Release         # Optional.
 ```
 
@@ -66,7 +66,7 @@ cmake --install build --config Release         # Optional.
 ```
 cmake -B build --preset vs2022 -DBUILD_GUI=OFF # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
 cmake --build build --config Release           # Append "-j N" for N parallel jobs.
-ctest --test-dir build --build-config Release  # Append "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+ctest --test-dir build --build-config Release  # Append "-j N" for N parallel tests.
 ```
 
 ### 6. vcpkg-specific Issues and Workarounds


### PR DESCRIPTION
The removed comment become obsolete after bitcoin/bitcoin#32697 and bitcoin/bitcoin#32881.