### PR TITLE
net: Decouple `CConnman::GetAddresses` from `CNode`

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3537,11 +3537,10 @@ std::vector<CAddress> CConnman::GetAddressesUnsafe(size_t max_addresses, size_t 
     return addresses;
 }
 
-std::vector<CAddress> CConnman::GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct)
+std::vector<CAddress> CConnman::GetAddresses(uint64_t network_key, size_t max_addresses, size_t max_pct)
 {
-    uint64_t network_id = requestor.m_network_key;
     const auto current_time = GetTime<std::chrono::microseconds>();
-    auto r = m_addr_response_caches.emplace(network_id, CachedAddrResponse{});
+    auto r = m_addr_response_caches.emplace(network_key, CachedAddrResponse{});
     CachedAddrResponse& cache_entry = r.first->second;
     if (cache_entry.m_cache_entry_expiration < current_time) { // If emplace() added new one it has expiration 0.
         cache_entry.m_addrs_response_cache = GetAddressesUnsafe(max_addresses, max_pct, /*network=*/std::nullopt);

--- a/src/net.h
+++ b/src/net.h
@@ -1220,14 +1220,14 @@ public:
      * A trusted caller (e.g. from RPC or a peer with addr permission) can use
      * @ref GetAddressesUnsafe to avoid using the cache.
      *
-     * @param[in] requestor      The requesting peer. Used to key the cache to prevent privacy leaks.
+     * @param[in] network_key    Per peer network key. Used to key the cache to prevent privacy leaks.
      * @param[in] max_addresses  Maximum number of addresses to return (0 = all). Ignored when cache
      *                           already contains an entry for requestor.
      * @param[in] max_pct        Maximum percentage of addresses to return (0 = all). Value must be
      *                           from 0 to 100. Ignored when cache already contains an entry for
      *                           requestor.
      */
-    std::vector<CAddress> GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct);
+    std::vector<CAddress> GetAddresses(uint64_t network_key, size_t max_addresses, size_t max_pct);
 
     // This allows temporarily exceeding m_max_outbound_full_relay, with the goal of finding
     // a peer that is better than all our current peers.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4703,7 +4703,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         if (pfrom.HasPermission(NetPermissionFlags::Addr)) {
             vAddr = m_connman.GetAddressesUnsafe(MAX_ADDR_TO_SEND, MAX_PCT_ADDR_TO_SEND, /*network=*/std::nullopt);
         } else {
-            vAddr = m_connman.GetAddresses(pfrom, MAX_ADDR_TO_SEND, MAX_PCT_ADDR_TO_SEND);
+            vAddr = m_connman.GetAddresses(pfrom.m_network_key, MAX_ADDR_TO_SEND, MAX_PCT_ADDR_TO_SEND);
         }
         for (const CAddress &addr : vAddr) {
             PushAddress(*peer, addr);

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -140,7 +140,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
             [&] {
                 auto max_addresses = fuzzed_data_provider.ConsumeIntegral<size_t>();
                 auto max_pct = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 100);
-                (void)connman.GetAddresses(/*requestor=*/random_node, max_addresses, max_pct);
+                (void)connman.GetAddresses(/*network_key=*/random_node.m_network_key, max_addresses, max_pct);
             },
             [&] {
                 (void)connman.GetDeterministicRandomizer(fuzzed_data_provider.ConsumeIntegral<uint64_t>());


### PR DESCRIPTION
Decouple `CConnman::GetAddresses` from `CNode` which was used only for getting network_key