### PR TITLE
fuzz: gate mempool entry based on weight

### DIFF
--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -121,6 +121,7 @@ FUZZ_TARGET(package_rbf, .init = initialize_package_rbf)
     CTransaction replacement_tx_final{*replacement_tx};
     auto replacement_entry = ConsumeTxMemPoolEntry(fuzzed_data_provider, replacement_tx_final);
     int32_t replacement_weight = replacement_entry.GetAdjustedWeight();
+    // Ensure that we don't hit FeeFrac limits, as we store TxGraph entries in terms of FeePerWeight
     int64_t running_vsize_total{replacement_entry.GetTxSize()};
 
     LOCK2(cs_main, pool.cs);
@@ -137,7 +138,7 @@ FUZZ_TARGET(package_rbf, .init = initialize_package_rbf)
         mempool_txs.emplace_back(parent);
         const auto parent_entry = ConsumeTxMemPoolEntry(fuzzed_data_provider, mempool_txs.back());
         running_vsize_total += parent_entry.GetTxSize();
-        if (running_vsize_total > std::numeric_limits<int32_t>::max()) {
+        if (running_vsize_total * WITNESS_SCALE_FACTOR > std::numeric_limits<int32_t>::max()) {
             // We aren't adding this final tx to mempool, so we don't want to conflict with it
             mempool_txs.pop_back();
             break;
@@ -156,7 +157,7 @@ FUZZ_TARGET(package_rbf, .init = initialize_package_rbf)
         mempool_txs.emplace_back(child);
         const auto child_entry = ConsumeTxMemPoolEntry(fuzzed_data_provider, mempool_txs.back());
         running_vsize_total += child_entry.GetTxSize();
-        if (running_vsize_total > std::numeric_limits<int32_t>::max()) {
+        if (running_vsize_total * WITNESS_SCALE_FACTOR > std::numeric_limits<int32_t>::max()) {
             // We aren't adding this final tx to mempool, so we don't want to conflict with it
             mempool_txs.pop_back();
             break;


### PR DESCRIPTION
The mempool implementation now uses TxGraph with entries using FeePerWeight, not vsize. This means our package_rbf harness will erroneously add more transaction weight than we can support inside of FeeFrac. Gate more aggressively using WITNESS_SCALE_FACTOR.

Fixes https://github.com/bitcoin/bitcoin/issues/33981