### PR TITLE
depends: Fix native_capnp to respect build_CC and build_CXX

### DIFF
--- a/depends/packages/native_capnp.mk
+++ b/depends/packages/native_capnp.mk
@@ -6,6 +6,8 @@ $(package)_file_name=capnproto-cxx-$($(package)_version).tar.gz
 $(package)_sha256_hash=ed00e44ecbbda5186bc78a41ba64a8dc4a861b5f8d4e822959b0144ae6fd42ef
 
 define $(package)_set_vars
+  $(package)_config_env := CC="$$(build_CC)"
+  $(package)_config_env += CXX="$$(build_CXX)"
   $(package)_config_opts := -DBUILD_TESTING=OFF
   $(package)_config_opts += -DWITH_OPENSSL=OFF
   $(package)_config_opts += -DWITH_ZLIB=OFF


### PR DESCRIPTION
Fixes #33859

native_capnp was ignoring CC/CXX environment variables and always using the system default compiler. This caused build failures on systems with older GCC versions when users tried to specify a different compiler.

Added config_env settings in native_capnp.mk to properly use build_CC and build_CXX variables, following the same pattern used in native_qt.mk.