### PR TITLE
validation: Prevent duplicate logging and looping in invalid block handling

### DIFF
--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -131,8 +131,8 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                                 BlockValidationState state;
                                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "consensus-invalid");
                                 chainman.InvalidBlockFound(block, state);
-                                // This results in duplicate calls to InvalidChainFound, but mirrors the behavior in validation
-                                chainman.InvalidChainFound(to_connect.front());
+                                // This results in duplicate calls to UpdateBestInvalid, but mirrors the behavior in validation
+                                chainman.UpdateBestInvalid(to_connect.front());
                                 break;
                             } else {
                                 block->RaiseValidity(BLOCK_VALID_SCRIPTS);

--- a/src/test/util/validation.cpp
+++ b/src/test/util/validation.cpp
@@ -63,16 +63,16 @@ void TestChainstateManager::InvalidBlockFound(CBlockIndex* pindex, const BlockVa
     static_cast<TestChainstate*>(&ActiveChainstate())->CallInvalidBlockFound(pindex, state);
 }
 
-void TestChainstateManager::InvalidChainFound(CBlockIndex* pindexNew)
+void TestChainstateManager::UpdateBestInvalid(CBlockIndex* pindexNew)
 {
     struct TestChainstate : public Chainstate {
-        void CallInvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+        void CallUpdateBestInvalid(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         {
-            InvalidChainFound(pindexNew);
+            UpdateBestInvalid(pindexNew);
         }
     };
 
-    static_cast<TestChainstate*>(&ActiveChainstate())->CallInvalidChainFound(pindexNew);
+    static_cast<TestChainstate*>(&ActiveChainstate())->CallUpdateBestInvalid(pindexNew);
 }
 
 CBlockIndex* TestChainstateManager::FindMostWorkChain()

--- a/src/test/util/validation.cpp
+++ b/src/test/util/validation.cpp
@@ -76,16 +76,16 @@ void TestChainstateManager::InvalidBlockFound(CBlockIndex* pindex, const BlockVa
     static_cast<TestChainstate*>(&ActiveChainstate())->CallInvalidBlockFound(pindex, state);
 }
 
-void TestChainstateManager::InvalidChainFound(CBlockIndex* pindexNew)
+void TestChainstateManager::UpdateBestInvalid(CBlockIndex* pindexNew)
 {
     struct TestChainstate : public Chainstate {
-        void CallInvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+        void CallUpdateBestInvalid(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         {
-            InvalidChainFound(pindexNew);
+            UpdateBestInvalid(pindexNew);
         }
     };
 
-    static_cast<TestChainstate*>(&ActiveChainstate())->CallInvalidChainFound(pindexNew);
+    static_cast<TestChainstate*>(&ActiveChainstate())->CallUpdateBestInvalid(pindexNew);
 }
 
 CBlockIndex* TestChainstateManager::FindMostWorkChain()

--- a/src/test/util/validation.h
+++ b/src/test/util/validation.h
@@ -26,7 +26,7 @@ struct TestChainstateManager : public ChainstateManager {
     void JumpOutOfIbd();
     /** Wrappers that avoid making chainstatemanager internals public for tests */
     void InvalidBlockFound(CBlockIndex* pindex, const BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    void InvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void UpdateBestInvalid(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     CBlockIndex* FindMostWorkChain() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     void ResetBestInvalid() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };

--- a/src/test/util/validation.h
+++ b/src/test/util/validation.h
@@ -32,7 +32,7 @@ struct TestChainstateManager : public ChainstateManager {
     void JumpOutOfIbd();
     /** Wrappers that avoid making chainstatemanager internals public for tests */
     void InvalidBlockFound(CBlockIndex* pindex, const BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    void InvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void UpdateBestInvalid(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     CBlockIndex* FindMostWorkChain() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     void ResetBestInvalid() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1989,31 +1989,18 @@ void Chainstate::CheckForkWarningConditions()
     }
 }
 
-// Called both upon regular invalid block discovery *and* InvalidateBlock
+// Update m_best_invalid to track the invalid block with the most work
 void Chainstate::InvalidChainFound(CBlockIndex* pindexNew)
 {
     AssertLockHeld(cs_main);
     if (!m_chainman.m_best_invalid || pindexNew->nChainWork > m_chainman.m_best_invalid->nChainWork) {
         m_chainman.m_best_invalid = pindexNew;
     }
-    SetBlockFailureFlags(pindexNew);
-    if (m_chainman.m_best_header != nullptr && m_chainman.m_best_header->GetAncestor(pindexNew->nHeight) == pindexNew) {
-        m_chainman.RecalculateBestHeader();
-    }
-
-    LogInfo("%s: invalid block=%s  height=%d  log2_work=%f  date=%s\n", __func__,
-      pindexNew->GetBlockHash().ToString(), pindexNew->nHeight,
-      log(pindexNew->nChainWork.getdouble())/log(2.0), FormatISO8601DateTime(pindexNew->GetBlockTime()));
-    CBlockIndex *tip = m_chain.Tip();
-    assert (tip);
-    LogInfo("%s:  current best=%s  height=%d  log2_work=%f  date=%s\n", __func__,
-      tip->GetBlockHash().ToString(), m_chain.Height(), log(tip->nChainWork.getdouble())/log(2.0),
-      FormatISO8601DateTime(tip->GetBlockTime()));
-    CheckForkWarningConditions();
 }
 
-// Same as InvalidChainFound, above, except not called directly from InvalidateBlock,
-// which does its own setBlockIndexCandidates management.
+// Mark block as failed, flag descendants as having an invalid ancestor,
+// and update best header/invalid tracking. Not called from InvalidateBlock,
+// which handles these updates itself.
 void Chainstate::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationState& state)
 {
     AssertLockHeld(cs_main);
@@ -2021,7 +2008,21 @@ void Chainstate::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationSta
         pindex->nStatus |= BLOCK_FAILED_VALID;
         m_blockman.m_dirty_blockindex.insert(pindex);
         setBlockIndexCandidates.erase(pindex);
+        SetBlockFailureFlags(pindex);
+        if (m_chainman.m_best_header != nullptr && m_chainman.m_best_header->GetAncestor(pindex->nHeight) == pindex) {
+            m_chainman.RecalculateBestHeader();
+        }
+
+        LogInfo("%s: invalid block=%s  height=%d  log2_work=%f  date=%s\n", __func__,
+                pindex->GetBlockHash().ToString(), pindex->nHeight,
+                log(pindex->nChainWork.getdouble()) / log(2.0), FormatISO8601DateTime(pindex->GetBlockTime()));
+        CBlockIndex* tip = m_chain.Tip();
+        assert(tip);
+        LogInfo("%s:  current best=%s  height=%d  log2_work=%f  date=%s\n", __func__,
+                tip->GetBlockHash().ToString(), m_chain.Height(), log(tip->nChainWork.getdouble()) / log(2.0),
+                FormatISO8601DateTime(tip->GetBlockTime()));
         InvalidChainFound(pindex);
+        CheckForkWarningConditions();
     }
 }
 
@@ -3734,6 +3735,9 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
         }
 
         InvalidChainFound(to_mark_failed);
+        LogInfo("Invalidated block: hash=%s height=%d\n",
+                to_mark_failed->GetBlockHash().ToString(), to_mark_failed->nHeight);
+        CheckForkWarningConditions();
     }
 
     // Only notify about a new block tip if the active chain was modified.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1990,7 +1990,7 @@ void Chainstate::CheckForkWarningConditions()
 }
 
 // Update m_best_invalid to track the invalid block with the most work
-void Chainstate::InvalidChainFound(CBlockIndex* pindexNew)
+void Chainstate::UpdateBestInvalid(CBlockIndex* pindexNew)
 {
     AssertLockHeld(cs_main);
     if (!m_chainman.m_best_invalid || pindexNew->nChainWork > m_chainman.m_best_invalid->nChainWork) {
@@ -2021,7 +2021,7 @@ void Chainstate::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationSta
         LogInfo("%s:  current best=%s  height=%d  log2_work=%f  date=%s\n", __func__,
                 tip->GetBlockHash().ToString(), m_chain.Height(), log(tip->nChainWork.getdouble()) / log(2.0),
                 FormatISO8601DateTime(tip->GetBlockTime()));
-        InvalidChainFound(pindex);
+        UpdateBestInvalid(pindex);
         CheckForkWarningConditions();
     }
 }
@@ -3302,7 +3302,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex*
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
                     if (state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
-                        InvalidChainFound(vpindexToConnect.front());
+                        UpdateBestInvalid(vpindexToConnect.front());
                     }
                     state = BlockValidationState();
                     fInvalidFound = true;
@@ -3701,7 +3701,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
         }
 
         // Track the last disconnected block, so we can correct its BLOCK_FAILED_CHILD status in future
