### PR TITLE
psbt: Fix `PSBTInputSignedAndVerified` bounds `assert`

### DIFF
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -325,7 +325,7 @@ bool PSBTInputSigned(const PSBTInput& input)
 bool PSBTInputSignedAndVerified(const PartiallySignedTransaction psbt, unsigned int input_index, const PrecomputedTransactionData* txdata)
 {
     CTxOut utxo;
-    assert(psbt.inputs.size() >= input_index);
+    assert(input_index < psbt.inputs.size());
     const PSBTInput& input = psbt.inputs[input_index];
 
     if (input.non_witness_utxo) {


### PR DESCRIPTION
This PR fixes an off-by-one in a debug assertion in `PSBTInputSignedAndVerified`.
The function indexes `psbt.inputs[input_index]`, so the assertion must not allow indexing at `psbt.inputs.size()`.

Found during review: https://github.com/bitcoin/bitcoin/pull/31650#discussion_r2685892867
