### PR TITLE
contrib: asmap-tool.py - Don't write binary to TTY

### DIFF
--- a/contrib/asmap/asmap-tool.py
+++ b/contrib/asmap/asmap-tool.py
@@ -131,6 +131,8 @@ def main():
     if args.subcommand is None:
         parser.print_help()
     elif args.subcommand == "encode":
+        if args.outfile.isatty():
+            sys.exit("Not much use in writing binary to a TTY. Please specify an output file or pipe output to another process.")
         state = load_file(args.infile)
         save_binary(args.outfile, state, fill=args.fill)
     elif args.subcommand == "decode":


### PR DESCRIPTION
Verify that we wouldn't be writing encoded asmap binary data directly to the TTY since it is the default but makes no sense. (Having stdout as default does make sense when piping to other applications however).

Found while exploring the ASMap data pipeline (https://github.com/asmap/asmap-data/pull/38#pullrequestreview-3547352533) from Kartograf into Bitcoin Core.