### PR TITLE
wallet: make migration more robust against failures

### DIFF
--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -17,6 +17,7 @@
 #include <ios>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 
@@ -139,6 +140,10 @@ template<typename T> static inline path operator+(path p1, T p2) = delete;
 static inline bool copy_file(const path& from, const path& to, copy_options options)
 {
     return std::filesystem::copy_file(from, to, options);
+}
+static inline bool copy_file(const path& from, const path& to, copy_options options, std::error_code& ec)
+{
+    return std::filesystem::copy_file(from, to, options, ec);
 }
 
 /**

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4181,6 +4181,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
         const auto fn_create_wallet = [&context, &options, &empty_context](const std::string& wallet_name,
                                                                            const std::vector<std::pair<std::string, int64_t>>& descs_to_import,
                                                                            std::shared_ptr<CWallet>& out_wallet, bilingual_str& error) {
+            try {
                 DatabaseStatus status;
                 std::vector<bilingual_str> warnings;
                 std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
@@ -4215,6 +4216,10 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
                 // Add the wallet to settings
                 UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/true, warnings);
                 return true;
+            } catch (std::exception& e) {
+                error = strprintf(_("Failed to create new wallet '%s'. Error: %s"), wallet_name, e.what());
+                return false;
+            }
         };
 
         if (data->watch_descs.size() > 0) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3874,7 +3874,16 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     // Close this database and delete the file
     fs::path db_path = fs::PathFromString(m_database->Filename());
     m_database->Close();
-    fs::remove(db_path);
+
+    std::error_code err_db;
+    fs::remove(db_path, err_db);
+    if (err_db) {
+        std::string err_help;
+        const bool perm_issue = err_db.value() == EACCES || err_db.value() == EPERM  || err_db.value() == EROFS;
+        if (perm_issue) err_help = "Adjust directory or file permissions to proceed with migration.";
+        error = strprintf(_("Error: Wallet db cannot be updated. %s"), err_help);
+        return false;
+    }
 
     // Generate the path for the location of the migrated wallet
     // Wallets that are plain files rather than wallet directories will be migrated to be wallet directories.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4177,83 +4177,57 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
         if (wallet.IsWalletFlagSet(WALLET_FLAG_KEY_ORIGIN_METADATA)) {
             options.create_flags |= WALLET_FLAG_KEY_ORIGIN_METADATA;
         }
+
+        const auto fn_create_wallet = [&context, &options, &empty_context](const std::string& wallet_name,
+                                                                           const std::vector<std::pair<std::string, int64_t>>& descs_to_import,
+                                                                           std::shared_ptr<CWallet>& out_wallet, bilingual_str& error) {
+                DatabaseStatus status;
+                std::vector<bilingual_str> warnings;
+                std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
+                if (!database) {
+                    error = strprintf(_("Wallet file creation failed: %s"), error);
+                    return false;
+                }
+
+                out_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, error, warnings);
+                if (!out_wallet) {
+                    error = _("Error: Failed to create new watchonly wallet");
+                    return false;
+                }
+                LOCK(out_wallet->cs_wallet);
+
+                // Parse the descriptors and add them to the new wallet
+                for (const auto& [desc_str, creation_time] : descs_to_import) {
+                    // Parse the descriptor
+                    FlatSigningProvider keys;
+                    std::string parse_err;
+                    std::vector<std::unique_ptr<Descriptor>> descs = Parse(desc_str, keys, parse_err, /*require_checksum=*/ true);
+                    assert(descs.size() == 1); // It shouldn't be possible to have the LegacyScriptPubKeyMan make an invalid descriptor or a multipath descriptors
+                    assert(!descs.at(0)->IsRange()); // It shouldn't be possible to have LegacyScriptPubKeyMan make a ranged watchonly descriptor
+
+                    // Add to the wallet
+                    WalletDescriptor w_desc(std::move(descs.at(0)), creation_time, 0, 0, 0);
+                    if (auto spkm_res = out_wallet->AddWalletDescriptor(w_desc, keys, "", false); !spkm_res) {
+                        throw std::runtime_error(util::ErrorString(spkm_res).original);
+                    }
+                }
+
+                // Add the wallet to settings
+                UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/true, warnings);
+                return true;
+        };
+
         if (data->watch_descs.size() > 0) {
             wallet.WalletLogPrintf("Making a new watchonly wallet containing the watched scripts\n");
-
-            DatabaseStatus status;
-            std::vector<bilingual_str> warnings;
-            std::string wallet_name = MigrationPrefixName(wallet) + "_watchonly";
-            std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
-            if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
-                return false;
-            }
-
-            data->watchonly_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, error, warnings);
-            if (!data->watchonly_wallet) {
-                error = _("Error: Failed to create new watchonly wallet");
-                return false;
-            }
-            res.watchonly_wallet = data->watchonly_wallet;
-            LOCK(data->watchonly_wallet->cs_wallet);
-
-            // Parse the descriptors and add them to the new wallet
-            for (const auto& [desc_str, creation_time] : data->watch_descs) {
-                // Parse the descriptor
-                FlatSigningProvider keys;
-                std::string parse_err;
-                std::vector<std::unique_ptr<Descriptor>> descs = Parse(desc_str, keys, parse_err, /*require_checksum=*/ true);
-                assert(descs.size() == 1); // It shouldn't be possible to have the LegacyScriptPubKeyMan make an invalid descriptor or a multipath descriptors
-                assert(!descs.at(0)->IsRange()); // It shouldn't be possible to have LegacyScriptPubKeyMan make a ranged watchonly descriptor
-
-                // Add to the wallet
-                WalletDescriptor w_desc(std::move(descs.at(0)), creation_time, 0, 0, 0);
-                if (auto spkm_res = data->watchonly_wallet->AddWalletDescriptor(w_desc, keys, "", false); !spkm_res) {
-                    throw std::runtime_error(util::ErrorString(spkm_res).original);
-                }
-            }
-
-            // Add the wallet to settings
-            UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/true, warnings);
+            bool ret = fn_create_wallet(/*wallet_name=*/MigrationPrefixName(wallet) + "_watchonly", data->watch_descs, /*out_wallet=*/data->watchonly_wallet, error);
+            res.watchonly_wallet = data->watchonly_wallet; // always set just so it can be cleaned up later
+            if (!ret) return false;
         }
         if (data->solvable_descs.size() > 0) {
             wallet.WalletLogPrintf("Making a new watchonly wallet containing the unwatched solvable scripts\n");
-
-            DatabaseStatus status;
-            std::vector<bilingual_str> warnings;
-            std::string wallet_name = MigrationPrefixName(wallet) + "_solvables";
-            std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
-            if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
-                return false;
-            }
-
-            data->solvable_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, error, warnings);
-            if (!data->solvable_wallet) {
-                error = _("Error: Failed to create new watchonly wallet");
-                return false;
-            }
-            res.solvables_wallet = data->solvable_wallet;
-            LOCK(data->solvable_wallet->cs_wallet);
-
-            // Parse the descriptors and add them to the new wallet
-            for (const auto& [desc_str, creation_time] : data->solvable_descs) {
-                // Parse the descriptor
-                FlatSigningProvider keys;
-                std::string parse_err;
-                std::vector<std::unique_ptr<Descriptor>> descs = Parse(desc_str, keys, parse_err, /*require_checksum=*/ true);
-                assert(descs.size() == 1); // It shouldn't be possible to have the LegacyScriptPubKeyMan make an invalid descriptor or a multipath descriptors
-                assert(!descs.at(0)->IsRange()); // It shouldn't be possible to have LegacyScriptPubKeyMan make a ranged watchonly descriptor
-
-                // Add to the wallet
-                WalletDescriptor w_desc(std::move(descs.at(0)), creation_time, 0, 0, 0);
-                if (auto spkm_res = data->solvable_wallet->AddWalletDescriptor(w_desc, keys, "", false); !spkm_res) {
-                    throw std::runtime_error(util::ErrorString(spkm_res).original);
-                }
-            }
-
-            // Add the wallet to settings
-            UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/true, warnings);
+            bool ret = fn_create_wallet(/*wallet_name=*/MigrationPrefixName(wallet) + "_solvables", data->solvable_descs, /*out_wallet=*/data->solvable_wallet, error);
+            res.solvables_wallet = data->solvable_wallet;  // always set just so it can be cleaned up later
+            if (!ret) return false;
         }
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3833,6 +3833,36 @@ util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWall
     return std::reference_wrapper(*spk_man);
 }
 
