### PR TITLE
clang-format: Set PackConstructorInitializers: CurrentLine

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -146,7 +146,7 @@ ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PackConstructorInitializers: BinPack
+PackConstructorInitializers: CurrentLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -995,7 +995,9 @@ void V2Transport::StartSendingHandshake() noexcept
 }
 
 V2Transport::V2Transport(NodeId nodeid, bool initiating, const CKey& key, std::span<const std::byte> ent32, std::vector<uint8_t> garbage) noexcept
-    : m_cipher{key, ent32}, m_initiating{initiating}, m_nodeid{nodeid},
+    : m_cipher{key, ent32},
+      m_initiating{initiating},
+      m_nodeid{nodeid},
       m_v1_fallback{nodeid},
       m_recv_state{initiating ? RecvState::KEY : RecvState::KEY_MAYBE_V1},
       m_send_garbage{std::move(garbage)},


### PR DESCRIPTION
Now that the minimum supported clang version is larger than 14, the `PackConstructorInitializers` setting can be set to `CurrentLine` in the clang-format file. (This option was added in clang 14. Ref: https://releases.llvm.org/17.0.1/tools/clang/docs/ClangFormatStyleOptions.html#packconstructorinitializers)

The `CurrentLine` option will either put all constructor initializers on the current line if they fit. Otherwise, it will put each one on its own line.

The `CurrentLine` option is desirable over the current `BinPack` option, because:

* It is what the majority of the codebase is currently using.
* It makes it easier to skim the lines to ensure all fields are properly initialized, without having to parse bin-packed constructor initializers, possibly with nested initializer lists, function calls, or ternary operators.
* It makes diffs smaller when an initializer is added or removed, because only a single line is touched. Otherwise, the whole bin-packed block could re-flow, making the diff harder to parse.

Note: The previous `BinPack` option allows any formatting, due to the current `ColumnLimit: 0`. I presume developers manually formatted most constructor initializers to be on separate lines? With the new `CurrentLine` setting, one has to only put the first initializer on a separate line, and clang-format will take care of the rest.

For example:

```sh
echo 'A::A(O o)
: m_first{o.a, o.b},
  m_second{fun(o)}, m_third{o.c?o.d:o.e} {}' | clang-format --style=file:./src/.clang-format
```

Will put each on a separate line. Previously, it was left as-is.