### PR TITLE
mining: add getMemoryLoad() and track template non-mempool memory footprint

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -234,7 +234,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(((bench|crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|common/license_info|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/(((bench|crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|common/license_info|node/(block_template_manager|blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,6 +214,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   net_processing.cpp
   netgroup.cpp
   node/abort.cpp
+  node/block_template_manager.cpp
   node/blockmanager_args.cpp
   node/blockstorage.cpp
   node/caches.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -33,7 +33,6 @@
 #include <interfaces/chain.h>
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
-#include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <ipc/exception.h>
 #include <kernel/blockmanager_opts.h>
@@ -1228,9 +1227,6 @@ bool AppInitLockDirectories()
 bool AppInitInterfaces(NodeContext& node)
 {
     node.chain = interfaces::MakeChain(node);
-    // Specify wait_loaded=false so internal mining interface can be initialized
-    // on early startup and does not need to be tied to chainstate loading.
-    node.mining = interfaces::MakeMining(node, /*wait_loaded=*/false);
     return true;
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1437,7 +1437,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
             auto mining_args{node::ReadMiningArgs(args)};
             Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
             // Must be set before setChainstateLoaded(true), which unblocks MakeMining waiters that assume it is non-null.
-            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman, std::move(*mining_args));
+            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman, *node.notifications, std::move(*mining_args));
             node.notifications->setChainstateLoaded(true);
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1345,9 +1345,6 @@ static ChainstateLoadResult InitAndLoadChainstate(
     if (!mempool_error.empty()) {
         return {ChainstateLoadStatus::FAILURE_FATAL, mempool_error};
     }
-    auto mining_args{node::ReadMiningArgs(args)};
-    Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
-    node.mining_args = std::move(*mining_args);
     LogInfo("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)",
             cache_sizes.coins / double(1_MiB),
             mempool_opts.max_size_bytes / double(1_MiB));
@@ -1437,7 +1434,10 @@ static ChainstateLoadResult InitAndLoadChainstate(
         std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
         if (status == node::ChainstateLoadStatus::SUCCESS) {
             LogInfo("Block index and chainstate loaded");
-            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman);
+            auto mining_args{node::ReadMiningArgs(args)};
+            Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
+            // Must be set before setChainstateLoaded(true), which unblocks MakeMining waiters that assume it is non-null.
+            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman, std::move(*mining_args));
             node.notifications->setChainstateLoaded(true);
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -51,6 +51,7 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <netgroup.h>
+#include <node/block_template_manager.h>
 #include <node/blockmanager_args.h>
 #include <node/blockstorage.h>
 #include <node/caches.h>
@@ -429,6 +430,7 @@ void Shutdown(NodeContext& node)
     if (node.validation_signals) {
         node.validation_signals->UnregisterAllValidationInterfaces();
     }
+    node.block_template_manager.reset();
     node.mempool.reset();
     node.fee_estimator.reset();
     node.chainman.reset();
@@ -1326,6 +1328,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
 {
     // This function may be called twice, so any dirty state must be reset.
     node.notifications->setChainstateLoaded(false); // Drop state, such as a cached tip block
+    node.block_template_manager.reset();
     node.mempool.reset();
     node.chainman.reset(); // Drop state, such as an initialized m_block_tree_db
 
@@ -1434,6 +1437,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
         std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
         if (status == node::ChainstateLoadStatus::SUCCESS) {
             LogInfo("Block index and chainstate loaded");
+            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman);
             node.notifications->setChainstateLoaded(true);
         }
     }
@@ -1868,6 +1872,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     assert(!node.mempool);
     assert(!node.chainman);
+    assert(!node.block_template_manager);
 
     bool do_reindex{args.GetBoolArg("-reindex", false)};
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -102,6 +102,12 @@ public:
     virtual void interruptWait() = 0;
 };
 
+//! Tracks memory usage for template-bound transactions.
+struct MemoryLoad
+{
+    uint64_t usage{0};
+};
+
 //! Interface giving clients (RPC, Stratum v2 Template Provider in the future)
 //! ability to create block templates.
 class Mining
@@ -203,6 +209,15 @@ public:
      *                     transaction if found, otherwise nullptr
      */
     virtual std::vector<CTransactionRef> getTransactionsByWitnessID(const std::vector<Wtxid>& wtxids) = 0;
+
+    /**
+     * Returns the current memory load for template transactions outside the
+     * mempool.
+     *
+     * Only counts templates created through this interface. The template
+     * cached by the getblocktemplate RPC is excluded.
+     */
+    virtual MemoryLoad getMemoryLoad() = 0;
 
     //! Get internal node context. Useful for RPC and testing,
     //! but not accessible across processes.

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -28,6 +28,7 @@ interface Mining $Proxy.wrap("interfaces::Mining") {
     submitBlock @7 (context :Proxy.Context, block: Data) -> (reason: Text, debug: Text, result: Bool);
     getTransactionsByTxID @8 (context :Proxy.Context, txids: List(Data)) -> (result: List(Data));
     getTransactionsByWitnessID @9 (context :Proxy.Context, wtxids: List(Data)) -> (result: List(Data));
+    getMemoryLoad @10 (context :Proxy.Context) -> (result: MemoryLoad);
 }
 
 interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {
@@ -50,6 +51,10 @@ struct BlockCreateOptions $Proxy.wrap("node::BlockCreateOptions") {
     useMempool @0 :Bool = true $Proxy.name("use_mempool");
     blockReservedWeight @1 :UInt64 = .defaultBlockReservedWeight $Proxy.name("block_reserved_weight");
     coinbaseOutputMaxAdditionalSigops @2 :UInt64 = .defaultCoinbaseOutputMaxAdditionalSigops $Proxy.name("coinbase_output_max_additional_sigops");
+}
+
+struct MemoryLoad $Proxy.wrap("interfaces::MemoryLoad") {
+    usage @0 :UInt64;
 }
 
 struct BlockWaitOptions $Proxy.wrap("node::BlockWaitOptions") {

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/block_template_manager.h>
+
+#include <node/miner.h>
+#include <validation.h>
+
+namespace node {
+
+BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManager& chainman)
+    : m_mempool(mempool), m_chainman(chainman)
+{
+}
+
+std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const BlockCreateOptions& options)
+{
+    return BlockAssembler{m_chainman.ActiveChainstate(), &m_mempool, options}.CreateNewBlock();
+}
+
+} // namespace node

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -25,6 +25,7 @@
 #include <compare>
 #include <condition_variable>
 #include <numeric>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -46,6 +47,37 @@ std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const Bl
         &m_mempool,
         MergeMiningOptions(options, m_block_create_args),
     }.CreateNewBlock();
+}
+
+void BlockTemplateManager::TrackTemplateTransactions(const std::vector<CTransactionRef>& txs)
+{
+    LOCK(m_mutex);
+    // Don't track the dummy coinbase, because it can be modified in-place
+    // by submitSolution()
+    for (const CTransactionRef& tx : txs | std::views::drop(1)) {
+        ++m_template_tx_refs[tx];
+    }
+}
+
+void BlockTemplateManager::StopTrackingTemplateTransactions(const std::vector<CTransactionRef>& txs)
+{
+    LOCK(m_mutex);
+    for (const CTransactionRef& tx : txs | std::views::drop(1)) {
+        auto ref_count{m_template_tx_refs.find(tx)};
+        if (!Assume(ref_count != m_template_tx_refs.end())) continue;
+        if (--ref_count->second == 0) {
+            m_template_tx_refs.erase(ref_count);
+        }
+    }
+}
+
+void BlockTemplateManager::SanityCheck() const
+{
+    LOCK(m_mutex);
+    for (const auto& [tx_ref, count] : m_template_tx_refs) {
+        Assume(tx_ref);
+        Assume(count > 0);
+    }
 }
 
 namespace {

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -4,22 +4,38 @@
 
 #include <node/block_template_manager.h>
 
+#include <chain.h>
+#include <consensus/amount.h>
+#include <consensus/params.h>
 #include <consensus/validation.h>
+#include <interfaces/types.h>
+#include <kernel/chainparams.h>
+#include <node/kernel_notifications.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
 #include <primitives/block.h>
+#include <sync.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/signalinterrupt.h>
 #include <validation.h>
 #include <validationinterface.h>
 
+#include <algorithm>
+#include <compare>
+#include <condition_variable>
+#include <numeric>
 #include <utility>
+#include <vector>
 
 namespace node {
 
+using interfaces::BlockRef;
+
 BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManager& chainman,
+                                           KernelNotifications& notifications,
                                            BlockCreateOptions block_create_args)
-    : m_mempool(mempool), m_chainman(chainman), m_block_create_args(std::move(block_create_args))
+    : m_mempool(mempool), m_chainman(chainman), m_notifications(notifications), m_block_create_args(std::move(block_create_args))
 {
 }
 
@@ -89,6 +105,174 @@ bool BlockTemplateManager::SubmitBlock(const std::shared_ptr<const CBlock>& bloc
     const bool result{accepted && new_block && reason.empty()};
     CHECK_NONFATAL(result == reason.empty());
     return result;
+}
+
+std::optional<BlockRef> BlockTemplateManager::GetTip()
+{
+    LOCK(::cs_main);
+    CBlockIndex* tip{m_chainman.ActiveChain().Tip()};
+    if (!tip) return {};
+    return BlockRef{tip->GetBlockHash(), tip->nHeight};
+}
+
+void BlockTemplateManager::InterruptWait(bool& interrupt_wait)
+{
+    LOCK(m_notifications.m_tip_block_mutex);
+    interrupt_wait = true;
+    m_notifications.m_tip_block_cv.notify_all();
+}
+
+std::unique_ptr<CBlockTemplate> BlockTemplateManager::WaitAndCreateNewBlock(
+    const std::unique_ptr<CBlockTemplate>& block_template,
+    const BlockWaitOptions& wait_options,
+    const BlockCreateOptions& create_options,
+    bool& interrupt_wait)
+{
+    // Delay calculating the current template fees, just in case a new block
+    // comes in before the next tick.
+    CAmount current_fees = -1;
+
+    // Alternate waiting for a new tip and checking if fees have risen.
+    // The latter check is expensive so we only run it once per second.
+    auto now{NodeClock::now()};
+    const auto deadline = now + wait_options.timeout;
+    const MillisecondsDouble tick{1000};
+    const bool allow_min_difficulty{m_chainman.GetParams().GetConsensus().fPowAllowMinDifficultyBlocks};
+
+    do {
+        bool tip_changed{false};
+        {
+            WAIT_LOCK(m_notifications.m_tip_block_mutex, lock);
+            // Note that wait_until() checks the predicate before waiting
+            m_notifications.m_tip_block_cv.wait_until(lock, std::min(now + tick, deadline), [&]() EXCLUSIVE_LOCKS_REQUIRED(m_notifications.m_tip_block_mutex) {
+                AssertLockHeld(m_notifications.m_tip_block_mutex);
+                const auto tip_block{m_notifications.TipBlock()};
+                // We assume tip_block is set, because this is an instance
+                // method on BlockTemplate and no template could have been
+                // generated before a tip exists.
+                tip_changed = Assume(tip_block) && tip_block != block_template->block.hashPrevBlock;
+                return tip_changed || m_chainman.m_interrupt || interrupt_wait;
+            });
+            if (interrupt_wait) {
+                interrupt_wait = false;
+                return nullptr;
+            }
+        }
+
+        if (m_chainman.m_interrupt) return nullptr;
+        // At this point the tip changed, a full tick went by or we reached
+        // the deadline.
+
+        // Must release m_tip_block_mutex before locking cs_main, to avoid deadlocks.
+        LOCK(::cs_main);
+
+        // On test networks return a minimum difficulty block after 20 minutes
+        if (!tip_changed && allow_min_difficulty) {
+            const NodeClock::time_point tip_time{std::chrono::seconds{m_chainman.ActiveChain().Tip()->GetBlockTime()}};
+            if (now > tip_time + 20min) {
+                tip_changed = true;
+            }
+        }
+
+        /**
+         * We determine if fees increased compared to the previous template by generating
+         * a fresh template. There may be more efficient ways to determine how much
+         * (approximate) fees for the next block increased, perhaps more so after
+         * Cluster Mempool.
+         *
+         * We'll also create a new template if the tip changed during this iteration.
+         */
+        if (wait_options.fee_threshold < MAX_MONEY || tip_changed) {
+            auto new_tmpl{CreateNewTemplate(create_options)};
+
+            // If the tip changed, return the new template regardless of its fees.
+            if (tip_changed) return new_tmpl;
+
+            // Calculate the original template total fees if we haven't already
+            if (current_fees == -1) {
+                current_fees = std::accumulate(block_template->vTxFees.begin(), block_template->vTxFees.end(), CAmount{0});
+            }
+
+            // Check if fees increased enough to return the new template
+            const CAmount new_fees = std::accumulate(new_tmpl->vTxFees.begin(), new_tmpl->vTxFees.end(), CAmount{0});
+            Assume(wait_options.fee_threshold != MAX_MONEY);
+            if (new_fees >= current_fees + wait_options.fee_threshold) return new_tmpl;
+        }
+
+        now = NodeClock::now();
+    } while (now < deadline);
+
+    return nullptr;
+}
+
+bool BlockTemplateManager::CooldownIfHeadersAhead(const BlockRef& last_tip, bool& interrupt_mining)
+{
+    uint256 last_tip_hash{last_tip.hash};
+
+    while (const std::optional<int> remaining = m_chainman.BlocksAheadOfTip()) {
+        const int cooldown_seconds = std::clamp(*remaining, 3, 20);
+        const auto cooldown_deadline{MockableSteadyClock::now() + std::chrono::seconds{cooldown_seconds}};
+
+        {
+            WAIT_LOCK(m_notifications.m_tip_block_mutex, lock);
+            m_notifications.m_tip_block_cv.wait_until(lock, cooldown_deadline, [&]() EXCLUSIVE_LOCKS_REQUIRED(m_notifications.m_tip_block_mutex) {
+                const auto tip_block = m_notifications.TipBlock();
+                return m_chainman.m_interrupt || interrupt_mining || (tip_block && *tip_block != last_tip_hash);
+            });
+            if (m_chainman.m_interrupt || interrupt_mining) {
+                interrupt_mining = false;
+                return false;
+            }
+
+            // If the tip changed during the wait, extend the deadline
+            const auto tip_block = m_notifications.TipBlock();
+            if (tip_block && *tip_block != last_tip_hash) {
+                last_tip_hash = *tip_block;
+                continue;
+            }
+        }
+
+        // No tip change and the cooldown window has expired.
+        if (MockableSteadyClock::now() >= cooldown_deadline) break;
+    }
+
+    return true;
+}
+
+std::optional<BlockRef> BlockTemplateManager::WaitTipChanged(const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt)
+{
+    Assume(timeout >= 0ms); // No internal callers should use a negative timeout
+    if (timeout < 0ms) timeout = 0ms;
+    if (timeout > std::chrono::years{100}) timeout = std::chrono::years{100}; // Upper bound to avoid UB in std::chrono
+    auto deadline{std::chrono::steady_clock::now() + timeout};
+    {
+        WAIT_LOCK(m_notifications.m_tip_block_mutex, lock);
+        // For callers convenience, wait longer than the provided timeout
+        // during startup for the tip to be non-null. That way this function
+        // always returns valid tip information when possible and only
+        // returns null when shutting down, not when timing out.
+        m_notifications.m_tip_block_cv.wait(lock, [&]() EXCLUSIVE_LOCKS_REQUIRED(m_notifications.m_tip_block_mutex) {
+            AssertLockHeld(m_notifications.m_tip_block_mutex);
+            return m_notifications.TipBlock() || m_chainman.m_interrupt || interrupt;
+        });
+        if (m_chainman.m_interrupt || interrupt) {
+            interrupt = false;
+            return {};
+        }
+        // At this point TipBlock is set, so continue to wait until it is
+        // different from `current_tip` provided by caller.
+        m_notifications.m_tip_block_cv.wait_until(lock, deadline, [&]() EXCLUSIVE_LOCKS_REQUIRED(m_notifications.m_tip_block_mutex) {
+            return Assume(m_notifications.TipBlock()) != current_tip || m_chainman.m_interrupt || interrupt;
+        });
+        if (m_chainman.m_interrupt || interrupt) {
+            interrupt = false;
+            return {};
+        }
+    }
+
+    // Must release m_tip_block_mutex before GetTip() locks cs_main, to
+    // avoid deadlocks.
+    return GetTip();
 }
 
 } // namespace node

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -243,6 +243,12 @@ bool BlockTemplateManager::CooldownIfHeadersAhead(const BlockRef& last_tip, bool
     return true;
 }
 
+std::optional<BlockRef> BlockTemplateManager::WaitTipChanged(const uint256& current_tip, MillisecondsDouble timeout)
+{
+    bool interrupt_wait{false};
+    return WaitTipChanged(current_tip, timeout, interrupt_wait);
+}
+
 std::optional<BlockRef> BlockTemplateManager::WaitTipChanged(const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt)
 {
     Assume(timeout >= 0ms); // No internal callers should use a negative timeout

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -8,13 +8,17 @@
 #include <consensus/amount.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
+#include <core_memusage.h>
 #include <interfaces/types.h>
 #include <kernel/chainparams.h>
+#include <logging/categories.h>
+#include <logging/timer.h>
 #include <node/kernel_notifications.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
 #include <primitives/block.h>
 #include <sync.h>
+#include <txmempool.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/signalinterrupt.h>
@@ -24,6 +28,7 @@
 #include <algorithm>
 #include <compare>
 #include <condition_variable>
+#include <iterator>
 #include <numeric>
 #include <ranges>
 #include <utility>
@@ -69,6 +74,37 @@ void BlockTemplateManager::StopTrackingTemplateTransactions(const std::vector<CT
             m_template_tx_refs.erase(ref_count);
         }
     }
+}
+
+size_t BlockTemplateManager::GetTemplateMemoryUsage() const
+{
+    LOG_TIME_MILLIS_WITH_CATEGORY("Calculate template transaction reference memory footprint", BCLog::BENCH);
+
+    // Copy the transaction references so that m_mutex is not held while
+    // mempool.exists() below repeatedly locks mempool.cs. Holding it would
+    // block template creation and destruction for the duration of this
+    // calculation.
+    std::vector<CTransactionRef> tx_refs;
+    {
+        LOCK(m_mutex);
+        tx_refs.reserve(m_template_tx_refs.size());
+        std::ranges::copy(m_template_tx_refs | std::views::keys, std::back_inserter(tx_refs));
+    }
+
+    size_t usage_bytes{0};
+    for (const auto& tx_ref : tx_refs) {
+        if (!Assume(tx_ref)) continue;
+        // mempool.exists() locks mempool.cs each time, which slows down
+        // our calculation. This is preferable to potentially blocking
+        // the node from processing new transactions while this
+        // (non-urgent) calculation is in progress.
+        //
+        // As a side-effect the result is not an accurate snapshot, because
+        // the mempool may change during the loop.
+        if (m_mempool.exists(tx_ref->GetWitnessHash())) continue;
+        usage_bytes += RecursiveDynamicUsage(*tx_ref);
+    }
+    return usage_bytes;
 }
 
 void BlockTemplateManager::SanityCheck() const

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -4,9 +4,14 @@
 
 #include <node/block_template_manager.h>
 
+#include <consensus/validation.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
+#include <primitives/block.h>
+#include <uint256.h>
+#include <util/check.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <utility>
 
@@ -21,6 +26,69 @@ BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManage
 std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const BlockCreateOptions& options)
 {
     return BlockAssembler{m_chainman.ActiveChainstate(), &m_mempool, options}.CreateNewBlock();
+}
+
+namespace {
+class SubmitBlockStateCatcher final : public CValidationInterface
+{
+public:
+    uint256 m_hash;
+    bool m_found{false};
+    BlockValidationState m_state;
+
+    explicit SubmitBlockStateCatcher(const uint256& hash) : m_hash{hash} {}
+
+protected:
+    void BlockChecked(const std::shared_ptr<const CBlock>& block, const BlockValidationState& state) override
+    {
+        if (block->GetHash() != m_hash) return;
+        // ProcessNewBlock emits BlockChecked synchronously while holding cs_main,
+        // so SubmitBlock can read these fields after ProcessNewBlock returns
+        // without extra synchronization.
+        m_found = true;
+        m_state = state;
+    }
+};
+} // namespace
+
+bool BlockTemplateManager::SubmitBlock(const std::shared_ptr<const CBlock>& block, std::string& reason, std::string& debug)
+{
+    reason.clear();
+    debug.clear();
+
+    // This follows the submitblock RPC's validation-state capture pattern, but
+    // is intentionally kept separate from the RPC implementation. The RPC entry
+    // point decodes hex, formats BIP22/JSONRPC results, and calls
+    // UpdateUncommittedBlockStructures() for legacy witness handling. IPC
+    // callers submit already-formed blocks and need bool + reason/debug
+    // results.
+    auto sc = std::make_shared<SubmitBlockStateCatcher>(block->GetHash());
+    CHECK_NONFATAL(m_chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
+    bool new_block;
+    bool accepted = m_chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
+    // No queue drain is needed. The BlockChecked notification used above is
+    // emitted synchronously by ProcessNewBlock, unlike most validation signals.
+    CHECK_NONFATAL(m_chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);
+
+    if (!new_block && accepted) {
+        reason = "duplicate";
+    } else if (!accepted && (!sc->m_found || sc->m_state.IsValid())) {
+        // ProcessNewBlock can fail without a validation result, for example
+        // from an activation or system error. It can also fail after a valid
+        // BlockChecked result. In these cases the validation result is
+        // inconclusive.
+        reason = "inconclusive";
+    } else if (!sc->m_found) {
+        // The block was accepted but not connected, for example if it does not
+        // have more work than the current tip.
+        reason = "inconclusive";
+    } else if (!sc->m_state.IsValid()) {
+        reason = sc->m_state.GetRejectReason();
+        debug = sc->m_state.GetDebugMessage();
+    }
+    const bool result{accepted && new_block && reason.empty()};
+    CHECK_NONFATAL(result == reason.empty());
+    return result;
 }
 
 } // namespace node

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -41,7 +41,11 @@ BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManage
 
 std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const BlockCreateOptions& options)
 {
-    return BlockAssembler{m_chainman.ActiveChainstate(), &m_mempool, options}.CreateNewBlock();
+    return BlockAssembler{
+        m_chainman.ActiveChainstate(),
+        &m_mempool,
+        MergeMiningOptions(options, m_block_create_args),
+    }.CreateNewBlock();
 }
 
 namespace {

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -5,12 +5,16 @@
 #include <node/block_template_manager.h>
 
 #include <node/miner.h>
+#include <node/mining_args.h>
 #include <validation.h>
+
+#include <utility>
 
 namespace node {
 
-BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManager& chainman)
-    : m_mempool(mempool), m_chainman(chainman)
+BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManager& chainman,
+                                           BlockCreateOptions block_create_args)
+    : m_mempool(mempool), m_chainman(chainman), m_block_create_args(std::move(block_create_args))
 {
 }
 

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -1,0 +1,34 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H
+#define BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H
+
+#include <node/mining_types.h>
+
+#include <memory>
+
+class ChainstateManager;
+class CTxMemPool;
+
+namespace node {
+struct CBlockTemplate;
+
+/** Creates block templates. */
+class BlockTemplateManager
+{
+private:
+    CTxMemPool& m_mempool;
+    ChainstateManager& m_chainman;
+
+public:
+    explicit BlockTemplateManager(CTxMemPool& mempool,
+                                  ChainstateManager& chainman);
+
+    /** Create a fresh block template. */
+    std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);
+};
+} // namespace node
+
+#endif // BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -63,6 +63,11 @@ public:
      *  interrupt is set (not when the timeout is reached). */
     std::optional<interfaces::BlockRef> WaitTipChanged(const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt);
 
