### PR TITLE
verify-commits: temporarily allow sha1 signatures for merge commits

### DIFF
--- a/contrib/verify-commits/verify-commits.py
+++ b/contrib/verify-commits/verify-commits.py
@@ -101,7 +101,7 @@ def main():
         print("Commit must not contain spaces", file=sys.stderr)
         sys.exit(1)
     verify_tree = args.verify_tree
-    no_sha1 = True
+    no_sha1 = False  # FIXME: temporary fix for a merge commit signature involving SHA1
     prev_commit = ""
     initial_commit = current_commit
 


### PR DESCRIPTION
This is to unbreak CI after a merge commit (aeaa67a9eac0decb89c60a67f9755ca10cbcc1d9) with a signature indirectly involving SHA1 was pushed to master.