### PR TITLE
kernel: Remove non-kernel module includes

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -209,7 +209,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
   fi
 
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_read.cpp|signet.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_read.cpp|signet.cpp|kernel/chain.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -209,7 +209,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
   fi
 
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(crypto|index)/.*\\.cpp"
+  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_read.cpp|signet.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -4,17 +4,27 @@
 
 #include <core_io.h>
 
-#include <primitives/block.h>
+#include <primitives/block.h> // IWYU pragma: keep
 #include <primitives/transaction.h>
+#include <script/interpreter.h>
 #include <script/script.h>
-#include <script/sign.h>
 #include <serialize.h>
 #include <streams.h>
 #include <util/result.h>
 #include <util/strencodings.h>
+#include <util/string.h>
+#include <util/translation.h>
 
 #include <algorithm>
-#include <string>
+#include <compare>
+#include <cstdint>
+#include <exception>
+#include <map>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 using util::SplitString;
 

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -9,7 +9,6 @@
 #include <dbwrapper.h>
 #include <interfaces/chain.h>
 #include <interfaces/types.h>
-#include <kernel/chain.h>
 #include <kernel/types.h>
 #include <logging.h>
 #include <node/abort.h>

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -7,6 +7,7 @@
 
 #include <blockfilter.h>
 #include <common/settings.h>
+#include <kernel/chain.h> // IWYU pragma: export
 #include <node/types.h>
 #include <primitives/transaction.h>
 #include <util/result.h>
@@ -76,22 +77,6 @@ public:
     const FoundBlock* m_next_block = nullptr;
     CBlock* m_data = nullptr;
     mutable bool found = false;
-};
-
-//! Block data sent with blockConnected, blockDisconnected notifications.
-struct BlockInfo {
-    const uint256& hash;
-    const uint256* prev_hash = nullptr;
-    int height = -1;
-    int file_number = -1;
-    unsigned data_pos = 0;
-    const CBlock* data = nullptr;
-    const CBlockUndo* undo_data = nullptr;
-    // The maximum time in the chain up to and including this block.
-    // A timestamp that can only move forward.
-    unsigned int chain_time_max{0};
-
-    BlockInfo(const uint256& hash LIFETIMEBOUND) : hash(hash) {}
 };
 
 //! The action to be taken after updating a settings value.

--- a/src/kernel/chain.cpp
+++ b/src/kernel/chain.cpp
@@ -2,9 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chain.h>
-#include <interfaces/chain.h>
 #include <kernel/chain.h>
+
+#include <chain.h>
+#include <kernel/cs_main.h>
 #include <kernel/types.h>
 #include <sync.h>
 #include <uint256.h>

--- a/src/kernel/chain.h
+++ b/src/kernel/chain.h
@@ -5,12 +5,31 @@
 #ifndef BITCOIN_KERNEL_CHAIN_H
 #define BITCOIN_KERNEL_CHAIN_H
 
-#include<iostream>
+#include <attributes.h>
+
+#include <iostream>
 
 class CBlock;
 class CBlockIndex;
