### PR TITLE
util: Add some more Unexpected and Expected methods

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -39,3 +39,5 @@ CheckOptions:
    value: false
  - key: bugprone-unused-return-value.CheckedReturnTypes
    value: '^::std::error_code$;^::std::error_condition$;^::std::errc$;^::std::expected$;^::util::Result$;^::util::Expected$'
+ - key: bugprone-unused-return-value.AllowCastToVoid
+   value: true  # Can be removed with C++26 once the _ placeholder exists.

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -130,7 +130,7 @@ static void BnBExhaustion(benchmark::Bench& bench)
     bench.run([&] {
         // Benchmark
         CAmount target = make_hard_case(17, utxo_pool);
-        [[maybe_unused]] auto _{SelectCoinsBnB(utxo_pool, target, /*cost_of_change=*/0, MAX_STANDARD_TX_WEIGHT)}; // Should exhaust
+        (void)SelectCoinsBnB(utxo_pool, target, /*cost_of_change=*/0, MAX_STANDARD_TX_WEIGHT); // Should exhaust
 
         // Cleanup
         utxo_pool.clear();

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -330,7 +330,7 @@ static void http_request_cb(struct evhttp_request* req, void* arg)
         std::unique_ptr<HTTPWorkItem> item(new HTTPWorkItem(std::move(hreq), path, i->handler));
         assert(g_work_queue);
         if (g_work_queue->Enqueue(item.get())) {
-            [[maybe_unused]] auto _{item.release()}; /* if true, queue took ownership */
+            (void)item.release(); /* if true, queue took ownership */
         } else {
             LogWarning("Request rejected because http work queue depth exceeded, it can be increased with the -rpcworkqueue= setting");
             item->req->WriteReply(HTTP_SERVICE_UNAVAILABLE, "Work queue depth exceeded");

--- a/src/ipc/test/ipc_test.cpp
+++ b/src/ipc/test/ipc_test.cpp
@@ -63,9 +63,7 @@ void IpcPipeTest()
         auto foo_client = std::make_unique<mp::ProxyClient<gen::FooInterface>>(
             connection_client->m_rpc_system->bootstrap(mp::ServerVatId().vat_id).castAs<gen::FooInterface>(),
             connection_client.get(), /* destroy_connection= */ true);
-        {
-            [[maybe_unused]] auto _{connection_client.release()};
-        }
+        (void)connection_client.release();
         foo_promise.set_value(std::move(foo_client));
 
         auto connection_server = std::make_unique<mp::Connection>(loop, kj::mv(pipe.ends[1]), [&](mp::Connection& connection) {

--- a/src/test/util_expected_tests.cpp
+++ b/src/test/util_expected_tests.cpp
@@ -7,6 +7,11 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <memory>
+#include <string>
+#include <utility>
+
+
 using namespace util;
 
 BOOST_AUTO_TEST_SUITE(util_expected_tests)
@@ -63,6 +68,19 @@ BOOST_AUTO_TEST_CASE(expected_error)
 
     const auto& read{e};
     BOOST_CHECK_EQUAL(read.error(), "fail1");
+}
+
+BOOST_AUTO_TEST_CASE(unexpected_error_accessors)
+{
+    Unexpected u{std::make_unique<int>(-1)};
+    BOOST_CHECK_EQUAL(*u.error(), -1);
+
+    *u.error() -= 1;
+    const auto& read{u};
+    BOOST_CHECK_EQUAL(*read.error(), -2);
+
+    const auto moved{std::move(u).error()};
+    BOOST_CHECK_EQUAL(*moved, -2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_expected_tests.cpp
+++ b/src/test/util_expected_tests.cpp
@@ -50,6 +50,13 @@ BOOST_AUTO_TEST_CASE(expected_value_rvalue)
     BOOST_CHECK_EQUAL(*moved, 5);
 }
 
+BOOST_AUTO_TEST_CASE(expected_deref_rvalue)
+{
+    Expected<std::unique_ptr<int>, int> no_copy{std::make_unique<int>(5)};
+    const auto moved{*std::move(no_copy)};
+    BOOST_CHECK_EQUAL(*moved, 5);
+}
+
 BOOST_AUTO_TEST_CASE(expected_value_or)
 {
     Expected<std::unique_ptr<int>, int> no_copy{std::make_unique<int>(1)};

--- a/src/test/util_expected_tests.cpp
+++ b/src/test/util_expected_tests.cpp
@@ -53,6 +53,15 @@ BOOST_AUTO_TEST_CASE(expected_value_or)
     BOOST_CHECK_EQUAL(const_val.value_or("fallback"), "fallback");
 }
 
+BOOST_AUTO_TEST_CASE(expected_value_throws)
+{
+    const Expected<int, std::string> e{Unexpected{"fail"}};
+    BOOST_CHECK_THROW(e.value(), BadExpectedAccess);
+
+    const Expected<void, std::string> void_e{Unexpected{"fail"}};
+    BOOST_CHECK_THROW(void_e.value(), BadExpectedAccess);
+}
+
 BOOST_AUTO_TEST_CASE(expected_error)
 {
     Expected<void, std::string> e{};

--- a/src/test/util_expected_tests.cpp
+++ b/src/test/util_expected_tests.cpp
@@ -122,4 +122,13 @@ BOOST_AUTO_TEST_CASE(unexpected_error_accessors)
     BOOST_CHECK_EQUAL(*moved, -2);
 }
 
+BOOST_AUTO_TEST_CASE(expected_swap)
+{
+    Expected<const char*, std::unique_ptr<int>> a{Unexpected{std::make_unique<int>(-1)}};
+    Expected<const char*, std::unique_ptr<int>> b{"good"};
+    a.swap(b);
+    BOOST_CHECK_EQUAL(a.value(), "good");
+    BOOST_CHECK_EQUAL(*b.error(), -1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_expected_tests.cpp
+++ b/src/test/util_expected_tests.cpp
@@ -17,15 +17,15 @@ BOOST_AUTO_TEST_CASE(expected_value)
         int x;
     };
     Expected<Obj, int> e{};
-    BOOST_CHECK(e.value().x == 0);
+    BOOST_CHECK_EQUAL(e.value().x, 0);
 
     e = Obj{42};
 
     BOOST_CHECK(e.has_value());
     BOOST_CHECK(static_cast<bool>(e));
-    BOOST_CHECK(e.value().x == 42);
-    BOOST_CHECK((*e).x == 42);
-    BOOST_CHECK(e->x == 42);
+    BOOST_CHECK_EQUAL(e.value().x, 42);
+    BOOST_CHECK_EQUAL((*e).x, 42);
+    BOOST_CHECK_EQUAL(e->x, 42);
 
     // modify value
     e.value().x += 1;
@@ -33,9 +33,9 @@ BOOST_AUTO_TEST_CASE(expected_value)
     e->x += 1;
 
     const auto& read{e};
-    BOOST_CHECK(read.value().x == 45);
-    BOOST_CHECK((*read).x == 45);
-    BOOST_CHECK(read->x == 45);
+    BOOST_CHECK_EQUAL(read.value().x, 45);
+    BOOST_CHECK_EQUAL((*read).x, 45);
+    BOOST_CHECK_EQUAL(read->x, 45);
 }
 
 BOOST_AUTO_TEST_CASE(expected_value_or)
@@ -56,13 +56,13 @@ BOOST_AUTO_TEST_CASE(expected_error)
     e = Unexpected{"fail"};
     BOOST_CHECK(!e.has_value());
     BOOST_CHECK(!static_cast<bool>(e));
-    BOOST_CHECK(e.error() == "fail");
+    BOOST_CHECK_EQUAL(e.error(), "fail");
 
     // modify error
     e.error() += "1";
 
     const auto& read{e};
-    BOOST_CHECK(read.error() == "fail1");
+    BOOST_CHECK_EQUAL(read.error(), "fail1");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_expected_tests.cpp
+++ b/src/test/util_expected_tests.cpp
@@ -66,6 +66,8 @@ BOOST_AUTO_TEST_CASE(expected_error)
 {
     Expected<void, std::string> e{};
     BOOST_CHECK(e.has_value());
+    [&]() -> void { return e.value(); }(); // check value returns void and does not throw
+    [&]() -> void { return *e; }();
 
     e = Unexpected{"fail"};
     BOOST_CHECK(!e.has_value());

--- a/src/test/util_expected_tests.cpp
+++ b/src/test/util_expected_tests.cpp
@@ -43,6 +43,13 @@ BOOST_AUTO_TEST_CASE(expected_value)
     BOOST_CHECK_EQUAL(read->x, 45);
 }
 
+BOOST_AUTO_TEST_CASE(expected_value_rvalue)
+{
+    Expected<std::unique_ptr<int>, int> no_copy{std::make_unique<int>(5)};
+    const auto moved{std::move(no_copy).value()};
+    BOOST_CHECK_EQUAL(*moved, 5);
+}
+
 BOOST_AUTO_TEST_CASE(expected_value_or)
 {
     Expected<std::unique_ptr<int>, int> no_copy{std::make_unique<int>(1)};
@@ -79,6 +86,20 @@ BOOST_AUTO_TEST_CASE(expected_error)
 
     const auto& read{e};
     BOOST_CHECK_EQUAL(read.error(), "fail1");
+}
+
+BOOST_AUTO_TEST_CASE(expected_error_rvalue)
+{
+    {
+        Expected<int, std::unique_ptr<int>> nocopy_err{Unexpected{std::make_unique<int>(7)}};
+        const auto moved{std::move(nocopy_err).error()};
+        BOOST_CHECK_EQUAL(*moved, 7);
+    }
+    {
+        Expected<void, std::unique_ptr<int>> void_nocopy_err{Unexpected{std::make_unique<int>(9)}};
+        const auto moved{std::move(void_nocopy_err).error()};
+        BOOST_CHECK_EQUAL(*moved, 9);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(unexpected_error_accessors)

--- a/src/util/expected.h
+++ b/src/util/expected.h
@@ -88,8 +88,9 @@ public:
     constexpr E& error() & noexcept LIFETIMEBOUND { return *Assert(std::get_if<1>(&m_data)); }
     constexpr E&& error() && noexcept LIFETIMEBOUND { return std::move(error()); }
 
-    constexpr T& operator*() noexcept LIFETIMEBOUND { return value(); }
-    constexpr const T& operator*() const noexcept LIFETIMEBOUND { return value(); }
+    constexpr T& operator*() & noexcept LIFETIMEBOUND { return value(); }
+    constexpr const T& operator*() const& noexcept LIFETIMEBOUND { return value(); }
+    constexpr T&& operator*() && noexcept LIFETIMEBOUND { return std::move(value()); }
 
     constexpr T* operator->() noexcept LIFETIMEBOUND { return &value(); }
     constexpr const T* operator->() const noexcept LIFETIMEBOUND { return &value(); }

--- a/src/util/expected.h
+++ b/src/util/expected.h
@@ -20,8 +20,14 @@ template <class E>
 class Unexpected
 {
 public:
-    constexpr explicit Unexpected(E e) : err(std::move(e)) {}
-    E err;
+    constexpr explicit Unexpected(E e) : m_error(std::move(e)) {}
+
+    constexpr const E& error() const& noexcept LIFETIMEBOUND { return m_error; }
+    constexpr E& error() & noexcept LIFETIMEBOUND { return m_error; }
+    constexpr E&& error() && noexcept LIFETIMEBOUND { return std::move(m_error); }
+
+private:
+    E m_error;
 };
 
 /// The util::Expected class provides a standard way for low-level functions to
@@ -40,7 +46,7 @@ public:
     constexpr Expected() : m_data{std::in_place_index_t<0>{}, ValueType{}} {}
     constexpr Expected(ValueType v) : m_data{std::in_place_index_t<0>{}, std::move(v)} {}
     template <class Err>
-    constexpr Expected(Unexpected<Err> u) : m_data{std::in_place_index_t<1>{}, std::move(u.err)}
+    constexpr Expected(Unexpected<Err> u) : m_data{std::in_place_index_t<1>{}, std::move(u).error()}
     {
     }
 

--- a/src/util/expected.h
+++ b/src/util/expected.h
@@ -6,10 +6,10 @@
 #define BITCOIN_UTIL_EXPECTED_H
 
 #include <attributes.h>
+#include <util/check.h>
 
 #include <cassert>
 #include <exception>
-#include <type_traits>
 #include <utility>
 #include <variant>
 
@@ -44,28 +44,27 @@ template <class T, class E>
 class Expected
 {
 private:
-    using ValueType = std::conditional_t<std::is_same_v<T, void>, std::monostate, T>;
-    std::variant<ValueType, E> m_data;
+    std::variant<T, E> m_data;
 
 public:
-    constexpr Expected() : m_data{std::in_place_index_t<0>{}, ValueType{}} {}
-    constexpr Expected(ValueType v) : m_data{std::in_place_index_t<0>{}, std::move(v)} {}
+    constexpr Expected() : m_data{std::in_place_index<0>, T{}} {}
+    constexpr Expected(T v) : m_data{std::in_place_index<0>, std::move(v)} {}
     template <class Err>
-    constexpr Expected(Unexpected<Err> u) : m_data{std::in_place_index_t<1>{}, std::move(u).error()}
+    constexpr Expected(Unexpected<Err> u) : m_data{std::in_place_index<1>, std::move(u).error()}
     {
     }
 
     constexpr bool has_value() const noexcept { return m_data.index() == 0; }
     constexpr explicit operator bool() const noexcept { return has_value(); }
 
-    constexpr const ValueType& value() const LIFETIMEBOUND
+    constexpr const T& value() const LIFETIMEBOUND
     {
         if (!has_value()) {
             throw BadExpectedAccess{};
         }
         return std::get<0>(m_data);
     }
-    constexpr ValueType& value() LIFETIMEBOUND
+    constexpr T& value() LIFETIMEBOUND
     {
         if (!has_value()) {
             throw BadExpectedAccess{};
@@ -74,12 +73,12 @@ public:
     }
 
     template <class U>
-    ValueType value_or(U&& default_value) const&
+    T value_or(U&& default_value) const&
     {
         return has_value() ? value() : std::forward<U>(default_value);
     }
     template <class U>
-    ValueType value_or(U&& default_value) &&
+    T value_or(U&& default_value) &&
     {
         return has_value() ? std::move(value()) : std::forward<U>(default_value);
     }
@@ -95,11 +94,40 @@ public:
         return std::get<1>(m_data);
     }
 
-    constexpr ValueType& operator*() noexcept LIFETIMEBOUND { return value(); }
-    constexpr const ValueType& operator*() const noexcept LIFETIMEBOUND { return value(); }
+    constexpr T& operator*() noexcept LIFETIMEBOUND { return value(); }
+    constexpr const T& operator*() const noexcept LIFETIMEBOUND { return value(); }
 
-    constexpr ValueType* operator->() noexcept LIFETIMEBOUND { return &value(); }
-    constexpr const ValueType* operator->() const noexcept LIFETIMEBOUND { return &value(); }
+    constexpr T* operator->() noexcept LIFETIMEBOUND { return &value(); }
+    constexpr const T* operator->() const noexcept LIFETIMEBOUND { return &value(); }
+};
+
+template <class E>
+class Expected<void, E>
+{
+private:
+    std::variant<std::monostate, E> m_data;
+
+public:
+    constexpr Expected() : m_data{std::in_place_index<0>, std::monostate{}} {}
+    template <class Err>
+    constexpr Expected(Unexpected<Err> u) : m_data{std::in_place_index<1>, std::move(u).error()}
+    {
+    }
+
+    constexpr bool has_value() const noexcept { return m_data.index() == 0; }
+    constexpr explicit operator bool() const noexcept { return has_value(); }
+
+    constexpr void operator*() const noexcept { return value(); }
+    constexpr void value() const
+    {
+        if (!has_value()) {
+            throw BadExpectedAccess{};
+        }
+    }
+
+    constexpr const E& error() const& noexcept LIFETIMEBOUND { return *Assert(std::get_if<1>(&m_data)); }
+    constexpr E& error() & noexcept LIFETIMEBOUND { return *Assert(std::get_if<1>(&m_data)); }
+    constexpr E&& error() && noexcept LIFETIMEBOUND { return std::move(error()); }
 };
 
 } // namespace util

--- a/src/util/expected.h
+++ b/src/util/expected.h
@@ -88,6 +88,8 @@ public:
     constexpr E& error() & noexcept LIFETIMEBOUND { return *Assert(std::get_if<1>(&m_data)); }
     constexpr E&& error() && noexcept LIFETIMEBOUND { return std::move(error()); }
 
+    constexpr void swap(Expected& other) noexcept { m_data.swap(other.m_data); }
+
     constexpr T& operator*() & noexcept LIFETIMEBOUND { return value(); }
     constexpr const T& operator*() const& noexcept LIFETIMEBOUND { return value(); }
     constexpr T&& operator*() && noexcept LIFETIMEBOUND { return std::move(value()); }

--- a/src/util/expected.h
+++ b/src/util/expected.h
@@ -8,6 +8,7 @@
 #include <attributes.h>
 
 #include <cassert>
+#include <exception>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -28,6 +29,10 @@ public:
 
 private:
     E m_error;
+};
+
+struct BadExpectedAccess : std::exception {
+    const char* what() const noexcept override { return "Bad util::Expected access"; }
 };
 
 /// The util::Expected class provides a standard way for low-level functions to
@@ -55,12 +60,16 @@ public:
 
     constexpr const ValueType& value() const LIFETIMEBOUND
     {
-        assert(has_value());
+        if (!has_value()) {
+            throw BadExpectedAccess{};
+        }
         return std::get<0>(m_data);
     }
     constexpr ValueType& value() LIFETIMEBOUND
     {
-        assert(has_value());
+        if (!has_value()) {
+            throw BadExpectedAccess{};
+        }
         return std::get<0>(m_data);
     }
 
@@ -86,11 +95,11 @@ public:
         return std::get<1>(m_data);
     }
 
-    constexpr ValueType& operator*() LIFETIMEBOUND { return value(); }
-    constexpr const ValueType& operator*() const LIFETIMEBOUND { return value(); }
+    constexpr ValueType& operator*() noexcept LIFETIMEBOUND { return value(); }
+    constexpr const ValueType& operator*() const noexcept LIFETIMEBOUND { return value(); }
 
-    constexpr ValueType* operator->() LIFETIMEBOUND { return &value(); }
-    constexpr const ValueType* operator->() const LIFETIMEBOUND { return &value(); }
+    constexpr ValueType* operator->() noexcept LIFETIMEBOUND { return &value(); }
+    constexpr const ValueType* operator->() const noexcept LIFETIMEBOUND { return &value(); }
 };
 
 } // namespace util

--- a/src/util/expected.h
+++ b/src/util/expected.h
@@ -57,20 +57,21 @@ public:
     constexpr bool has_value() const noexcept { return m_data.index() == 0; }
     constexpr explicit operator bool() const noexcept { return has_value(); }
 
-    constexpr const T& value() const LIFETIMEBOUND
+    constexpr const T& value() const& LIFETIMEBOUND
     {
         if (!has_value()) {
             throw BadExpectedAccess{};
         }
         return std::get<0>(m_data);
     }
-    constexpr T& value() LIFETIMEBOUND
+    constexpr T& value() & LIFETIMEBOUND
     {
         if (!has_value()) {
             throw BadExpectedAccess{};
         }
         return std::get<0>(m_data);
     }
+    constexpr T&& value() && LIFETIMEBOUND { return std::move(value()); }
 
     template <class U>
     T value_or(U&& default_value) const&
@@ -83,16 +84,9 @@ public:
         return has_value() ? std::move(value()) : std::forward<U>(default_value);
     }
 
-    constexpr const E& error() const LIFETIMEBOUND
-    {
-        assert(!has_value());
-        return std::get<1>(m_data);
-    }
-    constexpr E& error() LIFETIMEBOUND
-    {
-        assert(!has_value());
-        return std::get<1>(m_data);
-    }
+    constexpr const E& error() const& noexcept LIFETIMEBOUND { return *Assert(std::get_if<1>(&m_data)); }
+    constexpr E& error() & noexcept LIFETIMEBOUND { return *Assert(std::get_if<1>(&m_data)); }
+    constexpr E&& error() && noexcept LIFETIMEBOUND { return std::move(error()); }
 
     constexpr T& operator*() noexcept LIFETIMEBOUND { return value(); }
     constexpr const T& operator*() const noexcept LIFETIMEBOUND { return value(); }

--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -98,7 +98,7 @@ FUZZ_TARGET(wallet_create_transaction, .init = initialize_setup)
 
     std::optional<unsigned int> change_pos;
     if (fuzzed_data_provider.ConsumeBool()) change_pos = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
-    [[maybe_unused]] auto _{CreateTransaction(*fuzzed_wallet.wallet, recipients, change_pos, coin_control)};
+    (void)CreateTransaction(*fuzzed_wallet.wallet, recipients, change_pos, coin_control);
 }
 } // namespace
 } // namespace wallet


### PR DESCRIPTION
Reviewers requested more member functions In https://github.com/bitcoin/bitcoin/pull/34006.

They are currently unused, but bring the port closer to the original `std::expected` implementation:

* Make `Expected::value()` throw when no value exists
* Add `Unexpected::error()` methods
* Add `Expected<void, E>` specialization
* Add `Expected::value()&&` and `Expected::error()&&` methods
* Add `Expected::swap()`

Also, include a tiny tidy fixup:

* tidy: Set `AllowCastToVoid` in the `bugprone-unused-return-value` check