### PR TITLE
depends: update freetype and document remaining `bitcoin-qt` runtime libs

### DIFF
--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -26,6 +26,13 @@ import lief
 #
 # - libc version 2.34 (https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/)
 #
+# bitcoin-qt
+#
+# Ubuntu 22.04 is currently the baseline for ELF_ALLOWED_LIBRARIES:
+#
+# libfontconfig version 2.13.1 (https://packages.ubuntu.com/jammy/libfontconfig1)
+#
+# libfreetype version 2.11.1 (https://packages.ubuntu.com/jammy/libfreetype6)
 
 MAX_VERSIONS = {
 'GLIBC': {

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -1,8 +1,8 @@
 package=freetype
-$(package)_version=2.11.0
+$(package)_version=2.11.1
 $(package)_download_path=https://download.savannah.gnu.org/releases/$(package)
-$(package)_file_name=$(package)-$($(package)_version).tar.xz
-$(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=f8db94d307e9c54961b39a1cc799a67d46681480696ed72ecf78d4473770f09b
 $(package)_build_subdir=build
 $(package)_patches += cmake_minimum.patch
 

--- a/depends/patches/freetype/cmake_minimum.patch
+++ b/depends/patches/freetype/cmake_minimum.patch
@@ -2,7 +2,7 @@ build: set minimum required CMake to 3.12
 
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -97,7 +97,7 @@
+@@ -109,7 +109,7 @@
  # FreeType explicitly marks the API to be exported and relies on the compiler
  # to hide all other symbols. CMake supports a C_VISBILITY_PRESET property
  # starting with 2.8.12.


### PR DESCRIPTION
Update freetype to `2.11.1`.
Updating fontconfig (currently `2.12.6`) to `2.13.1` requires what looks like a hard dep on gperf; leaving that as-is for now.
Document expectations in `symbol-check.py`.
Closes #29977 (changes are based on discussion there).