### PR TITLE
bench: run `FindByte` across block-sized buffer

### DIFF
--- a/src/bench/streams_findbyte.cpp
+++ b/src/bench/streams_findbyte.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <consensus/consensus.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
 #include <util/fs.h>
@@ -14,19 +15,25 @@
 static void FindByte(benchmark::Bench& bench)
 {
     const auto testing_setup{MakeNoLogFileContext<const BasicTestingSetup>(ChainType::REGTEST)};
+    constexpr size_t file_size{2 * MAX_BLOCK_SERIALIZED_SIZE};
+    constexpr size_t stride{32 << 10};
+    constexpr size_t found_index{file_size - 1};
+    constexpr std::byte target{1};
+
     AutoFile file{fsbridge::fopen(testing_setup->m_path_root / "streams_tmp", "w+b")};
-    const size_t file_size = 200;
-    uint8_t data[file_size] = {0};
-    data[file_size - 1] = 1;
-    file << data;
+    std::vector data(file_size, std::byte{0});
+    data[found_index] = target;
+    file << std::span{data};
     file.seek(0, SEEK_SET);
     BufferedFile bf{file, /*nBufSize=*/file_size + 1, /*nRewindIn=*/file_size};
 
     bench.run([&] {
-        bf.SetPos(0);
-        bf.FindByte(std::byte(1));
+        for (size_t start{0}; start < file_size; start += stride) {
+            bf.SetPos(start);
+            bf.FindByte(target);
+            assert(bf.GetPos() == found_index);
+        }
     });
-
     assert(file.fclose() == 0);
 }
 


### PR DESCRIPTION
The benchmark was updated to start from different file positions and iterate with a stride of ~32kb to exercise a few "random" places.

Found while reviewing https://github.com/bitcoin/bitcoin/pull/34044

Note: this PR started off as making `FindByte` more realistic, but based on https://github.com/bitcoin/bitcoin/pull/34044#issuecomment-3651042162 I decided to remove it, and after https://github.com/bitcoin/bitcoin/pull/34046#issuecomment-3651776469 it was reverted to its original state