-        // iterations, or, if it's the last one, call InvalidChainFound on it.
+        // iterations, or, if it's the last one, call UpdateBestInvalid on it.
         to_mark_failed = invalid_walk_tip;
     }
 
@@ -3734,7 +3734,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
             }
         }
 
-        InvalidChainFound(to_mark_failed);
+        UpdateBestInvalid(to_mark_failed);
         LogInfo("Invalidated block: hash=%s height=%d\n",
                 to_mark_failed->GetBlockHash().ToString(), to_mark_failed->nHeight);
         CheckForkWarningConditions();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1971,7 +1971,7 @@ void Chainstate::CheckForkWarningConditions()
 }
 
 // Update m_best_invalid to track the invalid block with the most work
-void Chainstate::InvalidChainFound(CBlockIndex* pindexNew)
+void Chainstate::UpdateBestInvalid(CBlockIndex* pindexNew)
 {
     AssertLockHeld(cs_main);
     if (!m_chainman.m_best_invalid || pindexNew->nChainWork > m_chainman.m_best_invalid->nChainWork) {
@@ -2002,7 +2002,7 @@ void Chainstate::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationSta
         LogInfo("%s: current best=%s height=%d log2_work=%f date=%s", __func__,
                 tip->GetBlockHash().ToString(), m_chain.Height(), log(tip->nChainWork.getdouble()) / log(2.0),
                 FormatISO8601DateTime(tip->GetBlockTime()));
-        InvalidChainFound(pindex);
+        UpdateBestInvalid(pindex);
         CheckForkWarningConditions();
     }
 }
