### PR TITLE
rest: add interface for gettxspendingprevout rpc

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -155,6 +155,49 @@ Refer to the `getrawmempool` RPC help for details. Defaults to setting
 
 *Query parameters for `verbose` and `mempool_sequence` available in 25.0 and up.*
 
+#### Transaction Spending Previous Outputs
+`GET /rest/txspendingprevout/<TXID>-<N>/<TXID>-<N>/.../<TXID>-<N>.json`
+
+Scans the mempool (and the `txospenderindex`, if available) to find transactions
+spending any of the given outputs.
+Only supports JSON as output format.
+A maximum of 15 outpoints can be queried at once.
+Refer to the `gettxspendingprevout` RPC help for details.
+
+For each queried output, returns an object containing:
+- `txid`: the transaction id of the checked output
+- `vout`: the output number
+- `spendingtxid`: (optional) the transaction id of the transaction spending this output (omitted if unspent)
+- `spendingtx`: (optional) the full hex-encoded spending transaction, if requested and found
+- `blockhash`: (optional) the hash of the block including the spending transaction, if confirmed
+
+The following optional query parameters are supported and mirror the RPC options:
+
+- `mempool_only=<true|false>`: if `true`, limit scans to the mempool, even if
+  `txospenderindex` is available. If omitted, it defaults to `true` if
+  `txospenderindex` is unavailable, otherwise `false`.
+- `return_spending_tx=<true|false>`: if `true`, include the full hex-encoded
+  spending transaction in the `spendingtx` field. Defaults to `false`.
+
+Example:
+```
+$ curl localhost:8332/rest/txspendingprevout/a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0-3.json
+[
+  {
+    "txid": "a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0",
+    "vout": 3,
+    "spendingtxid": "b2cdfd7b89def827ff8af7cd9bff7627ff72e5e8b0f71210f92ea7a4000c5d75",
+    "blockhash": "0000000000000000000exampleblockhash0000000000000000000000000000"
+  }
+]
+```
+
+To also obtain the full spending transaction, use:
+
+```
+$ curl "localhost:8332/rest/txspendingprevout/a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0-3.json?return_spending_tx=true"
+```
+
 
 Risks
 -------------

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -162,6 +162,49 @@ Refer to the `getrawmempool` RPC help for details. Defaults to setting
 
 *Query parameters for `verbose` and `mempool_sequence` available in 25.0 and up.*
 
+#### Transaction Spending Previous Outputs
+`GET /rest/txspendingprevout/<TXID>-<N>/<TXID>-<N>/.../<TXID>-<N>.json`
+
+Scans the mempool (and the `txospenderindex`, if available) to find transactions
+spending any of the given outputs.
+Only supports JSON as output format.
+A maximum of 15 outpoints can be queried at once.
+Refer to the `gettxspendingprevout` RPC help for details.
+
+For each queried output, returns an object containing:
+- `txid`: the transaction id of the checked output
+- `vout`: the output number
+- `spendingtxid`: (optional) the transaction id of the transaction spending this output (omitted if unspent)
+- `spendingtx`: (optional) the full hex-encoded spending transaction, if requested and found
+- `blockhash`: (optional) the hash of the block including the spending transaction, if confirmed
+
+The following optional query parameters are supported and mirror the RPC options:
+
+- `mempool_only=<true|false>`: if `true`, limit scans to the mempool, even if
+  `txospenderindex` is available. If omitted, it defaults to `true` if
+  `txospenderindex` is unavailable, otherwise `false`.
+- `return_spending_tx=<true|false>`: if `true`, include the full hex-encoded
+  spending transaction in the `spendingtx` field. Defaults to `false`.
+
+Example:
+```
+$ curl localhost:8332/rest/txspendingprevout/a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0-3.json
+[
+  {
+    "txid": "a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0",
+    "vout": 3,
+    "spendingtxid": "b2cdfd7b89def827ff8af7cd9bff7627ff72e5e8b0f71210f92ea7a4000c5d75",
+    "blockhash": "0000000000000000000exampleblockhash0000000000000000000000000000"
+  }
+]
+```
+
+To also obtain the full spending transaction, use:
+
+```
+$ curl "localhost:8332/rest/txspendingprevout/a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0-3.json?return_spending_tx=true"
+```
+
 
 Risks
 -------------

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -13,6 +13,7 @@
 #include <httpserver.h>
 #include <index/blockfilterindex.h>
 #include <index/txindex.h>
