### PR TITLE
mining: add requestedOutputs field, e.g. for merged mining

### DIFF
--- a/doc/release-notes-33819.md
+++ b/doc/release-notes-33819.md
@@ -1,0 +1,6 @@
+Mining IPC
+----------
+
+- Adds `getCoinbase()` which clients should use instead of `getCoinbaseTx()`. It
+  contains all fields required to construct a coinbase transaction, and omits the
+  dummy output which Bitcoin Core uses internally. (#33819)

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -42,8 +42,24 @@ public:
     // Sigop cost per transaction, not including coinbase transaction.
     virtual std::vector<int64_t> getTxSigops() = 0;
 
+    /** Return fields needed to construct a coinbase transaction */
+    virtual node::CoinbaseTemplate getCoinbase() = 0;
+    /**
+     * Return dummy coinbase transaction.
+     *
+     * @note deprecated: use getCoinbase()
+     **/
     virtual CTransactionRef getCoinbaseTx() = 0;
+    /**
+     * Return scriptPubKey with SegWit OP_RETURN.
+     */
     virtual std::vector<unsigned char> getCoinbaseCommitment() = 0;
+    /**
+     * Return which output in the dummy coinbase contains the SegWit OP_RETURN.
+     *
+     * @note deprecated. Scan outputs from getCoinbase() outputs field for the
+     *       SegWit marker.
+     */
     virtual int getWitnessCommitmentIndex() = 0;
 
     /**

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -27,6 +27,7 @@ interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {
     getBlock @2 (context: Proxy.Context) -> (result: Data);
     getTxFees @3 (context: Proxy.Context) -> (result: List(Int64));
     getTxSigops @4 (context: Proxy.Context) -> (result: List(Int64));
+    getCoinbase @12 (context: Proxy.Context) -> (result: CoinbaseTemplate);
     getCoinbaseTx @5 (context: Proxy.Context) -> (result: Data);
     getCoinbaseCommitment @6 (context: Proxy.Context) -> (result: Data);
     getWitnessCommitmentIndex @7 (context: Proxy.Context) -> (result: Int32);
@@ -50,4 +51,14 @@ struct BlockWaitOptions $Proxy.wrap("node::BlockWaitOptions") {
 struct BlockCheckOptions $Proxy.wrap("node::BlockCheckOptions") {
     checkMerkleRoot @0 :Bool $Proxy.name("check_merkle_root");
     checkPow @1 :Bool $Proxy.name("check_pow");
+}
+
+struct CoinbaseTemplate $Proxy.wrap("node::CoinbaseTemplate") {
+    version @0 :UInt32 $Proxy.name("version");
+    sequence @1 :UInt32 $Proxy.name("sequence");
+    scriptSigPrefix @2 :Data $Proxy.name("script_sig_prefix");
+    witness @3 :Data $Proxy.name("witness");
+    valueRemaining @4 :Int64 $Proxy.name("value_remaining");
+    requiredOutputs @5 :List(Data) $Proxy.name("required_outputs");
+    lockTime @6 :UInt32 $Proxy.name("lock_time");
 }

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -41,6 +41,7 @@ struct BlockCreateOptions $Proxy.wrap("node::BlockCreateOptions") {
     useMempool @0 :Bool $Proxy.name("use_mempool");
     blockReservedWeight @1 :UInt64 $Proxy.name("block_reserved_weight");
     coinbaseOutputMaxAdditionalSigops @2 :UInt64 $Proxy.name("coinbase_output_max_additional_sigops");
+    requestedOutputs @3 :List(Data) $Proxy.name("requested_outputs");
 }
 
 struct BlockWaitOptions $Proxy.wrap("node::BlockWaitOptions") {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -83,6 +83,7 @@ using interfaces::Node;
 using interfaces::WalletLoader;
 using node::BlockAssembler;
 using node::BlockWaitOptions;
+using node::CoinbaseTemplate;
 using util::Join;
 
 namespace node {
@@ -863,6 +864,7 @@ public:
     explicit BlockTemplateImpl(BlockAssembler::Options assemble_options,
                                std::unique_ptr<CBlockTemplate> block_template,
                                NodeContext& node) : m_assemble_options(std::move(assemble_options)),
+                                                    m_coinbase_template(ExtractCoinbaseTemplate(*Assert(block_template))),
                                                     m_block_template(std::move(block_template)),
                                                     m_node(node)
     {
@@ -887,6 +889,11 @@ public:
     std::vector<int64_t> getTxSigops() override
     {
         return m_block_template->vTxSigOpsCost;
+    }
+
+    CoinbaseTemplate getCoinbase() override
+    {
+        return m_coinbase_template;
     }
 
     CTransactionRef getCoinbaseTx() override
@@ -928,6 +935,8 @@ public:
     }
 
     const BlockAssembler::Options m_assemble_options;
+
+    const CoinbaseTemplate m_coinbase_template;
 
     const std::unique_ptr<CBlockTemplate> m_block_template;
 

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -259,6 +259,17 @@ std::optional<BlockRef> GetTip(ChainstateManager& chainman);
 /* Waits for the connected tip to change until timeout has elapsed. During node initialization, this will wait until the tip is connected (regardless of `timeout`).
  * Returns the current tip, or nullopt if the node is shutting down. */
 std::optional<BlockRef> WaitTipChanged(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const uint256& current_tip, MillisecondsDouble& timeout);
+
+/*
+ * Extract relevant fields from the dummy coinbase transaction in the template.
+ *
+ * Extracts only OP_RETURN coinbase outputs, i.e. the witness commitment. If
+ * BlockAssembler::CreateNewBlock() is patched to add more OP_RETURN outputs
+ * e.g. for merge mining, those will be included. The dummy output that spends
+ * the full reward is excluded.
+ */
+node::CoinbaseTemplate ExtractCoinbaseTemplate(const node::CBlockTemplate& block_template);
+
 } // namespace node
 
 #endif // BITCOIN_NODE_MINER_H

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -16,10 +16,13 @@
 #include <consensus/amount.h>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <policy/policy.h>
