### PR TITLE
fuzz: Extend `spend` coverage

### DIFF
--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -134,6 +134,10 @@ FUZZ_TARGET(wallet_create_transaction, .init = initialize_setup)
                 bool lockUnspents = fuzzed_data_provider.ConsumeBool();
 
                 [[maybe_unused]] auto _{FundTransaction(*fuzzed_wallet.wallet, tx, recipients, change_pos, lockUnspents, coin_control)};
+            },
+            [&] {
+                LOCK(fuzzed_wallet.wallet->cs_wallet);
+                (void)ListCoins(*fuzzed_wallet.wallet);
             }
         );
     }


### PR DESCRIPTION
Make the `wallet/spend` fuzz target stateful and extend coverage for several missing methods.