### PR TITLE
kernel: revert accidentally removed copyright header

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -1,3 +1,16 @@
+// Copyright (c) 2022-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// The bitcoin-chainstate executable serves to surface the dependencies required
+// by a program wishing to use Bitcoin Core's consensus engine as it is right
+// now.
+//
+// DEVELOPER NOTE: Since this is a "demo-only", experimental, etc. executable,
+//                 it may diverge from Bitcoin Core's coding style.
+//
+// It is part of the libbitcoinkernel project.
+
 #include <kernel/bitcoinkernel_wrapper.h>
 
 #include <cassert>


### PR DESCRIPTION
Accidentally removed in #30595.
The author mentioned it was likely a bad rebase.

See:
https://github.com/bitcoin/bitcoin/commit/7990463b1059ba5fc4ebe37fd1105a9e168ae20d?diff=split#diff-04e685224f1ac5bfd91d47d8d7528a2e44f94fab5535d4b6b5af79b5a13aeb93L1-L12

Found while reviewing https://github.com/bitcoin/bitcoin/pull/34084#issuecomment-3670396535