### PR TITLE
fix assumevalid is ignored during reindex

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2049,7 +2049,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     node.background_init_thread = std::thread(&util::TraceThread, "initload", [=, &chainman, &args, &kernel_notifications, &node] {
         ScheduleBatchPriority();
         // Import blocks and ActivateBestChain()
-        ImportBlocks(chainman, vImportFiles);
+        ImportBlocks(chainman, vImportFiles, false);
         // An interrupted import may return without activating genesis. Wake
         // the init thread's genesis wait, which is otherwise only notified
         // on blockTip, and that never fires when the import was interrupted

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -292,7 +292,10 @@ void Interrupt(NodeContext& node)
     ShutdownNotify(*node.args);
 #endif
     // Wake any threads that may be waiting for the tip to change.
-    if (node.notifications) WITH_LOCK(node.notifications->m_tip_block_mutex, node.notifications->m_tip_block_cv.notify_all());
+    if (node.notifications) {
+        WITH_LOCK(node.notifications->m_tip_block_mutex, node.notifications->m_tip_block_cv.notify_all());
+        WITH_LOCK(node.notifications->m_header_tip_mutex, node.notifications->m_header_tip_cv.notify_all());
+    }
     InterruptHTTPServer();
     InterruptHTTPRPC();
     InterruptRPC();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -159,6 +159,7 @@ using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
 using node::DumpMempool;
 using node::ImportBlocks;
+using node::ImportingNow;
 using node::KernelNotifications;
 using node::LoadChainstate;
 using node::LoadMempool;
@@ -2051,33 +2052,58 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     /// \anchor initload
     node.background_init_thread = std::thread(&util::TraceThread, "initload", [=, &chainman, &args, &kernel_notifications, &node] {
         ScheduleBatchPriority();
-        // Import blocks and ActivateBestChain()
-        ImportBlocks(chainman, vImportFiles, false);
-        // An interrupted import may return without activating genesis. Wake
-        // the init thread's genesis wait, which is otherwise only notified
-        // on blockTip, and that never fires when the import was interrupted
-        // before activating genesis. This wakeup lets the wait observe the
-        // shutdown request.
-        WITH_LOCK(kernel_notifications.m_tip_block_mutex, kernel_notifications.m_tip_block_cv.notify_all());
-        WITH_LOCK(::cs_main, chainman.UpdateIBDStatus());
-        if (args.GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {
-            LogInfo("Stopping after block import");
-            if (!(Assert(node.shutdown_request))()) {
-                LogError("Failed to send shutdown signal after finishing block import\n");
+        {
+            // Import blocks and ActivateBestChain()
+            ImportingNow imp{chainman.m_blockman.m_importing};
+            bool force_activation = false;
+            ImportBlocks(chainman, vImportFiles, force_activation);
+            // An interrupted import may return without activating genesis. Wake
+            // the init thread's genesis wait, which is otherwise only notified
+            // on blockTip, and that never fires when the import was interrupted
+            // before activating genesis. This wakeup lets the wait observe the
+            // shutdown request.
+            WITH_LOCK(kernel_notifications.m_tip_block_mutex, kernel_notifications.m_tip_block_cv.notify_all());
+            if (args.GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {
+                LogInfo("Stopping after block import");
+                if (!(Assert(node.shutdown_request))()) {
+                    LogError("Failed to send shutdown signal after finishing block import\n");
+                }
+                return;
             }
-            return;
+
+            // Load mempool from disk
+            if (auto* pool{chainman.ActiveChainstate().GetMempool()}) {
+                LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {});
+                pool->SetLoadTried(!chainman.m_interrupt);
+            }
+
+            bool wait_for_headers_sync = !force_activation && WITH_LOCK(::cs_main,
+                return !chainman.m_best_header || chainman.m_best_header->nChainWork.CompareTo(chainman.MinimumChainWork()) < 0;);
+            if (wait_for_headers_sync) {
+                LogInfo("Waiting for header sync to finish before activating chain...");
+                auto& kernel_notifications{*Assert(node.notifications)};
+                WAIT_LOCK(kernel_notifications.m_header_tip_mutex, lock);
+                kernel_notifications.m_header_tip_cv.wait(lock, [&] () EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_header_tip_mutex) {
+                    return ShutdownRequested(node) || WITH_LOCK(::cs_main,
+                        return chainman.m_best_header && chainman.m_best_header->nChainWork.CompareTo(chainman.MinimumChainWork()) > -1);
+                });
+                if (ShutdownRequested(node)) return;
+                {
+                    REVERSE_LOCK(lock, kernel_notifications.m_header_tip_mutex);
+                    if (auto result = chainman.ActivateBestChains(); !result) {
+                        chainman.GetNotifications().fatalError(util::ErrorString(result));
+                    }
+                }
+            }
         }
+        // Update IBD status after loading blocks and activating chain
+        WITH_LOCK(::cs_main, chainman.UpdateIBDStatus());
 
         // Start indexes initial sync
         if (!StartIndexBackgroundSync(node)) {
             bilingual_str err_str = _("Failed to start indexes, shutting down…");
             chainman.GetNotifications().fatalError(err_str);
             return;
-        }
-        // Load mempool from disk
-        if (auto* pool{chainman.ActiveChainstate().GetMempool()}) {
-            LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {});
-            pool->SetLoadTried(!chainman.m_interrupt);
         }
     });
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4159,7 +4159,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 LogDebug(BCLog::NET, "got inv: %s %s peer=%d", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
 
                 UpdateBlockAvailability(pfrom.GetId(), inv.hash);
-                if (!fAlreadyHave && !m_chainman.m_blockman.LoadingBlocks() && !IsBlockRequested(inv.hash)) {
+                if (!fAlreadyHave && !IsBlockRequested(inv.hash)) {
                     // Headers-first is the primary method of announcement on
                     // the network. If a node fell back to sending blocks by
                     // inv, it may be for a re-org, or because we haven't
@@ -4836,12 +4836,6 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
     if (msg_type == NetMsgType::HEADERS)
     {
-        // Ignore headers received while importing
-        if (m_chainman.m_blockman.LoadingBlocks()) {
-            LogDebug(BCLog::NET, "Unexpected headers message received from peer %d\n", pfrom.GetId());
-            return;
-        }
-
         std::vector<CBlockHeader> headers;
 
         // Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
@@ -5913,7 +5907,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
             }
         }
 
-        if (!state.fSyncStarted && CanServeBlocks(peer) && !m_chainman.m_blockman.LoadingBlocks()) {
+        if (!state.fSyncStarted && CanServeBlocks(peer)) {
             // Only actively request headers from a single peer, unless we're close to today.
             if ((nSyncStarted == 0 && sync_blocks_and_headers_from_peer) || m_chainman.m_best_header->Time() > NodeClock::now() - 24h) {
                 const CBlockIndex* pindexStart = m_chainman.m_best_header;
@@ -6281,7 +6275,9 @@ bool PeerManagerImpl::SendMessages(CNode& node)
         // Message: getdata (blocks)
         //
         std::vector<CInv> vGetData;
-        if (CanServeBlocks(peer) && ((sync_blocks_and_headers_from_peer && !IsLimitedPeer(peer)) || !m_chainman.IsInitialBlockDownload()) && state.vBlocksInFlight.size() < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+        if (!m_chainman.m_blockman.LoadingBlocks() && CanServeBlocks(peer) &&
+            ((sync_blocks_and_headers_from_peer && !IsLimitedPeer(peer)) || !m_chainman.IsInitialBlockDownload()) &&
+            state.vBlocksInFlight.size() < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             std::vector<const CBlockIndex*> vToDownload;
             NodeId staller = -1;
             auto get_inflight_budget = [&state]() {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1256,27 +1256,16 @@ BlockManager::BlockManager(const util::SignalInterrupt& interrupt, Options opts)
     }
 }
 
-class ImportingNow
-{
-    std::atomic<bool>& m_importing;
-
-public:
-    ImportingNow(std::atomic<bool>& importing) : m_importing{importing}
-    {
-        assert(m_importing == false);
-        m_importing = true;
-    }
-    ~ImportingNow()
-    {
-        assert(m_importing == true);
-        m_importing = false;
-    }
-};
-
 void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths, bool force_activation)
 {
-    ImportingNow imp{chainman.m_blockman.m_importing};
-
+    ImportingNow imp;
+    if (force_activation) {
+        imp.Set(chainman.m_blockman.m_importing);
+    } else {
+        // If force_activation is false, m_importing must already be set
+        // by calling ImportBlocks inside an ImportingNow scope.
+        assert(chainman.m_blockman.m_importing);
+    }
     bool reindexed = false;
     // -reindex
     if (!chainman.m_blockman.m_blockfiles_indexed) {
@@ -1354,7 +1343,6 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
             chainman.GetNotifications().fatalError(util::ErrorString(result));
         }
     }
-    // End scope of ImportingNow
 }
 
 std::ostream& operator<<(std::ostream& os, const BlockfileType& type) {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1273,10 +1273,11 @@ public:
     }
 };
 
-void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths)
+void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths, bool force_activation)
 {
     ImportingNow imp{chainman.m_blockman.m_importing};
 
+    bool reindexed = false;
     // -reindex
     if (!chainman.m_blockman.m_blockfiles_indexed) {
         int total_files{0};
@@ -1323,6 +1324,7 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
         WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexing(false));
         chainman.m_blockman.m_blockfiles_indexed = true;
         LogInfo("Reindexing finished");
+        reindexed = true;
     }
 
     // -loadblock=
@@ -1340,9 +1342,17 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
         }
     }
 
+    // If started with -reindex, only connect blocks if there is high enough work chain,
+    // else allow normal node operation to sync headers before connecting blocks.
+    // This prevents unnecessary script verification work if assumevalid is enabled.
+    bool has_enough_work = WITH_LOCK(::cs_main, return chainman.m_best_header &&
+        chainman.m_best_header->nChainWork.CompareTo(chainman.MinimumChainWork()) >= 0);
+    bool activate_chains = !reindexed || force_activation || has_enough_work;
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
-    if (auto result = chainman.ActivateBestChains(); !result) {
-        chainman.GetNotifications().fatalError(util::ErrorString(result));
+    if (activate_chains) {
+        if (auto result = chainman.ActivateBestChains(); !result) {
+            chainman.GetNotifications().fatalError(util::ErrorString(result));
+        }
     }
     // End scope of ImportingNow
 }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1295,17 +1295,34 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
                 break; // This error is logged in OpenBlockFile
             }
             LogInfo("Reindexing block file blk%05u.dat (%d%% complete)...", (unsigned int)nFile, nFile * 100 / total_files);
+            // LoadExternalBlockFile will immediately call ABC when it finds
+            // the Genesis block
             chainman.LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
             if (chainman.m_interrupt) {
                 LogInfo("Interrupt requested. Exit reindexing.");
                 return;
             }
         }