+// Move files from `src` into `dst`.
+// Note: This function doesn't recurse: `src` must not contain subdirectories.
+util::Result<void> MoveDirContent(const fs::path& src, const fs::path& dst)
+{
+    Assert(fs::is_directory(src));
+    TryCreateDirectories(dst);
+
+    // Validate all dst paths up front to avoid partial moves
+    std::vector<std::pair<fs::path, fs::path>> files_to_move;
+    for (const auto& entry : fs::directory_iterator(src)) {
+        const fs::path target = dst / fs::path(entry.path().filename());
+        if (fs::exists(target)) {
+            return util::Error{strprintf(_("Error: destination already exists '%s'"), fs::PathToString(target))};
+        }
+        files_to_move.emplace_back(entry.path(), target);
+    }
+    // Paths are available, move entries
+    for (const auto& [from, to] : files_to_move) fs::rename(from, to);
+    return {};
+}
+
+// Returns wallet prefix for migration.
+// Used to name the backup file and newly created wallets.
+// E.g. a watch-only wallet is named "<prefix>_watchonly".
+static std::string MigrationPrefixName(CWallet& wallet)
+{
+    const std::string& name{wallet.GetName()};
+    return name.empty() ? "default_wallet" : name;
+}
+
 bool CWallet::MigrateToSQLite(bilingual_str& error)
 {
     AssertLockHeld(cs_wallet);
@@ -3871,12 +3901,54 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
         return false;
     }
 
