### PR TITLE
build: Fix source paths for debugging in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,16 @@ try_append_cxx_flags("-fno-extended-identifiers" TARGET core_interface SKIP_LINK
 try_append_cxx_flags("-fdebug-prefix-map=A=B" TARGET core_interface SKIP_LINK
   IF_CHECK_PASSED "-fdebug-prefix-map=${PROJECT_SOURCE_DIR}/src=."
 )
+
+
+# Adjust source paths for debugging:
+# This ensures that the debugger (gdb/lldb) can find the original source files
+# even when the build directory is separate from the source directory.
+try_append_cxx_flags("-fdebug-prefix-map=A=B" TARGET core_interface SKIP_LINK
+  IF_CHECK_PASSED
+  "-fdebug-prefix-map=${PROJECT_BINARY_DIR}/src=${PROJECT_SOURCE_DIR}/src"
+)
+
 try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
   IF_CHECK_PASSED "-fmacro-prefix-map=${PROJECT_SOURCE_DIR}/src=."
 )


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale or clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
With the build workflow change from Autotools to CMake, the debug information became incorrect due to outdated file path remapping (#31204). This issue comes from a workaround that was needed in the previous build system (#21885 problem, which was addressed in #20353 and later again on #22409. ).

This PR attempts to resolve the problem by correcting the file path remapping for the new out-of-source build.

I have tested the fix both in the terminal using GDB and in VS Code using LLDB

After my changes, I tested by running `gdb`:
```
cmake -DCMAKE_BUILD_TYPE=Debug -B build 
cmake --build build -j "$(($(nproc)/2+1))"

gdb  build/bin/bitcoind
break init.cpp:1848
run  -regtest 
      Thread 1 "bitcoind" hit Breakpoint 1, AppInitMain (node=..., tip_info=0x0) at ./init.cpp:1848
       1848        if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
```
And also with `lldb` and vscode using the following `.vscode/launch.json`:
```
{
"version": "0.2.0",
"configurations": [
	{
	"type": "lldb",
	"request": "launch",
	"name": "Debug",
	"program": "${workspaceFolder}/build/bin/bitcoind",
	"args": [
		"-regtest"
	],
	"cwd": "${workspaceFolder}",
	}
]
}
```
## Alternatives
If this PR is not considered, I have two alternative proposals:
- Update the doc to remove the text indicating the user must debug from the root of the project
- PR #https://github.com/bitcoin/bitcoin/pull/32205 Update the doc indicating they must use  `set substitute-path path/to/build/src /path/to/project/root/src`

