### PR TITLE
policy: restore 80-byte default for datacarriersize

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -76,9 +76,10 @@ static constexpr unsigned int DEFAULT_DESCENDANT_LIMIT{25};
 /** Default for -datacarrier */
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
 /**
- * Default setting for -datacarriersize in vbytes.
+ * Default setting for -datacarriersize. 80 bytes of data, +1 for OP_RETURN,
+ * +2 for the pushdata opcodes.
  */
-static const unsigned int MAX_OP_RETURN_RELAY = MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR;
+static const unsigned int MAX_OP_RETURN_RELAY = 83;
 /**
  * An extra transaction can be added to a package, as long as it only has one
  * ancestor and is no larger than this. Not really any reason to make this

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -852,17 +852,17 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     CheckIsStandard(t);
 
-    // Multiple TxoutType::NULL_DATA are permitted
+    // Multiple TxoutType::NULL_DATA are permitted (with sufficient max_op_return_relay)
     t.vout.resize(2);
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
     t.vout[0].nValue = 0;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
     t.vout[1].nValue = 0;
-    CheckIsStandard(t);
+    CheckIsStandard(t, /*max_op_return_relay=*/100000);
 
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    CheckIsStandard(t);
+    CheckIsStandard(t, /*max_op_return_relay=*/100000);
 
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
@@ -871,7 +871,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
     const auto datacarrier_size = t.vout[0].scriptPubKey.size() + t.vout[1].scriptPubKey.size();
-    CheckIsStandard(t); // Default max relay should never trigger
+    CheckIsNotStandard(t, "datacarrier"); // Default 83-byte limit triggers for large OP_RETURN
     CheckIsStandard(t, /*max_op_return_relay=*/datacarrier_size);
     CheckIsNotStandard(t, "datacarrier", /*max_op_return_relay=*/datacarrier_size-1);
 

--- a/test/functional/feature_blocksxor.py
+++ b/test/functional/feature_blocksxor.py
@@ -23,6 +23,7 @@ class BlocksXORTest(BitcoinTestFramework):
         self.extra_args = [[
             '-blocksxor=1',
             '-fastprune=1',             # use smaller block files
+            '-datacarriersize=100000',  # needed to pad transaction with MiniWallet
         ]]
 
     def run_test(self):

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -50,6 +50,7 @@ class MaxUploadTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             f"-maxuploadtarget={UPLOAD_TARGET_MB}M",
+            "-datacarriersize=100000",
         ]]
 
     def assert_uploadtarget_state(self, *, target_reached, serve_historical_blocks):

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -60,7 +60,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [[
-            '-txindex','-permitbaremultisig=0',
+            '-txindex','-permitbaremultisig=0','-datacarriersize=100000',
         ]] * self.num_nodes
         self.supports_cli = False
 

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -30,6 +30,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             "-maxmempool=5",
+            "-datacarriersize=100000",
         ]]
 
     def test_mid_package_eviction_success(self):

--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -39,7 +39,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [["-limitclustercount=25"]]
+        self.extra_args = [["-limitclustercount=25", "-datacarriersize=100000"]]
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -34,6 +34,7 @@ class PackageRBFTest(BitcoinTestFramework):
         # Required for fill_mempool()
         self.extra_args = [[
             "-maxmempool=5",
+            "-datacarriersize=100000",
         ]] * self.num_nodes
 
     def assert_mempool_contents(self, expected=None):

--- a/test/functional/mempool_sigoplimit.py
+++ b/test/functional/mempool_sigoplimit.py
@@ -52,6 +52,8 @@ MAX_PUBKEYS_PER_MULTISIG = 20
 class BytesPerSigOpTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        # Test requires large datacarrier for padding outputs