-    // Close this database and delete the file
-    fs::path db_path = fs::PathFromString(m_database->Filename());
+    // Close this database and delete the files.
+    fs::path origin_db_path = fs::PathFromString(m_database->Filename());
     m_database->Close();
 
+    // Create a temporary SQLite database.
+    // Once all records are imported, this new DB will replace the original one.
+    const std::string name_prefix = m_name.empty() ? MigrationPrefixName(*this) : [&] {
+        const auto legacy_wallet_path = fs::weakly_canonical(GetWalletDir() / fs::PathFromString(m_name));
+        return fs::PathToString(legacy_wallet_path.filename());
+    }();
+    const std::string new_db_name = strprintf("%s_sqlite_%d.tmp", name_prefix, GetTime());
+    const fs::path tmp_wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), fs::PathFromString(new_db_name));
+
+    // Make new DB
+    DatabaseOptions opts;
+    opts.require_create = true;
+    opts.require_format = DatabaseFormat::SQLITE;
+    DatabaseStatus db_status;
+    std::unique_ptr<WalletDatabase> new_db = MakeDatabase(tmp_wallet_path, opts, db_status, error);
+    if (!new_db) return false; // error msg appended internally
+    m_database.reset();
+    m_database = std::move(new_db);
+
+    auto tmp_files_to_remove = m_database->Files();
+    tmp_files_to_remove.emplace_back(tmp_wallet_path);
+
+    // Write existing records into the new DB
+    batch = m_database->MakeBatch();
+    bool began = batch->TxnBegin();
+    assert(began); // This is a critical error, the new db could not be written to. The original db is untouched, so we can abort safely.
+    for (const auto& [key, value] : records) {
+        if (!batch->Write(std::span{key}, std::span{value})) {
+            batch->TxnAbort();
+            m_database->Close();
+            fs::remove(m_database->Filename());
+            assert(false); // This is a critical error, the new db could not be written to. The original db is untouched, so we can abort safely.
+        }
+    }
+    bool committed = batch->TxnCommit();
+    assert(committed); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
+    batch.reset();
+
+    // ######################################################################
+    // At this point, the new database has all records.                     #
+    // We can remove the old db file and move the new db inside the wallet  #
+    // ######################################################################
     std::error_code err_db;
-    fs::remove(db_path, err_db);
+    fs::remove(origin_db_path, err_db);
     if (err_db) {
         std::string err_help;
         const bool perm_issue = err_db.value() == EACCES || err_db.value() == EPERM  || err_db.value() == EROFS;
@@ -3884,35 +3956,24 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
         error = strprintf(_("Error: Wallet db cannot be updated. %s"), err_help);
         return false;
     }
+    m_database.reset(); // reset sqlite connection so it can be moved to the new folder
 
-    // Generate the path for the location of the migrated wallet
+    // Move the new sqlite database into the original location
     // Wallets that are plain files rather than wallet directories will be migrated to be wallet directories.
-    const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), fs::PathFromString(m_name));
-
-    // Make new DB
-    DatabaseOptions opts;
-    opts.require_create = true;
-    opts.require_format = DatabaseFormat::SQLITE;
-    DatabaseStatus db_status;
-    std::unique_ptr<WalletDatabase> new_db = MakeDatabase(wallet_path, opts, db_status, error);
-    assert(new_db); // This is to prevent doing anything further with this wallet. The original file was deleted, but a backup exists.
-    m_database.reset();
-    m_database = std::move(new_db);
-
-    // Write existing records into the new DB
-    batch = m_database->MakeBatch();
-    bool began = batch->TxnBegin();
-    assert(began); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
-    for (const auto& [key, value] : records) {
-        if (!batch->Write(std::span{key}, std::span{value})) {
-            batch->TxnAbort();
-            m_database->Close();
-            fs::remove(m_database->Filename());
-            assert(false); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
-        }
+    const fs::path dst_wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), fs::PathFromString(m_name));
+    if (auto ret = MoveDirContent(tmp_wallet_path, dst_wallet_path); !ret) {
+        error = util::ErrorString(ret);
+        return false;
     }
-    bool committed = batch->TxnCommit();
-    assert(committed); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
+    Assert(fs::is_empty(tmp_wallet_path));
+    for (const auto& file : tmp_files_to_remove) {
+        fs::remove(file);
+    }
+
+    // Reload sqlite connection
+    opts.require_create = false;
+    m_database = Assert(MakeDatabase(dst_wallet_path, opts, db_status, error));
+
     return true;
 }
 
