### PR TITLE
netif: fix compilation warning in QueryDefaultGatewayImpl()

### DIFF
--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -34,6 +34,8 @@
 #include <ifaddrs.h>
 #endif
 
+#include <type_traits>
+
 namespace {
 
 //! Return CNetAddr for the specified OS-level network address.
@@ -134,7 +136,9 @@ std::optional<CNetAddr> QueryDefaultGatewayImpl(sa_family_t family)
             return std::nullopt;
         }
 
-        for (nlmsghdr* hdr = (nlmsghdr*)response; NLMSG_OK(hdr, recv_result); hdr = NLMSG_NEXT(hdr, recv_result)) {
+        using recv_result_t = std::conditional_t<std::is_signed_v<decltype(NLMSG_HDRLEN)>, int64_t, decltype(NLMSG_HDRLEN)>;
+
+        for (nlmsghdr* hdr = (nlmsghdr*)response; NLMSG_OK(hdr, static_cast<recv_result_t>(recv_result)); hdr = NLMSG_NEXT(hdr, recv_result)) {
             if (!(hdr->nlmsg_flags & NLM_F_MULTI)) {
                 done = true;
             }


### PR DESCRIPTION
```
src/common/netif.cpp:137:51: error: comparison of integers of different signs: 'int64_t' (aka 'long') and 'unsigned long' [-Werror,-Wsign-compare]
  137 |         for (nlmsghdr* hdr = (nlmsghdr*)response; NLMSG_OK(hdr, recv_result); hdr = NLMSG_NEXT(hdr, recv_result)) {
      |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/netlink/netlink.h:220:31: note: expanded from macro 'NLMSG_OK'
  220 | #define NLMSG_OK(_hdr, _len)            NL_ITEM_OK(_hdr, _len, NLMSG_HDRLEN, _NLMSG_LEN)
      |                                         ^                ~~~~  ~~~~~~~~~~~~
/usr/include/netlink/netlink.h:203:10: note: expanded from macro 'NL_ITEM_OK'
  203 |         ((_len) >= _hlen && _LEN_M(_ptr) >= _hlen && _LEN_M(_ptr) <= (_len))
      |           ~~~~  ^  ~~~~~
1 error generated.
```

Happens on FreeBSD 15.0, with the default compiler (Clang 19).

On FreeBSD 14, `/usr/include/netlink/netlink.h` contains:
```
 #define NLMSG_HDRLEN                    ((int)sizeof(struct nlmsghdr))
```

On FreeBSD 15, `/usr/include/netlink/netlink.h` contains:
```
 #define NLMSG_HDRLEN                    (sizeof(struct nlmsghdr))
```