### PR TITLE
depends: Unset `SOURCE_DATE_EPOCH` in `gen_id` script

### DIFF
--- a/depends/gen_id
+++ b/depends/gen_id
@@ -28,6 +28,10 @@
     # Redirect stderr to stdout
     exec 2>&1
 
+    # Unset SOURCE_DATE_EPOCH to prevent it from leaking into tool
+    # outputs and to maximize reuse of the built package cache.
+    unset SOURCE_DATE_EPOCH
+
     echo "BEGIN ALL"
 
     # Include any ID salts supplied via command line


### PR DESCRIPTION
When performing Guix builds for `{x86_64,arm64}-apple-darwin` hosts across different commits, all packages in `depends` are rebuilt even if there are no changes in either the  `depends` or `contrib/guix` subdirectories.

This occurs because the `SOURCE_DATE_EPOCH` environment variable enables Clang's `-source-date-epoch` option, which then appears in the output of `clang -v -E -xc -o /dev/null - < /dev/null`. For example:
```
$ SOURCE_DATE_EPOCH=1767855465 clang -v -E -xc++ -o /dev/null - < /dev/null
clang version 21.1.7 (Fedora 21.1.7-1.fc43)
Target: x86_64-redhat-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Configuration file: /etc/clang/x86_64-redhat-linux-gnu-clang.cfg
System configuration file directory: /etc/clang/
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-redhat-linux/14
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-redhat-linux/15
Selected GCC installation: /usr/bin/../lib/gcc/x86_64-redhat-linux/15
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Selected multilib: .;@m64
 (in-process)
 "/usr/bin/clang-21" -cc1 -triple x86_64-redhat-linux-gnu -E -disable-free -clear-ast-before-backend -disable-llvm-verifier -discard-value-names -main-file-name - -mrelocation-model static -mframe-pointer=all -fmath-errno -ffp-contract=on -fno-rounding-math -mconstructor-aliases -funwind-tables=2 -target-cpu x86-64 -tune-cpu generic -debugger-tuning=gdb -fdebug-compilation-dir=/home/hebasto -v -fcoverage-compilation-dir=/home/hebasto -resource-dir /usr/bin/../lib/clang/21 -internal-isystem /usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15 -internal-isystem /usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/x86_64-redhat-linux -internal-isystem /usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/backward -internal-isystem /usr/bin/../lib/clang/21/include -internal-isystem /usr/local/include -internal-isystem /usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../x86_64-redhat-linux/include -internal-externc-isystem /include -internal-externc-isystem /usr/include -source-date-epoch 1767855465 -fdeprecated-macro -ferror-limit 19 -fmessage-length=180 -fgnuc-version=4.2.1 -fskip-odr-check-in-gmf -fcxx-exceptions -fexceptions -fcolor-diagnostics -faddrsig -D__GCC_HAVE_DWARF2_CFI_ASM=1 -o /dev/null -x c++ -
clang -cc1 version 21.1.7 based upon LLVM 21.1.7 default target x86_64-redhat-linux-gnu
ignoring nonexistent directory "/usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../x86_64-redhat-linux/include"
ignoring nonexistent directory "/include"
#include "..." search starts here:
#include <...> search starts here:
 /usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15
 /usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/x86_64-redhat-linux
 /usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/backward
 /usr/bin/../lib/clang/21/include
 /usr/local/include
 /usr/include
End of search list.
```

As a result, each package id differs between builds, which causes the script to treat the toolchain as changed and triggers unnecessary rebuilds.

This PR resolves this issue by [clobbering](https://github.com/bitcoin/bitcoin/pull/34228#issuecomment-4387135450) the `SOURCE_DATE_EPOCH` value in the `gen_id` script.

---

Suggested testing scenario:
```
$ env HOSTS=arm64-apple-darwin ./contrib/guix/guix-build
$ git commit --allow-empty -m "Trigger rebuild"
$ env HOSTS=arm64-apple-darwin ./contrib/guix/guix-build
````

The last command will rebuild depends on the master branch, but will successfully use the cached built packages on this PR.