### PR TITLE
net_processing: make m_tx_for_private_broadcast optional

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1104,7 +1104,7 @@ private:
     void LogBlockHeader(const CBlockIndex& index, const CNode& peer, bool via_compact_block);
 
     /// The transactions to be broadcast privately.
-    PrivateBroadcast m_tx_for_private_broadcast;
+    std::optional<PrivateBroadcast> m_tx_for_private_broadcast;
 };
 
 const CNodeState* PeerManagerImpl::State(NodeId pnode) const
@@ -1657,27 +1657,29 @@ void PeerManagerImpl::ReattemptPrivateBroadcast(CScheduler& scheduler)
 {
     // Remove stale transactions that are no longer relevant (e.g. already in
     // the mempool or mined) and count the remaining ones.
-    size_t num_for_rebroadcast{0};
-    const auto stale_txs = m_tx_for_private_broadcast.GetStale();
-    if (!stale_txs.empty()) {
-        LOCK(cs_main);
-        for (const auto& stale_tx : stale_txs) {
-            auto mempool_acceptable = m_chainman.ProcessTransaction(stale_tx, /*test_accept=*/true);
-            if (mempool_acceptable.m_result_type == MempoolAcceptResult::ResultType::VALID) {
-                LogDebug(BCLog::PRIVBROADCAST,
-                         "Reattempting broadcast of stale txid=%s wtxid=%s",
-                         stale_tx->GetHash().ToString(), stale_tx->GetWitnessHash().ToString());
-                ++num_for_rebroadcast;
-            } else {
-                LogDebug(BCLog::PRIVBROADCAST, "Giving up broadcast attempts for txid=%s wtxid=%s: %s",
-                         stale_tx->GetHash().ToString(), stale_tx->GetWitnessHash().ToString(),
-                         mempool_acceptable.m_state.ToString());
-                m_tx_for_private_broadcast.Remove(stale_tx);
+    if (m_tx_for_private_broadcast.has_value()) {
+        size_t num_for_rebroadcast{0};
+        const auto stale_txs = m_tx_for_private_broadcast->GetStale();
+        if (!stale_txs.empty()) {
+            LOCK(cs_main);
+            for (const auto& stale_tx : stale_txs) {
+                auto mempool_acceptable = m_chainman.ProcessTransaction(stale_tx, /*test_accept=*/true);
+                if (mempool_acceptable.m_result_type == MempoolAcceptResult::ResultType::VALID) {
+                    LogDebug(BCLog::PRIVBROADCAST,
+                             "Reattempting broadcast of stale txid=%s wtxid=%s",
+                             stale_tx->GetHash().ToString(), stale_tx->GetWitnessHash().ToString());
+                    ++num_for_rebroadcast;
+                } else {
+                    LogDebug(BCLog::PRIVBROADCAST, "Giving up broadcast attempts for txid=%s wtxid=%s: %s",
+                             stale_tx->GetHash().ToString(), stale_tx->GetWitnessHash().ToString(),
+                             mempool_acceptable.m_state.ToString());
+                    m_tx_for_private_broadcast->Remove(stale_tx);
+                }
             }
-        }
 
-        // This could overshoot, but that is ok - we will open some private connections in vain.
-        m_connman.m_private_broadcast.NumToOpenAdd(num_for_rebroadcast);
+            // This could overshoot, but that is ok - we will open some private connections in vain.
+            m_connman.m_private_broadcast.NumToOpenAdd(num_for_rebroadcast);
+        }
     }
 
     const auto delta{2min + FastRandomContext().randrange<std::chrono::milliseconds>(1min)};
@@ -1753,8 +1755,9 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
         m_headers_presync_stats.erase(nodeid);
     }
     if (node.IsPrivateBroadcastConn() &&
-        !m_tx_for_private_broadcast.DidNodeConfirmReception(nodeid) &&
-        m_tx_for_private_broadcast.HavePendingTransactions()) {
+        m_tx_for_private_broadcast.has_value() &&
+        !m_tx_for_private_broadcast->DidNodeConfirmReception(nodeid) &&
+        m_tx_for_private_broadcast->HavePendingTransactions()) {
 
         m_connman.m_private_broadcast.NumToOpenAdd(1);
     }
@@ -1881,19 +1884,26 @@ PeerManagerInfo PeerManagerImpl::GetInfo() const
 
 std::vector<PrivateBroadcast::TxBroadcastInfo> PeerManagerImpl::GetPrivateBroadcastInfo() const
 {
-    return m_tx_for_private_broadcast.GetBroadcastInfo();
+    if (!m_tx_for_private_broadcast.has_value()) {
+        return {};
+    }
+    return m_tx_for_private_broadcast->GetBroadcastInfo();
 }
 
 std::vector<CTransactionRef> PeerManagerImpl::AbortPrivateBroadcast(const uint256& id)
 {
-    const auto snapshot{m_tx_for_private_broadcast.GetBroadcastInfo()};
+    if (!m_tx_for_private_broadcast.has_value()) {
+        return {};
+    }
+
+    const auto snapshot{m_tx_for_private_broadcast->GetBroadcastInfo()};
     std::vector<CTransactionRef> removed_txs;
 
     size_t connections_cancelled{0};
     for (const auto& tx_info : snapshot) {
         const CTransactionRef& tx{tx_info.tx};
         if (tx->GetHash().ToUint256() != id && tx->GetWitnessHash().ToUint256() != id) continue;
-        if (const auto peer_acks{m_tx_for_private_broadcast.Remove(tx)}) {
+        if (const auto peer_acks{m_tx_for_private_broadcast->Remove(tx)}) {
             removed_txs.push_back(tx);
             if (NUM_PRIVATE_BROADCAST_PER_TX > *peer_acks) {
                 connections_cancelled += (NUM_PRIVATE_BROADCAST_PER_TX - *peer_acks);
@@ -2048,6 +2058,10 @@ PeerManagerImpl::PeerManagerImpl(CConnman& connman, AddrMan& addrman,
     // This argument can go away after Erlay support is complete.
     if (opts.reconcile_txs) {
         m_txreconciliation = std::make_unique<TxReconciliationTracker>(TXRECONCILIATION_VERSION);
+    }
+
+    if (m_opts.private_broadcast) {
+        m_tx_for_private_broadcast.emplace();
     }
 }
 
@@ -2296,7 +2310,13 @@ void PeerManagerImpl::InitiateTxBroadcastToAll(const Txid& txid, const Wtxid& wt
 void PeerManagerImpl::InitiateTxBroadcastPrivate(const CTransactionRef& tx)
 {
     const auto txstr{strprintf("txid=%s, wtxid=%s", tx->GetHash().ToString(), tx->GetWitnessHash().ToString())};
-    if (m_tx_for_private_broadcast.Add(tx)) {
+    if (!m_tx_for_private_broadcast.has_value()) {
+        LogWarning("[privatebroadcast] Storage is not initialized but a private broadcast was attempted. "
+                   "Transaction not broadcast: %s",
+                   txstr);
+        return;
+    }
+    if (m_tx_for_private_broadcast->Add(tx)) {
         LogDebug(BCLog::PRIVBROADCAST, "Requesting %d new connections due to %s", NUM_PRIVATE_BROADCAST_PER_TX, txstr);
         m_connman.m_private_broadcast.NumToOpenAdd(NUM_PRIVATE_BROADCAST_PER_TX);
     } else {
@@ -3585,7 +3605,15 @@ void PeerManagerImpl::PushPrivateBroadcastTx(CNode& node)
 {
     Assume(node.IsPrivateBroadcastConn());
 
-    const auto opt_tx{m_tx_for_private_broadcast.PickTxForSend(node.GetId(), CService{node.addr})};
+    if (!m_tx_for_private_broadcast.has_value()) {
+        LogWarning("[privatebroadcast] Disconnecting: private broadcast storage is "
+                   "not initialized while attempting to push a transaction to %s",
+                   node.LogPeer());
+        node.fDisconnect = true;
+        return;
+    }
+
+    const auto opt_tx{m_tx_for_private_broadcast->PickTxForSend(node.GetId(), CService{node.addr})};
     if (!opt_tx) {
         LogDebug(BCLog::PRIVBROADCAST, "Disconnecting: no more transactions for private broadcast (connected in vain), %s", node.LogPeer());
         node.fDisconnect = true;
@@ -4223,7 +4251,14 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         if (pfrom.IsPrivateBroadcastConn()) {
-            const auto pushed_tx_opt{m_tx_for_private_broadcast.GetTxForNode(pfrom.GetId())};
+            if (!m_tx_for_private_broadcast.has_value()) {
+                LogWarning("[privatebroadcast] Disconnecting: private broadcast storage is "
+                           "not initialized while receiving GETDATA from %s",
+                           pfrom.LogPeer());
+                pfrom.fDisconnect = true;
+                return;
+            }
+            const auto pushed_tx_opt{m_tx_for_private_broadcast->GetTxForNode(pfrom.GetId())};
             if (!pushed_tx_opt) {
                 LogDebug(BCLog::PRIVBROADCAST, "Disconnecting: got GETDATA without sending an INV, %s",
                          pfrom.LogPeer());
@@ -4485,14 +4520,16 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         const uint256& hash = peer.m_wtxid_relay ? wtxid.ToUint256() : txid.ToUint256();
         AddKnownTx(peer, hash);
 
-        if (const auto num_broadcasted{m_tx_for_private_broadcast.Remove(ptx)}) {
-            LogDebug(BCLog::PRIVBROADCAST, "Received our privately broadcast transaction (txid=%s) from the "
-                                           "network from %s; stopping private broadcast attempts",
-                     txid.ToString(), pfrom.LogPeer());
-            if (NUM_PRIVATE_BROADCAST_PER_TX > num_broadcasted.value()) {
-                // Not all of the initial NUM_PRIVATE_BROADCAST_PER_TX connections were needed.
-                // Tell CConnman it does not need to start the remaining ones.
-                m_connman.m_private_broadcast.NumToOpenSub(NUM_PRIVATE_BROADCAST_PER_TX - num_broadcasted.value());
+        if (m_tx_for_private_broadcast.has_value()) {
+            if (const auto num_broadcasted{m_tx_for_private_broadcast->Remove(ptx)}) {
+                LogDebug(BCLog::PRIVBROADCAST, "Received our privately broadcast transaction (txid=%s) from the "
+                                               "network from %s; stopping private broadcast attempts",
+                                               txid.ToString(), pfrom.LogPeer());
+                if (NUM_PRIVATE_BROADCAST_PER_TX > num_broadcasted.value()) {
+                    // Not all of the initial NUM_PRIVATE_BROADCAST_PER_TX connections were needed.
+                    // Tell CConnman it does not need to start the remaining ones.
+                    m_connman.m_private_broadcast.NumToOpenSub(NUM_PRIVATE_BROADCAST_PER_TX - num_broadcasted.value());
+                }
             }
         }
 
@@ -5652,9 +5689,15 @@ void PeerManagerImpl::ProcessPong(CNode& pfrom, Peer& peer, const NodeClock::tim
                     // Let connman know about this successful ping-pong
                     pfrom.PongReceived(ping_time);
                     if (pfrom.IsPrivateBroadcastConn()) {
-                        m_tx_for_private_broadcast.NodeConfirmedReception(pfrom.GetId());
-                        LogDebug(BCLog::PRIVBROADCAST, "Got a PONG (the transaction will probably reach the network), marking for disconnect, %s",
-                                 pfrom.LogPeer());
+                        if (!m_tx_for_private_broadcast.has_value()) {
+                            LogWarning("[privatebroadcast] Disconnecting: private broadcast storage is "
+                                       "not initialized while receiving PONG from %s",
+                                       pfrom.LogPeer());
+                        } else {
+                            m_tx_for_private_broadcast->NodeConfirmedReception(pfrom.GetId());
+                            LogDebug(BCLog::PRIVBROADCAST, "Got a PONG (the transaction will probably reach the network), marking for disconnect, %s",
+                                     pfrom.LogPeer());
+                        }
                         pfrom.fDisconnect = true;
                     }
                 } else {

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -121,11 +121,17 @@ public:
     /** Get peer manager info. */
     virtual PeerManagerInfo GetInfo() const = 0;
 
-    /** Get info about transactions currently being privately broadcast. */
+    /**
+     * Get info about transactions currently being privately broadcast.
+     * Should only be called when the `PeerManager` has been constructed with
+     * `PeerManager::Options::private_broadcast == true`.
+     */
     virtual std::vector<PrivateBroadcast::TxBroadcastInfo> GetPrivateBroadcastInfo() const = 0;
 
     /**
      * Abort private broadcast attempts for transactions currently being privately broadcast.
+     * Should only be called when the `PeerManager` has been constructed with
+     * `PeerManager::Options::private_broadcast == true`.
      *
      * @param[in] id A transaction identifier. It will be matched against both txid and wtxid for
      *               all transactions in the private broadcast queue.
@@ -147,6 +153,8 @@ public:
     /**
      * Initiate a private transaction broadcast. This is done
      * asynchronously via short-lived connections to peers on privacy networks.
+     * Should only be called when the `PeerManager` has been constructed with
+     * `PeerManager::Options::private_broadcast == true`.
      */
     virtual void InitiateTxBroadcastPrivate(const CTransactionRef& tx) = 0;
 


### PR DESCRIPTION
Make `PeerManagerImpl::m_tx_for_private_broadcast` optional because it is needed only in private broadcast mode (`-privatebroadcast=1`).

A followup to #29415, requested in:
https://github.com/bitcoin/bitcoin/pull/29415#discussion_r2620864832
https://github.com/bitcoin/bitcoin/pull/29415/files#r2620864832

> has it ever been discussed to make this an `std::optional` that is only created in private broadcast mode? I don't love how we call various methods (that will usually return without doing anything) from net_processing if private broadcast is not enabled.