+        self.extra_args = [["-datacarriersize=100000"]]
 
     def create_p2wsh_spending_tx(self, witness_script, output_script):
         """Create a 1-input-1-output P2WSH spending transaction with only the
@@ -227,7 +229,7 @@ class BytesPerSigOpTest(BitcoinTestFramework):
             else:
                 bytespersigop_parameter = f"-bytespersigop={bytes_per_sigop}"
                 self.log.info(f"Test sigops limit setting {bytespersigop_parameter}...")
-                self.restart_node(0, extra_args=[bytespersigop_parameter])
+                self.restart_node(0, extra_args=[bytespersigop_parameter, "-datacarriersize=100000"])
 
             for num_sigops in (69, 101, 142, 183, 222):
                 self.test_sigops_limit(bytes_per_sigop, num_sigops)

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -44,7 +44,7 @@ def cleanup(extra_args=None):
 class MempoolTRUC(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [[]]
+        self.extra_args = [["-datacarriersize=100000"]]
         self.setup_clean_chain = True
 
     def check_mempool(self, txids):
@@ -209,7 +209,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.trigger_reorg(fork_blocks)
         self.check_mempool([tx_v3_block["txid"], tx_v2_block["txid"], tx_v3_block2["txid"], tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"], tx_chain_1["txid"], tx_chain_2["txid"], tx_chain_3["txid"], tx_chain_4["txid"]])
 
-    @cleanup(extra_args=["-limitclustercount=1"])
+    @cleanup(extra_args=["-limitclustercount=1", "-datacarriersize=100000"])
     def test_nondefault_package_limits(self):
         """
         Max standard tx size + TRUC rules imply the cluster rules (at their default
@@ -241,7 +241,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.generate(node, 1)
 
         self.log.info("Test that a decreased limitclustersize also applies to TRUC child")
-        self.restart_node(0, extra_args=["-limitclustersize=10", "-acceptnonstdtxn=1"])
+        self.restart_node(0, extra_args=["-limitclustersize=10", "-acceptnonstdtxn=1", "-datacarriersize=100000"])
         tx_v3_parent_large2 = self.wallet.send_self_transfer(from_node=node, target_vsize=parent_target_vsize, version=3)
         tx_v3_child_large2 = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_parent_large2["new_utxo"], target_vsize=child_target_vsize, version=3)
         # Parent and child are within TRUC limits
@@ -249,7 +249,7 @@ class MempoolTRUC(BitcoinTestFramework):
         assert_greater_than_or_equal(TRUC_CHILD_MAX_VSIZE, tx_v3_child_large2["tx"].get_vsize())
         assert_raises_rpc_error(-26, "too-large-cluster", node.sendrawtransaction, tx_v3_child_large2["hex"])
         self.log.info("Test that a decreased limitclustercount also applies to TRUC transactions")
-        self.restart_node(0, extra_args=["-limitclustercount=1", "-acceptnonstdtxn=1"])
+        self.restart_node(0, extra_args=["-limitclustercount=1", "-acceptnonstdtxn=1", "-datacarriersize=100000"])
         assert_raises_rpc_error(-26, "too-large-cluster", node.sendrawtransaction, tx_v3_child_large2["hex"])
         self.check_mempool([tx_v3_parent_large2["txid"]])
 

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -25,7 +25,7 @@ CUSTOM_DESCENDANT_COUNT = CUSTOM_ANCESTOR_COUNT
 class MempoolUpdateFromBlockTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [['-limitclustersize=1000']]
+        self.extra_args = [['-limitclustersize=1000', '-datacarriersize=100000']]
 
     def trigger_reorg(self, fork_blocks):
         """Trigger reorg of the fork blocks."""

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -61,9 +61,9 @@ class MiningTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.extra_args = [
-            [],
-            [],
-            ["-fastprune", "-prune=1"]
+            ["-datacarriersize=100000"],
+            ["-datacarriersize=100000"],
+            ["-fastprune", "-prune=1", "-datacarriersize=100000"]
         ]
         self.setup_clean_chain = True
 
@@ -318,7 +318,7 @@ class MiningTest(BitcoinTestFramework):
         # Test block template creation with custom -blockmaxweight
         custom_block_weight = MAX_BLOCK_WEIGHT - 2000
         # Reducing the weight by 2000 units will prevent 1 large transaction from fitting into the block.
