### PR TITLE
test: Allow mempool_updatefromblock.py to run on 32-bit

### DIFF
--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -12,8 +12,6 @@ export PACKAGES="python3-zmq g++-arm-linux-gnueabihf libc6:armhf libstdc++6:armh
 export CONTAINER_NAME=ci_arm_linux
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"  # Check that https://packages.ubuntu.com/noble/g++-arm-linux-gnueabihf (version 13.x, similar to guix) can cross-compile
 export CI_IMAGE_PLATFORM="linux/arm64"
-export RUN_UNIT_TESTS=true
-export RUN_FUNCTIONAL_TESTS=false
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1
 # -Wno-psabi is to disable ABI warnings: "note: parameter passing for argument of type ... changed in GCC 7.1"


### PR DESCRIPTION
The number of dropped parent transactions in the `test_max_disconnect_pool_bytes` test was hard-coded to `2`.

This happens to work fine on 64-bit for now. However, it seems to fail on 32-bit (https://github.com/bitcoin/bitcoin/issues/34108).

I don't think we care about the exact number, as long as it is at least `1`.

So hard-code `1` for an initial sanity check, and then calculate the exact value at runtime via `len(mempool) // 2`.


Also, enable the functional tests in 32-bit CI, to confirm the regression test.


Fixes https://github.com/bitcoin/bitcoin/issues/34108