@@ -4149,15 +4210,6 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
 bool CWallet::CanGrindR() const
 {
     return !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
-}
-
-// Returns wallet prefix for migration.
-// Used to name the backup file and newly created wallets.
-// E.g. a watch-only wallet is named "<prefix>_watchonly".
-static std::string MigrationPrefixName(CWallet& wallet)
-{
-    const std::string& name{wallet.GetName()};
-    return name.empty() ? "default_wallet" : name;
 }
 
 bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, MigrationResult& res) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3914,23 +3914,21 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     DatabaseStatus db_status;
     std::unique_ptr<WalletDatabase> new_db = MakeDatabase(wallet_path, opts, db_status, error);
     assert(new_db); // This is to prevent doing anything further with this wallet. The original file was deleted, but a backup exists.
-    m_database.reset();
-    m_database = std::move(new_db);
 
     // Write existing records into the new DB
-    batch = m_database->MakeBatch();
-    bool began = batch->TxnBegin();
-    assert(began); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
-    for (const auto& [key, value] : records) {
-        if (!batch->Write(std::span{key}, std::span{value})) {
-            batch->TxnAbort();
-            m_database->Close();
-            fs::remove(m_database->Filename());
-            assert(false); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
+    const bool written = RunWithinTxn(*new_db, "migration: write records to new db", [&records](DatabaseBatch& in_batch) {
+        for (const auto& [key, value] : records) {
+            if (!in_batch.Write(std::span{key}, std::span{value})) return false;
         }
+        return true;
+    });
+    if (!written) {
+        fs::remove(new_db->Filename());
+        assert(false); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
     }
-    bool committed = batch->TxnCommit();
-    assert(committed); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
+
+    m_database.reset();
+    m_database = std::move(new_db);
     return true;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4193,85 +4193,58 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
         if (wallet.IsWalletFlagSet(WALLET_FLAG_KEY_ORIGIN_METADATA)) {
             options.create_flags |= WALLET_FLAG_KEY_ORIGIN_METADATA;
         }
+
+        const auto fn_create_wallet = [&context, &options, &empty_context, load_on_startup](const std::string& wallet_name,
+                                                                           const std::vector<std::pair<std::string, int64_t>>& descs_to_import,
+                                                                           std::shared_ptr<CWallet>& out_wallet, bilingual_str& error) {
+                DatabaseStatus status;
+                std::vector<bilingual_str> warnings;
+                std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
+                if (!database) {
+                    error = strprintf(_("Wallet file creation failed: %s"), error);
+                    return false;
+                }
+
+                out_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, /*born_encrypted=*/false, error, warnings);
+                if (!out_wallet) {
+                    error = _("Error: Failed to create new watchonly wallet");
+                    return false;
+                }
+                LOCK(out_wallet->cs_wallet);
+
+                // Parse the descriptors and add them to the new wallet
+                for (const auto& [desc_str, creation_time] : descs_to_import) {
+                    // Parse the descriptor
+                    FlatSigningProvider keys;
+                    std::string parse_err;
+                    std::vector<std::unique_ptr<Descriptor>> descs = Parse(desc_str, keys, parse_err, /*require_checksum=*/ true);
+                    // LegacyDataSPKM should not produce invalid, multipath, or ranged watch-only descriptors.
+                    assert(descs.size() == 1);
+                    assert(!descs.at(0)->IsRange());
+
+                    // Add to the wallet
+                    WalletDescriptor w_desc(std::move(descs.at(0)), creation_time, 0, 0, 0);
+                    if (auto spkm_res = out_wallet->AddWalletDescriptor(w_desc, keys, "", false); !spkm_res) {
+                        throw std::runtime_error(util::ErrorString(spkm_res).original);
+                    }
+                }
+
+                // Add the wallet to settings
+                UpdateWalletSetting(*context.chain, wallet_name, load_on_startup, warnings);
+                return true;
+        };
+
         if (data->watch_descs.size() > 0) {
             wallet.WalletLogPrintf("Making a new watchonly wallet containing the watched scripts\n");
-
-            DatabaseStatus status;
-            std::vector<bilingual_str> warnings;
-            std::string wallet_name = MigrationPrefixName(wallet) + "_watchonly";
-            std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
-            if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
-                return false;
-            }
-
-            data->watchonly_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, /*born_encrypted=*/false, error, warnings);
-            if (!data->watchonly_wallet) {
-                error = _("Error: Failed to create new watchonly wallet");
-                return false;
-            }
-            res.watchonly_wallet = data->watchonly_wallet;
-            LOCK(data->watchonly_wallet->cs_wallet);
-
-            // Parse the descriptors and add them to the new wallet
-            for (const auto& [desc_str, creation_time] : data->watch_descs) {
-                // Parse the descriptor
-                FlatSigningProvider keys;
-                std::string parse_err;
-                std::vector<std::unique_ptr<Descriptor>> descs = Parse(desc_str, keys, parse_err, /*require_checksum=*/ true);
-                // LegacyDataSPKM should not produce invalid, multipath, or ranged watch-only descriptors.
-                assert(descs.size() == 1);
-                assert(!descs.at(0)->IsRange());
-
-                // Add to the wallet
-                WalletDescriptor w_desc(std::move(descs.at(0)), creation_time, 0, 0, 0);
-                if (auto spkm_res = data->watchonly_wallet->AddWalletDescriptor(w_desc, keys, "", false); !spkm_res) {
-                    throw std::runtime_error(util::ErrorString(spkm_res).original);
-                }
-            }
-
-            // Add the wallet to settings
-            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup, warnings);
+            bool ret = fn_create_wallet(/*wallet_name=*/MigrationPrefixName(wallet) + "_watchonly", data->watch_descs, /*out_wallet=*/data->watchonly_wallet, error);
+            res.watchonly_wallet = data->watchonly_wallet; // always set just so it can be cleaned up later
+            if (!ret) return false;
         }
         if (data->solvable_descs.size() > 0) {
             wallet.WalletLogPrintf("Making a new watchonly wallet containing the unwatched solvable scripts\n");
-
-            DatabaseStatus status;
-            std::vector<bilingual_str> warnings;
-            std::string wallet_name = MigrationPrefixName(wallet) + "_solvables";
-            std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
-            if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
-                return false;
-            }
-
-            data->solvable_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, /*born_encrypted=*/false, error, warnings);
-            if (!data->solvable_wallet) {
-                error = _("Error: Failed to create new watchonly wallet");
-                return false;
-            }
-            res.solvables_wallet = data->solvable_wallet;
-            LOCK(data->solvable_wallet->cs_wallet);
-
-            // Parse the descriptors and add them to the new wallet
-            for (const auto& [desc_str, creation_time] : data->solvable_descs) {
-                // Parse the descriptor
-                FlatSigningProvider keys;
-                std::string parse_err;
-                std::vector<std::unique_ptr<Descriptor>> descs = Parse(desc_str, keys, parse_err, /*require_checksum=*/ true);
-                // LegacyDataSPKM should not produce invalid, multipath, or ranged watch-only descriptors.
-                assert(descs.size() == 1);
-                assert(!descs.at(0)->IsRange());
-
-                // Add to the wallet
-                WalletDescriptor w_desc(std::move(descs.at(0)), creation_time, 0, 0, 0);
-                if (auto spkm_res = data->solvable_wallet->AddWalletDescriptor(w_desc, keys, "", false); !spkm_res) {
-                    throw std::runtime_error(util::ErrorString(spkm_res).original);
-                }
-            }
-
-            // Add the wallet to settings
-            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup, warnings);
+            bool ret = fn_create_wallet(/*wallet_name=*/MigrationPrefixName(wallet) + "_solvables", data->solvable_descs, /*out_wallet=*/data->solvable_wallet, error);
+            res.solvables_wallet = data->solvable_wallet;  // always set just so it can be cleaned up later
+            if (!ret) return false;
         }
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3892,7 +3892,16 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     // Close this database and delete the file
     fs::path db_path = fs::PathFromString(m_database->Filename());
     m_database->Close();
