### PR TITLE
index: Add ScriptTypeIndex to track script type statistics per block

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,6 +193,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   index/base.cpp
   index/blockfilterindex.cpp
   index/coinstatsindex.cpp
+  index/scripttypeindex.cpp
   index/txindex.cpp
   init.cpp
   kernel/chain.cpp

--- a/src/index/scripttypeindex.cpp
+++ b/src/index/scripttypeindex.cpp
@@ -20,8 +20,15 @@ bool ScriptTypeIndex::CustomAppend(const interfaces::BlockInfo& block) {
     m_db->Write(std::make_pair(DB_SCRIPT_TYPE_STATS, block.hash), stats);
     return true; 
 }
-bool ScriptTypeIndex::CustomRemove(const interfaces::BlockInfo& block) { return true; }
-bool ScriptTypeIndex::LookupStats(const uint256& block_hash, ScriptTypeBlockStats& stats) const { return false; }
+
+bool ScriptTypeIndex::CustomRemove(const interfaces::BlockInfo& block) {
+    m_db->Erase(std::make_pair(DB_SCRIPT_TYPE_STATS, block.hash));
+    return true;
+}
+
+bool ScriptTypeIndex::LookupStats(const uint256& block_hash, ScriptTypeBlockStats& stats) const {
+    return m_db->Read(std::make_pair(DB_SCRIPT_TYPE_STATS, block_hash), stats);
+}
 ScriptTypeBlockStats ScriptTypeIndex::ComputeStats(const CBlock& block) const { 
     
     // Init stats

--- a/src/index/scripttypeindex.cpp
+++ b/src/index/scripttypeindex.cpp
@@ -1,5 +1,7 @@
 #include <index/scripttypeindex.h>
 #include <common/args.h>
+#include <primitives/block.h>
+#include <logging.h>
 
 std::unique_ptr<ScriptTypeIndex> g_script_type_index;
 
@@ -15,4 +17,31 @@ ScriptTypeIndex::~ScriptTypeIndex() = default;
 bool ScriptTypeIndex::CustomAppend(const interfaces::BlockInfo& block) { return true; }
 bool ScriptTypeIndex::CustomRemove(const interfaces::BlockInfo& block) { return true; }
 bool ScriptTypeIndex::LookupStats(const uint256& block_hash, ScriptTypeBlockStats& stats) const { return false; }
-ScriptTypeBlockStats ScriptTypeIndex::ComputeStats(const CBlock& block) const { return {}; }
+ScriptTypeBlockStats ScriptTypeIndex::ComputeStats(const CBlock& block) const { 
+    
+    // Init stats
+    ScriptTypeBlockStats stats{};
+
+    // loop through all transactions in the block and check every output to determine the script type
+    for (const auto& tx :block.vtx) {
+        for(const auto& out : tx->vout) {
+            std::vector<std::vector<unsigned char>> solutions; // unused, but needed for Solver
+            TxoutType script_type = Solver(out.scriptPubKey, solutions);
+            size_t type_idx = static_cast<size_t>(script_type);
+
+            // skip unknown script types
+            if (type_idx >= ScriptTypeBlockStats::TXOUT_TYPE_COUNT) {
+                LogError("ScriptTypeIndex: Unknown script type %d\n", static_cast<int>(script_type));
+                continue;
+            }
+
+            // update stats
+            stats.output_counts[type_idx]++;
+            stats.output_values[type_idx] += out.nValue;
+        }
+    }
+
+    
+    return stats; 
+
+}

--- a/src/index/scripttypeindex.cpp
+++ b/src/index/scripttypeindex.cpp
@@ -1,0 +1,18 @@
+#include <index/scripttypeindex.h>
+#include <common/args.h>
+
+std::unique_ptr<ScriptTypeIndex> g_script_type_index;
+
+ScriptTypeIndex::ScriptTypeIndex(std::unique_ptr<interfaces::Chain> chain, size_t cache_size)
+    : BaseIndex(std::move(chain), "scripttypeindex")
+    , m_db(std::make_unique<BaseIndex::DB>(gArgs.GetDataDirNet() / "indexes" / "scripttypeindex",
+                                           cache_size, /*memory=*/false, /*wipe=*/false))
+{
+}
+
+ScriptTypeIndex::~ScriptTypeIndex() = default;
+
+bool ScriptTypeIndex::CustomAppend(const interfaces::BlockInfo& block) { return true; }
+bool ScriptTypeIndex::CustomRemove(const interfaces::BlockInfo& block) { return true; }
+bool ScriptTypeIndex::LookupStats(const uint256& block_hash, ScriptTypeBlockStats& stats) const { return false; }
+ScriptTypeBlockStats ScriptTypeIndex::ComputeStats(const CBlock& block) const { return {}; }

--- a/src/index/scripttypeindex.cpp
+++ b/src/index/scripttypeindex.cpp
@@ -5,7 +5,7 @@
 
 std::unique_ptr<ScriptTypeIndex> g_script_type_index;
 
-ScriptTypeIndex::ScriptTypeIndex(std::unique_ptr<interfaces::Chain> chain, size_t cache_size)
+ScriptTypeIndex::ScriptTypeIndex(std::unique_ptr<interfaces::Chain> chain, size_t cache_size, bool f_memory, bool f_wipe)
     : BaseIndex(std::move(chain), "scripttypeindex")
     , m_db(std::make_unique<BaseIndex::DB>(gArgs.GetDataDirNet() / "indexes" / "scripttypeindex",
                                            cache_size, /*memory=*/false, /*wipe=*/false))

--- a/src/index/scripttypeindex.cpp
+++ b/src/index/scripttypeindex.cpp
@@ -14,7 +14,12 @@ ScriptTypeIndex::ScriptTypeIndex(std::unique_ptr<interfaces::Chain> chain, size_
 
 ScriptTypeIndex::~ScriptTypeIndex() = default;
 
-bool ScriptTypeIndex::CustomAppend(const interfaces::BlockInfo& block) { return true; }
+bool ScriptTypeIndex::CustomAppend(const interfaces::BlockInfo& block) {
+    assert(block.data);
+    ScriptTypeBlockStats stats = ComputeStats(*block.data);
+    m_db->Write(std::make_pair(DB_SCRIPT_TYPE_STATS, block.hash), stats);
+    return true; 
+}
 bool ScriptTypeIndex::CustomRemove(const interfaces::BlockInfo& block) { return true; }
 bool ScriptTypeIndex::LookupStats(const uint256& block_hash, ScriptTypeBlockStats& stats) const { return false; }
 ScriptTypeBlockStats ScriptTypeIndex::ComputeStats(const CBlock& block) const { 
@@ -41,7 +46,5 @@ ScriptTypeBlockStats ScriptTypeIndex::ComputeStats(const CBlock& block) const {
         }
     }
 
-    
     return stats; 
-
 }

--- a/src/index/scripttypeindex.h
+++ b/src/index/scripttypeindex.h
@@ -1,0 +1,55 @@
+#ifndef BITCOIN_INDEX_SCRIPTTYPEINDEX_H
+#define BITCOIN_INDEX_SCRIPTTYPEINDEX_H
+
+#include <index/base.h>
+#include <script/solver.h>
+
+#include <array>
+#include <cstdint>
+
+/**
+ * Statistics for script types per block
+ */
+struct ScriptTypeBlockStats {
+    static constexpr size_t TXOUT_TYPE_COUNT = static_cast<size_t>(TxoutType::WITNESS_UNKNOWN) + 1;
+
+    /** Number of outputs created per script type in the block */
+    std::array<uint64_t, TXOUT_TYPE_COUNT> output_counts{};
+
+    /** Total satoshis locked in outputs per script type in the block */
+    std::array<CAmount, TXOUT_TYPE_COUNT> output_values{};
+
+    SERIALIZE_METHODS(ScriptTypeBlockStats, obj) {
+        READWRITE(obj.output_counts, obj.output_values);
+    }
+};
+
+/**
+ * ScriptTypeIndex tracks the statistics (number and value) per script type per block
+ */
+class ScriptTypeIndex final : public BaseIndex
+{
+private:
+    /** Database key prefix set to 's' */
+    static constexpr char DB_SCRIPT_TYPE_STATS{'s'};
+
+    std::unique_ptr<BaseIndex::DB> m_db;
+
+    ScriptTypeBlockStats ComputeStats(const CBlock& block) const;
+
+protected:
+    bool CustomAppend(const interfaces::BlockInfo& block) override;
+    bool CustomRemove(const interfaces::BlockInfo& block) override;
+    bool AllowPrune() const override { return false; }
+    BaseIndex::DB& GetDB() const override { return *m_db; }
+
+public:
+    explicit ScriptTypeIndex(std::unique_ptr<interfaces::Chain> chain, size_t cache_size);
+    ~ScriptTypeIndex() override;
+
+    bool LookupStats(const uint256& block_hash, ScriptTypeBlockStats& stats) const;
+};
+
+extern std::unique_ptr<ScriptTypeIndex> g_script_type_index;
+
+#endif

--- a/src/index/scripttypeindex.h
+++ b/src/index/scripttypeindex.h
@@ -7,6 +7,10 @@
 #include <array>
 #include <cstdint>
 
+// Default to not maintain a script type index (we can enable it with the -scripttypeindex flag)
+static constexpr bool DEFAULT_SCRIPTTYPEINDEX{false};
+
+
 /**
  * Statistics for script types per block
  */
@@ -50,7 +54,7 @@ protected:
     BaseIndex::DB& GetDB() const override { return *m_db; }
 
 public:
-    explicit ScriptTypeIndex(std::unique_ptr<interfaces::Chain> chain, size_t cache_size);
+    explicit ScriptTypeIndex(std::unique_ptr<interfaces::Chain> chain, size_t cache_size, bool f_memory = false, bool f_wipe = false);
     ~ScriptTypeIndex() override;
 
     bool LookupStats(const uint256& block_hash, ScriptTypeBlockStats& stats) const;

--- a/src/index/scripttypeindex.h
+++ b/src/index/scripttypeindex.h
@@ -20,7 +20,13 @@ struct ScriptTypeBlockStats {
     std::array<CAmount, TXOUT_TYPE_COUNT> output_values{};
 
     SERIALIZE_METHODS(ScriptTypeBlockStats, obj) {
-        READWRITE(obj.output_counts, obj.output_values);
+        // Serialize arrays element by element
+        for (size_t i = 0; i < TXOUT_TYPE_COUNT; ++i) {
+            READWRITE(obj.output_counts[i]);
+        }
+        for (size_t i = 0; i < TXOUT_TYPE_COUNT; ++i) {
+            READWRITE(obj.output_values[i]);
+        }
     }
 };
 
@@ -31,7 +37,7 @@ class ScriptTypeIndex final : public BaseIndex
 {
 private:
     /** Database key prefix set to 's' */
-    static constexpr char DB_SCRIPT_TYPE_STATS{'s'};
+    static constexpr uint8_t DB_SCRIPT_TYPE_STATS{'s'};
 
     std::unique_ptr<BaseIndex::DB> m_db;
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(test_bitcoin
   coins_tests.cpp
   coinscachepair_tests.cpp
   coinstatsindex_tests.cpp
+  scripttypeindex_tests.cpp
   common_url_tests.cpp
   compress_tests.cpp
   crypto_tests.cpp

--- a/src/test/scripttypeindex_tests.cpp
+++ b/src/test/scripttypeindex_tests.cpp
@@ -1,0 +1,276 @@
+#include <index/scripttypeindex.h>
+#include <interfaces/chain.h>
+#include <test/util/setup_common.h>
+#include <test/util/validation.h>
+#include <validation.h>
+#include <addresstype.h> 
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(scripttypeindex_tests)
+
+// Basic initial sync test
+BOOST_FIXTURE_TEST_CASE(scripttypeindex_initial_sync, TestChain100Setup)
+{
+    ScriptTypeIndex script_type_index{interfaces::MakeChain(m_node), 0, true};
+    BOOST_REQUIRE(script_type_index.Init());
+
+    const CBlockIndex* block_index;
+    {
+        LOCK(cs_main);
+        block_index = m_node.chainman->ActiveChain().Tip();
+    }
+
+    // ScriptTypeIndex should not be found before it is started.
+    ScriptTypeBlockStats stats;
+    BOOST_CHECK(!script_type_index.LookupStats(block_index->GetBlockHash(), stats));
+
+    // BlockUntilSyncedToCurrentChain should return false before index is started.
+    BOOST_CHECK(!script_type_index.BlockUntilSyncedToCurrentChain());
+
+    // Sync the index
+    script_type_index.Sync();
+
+    // Check that ScriptTypeIndex works for genesis block.
+    const CBlockIndex* genesis_block_index;
+    {
+        LOCK(cs_main);
+        genesis_block_index = m_node.chainman->ActiveChain().Genesis();
+    }
+    BOOST_CHECK(script_type_index.LookupStats(genesis_block_index->GetBlockHash(), stats));
+
+    // Check that ScriptTypeIndex updates with new blocks.
+    BOOST_CHECK(script_type_index.LookupStats(block_index->GetBlockHash(), stats));
+
+    // Create a new block with only a coinbase tx
+    const CScript script_pub_key{CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG};
+    std::vector<CMutableTransaction> noTxns;
+    CreateAndProcessBlock(noTxns, script_pub_key);
+
+    // Let the ScriptTypeIndex catch up again.
+    BOOST_CHECK(script_type_index.BlockUntilSyncedToCurrentChain());
+
+    // get new tip
+    const CBlockIndex* new_block_index;
+    {
+        LOCK(cs_main);
+        new_block_index = m_node.chainman->ActiveChain().Tip();
+    }
+    BOOST_CHECK(script_type_index.LookupStats(new_block_index->GetBlockHash(), stats));
+
+    // Check that the tip actually changed
+    BOOST_CHECK(block_index != new_block_index);
+
+
+    // It is not safe to stop and destroy the index until it finishes handling
+    // the last BlockConnected notification. The BlockUntilSyncedToCurrentChain()
+    // call above is sufficient to ensure this, but the
+    // SyncWithValidationInterfaceQueue() call below is also needed to ensure
+    // TSAN always sees the test thread waiting for the notification thread, and
+    // avoid potential false positive reports.
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+
+    script_type_index.Stop();
+}
+
+// Test with multiple script types: P2PK (coinbase), P2PKH, P2SH, MULTISIG, NULL_DATA, P2WPKH, P2WSH, P2TR
+// We create separate blocks for each script type to ensure they're all processed correctly
+BOOST_FIXTURE_TEST_CASE(scripttypeindex_two_script_types, TestChain100Setup)
+{
+    ScriptTypeIndex script_type_index{interfaces::MakeChain(m_node), 0, true};
+    BOOST_REQUIRE(script_type_index.Init());
+    script_type_index.Sync();
+
+    // Generate keys for different script types
+    CKey key1 = GenerateRandomKey();
+    CKey key2 = GenerateRandomKey();
+    CKey key3 = GenerateRandomKey();
+    CPubKey pubkey1 = key1.GetPubKey();
+    CPubKey pubkey2 = key2.GetPubKey();
+    CPubKey pubkey3 = key3.GetPubKey();
+
+    CScript coinbase_script = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG; // P2PK
+    CAmount coinbase_value = m_coinbase_txns[0]->vout[0].nValue;
+
+    // Create blocks with different script types and verify each one
+    std::map<TxoutType, uint256> block_hashes;
+
+    // Block 1: P2PKH
+    {
+        std::vector<CTxOut> outputs;
+        outputs.push_back(CTxOut(coinbase_value - 10000, GetScriptForDestination(PKHash(pubkey1))));
+        auto [tx, fee] = CreateValidTransaction(
+            {m_coinbase_txns[0]},
+            {COutPoint(m_coinbase_txns[0]->GetHash(), 0)},
+            0,
+            {coinbaseKey},
+            outputs,
+            std::nullopt,
+            std::nullopt
+        );
+        const CBlock& block = CreateAndProcessBlock({tx}, coinbase_script);
+        BOOST_CHECK(script_type_index.BlockUntilSyncedToCurrentChain());
+        {
+            LOCK(cs_main);
+            block_hashes[TxoutType::PUBKEYHASH] = m_node.chainman->ActiveChain().Tip()->GetBlockHash();
+        }
+    }
+
+    // Block 2: P2SH
+    {
+        CScript redeem_script = CScript() << OP_TRUE;
+        std::vector<CTxOut> outputs;
+        outputs.push_back(CTxOut(coinbase_value - 10000, GetScriptForDestination(ScriptHash(redeem_script))));
+        auto [tx, fee] = CreateValidTransaction(
+            {m_coinbase_txns[1]},
+            {COutPoint(m_coinbase_txns[1]->GetHash(), 0)},
+            0,
+            {coinbaseKey},
+            outputs,
+            std::nullopt,
+            std::nullopt
+        );
+        const CBlock& block = CreateAndProcessBlock({tx}, coinbase_script);
+        BOOST_CHECK(script_type_index.BlockUntilSyncedToCurrentChain());
+        {
+            LOCK(cs_main);
+            block_hashes[TxoutType::SCRIPTHASH] = m_node.chainman->ActiveChain().Tip()->GetBlockHash();
+        }
+    }
+
+    // Block 3: MULTISIG
+    {
+        std::vector<CPubKey> multisig_keys = {pubkey1, pubkey2, pubkey3};
+        CScript multisig_script = GetScriptForMultisig(2, multisig_keys);
+        std::vector<CTxOut> outputs;
+        outputs.push_back(CTxOut(coinbase_value - 10000, multisig_script));
+        auto [tx, fee] = CreateValidTransaction(
+            {m_coinbase_txns[2]},
+            {COutPoint(m_coinbase_txns[2]->GetHash(), 0)},
+            0,
+            {coinbaseKey},
+            outputs,
+            std::nullopt,
+            std::nullopt
+        );
+        const CBlock& block = CreateAndProcessBlock({tx}, coinbase_script);
+        BOOST_CHECK(script_type_index.BlockUntilSyncedToCurrentChain());
+        {
+            LOCK(cs_main);
+            block_hashes[TxoutType::MULTISIG] = m_node.chainman->ActiveChain().Tip()->GetBlockHash();
+        }
+    }
+
+    // Block 4: NULL_DATA
+    {
+        std::vector<CTxOut> outputs;
+        outputs.push_back(CTxOut(0, CScript() << OP_RETURN << std::vector<unsigned char>(20, 0x42)));
+        auto [tx, fee] = CreateValidTransaction(
+            {m_coinbase_txns[3]},
+            {COutPoint(m_coinbase_txns[3]->GetHash(), 0)},
+            0,
+            {coinbaseKey},
+            outputs,
+            std::nullopt,
+            std::nullopt
+        );
+        const CBlock& block = CreateAndProcessBlock({tx}, coinbase_script);
+        BOOST_CHECK(script_type_index.BlockUntilSyncedToCurrentChain());
+        {
+            LOCK(cs_main);
+            block_hashes[TxoutType::NULL_DATA] = m_node.chainman->ActiveChain().Tip()->GetBlockHash();
+        }
+    }
+
+    // Block 5: P2WPKH
+    {
+        std::vector<CTxOut> outputs;
+        outputs.push_back(CTxOut(coinbase_value - 10000, GetScriptForDestination(WitnessV0KeyHash(pubkey1.GetID()))));
+        auto [tx, fee] = CreateValidTransaction(
+            {m_coinbase_txns[4]},
+            {COutPoint(m_coinbase_txns[4]->GetHash(), 0)},
+            0,
+            {coinbaseKey},
+            outputs,
+            std::nullopt,
+            std::nullopt
+        );
+        const CBlock& block = CreateAndProcessBlock({tx}, coinbase_script);
+        BOOST_CHECK(script_type_index.BlockUntilSyncedToCurrentChain());
+        {
+            LOCK(cs_main);
+            block_hashes[TxoutType::WITNESS_V0_KEYHASH] = m_node.chainman->ActiveChain().Tip()->GetBlockHash();
+        }
+    }
+
+    // Block 6: P2WSH
+    {
+        CScript witness_script = CScript() << OP_1 << ToByteVector(pubkey1) << OP_1 << OP_CHECKMULTISIG;
+        WitnessV0ScriptHash witness_script_hash(witness_script);
+        std::vector<CTxOut> outputs;
+        outputs.push_back(CTxOut(coinbase_value - 10000, GetScriptForDestination(witness_script_hash)));
+        auto [tx, fee] = CreateValidTransaction(
+            {m_coinbase_txns[5]},
+            {COutPoint(m_coinbase_txns[5]->GetHash(), 0)},
+            0,
+            {coinbaseKey},
+            outputs,
+            std::nullopt,
+            std::nullopt
+        );
+        const CBlock& block = CreateAndProcessBlock({tx}, coinbase_script);
+        BOOST_CHECK(script_type_index.BlockUntilSyncedToCurrentChain());
+        {
+            LOCK(cs_main);
+            block_hashes[TxoutType::WITNESS_V0_SCRIPTHASH] = m_node.chainman->ActiveChain().Tip()->GetBlockHash();
+        }
+    }
+
+    // Block 7: P2TR (Taproot)
+    {
+        XOnlyPubKey xonly_pubkey(pubkey1);
+        std::vector<CTxOut> outputs;
+        outputs.push_back(CTxOut(coinbase_value - 10000, GetScriptForDestination(WitnessV1Taproot(xonly_pubkey))));
+        auto [tx, fee] = CreateValidTransaction(
+            {m_coinbase_txns[6]},
+            {COutPoint(m_coinbase_txns[6]->GetHash(), 0)},
+            0,
+            {coinbaseKey},
+            outputs,
+            std::nullopt,
+            std::nullopt
+        );
+        const CBlock& block = CreateAndProcessBlock({tx}, coinbase_script);
+        BOOST_CHECK(script_type_index.BlockUntilSyncedToCurrentChain());
+        {
+            LOCK(cs_main);
+            block_hashes[TxoutType::WITNESS_V1_TAPROOT] = m_node.chainman->ActiveChain().Tip()->GetBlockHash();
+        }
+    }
+
+    // Verify each block's stats
+    for (const auto& [type, block_hash] : block_hashes) {
+        ScriptTypeBlockStats stats;
+        BOOST_REQUIRE(script_type_index.LookupStats(block_hash, stats));
+        
+        size_t type_idx = static_cast<size_t>(type);
+        
+        // Each block should have: at least 1 P2PK (coinbase) + at least 1 of the specific script type
+        BOOST_CHECK_GE(stats.output_counts[static_cast<size_t>(TxoutType::PUBKEY)], 1U);
+        BOOST_CHECK_GE(stats.output_counts[type_idx], 1U);
+        
+        if (type == TxoutType::NULL_DATA) {
+            BOOST_CHECK_EQUAL(stats.output_values[type_idx], 0);
+        } else {
+            BOOST_CHECK_GT(stats.output_values[type_idx], 0);
+        }
+        
+        // Verify NONSTANDARD is 0 for each block
+        BOOST_CHECK_EQUAL(stats.output_counts[static_cast<size_t>(TxoutType::NONSTANDARD)], 0U);
+    }
+
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    script_type_index.Stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds a new optional index (`ScriptTypeIndex`) that traks statistics about script types for each block. The index maintains both the count and total value (in satoshis) of outputs for each script type per block.

Tracking script type statistics enables analysis of Bitcoin's UTXO set composition over time, (for example we can see addoption trends for: P2PKH, P2SH, SegWit, Taproot) and value distribution across script types.

## Implementation

- New `ScriptTypeIndex` class extending `BaseIndex`
- Tracks all standard script types: NONSTANDARD, P2PK, P2PKH, P2SH, MULTISIG, NULL_DATA, P2WPKH, P2WSH, P2TR
- For each script type, tracks both output count and total sats locked
- Disabled by default, enabled with `-scripttypeindex` flag

## RPC Interface

Adds new RPC method `getscripttypestats <blockhash>` that returns nested objects with `count` and `value` for each script type:
```
{
  "nonstandard": {"count": 0, "value": 0},
  "p2pk": {"count": 1, "value": 5000000000},
  "p2pkh": {"count": 5, "value": 25000000000},
  ...
}
```

## Testing

Unit tests included in `src/test/scripttypeindex_tests.cpp`:
- Basic initial sync test
- Test with multiple script types (P2PKH, P2SH, MULTISIG, NULL_DATA, P2WPKH, P2WSH, P2TR)


### Example output:
<img width="1305" height="677" alt="image" src="https://github.com/user-attachments/assets/bc7df617-50e0-4f47-a394-127a8370c231" />
