### PR TITLE
rpc: Reject distinct transactions in combinerawtransaction

### DIFF
--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -91,6 +91,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.decoderawtransaction_tests()
         self.transaction_version_number_tests()
         self.getrawtransaction_verbosity_tests()
+        self.combinerawtransaction_tests()
 
     def getrawtransaction_tests(self):
         tx = self.wallet.send_self_transfer(from_node=self.nodes[0])
@@ -496,6 +497,20 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx = tx.serialize().hex()
         decrawtx = self.nodes[0].decoderawtransaction(rawtx)
         assert_equal(decrawtx['version'], 0xffffffff)
+
+    def combinerawtransaction_tests(self):
+        self.log.info("Test combinerawtransaction with distinct transactions")
+        # Create two different transactions
+        tx1 = self.wallet.create_self_transfer()
+        tx2 = self.wallet.create_self_transfer()
+
+        # Combining two distinct transactions should fail
+        assert_raises_rpc_error(
+            -8,
+            "spends different inputs",
+            self.nodes[0].combinerawtransaction,
+            [tx1['hex'], tx2['hex']]
+        )
 
 if __name__ == '__main__':
     RawTransactionsTest(__file__).main()


### PR DESCRIPTION
Previously, combinerawtransaction silently processed only the first transaction when given unrelated transactions as input, ignoring the rest. This could be confusing and lead to unexpected behavior.

This change adds validation to ensure all transactions passed to combinerawtransaction have the same base structure (same inputs and outputs), throwing RPC_INVALID_PARAMETER if they differ.

Fixes #25980

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
