### PR TITLE
net: Fix `-Wmissing-braces`

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -38,6 +38,18 @@
 typedef u_short sa_family_t;
 #endif
 
+// Brace style in the IN6ADDR_*_INIT macros differs across platforms.
+#if defined(__illumos__)
+#define COMPAT_IN6ADDR_ANY_INIT {{IN6ADDR_ANY_INIT}}
+#else
+#define COMPAT_IN6ADDR_ANY_INIT IN6ADDR_ANY_INIT
+#endif
+#if defined(__illumos__) || defined(_MSC_VER)
+#define COMPAT_IN6ADDR_LOOPBACK_INIT {{IN6ADDR_LOOPBACK_INIT}}
+#else
+#define COMPAT_IN6ADDR_LOOPBACK_INIT IN6ADDR_LOOPBACK_INIT
+#endif
+
 // We map Linux / BSD error functions and codes, to the equivalent
 // Windows definitions, and use the WSA* names throughout our code.
 // Note that glibc defines EWOULDBLOCK as EAGAIN (see errno.h).

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3306,7 +3306,7 @@ bool CConnman::InitBinds(const Options& options)
         // Don't consider errors to bind on IPv6 "::" fatal because the host OS
         // may not have IPv6 support and the user did not explicitly ask us to
         // bind on that.
-        const CService ipv6_any{in6_addr(IN6ADDR_ANY_INIT), GetListenPort()}; // ::
+        const CService ipv6_any{in6_addr(COMPAT_IN6ADDR_ANY_INIT), GetListenPort()}; // ::
         Bind(ipv6_any, BF_NONE, NetPermissionFlags::None);
 
         struct in_addr inaddr_any;

--- a/src/test/fuzz/i2p.cpp
+++ b/src/test/fuzz/i2p.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/args.h>
+#include <compat/compat.h>
 #include <i2p.h>
 #include <netaddress.h>
 #include <netbase.h>
@@ -34,7 +35,7 @@ FUZZ_TARGET(i2p, .init = initialize_i2p)
     };
 
     const fs::path private_key_path = gArgs.GetDataDirNet() / "fuzzed_i2p_private_key";
-    const CService addr{in6_addr(IN6ADDR_LOOPBACK_INIT), 7656};
+    const CService addr{in6_addr(COMPAT_IN6ADDR_LOOPBACK_INIT), 7656};
     const Proxy sam_proxy{addr, /*tor_stream_isolation=*/false};
     auto interrupt{ConsumeThreadInterrupt(fuzzed_data_provider)};
 

--- a/src/test/i2p_tests.cpp
+++ b/src/test/i2p_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/args.h>
+#include <compat/compat.h>
 #include <i2p.h>
 #include <logging.h>
 #include <netaddress.h>
@@ -113,7 +114,7 @@ BOOST_AUTO_TEST_CASE(listen_ok_accept_fail)
     };
 
     auto interrupt{std::make_shared<CThreadInterrupt>()};
-    const CService addr{in6_addr(IN6ADDR_LOOPBACK_INIT), /*port=*/7656};
+    const CService addr{in6_addr(COMPAT_IN6ADDR_LOOPBACK_INIT), /*port=*/7656};
     const Proxy sam_proxy(addr, /*tor_stream_isolation=*/false);
     i2p::sam::Session session(gArgs.GetDataDirNet() / "test_i2p_private_key",
                               sam_proxy,
@@ -156,7 +157,7 @@ BOOST_AUTO_TEST_CASE(damaged_private_key)
         BOOST_REQUIRE(WriteBinaryFile(i2p_private_key_file, file_contents));
 
         auto interrupt{std::make_shared<CThreadInterrupt>()};
-        const CService addr{in6_addr(IN6ADDR_LOOPBACK_INIT), /*port=*/7656};
+        const CService addr{in6_addr(COMPAT_IN6ADDR_LOOPBACK_INIT), /*port=*/7656};
         const Proxy sam_proxy{addr, /*tor_stream_isolation=*/false};
         i2p::sam::Session session(i2p_private_key_file, sam_proxy, interrupt);
 

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <compat/compat.h>
 #include <net_permissions.h>
 #include <netaddress.h>
 #include <netbase.h>
@@ -502,17 +503,17 @@ BOOST_AUTO_TEST_CASE(netbase_dont_resolve_strings_with_embedded_nul_characters)
 
 static const std::vector<CAddress> fixture_addresses({
     CAddress{
-        CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0 /* port */),
+        CService(CNetAddr(in6_addr(COMPAT_IN6ADDR_LOOPBACK_INIT)), 0 /* port */),
         NODE_NONE,
         NodeSeconds{0x4966bc61s}, /* Fri Jan  9 02:54:25 UTC 2009 */
     },
     CAddress{
-        CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0x00f1 /* port */),
+        CService(CNetAddr(in6_addr(COMPAT_IN6ADDR_LOOPBACK_INIT)), 0x00f1 /* port */),
         NODE_NETWORK,
         NodeSeconds{0x83766279s}, /* Tue Nov 22 11:22:33 UTC 2039 */
     },
     CAddress{
-        CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0xf1f2 /* port */),
+        CService(CNetAddr(in6_addr(COMPAT_IN6ADDR_LOOPBACK_INIT)), 0xf1f2 /* port */),
         static_cast<ServiceFlags>(NODE_WITNESS | NODE_COMPACT_FILTERS | NODE_NETWORK_LIMITED),
         NodeSeconds{0xffffffffs}, /* Sun Feb  7 06:28:15 UTC 2106 */
     },