+    /** Convenience overload for in-process callers (e.g. RPC) that have no
+     *  interrupt handle. Takes the timeout by value so the caller's variable is
+     *  left unchanged; the wait still ends on chain shutdown. */
+    std::optional<interfaces::BlockRef> WaitTipChanged(const uint256& current_tip, MillisecondsDouble timeout = MillisecondsDouble::max());
+
     /**
      * Wait while the best known header extends the current chain tip AND at
      * least one block is being added to the tip every 3 seconds. If the tip is

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -11,6 +11,7 @@
 #include <util/hasher.h>
 #include <util/time.h>
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
@@ -69,6 +70,16 @@ public:
 
     /** Check internal tracking invariants. */
     void SanityCheck() const
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /**
+     * Estimate non-mempool memory footprint of transaction data referenced by block
+     * templates.
+     *
+     * Result is not guaranteed to be an accurate snapshot, because it does not
+     * lock mempool.cs while iterating over transaction references.
+     */
+    size_t GetTemplateMemoryUsage() const
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Submit a block via ProcessNewBlock and capture validation state.

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -6,30 +6,41 @@
 #define BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H
 
 #include <node/mining_types.h>
+#include <util/time.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 
 class CBlock;
 class ChainstateManager;
 class CTxMemPool;
+class uint256;
+
+namespace interfaces {
+struct BlockRef;
+} // namespace interfaces
 
 namespace node {
+class KernelNotifications;
 struct CBlockTemplate;
 
-/** Creates block templates, submits solved blocks.
- *  Owns the init-time block creation args.
+/**
+ * Creates block templates, submits solved blocks, and provides tip-waiting
+ * helpers for mining code. Owns the init-time block creation args.
  */
 class BlockTemplateManager
 {
 private:
     CTxMemPool& m_mempool;
     ChainstateManager& m_chainman;
+    KernelNotifications& m_notifications;
     const BlockCreateOptions m_block_create_args;
 
 public:
     explicit BlockTemplateManager(CTxMemPool& mempool,
                                   ChainstateManager& chainman,
+                                  KernelNotifications& notifications,
                                   BlockCreateOptions block_create_args = {});
 
     /** @return the block creation args set during node init. */
@@ -41,6 +52,49 @@ public:
     /** Submit a block via ProcessNewBlock and capture validation state.
      *  @return whether the block was accepted as a new valid block. */
     bool SubmitBlock(const std::shared_ptr<const CBlock>& block, std::string& reason, std::string& debug);
+
+    /** Locks cs_main.
+     *  @return the active chain tip, or nullopt if none exists. */
+    std::optional<interfaces::BlockRef> GetTip();
+
+    /** Wait for the tip to differ from @p current_tip or timeout.
+     *  Waits indefinitely during startup for a non-null tip.
+     *  @return the current tip, or nullopt if the node is shutting down or
+     *  interrupt is set (not when the timeout is reached). */
+    std::optional<interfaces::BlockRef> WaitTipChanged(const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt);
+
+    /**
+     * Wait while the best known header extends the current chain tip AND at
+     * least one block is being added to the tip every 3 seconds. If the tip is
+     * sufficiently far behind, allow up to 20 seconds for the next tip update.
+     *
+     * It's not safe to keep waiting, because a malicious miner could announce
+     * a header and delay revealing the block, causing all other miners using
+     * this software to stall. At the same time, we need to balance between the
+     * default waiting time being brief, but not ending the cooldown prematurely
+     * when a random block is slow to download (or process).
+     *
+     * The cooldown only applies to createNewBlock(), which is typically called
+     * once per connected client. Subsequent templates are provided by
+     * waitNext().
+     *
+     * @param last_tip tip at the start of the cooldown window.
+     * @param interrupt_mining set to true to interrupt the cooldown.
+     *
+     * @returns false if interrupted.
+     */
+    bool CooldownIfHeadersAhead(const interfaces::BlockRef& last_tip, bool& interrupt_mining);
+
+    /** Interrupt a blocking wait. */
+    void InterruptWait(bool& interrupt_wait);
+
+    /** Return a new block template when fees rise to a certain threshold or
+     *  after a new tip; return nullptr if timeout is reached. */
+    std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(
+        const std::unique_ptr<CBlockTemplate>& block_template,
+        const BlockWaitOptions& wait_options,
+        const BlockCreateOptions& create_options,
+        bool& interrupt_wait);
 };
 } // namespace node
 

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -8,14 +8,16 @@
 #include <node/mining_types.h>
 
 #include <memory>
+#include <string>
 
+class CBlock;
 class ChainstateManager;
 class CTxMemPool;
 
 namespace node {
 struct CBlockTemplate;
 
-/** Creates block templates.
+/** Creates block templates, submits solved blocks.
  *  Owns the init-time block creation args.
  */
 class BlockTemplateManager
@@ -35,6 +37,10 @@ public:
 
     /** Create a fresh block template. */
     std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);
