### PR TITLE
test: Remove `system_tests/run_command` runtime dependencies

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(test_bitcoin
   miniminer_tests.cpp
   miniscript_tests.cpp
   minisketch_tests.cpp
+  mock_process.cpp
   multisig_tests.cpp
   bip328_tests.cpp
   net_peer_connection_tests.cpp
@@ -188,6 +189,8 @@ function(add_boost_test source_file)
   list(TRANSFORM test_suite_macro
     REPLACE "(BOOST_FIXTURE_TEST_SUITE|BOOST_AUTO_TEST_SUITE)\\(" ""
   )
+  # The mock_process test suite does not contain unit tests.
+  list(REMOVE_ITEM test_suite_macro "mock_process")
   foreach(test_suite_name IN LISTS test_suite_macro)
     add_test(NAME ${test_suite_name}
       COMMAND test_bitcoin --run_test=${test_suite_name} --catch_system_error=no --log_level=test_suite -- DEBUG_LOG_OUT

--- a/src/test/mock_process.cpp
+++ b/src/test/mock_process.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <boost/test/unit_test.hpp>
+
+#include <iostream>
+#include <string>
+
+BOOST_AUTO_TEST_SUITE(mock_process, *boost::unit_test::disabled())
+
+BOOST_AUTO_TEST_CASE(valid_json, *boost::unit_test::disabled())
+{
+    std::cout << R"({"success": true})" << std::endl;
+}
+
+BOOST_AUTO_TEST_CASE(nonzeroexit_nooutput, *boost::unit_test::disabled())
+{
+    BOOST_FAIL("Test unconditionally fails.");
+}
+
+BOOST_AUTO_TEST_CASE(nonzeroexit_stderroutput, *boost::unit_test::disabled())
+{
+    std::cerr << "err\n";
+    BOOST_FAIL("Test unconditionally fails.");
+}
+
+BOOST_AUTO_TEST_CASE(invalid_json, *boost::unit_test::disabled())
+{
+    std::cout << "{\n";
+}
+
+BOOST_AUTO_TEST_CASE(pass_stdin_to_stdout, *boost::unit_test::disabled())
+{
+    std::string s;
+    std::getline(std::cin, s);
+    std::cout << s << std::endl;
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -74,7 +74,6 @@ BOOST_AUTO_TEST_CASE(run_command)
         // Unable to parse JSON
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(mock_executable("invalid_json")), std::runtime_error, HasReason("Unable to parse JSON: {"));
     }
-#ifndef WIN32
     {
         // Test stdin
         const UniValue result = RunCommandParseJSON(mock_executable("pass_stdin_to_stdout"), "{\"success\": true}");
@@ -83,7 +82,6 @@ BOOST_AUTO_TEST_CASE(run_command)
         BOOST_CHECK(!success.isNull());
         BOOST_CHECK_EQUAL(success.get_bool(), true);
     }
-#endif
 }
 #endif // ENABLE_EXTERNAL_SIGNER
 

--- a/test/lint/lint-includes.py
+++ b/test/lint/lint-includes.py
@@ -21,6 +21,7 @@ EXCLUDED_DIRS = ["contrib/devtools/bitcoin-tidy/",
                 ] + SHARED_EXCLUDED_SUBTREES
 
 EXPECTED_BOOST_INCLUDES = [
+                           "boost/cstdlib.hpp",
                            "boost/multi_index/detail/hash_index_iterator.hpp",
                            "boost/multi_index/hashed_index.hpp",
                            "boost/multi_index/identity.hpp",


### PR DESCRIPTION
`system_tests` currently rely on `cat`, `echo`, `false` and `sh` being available in `PATH` at runtime.

This PR:
1. Removes these dependencies.
2. Reduces the number of platform-specific code paths.

The change is primarily motivated by my work on maintaining the [`bitcoin-core`](https://packages.guix.gnu.org/packages/bitcoin-core) package in Guix. It enables the removal of the existing `bash` and `coreutils` native inputs, which in turn makes it possible to drop the implicit dependency on `qtbase@5` (see https://codeberg.org/guix/guix/pulls/4386#issuecomment-8613333).