@@ -3252,7 +3252,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
                     if (state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
-                        InvalidChainFound(vpindexToConnect.front());
+                        UpdateBestInvalid(vpindexToConnect.front());
                     }
                     state = BlockValidationState();
                     fInvalidFound = true;
@@ -3652,7 +3652,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
             ++candidate_it;
         }
 
-        // Track the last disconnected block to call InvalidChainFound on it.
+        // Track the last disconnected block to call UpdateBestInvalid on it.
         to_mark_failed = disconnected_tip;
     }
 
@@ -3693,7 +3693,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
             m_chainman.RecalculateBestHeader();
         }
 
-        InvalidChainFound(to_mark_failed);
+        UpdateBestInvalid(to_mark_failed);
         LogInfo("Invalidated block: hash=%s height=%d",
                 to_mark_failed->GetBlockHash().ToString(), to_mark_failed->nHeight);
         CheckForkWarningConditions();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1970,31 +1970,18 @@ void Chainstate::CheckForkWarningConditions()
     }
 }
 
-// Called both upon regular invalid block discovery *and* InvalidateBlock
+// Update m_best_invalid to track the invalid block with the most work
 void Chainstate::InvalidChainFound(CBlockIndex* pindexNew)
 {
     AssertLockHeld(cs_main);
     if (!m_chainman.m_best_invalid || pindexNew->nChainWork > m_chainman.m_best_invalid->nChainWork) {
         m_chainman.m_best_invalid = pindexNew;
     }
-    SetBlockFailureFlags(pindexNew);
-    if (m_chainman.m_best_header != nullptr && m_chainman.m_best_header->GetAncestor(pindexNew->nHeight) == pindexNew) {
-        m_chainman.RecalculateBestHeader();
-    }
-
-    LogInfo("%s: invalid block=%s height=%d log2_work=%f date=%s", __func__,
-      pindexNew->GetBlockHash().ToString(), pindexNew->nHeight,
-      log(pindexNew->nChainWork.getdouble())/log(2.0), FormatISO8601DateTime(pindexNew->GetBlockTime()));
-    CBlockIndex *tip = m_chain.Tip();
-    assert (tip);
-    LogInfo("%s: current best=%s height=%d log2_work=%f date=%s", __func__,
-      tip->GetBlockHash().ToString(), m_chain.Height(), log(tip->nChainWork.getdouble())/log(2.0),
-      FormatISO8601DateTime(tip->GetBlockTime()));
-    CheckForkWarningConditions();
 }
 
-// Same as InvalidChainFound, above, except not called directly from InvalidateBlock,
-// which does its own setBlockIndexCandidates management.
+// Mark block as failed, flag descendants as having an invalid ancestor,
+// and update best header/invalid tracking. Not called from InvalidateBlock,
+// which handles these updates itself.
 void Chainstate::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationState& state)
 {
     AssertLockHeld(cs_main);
@@ -2002,7 +1989,21 @@ void Chainstate::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationSta
         pindex->nStatus |= BLOCK_FAILED_VALID;
         m_blockman.m_dirty_blockindex.insert(pindex);
         setBlockIndexCandidates.erase(pindex);
+        SetBlockFailureFlags(pindex);
+        if (m_chainman.m_best_header != nullptr && m_chainman.m_best_header->GetAncestor(pindex->nHeight) == pindex) {
+            m_chainman.RecalculateBestHeader();
+        }
+
+        LogInfo("%s: invalid block=%s height=%d log2_work=%f date=%s", __func__,
+                pindex->GetBlockHash().ToString(), pindex->nHeight,
+                log(pindex->nChainWork.getdouble()) / log(2.0), FormatISO8601DateTime(pindex->GetBlockTime()));
+        CBlockIndex* tip = m_chain.Tip();
+        assert(tip);
+        LogInfo("%s: current best=%s height=%d log2_work=%f date=%s", __func__,
+                tip->GetBlockHash().ToString(), m_chain.Height(), log(tip->nChainWork.getdouble()) / log(2.0),
+                FormatISO8601DateTime(tip->GetBlockTime()));
         InvalidChainFound(pindex);
+        CheckForkWarningConditions();
     }
 }
 
