### PR TITLE
depends: Propagate native C compiler to `sqlite` package

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -19,7 +19,6 @@
              ((gnu packages python-crypto) #:select (python-asn1crypto))
              ((gnu packages python-science) #:select (python-scikit-build-core))
              ((gnu packages python-xyz) #:select (python-pydantic-2))
-             (gnu packages tcl)
              ((gnu packages tls) #:select (openssl))
              ((gnu packages version-control) #:select (git-minimal))
              (guix build-system cmake)
@@ -549,7 +548,6 @@ inspecting signatures in Mach-O binaries.")
         cmake-minimal
         gnu-make
         ninja
-        tcl
         ;; Scripting
         python-minimal ;; (3.10)
         ;; Git

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -3,8 +3,10 @@ $(package)_version=3500400
 $(package)_download_path=https://sqlite.org/2025/
 $(package)_file_name=sqlite-autoconf-$($(package)_version).tar.gz
 $(package)_sha256_hash=a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18
+$(package)_patches = autosetup-fixup.patch
 
 define $(package)_set_vars
+$(package)_config_env := CC_FOR_BUILD="$$(build_CC)"
 $(package)_config_opts = --disable-shared --disable-readline --disable-rtree
 $(package)_config_opts += --disable-fts4 --disable-fts5
 $(package)_config_opts_debug += --debug
@@ -12,6 +14,10 @@ $(package)_cppflags += -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT
 $(package)_cppflags += -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
 $(package)_cppflags += -DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
 $(package)_cppflags += -DSQLITE_OMIT_LOAD_EXTENSION
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/autosetup-fixup.patch
 endef
 
 # Remove --with-pic, which is applied globally to configure

--- a/depends/patches/sqlite/autosetup-fixup.patch
+++ b/depends/patches/sqlite/autosetup-fixup.patch
@@ -1,0 +1,20 @@
+autosetup-find-tclsh: Quote CC_FOR_BUILD to prevent word splitting
+
+In some build environments, CC_FOR_BUILD can include essential compiler
+flags. For example, in Guix it may have a value such as:
+`/gnu/store/10krix03rl5hqjv2c0qmj44ic9bgd8rc-gcc-toolchain-13.3.0/bin/gcc -isystem /gnu/store/10krix03rl5hqjv2c0qmj44ic9bgd8rc-gcc-toolchain-13.3.0/include`
+
+See upstream: https://github.com/msteveb/autosetup/pull/81.
+
+
+--- a/autosetup/autosetup-find-tclsh
++++ b/autosetup/autosetup-find-tclsh
+@@ -8,7 +8,7 @@
+ 	{ $tclsh "$d/${1-autosetup-test-tclsh}"; } 2>/dev/null && exit 0
+ done
+ echo 1>&2 "No installed jimsh or tclsh, building local bootstrap jimsh0"
+-for cc in ${CC_FOR_BUILD:-cc} gcc; do
++for cc in "${CC_FOR_BUILD:-cc}" gcc; do
+ 	{ $cc -o jimsh0 "$d/jimsh0.c"; } 2>/dev/null >/dev/null || continue
+ 	./jimsh0 "$d/${1-autosetup-test-tclsh}" && exit 0
+ done


### PR DESCRIPTION
This PR:

1. Ensures that autosetup can build the local bootstrap `jimsh0` when neither `jimsh` nor `tclsh` is available on the system.

2. Removes the `tcl` package from the Guix manifest.

This is an alternative to https://github.com/bitcoin/bitcoin/pull/33975.