### PR TITLE
cmake: Add fail pattern to `try_append_cxx_flags`

### DIFF
--- a/cmake/module/TryAppendCXXFlags.cmake
+++ b/cmake/module/TryAppendCXXFlags.cmake
@@ -64,7 +64,11 @@ function(try_append_cxx_flags flags)
   set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
   set(CMAKE_REQUIRED_FLAGS "${flags_as_string} ${working_compiler_werror_flag}")
   set(compiler_result CXX_SUPPORTS_${id_string})
-  check_cxx_source_compiles("${source}" ${compiler_result})
+  check_cxx_source_compiles("${source}" ${compiler_result}
+    # Ensure that a user-provided -Wno-error=unknown-warning-option
+    # does not lead to a false positive result.
+    FAIL_REGEX [=[\\[-Wunknown-warning-option\\]]=]
+  )
 
   if(${compiler_result})
     if(DEFINED TACXXF_IF_CHECK_PASSED)


### PR DESCRIPTION
This PR addresses scenarios where the build environment, such as OSS-Fuzz, provides the `-Wno-error=unknown-warning-option` flag, which undermines our use of `-Werror` when checking compiler flags.

To reproduce the issue on the master branch @ c1f0a89d9caeb62a0a5f3462b454746941e626e6:
```
$ env CXX=clang++ CC=clang CXXFLAGS="-Wno-error=unknown-warning-option" cmake -B build 2>&1 | grep WDUPLICATED_BRANCHES
-- Performing Test CXX_SUPPORTS__WDUPLICATED_BRANCHES
-- Performing Test CXX_SUPPORTS__WDUPLICATED_BRANCHES - Success
```

This output shows that the `-Wduplicated-branches` flag is incorrectly treated as recognised by the compiler.

Noticed while working on the [migration](https://github.com/google/oss-fuzz/pull/14457) to Ubuntu 24.04 in OSS-Fuzz.