### PR TITLE
bench: add fluent API for untimed `setup` steps in nanobench

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -27,38 +27,30 @@
 
 static void DeserializeBlockTest(benchmark::Bench& bench)
 {
-    DataStream stream(benchmark::data::block413567);
-    std::byte a{0};
-    stream.write({&a, 1}); // Prevent compaction
-
-    bench.unit("block").run([&] {
-        CBlock block;
-        stream >> TX_WITH_WITNESS(block);
-        bool rewound = stream.Rewind(benchmark::data::block413567.size());
-        assert(rewound);
-    });
+    DataStream stream;
+    bench.unit("block").epochIterations(1)
+        .setup([&] { stream = DataStream{benchmark::data::block413567}; })
+        .run([&] { CBlock block; stream >> TX_WITH_WITNESS(block); });
 }
 
-static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
+static void CheckBlockTest(benchmark::Bench& bench)
 {
-    DataStream stream(benchmark::data::block413567);
-    std::byte a{0};
-    stream.write({&a, 1}); // Prevent compaction
-
     ArgsManager bench_args;
     const auto chainParams = CreateChainParams(bench_args, ChainType::MAIN);
 
-    bench.unit("block").run([&] {
-        CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here
-        stream >> TX_WITH_WITNESS(block);
-        bool rewound = stream.Rewind(benchmark::data::block413567.size());
-        assert(rewound);
-
-        BlockValidationState validationState;
-        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus());
-        assert(checked);
-    });
+    CBlock block;
+    bench.unit("block").epochIterations(1)
+        .setup([&] {
+            block = CBlock{};
+            DataStream stream{benchmark::data::block413567};
+            stream >> TX_WITH_WITNESS(block);
+        })
+        .run([&] {
+            BlockValidationState validationState;
+            bool checked = CheckBlock(block, validationState, chainParams->GetConsensus());
+            assert(checked);
+        });
 }
 
 BENCHMARK(DeserializeBlockTest);
-BENCHMARK(DeserializeAndCheckBlockTest);
+BENCHMARK(CheckBlockTest);

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -124,17 +124,14 @@ static CAmount make_hard_case(int utxos, std::vector<OutputGroup>& utxo_pool)
 
 static void BnBExhaustion(benchmark::Bench& bench)
 {
-    // Setup
     std::vector<OutputGroup> utxo_pool;
-
-    bench.run([&] {
-        // Benchmark
-        CAmount target = make_hard_case(17, utxo_pool);
-        (void)SelectCoinsBnB(utxo_pool, target, /*cost_of_change=*/0, MAX_STANDARD_TX_WEIGHT); // Should exhaust
-
-        // Cleanup
-        utxo_pool.clear();
-    });
+    CAmount target;
+    bench.epochIterations(1)
+        .setup([&] { target = make_hard_case(17, utxo_pool); })
+        .run([&] {
+            auto res{SelectCoinsBnB(utxo_pool, target, /*cost_of_change=*/0, MAX_STANDARD_TX_WEIGHT)}; // Should exhaust
+            ankerl::nanobench::doNotOptimizeAway(res);
+        });
 }
 
 BENCHMARK(CoinSelection);

--- a/src/bench/load_external.cpp
+++ b/src/bench/load_external.cpp
@@ -62,12 +62,17 @@ static void LoadExternalBlockFile(benchmark::Bench& bench)
 
     std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
     FlatFilePos pos;
-    bench.run([&] {
-        // "rb" is "binary, O_RDONLY", positioned to the start of the file.
-        // The file will be closed by LoadExternalBlockFile().
-        AutoFile file{fsbridge::fopen(blkfile, "rb")};
-        testing_setup->m_node.chainman->LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
-    });
+    bench.epochIterations(1)
+        .setup([&] {
+            blocks_with_unknown_parent.clear();
+            pos = FlatFilePos{};
+        })
+        .run([&] {
+            // "rb" is "binary, O_RDONLY", positioned to the start of the file.
+            // The file will be closed by LoadExternalBlockFile().
+            AutoFile file{fsbridge::fopen(blkfile, "rb")};
+            testing_setup->m_node.chainman->LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
+        });
     fs::remove(blkfile);
 }
 

--- a/src/bench/streams_findbyte.cpp
+++ b/src/bench/streams_findbyte.cpp
@@ -22,10 +22,9 @@ static void FindByte(benchmark::Bench& bench)
     file.seek(0, SEEK_SET);
     BufferedFile bf{file, /*nBufSize=*/file_size + 1, /*nRewindIn=*/file_size};
 
-    bench.run([&] {
-        bf.SetPos(0);
-        bf.FindByte(std::byte(1));
-    });
+    bench.epochIterations(1)
+        .setup([&] { bf.SetPos(0); })
+        .run([&] { bf.FindByte(std::byte(1)); });
 
     assert(file.fclose() == 0);
 }


### PR DESCRIPTION
### Context
As described in https://github.com/martinus/nanobench/issues/130, we have a few benchmarks where we have to reset the state between runs; otherwise, the repetitions will do something different than the first iteration.

### Upstream
I have opened a PR to `nanobench` to introduce an untimed setup phase, see: https://github.com/martinus/nanobench/pull/136

### Tests

Tests were only added upstream. It would be a bit awkward to wire them into `nanobench.h` outside the benchmarking setup:
https://github.com/martinus/nanobench/pull/136/changes/58350cfe5912d7e0533ccfcd759eea5d62eb55bb#diff-88160f647ce57661afe7d755fa70a5fa342a2b79d72d3511596878e69ed5cdc3

### Fix
I have moved the changes here as well and applied them to a few simple benchmarks as a demonstration.
We can revert the ones that are controversial and add others in follow-ups. This PR is mostly meant to add the `setup` feature.

### Benchmarks
Most benchmarks show a modest "speedup"; others a "slowdown" - but it's only the effect of the setup that's not measured anymore - and a `run` phase that does the same operation in each epoch iteration (wallet benchmark changes were reverted for simplicity):
<img width="1496" height="882" alt="image" src="https://github.com/user-attachments/assets/34c14565-f3df-41e5-9a86-95b2ca21703a" />

