### PR TITLE
script: Default script_verify_flags comparisons

### DIFF
--- a/src/script/verify_flags.h
+++ b/src/script/verify_flags.h
@@ -46,13 +46,7 @@ public:
 
     // tests
     constexpr explicit operator bool() const { return m_value != 0; }
-    constexpr bool operator==(script_verify_flags other) const { return m_value == other.m_value; }
-
-    /** Compare two script_verify_flags. <, >, <=, and >= are auto-generated from this. */
-    friend constexpr std::strong_ordering operator<=>(const script_verify_flags& a, const script_verify_flags& b) noexcept
-    {
-        return a.m_value <=> b.m_value;
-    }
+    constexpr std::strong_ordering operator<=>(const script_verify_flags& other) const = default;
 
 private:
     value_type m_value{0}; // default value is SCRIPT_VERIFY_NONE


### PR DESCRIPTION
Replace the manual operator== and friend operator<=> in src/script/verify_flags.h with a defaulted member operator<=>.

This reduces boilerplate while preserving the existing semantics (m_value comparison) and continues to provide ==, <, >, <=, and >= via the compiler-generated comparison operators.

**Note**: This is a small refactor, but it removes duplicated comparison logic and reduces the chance of == and <=> diverging in future edits. If that’s not considered worthwhile, I can close/drop it.