+#include <index/txospenderindex.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <primitives/block.h>
@@ -835,6 +836,145 @@ static bool rest_mempool(const std::any& context, HTTPRequest* req, const std::s
     }
 }
 
+static bool rest_txspendingprevout(const std::any& context, HTTPRequest* req, const std::string& uri_part)
+{
+    if (!CheckWarmup(req)) {
+        return false;
+    }
+
+    std::string param;
+    const RESTResponseFormat rf = ParseDataFormat(param, uri_part);
+
+    std::vector<std::string> uri_parts = SplitString(param, '/');
+
+    // Check that we have at least one outpoint
+    if (uri_parts.size() == 0 || (uri_parts.size() == 1 && uri_parts[0].empty())) {
+        return RESTERR(req, HTTP_BAD_REQUEST, "Error: empty request");
+    }
+
+    std::vector<COutPoint> prevouts;
+
+    // Parse outpoints from URI in the format txid-vout
+    for (size_t i = 0; i < uri_parts.size(); ++i) {
+        const auto txid_out{util::Split<std::string_view>(uri_parts[i], '-')};
+        if (txid_out.size() != 2) {
+            return RESTERR(req, HTTP_BAD_REQUEST, "Parse error");
+        }
+        auto txid{Txid::FromHex(txid_out.at(0))};
+        auto output{ToIntegral<uint32_t>(txid_out.at(1))};
+
+        if (!txid || !output.has_value()) {
+            return RESTERR(req, HTTP_BAD_REQUEST, "Parse error");
+        }
+
+        prevouts.emplace_back(*txid, *output);
+    }
+
+    if (prevouts.size() > MAX_GETUTXOS_OUTPOINTS) {
+        return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Error: max outpoints exceeded (max: %d, tried: %d)", MAX_GETUTXOS_OUTPOINTS, prevouts.size()));
+    }
+
+    switch (rf) {
+    case RESTResponseFormat::JSON: {
+        // Parse optional query parameters
+        std::string raw_mempool_only;
+        try {
+            raw_mempool_only = req->GetQueryParameter("mempool_only").value_or("");
+        } catch (const std::runtime_error& e) {
+            return RESTERR(req, HTTP_BAD_REQUEST, e.what());
+        }
+        if (!raw_mempool_only.empty() && raw_mempool_only != "true" && raw_mempool_only != "false") {
+            return RESTERR(req, HTTP_BAD_REQUEST, "The \"mempool_only\" query parameter must be either \"true\" or \"false\".");
+        }
+        std::string raw_return_spending_tx;
+        try {
+            raw_return_spending_tx = req->GetQueryParameter("return_spending_tx").value_or("false");
+        } catch (const std::runtime_error& e) {
+            return RESTERR(req, HTTP_BAD_REQUEST, e.what());
+        }
+        if (raw_return_spending_tx != "true" && raw_return_spending_tx != "false") {
+            return RESTERR(req, HTTP_BAD_REQUEST, "The \"return_spending_tx\" query parameter must be either \"true\" or \"false\".");
+        }
+        const bool mempool_only{raw_mempool_only.empty() ? !g_txospenderindex : (raw_mempool_only == "true")};
+        const bool return_spending_tx{raw_return_spending_tx == "true"};
+
+        const CTxMemPool* mempool = GetMemPool(context, req);
+        if (!mempool) return false;
+
+        struct Entry {
+            COutPoint outpoint;
+            UniValue raw;
+        };
+        std::vector<Entry> prevouts_to_process;
+        prevouts_to_process.reserve(prevouts.size());
+        for (const COutPoint& prevout : prevouts) {
+            UniValue o(UniValue::VOBJ);
+            o.pushKV("txid", prevout.hash.ToString());
+            o.pushKV("vout", prevout.n);
+            prevouts_to_process.emplace_back(prevout, std::move(o));
+        }
+
+        auto make_output = [return_spending_tx](const Entry& prevout, const CTransaction* spending_tx = nullptr) {
+            UniValue o{prevout.raw};
+            if (spending_tx) {
+                o.pushKV("spendingtxid", spending_tx->GetHash().ToString());
+                if (return_spending_tx) {
+                    o.pushKV("spendingtx", EncodeHexTx(*spending_tx));
+                }
+            }
+            return o;
+        };
+
+        UniValue result{UniValue::VARR};
+
+        {
+            LOCK(mempool->cs);
+            for (auto it = prevouts_to_process.begin(); it != prevouts_to_process.end(); ) {
+                const CTransaction* spending_tx{mempool->GetConflictTx(it->outpoint)};
+
+                if (!spending_tx && !mempool_only) {
+                    ++it;
+                    continue;
+                }
+
+                result.push_back(make_output(*it, spending_tx));
+                it = prevouts_to_process.erase(it);
+            }
+        }
+
+        if (!prevouts_to_process.empty()) {
+            if (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain()) {
+                return RESTERR(req, HTTP_SERVICE_UNAVAILABLE, "Mempool lacks a relevant spend, and txospenderindex is unavailable.");
+            }
+
+            for (const auto& prevout : prevouts_to_process) {
+                const auto spender{g_txospenderindex->FindSpender(prevout.outpoint)};
+                if (!spender) {
+                    return RESTERR(req, HTTP_INTERNAL_SERVER_ERROR, spender.error());
+                }
+
+                if (const auto& spender_opt{spender.value()}) {
+                    UniValue o{make_output(prevout, spender_opt->tx.get())};
+                    o.pushKV("blockhash", spender_opt->block_hash.GetHex());
+                    result.push_back(std::move(o));
+                } else {
+                    result.push_back(make_output(prevout));
+                }
+            }
+        }
+
+        std::string str_json = result.write() + "\n";
+        req->WriteHeader("Content-Type", "application/json");
+        req->WriteReply(HTTP_OK, str_json);
+        return true;
+    }
+
+    default: {
+        return RESTERR(req, HTTP_NOT_FOUND, "output format not found (available: json)");
+    }
+    }
+}
+
 static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string& uri_part)
 {
     if (!CheckWarmup(req))
@@ -1156,6 +1296,7 @@ static const struct {
     {"/rest/deploymentinfo", rest_deploymentinfo},
     {"/rest/blockhashbyheight/", rest_blockhash_by_height},
     {"/rest/spenttxouts/", rest_spent_txouts},
+    {"/rest/txspendingprevout/", rest_txspendingprevout},
 };
 
 void StartREST(const std::any& context)

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -13,6 +13,7 @@
 #include <httpserver.h>
 #include <index/blockfilterindex.h>
 #include <index/txindex.h>
+#include <index/txospenderindex.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <primitives/block.h>
@@ -863,6 +864,145 @@ static bool rest_mempool(const std::any& context, HTTPRequest* req, const std::s
     }
 }
 
