### PR TITLE
Request: fix typos in "release-notes-0.18.0.md" and "release-notes-0.15.0.1.md"

### DIFF
--- a/doc/release-notes/release-notes-0.15.0.1.md
+++ b/doc/release-notes/release-notes-0.15.0.1.md
@@ -65,7 +65,7 @@ GUI startup crash issue
 
 After upgrade to 0.15.0, some clients would crash at startup because a custom
 fee setting was configured that no longer exists in the GUI. This is a minimal
-patch to avoid this issue from occuring.
+patch to avoid this issue from occurring.
 
 0.15.0.1 Change log
 ====================

--- a/doc/release-notes/release-notes-0.18.0.md
+++ b/doc/release-notes/release-notes-0.18.0.md
@@ -924,7 +924,7 @@ Changes for particular platforms
 - #14958 Remove race between connecting and shutdown on separate connections (promag)
 - #15166 Pin shellcheck version (practicalswift)
 - #15196 Update all `subprocess.check_output` functions to be Python 3.4 compatible (gkrizek)
-- #15043 Build fuzz targets into seperate executables (MarcoFalke)
+- #15043 Build fuzz targets into separate executables (MarcoFalke)
 - #15276 travis: Compile once on trusty (MarcoFalke)
 - #15246 Add tests for invalid message headers (MarcoFalke)
 - #15301 When testing with --usecli, unify RPC arg to cli arg conversion and handle dicts and lists (achow101)


### PR DESCRIPTION
Typos Identified:

1. "seperate" → should be "separate"
- File: doc/release-notes/release-notes-0.18.0.md
- Line: 909-947 region
- Text: "#15043 Build fuzz targets into seperate executables (MarcoFalke)"
- URL: https://github.com/bitcoin/bitcoin/blob/0690514d4f72aac251ee0b876cded9187d42c63e/doc/release-notes/release-notes-0.18.0.md#L909-L947

2. "occuring" → should be "occurring"
- File: doc/release-notes/release-notes-0.15.0.1.md
- Line: 1-87 region
- Text: "This is a minimal patch to avoid this issue from occuring."