### PR TITLE
test: add unit test coverage for the empty leaves path in MerkleComputation

### DIFF
--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -154,6 +154,11 @@ BOOST_AUTO_TEST_CASE(merkle_test_empty_block)
 
     BOOST_CHECK_EQUAL(root.IsNull(), true);
     BOOST_CHECK_EQUAL(mutated, false);
+
+    // Verify TransactionMerklePath handles empty block correctly
+    // This tests the early-return path in MerkleComputation
+    std::vector<uint256> merkle_path = TransactionMerklePath(block, 0);
+    BOOST_CHECK(merkle_path.empty());
 }
 
 BOOST_AUTO_TEST_CASE(merkle_test_oneTx_block)


### PR DESCRIPTION
As noted in [#32243 (comment)](https://github.com/bitcoin/bitcoin/pull/32243#issuecomment-2988854482), the early return inside `MerkleComputation` when `leaves.size() == 0` was only exercised by fuzz tests.

The existing `merkle_test_empty_block` calls `BlockMerkleRoot`, which uses `ComputeMerkleRoot`, but does not exercise the `TransactionMerklePath` → `ComputeMerklePath` → `MerkleComputation` code path.  

Coverage before adding test:
<img width="2459" height="66" alt="before" src="https://github.com/user-attachments/assets/ca94015a-d7c2-4281-ac60-13b22f177b67" />

Coverage after adding test:
<img width="2459" height="66" alt="after" src="https://github.com/user-attachments/assets/b1d4e1bb-af72-46ab-8898-f18db39dd2fb" />