+static bool rest_txspendingprevout(const std::any& context, HTTPRequest* req, const std::string& uri_part)
+{
+    if (!CheckWarmup(req)) {
+        return false;
+    }
+
+    std::string param;
+    const RESTResponseFormat rf = ParseDataFormat(param, uri_part);
+
+    std::vector<std::string> uri_parts = SplitString(param, '/');
+
+    // Check that we have at least one outpoint
+    if (uri_parts.size() == 0 || (uri_parts.size() == 1 && uri_parts[0].empty())) {
+        return RESTERR(req, HTTP_BAD_REQUEST, "Error: empty request");
+    }
+
+    std::vector<COutPoint> prevouts;
+
+    // Parse outpoints from URI in the format txid-vout
+    for (size_t i = 0; i < uri_parts.size(); ++i) {
+        const auto txid_out{util::Split<std::string_view>(uri_parts[i], '-')};
+        if (txid_out.size() != 2) {
+            return RESTERR(req, HTTP_BAD_REQUEST, "Parse error");
+        }
+        auto txid{Txid::FromHex(txid_out.at(0))};
+        auto output{ToIntegral<uint32_t>(txid_out.at(1))};
+
+        if (!txid || !output.has_value()) {
+            return RESTERR(req, HTTP_BAD_REQUEST, "Parse error");
+        }
+
+        prevouts.emplace_back(*txid, *output);
+    }
+
+    if (prevouts.size() > MAX_GETUTXOS_OUTPOINTS) {
+        return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Error: max outpoints exceeded (max: %d, tried: %d)", MAX_GETUTXOS_OUTPOINTS, prevouts.size()));
+    }
+
+    switch (rf) {
+    case RESTResponseFormat::JSON: {
+        // Parse optional query parameters
+        std::string raw_mempool_only;
+        try {
+            raw_mempool_only = req->GetQueryParameter("mempool_only").value_or("");
+        } catch (const std::runtime_error& e) {
+            return RESTERR(req, HTTP_BAD_REQUEST, e.what());
+        }
+        if (!raw_mempool_only.empty() && raw_mempool_only != "true" && raw_mempool_only != "false") {
+            return RESTERR(req, HTTP_BAD_REQUEST, "The \"mempool_only\" query parameter must be either \"true\" or \"false\".");
+        }
+        std::string raw_return_spending_tx;
+        try {
+            raw_return_spending_tx = req->GetQueryParameter("return_spending_tx").value_or("false");
+        } catch (const std::runtime_error& e) {
+            return RESTERR(req, HTTP_BAD_REQUEST, e.what());
+        }
+        if (raw_return_spending_tx != "true" && raw_return_spending_tx != "false") {
+            return RESTERR(req, HTTP_BAD_REQUEST, "The \"return_spending_tx\" query parameter must be either \"true\" or \"false\".");
+        }
+        const bool mempool_only{raw_mempool_only.empty() ? !g_txospenderindex : (raw_mempool_only == "true")};
+        const bool return_spending_tx{raw_return_spending_tx == "true"};
+
+        const CTxMemPool* mempool = GetMemPool(context, req);
+        if (!mempool) return false;
+
+        struct Entry {
+            COutPoint outpoint;
+            UniValue raw;
+        };
+        std::vector<Entry> prevouts_to_process;
+        prevouts_to_process.reserve(prevouts.size());
+        for (const COutPoint& prevout : prevouts) {
+            UniValue o(UniValue::VOBJ);
+            o.pushKV("txid", prevout.hash.ToString());
+            o.pushKV("vout", prevout.n);
+            prevouts_to_process.emplace_back(prevout, std::move(o));
+        }
+
+        auto make_output = [return_spending_tx](const Entry& prevout, const CTransaction* spending_tx = nullptr) {
+            UniValue o{prevout.raw};
+            if (spending_tx) {
+                o.pushKV("spendingtxid", spending_tx->GetHash().ToString());
+                if (return_spending_tx) {
+                    o.pushKV("spendingtx", EncodeHexTx(*spending_tx));
+                }
+            }
+            return o;
+        };
+
+        UniValue result{UniValue::VARR};
+
+        {
+            LOCK(mempool->cs);
+            for (auto it = prevouts_to_process.begin(); it != prevouts_to_process.end(); ) {
+                const CTransaction* spending_tx{mempool->GetConflictTx(it->outpoint)};
+
+                if (!spending_tx && !mempool_only) {
+                    ++it;
+                    continue;
+                }
+
+                result.push_back(make_output(*it, spending_tx));
+                it = prevouts_to_process.erase(it);
+            }
+        }
+
+        if (!prevouts_to_process.empty()) {
+            if (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain()) {
+                return RESTERR(req, HTTP_SERVICE_UNAVAILABLE, "Mempool lacks a relevant spend, and txospenderindex is unavailable.");
+            }
+
+            for (const auto& prevout : prevouts_to_process) {
+                const auto spender{g_txospenderindex->FindSpender(prevout.outpoint)};
+                if (!spender) {
+                    return RESTERR(req, HTTP_INTERNAL_SERVER_ERROR, spender.error());
+                }
+
+                if (const auto& spender_opt{spender.value()}) {
+                    UniValue o{make_output(prevout, spender_opt->tx.get())};
+                    o.pushKV("blockhash", spender_opt->block_hash.GetHex());
+                    result.push_back(std::move(o));
+                } else {
+                    result.push_back(make_output(prevout));
+                }
+            }
+        }
+
+        std::string str_json = result.write() + "\n";
+        req->WriteHeader("Content-Type", "application/json");
+        req->WriteReply(HTTP_OK, str_json);
+        return true;
+    }
+
+    default: {
+        return RESTERR(req, HTTP_NOT_FOUND, "output format not found (available: json)");
+    }
+    }
+}
+
 static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string& uri_part)
 {
     if (!CheckWarmup(req))
@@ -1193,6 +1333,7 @@ static const struct {
     {"/rest/deploymentinfo", rest_deploymentinfo},
     {"/rest/blockhashbyheight/", rest_blockhash_by_height},
     {"/rest/spenttxouts/", rest_spent_txouts},
+    {"/rest/txspendingprevout/", rest_txspendingprevout},
 };
 
 void StartREST(const std::any& context)

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -52,7 +52,7 @@ def filter_output_indices_by_value(vouts, value):
 class RESTTest (BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args = [["-rest", "-blockfilterindex=1"], []]
+        self.extra_args = [["-rest", "-blockfilterindex=1", "-txospenderindex=1"], []]
         # whitelist peers to speed up tx relay / mempool sync
         self.noban_tx_relay = True
         self.supports_cli = False
@@ -302,6 +302,7 @@ class RESTTest (BitcoinTestFramework):
         self.generate(self.nodes[1], 5)
         expected_filter = {
             'basic block filter index': {'synced': True, 'best_block_height': 208},
+            'txospenderindex': {'synced': True, 'best_block_height': 208},
         }
         self.wait_until(lambda: self.nodes[0].getindexinfo() == expected_filter)
         json_obj = self.test_rest_request(f"/headers/{bb_hash}", query_params={"count": 5})
@@ -413,6 +414,111 @@ class RESTTest (BitcoinTestFramework):
         json_obj = self.test_rest_request(f"/block/notxdetails/{newblockhash[0]}")
         for tx in txs:
             assert tx in json_obj['tx']
+
+        self.log.info("Test the /txspendingprevout URI")
+
+        # Create two new transactions - one to spend and one spending transaction
+        # First, create a transaction that will have an output to spend
+        utxo_for_new_tx = self.wallet.get_utxo()
+        base_tx = self.wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_for_new_tx)
+        base_txid = base_tx['txid']
+        base_vout = 0  # The change output
+        self.sync_all()
+
+        # Now create a transaction that spends from base_tx
+        spending_tx = self.wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=self.wallet.get_utxo(txid=base_txid))
+        spending_txid = spending_tx['txid']
+        self.sync_all()
+
+        # Test with single outpoint - should find the spending transaction
+        json_obj = self.test_rest_request(f"/txspendingprevout/{base_txid}-{base_vout}")
+        assert_equal(len(json_obj), 1)
+        assert_equal(json_obj[0]['txid'], base_txid)
+        assert_equal(json_obj[0]['vout'], base_vout)
+        assert_equal(json_obj[0]['spendingtxid'], spending_txid)
+
+        # Test return_spending_tx=true adds full transaction hex
+        json_obj = self.test_rest_request(
+            f"/txspendingprevout/{base_txid}-{base_vout}",
+            query_params={"return_spending_tx": "true"},
+        )
+        assert_equal(len(json_obj), 1)
+        assert_equal(json_obj[0]['txid'], base_txid)
+        assert_equal(json_obj[0]['vout'], base_vout)
+        assert_equal(json_obj[0]['spendingtxid'], spending_txid)
+        assert 'spendingtx' in json_obj[0]
+        assert_equal(json_obj[0]['spendingtx'], spending_tx['hex'])
+
+        # Test with unspent output - should not have spendingtxid
+        utxo_unspent = self.wallet.get_utxo()
+        json_obj = self.test_rest_request(f"/txspendingprevout/{utxo_unspent['txid']}-{utxo_unspent['vout']}")
+        assert_equal(len(json_obj), 1)
+        assert_equal(json_obj[0]['txid'], utxo_unspent['txid'])
+        assert_equal(json_obj[0]['vout'], utxo_unspent['vout'])
+        assert 'spendingtxid' not in json_obj[0]
+
+        # Test with multiple outpoints
+        json_obj = self.test_rest_request(f"/txspendingprevout/{base_txid}-{base_vout}/{utxo_unspent['txid']}-{utxo_unspent['vout']}")
+        assert_equal(len(json_obj), 2)
+        # First output is spent
+        assert_equal(json_obj[0]['txid'], base_txid)
+        assert_equal(json_obj[0]['vout'], base_vout)
+        assert_equal(json_obj[0]['spendingtxid'], spending_txid)
+        # Second output is unspent
+        assert_equal(json_obj[1]['txid'], utxo_unspent['txid'])
+        assert_equal(json_obj[1]['vout'], utxo_unspent['vout'])
+        assert 'spendingtxid' not in json_obj[1]
+
+        # Test with invalid outpoint format
+        resp = self.test_rest_request(f"/txspendingprevout/{INVALID_PARAM}", ret_type=RetType.OBJ, status=400)
+        assert_equal(resp.read().decode('utf-8').strip(), 'Parse error')
+
+        # Test with empty request
+        resp = self.test_rest_request("/txspendingprevout/", ret_type=RetType.OBJ, status=400)
+        assert_equal(resp.read().decode('utf-8').strip(), 'Error: empty request')
+
+        # Test max outpoints limit (same as getutxos: 15)
+        too_many = "/".join(f"{utxo_unspent['txid']}-{utxo_unspent['vout']}" for _ in range(16))
+        resp = self.test_rest_request(f"/txspendingprevout/{too_many}", ret_type=RetType.OBJ, status=400)
+        assert_equal(resp.read().decode('utf-8').strip(), 'Error: max outpoints exceeded (max: 15, tried: 16)')
+
+        # Test invalid mempool_only query parameter value
+        resp = self.test_rest_request(
+            f"/txspendingprevout/{base_txid}-{base_vout}",
+            ret_type=RetType.OBJ,
+            status=400,
+            query_params={"mempool_only": "not_bool"},
+        )
+        assert_equal(
+            resp.read().decode('utf-8').strip(),
+            'The "mempool_only" query parameter must be either "true" or "false".',
+        )
+
+        # Test invalid return_spending_tx query parameter value
+        resp = self.test_rest_request(
+            f"/txspendingprevout/{base_txid}-{base_vout}",
+            ret_type=RetType.OBJ,
+            status=400,
+            query_params={"return_spending_tx": "not_bool"},
+        )
+        assert_equal(
+            resp.read().decode('utf-8').strip(),
+            'The "return_spending_tx" query parameter must be either "true" or "false".',
+        )
+
+        # Mine the transactions to clean up mempool
+        blockhash = self.generate(self.nodes[0], 1)[0]
+
+        # Test txospenderindex path after confirmation
+        json_obj = self.test_rest_request(f"/txspendingprevout/{base_txid}-{base_vout}")
+        assert_equal(json_obj[0]['spendingtxid'], spending_txid)
+        assert_equal(json_obj[0]['blockhash'], blockhash)
+
+        json_obj = self.test_rest_request(
+            f"/txspendingprevout/{base_txid}-{base_vout}",
+            query_params={"mempool_only": "true"},
+        )
+        assert 'spendingtxid' not in json_obj[0]
 
         self.log.info("Test the /chaininfo URI")
 

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -54,7 +54,7 @@ def filter_output_indices_by_value(vouts, value):
 class RESTTest (BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args = [["-rest", "-blockfilterindex=1", "-txindex"], []]
+        self.extra_args = [["-rest", "-blockfilterindex=1", "-txindex", "-txospenderindex=1"], []]
         # whitelist peers to speed up tx relay / mempool sync
         self.noban_tx_relay = True
 
@@ -307,6 +307,10 @@ class RESTTest (BitcoinTestFramework):
             'basic block filter index': {'synced': True, 'best_block_height': 208},
         }
         self.wait_until(lambda: self.nodes[0].getindexinfo("basic block filter index") == expected_filter)
