### PR TITLE
clang-format: Set Bitcoin Core IncludeCategories

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -99,17 +99,20 @@ IfMacros:
   - KJ_IF_MAYBE
 IncludeBlocks:   Preserve
 IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+  - Regex:           '^<bitcoin-build-config\.h>'
+    Priority:        -1
+    CaseSensitive:   true
+  - Regex:           '^<boost/'
     Priority:        2
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    CaseSensitive:   true
+  - Regex:           '^<Q'
+    Priority:        2
+    CaseSensitive:   true
+  - Regex:           '^<[^>.]*>'
     Priority:        3
-    SortPriority:    0
     CaseSensitive:   false
   - Regex:           '.*'
     Priority:        1
-    SortPriority:    0
     CaseSensitive:   false
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -2,14 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <boost/test/unit_test.hpp>
-
 #include <chain.h>
 #include <node/blockstorage.h>
 #include <rpc/blockchain.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
 #include <util/string.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include <cstdlib>
 


### PR DESCRIPTION
Replace the default llvm include categories with the ones specific to Bitcoin Core.

Ref: https://releases.llvm.org/17.0.1/tools/clang/docs/ClangFormatStyleOptions.html#includecategories

Also, format a file as example. To test this, the diff in src/test needs
to be reverted. Also `IncludeBlocks: Regroup` needs to be set. Then
`clang-format -i src/test/blockchain_tests.cpp` should recreate the
diff.

```diff
diff --git a/src/.clang-format b/src/.clang-format
index 15335fe9ae..579079095f 100644
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -99,3 +99,3 @@ IfMacros:
   - KJ_IF_MAYBE
-IncludeBlocks:   Preserve
+IncludeBlocks:   Regroup
 IncludeCategories:
```
