### PR TITLE
coins, dbwrapper: remove error catcher, make point-read failures fatal

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -32,7 +32,7 @@ CoinsViewEmpty& CoinsViewEmpty::Get()
     return instance;
 }
 
-std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const noexcept
 {
     if (auto it{cacheCoins.find(outpoint)}; it != cacheCoins.end()) {
         return it->second.coin.IsSpent() ? std::nullopt : std::optional{it->second.coin};
@@ -56,7 +56,7 @@ std::optional<Coin> CCoinsViewCache::FetchCoinFromBase(const COutPoint& outpoint
     return base->GetCoin(outpoint);
 }
 
-CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const {
+CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const noexcept {
     const auto [ret, inserted] = cacheCoins.try_emplace(outpoint);
     if (inserted) {
         if (auto coin{FetchCoinFromBase(outpoint)}) {
@@ -71,7 +71,7 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const 
     return ret;
 }
 
-std::optional<Coin> CCoinsViewCache::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewCache::GetCoin(const COutPoint& outpoint) const noexcept
 {
     if (auto it{FetchCoin(outpoint)}; it != cacheCoins.end() && !it->second.coin.IsSpent()) return it->second.coin;
     return std::nullopt;
@@ -167,7 +167,7 @@ bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
 
 static const Coin coinEmpty;
 
-const Coin& CCoinsViewCache::AccessCoin(const COutPoint &outpoint) const {
+const Coin& CCoinsViewCache::AccessCoin(const COutPoint &outpoint) const noexcept {
     CCoinsMap::const_iterator it = FetchCoin(outpoint);
     if (it == cacheCoins.end()) {
         return coinEmpty;
@@ -176,13 +176,13 @@ const Coin& CCoinsViewCache::AccessCoin(const COutPoint &outpoint) const {
     }
 }
 
-bool CCoinsViewCache::HaveCoin(const COutPoint& outpoint) const
+bool CCoinsViewCache::HaveCoin(const COutPoint& outpoint) const noexcept
 {
     CCoinsMap::const_iterator it = FetchCoin(outpoint);
     return (it != cacheCoins.end() && !it->second.coin.IsSpent());
 }
 
-bool CCoinsViewCache::HaveCoinInCache(const COutPoint &outpoint) const {
+bool CCoinsViewCache::HaveCoinInCache(const COutPoint &outpoint) const noexcept {
     CCoinsMap::const_iterator it = cacheCoins.find(outpoint);
     return (it != cacheCoins.end() && !it->second.coin.IsSpent());
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -425,36 +425,3 @@ const Coin& AccessByTxid(const CCoinsViewCache& view, const Txid& txid)
     }
     return coinEmpty;
 }
-
-template <typename ReturnType, typename Func>
-static ReturnType ExecuteBackedWrapper(Func func, const std::vector<std::function<void()>>& err_callbacks)
-{
-    try {
-        return func();
-    } catch(const std::runtime_error& e) {
-        for (const auto& f : err_callbacks) {
-            f();
-        }
-        LogError("Error reading from database: %s\n", e.what());
-        // Starting the shutdown sequence and returning false to the caller would be
-        // interpreted as 'entry not found' (as opposed to unable to read data), and
-        // could lead to invalid interpretation. Just exit immediately, as we can't
-        // continue anyway, and all writes should be atomic.
-        std::abort();
-    }
-}
-
-std::optional<Coin> CCoinsViewErrorCatcher::GetCoin(const COutPoint& outpoint) const
-{
-    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return CCoinsViewBacked::GetCoin(outpoint); }, m_err_callbacks);
-}
-
-bool CCoinsViewErrorCatcher::HaveCoin(const COutPoint& outpoint) const
-{
-    return ExecuteBackedWrapper<bool>([&]() { return CCoinsViewBacked::HaveCoin(outpoint); }, m_err_callbacks);
-}
-
-std::optional<Coin> CCoinsViewErrorCatcher::PeekCoin(const COutPoint& outpoint) const
-{
-    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return CCoinsViewBacked::PeekCoin(outpoint); }, m_err_callbacks);
-}

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -424,36 +424,3 @@ const Coin& AccessByTxid(const CCoinsViewCache& view, const Txid& txid)
     }
     return coinEmpty;
 }
-
-template <typename ReturnType, typename Func>
-static ReturnType ExecuteBackedWrapper(Func func, const std::vector<std::function<void()>>& err_callbacks)
-{
-    try {
-        return func();
-    } catch(const std::runtime_error& e) {
-        for (const auto& f : err_callbacks) {
-            f();
-        }
-        LogError("Error reading from database: %s\n", e.what());
-        // Starting the shutdown sequence and returning false to the caller would be
-        // interpreted as 'entry not found' (as opposed to unable to read data), and
-        // could lead to invalid interpretation. Just exit immediately, as we can't
-        // continue anyway, and all writes should be atomic.
-        std::abort();
-    }
-}
-
-std::optional<Coin> CCoinsViewErrorCatcher::GetCoin(const COutPoint& outpoint) const
-{
-    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return CCoinsViewBacked::GetCoin(outpoint); }, m_err_callbacks);
-}
-
-bool CCoinsViewErrorCatcher::HaveCoin(const COutPoint& outpoint) const
-{
-    return ExecuteBackedWrapper<bool>([&]() { return CCoinsViewBacked::HaveCoin(outpoint); }, m_err_callbacks);
-}
-
-std::optional<Coin> CCoinsViewErrorCatcher::PeekCoin(const COutPoint& outpoint) const
-{
-    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return CCoinsViewBacked::PeekCoin(outpoint); }, m_err_callbacks);
-}

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -32,7 +32,7 @@ CoinsViewEmpty& CoinsViewEmpty::Get()
     return instance;
 }
 
