### PR TITLE
test: Enable ruff E713 lint

### DIFF
--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -172,7 +172,7 @@ PE_ALLOWED_LIBRARIES = {
 def check_version(max_versions, version, arch) -> bool:
     (lib, _, ver) = version.rpartition('_')
     ver = tuple([int(x) for x in ver.split('.')])
-    if not lib in max_versions:
+    if lib not in max_versions:
         return False
     if isinstance(max_versions[lib], tuple):
         return ver <= max_versions[lib]

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -229,7 +229,7 @@ class BlockDataCopier:
             inExtent = BlockExtent(self.inFn, self.inF.tell(), inhdr, blk_hdr, inLen)
 
             self.hash_str = calc_hash_str(blk_hdr)
-            if not self.hash_str in blkmap:
+            if self.hash_str not in blkmap:
                 # Because blocks can be written to files out-of-order as of 0.10, the script
                 # may encounter blocks it doesn't know about. Treat as debug output.
                 if settings['debug_output'] == 'true':
@@ -320,7 +320,7 @@ if __name__ == '__main__':
     blkmap = mkblockmap(blkindex)
 
     # Block hash map won't be byte-reversed. Neither should the genesis hash.
-    if not settings['genesis'] in blkmap:
+    if settings['genesis'] not in blkmap:
         print("Genesis block not found in hashlist")
     else:
         BlockDataCopier(settings, blkindex, blkmap).run()

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -233,13 +233,13 @@ class MempoolPersistTest(BitcoinTestFramework):
         self.nodes[0].sendrawtransaction(tx_node01["hex"])
         self.nodes[1].sendrawtransaction(tx_node01["hex"])
         assert tx_node0["txid"] in self.nodes[0].getrawmempool()
-        assert not tx_node0["txid"] in self.nodes[1].getrawmempool()
-        assert not tx_node1["txid"] in self.nodes[0].getrawmempool()
+        assert tx_node0["txid"] not in self.nodes[1].getrawmempool()
+        assert tx_node1["txid"] not in self.nodes[0].getrawmempool()
         assert tx_node1["txid"] in self.nodes[1].getrawmempool()
         assert tx_node01["txid"] in self.nodes[0].getrawmempool()
         assert tx_node01["txid"] in self.nodes[1].getrawmempool()
-        assert not tx_node01_secret["txid"] in self.nodes[0].getrawmempool()
-        assert not tx_node01_secret["txid"] in self.nodes[1].getrawmempool()
+        assert tx_node01_secret["txid"] not in self.nodes[0].getrawmempool()
+        assert tx_node01_secret["txid"] not in self.nodes[1].getrawmempool()
 
         self.log.debug("Check that importmempool can add txns without replacing the entire mempool")
         mempooldat0 = str(self.nodes[0].chain_path / "mempool.dat")
@@ -249,7 +249,7 @@ class MempoolPersistTest(BitcoinTestFramework):
         # All transactions should be in node1's mempool now.
         assert tx_node0["txid"] in self.nodes[1].getrawmempool()
         assert tx_node1["txid"] in self.nodes[1].getrawmempool()
-        assert not tx_node1["txid"] in self.nodes[0].getrawmempool()
+        assert tx_node1["txid"] not in self.nodes[0].getrawmempool()
         # For transactions that already existed, priority should be changed
         entry_node01 = self.nodes[1].getmempoolentry(tx_node01["txid"])
         assert_equal(entry_node01["fees"]["base"] + 1, entry_node01["fees"]["modified"])

--- a/test/functional/p2p_v2_transport.py
+++ b/test/functional/p2p_v2_transport.py
@@ -165,7 +165,7 @@ class V2TransportTest(BitcoinTestFramework):
                 peer_id = self.nodes[0].getpeerinfo()[-1]["id"]
                 s.sendall(b'\x00')  # send out last byte
                 # should disconnect immediately
-                self.wait_until(lambda: not peer_id in [p["id"] for p in self.nodes[0].getpeerinfo()])
+                self.wait_until(lambda: peer_id not in [p["id"] for p in self.nodes[0].getpeerinfo()])
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -126,7 +126,7 @@ class PSBTTest(BitcoinTestFramework):
         utxos = wonline.listunspent(addresses=[offline_addr])
         raw = wonline.createrawtransaction([{"txid":utxos[0]["txid"], "vout":utxos[0]["vout"]}],[{online_addr:0.9999}])
         psbt = wonline.walletprocesspsbt(online_node.converttopsbt(raw))["psbt"]
-        assert not "not_witness_utxo" in mining_node.decodepsbt(psbt)["inputs"][0]
+        assert "not_witness_utxo" not in mining_node.decodepsbt(psbt)["inputs"][0]
 
         # add non-witness UTXO manually
         psbt_new = PSBT.from_base64(psbt)
@@ -136,7 +136,7 @@ class PSBTTest(BitcoinTestFramework):
 
         # Have the offline node sign the PSBT (which will remove the non-witness UTXO)
         signed_psbt = offline_node.walletprocesspsbt(psbt_new.to_base64())
-        assert not "non_witness_utxo" in mining_node.decodepsbt(signed_psbt["psbt"])["inputs"][0]
+        assert "non_witness_utxo" not in mining_node.decodepsbt(signed_psbt["psbt"])["inputs"][0]
 
         # Make sure we can mine the resulting transaction
         txid = mining_node.sendrawtransaction(signed_psbt["hex"])

--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -24,7 +24,7 @@ class SetBanTests(BitcoinTestFramework):
         # Node 0 connects to Node 1, check that the noban permission is not granted
         self.connect_nodes(0, 1)
         peerinfo = self.nodes[1].getpeerinfo()[0]
-        assert not "noban" in peerinfo["permissions"]
+        assert "noban" not in peerinfo["permissions"]
 
         # Node 0 get banned by Node 1
         self.nodes[1].setban("127.0.0.1", "add")
@@ -51,7 +51,7 @@ class SetBanTests(BitcoinTestFramework):
         self.restart_node(1, [])
         self.connect_nodes(0, 1)
         peerinfo = self.nodes[1].getpeerinfo()[0]
-        assert not "noban" in peerinfo["permissions"]
+        assert "noban" not in peerinfo["permissions"]
 
         self.log.info("Test that a non-IP address can be banned/unbanned")
         node = self.nodes[1]

--- a/test/functional/test_framework/descriptors.py
+++ b/test/functional/test_framework/descriptors.py
@@ -25,7 +25,7 @@ def descsum_expand(s):
     groups = []
     symbols = []
     for c in s:
-        if not c in INPUT_CHARSET:
+        if c not in INPUT_CHARSET:
             return None
         v = INPUT_CHARSET.find(c)
         symbols.append(v & 31)
@@ -47,7 +47,7 @@ def descsum_create(s):
 
 def descsum_check(s, require=True):
     """Verify that the checksum is correct in a descriptor"""
-    if not '#' in s:
+    if '#' not in s:
         return not require
     if s[-9] != '#':
         return False

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -120,7 +120,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         balances = alice.getbalances()['mine']
         assert_equal(balances['untrusted_pending'] + balances['trusted'], newbalance)
         # Also shouldn't show up in listunspent
-        assert not txABC2 in [utxo["txid"] for utxo in alice.listunspent(0)]
+        assert txABC2 not in [utxo["txid"] for utxo in alice.listunspent(0)]
         balance = newbalance
 
         # Abandon original transaction and verify inputs are available again

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -159,7 +159,7 @@ class WalletSendTest(BitcoinTestFramework):
             assert "txid" in res
         else:
             assert_equal(res["complete"], False)
-            assert not "txid" in res
+            assert "txid" not in res
             assert "psbt" in res
 
         from_balance = from_wallet.getbalances()["mine"]["trusted"]

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -307,6 +307,7 @@ fn lint_py_lint() -> LintResult {
             "E702", // multiple statements on one line (semicolon)
             "E703", // statement ends with a semicolon
             "E711", // comparison to None should be 'if cond is None:'
+            "E713", // test for membership should be "not in"
             "E714", // test for object identity should be "is not"
             "E721", // do not compare types, use "isinstance()"
             "E722", // do not use bare 'except'


### PR DESCRIPTION
Membership tests of the form `not item in stuff` may be confusing, because they could be read as `(not item) in stuff`, which is different.

So enable the ruff E713 lint, which should also help to avoid having to go through review cycles for this.