+
+    /** Submit a block via ProcessNewBlock and capture validation state.
+     *  @return whether the block was accepted as a new valid block. */
+    bool SubmitBlock(const std::shared_ptr<const CBlock>& block, std::string& reason, std::string& debug);
 };
 } // namespace node
 

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -15,16 +15,23 @@ class CTxMemPool;
 namespace node {
 struct CBlockTemplate;
 
-/** Creates block templates. */
+/** Creates block templates.
+ *  Owns the init-time block creation args.
+ */
 class BlockTemplateManager
 {
 private:
     CTxMemPool& m_mempool;
     ChainstateManager& m_chainman;
+    const BlockCreateOptions m_block_create_args;
 
 public:
     explicit BlockTemplateManager(CTxMemPool& mempool,
-                                  ChainstateManager& chainman);
+                                  ChainstateManager& chainman,
+                                  BlockCreateOptions block_create_args = {});
+
+    /** @return the block creation args set during node init. */
+    const BlockCreateOptions& BlockCreateArgs() const { return m_block_create_args; }
 
     /** Create a fresh block template. */
     std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -6,11 +6,16 @@
 #define BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H
 
 #include <node/mining_types.h>
+#include <primitives/transaction.h>
+#include <sync.h>
+#include <util/hasher.h>
 #include <util/time.h>
 
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 class CBlock;
 class ChainstateManager;
@@ -36,6 +41,11 @@ private:
     ChainstateManager& m_chainman;
     KernelNotifications& m_notifications;
     const BlockCreateOptions m_block_create_args;
+    mutable Mutex m_mutex;
+    using TxTemplateMap = std::unordered_map<CTransactionRef, size_t, CTransactionRefSaltedHash, CTransactionRefComp>;
+    /** Track how many templates (which we hold on to on behalf of connected
+     *  IPC clients) are referencing each transaction, keyed by wtxid. */
+    TxTemplateMap m_template_tx_refs GUARDED_BY(m_mutex);
 
 public:
     explicit BlockTemplateManager(CTxMemPool& mempool,
@@ -48,6 +58,18 @@ public:
 
     /** Create a fresh block template, applying init-time defaults to any unset options. */
     std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);
+
+    /** Track transaction references held by a live block template. */
+    void TrackTemplateTransactions(const std::vector<CTransactionRef>& txs)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Stop tracking transaction references held by a live block template. */
+    void StopTrackingTemplateTransactions(const std::vector<CTransactionRef>& txs)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Check internal tracking invariants. */
+    void SanityCheck() const
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Submit a block via ProcessNewBlock and capture validation state.
      *  @return whether the block was accepted as a new valid block. */

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -46,7 +46,7 @@ public:
     /** @return the block creation args set during node init. */
     const BlockCreateOptions& BlockCreateArgs() const { return m_block_create_args; }
 
-    /** Create a fresh block template. */
+    /** Create a fresh block template, applying init-time defaults to any unset options. */
     std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);
 
     /** Submit a block via ProcessNewBlock and capture validation state.

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -13,6 +13,7 @@
 #include <net.h>
 #include <net_processing.h>
 #include <netgroup.h>
+#include <node/block_template_manager.h>
 #include <node/kernel_notifications.h>
 #include <node/warnings.h>
 #include <policy/fees/block_policy_estimator.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -7,7 +7,6 @@
 #include <addrman.h>
 #include <banman.h>
 #include <interfaces/chain.h>
-#include <interfaces/mining.h>
 #include <kernel/context.h>
 #include <key.h>
 #include <net.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_NODE_CONTEXT_H
 #define BITCOIN_NODE_CONTEXT_H
 
-#include <node/mining_types.h>
-
 #include <atomic>
 #include <cstdlib>
 #include <functional>
@@ -84,11 +82,6 @@ struct NodeContext {
     //! Reference to chain client that should used to load or create wallets
     //! opened by the gui.
     std::unique_ptr<interfaces::Mining> mining;
-    //! Mining options used to create block templates. This value member is an
-    //! exception to the dependency guidance above because BlockCreateOptions is
-    //! a minimal dependency. It could be moved to the BlockTemplateCache
-    //! proposed in bitcoin/bitcoin#33421.
-    BlockCreateOptions mining_args;
     interfaces::WalletLoader* wallet_loader{nullptr};
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -43,6 +43,7 @@ class SignalInterrupt;
 }
 
 namespace node {
+class BlockTemplateManager;
 class KernelNotifications;
 class Warnings;
 
@@ -93,6 +94,8 @@ struct NodeContext {
     std::function<void()> rpc_interruption_point = [] {};
     //! Issues blocking calls about sync status, errors and warnings
     std::unique_ptr<KernelNotifications> notifications;
+    //! Must be destroyed before its dependencies (holds references to them).
+    std::unique_ptr<BlockTemplateManager> block_template_manager;
     //! Issues calls about blocks and transactions
     std::unique_ptr<ValidationSignals> validation_signals;
     std::atomic<int> exit_status{EXIT_SUCCESS};

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -29,7 +29,6 @@ class TorController;
 namespace interfaces {
 class Chain;
 class ChainClient;
-class Mining;
 class Init;
 class WalletLoader;
 } // namespace interfaces
@@ -79,9 +78,6 @@ struct NodeContext {
     std::unique_ptr<interfaces::Chain> chain;
     //! List of all chain clients (wallet processes or other client) connected to node.
     std::vector<std::unique_ptr<interfaces::ChainClient>> chain_clients;
-    //! Reference to chain client that should used to load or create wallets
-    //! opened by the gui.
-    std::unique_ptr<interfaces::Mining> mining;
     interfaces::WalletLoader* wallet_loader{nullptr};
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -33,6 +33,7 @@
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/coin.h>
 #include <node/context.h>
@@ -998,7 +999,8 @@ public:
             // Also wait during the final catch-up moments after IBD.
             if (!CooldownIfHeadersAhead(chainman(), notifications(), *maybe_tip, m_interrupt_mining)) return {};
         }
-        const BlockCreateOptions create_options{MergeMiningOptions(options, m_node.mining_args)};
+        auto& block_template_manager = *Assert(m_node.block_template_manager);
+        const BlockCreateOptions create_options{MergeMiningOptions(options, block_template_manager.BlockCreateArgs())};
         return std::make_unique<BlockTemplateImpl>(create_options,
                                                    BlockAssembler{
                                                        chainman().ActiveChainstate(),

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -922,7 +922,7 @@ public:
     {
         if (!coinbase) return false;
         AddMerkleRootAndCoinbase(m_block_template->block, std::move(coinbase), version, timestamp, nonce);
-        return SubmitBlock(chainman(), std::make_shared<const CBlock>(m_block_template->block), reason, debug);
+        return block_template_manager().SubmitBlock(std::make_shared<const CBlock>(m_block_template->block), reason, debug);
     }
 
     std::unique_ptr<BlockTemplate> waitNext(BlockWaitOptions options) override
@@ -950,6 +950,7 @@ public:
     bool m_interrupt_wait{false};
     ChainstateManager& chainman() { return *Assert(m_node.chainman); }
     KernelNotifications& notifications() { return *Assert(m_node.notifications); }
+    node::BlockTemplateManager& block_template_manager() { return *Assert(m_node.block_template_manager); }
     const NodeContext& m_node;
 };
 
@@ -1026,7 +1027,7 @@ public:
 
     bool submitBlock(const CBlock& block_in, std::string& reason, std::string& debug) override
     {
-        return SubmitBlock(chainman(), std::make_shared<const CBlock>(block_in), reason, debug);
+        return block_template_manager().SubmitBlock(std::make_shared<const CBlock>(block_in), reason, debug);
     }
 
     std::vector<CTransactionRef> getTransactionsByTxID(const std::vector<Txid>& txids) override
@@ -1058,6 +1059,7 @@ public:
     const NodeContext* context() override { return &m_node; }
     ChainstateManager& chainman() { return *Assert(m_node.chainman); }
     KernelNotifications& notifications() { return *Assert(m_node.notifications); }
+    node::BlockTemplateManager& block_template_manager() { return *Assert(m_node.block_template_manager); }
     // Treat as if guarded by notifications().m_tip_block_mutex
     bool m_interrupt_mining{false};
     const NodeContext& m_node;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -90,6 +90,7 @@ using interfaces::Chain;
 using interfaces::FoundBlock;
 using interfaces::Handler;
 using interfaces::MakeSignalHandler;
+using interfaces::MemoryLoad;
 using interfaces::Mining;
 using interfaces::Node;
 using interfaces::Rpc;
@@ -1047,6 +1048,11 @@ public:
             results.emplace_back(m_node.mempool->get(wtxid));
         }
         return results;
+    }
+
+    MemoryLoad getMemoryLoad() override
+    {
+        return {.usage = block_template_manager().GetTemplateMemoryUsage()};
     }
 
     const NodeContext* context() override { return &m_node; }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -41,7 +41,6 @@
 #include <node/kernel_notifications.h>
 #include <node/miner.h>
 #include <node/mini_miner.h>
-#include <node/mining_args.h>
 #include <node/mining_types.h>
 #include <node/transaction.h>
 #include <node/types.h>
@@ -96,7 +95,6 @@ using interfaces::Node;
 using interfaces::Rpc;
 using interfaces::WalletLoader;
 using kernel::ChainstateRole;
-using node::BlockAssembler;
 using node::BlockCreateOptions;
 using node::BlockWaitOptions;
 using node::CoinbaseTx;
@@ -993,15 +991,8 @@ public:
             // Also wait during the final catch-up moments after IBD.
             if (!block_template_manager().CooldownIfHeadersAhead(*maybe_tip, m_interrupt_mining)) return {};
         }
-        auto& block_template_manager = *Assert(m_node.block_template_manager);
-        const BlockCreateOptions create_options{MergeMiningOptions(options, block_template_manager.BlockCreateArgs())};
-        return std::make_unique<BlockTemplateImpl>(create_options,
-                                                   BlockAssembler{
-                                                       chainman().ActiveChainstate(),
-                                                       m_node.mempool.get(),
-                                                       create_options,
-                                                   }.CreateNewBlock(),
-                                                   m_node);
+        auto new_template = block_template_manager().CreateNewTemplate(options);
+        return std::make_unique<BlockTemplateImpl>(options, std::move(new_template), m_node);
     }
 
     void interrupt() override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -927,20 +927,15 @@ public:
 
     std::unique_ptr<BlockTemplate> waitNext(BlockWaitOptions options) override
     {
-        auto new_template = WaitAndCreateNewBlock(chainman(),
-                                                  notifications(),
-                                                  m_node.mempool.get(),
-                                                  m_block_template,
-                                                  /*wait_options=*/options,
-                                                  /*create_options=*/m_create_options,
-                                                  /*interrupt_wait=*/m_interrupt_wait);
+        auto new_template = block_template_manager().WaitAndCreateNewBlock(
+            m_block_template, options, m_create_options, m_interrupt_wait);
         if (new_template) return std::make_unique<BlockTemplateImpl>(m_create_options, std::move(new_template), m_node);
         return nullptr;
     }
 
     void interruptWait() override
     {
-        InterruptWait(notifications(), m_interrupt_wait);
+        block_template_manager().InterruptWait(m_interrupt_wait);
     }
 
     const BlockCreateOptions m_create_options;
@@ -948,8 +943,6 @@ public:
     const std::unique_ptr<CBlockTemplate> m_block_template;
 
     bool m_interrupt_wait{false};
-    ChainstateManager& chainman() { return *Assert(m_node.chainman); }
-    KernelNotifications& notifications() { return *Assert(m_node.notifications); }
     node::BlockTemplateManager& block_template_manager() { return *Assert(m_node.block_template_manager); }
     const NodeContext& m_node;
 };
@@ -971,12 +964,12 @@ public:
 
     std::optional<BlockRef> getTip() override
     {
-        return GetTip(chainman());
+        return block_template_manager().GetTip();
     }
 
     std::optional<BlockRef> waitTipChanged(uint256 current_tip, MillisecondsDouble timeout) override
     {
-        return WaitTipChanged(chainman(), notifications(), current_tip, timeout, m_interrupt_mining);
+        return block_template_manager().WaitTipChanged(current_tip, timeout, m_interrupt_mining);
     }
 
     std::unique_ptr<BlockTemplate> createNewBlock(const BlockCreateOptions& options, bool cooldown) override
@@ -998,7 +991,7 @@ public:
             }
 
             // Also wait during the final catch-up moments after IBD.
-            if (!CooldownIfHeadersAhead(chainman(), notifications(), *maybe_tip, m_interrupt_mining)) return {};
+            if (!block_template_manager().CooldownIfHeadersAhead(*maybe_tip, m_interrupt_mining)) return {};
         }
         auto& block_template_manager = *Assert(m_node.block_template_manager);
         const BlockCreateOptions create_options{MergeMiningOptions(options, block_template_manager.BlockCreateArgs())};
@@ -1013,7 +1006,7 @@ public:
 
     void interrupt() override
     {
-        InterruptWait(notifications(), m_interrupt_mining);
+        block_template_manager().InterruptWait(m_interrupt_mining);
     }
 
     bool checkBlock(const CBlock& block, const node::BlockCheckOptions& options, std::string& reason, std::string& debug) override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -884,6 +884,15 @@ public:
                                                           m_node(node)
     {
         assert(m_block_template);
+        // Track transaction references here because their memory footprint
+        // is tied to this template object's lifetime.
+        block_template_manager().TrackTemplateTransactions(m_block_template->block.vtx);
+    }
+
+    ~BlockTemplateImpl() override
+    {
+        // Transaction references are held until this template object is released.
+        block_template_manager().StopTrackingTemplateTransactions(m_block_template->block.vtx);
     }
 
     CBlockHeader getBlockHeader() override

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -362,69 +362,6 @@ void AddMerkleRootAndCoinbase(CBlock& block, CTransactionRef coinbase, uint32_t 
     block.fChecked = false;
 }
 
