### PR TITLE
net: Execute Discover() when bind=0.0.0.0 or :: is set

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2112,7 +2112,28 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         StartTorControl(onion_service_target);
     }
 
-    if (connOptions.bind_on_any) {
+    // Determine if we should discover local addresses
+    bool should_discover = connOptions.bind_on_any;
+    if (!should_discover) {
+        // Check if any -bind address is 0.0.0.0 or ::
+        for (const auto& bind_addr : connOptions.vBinds) {
+            if (bind_addr.IsBindAny()) {
+                should_discover = true;
+                break;
+            }
+        }
+    }
+    if (!should_discover) {
+        // Check if any -whitebind address is 0.0.0.0 or ::
+        for (const auto& whitebind : connOptions.vWhiteBinds) {
+            if (whitebind.m_service.IsBindAny()) {
+                should_discover = true;
+                break;
+            }
+        }
+    }
+
+    if (should_discover) {
         // Only add all IP addresses of the machine if we would be listening on
         // any address - 0.0.0.0 (IPv4) and :: (IPv6).
         Discover();


### PR DESCRIPTION
Fixes #31293

When using `-bind=0.0.0.0:port` or `-bind=[::]:port` (or their `-whitebind` equivalents), the `Discover()` function was not being executed because `bind_on_any` was set to false when explicit bind addresses were provided.

This meant that nodes using explicit "any" bind addresses would not discover and advertise their own local addresses to peers, even though they were effectively listening on all interfaces.

This commit checks if any of the explicitly provided `-bind` or `-whitebind` addresses are "any" addresses (0.0.0.0 or ::) and ensures `Discover()` runs in those cases, matching the behavior when no explicit bind is given.