### PR TITLE
kernel: don't use assert to handle invalid user input

### DIFF
--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -516,7 +516,10 @@ size_t btck_transaction_count_outputs(const btck_Transaction* transaction)
 const btck_TransactionOutput* btck_transaction_get_output_at(const btck_Transaction* transaction, size_t output_index)
 {
     const CTransaction& tx = *btck_Transaction::get(transaction);
-    assert(output_index < tx.vout.size());
+    if (output_index >= tx.vout.size()) {
+        LogError("output_index is out of bounds.");
+        return nullptr;
+    }
     return btck_TransactionOutput::ref(&tx.vout[output_index]);
 }
 
@@ -527,8 +530,12 @@ size_t btck_transaction_count_inputs(const btck_Transaction* transaction)
 
 const btck_TransactionInput* btck_transaction_get_input_at(const btck_Transaction* transaction, size_t input_index)
 {
-    assert(input_index < btck_Transaction::get(transaction)->vin.size());
-    return btck_TransactionInput::ref(&btck_Transaction::get(transaction)->vin[input_index]);
+    const CTransaction& tx = *btck_Transaction::get(transaction);
+    if (input_index >= tx.vin.size()) {
+        LogError("input_index is out of bounds.");
+        return nullptr;
+    }
+    return btck_TransactionInput::ref(&tx.vin[input_index]);
 }
 
 const btck_Txid* btck_transaction_get_txid(const btck_Transaction* transaction)
@@ -1084,8 +1091,12 @@ size_t btck_block_count_transactions(const btck_Block* block)
 
 const btck_Transaction* btck_block_get_transaction_at(const btck_Block* block, size_t index)
 {
-    assert(index < btck_Block::get(block)->vtx.size());
-    return btck_Transaction::ref(&btck_Block::get(block)->vtx[index]);
+    const auto& block_vtx = btck_Block::get(block)->vtx;
+    if (index >= block_vtx.size()) {
+        LogError("transaction_index is out of bounds.");
+        return nullptr;
+    }
+    return btck_Transaction::ref(&block_vtx[index]);
 }
 
 int btck_block_to_bytes(const btck_Block* block, btck_WriteBytes writer, void* user_data)
