### PR TITLE
leveldb: correct trailer boundary check in Reader::SkipToInitialBlock

### DIFF
--- a/src/leveldb/db/log_reader.cc
+++ b/src/leveldb/db/log_reader.cc
@@ -35,7 +35,7 @@ bool Reader::SkipToInitialBlock() {
   uint64_t block_start_location = initial_offset_ - offset_in_block;
 
   // Don't search a block if we'd be in the trailer
-  if (offset_in_block > kBlockSize - 6) {
+  if (offset_in_block > kBlockSize - kHeaderSize) {
     block_start_location += kBlockSize;
   }
 


### PR DESCRIPTION
replaces the magic number 6 in the trailer boundary condition with kHeaderSize and corrects an off-by-one by expressing the rule as offset_in_block > kBlockSize - kHeaderSize, which is equivalent to offset_in_block >= kBlockSize - 6. According to 
src/leveldb/doc/log_format.md:
“A record never starts within the last six bytes of a block” 
and when exactly seven bytes remain a record may start (e.g., a zero-length FIRST), so the equal case must be treated as trailer. The writer already uses kHeaderSize to manage trailers, and aligning the reader with kHeaderSize removes a format-coupled magic number and ensures future-proof consistency. Functionally this avoids scanning a block when initial_offset_ is in the last six bytes, matching the documented format; it was previously a minor inefficiency and comment mismatch rather than a correctness issue.