### PR TITLE
doc: fix double-word typos in comments

### DIFF
--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -140,7 +140,7 @@ static void ComplexMemPool(benchmark::Bench& bench)
 
         // Add all transactions to the mempool.
         // Also store the first 10 transactions from each cluster as the
-        // transactions we'll "mine" in the the benchmark.
+        // transactions we'll "mine" in the benchmark.
         int tx_count = 0;
         for (auto& tx : transactions) {
             if (tx_count < 10) {

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -38,7 +38,7 @@ class DepGraph
         /** All descendants of the transaction (including itself). */
         SetType descendants;
 
-        /** Equality operator (primarily for for testing purposes). */
+        /** Equality operator (primarily for testing purposes). */
         friend bool operator==(const Entry&, const Entry&) noexcept = default;
 
         /** Construct an empty entry. */

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -710,7 +710,7 @@ FUZZ_TARGET(txgraph)
                 std::shuffle(refs.begin(), refs.end(), rng);
                 // Invoke the real function.
                 auto result = real->CountDistinctClusters(refs, level_select);
-                // Build a set with representatives of the clusters the Refs occur in in the
+                // Build a set with representatives of the clusters the Refs occur in the
                 // simulated graph. For each, remember the lowest-index transaction SimPos in the
                 // cluster.
                 SimTxGraph::SetType sim_reps;

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -1834,7 +1834,7 @@ void TxGraphImpl::GroupClusters(int level) noexcept
     // Sort an_deps by applying the same order to the involved child cluster.
     std::sort(an_deps.begin(), an_deps.end(), [&](auto& a, auto& b) noexcept { return a.second < b.second; });
 
-    // Run the union-find algorithm to to find partitions of the input Clusters which need to be
+    // Run the union-find algorithm to find partitions of the input Clusters which need to be
     // grouped together. See https://en.wikipedia.org/wiki/Disjoint-set_data_structure.
     {
         /** Each PartitionData entry contains information about a single input Cluster. */

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -25,7 +25,7 @@
  * - Which peer announced it (through their NodeId)
  * - The txid or wtxid of the transaction (collectively called "txhash" in what follows)
  * - Whether it was a tx or wtx announcement (see BIP339).
- * - What the earliest permitted time is that that transaction can be requested from that peer (called "reqtime").
+ * - What the earliest permitted time is that the transaction can be requested from that peer (called "reqtime").
  * - Whether it's from a "preferred" peer or not. Which announcements get this flag is determined by the caller, but
  *   this is designed for outbound peers, or other peers that we have a higher level of trust in. Even when the
  *   peers' preferredness changes, the preferred flag of existing announcements from that peer won't change.


### PR DESCRIPTION
Spotted a few duplicated words while reading through the code:

1. "the the" in mempool_stress.cpp
2. "to to" in txgraph.cpp
3. "for for" in cluster_linearize.h
4. "that that" in txrequest.h
5. "in in" in test/fuzz/txgraph.cpp