### PR TITLE
ci: Run feature_unsupported_utxo_db.py on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,6 +506,10 @@ jobs:
             --exclude feature_unsupported_utxo_db.py \
             `# See https://github.com/bitcoin/bitcoin/issues/31409.` \
             --exclude wallet_multiwallet.py
+          # Run feature_unsupported_utxo_db sequentially in ASCII-only tmp dir,
+          # because it is excluded above due to lack of UTF-8 support in the
+          # ancient release.
+          py -3 test/functional/feature_unsupported_utxo_db.py --previous-releases --tmpdir="${RUNNER_TEMP}/test_feature_unsupported_utxo_db"
 
   ci-matrix:
     name: ${{ matrix.name }}


### PR DESCRIPTION
The feature_unsupported_utxo_db.py test is skipped on Windows, because the ancient exe used in the test does not support UTF-8.

One way to fix this could be to rework the test_runner to supply an ASCII temp dir. However, this is tedious and probably not worth it for a test that is close to being deleted: The test only checks that a `-reindex-chainstate` is sufficient, but at this point, it seems fine to accept users having to go through a full `-reindex`, or even full re-download.

I am not deleting it just yet, because it is still minimally useful: E.g. https://github.com/bitcoin/bitcoin/pull/31674#issuecomment-2599106040. Though, I think the next time an issue pops up with this test, it can be considered for deletion.