### PR TITLE
test: fix race condition in p2p_v2_misbehaving.py peerid assertion

### DIFF
--- a/test/functional/p2p_v2_misbehaving.py
+++ b/test/functional/p2p_v2_misbehaving.py
@@ -161,8 +161,8 @@ class EncryptedP2PMisbehaving(BitcoinTestFramework):
         node0 = self.nodes[0]
         expected_debug_message = [
             [],  # EARLY_KEY_RESPONSE
-            ["V2 transport error: missing garbage terminator, peer=1"],  # EXCESS_GARBAGE
-            ["V2 handshake timeout, disconnecting peer=3"],  # WRONG_GARBAGE_TERMINATOR
+            ["V2 transport error: missing garbage terminator"],  # EXCESS_GARBAGE
+            ["V2 handshake timeout, disconnecting peer"],  # WRONG_GARBAGE_TERMINATOR
             ["V2 transport error: packet decryption failure"],  # WRONG_GARBAGE
             ["V2 transport error: packet decryption failure"],  # SEND_NO_AAD
             [],  # SEND_NON_EMPTY_VERSION_PACKET


### PR DESCRIPTION
Remove the hard-coded peer id from the debug message in `p2p_v2_misbehaving.py`.

asyncio's non-deterministic task scheduling might cause [peer2](https://github.com/bitcoin/bitcoin/blob/938d7aacabd0bb3784bb3e529b1ed06bb2891864/test/functional/p2p_v2_misbehaving.py#L181)'s connection to happen before [peer1](https://github.com/bitcoin/bitcoin/blob/938d7aacabd0bb3784bb3e529b1ed06bb2891864/test/functional/p2p_v2_misbehaving.py#L179)'s. since we test that peer2 [remains connected](https://github.com/bitcoin/bitcoin/blob/938d7aacabd0bb3784bb3e529b1ed06bb2891864/test/functional/p2p_v2_misbehaving.py#L182), any disconnection must originate from peer1, making the specific peer id not necessary for test correctness. so we can remove the hard coded peer id from the expected debug log message.

Fixes #34035.