### PR TITLE
refactor: Avoid -W*-whitespace in git archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
 
     env:
       DANGER_RUN_CI_ON_HOST: 1
-      BASE_ROOT_DIR: ${{ github.workspace }}
+      BASE_ROOT_DIR: ${{ github.workspace }}/repo_archive
 
     steps:
       - &CHECKOUT
@@ -176,8 +176,16 @@ jobs:
           key: ${{ github.job }}-${{ matrix.job-type }}-ccache-${{ github.run_id }}
           restore-keys: ${{ github.job }}-${{ matrix.job-type }}-ccache-
 
+      - name: Create git archive
+        run: |
+          git log -1
+          git archive --format=tar --prefix=repo_archive/ --output=repo.tar HEAD
+          tar -xf repo.tar
+
       - name: CI script
-        run: ./ci/test_run_all.sh
+        run: |
+          cd repo_archive
+          ./ci/test_run_all.sh
         env:
           FILE_ENV: ${{ matrix.file-env }}
 

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -1,10 +1,11 @@
-// Copyright (c) 2012-2022 The Bitcoin Core developers
+// Copyright (c) 2012-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <clientversion.h>
+
 #include <util/string.h>
 #include <util/translation.h>
 
@@ -30,7 +31,8 @@ const std::string UA_NAME("Satoshi");
 //   - "#define BUILD_GIT_COMMIT ...", if the top commit is not tagged
 //   - "// No build information available", if proper git information is not available
 
-//! git will put "#define GIT_COMMIT_ID ..." on the next line inside archives. $Format:%n#define GIT_COMMIT_ID "%H"$
+// git will expand the next line to "#define GIT_COMMIT_ID ..." inside archives:
+//$Format:%n#define GIT_COMMIT_ID "%H"$
 
 #ifdef BUILD_GIT_TAG
     #define BUILD_DESC BUILD_GIT_TAG


### PR DESCRIPTION
Otherwise, compilation with GCC-15+ will warn about it:

```
src/clientversion.cpp:33:79: error: trailing whitespace [-Werror=trailing-whitespace=]
   33 | //! git will put "#define GIT_COMMIT_ID ..." on the next line inside archives.
```

Follow-up to https://github.com/bitcoin/bitcoin/pull/32482#issuecomment-3522280482

Can be tested via `git archive --output=/tmp/a.tar HEAD`