### PR TITLE
kernel: Rename in-memory DB option setters and simplify API

### DIFF
--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -461,8 +461,12 @@ struct ChainstateManagerOptions {
               .block_tree_db_params = DBParams{
                   .path = data_dir / "blocks" / "index",
                   .cache_bytes = kernel::CacheSizes{DEFAULT_KERNEL_CACHE}.block_tree_db,
+                  .memory_only = false,
               }}},
-          m_context{context}, m_chainstate_load_options{node::ChainstateLoadOptions{}}
+          m_context{context}, m_chainstate_load_options{node::ChainstateLoadOptions{
+              .coins_db_in_memory = false,
+              .coins_error_cb = {},
+          }}
     {
     }
 };
@@ -932,22 +936,20 @@ int btck_chainstate_manager_options_set_wipe_dbs(btck_ChainstateManagerOptions* 
     return 0;
 }
 
-void btck_chainstate_manager_options_update_block_tree_db_in_memory(
-    btck_ChainstateManagerOptions* chainman_opts,
-    int block_tree_db_in_memory)
+void btck_chainstate_manager_options_set_block_tree_db_in_memory(
+    btck_ChainstateManagerOptions* chainman_opts)
 {
     auto& opts{btck_ChainstateManagerOptions::get(chainman_opts)};
     LOCK(opts.m_mutex);
-    opts.m_blockman_options.block_tree_db_params.memory_only = block_tree_db_in_memory == 1;
+    opts.m_blockman_options.block_tree_db_params.memory_only = true;
 }
 
-void btck_chainstate_manager_options_update_chainstate_db_in_memory(
-    btck_ChainstateManagerOptions* chainman_opts,
-    int chainstate_db_in_memory)
+void btck_chainstate_manager_options_set_chainstate_db_in_memory(
+    btck_ChainstateManagerOptions* chainman_opts)
 {
     auto& opts{btck_ChainstateManagerOptions::get(chainman_opts)};
     LOCK(opts.m_mutex);
-    opts.m_chainstate_load_options.coins_db_in_memory = chainstate_db_in_memory == 1;
+    opts.m_chainstate_load_options.coins_db_in_memory = true;
 }
 
 btck_ChainstateManager* btck_chainstate_manager_create(

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -975,24 +975,20 @@ BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_o
     int wipe_chainstate_db) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
- * @brief Sets block tree db in memory in the options.
+ * @brief Sets block tree db to use in-memory storage.
  *
  * @param[in] chainstate_manager_options   Non-null, created by @ref btck_chainstate_manager_options_create.
- * @param[in] block_tree_db_in_memory      Set block tree db in memory.
  */
-BITCOINKERNEL_API void btck_chainstate_manager_options_update_block_tree_db_in_memory(
-    btck_ChainstateManagerOptions* chainstate_manager_options,
-    int block_tree_db_in_memory) BITCOINKERNEL_ARG_NONNULL(1);
+BITCOINKERNEL_API void btck_chainstate_manager_options_set_block_tree_db_in_memory(
+    btck_ChainstateManagerOptions* chainstate_manager_options) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
- * @brief Sets chainstate db in memory in the options.
+ * @brief Sets chainstate db to use in-memory storage.
  *
  * @param[in] chainstate_manager_options Non-null, created by @ref btck_chainstate_manager_options_create.
- * @param[in] chainstate_db_in_memory    Set chainstate db in memory.
  */
-BITCOINKERNEL_API void btck_chainstate_manager_options_update_chainstate_db_in_memory(
-    btck_ChainstateManagerOptions* chainstate_manager_options,
-    int chainstate_db_in_memory) BITCOINKERNEL_ARG_NONNULL(1);
+BITCOINKERNEL_API void btck_chainstate_manager_options_set_chainstate_db_in_memory(
+    btck_ChainstateManagerOptions* chainstate_manager_options) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
  * Destroy the chainstate manager options.

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -952,14 +952,14 @@ public:
         return btck_chainstate_manager_options_set_wipe_dbs(get(), wipe_block_tree, wipe_chainstate) == 0;
     }
 
-    void UpdateBlockTreeDbInMemory(bool block_tree_db_in_memory)
+    void SetBlockTreeDbInMemory()
     {
-        btck_chainstate_manager_options_update_block_tree_db_in_memory(get(), block_tree_db_in_memory);
+        btck_chainstate_manager_options_set_block_tree_db_in_memory(get());
     }
 
-    void UpdateChainstateDbInMemory(bool chainstate_db_in_memory)
+    void SetChainstateDbInMemory()
     {
-        btck_chainstate_manager_options_update_chainstate_db_in_memory(get(), chainstate_db_in_memory);
+        btck_chainstate_manager_options_set_chainstate_db_in_memory(get());
     }
 };
 

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -654,10 +654,10 @@ std::unique_ptr<ChainMan> create_chainman(TestDirectory& test_directory,
         chainman_opts.SetWipeDbs(/*wipe_block_tree=*/false, /*wipe_chainstate=*/wipe_chainstate);
     }
     if (block_tree_db_in_memory) {
-        chainman_opts.UpdateBlockTreeDbInMemory(block_tree_db_in_memory);
+        chainman_opts.SetBlockTreeDbInMemory();
     }
     if (chainstate_db_in_memory) {
-        chainman_opts.UpdateChainstateDbInMemory(chainstate_db_in_memory);
+        chainman_opts.SetChainstateDbInMemory();
     }
 
     auto chainman{std::make_unique<ChainMan>(context, chainman_opts)};


### PR DESCRIPTION
Remove the int parameter from `btck_chainstate_manager_options_*_in_memory` functions and rename them from "update" to "set". These functions now only set the options to `true` for enabling in-memory mode. This, combined with explicit default initialization of in-memory options to `false` in `ChainstateManagerOptions` constructor, should remove ambiguity about what happens when these functions are not called.