### PR TITLE
test: deduplicate reorg test code

### DIFF
--- a/test/functional/mempool_ephemeral_dust.py
+++ b/test/functional/mempool_ephemeral_dust.py
@@ -21,7 +21,8 @@ from test_framework.wallet import (
     MiniWallet,
 )
 from test_framework.blocktools import (
-    create_empty_fork
+    create_empty_fork,
+    trigger_reorg,
 )
 
 class EphemeralDustTest(BitcoinTestFramework):
@@ -66,12 +67,6 @@ class EphemeralDustTest(BitcoinTestFramework):
         )
 
         return dusty_tx, sweep_tx
-
-    def trigger_reorg(self, fork_blocks):
-        """Trigger reorg of the fork blocks."""
-        for block in fork_blocks:
-            self.nodes[0].submitblock(block.serialize().hex())
-        assert_equal(self.nodes[0].getbestblockhash(), fork_blocks[-1].hash_hex)
 
     def run_test(self):
 
@@ -338,7 +333,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         assert_raises_rpc_error(-26, "min relay fee not met", self.nodes[0].sendrawtransaction, dusty_tx["hex"])
 
         self.generateblock(self.nodes[0], self.wallet.get_address(), [dusty_tx["hex"]], sync_fun=self.no_op)
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(self.nodes[0], fork_blocks)
         assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"]], sync=False)
 
         # Create a sweep that has dust of its own and leaves dusty_tx's dust unspent
@@ -351,7 +346,7 @@ class EphemeralDustTest(BitcoinTestFramework):
 
         # Mine the sweep then re-org, the sweep will make it back in due to lack of eph dust spend checks on reorg
         self.generateblock(self.nodes[0], self.wallet.get_address(), [dusty_tx["hex"], sweep_tx["hex"]], sync_fun=self.no_op)
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(self.nodes[0], fork_blocks)
         assert_mempool_contents(self, self.nodes[0], expected=[dusty_tx["tx"], sweep_tx["tx"]], sync=False)
 
         # Test that dusty tx being reorged back into mempool doesn't invalidate descendants
@@ -371,7 +366,7 @@ class EphemeralDustTest(BitcoinTestFramework):
 
         # Add ultimate parent back into mempool
         expected_pool = [dusty_tx["tx"]] + expected_pool
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(self.nodes[0], fork_blocks)
         assert_mempool_contents(self, self.nodes[0], expected=expected_pool, sync=False)
 
         hex_to_mine = [tx.serialize().hex() for tx in expected_pool]
@@ -385,7 +380,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         fork_blocks = create_empty_fork(self.nodes[0])
 
         self.generateblock(self.nodes[0], self.wallet.get_address(), [multi_dusty_tx["hex"]], sync_fun=self.no_op)
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(self.nodes[0], fork_blocks)
         assert_equal(self.nodes[0].getrawmempool(), [])
 
         # With fee and one dust
@@ -395,7 +390,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         fork_blocks = create_empty_fork(self.nodes[0])
 
         self.generateblock(self.nodes[0], self.wallet.get_address(), [dusty_fee_tx["hex"]], sync_fun=self.no_op)
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(self.nodes[0], fork_blocks)
         assert_equal(self.nodes[0].getrawmempool(), [])
 
         # Re-connect and make sure we have same state still

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -15,7 +15,10 @@ from test_framework.util import (
     assert_equal,
 )
 from test_framework.wallet import MiniWallet
-from test_framework.blocktools import create_empty_fork
+from test_framework.blocktools import (
+    create_empty_fork,
+    trigger_reorg,
+)
 
 # custom limits for node1
 CUSTOM_CLUSTER_LIMIT = 10
@@ -33,12 +36,6 @@ class MempoolPackagesTest(BitcoinTestFramework):
                 "-limitclustercount={}".format(CUSTOM_CLUSTER_LIMIT),
             ],
         ]
