### PR TITLE
txgraph: drop move assignment operator

### DIFF
--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -3451,20 +3451,6 @@ TxGraph::Ref::~Ref()
     }
 }
 
-TxGraph::Ref& TxGraph::Ref::operator=(Ref&& other) noexcept
-{
-    // Unlink the current graph, if any.
-    if (m_graph) m_graph->UnlinkRef(m_index);
-    // Inform the other's graph about the move, if any.
-    if (other.m_graph) other.m_graph->UpdateRef(other.m_index, *this);
-    // Actually update the contents.
-    m_graph = other.m_graph;
-    m_index = other.m_index;
-    other.m_graph = nullptr;
-    other.m_index = GraphIndex(-1);
-    return *this;
-}
-
 TxGraph::Ref::Ref(Ref&& other) noexcept
 {
     // Inform the TxGraph of other that its Ref is being moved.

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -241,8 +241,8 @@ public:
         /** Destroy this Ref. If it is not empty, the corresponding transaction is removed (in both
          *  main and staging, if it exists). */
         virtual ~Ref();
-        // Support moving a Ref.
-        Ref& operator=(Ref&& other) noexcept;
+        // Support move-constructing a Ref.
+        Ref& operator=(Ref&& other) noexcept = delete;
         Ref(Ref&& other) noexcept;
         // Do not permit copy constructing or copy assignment. A TxGraph entry can have at most one
         // Ref pointing to it.


### PR DESCRIPTION
This removes the only place where move-assignment of `TxGraph::Ref` is used (in tests), and drops supports for it.

Suggested in https://github.com/bitcoin/bitcoin/pull/33629#discussion_r2518940184