### PR TITLE
script: Remove dead code from OP_CHECKMULTISIG

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1196,8 +1196,6 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     // Unfortunately this is a potential source of mutability,
                     // so optionally verify it is exactly equal to zero prior
                     // to removing it from the stack.
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
                     if ((flags & SCRIPT_VERIFY_NULLDUMMY) && stacktop(-1).size())
                         return set_error(serror, SCRIPT_ERR_SIG_NULLDUMMY);
                     popstack(stack);


### PR DESCRIPTION
The stack size check before the dummy element check in OP_CHECKMULTISIG is redundant. The stack is previously validated to have least *i* elements (where *i* is number of pubkeys + number of signatures + 3), and then *i* - 1 elements are popped off the stack, leaving at least one element still in.

The redundant check was added in #3843 (commit 6380180821917c22ecfd89128ee60aae6f4cac33). There it's easy to see why it's redundant – it's inserted into a code path where another `popstack` would previously follow.

Note the missing code coverage: https://maflcko.github.io/b-c-cov/total.coverage/src/script/interpreter.cpp.gcov.html#L1200