### PR TITLE
test: Fix race condition in IPC interface block progation test

### DIFF
--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -256,9 +256,11 @@ class IPCInterfaceTest(BitcoinTestFramework):
             assert_equal(res.result, True)
 
             self.log.debug("Block should propagate")
-            assert_equal(self.nodes[1].getchaintips()[0]["height"], current_block_height + 1)
+            # Check that the IPC node actually updates its own chain
+            assert_equal(self.nodes[0].getchaintips()[0]["height"], current_block_height + 1)
             # Stalls if a regression causes submitBlock() to accept an invalid block:
             self.sync_all()
+            # Check that the other node accepts the block
             assert_equal(self.nodes[0].getchaintips()[0], self.nodes[1].getchaintips()[0])
 
             miniwallet.rescan_utxos()


### PR DESCRIPTION
CI failed on this condition here: https://github.com/bitcoin/bitcoin/actions/runs/19395398994/job/55494696022?pr=33878#step:9:3983

The check was added not too long ago in https://github.com/bitcoin/bitcoin/pull/33745 and the fix here switches the check to the node which actually produces the block. There are also some comments added to make the checks easier so understand.

Closes #33884