-namespace {
-class SubmitBlockStateCatcher final : public CValidationInterface
-{
-public:
-    uint256 m_hash;
-    bool m_found{false};
-    BlockValidationState m_state;
-
-    explicit SubmitBlockStateCatcher(const uint256& hash) : m_hash{hash} {}
-
-protected:
-    void BlockChecked(const std::shared_ptr<const CBlock>& block, const BlockValidationState& state) override
-    {
-        if (block->GetHash() != m_hash) return;
-        // ProcessNewBlock emits BlockChecked synchronously while holding cs_main,
-        // so SubmitBlock can read these fields after ProcessNewBlock returns
-        // without extra synchronization.
-        m_found = true;
-        m_state = state;
-    }
-};
-} // namespace
-
-bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock>& block, std::string& reason, std::string& debug)
-{
-    reason.clear();
-    debug.clear();
-
-    // This follows the submitblock RPC's validation-state capture pattern, but
-    // is intentionally kept separate from the RPC implementation. The RPC entry
-    // point decodes hex, formats BIP22/JSONRPC results, and calls
-    // UpdateUncommittedBlockStructures() for legacy witness handling. IPC
-    // callers submit already-formed blocks and need bool + reason/debug
-    // results.
-    auto sc = std::make_shared<SubmitBlockStateCatcher>(block->GetHash());
-    CHECK_NONFATAL(chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
-    bool new_block;
-    bool accepted = chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
-    // No queue drain is needed. The BlockChecked notification used above is
-    // emitted synchronously by ProcessNewBlock, unlike most validation signals.
-    CHECK_NONFATAL(chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);
-
-    if (!new_block && accepted) {
-        reason = "duplicate";
-    } else if (!accepted && (!sc->m_found || sc->m_state.IsValid())) {
-        // ProcessNewBlock can fail without a validation result, for example
-        // from an activation or system error. It can also fail after a valid
-        // BlockChecked result. In these cases the validation result is
-        // inconclusive.
-        reason = "inconclusive";
-    } else if (!sc->m_found) {
-        // The block was accepted but not connected, for example if it does not
-        // have more work than the current tip.
-        reason = "inconclusive";
-    } else if (!sc->m_state.IsValid()) {
-        reason = sc->m_state.GetRejectReason();
-        debug = sc->m_state.GetDebugMessage();
-    }
-    const bool result{accepted && new_block && reason.empty()};
-    CHECK_NONFATAL(result == reason.empty());
-    return result;
-}
-
 void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wait)
 {
     LOCK(kernel_notifications.m_tip_block_mutex);

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -14,9 +14,7 @@
 #include <consensus/params.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
-#include <interfaces/types.h>
 #include <node/blockstorage.h>
-#include <node/kernel_notifications.h>
 #include <node/mining_args.h>
 #include <node/mining_types.h>
 #include <policy/feerate.h>
@@ -34,19 +32,14 @@
 #include <util/feefrac.h>
 #include <util/log.h>
 #include <util/result.h>
-#include <util/signalinterrupt.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
-#include <validationinterface.h>
 #include <versionbits.h>
 
 #include <algorithm>
-#include <compare>
-#include <condition_variable>
 #include <cstddef>
 #include <functional>
-#include <numeric>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -360,179 +353,6 @@ void AddMerkleRootAndCoinbase(CBlock& block, CTransactionRef coinbase, uint32_t 
     block.m_checked_witness_commitment = false;
     block.m_checked_merkle_root = false;
     block.fChecked = false;
-}
-
-void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wait)
-{
-    LOCK(kernel_notifications.m_tip_block_mutex);
-    interrupt_wait = true;
-    kernel_notifications.m_tip_block_cv.notify_all();
-}
-
-std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainman,
-                                                      KernelNotifications& kernel_notifications,
-                                                      CTxMemPool* mempool,
-                                                      const std::unique_ptr<CBlockTemplate>& block_template,
-                                                      const BlockWaitOptions& wait_options,
-                                                      const BlockCreateOptions& create_options,
-                                                      bool& interrupt_wait)
-{
-    // Delay calculating the current template fees, just in case a new block
-    // comes in before the next tick.
-    CAmount current_fees = -1;
-
-    // Alternate waiting for a new tip and checking if fees have risen.
-    // The latter check is expensive so we only run it once per second.
-    auto now{NodeClock::now()};
-    const auto deadline = now + wait_options.timeout;
-    const MillisecondsDouble tick{1000};
-    const bool allow_min_difficulty{chainman.GetParams().GetConsensus().fPowAllowMinDifficultyBlocks};
-
-    do {
-        bool tip_changed{false};
-        {
-            WAIT_LOCK(kernel_notifications.m_tip_block_mutex, lock);
-            // Note that wait_until() checks the predicate before waiting
-            kernel_notifications.m_tip_block_cv.wait_until(lock, std::min(now + tick, deadline), [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
-                AssertLockHeld(kernel_notifications.m_tip_block_mutex);
-                const auto tip_block{kernel_notifications.TipBlock()};
-                // We assume tip_block is set, because this is an instance
-                // method on BlockTemplate and no template could have been
-                // generated before a tip exists.
-                tip_changed = Assume(tip_block) && tip_block != block_template->block.hashPrevBlock;
-                return tip_changed || chainman.m_interrupt || interrupt_wait;
-            });
-            if (interrupt_wait) {
-                interrupt_wait = false;
-                return nullptr;
-            }
-        }
-
-        if (chainman.m_interrupt) return nullptr;
-        // At this point the tip changed, a full tick went by or we reached
-        // the deadline.
-
-        // Must release m_tip_block_mutex before locking cs_main, to avoid deadlocks.
-        LOCK(::cs_main);
-
-        // On test networks return a minimum difficulty block after 20 minutes
-        if (!tip_changed && allow_min_difficulty) {
-            const NodeClock::time_point tip_time{std::chrono::seconds{chainman.ActiveChain().Tip()->GetBlockTime()}};
-            if (now > tip_time + 20min) {
-                tip_changed = true;
-            }
-        }
-
-        /**
-         * We determine if fees increased compared to the previous template by generating
-         * a fresh template. There may be more efficient ways to determine how much
-         * (approximate) fees for the next block increased, perhaps more so after
-         * Cluster Mempool.
-         *
-         * We'll also create a new template if the tip changed during this iteration.
-         */
-        if (wait_options.fee_threshold < MAX_MONEY || tip_changed) {
-            auto new_tmpl{BlockAssembler{
-                chainman.ActiveChainstate(),
-                mempool,
-                create_options
-                }.CreateNewBlock()};
-
-            // If the tip changed, return the new template regardless of its fees.
-            if (tip_changed) return new_tmpl;
-
-            // Calculate the original template total fees if we haven't already
-            if (current_fees == -1) {
-                current_fees = std::accumulate(block_template->vTxFees.begin(), block_template->vTxFees.end(), CAmount{0});
-            }
-
-            // Check if fees increased enough to return the new template
-            const CAmount new_fees = std::accumulate(new_tmpl->vTxFees.begin(), new_tmpl->vTxFees.end(), CAmount{0});
-            Assume(wait_options.fee_threshold != MAX_MONEY);
-            if (new_fees >= current_fees + wait_options.fee_threshold) return new_tmpl;
-        }
-
-        now = NodeClock::now();
-    } while (now < deadline);
-
-    return nullptr;
-}
-
-std::optional<BlockRef> GetTip(ChainstateManager& chainman)
-{
-    LOCK(::cs_main);
-    CBlockIndex* tip{chainman.ActiveChain().Tip()};
-    if (!tip) return {};
-    return BlockRef{tip->GetBlockHash(), tip->nHeight};
-}
-
-bool CooldownIfHeadersAhead(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const BlockRef& last_tip, bool& interrupt_mining)
-{
-    uint256 last_tip_hash{last_tip.hash};
-
-    while (const std::optional<int> remaining = chainman.BlocksAheadOfTip()) {
-        const int cooldown_seconds = std::clamp(*remaining, 3, 20);
-        const auto cooldown_deadline{MockableSteadyClock::now() + std::chrono::seconds{cooldown_seconds}};
-
-        {
-            WAIT_LOCK(kernel_notifications.m_tip_block_mutex, lock);
-            kernel_notifications.m_tip_block_cv.wait_until(lock, cooldown_deadline, [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
-                const auto tip_block = kernel_notifications.TipBlock();
-                return chainman.m_interrupt || interrupt_mining || (tip_block && *tip_block != last_tip_hash);
-            });
-            if (chainman.m_interrupt || interrupt_mining) {
-                interrupt_mining = false;
-                return false;
-            }
-
-            // If the tip changed during the wait, extend the deadline
-            const auto tip_block = kernel_notifications.TipBlock();
-            if (tip_block && *tip_block != last_tip_hash) {
-                last_tip_hash = *tip_block;
-                continue;
-            }
-        }
-
-        // No tip change and the cooldown window has expired.
-        if (MockableSteadyClock::now() >= cooldown_deadline) break;
-    }
-
-    return true;
-}
-
-std::optional<BlockRef> WaitTipChanged(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt)
-{
-    Assume(timeout >= 0ms); // No internal callers should use a negative timeout
-    if (timeout < 0ms) timeout = 0ms;
-    if (timeout > std::chrono::years{100}) timeout = std::chrono::years{100}; // Upper bound to avoid UB in std::chrono
-    auto deadline{std::chrono::steady_clock::now() + timeout};
-    {
-        WAIT_LOCK(kernel_notifications.m_tip_block_mutex, lock);
-        // For callers convenience, wait longer than the provided timeout
-        // during startup for the tip to be non-null. That way this function
-        // always returns valid tip information when possible and only
-        // returns null when shutting down, not when timing out.
-        kernel_notifications.m_tip_block_cv.wait(lock, [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
-            return kernel_notifications.TipBlock() || chainman.m_interrupt || interrupt;
-        });
-        if (chainman.m_interrupt || interrupt) {
-            interrupt = false;
-            return {};
-        }
-        // At this point TipBlock is set, so continue to wait until it is
-        // different then `current_tip` provided by caller.
-        kernel_notifications.m_tip_block_cv.wait_until(lock, deadline, [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
-            return Assume(kernel_notifications.TipBlock()) != current_tip || chainman.m_interrupt || interrupt;
-        });
-        if (chainman.m_interrupt || interrupt) {
-            interrupt = false;
-            return {};
-        }
-    }
-
-    // Must release m_tip_block_mutex before getTip() locks cs_main, to
-    // avoid deadlocks.
-    return GetTip(chainman);
 }
 
 } // namespace node

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -13,12 +13,10 @@
 #include <threadsafety.h>
 #include <txmempool.h>
 #include <util/feefrac.h>
-#include <util/time.h>
 
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <string>
 #include <vector>
 
 class CBlockIndex;
@@ -29,15 +27,7 @@ class ChainstateManager;
 namespace Consensus {
 struct Params;
 } // namespace Consensus
-class uint256;
-namespace interfaces {
-struct BlockRef;
-} // namespace interfaces
-
-using interfaces::BlockRef;
-
 namespace node {
-class KernelNotifications;
 
 struct CBlockTemplate
 {
@@ -129,50 +119,6 @@ void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
 /* Compute the block's merkle root, insert or replace the coinbase transaction and the merkle root into the block */
 void AddMerkleRootAndCoinbase(CBlock& block, CTransactionRef coinbase, uint32_t version, uint32_t timestamp, uint32_t nonce);
-
-/* Interrupt a blocking call. */
-void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wait);
-/**
- * Return a new block template when fees rise to a certain threshold or after a
- * new tip; return nullopt if timeout is reached.
- */
-std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainman,
-                                                      KernelNotifications& kernel_notifications,
-                                                      CTxMemPool* mempool,
-                                                      const std::unique_ptr<CBlockTemplate>& block_template,
-                                                      const BlockWaitOptions& wait_options,
-                                                      const BlockCreateOptions& create_options,
-                                                      bool& interrupt_wait);
-
-/* Locks cs_main and returns the block hash and block height of the active chain if it exists; otherwise, returns nullopt.*/
-std::optional<BlockRef> GetTip(ChainstateManager& chainman);
-
-/* Waits for the connected tip to change until timeout has elapsed. During node initialization, this will wait until the tip is connected (regardless of `timeout`).
- * Returns the current tip, or nullopt if the node is shutting down or interrupt()
- * is called.
- */
-std::optional<BlockRef> WaitTipChanged(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt);
-
-/**
- * Wait while the best known header extends the current chain tip AND at least
- * one block is being added to the tip every 3 seconds. If the tip is
- * sufficiently far behind, allow up to 20 seconds for the next tip update.
- *
- * It’s not safe to keep waiting, because a malicious miner could announce a
- * header and delay revealing the block, causing all other miners using this
- * software to stall. At the same time, we need to balance between the default
- * waiting time being brief, but not ending the cooldown prematurely when a
- * random block is slow to download (or process).
- *
- * The cooldown only applies to createNewBlock(), which is typically called
- * once per connected client. Subsequent templates are provided by waitNext().
- *
- * @param last_tip tip at the start of the cooldown window.
- * @param interrupt_mining set to true to interrupt the cooldown.
- *
- * @returns false if interrupted.
- */
-bool CooldownIfHeadersAhead(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const BlockRef& last_tip, bool& interrupt_mining);
 } // namespace node
 
 #endif // BITCOIN_NODE_MINER_H

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -130,10 +130,6 @@ void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 /* Compute the block's merkle root, insert or replace the coinbase transaction and the merkle root into the block */
 void AddMerkleRootAndCoinbase(CBlock& block, CTransactionRef coinbase, uint32_t version, uint32_t timestamp, uint32_t nonce);
 
