### PR TITLE
net: Remove "tor" as a network specification

### DIFF
--- a/doc/release-notes-34031.md
+++ b/doc/release-notes-34031.md
@@ -1,0 +1,4 @@
+Net
+---
+- `tor` has been removed as a network specification. It
+  was deprecated in favour of `onion` in v0.17.0. (#34031)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1683,7 +1683,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             ipv4_proxy = name_proxy = proxy;
         } else if (net_str == "ipv6") {
             ipv6_proxy = name_proxy = proxy;
-        } else if (net_str == "tor" || net_str == "onion") {
+        } else if (net_str == "onion") {
             onion_proxy = proxy;
         } else if (net_str == "cjdns") {
             cjdns_proxy = proxy;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -102,10 +102,6 @@ enum Network ParseNetwork(const std::string& net_in) {
     if (net == "ipv4") return NET_IPV4;
     if (net == "ipv6") return NET_IPV6;
     if (net == "onion") return NET_ONION;
-    if (net == "tor") {
-        LogWarning("Net name 'tor' is deprecated and will be removed in the future. You should use 'onion' instead.");
-        return NET_ONION;
-    }
     if (net == "i2p") {
         return NET_I2P;
     }

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2022 The Bitcoin Core developers
+// Copyright (c) 2012-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -348,17 +348,20 @@ BOOST_AUTO_TEST_CASE(netbase_parsenetwork)
     BOOST_CHECK_EQUAL(ParseNetwork("ipv4"), NET_IPV4);
     BOOST_CHECK_EQUAL(ParseNetwork("ipv6"), NET_IPV6);
     BOOST_CHECK_EQUAL(ParseNetwork("onion"), NET_ONION);
-    BOOST_CHECK_EQUAL(ParseNetwork("tor"), NET_ONION);
     BOOST_CHECK_EQUAL(ParseNetwork("cjdns"), NET_CJDNS);
 
     BOOST_CHECK_EQUAL(ParseNetwork("IPv4"), NET_IPV4);
     BOOST_CHECK_EQUAL(ParseNetwork("IPv6"), NET_IPV6);
     BOOST_CHECK_EQUAL(ParseNetwork("ONION"), NET_ONION);
-    BOOST_CHECK_EQUAL(ParseNetwork("TOR"), NET_ONION);
     BOOST_CHECK_EQUAL(ParseNetwork("CJDNS"), NET_CJDNS);
 
+    // "tor" as a network specification was deprecated in 60dc8e4208 in favor of
+    // "onion" and later removed.
+    BOOST_CHECK_EQUAL(ParseNetwork("tor"), NET_UNROUTABLE);
+    BOOST_CHECK_EQUAL(ParseNetwork("TOR"), NET_UNROUTABLE);
+
     BOOST_CHECK_EQUAL(ParseNetwork(":)"), NET_UNROUTABLE);
-    BOOST_CHECK_EQUAL(ParseNetwork("tÖr"), NET_UNROUTABLE);
+    BOOST_CHECK_EQUAL(ParseNetwork("oniÖn"), NET_UNROUTABLE);
     BOOST_CHECK_EQUAL(ParseNetwork("\xfe\xff"), NET_UNROUTABLE);
     BOOST_CHECK_EQUAL(ParseNetwork(""), NET_UNROUTABLE);
 }

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -468,8 +468,8 @@ class ProxyTest(BitcoinTestFramework):
         assert_equal(nets["ipv6"]["proxy"], "127.6.6.6:6666")
         self.stop_node(1)
 
-        self.log.info("Test overriding the Tor proxy")
-        self.start_node(1, extra_args=["-proxy=127.1.1.1:1111", "-proxy=127.2.2.2:2222=tor"])
+        self.log.info("Test overriding the Onion proxy")
+        self.start_node(1, extra_args=["-proxy=127.1.1.1:1111", "-proxy=127.2.2.2:2222=onion"])
         nets = networks_dict(self.nodes[1].getnetworkinfo())
         assert_equal(nets["ipv4"]["proxy"], "127.1.1.1:1111")
         assert_equal(nets["ipv6"]["proxy"], "127.1.1.1:1111")


### PR DESCRIPTION
"tor" as a network specification was deprecated in 60dc8e4208 in favor of "onion" 
and this commit removes it and updates the relevant test.

Previously #16029. This has been warning as being deprecated since `v0.17.0`.

This PR only removes the already deprecated usage of tor as a network specification, the use of tor throughout the codebase, is not deprecated.