### PR TITLE
test: add functional test for outbound connection management

### DIFF
--- a/test/functional/p2p_outbound_management.py
+++ b/test/functional/p2p_outbound_management.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test management of automatic connections:
+- Extra outbound connections when the tip is stale
+- Regularly scheduled extra block-relay-only connections
+- Management of full outbound connection slots with respect to network-specific peers
+"""
+
+import random
+import time
+
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+)
+from test_framework.messages import (
+    CBlock,
+    CBlockHeader,
+    from_hex,
+    msg_block,
+    msg_headers,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+
+class P2POutboundManagement(BitcoinTestFramework):
+
+    # makes sure stale tip check / extra peer eviction is run
+    SCHEDULE_EXTRA_PEER_CHECK = 46
+    # chosen large enough that EXTRA_NETWORK_PEER_INTERVAL and EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL
+    # which are on exponential 5min timers, will hit with very high probability
+    MOCKTIME_BUMP = 5000
+
+    def set_test_params(self):
+        self.auto_outbound_mode = True
+        self.num_nodes = 1
+        self.extra_args = [["-test=addrman", "-cjdnsreachable"]]
+
+    def all_sync_send_with_ping(self, peers):
+        """Send a ping to all connected peers and wait for pongs."""
+        for p in peers:
+            node = p["node"]
+            if node.is_connected:
+                node.sync_with_ping()
+
+    def has_regular_outbounds(self):
+        """Check if we have 8 full outbound and 2 block-relay-only connections."""
+        peer_info = self.nodes[0].getpeerinfo()
+        full_outbound = [p for p in peer_info if p['connection_type'] == 'outbound-full-relay']
+        block_relay = [p for p in peer_info if p['connection_type'] == 'block-relay-only']
+        return len(full_outbound) == 8 and len(block_relay) == 2
+
+    def has_extra_block_relay_peer(self):
+        """Check if we have more than 2 block-relay-only peers."""
+        peer_info = self.nodes[0].getpeerinfo()
+        block_relay_peers = [p for p in peer_info if p['connection_type'] == 'block-relay-only']
+        return len(block_relay_peers) > 2
+
+    def has_extra_full_outbound_peer(self):
+        """Check if we have more than 8 full outbound peers."""
+        peer_info = self.nodes[0].getpeerinfo()
+        full_outbound = [p for p in peer_info if p['connection_type'] == 'outbound-full-relay']
+        return len(full_outbound) > 8
+
+    def disconnect_last_block_relay_peer(self):
+        """Find and disconnect the most recently connected block-relay-only peer.
+           Done manually instead of waiting for the node to disconnect automatically to
+           avoid rare interactions with the scheduling of the next extra block-relay-only peer"""
+        node = self.nodes[0]
+        peer_info = node.getpeerinfo()
+        block_relay_peers = [p for p in peer_info if p['connection_type'] == 'block-relay-only']
+        assert block_relay_peers
+        # Disconnect the peer with the highest id
+        last_peer = max(block_relay_peers, key=lambda p: p['id'])
+        node.disconnectnode(nodeid=last_peer['id'])
+
+    def wait_for_network_specific_peer(self):
+        """Advance time, wait for a network-specific full outbound peer, and trigger eviction.
+
+        Extra block-relay-only connections are prioritized over network-specific ones, but defensively:
+        if an already connected tor or cjdns address is picked, there is no retry. This can cause either
+        type of peer to arrive first.
+        """
+        node = self.nodes[0]
+
+        self.log.info("Advance time")
+        self.cur_time += self.MOCKTIME_BUMP
+        node.setmocktime(self.cur_time)
+        self.generate(node, 1)  # Disable stale-tip extra-outbound connections that could interfere
+
+        self.log.info("Wait for either extra block-relay or network-specific peer")
+        self.wait_until(lambda: self.has_extra_block_relay_peer() or self.has_extra_full_outbound_peer())
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+        if self.has_extra_block_relay_peer() and not self.has_extra_full_outbound_peer():
+            self.log.info("Got extra block-relay peer first, disconnecting to allow network-specific peer")
+            self.disconnect_last_block_relay_peer()
+            self.wait_until(lambda: self.has_regular_outbounds())
+            self.log.info("Now wait for network-specific peer")
+            self.wait_until(lambda: self.has_extra_full_outbound_peer())
+            self.all_sync_send_with_ping(self.auto_outbound_destinations)
+        else:
+            self.log.info("Got network-specific peer directly")
+
+        self.log.info("Trigger eviction to get back to regular outbound count")
+        node.mockscheduler(self.SCHEDULE_EXTRA_PEER_CHECK)  # triggers eviction
+        self.wait_until(lambda: self.has_regular_outbounds())
+
+    def setup_peers(self):
+        self.log.info("Wait for the node to make 10 automatic outbound connections")
+        self.wait_until(lambda: self.has_regular_outbounds())
+
+        # Send current tip header from all peers to avoid being disconnected later on
+        self.log.info("Send current tip header from all peers")
+        node = self.nodes[0]
+        tip_hash = node.getbestblockhash()
+        tip_block = node.getblock(tip_hash, 0)
+        block = from_hex(CBlock(), tip_block)
+        tip_header = CBlockHeader(block)
+
+        headers_msg = msg_headers()
+        headers_msg.headers = [tip_header]
+
+        for peer in self.auto_outbound_destinations:
+            peer_node = peer["node"]
+            if peer_node.is_connected:
+                peer_node.send_and_ping(headers_msg)
+
+        # Initialize regular scheduling of extra block relay connections
+        node.mockscheduler(self.SCHEDULE_EXTRA_PEER_CHECK)
+
+    def test_stale_tip_and_extra_block_relay_only(self):
+        self.log.info("Part 1: Test extra outbound connections when the tip is stale")
+        node = self.nodes[0]
+
+        self.setup_peers()
+
+        self.log.info("Advance time to trigger stale tip and extra block relay only peers")
+        self.cur_time += self.MOCKTIME_BUMP
+        node.setmocktime(self.cur_time)
+        node.mockscheduler(self.SCHEDULE_EXTRA_PEER_CHECK)  # triggers stale tip check
+
+        self.log.info("Wait for extra full outbound peer due to stale tip")
+        self.wait_until(lambda: self.has_extra_full_outbound_peer())
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+        self.log.info("Create new block and have the extra peer send it")
+        tip = node.getbestblockhash()
+        tip_info = node.getblock(tip)
+        height = tip_info['height'] + 1
+        block_time = tip_info['time'] + 1
+
+        block = create_block(int(tip, 16), create_coinbase(height), block_time)
+        block.solve()
+
+        block_header = CBlockHeader(block)
+        headers_msg = msg_headers()
+        headers_msg.headers = [block_header]
+        extra_peer = self.auto_outbound_destinations[-1]['node']
+        extra_peer.send_and_ping(headers_msg)
+
+        self.log.info("Wait for eviction of another peer")
+        node.mockscheduler(self.SCHEDULE_EXTRA_PEER_CHECK)
+
+        self.log.info("Send full block from stale tip peer")
+        assert extra_peer.is_connected
+        extra_peer.send_and_ping(msg_block(block))
+
+        self.log.info("Check for extra block-relay-only peer")
+        self.wait_until(lambda: self.has_extra_block_relay_peer())
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+        # Verify we now have an extra block-relay-only peer
+        peer_info = node.getpeerinfo()
+        block_relay_peers = [p for p in peer_info if p['connection_type'] == 'block-relay-only']
+        assert_equal(len(block_relay_peers), 3)
+
+        self.log.info("Disconnect extra block-relay-only peer")
+        self.disconnect_last_block_relay_peer()
+
+        self.wait_until(lambda: self.has_regular_outbounds())
+
+    def test_network_management(self):
+        self.log.info("Part 2: Test management of outbound connection slots with respect to networks.")
+        self.restart_node(0)
+        node = self.nodes[0]
+        node.setmocktime(self.cur_time)
+        # Generate a block to prevent stale tip detection
+        self.generate(node, 1)
+
+        self.setup_peers()
+
+        self.log.info("Add two onion and two cjdns addrs to addrman")
+        addresses = [
+            "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion",
+            "nrfj6inpyf73gpkyool35hcmne5zwfmse3jl3aw23vk7chdemalyaqad.onion",
+            "[fc00:1234:5678:9abc:def0:1234:5678:9abc]",
+            "[fc11:abcd:ef01:2345:6789:abcd:ef01:2345]",
+        ]
+        for addr in addresses:
+            node.addpeeraddress(address=addr, port=8333, tried=False)
+
+        self.wait_for_network_specific_peer()
+
+        peer_info = node.getpeerinfo()
+        networks = set(p['network'] for p in peer_info)
+        assert_equal(len(networks), 2)
+        assert 'ipv4' in networks, "Expected IPv4 connections"
+        assert 'onion' in networks or 'cjdns' in networks, "Expected at least one onion or cjdns connection"
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+        self.wait_for_network_specific_peer()
+
+        peer_info = node.getpeerinfo()
+        networks = set(p['network'] for p in peer_info)
+        assert_equal(len(networks), 3)
+        assert 'ipv4' in networks, "Expected IPv4 connections"
+        assert 'onion' in networks, "Expected onion connection"
+        assert 'cjdns' in networks, "Expected cjdns connection"
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.cur_time = int(time.time())
+        node.setmocktime(self.cur_time)
+
+        self.log.info("Add 100 random IPv4 addresses to addrman")
+        for _ in range(100):
+            ip = f"{random.randint(1, 223)}.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(1, 254)}"
+            node.addpeeraddress(address=ip, port=8333, tried=False)
+
+        self.test_stale_tip_and_extra_block_relay_only()
+        self.test_network_management()
+
+
+if __name__ == '__main__':
+    P2POutboundManagement(__file__).main()

--- a/test/functional/p2p_outbound_management.py
+++ b/test/functional/p2p_outbound_management.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test management of automatic connections:
+- Extra outbound connections when the tip is stale
+- Regularly scheduled extra block-relay-only connections
+- Management of full outbound connection slots with respect to network-specific peers
+"""
+
+import random
+import time
+
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+)
+from test_framework.messages import (
+    CBlock,
+    CBlockHeader,
+    from_hex,
+    msg_block,
+    msg_headers,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+
+class P2POutboundManagement(BitcoinTestFramework):
+
+    # makes sure stale tip check / extra peer eviction is run
+    SCHEDULE_EXTRA_PEER_CHECK = 46
+    # chosen large enough that EXTRA_NETWORK_PEER_INTERVAL and EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL
+    # which are on exponential 5min timers, will hit with very high probability
+    MOCKTIME_BUMP = 5000
+
+    def set_test_params(self):
+        self.auto_outbound_mode = True
+        self.num_nodes = 1
+        self.extra_args = [["-test=addrman", "-cjdnsreachable"]]
+
+    def all_sync_send_with_ping(self, peers):
+        """Send a ping to all connected peers and wait for pongs."""
+        for p in peers:
+            node = p["node"]
+            if node.is_connected:
+                node.sync_with_ping()
+
+    def last_destination_of_type(self, conn_type):
+        """Return the python peer of the most recent outbound connection of the given type."""
+        with self.auto_outbound_destinations_lock:
+            peers = [d['node'] for d in self.auto_outbound_destinations if d['conn_type'] == conn_type]
+        assert peers
+        return peers[-1]
+
+    def has_regular_outbounds(self):
+        """Check if we have 8 full outbound and 2 block-relay-only connections."""
+        peer_info = self.nodes[0].getpeerinfo()
+        full_outbound = [p for p in peer_info if p['connection_type'] == 'outbound-full-relay']
+        block_relay = [p for p in peer_info if p['connection_type'] == 'block-relay-only']
+        return len(full_outbound) == 8 and len(block_relay) == 2
+
+    def has_extra_block_relay_peer(self):
+        """Check if we have more than 2 block-relay-only peers."""
+        peer_info = self.nodes[0].getpeerinfo()
+        block_relay_peers = [p for p in peer_info if p['connection_type'] == 'block-relay-only']
+        return len(block_relay_peers) > 2
+
+    def has_extra_full_outbound_peer(self):
+        """Check if we have more than 8 full outbound peers."""
+        peer_info = self.nodes[0].getpeerinfo()
+        full_outbound = [p for p in peer_info if p['connection_type'] == 'outbound-full-relay']
+        return len(full_outbound) > 8
+
+    def disconnect_last_block_relay_peer(self):
+        """Find and disconnect the most recently connected block-relay-only peer.
+           Done manually instead of waiting for the node to disconnect automatically to
+           avoid rare interactions with the scheduling of the next extra block-relay-only peer"""
+        node = self.nodes[0]
+        peer_info = node.getpeerinfo()
+        block_relay_peers = [p for p in peer_info if p['connection_type'] == 'block-relay-only']
+        assert block_relay_peers
+        # Disconnect the peer with the highest id
+        last_peer = max(block_relay_peers, key=lambda p: p['id'])
+        node.disconnectnode(nodeid=last_peer['id'])
+
+    def wait_for_network_specific_peer(self):
+        """Advance time, wait for a network-specific full outbound peer, and trigger eviction.
+
+        Extra block-relay-only connections are prioritized over network-specific ones, but defensively:
+        if an already connected tor or cjdns address is picked, there is no retry. This can cause either
+        type of peer to arrive first.
+        """
+        node = self.nodes[0]
+
+        self.log.info("Advance time")
+        self.cur_time += self.MOCKTIME_BUMP
+        node.setmocktime(self.cur_time)
+        self.generate(node, 1)  # Disable stale-tip extra-outbound connections that could interfere
+
+        self.log.info("Wait for either extra block-relay or network-specific peer")
+        self.wait_until(lambda: self.has_extra_block_relay_peer() or self.has_extra_full_outbound_peer())
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+        if self.has_extra_block_relay_peer() and not self.has_extra_full_outbound_peer():
+            self.log.info("Got extra block-relay peer first, disconnecting to allow network-specific peer")
+            self.disconnect_last_block_relay_peer()
+            self.wait_until(lambda: self.has_regular_outbounds())
+            self.log.info("Now wait for network-specific peer")
+            self.wait_until(lambda: self.has_extra_full_outbound_peer())
+            self.all_sync_send_with_ping(self.auto_outbound_destinations)
+        else:
+            self.log.info("Got network-specific peer directly")
+
+        self.log.info("Trigger eviction to get back to regular outbound count")
+        node.mockscheduler(self.SCHEDULE_EXTRA_PEER_CHECK)  # triggers eviction
+        self.wait_until(lambda: self.has_regular_outbounds())
+
+    def setup_peers(self):
+        self.log.info("Wait for the node to make 10 automatic outbound connections")
+        self.wait_until(lambda: self.has_regular_outbounds())
+
+        # Send current tip header from all peers to avoid being disconnected later on
+        self.log.info("Send current tip header from all peers")
+        node = self.nodes[0]
+        tip_hash = node.getbestblockhash()
+        tip_block = node.getblock(tip_hash, 0)
+        block = from_hex(CBlock(), tip_block)
+        tip_header = CBlockHeader(block)
+
+        headers_msg = msg_headers()
+        headers_msg.headers = [tip_header]
+
+        for peer in self.auto_outbound_destinations:
+            peer_node = peer["node"]
+            if peer_node.is_connected:
+                peer_node.send_and_ping(headers_msg)
+
+        # Initialize regular scheduling of extra block relay connections
+        node.mockscheduler(self.SCHEDULE_EXTRA_PEER_CHECK)
+
+    def test_stale_tip_and_extra_block_relay_only(self):
+        self.log.info("Part 1: Test extra outbound connections when the tip is stale")
+        node = self.nodes[0]
+
+        self.setup_peers()
+
+        self.log.info("Advance time to trigger stale tip and extra block relay only peers")
+        self.cur_time += self.MOCKTIME_BUMP
+        node.setmocktime(self.cur_time)
+        node.mockscheduler(self.SCHEDULE_EXTRA_PEER_CHECK)  # triggers stale tip check
+
+        self.log.info("Wait for extra full outbound peer due to stale tip")
+        self.wait_until(lambda: self.has_extra_full_outbound_peer())
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+        self.log.info("Create new block and have the extra peer send it")
+        tip = node.getbestblockhash()
+        tip_info = node.getblock(tip)
+        height = tip_info['height'] + 1
+        block_time = tip_info['time'] + 1
+
+        block = create_block(int(tip, 16), create_coinbase(height), ntime=block_time)
+        block.solve()
+
+        block_header = CBlockHeader(block)
+        headers_msg = msg_headers()
+        headers_msg.headers = [block_header]
+        extra_peer = self.last_destination_of_type('outbound-full-relay')
+        extra_peer.send_and_ping(headers_msg)
+
+        self.log.info("Wait for eviction of another peer")
+        node.mockscheduler(self.SCHEDULE_EXTRA_PEER_CHECK)
+
+        self.log.info("Send full block from stale tip peer")
+        assert extra_peer.is_connected
+        extra_peer.send_and_ping(msg_block(block))
+
+        self.log.info("Check for extra block-relay-only peer")
+        self.wait_until(lambda: self.has_extra_block_relay_peer())
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+        # Verify we now have an extra block-relay-only peer
+        peer_info = node.getpeerinfo()
+        block_relay_peers = [p for p in peer_info if p['connection_type'] == 'block-relay-only']
+        assert_equal(len(block_relay_peers), 3)
+
+        self.log.info("Disconnect extra block-relay-only peer")
+        self.disconnect_last_block_relay_peer()
+
+        self.wait_until(lambda: self.has_regular_outbounds())
+
+    def test_network_management(self):
+        self.log.info("Part 2: Test management of outbound connection slots with respect to networks.")
+        self.restart_node(0)
+        node = self.nodes[0]
+        node.setmocktime(self.cur_time)
+        # Generate a block to prevent stale tip detection
+        self.generate(node, 1)
+
+        self.setup_peers()
+
+        self.log.info("Add two onion and two cjdns addrs to addrman")
+        addresses = [
+            "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion",
+            "nrfj6inpyf73gpkyool35hcmne5zwfmse3jl3aw23vk7chdemalyaqad.onion",
+            "[fc00:1234:5678:9abc:def0:1234:5678:9abc]",
+            "[fc11:abcd:ef01:2345:6789:abcd:ef01:2345]",
+        ]
+        for addr in addresses:
+            node.addpeeraddress(address=addr, port=8333, tried=False)
+
+        self.wait_for_network_specific_peer()
+
+        peer_info = node.getpeerinfo()
+        networks = set(p['network'] for p in peer_info)
+        assert_equal(len(networks), 2)
+        assert 'ipv4' in networks, "Expected IPv4 connections"
+        assert 'onion' in networks or 'cjdns' in networks, "Expected at least one onion or cjdns connection"
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+        self.wait_for_network_specific_peer()
+
+        peer_info = node.getpeerinfo()
+        networks = set(p['network'] for p in peer_info)
+        assert_equal(len(networks), 3)
+        assert 'ipv4' in networks, "Expected IPv4 connections"
+        assert 'onion' in networks, "Expected onion connection"
+        assert 'cjdns' in networks, "Expected cjdns connection"
+        self.all_sync_send_with_ping(self.auto_outbound_destinations)
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.cur_time = int(time.time())
+        node.setmocktime(self.cur_time)
+
+        self.log.info("Add 100 random IPv4 addresses to addrman")
+        for _ in range(100):
+            ip = f"{random.randint(1, 223)}.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(1, 254)}"
+            node.addpeeraddress(address=ip, port=8333, tried=False)
+
+        self.test_stale_tip_and_extra_block_relay_only()
+        self.test_network_management()
+
+
+if __name__ == '__main__':
+    P2POutboundManagement(__file__).main()

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -7,7 +7,6 @@ Test how locally submitted transactions are sent to the network when private bro
 """
 
 import time
-import threading
 
 from test_framework.p2p import (
     P2PDataStore,
@@ -23,14 +22,7 @@ from test_framework.messages import (
     msg_inv,
     msg_tx,
 )
-from test_framework.netutil import (
-    format_addr_port
-)
 from test_framework.script_util import build_malleated_tx_package
-from test_framework.socks5 import (
-    Socks5Configuration,
-    Socks5Server,
-)
 from test_framework.test_framework import (
     BitcoinTestFramework,
 )
@@ -39,7 +31,6 @@ from test_framework.util import (
     assert_greater_than_or_equal,
     assert_not_equal,
     assert_raises_rpc_error,
-    p2p_port,
     tor_port,
 )
 from test_framework.wallet import (
@@ -164,79 +155,32 @@ ADDRMAN_ADDRESSES = [
 
 class P2PPrivateBroadcast(BitcoinTestFramework):
     def set_test_params(self):
-        self.disable_autoconnect = False
+        self.auto_outbound_mode = True
         self.num_nodes = 2
 
-    def setup_nodes(self):
-        # Start a SOCKS5 proxy server.
-        socks5_server_config = Socks5Configuration()
-        # self.nodes[0] listens on p2p_port(0),
-        # self.nodes[1] listens on p2p_port(1),
-        # thus we tell the SOCKS5 server to listen on p2p_port(self.num_nodes) (self.num_nodes is 2)
-        socks5_server_config.addr = ("127.0.0.1", p2p_port(self.num_nodes))
-        socks5_server_config.unauth = True
-        socks5_server_config.auth = True
-
-        self.socks5_server = Socks5Server(socks5_server_config)
-        self.socks5_server.start()
-
-        self.destinations = []
-
-        self.destinations_lock = threading.Lock()
-
-        def destinations_factory(requested_to_addr, requested_to_port):
-            with self.destinations_lock:
-                i = len(self.destinations)
+        def custom_auto_outbound_factory(i):
+            if i == NUM_INITIAL_CONNECTIONS:
+                # Redirect the first private broadcast connection from nodes[0] to nodes[1]
+                return ("127.0.0.1", tor_port(1), None)
+            else:
+                # The first outbound connection is used later to serve GETDATA,
+                # thus make it P2PDataStore().
+                listener = P2PDataStore() if i == 0 else P2PInterface()
                 actual_to_addr = ""
                 actual_to_port = 0
-                listener = None
-                if i == NUM_INITIAL_CONNECTIONS:
-                    # Instruct the SOCKS5 server to redirect the first private
-                    # broadcast connection from nodes[0] to nodes[1]
-                    actual_to_addr = "127.0.0.1" # nodes[1] listen address
-                    actual_to_port = tor_port(1) # nodes[1] listen port for Tor
-                    self.log.debug(f"Instructing the SOCKS5 proxy to redirect connection i={i} to "
-                                   f"{format_addr_port(actual_to_addr, actual_to_port)} (nodes[1])")
-                else:
-                    # Create a Python P2P listening node and instruct the SOCKS5 proxy to
-                    # redirect the connection to it. The first outbound connection is used
-                    # later to serve GETDATA, thus make it P2PDataStore().
-                    listener = P2PDataStore() if i == 0 else P2PInterface()
-                    listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
-                    listener.peer_connect_send_version(services=P2P_SERVICES)
+                listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
+                listener.peer_connect_send_version(services=P2P_SERVICES)
+                def on_listen_done(addr, port):
+                    nonlocal actual_to_addr, actual_to_port
+                    actual_to_addr = addr
+                    actual_to_port = port
+                self.network_thread.listen(addr="127.0.0.1", port=0, p2p=listener, callback=on_listen_done)
+                self.wait_until(lambda: actual_to_port != 0)
+                return (actual_to_addr, actual_to_port, listener)
 
-                    def on_listen_done(addr, port):
-                        nonlocal actual_to_addr
-                        nonlocal actual_to_port
-                        actual_to_addr = addr
-                        actual_to_port = port
+        self.auto_outbound_factory = custom_auto_outbound_factory
 
-                    # Use port=0 to let the OS assign an available port. This
-                    # avoids "address already in use" errors when tests run
-                    # concurrently or ports are still in TIME_WAIT state.
-                    self.network_thread.listen(
-                        addr="127.0.0.1",
-                        port=0,
-                        p2p=listener,
-                        callback=on_listen_done)
-                    # Wait until the callback has been called.
-                    self.wait_until(lambda: actual_to_port != 0)
-                    self.log.debug(f"Instructing the SOCKS5 proxy to redirect connection i={i} to "
-                                   f"{format_addr_port(actual_to_addr, actual_to_port)} (a Python node)")
-
-                self.destinations.append({
-                    "requested_to": format_addr_port(requested_to_addr, requested_to_port),
-                    "node": listener,
-                })
-                assert_equal(len(self.destinations), i + 1)
-
-                return {
-                    "actual_to_addr": actual_to_addr,
-                    "actual_to_port": actual_to_port,
-                }
-
-        self.socks5_server.conf.destinations_factory = destinations_factory
-
+    def setup_nodes(self):
         self.extra_args = [
             [
                 # Needed to be able to add CJDNS addresses to addrman (otherwise they are unroutable).
@@ -246,7 +190,6 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
                 "-v2transport=0",
                 "-test=addrman",
                 "-privatebroadcast",
-                f"-proxy={socks5_server_config.addr[0]}:{socks5_server_config.addr[1]}",
                 # To increase coverage, make it think that the I2P network is reachable so that it
                 # selects such addresses as well. Pick a proxy address where nobody is listening
                 # and connection attempts fail quickly.
@@ -270,8 +213,8 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             self.log.debug(f"{label}: waiting for outbound connection i={i}")
             # At this point the connection may not yet have been established (A),
             # may be active (B), or may have already been closed (C).
-            self.wait_until(lambda: len(self.destinations) > i)
-            dest = self.destinations[i]
+            self.wait_until(lambda: len(self.auto_outbound_destinations) > i)
+            dest = self.auto_outbound_destinations[i]
             peer = dest["node"]
             peer.wait_until(lambda: peer.message_count["version"] == 1, check_connected=False)
             # Now it is either (B) or (C).
@@ -325,7 +268,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             if not res["success"]:
                 self.log.debug(f"Could not add {addr} to tx_originator's addrman (collision?)")
 
-        self.wait_until(lambda: len(self.destinations) == NUM_INITIAL_CONNECTIONS)
+        self.wait_until(lambda: len(self.auto_outbound_destinations) == NUM_INITIAL_CONNECTIONS)
 
         # The next opened connection by tx_originator should be "private broadcast"
         # for sending the transaction. The SOCKS5 proxy should redirect it to tx_receiver.
@@ -365,7 +308,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         inv = CInv(MSG_WTX, wtxid_int)
 
         self.log.info("Sending INV and waiting for GETDATA from node")
-        tx_returner = self.destinations[0]["node"] # Will return the transaction back to the originator.
+        tx_returner = self.auto_outbound_destinations[0]["node"] # Will return the transaction back to the originator.
         tx_returner.tx_store[wtxid_int] = txs[0]["tx"]
         assert "getdata" not in tx_returner.last_message
         received_back_msg = f"Received our privately broadcast transaction (txid={txs[0]['txid']}) from the network"
@@ -375,7 +318,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             self.wait_until(lambda: len(tx_originator.getrawmempool()) > 0)
 
         self.log.info("Waiting for normal broadcast to another peer")
-        self.destinations[1]["node"].wait_for_inv([inv])
+        self.auto_outbound_destinations[1]["node"].wait_for_inv([inv])
 
         self.log.info("Checking getprivatebroadcastinfo no longer reports the transaction after it is received back")
         pbinfo = tx_originator.getprivatebroadcastinfo()
@@ -383,12 +326,12 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         assert_equal(len(pending), 0)
 
         self.log.info("Sending a transaction that is already in the mempool")
-        skip_destinations = len(self.destinations)
+        skip_destinations = len(self.auto_outbound_destinations)
         tx_originator.sendrawtransaction(hexstring=txs[0]["hex"], maxfeerate=0)
         self.check_broadcasts("Broadcast of mempool transaction", txs[0], NUM_PRIVATE_BROADCAST_PER_TX, skip_destinations)
 
         self.log.info("Sending a transaction with a dependency in the mempool")
-        skip_destinations = len(self.destinations)
+        skip_destinations = len(self.auto_outbound_destinations)
         tx_originator.sendrawtransaction(hexstring=txs[1]["hex"], maxfeerate=0.1)
         self.check_broadcasts("Dependency in mempool", txs[1], NUM_PRIVATE_BROADCAST_PER_TX, skip_destinations)
 
@@ -405,7 +348,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         # NextTxBroadcast() in net_processing.cpp.
         self.log.info("Checking that rebroadcast works")
         delta = 20 * 60 # 20min
-        skip_destinations = len(self.destinations)
+        skip_destinations = len(self.auto_outbound_destinations)
         rebroadcast_msg = f"Reattempting broadcast of stale txid={txs[1]['txid']}"
         with tx_originator.busy_wait_for_debug_log(expected_msgs=[rebroadcast_msg.encode()]):
             tx_originator.setmocktime(int(time.time()) + delta)

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -7,13 +7,10 @@ Test how locally submitted transactions are sent to the network when private bro
 """
 
 import time
-import threading
 
 from test_framework.p2p import (
     P2PDataStore,
     P2PInterface,
-    P2P_SERVICES,
-    start_p2p_listener,
 )
 from test_framework.messages import (
     CAddress,
@@ -23,13 +20,7 @@ from test_framework.messages import (
     msg_inv,
     msg_tx,
 )
-from test_framework.netutil import (
-    format_addr_port
-)
 from test_framework.script_util import build_malleated_tx_package
-from test_framework.socks5 import (
-    start_socks5_server,
-)
 from test_framework.test_framework import (
     BitcoinTestFramework,
 )
@@ -57,94 +48,42 @@ class NoRelayP2PInterface(P2PInterface):
 
 class P2PPrivateBroadcast(BitcoinTestFramework):
     def set_test_params(self):
-        self.disable_autoconnect = False
+        self.auto_outbound_mode = True
         self.num_nodes = 2
-
-    def setup_nodes(self):
-        self.destinations = []
-
-        self.destinations_lock = threading.Lock()
 
         self.trigger_no_relay_peer = False
         self.no_relay_peer = None
 
-        def destinations_factory(requested_to_addr, requested_to_port, proxy_client):
+        def auto_outbound_factory(conn_type):
             """
             Instruct the SOCKS5 proxy to redirect connections:
             * The first automatic outbound connection -> P2PDataStore
             * The first private broadcast connection -> nodes[1]
             * Anything else -> P2PInterface
-
-            proxy_client is the client's socket address as seen by the proxy (host:port),
-            equal to the node's addrbind for this connection.
             """
-            conn_type = None
-            # SOCKS handlers run in separate threads, so each needs its own RPC connection.
-            rpc = self.nodes[0].create_new_rpc_connection()
-
-            def connection_type_found():
-                nonlocal conn_type
-                # The proxy has already replied SUCCESS to the SOCKS5 request, so the node
-                # has finished ConnectNode and registered the peer (or is about to).
-                # The proxy client address equals the node's addrbind for this connection.
-                for peer in rpc.getpeerinfo():
-                    if peer.get("addrbind") == proxy_client:
-                        conn_type = peer["connection_type"]
-                        return True
-                return False
-
-            self.wait_until(connection_type_found)
-
-            with self.destinations_lock:
-                i = len(self.destinations)
-                actual_to_addr = ""
-                actual_to_port = 0
-                listener = None
-                target_name = ""
-                if conn_type == "private-broadcast" and not any(dest["conn_type"] == "private-broadcast" for dest in self.destinations):
-                    # Instruct the SOCKS5 server to redirect the first private
-                    # broadcast connection from nodes[0] to nodes[1]
-                    actual_to_addr = "127.0.0.1" # nodes[1] listen address
-                    actual_to_port = tor_port(1) # nodes[1] listen port for Tor
-                    target_name = "nodes[1]"
+            if conn_type == "private-broadcast" and not any(dest["conn_type"] == "private-broadcast" for dest in self.auto_outbound_destinations):
+                # Instruct the SOCKS5 server to redirect the first private
+                # broadcast connection from nodes[0] to nodes[1]
+                actual_to_addr = "127.0.0.1" # nodes[1] listen address
+                actual_to_port = tor_port(1) # nodes[1] listen port for Tor
+                return (actual_to_addr, actual_to_port, None)
+            else:
+                # Create a Python P2P listening node and instruct the SOCKS5 proxy to
+                # redirect the connection to it. The first outbound connection is used
+                # later to serve GETDATA, thus make it P2PDataStore().
+                if conn_type == "outbound-full-relay" and not any(dest["conn_type"] == "outbound-full-relay" for dest in self.auto_outbound_destinations):
+                    listener = P2PDataStore()
+                elif conn_type == "private-broadcast" and self.trigger_no_relay_peer:
+                    listener = NoRelayP2PInterface()
+                    self.trigger_no_relay_peer = False
+                    self.no_relay_peer = listener
                 else:
-                    # Create a Python P2P listening node and instruct the SOCKS5 proxy to
-                    # redirect the connection to it. The first outbound connection is used
-                    # later to serve GETDATA, thus make it P2PDataStore().
-                    if conn_type == "outbound-full-relay" and not any(dest["conn_type"] == "outbound-full-relay" for dest in self.destinations):
-                        listener = P2PDataStore()
-                        target_name = "Python P2PDataStore"
-                    elif conn_type == "private-broadcast" and self.trigger_no_relay_peer:
-                        listener = NoRelayP2PInterface()
-                        target_name = "Python NoRelayP2PInterface"
-                        self.trigger_no_relay_peer = False
-                        self.no_relay_peer = listener
-                    else:
-                        listener = P2PInterface()
-                        target_name = "Python P2PInterface"
-                    listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
-                    listener.peer_connect_send_version(services=P2P_SERVICES)
+                    listener = P2PInterface()
+                return self.start_auto_outbound_listener(listener)
 
-                    actual_to_addr, actual_to_port = start_p2p_listener(self.network_thread, listener)
+        self.auto_outbound_factory = auto_outbound_factory
 
-                self.log.debug(f"Instructing the SOCKS5 proxy to redirect connection i={i} ({conn_type}) for "
-                               f"{format_addr_port(requested_to_addr, requested_to_port)} to "
-                               f"{format_addr_port(actual_to_addr, actual_to_port)} ({target_name})")
-
-                self.destinations.append({
-                    "requested_to": format_addr_port(requested_to_addr, requested_to_port),
-                    "conn_type": conn_type,
-                    "node": listener,
-                })
-                assert_equal(len(self.destinations), i + 1)
-
-                return {
-                    "actual_to_addr": actual_to_addr,
-                    "actual_to_port": actual_to_port,
-                }
-
-        self.socks5_server = start_socks5_server(destinations_factory)
-
+    def setup_nodes(self):
         self.extra_args = [
             [
                 # Needed to be able to add CJDNS addresses to addrman (otherwise they are unroutable).
@@ -154,7 +93,6 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
                 "-v2transport=0",
                 "-test=addrman",
                 "-privatebroadcast",
-                f"-proxy={self.socks5_server.conf.addr[0]}:{self.socks5_server.conf.addr[1]}",
                 # To increase coverage, make it think that the I2P network is reachable so that it
                 # selects such addresses as well. Pick a proxy address where nobody is listening
                 # and connection attempts fail quickly.
@@ -171,15 +109,6 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         self.setup_nodes()
 
     def check_broadcasts(self, label, tx, broadcasts_to_expect, skip_destinations):
-        def wait_and_get_destination(n):
-            """Wait for self.destinations[] to have at least n elements and return the 'n'th."""
-            def get_destinations_len():
-                with self.destinations_lock:
-                    return len(self.destinations)
-            self.wait_until(lambda: get_destinations_len() > n)
-            with self.destinations_lock:
-                return self.destinations[n]
-
         broadcasts_done = 0
         i = skip_destinations - 1
         while broadcasts_done < broadcasts_to_expect:
@@ -187,7 +116,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             self.log.debug(f"{label}: waiting for outbound connection i={i}")
             # At this point the connection may not yet have been established (A),
             # may be active (B), or may have already been closed (C).
-            dest = wait_and_get_destination(i)
+            dest = self.wait_for_auto_outbound_destination(i)
             peer = dest["node"]
             if peer is None:
                 continue # That is the first private broadcast connection, redirected to nodes[1]
@@ -287,8 +216,8 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             nonlocal other_peer
             tx_returner = None
             other_peer = None
-            with self.destinations_lock:
-                for dest in self.destinations:
+            with self.auto_outbound_destinations_lock:
+                for dest in self.auto_outbound_destinations:
                     if dest["conn_type"] == "outbound-full-relay" and dest["node"] is not None:
                         if tx_returner is None:
                             assert(type(dest["node"]) is P2PDataStore)
@@ -322,12 +251,12 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         assert_equal(len(pending), 0)
 
         self.log.info("Sending a transaction that is already in the mempool")
-        skip_destinations = len(self.destinations)
+        skip_destinations = len(self.auto_outbound_destinations)
         tx_originator.sendrawtransaction(hexstring=txs[0]["hex"], maxfeerate=0)
         self.check_broadcasts("Broadcast of mempool transaction", txs[0], NUM_PRIVATE_BROADCAST_PER_TX, skip_destinations)
 
         self.log.info("Sending a transaction with a dependency in the mempool")
-        skip_destinations = len(self.destinations)
+        skip_destinations = len(self.auto_outbound_destinations)
         tx_originator.sendrawtransaction(hexstring=txs[1]["hex"], maxfeerate=0.1)
         self.check_broadcasts("Dependency in mempool", txs[1], NUM_PRIVATE_BROADCAST_PER_TX, skip_destinations)
 
@@ -344,7 +273,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         # NextTxBroadcast() in net_processing.cpp.
         self.log.info("Checking that rebroadcast works")
         delta = 20 * 60 # 20min
-        skip_destinations = len(self.destinations)
+        skip_destinations = len(self.auto_outbound_destinations)
         rebroadcast_msg = f"Reattempting broadcast of stale txid={txs[1]['txid']}"
         with tx_originator.busy_wait_for_debug_log(expected_msgs=[rebroadcast_msg.encode()]):
             tx_originator.setmocktime(int(time.time()) + delta)
@@ -396,7 +325,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         tx_no_relay = wallet.create_self_transfer()
         disconnect_msg = "Disconnecting: does not support transaction relay (connected in vain)"
         with tx_originator.assert_debug_log(expected_msgs=[disconnect_msg]):
-            with self.destinations_lock:
+            with self.auto_outbound_destinations_lock:
                 self.no_relay_peer = None
                 self.trigger_no_relay_peer = True
             tx_originator.sendrawtransaction(hexstring=tx_no_relay["hex"], maxfeerate=0.1)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -18,12 +18,15 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 
 from .address import create_deterministic_address_bcrt1_p2tr_op_true
 from .authproxy import JSONRPCException
 from . import coverage
-from .p2p import NetworkThread
+from .netutil import format_addr_port
+from .p2p import NetworkThread, P2P_SERVICES, P2PInterface
+from .socks5 import Socks5Configuration, Socks5Server
 from .test_node import TestNode
 from .util import (
     Binaries,
@@ -125,7 +128,16 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         # Disable ThreadOpenConnections by default, so that adding entries to
         # addrman will not result in automatic connections to them.
         self.disable_autoconnect = True
+        # Auto outbound mode re-routes automatic outbound connections with a SOCKS5 proxy
+        # to local addresses, behind which there could be a python p2p or another node.
+        self.auto_outbound_mode = False
+        # Callback for auto outbound destinations. Takes the connection index as argument,
+        # returns (addr, port, listener).
+        # Tests can override this in set_test_params() to customize where outbound connections go.
+        self.auto_outbound_factory = self._default_auto_outbound_factory
         self.set_test_params()
+        if self.auto_outbound_mode:
+            self.disable_autoconnect = False
         assert self.wallet_names is None or len(self.wallet_names) <= self.num_nodes
         self.rpc_timeout = int(self.rpc_timeout * self.options.timeout_factor) # optionally, increase timeout by a factor
 
@@ -398,6 +410,68 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 assert_equal(chain_info["blocks"], 200)
                 assert_equal(chain_info["initialblockdownload"], False)
 
+    def _default_auto_outbound_factory(self, i):
+        """Default factory for auto outbound mode: creates a P2PInterface listener."""
+        listener = P2PInterface()
+        actual_to_addr = ""
+        actual_to_port = 0
+
+        listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
+        listener.peer_connect_send_version(services=P2P_SERVICES)
+
+        def on_listen_done(addr, port):
+            nonlocal actual_to_addr
+            nonlocal actual_to_port
+            actual_to_addr = addr
+            actual_to_port = port
+
+        self.network_thread.listen(
+            addr="127.0.0.1",
+            port=0, # Dynamic port allocation
+            p2p=listener,
+            callback=on_listen_done)
+
+        # Wait until the callback has been called.
+        self.wait_until(lambda: actual_to_port != 0)
+
+        return (actual_to_addr, actual_to_port, listener)
+
+    def _setup_auto_outbound_mode(self):
+        """Setup SOCKS5 proxy with destinations factory for auto outbound mode."""
+        socks5_server_config = Socks5Configuration()
+        socks5_server_config.addr = ("127.0.0.1", 0)
+        socks5_server_config.unauth = True
+        socks5_server_config.auth = True
+
+        self.socks5_server = Socks5Server(socks5_server_config)
+        self.socks5_server.start()
+
+        self.auto_outbound_destinations = []
+        self.auto_outbound_destinations_lock = threading.Lock()
+
+        def destinations_factory(requested_to_addr, requested_to_port):
+            with self.auto_outbound_destinations_lock:
+                i = len(self.auto_outbound_destinations)
+
+                actual_to_addr, actual_to_port, listener = self.auto_outbound_factory(i)
+
+                self.log.debug(f"Instructing the SOCKS5 proxy to redirect connection i={i} to "
+                               f"{format_addr_port(actual_to_addr, actual_to_port)}")
+
+                self.auto_outbound_destinations.append({
+                    "requested_to": format_addr_port(requested_to_addr, requested_to_port),
+                    "node": listener,
+                })
+
+                assert_equal(len(self.auto_outbound_destinations), i + 1)
+                return {
+                    "actual_to_addr": actual_to_addr,
+                    "actual_to_port": actual_to_port,
+                }
+
+        self.socks5_server.conf.destinations_factory = destinations_factory
+        return socks5_server_config
+
     def import_deterministic_coinbase_privkeys(self):
         for i in range(self.num_nodes):
             self.init_wallet(node=i)
@@ -449,6 +523,13 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             extra_confs = [[]] * num_nodes
         if extra_args is None:
             extra_args = [[]] * num_nodes
+        # Add auto outbound mode proxy configuration
+        if self.auto_outbound_mode:
+            socks5_config = self._setup_auto_outbound_mode()
+            for i in range(num_nodes):
+                extra_args[i] = extra_args[i] + [
+                    f"-proxy={socks5_config.addr[0]}:{socks5_config.addr[1]}"
+                ]
         # Whitelist peers to speed up tx relay / mempool sync. Don't use it if testing tx relay or timing.
         if self.noban_tx_relay:
             for i in range(len(extra_args)):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -20,12 +20,20 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 
 from .address import create_deterministic_address_bcrt1_p2tr_op_true
 from . import coverage
 from .messages import CAddress
-from .p2p import NetworkThread
+from .netutil import format_addr_port
+from .p2p import (
+    NetworkThread,
+    P2P_SERVICES,
+    P2PInterface,
+    start_p2p_listener,
+)
+from .socks5 import start_socks5_server
 from .test_node import TestNode
 from .util import (
     Binaries,
@@ -128,7 +136,23 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         # Disable ThreadOpenConnections by default, so that adding entries to
         # addrman will not result in automatic connections to them.
         self.disable_autoconnect = True
+        # Auto outbound mode enables ThreadOpenConnections and re-routes all outbound
+        # connections the nodes make with a SOCKS5 proxy to local addresses, behind which
+        # there could be a python p2p or another node.
+        self.auto_outbound_mode = False
+        # Indices of the nodes whose outbound connections go through the proxy. Note that
+        # -proxy applies to every outbound connection, so a node listed here cannot be
+        # connected to the other nodes with connect_nodes().
+        self.auto_outbound_nodes = [0]
+        # The SOCKS5 proxy used by auto outbound mode
+        self.socks5_server = None
+        # Callback that decides where an automatic outbound connection is redirected to.
+        # Takes the connection type as an argument, returns (addr, port, listener)
+        # Tests can override this in set_test_params() to customize where outbound connections go.
+        self.auto_outbound_factory = self._default_auto_outbound_factory
         self.set_test_params()
+        if self.auto_outbound_mode:
+            self.disable_autoconnect = False
         assert self.wallet_names is None or len(self.wallet_names) <= self.num_nodes
         self.rpc_timeout = int(self.rpc_timeout * self.options.timeout_factor) # optionally, increase timeout by a factor
 
@@ -280,6 +304,10 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             print("Testcase failed. Attaching python debugger. Enter ? for help")
             pdb.set_trace()
 
+        if self.socks5_server is not None and self.socks5_server.is_running():
+            self.log.debug('Stopping the auto outbound SOCKS5 proxy')
+            self.socks5_server.stop()
+
         self.log.debug('Closing down network thread')
         self.network_thread.close(timeout=self.options.timeout_factor * 10)
         if self.success == TestStatus.FAILED:
@@ -395,6 +423,87 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 assert_equal(chain_info["blocks"], 200)
                 assert_equal(chain_info["initialblockdownload"], False)
 
+    def start_auto_outbound_listener(self, listener=None):
+        """Start listening with the given Python P2P node (a fresh P2PInterface by default).
+
+        Returns (addr, port, listener), ready to be returned from an auto outbound factory."""
+        if listener is None:
+            listener = P2PInterface()
+        listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
+        listener.peer_connect_send_version(services=P2P_SERVICES)
+        actual_to_addr, actual_to_port = start_p2p_listener(self.network_thread, listener)
+        return (actual_to_addr, actual_to_port, listener)
+
+    def _default_auto_outbound_factory(self, conn_type):
+        """Default destination for an automatic outbound connection: a fresh Python P2P node."""
+        return self.start_auto_outbound_listener()
+
+    def _auto_outbound_conn_type(self, proxy_client):
+        """Return the connection type of the node connection served by the SOCKS5 proxy.
+
+        The proxy has already replied SUCCESS to the SOCKS5 request, so the node has finished
+        ConnectNode() and registered the peer (or is about to). The source addr:port of the
+        proxy's client socket equals the node's addrbind for that peer, which identifies
+        precisely the connection being served."""
+        conn_type = None
+        # SOCKS5 handlers run in separate threads, so each needs its own RPC connection.
+        rpcs = [self.nodes[i].create_new_rpc_connection() for i in self.auto_outbound_nodes]
+
+        def connection_type_found():
+            nonlocal conn_type
+            for rpc in rpcs:
+                for peer in rpc.getpeerinfo():
+                    if peer.get("addrbind") == proxy_client:
+                        conn_type = peer["connection_type"]
+                        return True
+            return False
+
+        self.wait_until(connection_type_found)
+        return conn_type
+
+    def _setup_auto_outbound_mode(self):
+        """Start a SOCKS5 proxy that redirects the nodes' automatic outbound connections."""
+        self.auto_outbound_destinations = []
+        self.auto_outbound_destinations_lock = threading.Lock()
+
+        def destinations_factory(requested_to_addr, requested_to_port, proxy_client):
+            # Must be resolved before taking the lock: it waits on the node's RPC.
+            conn_type = self._auto_outbound_conn_type(proxy_client)
+
+            with self.auto_outbound_destinations_lock:
+                i = len(self.auto_outbound_destinations)
+
+                actual_to_addr, actual_to_port, listener = self.auto_outbound_factory(conn_type)
+
+                target_name = f"Python {type(listener).__name__}" if listener is not None else "another node"
+                self.log.debug(f"Instructing the SOCKS5 proxy to redirect connection i={i} ({conn_type}) for "
+                               f"{format_addr_port(requested_to_addr, requested_to_port)} to "
+                               f"{format_addr_port(actual_to_addr, actual_to_port)} ({target_name})")
+
+                self.auto_outbound_destinations.append({
+                    "requested_to": format_addr_port(requested_to_addr, requested_to_port),
+                    "conn_type": conn_type,
+                    "node": listener,
+                })
+
+                assert_equal(len(self.auto_outbound_destinations), i + 1)
+                return {
+                    "actual_to_addr": actual_to_addr,
+                    "actual_to_port": actual_to_port,
+                }
+
+        self.socks5_server = start_socks5_server(destinations_factory)
+        return self.socks5_server
+
+    def wait_for_auto_outbound_destination(self, n):
+        """Wait for auto_outbound_destinations[] to have at least n elements and return the 'n'th."""
+        def get_destinations_len():
+            with self.auto_outbound_destinations_lock:
+                return len(self.auto_outbound_destinations)
+        self.wait_until(lambda: get_destinations_len() > n)
+        with self.auto_outbound_destinations_lock:
+            return self.auto_outbound_destinations[n]
+
     def import_deterministic_coinbase_privkeys(self):
         for i in range(self.num_nodes):
             self.init_wallet(node=i)
@@ -446,6 +555,13 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             extra_confs = [[]] * num_nodes
         if extra_args is None:
             extra_args = [[]] * num_nodes
+        # Route the outbound connections of the auto outbound nodes through our SOCKS5 proxy.
+        if self.auto_outbound_mode:
+            socks5_addr = self._setup_auto_outbound_mode().conf.addr
+            for i in self.auto_outbound_nodes:
+                extra_args[i] = extra_args[i] + [
+                    f"-proxy={socks5_addr[0]}:{socks5_addr[1]}"
+                ]
         # Whitelist peers to speed up tx relay / mempool sync. Don't use it if testing tx relay or timing.
         if self.noban_tx_relay:
             for i in range(len(extra_args)):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -215,6 +215,7 @@ BASE_SCRIPTS = [
     'rpc_rawtransaction.py',
     'wallet_transactiontime_rescan.py',
     'p2p_addrv2_relay.py',
+    'p2p_outbound_management.py',
     'p2p_compactblocks_hb.py --v1transport',
     'p2p_compactblocks_hb.py --v2transport',
     'p2p_disconnect_ban.py --v1transport',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -220,6 +220,7 @@ BASE_SCRIPTS = [
     'rpc_rawtransaction.py',
     'wallet_transactiontime_rescan.py',
     'p2p_addrv2_relay.py',
+    'p2p_outbound_management.py',
     'p2p_compactblocks_hb.py --v1transport',
     'p2p_compactblocks_hb.py --v2transport',
     'p2p_disconnect_ban.py --v1transport',


### PR DESCRIPTION
For #29415, vasild added the possibility to have outbound connections made "naturally" by the node using addrman entries, by redirecting them via a SOCKS5 proxy to python p2ps or other full nodes, so that the node under test behaves as if it is connected to normal non-local peers from arbitrary networks, while we have full control over the peers.

I think this feature is really cool and want to suggest to integrate it more prominently into the test framework ("`auto_outbound_mode`") in the first commit because it allows to test the code in which the node decides to make connections - in contrast to the existing `add_outbound_p2p_connection` where the functional test intiates the connections.

The second commit uses it to add functional test coverage for the following features of outbound connection management:
- extra full outbound connections due to a stale tip (#11560)
- periodic block-relay-only connections (#19858)
- full outbound connection management with respect to networks (#27213)

This should work well with the test from #29415 (which would keep its own `destinations_factory` but can call `_create_auto_outbound_listener` to avoid much of code duplication). 

Other possible uses for `auto_outbound_mode` I could think of are more detailed testing of anchors (`feature_anchors.py`), feeler connections, or any other p2p logic that uses the network of peers.