-//! Submit a block and capture the validation state via the BlockChecked callback.
-//! Returns whether the block was accepted as a new valid block.
-bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock>& block, std::string& reason, std::string& debug);
-
 /* Interrupt a blocking call. */
 void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wait);
 /**

--- a/src/private_broadcast.h
+++ b/src/private_broadcast.h
@@ -9,6 +9,7 @@
 #include <primitives/transaction.h>
 #include <primitives/transaction_identifier.h>
 #include <sync.h>
+#include <util/hasher.h>
 #include <util/time.h>
 
 #include <optional>
@@ -188,13 +189,6 @@ private:
         size_t operator()(const CTransactionRef& tx) const
         {
             return static_cast<size_t>(tx->GetWitnessHash().ToUint256().GetUint64(0));
-        }
-    };
-
-    struct CTransactionRefComp {
-        bool operator()(const CTransactionRef& a, const CTransactionRef& b) const
-        {
-            return a->GetWitnessHash() == b->GetWitnessHash(); // If wtxid equals, then txid also equals.
         }
     };
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -22,11 +22,12 @@
 #include <hash.h>
 #include <index/blockfilterindex.h>
 #include <index/coinstatsindex.h>
-#include <interfaces/mining.h>
+#include <interfaces/types.h>
 #include <kernel/coinstats.h>
 #include <logging/timer.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/transaction.h>
@@ -70,7 +71,6 @@ using kernel::CCoinsStats;
 using kernel::CoinStatsHashType;
 
 using interfaces::BlockRef;
-using interfaces::Mining;
 using node::BlockManager;
 using node::NodeContext;
 using node::SnapshotMetadata;
@@ -326,15 +326,15 @@ static RPCMethod waitfornewblock()
     if (timeout < 0) throw JSONRPCError(RPC_MISC_ERROR, "Negative timeout");
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
-    // If the caller provided a current_tip value, pass it to waitTipChanged().
+    // If the caller provided a current_tip value, pass it to WaitTipChanged().
     //
-    // If the caller did not provide a current tip hash, call getTip() to get
+    // If the caller did not provide a current tip hash, call GetTip() to get
     // one and wait for the tip to be different from this value. This mode is
     // less reliable because if the tip changed between waitfornewblock calls,
     // it will need to change a second time before this call returns.
-    BlockRef current_block{CHECK_NONFATAL(miner.getTip()).value()};
+    BlockRef current_block{CHECK_NONFATAL(block_template_manager.GetTip()).value()};
 
     uint256 tip_hash{request.params[1].isNull()
         ? current_block.hash
@@ -342,8 +342,8 @@ static RPCMethod waitfornewblock()
 
     // If the user provided an invalid current_tip then this call immediately
     // returns the current tip.
-    std::optional<BlockRef> block = timeout ? miner.waitTipChanged(tip_hash, std::chrono::milliseconds(timeout)) :
-                                              miner.waitTipChanged(tip_hash);
+    std::optional<BlockRef> block = timeout ? block_template_manager.WaitTipChanged(tip_hash, std::chrono::milliseconds(timeout)) :
+                                              block_template_manager.WaitTipChanged(tip_hash);
 
     // Return current block upon shutdown
     if (block) current_block = *block;
@@ -388,10 +388,10 @@ static RPCMethod waitforblock()
     if (timeout < 0) throw JSONRPCError(RPC_MISC_ERROR, "Negative timeout");
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
     // Abort if RPC came out of warmup too early
-    BlockRef current_block{CHECK_NONFATAL(miner.getTip()).value()};
+    BlockRef current_block{CHECK_NONFATAL(block_template_manager.GetTip()).value()};
 
     const auto deadline{std::chrono::steady_clock::now() + 1ms * timeout};
     while (current_block.hash != hash) {
@@ -400,9 +400,9 @@ static RPCMethod waitforblock()
             auto now{std::chrono::steady_clock::now()};
             if (now >= deadline) break;
             const MillisecondsDouble remaining{deadline - now};
-            block = miner.waitTipChanged(current_block.hash, remaining);
+            block = block_template_manager.WaitTipChanged(current_block.hash, remaining);
         } else {
-            block = miner.waitTipChanged(current_block.hash);
+            block = block_template_manager.WaitTipChanged(current_block.hash);
         }
         // Return current block upon shutdown
         if (!block) break;
@@ -450,10 +450,10 @@ static RPCMethod waitforblockheight()
     if (timeout < 0) throw JSONRPCError(RPC_MISC_ERROR, "Negative timeout");
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
     // Abort if RPC came out of warmup too early
-    BlockRef current_block{CHECK_NONFATAL(miner.getTip()).value()};
+    BlockRef current_block{CHECK_NONFATAL(block_template_manager.GetTip()).value()};
 
     const auto deadline{std::chrono::steady_clock::now() + 1ms * timeout};
 
@@ -463,9 +463,9 @@ static RPCMethod waitforblockheight()
             auto now{std::chrono::steady_clock::now()};
             if (now >= deadline) break;
             const MillisecondsDouble remaining{deadline - now};
-            block = miner.waitTipChanged(current_block.hash, remaining);
+            block = block_template_manager.WaitTipChanged(current_block.hash, remaining);
         } else {
-            block = miner.waitTipChanged(current_block.hash);
+            block = block_template_manager.WaitTipChanged(current_block.hash);
         }
         // Return current block on shutdown
         if (!block) break;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -5,8 +5,6 @@
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
-#include <interfaces/mining.h>
-
 #include <addresstype.h>
 #include <arith_uint256.h>
 #include <chain.h>
@@ -79,8 +77,6 @@
 #include <vector>
 
 using interfaces::BlockRef;
-using interfaces::BlockTemplate;
-using interfaces::Mining;
 using node::BlockAssembler;
 using node::GetMinimumTime;
 using node::NodeContext;
@@ -193,15 +189,15 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock&& block, uint64_t&
     return true;
 }
 
-static UniValue generateBlocks(ChainstateManager& chainman, Mining& miner, const CScript& coinbase_output_script, int nGenerate, uint64_t nMaxTries)
+static UniValue generateBlocks(ChainstateManager& chainman, node::BlockTemplateManager& block_template_manager, const CScript& coinbase_output_script, int nGenerate, uint64_t nMaxTries)
 {
     UniValue blockHashes(UniValue::VARR);
     while (nGenerate > 0 && !chainman.m_interrupt) {
-        std::unique_ptr<BlockTemplate> block_template(miner.createNewBlock({ .coinbase_output_script = coinbase_output_script }, /*cooldown=*/false));
+        std::unique_ptr<node::CBlockTemplate> block_template{block_template_manager.CreateNewTemplate({.coinbase_output_script = coinbase_output_script})};
         CHECK_NONFATAL(block_template);
 
         std::shared_ptr<const CBlock> block_out;
-        if (!GenerateBlock(chainman, block_template->getBlock(), nMaxTries, block_out, /*process_new_block=*/true)) {
+        if (!GenerateBlock(chainman, CBlock{block_template->block}, nMaxTries, block_out, /*process_new_block=*/true)) {
             break;
         }
 
@@ -278,10 +274,10 @@ static RPCMethod generatetodescriptor()
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
     ChainstateManager& chainman = EnsureChainman(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
-    return generateBlocks(chainman, miner, coinbase_output_script, num_blocks, max_tries);
+    return generateBlocks(chainman, block_template_manager, coinbase_output_script, num_blocks, max_tries);
 },
     };
 }
@@ -324,12 +320,12 @@ static RPCMethod generatetoaddress()
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
     ChainstateManager& chainman = EnsureChainman(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
     CScript coinbase_output_script = GetScriptForDestination(destination);
 
-    return generateBlocks(chainman, miner, coinbase_output_script, num_blocks, max_tries);
+    return generateBlocks(chainman, block_template_manager, coinbase_output_script, num_blocks, max_tries);
 },
     };
 }
@@ -377,7 +373,7 @@ static RPCMethod generateblock()
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
     const CTxMemPool& mempool = EnsureMemPool(node);
 
     std::vector<CTransactionRef> txs;
@@ -409,10 +405,10 @@ static RPCMethod generateblock()
     {
         LOCK(chainman.GetMutex());
         {
-            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({.use_mempool = false, .coinbase_output_script = coinbase_output_script}, /*cooldown=*/false)};
+            std::unique_ptr<node::CBlockTemplate> block_template{block_template_manager.CreateNewTemplate({.use_mempool = false, .coinbase_output_script = coinbase_output_script})};
             CHECK_NONFATAL(block_template);
 
-            block = block_template->getBlock();
+            block = block_template->block;
         }
 
         CHECK_NONFATAL(block.vtx.size() == 1);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -739,7 +739,6 @@ static RPCMethod getblocktemplate()
 {
     NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
-    Mining& miner = EnsureMining(node);
     node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
     std::string strMode = "template";
@@ -891,7 +890,7 @@ static RPCMethod getblocktemplate()
     // Update block
     static CBlockIndex* pindexPrev;
     static int64_t time_start;
-    static std::unique_ptr<BlockTemplate> block_template;
+    static std::unique_ptr<node::CBlockTemplate> block_template;
     if (!pindexPrev || pindexPrev->GetBlockHash() != tip ||
         (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - time_start > 5))
     {
@@ -907,7 +906,7 @@ static RPCMethod getblocktemplate()
         // a delay to each getblocktemplate call. This differs from typical
         // long-lived IPC usage, where the overhead is paid only when creating
         // the initial template.
-        block_template = miner.createNewBlock({}, /*cooldown=*/false);
+        block_template = block_template_manager.CreateNewTemplate({});
         CHECK_NONFATAL(block_template);
 
 
@@ -915,7 +914,7 @@ static RPCMethod getblocktemplate()
         pindexPrev = pindexPrevNew;
     }
     CHECK_NONFATAL(pindexPrev);
-    CBlock block{block_template->getBlock()};
+    CBlock block{block_template->block};
 
     // Update nTime
     UpdateTime(&block, consensusParams, pindexPrev);
@@ -928,8 +927,8 @@ static RPCMethod getblocktemplate()
 
     UniValue transactions(UniValue::VARR);
     std::map<Txid, int64_t> setTxIndex;
-    std::vector<CAmount> tx_fees{block_template->getTxFees()};
-    std::vector<int64_t> tx_sigops{block_template->getTxSigops()};
+    std::vector<CAmount> tx_fees{block_template->vTxFees};
+    std::vector<int64_t> tx_sigops{block_template->vTxSigOpsCost};
 
     int i = 0;
     for (const auto& it : block.vtx) {
@@ -1057,7 +1056,7 @@ static RPCMethod getblocktemplate()
         result.pushKV("signet_challenge", HexStr(consensusParams.signet_challenge));
     }
 
-    if (auto coinbase{block_template->getCoinbaseTx()}; coinbase.required_outputs.size() > 0) {
+    if (auto coinbase{block_template->m_coinbase_tx}; coinbase.required_outputs.size() > 0) {
         CHECK_NONFATAL(coinbase.required_outputs.size() == 1); // Only one output is currently expected
         result.pushKV("default_witness_commitment", HexStr(coinbase.required_outputs[0].scriptPubKey));
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -927,11 +927,11 @@ static RPCMethod getblocktemplate()
 
     UniValue transactions(UniValue::VARR);
     std::map<Txid, int64_t> setTxIndex;
-    std::vector<CAmount> tx_fees{block_template->vTxFees};
-    std::vector<int64_t> tx_sigops{block_template->vTxSigOpsCost};
+    const std::vector<CAmount>& tx_fees{block_template->vTxFees};
+    const std::vector<int64_t>& tx_sigops{block_template->vTxSigOpsCost};
 
     int i = 0;
-    for (const auto& it : block.vtx) {
+    for (const auto& it : block_template->block.vtx) {
         const CTransaction& tx = *it;
         Txid txHash = tx.GetHash();
         setTxIndex[txHash] = i++;
@@ -1029,7 +1029,7 @@ static RPCMethod getblocktemplate()
     result.pushKV("previousblockhash", block.hashPrevBlock.GetHex());
     result.pushKV("transactions", std::move(transactions));
     result.pushKV("coinbaseaux", std::move(aux));
-    result.pushKV("coinbasevalue", block.vtx[0]->vout[0].nValue);
+    result.pushKV("coinbasevalue", block_template->block.vtx[0]->vout[0].nValue);
     result.pushKV("longpollid", tip.GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", GetMinimumTime(pindexPrev, consensusParams.DifficultyAdjustmentInterval()));
@@ -1056,7 +1056,7 @@ static RPCMethod getblocktemplate()
         result.pushKV("signet_challenge", HexStr(consensusParams.signet_challenge));
     }
 
-    if (auto coinbase{block_template->m_coinbase_tx}; coinbase.required_outputs.size() > 0) {
+    if (const auto& coinbase{block_template->m_coinbase_tx}; coinbase.required_outputs.size() > 0) {
         CHECK_NONFATAL(coinbase.required_outputs.size() == 1); // Only one output is currently expected
         result.pushKV("default_witness_commitment", HexStr(coinbase.required_outputs[0].scriptPubKey));
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -503,7 +503,7 @@ static RPCMethod getmininginfo()
     obj.pushKV("target", GetTarget(tip, chainman.GetConsensus().powLimit).GetHex());
     obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
     obj.pushKV("pooledtx", mempool.size());
-    const auto mining_options{node::FlattenMiningOptions(CHECK_NONFATAL(node.block_template_manager)->BlockCreateArgs())};
+    const auto mining_options{node::FlattenMiningOptions(EnsureBlockTemplateManager(node).BlockCreateArgs())};
     obj.pushKV("blockmintxfee", ValueFromAmount(CHECK_NONFATAL(mining_options.block_min_fee_rate)->GetFeePerK()));
     obj.pushKV("chain", chainman.GetParams().GetChainTypeString());
 
@@ -740,6 +740,7 @@ static RPCMethod getblocktemplate()
     NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
     Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
     std::string strMode = "template";
     UniValue lpval = NullUniValue;
@@ -794,13 +795,13 @@ static RPCMethod getblocktemplate()
     if (strMode != "template")
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
 
-    if (!miner.isTestChain()) {
+    if (!chainman.GetParams().IsTestChain()) {
         const CConnman& connman = EnsureConnman(node);
         if (connman.GetNodeCount(ConnectionDirection::Both) == 0) {
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, CLIENT_NAME " is not connected!");
         }
 
-        if (miner.isInitialBlockDownload()) {
+        if (chainman.IsInitialBlockDownload()) {
             throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, CLIENT_NAME " is in initial sync and waiting for blocks...");
         }
     }
@@ -809,7 +810,7 @@ static RPCMethod getblocktemplate()
     const CTxMemPool& mempool = EnsureMemPool(node);
 
     WAIT_LOCK(cs_main, cs_main_lock);
-    uint256 tip{CHECK_NONFATAL(miner.getTip()).value().hash};
+    uint256 tip{CHECK_NONFATAL(block_template_manager.GetTip()).value().hash};
 
     // Long Polling (BIP22)
     if (!lpval.isNull()) {
@@ -854,7 +855,7 @@ static RPCMethod getblocktemplate()
             while (IsRPCRunning()) {
                 // If hashWatchedChain is not a real block hash, this will
                 // return immediately.
-                std::optional<BlockRef> maybe_tip{miner.waitTipChanged(hashWatchedChain, checktxtime)};
+                std::optional<BlockRef> maybe_tip{block_template_manager.WaitTipChanged(hashWatchedChain, checktxtime)};
                 // Node is shutting down
                 if (!maybe_tip) break;
                 tip = maybe_tip->hash;
@@ -868,7 +869,7 @@ static RPCMethod getblocktemplate()
                 checktxtime = std::chrono::seconds(10);
             }
         }
-        tip = CHECK_NONFATAL(miner.getTip()).value().hash;
+        tip = CHECK_NONFATAL(block_template_manager.GetTip()).value().hash;
 
         if (!IsRPCRunning())
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Shutting down");

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -23,6 +23,7 @@
 #include <key_io.h>
 #include <net.h>
 #include <netbase.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/miner.h>
@@ -502,7 +503,7 @@ static RPCMethod getmininginfo()
     obj.pushKV("target", GetTarget(tip, chainman.GetConsensus().powLimit).GetHex());
     obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
     obj.pushKV("pooledtx", mempool.size());
-    const auto mining_options{node::FlattenMiningOptions(node.mining_args)};
+    const auto mining_options{node::FlattenMiningOptions(CHECK_NONFATAL(node.block_template_manager)->BlockCreateArgs())};
     obj.pushKV("blockmintxfee", ValueFromAmount(CHECK_NONFATAL(mining_options.block_min_fee_rate)->GetFeePerK()));
     obj.pushKV("chain", chainman.GetParams().GetChainTypeString());
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -914,11 +914,11 @@ static RPCMethod getblocktemplate()
         pindexPrev = pindexPrevNew;
     }
     CHECK_NONFATAL(pindexPrev);
-    CBlock block{block_template->block};
+    CBlockHeader block_header{block_template->block};
 
     // Update nTime
-    UpdateTime(&block, consensusParams, pindexPrev);
-    block.nNonce = 0;
+    UpdateTime(&block_header, consensusParams, pindexPrev);
+    block_header.nNonce = 0;
 
     // NOTE: If at some point we support pre-segwit miners post-segwit-activation, this needs to take segwit support into consideration
     const bool fPreSegWit = !DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT);
@@ -968,7 +968,7 @@ static RPCMethod getblocktemplate()
 
     UniValue aux(UniValue::VOBJ);
 
-    arith_uint256 hashTarget = arith_uint256().SetCompact(block.nBits);
+    arith_uint256 hashTarget = arith_uint256().SetCompact(block_header.nBits);
 
     UniValue aMutable(UniValue::VARR);
     aMutable.push_back("time");
@@ -1000,16 +1000,16 @@ static RPCMethod getblocktemplate()
         vbavailable.pushKV(gbt_rule_value(name, info.gbt_optional_rule), info.bit);
         if (!info.gbt_optional_rule && !setClientRules.contains(name)) {
             // If the client doesn't support this, don't indicate it in the [default] version
-            block.nVersion &= ~info.mask;
+            block_header.nVersion &= ~info.mask;
         }
     }
 
     for (const auto& [name, info] : gbtstatus.locked_in) {
-        block.nVersion |= info.mask;
+        block_header.nVersion |= info.mask;
         vbavailable.pushKV(gbt_rule_value(name, info.gbt_optional_rule), info.bit);
         if (!info.gbt_optional_rule && !setClientRules.contains(name)) {
             // If the client doesn't support this, don't indicate it in the [default] version
-            block.nVersion &= ~info.mask;
+            block_header.nVersion &= ~info.mask;
         }
     }
 
@@ -1021,12 +1021,12 @@ static RPCMethod getblocktemplate()
         }
     }
 
-    result.pushKV("version", block.nVersion);
+    result.pushKV("version", block_header.nVersion);
     result.pushKV("rules", std::move(aRules));
     result.pushKV("vbavailable", std::move(vbavailable));
     result.pushKV("vbrequired", 0);
 
-    result.pushKV("previousblockhash", block.hashPrevBlock.GetHex());
+    result.pushKV("previousblockhash", block_header.hashPrevBlock.GetHex());
     result.pushKV("transactions", std::move(transactions));
     result.pushKV("coinbaseaux", std::move(aux));
     result.pushKV("coinbasevalue", block_template->block.vtx[0]->vout[0].nValue);
@@ -1048,8 +1048,8 @@ static RPCMethod getblocktemplate()
     if (!fPreSegWit) {
         result.pushKV("weightlimit", MAX_BLOCK_WEIGHT);
     }
-    result.pushKV("curtime", block.GetBlockTime());
-    result.pushKV("bits", strprintf("%08x", block.nBits));
+    result.pushKV("curtime", block_header.GetBlockTime());
+    result.pushKV("bits", strprintf("%08x", block_header.nBits));
     result.pushKV("height", pindexPrev->nHeight + 1);
 
     if (consensusParams.signet_blocks) {

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -6,7 +6,9 @@
 
 #include <chain.h>
 #include <common/args.h>
+#include <interfaces/mining.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
 #include <node/context.h>
 #include <node/miner.h>
 #include <policy/fees/block_policy_estimator.h>
@@ -111,6 +113,14 @@ interfaces::Mining& EnsureMining(const NodeContext& node)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Node miner not found");
     }
     return *node.mining;
+}
+
+node::BlockTemplateManager& EnsureBlockTemplateManager(const NodeContext& node)
+{
+    if (!node.block_template_manager) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Block template manager not found");
+    }
+    return *node.block_template_manager;
 }
 
 PeerManager& EnsurePeerman(const NodeContext& node)

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -6,7 +6,6 @@
 
 #include <chain.h>
 #include <common/args.h>
