### PR TITLE
depends: Hash included makefiles in package checksums

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -60,7 +60,7 @@ endef
 
 define int_get_build_recipe_hash
 $(eval $(1)_patches_path?=$(PATCHES_PATH)/$(1))
-$(eval $(1)_all_file_checksums:=$(shell $(build_SHA256SUM) $(meta_depends) packages/$(1).mk $(addprefix $($(1)_patches_path)/,$($(1)_patches)) | cut -d" " -f1))
+$(eval $(1)_all_file_checksums:=$(shell $(build_SHA256SUM) $(meta_depends) packages/$(1).mk $$(grep "^include " packages/$(1).mk | cut -d' ' -f2 | xargs) $(addprefix $($(1)_patches_path)/,$($(1)_patches)) | cut -d" " -f1))
 # If $(1)_local_dir is set, create a tarball of the local directory contents to
 # use as the source of the package, and include a hash of the tarball in the
 # package id, so if directory contents change, the package and packages


### PR DESCRIPTION
This PR fixes an issue where modifications in included files (e.g. `packages/qt_details.mk`) do not trigger a rebuild of the parent packages (`native_qt` and `qt`).

This addresses an oversight in 248613eb3ee034bf143821a51635e697dc114e6c from https://github.com/bitcoin/bitcoin/pull/30997.

### Reproduction

On master (@ 595504a43209bead162da54a204df7d140a25f0e), modifying the included makefile does not change the build ID:
```
$ cd depends
$ gmake print-qt_build_id HOST=x86_64-w64-mingw32
qt_build_id=b2ce790473c
$ gmake print-native_qt_build_id HOST=x86_64-w64-mingw32
native_qt_build_id=70e1e5164c5
$ echo "" >> packages/qt_details.mk
$ gmake print-qt_build_id HOST=x86_64-w64-mingw32
qt_build_id=b2ce790473c
$ gmake print-native_qt_build_id HOST=x86_64-w64-mingw32
native_qt_build_id=70e1e5164c5
```

### With this patch

The checksum calculation now parses `include` directives and adds those files to the hash. The IDs now update correctly:
```
$ cd depends
$ gmake print-qt_build_id HOST=x86_64-w64-mingw32
qt_build_id=9a6ebf79cb3
$ gmake print-native_qt_build_id HOST=x86_64-w64-mingw32
native_qt_build_id=6ad78a3f644
$ echo "" >> packages/qt_details.mk
$ gmake print-qt_build_id HOST=x86_64-w64-mingw32
qt_build_id=ca820665c52
$ gmake print-native_qt_build_id HOST=x86_64-w64-mingw32
native_qt_build_id=082e4cb2364
```