### PR TITLE
refactor: use static_cast and add Doxygen to BlockTreeDB

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -305,7 +305,7 @@ void BlockManager::FindFilesToPruneManual(
     int count = 0;
     for (int fileNumber = 0; fileNumber < this->MaxBlockfileNum(); fileNumber++) {
         const auto& fileinfo = m_blockfile_info[fileNumber];
-        if (fileinfo.nSize == 0 || fileinfo.nHeightLast > (unsigned)last_block_can_prune || fileinfo.nHeightFirst < (unsigned)min_block_to_prune) {
+        if (fileinfo.nSize == 0 || fileinfo.nHeightLast > static_cast<unsigned>(last_block_can_prune) || fileinfo.nHeightFirst < static_cast<unsigned>(min_block_to_prune)) {
             continue;
         }
 
@@ -380,7 +380,7 @@ void BlockManager::FindFilesToPrune(
 
             // don't prune files that could have a block that's not within the allowable
             // prune range for the chain being pruned.
-            if (fileinfo.nHeightLast > (unsigned)last_block_can_prune || fileinfo.nHeightFirst < (unsigned)min_block_to_prune) {
+            if (fileinfo.nHeightLast > static_cast<unsigned>(last_block_can_prune) || fileinfo.nHeightFirst < static_cast<unsigned>(min_block_to_prune)) {
                 continue;
             }
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -99,13 +99,29 @@ class BlockTreeDB : public CDBWrapper
 {
 public:
     using CDBWrapper::CDBWrapper;
+
+    /** Write block file info and block index entries to the database in a single batch. */
     void WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*>>& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
+
+    /** Read block file info for the given file number. */
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo& info);
+
+    /** Read the last block file number from the database. */
     bool ReadLastBlockFile(int& nFile);
+
+    /** Write a flag indicating whether reindexing is in progress. */
     void WriteReindexing(bool fReindexing);
+
+    /** Read the reindexing flag from the database. */
     void ReadReindexing(bool& fReindexing);
+
+    /** Write a named boolean flag to the database. */
     void WriteFlag(const std::string& name, bool fValue);
+
+    /** Read a named boolean flag from the database. */
     bool ReadFlag(const std::string& name, bool& fValue);
+
+    /** Load the block index from disk into memory. */
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, const util::SignalInterrupt& interrupt)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };


### PR DESCRIPTION
## Summary

- Replace C-style casts `(unsigned)` with `static_cast<unsigned>()` in `FindFilesToPruneManual()` and `FindFilesToPrune()` for compliance with coding standards
- Add Doxygen documentation to all `BlockTreeDB` public methods

## Test plan

- [x] Build completes successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)