### PR TITLE
build: Prevent system header fallback and include path pollution

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -13,6 +13,8 @@ define $(package)_set_vars
   $(package)_config_opts += -DBOOST_INSTALL_LAYOUT=system
   $(package)_config_opts += -DBUILD_TESTING=OFF
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_ICU=ON
+  # Install to a unique path to prevent accidental inclusion via other dependencies' -I flags.
+  $(package)_config_opts += -DCMAKE_INSTALL_INCLUDEDIR=$(package)/include
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/systemtap.mk
+++ b/depends/packages/systemtap.mk
@@ -6,7 +6,11 @@ $(package)_sha256_hash=966a360fb73a4b65a8d0b51b389577b3c4f92a327e84aae58682103e8
 $(package)_patches=remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
 
 define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch && \
-  mkdir -p $($(package)_staging_prefix_dir)/include/sys && \
-  cp includes/sys/sdt.h $($(package)_staging_prefix_dir)/include/sys/sdt.h
+  patch -p1 < $($(package)_patch_dir)/remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
+endef
+
+# Install to a unique path to prevent accidental inclusion via other dependencies' -I flags.
+define $(package)_stage_cmds
+  mkdir -p $($(package)_staging_prefix_dir)/$(package)/include/sys && \
+  cp includes/sys/sdt.h $($(package)_staging_prefix_dir)/$(package)/include/sys/sdt.h
 endef

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -163,6 +163,7 @@ if("@usdt_packages@" MATCHES "^[ ]*$")
   set(WITH_USDT OFF CACHE BOOL "")
 else()
   set(WITH_USDT ON CACHE BOOL "")
+  set(USDT_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/systemtap/include" CACHE PATH "")
 endif()
 
 set(ipc_packages @ipc_packages@)

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(bitcoin_ipc
   PRIVATE
     core_interface
     univalue
+    Boost::headers
 )
 
 if(BUILD_TESTS)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -163,6 +163,7 @@ target_link_libraries(test_bitcoin
   secp256k1
   Boost::headers
   libevent::extra
+  $<TARGET_NAME_IF_EXISTS:USDT::headers>
 )
 
 if(ENABLE_WALLET)


### PR DESCRIPTION
Currently, header-only dependencies in the depends subsystem are installed into the standard `include/` subdirectory. This inadvertently exposes their headers to the compiler via `-I` flags brought in by other dependencies (e.g., `libevent` or `sqlite`). This "include path pollution" masks missing dependencies in the build configuration. While the build might succeed by accident due to this overlap, it creates a fragile state. If the overlapping library is removed, the build will break, or, worse, the compiler may silently fall back to the host system's default paths (e.g., `/usr/include`).

This PR improves build system security and hygiene by enforcing strict, distinguished include paths for header-only dependencies. The missing dependencies revealed by this change (`Boost::headers`, `USDT::headers`) have been fixed in separate commits.