### PR TITLE
fuzz: exercise `ComputeMerkleRoot` without `mutated` parameter

### DIFF
--- a/src/test/fuzz/merkle.cpp
+++ b/src/test/fuzz/merkle.cpp
@@ -52,7 +52,7 @@ FUZZ_TARGET(merkle)
 
     // Test ComputeMerkleRoot
     bool mutated = fuzzed_data_provider.ConsumeBool(); // output param, initial value shouldn't matter
-    const uint256 merkle_root = ComputeMerkleRoot(tx_hashes, &mutated);
+    const uint256 merkle_root = ComputeMerkleRoot(tx_hashes, fuzzed_data_provider.ConsumeBool() ? &mutated : nullptr);
 
     // Basic sanity checks for ComputeMerkleRoot
     if (tx_hashes.size() == 1) {


### PR DESCRIPTION
The `mutated` parameter in `ComputeMerkleRoot` unlocks a different path that was always exercised in the fuzz test.
Adjusted to be fuzzer to pass `nullptr` as well to make sure that path is also tested: https://github.com/bitcoin/bitcoin/blob/24ed820d4f0d8f7fa2f69e1909c2d98f809d2f94/src/consensus/merkle.cpp#L49-L53

Follow-up to https://github.com/bitcoin/bitcoin/pull/33805#discussion_r2589073735