### PR TITLE
ci: remove `doc/release-notes.md` from lint-spelling.py

### DIFF
--- a/test/lint/lint-spelling.py
+++ b/test/lint/lint-spelling.py
@@ -14,7 +14,7 @@ from subprocess import check_output, STDOUT, CalledProcessError
 from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
 
 IGNORE_WORDS_FILE = 'test/lint/spelling.ignore-words.txt'
-FILES_ARGS = ['git', 'ls-files', '--', ":(exclude)contrib/seeds/*.txt", ":(exclude)depends/", ":(exclude)doc/release-notes/", ":(exclude)src/qt/locale/", ":(exclude)src/qt/*.qrc", ":(exclude)contrib/guix/patches"]
+FILES_ARGS = ['git', 'ls-files', '--', ":(exclude)contrib/seeds/*.txt", ":(exclude)depends/", ":(exclude)doc/release-notes/", ":(exclude)doc/release-notes.md", ":(exclude)src/qt/locale/", ":(exclude)src/qt/*.qrc", ":(exclude)contrib/guix/patches"]
 FILES_ARGS += [f":(exclude){dir}" for dir in SHARED_EXCLUDED_SUBTREES]
 
 


### PR DESCRIPTION
`/doc/release-notes/` is ignored, but during release branch-off, the latest release is copied to `doc/release-notes.md`. This means that CI runs based off of the branch off point (e.g., for backport dev) will fail CI if there are spelling errors, or if there are e.g. contributors names that resemble spelling errors (not a hypothetical example).