### PR TITLE
refactor: replace manual promise with SyncWithValidationInterfaceQueue

### DIFF
--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -15,8 +15,6 @@
 #include <validationinterface.h>
 #include <node/transaction.h>
 
-#include <future>
-
 namespace node {
 static TransactionError HandleATMPError(const TxValidationState& state, std::string& err_string_out)
 {
@@ -45,7 +43,6 @@ TransactionError BroadcastTransaction(NodeContext& node,
     assert(node.mempool);
     assert(node.peerman);
 
-    std::promise<void> promise;
     Txid txid = tx->GetHash();
     Wtxid wtxid = tx->GetWitnessHash();
     bool callback_set = false;
@@ -115,9 +112,6 @@ TransactionError BroadcastTransaction(NodeContext& node,
                 // with a transaction to/from their wallet, immediately call some
                 // wallet RPC, and get a stale result because callbacks have not
                 // yet been processed.
-                node.validation_signals->CallFunctionInValidationInterfaceQueue([&promise] {
-                    promise.set_value();
-                });
                 callback_set = true;
             }
         }
@@ -126,7 +120,7 @@ TransactionError BroadcastTransaction(NodeContext& node,
     if (callback_set) {
         // Wait until Validation Interface clients have been notified of the
         // transaction entering the mempool.
-        promise.get_future().wait();
+        node.validation_signals->SyncWithValidationInterfaceQueue();
     }
 
     switch (broadcast_method) {


### PR DESCRIPTION
`BroadcastTransaction()` now waits for validation callbacks using the built-in `validation_signals>SyncWithValidationInterfaceQueue()` instead of creating a local `std::promise` and scheduling a lambda. This removes an unnecessary allocation and uses the canonical API.