### PR TITLE
test: migration, avoid backup name mismatch in default_wallet_failure

### DIFF
--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -711,6 +711,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         master_wallet = self.master_node.get_wallet_rpc(self.default_wallet_name)
         wallet = self.create_legacy_wallet("", blank=True)
         wallet.importaddress(master_wallet.getnewaddress(address_type="legacy"))
+        wallet.unloadwallet()
 
         # Create wallet directory with the watch-only name and a wallet file.
         # Because the wallet dir exists, this will cause migration to fail.
@@ -720,7 +721,8 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         mocked_time = int(time.time())
         self.master_node.setmocktime(mocked_time)
-        assert_raises_rpc_error(-4, "Failed to create database", self.migrate_and_get_rpc, "")
+        shutil.copyfile(self.old_node.wallets_path / "wallet.dat", self.master_node.wallets_path / "wallet.dat")
+        assert_raises_rpc_error(-4, "Failed to create database", self.master_node.migratewallet, wallet_name="")
         self.master_node.setmocktime(0)
 
         # Verify the /wallets/ path exists


### PR DESCRIPTION
This is a possible test failure, pushing it in case the CI starts complaining.
The change affects only test code; no cpp logic is involved.

The `test_default_wallet_failure` migration test calls the function
`migrate_and_get_rpc()`, which sets the mock time internally. But, at the
same time, the test already caches the mock time value, to later use it
in the backup existence check.
Setting the mock time twice can lead to a name mismatch during the
mentioned check (diff timestamp == diff backup names), which could
cause the test to fail.

The fix is very simple, just need to call the migration RPC directly.
Since the test expects the migration to fail, `migrate_and_get_rpc()` is
unnecessary here. I'm surprised the CI hasn't complained about this yet.