+
+        auto genesisHash{chainman.GetParams().GenesisBlock().GetHash()};
+        if (WITH_LOCK(::cs_main, return !chainman.m_blockman.m_block_index.contains(genesisHash))) {
+            // Genesis Block wasn't added to the index.
+            // This means that no block was added to the index, and
+            // all of the blocks are in `blocks_with_unknown_parent`.
+            // To avoid ending up in a situation without genesis block,
+            // re-try initializing:
+            (void)chainman.LoadGenesisBlock();
+            // Attempt to Activate the Genesis Block
+            if (auto result = chainman.ActivateBestChains(); !result) {
+                chainman.GetNotifications().fatalError(util::ErrorString(result));
+                return;
+            }
+            chainman.LoadOutOfOrderBlocks(genesisHash, &blocks_with_unknown_parent);
+        }
+
         WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexing(false));
         chainman.m_blockman.m_blockfiles_indexed = true;
         LogInfo("Reindexing finished");
-        // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):
-        (void)chainman.LoadGenesisBlock();
     }
 
     // -loadblock=

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -483,7 +483,10 @@ public:
 };
 
 // Calls ActivateBestChain() even if no blocks are imported.
-void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths);
+// When force_activation is `false`, ActivateBestChain will not
+// be called on reindexed blocks if best_header chainwork is below
+// minchainwork.
+void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths,  bool force_activation = true);
 } // namespace node
 
 #endif // BITCOIN_NODE_BLOCKSTORAGE_H

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -480,6 +481,33 @@ public:
     bool ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index) const;
 
     void CleanupBlockRevFiles() const;
