### PR TITLE
net: preserve anchors when network is disabled

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2554,7 +2554,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
     AssertLockNotHeld(m_nodes_mutex);
     AssertLockNotHeld(m_reconnections_mutex);
     AssertLockNotHeld(m_unused_i2p_sessions_mutex);
-
+    AssertLockNotHeld(m_anchors_mutex);
     FastRandomContext rng;
     // Connect to specific addresses
     if (!connect.empty())
@@ -2741,7 +2741,8 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
         // block-relay-only peer (to confirm our tip is current, see below) or the next_feeler
         // timer to decide if we should open a FEELER.
 
-        if (!m_anchors.empty() && (nOutboundBlockRelay < m_max_outbound_block_relay)) {
+        const bool have_anchors{WITH_LOCK(m_anchors_mutex, return !m_anchors.empty())};
+        if (have_anchors && (nOutboundBlockRelay < m_max_outbound_block_relay)) {
             conn_type = ConnectionType::BLOCK_RELAY;
             anchor = true;
         } else if (nOutboundFullRelay < m_max_outbound_full_relay) {
@@ -2801,15 +2802,23 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
         const auto reachable_nets{g_reachable_nets.All()};
 
         while (!m_interrupt_net->interrupted()) {
-            if (anchor && !m_anchors.empty()) {
-                const CAddress addr = m_anchors.back();
-                m_anchors.pop_back();
-                if (!addr.IsValid() || IsLocal(addr) || !g_reachable_nets.Contains(addr) ||
-                    !m_msgproc->HasAllDesirableServiceFlags(addr.nServices) ||
-                    outbound_ipv46_peer_netgroups.contains(m_netgroupman.GetGroup(addr))) continue;
-                addrConnect = addr;
-                LogDebug(BCLog::NET, "Trying to make an anchor connection to %s\n", addrConnect.ToStringAddrPort());
-                break;
+            if (anchor) {
+                std::optional<CAddress> anchor_addr;
+                {
+                    LOCK(m_anchors_mutex);
+                    if (!m_anchors.empty()) {
+                        anchor_addr = m_anchors.back();
+                        m_anchors.pop_back();
+                    }
+                }
+                if (anchor_addr) {
+                    if (!anchor_addr->IsValid() || IsLocal(*anchor_addr) || !g_reachable_nets.Contains(*anchor_addr) ||
+                        !m_msgproc->HasAllDesirableServiceFlags(anchor_addr->nServices) ||
+                        outbound_ipv46_peer_netgroups.contains(m_netgroupman.GetGroup(*anchor_addr))) continue;
+                    addrConnect = *anchor_addr;
+                    LogDebug(BCLog::NET, "Trying to make an anchor connection to %s\n", addrConnect.ToStringAddrPort());
+                    break;
+                }
             }
 
             // If we didn't find an appropriate destination after trying 100 addresses fetched from addrman,
@@ -3527,6 +3536,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
 
     if (m_use_addrman_outgoing) {
         // Load addresses from anchors.dat
+        LOCK(m_anchors_mutex);
         m_anchors = ReadAnchors(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
         if (m_anchors.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
             m_anchors.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3547,7 +3547,9 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         if (m_anchors.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
             m_anchors.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
         }
-        LogInfo("%i block-relay-only anchors will be tried for connections.\n", m_anchors.size());
+        if (fNetworkActive) {
+            LogInfo("%i block-relay-only anchors will be tried for connections.\n", m_anchors.size());
+        }
     }
 
     if (m_client_interface) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3410,6 +3410,12 @@ void CConnman::SetNetworkActive(bool active)
         return;
     }
 
+    if (!active) {
+        auto anchors = GetCurrentBlockRelayOnlyConns();
+        LOCK(m_anchors_mutex);
+        m_anchors = std::move(anchors);
+    }
+
     fNetworkActive = active;
 
     if (m_client_interface) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3693,6 +3693,7 @@ void CConnman::StopNodes()
 {
     AssertLockNotHeld(m_nodes_mutex);
     AssertLockNotHeld(m_reconnections_mutex);
+    AssertLockNotHeld(m_anchors_mutex);
 
     if (fAddressesInitialized) {
         DumpAddresses();
@@ -3701,10 +3702,18 @@ void CConnman::StopNodes()
         if (m_use_addrman_outgoing) {
             // Anchor connections are only dumped during clean shutdown.
             std::vector<CAddress> anchors_to_dump = GetCurrentBlockRelayOnlyConns();
-            if (anchors_to_dump.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
-                anchors_to_dump.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
+            {
+                LOCK(m_anchors_mutex);
+                if (!fNetworkActive && !m_anchors.empty()) {
+                    anchors_to_dump = m_anchors;
+                }
             }
-            DumpAnchors(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME, anchors_to_dump);
+            if (!anchors_to_dump.empty()) {
+                if (anchors_to_dump.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
+                    anchors_to_dump.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
+                }
+                DumpAnchors(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME, anchors_to_dump);
+            }
         }
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3762,6 +3762,7 @@ void CConnman::StopNodes()
 {
     AssertLockNotHeld(m_nodes_mutex);
     AssertLockNotHeld(m_reconnections_mutex);
+    AssertLockNotHeld(m_anchors_mutex);
 
     if (fAddressesInitialized) {
         DumpAddresses();
@@ -3770,6 +3771,12 @@ void CConnman::StopNodes()
         if (m_use_addrman_outgoing) {
             // Anchor connections are only dumped during clean shutdown.
             std::vector<CAddress> anchors_to_dump = GetCurrentBlockRelayOnlyConns();
+            {
+                LOCK(m_anchors_mutex);
+                if (!fNetworkActive && !m_anchors.empty()) {
+                    anchors_to_dump = m_anchors;
+                }
+            }
             if (anchors_to_dump.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
                 anchors_to_dump.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
             }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2595,7 +2595,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
     AssertLockNotHeld(m_nodes_mutex);
     AssertLockNotHeld(m_reconnections_mutex);
     AssertLockNotHeld(m_unused_i2p_sessions_mutex);
-
+    AssertLockNotHeld(m_anchors_mutex);
     FastRandomContext rng;
     // Connect to specific addresses
     if (!connect.empty())
@@ -2787,7 +2787,8 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
         // block-relay-only peer (to confirm our tip is current, see below) or the next_feeler
         // timer to decide if we should open a FEELER.
 
-        if (!m_anchors.empty() && (nOutboundBlockRelay < m_max_outbound_block_relay)) {
+        const bool have_anchors{WITH_LOCK(m_anchors_mutex, return !m_anchors.empty())};
+        if (have_anchors && (nOutboundBlockRelay < m_max_outbound_block_relay)) {
             conn_type = ConnectionType::BLOCK_RELAY;
             anchor = true;
         } else if (nOutboundFullRelay < m_max_outbound_full_relay) {
@@ -2847,15 +2848,23 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
         const auto reachable_nets{g_reachable_nets.All()};
 
         while (!m_interrupt_net->interrupted()) {
-            if (anchor && !m_anchors.empty()) {
-                const CAddress addr = m_anchors.back();
-                m_anchors.pop_back();
-                if (!addr.IsValid() || IsLocal(addr) || !g_reachable_nets.Contains(addr) ||
-                    !m_msgproc->HasAllDesirableServiceFlags(addr.nServices) ||
-                    outbound_ipv46_peer_netgroups.contains(m_netgroupman.GetGroup(addr))) continue;
-                addrConnect = addr;
-                LogDebug(BCLog::NET, "Trying to make an anchor connection to %s\n", addrConnect.ToStringAddrPort());
-                break;
+            if (anchor) {
+                std::optional<CAddress> anchor_addr;
+                {
+                    LOCK(m_anchors_mutex);
+                    if (!m_anchors.empty()) {
+                        anchor_addr = m_anchors.back();
+                        m_anchors.pop_back();
+                    }
+                }
+                if (anchor_addr) {
+                    if (!anchor_addr->IsValid() || IsLocal(*anchor_addr) || !g_reachable_nets.Contains(*anchor_addr) ||
+                        !m_msgproc->HasAllDesirableServiceFlags(anchor_addr->nServices) ||
+                        outbound_ipv46_peer_netgroups.contains(m_netgroupman.GetGroup(*anchor_addr))) continue;
+                    addrConnect = *anchor_addr;
+                    LogDebug(BCLog::NET, "Trying to make an anchor connection to %s\n", addrConnect.ToStringAddrPort());
+                    break;
+                }
             }
 
             // If we didn't find an appropriate destination after trying 100 addresses fetched from addrman,
@@ -3584,6 +3593,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
 
     if (m_use_addrman_outgoing) {
         // Load addresses from anchors.dat
+        LOCK(m_anchors_mutex);
         m_anchors = ReadAnchors(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
         if (m_anchors.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
             m_anchors.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3616,7 +3616,9 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         if (m_anchors.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
             m_anchors.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
         }
-        LogInfo("%i block-relay-only anchors will be tried for connections.\n", m_anchors.size());
+        if (fNetworkActive) {
+            LogInfo("%i block-relay-only anchors will be tried for connections.\n", m_anchors.size());
+        }
     }
 
     if (m_client_interface) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2787,7 +2787,10 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
         // block-relay-only peer (to confirm our tip is current, see below) or the next_feeler
         // timer to decide if we should open a FEELER.
 
-        const bool have_anchors{WITH_LOCK(m_anchors_mutex, return !m_anchors.empty())};
+        // Only consume anchors while the network is active; otherwise they would be
+        // popped and then dropped by OpenNetworkConnection(), losing them for the
+        // next activation and for the dump at shutdown.
+        const bool have_anchors{fNetworkActive && WITH_LOCK(m_anchors_mutex, return !m_anchors.empty())};
         if (have_anchors && (nOutboundBlockRelay < m_max_outbound_block_relay)) {
             conn_type = ConnectionType::BLOCK_RELAY;
             anchor = true;
@@ -3465,6 +3468,21 @@ void CConnman::SetNetworkActive(bool active)
 
     if (fNetworkActive == active) {
         return;
+    }
+
+    if (!active) {
+        // Remember the current block-relay-only peers so they can be retried
+        // once the network is re-enabled, or dumped at shutdown. Keep any
+        // not-yet-tried anchors if there are no such peers.
+        auto anchors = GetCurrentBlockRelayOnlyConns();
+        if (anchors.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
+            // Keep the oldest peers, as when saving anchors at shutdown.
+            anchors.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
+        }
+        if (!anchors.empty()) {
+            LOCK(m_anchors_mutex);
+            m_anchors = std::move(anchors);
+        }
     }
 
     fNetworkActive = active;

--- a/src/net.h
+++ b/src/net.h
@@ -1166,7 +1166,7 @@ public:
     void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
     bool GetNetworkActive() const { return fNetworkActive; };
     bool GetUseAddrmanOutgoing() const { return m_use_addrman_outgoing; };
-    void SetNetworkActive(bool active) EXCLUSIVE_LOCKS_REQUIRED(!m_anchors_mutex);
+    void SetNetworkActive(bool active) EXCLUSIVE_LOCKS_REQUIRED(!m_anchors_mutex, !m_nodes_mutex);
 
     /**
      * Open a new P2P connection and initialize it with the PeerManager at `m_msgproc`.

--- a/src/net.h
+++ b/src/net.h
@@ -1705,8 +1705,9 @@ private:
     BanMan* m_banman;
 
     /**
-     * Addresses that were saved during the previous clean shutdown. We'll
-     * attempt to make block-relay-only connections to them.
+     * Addresses that were saved during the previous clean shutdown or when
+     * the network was deactivated. We'll attempt to make block-relay-only
+     * connections to them once the network is active.
      */
     mutable Mutex m_anchors_mutex;
     std::vector<CAddress> m_anchors GUARDED_BY(m_anchors_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -1151,11 +1151,11 @@ public:
 
     ~CConnman();
 
-    bool Start(CScheduler& scheduler, const Options& options) EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !m_added_nodes_mutex, !m_addr_fetches_mutex, !mutexMsgProc);
+    bool Start(CScheduler& scheduler, const Options& options) EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !m_added_nodes_mutex, !m_addr_fetches_mutex, !mutexMsgProc, !m_anchors_mutex);
 
     void StopThreads();
-    void StopNodes() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex);
-    void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex)
+    void StopNodes() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex, !m_anchors_mutex);
+    void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex, !m_anchors_mutex)
     {
         AssertLockNotHeld(m_nodes_mutex);
         AssertLockNotHeld(m_reconnections_mutex);
@@ -1166,7 +1166,7 @@ public:
     void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
     bool GetNetworkActive() const { return fNetworkActive; };
     bool GetUseAddrmanOutgoing() const { return m_use_addrman_outgoing; };
-    void SetNetworkActive(bool active);
+    void SetNetworkActive(bool active) EXCLUSIVE_LOCKS_REQUIRED(!m_anchors_mutex);
 
     /**
      * Open a new P2P connection and initialize it with the PeerManager at `m_msgproc`.
@@ -1441,7 +1441,8 @@ private:
                                  !m_addr_fetches_mutex,
                                  !m_nodes_mutex,
                                  !m_reconnections_mutex,
-                                 !m_unused_i2p_sessions_mutex);
+                                 !m_unused_i2p_sessions_mutex,
+                                 !m_anchors_mutex);
 
     void ThreadMessageHandler() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !mutexMsgProc);
     void ThreadI2PAcceptIncoming() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
@@ -1707,7 +1708,8 @@ private:
      * Addresses that were saved during the previous clean shutdown. We'll
      * attempt to make block-relay-only connections to them.
      */
-    std::vector<CAddress> m_anchors;
+    mutable Mutex m_anchors_mutex;
+    std::vector<CAddress> m_anchors GUARDED_BY(m_anchors_mutex);
 
     /** SipHasher seeds for deterministic randomness */
     const uint64_t nSeed0, nSeed1;

--- a/src/net.h
+++ b/src/net.h
@@ -1744,8 +1744,9 @@ private:
     BanMan* m_banman;
 
     /**
-     * Addresses that were saved during the previous clean shutdown. We'll
-     * attempt to make block-relay-only connections to them.
+     * Addresses that were saved during the previous clean shutdown or when
+     * the network was deactivated. We'll attempt to make block-relay-only
+     * connections to them once the network is active.
      */
     mutable Mutex m_anchors_mutex;
     std::vector<CAddress> m_anchors GUARDED_BY(m_anchors_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -1167,11 +1167,11 @@ public:
 
     ~CConnman();
 
-    bool Start(CScheduler& scheduler, const Options& options) EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !m_added_nodes_mutex, !m_addr_fetches_mutex, !mutexMsgProc);
+    bool Start(CScheduler& scheduler, const Options& options) EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !m_added_nodes_mutex, !m_addr_fetches_mutex, !mutexMsgProc, !m_anchors_mutex);
 
     void StopThreads();
-    void StopNodes() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex);
-    void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex)
+    void StopNodes() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex, !m_anchors_mutex);
+    void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_reconnections_mutex, !m_anchors_mutex)
     {
         AssertLockNotHeld(m_nodes_mutex);
         AssertLockNotHeld(m_reconnections_mutex);
@@ -1182,7 +1182,7 @@ public:
     void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
     bool GetNetworkActive() const { return fNetworkActive; };
     bool GetUseAddrmanOutgoing() const { return m_use_addrman_outgoing; };
-    void SetNetworkActive(bool active);
+    void SetNetworkActive(bool active) EXCLUSIVE_LOCKS_REQUIRED(!m_anchors_mutex);
 
     /**
      * Open a new P2P connection and initialize it with the PeerManager at `m_msgproc`.
@@ -1469,7 +1469,8 @@ private:
                                  !m_addr_fetches_mutex,
                                  !m_nodes_mutex,
                                  !m_reconnections_mutex,
-                                 !m_unused_i2p_sessions_mutex);
+                                 !m_unused_i2p_sessions_mutex,
+                                 !m_anchors_mutex);
 
     /// \anchor msghand
     void ThreadMessageHandler() EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !mutexMsgProc);
@@ -1746,7 +1747,8 @@ private:
      * Addresses that were saved during the previous clean shutdown. We'll
      * attempt to make block-relay-only connections to them.
      */
-    std::vector<CAddress> m_anchors;
+    mutable Mutex m_anchors_mutex;
+    std::vector<CAddress> m_anchors GUARDED_BY(m_anchors_mutex);
 
     /** SipHasher seeds for deterministic randomness */
     const uint64_t nSeed0, nSeed1;

--- a/src/net.h
+++ b/src/net.h
@@ -1182,7 +1182,7 @@ public:
     void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
     bool GetNetworkActive() const { return fNetworkActive; };
     bool GetUseAddrmanOutgoing() const { return m_use_addrman_outgoing; };
-    void SetNetworkActive(bool active) EXCLUSIVE_LOCKS_REQUIRED(!m_anchors_mutex);
+    void SetNetworkActive(bool active) EXCLUSIVE_LOCKS_REQUIRED(!m_anchors_mutex, !m_nodes_mutex);
 
     /**
      * Open a new P2P connection and initialize it with the PeerManager at `m_msgproc`.

--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -57,6 +57,9 @@ class AnchorsTest(BitcoinTestFramework):
             else:
                 inbound_nodes_port.append(hex(int(addr_split[1]))[2:])
 
+        self.log.info("Disabling network activity should not affect the anchors")
+        self.nodes[0].setnetworkactive(False)
+
         self.log.debug("Stop node")
         self.stop_node(0)
 
@@ -136,6 +139,10 @@ class AnchorsTest(BitcoinTestFramework):
             new_data[services_index] = P2P_SERVICES
             new_data_hash = hash256(new_data)
             file_handler.write(new_data + new_data_hash)
+
+        self.log.info("Check that disabling network does not affect the anchors")
+        self.restart_node(0, extra_args=["-networkactive=0"])
+        self.stop_node(0)
 
         self.log.info("Restarting node attempts to reconnect to anchors")
         with self.nodes[0].assert_debug_log([f"Trying to make an anchor connection to {ONION_ADDR}"], timeout=2):

--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -5,6 +5,7 @@
 """Test block-relay-only anchors functionality"""
 
 import os
+import time
 
 from test_framework.p2p import P2PInterface, P2P_SERVICES
 from test_framework.socks5 import Socks5Configuration, Socks5Server
@@ -15,12 +16,24 @@ from test_framework.util import check_node_connections, assert_equal
 INBOUND_CONNECTIONS = 5
 BLOCK_RELAY_CONNECTIONS = 2
 ONION_ADDR = "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion:8333"
+SEED_NODE = "127.0.0.1:1"
+SEED_ARGS = [f"-seednode={SEED_NODE}", f"-seednode={SEED_NODE}"]
+SEED_LOG = f"adding seednode ({SEED_NODE}) to addrfetch"
 
 
 class AnchorsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.disable_autoconnect = False
+
+    def wait_for_open_connections_pass(self):
+        """Wait until ThreadOpenConnections has passed the anchor selection logic
+        at least once while the network is inactive. The seednode retry timer is
+        checked right before that logic and uses the mockable clock, so bumping
+        mocktime past ADD_NEXT_SEEDNODE (10s) queues the second seednode on the
+        next pass, which is logged at the top of the following iteration."""
+        with self.nodes[0].assert_debug_log([SEED_LOG], timeout=10):
+            self.nodes[0].setmocktime(int(time.time()) + 11)
 
     def run_test(self):
         node_anchors_path = self.nodes[0].chain_path / "anchors.dat"
@@ -142,7 +155,9 @@ class AnchorsTest(BitcoinTestFramework):
             file_handler.write(new_data + new_data_hash)
 
         self.log.info("Check that starting with the network disabled preserves the anchors")
-        self.restart_node(0, extra_args=["-networkactive=0"])
+        with self.nodes[0].assert_debug_log([SEED_LOG], unexpected_msgs=["block-relay-only anchors will be tried for connections"], timeout=10):
+            self.restart_node(0, extra_args=["-networkactive=0"] + SEED_ARGS)
+        self.wait_for_open_connections_pass()
         self.stop_node(0)
 
         self.log.info("Restarting node attempts to reconnect to anchors")
@@ -153,9 +168,21 @@ class AnchorsTest(BitcoinTestFramework):
         self.stop_node(0)
         with open(node_anchors_path, "wb") as file_handler:
             file_handler.write(new_data + new_data_hash)
-        self.start_node(0, extra_args=["-networkactive=0", f"-onion={onion_conf.addr[0]}:{onion_conf.addr[1]}"])
+        with self.nodes[0].assert_debug_log([SEED_LOG], timeout=10):
+            self.start_node(0, extra_args=["-networkactive=0", f"-onion={onion_conf.addr[0]}:{onion_conf.addr[1]}"] + SEED_ARGS)
+        self.wait_for_open_connections_pass()
         with self.nodes[0].assert_debug_log([f"Trying to make an anchor connection to {ONION_ADDR}"], timeout=2):
             self.nodes[0].setnetworkactive(True)
+
+        self.log.info("Unconsumed anchors are discarded at shutdown when the network is active")
+        self.stop_node(0)
+        with open(node_anchors_path, "wb") as file_handler:
+            file_handler.write(new_data + new_data_hash)
+        # -maxconnections=8 leaves no block-relay-only slots, so the anchor is loaded but never tried
+        with self.nodes[0].assert_debug_log(["1 block-relay-only anchors will be tried for connections"]):
+            self.start_node(0, extra_args=["-maxconnections=8"])
+        with self.nodes[0].assert_debug_log(["DumpAnchors: Flush 0 outbound block-relay-only peer addresses"]):
+            self.stop_node(0)
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -57,6 +57,10 @@ class AnchorsTest(BitcoinTestFramework):
             else:
                 inbound_nodes_port.append(hex(int(addr_split[1]))[2:])
 
+        self.log.info("Disabling network activity should not affect the anchors")
+        self.nodes[0].setnetworkactive(False)
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0)
+
         self.log.debug("Stop node")
         self.stop_node(0)
 
@@ -137,9 +141,21 @@ class AnchorsTest(BitcoinTestFramework):
             new_data_hash = hash256(new_data)
             file_handler.write(new_data + new_data_hash)
 
+        self.log.info("Check that starting with the network disabled preserves the anchors")
+        self.restart_node(0, extra_args=["-networkactive=0"])
+        self.stop_node(0)
+
         self.log.info("Restarting node attempts to reconnect to anchors")
         with self.nodes[0].assert_debug_log([f"Trying to make an anchor connection to {ONION_ADDR}"], timeout=2):
             self.start_node(0, extra_args=[f"-onion={onion_conf.addr[0]}:{onion_conf.addr[1]}"])
+
+        self.log.info("Check that anchors are tried once the network is re-enabled")
+        self.stop_node(0)
+        with open(node_anchors_path, "wb") as file_handler:
+            file_handler.write(new_data + new_data_hash)
+        self.start_node(0, extra_args=["-networkactive=0", f"-onion={onion_conf.addr[0]}:{onion_conf.addr[1]}"])
+        with self.nodes[0].assert_debug_log([f"Trying to make an anchor connection to {ONION_ADDR}"], timeout=2):
+            self.nodes[0].setnetworkactive(True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem 

When a node is shut down while network activity is disabled (e.g. via -networkactive=0 or `setnetworkactive` false), `anchors.dat` is overwritten with an empty list. This happens because `StopNodes()` collects anchors via `GetCurrentBlockRelayOnlyConns()`, which returns nothing when there are no active connections. The node then loses its anchors and cannot reconnect to them on the next startup.

### Fix

-  Guard `m_anchors` with a mutex, since it is now accessed outside the connection-opening thread.
-  In `SetNetworkActive(false)`, save the current block-relay-only connections into `m_anchors` before the connections are closed, so the anchor list is preserved after the network is deactivated. Stored anchors are kept if there are no such
  connections.
- In `ThreadOpenConnections()`, only consume anchors while the network is active; otherwise they would be popped and dropped by the connection attempt.
- In `StopNodes()`, if the network is inactive and `m_anchors` is non-empty, use those stored anchors as the source for `anchors.dat` instead of the (empty) live connection list.

Also, log that "X anchors will be tried for connections" only if the network is active.

