### PR TITLE
test: Detect truncated download in get_previous_releases.py

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -122,7 +122,7 @@ def download_from_url(url, archive):
         if response.status != 200:
             raise RuntimeError(f"HTTP request failed with status code: {response.status}")
 
-        total_size = int(response.getheader('Content-Length', 0))
+        total_size = int(response.getheader("Content-Length"))
         progress_bytes = 0
 
         with open(archive, 'wb') as file:
@@ -133,6 +133,9 @@ def download_from_url(url, archive):
                 file.write(chunk)
                 progress_bytes += len(chunk)
                 progress_hook(progress_bytes, total_size)
+
+        if progress_bytes < total_size:
+            raise RuntimeError(f"Download incomplete: expected {total_size} bytes, got {progress_bytes} bytes")
 
     print('\n', flush=True, end="") # Flush to avoid error output on the same line.
 


### PR DESCRIPTION
Without this, and end-of-stream is not detected and will just lead to an immediate exit, instead of a re-try.

E.g. https://github.com/bitcoin/bitcoin/actions/runs/20089133013/job/57633839315?pr=34038#step:12:201:

```
...
Downloading: [##--------------------------------------] 5.4%
Downloading: [##--------------------------------------] 5.4%
Downloading: [##--------------------------------------] 5.5%
Downloading: [##--------------------------------------] 5.6%
Checksum dd02eab18f9154604e38135ef3f98fd310ba3c748074aeb83a71118cd2cd1367 did not match
Error: Process completed with exit code 1.
```

Also, remove the `0` fallback value, because if the fallback was ever hit, the program would fail anyway with `division by zero` error.