+};
+
+class ImportingNow
+{
+    std::atomic<bool>* m_importing;
+
+public:
+    ImportingNow(std::atomic<bool>& importing) : m_importing{&importing}
+    {
+        assert(*m_importing == false);
+        *m_importing = true;
+    }
+
+    ImportingNow() : m_importing{nullptr} {}
+
+    void Set(std::atomic<bool>& importing) {
+        m_importing = &importing;
+        assert(*m_importing == false);
+        *m_importing = true;
+    }
+
+    ~ImportingNow()
+    {
+        if (!m_importing) return;
+        assert(*m_importing == true);
+        *m_importing = false;
+    }
 };
 
 // Calls ActivateBestChain() even if no blocks are imported.

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -69,6 +69,10 @@ kernel::InterruptResult KernelNotifications::blockTip(SynchronizationState state
 
 void KernelNotifications::headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync)
 {
+    {
+        LOCK(m_header_tip_mutex);
+        m_header_tip_cv.notify_all();
+    }
     uiInterface.NotifyHeaderTip(state, height, timestamp, presync);
 }
 

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -48,7 +48,7 @@ public:
 
     [[nodiscard]] kernel::InterruptResult blockTip(SynchronizationState state, const CBlockIndex& index, double verification_progress) override EXCLUSIVE_LOCKS_REQUIRED(!m_tip_block_mutex);
 
