### PR TITLE
cmake: Specify Windows plugin path in `test_bitcoin-qt` property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,8 +295,6 @@ jobs:
       - name: Run test suite
         if: matrix.job-type == 'standard'
         working-directory: build
-        env:
-          QT_PLUGIN_PATH: '${{ github.workspace }}\build\vcpkg_installed\x64-windows\Qt6\plugins'
         run: |
           ctest --output-on-failure --stop-on-failure -j $NUMBER_OF_PROCESSORS -C Release
 

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -40,11 +40,15 @@ add_test(NAME test_bitcoin-qt
   COMMAND test_bitcoin-qt
 )
 if(WIN32 AND VCPKG_TARGET_TRIPLET)
-  # On Windows, vcpkg configures Qt with `-opengl dynamic`, which makes
-  # the "minimal" platform plugin unusable due to internal Qt bugs.
-  set_tests_properties(test_bitcoin-qt PROPERTIES
-    ENVIRONMENT "QT_QPA_PLATFORM=windows"
+  set(plugin_path "$<SHELL_PATH:$<PATH:GET_PARENT_PATH,$<PATH:GET_PARENT_PATH,$<TARGET_PROPERTY:Qt6::QWindowsIntegrationPlugin,LOCATION_$<CONFIG>>>>>")
+  set_property(TEST test_bitcoin-qt APPEND PROPERTY
+    ENVIRONMENT_MODIFICATION
+      # On Windows, vcpkg configures Qt with `-opengl dynamic`, which makes
+      # the "minimal" platform plugin unusable due to internal Qt bugs.
+      QT_QPA_PLATFORM=set:windows
+      QT_PLUGIN_PATH=set:${plugin_path}
   )
+  unset(plugin_path)
 endif()
 
 install_binary_component(test_bitcoin-qt INTERNAL)


### PR DESCRIPTION
This PR simplifies testing on Windows by removing the need to set the `QT_PLUGIN_PATH` environment variable for different build configurations. For example, the paths might otherwise be:
- `C:/Users/hebasto/dev/bitcoin/build/vcpkg_installed/x64-windows/Qt6/plugins/` for "Release"
- `C:/Users/hebasto/dev/bitcoin/build/vcpkg_installed/x64-windows/debug/Qt6/plugins/` for "Debug"