### PR TITLE
doc: Add `x86_64-w64-mingw32ucrt` triplet to `depends/README.md`

### DIFF
--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -9,7 +9,6 @@ export LC_ALL=C.UTF-8
 export CONTAINER_NAME=ci_win64
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"  # Check that https://packages.debian.org/trixie/g++-mingw-w64-ucrt64 can cross-compile
 export HOST=x86_64-w64-mingw32ucrt
-export DEP_OPTS="CC=${HOST}-gcc CXX=${HOST}-g++"
 export PACKAGES="g++-mingw-w64-ucrt64 nsis"
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false

--- a/depends/README.md
+++ b/depends/README.md
@@ -122,7 +122,8 @@ Common `host-platform-triplet`s for cross compilation are:
 
 - `i686-pc-linux-gnu` for Linux x86 32 bit
 - `x86_64-pc-linux-gnu` for Linux x86 64 bit
-- `x86_64-w64-mingw32` for Win64
+- `x86_64-w64-mingw32` for Windows using MSVCRT
+- `x86_64-w64-mingw32ucrt` for Windows using UCRT
 - `x86_64-apple-darwin` for Intel macOS
 - `arm64-apple-darwin` for ARM macOS
 - `arm-linux-gnueabihf` for Linux ARM 32 bit
@@ -144,9 +145,13 @@ proceeding with a cross-compile. Under the depends directory, create a
 subdirectory named `SDKs`. Then, place the extracted SDK under this new directory.
 For more information, see [SDK Extraction](../contrib/macdeploy/README.md#sdk-extraction).
 
-#### For Win64 cross compilation
+#### For Windows cross compilation using MSVCRT
 
     apt install g++-mingw-w64-x86-64-posix
+
+#### For Windows cross compilation using UCRT
+
+    apt install g++-mingw-w64-ucrt64
 
 #### For linux (including i386, ARM) cross compilation
 


### PR DESCRIPTION
This PR is part of the ongoing effort to migrate to the modern UCRT runtime for cross-compiled Windows binaries, including release builds.

For more details about this migration, see:
- https://github.com/bitcoin/bitcoin/issues/30210
- https://github.com/bitcoin/bitcoin/pull/33593
- https://github.com/bitcoin/bitcoin/pull/33764

Can be tested on the following systems:
-  Debian Trixie x86_64 (requires the [`g++-mingw-w64-ucrt64`](https://packages.debian.org/trixie/g++-mingw-w64-ucrt64) package, as documented).
-  Fedora 42 or 43 (requires the [`ucrt64-gcc-c++`](https://packages.fedoraproject.org/pkgs/mingw-gcc/ucrt64-gcc-c++/) package).

Also see related upstream issues:
- https://bugs.launchpad.net/ubuntu/+source/gcc-mingw-w64/+bug/2132114
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1121403