### PR TITLE
ubsan: add another suppression for InsecureRandomContext

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -52,6 +52,7 @@ unsigned-integer-overflow:DecompressAmount
 unsigned-integer-overflow:crypto/
 unsigned-integer-overflow:MurmurHash3
 unsigned-integer-overflow:TxConfirmStats::EstimateMedianVal
+unsigned-integer-overflow:InsecureRandomContext::InsecureRandomContext
 unsigned-integer-overflow:InsecureRandomContext::rand64
 unsigned-integer-overflow:InsecureRandomContext::SplitMix64
 unsigned-integer-overflow:bitset_detail::PopCount


### PR DESCRIPTION
We've been suppressing this in infra for a little while, it's now appearing elsewhere. i.e
https://github.com/willcl-ark/bitcoin/actions/runs/19702968577/job/56443491265#step:9:2738:
```bash
Run bip324_cipher_roundtrip with args ['/home/runner/work/_temp/build/bin/fuzz', '-runs=1', PosixPath('/home/runner/work/_temp/ci/scratch/qa-assets/fuzz_corpora/bip324_cipher_roundtrip')]INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 2138761624
INFO: Loaded 1 modules   (612416 inline 8-bit counters): 612416 [0x55aa0745d458, 0x55aa074f2c98), 
INFO: Loaded 1 PC tables (612416 PCs): 612416 [0x55aa074f2c98,0x55aa07e4b098), 
INFO:     1479 files found in /home/runner/work/_temp/ci/scratch/qa-assets/fuzz_corpora/bip324_cipher_roundtrip
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 214082 bytes
INFO: seed corpus: files: 1479 min: 1b max: 214082b total: 869543b rss: 112Mb
/home/runner/work/_temp/src/random.h:432:29: runtime error: unsigned integer overflow: 11400714825904921328 * 13787848793156543929 cannot be represented in type 'unsigned long'
    #0 0x55aa041751db in InsecureRandomContext::InsecureRandomContext(unsigned long) (/home/runner/work/_temp/build/bin/fuzz+0x1c181db) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)
    #1 0x55aa041737c4 in bip324_cipher_roundtrip_fuzz_target(std::span<unsigned char const, 18446744073709551615ul>) (/home/runner/work/_temp/build/bin/fuzz+0x1c167c4) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)
    #2 0x55aa04a13ea5 in LLVMFuzzerTestOneInput (/home/runner/work/_temp/build/bin/fuzz+0x24b6ea5) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)
    #3 0x55aa040189ff in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/runner/work/_temp/build/bin/fuzz+0x1abb9ff) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)
    #4 0x55aa04018009 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) (/home/runner/work/_temp/build/bin/fuzz+0x1abb009) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)
    #5 0x55aa04019d72 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (/home/runner/work/_temp/build/bin/fuzz+0x1abcd72) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)
    #6 0x55aa0401a290 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (/home/runner/work/_temp/build/bin/fuzz+0x1abd290) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)
    #7 0x55aa04006915 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/runner/work/_temp/build/bin/fuzz+0x1aa9915) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)
    #8 0x55aa04032cd6 in main (/home/runner/work/_temp/build/bin/fuzz+0x1ad5cd6) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)
    #9 0x7f8d6de271c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #10 0x7f8d6de2728a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #11 0x55aa03ffaee4 in _start (/home/runner/work/_temp/build/bin/fuzz+0x1a9dee4) (BuildId: 240d4d47bf0144daf13a950328fb39f74c0478d6)

SUMMARY: UndefinedBehaviorSanitizer: unsigned-integer-overflow /home/runner/work/_temp/src/random.h:432:29 
```