-std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const noexcept
 {
     if (auto it{cacheCoins.find(outpoint)}; it != cacheCoins.end()) {
         return it->second.coin.IsSpent() ? std::nullopt : std::optional{it->second.coin};
@@ -56,7 +56,8 @@ std::optional<Coin> CCoinsViewCache::FetchCoinFromBase(const COutPoint& outpoint
     return base->GetCoin(outpoint);
 }
 
-CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const {
+CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint& outpoint) const noexcept
+{
     const auto [ret, inserted] = cacheCoins.try_emplace(outpoint);
     if (inserted) {
         if (auto coin{FetchCoinFromBase(outpoint)}) {
@@ -71,7 +72,7 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const 
     return ret;
 }
 
-std::optional<Coin> CCoinsViewCache::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewCache::GetCoin(const COutPoint& outpoint) const noexcept
 {
     if (auto it{FetchCoin(outpoint)}; it != cacheCoins.end() && !it->second.coin.IsSpent()) return it->second.coin;
     return std::nullopt;
@@ -167,7 +168,8 @@ bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
 
 static const Coin coinEmpty;
 
-const Coin& CCoinsViewCache::AccessCoin(const COutPoint &outpoint) const {
+const Coin& CCoinsViewCache::AccessCoin(const COutPoint& outpoint) const noexcept
+{
     CCoinsMap::const_iterator it = FetchCoin(outpoint);
     if (it == cacheCoins.end()) {
         return coinEmpty;
@@ -176,13 +178,14 @@ const Coin& CCoinsViewCache::AccessCoin(const COutPoint &outpoint) const {
     }
 }
 
-bool CCoinsViewCache::HaveCoin(const COutPoint& outpoint) const
+bool CCoinsViewCache::HaveCoin(const COutPoint& outpoint) const noexcept
 {
     CCoinsMap::const_iterator it = FetchCoin(outpoint);
     return (it != cacheCoins.end() && !it->second.coin.IsSpent());
 }
 
-bool CCoinsViewCache::HaveCoinInCache(const COutPoint &outpoint) const {
+bool CCoinsViewCache::HaveCoinInCache(const COutPoint& outpoint) const noexcept
+{
     CCoinsMap::const_iterator it = cacheCoins.find(outpoint);
     return (it != cacheCoins.end() && !it->second.coin.IsSpent());
 }

--- a/src/coins.h
+++ b/src/coins.h
@@ -797,30 +797,4 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction& tx, int nHeight, bool 
 //! lookups to database, so it should be used with care.
 const Coin& AccessByTxid(const CCoinsViewCache& cache, const Txid& txid);
 
-/**
- * This is a minimally invasive approach to shutdown on LevelDB read errors from the
- * chainstate, while keeping user interface out of the common library, which is shared
- * between bitcoind, and bitcoin-qt and non-server tools.
- *
- * Writes do not need similar protection, as failure to write is handled by the caller.
-*/
-class CCoinsViewErrorCatcher final : public CCoinsViewBacked
-{
-public:
-    explicit CCoinsViewErrorCatcher(CCoinsView* view) : CCoinsViewBacked(view) {}
-
-    void AddReadErrCallback(std::function<void()> f) {
-        m_err_callbacks.emplace_back(std::move(f));
-    }
-
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
-    bool HaveCoin(const COutPoint& outpoint) const override;
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
-
-private:
-    /** A list of callbacks to execute upon leveldb read error. */
-    std::vector<std::function<void()>> m_err_callbacks;
-
-};
-
 #endif // BITCOIN_COINS_H

--- a/src/coins.h
+++ b/src/coins.h
@@ -787,30 +787,4 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction& tx, int nHeight, bool 
 //! lookups to database, so it should be used with care.
 const Coin& AccessByTxid(const CCoinsViewCache& cache, const Txid& txid);
 
-/**
- * This is a minimally invasive approach to shutdown on LevelDB read errors from the
- * chainstate, while keeping user interface out of the common library, which is shared
- * between bitcoind, and bitcoin-qt and non-server tools.
- *
- * Writes do not need similar protection, as failure to write is handled by the caller.
-*/
-class CCoinsViewErrorCatcher final : public CCoinsViewBacked
-{
-public:
-    explicit CCoinsViewErrorCatcher(CCoinsView* view) : CCoinsViewBacked(view) {}
-
-    void AddReadErrCallback(std::function<void()> f) {
-        m_err_callbacks.emplace_back(std::move(f));
-    }
-
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
-    bool HaveCoin(const COutPoint& outpoint) const override;
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
-
-private:
-    /** A list of callbacks to execute upon leveldb read error. */
-    std::vector<std::function<void()>> m_err_callbacks;
-
-};
-
 #endif // BITCOIN_COINS_H

--- a/src/coins.h
+++ b/src/coins.h
@@ -360,15 +360,15 @@ public:
 
     //! Retrieve the Coin (unspent transaction output) for a given outpoint.
     //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
-    virtual std::optional<Coin> GetCoin(const COutPoint& outpoint) const = 0;
+    virtual std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept = 0;
 
     //! Retrieve the Coin (unspent transaction output) for a given outpoint, without caching results.
     //! Does not populate the cache. Use GetCoin() to cache the result.
-    virtual std::optional<Coin> PeekCoin(const COutPoint& outpoint) const = 0;
+    virtual std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept = 0;
 
     //! Just check whether a given outpoint is unspent.
     //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
-    virtual bool HaveCoin(const COutPoint& outpoint) const = 0;
+    virtual bool HaveCoin(const COutPoint& outpoint) const noexcept = 0;
 
     //! Retrieve the block hash whose state this CCoinsView currently represents
     virtual uint256 GetBestBlock() const = 0;
@@ -399,9 +399,9 @@ public:
     CoinsViewEmpty(const CoinsViewEmpty&) = delete;
     CoinsViewEmpty& operator=(const CoinsViewEmpty&) = delete;
 
-    std::optional<Coin> GetCoin(const COutPoint&) const override { return {}; }
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return GetCoin(outpoint); }
-    bool HaveCoin(const COutPoint& outpoint) const override { return !!GetCoin(outpoint); }
+    std::optional<Coin> GetCoin(const COutPoint&) const noexcept override { return {}; }
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override { return GetCoin(outpoint); }
+    bool HaveCoin(const COutPoint& outpoint) const noexcept override { return !!GetCoin(outpoint); }
     uint256 GetBestBlock() const override { return {}; }
     std::vector<uint256> GetHeadBlocks() const override { return {}; }
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256&) override
@@ -422,9 +422,9 @@ public:
 
     void SetBackend(CCoinsView& in_view) { base = &in_view; }
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override { return base->GetCoin(outpoint); }
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return base->PeekCoin(outpoint); }
-    bool HaveCoin(const COutPoint& outpoint) const override { return base->HaveCoin(outpoint); }
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override { return base->GetCoin(outpoint); }
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override { return base->PeekCoin(outpoint); }
+    bool HaveCoin(const COutPoint& outpoint) const noexcept override { return base->HaveCoin(outpoint); }
     uint256 GetBestBlock() const override { return base->GetBestBlock(); }
     std::vector<uint256> GetHeadBlocks() const override { return base->GetHeadBlocks(); }
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override { base->BatchWrite(cursor, block_hash); }
@@ -449,7 +449,7 @@ private:
      * @note this is marked const, but may actually append to `cacheCoins`, increasing
      * memory usage.
      */
-    CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
+    CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const noexcept;
 
 protected:
     /**
@@ -485,9 +485,9 @@ public:
     CCoinsViewCache(const CCoinsViewCache &) = delete;
 
     // Standard CCoinsView methods
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
-    bool HaveCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override;
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override;
+    bool HaveCoin(const COutPoint& outpoint) const noexcept override;
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256& block_hash);
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override;
@@ -497,7 +497,7 @@ public:
      * The semantics are the same as HaveCoin(), but no calls to
      * the backing CCoinsView are made.
      */
-    bool HaveCoinInCache(const COutPoint &outpoint) const;
+    bool HaveCoinInCache(const COutPoint &outpoint) const noexcept;
 
     /**
      * Return a reference to Coin in the cache, or coinEmpty if not found. This is
@@ -509,7 +509,7 @@ public:
      * on! To be safe, best to not hold the returned reference through any other
      * calls to this cache.
      */
-    const Coin& AccessCoin(const COutPoint &output) const;
+    const Coin& AccessCoin(const COutPoint &output) const noexcept;
 
     /**
      * Add a coin. Set possible_overwrite to true if an unspent version may

--- a/src/coins.h
+++ b/src/coins.h
@@ -351,7 +351,7 @@ private:
     bool m_will_erase;
 };
 
-/** Pure abstract view on the open txout dataset. */
+/** Interface for operations required of coin-view backends. */
 class CCoinsView
 {
 public:
@@ -365,10 +365,6 @@ public:
     //! Retrieve the Coin (unspent transaction output) for a given outpoint, without caching results.
     //! Does not populate the cache. Use GetCoin() to cache the result.
     virtual std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept = 0;
-
-    //! Just check whether a given outpoint is unspent.
-    //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
-    virtual bool HaveCoin(const COutPoint& outpoint) const = 0;
 
     //! Retrieve the block hash whose state this CCoinsView currently represents
     virtual uint256 GetBestBlock() const = 0;
@@ -401,7 +397,6 @@ public:
 
     std::optional<Coin> GetCoin(const COutPoint&) const noexcept override { return {}; }
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override { return GetCoin(outpoint); }
-    bool HaveCoin(const COutPoint& outpoint) const override { return !!GetCoin(outpoint); }
     uint256 GetBestBlock() const override { return {}; }
     std::vector<uint256> GetHeadBlocks() const override { return {}; }
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256&) override
@@ -424,7 +419,6 @@ public:
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override { return base->GetCoin(outpoint); }
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override { return base->PeekCoin(outpoint); }
-    bool HaveCoin(const COutPoint& outpoint) const override { return base->HaveCoin(outpoint); }
     uint256 GetBestBlock() const override { return base->GetBestBlock(); }
     std::vector<uint256> GetHeadBlocks() const override { return base->GetHeadBlocks(); }
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override { base->BatchWrite(cursor, block_hash); }
@@ -487,10 +481,13 @@ public:
     // Standard CCoinsView methods
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override;
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override;
-    bool HaveCoin(const COutPoint& outpoint) const noexcept override;
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256& block_hash);
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override;
+
+    //! Check whether a given outpoint is unspent.
+    //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
+    bool HaveCoin(const COutPoint& outpoint) const noexcept;
 
     /**
      * Check if we have the given utxo already loaded in this cache.

--- a/src/coins.h
+++ b/src/coins.h
@@ -360,11 +360,11 @@ public:
 
     //! Retrieve the Coin (unspent transaction output) for a given outpoint.
     //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
-    virtual std::optional<Coin> GetCoin(const COutPoint& outpoint) const = 0;
+    virtual std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept = 0;
 
     //! Retrieve the Coin (unspent transaction output) for a given outpoint, without caching results.
     //! Does not populate the cache. Use GetCoin() to cache the result.
-    virtual std::optional<Coin> PeekCoin(const COutPoint& outpoint) const = 0;
+    virtual std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept = 0;
 
     //! Just check whether a given outpoint is unspent.
     //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
@@ -399,8 +399,8 @@ public:
     CoinsViewEmpty(const CoinsViewEmpty&) = delete;
     CoinsViewEmpty& operator=(const CoinsViewEmpty&) = delete;
 
-    std::optional<Coin> GetCoin(const COutPoint&) const override { return {}; }
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return GetCoin(outpoint); }
+    std::optional<Coin> GetCoin(const COutPoint&) const noexcept override { return {}; }
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override { return GetCoin(outpoint); }
     bool HaveCoin(const COutPoint& outpoint) const override { return !!GetCoin(outpoint); }
     uint256 GetBestBlock() const override { return {}; }
     std::vector<uint256> GetHeadBlocks() const override { return {}; }
@@ -422,8 +422,8 @@ public:
 
     void SetBackend(CCoinsView& in_view) { base = &in_view; }
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override { return base->GetCoin(outpoint); }
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return base->PeekCoin(outpoint); }
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override { return base->GetCoin(outpoint); }
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override { return base->PeekCoin(outpoint); }
     bool HaveCoin(const COutPoint& outpoint) const override { return base->HaveCoin(outpoint); }
     uint256 GetBestBlock() const override { return base->GetBestBlock(); }
     std::vector<uint256> GetHeadBlocks() const override { return base->GetHeadBlocks(); }
@@ -449,7 +449,7 @@ private:
      * @note this is marked const, but may actually append to `cacheCoins`, increasing
      * memory usage.
      */
-    CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
+    CCoinsMap::iterator FetchCoin(const COutPoint& outpoint) const noexcept;
 
 protected:
     /**
@@ -485,9 +485,9 @@ public:
     CCoinsViewCache(const CCoinsViewCache &) = delete;
 
     // Standard CCoinsView methods
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
-    bool HaveCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override;
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override;
+    bool HaveCoin(const COutPoint& outpoint) const noexcept override;
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256& block_hash);
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override;
@@ -497,7 +497,7 @@ public:
      * The semantics are the same as HaveCoin(), but no calls to
      * the backing CCoinsView are made.
      */
-    bool HaveCoinInCache(const COutPoint &outpoint) const;
+    bool HaveCoinInCache(const COutPoint& outpoint) const noexcept;
 
     /**
      * Return a reference to Coin in the cache, or coinEmpty if not found. This is
@@ -509,7 +509,7 @@ public:
      * on! To be safe, best to not hold the returned reference through any other
      * calls to this cache.
      */
-    const Coin& AccessCoin(const COutPoint &output) const;
+    const Coin& AccessCoin(const COutPoint& output) const noexcept;
 
     /**
      * Add a coin. Set possible_overwrite to true if an unspent version may

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -218,7 +218,9 @@ struct LevelDBContext {
 };
 
 CDBWrapper::CDBWrapper(const DBParams& params)
-    : m_db_context{std::make_unique<LevelDBContext>()}, m_name{fs::PathToString(params.path.stem())}
+    : m_db_context{std::make_unique<LevelDBContext>()},
+      m_name{fs::PathToString(params.path.stem())},
+      m_read_error_cb{params.read_error_cb}
 {
     DBContext().penv = nullptr;
     DBContext().readoptions.verify_checksums = true;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdarg>
+#include <cstdlib>
 #include <cstdint>
 #include <cstdio>
 #include <memory>
@@ -329,10 +330,16 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
     if (!status.ok()) {
         if (status.IsNotFound())
             return std::nullopt;
-        LogError("LevelDB read failure: %s", status.ToString());
-        HandleError(status);
+        FatalReadError(strprintf("LevelDB read failure: %s", status.ToString()));
     }
     return strValue;
+}
+
+[[noreturn]] void CDBWrapper::FatalReadError(const std::string& message) const
+{
+    LogError("%s", message);
+    m_read_error_cb();
+    std::abort();
 }
 
 size_t CDBWrapper::EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -333,21 +333,6 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
     return strValue;
 }
 
-bool CDBWrapper::ExistsImpl(std::span<const std::byte> key) const
-{
-    leveldb::Slice slKey(CharCast(key.data()), key.size());
-
-    std::string strValue;
-    leveldb::Status status = DBContext().pdb->Get(DBContext().readoptions, slKey, &strValue);
-    if (!status.ok()) {
-        if (status.IsNotFound())
-            return false;
-        LogError("LevelDB read failure: %s", status.ToString());
-        HandleError(status);
-    }
-    return true;
-}
-
 size_t CDBWrapper::EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const
 {
     leveldb::Slice slKey1(CharCast(key1.data()), key1.size());

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -357,21 +357,6 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
     return strValue;
 }
 
-bool CDBWrapper::ExistsImpl(std::span<const std::byte> key) const
-{
-    leveldb::Slice slKey(CharCast(key.data()), key.size());
-
-    std::string strValue;
-    leveldb::Status status = DBContext().pdb->Get(DBContext().readoptions, slKey, &strValue);
-    if (!status.ok()) {
-        if (status.IsNotFound())
-            return false;
-        LogError("LevelDB read failure: %s", status.ToString());
-        HandleError(status);
-    }
-    return true;
-}
-
 size_t CDBWrapper::EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const
 {
     leveldb::Slice slKey1(CharCast(key1.data()), key1.size());

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -242,7 +242,9 @@ struct LevelDBContext {
 };
 
 CDBWrapper::CDBWrapper(const DBParams& params)
-    : m_db_context{std::make_unique<LevelDBContext>()}, m_name{fs::PathToString(params.path.stem())}
+    : m_db_context{std::make_unique<LevelDBContext>()},
+      m_name{fs::PathToString(params.path.stem())},
+      m_read_error_cb{params.read_error_cb}
 {
     DBContext().penv = nullptr;
     DBContext().readoptions.verify_checksums = true;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -33,6 +33,7 @@
 #include <cstdlib>
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <utility>
 
 static auto CharCast(const std::byte* data) { return reinterpret_cast<const char*>(data); }
@@ -354,11 +355,16 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
     if (!status.ok()) {
         if (status.IsNotFound())
             return std::nullopt;
-        LogError("LevelDB read failure in %s: %s", m_name, status.ToString());
-        if (m_read_error_cb) m_read_error_cb();
-        std::abort();
+        FatalReadError("LevelDB read failure", status.ToString());
     }
     return strValue;
+}
+
+void CDBWrapper::FatalReadError(std::string_view what, std::string_view detail) const
+{
+    LogError("%s in %s: %s", what, m_name, detail);
+    if (m_read_error_cb) m_read_error_cb();
+    std::abort();
 }
 
 size_t CDBWrapper::EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -30,6 +30,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -243,7 +244,7 @@ struct LevelDBContext {
 
 CDBWrapper::CDBWrapper(const DBParams& params)
     : m_db_context{std::make_unique<LevelDBContext>()},
-      m_name{fs::PathToString(params.path.stem())},
+      m_name{fs::PathToString(params.path)},
       m_read_error_cb{params.read_error_cb}
 {
     DBContext().penv = nullptr;
@@ -353,8 +354,9 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
     if (!status.ok()) {
         if (status.IsNotFound())
             return std::nullopt;
-        LogError("LevelDB read failure: %s", status.ToString());
-        HandleError(status);
+        LogError("LevelDB read failure in %s: %s", m_name, status.ToString());
+        if (m_read_error_cb) m_read_error_cb();
+        std::abort();
     }
     return strValue;
 }

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -206,7 +206,6 @@ private:
     inline static const std::string OBFUSCATION_KEY{"\000obfuscate_key", 14}; // explicit size to avoid truncation at leading \0
 
     std::optional<std::string> ReadImpl(std::span<const std::byte> key) const;
-    bool ExistsImpl(std::span<const std::byte> key) const;
     size_t EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const;
     auto& DBContext() const LIFETIMEBOUND { return *Assert(m_db_context); }
 
@@ -244,10 +243,7 @@ public:
     template <typename K>
     bool Exists(const K& key) const
     {
-        DataStream ssKey{};
-        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey << key;
-        return ExistsImpl(ssKey);
+        return !!ReadRaw(key);
     }
 
     template <typename K, typename V>

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -22,6 +22,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace leveldb {
 class Env;
@@ -167,10 +168,10 @@ public:
         try {
             SpanReader ssKey{GetKeyImpl()};
             ssKey >> key;
+            return true;
         } catch (const std::exception&) {
             return false;
         }
-        return true;
     }
 
     template<typename V> bool GetValue(V& value) {
@@ -179,10 +180,10 @@ public:
             m_scratch.write(GetValueImpl());
             dbwrapper_private::GetObfuscation(parent)(m_scratch);
             m_scratch >> value;
+            return true;
         } catch (const std::exception&) {
             return false;
         }
-        return true;
     }
 };
 
@@ -216,32 +217,28 @@ public:
     CDBWrapper(const CDBWrapper&) = delete;
     CDBWrapper& operator=(const CDBWrapper&) = delete;
 
-    template <typename K, typename V>
-    bool Read(const K& key, V& value) const
+    template <typename K>
+    std::optional<std::string> ReadRaw(const K& key) const
     {
         DataStream ssKey{};
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        std::optional<std::string> strValue{ReadImpl(ssKey)};
-        if (!strValue) {
-            return false;
-        }
+        return ReadImpl(ssKey);
+    }
+
+    template <typename K, typename V>
+    bool Read(const K& key, V& value) const
+    {
+        auto strValue{ReadRaw(key)};
+        if (!strValue) return false;
         try {
             std::span ssValue{MakeWritableByteSpan(*strValue)};
             m_obfuscation(ssValue);
             SpanReader{ssValue} >> value;
+            return true;
         } catch (const std::exception&) {
             return false;
         }
-        return true;
-    }
-
-    template <typename K, typename V>
-    void Write(const K& key, const V& value, bool fSync = false)
-    {
-        CDBBatch batch(*this);
-        batch.Write(key, value);
-        WriteBatch(batch, fSync);
     }
 
     template <typename K>
@@ -251,6 +248,14 @@ public:
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
         return ExistsImpl(ssKey);
+    }
+
+    template <typename K, typename V>
+    void Write(const K& key, const V& value, bool fSync = false)
+    {
+        CDBBatch batch(*this);
+        batch.Write(key, value);
+        WriteBatch(batch, fSync);
     }
 
     template <typename K>

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <span>
@@ -53,6 +54,11 @@ struct DBParams {
     bool obfuscate = false;
     //! If true, build a LevelDB bloom filter to accelerate point lookups.
     bool bloom_filter = true;
+    //! Callback executed on fatal read failures.
+    //!
+    //! Called synchronously from database read paths. It must be safe to call
+    //! from any thread, with or without locks held.
+    std::function<void()> read_error_cb{[] {}};
     //! Passed-through options.
     DBOptions options{};
     //! If non-null, use this as the leveldb::Env instead of the default.
@@ -201,6 +207,9 @@ private:
 
     //! optional XOR-obfuscation of the database
     Obfuscation m_obfuscation;
+
+    //! Callback executed on fatal read failures.
+    std::function<void()> m_read_error_cb;
 
     //! obfuscation key storage key, null-prefixed to avoid collisions
     inline static const std::string OBFUSCATION_KEY{"\000obfuscate_key", 14}; // explicit size to avoid truncation at leading \0

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -9,6 +9,7 @@
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
+#include <tinyformat.h>
 #include <util/byte_units.h>
 #include <util/check.h>
 #include <util/fs.h>
@@ -215,6 +216,7 @@ private:
     inline static const std::string OBFUSCATION_KEY{"\000obfuscate_key", 14}; // explicit size to avoid truncation at leading \0
 
     std::optional<std::string> ReadImpl(std::span<const std::byte> key) const;
+    [[noreturn]] void FatalReadError(const std::string& message) const;
     size_t EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const;
     auto& DBContext() const LIFETIMEBOUND { return *Assert(m_db_context); }
 
@@ -244,8 +246,8 @@ public:
             m_obfuscation(ssValue);
             SpanReader{ssValue} >> value;
             return true;
-        } catch (const std::exception&) {
-            return false;
+        } catch (const std::exception& e) {
+            FatalReadError(strprintf("Corrupted database entry in %s: %s", m_name, e.what()));
         }
     }
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -206,9 +206,17 @@ private:
     inline static const std::string OBFUSCATION_KEY{"\000obfuscate_key", 14}; // explicit size to avoid truncation at leading \0
 
     std::optional<std::string> ReadImpl(std::span<const std::byte> key) const;
-    bool ExistsImpl(std::span<const std::byte> key) const;
     size_t EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const;
     auto& DBContext() const LIFETIMEBOUND { return *Assert(m_db_context); }
+
+    template <typename K>
+    std::optional<std::string> ReadRaw(const K& key) const
+    {
+        DataStream ssKey{};
+        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
+        ssKey << key;
+        return ReadImpl(ssKey);
+    }
 
 public:
     CDBWrapper(const DBParams& params);
@@ -306,10 +314,7 @@ public:
     template <typename K>
     bool Exists(const K& key) const
     {
-        DataStream ssKey{};
-        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey << key;
-        return ExistsImpl(ssKey);
+        return !!ReadRaw(key);
     }
 
     template <typename K>

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -294,24 +294,20 @@ public:
         return true;
     }
 
-    /**
-     * Wrapper around TryRead() that preserves the original Read() semantics:
-     * returns true on success, false if the key is absent or deserialization
-     * fails, and throws dbwrapper_error on an internal DB error.
-     *
-     * Prefer TryRead() when the caller needs to distinguish between a missing
-     * key and a corrupt value.
-     */
+    //! Returns false only for a missing key. LevelDB and value-deserialization errors are fatal.
     template <typename K, typename V>
     bool Read(const K& key, V& value) const
     {
-        const ReadStatus res = TryRead(key,value);
-        if (res.has_value()) return res.value();
-        switch (const auto& [err_code, err_msg] = res.error(); err_code) {
-            case ReadFailure::Code::DeserializationError: return false;
-            case ReadFailure::Code::DatabaseError: throw dbwrapper_error(err_msg);
-        } // no default case, so the compiler can warn about missing cases
-        std::abort(); // unreachable
+        auto strValue{ReadRaw(key)};
+        if (!strValue) return false;
+        try {
+            std::span ssValue{MakeWritableByteSpan(*strValue)};
+            m_obfuscation(ssValue);
+            SpanReader{ssValue} >> value;
+        } catch (const std::exception& e) {
+            FatalReadError("Corrupted database entry", e.what());
+        }
+        return true;
     }
 
     template <typename K, typename V>

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <span>
@@ -53,6 +54,10 @@ struct DBParams {
     bool obfuscate = false;
     //! If true, build a LevelDB bloom filter to accelerate point lookups.
     bool bloom_filter = true;
+    //! Invoked right before the process aborts on a read failure.
+    //! Runs synchronously from database reads, potentially on any thread while locks are held.
+    //! The callback must be safe in that context.
+    std::function<void()> read_error_cb{};
     //! Passed-through options.
     DBOptions options{};
     //! If non-null, use this as the leveldb::Env instead of the default.
@@ -201,6 +206,9 @@ private:
 
     //! optional XOR-obfuscation of the database
     Obfuscation m_obfuscation;
+
+    //! runs before aborting on a read failure
+    std::function<void()> m_read_error_cb;
 
     //! obfuscation key storage key, null-prefixed to avoid collisions
     inline static const std::string OBFUSCATION_KEY{"\000obfuscate_key", 14}; // explicit size to avoid truncation at leading \0

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -24,6 +24,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace leveldb {
 class Env;
@@ -214,6 +215,8 @@ private:
     inline static const std::string OBFUSCATION_KEY{"\000obfuscate_key", 14}; // explicit size to avoid truncation at leading \0
 
     std::optional<std::string> ReadImpl(std::span<const std::byte> key) const;
+    //! Aborts rather than returning "not found", which would misreport an unreadable database as a missing entry
+    [[noreturn]] void FatalReadError(std::string_view what, std::string_view detail) const;
     size_t EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const;
     auto& DBContext() const LIFETIMEBOUND { return *Assert(m_db_context); }
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -11,7 +11,6 @@
 #include <streams.h>
 #include <util/byte_units.h>
 #include <util/check.h>
-#include <util/expected.h>
 #include <util/fs.h>
 #include <util/obfuscation.h>
 
@@ -236,67 +235,9 @@ public:
     CDBWrapper(const CDBWrapper&) = delete;
     CDBWrapper& operator=(const CDBWrapper&) = delete;
 
-    struct ReadFailure {
-        enum class Code {
-            DeserializationError,   //!< Key exists but value could not be deserialized.
-            DatabaseError,          //!< Unexpected internal DB error.
-        };
-
-        Code status;
-        std::string err_msg;
-    };
-
-    using ReadStatus = util::Expected<bool, ReadFailure>;
-
-    /**
-     * Read and deserialize a value from the database, with explicit error discrimination.
-     *
-     * Unlike Read(), this method distinguishes between a missing key, a deserialization
-     * failure (DeserializationError), and an internal DB error (DatabaseError),
-     * enabling callers to treat data corruption differently from an absent entry.
-     *
-     * @note Callers are expected to provide well-formed keys; key serialization
-     *       is the only operation that may throw.
-     *
-     * @param[in]  key    The key to look up.
-     * @param[out] value  Populated with the deserialized value when the returned
-     *                    Expected holds true; indeterminate otherwise.
-     * @return On success, true if the key was found (value populated) or false if
-     *         the key was absent. On failure, a ReadFailure describing the error.
-     */
-    template <typename K, typename V>
-    [[nodiscard]] ReadStatus TryRead(const K& key, V& value) const
-    {
-        DataStream ssKey{};
-        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        // Key serialization is the only operation that may throw.
-        // Callers are expected to provide well-formed keys.
-        ssKey << key;
-
-        std::optional<std::string> strValue;
-        try {
-            strValue = ReadImpl(ssKey);
-            if (!strValue) {
-                return false; // not found
-            }
-        } catch (const std::exception& e) {
-            return util::Unexpected(ReadFailure{ReadFailure::Code::DatabaseError, e.what()});
-        }
-
-        try {
-            std::span ssValue{MakeWritableByteSpan(*strValue)};
-            m_obfuscation(ssValue);
-            SpanReader{ssValue} >> value;
-        } catch (const std::exception& e) {
-            return util::Unexpected(ReadFailure{ReadFailure::Code::DeserializationError, e.what()});
-        }
-
-        return true;
-    }
-
     //! Returns false only for a missing key. LevelDB and value-deserialization errors are fatal.
     template <typename K, typename V>
-    bool Read(const K& key, V& value) const
+    [[nodiscard]] bool Read(const K& key, V& value) const
     {
         auto strValue{ReadRaw(key)};
         if (!strValue) return false;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -65,7 +65,8 @@ CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
     return locator;
 }
 
-BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom) :
+BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe,
+                  bool f_obfuscate, bool f_bloom, std::function<void()> read_error_cb) :
     CDBWrapper{DBParams{
         .path = path,
         .cache_bytes = n_cache_size,
@@ -73,6 +74,7 @@ BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool
         .wipe_data = f_wipe,
         .obfuscate = f_obfuscate,
         .bloom_filter = f_bloom,
+        .read_error_cb = std::move(read_error_cb),
         .options = [] { DBOptions options; node::ReadDatabaseArgs(gArgs, options); return options; }()}}
 {}
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -65,7 +66,9 @@ protected:
     {
     public:
         DB(const fs::path& path, size_t n_cache_size,
-           bool f_memory = false, bool f_wipe = false, bool f_obfuscate = false, bool f_bloom = true);
+           bool f_memory = false, bool f_wipe = false,
+           bool f_obfuscate = false, bool f_bloom = true,
+           std::function<void()> read_error_cb = [] {});
 
         /// Read block locator of the chain that the index is in sync with.
         /// Note, the returned locator will be empty if no record exists.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -65,7 +66,9 @@ protected:
     {
     public:
         DB(const fs::path& path, size_t n_cache_size,
-           bool f_memory = false, bool f_wipe = false, bool f_obfuscate = false, bool f_bloom = true);
+           bool f_memory = false, bool f_wipe = false,
+           bool f_obfuscate = false, bool f_bloom = true,
+           std::function<void()> read_error_cb = {});
         virtual ~DB() = default;
 
         /// Read block locator of the chain that the index is in sync with.

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -108,9 +108,8 @@ interfaces::Chain::NotifyOptions BlockFilterIndex::CustomOptions()
 bool BlockFilterIndex::CustomInit(const std::optional<interfaces::BlockRef>& block)
 {
     if (!m_db->Read(DB_FILTER_POS, m_next_filter_pos)) {
-        // Check that the cause of the read failure is that the key does not exist. Any other errors
-        // indicate database corruption or a disk failure, and starting the index would cause
-        // further corruption.
+        // TODO: Drop this Read+Exists pattern. Read() now terminates on corruption,
+        // so this branch should only represent the missing-key initialization path.
         if (m_db->Exists(DB_FILTER_POS)) {
             LogError("Cannot read current %s state; index may be corrupted",
                       GetName());

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -83,7 +83,8 @@ struct DBVal {
 static std::map<BlockFilterType, BlockFilterIndex> g_filter_indexes;
 
 BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
-                                   size_t n_cache_size, bool f_memory, bool f_wipe)
+                                   size_t n_cache_size, bool f_memory, bool f_wipe,
+                                   std::function<void()> read_error_cb)
     : BaseIndex(std::move(chain), BlockFilterTypeName(filter_type) + " block filter index", BlockFilterThreadName(filter_type))
     , m_filter_type(filter_type)
 {
@@ -93,7 +94,7 @@ BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, Blo
     fs::path path = gArgs.GetDataDirNet() / "indexes" / "blockfilter" / fs::u8path(filter_name);
     fs::create_directories(path);
 
-    m_db = std::make_unique<BaseIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
+    m_db = std::make_unique<BaseIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom*/true, std::move(read_error_cb));
     m_filter_fileseq = std::make_unique<FlatFileSeq>(std::move(path), "fltr", FLTR_FILE_CHUNK_SIZE);
 }
 
@@ -453,12 +454,13 @@ void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn)
 }
 
 bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
-                          size_t n_cache_size, bool f_memory, bool f_wipe)
+                          size_t n_cache_size, bool f_memory, bool f_wipe, std::function<void()> read_error_cb)
 {
     auto result = g_filter_indexes.emplace(std::piecewise_construct,
                                            std::forward_as_tuple(filter_type),
                                            std::forward_as_tuple(make_chain(), filter_type,
-                                                                 n_cache_size, f_memory, f_wipe));
+                                                                 n_cache_size, f_memory, f_wipe,
+                                                                 std::move(read_error_cb)));
     return result.second;
 }
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -84,7 +84,8 @@ struct DBVal {
 static std::map<BlockFilterType, BlockFilterIndex> g_filter_indexes;
 
 BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
-                                   size_t n_cache_size, bool f_memory, bool f_wipe)
+                                   size_t n_cache_size, bool f_memory, bool f_wipe,
+                                   std::function<void()> read_error_cb)
     : BaseIndex(std::move(chain), BlockFilterTypeName(filter_type) + " block filter index", BlockFilterThreadName(filter_type))
     , m_filter_type(filter_type)
 {
@@ -94,7 +95,7 @@ BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, Blo
     fs::path path = gArgs.GetDataDirNet() / "indexes" / "blockfilter" / fs::u8path(filter_name);
     fs::create_directories(path);
 
-    m_db = std::make_unique<BaseIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
+    m_db = std::make_unique<BaseIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/true, std::move(read_error_cb));
     m_filter_fileseq = std::make_unique<FlatFileSeq>(std::move(path), "fltr", FLTR_FILE_CHUNK_SIZE);
 }
 
