### PR TITLE
Implementation of SwiftSync

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -260,6 +260,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   rpc/txoutproof.cpp
   script/sigcache.cpp
   signet.cpp
+  swiftsync.cpp
   torcontrol.cpp
   txdb.cpp
   txgraph.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -69,6 +69,7 @@
 #include <rpc/util.h>
 #include <scheduler.h>
 #include <script/sigcache.h>
+#include <swiftsync.h>
 #include <sync.h>
 #include <torcontrol.h>
 #include <txdb.h>
@@ -478,6 +479,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-alertnotify=<cmd>", "Execute command when an alert is raised (%s in cmd is replaced by message)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif
     argsman.AddArg("-assumevalid=<hex>", strprintf("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet3: %s, testnet4: %s, signet: %s)", defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnet4ChainParams->GetConsensus().defaultAssumeValid.GetHex(), signetChainParams->GetConsensus().defaultAssumeValid.GetHex()), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-utxohints=<path>", "Accelerate initial block download with the assistance of a UTXO hint file.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS),
     argsman.AddArg("-blocksdir=<dir>", "Specify directory to hold blocks subdirectory for *.dat files (default: <datadir>)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blocksxor",
                    strprintf("Whether an XOR-key applies to blocksdir *.dat files. "
@@ -981,6 +983,10 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         if (args.GetBoolArg("-reindex-chainstate", false)) {
             return InitError(_("Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead."));
         }
+    } else {
+        if (args.IsArgSet("-utxohints")) {
+            return InitError(_("UTXO hints cannot be used without pruned mode."));
+        }
     }
 
     // If -forcednsseed is set to true, ensure -dnsseed has not been set to false
@@ -1272,6 +1278,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
+    std::optional<swiftsync::HintsfileReader> utxo_hints,
     const kernel::CacheSizes& cache_sizes,
     const ArgsManager& args)
 {
@@ -1377,6 +1384,9 @@ static ChainstateLoadResult InitAndLoadChainstate(
         }
     };
     auto [status, error] = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
+    if (utxo_hints.has_value()) {
+        chainman.ActiveChainstate().ApplyUtxoHints(std::move(utxo_hints.value()));
+    }
     if (status == node::ChainstateLoadStatus::SUCCESS) {
         uiInterface.InitMessage(_("Verifying blocks…"));
         if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
@@ -1794,11 +1804,35 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     bool do_reindex{args.GetBoolArg("-reindex", false)};
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};
 
+    std::optional<swiftsync::HintsfileReader> utxo_hints;
+    if (args.IsArgSet("-utxohints")) {
+        fs::path path = fs::absolute(args.GetPathArg("-utxohints"));
+        if (!fs::exists(path)) {
+            LogError("Provided UTXO file does not exist: %s", path.utf8string());
+            return false;
+        }
+        FILE* file{fsbridge::fopen(path, "rb")};
+        AutoFile afile{file};
+        if (afile.IsNull()) {
+            LogError("Failed to open UTXO hint file.");
+            return false;
+        }
+        try {
+            swiftsync::HintsfileReader reader{afile};
+            LogInfo("Applying UTXO hints from file: %s", path.utf8string());
+            utxo_hints.emplace(std::move(reader));
+        } catch (const std::exception& e) {
+            LogError("Failed to parse UTXO hint file: %s", e.what());
+            return false;
+        }
+    }
+
     // Chainstate initialization and loading may be retried once with reindexing by GUI users
     auto [status, error] = InitAndLoadChainstate(
         node,
         do_reindex,
         do_reindex_chainstate,
+        std::move(utxo_hints),
         kernel_cache_sizes,
         args);
     if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
@@ -1819,6 +1853,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             node,
             do_reindex,
             do_reindex_chainstate,
+            {},
             kernel_cache_sizes,
             args);
     }

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(bitcoinkernel
   ../signet.cpp
   ../streams.cpp
   ../support/lockedpool.cpp
+  ../swiftsync.cpp
   ../sync.cpp
   ../txdb.cpp
   ../txgraph.cpp

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -39,6 +39,7 @@
 #include <script/descriptor.h>
 #include <serialize.h>
 #include <streams.h>
+#include <swiftsync.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <txdb.h>
@@ -3392,6 +3393,124 @@ static RPCHelpMan loadtxoutset()
     };
 }
 