-    fs::remove(db_path);
+
+    std::error_code err_db;
+    fs::remove(db_path, err_db);
+    if (err_db) {
+        std::string err_help;
+        const bool perm_issue = err_db.value() == EACCES || err_db.value() == EPERM  || err_db.value() == EROFS;
+        if (perm_issue) err_help = "Adjust directory or file permissions to proceed with migration.";
+        error = strprintf(_("Error: Wallet db cannot be updated. %s"), err_help);
+        return false;
+    }
 
     // Generate the path for the location of the migrated wallet
     // Wallets that are plain files rather than wallet directories will be migrated to be wallet directories.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4197,6 +4197,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
         const auto fn_create_wallet = [&context, &options, &empty_context, load_on_startup](const std::string& wallet_name,
                                                                            const std::vector<std::pair<std::string, int64_t>>& descs_to_import,
                                                                            std::shared_ptr<CWallet>& out_wallet, bilingual_str& error) {
+            try {
                 DatabaseStatus status;
                 std::vector<bilingual_str> warnings;
                 std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
@@ -4232,6 +4233,10 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
                 // Add the wallet to settings
                 UpdateWalletSetting(*context.chain, wallet_name, load_on_startup, warnings);
                 return true;
+            } catch (std::exception& e) {
+                error = strprintf(_("Failed to create new wallet '%s'. Error: %s"), wallet_name, e.what());
+                return false;
+            }
         };
 
         if (data->watch_descs.size() > 0) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4410,7 +4410,7 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
     //             migrating only watch-only scripts.
     bool empty_local_wallet = false;
 