+        expected_txospender = {
+            'txospenderindex': {'synced': True, 'best_block_height': 208},
+        }
+        self.wait_until(lambda: self.nodes[0].getindexinfo("txospenderindex") == expected_txospender)
         json_obj = self.test_rest_request(f"/headers/{bb_hash}", query_params={"count": 5})
         assert_equal(len(json_obj), 5)  # now we should have 5 header objects
         json_obj = self.test_rest_request(f"/blockfilterheaders/basic/{bb_hash}", query_params={"count": 5})
@@ -416,6 +420,111 @@ class RESTTest (BitcoinTestFramework):
         json_obj = self.test_rest_request(f"/block/notxdetails/{newblockhash[0]}")
         for tx in txs:
             assert tx in json_obj['tx']
+
+        self.log.info("Test the /txspendingprevout URI")
+
+        # Create two new transactions - one to spend and one spending transaction
+        # First, create a transaction that will have an output to spend
+        utxo_for_new_tx = self.wallet.get_utxo()
+        base_tx = self.wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_for_new_tx)
+        base_txid = base_tx['txid']
+        base_vout = 0  # The change output
+        self.sync_all()
+
+        # Now create a transaction that spends from base_tx
+        spending_tx = self.wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=self.wallet.get_utxo(txid=base_txid))
+        spending_txid = spending_tx['txid']
+        self.sync_all()
+
+        # Test with single outpoint - should find the spending transaction
+        json_obj = self.test_rest_request(f"/txspendingprevout/{base_txid}-{base_vout}")
+        assert_equal(len(json_obj), 1)
+        assert_equal(json_obj[0]['txid'], base_txid)
+        assert_equal(json_obj[0]['vout'], base_vout)
+        assert_equal(json_obj[0]['spendingtxid'], spending_txid)
+
+        # Test return_spending_tx=true adds full transaction hex
+        json_obj = self.test_rest_request(
+            f"/txspendingprevout/{base_txid}-{base_vout}",
+            query_params={"return_spending_tx": "true"},
+        )
+        assert_equal(len(json_obj), 1)
+        assert_equal(json_obj[0]['txid'], base_txid)
+        assert_equal(json_obj[0]['vout'], base_vout)
+        assert_equal(json_obj[0]['spendingtxid'], spending_txid)
+        assert 'spendingtx' in json_obj[0]
+        assert_equal(json_obj[0]['spendingtx'], spending_tx['hex'])
+
+        # Test with unspent output - should not have spendingtxid
+        utxo_unspent = self.wallet.get_utxo()
+        json_obj = self.test_rest_request(f"/txspendingprevout/{utxo_unspent['txid']}-{utxo_unspent['vout']}")
+        assert_equal(len(json_obj), 1)
+        assert_equal(json_obj[0]['txid'], utxo_unspent['txid'])
+        assert_equal(json_obj[0]['vout'], utxo_unspent['vout'])
+        assert 'spendingtxid' not in json_obj[0]
+
+        # Test with multiple outpoints
+        json_obj = self.test_rest_request(f"/txspendingprevout/{base_txid}-{base_vout}/{utxo_unspent['txid']}-{utxo_unspent['vout']}")
+        assert_equal(len(json_obj), 2)
+        # First output is spent
+        assert_equal(json_obj[0]['txid'], base_txid)
+        assert_equal(json_obj[0]['vout'], base_vout)
+        assert_equal(json_obj[0]['spendingtxid'], spending_txid)
+        # Second output is unspent
+        assert_equal(json_obj[1]['txid'], utxo_unspent['txid'])
+        assert_equal(json_obj[1]['vout'], utxo_unspent['vout'])
+        assert 'spendingtxid' not in json_obj[1]
+
+        # Test with invalid outpoint format
+        resp = self.test_rest_request(f"/txspendingprevout/{INVALID_PARAM}", ret_type=RetType.OBJ, status=400)
+        assert_equal(resp.read().decode('utf-8').strip(), 'Parse error')
+
+        # Test with empty request
+        resp = self.test_rest_request("/txspendingprevout/", ret_type=RetType.OBJ, status=400)
+        assert_equal(resp.read().decode('utf-8').strip(), 'Error: empty request')
+
+        # Test max outpoints limit (same as getutxos: 15)
+        too_many = "/".join(f"{utxo_unspent['txid']}-{utxo_unspent['vout']}" for _ in range(16))
+        resp = self.test_rest_request(f"/txspendingprevout/{too_many}", ret_type=RetType.OBJ, status=400)
+        assert_equal(resp.read().decode('utf-8').strip(), 'Error: max outpoints exceeded (max: 15, tried: 16)')
+
+        # Test invalid mempool_only query parameter value
+        resp = self.test_rest_request(
+            f"/txspendingprevout/{base_txid}-{base_vout}",
+            ret_type=RetType.OBJ,
+            status=400,
+            query_params={"mempool_only": "not_bool"},
+        )
+        assert_equal(
+            resp.read().decode('utf-8').strip(),
+            'The "mempool_only" query parameter must be either "true" or "false".',
+        )
+
+        # Test invalid return_spending_tx query parameter value
+        resp = self.test_rest_request(
+            f"/txspendingprevout/{base_txid}-{base_vout}",
+            ret_type=RetType.OBJ,
+            status=400,
+            query_params={"return_spending_tx": "not_bool"},
+        )
+        assert_equal(
+            resp.read().decode('utf-8').strip(),
+            'The "return_spending_tx" query parameter must be either "true" or "false".',
+        )
+
+        # Mine the transactions to clean up mempool
+        blockhash = self.generate(self.nodes[0], 1)[0]
+
+        # Test txospenderindex path after confirmation
+        json_obj = self.test_rest_request(f"/txspendingprevout/{base_txid}-{base_vout}")
+        assert_equal(json_obj[0]['spendingtxid'], spending_txid)
+        assert_equal(json_obj[0]['blockhash'], blockhash)
+
+        json_obj = self.test_rest_request(
+            f"/txspendingprevout/{base_txid}-{base_vout}",
+            query_params={"mempool_only": "true"},
+        )
+        assert 'spendingtxid' not in json_obj[0]
 
         self.log.info("Test the /chaininfo URI")
 


### PR DESCRIPTION
## Summary
This creates a REST interface for the `gettxspendingprevout` RPC, it also includes functional tests and updates to the REST docs

This is part of https://github.com/bitcoin/bitcoin/issues/33808, and now that sstone’s PR https://github.com/bitcoin/bitcoin/pull/24539 is merged, I added `mempool_only` and `return_spending_tx` as query params.