### PR TITLE
doc: Clarify CMake test runner workflow in README

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -67,6 +67,12 @@ Individual tests can be run by directly calling the test script, e.g.:
 build/test/functional/feature_rbf.py
 ```
 
+**Note for CMake users:** It is recommended to run the test runner from the build directory. This ensures the configuration file is loaded automatically via symlinks:
+
+```
+./build/test/functional/test_runner.py
+```
+
 or can be run through the test_runner harness, eg:
 
 ```


### PR DESCRIPTION
This PR updates `test/README.md` to recommend running `test_runner.py` from the `build/` directory when using CMake.

Running from the source directory (e.g., `./test/functional/test_runner.py`) fails on fresh builds because `config.ini` is located in the build directory. Using the build directory path leverages the symlinks correctly and ensures the configuration is found without needing manual flags.

Context: Supersedes #34073 based on feedback from @maflcko.