### PR TITLE
fuzz: Add a test case for `ParseByteUnits()`

### DIFF
--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -147,4 +147,19 @@ FUZZ_TARGET(string)
         const bilingual_str bs2{random_string_2, random_string_1};
         (void)(bs1 + bs2);
     }
+    {
+        const ByteUnit all_units[] = {
+            ByteUnit::NOOP,
+            ByteUnit::k,
+            ByteUnit::K,
+            ByteUnit::m,
+            ByteUnit::M,
+            ByteUnit::g,
+            ByteUnit::G,
+            ByteUnit::t,
+            ByteUnit::T
+        };
+        ByteUnit default_multiplier = fuzzed_data_provider.PickValueInArray(all_units);
+        (void)ParseByteUnits(random_string_1, default_multiplier);
+    }
 }


### PR DESCRIPTION
`ParseByteUnits()` is the only parsing function in `strencodings.cpp` lacking a fuzz test. Add a test case to check the function against arbitrary strings and randomized `default_multiplier`.