### PR TITLE
net: reduce log level for PCP/NAT-PMP NOT_AUTHORIZED failures

### DIFF
--- a/src/common/pcp.cpp
+++ b/src/common/pcp.cpp
@@ -81,6 +81,8 @@ constexpr size_t NATPMP_MAP_RESPONSE_LIFETIME_OFS = 12;
 constexpr uint8_t NATPMP_RESULT_SUCCESS = 0;
 //! Result code representing unsupported version.
 constexpr uint8_t NATPMP_RESULT_UNSUPP_VERSION = 1;
+//! Result code representing not authorized (router doesn't support port mapping).
+constexpr uint8_t NATPMP_RESULT_NOT_AUTHORIZED = 2;
 //! Result code representing lack of resources.
 constexpr uint8_t NATPMP_RESULT_NO_RESOURCES = 4;
 
@@ -144,6 +146,8 @@ constexpr size_t PCP_MAP_EXTERNAL_IP_OFS = 20;
 
 //! Result code representing success (RFC6887 7.4), shared with NAT-PMP.
 constexpr uint8_t PCP_RESULT_SUCCESS = NATPMP_RESULT_SUCCESS;
+//! Result code representing not authorized (RFC6887 7.4), shared with NAT-PMP.
+constexpr uint8_t PCP_RESULT_NOT_AUTHORIZED = NATPMP_RESULT_NOT_AUTHORIZED;
 //! Result code representing lack of resources (RFC6887 7.4).
 constexpr uint8_t PCP_RESULT_NO_RESOURCES = 8;
 
@@ -374,7 +378,12 @@ std::variant<MappingResult, MappingError> NATPMPRequestPortMap(const CNetAddr &g
         Assume(response.size() >= NATPMP_MAP_RESPONSE_SIZE);
         uint16_t result_code = ReadBE16(response.data() + NATPMP_RESPONSE_HDR_RESULT_OFS);
         if (result_code != NATPMP_RESULT_SUCCESS) {
-            LogWarning("natpmp: Port mapping failed with result %s\n", NATPMPResultString(result_code));
+            if (result_code == NATPMP_RESULT_NOT_AUTHORIZED) {
+                // NOT_AUTHORIZED is expected on many routers that don't support port mapping.
+                LogDebug(BCLog::NET, "natpmp: Port mapping failed with result %s\n", NATPMPResultString(result_code));
+            } else {
+                LogWarning("natpmp: Port mapping failed with result %s\n", NATPMPResultString(result_code));
+            }
             if (result_code == NATPMP_RESULT_NO_RESOURCES) {
                 return MappingError::NO_RESOURCES;
             }
@@ -508,7 +517,12 @@ std::variant<MappingResult, MappingError> PCPRequestPortMap(const PCPMappingNonc
     uint16_t external_port = ReadBE16(response.data() + PCP_HDR_SIZE + PCP_MAP_EXTERNAL_PORT_OFS);
     CNetAddr external_addr{PCPUnwrapAddress(response.subspan(PCP_HDR_SIZE + PCP_MAP_EXTERNAL_IP_OFS, ADDR_IPV6_SIZE))};
     if (result_code != PCP_RESULT_SUCCESS) {
-        LogWarning("pcp: Mapping failed with result %s\n", PCPResultString(result_code));
+        if (result_code == PCP_RESULT_NOT_AUTHORIZED) {
+            // NOT_AUTHORIZED is expected on many routers that don't support port mapping.
+            LogDebug(BCLog::NET, "pcp: Mapping failed with result %s\n", PCPResultString(result_code));
+        } else {
+            LogWarning("pcp: Mapping failed with result %s\n", PCPResultString(result_code));
+        }
         if (result_code == PCP_RESULT_NO_RESOURCES) {
             return MappingError::NO_RESOURCES;
         }


### PR DESCRIPTION
Users running Bitcoin Core on home networks with routers that don't support PCP (Port Control Protocol) or NAT-PMP port mapping receive frequent warning-level log messages every few minutes:

  "pcp: Mapping failed with result NOT_AUTHORIZED (code 2)"

This is expected behavior for many consumer routers that have PCP disabled by default, not an actionable error. The repeated warnings create unnecessary log noise.

This change:
- Adds explicit constants for NOT_AUTHORIZED result code (value 2) for both NAT-PMP and PCP protocols
- Downgrades NOT_AUTHORIZED failures from LogWarning to LogDebug since this is an expected condition on many networks
- Keeps LogWarning for other failure types that may indicate actual configuration or network issues

The NOT_AUTHORIZED message will still be visible when running with -debug=net for users who need to troubleshoot port mapping issues.

Fixes #34114

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
