### PR TITLE
guix: reduce allowed exported symbols

### DIFF
--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -39,8 +39,7 @@ MAX_VERSIONS = {
 
 # Ignore symbols that are exported as part of every executable
 IGNORE_EXPORTS = {
-'environ', '_environ', '__environ', '_fini', '_init', 'stdin',
-'stdout', 'stderr',
+'stdin', 'stdout', 'stderr',
 }
 
 # Expected linker-loader names can be found here:


### PR DESCRIPTION
Need to double-check, but pretty sure this is atleast partly from #33181.