### PR TITLE
contrib: Count entry differences in asmap-tool diff summary

### DIFF
--- a/contrib/asmap/asmap-tool.py
+++ b/contrib/asmap/asmap-tool.py
@@ -140,15 +140,19 @@ def main():
         state1 = load_file(args.infile1)
         state2 = load_file(args.infile2)
         ipv4_changed = 0
+        ipv4_entries_changed = 0
         ipv6_changed = 0
+        ipv6_entries_changed = 0
         for prefix, old_asn, new_asn in state1.diff(state2):
             if args.ignore_unassigned and old_asn == 0:
                 continue
             net = asmap.prefix_to_net(prefix)
             if isinstance(net, ipaddress.IPv4Network):
-                ipv4_changed += 1 << (32 - net.prefixlen)
+                ipv4_changed += net.num_addresses
+                ipv4_entries_changed += 1
             elif isinstance(net, ipaddress.IPv6Network):
-                ipv6_changed += 1 << (128 - net.prefixlen)
+                ipv6_changed += net.num_addresses
+                ipv6_entries_changed += 1
             if new_asn == 0:
                 print(f"# {net} was AS{old_asn}")
             elif old_asn == 0:
@@ -159,8 +163,9 @@ def main():
         ipv6_change_str = "" if ipv6_changed == 0 else f" (2^{math.log2(ipv6_changed):.2f})"
 
         print(
-            f"# {ipv4_changed}{ipv4_change_str} IPv4 addresses changed; "
-            f"{ipv6_changed}{ipv6_change_str} IPv6 addresses changed"
+f"""# Summary
+IPv4: {ipv4_entries_changed} entries with {ipv4_changed}{ipv4_change_str} addresses changed
+IPv6: {ipv6_entries_changed} entries with {ipv6_changed}{ipv6_change_str} addresses changed"""
         )
     elif args.subcommand == "diff_addrs":
         state1 = load_file(args.infile1)


### PR DESCRIPTION
Currently the output of `asmap-tool.py diff` returns the total number of addresses that has changed at the end of the list.

Example output currently:

```
2602:feda:c0::/48 AS1029 # was AS43126
2604:7c00:100::/40 AS29802 # was AS40244
# 0 IPv4 addresses changed; 79552154633921058212365205504 (2^96.01) IPv6 addresses changed
```

This is good indicator but in case of a longer list I would like the number of changed entries as well, since that is an easier number to parse and for debugging of certain issues also the more relevant value. This PR adds the count of changed entries to this summary output at the end. There as also a bit more structure so it's easier to parse as well.

Example new output:

```
2602:feda:c0::/48 AS1029 # was AS43126
2604:7c00:100::/40 AS29802 # was AS40244
# Summary
IPv4: 0 entries with 0 addresses changed
IPv6: 12 entries with 79552154633921058212365205504 (2^96.01) addresses changed
```