### PR TITLE
net: Remove unused `local_socket_bytes` variable in `CConnman::GetAddresses()`

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3539,7 +3539,6 @@ std::vector<CAddress> CConnman::GetAddressesUnsafe(size_t max_addresses, size_t 
 
 std::vector<CAddress> CConnman::GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct)
 {
-    auto local_socket_bytes = requestor.addrBind.GetAddrBytes();
     uint64_t network_id = requestor.m_network_key;
     const auto current_time = GetTime<std::chrono::microseconds>();
     auto r = m_addr_response_caches.emplace(network_id, CachedAddrResponse{});


### PR DESCRIPTION
The local_socket_bytes variable was never used. Removed it to clean up dead code.