-    {
+    try {
         LOCK(local_wallet->cs_wallet);
         // First change to using SQLite
         if (!local_wallet->MigrateToSQLite(error)) return util::Error{error};
@@ -4425,6 +4425,8 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
             local_wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
             success = true;
         }
+    } catch (const std::exception& e) {
+        error = Untranslated(strprintf("Unexpected exception during migration: %s", e.what()));
     }
 
     // In case of loading failure, we need to remember the wallet files we have created to remove.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3851,6 +3851,15 @@ util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWall
     return std::reference_wrapper(*spk_man);
 }
 
+// Returns wallet prefix for migration.
+// Used to name the backup file and newly created wallets.
+// E.g. a watch-only wallet is named "<prefix>_watchonly".
+static std::string MigrationPrefixName(CWallet& wallet)
+{
+    const std::string& name{wallet.GetName()};
+    return name.empty() ? "default_wallet" : name;
+}
+
 bool CWallet::MigrateToSQLite(bilingual_str& error)
 {
     AssertLockHeld(cs_wallet);
@@ -3889,31 +3898,40 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
         return false;
     }
 
-    // Close this database and delete the file
-    fs::path db_path = fs::PathFromString(m_database->Filename());
+    // Close this database. It is replaced once the new one is fully built.
+    const fs::path origin_db_path = fs::PathFromString(m_database->Filename());
     m_database->Close();
 
-    std::error_code err_db;
-    fs::remove(db_path, err_db);
-    if (err_db) {
-        std::string err_help;
-        const bool perm_issue = err_db.value() == EACCES || err_db.value() == EPERM  || err_db.value() == EROFS;
-        if (perm_issue) err_help = "Adjust directory or file permissions to proceed with migration.";
-        error = strprintf(_("Error: Wallet db cannot be updated. %s"), err_help);
+    // Create a temporary database in the wallets directory. The process will replace the
+    // real one upon completion.
+    const std::string name_prefix = m_name.empty() ? MigrationPrefixName(*this) : [&] {
+        const auto legacy_wallet_path = fs::weakly_canonical(GetWalletDir() / fs::PathFromString(m_name));
+        return fs::PathToString(legacy_wallet_path.filename());
+    }();
+    const std::string new_db_name = strprintf("%s_sqlite_%d.tmp", name_prefix, GetTime());
+    const fs::path tmp_wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), fs::PathFromString(new_db_name));
+    if (fs::exists(fs::symlink_status(tmp_wallet_path))) {
+        error = strprintf(_("Error: Unable to create new database for wallet '%s': temporary path '%s' already exists"), GetName(), fs::PathToString(tmp_wallet_path));
         return false;
     }
 
-    // Generate the path for the location of the migrated wallet
-    // Wallets that are plain files rather than wallet directories will be migrated to be wallet directories.
-    const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), fs::PathFromString(m_name));
+    // Temporary dir did not exist before, it is safe to remove it entirely. It only ever contains the new db file.
+    const auto remove_tmp{[&tmp_wallet_path] {
+        std::error_code ec;
+        fs::remove(SQLiteDataFile(tmp_wallet_path), ec);
+        fs::remove(tmp_wallet_path, ec);
+    }};
+    const auto fail = [&](bilingual_str err) { error = std::move(err); remove_tmp(); return false; };
 
     // Make new DB
     DatabaseOptions opts;
     opts.require_create = true;
     opts.require_format = DatabaseFormat::SQLITE;
     DatabaseStatus db_status;
-    std::unique_ptr<WalletDatabase> new_db = MakeDatabase(wallet_path, opts, db_status, error);
-    assert(new_db); // This is to prevent doing anything further with this wallet. The original file was deleted, but a backup exists.
+    std::unique_ptr<WalletDatabase> new_db = MakeDatabase(tmp_wallet_path, opts, db_status, error);
+    if (!new_db) {
+        return fail(strprintf(_("Error: Unable to create the new database for wallet '%s'."), GetName()) + Untranslated(" ") + error);
+    }
 
     // Write existing records into the new DB
     const bool written = RunWithinTxn(*new_db, "migration: write records to new db", [&records](DatabaseBatch& in_batch) {
@@ -3923,12 +3941,38 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
         return true;
     });
     if (!written) {
-        fs::remove(new_db->Filename());
-        assert(false); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
+        return fail(strprintf(_("Error: Unable to write records into the new database for wallet '%s'"), GetName()));
     }
 