+static RPCHelpMan generatetxohints()
+{
+    return RPCHelpMan{
+        "generatetxohints",
+        "Build a file of hints for the state of the UTXO set at a particular height.\n"
+        "The purpose of said hints is to allow clients performing initial block download\n"
+        "to omit unnecessary disk I/O and CPU usage.\n"
+        "The hint file is constructed by reading in blocks sequentially and determining what outputs\n"
+        "will remain in the UTXO set. Network activity will be suspended during this process, and the\n"
+        "hint file may take a few hours to build."
+        "Make sure to use no RPC timeout (bitcoin-cli -rpcclienttimeout=0)",
+        {
+            {"path",
+                RPCArg::Type::STR,
+                RPCArg::Optional::NO,
+                "Path to the hint file. If relative, will be prefixed by datadir."},
+            {"rollback",
+                RPCArg::Type::NUM,
+                RPCArg::Optional::OMITTED,
+                "The block hash or height to build the hint file up to. If none is provided, the file will be built from the current block tip.",
+                RPCArgOptions{
+                    .skip_type_check = true,
+                    .type_str = {"", "string or numeric"},}},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+                {
+                    {RPCResult::Type::NUM, "height", "The stopping height encoded by the hint file."},
+                    {RPCResult::Type::STR, "path", "Absolute path where the file was written."},
+                    {RPCResult::Type::STR, "duration", "Time taken to build the file."},
+                }
+        },
+        RPCExamples{
+            HelpExampleCli("--rpcclienttimeout=0 generatetxohints", "signet.hints 270000"),
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    const auto start{SteadyClock::now()};
+    NodeContext& node{EnsureAnyNodeContext(request.context)};
+    if (node.chainman->m_blockman.IsPruneMode()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Creating a hint file in pruned mode is not possible.");
+    }
+    const ArgsManager& args{EnsureAnyArgsman(request.context)};
+    const fs::path path = fsbridge::AbsPathJoin(args.GetDataDirNet(), fs::u8path(self.Arg<std::string_view>("path")));
+    const fs::path temppath = path + ".incomplete";
+    if (fs::exists(path)) {
+        throw JSONRPCError(
+            RPC_INVALID_PARAMETER,
+            path.utf8string() + " already exists. If you are sure this is what you want, "
+            "move it out of the way first");
+    }
+    FILE* file{fsbridge::fopen(temppath, "wb")};
+    AutoFile afile{file};
+    if (afile.IsNull()) {
+        throw JSONRPCError(
+            RPC_INVALID_PARAMETER,
+            "Couldn't open file " + temppath.utf8string() + " for writing.");
+    }
+    CConnman& connman{EnsureConnman(node)};
+    NetworkDisable disable_net{NetworkDisable(connman)};
+    std::optional<TemporaryRollback> rollback;
+    if (!request.params[1].isNull()) {
+        const CBlockIndex* invalidate_index = ParseHashOrHeight(request.params[1], *node.chainman);
+        invalidate_index = WITH_LOCK(::cs_main, return node.chainman->ActiveChain().Next(invalidate_index));
+        rollback.emplace(*node.chainman, *invalidate_index);
+    }
+    node.rpc_interruption_point();
+    LOCK(node.chainman->GetMutex());
+    CChain& active_chain{node.chainman->ActiveChain()};
+    Chainstate& active_state{node.chainman->ActiveChainstate()};
+    active_state.ForceFlushStateToDisk();
+    const CBlockIndex* end_index{active_chain.Tip()};
+    const auto tip_height{end_index->nHeight};
+    LogDebug(BCLog::RPC, "Active chain best tip %d", tip_height);
+    swiftsync::HintsfileWriter writer{swiftsync::HintsfileWriter(afile, tip_height)};
+    CBlockIndex* curr{active_chain.Next(active_chain.Genesis())};
+    while (curr) {
+        auto height{curr->nHeight};
+        if (height % 10000 == 0) {
+            LogDebug(BCLog::RPC, "Wrote hints up to height (%s)", height);
+        }
+        FlatFilePos file_pos = curr->GetBlockPos();
+        std::unique_ptr<CBlock> pblock = std::make_unique<CBlock>();
+        bool read = node.chainman->m_blockman.ReadBlock(*pblock, file_pos, curr->GetBlockHash());
+        if (!read) {
+            throw JSONRPCError(RPC_DATABASE_ERROR, "Block could not be read from disk.");
+        }
+        swiftsync::BlockHintsWriter hints{};
+        for (const auto& tx: pblock->vtx) {
+            const Txid& txid = tx->GetHash();
+            for (size_t vout{}; vout < tx->vout.size(); ++vout) {
+                const COutPoint outpoint = COutPoint(txid, vout);
+                if (active_state.CoinsDB().HaveCoin(outpoint)) {
+                    hints.PushHighBit();
+                } else {
+                    hints.PushLowBit();
+                }
+            }
+        }
+        if (!writer.WriteNextUnspents(hints, uint32_t(height))) {
+            throw JSONRPCError(RPC_DATABASE_ERROR, "Failed to commit changes to hint file.");
+        }
+        node.rpc_interruption_point();
+        curr = active_chain.Next(curr);
+    }
+    writer.Close();
+    fs::rename(temppath, path);
+    const auto end{SteadyClock::now()};
+    const auto duration = std::chrono::duration_cast<std::chrono::minutes>(end - start).count();
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("height", tip_height);
+    result.pushKV("path", path.utf8string());
+    result.pushKV("duration", tfm::format("%d minutes", duration));
+    return result;
+},
+    };
+}
+
 const std::vector<RPCResult> RPCHelpForChainstate{
     {RPCResult::Type::NUM, "blocks", "number of blocks in this chainstate"},
     {RPCResult::Type::STR_HEX, "bestblockhash", "blockhash of the tip"},
@@ -3491,6 +3610,7 @@ void RegisterBlockchainRPCCommands(CRPCTable& t)
         {"blockchain", &getblockfilter},
         {"blockchain", &dumptxoutset},
         {"blockchain", &loadtxoutset},
+        {"blockchain", &generatetxohints},
         {"blockchain", &getchainstates},
         {"hidden", &invalidateblock},
         {"hidden", &reconsiderblock},

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -386,6 +386,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "signmessagewithprivkey", 1, "message", ParamFormat::STRING },
     { "walletpassphrasechange", 0, "oldpassphrase", ParamFormat::STRING },
     { "walletpassphrasechange", 1, "newpassphrase", ParamFormat::STRING },
+    { "generatetxohints", 1, "rollback", ParamFormat::JSON_OR_STRING }
 };
 // clang-format on
 

--- a/src/swiftsync.cpp
+++ b/src/swiftsync.cpp
@@ -7,10 +7,12 @@
 #include <streams.h>
 #include <swiftsync.h>
 #include <uint256.h>
+#include <util/fs.h>
 #include <array>
 #include <cstdint>
 #include <cstdio>
 #include <ios>
+#include <utility>
 #include <vector>
 
 using namespace swiftsync;
@@ -104,4 +106,14 @@ BlockHints HintsfileReader::ReadBlock(uint32_t height)
         block_hints.push_back((curr_byte >> leftover) & 0x01);
     }
     return block_hints;