+class CBlockUndo;
+class uint256;
+
 namespace interfaces {
-struct BlockInfo;
+//! Block data sent with blockConnected, blockDisconnected notifications.
+struct BlockInfo {
+    const uint256& hash;
+    const uint256* prev_hash = nullptr;
+    int height = -1;
+    int file_number = -1;
+    unsigned data_pos = 0;
+    const CBlock* data = nullptr;
+    const CBlockUndo* undo_data = nullptr;
+    // The maximum time in the chain up to and including this block.
+    // A timestamp that can only move forward.
+    unsigned int chain_time_max{0};
+
+    BlockInfo(const uint256& hash LIFETIMEBOUND) : hash(hash) {}
+};
 } // namespace interfaces
 
 namespace kernel {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -7,12 +7,10 @@
 #include <arith_uint256.h>
 #include <chain.h>
 #include <consensus/params.h>
-#include <consensus/validation.h>
 #include <dbwrapper.h>
 #include <flatfile.h>
 #include <hash.h>
 #include <kernel/blockmanager_opts.h>
-#include <kernel/chain.h>
 #include <kernel/chainparams.h>
 #include <kernel/messagestartchars.h>
 #include <kernel/notifications_interface.h>
@@ -24,16 +22,17 @@
 #include <random.h>
 #include <serialize.h>
 #include <signet.h>
-#include <span.h>
 #include <streams.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <uint256.h>
 #include <undo.h>
-#include <util/batchpriority.h>
 #include <util/check.h>
+#include <util/expected.h>
 #include <util/fs.h>
 #include <util/obfuscation.h>
+#include <util/overflow.h>
+#include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 #include <util/syserror.h>
@@ -41,9 +40,17 @@
 #include <util/translation.h>
 #include <validation.h>
 
+#include <cerrno>
+#include <compare>
 #include <cstddef>
+#include <cstdio>
+#include <exception>
 #include <map>
 #include <optional>
+#include <ostream>
+#include <span>
+#include <stdexcept>
+#include <system_error>
 #include <unordered_map>
 
 namespace kernel {

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -14,17 +14,22 @@
 #include <kernel/cs_main.h>
 #include <kernel/messagestartchars.h>
 #include <primitives/block.h>
+#include <serialize.h>
 #include <streams.h>
 #include <sync.h>
 #include <uint256.h>
 #include <util/expected.h>
 #include <util/fs.h>
 #include <util/hasher.h>
+#include <util/obfuscation.h>
 
+#include <algorithm>
 #include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <iosfwd>
 #include <limits>
 #include <map>
 #include <memory>

--- a/src/node/utxo_snapshot.cpp
+++ b/src/node/utxo_snapshot.cpp
@@ -8,7 +8,6 @@
 #include <streams.h>
 #include <sync.h>
 #include <tinyformat.h>
-#include <txdb.h>
 #include <uint256.h>
 #include <util/fs.h>
 #include <validation.h>
@@ -16,6 +15,7 @@
 #include <cassert>
 #include <cstdio>
 #include <optional>
+#include <span>
 #include <string>
 
 namespace node {

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -6,18 +6,22 @@
 #ifndef BITCOIN_NODE_UTXO_SNAPSHOT_H
 #define BITCOIN_NODE_UTXO_SNAPSHOT_H
 
-#include <chainparams.h>
 #include <kernel/chainparams.h>
 #include <kernel/cs_main.h>
-#include <serialize.h>
+#include <kernel/messagestartchars.h>
 #include <sync.h>
+#include <tinyformat.h>
 #include <uint256.h>
 #include <util/chaintype.h>
-#include <util/check.h>
 #include <util/fs.h>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
+#include <ios>
 #include <optional>
+#include <set>
+#include <string>
 #include <string_view>
 
 // UTXO set snapshot magic bytes

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -4,24 +4,25 @@
 
 #include <signet.h>
 
-#include <common/system.h>
 #include <consensus/merkle.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
-#include <core_io.h>
-#include <hash.h>
 #include <logging.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
-#include <span.h>
+#include <script/script.h>
 #include <streams.h>
 #include <uint256.h>
-#include <util/strencodings.h>
+#include <util/check.h>
 
 #include <algorithm>
-#include <array>
+#include <cstddef>
 #include <cstdint>
+#include <exception>
+#include <memory>
+#include <span>
+#include <utility>
 #include <vector>
 
 static constexpr uint8_t SIGNET_HEADER[4] = {0xec, 0xc7, 0xda, 0xa2};

--- a/src/signet.h
+++ b/src/signet.h
@@ -5,11 +5,15 @@
 #ifndef BITCOIN_SIGNET_H
 #define BITCOIN_SIGNET_H
 
-#include <consensus/params.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 
 #include <optional>
+
+class CScript;
+namespace Consensus {
+struct Params;
+} // namespace Consensus
 
 /**
  * Extract signature and check whether a block has a valid solution


### PR DESCRIPTION
Found these while attempting to isolate the kernel library sources into their own repository. There still is no mechanism for preventing including headers into the kernel library that don't belong to kernel modules, but it is also fairly straight forward to correct manually for now. However, the changes here might be incomplete.