### PR TITLE
depends, doc: Add `tcl` as build dependency for `sqlite` package

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -8,7 +8,7 @@ as well as [packages.md](packages.md) for how to add packages.
 
 ### Ubuntu & Debian
 
-    apt install cmake curl make patch
+    apt install cmake curl make patch tcl
 
 Skip the following packages if you don't intend to use the GUI and will build with [`NO_QT=1`](#dependency-options):
 


### PR DESCRIPTION
Since https://github.com/bitcoin/bitcoin/pull/32655, the `sqlite` package has relied on a native C compiler being incidentally available on the system under the default names. However, this is not always the case. For example, on Ubuntu 24.04:
```
$ gmake -C depends sqlite CC=gcc-14 CXX=g++-14
gmake: Entering directory '/bitcoin/depends'
Configuring sqlite...
No installed jimsh or tclsh, building local bootstrap jimsh0
No working C compiler found. Tried cc and gcc.
gmake: *** [funcs.mk:344: /bitcoin/depends/x86_64-pc-linux-gnu/.sqlite_stamp_configured] Error 1
gmake: Leaving directory '/bitcoin/depends'
```

Adding the `tcl` package as an explicit build dependency, as is [done](https://github.com/fanquake/bitcoin/blob/f6acbef1084e34f126bf530df99e4ef6a11c38e8/contrib/guix/manifest.scm#L552) in the Guix script, avoids this behaviour and improves robustness.