### PR TITLE
log: exempt all category-specific logs from ratelimiting when running with debug

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3663,12 +3663,14 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         // can be triggered by an attacker at high rate.
         if (!pfrom.IsInboundConn() || LogAcceptCategory(BCLog::NET, BCLog::Level::Debug)) {
             const auto mapped_as{m_connman.GetMappedAS(pfrom.addr)};
-            LogInfo("New %s %s peer connected: version: %d, blocks=%d, peer=%d%s%s\n",
-                      pfrom.ConnectionTypeAsString(),
-                      TransportTypeAsString(pfrom.m_transport->GetInfo().transport_type),
-                      pfrom.nVersion.load(), peer->m_starting_height,
-                      pfrom.GetId(), pfrom.LogIP(fLogIPs),
-                      (mapped_as ? strprintf(", mapped_as=%d", mapped_as) : ""));
+            LogPrintLevel(
+                BCLog::NET, BCLog::Level::Info,
+                "New %s %s peer connected: version: %d, blocks=%d, peer=%d%s%s\n",
+                pfrom.ConnectionTypeAsString(),
+                TransportTypeAsString(pfrom.m_transport->GetInfo().transport_type),
+                pfrom.nVersion.load(), peer->m_starting_height,
+                pfrom.GetId(), pfrom.LogIP(fLogIPs),
+                (mapped_as ? strprintf(", mapped_as=%d", mapped_as) : ""));
         }
 
         if (pfrom.GetCommonVersion() >= SHORT_IDS_BLOCKS_VERSION) {

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -489,8 +489,8 @@ BOOST_FIXTURE_TEST_CASE(logging_filesize_rate_limit, LogSetup)
         }
     }
 
-    // Check that unconditional logs with a specific category are rate-limited
-    // even when that category (here: http) has debug logging enabled.
+    // Check that unconditional logs with a specific category are NOT rate-limited
+    // when that category (here: http) has debug logging enabled.
     scheduler.MockForwardAndSync(time_window);
     BOOST_REQUIRE(!limiter->SuppressionsActive());
 
@@ -499,7 +499,7 @@ BOOST_FIXTURE_TEST_CASE(logging_filesize_rate_limit, LogSetup)
         TestLogFromLocation(Location::INFO_HTTP, log_message.substr(12), Status::UNSUPPRESSED, /*suppressions_active=*/false);
         TestLogFromLocation(Location::WARNING_NET, log_message.substr(14), Status::UNSUPPRESSED, /*suppressions_active=*/false);
     }
-    TestLogFromLocation(Location::INFO_HTTP, "1", Status::NEWLY_SUPPRESSED, /*suppressions_active=*/true);
+    TestLogFromLocation(Location::INFO_HTTP, "1", Status::UNSUPPRESSED, /*suppressions_active=*/false);
     TestLogFromLocation(Location::WARNING_NET, "1", Status::NEWLY_SUPPRESSED, /*suppressions_active=*/true);
 }
 


### PR DESCRIPTION
Previously, running with `-debug=<category>` would exempt the debug and trace log messages in that category from rate limiting, but not the info/warning/error category-specific messages (which are rare). This is unintuitive and unnecessary.

When users run with `-debug`, we already assume they are power users and that they will have significantly higher log volumes, so there is no real benefit from suppressing info log messages in that category.

Fix this by applying ratelimiting exceptions from `-debug=<category>` to all logs in that category.

Also updates `net_processing` to log new peer connections with `NET` category. This way, when running with `-debug=net`, the log message (which can be frequent) will not get ratelimited when the user explicitly opts into getting higher log volumes for net.

Introduces slight behaviour change by prefixing the log message with [net:info].

Alternative to #34008