### PR TITLE
kernel: Allow null arguments for serialized data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
             file-env: './ci/test/00_setup_env_arm.sh'
             provider: 'gha'
 
-          - name: 'ASan + LSan + UBSan + integer, no depends, USDT'
+          - name: 'ASan + LSan + UBSan + integer'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' # has to match container in ci/test/00_setup_env_native_asan.sh for tracing tools
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -26,7 +26,7 @@ export NO_DEPENDS=1
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1
 export BITCOIN_CONFIG="\
- -DWITH_USDT=ON -DWITH_ZMQ=ON -DBUILD_GUI=ON \
+ --preset=dev-mode \
  -DSANITIZERS=address,float-divide-by-zero,integer,undefined \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_CXX_COMPILER=clang++ \

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -497,6 +497,9 @@ struct btck_Txid: Handle<btck_Txid, Txid> {};
 
 btck_Transaction* btck_transaction_create(const void* raw_transaction, size_t raw_transaction_len)
 {
+    if (raw_transaction == nullptr && raw_transaction_len != 0) {
+        return nullptr;
+    }
     try {
         DataStream stream{std::span{reinterpret_cast<const std::byte*>(raw_transaction), raw_transaction_len}};
         return btck_Transaction::create(std::make_shared<const CTransaction>(deserialize, TX_WITH_WITNESS, stream));
@@ -556,6 +559,9 @@ void btck_transaction_destroy(btck_Transaction* transaction)
 
 btck_ScriptPubkey* btck_script_pubkey_create(const void* script_pubkey, size_t script_pubkey_len)
 {
+    if (script_pubkey == nullptr && script_pubkey_len != 0) {
+        return nullptr;
+    }
     auto data = std::span{reinterpret_cast<const uint8_t*>(script_pubkey), script_pubkey_len};
     return btck_ScriptPubkey::create(data.begin(), data.end());
 }
@@ -1033,6 +1039,9 @@ int btck_chainstate_manager_import_blocks(btck_ChainstateManager* chainman, cons
 
 btck_Block* btck_block_create(const void* raw_block, size_t raw_block_length)
 {
+    if (raw_block == nullptr && raw_block_length != 0) {
+        return nullptr;
+    }
     auto block{std::make_shared<CBlock>()};
 
     DataStream stream{std::span{reinterpret_cast<const std::byte*>(raw_block), raw_block_length}};

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -469,12 +469,12 @@ typedef uint8_t btck_ChainType;
 /**
  * @brief Create a new transaction from the serialized data.
  *
- * @param[in] raw_transaction     Non-null.
+ * @param[in] raw_transaction     Serialized transaction.
  * @param[in] raw_transaction_len Length of the serialized transaction.
  * @return                        The transaction, or null on error.
  */
 BITCOINKERNEL_API btck_Transaction* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_create(
-    const void* raw_transaction, size_t raw_transaction_len) BITCOINKERNEL_ARG_NONNULL(1);
+    const void* raw_transaction, size_t raw_transaction_len);
 
 /**
  * @brief Copy a transaction. Transactions are reference counted, so this just
@@ -567,12 +567,12 @@ BITCOINKERNEL_API void btck_transaction_destroy(btck_Transaction* transaction);
 
 /**
  * @brief Create a script pubkey from serialized data.
- * @param[in] script_pubkey     Non-null.
+ * @param[in] script_pubkey     Serialized script pubkey.
  * @param[in] script_pubkey_len Length of the script pubkey data.
  * @return                      The script pubkey.
  */
 BITCOINKERNEL_API btck_ScriptPubkey* BITCOINKERNEL_WARN_UNUSED_RESULT btck_script_pubkey_create(
-    const void* script_pubkey, size_t script_pubkey_len) BITCOINKERNEL_ARG_NONNULL(1);
+    const void* script_pubkey, size_t script_pubkey_len);
 
 /**
  * @brief Copy a script pubkey.
@@ -1111,12 +1111,12 @@ BITCOINKERNEL_API btck_Block* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_read(
 /**
  * @brief Parse a serialized raw block into a new block object.
  *
- * @param[in] raw_block     Non-null, serialized block.
+ * @param[in] raw_block     Serialized block.
  * @param[in] raw_block_len Length of the serialized block.
  * @return                  The allocated block, or null on error.
  */
 BITCOINKERNEL_API btck_Block* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_create(
-    const void* raw_block, size_t raw_block_len) BITCOINKERNEL_ARG_NONNULL(1);
+    const void* raw_block, size_t raw_block_len);
 
 /**
  * @brief Copy a block. Blocks are reference counted, so this just increments


### PR DESCRIPTION
An empty span constructed from an empty vector may have a null data pointer depending on the implementation. Remove the BITCOINKERNEL_ARG_NONNULL requirement for these arguments and instead handle such null arguments in the implementation.

Also cherry-picked from #33845 to show that CI task passing now.