-
-    def trigger_reorg(self, fork_blocks, node):
-        """Trigger reorg of the fork blocks."""
-        for block in fork_blocks:
-            node.submitblock(block.serialize().hex())
-        assert_equal(node.getbestblockhash(), fork_blocks[-1].hash_hex)
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
@@ -237,7 +234,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         fork_blocks = create_empty_fork(self.nodes[0])
         mempool0 = self.nodes[0].getrawmempool(False)
         self.generate(self.nodes[0], 1)
-        self.trigger_reorg(fork_blocks, self.nodes[0])
+        trigger_reorg(self.nodes[0], fork_blocks)
 
         # Check that the txs are returned to the mempool, and that transaction ordering is
         # unchanged, as it is deterministic.
@@ -259,7 +256,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # Tx1 and Tx7, and add to node1's mempool, then disconnect the
         # last block.
 
-        # Prep for fork
+        # Prep for another fork
         fork_blocks = create_empty_fork(self.nodes[0])
 
         # Create tx0 with 2 outputs
@@ -279,7 +276,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         self.sync_mempools()
 
         # Now try to disconnect the tip on each node...
-        self.trigger_reorg(fork_blocks, self.nodes[0])
+        trigger_reorg(self.nodes[0], fork_blocks)
         self.sync_blocks()
 
 if __name__ == '__main__':

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -24,6 +24,7 @@ from test_framework.util import assert_equal, assert_raises_rpc_error
 from test_framework.wallet import MiniWallet
 from test_framework.blocktools import (
     create_empty_fork,
+    trigger_reorg,
 )
 
 # Number of blocks to create in temporary blockchain branch for reorg testing
@@ -39,12 +40,6 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
             ],
             []
         ]
-
-    def trigger_reorg(self, fork_blocks, node):
-        """Trigger reorg of the fork blocks."""
-        for block in fork_blocks:
-            node.submitblock(block.serialize().hex())
-        assert_equal(self.nodes[0].getbestblockhash(), fork_blocks[-1].hash_hex)
 
     def test_reorg_relay(self):
         self.log.info("Test that transactions from disconnected blocks are available for relay immediately")
@@ -200,7 +195,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_1_id, spend_2_1_id, timelock_tx_id})
         self.sync_all()
 
-        self.trigger_reorg(fork_blocks, self.nodes[0])
+        trigger_reorg(self.nodes[0], fork_blocks)
         self.sync_blocks()
 
         # We went backwards in time to boot timelock_tx_id

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -7,17 +7,14 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 from test_framework.wallet import MiniWallet
-from test_framework.blocktools import create_empty_fork
+from test_framework.blocktools import (
+    create_empty_fork,
+    trigger_reorg,
+)
 
 class MempoolCoinbaseTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-
-    def trigger_reorg(self, fork_blocks):
-        """Trigger reorg of the fork blocks."""
-        for block in fork_blocks:
-            self.nodes[0].submitblock(block.serialize().hex())
-        assert_equal(self.nodes[0].getbestblockhash(), fork_blocks[-1].hash_hex)
 
     def run_test(self):
         node = self.nodes[0]
@@ -28,7 +25,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # Create three more transactions, spending the spends
         # Mine another block
         # ... make sure all the transactions are confirmed
-        # Invalidate both blocks
+        # Reorg both blocks
         # ... make sure all the transactions are put back in the mempool
         # Mine a new block
         # ... make sure all the transactions are confirmed again
@@ -50,7 +47,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         assert spends_ids < confirmed_txns
 
         # Trigger reorg
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(self.nodes[0], fork_blocks)
 
         # All txns should be back in mempool with 0 confirmations
         assert_equal(set(node.getrawmempool()), spends_ids)

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -20,6 +20,7 @@ from test_framework.wallet import (
 )
 from test_framework.blocktools import (
     create_empty_fork,
+    trigger_reorg,
 )
 
 MAX_REPLACEMENT_CANDIDATES = 100
@@ -52,12 +53,6 @@ class MempoolTRUC(BitcoinTestFramework):
         mempool_contents = self.nodes[0].getrawmempool()
         assert_equal(len(txids), len(mempool_contents))
         assert all([txid in txids for txid in mempool_contents])
