### PR TITLE
cmake: Add missed `Boost::headers`

### DIFF
--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(bitcoin_ipc
   PRIVATE
     core_interface
     univalue
+    Boost::headers
 )
 
 if(BUILD_TESTS)


### PR DESCRIPTION
On Fedora 43:
```
$ gmake -C depends NO_LIBEVENT=1 NO_QT=1 NO_ZMQ=1 NO_WALLET=1 NO_USDT=1 NO_IPC=1
$ cmake -B build -DBoost_ROOT=depends/x86_64-pc-linux-gnu --preset dev-mode
<snip>
[363/1092] Building CXX object src/ipc/CMakeFiles/bitcoin_ipc.dir/capnp/mining.cpp.o
FAILED: [code=1] src/ipc/CMakeFiles/bitcoin_ipc.dir/capnp/mining.cpp.o 
/usr/bin/ccache /usr/lib64/ccache/c++ -DKJ_USE_FIBERS -I/home/hebasto/dev/bitcoin/build/src -I/home/hebasto/dev/bitcoin/src -I/home/hebasto/dev/bitcoin/build/src/ipc -I/home/hebasto/dev/bitcoin/src/ipc/libmultiprocess/include -I/home/hebasto/dev/bitcoin/build/src/ipc/libmultiprocess/include -I/home/hebasto/dev/bitcoin/src/univalue/include -O2 -g -std=c++20 -fPIC -pthread -fno-extended-identifiers -fdebug-prefix-map=/home/hebasto/dev/bitcoin/src=. -fmacro-prefix-map=/home/hebasto/dev/bitcoin/src=. -fstack-reuse=none -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wbidi-chars=any -Wundef -Wleading-whitespace=spaces -Wtrailing-whitespace=any -Wno-unused-parameter -MD -MT src/ipc/CMakeFiles/bitcoin_ipc.dir/capnp/mining.cpp.o -MF src/ipc/CMakeFiles/bitcoin_ipc.dir/capnp/mining.cpp.o.d -o src/ipc/CMakeFiles/bitcoin_ipc.dir/capnp/mining.cpp.o -c /home/hebasto/dev/bitcoin/src/ipc/capnp/mining.cpp 
In file included from /home/hebasto/dev/bitcoin/src/node/miner.h:13,
                 from /home/hebasto/dev/bitcoin/src/ipc/capnp/mining-types.h:12,
                 from /home/hebasto/dev/bitcoin/src/ipc/capnp/mining.cpp:5:
/home/hebasto/dev/bitcoin/src/txmempool.h:28:10: fatal error: boost/multi_index/hashed_index.hpp: No such file or directory
   28 | #include <boost/multi_index/hashed_index.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
<snip>
```

This PR fixes the issue.