-#include <interfaces/mining.h>
 #include <net_processing.h>
 #include <node/block_template_manager.h>
 #include <node/context.h>
@@ -105,14 +104,6 @@ CConnman& EnsureConnman(const NodeContext& node)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
     }
     return *node.connman;
-}
-
-interfaces::Mining& EnsureMining(const NodeContext& node)
-{
-    if (!node.mining) {
-        throw JSONRPCError(RPC_INTERNAL_ERROR, "Node miner not found");
-    }
-    return *node.mining;
 }
 
 node::BlockTemplateManager& EnsureBlockTemplateManager(const NodeContext& node)

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -22,9 +22,6 @@ namespace node {
 struct NodeContext;
 class BlockTemplateManager;
 } // namespace node
-namespace interfaces {
-class Mining;
-} // namespace interfaces
 
 node::NodeContext& EnsureAnyNodeContext(const std::any& context);
 CTxMemPool& EnsureMemPool(const node::NodeContext& node);
@@ -38,7 +35,6 @@ ChainstateManager& EnsureAnyChainman(const std::any& context);
 CBlockPolicyEstimator& EnsureFeeEstimator(const node::NodeContext& node);
 CBlockPolicyEstimator& EnsureAnyFeeEstimator(const std::any& context);
 CConnman& EnsureConnman(const node::NodeContext& node);
-interfaces::Mining& EnsureMining(const node::NodeContext& node);
 node::BlockTemplateManager& EnsureBlockTemplateManager(const node::NodeContext& node);
 PeerManager& EnsurePeerman(const node::NodeContext& node);
 AddrMan& EnsureAddrman(const node::NodeContext& node);

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -20,6 +20,7 @@ class PeerManager;
 class BanMan;
 namespace node {
 struct NodeContext;
+class BlockTemplateManager;
 } // namespace node
 namespace interfaces {
 class Mining;
@@ -38,6 +39,7 @@ CBlockPolicyEstimator& EnsureFeeEstimator(const node::NodeContext& node);
 CBlockPolicyEstimator& EnsureAnyFeeEstimator(const std::any& context);
 CConnman& EnsureConnman(const node::NodeContext& node);
 interfaces::Mining& EnsureMining(const node::NodeContext& node);
+node::BlockTemplateManager& EnsureBlockTemplateManager(const node::NodeContext& node);
 PeerManager& EnsurePeerman(const node::NodeContext& node);
 AddrMan& EnsureAddrman(const node::NodeContext& node);
 AddrMan& EnsureAnyAddrman(const std::any& context);

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -10,9 +10,10 @@
 #include <index/base.h>
 #include <index/blockfilterindex.h>
 #include <interfaces/chain.h>
-#include <interfaces/mining.h>
 #include <key.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -89,12 +90,12 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     const std::vector<CMutableTransaction>& txns,
     const CScript& scriptPubKey)
 {
-    auto mining{interfaces::MakeMining(m_node)};
-    auto block_template{mining->createNewBlock({
+    auto& block_template_manager{*Assert(m_node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({
         .coinbase_output_script = scriptPubKey,
-    }, /*cooldown=*/false)};
+    })};
     BOOST_REQUIRE(block_template);
-    CBlock block{block_template->getBlock()};
+    CBlock block{block_template->block};
     block.hashPrevBlock = prev->GetBlockHash();
     block.nTime = prev->nTime + 1;
 

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(fuzz
   block_index.cpp
   block_index_tree.cpp
   blockfilter.cpp
+  block_template_manager.cpp
   bloom_filter.cpp
   buffered_file.cpp
   chain.cpp

--- a/src/test/fuzz/block_template_manager.cpp
+++ b/src/test/fuzz/block_template_manager.cpp
@@ -7,6 +7,7 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
+#include <core_memusage.h>
 #include <interfaces/types.h>
 #include <kernel/mempool_entry.h>
 #include <node/miner.h>
@@ -38,6 +39,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -223,6 +225,9 @@ FUZZ_TARGET(block_template_manager, .init = initialize_block_template_manager)
         assert(block_template);
         block_template_manager.TrackTemplateTransactions(block_template->block.vtx);
         block_template_manager.SanityCheck();
+        // The mempool still contains every tracked transaction, so no
+        // additional memory usage is reported.
+        assert(block_template_manager.GetTemplateMemoryUsage() == 0);
         const auto resolved{node::FlattenMiningOptions(merged_options)};
         const CBlock& block{block_template->block};
         // Coinbase is first; the per-tx vectors exclude it and track the block.
@@ -325,6 +330,16 @@ FUZZ_TARGET(block_template_manager, .init = initialize_block_template_manager)
                 assert(reason == "high-hash");
                 assert(debug == "proof of work failed");
             }
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            // Evict all mempool transactions. The template now holds the only
+            // references, so their full memory usage is reported.
+            WITH_LOCK(mempool.cs, mempool.TrimToSize(0));
+            size_t expected_usage{0};
+            for (const CTransactionRef& tx : block.vtx | std::views::drop(1)) {
+                expected_usage += RecursiveDynamicUsage(*tx);
+            }
+            assert(block_template_manager.GetTemplateMemoryUsage() == expected_usage);
         }
         block_template_manager.StopTrackingTemplateTransactions(block_template->block.vtx);
         block_template_manager.SanityCheck();

--- a/src/test/fuzz/block_template_manager.cpp
+++ b/src/test/fuzz/block_template_manager.cpp
@@ -1,0 +1,329 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/block_template_manager.h>
+
+#include <consensus/amount.h>
+#include <consensus/consensus.h>
+#include <consensus/validation.h>
+#include <interfaces/types.h>
+#include <kernel/mempool_entry.h>
+#include <node/miner.h>
+#include <node/mining_args.h>
+#include <node/mining_types.h>
+#include <policy/feerate.h>
+#include <policy/policy.h>
+#include <pow.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/fuzz/util/mempool.h>
+#include <test/util/mining.h>
+#include <test/util/random.h>
+#include <test/util/script.h>
+#include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
+#include <txmempool.h>
+#include <uint256.h>
+#include <util/time.h>
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using node::BlockCreateOptions;
+
+namespace {
+struct SpendableCoin {
+    COutPoint outpoint;
+    CAmount amount;
+    bool is_coinbase;
+};
+const TestingSetup* g_setup;
+std::vector<SpendableCoin> g_mature_coinbase_outpoints;
+
+void initialize_block_template_manager()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+    SetMockTime(WITH_LOCK(g_setup->m_node.chainman->GetMutex(),
+                          return g_setup->m_node.chainman->ActiveTip()->Time()));
+    const BlockCreateOptions assembler_options{.coinbase_output_script = P2WSH_OP_TRUE};
+    for (int i{0}; i < 2 * COINBASE_MATURITY; ++i) {
+        COutPoint prevout{MineBlock(g_setup->m_node, assembler_options)};
+        if (i < COINBASE_MATURITY) {
+            LOCK(::cs_main);
+            const auto coin{g_setup->m_node.chainman->ActiveChainstate().CoinsTip().GetCoin(prevout)};
+            assert(coin);
+            g_mature_coinbase_outpoints.push_back({prevout, coin->out.nValue, /*is_coinbase=*/true});
+        }
+    }
+    g_setup->m_node.validation_signals->SyncWithValidationInterfaceQueue();
+}
+
+/** Add random transactions to the mempool, bypassing validation. */
+void PopulateRandTransactionsToMempool(FuzzedDataProvider& fuzzed_data_provider, CTxMemPool& mempool, int weight_budget)
+{
+    while (weight_budget > 0 && fuzzed_data_provider.remaining_bytes() > 0) {
+        const std::optional<CMutableTransaction> mutable_tx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS);
+        if (!mutable_tx) break;
+        auto tx = MakeTransactionRef(*mutable_tx);
+        CTxMemPoolEntry mempool_entry{ConsumeTxMemPoolEntry(fuzzed_data_provider, *tx)};
+        const Txid txid = tx->GetHash();
+        if (mempool.exists(txid)) continue;
+        const int32_t tx_weight = mempool_entry.GetTxWeight();
+        if (tx_weight > weight_budget) break;
+        TryAddToMempool(mempool, mempool_entry);
+        weight_budget -= tx_weight;
+    }
+}
+
+/** Add transactions with existing inputs and valid scripts, bypassing mempool validation. */
+void PopulateResolvableTransactionsToMempool(FuzzedDataProvider& fuzzed_data_provider,
+                                             CTxMemPool& mempool,
+                                             int weight_budget,
+                                             std::vector<SpendableCoin>& spendable_outpoints)
+{
+    while (weight_budget > 0 && !spendable_outpoints.empty() && fuzzed_data_provider.remaining_bytes() > 0) {
+        CMutableTransaction tx_mut;
+        tx_mut.nLockTime = fuzzed_data_provider.ConsumeBool() ? 0 : fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+        // Small fan-in keeps the outpoint pool alive, so many transactions form layered clusters.
+        const auto num_in = fuzzed_data_provider.ConsumeIntegralInRange<int>(1, std::min<size_t>(5, spendable_outpoints.size()));
+        const auto num_out = fuzzed_data_provider.ConsumeIntegralInRange<int>(1, num_in * 2);
+        std::vector<SpendableCoin> consumed_outpoints;
+        CAmount amount_in{0};
+        bool spends_coinbase{false};
+        for (int i{0}; i < num_in; ++i) {
+            const size_t outpoint_index{
+                fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, spendable_outpoints.size() - 1)};
+            const auto [prevout, amount, is_coinbase]{spendable_outpoints[outpoint_index]};
+            spendable_outpoints.erase(spendable_outpoints.begin() + outpoint_index);
+            consumed_outpoints.push_back({prevout, amount, is_coinbase});
+            amount_in += amount;
+            spends_coinbase |= is_coinbase;
+            CTxIn in;
+            in.prevout = prevout;
+            // The assembler checks locktime finality but not BIP68, so keep relative locktime disabled.
+            in.nSequence = ConsumeSequence(fuzzed_data_provider) | CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG;
+            in.scriptWitness.stack = {WITNESS_STACK_ELEM_OP_TRUE};
+            tx_mut.vin.push_back(in);
+        }
+        // A bare P2PK output adds legacy sigops without needing a valid signature.
+        const bool add_sigops{fuzzed_data_provider.ConsumeBool()};
+        const CAmount fee{fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, amount_in)};
+        const CAmount amount_out{(amount_in - fee) / num_out};
+        for (int i{0}; i < num_out; ++i) {
+            if (i == 0 && add_sigops) {
+                tx_mut.vout.emplace_back(amount_out, CScript() << std::vector<unsigned char>(33, 0x02) << OP_CHECKSIG);
+            } else {
+                tx_mut.vout.emplace_back(amount_out, P2WSH_OP_TRUE);
+            }
+        }
+        CTransactionRef tx{MakeTransactionRef(tx_mut)};
+        // The output division remainder also goes to fees.
+        const CAmount actual_fee{amount_in - amount_out * num_out};
+        TestMemPoolEntryHelper entry;
+        CTxMemPoolEntry mempool_entry{
+            entry.Fee(actual_fee).SpendsCoinbase(spends_coinbase).SigOpsCost(add_sigops ? WITNESS_SCALE_FACTOR : 0).FromTx(tx)};
+        const int32_t tx_weight{mempool_entry.GetTxWeight()};
+        if (tx_weight > weight_budget) {
+            spendable_outpoints.insert(spendable_outpoints.end(), consumed_outpoints.begin(), consumed_outpoints.end());
+            break;
+        }
+        TryAddToMempool(mempool, mempool_entry);
+        // Only offer the outputs for spending when the mempool accepted the transaction.
+        if (!mempool.exists(tx->GetHash())) {
+            spendable_outpoints.insert(spendable_outpoints.end(), consumed_outpoints.begin(), consumed_outpoints.end());
+            continue;
+        }
+        weight_budget -= tx_weight;
+        for (uint32_t n{add_sigops ? 1u : 0u}; n < tx->vout.size(); ++n) {
+            spendable_outpoints.push_back({COutPoint{tx->GetHash(), n}, tx->vout[n].nValue, /*is_coinbase=*/false});
+        }
+    }
+}
+} // namespace
+
+FUZZ_TARGET(block_template_manager, .init = initialize_block_template_manager)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    const auto& node = g_setup->m_node;
+    auto& block_template_manager = *Assert(node.block_template_manager);
+    auto& mempool = *Assert(node.mempool);
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    SetMockTime(WITH_LOCK(node.chainman->GetMutex(),
+                          return node.chainman->ActiveTip()->Time()));
+    {
+        LOCK(mempool.cs);
+        mempool.TrimToSize(0);
+    }
+    const bool use_valid_transactions{fuzzed_data_provider.ConsumeBool()};
+    std::vector<SpendableCoin> spendable_outpoints;
+    int weight_budget = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, DEFAULT_BLOCK_MAX_WEIGHT * 10);
+    if (use_valid_transactions) {
+        spendable_outpoints = g_mature_coinbase_outpoints;
+        PopulateResolvableTransactionsToMempool(fuzzed_data_provider, mempool, weight_budget, spendable_outpoints);
+    } else {
+        PopulateRandTransactionsToMempool(fuzzed_data_provider, mempool, weight_budget);
+    }
+    LIMITED_WHILE (fuzzed_data_provider.remaining_bytes() > 0, 10) {
+        BlockCreateOptions options;
+        options.test_block_validity = use_valid_transactions;
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.use_mempool = fuzzed_data_provider.ConsumeBool();
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.block_reserved_weight = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            const CAmount fee_amount = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, COIN);
+            const int32_t fee_size = fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(1, DEFAULT_BLOCK_MAX_WEIGHT / WITNESS_SCALE_FACTOR);
+            options.block_min_fee_rate = CFeeRate(fee_amount, fee_size);
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.block_max_weight = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.print_modified_fee = fuzzed_data_provider.ConsumeBool();
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.coinbase_output_max_additional_sigops = fuzzed_data_provider.ConsumeIntegral<size_t>();
+        }
+        // An arbitrary coinbase script can exceed consensus weight/sigops limits and fail TestBlockValidity.
+        if (!use_valid_transactions && fuzzed_data_provider.ConsumeBool()) {
+            options.coinbase_output_script = ConsumeScript(fuzzed_data_provider);
+        }
+        const auto merged_options{node::MergeMiningOptions(options, block_template_manager.BlockCreateArgs())};
+        const auto options_check{node::CheckMiningOptions(merged_options, /*use_argnames=*/false)};
+        std::unique_ptr<node::CBlockTemplate> block_template;
+        try {
+            block_template = block_template_manager.CreateNewTemplate(options);
+        } catch (const std::runtime_error& e) {
+            if (!options_check) {
+                assert(e.what() == util::ErrorString(options_check).original);
+                continue;
+            }
+            // test_block_validity is set only for valid transactions, so TestBlockValidity
+            // should not fail.
+            throw;
+        }
+        assert(options_check);
+        assert(block_template);
+        const auto resolved{node::FlattenMiningOptions(merged_options)};
+        const CBlock& block{block_template->block};
+        // Coinbase is first; the per-tx vectors exclude it and track the block.
+        assert(!block.vtx.empty() && block.vtx[0]->IsCoinBase());
+        assert(block_template->vTxFees.size() == block.vtx.size() - 1);
+        assert(block_template->vTxSigOpsCost.size() == block.vtx.size() - 1);
+        // Reserved weight plus selected transactions stays within the limit. The
+        // coinbase is covered by the reserved weight, so it is not counted here.
+        uint64_t weight{*resolved.block_reserved_weight};
+        for (size_t i{1}; i < block.vtx.size(); ++i)
+            weight += GetTransactionWeight(*block.vtx[i]);
+        assert(weight <= *resolved.block_max_weight);
+        // Reserved coinbase sigops plus selected transactions stays within the limit.
+        int64_t sigops = resolved.coinbase_output_max_additional_sigops;
+        for (const int64_t tx_sigops : block_template->vTxSigOpsCost)
+            sigops += tx_sigops;
+        assert(sigops <= MAX_BLOCK_SIGOPS_COST);
+        // Tracked fees are non-negative; without the mempool only the coinbase is included.
+        for (const CAmount fee : block_template->vTxFees)
+            assert(fee >= 0);
+        if (!resolved.use_mempool) assert(block.vtx.size() == 1);
+
+        const uint256 tip_hash{block.hashPrevBlock};
+        // The template builds on the current tip.
+        {
+            const std::optional<interfaces::BlockRef> tip{block_template_manager.GetTip()};
+            assert(tip && tip->hash == tip_hash);
+            assert(tip->height == WITH_LOCK(node.chainman->GetMutex(), return node.chainman->ActiveHeight()));
+        }
+
+        // Zero-timeout waits still check their predicates once.
+        {
+            // The wait consumes and resets the interrupt flag, so keep a copy of the request.
+            const bool interrupted{fuzzed_data_provider.ConsumeBool()};
+            bool interrupt{false};
+            if (interrupted) block_template_manager.InterruptWait(interrupt);
+            assert(interrupt == interrupted);
+            const uint256 current_tip{fuzzed_data_provider.ConsumeBool() ? tip_hash : ConsumeUInt256(fuzzed_data_provider)};
+            MillisecondsDouble timeout{0};
+            const std::optional<interfaces::BlockRef> wait_tip{block_template_manager.WaitTipChanged(current_tip, timeout, interrupt)};
+            assert(!interrupt);
+            if (interrupted) {
+                assert(!wait_tip);
+            } else {
+                assert(wait_tip && wait_tip->hash == tip_hash);
+            }
+        }
+        {
+            // Fees or testnet min-difficulty can produce a template without a tip change.
+            if (fuzzed_data_provider.ConsumeBool()) {
+                const int extra_weight_budget{
+                    fuzzed_data_provider.ConsumeIntegralInRange<int>(0, DEFAULT_BLOCK_MAX_WEIGHT)};
+                if (use_valid_transactions) {
+                    PopulateResolvableTransactionsToMempool(fuzzed_data_provider, mempool, extra_weight_budget, spendable_outpoints);
+                } else {
+                    PopulateRandTransactionsToMempool(fuzzed_data_provider, mempool, extra_weight_budget);
+                }
+            }
+            const std::chrono::seconds mock_offset{fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, 30 * 60)};
+            SetMockTime(WITH_LOCK(node.chainman->GetMutex(),
+                                  return node.chainman->ActiveTip()->Time()) +
+                        mock_offset);
+            const bool min_difficulty_window{mock_offset > std::chrono::minutes{20}};
+            node::BlockWaitOptions wait_options;
+            wait_options.timeout = MillisecondsDouble{0};
+            if (fuzzed_data_provider.ConsumeBool()) {
+                wait_options.fee_threshold = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, MAX_MONEY);
+            }
+            const bool interrupted{fuzzed_data_provider.ConsumeBool()};
+            bool interrupt{false};
+            if (interrupted) block_template_manager.InterruptWait(interrupt);
+            assert(interrupt == interrupted);
+            const auto next_template{block_template_manager.WaitAndCreateNewBlock(block_template, wait_options, options, interrupt)};
+            assert(!interrupt);
+            if (interrupted) {
+                assert(!next_template);
+            } else if (min_difficulty_window) {
+                assert(next_template && next_template->block.hashPrevBlock == tip_hash);
+            } else if (next_template) {
+                assert(next_template->block.hashPrevBlock == tip_hash);
+                const CAmount old_fees{std::accumulate(block_template->vTxFees.begin(), block_template->vTxFees.end(), CAmount{0})};
+                const CAmount new_fees{std::accumulate(next_template->vTxFees.begin(), next_template->vTxFees.end(), CAmount{0})};
+                assert(wait_options.fee_threshold < MAX_MONEY);
+                assert(new_fees >= old_fees + wait_options.fee_threshold);
+            }
+        }
+        {
+            // With no headers ahead of the tip the cooldown returns
+            // immediately and leaves the interrupt flag untouched.
+            bool interrupt{fuzzed_data_provider.ConsumeBool()};
+            const bool interrupted{interrupt};
+            assert(block_template_manager.CooldownIfHeadersAhead(*block_template_manager.GetTip(), interrupt));
+            assert(interrupt == interrupted);
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            // An unsolved header can pass the regtest target by chance.
+            if (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) {
+                std::string reason;
+                std::string debug;
+                assert(!block_template_manager.SubmitBlock(std::make_shared<const CBlock>(block), reason, debug));
+                assert(reason == "high-hash");
+                assert(debug == "proof of work failed");
+            }
+        }
+    }
+}

