### PR TITLE
doc: Update NetBSD Build Guide

### DIFF
--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -93,7 +93,7 @@ There is an included test suite that is useful for testing code changes when dev
 To run the test suite (recommended), you will need to have Python 3 installed:
 
 ```bash
-pkgin install python310 py310-zmq
+pkgin install python313 py313-zmq
 ```
 
 ## Building Bitcoin Core


### PR DESCRIPTION
The `py310-zmq` binary package is not available by default on NetBSD 10.1. It has been updated to `py313-zmq`, and the `python310` package is updated accordingly.

See: https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/index-all.html.