### PR TITLE
interfaces: remove redundant mempool lock in ChainImpl::isInMempool()

### DIFF
--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -658,7 +658,6 @@ public:
     bool isInMempool(const Txid& txid) override
     {
         if (!m_node.mempool) return false;
-        LOCK(m_node.mempool->cs);
         return m_node.mempool->exists(txid);
     }
     bool hasDescendantsInMempool(const Txid& txid) override


### PR DESCRIPTION
This PR removes an unnecessary `LOCK(mempool->cs)` in `ChainImpl::isInMempool()`. The method calls `CTxMemPool::exists()`, which already locks `mempool->cs` internally. Because the mempool mutex is a RecursiveMutex, double-locking was safe but redundant. Dropping the outer lock matches patterns used elsewhere in ChainImpl (e.g. `hasDescendantsInMempool()` and `GetTransactionAncestry()` callers) where mempool read APIs are invoked without an additional lock and rely on the callee’s internal locking. `isRBFOptIn()` remains unchanged since `IsRBFOptIn(tx, pool)` explicitly requires the caller to hold `pool.cs` as indicated by its thread-safety annotation.