### PR TITLE
cmake: Fix debugging info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,16 +483,8 @@ configure_file(contrib/filter-lcov.py filter-lcov.py USE_SOURCE_PERMISSIONS COPY
 # Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.
 try_append_cxx_flags("-fno-extended-identifiers" TARGET core_interface SKIP_LINK)
 
-# Avoiding the `-ffile-prefix-map` compiler option because it implies
-# `-fcoverage-prefix-map` on Clang or `-fprofile-prefix-map` on GCC,
-# which can cause issues with coverage builds, particularly when using
-# Clang in the OSS-Fuzz environment due to its use of other options
-# and a third party script, or with GCC.
-try_append_cxx_flags("-fdebug-prefix-map=A=B" TARGET core_interface SKIP_LINK
-  IF_CHECK_PASSED "-fdebug-prefix-map=${PROJECT_SOURCE_DIR}/src=."
-)
-try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
-  IF_CHECK_PASSED "-fmacro-prefix-map=${PROJECT_SOURCE_DIR}/src=."
+try_append_cxx_flags("-ffile-prefix-map=A=B" TARGET core_interface SKIP_LINK
+  IF_CHECK_PASSED "-ffile-prefix-map=${PROJECT_SOURCE_DIR}/src=."
 )
 
 # GCC versions 13.2 (and earlier) are subject to a class of bugs, see

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,10 +483,6 @@ configure_file(contrib/filter-lcov.py filter-lcov.py USE_SOURCE_PERMISSIONS COPY
 # Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.
 try_append_cxx_flags("-fno-extended-identifiers" TARGET core_interface SKIP_LINK)
 
-try_append_cxx_flags("-ffile-prefix-map=A=B" TARGET core_interface SKIP_LINK
-  IF_CHECK_PASSED "-ffile-prefix-map=${PROJECT_SOURCE_DIR}/src=."
-)
-
 # GCC versions 13.2 (and earlier) are subject to a class of bugs, see
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90348 and the meta bug
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111843. To work around that, set

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -23,6 +23,14 @@ if(NOT MSVC)
   else()
     set(WITH_CCACHE OFF)
   endif()
+  if(WITH_CCACHE)
+    try_append_cxx_flags("-fdebug-prefix-map=A=B" TARGET core_interface SKIP_LINK
+      IF_CHECK_PASSED "-fdebug-prefix-map=${PROJECT_SOURCE_DIR}=."
+    )
+    try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
+      IF_CHECK_PASSED "-fmacro-prefix-map=${PROJECT_SOURCE_DIR}=."
+    )
+  endif()
 else()
   set(WITH_CCACHE OFF)
 endif()

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -212,6 +212,7 @@ CONFIGFLAGS="-DREDUCE_EXPORTS=ON -DBUILD_BENCH=OFF -DBUILD_GUI_TESTS=OFF -DBUILD
 HOST_CFLAGS="-O2 -g"
 HOST_CFLAGS+=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
 case "$HOST" in
+    *linux*)  HOST_CFLAGS+=" -ffile-prefix-map=${DISTSRC}/src=." ;;
     *mingw*)  HOST_CFLAGS+=" -fno-ident" ;;
     *darwin*) unset HOST_CFLAGS ;;
 esac

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -410,7 +410,7 @@ void BCLog::Logger::FormatLogStrInPlace(std::string& str, BCLog::LogFlags catego
     str.insert(0, GetLogPrefix(category, level));
 
     if (m_log_sourcelocations) {
-        str.insert(0, strprintf("[%s:%d] [%s] ", RemovePrefixView(source_loc.file_name(), "./"), source_loc.line(), source_loc.function_name_short()));
+        str.insert(0, strprintf("[%s:%d] [%s] ", RemovePrefixView(RemovePrefixView(source_loc.file_name(), "./"), "src/"), source_loc.line(), source_loc.function_name_short()));
     }
 
     if (m_log_threadnames) {

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -132,7 +132,7 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintStr, LogSetup)
 
     std::vector<std::string> expected;
     for (auto& [msg, category, level, prefix, loc] : cases) {
-        expected.push_back(tfm::format("[%s:%s] [%s] %s%s", util::RemovePrefix(loc.file_name(), "./"), loc.line(), loc.function_name_short(), prefix, msg));
+        expected.push_back(tfm::format("[%s:%s] [%s] %s%s", util::RemovePrefix(util::RemovePrefix(loc.file_name(), "./"), "src/"), loc.line(), loc.function_name_short(), prefix, msg));
         LogInstance().LogPrintStr(msg, std::move(loc), category, level, /*should_ratelimit=*/false);
     }
     std::vector<std::string> log_lines{ReadDebugLogLines()};


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/30811 was intended to address https://github.com/bitcoin/bitcoin/issues/30799. However, it introduced several unforeseen consequences, including https://github.com/bitcoin/bitcoin/issues/31957 and https://github.com/bitcoin/bitcoin/issues/31204.

This PR takes an alternative approach to resolving https://github.com/bitcoin/bitcoin/pull/30799 and reverts https://github.com/bitcoin/bitcoin/pull/30811.