### PR TITLE
fuzz: change fuzz runner test_runner.py to be cwd independent

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -208,10 +208,11 @@ def transform_process_message_target(targets, src_dir):
     p2p_msg_target = "process_message"
     if (p2p_msg_target, {}) in targets:
         lines = subprocess.run(
-            ["git", "grep", "--function-context", "ALL_NET_MESSAGE_TYPES{", src_dir / "src" / "protocol.h"],
+            ["git", "grep", "--function-context", "ALL_NET_MESSAGE_TYPES{", "src/protocol.h"],
             check=True,
             stdout=subprocess.PIPE,
             text=True,
+            cwd=src_dir,
         ).stdout.splitlines()
         lines = [l.split("::", 1)[1].split(",")[0].lower() for l in lines if l.startswith("src/protocol.h-    NetMsgType::")]
         assert len(lines)
@@ -226,10 +227,11 @@ def transform_rpc_target(targets, src_dir):
     rpc_target = "rpc"
     if (rpc_target, {}) in targets:
         lines = subprocess.run(
-            ["git", "grep", "--function-context", "RPC_COMMANDS_SAFE_FOR_FUZZING{", src_dir / "src" / "test" / "fuzz" / "rpc.cpp"],
+            ["git", "grep", "--function-context", "RPC_COMMANDS_SAFE_FOR_FUZZING{", "src/test/fuzz/rpc.cpp"],
             check=True,
             stdout=subprocess.PIPE,
             text=True,
+            cwd=src_dir,
         ).stdout.splitlines()
         lines = [l.split("\"", 1)[1].split("\"")[0] for l in lines if l.startswith("src/test/fuzz/rpc.cpp-    \"")]
         assert len(lines)


### PR DESCRIPTION
Dear Maintainers,

While using `test_runner.py` that runs fuzz tests and produces coverage results I encountered the following error.

If not running the script from the project root directory the `git grep --function-context [...]` does not return the same output which results in the following Python error:

```
../../src/protocol.h-', '../../../src/protocol.h-/** nServices flags */']
Traceback (most recent call last):
  File "/path/to/bitcoin/build_libfuzzer/test/fuzz/./test_runner.py", line 405, in <module>
    main()
    ~~~~^^
  File "/path/to/bitcoin/build_libfuzzer/test/fuzz/./test_runner.py", line 173, in main
    return generate_corpus(
        fuzz_pool=fuzz_pool,
    ...<3 lines>...
        targets=test_list_selection,
    )
  File "/path/to/bitcoin/build_libfuzzer/test/fuzz/./test_runner.py", line 249, in generate_corpus
    targets = transform_process_message_target(targets, Path(src_dir))
  File "/path/to/build_libfuzzer/test/fuzz/./test_runner.py", line 218, in transform_process_message_target
    assert len(lines)
           ~~~^^^^^^^
AssertionError
```

The script is not able to retrieve lines as the filter applied is:

```python
lines = [l.split("::", 1)[1].split(",")[0].lower() for l in lines if l.startswith("src/protocol.h-    NetMsgType::")]
```

Which when running from the root directory returns:
```
[snip]
src/protocol.h-    NetMsgType::VERSION,
[snip]
```
but returns a relative path to CWD when run from other directories e.g:
```
../../../src/protocol.h-    NetMsgType::VERSION,
```

This is very unfortunate as the script rightfully read the `config.ini` relatively to itself and go fetch `BUILDDIR` and `SRCDIR`  variables to obtain absolute paths.


Options are:
* enforce running the script from *bitcoin/* directory  (and thus explicitly mentioning it in the doc)
* make the script independent from where it is being run

I chose the second option as it was fairly easy to make the script independent from where it is being run.
