### PR TITLE
refactor: avoid possible UB from `std::distance` for `nullptr` args

### DIFF
--- a/src/support/allocators/pool.h
+++ b/src/support/allocators/pool.h
@@ -155,7 +155,7 @@ class PoolResource final
     void AllocateChunk()
     {
         // if there is still any available memory left, put it into the freelist.
-        size_t remaining_available_bytes = std::distance(m_available_memory_it, m_available_memory_end);
+        size_t remaining_available_bytes = m_available_memory_end - m_available_memory_it;
         if (0 != remaining_available_bytes) {
             ASAN_UNPOISON_MEMORY_REGION(m_available_memory_it, sizeof(ListNode));
             PlacementAddToList(m_available_memory_it, m_free_lists[remaining_available_bytes / ELEM_ALIGN_BYTES]);


### PR DESCRIPTION
### Problem

Calling `std::distance(nullptr, nullptr)` has ambiguous status in the C++ standard [iterator.requirements.general](https://eel.is/c++draft/iterator.requirements.general#7):
> Iterators can also have singular values that are not associated with any sequence. Results of most expressions are undefined for singular values.

It seems to work correctly in every implementation we use, but [LWG 1213](https://cplusplus.github.io/LWG/issue1213) ("Meaning of valid and singular iterator underspecified") has been Open since 2009, acknowledging that the standard's wording on this topic is unclear.

<details>
<summary>Details</summary>

The [iterator.requirements.general](https://eel.is/c++draft/iterator.requirements.general#7) states:
> Iterators can also have singular values that are not associated with any sequence. Results of most expressions are undefined for singular values.

And [LWG 208](https://cplusplus.github.io/LWG/issue208)'s rationale explicitly confirms:
> Null pointers are singular.

Therefore they cannot form a valid range required by [std::distance](https://eel.is/c++draft/iterator.operations#4):
> Preconditions: last is reachable from first, or InputIterator meets the Cpp17RandomAccessIterator requirements and first is reachable from last.

</details>

### Fix

A previous version of this PR checked both values for `nullptr`, the current one uses unambiguously well-defined pointer subtraction instead, which is per [expr.add](https://eel.is/c++draft/expr.add#5):
> If P and Q both evaluate to null pointer values, the value is 0.

This applies on the first call before any memory is allocated, when both pointers are `nullptr`.
Using `operator-` directly is simpler and avoids the ambiguity entirely.