### PR TITLE
guix: Fix `osslsigncode` tests

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -2,6 +2,7 @@
              ((gnu packages bash) #:select (bash-minimal))
              (gnu packages bison)
              ((gnu packages certs) #:select (nss-certs))
+             ((gnu packages check) #:select (libfaketime))
              ((gnu packages cmake) #:select (cmake-minimal))
              (gnu packages commencement)
              (gnu packages compression)
@@ -208,7 +209,17 @@ and abstract ELF, PE and MachO formats.")
                (base32
                 "1j47vwq4caxfv0xw68kw5yh00qcpbd56d7rq6c483ma3y7s96yyz"))))
     (build-system cmake-build-system)
-    (inputs (list openssl))
+    (arguments
+     (list
+      #:phases
+      #~(modify-phases %standard-phases
+          (replace 'check
+            (lambda* (#:key tests? #:allow-other-keys)
+              (if tests?
+                  (invoke "faketime" "-f" "@2025-01-01 00:00:00" ;; Tests fail after 2025.
+                          "ctest" "--output-on-failure" "--no-tests=error")
+                  (format #t "test suite not run~%")))))))
+    (inputs (list libfaketime openssl))
     (home-page "https://github.com/mtrojnar/osslsigncode")
     (synopsis "Authenticode signing and timestamping tool")
     (description "osslsigncode is a small tool that implements part of the


### PR DESCRIPTION
This PR aims to improve the experience for Guix builders when creating new Guix profiles after 2025. In particular, it should be helpful for those who are new to building with Guix.

Fixes https://github.com/bitcoin/bitcoin/issues/34220.

Other possible alternatives to consider include:
1. Applying a workaround as suggested [here](https://github.com/bitcoin/bitcoin/issues/34220#issuecomment-3718991398).

2. Updating the package as suggested [here](https://github.com/bitcoin/bitcoin/issues/34220#issuecomment-3719022287).

3. Disabling tests as suggested [here](https://github.com/bitcoin/bitcoin/issues/34220#issuecomment-3719538660).