@@ -454,12 +455,13 @@ void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn)
 }
 
 bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
-                          size_t n_cache_size, bool f_memory, bool f_wipe)
+                          size_t n_cache_size, bool f_memory, bool f_wipe, std::function<void()> read_error_cb)
 {
     auto result = g_filter_indexes.emplace(std::piecewise_construct,
                                            std::forward_as_tuple(filter_type),
                                            std::forward_as_tuple(make_chain(), filter_type,
-                                                                 n_cache_size, f_memory, f_wipe));
+                                                                 n_cache_size, f_memory, f_wipe,
+                                                                 std::move(read_error_cb)));
     return result.second;
 }
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -109,15 +109,6 @@ interfaces::Chain::NotifyOptions BlockFilterIndex::CustomOptions()
 bool BlockFilterIndex::CustomInit(const std::optional<interfaces::BlockRef>& block)
 {
     if (!m_db->Read(DB_FILTER_POS, m_next_filter_pos)) {
-        // Check that the cause of the read failure is that the key does not exist. Any other errors
-        // indicate database corruption or a disk failure, and starting the index would cause
-        // further corruption.
-        if (m_db->Exists(DB_FILTER_POS)) {
-            LogError("Cannot read current %s state; index may be corrupted",
-                      GetName());
-            return false;
-        }
-
         // If the DB_FILTER_POS is not set, then initialize to the first location.
         m_next_filter_pos.nFile = 0;
         m_next_filter_pos.nPos = 0;

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -76,7 +76,8 @@ protected:
 public:
     /** Constructs the index, which becomes available to be queried. */
     explicit BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
-                              size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+                              size_t n_cache_size, bool f_memory = false, bool f_wipe = false,
+                              std::function<void()> read_error_cb = [] {});
 
     interfaces::Chain::NotifyOptions CustomOptions() override;
 
@@ -111,7 +112,8 @@ void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn);
  * a new index is created and false if one has already been initialized.
  */
 bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