+}
+
+void Context::ApplyHints(HintsfileReader reader)
+{
+    m_hint_reader.emplace(std::move(reader));
+}
+
+BlockHints Context::ReadBlockHints(int nHeight)
+{
+    return m_hint_reader->ReadBlock(nHeight);
 }

--- a/src/swiftsync.cpp
+++ b/src/swiftsync.cpp
@@ -1,6 +1,107 @@
 // Copyright (c) 2025-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <primitives/transaction.h>
+#include <random.h>
+#include <serialize.h>
+#include <streams.h>
 #include <swiftsync.h>
+#include <uint256.h>
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <ios>
+#include <vector>
 
 using namespace swiftsync;
+
+void BlockHintsWriter::WriteBit(uint8_t bit) noexcept
+{
+    uint8_t shift = m_bits_written % 8;
+    m_curr_byte |= bit << shift;
+    ++m_bits_written;
+    if (m_bits_written % 8 == 0) {
+        m_hints.push_back(m_curr_byte);
+        m_curr_byte = 0x00;
+    }
+}
+
+bool BlockHintsWriter::EncodeToFile(AutoFile& file)
+{
+    if (m_bits_written % 8 != 0) {
+        m_hints.push_back(m_curr_byte);
+    }
+    file << m_bits_written;
+    for (const uint8_t packed : m_hints) {
+        file << packed;
+    }
+    return file.Commit();
+}
+
+HintsfileWriter::HintsfileWriter(AutoFile& file, uint32_t preallocate) : m_file(file.release())
+{
+    uint64_t dummy_file_pos{};
+    m_file << FILE_MAGIC;
+    m_file << FILE_VERSION;
+    m_file << preallocate;
+    for (uint32_t height{}; height < preallocate; ++height) {
+        m_file << height;
+        m_file << dummy_file_pos;
+    }
+}
+
+bool HintsfileWriter::WriteNextUnspents(BlockHintsWriter& hints, uint32_t height)
+{
+    // First write the current file position for the current height in the header section.
+    uint64_t curr_pos = m_file.size();
+    uint64_t cursor = FILE_HEADER_LEN + (m_index * (sizeof(uint64_t) + sizeof(uint32_t)));
+    m_file.seek(cursor, SEEK_SET);
+    m_file << height;
+    m_file << curr_pos;
+    // Next append the positions of the unspent offsets in the block at this height.
+    ++m_index;
+    m_file.seek(curr_pos, SEEK_SET);
+    return hints.EncodeToFile(m_file);
+}
+
+HintsfileReader::HintsfileReader(AutoFile& file) : m_file(file.release())
+{
+    std::array<uint8_t, 4> magic{};
+    m_file >> magic;
+    if (magic != FILE_MAGIC) {
+        throw std::ios_base::failure("HintsfileReader: This is not a hint file.");
+    }
+    uint8_t version{};
+    m_file >> version;
+    if (version != FILE_VERSION) {
+        throw std::ios_base::failure("HintsfileReader: Unsupported file version.");
+    }
+    m_file >> m_stop_height;
+    for (uint32_t index{}; index < m_stop_height; ++index) {
+        uint32_t height;
+        uint64_t file_pos;
+        m_file >> height;
+        m_file >> file_pos;
+        m_height_to_file_pos.emplace(height, file_pos);
+    }
+}
+HintsfileReader::HintsfileReader(HintsfileReader&& o) noexcept : m_file{o.m_file.release()}, m_stop_height{o.m_stop_height}, m_height_to_file_pos{std::move(o.m_height_to_file_pos)} {};
+
+BlockHints HintsfileReader::ReadBlock(uint32_t height)
+{
+    uint64_t file_pos = m_height_to_file_pos.at(height);
+    m_file.seek(file_pos, SEEK_SET);
+    uint32_t num_hints{};
+    m_file >> num_hints;
+    std::vector<bool> block_hints{};
+    block_hints.reserve(num_hints);
+    uint8_t curr_byte{};
+    for (uint32_t i{}; i < num_hints; ++i) {
+        uint8_t leftover = i % 8;
+        if (leftover == 0) {
+            m_file >> curr_byte;
+        }
+        block_hints.push_back((curr_byte >> leftover) & 0x01);
+    }
+    return block_hints;
+}

--- a/src/swiftsync.cpp
+++ b/src/swiftsync.cpp
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <swiftsync.h>
+
+using namespace swiftsync;

--- a/src/swiftsync.h
+++ b/src/swiftsync.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_SWIFTSYNC_H
+#define BITCOIN_SWIFTSYNC_H
+#include <arith_uint256.h>
+#include <primitives/transaction.h>
+#include <util/hasher.h>
+
+namespace swiftsync {
+/** An aggregate for the SwiftSync protocol.
+ * This class is intentionally left opaque, as internal changes may occur,
+ * but all aggregates will have the concept of "create" and "spending" an
+ * outpoint.
+ *
+ * The current implementation uses the existing `SaltedOutpointHasher` and
+ * maintains two rotating integers.
+ * */
+class Aggregate
+{
+    arith_uint256 m_created{};
+    arith_uint256 m_spent{};
+    SaltedOutpointHasher m_hasher{};
+
+public:
+    bool IsBalanced() const { return m_created == m_spent; }
+    void Create(const COutPoint& outpoint) { m_created += m_hasher(outpoint); }
+    void Spend(const COutPoint& outpoint) { m_spent += m_hasher(outpoint); }
+};
+} // namespace swiftsync
+#endif // BITCOIN_SWIFTSYNC_H

--- a/src/swiftsync.h
+++ b/src/swiftsync.h
@@ -5,9 +5,19 @@
 #define BITCOIN_SWIFTSYNC_H
 #include <arith_uint256.h>
 #include <primitives/transaction.h>
