### PR TITLE
build: Update minimum required Boost version

### DIFF
--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -29,7 +29,7 @@ function(add_boost_if_needed)
     endif()
   endif()
 
-  find_package(Boost 1.73.0 REQUIRED CONFIG)
+  find_package(Boost 1.74.0 REQUIRED CONFIG)
   mark_as_advanced(Boost_INCLUDE_DIR boost_headers_DIR)
   # Workaround for a bug in NetBSD pkgsrc.
   # See: https://github.com/NetBSD/pkgsrc/issues/167.

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -19,7 +19,7 @@ Bitcoin Core requires one of the following compilers.
 
 | Dependency | Releases | Minimum required |
 | --- | --- | --- |
-| [Boost](../depends/packages/boost.mk) | [link](https://www.boost.org/users/download/) | [1.73.0](https://github.com/bitcoin/bitcoin/pull/29066) |
+| [Boost](../depends/packages/boost.mk) | [link](https://www.boost.org/users/download/) | [1.74.0](https://github.com/bitcoin/bitcoin/pull/34107) |
 | CMake | [link](https://cmake.org/) | [3.22](https://github.com/bitcoin/bitcoin/pull/30454) |
 | [libevent](../depends/packages/libevent.mk) | [link](https://github.com/libevent/libevent/releases) | [2.1.8](https://github.com/bitcoin/bitcoin/pull/24681) |
 


### PR DESCRIPTION
Building with Boost 1.73.0 has been [broken](https://github.com/bitcoin/bitcoin/pull/34095#pullrequestreview-3594758109) since https://github.com/bitcoin/bitcoin/pull/31122 was merged.

This PR updates the minimum required Boost version to 1.74.0.

According to https://repology.org/project/boost/versions,  none of the major distros are affected by this change.