@@ -1185,8 +1196,12 @@ size_t btck_block_spent_outputs_count(const btck_BlockSpentOutputs* block_spent_
 
 const btck_TransactionSpentOutputs* btck_block_spent_outputs_get_transaction_spent_outputs_at(const btck_BlockSpentOutputs* block_spent_outputs, size_t transaction_index)
 {
-    assert(transaction_index < btck_BlockSpentOutputs::get(block_spent_outputs)->vtxundo.size());
-    const auto* tx_undo{&btck_BlockSpentOutputs::get(block_spent_outputs)->vtxundo.at(transaction_index)};
+    const auto& vtxundo = btck_BlockSpentOutputs::get(block_spent_outputs)->vtxundo;
+    if (transaction_index >= vtxundo.size()) {
+        LogError("transaction_spent_outputs_index is out of bounds.");
+        return nullptr;
+    }
+    const auto* tx_undo{&vtxundo.at(transaction_index)};
     return btck_TransactionSpentOutputs::ref(tx_undo);
 }
 
@@ -1212,8 +1227,12 @@ void btck_transaction_spent_outputs_destroy(btck_TransactionSpentOutputs* transa
 
 const btck_Coin* btck_transaction_spent_outputs_get_coin_at(const btck_TransactionSpentOutputs* transaction_spent_outputs, size_t coin_index)
 {
-    assert(coin_index < btck_TransactionSpentOutputs::get(transaction_spent_outputs).vprevout.size());
-    const Coin* coin{&btck_TransactionSpentOutputs::get(transaction_spent_outputs).vprevout.at(coin_index)};
+    const auto& vprevout = btck_TransactionSpentOutputs::get(transaction_spent_outputs).vprevout;
+    if (coin_index >= vprevout.size()) {
+        LogError("coin_index is out of bounds.");
+        return nullptr;
+    }
+    const Coin* coin{&vprevout.at(coin_index)};
     return btck_Coin::ref(coin);
 }
 

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -528,7 +528,7 @@ BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_count
  *
  * @param[in] transaction  Non-null.
  * @param[in] output_index The index of the transaction output to be retrieved.
- * @return                 The transaction output
+ * @return                 The transaction output, or null if output_index is out of bounds.
  */
 BITCOINKERNEL_API const btck_TransactionOutput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_get_output_at(
     const btck_Transaction* transaction, size_t output_index) BITCOINKERNEL_ARG_NONNULL(1);
@@ -540,7 +540,7 @@ BITCOINKERNEL_API const btck_TransactionOutput* BITCOINKERNEL_WARN_UNUSED_RESULT
  *
  * @param[in] transaction Non-null.
  * @param[in] input_index The index of the transaction input to be retrieved.
- * @return                 The transaction input
+ * @return                The transaction input, or null if input_index is out of bounds.
  */
 BITCOINKERNEL_API const btck_TransactionInput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_get_input_at(
     const btck_Transaction* transaction, size_t input_index) BITCOINKERNEL_ARG_NONNULL(1);
@@ -1166,7 +1166,7 @@ BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_count_trans
  *
  * @param[in] block             Non-null.
  * @param[in] transaction_index The index of the transaction to be retrieved.
- * @return                      The transaction.
+ * @return                      The transaction, or null if transaction_index is out of bounds.
  */
 BITCOINKERNEL_API const btck_Transaction* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_get_transaction_at(
     const btck_Block* block, size_t transaction_index) BITCOINKERNEL_ARG_NONNULL(1);
@@ -1305,7 +1305,7 @@ BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_spent_outpu
  *
  * @param[in] block_spent_outputs             Non-null.
  * @param[in] transaction_spent_outputs_index The index of the transaction spent outputs within the block spent outputs.
- * @return                                    A transaction spent outputs pointer.
+ * @return                                    A transaction spent outputs pointer, or null if the index is out of bounds.
  */
 BITCOINKERNEL_API const btck_TransactionSpentOutputs* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_spent_outputs_get_transaction_spent_outputs_at(
     const btck_BlockSpentOutputs* block_spent_outputs,
@@ -1350,7 +1350,7 @@ BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_spent
  * @param[in] transaction_spent_outputs Non-null.
  * @param[in] coin_index                The index of the to be retrieved coin within the
  *                                      transaction spent outputs.
- * @return                              A coin pointer.
+ * @return                              A coin pointer, or null if coin_index is out of bounds.
  */
 BITCOINKERNEL_API const btck_Coin* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_spent_outputs_get_coin_at(
     const btck_TransactionSpentOutputs* transaction_spent_outputs,

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -611,7 +611,7 @@ BITCOINKERNEL_API btck_ScriptPubkey* BITCOINKERNEL_WARN_UNUSED_RESULT btck_scrip
  * @param[in] input_index       Index of the input in tx_to spending the script_pubkey.
  * @param[in] flags             Bitfield of btck_ScriptVerificationFlags controlling validation constraints.
  * @param[out] status           Nullable, will be set to an error code if the operation fails, or OK otherwise.
- * @return                      1 if the script is valid, 0 otherwise.
+ * @return                      1 if the script is valid, 0 if the script is invalid, or -1 if the request is invalid
  */
 BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_script_pubkey_verify(
     const btck_ScriptPubkey* script_pubkey,

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -383,6 +383,10 @@ private:
     ScriptPubkeyApi() = default;
 
 public:
+    /**
+     * @return true if the script is valid, false if the script is invalid.
+     * @throws std::runtime_error if the request is invalid (e.g., input_index out of bounds).
+     */
     bool Verify(int64_t amount,
                 const Transaction& tx_to,
                 std::span<const TransactionOutput> spent_outputs,
@@ -652,6 +656,9 @@ bool ScriptPubkeyApi<Derived>::Verify(int64_t amount,
         input_index,
         static_cast<btck_ScriptVerificationFlags>(flags),
         reinterpret_cast<btck_ScriptVerifyStatus*>(&status));
+    if (result == -1) {
+        throw std::runtime_error("invalid script verification request");
+    }
     return result == 1;
 }
 

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -591,12 +591,16 @@ public:
 
     TransactionOutputView GetOutput(size_t index) const
     {
-        return TransactionOutputView{btck_transaction_get_output_at(impl(), index)};
+        auto output = btck_transaction_get_output_at(impl(), index);
+        if (!output) throw std::out_of_range("index out of bounds");
+        return TransactionOutputView{output};
     }
 
     TransactionInputView GetInput(size_t index) const
     {
-        return TransactionInputView{btck_transaction_get_input_at(impl(), index)};
+        auto input = btck_transaction_get_input_at(impl(), index);
+        if (!input) throw std::out_of_range("index out of bounds");
+        return TransactionInputView{input};
     }
 
     TxidView Txid() const
@@ -726,7 +730,9 @@ public:
 
     TransactionView GetTransaction(size_t index) const
     {
-        return TransactionView{btck_block_get_transaction_at(get(), index)};
+        auto tx = btck_block_get_transaction_at(get(), index);
+        if (!tx) throw std::out_of_range("index out of bounds");
+        return TransactionView{tx};
     }
 
     MAKE_RANGE_METHOD(Transactions, Block, &Block::CountTransactions, &Block::GetTransaction, *this)
@@ -1063,7 +1069,9 @@ public:
 
     CoinView GetCoin(size_t index) const
     {
-        return CoinView{btck_transaction_spent_outputs_get_coin_at(impl(), index)};
+        auto coin = btck_transaction_spent_outputs_get_coin_at(impl(), index);
+        if (!coin) throw std::out_of_range("index out of bounds");
+        return CoinView{coin};
     }
 
     MAKE_RANGE_METHOD(Coins, Derived, &TransactionSpentOutputsApi<Derived>::Count, &TransactionSpentOutputsApi<Derived>::GetCoin, *static_cast<const Derived*>(this))
@@ -1099,7 +1107,9 @@ public:
 
     TransactionSpentOutputsView GetTxSpentOutputs(size_t tx_undo_index) const
     {
-        return TransactionSpentOutputsView{btck_block_spent_outputs_get_transaction_spent_outputs_at(get(), tx_undo_index)};
+        auto tx_spent_outputs = btck_block_spent_outputs_get_transaction_spent_outputs_at(get(), tx_undo_index);
+        if (!tx_spent_outputs) throw std::out_of_range("index out of bounds");
+        return TransactionSpentOutputsView{tx_spent_outputs};
     }
 
     MAKE_RANGE_METHOD(TxsSpentOutputs, BlockSpentOutputs, &BlockSpentOutputs::Count, &BlockSpentOutputs::GetTxSpentOutputs, *this)

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -463,6 +463,9 @@ BOOST_AUTO_TEST_CASE(btck_transaction_tests)
 
     ScriptPubkey script_pubkey_roundtrip{script_pubkey.ToBytes()};
     check_equal(script_pubkey_roundtrip.ToBytes(), script_pubkey.ToBytes());
+
+    BOOST_CHECK_THROW(tx.GetOutput(tx.CountOutputs()), std::out_of_range);
+    BOOST_CHECK_THROW(tx.GetInput(tx.CountInputs()), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_CASE(btck_script_pubkey)
@@ -632,6 +635,8 @@ BOOST_AUTO_TEST_CASE(btck_block)
     BOOST_CHECK_THROW(Block{invalid_data}, std::runtime_error);
     auto empty_data = hex_string_to_byte_vec("");
     BOOST_CHECK_THROW(Block{empty_data}, std::runtime_error);
+
+    BOOST_CHECK_THROW(block_tx.GetTransaction(block_tx.CountTransactions()), std::out_of_range);
 }
 
 Context create_context(std::shared_ptr<TestKernelNotifications> notifications, ChainType chain_type, std::shared_ptr<TestValidationInterface> validation_interface = nullptr)
@@ -1032,6 +1037,9 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     BOOST_CHECK_EQUAL(script_pubkey_bytes.size(), 22);
     auto round_trip_script_pubkey{ScriptPubkey(script_pubkey_bytes)};
     BOOST_CHECK_EQUAL(round_trip_script_pubkey.ToBytes().size(), 22);
+
+    BOOST_CHECK_THROW(block_spent_outputs.GetTxSpentOutputs(block_spent_outputs.Count()), std::out_of_range);
+    BOOST_CHECK_THROW(transaction_spent_outputs.GetCoin(transaction_spent_outputs.Count()), std::out_of_range);
 
     for (const auto tx_spent_outputs : block_spent_outputs.TxsSpentOutputs()) {
         for (const auto coins : tx_spent_outputs.Coins()) {


### PR DESCRIPTION
Crashing with `assert` for invalid user input is problematic for a library, e.g. this is impossible for FFI users to recover from, forcing them to re-implement the error handling logic client-side. See e.g. the [go](https://github.com/stringintech/go-bitcoinkernel/blob/88105c69b32c48919a45bb07fc05ca2c79d2728b/kernel/script_pubkey.go#L91-L102) and [.net](https://github.com/janb84/BitcoinKernel.NET/blob/4ba1ff802fe9a3b7c0af0012e6fdc33e5bc4f961/src/BitcoinKernel.Core/ScriptVerification/ScriptVerifier.cs#L38-L56) bindings, or the discussion in https://github.com/stringintech/kernel-bindings-tests/issues/5.

This PR changes behaviour by:
- updating `btck_script_pubkey_verify` to return `-1` for invalid/malformed requests, `0` for invalid scripts, and `1` for valid scripts. Previously, the program would crash for the `-1` cases.
- updating 5 getters to return `nullptr` when the request index is out of bounds. Previously, the program would crash in these cases.

The wrapper is updated to throw `std::runtime_error` or `std::out_of_bounds` errors, and the tests are also updated.

By not crashing, we can properly test for these edge cases in [`kernel-bindings-tests`](https://github.com/stringintech/kernel-bindings-tests) to ensure that wrappers are handling them properly, as opposed to e.g. not differentiating between `0` and `-1`, which a naive (incorrect) implementation could do.

Note: I'm not sure why `btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION` and `btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED` are currently handled as `INVALID_SCRIPT`, in my view they should probably be `INVALID_REQUEST` (which means `btck_ScriptVerifyStatus` becomes meaningless in its current form), but I've not implemented that yet as I'm not 100% sure. Happy to update that here, or can also be done in a separate pull later.