### PR TITLE
guix: update per-host disk-space estimates in build gate

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -154,8 +154,8 @@ avail_KiB="$(df -Pk "$VERSION_BASE" | sed 1d | tr -s ' ' | cut -d' ' -f4)"
 total_required_KiB=0
 for host in $HOSTS; do
     case "$host" in
-        *darwin*) required_KiB=440000 ;;
-        *mingw*)  required_KiB=7600000 ;;
+        *darwin*) required_KiB=8388608 ;;
+        *mingw*)  required_KiB=15728640 ;;
         *)        required_KiB=6400000 ;;
     esac
     total_required_KiB=$((total_required_KiB+required_KiB))


### PR DESCRIPTION
Today, the build gates are obsolete. I found this out after seeing someone flag this on a commit setting `-static-libgcc`. Note that the Linux builds came in at the expected amount of disk space utilization, so I did not touch the values for them.

This PR aims to readjust the build gate disk space per-host estimates for darwin and mingw based on some testing I did locally in my build VM.

Details:
(Copied from https://github.com/kevkevinpal/bitcoin/issues/200):

I ran `HOSTS="x86_64-w64-mingw32" ./contrib/guix/guix-build`

After (+10 GiB):
```
Filesystem     1G-blocks  Used Available Use% Mounted on
/dev/sda5           512G   98G      393G  20% /gnu/store
```

These numbers makes this change seem reasonable (1.5x safety factor):
```
-        *mingw*)  required_KiB=7600000 ;;
+        *mingw*)  required_KiB=15728640 ;;
```

---

Then I ran `HOSTS="aarch64-linux-gnu" ./contrib/guix/guix-build`.

After (+6 GiB):
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda5       512G  104G  387G  22% /gnu/store
```

---

Then I setup the SDK for macOS. This established a new *before* snapshot of disk use:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda5       512G  116G  375G  24% /gnu/store
```

Then I ran `HOSTS="x86_64-apple-darwin" ./contrib/guix/guix-build`.

After (+5 GiB):
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda5       512G  121G  370G  25% /gnu/store
```

IMO, this is grounds for updating this (5 GiB * 1.5x safety factor):
```
-        *darwin*) required_KiB=440000 ;;
+        *darwin*) required_KiB=8388608 ;;
```