+#include <streams.h>
+#include <uint256.h>
 #include <util/hasher.h>
+#include <array>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
 
 namespace swiftsync {
+inline constexpr std::array<uint8_t, 4> FILE_MAGIC = {0x55, 0x54, 0x58, 0x4f};
+const uint8_t FILE_VERSION = 0x00;
+// file magic length + version + height
+const uint64_t FILE_HEADER_LEN = 9;
 /** An aggregate for the SwiftSync protocol.
  * This class is intentionally left opaque, as internal changes may occur,
  * but all aggregates will have the concept of "create" and "spending" an
@@ -26,6 +36,83 @@ public:
     bool IsBalanced() const { return m_created == m_spent; }
     void Create(const COutPoint& outpoint) { m_created += m_hasher(outpoint); }
     void Spend(const COutPoint& outpoint) { m_spent += m_hasher(outpoint); }
+};
+
+/**
+ * Write the hints of a single block.
+ */
+class BlockHintsWriter
+{
+private:
+    std::vector<uint8_t> m_hints{};
+    uint8_t m_curr_byte{};
+    uint32_t m_bits_written{};
+    void WriteBit(uint8_t bit) noexcept;
+
+public:
+    /** Push a `1` to the stack. */
+    void PushHighBit() noexcept { return WriteBit(0x01); }
+    /** Push a `0` to the stack. */
+    void PushLowBit() noexcept { return WriteBit(0x00); }
+    /** Push the hints to a file and commit the changes. */
+    bool EncodeToFile(AutoFile& file);
+};
+
+/**
+ * Create a new hint file for writing.
+ */
+class HintsfileWriter
+{
+private:
+    AutoFile m_file;
+    uint32_t m_index{};
+
+public:
+    // Create a new hint file writer that will encode `preallocate` number of blocks.
+    HintsfileWriter(AutoFile& file, uint32_t preallocate);
+    ~HintsfileWriter()
+    {
+        (void)m_file.fclose();
+    }
+    // Write the next hints to file.
+    bool WriteNextUnspents(BlockHintsWriter& hints, uint32_t height);
+    // Close the underlying file.
+    int Close() { return m_file.fclose(); };
+};
+
+class BlockHints
+{
+private:
+    std::vector<bool> m_hints{};
+    uint32_t m_index{};
+
+public:
+    BlockHints(std::vector<bool> hints) : m_hints{hints} {};
+    void Next() noexcept { ++m_index; };
+    bool IsCurrUnspent() const { return m_hints.at(m_index); }
+};
+
+/**
+ * A file that encodes the UTXO set state at a particular block height.
+ */
+class HintsfileReader
+{
+private:
+    AutoFile m_file;
+    uint32_t m_stop_height;
+    std::unordered_map<uint32_t, size_t> m_height_to_file_pos;
+
+public:
+    HintsfileReader(AutoFile& file);
+    HintsfileReader(HintsfileReader&& o) noexcept;
+    ~HintsfileReader()
+    {
+        (void)m_file.fclose();
+    }
+    /** Read the hints for the specified block height. */
+    BlockHints ReadBlock(uint32_t height);
+    /** The height this file encodes up to. */
+    uint32_t StopHeight() const noexcept { return m_stop_height; };
 };
 } // namespace swiftsync
 #endif // BITCOIN_SWIFTSYNC_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -101,6 +101,7 @@ add_executable(test_bitcoin
   sock_tests.cpp
   span_tests.cpp
   streams_tests.cpp
+  swiftsync_tests.cpp
   sync_tests.cpp
   system_ram_tests.cpp
   system_tests.cpp

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -79,6 +79,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "echoipc",              // avoid assertion failure (Assertion `"EnsureAnyNodeContext(request.context).init" && check' failed.)
     "generatetoaddress",    // avoid prohibitively slow execution (when `num_blocks` is large)
     "generatetodescriptor", // avoid prohibitively slow execution (when `nblocks` is large)
+    "generatetxohints",     // avoid writing to disk
     "gettxoutproof",        // avoid prohibitively slow execution
     "importmempool", // avoid reading from disk
     "loadtxoutset",   // avoid reading from disk

--- a/src/test/swiftsync_tests.cpp
+++ b/src/test/swiftsync_tests.cpp
@@ -2,8 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <primitives/transaction.h>
+#include <streams.h>
 #include <swiftsync.h>
+#include <test/util/setup_common.h>
 #include <boost/test/unit_test.hpp>