-    m_database.reset();
-    m_database = std::move(new_db);
+    // ######################################################################
+    // At this point, the new database has all records.                     #
+    // We can remove the old db file and move the new db inside the wallet  #
+    // ######################################################################
+    std::error_code err_db;
+    fs::remove(origin_db_path, err_db);
+    if (err_db) {
+        std::string err_help;
+        const bool perm_issue = err_db.value() == EACCES || err_db.value() == EPERM  || err_db.value() == EROFS;
+        if (perm_issue) err_help = " Adjust directory or file permissions to proceed with migration.";
+        return fail(strprintf(_("Error: Wallet db cannot be updated. Path: %s, Error: %s.%s"), fs::PathToString(origin_db_path), err_db.message(), err_help));
+    }
+
+    // Move the new sqlite database into the original location
+    const fs::path tmp_db = fs::PathFromString(new_db->Filename());
+    new_db.reset(); // reset sqlite connection so it can be moved to the new folder
+
+    // Wallets that are plain files rather than wallet directories will be migrated to be wallet directories.
+    const fs::path dst_wallet_dir = fsbridge::AbsPathJoin(GetWalletDir(), fs::PathFromString(m_name));
+    TryCreateDirectories(dst_wallet_dir);
+    fs::copy_file(tmp_db, dst_wallet_dir / "wallet.dat", fs::copy_options::none, err_db);
+    if (err_db) {
+        return fail(strprintf(_("Error: Wallet db cannot be updated. Path: %s, Error: %s."), fs::PathToString(dst_wallet_dir), err_db.message()));
+    }
+    remove_tmp();
+
+    // Reload db connection
+    opts.require_create = false;
+    m_database = Assert(MakeDatabase(dst_wallet_dir, opts, db_status, error));
     return true;
 }
 
@@ -4163,15 +4207,6 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
 bool CWallet::CanGrindR() const
 {
     return !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
-}
-
-// Returns wallet prefix for migration.
-// Used to name the backup file and newly created wallets.
-// E.g. a watch-only wallet is named "<prefix>_watchonly".
-static std::string MigrationPrefixName(CWallet& wallet)
-{
-    const std::string& name{wallet.GetName()};
-    return name.empty() ? "default_wallet" : name;
 }
 
 bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, MigrationResult& res, const bool load_on_startup = true) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1225,7 +1225,8 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     return result;
 }
 
