### PR TITLE
tests: add concise docstrings in chain_tiebreaks

### DIFF
--- a/test/functional/feature_chain_tiebreaks.py
+++ b/test/functional/feature_chain_tiebreaks.py
@@ -104,7 +104,7 @@ class ChainTiebreaksTest(BitcoinTestFramework):
         node.invalidateblock(blocks[0].hash_hex)
 
     def test_chain_split_from_disk(self):
-        """Test active chain selection with in-memory forks and out-of-order blocks."""
+        """Test active chain selection with on-disk forks and out-of-order blocks."""
         node = self.nodes[0]
         peer = node.add_p2p_connection(P2PDataStore())
 

--- a/test/functional/feature_chain_tiebreaks.py
+++ b/test/functional/feature_chain_tiebreaks.py
@@ -24,6 +24,7 @@ class ChainTiebreaksTest(BitcoinTestFramework):
             node.submitheader(hexdata=CBlockHeader(block).serialize().hex())
 
     def test_chain_split_in_memory(self):
+        """Test active chain selection with in-memory forks and out-of-order blocks."""
         node = self.nodes[0]
         # Add P2P connection to bitcoind
         peer = node.add_p2p_connection(P2PDataStore())
@@ -103,6 +104,7 @@ class ChainTiebreaksTest(BitcoinTestFramework):
         node.invalidateblock(blocks[0].hash_hex)
 
     def test_chain_split_from_disk(self):
+        """Test active chain selection with in-memory forks and out-of-order blocks."""
         node = self.nodes[0]
         peer = node.add_p2p_connection(P2PDataStore())
 


### PR DESCRIPTION
Added concise docstrings for test_chain_split_in_memory and test_chain_split_from_disk