### PR DESCRIPTION
On some non-POSIX platforms, Clang emits `-Wmissing-braces` warnings for the `IN6ADDR_ANY_INIT` and `IN6ADDR_LOOPBACK_INIT` macros. For example, on OpenIndiana / illumos:
```
$ uname -srv
SunOS 5.11 illumos-325e0fc8bb
$ clang --version
clang version 21.1.7 (https://github.com/OpenIndiana/oi-userland.git 36a81bf5e5d307d4e85893422600678d46328010)
Target: x86_64-pc-solaris2.11
Thread model: posix
InstalledDir: /usr/clang/21/bin
$ cmake -B build -DCMAKE_GENERATOR=Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DENABLE_IPC=OFF -DAPPEND_CXXFLAGS='-Wno-unused-command-line-argument'
$ cmake --build build
[284/573] Building CXX object src/CMakeFiles/bitcoin_node.dir/net.cpp.o
/export/home/hebasto/dev/bitcoin/src/net.cpp:3309:42: warning: suggest braces around initialization of subobject [-Wmissing-braces]
 3309 |         const CService ipv6_any{in6_addr(IN6ADDR_ANY_INIT), GetListenPort()}; // ::
      |                                          ^~~~~~~~~~~~~~~~
/usr/include/netinet/in.h:479:32: note: expanded from macro 'IN6ADDR_ANY_INIT'
  479 | #define IN6ADDR_ANY_INIT            {   0, 0, 0, 0,     \
      |                                         ^~~~~~~~~~~~~~~~~
  480 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  481 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  482 |                                         0, 0, 0, 0 }
      |                                         ~~~~~~~~~~
1 warning generated.
[467/573] Building CXX object src/test/CMakeFiles/test_bitcoin.dir/i2p_tests.cpp.o
/export/home/hebasto/dev/bitcoin/src/test/i2p_tests.cpp:116:34: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  116 |     const CService addr{in6_addr(IN6ADDR_LOOPBACK_INIT), /*port=*/7656};
      |                                  ^~~~~~~~~~~~~~~~~~~~~
/usr/include/netinet/in.h:484:37: note: expanded from macro 'IN6ADDR_LOOPBACK_INIT'
  484 | #define IN6ADDR_LOOPBACK_INIT       {   0, 0, 0, 0,     \
      |                                         ^~~~~~~~~~~~~~~~~
  485 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  486 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  487 |                                         0, 0, 0, 0x1U }
      |                                         ~~~~~~~~~~~~~
/export/home/hebasto/dev/bitcoin/src/test/i2p_tests.cpp:159:38: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  159 |         const CService addr{in6_addr(IN6ADDR_LOOPBACK_INIT), /*port=*/7656};
      |                                      ^~~~~~~~~~~~~~~~~~~~~
/usr/include/netinet/in.h:484:37: note: expanded from macro 'IN6ADDR_LOOPBACK_INIT'
  484 | #define IN6ADDR_LOOPBACK_INIT       {   0, 0, 0, 0,     \
      |                                         ^~~~~~~~~~~~~~~~~
  485 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  486 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  487 |                                         0, 0, 0, 0x1U }
      |                                         ~~~~~~~~~~~~~
2 warnings generated.
[483/573] Building CXX object src/test/CMakeFiles/test_bitcoin.dir/netbase_tests.cpp.o
/export/home/hebasto/dev/bitcoin/src/test/netbase_tests.cpp:505:36: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  505 |         CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0 /* port */),
      |                                    ^~~~~~~~~~~~~~~~~~~~~
/usr/include/netinet/in.h:484:37: note: expanded from macro 'IN6ADDR_LOOPBACK_INIT'
  484 | #define IN6ADDR_LOOPBACK_INIT       {   0, 0, 0, 0,     \
      |                                         ^~~~~~~~~~~~~~~~~
  485 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  486 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  487 |                                         0, 0, 0, 0x1U }
      |                                         ~~~~~~~~~~~~~
/export/home/hebasto/dev/bitcoin/src/test/netbase_tests.cpp:510:36: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  510 |         CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0x00f1 /* port */),
      |                                    ^~~~~~~~~~~~~~~~~~~~~
/usr/include/netinet/in.h:484:37: note: expanded from macro 'IN6ADDR_LOOPBACK_INIT'
  484 | #define IN6ADDR_LOOPBACK_INIT       {   0, 0, 0, 0,     \
      |                                         ^~~~~~~~~~~~~~~~~
  485 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  486 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  487 |                                         0, 0, 0, 0x1U }
      |                                         ~~~~~~~~~~~~~
/export/home/hebasto/dev/bitcoin/src/test/netbase_tests.cpp:515:36: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  515 |         CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0xf1f2 /* port */),
      |                                    ^~~~~~~~~~~~~~~~~~~~~
/usr/include/netinet/in.h:484:37: note: expanded from macro 'IN6ADDR_LOOPBACK_INIT'
  484 | #define IN6ADDR_LOOPBACK_INIT       {   0, 0, 0, 0,     \
      |                                         ^~~~~~~~~~~~~~~~~
  485 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  486 |                                         0, 0, 0, 0,     \
      |                                         ~~~~~~~~~~~~~~~~~
  487 |                                         0, 0, 0, 0x1U }
      |                                         ~~~~~~~~~~~~~
3 warnings generated.
[573/573] Linking CXX executable bin/test_bitcoin
```

The same issue is observed on Windows. For further details, see https://github.com/bitcoin/bitcoin/pull/31507.