-static bool RunWithinTxn(WalletBatch& batch, std::string_view process_desc, const std::function<bool(WalletBatch&)>& func)
+template <typename T>
+static bool RunWithinTxn(T& batch, std::string_view process_desc, const std::function<bool(T&)>& func)
 {
     if (!batch.TxnBegin()) {
         LogDebug(BCLog::WALLETDB, "Error: cannot create db txn for %s\n", process_desc);
@@ -1252,6 +1253,12 @@ bool RunWithinTxn(WalletDatabase& database, std::string_view process_desc, const
 {
     WalletBatch batch(database);
     return RunWithinTxn(batch, process_desc, func);
+}
+
+bool RunWithinTxn(WalletDatabase& database, std::string_view process_desc, const std::function<bool(DatabaseBatch&)>& func)
+{
+    const auto batch = database.MakeBatch();
+    return RunWithinTxn(*batch, process_desc, func);
 }
 
 bool WalletBatch::WriteAddressPreviouslySpent(const CTxDestination& dest, bool previously_spent)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -316,6 +316,7 @@ private:
  * @return true if the db txn executed successfully, false otherwise.
  */
 bool RunWithinTxn(WalletDatabase& database, std::string_view process_desc, const std::function<bool(WalletBatch&)>& func);
+bool RunWithinTxn(WalletDatabase& database, std::string_view process_desc, const std::function<bool(DatabaseBatch&)>& func);
 
 bool LoadKey(CWallet* pwallet, DataStream& ssKey, DataStream& ssValue, std::string& strErr);
 bool LoadCryptedKey(CWallet* pwallet, DataStream& ssKey, DataStream& ssValue, std::string& strErr);

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -720,3 +720,13 @@ def wallet_importprivkey(wallet_rpc, privkey, timestamp, *, label=""):
     }]
     import_res = wallet_rpc.importdescriptors(req)
     assert_equal(import_res[0]["success"], True)
+
+def is_dir_writable(dir_path: pathlib.Path) -> bool:
+    """Return True if we can create a file in the directory, False otherwise"""
+    try:
+        tmp = dir_path / f".tmp_{random.randrange(1 << 32)}"
+        tmp.touch()
+        tmp.unlink()
+        return True
+    except OSError:
+        return False

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -6,9 +6,10 @@
 from contextlib import suppress
 from pathlib import Path
 import json
-import os.path
+import os
 import random
 import shutil
+import stat
 import struct
 import time
 from decimal import Decimal
@@ -30,6 +31,7 @@ from test_framework.util import (
     assert_greater_than,
     assert_raises_rpc_error,
     find_vout_for_address,
+    is_dir_writable,
     sha256sum_file,
 )
 from test_framework.wallet_util import (
@@ -182,6 +184,27 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.inspect_sqlite_db(inspect_path, check_last_hardened)
 
         return migrate_info, wallet
+
+    def test_unwritable_dir_failure(self):
+        self.log.info("Test migration failure due to non-writable directory")
+        wallet_name = "bad_permissions"
+        wallet = self.create_legacy_wallet(wallet_name)
+        wallet.unloadwallet()
+        shutil.copytree(self.old_node.wallets_path / wallet_name, self.master_node.wallets_path / wallet_name, dirs_exist_ok=True)
+
+        # Change dir perms and migrate
+        wallet_path = self.master_node.wallets_path / wallet_name
+        original_dir_perms = wallet_path.stat().st_mode
+        os.chmod(wallet_path, original_dir_perms & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+        if is_dir_writable(wallet_path):
+            self.log.warning("Skipping migration non-writable directory test: unable to enforce read-only permissions")
+        else:
+            assert_raises_rpc_error(-4, "Error: Wallet db cannot be updated. Adjust directory or file permissions to proceed with migration.", self.master_node.migratewallet, wallet_name)
+        # Reset directory permissions
+        wallet_path.chmod(original_dir_perms)
+
+        # Check the wallet we tried to migrate is still BDB
+        self.assert_is_bdb(wallet_name)
 
     def test_basic(self):
         # Update listtransctions' output from old nodes to be compatible
@@ -1758,6 +1781,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.generate(self.master_node, 101)
 
         # TODO: Test the actual records in the wallet for these tests too. The behavior may be correct, but the data written may not be what we actually want
+        self.test_unwritable_dir_failure()
         self.test_basic()
         self.test_multisig()
         self.test_other_watchonly()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -199,9 +199,10 @@ class WalletMigrationTest(BitcoinTestFramework):
         if is_dir_writable(wallet_path):
             self.log.warning("Skipping migration non-writable directory test: unable to enforce read-only permissions")
         else:
-            assert_raises_rpc_error(-4, "Error: Wallet db cannot be updated. Adjust directory or file permissions to proceed with migration.", self.master_node.migratewallet, wallet_name)
+            assert_raises_rpc_error(-4, f'Error: Wallet db cannot be updated. Path: {wallet_path}/wallet.dat', self.master_node.migratewallet, wallet_name)
         # Reset directory permissions
         wallet_path.chmod(original_dir_perms)
+        assert not [f for f in os.listdir(self.master_node.wallets_path) if "_sqlite_" in f]  # tmp db cleaned up
 
         # Check the wallet we tried to migrate is still BDB
         self.assert_is_bdb(wallet_name)

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -11,6 +11,7 @@ import random
 import shutil
 import stat
 import struct
+import tempfile
 import time
 from decimal import Decimal
 
@@ -206,6 +207,25 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         # Check the wallet we tried to migrate is still BDB
         self.assert_is_bdb(wallet_name)
+
+    def test_other_filesystem(self):
+        self.log.info("Test migration of a wallet located on a different filesystem than the wallets directory")
+        wallets_dev = os.stat(self.master_node.wallets_path).st_dev
+        other_fs = next((p for p in [Path("/dev/shm"), Path(tempfile.gettempdir())] if p.is_dir() and os.stat(p).st_dev != wallets_dev), None)
+        if other_fs is None:
+            self.log.warning("Skipping migration on other filesystem test: no other filesystem available")
+            return
+
+        with tempfile.TemporaryDirectory(prefix="wallet_migration_", dir=other_fs) as parent_dir:
+            wallet_name = str(Path(parent_dir) / "wallet")
+            wallet = self.create_legacy_wallet(wallet_name)
+            addr = wallet.getnewaddress()
+
+            migrate_res, wallet = self.migrate_and_get_rpc(wallet_name)
+            assert_equal(wallet.getaddressinfo(addr)["ismine"], True)
+            assert not [f for f in os.listdir(self.master_node.wallets_path) if "_sqlite_" in f]  # tmp db cleaned up
+            wallet.unloadwallet()
+        os.remove(migrate_res["backup_path"])
 
     def test_basic(self):
         # Update listtransctions' output from old nodes to be compatible
@@ -1783,6 +1803,7 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         # TODO: Test the actual records in the wallet for these tests too. The behavior may be correct, but the data written may not be what we actually want
         self.test_unwritable_dir_failure()
+        self.test_other_filesystem()
         self.test_basic()
         self.test_multisig()
         self.test_other_watchonly()


### PR DESCRIPTION
This is just me finding a few more edge cases after #34156 and #34176

The goal of the PR is to handle failures in a controlled way. Just so the process can automatically restore the original wallet without requiring user manual intervention.

The covered cases are:

1. During `DoMigration()`: There are methods that can throw exceptions and abruptly abort the process. 
Instead of crashing (GUI) or returning a generic exception, we now will catch and return the error gracefully. This lets the process restore the original wallet automatically.

2. Trying to migrate a wallet in a read-only directory throws a filesystem exception and skips cleanup.
 Now the process will fail gracefully with a clear error msg, and automatically restore the original wallet.

3. Any failure during `MigrateToSQLite` requires user manual intervention. 
Now the original wallet db will remain untouched, and only be updated once the sqlite db creation fully succeeds.