### PR TITLE
ci: Enable experimental kernel stuff in ASan task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
             file-env: './ci/test/00_setup_env_arm.sh'
             provider: 'gha'
 
-          - name: 'ASan + LSan + UBSan + integer, no depends, USDT'
+          - name: 'ASan + LSan + UBSan + integer'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' # has to match container in ci/test/00_setup_env_native_asan.sh for tracing tools
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -26,7 +26,7 @@ export NO_DEPENDS=1
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1
 export BITCOIN_CONFIG="\
- -DWITH_USDT=ON -DWITH_ZMQ=ON -DBUILD_GUI=ON \
+ --preset=dev-mode \
  -DSANITIZERS=address,float-divide-by-zero,integer,undefined \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_CXX_COMPILER=clang++ \


### PR DESCRIPTION
Base the task on --preset=dev-mode to ensure maximal coverage and add the following:

```
   bitcoin-chainstate (experimental) ... ON
   libbitcoinkernel (experimental) ..... ON
   kernel-test (experimental) .......... ON
```

Currently a draft to figure out https://github.com/bitcoin/bitcoin/pull/33824#issuecomment-3511082065