### PR TITLE
test: support `get_bind_addrs` and `feature_bind_extra` on macOS & BSD

### DIFF
--- a/test/functional/feature_bind_extra.py
+++ b/test/functional/feature_bind_extra.py
@@ -32,8 +32,7 @@ class BindExtraTest(BitcoinTestFramework):
         self.num_nodes = 3
 
     def skip_test_if_missing_module(self):
-        # Due to OS-specific network stats queries, we only run on Linux.
-        self.skip_if_platform_not_linux()
+        self.skip_if_platform_not_posix()
 
     def setup_network(self):
         loopback_ipv4 = addr_to_hex("127.0.0.1")

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -17,8 +17,7 @@ class RPCBindTest(BitcoinTestFramework):
         self.supports_cli = False
 
     def skip_test_if_missing_module(self):
-        # due to OS-specific network stats queries, this test works only on Linux
-        self.skip_if_platform_not_linux()
+        self.skip_if_platform_not_posix()
 
     def setup_network(self):
         self.add_nodes(self.num_nodes, None)
@@ -105,8 +104,11 @@ class RPCBindTest(BitcoinTestFramework):
             raise SkipTest("This test requires ipv6 support.")
 
         self.log.info("Check for non-loopback interface")
+        interfaces = all_interfaces()
+        if not interfaces:
+            raise AssertionError("all_interfaces() returned no IPv4 interfaces")
         self.non_loopback_ip = None
-        for name,ip in all_interfaces():
+        for name,ip in interfaces:
             if ip != '127.0.0.1':
                 self.non_loopback_ip = ip
                 break

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -114,33 +114,44 @@ def get_bind_addrs(pid):
     else:
         raise NotImplementedError(f"get_bind_addrs is not supported on {sys.platform}")
 
-# from: https://code.activestate.com/recipes/439093/
 def all_interfaces():
     '''
-    Return all interfaces that are up
+    Return all IPv4 interfaces that are up.
     '''
-    import fcntl  # Linux only, so only import when required
+    if sys.platform == 'linux':
+        import fcntl  # Linux only, so only import when required
 
