### PR TITLE
mining: pass missing context to createNewBlock() and checkBlock()

### DIFF
--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -17,8 +17,8 @@ interface Mining $Proxy.wrap("interfaces::Mining") {
     isInitialBlockDownload @1 (context :Proxy.Context) -> (result: Bool);
     getTip @2 (context :Proxy.Context) -> (result: Common.BlockRef, hasResult: Bool);
     waitTipChanged @3 (context :Proxy.Context, currentTip: Data, timeout: Float64) -> (result: Common.BlockRef);
-    createNewBlock @4 (options: BlockCreateOptions) -> (result: BlockTemplate);
-    checkBlock @5 (block: Data, options: BlockCheckOptions) -> (reason: Text, debug: Text, result: Bool);
+    createNewBlock @4 (context :Proxy.Context, options: BlockCreateOptions) -> (result: BlockTemplate);
+    checkBlock @5 (context :Proxy.Context, block: Data, options: BlockCheckOptions) -> (reason: Text, debug: Text, result: Bool);
 }
 
 interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {


### PR DESCRIPTION
Adding a `context` parameter ensures that these methods are run in their own thread and don't block other calls.

For `createNewBlock()` this is not expected to have much impact, because block template creation is fast.

For `checkBlock()` this ensures that if we receive a slow to validate block from an untrusted origin (the IPC connection itself is assumed to trusted), it will not block the IPC server. But since validation itself blocks `cs_main` this is also not a huge performance win.

This is a breaking change both ways:
- clients must use the updated capnp file
- updated clients can't call these methods on an unupgraded node

---

Because it's a breaking change, but not really important, this PR is marked pending some other more important breaking change. See #33777.