### PR TITLE
depends: capnp 1.3.0

### DIFF
--- a/depends/packages/native_capnp.mk
+++ b/depends/packages/native_capnp.mk
@@ -1,9 +1,9 @@
 package=native_capnp
-$(package)_version=1.2.0
+$(package)_version=1.3.0
 $(package)_download_path=https://capnproto.org/
 $(package)_download_file=capnproto-c++-$($(package)_version).tar.gz
 $(package)_file_name=capnproto-cxx-$($(package)_version).tar.gz
-$(package)_sha256_hash=ed00e44ecbbda5186bc78a41ba64a8dc4a861b5f8d4e822959b0144ae6fd42ef
+$(package)_sha256_hash=098f824a495a1a837d56ae17e07b3f721ac86f8dbaf58896a389923458522108
 
 define $(package)_set_vars
   $(package)_config_opts := -DBUILD_TESTING=OFF


### PR DESCRIPTION
Update capnp in depends to `1.3.0`.

Changes: https://github.com/capnproto/capnproto/compare/release-1.2.0...release-1.3.0.