### PR TITLE
doc: Add CMake config note to functional test README

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -73,6 +73,10 @@ or can be run through the test_runner harness, eg:
 build/test/functional/test_runner.py feature_rbf.py
 ```
 
+> **Note for CMake users:** The configuration file (`config.ini`) is generated in the build directory. When running the test runner directly, you must specify the path:
+>
+>     ./test/functional/test_runner.py --configfile=build/test/config.ini
+
 You can run any combination (incl. duplicates) of tests by calling:
 
 ```


### PR DESCRIPTION
The current documentation does not specify how to run `test_runner.py` directly when using the new CMake build system. Attempting to run it without flags leads to a `FileNotFoundError: config.ini`.

This PR adds a note to `test/README.md` explaining that users must point to `build/test/config.ini` using the `--configfile` flag when running tests from the source root.