-    is_64bits = sys.maxsize > 2**32
-    struct_size = 40 if is_64bits else 32
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    max_possible = 8 # initial value
-    while True:
-        bytes = max_possible * struct_size
-        names = array.array('B', b'\0' * bytes)
-        outbytes = struct.unpack('iL', fcntl.ioctl(
-            s.fileno(),
-            0x8912,  # SIOCGIFCONF
-            struct.pack('iL', bytes, names.buffer_info()[0])
-        ))[0]
-        if outbytes == bytes:
-            max_possible *= 2
-        else:
-            break
-    namestr = names.tobytes()
-    return [(namestr[i:i+16].split(b'\0', 1)[0],
-             socket.inet_ntoa(namestr[i+20:i+24]))
-            for i in range(0, outbytes, struct_size)]
+        is_64bits = sys.maxsize > 2**32
+        struct_size = 40 if is_64bits else 32
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        max_possible = 8 # initial value
+        while True:
+            bytes = max_possible * struct_size
+            names = array.array('B', b'\0' * bytes)
+            outbytes = struct.unpack('iL', fcntl.ioctl(
+                s.fileno(),
+                0x8912,  # SIOCGIFCONF
+                struct.pack('iL', bytes, names.buffer_info()[0])
+            ))[0]
+            if outbytes == bytes:
+                max_possible *= 2
+            else:
+                break
+        namestr = names.tobytes()
+        return [(namestr[i:i+16].split(b'\0', 1)[0],
+                 socket.inet_ntoa(namestr[i+20:i+24]))
+                for i in range(0, outbytes, struct_size)]
+    elif sys.platform.startswith(("darwin", "freebsd", "netbsd", "openbsd")):
+        import re
+        import subprocess
+        output = subprocess.check_output(["ifconfig", "-au"], text=True)
+        return [
+            (m["iface"].encode(), ip)
+            for m in re.finditer(r"(?m)^(?P<iface>\S+):(?P<block>[^\n]*(?:\n[ \t]+[^\n]*)*)", output)
+            for ip in re.findall(r"inet (\S+)", m["block"])
+        ]
+    else:
+        raise NotImplementedError(f"all_interfaces is not supported on {sys.platform}")
 
 def addr_to_hex(addr):
     '''

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Linux network utilities.
+"""Linux, macOS, and BSD network utilities.
 
 Roughly based on https://web.archive.org/web/20190424172231/http://voorloopnul.com/blog/a-python-netstat-in-less-than-100-lines-of-code/ by Ricardo Pascal
 """
@@ -88,12 +88,31 @@ def get_bind_addrs(pid):
     '''
     Get bind addresses as (host,port) tuples for process pid.
     '''
-    inodes = get_socket_inodes(pid)
-    bind_addrs = []
-    for conn in netstat('tcp') + netstat('tcp6'):
-        if conn[3] == STATE_LISTEN and conn[4] in inodes:
-            bind_addrs.append(conn[1])
-    return bind_addrs
+    if sys.platform == 'linux':
+        inodes = get_socket_inodes(pid)
+        bind_addrs = []
+        for conn in netstat('tcp') + netstat('tcp6'):
+            if conn[3] == STATE_LISTEN and conn[4] in inodes:
+                bind_addrs.append(conn[1])
+        return bind_addrs
+    elif sys.platform.startswith(("darwin", "freebsd", "netbsd", "openbsd")):
+        import re
+        import subprocess
+        output = subprocess.check_output(["lsof",
+            *(["-Di"] if sys.platform.startswith("freebsd") else []), # Ignore device cache to avoid stderr warnings.
+            "-nP",          # Keep hosts and ports numeric.
+            "-a",           # Require all filters to match.
+            "-p", str(pid), # Limit results to the target pid.
+            "-iTCP",        # Only inspect TCP sockets.
+            "-sTCP:LISTEN", # Only keep listening sockets.
+            "-Ftn",         # Emit machine-readable type and name fields.
+        ], text=True)
+        return [
+            (addr_to_hex(("::" if sock_type == "IPv6" else "0.0.0.0") if host == "*" else host.strip("[]")), int(port))
+            for sock_type, host, port in re.findall(r"t(IPv[46])\nn(\*|\[.+?]|[^:]+):(\d+)", output)
+        ]
+    else:
+        raise NotImplementedError(f"get_bind_addrs is not supported on {sys.platform}")
 
 # from: https://code.activestate.com/recipes/439093/
 def all_interfaces():


### PR DESCRIPTION
### Problem

Some functional tests are shown as skipped when running on macOS & BSD because `test_framework/netutil.py` only implemented the Linux-specific logic for checking which TCP sockets a node is listening on.

### Fix

Add macOS and BSD implementations in `test/functional/test_framework/netutil.py` so tests can query:

* which TCP sockets a node is listening on (`get_bind_addrs()`, via `lsof`)
* a non-loopback interface address (`all_interfaces()`, via `ifconfig`)

Then enable the previously Linux-only tests by switching to a shared POSIX platform guard.

### Commands
<details>
<summary><code>get_bind_addrs()</code> (<code>lsof</code> + regex)</summary>


> Command used
```bash
lsof -nP -a -p <pid> -iTCP -sTCP:LISTEN -Ftn
```


> Flags

- -D: device cache warnings
- -n: no hostname resolution
- -P: no service/port-name resolution
- -a: AND all conditions
- -p <pid>: filter by process ID
- -iTCP: TCP sockets only
- -sTCP:LISTEN: listening sockets only
- -Ftn: machine-readable output (fields: type `t`, name `n`)

> Regex parser

```regex
t(IPv[46])\nn(\*|\[.+?]|[^:]+):(\d+)
```
> Captured groups

- group 1: IPv4 / IPv6 (used to disambiguate `*`)
- group 2: host (`*`, `[::1]`, `127.0.0.1`, ...)
- group 3: port
</details>


<details>
<summary><code>all_interfaces()</code> (<code>ifconfig</code> + regex)</summary>


> Command used

```bash
ifconfig -au
```


> Regex parsing

Interface blocks:
```regex
(?m)^(?P<iface>\S+):(?P<block>[^\n]*(?:\n[ \t]+[^\n]*)*)
```

IPv4 extraction within each block:
```regex
inet (\S+)
```
</details>

### Notes

The only remaining platform skips on macOS are the USDT/BPF tracing tests (`interface_usdt_*.py`).

