### PR TITLE
doc, ci: Make the max number of commits tested explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,12 @@ jobs:
           fi
 
   test-each-commit:
-    name: 'test each commit'
+    name: 'test max 6 ancestor commits'
     runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request' && github.event.pull_request.commits != 1
     timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes. Assuming a worst case time of 1 hour per commit, this leads to a --max-count=6 below.
     env:
-      MAX_COUNT: 6
+      MAX_COUNT: 6  # Keep in sync with name above
     steps:
       - name: Determine fetch depth
         run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"


### PR DESCRIPTION
Gives less of a false sense of security.