### PR TITLE
init: completely remove `-maxorphantx` option

### DIFF
--- a/doc/release-notes-33872.md
+++ b/doc/release-notes-33872.md
@@ -1,0 +1,5 @@
+P2P and network changes
+-----------------------
+
+- The `-maxorphantx` startup option has been removed. It was
+  previously deprecated and has no effect anymore since v30.0. (#33872)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -502,8 +502,6 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-allowignoredconf", strprintf("For backwards compatibility, treat an unused %s file in the datadir as a warning, not an error.", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-loadblock=<file>", "Imports blocks from external file on startup", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-maxmempool=<n>", strprintf("Keep the transaction memory pool below <n> megabytes (default: %u)", DEFAULT_MAX_MEMPOOL_SIZE_MB), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    // TODO: remove in v31.0
-    argsman.AddArg("-maxorphantx=<n>", strprintf("(Removed option, see release notes)"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-mempoolexpiry=<n>", strprintf("Do not keep transactions in the mempool longer than <n> hours (default: %u)", DEFAULT_MEMPOOL_EXPIRY_HOURS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet3: %s, testnet4: %s, signet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnet4ChainParams->GetConsensus().nMinimumChainWork.GetHex(), signetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (0 = auto, up to %d, <0 = leave that many cores free, default: %d)",
@@ -901,11 +899,6 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // We removed checkpoints but keep the option to warn users who still have it in their config.
     if (args.IsArgSet("-checkpoints")) {
         InitWarning(_("Option '-checkpoints' is set but checkpoints were removed. This option has no effect."));
-    }
-
-    // We no longer limit the orphanage based on number of transactions but keep the option to warn users who still have it in their config.
-    if (args.IsArgSet("-maxorphantx")) {
-        InitWarning(_("Option '-maxorphantx' is set but no longer has any effect (see release notes). Please remove it from your configuration."));
     }
 
     // Error if network-specific options (-addnode, -connect, etc) are

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -814,16 +814,6 @@ class OrphanHandlingTest(BitcoinTestFramework):
         assert orphan["txid"] in final_mempool
         assert tx_replacer_C["txid"] in final_mempool
 
-    @cleanup
-    def test_maxorphantx_option(self):
-        # This test should be removed when -maxorphantx is removed.
-        self.log.info("Test that setting the -maxorphantx option does not error")
-        warning = "Warning: Option '-maxorphantx' is set but no longer has any effect (see release notes). Please remove it from your configuration."
-        self.restart_node(0, extra_args=["-maxorphantx=5"])
-        assert_equal(self.nodes[0].getorphantxs(), [])
-        self.stop_node(0, expected_stderr=warning)
-        self.restart_node(0)
-
     def run_test(self):
         self.nodes[0].setmocktime(int(time.time()))
         self.wallet_nonsegwit = MiniWallet(self.nodes[0], mode=MiniWalletMode.RAW_P2PK)
@@ -844,7 +834,6 @@ class OrphanHandlingTest(BitcoinTestFramework):
         self.test_announcers_before_and_after()
         self.test_parents_change()
         self.test_maximal_package_protected()
-        self.test_maxorphantx_option()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a small follow-up for #32941 (commit 1384dbaf6d0bfcdb05f97e1e3cb3d5e498bee505), removing the `-maxorphantx` option completely, now that v30 has been released. If removing it for v31 is seen as controversial/premature (I personally don't think it is), the merge can be delayed for a future release.