-
-    def trigger_reorg(self, fork_blocks):
-        """Trigger reorg of the fork blocks."""
-        for block in fork_blocks:
-            self.nodes[0].submitblock(block.serialize().hex())
-        assert_equal(self.nodes[0].getbestblockhash(), fork_blocks[-1].hash_hex)
 
     @cleanup()
     def test_truc_max_vsize(self):
@@ -176,6 +171,7 @@ class MempoolTRUC(BitcoinTestFramework):
 
         # Prep for fork
         fork_blocks = create_empty_fork(node)
+
         self.log.info("Test that, during a reorg, TRUC rules are not enforced")
         self.check_mempool([])
 
@@ -206,7 +202,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"], tx_chain_4["txid"]])
 
         # Reorg should have all block transactions re-accepted, ignoring TRUC enforcement
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(node, fork_blocks)
         self.check_mempool([tx_v3_block["txid"], tx_v2_block["txid"], tx_v3_block2["txid"], tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"], tx_chain_1["txid"], tx_chain_2["txid"], tx_chain_3["txid"], tx_chain_4["txid"]])
 
     @cleanup(extra_args=["-limitclustercount=1"])
@@ -495,7 +491,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([child_1["txid"], child_2["txid"]])
 
         # Create a reorg, causing ancestor_tx to exceed the 1-child limit
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(node, fork_blocks)
         self.check_mempool([ancestor_tx["txid"], child_1["txid"], child_2["txid"]])
         assert_equal(node.getmempoolentry(ancestor_tx["txid"])["descendantcount"], 3)
 
@@ -593,7 +589,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([tx_with_sibling1["txid"], tx_with_sibling2["txid"]])
 
         # Create a reorg, bringing tx_with_multi_children back into the mempool with a descendant count of 3.
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(node, fork_blocks)
         self.check_mempool([tx_with_multi_children["txid"], tx_with_sibling1["txid"], tx_with_sibling2["txid"]])
         assert_equal(node.getmempoolentry(tx_with_multi_children["txid"])["descendantcount"], 3)
 

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -11,7 +11,10 @@ from decimal import Decimal
 from math import ceil
 import time
 
-from test_framework.blocktools import create_empty_fork
+from test_framework.blocktools import (
+    create_empty_fork,
+    trigger_reorg,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_greater_than_or_equal, assert_raises_rpc_error
 from test_framework.wallet import MiniWallet
@@ -23,12 +26,6 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [['-limitclustersize=1000']]
-
-    def trigger_reorg(self, fork_blocks):
-        """Trigger reorg of the fork blocks."""
-        for block in fork_blocks:
-            self.nodes[0].submitblock(block.serialize().hex())
-        assert_equal(self.nodes[0].getbestblockhash(), fork_blocks[-1].hash_hex)
 
     def transaction_graph_test(self, size, *, n_tx_to_mine, fee=100_000):
         """Create an acyclic tournament (a type of directed graph) of transactions and use it for testing.
@@ -47,8 +44,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
         """
         wallet = MiniWallet(self.nodes[0])
 
-        # Prep for fork with empty blocks to not use invalidateblock directly
-        # for reorg case. The rpc has different codepath
+        # Prep for fork with empty blocks
         fork_blocks = create_empty_fork(self.nodes[0], fork_length=7)
 
         tx_id = []
@@ -96,8 +92,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
                 self.log.info('The last batch of {} transactions has been accepted into the mempool.'.format(len(self.nodes[0].getrawmempool())))
                 start = time.time()
                 # Trigger reorg
-                for block in fork_blocks:
-                    self.nodes[0].submitblock(block.serialize().hex())
+                trigger_reorg(self.nodes[0], fork_blocks)
                 end = time.time()
                 assert_equal(len(self.nodes[0].getrawmempool()), size)
                 self.log.info('All of the recently mined transactions have been re-added into the mempool in {} seconds.'.format(end - start))
@@ -156,7 +151,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
 
         # Reorg back before the first block in the series, should drop something
         # but not all, and any time parent is dropped, child is also removed
-        self.trigger_reorg(fork_blocks=fork_blocks)
+        trigger_reorg(self.nodes[0], fork_blocks)
         mempool = self.nodes[0].getrawmempool()
         # At least one parent must be dropped, but more may be dropped,
         # depending on the dynamic cost overhead.

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -5,7 +5,11 @@
 
 import time
 
-from test_framework.blocktools import MAX_STANDARD_TX_WEIGHT
+from test_framework.blocktools import (
+    create_empty_fork,
+    MAX_STANDARD_TX_WEIGHT,
+    trigger_reorg,
+)
 from test_framework.mempool_util import (
     create_large_orphan,
     tx_in_orphanage,
@@ -264,11 +268,12 @@ class OrphanHandlingTest(BitcoinTestFramework):
         txid_conf_old = utxo_conf_old["txid"]
         self.generate(self.wallet, 10)
 
-        # Create a fake reorg to trigger BlockDisconnected, which resets the rolling bloom filter.
+        # Trigger a reorg to fire BlockDisconnected, which resets the rolling bloom filter.
         # The alternative is to mine thousands of transactions to push it out of the filter.
-        last_block = node.getbestblockhash()
-        node.invalidateblock(last_block)
-        node.preciousblock(last_block)
+        # Prepare an empty fork at the current tip, mine a block on top, then reorg it out.
+        fork_blocks = create_empty_fork(node)
+        self.generate(self.wallet, 1)
+        trigger_reorg(node, fork_blocks)
         node.syncwithvalidationinterfacequeue()
 
         # This UTXO confirmed recently.

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -79,7 +79,7 @@ a. Repeat 100 times:
 b. Then send 99 more headers that don't connect.
    Expect: getheaders message each time.
 """
-from test_framework.blocktools import create_block
+from test_framework.blocktools import create_block, create_empty_fork, trigger_reorg
 from test_framework.messages import CInv
 from test_framework.p2p import (
     CBlockHeader,
@@ -208,17 +208,17 @@ class SendHeadersTest(BitcoinTestFramework):
         to-be-reorged-out blocks are mined, so that we don't break later tests.
         return the list of block hashes newly mined."""
 
-        # make sure all invalidated blocks are node0's
+        # Prep for fork with empty blocks
+        fork_blocks = create_empty_fork(self.nodes[1], fork_length=length + 1)
+
+        # make sure all blocks to be reorged out are node0's
         self.generatetoaddress(self.nodes[0], length, self.nodes[0].get_deterministic_priv_key().address)
         for x in self.nodes[0].p2ps:
             x.wait_for_block_announcement(int(self.nodes[0].getbestblockhash(), 16))
             x.clear_block_announcements()
 
-        tip_height = self.nodes[1].getblockcount()
-        hash_to_invalidate = self.nodes[1].getblockhash(tip_height - (length - 1))
-        self.nodes[1].invalidateblock(hash_to_invalidate)
-        all_hashes = self.generatetoaddress(self.nodes[1], length + 1, self.nodes[1].get_deterministic_priv_key().address)  # Must be longer than the orig chain
-        return [int(x, 16) for x in all_hashes]
+        trigger_reorg(self.nodes[1], fork_blocks)
+        return [block.hash_int for block in fork_blocks]
 
     def run_test(self):
         # Setup the p2p connections

--- a/test/functional/rpc_gettxspendingprevout.py
+++ b/test/functional/rpc_gettxspendingprevout.py
@@ -4,6 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test gettxspendingprevout RPC."""
 
+from test_framework.blocktools import (
+    create_empty_fork,
+    trigger_reorg,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -144,6 +148,8 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         txid_reorg_replace_utxo = reorg_replace_utxo['txid']
 
         tx1 = create_tx(utxos_to_spend=[reorg_replace_utxo], num_outputs=1)
+        # Prep a fork on each node so tx1's block can later be reorged out
+        fork_blocks_per_node = [create_empty_fork(node) for node in self.nodes]
         blockhash = self.generate(self.wallet, 1)[0]
 
         # tx1 is confirmed, and indexed in txospenderindex as spending our utxo
@@ -151,10 +157,9 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         result = node0.gettxspendingprevout([prevout(txid_reorg_replace_utxo, vout=0)], return_spending_tx=True)
         assert_equal(result, [spent_out_in_block(txid_reorg_replace_utxo, vout=0, spending_tx_id=tx1["txid"], blockhash=blockhash, spending_tx=tx1['hex'])])
 
-        # replace tx1 with tx2 triggering a "reorg"
-        best_block_hash = node0.getbestblockhash()
-        for node in self.nodes:
-            node.invalidateblock(best_block_hash)
+        # replace tx1 with tx2 by triggering a reorg that disconnects tx1's block
+        for fork_blocks, node in zip(fork_blocks_per_node, self.nodes):
+            trigger_reorg(node, fork_blocks)
             assert tx1["txid"] in node.getrawmempool()
 
         # create and submit replacement
@@ -184,7 +189,11 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         result = node0.gettxspendingprevout([prevout(tx1['txid'], vout=0)], return_spending_tx=True)
         assert_equal(result, [spent_out_in_block(tx1['txid'], vout=0, spending_tx_id=tx2["txid"], blockhash=blockhash, spending_tx=tx2['hex'])])
 
-        # replace tx1 with tx3
+        # Disconnect tx1's block so tx1 can be replaced by tx3 below, which also
+        # evicts tx1's child tx2. Unlike the case above, use invalidateblock rather
+        # than a fork-based reorg: the index is only rewound when a block connects,
+        # so disconnecting without connecting anything lets us check below that tx2
+        # is still indexed until the next block.
         blockhash = node0.getbestblockhash()
         for node in self.nodes:
             node.invalidateblock(blockhash)

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -121,7 +121,13 @@ def create_block(hashprev=None, coinbase=None, *, ntime=None, height=None, versi
 def create_empty_fork(node, fork_length=FORK_LENGTH):
     '''
         Creates a fork using node's chaintip as the starting point.
-        Returns a list of blocks to submit in order.
+        Returns a list of blocks to submit in order (see trigger_reorg()).
+
+        Prefer this over calling the invalidateblock RPC to simulate a reorg:
+        invalidateblock takes a different codepath than a reorg caused by a
+        competing chain arriving, so tests using it are not exercising the
+        behaviour they mean to. Create the fork before the blocks to be reorged
+        out are mined, then submit it with trigger_reorg().
     '''
     tip = int(node.getbestblockhash(), 16)
     height = node.getblockcount()
@@ -137,6 +143,15 @@ def create_empty_fork(node, fork_length=FORK_LENGTH):
         height += 1
 
     return blocks
+
+def trigger_reorg(node, fork_blocks):
+    '''
+        Submit the fork blocks created by create_empty_fork() to trigger a reorg,
+        then assert the node reorged onto the fork tip.
+    '''
+    for block in fork_blocks:
+        node.submitblock(block.serialize().hex())
+    assert_equal(node.getbestblockhash(), fork_blocks[-1].hash_hex)
 
 def get_witness_script(witness_root, witness_nonce):
     witness_commitment = hash256(ser_uint256(witness_root) + ser_uint256(witness_nonce))

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -7,7 +7,11 @@ from decimal import Decimal
 import time
 
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE as ADDRESS_WATCHONLY
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    create_empty_fork,
+    trigger_reorg,
+)
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -237,13 +241,16 @@ class WalletTest(BitcoinTestFramework):
         self.sync_all()
         self.nodes[1].sendrawtransaction(hexstring=tx_replace, maxfeerate=0)
 
+        # Prep for fork. Both nodes are in sync here, so one fork serves both.
+        fork_blocks = create_empty_fork(self.nodes[0])
+
         # Now confirm tx_replace
-        block_reorg = self.generatetoaddress(self.nodes[1], 1, ADDRESS_WATCHONLY)[0]
+        self.generatetoaddress(self.nodes[1], 1, ADDRESS_WATCHONLY)
         assert_equal(self.nodes[0].getbalance(minconf=0), total_amount)
 
         self.log.info('Put txs back into mempool of node 1 (not node 0)')
-        self.nodes[0].invalidateblock(block_reorg)
-        self.nodes[1].invalidateblock(block_reorg)
+        trigger_reorg(self.nodes[0], fork_blocks)
+        trigger_reorg(self.nodes[1], fork_blocks)
         assert_equal(self.nodes[0].getbalance(minconf=0), 0)  # wallet txs not in the mempool are untrusted
         self.generatetoaddress(self.nodes[0], 1, ADDRESS_WATCHONLY, sync_fun=self.no_op)
 

--- a/test/functional/wallet_rescan_unconfirmed.py
+++ b/test/functional/wallet_rescan_unconfirmed.py
@@ -8,6 +8,10 @@ from test_framework.address import (
     address_to_scriptpubkey,
     ADDRESS_BCRT1_UNSPENDABLE,
 )
+from test_framework.blocktools import (
+    create_empty_fork,
+    trigger_reorg,
+)
 from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -32,13 +36,17 @@ class WalletRescanUnconfirmed(BitcoinTestFramework):
 
         self.log.info("Create a parent tx and mine it in a block that will later be disconnected")
         parent_address = w0.getnewaddress()
+
+        # Prep for fork with empty blocks
+        fork_blocks = create_empty_fork(node)
+
         tx_parent_to_reorg = tester_wallet.send_to(
             from_node=node,
             scriptPubKey=address_to_scriptpubkey(parent_address),
             amount=COIN,
         )
         assert tx_parent_to_reorg["txid"] in node.getrawmempool()
-        block_to_reorg = self.generate(tester_wallet, 1)[0]
+        self.generate(tester_wallet, 1)[0]
         assert_equal(len(node.getrawmempool()), 0)
         node.syncwithvalidationinterfacequeue()
         assert_equal(w0.gettransaction(tx_parent_to_reorg["txid"])["confirmations"], 1)
@@ -58,7 +66,7 @@ class WalletRescanUnconfirmed(BitcoinTestFramework):
         node.syncwithvalidationinterfacequeue()
 
         self.log.info("Mock a reorg, causing parent to re-enter mempools after its child")
-        node.invalidateblock(block_to_reorg)
+        trigger_reorg(node, fork_blocks)
         assert tx_parent_to_reorg["txid"] in node.getrawmempool()
 
         self.log.info("Import descriptor wallet on another node")

--- a/test/functional/wallet_v3_txs.py
+++ b/test/functional/wallet_v3_txs.py
@@ -20,6 +20,7 @@ from test_framework.script_util import bulk_vout
 
 from test_framework.blocktools import (
     create_empty_fork,
+    trigger_reorg,
 )
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -87,12 +88,6 @@ class WalletV3Test(BitcoinTestFramework):
     def run_test_with_swapped_versions(self, test_func):
         test_func(2, 3)
         test_func(3, 2)
-
-    def trigger_reorg(self, fork_blocks):
-        """Trigger reorg of the fork blocks."""
-        for block in fork_blocks:
-            self.nodes[0].submitblock(block.serialize().hex())
-        assert_equal(self.nodes[0].getbestblockhash(), fork_blocks[-1].hash_hex)
 
     def run_test(self):
         self.nodes[0].createwallet("alice")
@@ -692,7 +687,7 @@ class WalletV3Test(BitcoinTestFramework):
         assert truc_txid in truc_output_txids
 
         # Trigger the reorg
-        self.trigger_reorg(fork_blocks)
+        trigger_reorg(self.nodes[0], fork_blocks)
         # The TRUC transaction is now in a cluster of size 3, which is only permitted in a reorg.
         assert_equal(self.nodes[0].getmempoolcluster(truc_txid)["txcount"], 3)
 


### PR DESCRIPTION
Follow-up to #32587. 

`trigger_reorg()` was copy-pasted across several functional tests. This moves it into `blocktools.py`, together with the fork construction, as two helpers: `create_empty_fork()` and `trigger_reorg()`. 

The remaining tests that still simulated reorgs with the `invalidateblock` RPC are converted to use them, since `invalidateblock` takes a different codepath than a reorg caused by a competing chain arriving.