### PR TITLE
doc: fix typo in MAX_MONEY comment

### DIFF
--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -20,7 +20,7 @@ static constexpr CAmount COIN = 100000000;
  * currently happens to be less than 21,000,000 BTC for various reasons, but
  * rather a sanity check. As this sanity check is used by consensus-critical
  * validation code, the exact value of the MAX_MONEY constant is consensus
- * critical; in unusual circumstances like a(nother) overflow bug that allowed
+ * critical; in unusual circumstances like another overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
 static constexpr CAmount MAX_MONEY = 21000000 * COIN;


### PR DESCRIPTION
This PR fixes a small typo for grammar in the MAX_MONEY comment in src/consensus/amount.h.

* Replace “a(nother)” with “another”.

No functional changes; comment-only.