-    void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) override;
+    void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) override EXCLUSIVE_LOCKS_REQUIRED(!m_header_tip_mutex);
 
     void progress(const bilingual_str& title, int progress_percent, bool resume_possible) override;
 
@@ -71,6 +71,9 @@ public:
     int m_stop_at_height{DEFAULT_STOPATHEIGHT};
     //! Useful for tests, can be set to false to avoid shutdown on fatal error.
     bool m_shutdown_on_fatal_error{true};
+
+    Mutex m_header_tip_mutex;
+    std::condition_variable m_header_tip_cv GUARDED_BY(m_header_tip_mutex);
 
     Mutex m_tip_block_mutex;
     std::condition_variable m_tip_block_cv GUARDED_BY(m_tip_block_mutex);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4980,6 +4980,36 @@ bool ChainstateManager::LoadGenesisBlock()
     return true;
 }
 
+int ChainstateManager::LoadOutOfOrderBlocks(const uint256& hash, std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent)
+{
+    int nLoaded = 0;
+    std::deque<uint256> queue;
+    queue.push_back(hash);
+    while (!queue.empty()) {
+        uint256 head = queue.front();
+        queue.pop_front();
+        auto range = blocks_with_unknown_parent->equal_range(head);
+        while (range.first != range.second) {
+            std::multimap<uint256, FlatFilePos>::iterator it = range.first;
+            std::shared_ptr<CBlock> pblockrecursive = std::make_shared<CBlock>();
+            if (m_blockman.ReadBlock(*pblockrecursive, it->second, {})) {
+                const auto& block_hash{pblockrecursive->GetHash()};
+                LogDebug(BCLog::REINDEX, "%s: Processing out of order child %s of %s", __func__, block_hash.ToString(), head.ToString());
+                LOCK(cs_main);
+                BlockValidationState dummy;
+                if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr, true)) {
+                    nLoaded++;
+                    queue.push_back(block_hash);
+                }
+            }
+            range.first++;
+            blocks_with_unknown_parent->erase(it);
+            NotifyHeaderTip();
+        }
+    }
+    return nLoaded;
+}
+
 void ChainstateManager::LoadExternalBlockFile(
     AutoFile& file_in,
     FlatFilePos* dbp,
@@ -5103,31 +5133,7 @@ void ChainstateManager::LoadExternalBlockFile(
 
                 if (!blocks_with_unknown_parent) continue;
 
-                // Recursively process earlier encountered successors of this block
-                std::deque<uint256> queue;
-                queue.push_back(hash);
-                while (!queue.empty()) {
-                    uint256 head = queue.front();
-                    queue.pop_front();
-                    auto range = blocks_with_unknown_parent->equal_range(head);
-                    while (range.first != range.second) {
-                        std::multimap<uint256, FlatFilePos>::iterator it = range.first;
-                        std::shared_ptr<CBlock> pblockrecursive = std::make_shared<CBlock>();
-                        if (m_blockman.ReadBlock(*pblockrecursive, it->second, {})) {
-                            const auto& block_hash{pblockrecursive->GetHash()};
-                            LogDebug(BCLog::REINDEX, "%s: Processing out of order child %s of %s", __func__, block_hash.ToString(), head.ToString());
-                            LOCK(cs_main);
-                            BlockValidationState dummy;
-                            if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr, true)) {
-                                nLoaded++;
-                                queue.push_back(block_hash);
-                            }
-                        }
-                        range.first++;
-                        blocks_with_unknown_parent->erase(it);
-                        NotifyHeaderTip();
-                    }
-                }
+                nLoaded += LoadOutOfOrderBlocks(hash, blocks_with_unknown_parent);
             } catch (const std::exception& e) {
                 // historical bugs added extra data to the block files that does not deserialize cleanly.
                 // commonly this data is between readable blocks, but it does not really matter. such data is not fatal to the import process.

--- a/src/validation.h
+++ b/src/validation.h
@@ -1212,6 +1212,16 @@ public:
     double GetBackgroundVerificationProgress(const CBlockIndex& pindex) const EXCLUSIVE_LOCKS_REQUIRED(GetMutex());
 
     /**
+     * Recursively process earlier encountered successors of this block
+     *
+     * @param[in]     hash                         hash of the ancestor block
+     * @param[in,out] blocks_with_unknown_parent   Map of disk positions for blocks with
+     *                                             unknown parent, key is parent block hash
+     */
+    int LoadOutOfOrderBlocks(const uint256& hash, std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent);
+
+
+    /**
      * Import blocks from an external file
      *
      * During reindexing, this function is called for each block file (datadir/blocks/blk?????.dat).
@@ -1226,6 +1236,9 @@ public:
      * blocks_with_unknown_parent map must be passed in and out with each call. It's a multimap,
      * rather than just a map, because multiple blocks may have the same parent (when chain splits
      * or stale blocks exist). It maps from parent-hash to child-disk-position.
+     *
+     * This function will call ActivateBestChain when the Genesis Block is added to the Block Index
+     * so normal node progress can continue.
      *
      * This function can also be used to read blocks from user-specified block files using the
      * -loadblock= option. There's no unknown-parent tracking, so the last two arguments are omitted.

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -33,6 +33,9 @@ Start a few nodes:
       block #1 that is not part of the assumevalid chain.
     - node5 starts with no -assumevalid parameter. Reindex to hit
       "assumevalid hash not in headers" and "below minimum chainwork".
+    - node6 has -assumevalid set to the hash of block 102. Reindex
+      with assumevalid to check that script verification is skipped during
+      reindexing.
 """
 
 from test_framework.blocktools import (
@@ -69,7 +72,7 @@ class BaseNode(P2PInterface):
 class AssumeValidTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 6
+        self.num_nodes = 7
         self.rpc_timeout = 120
 
     def setup_network(self):
@@ -137,6 +140,7 @@ class AssumeValidTest(BitcoinTestFramework):
         self.start_node(3, extra_args=[f"-assumevalid={block102.hash_hex}"])
         self.start_node(4, extra_args=[f"-assumevalid={block102.hash_hex}"])
         self.start_node(5)
+        self.start_node(6, extra_args=[f"-assumevalid={block102.hash_hex}"])
 
         # nodes[0]
         self.log.info("Send blocks to node0. Block 102 will be rejected.")
@@ -242,6 +246,27 @@ class AssumeValidTest(BitcoinTestFramework):
             self.restart_node(5, extra_args=["-reindex-chainstate", f"-assumevalid={block102.hash_hex}", "-minimumchainwork=0xffff"])
             assert_equal(self.nodes[5].getblockcount(), 1)
 
+        # nodes[6]
+        # Reindex with assumevalid set to block102. Should skip script verification
+        p2p6 = self.nodes[6].add_p2p_connection(BaseNode())
+        p2p6.send_header_for_blocks(self.blocks[0:2000])
+        p2p6.send_header_for_blocks(self.blocks[2000:])
+        for block in self.blocks[0:101]:
+            p2p6.send_without_ping(msg_block(block))
+        self.wait_until(lambda: self.nodes[6].getblockcount() == 101)
+        # Set minimumchainwork > 2000 blocks to force background init thread
+        # to wait for best_header to reach 2 weeks before connecting blocks.
+        self.restart_node(6, extra_args=["-reindex", f"-assumevalid={block102.hash_hex}", "-minimumchainwork=0x0fd2"])
+        p2p6 = self.nodes[6].add_p2p_connection(BaseNode())
+        with self.nodes[6].assert_debug_log(expected_msgs=[
+            f"Disabling script verification at block #1 ({self.blocks[0].hash_hex}).",
+        ]):
+            p2p6.send_header_for_blocks(self.blocks[0:2000])
+            p2p6.send_header_for_blocks(self.blocks[2000:])
+            # Resend headers because HeadersSync m_download_state will be in REDOWNLOAD
+            p2p6.send_header_for_blocks(self.blocks[0:2000])
+            p2p6.send_header_for_blocks(self.blocks[2000:])
+            self.wait_until(lambda: self.nodes[6].getblockcount() == 101)
 
 if __name__ == '__main__':
     AssumeValidTest(__file__).main()

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -71,7 +71,7 @@ class ReindexTest(BitcoinTestFramework):
         # The reindexing code should detect and accommodate out of order blocks.
         with self.nodes[0].assert_debug_log([
             'LoadExternalBlockFile: Out of order block',
-            'LoadExternalBlockFile: Processing out of order child',
+            'LoadOutOfOrderBlocks: Processing out of order child',
         ]):
             extra_args = [["-reindex"]]
             self.start_nodes(extra_args)

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -8,14 +8,28 @@
 - Stop the node and restart it with -reindex. Verify that the node has reindexed up to block 3.
 - Stop the node and restart it with -reindex-chainstate. Verify that the node has reindexed up to block 3.
 - Verify that out-of-order blocks are correctly processed, see LoadExternalBlockFile()
+- Verify that -reindex does not attempt to connect blocks when best_header chainwork is below MinimumChainWork
 """
 
+from test_framework.blocktools import create_block
+from test_framework.messages import (
+    CBlockHeader,
+    msg_block,
+    msg_headers,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import MAGIC_BYTES
+from test_framework.p2p import P2PInterface
 from test_framework.util import (
     assert_equal,
     util_xor,
 )
+
+class BaseNode(P2PInterface):
+    def send_header_for_blocks(self, new_blocks):
+        headers_message = msg_headers()
+        headers_message.headers = [CBlockHeader(b) for b in new_blocks]
+        self.send_without_ping(headers_message)
 
 
 class ReindexTest(BitcoinTestFramework):
@@ -98,6 +112,45 @@ class ReindexTest(BitcoinTestFramework):
             node.wait_for_rpc_connection(wait_for_import=False)
         node.stop_node()
 
+    def only_connect_minchainwork_chain(self):
+        self.start_node(0)
+        node = self.nodes[0]
+        self.generatetoaddress(self.nodes[0], 3, self.nodes[0].get_deterministic_priv_key().address)
+        blockcount = node.getblockcount()
+        best_header_target = int(node.getblock(node.getbestblockhash())['target'], 16)
+        chainwork = (100 + blockcount) * (2**256) // (best_header_target + 1)
+        chainwork = format(chainwork, '064x')
+
+        tip = int(node.getbestblockhash(), 16)
+        block_time = node.getblock(node.getbestblockhash())['time'] + 1
+        height = node.getblock(node.getbestblockhash())['height'] + 1
+
+        blocks = []
+        for _ in range(100):
+            block = create_block(tip, height=height, ntime=block_time)
+            block.solve()
+            blocks.append(block)
+            tip = block.hash_int
+            block_time += 1
+            height += 1
+
+        self.stop_node(0)
+        extra_args = ["-reindex", "-minimumchainwork=" + chainwork]
+        with node.assert_debug_log(expected_msgs=["Waiting for header sync to finish before activating chain..."]):
+            # No blocks are connected because chainwork of best_header is too low
+            self.start_node(0, extra_args)
+
+        p2p = node.add_p2p_connection(BaseNode())
+        p2p.send_header_for_blocks(blocks)
+
+        # Reindexed blocks are connected after headers sync
+        self.wait_until(lambda: node.getblockcount() == blockcount)
+
+        # Send headers again to ensure that the block is requested
+        p2p.send_header_for_blocks(blocks)
+        p2p.send_without_ping(msg_block(blocks[0]))
+        self.wait_until(lambda: node.getblockcount() == blockcount + 1)
+
     def run_test(self):
         self.reindex(False)
         self.reindex(True)
@@ -106,6 +159,7 @@ class ReindexTest(BitcoinTestFramework):
 
         self.out_of_order()
         self.continue_reindex_after_shutdown()
+        self.only_connect_minchainwork_chain()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -13,7 +13,7 @@ called min_work_node.
 The test:
 1. Generate one block on each node, to leave IBD.
 
-2. Mine a new block on each tip, and deliver to each node from node's peer.
+2. Mine blocks on each tip, and deliver to each node from node's peer.
    The tip should advance for node0, but node1 should skip processing due to
    nMinimumChainWork.
 
@@ -85,27 +85,40 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # 1. Have nodes mine a block (leave IBD)
         [self.generate(n, 1, sync_fun=self.no_op) for n in self.nodes]
-        tips = [int("0x" + n.getbestblockhash(), 0) for n in self.nodes]
 
-        # 2. Send one block that builds on each tip.
+        # 2. Send one block that builds on node0.
         # This should be accepted by node0
-        blocks_h2 = []  # the height 2 blocks on each node's chain
         block_time = int(time.time()) + 1
-        for i in range(2):
-            blocks_h2.append(create_block(tips[i], height=2, ntime=block_time))
-            blocks_h2[i].solve()
-            block_time += 1
-        test_node.send_and_ping(msg_block(blocks_h2[0]))
+        blocks_h2 = create_block(int("0x" + self.nodes[0].getbestblockhash(), 0), height=2, ntime=block_time)
+        blocks_h2.solve()
+        test_node.send_and_ping(msg_block(blocks_h2))
 
-        with self.nodes[1].assert_debug_log(expected_msgs=[f"AcceptBlockHeader: not adding new block header {blocks_h2[1].hash_hex}, missing anti-dos proof-of-work validation"]):
-            min_work_node.send_and_ping(msg_block(blocks_h2[1]))
+        # Mine a long enough chain to surpass minchainwork
+        headers_message = msg_headers()
+        tip = int("0x" + self.nodes[1].getbestblockhash(), 0)
+        nTime = int(time.time())
+        blocks = []
+        for i in range(8):
+            next_block = create_block(tip, height=i+2, ntime=nTime + 1)
+            next_block.solve()
+            tip = next_block.hash_int
+            nTime = next_block.nTime
+            headers_message.headers.append(CBlockHeader(next_block))
+            blocks.append(next_block)
+
+        # Create a fork below the chain tip and below minchainwork
+        test_block = create_block(blocks[2].hash_int, height=4, ntime=blocks[2].nTime + 1)
+        test_block.solve()
+        min_work_node.send_and_ping(headers_message)
+        with self.nodes[1].assert_debug_log(expected_msgs=[f"AcceptBlockHeader: not adding new block header {test_block.hash_hex}, missing anti-dos proof-of-work validation"]):
+            min_work_node.send_and_ping(msg_block(test_block))
 
         assert_equal(self.nodes[0].getblockcount(), 2)
         assert_equal(self.nodes[1].getblockcount(), 1)
 
-        # Ensure that the header of the second block was also not accepted by node1
-        assert_equal(self.check_hash_in_chaintips(self.nodes[1], blocks_h2[1].hash_hex), False)
-        self.log.info("First height 2 block accepted by node0; correctly rejected by node1")
+        # Ensure that the header of the block was also not accepted by node1
+        assert_equal(self.check_hash_in_chaintips(self.nodes[1], test_block.hash_hex), False)
+        self.log.info("First height 2 block accepted by node0; low work block correctly rejected by node1")
 
         # 3. Send another block that builds on genesis.
         block_h1f = create_block(int("0x" + self.nodes[0].getblockhash(0), 0), height=1, ntime=block_time)


### PR DESCRIPTION
During a reindex, the assumevalid setting may be ignored if the chainwork of the best header is below `minimumchainwork`. This happens when the previous IBD was stopped before connecting enough blocks to reach the required `minimumchainwork`. The assumevalid block will also be missing from the block index because the assumevalid block is set to match the `minimumchainwork`. See [Issue #31494](https://github.com/bitcoin/bitcoin/issues/31494).

As a result, `reindex` can take significantly longer to complete than necessary.

This PR addresses the issue by modifying reindex behaviour: if the chainwork of the `best_header` is below `minimumchainwork`, the node skips the `ActivateBestChain()` step and proceeds directly to synchronisation.

This PR takes a different approach from [PR #31615](https://github.com/bitcoin/bitcoin/pull/31615) to keep the validation path for `reindex` the same as the regular IBD validation path.

Developers benchmarking IBD with `-reindex` may find this behaviour undesirable. In such cases, it’s recommended to use `-reindex-chainstate` instead or ensure that the available blocks have sufficient chainwork.

`libbitcoinkernel` exposes the `ImportBlocks` function and expects `reindex` to connect blocks, so an attempt was made to preserve the existing behaviour for `libbitcoinkernel`.