### PR TITLE
refactor: Use an enum for `Autofile::seek` wrapper

### DIFF
--- a/src/bench/streams_findbyte.cpp
+++ b/src/bench/streams_findbyte.cpp
@@ -19,7 +19,7 @@ static void FindByte(benchmark::Bench& bench)
     uint8_t data[file_size] = {0};
     data[file_size - 1] = 1;
     file << data;
-    file.seek(0, SEEK_SET);
+    file.seek(0, SeekFrom::Set);
     BufferedFile bf{file, /*nBufSize=*/file_size + 1, /*nRewindIn=*/file_size};
 
     bench.run([&] {

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -22,7 +22,6 @@
 
 #include <cassert>
 #include <cstdint>
-#include <cstdio>
 #include <exception>
 #include <iterator>
 #include <span>
@@ -107,7 +106,7 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
     CBlockHeader header;
     try {
         file >> header;
-        file.seek(postx.nTxOffset, SEEK_CUR);
+        file.seek(postx.nTxOffset, SeekFrom::Curr);
         file >> TX_WITH_WITNESS(tx);
     } catch (const std::exception& e) {
         LogError("Deserialize or I/O error - %s", e.what());

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1086,7 +1086,7 @@ BlockManager::ReadRawBlockResult BlockManager::ReadRawBlock(const FlatFilePos& p
             if (size == 0 || offset >= blk_size || size > blk_size - offset) {
                 return util::Unexpected{ReadRawError::BadPartRange}; // Avoid logging - offset/size come from untrusted REST input
             }
-            filein.seek(offset, SEEK_CUR);
+            filein.seek(offset, SeekFrom::Curr);
             blk_size = size;
         }
 

--- a/src/node/utxo_snapshot.cpp
+++ b/src/node/utxo_snapshot.cpp
@@ -74,7 +74,7 @@ std::optional<uint256> ReadSnapshotBaseBlockhash(fs::path chaindir)
     afile >> base_blockhash;
 
     int64_t position = afile.tell();
-    afile.seek(0, SEEK_END);
+    afile.seek(0, SeekFrom::End);
     if (position != afile.tell()) {
         LogWarning("[snapshot] unexpected trailing data in %s", read_from_str);
     }

--- a/src/streams.cpp
+++ b/src/streams.cpp
@@ -30,7 +30,7 @@ std::size_t AutoFile::detail_fread(std::span<std::byte> dst)
     return ret;
 }
 
-void AutoFile::seek(int64_t offset, int origin)
+void AutoFile::seek(int64_t offset, SeekFrom origin)
 {
     if (IsNull()) {
         throw std::ios_base::failure("AutoFile::seek: file handle is nullptr");
@@ -38,9 +38,9 @@ void AutoFile::seek(int64_t offset, int origin)
     if (std::fseek(m_file, offset, origin) != 0) {
         throw std::ios_base::failure(feof() ? "AutoFile::seek: end of file" : "AutoFile::seek: fseek failed");
     }
-    if (origin == SEEK_SET) {
+    if (origin == SeekFrom::Set) {
         m_position = offset;
-    } else if (origin == SEEK_CUR && m_position.has_value()) {
+    } else if (origin == SeekFrom::Curr && m_position.has_value()) {
         *m_position += offset;
     } else {
         int64_t r{std::ftell(m_file)};
@@ -64,10 +64,10 @@ int64_t AutoFile::size()
     }
     // Temporarily save the current position
     int64_t current_pos = tell();
-    seek(0, SEEK_END);
+    seek(0, SeekFrom::End);
     int64_t file_size = tell();
     // Restore the original position
-    seek(current_pos, SEEK_SET);
+    seek(current_pos, SeekFrom::Set);
     return file_size;
 }
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -355,6 +355,18 @@ public:
     }
 };
 
+/**
+ * Relative position to move the file cursor.
+ */
+enum SeekFrom {
+    /* Start of the file. */
+    Set = 0,
+    /* Current position. */
+    Curr,
+    /* End of the file. */
+    End
+};
+
 /** Non-refcounted RAII wrapper for FILE*
  *
  * Will automatically close the file when it goes out of scope if not null.
@@ -430,7 +442,7 @@ public:
     std::size_t detail_fread(std::span<std::byte> dst);
 
     /** Wrapper around fseek(). Will throw if seeking is not possible. */
-    void seek(int64_t offset, int origin);
+    void seek(int64_t offset, SeekFrom origin);
 
     /** Find position within the file. Will throw if unknown. */
     int64_t tell();

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     for (uint8_t j = 0; j < 40; ++j) {
         file << j;
     }
-    file.seek(0, SEEK_SET);
+    file.seek(0, SeekFrom::Set);
 
     // The buffer size (second arg) must be greater than the rewind
     // amount (third arg).
@@ -462,7 +462,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_skip)
     for (uint8_t j = 0; j < 40; ++j) {
         file << j;
     }
-    file.seek(0, SEEK_SET);
+    file.seek(0, SeekFrom::Set);
 
     // The buffer is 25 bytes, allow rewinding 10 bytes.
     BufferedFile bf{file, 25, 10};
@@ -515,7 +515,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
         for (uint8_t i = 0; i < fileSize; ++i) {
             file << i;
         }
-        file.seek(0, SEEK_SET);
+        file.seek(0, SeekFrom::Set);
 
         size_t bufSize = m_rng.randrange(300) + 1;
         size_t rewindSize = m_rng.randrange(bufSize);
@@ -797,14 +797,14 @@ BOOST_AUTO_TEST_CASE(size_preserves_position)
     // Test that usage of size() does not change the current position
     //
     // Case: Pos at beginning of the file
-    f.seek(0, SEEK_SET);
+    f.seek(0, SeekFrom::Set);
     (void)f.size();
     uint8_t first{};
     f >> first;
     BOOST_CHECK_EQUAL(first, 0);
 
     // Case: Pos at middle of the file
-    f.seek(0, SEEK_SET);
+    f.seek(0, SeekFrom::Set);
     // Move pos to middle
     f.ignore(4);
     (void)f.size();
@@ -814,7 +814,7 @@ BOOST_AUTO_TEST_CASE(size_preserves_position)
     BOOST_CHECK_EQUAL(middle, 4);
 
     // Case: Pos at EOF
-    f.seek(0, SEEK_END);
+    f.seek(0, SeekFrom::End);
     (void)f.size();
     uint8_t end{};
     BOOST_CHECK_EXCEPTION(f >> end, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -436,7 +436,7 @@ public:
             }
 
             // Go back to the indexes
-            s.seek(-to_jump, SEEK_CUR);
+            s.seek(-to_jump, SeekFrom::Curr);
         }
     }
 };
@@ -515,7 +515,7 @@ public:
             to_jump += InternalRecord::FIXED_SIZE + rec_hdr.len;
 
             // Go back to the indexes
-            s.seek(-to_jump, SEEK_CUR);
+            s.seek(-to_jump, SeekFrom::Curr);
         }
     }
 };
@@ -523,7 +523,7 @@ public:
 static void SeekToPage(AutoFile& s, uint32_t page_num, uint32_t page_size)
 {
     int64_t pos = int64_t{page_num} * page_size;
-    s.seek(pos, SEEK_SET);
+    s.seek(pos, SeekFrom::Set);
 }
 
 void BerkeleyRODatabase::Open()


### PR DESCRIPTION
The `int origin` argument of the `seek` method has no meaning to those without domain specific knowledge as to how `FILE` works. The only way for a caller to understand what this is doing is to enter the method body. This enum makes it clear as to what the `origin` argument represents at the expense of the Unix-specific options, which were unused anyway.