-        self.restart_node(0, extra_args=[f"-blockmaxweight={custom_block_weight}"])
+        self.restart_node(0, extra_args=[f"-blockmaxweight={custom_block_weight}", "-datacarriersize=100000"])
 
         self.log.info("Testing the block template with custom -blockmaxweight to include 9 large and 2 normal transactions.")
         self.verify_block_template(
@@ -328,7 +328,7 @@ class MiningTest(BitcoinTestFramework):
 
         # Ensure the block weight does not exceed the maximum
         self.log.info(f"Testing that the block weight will never exceed {MAX_BLOCK_WEIGHT - DEFAULT_BLOCK_RESERVED_WEIGHT}.")
-        self.restart_node(0, extra_args=[f"-blockmaxweight={MAX_BLOCK_WEIGHT}"])
+        self.restart_node(0, extra_args=[f"-blockmaxweight={MAX_BLOCK_WEIGHT}", "-datacarriersize=100000"])
         self.log.info("Sending 2 additional normal transactions to fill the mempool to the maximum block weight.")
         self.send_transactions(utxos[LARGE_TXS_COUNT + 2:], NORMAL_FEERATE, NORMAL_VSIZE)
         self.log.info(f"Testing that the mempool's weight matches the maximum block weight: {MAX_BLOCK_WEIGHT}.")
@@ -342,7 +342,7 @@ class MiningTest(BitcoinTestFramework):
 
         self.log.info("Test -blockreservedweight startup option.")
         # Lowering the -blockreservedweight by 4000 will allow for two more transactions.
-        self.restart_node(0, extra_args=["-blockreservedweight=4000"])
+        self.restart_node(0, extra_args=["-blockreservedweight=4000", "-datacarriersize=100000"])
         self.verify_block_template(
             expected_tx_count=12,
             expected_weight=MAX_BLOCK_WEIGHT - 4000,

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -27,6 +27,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             "-printpriority=1",
+            "-datacarriersize=100000",
         ]] * self.num_nodes
         self.supports_cli = False
 
@@ -176,7 +177,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.clear_prioritisation(node=self.nodes[0])
 
         self.log.info("Test priority while txs are not in mempool")
-        self.restart_node(0, extra_args=["-nopersistmempool"])
+        self.restart_node(0, extra_args=["-nopersistmempool", "-datacarriersize=100000"])
         self.nodes[0].setmocktime(mock_time)
         assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
         self.nodes[0].prioritisetransaction(txid=txid_b, fee_delta=int(fee_delta_b * COIN))

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -78,6 +78,7 @@ class PackageRelayTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             "-maxmempool=5",
+            "-datacarriersize=100000",
         ]]
 
     def create_tx_below_mempoolminfee(self, wallet, utxo_to_spend=None):

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -68,7 +68,7 @@ class ConnectionType(Enum):
 class TxDownloadTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args= [['-maxmempool=5', '-persistmempool=0']] * self.num_nodes
+        self.extra_args= [['-maxmempool=5', '-persistmempool=0', '-datacarriersize=100000']] * self.num_nodes
 
     def test_tx_requests(self):
         self.log.info("Test that we request transactions from all our peers, eventually")

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -453,6 +453,7 @@ class RPCPackagesTest(BitcoinTestFramework):
         self.restart_node(0, extra_args=[
             "-maxmempool=5",
             "-persistmempool=0",
+            "-datacarriersize=100000",
         ])
         self.wallet.rescan_utxos()
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -78,8 +78,9 @@ DEFAULT_DESCENDANT_LIMIT = 25  # default max number of in-mempool descendants
 DEFAULT_CLUSTER_LIMIT = 64     # default max number of transactions in a cluster
 
 
-# Default setting for -datacarriersize.
-MAX_OP_RETURN_RELAY = 100_000
+# Default setting for -datacarriersize. 80 bytes of data, +1 for OP_RETURN,
+# +2 for the pushdata opcodes.
+MAX_OP_RETURN_RELAY = 83
 
 
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours


### PR DESCRIPTION
Restore the historical default of 80 bytes (83 with OP_RETURN + pushdata overhead) for -datacarriersize, while preserving the ability for node operators to configure any limit they prefer.

This is not a hard cap - users can still set -datacarriersize=100000 (or any value) to allow larger OP_RETURN outputs. The change only affects the default behavior when no explicit configuration is provided.

Rationale:
- The unlimited default introduced in #32406 remains controversial
- ~20% of nodes run Bitcoin Knots which maintains the 80-byte default
- Inscriptions have no economic incentive to move to OP_RETURN since witness data is ~4x cheaper due to the segwit discount
- Restoring the default provides a middle ground while respecting node operator choice

Test changes add explicit -datacarriersize=100000 to tests that require large OP_RETURN outputs for transaction padding.