### PR TITLE
test: add comprehensive bech32 unit tests based on BIP-173 :christmas_tree:

### DIFF
--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -156,4 +156,284 @@ BOOST_AUTO_TEST_CASE(bech32m_testvectors_invalid)
     }
 }
 
+/** BIP-173 specifies the valid character set for bech32 data part.
+ *  This test verifies that all 32 valid characters encode and decode correctly.
+ *  Reference: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+ */
+BOOST_AUTO_TEST_CASE(bech32_charset_encoding)
+{
+    // The BIP-173 character set: qpzry9x8gf2tvdw0s3jn54khce6mua7l
+    // Each character maps to a 5-bit value (0-31)
+    const std::string CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+    // Test that each value 0-31 encodes to the correct character
+    for (uint8_t i = 0; i < 32; ++i) {
+        std::vector<uint8_t> data = {i};
+        std::string encoded = bech32::Encode(bech32::Encoding::BECH32, "test", data);
+        BOOST_CHECK(!encoded.empty());
+
+        // The data character should be at position 5 (after "test1")
+        BOOST_CHECK_EQUAL(encoded[5], CHARSET[i]);
+
+        // Verify round-trip
+        const auto decoded = bech32::Decode(encoded);
+        BOOST_CHECK(decoded.encoding == bech32::Encoding::BECH32);
+        BOOST_CHECK_EQUAL(decoded.hrp, "test");
+        BOOST_REQUIRE_EQUAL(decoded.data.size(), 1U);
+        BOOST_CHECK_EQUAL(decoded.data[0], i);
+    }
+}
+
+/** Test round-trip encoding for various data sizes.
+ *  Verifies that Encode followed by Decode returns the original data.
+ */
+BOOST_AUTO_TEST_CASE(bech32_roundtrip_encoding)
+{
+    const std::string hrp = "bc";
+
+    // Test various data lengths
+    for (size_t data_len = 0; data_len <= 40; ++data_len) {
+        std::vector<uint8_t> data(data_len);
+        // Fill with deterministic pattern
+        for (size_t i = 0; i < data_len; ++i) {
+            data[i] = static_cast<uint8_t>(i % 32);
+        }
+
+        // Test both Bech32 and Bech32m
+        for (auto encoding : {bech32::Encoding::BECH32, bech32::Encoding::BECH32M}) {
+            std::string encoded = bech32::Encode(encoding, hrp, data);
+            BOOST_CHECK(!encoded.empty());
+
+            const auto decoded = bech32::Decode(encoded);
+            BOOST_CHECK(decoded.encoding == encoding);
+            BOOST_CHECK_EQUAL(decoded.hrp, hrp);
+            BOOST_CHECK(decoded.data == data);
+        }
+    }
+}
+
+/** Test the 90-character limit specified in BIP-173.
+ *  Strings at exactly 90 characters should be valid.
+ *  Strings exceeding 90 characters should be invalid.
+ */
+BOOST_AUTO_TEST_CASE(bech32_length_limits)
+{
+    // Create a string of exactly 90 characters
+    // HRP (1) + separator (1) + data (82) + checksum (6) = 90
+    std::vector<uint8_t> max_data(82);
+    for (size_t i = 0; i < max_data.size(); ++i) {
+        max_data[i] = static_cast<uint8_t>(i % 32);
+    }
+
+    std::string at_limit = bech32::Encode(bech32::Encoding::BECH32, "a", max_data);
+    BOOST_CHECK_EQUAL(at_limit.size(), 90U);
+
+    const auto dec_at_limit = bech32::Decode(at_limit);
+    BOOST_CHECK(dec_at_limit.encoding == bech32::Encoding::BECH32);
+    BOOST_CHECK_EQUAL(dec_at_limit.hrp, "a");
+    BOOST_CHECK(dec_at_limit.data == max_data);
+
+    // Verify that 91 characters is rejected
+    // Use the existing test vector from BIP-173
+    const std::string too_long = "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx";
+    BOOST_CHECK(too_long.size() > 90U);
+    const auto dec_too_long = bech32::Decode(too_long);
+    BOOST_CHECK(dec_too_long.encoding == bech32::Encoding::INVALID);
+}
+
+/** Test HRP edge cases as specified in BIP-173.
+ *  HRP must be 1-83 characters, using ASCII 33-126.
+ */
+BOOST_AUTO_TEST_CASE(bech32_hrp_limits)
+{
+    std::vector<uint8_t> data = {0, 1, 2};
+
+    // Minimum HRP length (1 character)
+    std::string min_hrp = bech32::Encode(bech32::Encoding::BECH32, "a", data);
+    BOOST_CHECK(!min_hrp.empty());
+    auto dec_min = bech32::Decode(min_hrp);
+    BOOST_CHECK(dec_min.encoding == bech32::Encoding::BECH32);
+    BOOST_CHECK_EQUAL(dec_min.hrp, "a");
+
+    // HRP with boundary ASCII characters (33 '!' and 126 '~')
+    std::string boundary_hrp = bech32::Encode(bech32::Encoding::BECH32, "!~", data);
+    BOOST_CHECK(!boundary_hrp.empty());
+    auto dec_boundary = bech32::Decode(boundary_hrp);
+    BOOST_CHECK(dec_boundary.encoding == bech32::Encoding::BECH32);
+    BOOST_CHECK_EQUAL(dec_boundary.hrp, "!~");
+
+    // HRP containing the separator character '1' (last '1' should be the separator)
+    std::string hrp_with_one = bech32::Encode(bech32::Encoding::BECH32, "a1b", data);
+    BOOST_CHECK(!hrp_with_one.empty());
+    auto dec_with_one = bech32::Decode(hrp_with_one);
+    BOOST_CHECK(dec_with_one.encoding == bech32::Encoding::BECH32);
+    BOOST_CHECK_EQUAL(dec_with_one.hrp, "a1b");
+
+    // Empty HRP should fail to decode
+    const std::string empty_hrp = "1qqqqqqqqqq3nmt9y";
+    auto dec_empty = bech32::Decode(empty_hrp);
+    BOOST_CHECK(dec_empty.encoding == bech32::Encoding::INVALID);
+}
+
+/** Test that single-character errors are detected.
+ *  BIP-173 guarantees detection of any error affecting at most 4 characters.
+ */
+BOOST_AUTO_TEST_CASE(bech32_single_error_detection)
+{
+    // Valid test string
+    const std::string valid = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+    auto dec_valid = bech32::Decode(valid);
+    BOOST_CHECK(dec_valid.encoding == bech32::Encoding::BECH32);
+
+    // Introduce a single character error at various positions in the data part
+    const size_t data_start = 4; // After "bc1"
+    const size_t data_end = valid.size() - 1; // Before last checksum char
+
+    for (size_t pos = data_start; pos < data_end; ++pos) {
+        std::string corrupted = valid;
+        // Change the character to a different valid bech32 character
+        char orig = corrupted[pos];
+        corrupted[pos] = (orig == 'q') ? 'p' : 'q';
+
+        auto dec_corrupted = bech32::Decode(corrupted);
+        BOOST_CHECK_MESSAGE(dec_corrupted.encoding == bech32::Encoding::INVALID,
+            "Single error at position " + std::to_string(pos) + " was not detected");
+    }
+}
+
+/** Test that adjacent character transpositions are detected.
+ *  This is a common type of human error when transcribing addresses.
+ */
+BOOST_AUTO_TEST_CASE(bech32_transposition_detection)
+{
+    // Valid test string with distinct adjacent characters
+    const std::string valid = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+    auto dec_valid = bech32::Decode(valid);
+    BOOST_CHECK(dec_valid.encoding == bech32::Encoding::BECH32);
+
+    // Test transpositions in the data part
+    const size_t data_start = 4;
+    const size_t data_end = valid.size() - 2;
+
+    for (size_t pos = data_start; pos < data_end; ++pos) {
+        if (valid[pos] == valid[pos + 1]) continue; // Skip if chars are same
+
+        std::string transposed = valid;
+        std::swap(transposed[pos], transposed[pos + 1]);
+
+        auto dec_transposed = bech32::Decode(transposed);
+        BOOST_CHECK_MESSAGE(dec_transposed.encoding == bech32::Encoding::INVALID,
+            "Transposition at position " + std::to_string(pos) + " was not detected");
+    }
+}
+
+/** Test error detection with multiple errors (up to 4).
+ *  BIP-173 guarantees detection of up to 4 errors.
+ */
+BOOST_AUTO_TEST_CASE(bech32_multiple_error_detection)
+{
+    const std::string valid = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+    auto dec_valid = bech32::Decode(valid);
+    BOOST_CHECK(dec_valid.encoding == bech32::Encoding::BECH32);
+
+    // Test with 2 errors
+    {
+        std::string corrupted = valid;
+        corrupted[5] = (corrupted[5] == 'q') ? 'p' : 'q';
+        corrupted[10] = (corrupted[10] == 'q') ? 'p' : 'q';
+        auto dec = bech32::Decode(corrupted);
+        BOOST_CHECK(dec.encoding == bech32::Encoding::INVALID);
+    }
+
+    // Test with 3 errors
+    {
+        std::string corrupted = valid;
+        corrupted[5] = (corrupted[5] == 'q') ? 'p' : 'q';
+        corrupted[10] = (corrupted[10] == 'q') ? 'p' : 'q';
+        corrupted[15] = (corrupted[15] == 'q') ? 'p' : 'q';
+        auto dec = bech32::Decode(corrupted);
+        BOOST_CHECK(dec.encoding == bech32::Encoding::INVALID);
+    }
+
+    // Test with 4 errors
+    {
+        std::string corrupted = valid;
+        corrupted[5] = (corrupted[5] == 'q') ? 'p' : 'q';
+        corrupted[10] = (corrupted[10] == 'q') ? 'p' : 'q';
+        corrupted[15] = (corrupted[15] == 'q') ? 'p' : 'q';
+        corrupted[20] = (corrupted[20] == 'q') ? 'p' : 'q';
+        auto dec = bech32::Decode(corrupted);
+        BOOST_CHECK(dec.encoding == bech32::Encoding::INVALID);
+    }
+}
+
+/** Test case sensitivity as specified in BIP-173.
+ *  Encoders must always output lowercase.
+ *  Decoders must not accept mixed case.
+ */
+BOOST_AUTO_TEST_CASE(bech32_case_sensitivity)
+{
+    // All uppercase should decode successfully (BIP-173 allows this)
+    const std::string all_upper = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+    auto dec_upper = bech32::Decode(all_upper);
+    BOOST_CHECK(dec_upper.encoding == bech32::Encoding::BECH32);
+    BOOST_CHECK_EQUAL(dec_upper.hrp, "bc");
+
+    // All lowercase should decode successfully
+    const std::string all_lower = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+    auto dec_lower = bech32::Decode(all_lower);
+    BOOST_CHECK(dec_lower.encoding == bech32::Encoding::BECH32);
+    BOOST_CHECK_EQUAL(dec_lower.hrp, "bc");
+
+    // Mixed case should fail
+    const std::string mixed_case = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kV8f3t4";
+    auto dec_mixed = bech32::Decode(mixed_case);
+    BOOST_CHECK(dec_mixed.encoding == bech32::Encoding::INVALID);
+
+    // Mixed case in HRP only should also fail
+    const std::string mixed_hrp = "Bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+    auto dec_mixed_hrp = bech32::Decode(mixed_hrp);
+    BOOST_CHECK(dec_mixed_hrp.encoding == bech32::Encoding::INVALID);
+
+    // Encoding should always produce lowercase
+    std::vector<uint8_t> data = {0, 1, 2, 3};
+    std::string encoded = bech32::Encode(bech32::Encoding::BECH32, "test", data);
+    for (char c : encoded) {
+        BOOST_CHECK(c < 'A' || c > 'Z'); // No uppercase letters
+    }
+}
+
+/** Test checksum properties.
+ *  Verify that the checksum is exactly 6 characters and changes with input.
+ */
+BOOST_AUTO_TEST_CASE(bech32_checksum_properties)
+{
+    std::vector<uint8_t> data1 = {0, 1, 2, 3};
+    std::vector<uint8_t> data2 = {0, 1, 2, 4}; // One bit different
+
+    std::string enc1 = bech32::Encode(bech32::Encoding::BECH32, "test", data1);
+    std::string enc2 = bech32::Encode(bech32::Encoding::BECH32, "test", data2);
+
+    // Both should encode successfully
+    BOOST_CHECK(!enc1.empty());
+    BOOST_CHECK(!enc2.empty());
+
+    // Checksums should be different (last 6 characters)
+    std::string checksum1 = enc1.substr(enc1.size() - 6);
+    std::string checksum2 = enc2.substr(enc2.size() - 6);
+    BOOST_CHECK(checksum1 != checksum2);
+
+    // Verify checksum is exactly 6 characters
+    BOOST_CHECK_EQUAL(checksum1.size(), 6U);
+    BOOST_CHECK_EQUAL(checksum2.size(), 6U);
+
+    // Same data should produce same checksum
+    std::string enc1_again = bech32::Encode(bech32::Encoding::BECH32, "test", data1);
+    BOOST_CHECK_EQUAL(enc1, enc1_again);
+
+    // Different HRP should produce different result
+    std::string enc_diff_hrp = bech32::Encode(bech32::Encoding::BECH32, "tset", data1);
+    BOOST_CHECK(enc1 != enc_diff_hrp);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description

This PR improves unit test coverage for the bech32 encoding implementation by adding 9 new test cases based on the BIP-173 specification.

### Motivation

The existing bech32 tests cover the standard test vectors from BIP-173/350 but don't extensively test edge cases and error detection properties. Since bech32 is used for SegWit and Taproot addresses, comprehensive testing is important to catch potential regressions.

### Changes

New test cases added to `src/test/bech32_tests.cpp`:

| Test | Description |
|------|-------------|
| `bech32_charset_encoding` | Verifies all 32 valid characters encode and decode correctly |
| `bech32_roundtrip_encoding` | Tests encode/decode round-trip for data sizes 0-40 bytes |
| `bech32_length_limits` | Tests the 90-character maximum length boundary |
| `bech32_hrp_limits` | Tests HRP edge cases: minimum length, boundary ASCII chars (33, 126), separator in HRP |
| `bech32_single_error_detection` | Verifies single-character errors are detected at every position |
| `bech32_transposition_detection` | Verifies adjacent character transpositions are detected |
| `bech32_multiple_error_detection` | Tests guaranteed detection of 2, 3, and 4 errors |
| `bech32_case_sensitivity` | Tests uppercase, lowercase, and mixed case handling per BIP-173 |
| `bech32_checksum_properties` | Verifies checksum is exactly 6 characters and deterministic |

These tests cover the following BIP-173 specification requirements:
- Character set validation (32-character alphabet)
- Maximum length enforcement (90 characters)
- Error detection guarantees (up to 4 errors)
- Case sensitivity rules (reject mixed case)
- Checksum properties (6-character BCH code)

### References

- [BIP-173: Base32 address format for native v0-16 witness outputs](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
- [BIP-350: Bech32m format for v1+ witness addresses](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)

---

## PR Checklist

- [x] Tests pass locally: `ctest --test-dir build -R bech32`
- [x] Code follows existing style in `bech32_tests.cpp`
- [x] Comments reference BIP-173 sections where applicable
- [x] No new dependencies introduced