### PR TITLE
net: Avoid undershooting in GetAddressesUnsafe

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3695,11 +3695,13 @@ CConnman::~CConnman()
 
 std::vector<CAddress> CConnman::GetAddressesUnsafe(size_t max_addresses, size_t max_pct, std::optional<Network> network, const bool filtered) const
 {
-    std::vector<CAddress> addresses = addrman.get().GetAddr(max_addresses, max_pct, network, filtered);
+    // Get all addresses if filtering for banned addresses to avoid undershooting max_addresses in the returned vec
+    std::vector<CAddress> addresses = addrman.get().GetAddr(m_banman ? 0 : max_addresses, max_pct, network, filtered);
     if (m_banman) {
         addresses.erase(std::remove_if(addresses.begin(), addresses.end(),
                         [this](const CAddress& addr){return m_banman->IsDiscouraged(addr) || m_banman->IsBanned(addr);}),
                         addresses.end());
+        if (max_addresses && addresses.size() > max_addresses) addresses.resize(max_addresses);
     }
     return addresses;
 }


### PR DESCRIPTION
This is demonstrating an alternative approach to #33663. The author didn't seem to like by suggestion so I am putting it here to be considered by reviewers. I personally prefer this approach due to it's simplicity.

`GetAddressesUnsafe` filters banned and discouraged addresses if those exist. If addresses are filtered the returned list of addresses can be shorter than originally requested because the list isn't backfilled with more valid addresses. These results end up in `GETADDR` responses as well as the `getnodeaddresses` RPC.

Fix this by requesting all available addresses and filter them, then only trim them to the requested `max_addresses` afterwards. Also adds a functional test which checks the new behavior via `getnodeaddresses` RPC.