+#include <cstdio>
 
 namespace {
 Txid txid_1{Txid{"bd0f71c1d5e50589063e134fad22053cdae5ab2320db5bf5e540198b0b5a4e69"}};
@@ -12,9 +15,15 @@ Txid txid_3{Txid{"ee707be5201160e32c4fc715bec227d1aeea5940fb4295605e7373edce3b1a
 COutPoint outpoint_1{COutPoint{txid_1, 2142}};
 COutPoint outpoint_2{COutPoint{txid_2, 99328}};
 COutPoint outpoint_3{COutPoint{txid_3, 5438584}};
+// One byte worth of hints.
+std::vector<bool> unspent_block_1{true, false, false, true, false, true, true, true};
+// Between one and two bytes worth of hints.
+std::vector<bool> unspent_block_2{true, false, false, true, false, true, true, true, true, false, true};
+// Two bytes worth of hints.
+std::vector<bool> unspent_block_3{true, false, false, true, false, true, true, true, true, false, true, true, true, true, true, true};
 } // namespace
 
-BOOST_AUTO_TEST_SUITE(swiftsync_tests);
+BOOST_FIXTURE_TEST_SUITE(swiftsync_tests, BasicTestingSetup);
 
 BOOST_AUTO_TEST_CASE(swiftsync_aggregate_test)
 {
@@ -27,6 +36,82 @@ BOOST_AUTO_TEST_CASE(swiftsync_aggregate_test)
     agg.Create(outpoint_2);
     agg.Spend(outpoint_3);
     BOOST_CHECK(agg.IsBalanced());
+}
+
+BOOST_AUTO_TEST_CASE(swiftsync_hintfile_test)
+{
+    const fs::path temppath = fsbridge::AbsPathJoin(gArgs.GetDataDirNet(), fs::u8path("test.hints"));
+    {
+        FILE* file{fsbridge::fopen(temppath, "wb")};
+        AutoFile afile{file};
+        swiftsync::HintsfileWriter writer{afile, 3};
+        swiftsync::BlockHintsWriter block_one{};
+        for (const bool hint : unspent_block_1) {
+            if (hint) {
+                block_one.PushHighBit();
+            } else {
+                block_one.PushLowBit();
+            };
+        }
+        BOOST_CHECK(writer.WriteNextUnspents(block_one, 1));
+        swiftsync::BlockHintsWriter block_three{};
+        for (const bool hint : unspent_block_3) {
+            if (hint) {
+                block_three.PushHighBit();
+            } else {
+                block_three.PushLowBit();
+            };
+        }
+        BOOST_CHECK(writer.WriteNextUnspents(block_three, 3));
+        swiftsync::BlockHintsWriter block_two{};
+        for (const bool hint : unspent_block_2) {
+            if (hint) {
+                block_two.PushHighBit();
+            } else {
+                block_two.PushLowBit();
+            };
+        }
+        BOOST_CHECK(writer.WriteNextUnspents(block_two, 2));
+    }
+    FILE* file{fsbridge::fopen(temppath, "rb")};
+    AutoFile afile{file};
+    swiftsync::HintsfileReader reader{afile};
+    BOOST_CHECK_EQUAL(reader.StopHeight(), 3);
+    auto query_block_3 = reader.ReadBlock(3);
+    for (const bool want : unspent_block_3) {
+        BOOST_CHECK_EQUAL(want, query_block_3.IsCurrUnspent());
+        query_block_3.Next();
+    }
+    auto query_block_1 = reader.ReadBlock(1);
+    for (const bool want : unspent_block_1) {
+        BOOST_CHECK_EQUAL(want, query_block_1.IsCurrUnspent());
+        query_block_1.Next();
+    }
+    auto query_block_2 = reader.ReadBlock(2);
+    for (const bool want : unspent_block_2) {
+        BOOST_CHECK_EQUAL(want, query_block_2.IsCurrUnspent());
+        query_block_2.Next();
+    }
+    BOOST_CHECK_THROW(reader.ReadBlock(0), std::out_of_range);
+    BOOST_CHECK_THROW(reader.ReadBlock(4), std::out_of_range);
+    const fs::path bogus_path = fsbridge::AbsPathJoin(gArgs.GetDataDirNet(), fs::u8path("bogus.hints"));
+    // Unknown file version.
+    {
+        FILE* file{fsbridge::fopen(bogus_path, "wb")};
+        AutoFile afile{file};
+        afile << swiftsync::FILE_MAGIC;
+        // Version not currently supported
+        afile << 0x01;
+        BOOST_CHECK_THROW(swiftsync::HintsfileReader{afile}, std::ios_base::failure);
+    }
+    // Magic does not match.
+    {
+        FILE* file{fsbridge::fopen(bogus_path, "wb")};
+        AutoFile afile{file};
+        afile.seek(0, SEEK_SET);
+        afile << 0xFF;
+        BOOST_CHECK_THROW(swiftsync::HintsfileReader{afile}, std::ios_base::failure);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/swiftsync_tests.cpp
+++ b/src/test/swiftsync_tests.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <primitives/transaction.h>
+#include <swiftsync.h>
+#include <boost/test/unit_test.hpp>
+
+namespace {
+Txid txid_1{Txid{"bd0f71c1d5e50589063e134fad22053cdae5ab2320db5bf5e540198b0b5a4e69"}};
+Txid txid_2{Txid{"b4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"}};
+Txid txid_3{Txid{"ee707be5201160e32c4fc715bec227d1aeea5940fb4295605e7373edce3b1a93"}};
+COutPoint outpoint_1{COutPoint{txid_1, 2142}};
+COutPoint outpoint_2{COutPoint{txid_2, 99328}};
+COutPoint outpoint_3{COutPoint{txid_3, 5438584}};
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(swiftsync_tests);
+
+BOOST_AUTO_TEST_CASE(swiftsync_aggregate_test)
+{
+    swiftsync::Aggregate agg{};
+    agg.Create(outpoint_1);
+    agg.Spend(outpoint_2);
+    agg.Create(outpoint_3);
+    BOOST_CHECK(!agg.IsBalanced());
+    agg.Spend(outpoint_1);
+    agg.Create(outpoint_2);
+    agg.Spend(outpoint_3);
+    BOOST_CHECK(agg.IsBalanced());
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5527,6 +5527,11 @@ void ChainstateManager::CheckBlockIndex() const
     assert(nNodes == forward.size() + best_hdr_chain.Height() + 1);
 }
 
+void Chainstate::ApplyUtxoHints(swiftsync::HintsfileReader reader)
+{
+    m_swiftsync_ctx.ApplyHints(std::move(reader));
+}
+
 std::string Chainstate::ToString()
 {
     AssertLockHeld(::cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -44,6 +44,7 @@
 #include <script/script.h>
 #include <script/sigcache.h>
 #include <signet.h>
+#include <swiftsync.h>
 #include <tinyformat.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -2052,6 +2053,33 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txund
     AddCoins(inputs, tx, nHeight);
 }
 
+void UpdateCoinsWithHints(const CTransaction& tx, CCoinsViewCache& inputs, const CBlockIndex& pindex, swiftsync::Aggregate& agg, swiftsync::BlockHints& hints)
+{
+    const bool is_coinbase = tx.IsCoinBase();
+    if (is_coinbase && IsBIP30Unspendable(pindex.GetBlockHash(), pindex.nHeight)) {
+        for (uint64_t index = 0; index < tx.vout.size(); ++index) {
+            // No-op on the aggregator and TXO set. These coins will show up again.
+            hints.Next();
+        }
+        return;
+    }
+    if (!is_coinbase) {
+        for (const CTxIn& txin : tx.vin) {
+            agg.Spend(txin.prevout);
+        }
+    }
+    const Txid& txid{tx.GetHash()};
+    for (uint64_t index = 0; index < tx.vout.size(); ++index) {
+        COutPoint outpoint = COutPoint(txid, index);
+        if (!hints.IsCurrUnspent() && !tx.vout[index].scriptPubKey.IsUnspendable()) {
+            agg.Create(outpoint);
+        } else {
+            inputs.AddCoin(outpoint, Coin(tx.vout[index], pindex.nHeight, is_coinbase), is_coinbase);
+        }
+        hints.Next();
+    }
+}
+
 std::optional<std::pair<ScriptError, std::string>> CScriptCheck::operator()() {
     const CScript &scriptSig = ptxTo->vin[nIn].scriptSig;
     const CScriptWitness *witness = &ptxTo->vin[nIn].scriptWitness;
@@ -2378,11 +2406,13 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // Special case for the genesis block, skipping connection of its transactions
     // (its coinbase is unspendable)
     if (block_hash == params.GetConsensus().hashGenesisBlock) {
+        m_swiftsync_ctx.StartFromGenesis();
         if (!fJustCheck)
             view.SetBestBlock(pindex->GetBlockHash());
         return true;
     }
 
+    const bool swiftsync_active = m_swiftsync_ctx.IsPossible();
     const char* script_check_reason;
     if (m_chainman.AssumedValidBlock().IsNull()) {
         script_check_reason = "assumevalid=0 (always verify)";
@@ -2562,6 +2592,10 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     int nInputs = 0;
     int64_t nSigOpsCost = 0;
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
+    std::optional<swiftsync::BlockHints> hints;
+    if (swiftsync_active) {
+        hints.emplace(m_swiftsync_ctx.ReadBlockHints(pindex->nHeight));
+    }
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         if (!state.IsValid()) break;
@@ -2569,7 +2603,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
         nInputs += tx.vin.size();
 
-        if (!tx.IsCoinBase())
+        if (!tx.IsCoinBase() && !swiftsync_active)
         {
             CAmount txfee = 0;
             TxValidationState tx_state;
@@ -2606,13 +2640,15 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         // * legacy (always)
         // * p2sh (when P2SH enabled in flags and excludes coinbase)
         // * witness (when witness enabled in flags and excludes coinbase)
-        nSigOpsCost += GetTransactionSigOpCost(tx, view, flags);
-        if (nSigOpsCost > MAX_BLOCK_SIGOPS_COST) {
-            state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-sigops", "too many sigops");
-            break;
+        if (!swiftsync_active) {
+            nSigOpsCost += GetTransactionSigOpCost(tx, view, flags);
+            if (nSigOpsCost > MAX_BLOCK_SIGOPS_COST) {
+                state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-sigops", "too many sigops");
+                break;
+            }
         }
 
-        if (!tx.IsCoinBase() && fScriptChecks)
+        if (!tx.IsCoinBase() && fScriptChecks && !swiftsync_active)
         {
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
             bool tx_ok;
@@ -2638,7 +2674,19 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         if (i > 0) {
             blockundo.vtxundo.emplace_back();
         }
-        UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
+        if (swiftsync_active) {
+            UpdateCoinsWithHints(tx, view, *pindex, m_swiftsync_ctx.m_aggregate, hints.value());
+        } else {
+            UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
+        }
+    }
+    if (swiftsync_active && m_swiftsync_ctx.StopHeight() == (uint32_t)pindex->nHeight) {
+        m_swiftsync_ctx.Complete();
+        if (m_swiftsync_ctx.m_aggregate.IsBalanced()) {
+            LogInfo("SwiftSync IBD succeeded.");
+        } else {
+            return FatalError(m_chainman.GetNotifications(), state, _("UTXO set check failed indicating a corrupt file. Restart with -reindex to recover."));
+        }
     }
     const auto time_3{SteadyClock::now()};
     m_chainman.time_connect += time_3 - time_2;
@@ -2648,10 +2696,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
              Ticks<SecondsDouble>(m_chainman.time_connect),
              Ticks<MillisecondsDouble>(m_chainman.time_connect) / m_chainman.num_blocks_total);
 
-    CAmount blockReward = nFees + GetBlockSubsidy(pindex->nHeight, params.GetConsensus());
-    if (block.vtx[0]->GetValueOut() > blockReward && state.IsValid()) {
-        state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-amount",
+    if (!swiftsync_active) {
+        CAmount blockReward = nFees + GetBlockSubsidy(pindex->nHeight, params.GetConsensus());
+        if (block.vtx[0]->GetValueOut() > blockReward && state.IsValid()) {
+            state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-amount",
                       strprintf("coinbase pays too much (actual=%d vs limit=%d)", block.vtx[0]->GetValueOut(), blockReward));
+        }
     }
     if (control) {
         auto parallel_result = control->Complete();
@@ -2675,7 +2725,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         return true;
     }
 
-    if (!m_blockman.WriteBlockUndo(blockundo, state, *pindex)) {
+    if (!swiftsync_active && !m_blockman.WriteBlockUndo(blockundo, state, *pindex)) {
         return false;
     }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -24,6 +24,7 @@
 #include <script/script_error.h>
 #include <script/sigcache.h>
 #include <script/verify_flags.h>
+#include <swiftsync.h>
 #include <sync.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -558,6 +559,9 @@ protected:
     //! Manages the UTXO set, which is a reflection of the contents of `m_chain`.
     std::unique_ptr<CoinsViews> m_coins_views;
 
+    //! Manages the state of accelerated IBD with external hints.
+    swiftsync::Context m_swiftsync_ctx{};
+
     //! Cached result of LookupBlockIndex(*m_from_snapshot_blockhash)
     mutable const CBlockIndex* m_cached_snapshot_base GUARDED_BY(::cs_main){nullptr};
 
@@ -839,6 +843,9 @@ public:
     //!
     //! start > end is possible, meaning no blocks can be pruned.
     std::pair<int, int> GetPruneRange(int last_height_can_prune) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Accelerate initial block download with external hints. */
+    void ApplyUtxoHints(swiftsync::HintsfileReader reader);
 
 protected:
     bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);

--- a/test/functional/feature_swiftsync.py
+++ b/test/functional/feature_swiftsync.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+""" Testing related to SwiftSync initial block download protocol.
+
+This test creates a node that acts as a single source of truth for two other nodes.
+It tests three properties:
+- A correctly constructed hints file allows a new client to perform initial block download
+- Block reorganizations are handled by the new node online
+- A faulty hints file is recognized by a new client and the new client can recover with a `-reindex`
+"""
+from test_framework.util import assert_equal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.wallet import MiniWallet
+
+BASE_BLOCKS = 200
+NUM_SWIFTSYNC_BLOCKS = 100
+NUM_ADDITIONAL_BLOCKS = 100
+GOOD_FILE = "good.hints"
+BAD_FILE = "bad.hints"
+
+class SwiftSyncTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+        self.setup_clean_chain = True
+
+    def setup_network(self):
+        self.add_nodes(3)
+
+    def run_test(self):
+        full_node = self.nodes[0]
+        sync_node = self.nodes[1]
+        fail_node = self.nodes[2]
+        self.start_node(0)
+        mini_wallet = MiniWallet(full_node)
+        ## Coinbase outputs are treated differently by the SwiftSync protocol as their inputs are ignored.
+        ## To ensure the hash aggregate is working correctly, we also create non-coinbase transactions.
+        self.log.info(f"Generating {BASE_BLOCKS} blocks to a source node")
+        self.generate(mini_wallet, BASE_BLOCKS, sync_fun=self.no_op)
+        self.log.info(f"Sending {NUM_SWIFTSYNC_BLOCKS} self transfers")
+        for _ in range(NUM_SWIFTSYNC_BLOCKS):
+            mini_wallet.send_self_transfer(from_node=full_node)
+            self.generate(full_node, nblocks=1, sync_fun=self.no_op)
+        self.log.info("Creating hints file")
+        result = full_node.generatetxohints(GOOD_FILE)
+        hints_path = result["path"]
+        self.log.info(f"Created hints file at {hints_path}")
+        assert_equal(full_node.getblockcount(), NUM_SWIFTSYNC_BLOCKS + BASE_BLOCKS)
+        self.log.info(f"Generating {NUM_ADDITIONAL_BLOCKS} blocks with additional self transfers")
+        for _ in range(NUM_ADDITIONAL_BLOCKS):
+            mini_wallet.send_self_transfer(from_node=full_node)
+            self.generate(full_node, nblocks=1, sync_fun=self.no_op)
+        self.log.info("Starting a pruned node with a hints file and performing IBD")
+        self.start_node(1, extra_args=["-prune=1", f"-utxohints={hints_path}"])
+        assert_equal(sync_node.getblockcount(), 0)
+        self.connect_nodes(0, 1)
+        self.log.info("Asserting sync is successful")
+        self.sync_blocks([full_node, sync_node])
+        assert_equal(full_node.getblockcount(), sync_node.getblockcount())
+        self.log.info("Sync successful")
+        self.log.info("Creating a hints file from a stale block")
+        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
+        mini_wallet.send_self_transfer(from_node=full_node)
+        self.generate(full_node, nblocks=1, sync_fun=self.no_op)
+        result = full_node.generatetxohints(BAD_FILE)
+        bad_hints_path = result["path"]
+        self.log.info(f"Created defect hints file at {bad_hints_path}")
+        self.log.info("Creating heavier chain")
+        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
+        mini_wallet.send_self_transfer(from_node=full_node)
+        self.generate(full_node, nblocks=2, sync_fun=self.no_op)
+        self.log.info("Asserting pruned node can reorganize")
+        self.connect_nodes(0, 1)
+        self.sync_blocks([full_node, sync_node])
+        assert_equal(full_node.getbestblockhash(), sync_node.getbestblockhash())
+        self.log.info("Reorganize successful")
+        self.log.info("Syncing a third node to a bad hints file and waiting for crash")
+        try:
+            self.start_node(2, extra_args=["-prune=1", f"-utxohints={bad_hints_path}"])
+            self.connect_nodes(0, 2)
+            self.sync_blocks([full_node, fail_node])
+            raise AssertionError("Syncing with a stale or faulty hints file should not be possible.")
+        except Exception:
+            self.wait_for_node_exit(2, timeout=5)
+        self.log.info("Reindexing to test the new node can recover")
+        self.start_node(2, extra_args=["-prune=1", "-reindex"])
+        self.connect_nodes(0, 2)
+        self.sync_blocks([full_node, fail_node])
+        assert_equal(full_node.getbestblockhash(), fail_node.getbestblockhash())
+        self.log.info("New node synced successfully")
+
+if __name__ == '__main__':
+    SwiftSyncTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -104,6 +104,7 @@ BASE_SCRIPTS = [
     'p2p_segwit.py',
     'feature_maxuploadtarget.py',
     'feature_assumeutxo.py',
+    'feature_swiftsync.py',
     'mempool_updatefromblock.py',
     'mempool_persist.py',
     # vv Tests less than 60s vv

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -55,6 +55,8 @@ unsigned-integer-overflow:TxConfirmStats::EstimateMedianVal
 unsigned-integer-overflow:InsecureRandomContext::rand64
 unsigned-integer-overflow:InsecureRandomContext::SplitMix64
 unsigned-integer-overflow:bitset_detail::PopCount
+unsigned-integer-overflow:Aggregate::Create
+unsigned-integer-overflow:Aggregate::Spend
 implicit-integer-sign-change:SetStdinEcho
 implicit-integer-sign-change:compressor.h
 implicit-integer-sign-change:crypto/


### PR DESCRIPTION
Link to the original protocol writeup found [here](https://gist.github.com/RubenSomsen/a61a37d14182ccd78760e477c78133cd). See the [Delving Bitcoin post](https://delvingbitcoin.org/t/swiftsync-speeding-up-ibd-with-pre-generated-hints-poc/1562) for initial works and discussion.

# Motivation

While many coins are available in cache when spent, every cache miss requires a trip to the disk. Memory can be scarce for single board machines, so cache misses are expected to be far more frequent. A trip to disk is all-the-more severe on low end hardware, so any minimization of disk interactions can speed up initial block download for limited resource devices. One such example may be a block template provider serving a home miner.

# Intuition

The vast majority of coins created are later spent. The cost of this observation is many coins will be written to disk, only to be removed later. The SwiftSync protocol alleviates the problem by recording what coins have been added and removed with a small, in-memory aggregate. This allows for the removal of intermediate coin states until SwiftSync has completed. The state of the aggregate is verified at a predetermined chain height, and IBD continues as usual thereafter.

For any chain height, we know `all outputs - all inputs = UTXO set`, which is equivalently `all outputs - UTXO set = all inputs`. The goal is to verify the set `all outputs - UTXO set` is equal to `all inputs`. Addition and subtraction modulo a field offers a way to do so. For any set, if we add all elements of the set and subtract them, regardless of ordering, we will arrive at zero. In the current implementation, the set elements being compared are hashed outpoints.

The SwiftSync protocol is comprised of two structures. First, the aggregate that will record the state of what outpoints have been added (created) or subtracted (spent). Next, notice that the UTXO set must be reported in order to verify `all outputs - UTXO set = all inputs`. SwiftSync introduces a hints file, which may be provided to the client at startup. This hints file is nothing more than a pointer to each unspent output by recording the block height and the indexes that will remain unspent. By using this file, a client may omit outpoints that will be in the UTXO set when updating the aggregate. Note this file is not trusted. If a malicious actor provides a faulty UTXO set, the set comparison above will fail, and the client may begin a reindex.
# Implementation

## Aggregate

The hash aggregate takes outpoints, hashes them with a salted hasher, and updates 4, 64-bit limbs with wrapping modulo arithmetic. The choice of 4, 64-bit limbs with no carries between limbs was made to: 1. minimize code complexity within the aggregate 2. conform to existing APIs, namely `uint256`. After adding and subtracting some arbitrary list of outpoints, we may poll if the sets were equivalent with `IsZero`.
## Hintsfile

The hints file is a map of block height to the indexes of the outputs in that block that _will_ be in the UTXO set. To construct this file for a particular UTXO set state, each block must be read and queried to find the outputs in that block that remain unspent. Because this is a read-only operation, this may be done on parallel threads in the future. To allow for parallelization, the hints file contains a "contents" section, which denotes the height and corresponding file position to find the hints for that block.

To save space when representing the indexes that remain unspent in a block, an easy choice is to take the difference between the last coin that was unspent and the next one in the block. AFICT this is a version of run-length-encoding. These indexes are encoded using `compactSize` to further save space, the run-lengths should normally fit into at least 16 bits, often 8 bits.
## Parameter Interaction

A side effect of omitting intermediate UTXO states while performing IBD is the "undo data" cannot be derived. There are already configurations that do not have full undo data history, namely pruned nodes. To avoid additional complexity in this PR, this version of accelerated IBD is only made available to pruned nodes, as the undo data would have been removed regardless of the this setting.

Other parameter interactions, not yet implemented:
- `assumeutxo`: Startup should fail if both are configured. A hints file will have no effect, as the UTXO set is already present.
- `assumevalid`: A natural choice is to only allow SwiftSync when using `assumevalid`, and to only allow a hints file that commits to the `assumevalid` block. Similar to `assumeutxo`, a hash of the hints file may be committed to in the binary, which would be resistant to griefing attacks.
# Open Questions

- Given the outcome of SwiftSync is pass/fail, and there is no use of intermediate states, should blocks be persisted to disk at all during the protocol?
- To what degree should a hints file be committed to in the binary. No commitment allows for a server to provide hints for an arbitrary height, providing a convenience for the client, but opens up the possibility of a grief attack. Of course the server risks losing reputation for serving faulty files.

# Future Iteration

This is the first iteration of the SwiftSync proposal, however more optimizations may be made. Namely, because set elements may be added or subtracted from the aggregate in any order, blocks may be downloaded in parallel from multiple peers. If you are interested in benchmarking the performance of a fully-parallel version, see the [Rust implementation](https://github.com/2140-dev/swiftsync).
