### PR TITLE
coins: don't mutate main cache when connecting block

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -60,10 +60,15 @@ size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
 }
 
+std::optional<Coin> CCoinsViewCache::FetchCoinFromBase(const COutPoint& outpoint) const
+{
+    return base->GetCoin(outpoint);
+}
+
 CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const {
     const auto [ret, inserted] = cacheCoins.try_emplace(outpoint);
     if (inserted) {
-        if (auto coin{base->GetCoin(outpoint)}) {
+        if (auto coin{FetchCoinFromBase(outpoint)}) {
             ret->second.coin = std::move(*coin);
             cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
             Assert(!ret->second.coin.IsSpent());

--- a/src/coins.h
+++ b/src/coins.h
@@ -302,9 +302,15 @@ class CCoinsView
 {
 public:
     //! Retrieve the Coin (unspent transaction output) for a given outpoint.
+    //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
     virtual std::optional<Coin> GetCoin(const COutPoint& outpoint) const;
 
+    //! Retrieve the Coin (unspent transaction output) for a given outpoint, without caching results.
+    //! Does not populate the cache. Use GetCoin() to cache the result.
+    virtual std::optional<Coin> PeekCoin(const COutPoint& outpoint) const;
+
     //! Just check whether a given outpoint is unspent.
+    //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
     virtual bool HaveCoin(const COutPoint &outpoint) const;
 
     //! Retrieve the block hash whose state this CCoinsView currently represents
@@ -340,6 +346,7 @@ protected:
 public:
     CCoinsViewBacked(CCoinsView *viewIn);
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
@@ -386,6 +393,7 @@ public:
 
     // Standard CCoinsView methods
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256 &hashBlock);
@@ -536,6 +544,7 @@ public:
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
 
 private:
     /** A list of callbacks to execute upon leveldb read error. */

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(test_bitcoin
   coins_tests.cpp
   coinscachepair_tests.cpp
   coinstatsindex_tests.cpp
+  coinsviewoverlay_tests.cpp
   common_url_tests.cpp
   compress_tests.cpp
   crypto_tests.cpp

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <primitives/transaction_identifier.h>
+#include <txdb.h>
+#include <uint256.h>
+#include <util/byte_units.h>
+#include <util/hasher.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <ranges>
+
+BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests)
+
+namespace {
+
+CBlock CreateBlock() noexcept
+{
+    static constexpr auto NUM_TXS{100};
+    CBlock block;
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back();
+    block.vtx.push_back(MakeTransactionRef(coinbase));
+
+    for (const auto i : std::views::iota(1, NUM_TXS)) {
+        CMutableTransaction tx;
+        Txid txid{Txid::FromUint256(uint256(i))};
+        tx.vin.emplace_back(txid, 0);
+        block.vtx.push_back(MakeTransactionRef(tx));
+    }
+
+    return block;
+}
+
+void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
+{
+    CCoinsViewCache cache{&view};
+    cache.SetBestBlock(uint256::ONE);
+
+    for (const auto& tx : block.vtx | std::views::drop(1)) {
+        for (const auto& in : tx->vin) {
+            Coin coin{};
+            if (!spent) coin.out.nValue = 1;
+            cache.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
+        }
+    }
+
+    cache.Flush();
+}
+
+void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
+{
+    uint32_t counter{0};
+
+    for (const auto& tx : block.vtx) {
+        if (tx->IsCoinBase()) {
+            BOOST_CHECK(!cache.HaveCoinInCache(tx->vin[0].prevout));
+        } else {
+            for (const auto& in : tx->vin) {
+                const auto& outpoint{in.prevout};
+                const auto& first{cache.AccessCoin(outpoint)};
+                const auto& second{cache.AccessCoin(outpoint)};
+                BOOST_CHECK_EQUAL(&first, &second);
+                ++counter;
+                BOOST_CHECK(cache.HaveCoinInCache(outpoint));
+            }
+        }
+    }
+    BOOST_CHECK_EQUAL(cache.GetCacheSize(), counter);
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    PopulateView(block, db);
+    CCoinsViewCache main_cache{&db};
+    CoinsViewOverlay view{&main_cache};
+    const auto& outpoint{block.vtx[1]->vin[0].prevout};
+
+    BOOST_CHECK(view.HaveCoin(outpoint));
+    BOOST_CHECK(view.GetCoin(outpoint).has_value());
+    BOOST_CHECK(!main_cache.HaveCoinInCache(outpoint));
+
+    CheckCache(block, view);
+    // Check that no coins have been moved up to main cache from db
+    for (const auto& tx : block.vtx) {
+        for (const auto& in : tx->vin) {
+            BOOST_CHECK(!main_cache.HaveCoinInCache(in.prevout));
+        }
+    }
+
+    view.SetBestBlock(uint256::ONE);
+    BOOST_CHECK(view.SpendCoin(outpoint));
+    view.Flush();
+    BOOST_CHECK(!main_cache.PeekCoin(outpoint).has_value());
+}
+
+BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    PopulateView(block, main_cache);
+    CoinsViewOverlay view{&main_cache};
+    CheckCache(block, view);
+
+    const auto& outpoint{block.vtx[1]->vin[0].prevout};
+    view.SetBestBlock(uint256::ONE);
+    BOOST_CHECK(view.SpendCoin(outpoint));
+    view.Flush();
+    BOOST_CHECK(!main_cache.PeekCoin(outpoint).has_value());
+}
+
+// Test for the case where a block spends coins that are spent in the cache, but
+// the spentness has not been flushed to the db.
+BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    PopulateView(block, db);
+    CCoinsViewCache main_cache{&db};
+    // Add all inputs as spent already in cache
+    PopulateView(block, main_cache, /*spent=*/true);
+    CoinsViewOverlay view{&main_cache};
+    for (const auto& tx : block.vtx) {
+        for (const auto& in : tx->vin) {
+            const auto& c{view.AccessCoin(in.prevout)};
+            BOOST_CHECK(c.IsSpent());
+            BOOST_CHECK(!view.HaveCoin(in.prevout));
+            BOOST_CHECK(!view.GetCoin(in.prevout));
+        }
+    }
+    // Coins are not added to the view, even though they exist unspent in the parent db
+    BOOST_CHECK_EQUAL(view.GetCacheSize(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(fetch_no_inputs)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    CoinsViewOverlay view{&main_cache};
+    for (const auto& tx : block.vtx) {
+        for (const auto& in : tx->vin) {
+            const auto& c{view.AccessCoin(in.prevout)};
+            BOOST_CHECK(c.IsSpent());
+            BOOST_CHECK(!view.HaveCoin(in.prevout));
+            BOOST_CHECK(!view.GetCoin(in.prevout));
+        }
+    }
+    BOOST_CHECK_EQUAL(view.GetCacheSize(), 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -178,31 +178,6 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
     }
 
     {
-        const Coin& coin_using_access_coin = coins_view_cache.AccessCoin(random_out_point);
-        const bool exists_using_access_coin = !(coin_using_access_coin == EMPTY_COIN);
-        const bool exists_using_have_coin = coins_view_cache.HaveCoin(random_out_point);
-        const bool exists_using_have_coin_in_cache = coins_view_cache.HaveCoinInCache(random_out_point);
-        if (auto coin{coins_view_cache.GetCoin(random_out_point)}) {
-            assert(*coin == coin_using_access_coin);
-            assert(exists_using_access_coin && exists_using_have_coin_in_cache && exists_using_have_coin);
-        } else {
-            assert(!exists_using_access_coin && !exists_using_have_coin_in_cache && !exists_using_have_coin);
-        }
-        // If HaveCoin on the backend is true, it must also be on the cache if the coin wasn't spent.
-        const bool exists_using_have_coin_in_backend = backend_coins_view.HaveCoin(random_out_point);
-        if (!coin_using_access_coin.IsSpent() && exists_using_have_coin_in_backend) {
-            assert(exists_using_have_coin);
-        }
-        if (auto coin{backend_coins_view.GetCoin(random_out_point)}) {
-            assert(exists_using_have_coin_in_backend);
-            // Note we can't assert that `coin_using_get_coin == *coin` because the coin in
-            // the cache may have been modified but not yet flushed.
-        } else {
-            assert(!exists_using_have_coin_in_backend);
-        }
-    }
-
-    {
         bool expected_code_path = false;
         try {
             (void)coins_view_cache.Cursor();
@@ -304,6 +279,31 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
             [&] {
                 (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache);
             });
+    }
+
+    {
+        const Coin& coin_using_access_coin = coins_view_cache.AccessCoin(random_out_point);
+        const bool exists_using_access_coin = !(coin_using_access_coin == EMPTY_COIN);
+        const bool exists_using_have_coin = coins_view_cache.HaveCoin(random_out_point);
+        const bool exists_using_have_coin_in_cache = coins_view_cache.HaveCoinInCache(random_out_point);
+        if (auto coin{coins_view_cache.GetCoin(random_out_point)}) {
+            assert(*coin == coin_using_access_coin);
+            assert(exists_using_access_coin && exists_using_have_coin_in_cache && exists_using_have_coin);
+        } else {
+            assert(!exists_using_access_coin && !exists_using_have_coin_in_cache && !exists_using_have_coin);
+        }
+        // If HaveCoin on the backend is true, it must also be on the cache if the coin wasn't spent.
+        const bool exists_using_have_coin_in_backend = backend_coins_view.HaveCoin(random_out_point);
+        if (!coin_using_access_coin.IsSpent() && exists_using_have_coin_in_backend) {
+            assert(exists_using_have_coin);
+        }
+        if (auto coin{backend_coins_view.GetCoin(random_out_point)}) {
+            assert(exists_using_have_coin_in_backend);
+            // Note we can't assert that `coin_using_get_coin == *coin` because the coin in
+            // the cache may have been modified but not yet flushed.
+        } else {
+            assert(!exists_using_have_coin_in_backend);
+        }
     }
 }
 

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -257,7 +257,9 @@ FUZZ_TARGET(coinscache_sim)
                 // Look up in simulation data.
                 auto sim = lookup(outpointidx);
                 // Look up in real caches.
-                auto realcoin = caches.back()->GetCoin(data.outpoints[outpointidx]);
+                auto realcoin = provider.ConsumeBool() ?
+                    caches.back()->PeekCoin(data.outpoints[outpointidx]) :
+                    caches.back()->GetCoin(data.outpoints[outpointidx]);
                 // Compare results.
                 if (!sim.has_value()) {
                     assert(!realcoin);

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -374,7 +374,11 @@ FUZZ_TARGET(coinscache_sim)
             [&]() { // Add a cache level (if not already at the max).
                 if (caches.size() != MAX_CACHES) {
                     // Apply to real caches.
-                    caches.emplace_back(new CCoinsViewCache(&*caches.back(), /*deterministic=*/true));
+                    if (provider.ConsumeBool()) {
+                        caches.emplace_back(new CCoinsViewCache(&*caches.back(), /*deterministic=*/true));
+                    } else {
+                        caches.emplace_back(new CoinsViewOverlay(&*caches.back(), /*deterministic=*/true));
+                    }
                     // Apply to simulation data.
                     sim_caches[caches.size()].Wipe();
                 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1856,7 +1856,7 @@ void CoinsViews::InitCache()
 {
     AssertLockHeld(::cs_main);
     m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
-    m_connect_block_view = std::make_unique<CCoinsViewCache>(&*m_cacheview);
+    m_connect_block_view = std::make_unique<CoinsViewOverlay>(&*m_cacheview);
 }
 
 Chainstate::Chainstate(

--- a/src/validation.h
+++ b/src/validation.h
@@ -10,6 +10,7 @@
 #include <attributes.h>
 #include <chain.h>
 #include <checkqueue.h>
+#include <coins.h>
 #include <consensus/amount.h>
 #include <cuckoocache.h>
 #include <deploymentstatus.h>
@@ -489,9 +490,9 @@ public:
     //! can fit per the dbcache setting.
     std::unique_ptr<CCoinsViewCache> m_cacheview GUARDED_BY(cs_main);
 
-    //! Temporary CCoinsViewCache layered on top of m_cacheview and passed to ConnectBlock().
+    //! Reused CoinsViewOverlay layered on top of m_cacheview and passed to ConnectBlock().
     //! Reset between calls and flushed only on success, so invalid blocks don't pollute the underlying cache.
-    std::unique_ptr<CCoinsViewCache> m_connect_block_view GUARDED_BY(cs_main);
+    std::unique_ptr<CoinsViewOverlay> m_connect_block_view GUARDED_BY(cs_main);
 
     //! This constructor initializes CCoinsViewDB and CCoinsViewErrorCatcher instances, but it
     //! *does not* create a CCoinsViewCache instance by default. This is done separately because the


### PR DESCRIPTION
This is a slightly modified version of the first few commits of #31132, which can be merged as an independent change. It has a small benefit on its own, but will help in moving the parent PR forward.

When accessing coins via the `CCoinsViewCache`, methods like `GetCoin` can call `FetchCoin` which actually mutate `cacheCoins` internally to cache entries when they are pulled from the backing db. This is generally a performance improvement for single threaded access patterns, but it precludes us from accessing entries in a `CCoinsViewCache` from multiple threads without a lock.

Another aspect is that when we use the resettable `CCoinsViewCache` view backed by the main cache for use in `ConnectBlock()`, we will insert entries into the main cache even if the block is determined to be invalid. This is not the biggest concern, since an invalid block requires proof-of-work. But, an attacker could craft multiple invalid blocks to fill the main cache. This would make us `Flush` the cache more often than necessary. Obviously this would be very expensive to do on mainnet.

Introduce `CoinsViewOverlay`, a `CCoinsViewCache` subclass that reads coins without mutating the underlying cache via `FetchCoin()`.

Add `PeekCoin()` to look up a Coin through a stack of `CCoinsViewCache` layers without populating parent caches. This prevents the main cache from caching inputs pulled from disk for a block that has not yet been fully validated. Once `Flush()` is called on the view, these inputs will be added as spent to `coinsCache` in the main cache via `BatchWrite()`.

This is the foundation for async input fetching, where worker threads must not mutate shared state.