-                          size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+                          size_t n_cache_size, bool f_memory = false, bool f_wipe = false,
+                          std::function<void()> read_error_cb = [] {});
 
 /**
  * Destroy the block filter index with the given type. Returns false if no such index exists. This

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -76,7 +76,8 @@ protected:
 public:
     /** Constructs the index, which becomes available to be queried. */
     explicit BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
-                              size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+                              size_t n_cache_size, bool f_memory = false, bool f_wipe = false,
+                              std::function<void()> read_error_cb = {});
 
     interfaces::Chain::NotifyOptions CustomOptions() override;
 
@@ -111,7 +112,8 @@ void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn);
  * a new index is created and false if one has already been initialized.
  */
 bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
-                          size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+                          size_t n_cache_size, bool f_memory = false, bool f_wipe = false,
+                          std::function<void()> read_error_cb = {});
 
 /**
  * Destroy the block filter index with the given type. Returns false if no such index exists. This

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -263,9 +263,8 @@ std::optional<CCoinsStats> CoinStatsIndex::LookUpStats(const CBlockIndex& block_
 bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockRef>& block)
 {
     if (!m_db->Read(DB_MUHASH, m_muhash)) {
-        // Check that the cause of the read failure is that the key does not
-        // exist. Any other errors indicate database corruption or a disk
-        // failure, and starting the index would cause further corruption.
+        // TODO: Drop this Read+Exists pattern. Read() now terminates on corruption,
+        // so this branch should only represent the missing-key initialization path.
         if (m_db->Exists(DB_MUHASH)) {
             LogError("Cannot read current %s state; index may be corrupted",
                       GetName());

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -86,7 +86,8 @@ struct DBVal {
 
 std::unique_ptr<CoinStatsIndex> g_coin_stats_index;
 
-CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
+CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe,
+                               std::function<void()> read_error_cb)
     : BaseIndex(std::move(chain), "coinstatsindex", "coinstatsidx")
 {
     // An earlier version of the index used "indexes/coinstats" but it contained
@@ -102,7 +103,7 @@ CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t 
     fs::path path{gArgs.GetDataDirNet() / "indexes" / "coinstatsindex"};
     fs::create_directories(path);
 
-    m_db = std::make_unique<CoinStatsIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
+    m_db = std::make_unique<CoinStatsIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false,  /*f_bloom*/true, std::move(read_error_cb));
 }
 
 bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -86,7 +86,8 @@ struct DBVal {
 
 std::unique_ptr<CoinStatsIndex> g_coin_stats_index;
 
-CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
+CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe,
+                               std::function<void()> read_error_cb)
     : BaseIndex(std::move(chain), "coinstatsindex", "coinstatsidx")
 {
     // An earlier version of the index used "indexes/coinstats" but it contained
@@ -102,7 +103,7 @@ CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t 
     fs::path path{gArgs.GetDataDirNet() / "indexes" / "coinstatsindex"};
     fs::create_directories(path);
 
-    m_db = std::make_unique<CoinStatsIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
+    m_db = std::make_unique<CoinStatsIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/true, std::move(read_error_cb));
 }
 
 bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -262,16 +262,7 @@ std::optional<CCoinsStats> CoinStatsIndex::LookUpStats(const CBlockIndex& block_
 
 bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockRef>& block)
 {
-    if (!m_db->Read(DB_MUHASH, m_muhash)) {
-        // Check that the cause of the read failure is that the key does not
-        // exist. Any other errors indicate database corruption or a disk
-        // failure, and starting the index would cause further corruption.
-        if (m_db->Exists(DB_MUHASH)) {
-            LogError("Cannot read current %s state; index may be corrupted",
-                      GetName());
-            return false;
-        }
-    }
+    (void)m_db->Read(DB_MUHASH, m_muhash); // Absent on a fresh index
 
     if (block) {
         DBVal entry;

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -64,7 +65,8 @@ protected:
 
 public:
     // Constructs the index, which becomes available to be queried.
-    explicit CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false,
+                            std::function<void()> read_error_cb = [] {});
 
     interfaces::Chain::NotifyOptions CustomOptions() override;
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -64,7 +65,8 @@ protected:
 
 public:
     // Constructs the index, which becomes available to be queried.
-    explicit CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false,
+                            std::function<void()> read_error_cb = {});
 
     interfaces::Chain::NotifyOptions CustomOptions() override;
 

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<TxIndex> g_txindex;
 class TxIndex::DB : public BaseIndex::DB
 {
 public:
-    explicit DB(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit DB(size_t n_cache_size, bool f_memory = false, bool f_wipe = false, std::function<void()> read_error_cb = [] {});
 
     /// Read the disk location of the transaction data with the given hash. Returns false if the
     /// transaction hash is not indexed.
@@ -47,8 +47,8 @@ public:
     void WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos);
 };
 
-TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
-    BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "txindex", n_cache_size, f_memory, f_wipe)
+TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, std::function<void()> read_error_cb) :
+    BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "txindex", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom*/true, std::move(read_error_cb))
 {}
 
 bool TxIndex::DB::ReadTxPos(const Txid& txid, CDiskTxPos& pos) const
@@ -65,8 +65,10 @@ void TxIndex::DB::WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos
     WriteBatch(batch);
 }
 
-TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txindex", "txidx"), m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
+TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe,
+                 std::function<void()> read_error_cb)
+    : BaseIndex(std::move(chain), "txindex", "txidx"),
+      m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe, std::move(read_error_cb)))
 {}
 
 TxIndex::~TxIndex() = default;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -57,7 +57,7 @@ SipHasher13UJ ReadOrCreateTxidHasher(CDBWrapper& db)
 class TxIndex::DB : public BaseIndex::DB
 {
 public:
-    explicit DB(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit DB(size_t n_cache_size, bool f_memory = false, bool f_wipe = false, std::function<void()> read_error_cb = {});
 
     /// Write a block of transaction positions to the DB.
     void WriteTxs(const interfaces::BlockInfo& block);
@@ -72,23 +72,24 @@ public:
     void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator) override;
 
 private:
-    DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool has_legacy);
+    DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool has_legacy, std::function<void()> read_error_cb);
 };
 
 static fs::path TxIndexDBPath() { return gArgs.GetDataDirNet() / "indexes" / "txindex"; }
 
-TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
+TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, std::function<void()> read_error_cb) :
     // Bloom filters are built for every key but only consulted by point reads,
     // which iterators bypass: the per-tx hashed ('x') lookups seek with an
     // iterator, and the 's'/'h' point reads are at most one per block against a
     // tiny keyspace. Only the legacy entries' per-tx point lookups benefit, so
     // enable the filters only for databases still containing them.
     DB(n_cache_size, f_memory, f_wipe,
-       /*has_legacy=*/!f_memory && !f_wipe && CDBWrapper::HasKeyStartingWith(TxIndexDBPath(), txindex::DB_TXINDEX))
+       /*has_legacy=*/!f_memory && !f_wipe && CDBWrapper::HasKeyStartingWith(TxIndexDBPath(), txindex::DB_TXINDEX),
+       std::move(read_error_cb))
 {}
 
-TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool has_legacy) :
-    BaseIndex::DB(TxIndexDBPath(), n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/has_legacy),
+TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool has_legacy, std::function<void()> read_error_cb) :
+    BaseIndex::DB(TxIndexDBPath(), n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/has_legacy, std::move(read_error_cb)),
     m_hasher{ReadOrCreateTxidHasher(*this)},
     m_has_legacy{has_legacy}
 {}
@@ -132,8 +133,10 @@ void TxIndex::DB::WriteTxs(const interfaces::BlockInfo& block)
     WriteBatch(batch);
 }
 
-TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txindex", "txidx"), m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
+TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe,
+                 std::function<void()> read_error_cb)
+    : BaseIndex(std::move(chain), "txindex", "txidx"),
+      m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe, std::move(read_error_cb)))
 {
     if (m_db->m_has_legacy) {
         LogInfo("txindex contains entries in the legacy format, which uses excessive disk space. "

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -117,7 +117,7 @@ void TxIndex::DB::WriteTxs(const interfaces::BlockInfo& block)
     if (Exists(txindex::BlockHashKey{block.hash})) return;
 
     uint32_t block_seq{0};
-    Read(txindex::DB_NEXT_BLOCK_SEQ, block_seq);
+    (void)Read(txindex::DB_NEXT_BLOCK_SEQ, block_seq);
 
     CDBBatch batch(*this);
     batch.Write(txindex::BlockHashKey{block.hash}, block_seq);

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -9,6 +9,7 @@
 #include <primitives/transaction.h>
 
 #include <cstddef>
+#include <functional>
 #include <memory>
 
 class uint256;
@@ -40,7 +41,8 @@ protected:
 
 public:
     /// Constructs the index, which becomes available to be queried.
-    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false,
+                     std::function<void()> read_error_cb = [] {});
 
     // Destructor is declared because this class contains a unique_ptr to an incomplete type.
     virtual ~TxIndex() override;

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -10,6 +10,7 @@
 #include <uint256.h>
 
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -54,7 +55,8 @@ protected:
 
 public:
     /// Constructs the index, which becomes available to be queried.
-    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false,
+                     std::function<void()> read_error_cb = {});
 
     // Destructor is declared because this class contains a unique_ptr to an incomplete type.
     virtual ~TxIndex() override;

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -61,8 +61,9 @@ struct DBKey {
     }
 };
 
-TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/false)}
+TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe,
+                                 std::function<void()> read_error_cb)
+    : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/false, std::move(read_error_cb))}
 {
     if (!m_db->Read("siphash_key", m_siphash_key)) {
         FastRandomContext rng(false);

--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -13,6 +13,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -53,7 +54,8 @@ protected:
     BaseIndex::DB& GetDB() const override;
 
 public:
-    explicit TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false,
+                             std::function<void()> read_error_cb = {});
 
     /**
      * Search the index for a transaction that spends the given outpoint.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1422,7 +1422,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     options.require_full_verification = args.IsArgSet("-checkblocks") || args.IsArgSet("-checklevel");
     options.coins_error_cb = [] {
         uiInterface.ThreadSafeMessageBox(
-            _("Error reading from database, shutting down."),
+            _("Cannot read from database, shutting down."),
             CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1332,7 +1332,8 @@ static ChainstateLoadResult InitAndLoadChainstate(
     bool do_reindex,
     const bool do_reindex_chainstate,
     const kernel::CacheSizes& cache_sizes,
-    const ArgsManager& args)
+    const ArgsManager& args,
+    const std::function<void()>& read_error_cb)
 {
     // This function may be called twice, so any dirty state must be reset.
     node.notifications->setChainstateLoaded(false); // Drop state, such as a cached tip block
@@ -1361,6 +1362,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
         .datadir = args.GetDataDirNet(),
+        .read_error_cb = read_error_cb,
         .notifications = *node.notifications,
         .signals = node.validation_signals.get(),
     };
@@ -1374,6 +1376,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
             .path = args.GetDataDirNet() / "blocks" / "index",
             .cache_bytes = cache_sizes.block_tree_db,
             .wipe_data = do_reindex,
+            .read_error_cb = read_error_cb,
         },
     };
     Assert(ApplyArgsManOptions(args, blockman_opts)); // no error can happen, already checked in AppInitParameterInteraction
@@ -1420,11 +1423,6 @@ static ChainstateLoadResult InitAndLoadChainstate(
     options.check_blocks = args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = args.IsArgSet("-checkblocks") || args.IsArgSet("-checklevel");
-    options.coins_error_cb = [] {
-        uiInterface.ThreadSafeMessageBox(
-            _("Cannot read from database, shutting down."),
-            CClientUIInterface::MSG_ERROR);
-    };
     uiInterface.InitMessage(_("Loading block index…"));
     auto catch_exceptions = [](auto&& f) -> ChainstateLoadResult {
         try {
@@ -1881,6 +1879,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     bool do_reindex{args.GetBoolArg("-reindex", false)};
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};
+    const std::function<void()> read_error_cb{[&node] {
+        node.notifications->fatalError(_("Cannot read from database, shutting down."));
+    }};
 
     // Chainstate initialization and loading may be retried once with reindexing by GUI users
     auto [status, error] = InitAndLoadChainstate(
@@ -1888,7 +1889,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         do_reindex,
         do_reindex_chainstate,
         kernel_cache_sizes,
-        args);
+        args,
+        read_error_cb);
     if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
         // suggest a reindex
         bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
@@ -1908,7 +1910,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             do_reindex,
             do_reindex_chainstate,
             kernel_cache_sizes,
-            args);
+            args,
+            read_error_cb);
     }
     if (status != ChainstateLoadStatus::SUCCESS && status != ChainstateLoadStatus::INTERRUPTED) {
         return InitError(error);
@@ -1934,7 +1937,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 8: start indexers
 
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex);
+        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex, read_error_cb);
         node.indexes.emplace_back(g_txindex.get());
     }
 
@@ -1944,12 +1947,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {
-        InitBlockFilterIndex([&]{ return interfaces::MakeChain(node); }, filter_type, index_cache_sizes.filter_index, false, do_reindex);
+        InitBlockFilterIndex([&]{ return interfaces::MakeChain(node); }, filter_type, index_cache_sizes.filter_index, false, do_reindex, read_error_cb);
         node.indexes.emplace_back(GetBlockFilterIndex(filter_type));
     }
 
     if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
-        g_coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /*cache_size=*/0, false, do_reindex);
+        g_coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /*cache_size=*/0, false, do_reindex, read_error_cb);
         node.indexes.emplace_back(g_coin_stats_index.get());
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1376,7 +1376,8 @@ static ChainstateLoadResult InitAndLoadChainstate(
     bool do_reindex,
     const bool do_reindex_chainstate,
     const kernel::CacheSizes& cache_sizes,
-    const ArgsManager& args)
+    const ArgsManager& args,
+    const std::function<void()>& read_error_cb)
 {
     // This function may be called twice, so any dirty state must be reset.
     node.notifications->setChainstateLoaded(false); // Drop state, such as a cached tip block
@@ -1405,6 +1406,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
         .datadir = args.GetDataDirNet(),
+        .read_error_cb = read_error_cb,
         .notifications = *node.notifications,
         .signals = node.validation_signals.get(),
     };
