### PR TITLE
ci: Use latest Xcode that the minimum macOS version allows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,11 +155,11 @@ jobs:
 
       - name: Clang version
         run: |
-          # Use the earliest Xcode supported by the version of macOS denoted in
+          # Use the latest Xcode supported by the version of macOS denoted in
           # doc/release-notes-empty-template.md and providing at least the
           # minimum clang version denoted in doc/dependencies.md.
-          # See: https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes
-          sudo xcode-select --switch /Applications/Xcode_16.0.app
+          # See: https://developer.apple.com/documentation/xcode-release-notes/xcode-16_2-release-notes
+          sudo xcode-select --switch /Applications/Xcode_16.2.app
           clang --version
 
       - name: Install Homebrew packages


### PR DESCRIPTION
Changing the CI policy to use the *latest* Xcode (instead of the *earliest*), allowed by the Bitcoin Core minimum supported macOS version, makes sense: While this may require the developer or user to install a later security point-release on macOS, this should generally be fine and it is even expected that users run the latest supported security release of their operating system. Also, in practise, this often doesn't result in a visible change anyway: This specific change from Xcode 16.0 to 16.2 does not change any behavior of the Bitcoin Core CI, because there are no C++-related changes in those point releases.