### PR TITLE
doc: p2p: replace last remaining "command" terminology with "message type"

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4945,8 +4945,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         return;
     }
 
-    // Ignore unknown commands for extensibility
-    LogDebug(BCLog::NET, "Unknown command \"%s\" from peer=%d\n", SanitizeString(msg_type), pfrom.GetId());
+    // Ignore unknown message types for extensibility
+    LogDebug(BCLog::NET, "Unknown message type \"%s\" from peer=%d", SanitizeString(msg_type), pfrom.GetId());
     return;
 }
 
@@ -5301,7 +5301,7 @@ void PeerManagerImpl::MaybeSendPing(CNode& node_to, Peer& peer, std::chrono::mic
             peer.m_ping_nonce_sent = nonce;
             MakeAndPushMessage(node_to, NetMsgType::PING, nonce);
         } else {
-            // Peer is too old to support ping command with nonce, pong will never arrive.
+            // Peer is too old to support ping message type with nonce, pong will never arrive.
             peer.m_ping_nonce_sent = 0;
             MakeAndPushMessage(node_to, NetMsgType::PING);
         }

--- a/src/node/protocol_version.h
+++ b/src/node/protocol_version.h
@@ -20,7 +20,7 @@ static const int MIN_PEER_PROTO_VERSION = 31800;
 //! BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;
 
-//! "sendheaders" command and announcing blocks with headers starts with this version
+//! "sendheaders" message type and announcing blocks with headers starts with this version
 static const int SENDHEADERS_VERSION = 70012;
 
 //! "feefilter" tells peers to filter invs to you by fee starts with this version
@@ -32,7 +32,7 @@ static const int SHORT_IDS_BLOCKS_VERSION = 70014;
 //! not banning for invalid compact blocks starts with this version
 static const int INVALID_CB_NO_BAN_VERSION = 70015;
 
-//! "wtxidrelay" command for wtxid-based relay starts with this version
+//! "wtxidrelay" message type for wtxid-based relay starts with this version
 static const int WTXID_RELAY_VERSION = 70016;
 
 #endif // BITCOIN_NODE_PROTOCOL_VERSION_H


### PR DESCRIPTION
This small PR is (presumably) the final one in a long series of replacing the confusing "command" terminology with "message type" when referring to the header field of P2P messages, see #18533, #18937, #24078, #24141 and #31163.

The instances were found manually via `$ git grep -i command`, hope I didn't miss any.