@@ -1418,6 +1420,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
             .path = args.GetDataDirNet() / "blocks" / "index",
             .cache_bytes = cache_sizes.block_tree_db,
             .wipe_data = do_reindex,
+            .read_error_cb = read_error_cb,
         },
     };
     Assert(ApplyArgsManOptions(args, blockman_opts)); // no error can happen, already checked in AppInitParameterInteraction
@@ -1464,11 +1467,6 @@ static ChainstateLoadResult InitAndLoadChainstate(
     options.check_blocks = args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = args.IsArgSet("-checkblocks") || args.IsArgSet("-checklevel");
-    options.coins_error_cb = [] {
-        uiInterface.ThreadSafeMessageBox(
-            _("Error reading from database, shutting down."),
-            CClientUIInterface::MSG_ERROR);
-    };
     uiInterface.InitMessage(_("Loading block index…"));
     auto catch_exceptions = [](auto&& f) -> ChainstateLoadResult {
         try {
@@ -1909,6 +1907,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     bool do_reindex{args.GetBoolArg("-reindex", false)};
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};
+    const std::function<void()> read_error_cb{[&node] {
+        node.notifications->fatalError(_("Error reading from database, shutting down."));
+    }};
 
     // Chainstate initialization and loading may be retried once with reindexing by GUI users
     auto [status, error] = InitAndLoadChainstate(
@@ -1916,7 +1917,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         do_reindex,
         do_reindex_chainstate,
         kernel_cache_sizes,
-        args);
+        args,
+        read_error_cb);
     if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
         // suggest a reindex
         bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
@@ -1936,7 +1938,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             do_reindex,
             do_reindex_chainstate,
             kernel_cache_sizes,
-            args);
+            args,
+            read_error_cb);
     }
     if (status != ChainstateLoadStatus::SUCCESS && status != ChainstateLoadStatus::INTERRUPTED) {
         return InitError(error);
@@ -1980,22 +1983,22 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 8: start indexers
 
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex);
+        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex, read_error_cb);
         node.indexes.emplace_back(g_txindex.get());
     }
 
     if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {
-        g_txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), index_cache_sizes.txospender_index, false, do_reindex);
+        g_txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), index_cache_sizes.txospender_index, false, do_reindex, read_error_cb);
         node.indexes.emplace_back(g_txospenderindex.get());
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {
-        InitBlockFilterIndex([&]{ return interfaces::MakeChain(node); }, filter_type, index_cache_sizes.filter_index, false, do_reindex);
+        InitBlockFilterIndex([&]{ return interfaces::MakeChain(node); }, filter_type, index_cache_sizes.filter_index, false, do_reindex, read_error_cb);
         node.indexes.emplace_back(GetBlockFilterIndex(filter_type));
     }
 
     if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
-        g_coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /*cache_size=*/0, false, do_reindex);
+        g_coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /*cache_size=*/0, false, do_reindex, read_error_cb);
         node.indexes.emplace_back(g_coin_stats_index.get());
     }
 

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -43,6 +43,11 @@ struct ChainstateManagerOpts {
     std::chrono::seconds max_tip_age{DEFAULT_MAX_TIP_AGE};
     DBOptions coins_db{};
     CoinsViewOptions coins_view{};
+    //! Callback executed on fatal read failures.
+    //!
+    //! Called synchronously from database read paths. It must be safe to call
+    //! from any thread, with or without locks held.
+    std::function<void()> read_error_cb{[] {}};
     Notifications& notifications;
     ValidationSignals* signals{nullptr};
     //! Number of script check worker threads. Zero means no parallel verification.

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -42,6 +42,9 @@ struct ChainstateManagerOpts {
     //! If the tip is older than this, the node is considered to be in initial block download.
     std::chrono::seconds max_tip_age{DEFAULT_MAX_TIP_AGE};
     DBOptions coins_db{};
+    //! Invoked before the process aborts on a coins database read failure.
+    //! Must be safe to call synchronously from any thread, including while locks are held.
+    std::function<void()> read_error_cb{};
     CoinsViewOptions coins_view{};
     Notifications& notifications;
     ValidationSignals* signals{nullptr};

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -96,9 +96,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
             return {ChainstateLoadStatus::FAILURE, _("Error opening coins database")};
         }
 
-        if (options.coins_error_cb) {
-            chainstate->CoinsErrorCatcher().AddReadErrCallback(options.coins_error_cb);
-        }
+        chainstate->CoinsErrorCatcher().AddReadErrCallback(chainman.m_options.read_error_cb);
 
         // Refuse to load unsupported database format.
         // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -96,8 +96,6 @@ static ChainstateLoadResult CompleteChainstateInitialization(
             return {ChainstateLoadStatus::FAILURE, _("Error opening coins database")};
         }
 
-        chainstate->CoinsErrorCatcher().AddReadErrCallback(chainman.m_options.read_error_cb);
-
         // Refuse to load unsupported database format.
         // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (chainstate->CoinsDB().NeedsUpgrade()) {

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -96,10 +96,6 @@ static ChainstateLoadResult CompleteChainstateInitialization(
             return {ChainstateLoadStatus::FAILURE, _("Error opening coins database")};
         }
 
-        if (chainman.m_options.read_error_cb) {
-            chainstate->CoinsErrorCatcher().AddReadErrCallback(chainman.m_options.read_error_cb);
-        }
-
         // Refuse to load unsupported database format.
         // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (chainstate->CoinsDB().NeedsUpgrade()) {

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -96,8 +96,8 @@ static ChainstateLoadResult CompleteChainstateInitialization(
             return {ChainstateLoadStatus::FAILURE, _("Error opening coins database")};
         }
 
-        if (options.coins_error_cb) {
-            chainstate->CoinsErrorCatcher().AddReadErrCallback(options.coins_error_cb);
+        if (chainman.m_options.read_error_cb) {
+            chainstate->CoinsErrorCatcher().AddReadErrCallback(chainman.m_options.read_error_cb);
         }
 
         // Refuse to load unsupported database format.

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -9,7 +9,6 @@
 #include <validation.h>
 
 #include <cstdint>
-#include <functional>
 #include <tuple>
 
 class CTxMemPool;
@@ -34,7 +33,6 @@ struct ChainstateLoadOptions {
     bool require_full_verification{true};
     int64_t check_blocks{DEFAULT_CHECKBLOCKS};
     int64_t check_level{DEFAULT_CHECKLEVEL};
-    std::function<void()> coins_error_cb;
 };
 
 //! Chainstate load status. Simple applications can just check for the success

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -49,7 +49,7 @@ class CCoinsViewTest : public CoinsViewEmpty
 public:
     explicit CCoinsViewTest(FastRandomContext& rng) : m_rng{rng} {}
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override
     {
         if (auto it{map_.find(outpoint)}; it != map_.end() && !it->second.IsSpent()) return it->second;
         return std::nullopt;

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -42,7 +42,7 @@ class CCoinsViewTest : public CoinsViewEmpty
 public:
     explicit CCoinsViewTest(FastRandomContext& rng) : m_rng{rng} {}
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override
     {
         if (auto it{map_.find(outpoint)}; it != map_.end() && !it->second.IsSpent()) return it->second;
         return std::nullopt;

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -905,7 +905,7 @@ void TestFlushBehavior(
     COutPoint outp = COutPoint(txid, 0);
     Coin coin = MakeCoin();
     // Ensure the coins views haven't seen this coin before.
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.GetCoin(outp));
     BOOST_CHECK(!view->HaveCoin(outp));
 
     // --- 1. Adding a random coin to the child cache
@@ -916,7 +916,7 @@ void TestFlushBehavior(
     cache_size = view->map().size();
 
     // `base` shouldn't have coin (no flush yet) but `view` should have cached it.
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.GetCoin(outp));
     BOOST_CHECK(view->HaveCoin(outp));
 
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(view->map(), outp), CoinEntry(coin.out.nValue, CoinEntry::State::DIRTY_FRESH));
@@ -934,7 +934,7 @@ void TestFlushBehavior(
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(view->map(), outp), CoinEntry(coin.out.nValue, CoinEntry::State::CLEAN)); // State should have been wiped.
 
     // Both views should now have the coin.
-    BOOST_CHECK(base.HaveCoin(outp));
+    BOOST_CHECK(base.GetCoin(outp));
     BOOST_CHECK(view->HaveCoin(outp));
 
     if (do_erasing_flush) {
@@ -967,13 +967,13 @@ void TestFlushBehavior(
     // The coin should be in the cache, but spent and marked dirty.
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(view->map(), outp), SPENT_DIRTY);
     BOOST_CHECK(!view->HaveCoin(outp)); // Coin should be considered spent in `view`.
-    BOOST_CHECK(base.HaveCoin(outp));  // But coin should still be unspent in `base`.
+    BOOST_CHECK(base.GetCoin(outp));    // But coin should still be unspent in `base`.
 
     flush_all(/*erase=*/ false);
 
     // Coin should be considered spent in both views.
     BOOST_CHECK(!view->HaveCoin(outp));
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.GetCoin(outp));
 
     // Spent coin should not be spendable.
     BOOST_CHECK(!view->SpendCoin(outp));
@@ -984,19 +984,19 @@ void TestFlushBehavior(
     txid = Txid::FromUint256(m_rng.rand256());
     outp = COutPoint(txid, 0);
     coin = MakeCoin();
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.GetCoin(outp));
     BOOST_CHECK(!all_caches[0]->HaveCoin(outp));
     BOOST_CHECK(!all_caches[1]->HaveCoin(outp));
 
     all_caches[0]->AddCoin(outp, std::move(coin), false);
     all_caches[0]->Sync();
-    BOOST_CHECK(base.HaveCoin(outp));
+    BOOST_CHECK(base.GetCoin(outp));
     BOOST_CHECK(all_caches[0]->HaveCoin(outp));
     BOOST_CHECK(!all_caches[1]->HaveCoinInCache(outp));
 
     BOOST_CHECK(all_caches[1]->SpendCoin(outp));
     flush_all(/*erase=*/ false);
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.GetCoin(outp));
     BOOST_CHECK(!all_caches[0]->HaveCoin(outp));
     BOOST_CHECK(!all_caches[1]->HaveCoin(outp));
 
@@ -1008,7 +1008,7 @@ void TestFlushBehavior(
     outp = COutPoint(txid, 0);
     coin = MakeCoin();
     CAmount coin_val = coin.out.nValue;
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.GetCoin(outp));
     BOOST_CHECK(!all_caches[0]->HaveCoin(outp));
     BOOST_CHECK(!all_caches[1]->HaveCoin(outp));
 
@@ -1018,7 +1018,7 @@ void TestFlushBehavior(
     // Coin should be FRESH in the cache.
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(all_caches[0]->map(), outp), CoinEntry(coin_val, CoinEntry::State::DIRTY_FRESH));
     // Base shouldn't have seen coin.
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.GetCoin(outp));
 
     BOOST_CHECK(all_caches[0]->SpendCoin(outp));
     all_caches[0]->Sync();
@@ -1026,7 +1026,7 @@ void TestFlushBehavior(
     // Ensure there is no sign of the coin after spend/flush.
     BOOST_CHECK(!GetCoinsMapEntry(all_caches[0]->map(), outp));
     BOOST_CHECK(!all_caches[0]->HaveCoinInCache(outp));
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.GetCoin(outp));
 }
 }; // struct FlushTest
 
@@ -1066,6 +1066,44 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
 
     BOOST_CHECK_EQUAL(*Assert(base.GetCoin(outpoint)), coin);
     BOOST_CHECK_EQUAL(base.GetBestBlock(), block_hash);