--- a/src/test/fuzz/block_template_manager.cpp
+++ b/src/test/fuzz/block_template_manager.cpp
@@ -221,6 +221,8 @@ FUZZ_TARGET(block_template_manager, .init = initialize_block_template_manager)
         }
         assert(options_check);
         assert(block_template);
+        block_template_manager.TrackTemplateTransactions(block_template->block.vtx);
+        block_template_manager.SanityCheck();
         const auto resolved{node::FlattenMiningOptions(merged_options)};
         const CBlock& block{block_template->block};
         // Coinbase is first; the per-tx vectors exclude it and track the block.
@@ -242,7 +244,6 @@ FUZZ_TARGET(block_template_manager, .init = initialize_block_template_manager)
         for (const CAmount fee : block_template->vTxFees)
             assert(fee >= 0);
         if (!resolved.use_mempool) assert(block.vtx.size() == 1);
-
         const uint256 tip_hash{block.hashPrevBlock};
         // The template builds on the current tip.
         {
@@ -325,5 +326,7 @@ FUZZ_TARGET(block_template_manager, .init = initialize_block_template_manager)
                 assert(debug == "proof of work failed");
             }
         }
+        block_template_manager.StopTrackingTemplateTransactions(block_template->block.vtx);
+        block_template_manager.SanityCheck();
     }
 }

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -13,6 +13,7 @@
 #include <net.h>
 #include <net_processing.h>
 #include <netmessagemaker.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/mining_types.h>
 #include <policy/truc_policy.h>
@@ -112,6 +113,7 @@ void ResetChainmanAndMempool(TestingSetup& setup)
     SetMockTime(Params().GenesisBlock().Time());
 
     bilingual_str error{};
+    setup.m_node.block_template_manager.reset();
     setup.m_node.mempool.reset();
     setup.m_node.mempool = std::make_unique<CTxMemPool>(MemPoolOptionsForTest(setup.m_node), error);
     Assert(error.empty());
@@ -119,6 +121,7 @@ void ResetChainmanAndMempool(TestingSetup& setup)
     setup.m_node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();
+    setup.CreateBlockTemplateManager();
 
     node::BlockCreateOptions options;
     options.coinbase_output_script = P2WSH_OP_TRUE;

--- a/src/test/fuzz/private_broadcast.cpp
+++ b/src/test/fuzz/private_broadcast.cpp
@@ -13,6 +13,7 @@
 #include <test/fuzz/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/hasher.h>
 #include <util/overflow.h>
 #include <util/time.h>
 
@@ -22,13 +23,6 @@ struct CTransactionRefHash {
     size_t operator()(const CTransactionRef& tx) const
     {
         return static_cast<size_t>(tx->GetWitnessHash().ToUint256().GetUint64(0));
-    }
-};
-
-struct CTransactionRefComp {
-    bool operator()(const CTransactionRef& a, const CTransactionRef& b) const
-    {
-        return a->GetWitnessHash() == b->GetWitnessHash();
     }
 };
 

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -8,6 +8,7 @@
 #include <kernel/chainparams.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
 #include <node/mining_types.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -47,9 +48,12 @@ std::string_view LIMIT_TO_MESSAGE_TYPE{};
 void ResetChainman(TestingSetup& setup)
 {
     SetMockTime(setup.m_node.chainman->GetParams().GenesisBlock().Time());
+    setup.m_node.block_template_manager.reset();
     setup.m_node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();
+    setup.CreateBlockTemplateManager();
+
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
         node::BlockCreateOptions options;
         MineBlock(setup.m_node, options);

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -8,6 +8,7 @@
 #include <kernel/chainparams.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
 #include <node/mining_types.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -41,9 +42,12 @@ TestingSetup* g_setup;
 void ResetChainman(TestingSetup& setup)
 {
     SetMockTime(setup.m_node.chainman->GetParams().GenesisBlock().Time());
+    setup.m_node.block_template_manager.reset();
     setup.m_node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();
+    setup.CreateBlockTemplateManager();
+
     node::BlockCreateOptions options;
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
         MineBlock(setup.m_node, options);

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -89,6 +89,9 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "savemempool",          // disabled as a precautionary measure: may take a file path argument in the future
     "setban",               // avoid DNS lookups
     "stop",                 // avoid shutdown state
+    "waitforblock",         // avoid blocking forever (tip never changes during fuzzing; no timeout by default)
+    "waitforblockheight",   // avoid blocking forever (tip never changes during fuzzing; no timeout by default)
+    "waitfornewblock",      // avoid blocking forever (tip never changes during fuzzing; no timeout by default)
 };
 
 // RPC commands which are safe for fuzzing.
@@ -188,9 +191,6 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "verifychain",
     "verifymessage",
     "verifytxoutproof",
-    "waitforblock",
-    "waitforblockheight",
-    "waitfornewblock",
 };
 
 std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data)

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -79,6 +79,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "enumeratesigners",
     "echoipc",              // avoid assertion failure (Assertion `"EnsureAnyNodeContext(request.context).init" && check' failed.)
     "exportasmap",          // avoid writing to disk
+    "generateblock",        // avoid chain state changes and disk writes (mines and submits a block)
     "generatetoaddress",    // avoid prohibitively slow execution (when `num_blocks` is large)
     "generatetodescriptor", // avoid prohibitively slow execution (when `nblocks` is large)
     "gettxoutproof",        // avoid prohibitively slow execution
@@ -113,7 +114,6 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "estimatesmartfee",
     "finalizepsbt",
     "generate",
-    "generateblock",
     "getaddednodeinfo",
     "getaddrmaninfo",
     "getbestblockhash",

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -8,6 +8,7 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <kernel/coinstats.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/utxo_snapshot.h>
 #include <primitives/block.h>
@@ -211,9 +212,11 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
         Assert(!dirty_chainman);
     }
     if (dirty_chainman) {
+        setup.m_node.block_template_manager.reset();
         setup.m_node.chainman.reset();
         setup.m_make_chainman();
         setup.LoadVerifyActivateChainstate();
+        setup.CreateBlockTemplateManager();
     }
 }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -54,7 +54,6 @@
 using namespace util::hex_literals;
 using interfaces::BlockTemplate;
 using interfaces::Mining;