@@ -3684,7 +3685,18 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
             }
         }
 
+        // Flag the remaining descendants as invalid: The marking in the disconnect loop only
+        // covers blocks that were already present in highpow_outofchain_headers when it was
+        // built, and it doesn't run at all if pindex never was in the active chain.
+        SetBlockFailureFlags(to_mark_failed);
+        if (m_chainman.m_best_header != nullptr && m_chainman.m_best_header->GetAncestor(to_mark_failed->nHeight) == to_mark_failed) {
+            m_chainman.RecalculateBestHeader();
+        }
+
         InvalidChainFound(to_mark_failed);
+        LogInfo("Invalidated block: hash=%s height=%d",
+                to_mark_failed->GetBlockHash().ToString(), to_mark_failed->nHeight);
+        CheckForkWarningConditions();
     }
 
     // Only notify about a new block tip if the active chain was modified.

--- a/src/validation.h
+++ b/src/validation.h
@@ -855,7 +855,7 @@ protected:
     bool RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& inputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     void CheckForkWarningConditions() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    void InvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void UpdateBestInvalid(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
      * Make mempool consistent after a reorg, by re-adding or recursively erasing

--- a/src/validation.h
+++ b/src/validation.h
@@ -869,7 +869,7 @@ protected:
     bool RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& inputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     void CheckForkWarningConditions() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    void InvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void UpdateBestInvalid(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
      * Make mempool consistent after a reorg, by re-adding or recursively erasing

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -135,6 +135,28 @@ class InvalidateTest(BitcoinTestFramework):
         # Should report consistent blockchain info
         assert_equal(self.nodes[1].getblockchaininfo()["headers"], self.nodes[1].getblockchaininfo()["blocks"])
 
+        self.log.info("Verify that invalidating a block that never was in the active chain flags its descendants")
+        node = self.nodes[1]
+        tip_hash = node.getbestblockhash()
+        tip_height = node.getblockcount()
+        # Submit two headers building on the tip
+        block_time = node.getblock(tip_hash)["time"] + 1
+        header1 = create_block(int(tip_hash, 16), height=tip_height + 1, ntime=block_time)
+        header1.solve()
+        node.submitheader(header1.serialize().hex())
+        header2 = create_block(header1.hash_int, height=tip_height + 2, ntime=block_time + 1)
+        header2.solve()
+        node.submitheader(header2.serialize().hex())
+        assert_equal(node.getblockchaininfo()["headers"], tip_height + 2)
+
+        # Invalidating the first header must also mark its descendant as invalid and move the
+        # best header back to the tip of the active chain.
+        node.invalidateblock(header1.hash_hex)
+        chaintips = {chaintip["hash"]: chaintip["status"] for chaintip in node.getchaintips()}
+        assert_equal(chaintips[header2.hash_hex], "invalid")
+        assert_equal(node.getblockchaininfo()["headers"], tip_height)
+        assert_equal(node.getbestblockhash(), tip_hash)
+
         self.log.info("Verify that invalidating an unknown block throws an error")
         assert_raises_rpc_error(-5, "Block not found", self.nodes[1].invalidateblock, "00" * 32)
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])


### PR DESCRIPTION
`InvalidChainFound()` is called from 3 spots:
1. from `InvalidBlockFound()`
2. from `ActivateBestChain()`, with the highest connectable block of the chain
as an arg (after having called `InvalidBlockFound()` already for the block that failed in `ConnectTip()`)
3. from `InvalidateBlock()` (rpc-only)

Most of the logic in `InvalidChainFound()` is not required for 2) and 3):
In `ActivateBestChain()`, the previous call to `InvalidChainFound()` before via `InvalidBlockFound` did the flag updates, best header calculation and logging, so only `m_best_invalid` could need additional updating.
In `InvalidateBlock()` (which doesn't call `InvalidBlockFound()`), we do most of the accounting manually.

Therefore move of all logic but the `m_best_invalid` update into `InvalidBlockFound()`, avoiding duplicate logging and unnecessary work (the loops over the block index in `SetBlockFailureFlags()` and `RecalculateBestHeader()`
were done twice before).

The second commit renames `InvalidChainFound` to `UpdateBestInvalid` to adjust to its remaining role.

This addresses past discussions about repeated work in `InvalidateBlock()` (https://github.com/bitcoin/bitcoin/pull/31405#discussion_r2135717500) and `ActivateBestChain()` (https://github.com/bitcoin/bitcoin/pull/31533#discussion_r2607189790)