+}
+
+BOOST_AUTO_TEST_CASE(ccoins_cache_have_inputs)
+{
+    struct CCoinsViewSpy final : CoinsViewEmpty {
+        const COutPoint expected;
+        mutable int getcoin_calls{0};
+
+        explicit CCoinsViewSpy(const COutPoint& outpoint) : expected{outpoint} {}
+
+        std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override
+        {
+            BOOST_CHECK(outpoint == expected);
+            ++getcoin_calls;
+            return Coin{CTxOut{1, CScript{}}, 1, false};
+        }
+    };
+
+    for (bool prefilled : {false, true}) {
+        const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), 0};
+        CCoinsViewSpy base{outpoint};
+        CCoinsViewCache cache{&base};
+        if (prefilled) cache.AddCoin(outpoint, Coin{CTxOut{1, CScript{}}, 1, false}, /*possible_overwrite=*/false);
+
+        CMutableTransaction mtx;
+        mtx.vin.emplace_back(outpoint);
+        const CTransaction tx{mtx};
+
+        BOOST_CHECK(cache.HaveInputs(tx));
+        BOOST_CHECK(cache.HaveInputs(tx));
+        BOOST_CHECK(cache.GetCoin(outpoint));
+        BOOST_CHECK(!cache.AccessCoin(outpoint).IsSpent());
+        BOOST_CHECK(cache.HaveCoin(outpoint));
+        BOOST_CHECK(cache.HaveCoinInCache(outpoint));
+        BOOST_CHECK(cache.SpendCoin(outpoint));
+        BOOST_CHECK(!cache.HaveCoinInCache(outpoint));
+        BOOST_CHECK_EQUAL(base.getcoin_calls, prefilled ? 0 : 1);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(coins_resource_is_used)

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -75,13 +75,12 @@ BOOST_AUTO_TEST_CASE(dbwrapper_read_deserialization_error)
     CDBWrapper dbw{{.path = "",
                     .cache_bytes = 1_MiB,
                     .memory_only = true,
-                    }};
-
+                    .read_error_cb = [] { throw dbwrapper_error{"dbwrapper test read error"}; }}};
     constexpr uint8_t key{'k'};
     dbw.Write(key, uint8_t{0x01});
 
     uint256 value{};
-    BOOST_CHECK(!dbw.Read(key, value)); // TODO abort on deserialization failure
+    BOOST_CHECK_THROW(dbw.Read(key, value), dbwrapper_error); // Check that callback is called before abort
 
     constexpr uint8_t missing_key{'m'};
     BOOST_CHECK(!dbw.Read(missing_key, value));

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -70,6 +70,48 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
     }
 }
 
+BOOST_AUTO_TEST_CASE(dbwrapper_read_deserialization_error)
+{
+    CDBWrapper dbw{{.path = "",
+                    .cache_bytes = 1_MiB,
+                    .memory_only = true,
+                    }};
+
+    constexpr uint8_t key{'k'};
+    dbw.Write(key, uint8_t{0x01});
+
+    uint256 value{};
+    BOOST_CHECK(!dbw.Read(key, value)); // TODO abort on deserialization failure
+
+    constexpr uint8_t missing_key{'m'};
+    BOOST_CHECK(!dbw.Read(missing_key, value));
+}
+
+BOOST_AUTO_TEST_CASE(dbwrapper_iterator_deserialization_error)
+{
+    CDBWrapper dbw{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}};
+
+    constexpr uint8_t key{'k'};
+    dbw.Write(key, uint8_t{0x01});
+
+    {
+        const std::unique_ptr<CDBIterator> it{dbw.NewIterator()};
+        it->Seek(key);
+        uint256 key_res{};
+        BOOST_CHECK(!it->GetKey(key_res)); // TODO abort on deserialization failure
+    }
+
+    {
+        const std::unique_ptr<CDBIterator> it{dbw.NewIterator()};
+        it->Seek(key);
+        uint8_t key_res{};
+        it->GetKey(key_res);
+
+        uint256 val_res{};
+        BOOST_CHECK(!it->GetValue(val_res)); // TODO abort on deserialization failure
+    }
+}
+
 BOOST_AUTO_TEST_CASE(dbwrapper_basic_data)
 {
     // Perform tests both obfuscated and non-obfuscated.

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -244,13 +244,13 @@ BOOST_AUTO_TEST_CASE(dbwrapper_read_db_error)
     // Read() should detect the issue
     const auto db{make_db(path, /*force_compact=*/false)};
     uint256 result;
-    BOOST_CHECK_EXCEPTION((void)db.Read(key, result), dbwrapper_error, HasReason{"Fatal LevelDB error"}); // TODO: Read failures must run the read error callback
+    BOOST_CHECK_EXCEPTION((void)db.Read(key, result), dbwrapper_error, HasReason{"dbwrapper test read error"});
 
     // TryRead() must return DatabaseError (without throwing).
     CDBWrapper::ReadStatus status = db.TryRead(key, result);
     BOOST_REQUIRE(!status);
     BOOST_CHECK(status.error().status == CDBWrapper::ReadFailure::Code::DatabaseError);
-    BOOST_CHECK(status.error().err_msg.find("Fatal LevelDB error") != std::string::npos); // TODO: Read failures must run the read error callback
+    BOOST_CHECK(status.error().err_msg.find("dbwrapper test read error") != std::string::npos);
 }
 
 // Exercise TryRead() return values directly: found, absent and DeserializationError.

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -245,56 +245,6 @@ BOOST_AUTO_TEST_CASE(dbwrapper_read_db_error)
     const auto db{make_db(path, /*force_compact=*/false)};
     uint256 result;
     BOOST_CHECK_EXCEPTION((void)db.Read(key, result), dbwrapper_error, HasReason{"dbwrapper test read error"});
-
-    // TryRead() must return DatabaseError (without throwing).
-    CDBWrapper::ReadStatus status = db.TryRead(key, result);
-    BOOST_REQUIRE(!status);
-    BOOST_CHECK(status.error().status == CDBWrapper::ReadFailure::Code::DatabaseError);
-    BOOST_CHECK(status.error().err_msg.find("dbwrapper test read error") != std::string::npos);
-}
-
-// Exercise TryRead() return values directly: found, absent and DeserializationError.
-// DatabaseError is tested inside 'dbwrapper_read_db_error' test
-BOOST_AUTO_TEST_CASE(dbwrapper_tryread)
-{
-    for (const bool obfuscate : {false, true}) {
-        const fs::path path{m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_tryread_obf" : "dbwrapper_tryread_noobf")};
-        CDBWrapper dbw({.path = path, .cache_bytes = 1 << 20, .wipe_data = true, .obfuscate = obfuscate});
-
-        constexpr uint8_t key_ok{'A'};
-        constexpr uint8_t key_missing{'B'};
-        constexpr uint8_t key_bad{'C'};
-
-        uint256 written_value{m_rng.rand256()};
-        dbw.Write(key_ok, written_value);
-        dbw.Write(key_bad, uint8_t{0xFF});
-
-        // Found: key exists, value deserializes correctly
-        {
-            uint256 read_value;
-            CDBWrapper::ReadStatus status = dbw.TryRead(key_ok, read_value);
-            BOOST_REQUIRE(status);
-            BOOST_CHECK(status.value());
-            BOOST_CHECK_EQUAL(read_value, written_value);
-        }
-
-        // Absent: key does not exist
-        {
-            uint256 read_value;
-            CDBWrapper::ReadStatus status = dbw.TryRead(key_missing, read_value);
-            BOOST_REQUIRE(status);
-            BOOST_CHECK(!status.value());
-        }
-
-        // DeserializationError: key exists but stored value is too short
-        {
-            uint256 read_value;
-            CDBWrapper::ReadStatus status = dbw.TryRead(key_bad, read_value);
-            BOOST_REQUIRE(!status);
-            BOOST_CHECK(status.error().status == CDBWrapper::ReadFailure::Code::DeserializationError);
-            BOOST_CHECK(!status.error().err_msg.empty());
-        }
-    }
 }
 
 BOOST_AUTO_TEST_CASE(dbwrapper_iterator)

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -195,13 +195,12 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
     }
 }
 
-// Verify that Read() returns false (without throwing) when the stored value
-// fails to be deserialized
-BOOST_AUTO_TEST_CASE(dbwrapper_read_returns_false_on_deserialization_error)
+BOOST_AUTO_TEST_CASE(dbwrapper_read_deserialization_error)
 {
     for (const bool obfuscate : {false, true}) {
         const fs::path path{m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_deser_obf" : "dbwrapper_deser_noobf")};
-        CDBWrapper dbw({.path = path, .cache_bytes = 1 << 20, .wipe_data = true, .obfuscate = obfuscate});
+        CDBWrapper dbw({.path = path, .cache_bytes = 1_MiB, .wipe_data = true, .obfuscate = obfuscate,
+                        .read_error_cb = [] { throw dbwrapper_error{"dbwrapper test read error"}; }});
 
         constexpr uint8_t key{'X'};
 
@@ -210,23 +209,22 @@ BOOST_AUTO_TEST_CASE(dbwrapper_read_returns_false_on_deserialization_error)
         dbw.Write(key, uint8_t{0xFF});
         BOOST_CHECK(dbw.Exists(key));
 
-        // Read() must catch the deserialization exception and return false,
-        // the same as if the key were absent
         uint256 result;
-        BOOST_CHECK(!dbw.Read(key, result));
+        BOOST_CHECK(!dbw.Read(key, result)); // TODO: A corrupt value must not be reported as a missing key
     }
 }
 
-// Verify Read() throws dbwrapper_error due to an internal db error
-BOOST_AUTO_TEST_CASE(dbwrapper_read_throws_on_db_error)
+BOOST_AUTO_TEST_CASE(dbwrapper_read_db_error)
 {
     const fs::path path{m_args.GetDataDirBase() / "dbwrapper_db_error"};
     constexpr uint8_t key{'Y'};
 
-    const auto make_db = [] (const fs::path& path, const bool force_compact) {
-        return CDBWrapper({.path = path, .cache_bytes = 1 << 20, .obfuscate = false,
-                        .options = {.force_compact = force_compact}});
-    };
+    const auto make_db{[](const fs::path& path, bool force_compact) {
+        return CDBWrapper({.path = path, .cache_bytes = 1_MiB,
+                           .obfuscate = false, // A stored obfuscation key would be read from the corrupted table at open
+                           .read_error_cb = [] { throw dbwrapper_error{"dbwrapper test read error"}; },
+                           .options = {.force_compact = force_compact}});
+    }};
 
     // Write a value and close the database
     make_db(path, /*force_compact=*/false).Write(key, m_rng.rand256());
@@ -243,20 +241,20 @@ BOOST_AUTO_TEST_CASE(dbwrapper_read_throws_on_db_error)
         }
     }
 
-    // Read() should detect the issue now and throw
+    // Read() should detect the issue
     const auto db{make_db(path, /*force_compact=*/false)};
     uint256 result;
-    BOOST_CHECK_EXCEPTION(db.Read(key, result), dbwrapper_error, HasReason("Fatal LevelDB error"));
+    BOOST_CHECK_EXCEPTION((void)db.Read(key, result), dbwrapper_error, HasReason{"Fatal LevelDB error"}); // TODO: Read failures must run the read error callback
 
     // TryRead() must return DatabaseError (without throwing).
     CDBWrapper::ReadStatus status = db.TryRead(key, result);
     BOOST_REQUIRE(!status);
     BOOST_CHECK(status.error().status == CDBWrapper::ReadFailure::Code::DatabaseError);
-    BOOST_CHECK(status.error().err_msg.find("Fatal LevelDB error") != std::string::npos);
+    BOOST_CHECK(status.error().err_msg.find("Fatal LevelDB error") != std::string::npos); // TODO: Read failures must run the read error callback
 }
 
 // Exercise TryRead() return values directly: found, absent and DeserializationError.
-// DatabaseError is tested inside 'dbwrapper_read_throws_on_db_error' test
+// DatabaseError is tested inside 'dbwrapper_read_db_error' test
 BOOST_AUTO_TEST_CASE(dbwrapper_tryread)
 {
     for (const bool obfuscate : {false, true}) {

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_read_deserialization_error)
         BOOST_CHECK(dbw.Exists(key));
 
         uint256 result;
-        BOOST_CHECK(!dbw.Read(key, result)); // TODO: A corrupt value must not be reported as a missing key
+        BOOST_CHECK_EXCEPTION((void)dbw.Read(key, result), dbwrapper_error, HasReason{"dbwrapper test read error"});
     }
 }
 

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -372,26 +372,18 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
         } else {
             assert(!exists_using_access_coin && !exists_using_have_coin_in_cache && !exists_using_have_coin);
         }
-        // If HaveCoin on the backend is true, it must also be on the cache if the coin wasn't spent.
+        // If the backend coin exists, it must also be in the cache if the cached coin wasn't spent.
         std::optional<Coin> coin_in_backend;
-        bool exists_using_have_coin_in_backend;
         if (overlay) {
             // PeekCoin does not mutate cacheCoins, so async workers can keep running.
             coin_in_backend = backend_coins_view->PeekCoin(random_out_point);
-            exists_using_have_coin_in_backend = coin_in_backend.has_value();
         } else {
-            exists_using_have_coin_in_backend = backend_coins_view->HaveCoin(random_out_point);
             coin_in_backend = backend_coins_view->GetCoin(random_out_point);
         }