-using node::BlockAssembler;
 using node::BlockCreateOptions;
 
 namespace miner_tests {
@@ -219,11 +218,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
 
     // Test the inclusion of package feerates in the block template and ensure they are sequential.
     // Can't use the Mining interface because it needs access to m_package_feerates.
-    const auto block_package_feerates = BlockAssembler{
-        m_node.chainman->ActiveChainstate(),
-        &tx_mempool,
-        MergeMiningOptions(options, Assert(m_node.block_template_manager)->BlockCreateArgs()),
-    }.CreateNewBlock()->m_package_feerates;
+    const auto block_package_feerates = Assert(m_node.block_template_manager)->CreateNewTemplate(options)->m_package_feerates;
     BOOST_CHECK(block_package_feerates.size() == 2);
 
     // parent_tx and high_fee_tx are added to the block as a package.

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -222,7 +222,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     const auto block_package_feerates = BlockAssembler{
         m_node.chainman->ActiveChainstate(),
         &tx_mempool,
-        MergeMiningOptions(options, m_node.mining_args),
+        MergeMiningOptions(options, Assert(m_node.block_template_manager)->BlockCreateArgs()),
     }.CreateNewBlock()->m_package_feerates;
     BOOST_CHECK(block_package_feerates.size() == 2);
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -12,6 +12,7 @@
 #include <interfaces/mining.h>
 #include <interfaces/types.h>
 #include <kernel/chainparams.h>
+#include <node/block_template_manager.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
 #include <node/mining_types.h>
@@ -70,6 +71,7 @@ struct MinerTestingSetup : public TestingSetup {
     }
     CTxMemPool& MakeMempool()
     {
+        m_node.block_template_manager.reset();
         // Delete the previous mempool to ensure with valgrind that the old
         // pointer is not accessed, when the new one should be accessed
         // instead.
@@ -82,6 +84,7 @@ struct MinerTestingSetup : public TestingSetup {
         opts.limits.cluster_size_vbytes = 1'200'000;
         m_node.mempool = std::make_unique<CTxMemPool>(opts, error);
         Assert(error.empty());
+        CreateBlockTemplateManager();
         return *m_node.mempool;
     }
     std::unique_ptr<Mining> MakeMining()
@@ -933,6 +936,22 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     m_node.chainman->ActiveChain().Tip()->nHeight--;
 
     TestPrioritisedMining(scriptPubKey, txFirst);
+}
+
+BOOST_AUTO_TEST_CASE(block_template_manager)
+{
+    auto& block_template_manager = *Assert(m_node.block_template_manager);
+    BlockCreateOptions options;
+    options.use_mempool = false;
+    auto block_template = block_template_manager.CreateNewTemplate(options);
+    BOOST_REQUIRE(block_template);
+    const CBlock& block{block_template->block};
+    // Without the mempool the template holds only the coinbase, and the per-tx
+    // fee/sigops vectors exclude it.
+    BOOST_CHECK_EQUAL(block.vtx.size(), 1U);
+    BOOST_CHECK(block.vtx[0]->IsCoinBase());
+    BOOST_CHECK(block_template->vTxFees.empty());
+    BOOST_CHECK(block_template->vTxSigOpsCost.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -5,8 +5,9 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/params.h>
-#include <interfaces/mining.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <protocol.h>
@@ -31,10 +32,10 @@ static void mineBlock(node::NodeContext& node, FakeNodeClock& clock, std::chrono
 {
     auto curr_time = GetTime<std::chrono::seconds>();
     clock.set(block_time); // update time so the block is created with it
-    auto mining{interfaces::MakeMining(node)};
-    auto block_template{mining->createNewBlock({}, /*cooldown=*/false)};
+    auto& block_template_manager{*Assert(node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({})};
     BOOST_REQUIRE(block_template);
-    CBlock block{block_template->getBlock()};
+    CBlock block{block_template->block};
     while (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
     block.fChecked = true; // little speedup
     clock.set(curr_time); // process block at current time

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -9,9 +9,10 @@
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
-#include <interfaces/mining.h>
 #include <key_io.h>
+#include <node/block_template_manager.h>
 #include <node/context.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -131,9 +132,9 @@ COutPoint ProcessBlock(const NodeContext& node, const std::shared_ptr<CBlock>& b
 std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node,
                                      const node::BlockCreateOptions& assembler_options)
 {
-    auto mining = interfaces::MakeMining(node);
-    auto block_template = mining->createNewBlock(assembler_options, /*cooldown=*/false);
-    auto block = std::make_shared<CBlock>(Assert(block_template)->getBlock());
+    auto& block_template_manager = *Assert(node.block_template_manager);
+    auto block_template = block_template_manager.CreateNewTemplate(assembler_options);
+    auto block = std::make_shared<CBlock>(Assert(block_template)->block);
 
     LOCK(cs_main);
     block->nTime = Assert(node.chainman)->ActiveChain().Tip()->GetMedianTimePast() + 1;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -26,6 +26,7 @@
 #include <net_processing.h>
 #include <netbase.h>
 #include <netgroup.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/chainstate.h>
 #include <node/context.h>
@@ -330,12 +331,20 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
         m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
     };
     m_make_chainman();
+    CreateBlockTemplateManager();
+}
+
+void ChainTestingSetup::CreateBlockTemplateManager()
+{
+    Assert(!m_node.block_template_manager);
+    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman);
 }
 
 ChainTestingSetup::~ChainTestingSetup()
 {
     if (m_node.scheduler) m_node.scheduler->stop();
     if (m_node.validation_signals) m_node.validation_signals->FlushBackgroundCallbacks();
+    m_node.block_template_manager.reset();
     m_node.connman.reset();
     m_node.banman.reset();
     m_node.addrman.reset();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -336,8 +336,10 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
 
 void ChainTestingSetup::CreateBlockTemplateManager()
 {
+    auto mining_args{node::ReadMiningArgs(*Assert(m_node.args))};
+    Assert(mining_args);
     Assert(!m_node.block_template_manager);
-    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman);
+    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman, std::move(*mining_args));
 }
 
 ChainTestingSetup::~ChainTestingSetup()
@@ -403,9 +405,6 @@ TestingSetup::TestingSetup(
                                                m_node.args->GetIntArg("-checkaddrman", 0));
     m_node.banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     m_node.connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params()); // Deterministic randomness for tests.
-    auto mining_args{node::ReadMiningArgs(*m_node.args)};
-    Assert(mining_args);
-    m_node.mining_args = std::move(*mining_args);
     PeerManager::Options peerman_opts;
     ApplyArgsManOptions(*m_node.args, peerman_opts);
     peerman_opts.deterministic_rng = true;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -17,7 +17,6 @@
 #include <dbwrapper.h>
 #include <init.h>
 #include <interfaces/chain.h>
-#include <interfaces/mining.h>
 #include <kernel/caches.h>
 #include <kernel/context.h>
 #include <key.h>
@@ -455,13 +454,13 @@ CBlock TestChain100Setup::CreateBlock(
     const std::vector<CMutableTransaction>& txns,
     const CScript& scriptPubKey)
 {
-    auto mining{interfaces::MakeMining(m_node)};
-    auto block_template{mining->createNewBlock({
+    auto& block_template_manager{*Assert(m_node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({
         .use_mempool = false,
         .coinbase_output_script = scriptPubKey,
-    }, /*cooldown=*/false)};
+    })};
     Assert(block_template);
-    CBlock block{block_template->getBlock()};
+    CBlock block{block_template->block};
 
     Assert(block.vtx.size() == 1);
     for (const CMutableTransaction& tx : txns) {

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -339,7 +339,7 @@ void ChainTestingSetup::CreateBlockTemplateManager()
     auto mining_args{node::ReadMiningArgs(*Assert(m_node.args))};
     Assert(mining_args);
     Assert(!m_node.block_template_manager);
-    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman, std::move(*mining_args));
+    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman, *Assert(m_node.notifications), std::move(*mining_args));
 }
 
 ChainTestingSetup::~ChainTestingSetup()

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -106,6 +106,10 @@ struct ChainTestingSetup : public BasicTestingSetup {
     explicit ChainTestingSetup(ChainType chainType = ChainType::MAIN, TestOpts = {});
     ~ChainTestingSetup();
 
+    //! Create the block template manager. Must be destroyed before resetting
+    //! any of its dependencies.
+    void CreateBlockTemplateManager();
+
     // Supplies a chainstate, if one is needed
     void LoadVerifyActivateChainstate();
 };

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -7,8 +7,9 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
-#include <interfaces/mining.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -80,12 +81,12 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     static int i = 0;
     static uint64_t time = Params().GenesisBlock().nTime;
 
-    auto mining{interfaces::MakeMining(m_node)};
-    auto block_template{mining->createNewBlock({
+    auto& block_template_manager{*Assert(m_node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({
         .coinbase_output_script = CScript{} << i++ << OP_TRUE,
-    }, /*cooldown=*/false)};
+    })};
     BOOST_REQUIRE(block_template);
-    auto pblock = std::make_shared<CBlock>(block_template->getBlock());
+    auto pblock = std::make_shared<CBlock>(block_template->block);
     pblock->hashPrevBlock = prev_hash;
     pblock->nTime = ++time;
 
@@ -350,12 +351,12 @@ BOOST_AUTO_TEST_CASE(witness_commitment_index)
     LOCK(Assert(m_node.chainman)->GetMutex());
     CScript pubKey;
     pubKey << 1 << OP_TRUE;
-    auto mining{interfaces::MakeMining(m_node)};
-    auto block_template{mining->createNewBlock({
+    auto& block_template_manager{*Assert(m_node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({
         .coinbase_output_script = pubKey,
-    }, /*cooldown=*/false)};
+    })};
     BOOST_REQUIRE(block_template);
-    CBlock pblock{block_template->getBlock()};
+    CBlock pblock{block_template->block};
 
     CTxOut witness;
     witness.scriptPubKey.resize(MINIMUM_WITNESS_COMMITMENT);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -5,6 +5,7 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <kernel/disconnected_transactions.h>
+#include <node/block_template_manager.h>
 #include <node/chainstatemanager_args.h>
 #include <node/kernel_notifications.h>
 #include <node/utxo_snapshot.h>
@@ -422,6 +423,7 @@ struct SnapshotTestSetup : TestChain100Setup {
         {
             // Process all callbacks referring to the old manager before wiping it.
             m_node.validation_signals->SyncWithValidationInterfaceQueue();
+            m_node.block_template_manager.reset();
             LOCK(::cs_main);
             chainman.ResetChainstates();
             BOOST_CHECK_EQUAL(chainman.m_chainstates.size(), 0);
@@ -446,6 +448,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             // new one.
             m_node.chainman.reset();
             m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
+            CreateBlockTemplateManager();
         }
         return *Assert(m_node.chainman);
     }

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -116,6 +116,15 @@ public:
     size_t operator()(const std::span<const unsigned char>& script) const;
 };
 
+struct CTransactionRefSaltedHash {
+    SaltedWtxidHasher m_hasher;
+
+    size_t operator()(const CTransactionRef& tx) const
+    {
+        return m_hasher(tx->GetWitnessHash());
+    }
+};
+
 struct CTransactionRefComp {
     bool operator()(const CTransactionRef& a, const CTransactionRef& b) const
     {

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -116,4 +116,11 @@ public:
     size_t operator()(const std::span<const unsigned char>& script) const;
 };
 
+struct CTransactionRefComp {
+    bool operator()(const CTransactionRef& a, const CTransactionRef& b) const
+    {
+        return a->GetWitnessHash() == b->GetWitnessHash(); // If wtxid equals, then txid also equals.
+    }
+};
+
 #endif // BITCOIN_UTIL_HASHER_H

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -31,6 +31,7 @@ from test_framework.messages import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_greater_than_or_equal,
     assert_not_equal,
 )
@@ -306,6 +307,11 @@ class IPCMiningTest(BitcoinTestFramework):
                 block4 = await mining_get_block(template6, ctx)
                 assert_equal(len(block4.vtx), 3)
 
+                self.log.debug("Memory load should be zero because there was no mempool churn")
+                with self.nodes[0].assert_debug_log(["Calculate template transaction reference memory footprint"]):
+                    memory_load = await mining.getMemoryLoad(ctx)
+                assert_equal(memory_load.result.usage, 0)
+
                 self.log.debug("Wait for another, but time out, since the fee threshold is set now")
                 template7 = await mining_wait_next_template(template6, stack, ctx, waitoptions)
                 assert template7 is None
@@ -318,6 +324,13 @@ class IPCMiningTest(BitcoinTestFramework):
                     template7 = await mining_wait_next_template(template6, stack, ctx, new_waitoptions)
                     assert template7 is None
                 await wait_and_do(wait_for_block(), template6.interruptWait())
+
+                self.log.debug("Template objects go out of scope")
+                # Since multiple templates have common transaction references,
+                # a regression in BlockTemplateImpl / ~BlockTemplateImpl reference
+                # counting should result in a crash here.
+
+            self.log.debug("Template objects are out of scope")
 
         asyncio.run(capnp.run(async_routine()))
 
@@ -605,6 +618,18 @@ class IPCMiningTest(BitcoinTestFramework):
                 assert_equal(self.nodes[2].getchaintips()[0]["height"], current_block_height + 1)
                 self.log.debug("submitBlock should reject the duplicate complete block")
                 await self.assert_submit_block(mining2, ctx2, block, result=False, reason="duplicate")
+
+                self.log.debug("Reported memory load should be > 0")
+                # Clients are expected to drop references to stale block templates
+                # briefly after the tip updates. In practice we mainly care about
+                # the memory footprint caused by mempool churn, but this scenario
+                # is easier to test.
+                assert_greater_than((await mining.getMemoryLoad(ctx)).result.usage, 0)
+
+                # Manually release the template:
+                await template.destroy(ctx)
+                self.log.debug("Reported memory load should be 0")
+                assert_equal((await mining.getMemoryLoad(ctx)).result.usage, 0)
 
             self.log.debug("Block should propagate")
             # Check that the IPC node actually updates its own chain


### PR DESCRIPTION
Implements a way to track the memory footprint of all non-mempool transactions that are still being referenced by block templates, see discussion in  #33899. It does not impose a limit.

IPC clients can query this footprint (total, across all clients) using the `getMemoryLoad()` IPC method. Its client-side usage is demonstrated here:
- https://github.com/stratum-mining/sv2-tp/pull/63

Additionally, the functional test in `interface_ipc.py` is expanded to demonstrate how template memory management works: templates are not released until the client drops references to them, or calls the template destroy method, or disconnects. The destroy method is called automatically by clients using [libmultiprocess](https://github.com/bitcoin-core/libmultiprocess), as [sv2-tp](https://github.com/stratum-mining/sv2-tp) does. In the Python tests it also happens when references are destroyed or go out of scope.

Based on:

- #35675

Commits:

- _refactor: move CTransactionRefComp to util/hasher_
- _mining: track non-mempool memory usage_: add `TxTemplateMap` to `BlockTemplateManager` to track how many templates contain any given transaction. This map is updated by the `BlockTemplate` constructor and destructor.
- _mining: add GetTemplateMemoryUsage()_ - loops over this map and sums up the memory footprint for transactions outside the mempool (includes a fuzzer)
- _ipc: add getMemoryLoad()_ expose this information to IPC clients and add test coverage
