### PR TITLE
rpc: [wallet] Use unsigned type for tx version in sendall

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1467,7 +1467,7 @@ RPCHelpMan sendall()
             }
 
             if (options.exists("version")) {
-                coin_control.m_version = options["version"].getInt<int>();
+                coin_control.m_version = options["version"].getInt<decltype(coin_control.m_version)>();
             }
 
             if (coin_control.m_version == TRUC_VERSION) {


### PR DESCRIPTION
It is confusing to parse the unsigned tx version as a signed type. Also, it makes it harder to use the integer sanitizer.

Can be tested via:

* Build with the flags `-DCMAKE_C_COMPILER='clang' -DCMAKE_CXX_COMPILER='clang++' -DSANITIZERS=undefined,integer,float-divide-by-zero`
* Set the existing suppressions: `export UBSAN_OPTIONS="suppressions=$(pwd)/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=0:report_error_type=1"`
* Start the RPC server, e.g. `./bld-cmake/bin/bitcoin-qt -datadir=/tmp -regtest -server`
* Call the sendall RPC, e.g. `./bld-cmake/bin/bitcoin-cli -datadir=/tmp -regtest -named sendall '["bcrt1qlrt3xps4wxpfcjmljrayr2ualczmnfvd4vzdq3"]' fee_rate=1.234  version=-1`

Before:

```
src/wallet/rpc/spend.cpp:1470:42: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'uint32_t' (aka 'unsigned int') changed the value to 4294967295 (32-bit, unsigned)

Invalid parameter, version out of range(1~3)
```

After:

```
JSON integer out of range

