### PR TITLE
test, refactor: Fix `-Warray-bounds` warning

### DIFF
--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1301,7 +1301,7 @@ public:
     {
         // Construct contents consisting of 0x00 + 12-byte message type + payload.
         std::vector<uint8_t> contents(1 + CMessageHeader::MESSAGE_TYPE_SIZE + payload.size());
-        std::copy(mtype.begin(), mtype.end(), reinterpret_cast<char*>(contents.data() + 1));
+        std::copy(mtype.begin(), mtype.end(), contents.begin() + 1);
         std::copy(payload.begin(), payload.end(), contents.begin() + 1 + CMessageHeader::MESSAGE_TYPE_SIZE);
         // Send a packet with that as contents.
         SendPacket(contents);


### PR DESCRIPTION
This warning is triggered by GCC 14 when cross-compiling for Windows.

Split from https://github.com/bitcoin/bitcoin/pull/33775/ and https://github.com/bitcoin/bitcoin/pull/33764.