-        if (!coin_using_access_coin.IsSpent() && exists_using_have_coin_in_backend) {
+        if (!coin_using_access_coin.IsSpent() && coin_in_backend) {
             assert(exists_using_have_coin);
-        }
-        if (coin_in_backend) {
-            assert(exists_using_have_coin_in_backend);
-            // Note we can't assert that `coin_using_get_coin == *coin` because the coin in
+            // Note we can't assert that `coin_using_access_coin == *coin_in_backend` because the coin in
             // the cache may have been modified but not yet flushed.
-        } else {
-            assert(!exists_using_have_coin_in_backend);
         }
     }
 }

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -158,7 +158,7 @@ class CoinsViewBottom final : public CoinsViewEmpty
     std::map<COutPoint, Coin> m_data;
 
 public:
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const final
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept final
     {
         if (auto it{m_data.find(outpoint)}; it != m_data.end()) {
             assert(!it->second.IsSpent());

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -124,11 +124,6 @@ struct LevelDBBytewiseU16Cmp {
 /** key → value-size map ordered by LevelDB's bytewise comparator. */
 using Oracle = std::map<uint16_t, uint32_t, LevelDBBytewiseU16Cmp>;
 
-struct FailUnserialize {
-    template <typename Stream>
-    void Unserialize(Stream&) { throw std::ios_base::failure{"always fail"}; }
-};
-
 uint16_t ConsumeKey(FuzzedDataProvider& provider) { return provider.ConsumeIntegral<uint16_t>(); }
 uint32_t ConsumeValueSize(FuzzedDataProvider& provider)
 {
@@ -300,8 +295,7 @@ void TestDbWrapper(FuzzedDataProvider& provider,
                 } else {
                     key = ConsumeKey(provider);
                 }
-                FailUnserialize wrong_type;
-                assert(!dbw->Read(key, wrong_type));
+                assert(dbw->ReadRaw(key).has_value() == oracle.contains(key));
             },
             [&] {
                 const auto seek_key{provider.ConsumeBool()

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -288,7 +288,14 @@ void TestDbWrapper(FuzzedDataProvider& provider,
                 }
             },
             [&] {
-                const auto key{ConsumeKey(provider)};
+                uint16_t key{};
+                if (!oracle.empty() && provider.ConsumeBool()) {
+                    auto it{oracle.begin()};
+                    std::advance(it, provider.ConsumeIntegralInRange<size_t>(0, oracle.size() - 1));
+                    key = it->first;
+                } else {
+                    key = ConsumeKey(provider);
+                }
                 assert(dbw->Exists(key) == oracle.contains(key));
             },
             [&] {

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -124,11 +124,6 @@ struct LevelDBBytewiseU16Cmp {
 /** key → value-size map ordered by LevelDB's bytewise comparator. */
 using Oracle = std::map<uint16_t, uint32_t, LevelDBBytewiseU16Cmp>;
 
-struct FailUnserialize {
-    template <typename Stream>
-    void Unserialize(Stream&) { throw std::ios_base::failure{"always fail"}; }
-};
-
 uint16_t ConsumeKey(FuzzedDataProvider& provider) { return provider.ConsumeIntegral<uint16_t>(); }
 uint32_t ConsumeValueSize(FuzzedDataProvider& provider)
 {
@@ -297,18 +292,6 @@ void TestDbWrapper(FuzzedDataProvider& provider,
                     key = ConsumeKey(provider);
                 }
                 assert(dbw->Exists(key) == oracle.contains(key));
-            },
-            [&] {
-                uint16_t key{};
-                if (!oracle.empty() && provider.ConsumeBool()) {
-                    auto it{oracle.begin()};
-                    std::advance(it, provider.ConsumeIntegralInRange<size_t>(0, oracle.size() - 1));
-                    key = it->first;
-                } else {
-                    key = ConsumeKey(provider);
-                }
-                FailUnserialize wrong_type;
-                assert(!dbw->Read(key, wrong_type));
             },
             [&] {
                 const auto seek_key{provider.ConsumeBool()

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -87,21 +87,11 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
 
 std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
 {
-    try {
-        if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
-            Assert(!coin.IsSpent()); // The UTXO database should never contain spent coins
-            return coin;
-        }
-        return std::nullopt;
-    } catch (const std::runtime_error& e) {
-        m_db_params.read_error_cb();
-        LogError("Error reading from database: %s\n", e.what());
-        // Starting the shutdown sequence and returning false to the caller would be
-        // interpreted as 'entry not found' (as opposed to unable to read data), and
-        // could lead to invalid interpretation. Just exit immediately, as we can't
-        // continue anyway, and all writes should be atomic.
-        std::abort();
+    if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
+        Assert(!coin.IsSpent()); // The UTXO database should never contain spent coins
+        return coin;
     }
+    return std::nullopt;
 }
 
 std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -111,7 +111,7 @@ std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const
 
 bool CCoinsViewDB::HaveCoin(const COutPoint& outpoint) const
 {
-    return m_db->Exists(CoinEntry(&outpoint));
+    return !!GetCoin(outpoint);
 }
 
 uint256 CCoinsViewDB::GetBestBlock() const {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -87,11 +87,21 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
 
 std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
 {
-    if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
-        Assert(!coin.IsSpent()); // The UTXO database should never contain spent coins
-        return coin;
+    try {
+        if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
+            Assert(!coin.IsSpent()); // The UTXO database should never contain spent coins
+            return coin;
+        }
+        return std::nullopt;
+    } catch (const std::runtime_error& e) {
+        m_db_params.read_error_cb();
+        LogError("Error reading from database: %s\n", e.what());
+        // Starting the shutdown sequence and returning false to the caller would be
+        // interpreted as 'entry not found' (as opposed to unable to read data), and
+        // could lead to invalid interpretation. Just exit immediately, as we can't
+        // continue anyway, and all writes should be atomic.
+        std::abort();
     }
-    return std::nullopt;
 }
 
 std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -85,7 +85,7 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
     }
 }
 
-std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const noexcept
 {
     if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
         Assert(!coin.IsSpent()); // The UTXO database should never contain spent coins
@@ -94,12 +94,12 @@ std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
     return std::nullopt;
 }
 
-std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const noexcept
 {
     return GetCoin(outpoint);
 }
 
-bool CCoinsViewDB::HaveCoin(const COutPoint& outpoint) const
+bool CCoinsViewDB::HaveCoin(const COutPoint& outpoint) const noexcept
 {
     return !!GetCoin(outpoint);
 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -84,7 +84,7 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
     }
 }
 
-std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const noexcept
 {
     if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
         Assert(!coin.IsSpent()); // The UTXO database should never contain spent coins
@@ -93,7 +93,7 @@ std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
     return std::nullopt;
 }
 
-std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const noexcept
 {
     return GetCoin(outpoint);
 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -98,11 +98,6 @@ std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const noex
     return GetCoin(outpoint);
 }
 
-bool CCoinsViewDB::HaveCoin(const COutPoint& outpoint) const
-{
-    return m_db->Exists(CoinEntry(&outpoint));
-}
-
 uint256 CCoinsViewDB::GetBestBlock() const {
     uint256 hashBestChain;
     if (!m_db->Read(DB_BEST_BLOCK, hashBestChain))

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -19,7 +19,6 @@
 
 #include <cassert>
 #include <chrono>
-#include <cstdlib>
 #include <exception>
 #include <future>
 #include <iterator>
@@ -87,24 +86,11 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
 
 std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
 {
-    Coin coin;
-    const CDBWrapper::ReadStatus res = m_db->TryRead(CoinEntry(&outpoint), coin);
-    if (!res) {
-        // Propagate errors so CCoinsViewErrorCatcher triggers a clean shutdown.
-        switch (const auto& [err_code, err_msg] = res.error(); err_code) {
-            case CDBWrapper::ReadFailure::Code::DeserializationError:
-                throw dbwrapper_error{strprintf("Coin deserialization failure: %s", err_msg)};
-            case CDBWrapper::ReadFailure::Code::DatabaseError:
-                throw dbwrapper_error{strprintf("Coin DB read failure: %s", err_msg)};
-        } // no default case, so the compiler can warn about missing cases
-        std::abort(); // unreachable
+    if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
+        Assert(!coin.IsSpent()); // The UTXO database should never contain spent coins
+        return coin;
     }
-
-    // Check whether the coin exists
-    if (!res.value()) return std::nullopt;
-    // Coin found, ensure UTXO database never contains spent coins
-    Assert(!coin.IsSpent());
-    return coin;
+    return std::nullopt;
 }
 
 std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -46,9 +46,9 @@ public:
     explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
     ~CCoinsViewDB() override;
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
-    bool HaveCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override;
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override;
+    bool HaveCoin(const COutPoint& outpoint) const noexcept override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -46,8 +46,8 @@ public:
     explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
     ~CCoinsViewDB() override;
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override;
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override;
     bool HaveCoin(const COutPoint& outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -48,7 +48,6 @@ public:
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override;
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const noexcept override;
-    bool HaveCoin(const COutPoint& outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -789,7 +789,7 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 
 CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
 
-std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const noexcept
 {
     // Check to see if the inputs are made available by another tx in the package.
     // These Coins would not be available in the underlying CoinsView.

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -787,7 +787,7 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 
 CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
 
-std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const noexcept
 {
     // Check to see if the inputs are made available by another tx in the package.
     // These Coins would not be available in the underlying CoinsView.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -793,7 +793,7 @@ public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
     /** GetCoin, returning whether it exists and is not spent. Also updates m_non_base_coins if the
      * coin is not fetched from base. May populate the base view on cache misses. */
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const noexcept override;
     /** Add the coins created by this transaction. These coins are only temporarily stored in
      * m_temp_added and cannot be flushed to the back end. Only used for package validation. */
     void PackageAddTransaction(const CTransactionRef& tx);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1921,6 +1921,7 @@ void Chainstate::InitCoinsDB(
             .memory_only = in_memory,
             .wipe_data = should_wipe,
             .obfuscate = true,
+            .read_error_cb = m_chainman.m_options.read_error_cb,
             .options = m_chainman.m_options.coins_db},
         m_chainman.m_options.coins_view);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1934,6 +1934,7 @@ void Chainstate::InitCoinsDB(
             .memory_only = in_memory,
             .wipe_data = should_wipe,
             .obfuscate = true,
+            .read_error_cb = m_chainman.m_options.read_error_cb,
             .options = m_chainman.m_options.coins_db},
         m_chainman.m_options.coins_view);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1857,13 +1857,12 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 }
 
 CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)
-    : m_dbview{std::move(db_params), std::move(options)},
-      m_catcherview(&m_dbview) {}
+    : m_dbview{std::move(db_params), std::move(options)} {}
 
 void CoinsViews::InitCache(int32_t prevoutfetch_threads)
 {
     AssertLockHeld(::cs_main);
-    m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
+    m_cacheview = std::make_unique<CCoinsViewCache>(&m_dbview);
     auto thread_pool{std::make_shared<ThreadPool>("prevout")};
     if (prevoutfetch_threads > 0) {
         thread_pool->Start(prevoutfetch_threads);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1844,13 +1844,12 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 }
 
 CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)
-    : m_dbview{std::move(db_params), std::move(options)},
-      m_catcherview(&m_dbview) {}
+    : m_dbview{std::move(db_params), std::move(options)} {}
 
 void CoinsViews::InitCache(int32_t prevoutfetch_threads)
 {
     AssertLockHeld(::cs_main);
-    m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
+    m_cacheview = std::make_unique<CCoinsViewCache>(&m_dbview);
     auto thread_pool{std::make_shared<ThreadPool>("prevout")};
     if (prevoutfetch_threads > 0) {
         thread_pool->Start(prevoutfetch_threads);

--- a/src/validation.h
+++ b/src/validation.h
@@ -486,9 +486,6 @@ public:
     //! All unspent coins reside in this store.
     CCoinsViewDB m_dbview GUARDED_BY(cs_main);
 
-    //! This view wraps access to the leveldb instance and handles read errors gracefully.
-    CCoinsViewErrorCatcher m_catcherview GUARDED_BY(cs_main);
-
     //! This is the top layer of the cache hierarchy - it keeps as many coins in memory as
     //! can fit per the dbcache setting.
     std::unique_ptr<CCoinsViewCache> m_cacheview GUARDED_BY(cs_main);
@@ -497,8 +494,8 @@ public:
     //! Reset between calls and flushed only on success, so invalid blocks don't pollute the underlying cache.
     std::unique_ptr<CoinsViewOverlay> m_connect_block_view GUARDED_BY(cs_main);
 
-    //! This constructor initializes CCoinsViewDB and CCoinsViewErrorCatcher instances, but it
-    //! *does not* create a CCoinsViewCache instance by default. This is done separately because the
+    //! This constructor initializes CCoinsViewDB, but it *does not* create a
+    //! CCoinsViewCache instance by default. This is done separately because the
     //! presence of the cache has implications on whether or not we're allowed to flush the cache's
     //! state to disk, which should not be done until the health of the database is verified.
     //!
@@ -704,14 +701,6 @@ public:
     CTxMemPool* GetMempool()
     {
         return m_mempool;
-    }
-
-    //! @returns A reference to a wrapped view of the in-memory UTXO set that
-    //!     handles disk read errors gracefully.
-    CCoinsViewErrorCatcher& CoinsErrorCatcher() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
-    {
-        AssertLockHeld(::cs_main);
-        return Assert(m_coins_views)->m_catcherview;
     }
 
     //! Destructs all objects related to accessing the UTXO set.

--- a/src/validation.h
+++ b/src/validation.h
@@ -482,9 +482,6 @@ public:
     //! All unspent coins reside in this store.
     CCoinsViewDB m_dbview GUARDED_BY(cs_main);
 
-    //! This view wraps access to the leveldb instance and handles read errors gracefully.
-    CCoinsViewErrorCatcher m_catcherview GUARDED_BY(cs_main);
-
     //! This is the top layer of the cache hierarchy - it keeps as many coins in memory as
     //! can fit per the dbcache setting.
     std::unique_ptr<CCoinsViewCache> m_cacheview GUARDED_BY(cs_main);
@@ -493,8 +490,8 @@ public:
     //! Reset between calls and flushed only on success, so invalid blocks don't pollute the underlying cache.
     std::unique_ptr<CoinsViewOverlay> m_connect_block_view GUARDED_BY(cs_main);
 
-    //! This constructor initializes CCoinsViewDB and CCoinsViewErrorCatcher instances, but it
-    //! *does not* create a CCoinsViewCache instance by default. This is done separately because the
+    //! This constructor initializes CCoinsViewDB, but it *does not* create a
+    //! CCoinsViewCache instance by default. This is done separately because the
     //! presence of the cache has implications on whether or not we're allowed to flush the cache's
     //! state to disk, which should not be done until the health of the database is verified.
     //!
@@ -709,14 +706,6 @@ public:
     CTxMemPool* GetMempool()
     {
         return m_mempool;
-    }
-
-    //! @returns A reference to a wrapped view of the in-memory UTXO set that
-    //!     handles disk read errors gracefully.
-    CCoinsViewErrorCatcher& CoinsErrorCatcher() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
-    {
-        AssertLockHeld(::cs_main);
-        return Assert(m_coins_views)->m_catcherview;
     }
 
     //! Destructs all objects related to accessing the UTXO set.

--- a/test/functional/feature_coinsdb_read_error.py
+++ b/test/functional/feature_coinsdb_read_error.py
@@ -94,7 +94,7 @@ class DBReadErrorTest(BitcoinTestFramework):
         self.corrupt_leveldb(node, "indexes/txindex")
         self.start_node(2, extra_args=["-txindex=1"])
 
-        self.assert_read_error_without_shutdown(node, rpc_fn=lambda: self.for_txids(node, node.getrawtransaction))  # TODO: assert that shutdown after read decode errors throw
+        self.assert_shutdown_on_read_error(node, rpc_fn=lambda: self.for_txids(node, node.getrawtransaction))
 
     def test_coinsdb_gettxoutsetinfo_read_error(self):
         node = self.nodes[1]

--- a/test/functional/feature_coinsdb_read_error.py
+++ b/test/functional/feature_coinsdb_read_error.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test corruption behavior on database read paths."""
+import contextlib
+import http.client
+import re
+import subprocess
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import BitcoinTestFramework
+
+# Exceptions expected when the node aborts mid-RPC-request.
+RPC_CONN_LOST = (
+    subprocess.CalledProcessError,
+    http.client.CannotSendRequest,
+    http.client.RemoteDisconnected,
+    ConnectionResetError,
+)
+
+
+class DBReadErrorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        # Separate nodes avoid having to rebuild datadirs between corruption cases.
+        self.num_nodes = 3
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    @staticmethod
+    def for_txids(node, callback):
+        for height in range(1, node.getblockcount() + 1):
+            txid = node.getblock(node.getblockhash(height))["tx"][0]
+            callback(txid)
+
+    @staticmethod
+    def corrupt_leveldb(node, leveldb_dir):
+        db_path = node.chain_path / leveldb_dir
+        for table_path in sorted(db_path.glob("*.ldb")) + sorted(db_path.glob("*.sst")):
+            with open(table_path, "r+b") as f:
+                file_size = table_path.stat().st_size
+                for offset in (file_size // 3, file_size // 2, (file_size * 2) // 3):
+                    f.seek(offset)
+                    f.write(b"\xff")
+
+    @staticmethod
+    def assert_shutdown_on_read_error(node, rpc_fn, expected_msgs=None):
+        with node.assert_debug_log(expected_msgs) if expected_msgs is not None else contextlib.nullcontext():
+            try:
+                rpc_fn()
+            except RPC_CONN_LOST:
+                pass
+
+        node.wait_until(lambda: node.process.poll(), timeout=60)
+        assert node.is_node_stopped(
+            expected_stderr=re.compile(r"Cannot read from database, shutting down\."),
+            expected_ret_code=node.process.returncode,
+        )
+
+    @staticmethod
+    def assert_read_error_without_shutdown(node, rpc_fn):
+        try:
+            rpc_fn()
+        except (JSONRPCException, *RPC_CONN_LOST):
+            pass
+
+        assert node.process.poll() is None
+        node.getblockcount()
+
+    def test_coinsdb_gettxout_read_error(self):
+        node = self.nodes[0]
+        # Stop node to clear LevelDB block cache (required for 32-bit where mmap is disabled)
+        self.stop_node(0)
+        self.corrupt_leveldb(node, "chainstate")
+        self.start_node(0, extra_args=["-checkblocks=0", "-checklevel=0"])
+
+        self.assert_shutdown_on_read_error(
+            node,
+            rpc_fn=lambda: self.for_txids(node, lambda txid: node.gettxout(txid, 0)),
+            expected_msgs=["block checksum mismatch"],
+        )
+
+    def test_txindex_getrawtransaction_read_error(self):
+        node = self.nodes[2]
+        # Build txindex with small dbcache, then compact to ensure data lands in table files.
+        for _ in range(2):
+            self.restart_node(2, extra_args=["-txindex=1", "-dbcache=4", "-forcecompactdb=1"])
+            node.wait_until(lambda: node.getindexinfo().get("txindex", {}).get("synced", False))
+
+        self.stop_node(2)
+        self.corrupt_leveldb(node, "indexes/txindex")
+        self.start_node(2, extra_args=["-txindex=1"])
+
+        self.assert_read_error_without_shutdown(node, rpc_fn=lambda: self.for_txids(node, node.getrawtransaction))  # TODO: assert that shutdown after read decode errors throw
+
+    def test_coinsdb_gettxoutsetinfo_read_error(self):
+        node = self.nodes[1]
+        # Corrupt after startup to avoid turning this into a DB-open failure path.
+        self.corrupt_leveldb(node, "chainstate")
+
+        self.assert_read_error_without_shutdown(node, rpc_fn=lambda: node.gettxoutsetinfo("none"))  # TODO: assert that shutdown after iterator decode errors throw
+
+    def run_test(self):
+        self.log.info("coinsdb: corrupt chainstate and trigger read via gettxout")
+        self.test_coinsdb_gettxout_read_error()
+
+        self.log.info("coinsdb: corrupt chainstate and trigger read via gettxoutsetinfo")
+        self.test_coinsdb_gettxoutsetinfo_read_error()
+
+        self.log.info("txindex: corrupt index DB and trigger read via getrawtransaction")
+        self.test_txindex_getrawtransaction_read_error()
+
+
+if __name__ == '__main__':
+    DBReadErrorTest(__file__).main()

--- a/test/functional/feature_coinsdb_read_error.py
+++ b/test/functional/feature_coinsdb_read_error.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test corruption behavior on coin and index point-read paths."""
+import http.client
+import re
+import subprocess
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, sync_txindex
+
+
+class DBReadErrorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [[], ['-txindex=1']]
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    @staticmethod
+    def corrupt_tables(node, directory):
+        db_path = node.chain_path / directory
+        table_paths = [*db_path.glob('*.ldb'), *db_path.glob('*.sst')]
+        assert table_paths
+        for table_path in table_paths:
+            with open(table_path, 'r+b') as f:
+                file_size = table_path.stat().st_size
+                # Hit data blocks in the middle and leave the footer intact, so the database still opens
+                for offset in (file_size // 3, file_size // 2, file_size * 2 // 3):
+                    f.seek(offset)
+                    f.write(b'\xff')
+
+    @staticmethod
+    def trigger_read_error(node, read_tx):
+        with node.assert_debug_log(['LevelDB read failure']):
+            try:
+                for height in range(1, node.getblockcount() + 1):
+                    read_tx(node.getblock(node.getblockhash(height))['tx'][0])
+            except JSONRPCException as e:
+                assert_equal(e.error['code'], -1)
+                assert 'Fatal LevelDB error' in e.error['message']
+            except (subprocess.CalledProcessError, http.client.CannotSendRequest, http.client.RemoteDisconnected, ConnectionError):
+                pass  # Aborting may close the RPC connection
+
+    @staticmethod
+    def assert_shutdown(node):
+        node.wait_until_stopped(
+            expected_stderr=re.compile(r'A fatal internal error occurred, see .* for details: Error reading from database, shutting down\.'),
+            expected_ret_code=[-6, 3, 0xC0000409],  # Unix, Windows native, Windows cross builds
+        )
+
+    def run_test(self):
+        self.log.info('Corrupt chainstate and trigger a read through gettxout')
+        node = self.nodes[0]
+        self.stop_node(0)  # Clear the block cache before corruption, including on 32-bit systems
+        self.corrupt_tables(node, 'chainstate')
+        self.start_node(0, extra_args=['-checkblocks=0', '-checklevel=0'])
+        self.trigger_read_error(node, lambda txid: node.gettxout(txid, 0))
+        self.assert_shutdown(node)
+
+        self.log.info('Build txindex and corrupt its tables')
+        node = self.nodes[1]
+        sync_txindex(self, node)
+        self.restart_node(1)  # Log recovery on startup writes the index from the WAL into a .ldb table
+        self.stop_node(1)
+        self.corrupt_tables(node, 'indexes/txindex')
+        self.start_node(1)
+        self.trigger_read_error(node, node.getrawtransaction)
+        assert node.process.poll() is None  # TODO: Abort instead of continuing after an index point-read error
+
+
+if __name__ == '__main__':
+    DBReadErrorTest(__file__).main()

--- a/test/functional/feature_coinsdb_read_error.py
+++ b/test/functional/feature_coinsdb_read_error.py
@@ -70,7 +70,7 @@ class DBReadErrorTest(BitcoinTestFramework):
         self.corrupt_tables(node, 'indexes/txindex')
         self.start_node(1)
         self.trigger_read_error(node, node.getrawtransaction)
-        assert node.process.poll() is None  # TODO: Abort instead of continuing after an index point-read error
+        self.assert_shutdown(node)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -163,8 +163,15 @@ class InitTest(BitcoinTestFramework):
             },
             {
                 'filepath_glob': 'chainstate/*.ldb',
+                'error_message': 'Cannot read from database, shutting down.',
+                'startup_args': [],
+            },
+            {
+                'filepath_glob': 'chainstate/CURRENT',
                 'error_message': 'Error opening coins database.',
                 'startup_args': [],
+                'perturb_offset': 0,
+                'perturb_bytes': b'X',
             },
             {
                 'filepath_glob': 'blocks/blk*.dat',
@@ -238,10 +245,10 @@ class InitTest(BitcoinTestFramework):
                 self.log.info(f"Perturbing file to ensure failure {target_file}")
                 with open(target_file, "r+b") as tf:
                     # Since the genesis block is not checked by -checkblocks, the
-                    # perturbation window must be chosen such that a higher block
-                    # in blk*.dat is affected.
-                    tf.seek(150)
-                    tf.write(b"1" * 200)
+                    # default perturbation window must be chosen such that a
+                    # higher block in blk*.dat is affected.
+                    tf.seek(round_info.get('perturb_offset', 150))
+                    tf.write(round_info.get('perturb_bytes', b"1" * 200))
 
             start_expecting_error(err_fragment, startup_args)
 

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -164,7 +164,7 @@ class InitTest(BitcoinTestFramework):
             },
             {
                 'filepath_glob': 'chainstate/*.ldb',
-                'error_message': 'Error opening coins database.',  # TODO: A corrupt chainstate table must abort through the read error callback
+                'error_message': 'Error reading from database, shutting down.',
                 'startup_args': [],
             },
             {

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -164,6 +164,11 @@ class InitTest(BitcoinTestFramework):
             },
             {
                 'filepath_glob': 'chainstate/*.ldb',
+                'error_message': 'Error opening coins database.',  # TODO: A corrupt chainstate table must abort through the read error callback
+                'startup_args': [],
+            },
+            {
+                'filepath_glob': 'chainstate/CURRENT',
                 'error_message': 'Error opening coins database.',
                 'startup_args': [],
             },

--- a/test/functional/feature_utxo_abort_on_error.py
+++ b/test/functional/feature_utxo_abort_on_error.py
@@ -107,7 +107,7 @@ class UTXOAbortOnErrorTest(BitcoinTestFramework):
             # Confirm node0 aborted with SIGABRT
             self.wait_until(lambda: self.nodes[0].is_node_stopped(
                 expected_ret_code=-6,
-                expected_stderr="Error: Error reading from database, shutting down.",
+                expected_stderr="Error: A fatal internal error occurred, see debug.log for details: Error reading from database, shutting down.",
             ))
 
         self.log.info("node0 aborted cleanly — no silent divergence occurred")

--- a/test/functional/feature_utxo_abort_on_error.py
+++ b/test/functional/feature_utxo_abort_on_error.py
@@ -97,7 +97,7 @@ class UTXOAbortOnErrorTest(BitcoinTestFramework):
         # Verify that the unserializable entry triggers the expected error and is
         # never silently misreported as a missing input (bad-txns-inputs-missingorspent),
         # which would indicate the previous silent-divergence behaviour.
-        with node0.assert_debug_log(expected_msgs=["Error reading from database: Coin deserialization failure"],
+        with node0.assert_debug_log(expected_msgs=[f"Corrupted database entry in {node0.chain_path / 'chainstate'}"],
                                     unexpected_msgs=["bad-txns-inputs-missingorspent"]):
             try:
                 self.connect_nodes(0, 1)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -330,6 +330,7 @@ BASE_SCRIPTS = [
     'p2p_fingerprint.py',
     'feature_uacomment.py',
     'feature_init.py',
+    'feature_coinsdb_read_error.py',
     'wallet_coinbase_category.py',
     'feature_filelock.py',
     'feature_loadblock.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -334,6 +334,7 @@ BASE_SCRIPTS = [
     'p2p_fingerprint.py',
     'feature_uacomment.py',
     'feature_init.py',
+    'feature_coinsdb_read_error.py',
     'wallet_coinbase_category.py',
     'feature_filelock.py',
     'feature_loadblock.py',


### PR DESCRIPTION
**Problem:** #34931 made unreadable coin entries fatal, but `CDBWrapper::Read()` still returns `false` for deserialization failures at every other caller and propagates LevelDB point-read exceptions back to them.
A corrupt txindex point read can consequently fail one RPC while the node continues running.
Chainstate also retains `CCoinsViewErrorCatcher` as a separate view layer solely to invoke its fatal-error callback.

**Fix:** Make LevelDB point-read and typed deserialization failures fatal in `CDBWrapper`, after logging the database path and error and invoking the fatal-notification callback when one was provided.
Missing keys still return `false`, database-open failures keep using the existing initialization paths, and iterator decoding remains unchanged.
Pass the callback at construction for chainstate, the block-index database, and optional index databases, remove `CCoinsViewErrorCatcher`, keep `HaveCoin()` on the cache view that owns its caching behavior, and mark coin-view lookups `noexcept`.