### PR TITLE
refactor: inline constant `f_obfuscate = false` parameter

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -63,13 +63,13 @@ CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
     return locator;
 }
 
-BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate) :
+BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe) :
     CDBWrapper{DBParams{
         .path = path,
         .cache_bytes = n_cache_size,
         .memory_only = f_memory,
         .wipe_data = f_wipe,
-        .obfuscate = f_obfuscate,
+        .obfuscate = false,
         .options = [] { DBOptions options; node::ReadDatabaseArgs(gArgs, options); return options; }()}}
 {}
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -64,8 +64,7 @@ protected:
     class DB : public CDBWrapper
     {
     public:
-        DB(const fs::path& path, size_t n_cache_size,
-           bool f_memory = false, bool f_wipe = false, bool f_obfuscate = false);
+        DB(const fs::path& path, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
         /// Read block locator of the chain that the index is in sync with.
         /// Note, the returned locator will be empty if no record exists.


### PR DESCRIPTION
Split out of https://github.com/bitcoin/bitcoin/pull/33324 since it makes sense on its own.

Currently the parameter is only called with a single constant parameter, it doesn't make sense to needlessly obfuscate the constructor (pun intended).