+#include <primitives/transaction.h>
 #include <script/script.h>
 #include <uint256.h>
 #include <util/time.h>
+#include <vector>
 
 namespace node {
 enum class TransactionError {
@@ -97,6 +100,45 @@ struct BlockCheckOptions {
      * Set false to omit the proof-of-work check
      */
     bool check_pow{true};
+};
+
+struct CoinbaseTemplate {
+    /* nVersion */
+    uint32_t version;
+    /* nSequence for the only coinbase transaction input */
+    uint32_t sequence;
+    /**
+     * Bytes which are to be placed at the beginning of scriptSig. Guaranteed
+     * to be less than 8 bytes (not including the length byte). This allows
+     * clients to add up to 92 bytes.
+     */
+    CScript script_sig_prefix;
+    /**
+     * The first (and only) witness stack element of the coinbase input.
+     *
+     * Omitted for block templates without witness data.
+     *
+     * This is currently the BIP 141 witness reserved value. A future soft fork
+     * may move the witness reserved value elsewhere, but there will still be a
+     * coinbase witness.
+     */
+    std::optional<uint256> witness;
+    /**
+     * Block subsidy plus fees, minus any non-zero required_outputs.
+     *
+     * Currently there are no non-zero required_outputs, see below.
+     */
+    CAmount value_remaining;
+    /*
+     * To be included as the last outputs in the coinbase transaction.
+     * Currently this is only the witness commitment OP_RETURN, but future
+     * softforks could add more.
+     * If a patch to BlockAssembler::CreateNewBlock() adds outputs e.g. for
+     * merge mining, those will be included. The dummy output that spends
+     * the full reward is excluded.
+     */
+    std::vector<CTxOut> required_outputs;
+    uint32_t lock_time;
 };
 
 /**

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -52,10 +52,10 @@ struct BlockCreateOptions {
      */
     size_t coinbase_output_max_additional_sigops{400};
     /**
-     * Script to put in the coinbase transaction. The default is an
-     * anyone-can-spend dummy.
+     * Script to use for the coinbase transaction output which spends
+     * value_remaining. The default is an anyone-can-spend dummy.
      *
-     * Should only be used for tests, when the default doesn't suffice.
+     * Should only be needed for tests, when the default doesn't suffice.
      *
      * Note that higher level code like the getblocktemplate RPC may omit the
      * coinbase transaction entirely. It's instead constructed by pool software
@@ -67,6 +67,25 @@ struct BlockCreateOptions {
      * coinbase_max_additional_weight and coinbase_output_max_additional_sigops.
      */
     CScript coinbase_output_script{CScript() << OP_TRUE};
+
+    /**
+     * Requested extra outputs for the coinbase transaction. Typically not
+     * needed. An example use case is adding an OP_RETURN for merged mining.
+     *
+     * Do not pass in a SegWit commitment.
+     *
+     * The outputs will be placed at the start of required_outputs. Non-zero
+     * amounts are subtracted from value_remaining.
+     *
+     * It's possible, but not recommended, to use a non-zero output amount.
+     * Since the amount including fees can't be known ahead of generating
+     * the template, only amounts below the block subsidy are safe. Negative
+     * value_remaining results in an error.
+     *
+     * @note IPC clients that wish to be compatible with v30.x should omit
+     *       this field.
+     */
+    std::vector<CTxOut> requested_outputs{};
 };
 
 struct BlockWaitOptions {

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -63,6 +63,8 @@ COINBASE_MATURITY = 100
 # From BIP141
 WITNESS_COMMITMENT_HEADER = b"\xaa\x21\xa9\xed"
 
+NULL_OUTPOINT = COutPoint(0, 0xffffffff)
+
 NORMAL_GBT_REQUEST_PARAMS = {"rules": ["segwit"]}
 VERSIONBITS_LAST_OLD_BLOCK_VERSION = 4
 MIN_BLOCKS_TO_KEEP = 288
@@ -154,7 +156,7 @@ def create_coinbase(height, pubkey=None, *, script_pubkey=None, extra_output_scr
     script. This is useful to pad block weight/sigops as needed. """
     coinbase = CTransaction()
     coinbase.nLockTime = height - 1
-    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), script_BIP34_coinbase_height(height), MAX_SEQUENCE_NONFINAL))
+    coinbase.vin.append(CTxIn(NULL_OUTPOINT, script_BIP34_coinbase_height(height), MAX_SEQUENCE_NONFINAL))
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = nValue * COIN
     if nValue == 50:

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -112,6 +112,18 @@ def assert_raises_message(exc, message, fun, *args, **kwds):
     else:
         raise AssertionError("No exception raised")
 
+async def assert_raises_message_async(exc, message, fun, *args, **kwds):
+    try:
+        await fun(*args, **kwds)
+    except exc as e:
+        if message is not None and message not in str(e):
+            raise AssertionError("Expected substring not found in exception:\n"
+                                 f"substring: '{message}'\nexception: {e!r}.")
+    except Exception as e:
+        raise AssertionError("Unexpected exception raised: " + type(e).__name__)
+    else:
+        raise AssertionError("No exception raised")
+
 
 def assert_raises_process_error(returncode: int, output: str, fun: Callable, *args, **kwds):
     """Execute a process and asserts the process return code and output.


### PR DESCRIPTION
This adds a `requestedOutputs` field to `BlockCreateOptions` which lets the Mining IPC client request outputs to be added before the consensus mandatory commitments.

The main use case is being able to add `OP_RETURN` outputs for merged mining without patching `BlockAssembler::CreateNewBlock()`.

It could potentially also be used to make payouts directly from the coinbase, but this is unsafe for any amount above the subsidy (this PR adds checks for that). In general a pool should add payout outputs _after_ obtaining the block template, even a solo pool.

Although it's possible to modify pool software to add merge mining outputs on top of the returned block template (e.g. by intercepting and modifying the Stratum v2 `NewTemplate` message), it may in practice be easier to do this when requesting a template.

Suggested in https://github.com/bitcoin/bitcoin/pull/33819#issuecomment-3539952304.

Builds on:
- #33819