### PR TITLE
Remove empty caption from user interface (noui, gui)

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -230,7 +230,7 @@ static bool InitHTTPAllowList()
         if (!subnet.IsValid()) {
             uiInterface.ThreadSafeMessageBox(
                 Untranslated(strprintf("Invalid -rpcallowip subnet specification: %s. Valid values are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0), a network/CIDR (e.g. 1.2.3.4/24), all ipv4 (0.0.0.0/0), or all ipv6 (::/0). RFC4193 is allowed only if -cjdnsreachable=0.", strAllow)),
-                "", CClientUIInterface::MSG_ERROR);
+                CClientUIInterface::MSG_ERROR);
             return false;
         }
         rpc_allow_subnets.push_back(subnet);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1819,7 +1819,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             uiInterface.ThreadSafeQuestion(
             error + Untranslated(".\n\n") + _("Do you want to rebuild the databases now?"),
             error.original + ".\nPlease restart with -reindex or -reindex-chainstate to recover.",
-            "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT)};
+            CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT)};
         if (!do_retry) {
             return false;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1377,7 +1377,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     options.coins_error_cb = [] {
         uiInterface.ThreadSafeMessageBox(
             _("Error reading from database, shutting down."),
-            "", CClientUIInterface::MSG_ERROR);
+            CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));
     auto catch_exceptions = [](auto&& f) -> ChainstateLoadResult {

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -219,7 +219,7 @@ public:
 
     //! Register handler for message box messages.
     using MessageBoxFn =
-        std::function<bool(const bilingual_str& message, const std::string& caption, unsigned int style)>;
+        std::function<bool(const bilingual_str& message, unsigned int style)>;
     virtual std::unique_ptr<Handler> handleMessageBox(MessageBoxFn fn) = 0;
 
     //! Register handler for question messages.

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -225,7 +225,6 @@ public:
     //! Register handler for question messages.
     using QuestionFn = std::function<bool(const bilingual_str& message,
         const std::string& non_interactive_message,
-        const std::string& caption,
         unsigned int style)>;
     virtual std::unique_ptr<Handler> handleQuestion(QuestionFn fn) = 0;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3423,7 +3423,7 @@ bool CConnman::Bind(const CService& addr_, unsigned int flags, NetPermissionFlag
     bilingual_str strError;
     if (!BindListenPort(addr, strError, permissions)) {
         if ((flags & BF_REPORT_ERROR) && m_client_interface) {
-            m_client_interface->ThreadSafeMessageBox(strError, "", CClientUIInterface::MSG_ERROR);
+            m_client_interface->ThreadSafeMessageBox(strError, CClientUIInterface::MSG_ERROR);
         }
         return false;
     }
@@ -3478,7 +3478,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         if (m_client_interface) {
             m_client_interface->ThreadSafeMessageBox(
                 _("Failed to listen on any port. Use -listen=0 if you want this."),
-                "", CClientUIInterface::MSG_ERROR);
+                CClientUIInterface::MSG_ERROR);
         }
         return false;
     }
@@ -3546,7 +3546,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         if (m_client_interface) {
             m_client_interface->ThreadSafeMessageBox(
                 _("Cannot provide specific connections and have addrman find outgoing connections at the same time."),
-                "", CClientUIInterface::MSG_ERROR);
+                CClientUIInterface::MSG_ERROR);
         }
         return false;
     }

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -47,7 +47,7 @@ ADD_SIGNALS_IMPL_WRAPPER(NotifyBlockTip);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyHeaderTip);
 ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
 
-bool CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style).value_or(false);}
+bool CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, style).value_or(false);}
 bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, style).value_or(false);}
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::InitWallet() { return g_ui_signals.InitWallet(); }
@@ -61,7 +61,7 @@ void CClientUIInterface::BannedListChanged() { return g_ui_signals.BannedListCha
 
 bool InitError(const bilingual_str& str)
 {
-    uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_ERROR);
+    uiInterface.ThreadSafeMessageBox(str, CClientUIInterface::MSG_ERROR);
     return false;
 }
 
@@ -79,5 +79,5 @@ bool InitError(const bilingual_str& str, const std::vector<std::string>& details
 
 void InitWarning(const bilingual_str& str)
 {
-    uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_WARNING);
+    uiInterface.ThreadSafeMessageBox(str, CClientUIInterface::MSG_WARNING);
 }

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -48,7 +48,7 @@ ADD_SIGNALS_IMPL_WRAPPER(NotifyHeaderTip);
 ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
 
 bool CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style).value_or(false);}
-bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, caption, style).value_or(false);}
+bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, style).value_or(false);}
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::InitWallet() { return g_ui_signals.InitWallet(); }
 void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -71,7 +71,7 @@ public:
 #define ADD_SIGNALS_DECL_WRAPPER(signal_name, rtype, ...)                                  \
     rtype signal_name(__VA_ARGS__);                                                        \
     using signal_name##Sig = rtype(__VA_ARGS__);                                           \
-    boost::signals2::connection signal_name##_connect(std::function<signal_name##Sig> fn);
+    boost::signals2::connection signal_name##_connect(std::function<signal_name##Sig> fn)
 
     /** Show message box. */
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeMessageBox, bool, const bilingual_str& message, const std::string& caption, unsigned int style);

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -74,9 +74,9 @@ public:
     boost::signals2::connection signal_name##_connect(std::function<signal_name##Sig> fn)
 
     /** Show message box. */
-    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeMessageBox, bool, const bilingual_str& message, const std::string& caption, unsigned int style);
+    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeMessageBox, bool, const bilingual_str& message, unsigned int style);
 
-    /** If possible, ask the user a question. If not, falls back to ThreadSafeMessageBox(noninteractive_message, caption, style) and returns false. */
+    /** If possible, ask the user a question. If not, falls back to ThreadSafeMessageBox(noninteractive_message, style) and returns false. */
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeQuestion, bool, const bilingual_str& message, const std::string& noninteractive_message, unsigned int style);
 
     /** Progress message during initialization. */

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -77,7 +77,7 @@ public:
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeMessageBox, bool, const bilingual_str& message, const std::string& caption, unsigned int style);
 
     /** If possible, ask the user a question. If not, falls back to ThreadSafeMessageBox(noninteractive_message, caption, style) and returns false. */
-    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeQuestion, bool, const bilingual_str& message, const std::string& noninteractive_message, const std::string& caption, unsigned int style);
+    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeQuestion, bool, const bilingual_str& message, const std::string& noninteractive_message, unsigned int style);
 
     /** Progress message during initialization. */
     ADD_SIGNALS_DECL_WRAPPER(InitMessage, void, const std::string& message);

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -39,7 +39,6 @@ bool noui_ThreadSafeMessageBox(const bilingual_str& message, unsigned int style)
         if (!fSecure) LogInfo("%s\n", message.original);
         break;
     default:
-        strCaption = ": "; // caption is always empty TODO fix this
         if (!fSecure) LogInfo("%s%s\n", strCaption, message.original);
     }
 

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -47,9 +47,9 @@ bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& 
     return false;
 }
 
-bool noui_ThreadSafeQuestion(const bilingual_str& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style)
+bool noui_ThreadSafeQuestion(const bilingual_str& /* ignored interactive message */, const std::string& message, unsigned int style)
 {
-    return noui_ThreadSafeMessageBox(Untranslated(message), caption, style);
+    return noui_ThreadSafeMessageBox(Untranslated(message), /*caption=*/"", style);
 }
 
 void noui_InitMessage(const std::string& message)
@@ -70,9 +70,9 @@ bool noui_ThreadSafeMessageBoxRedirect(const bilingual_str& message, const std::
     return false;
 }
 
-bool noui_ThreadSafeQuestionRedirect(const bilingual_str& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style)
+bool noui_ThreadSafeQuestionRedirect(const bilingual_str& /* ignored interactive message */, const std::string& message, unsigned int style)
 {
-    LogInfo("%s: %s", caption, message);
+    LogInfo("%s", message);
     return false;
 }
 

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -19,7 +19,7 @@ boost::signals2::connection noui_ThreadSafeMessageBoxConn;
 boost::signals2::connection noui_ThreadSafeQuestionConn;
 boost::signals2::connection noui_InitMessageConn;
 
-bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& caption, unsigned int style)
+bool noui_ThreadSafeMessageBox(const bilingual_str& message, unsigned int style)
 {
     bool fSecure = style & CClientUIInterface::SECURE;
     style &= ~CClientUIInterface::SECURE;
@@ -39,7 +39,7 @@ bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& 
         if (!fSecure) LogInfo("%s\n", message.original);
         break;
     default:
-        strCaption = caption + ": "; // Use supplied caption (can be empty)
+        strCaption = ": "; // caption is always empty TODO fix this
         if (!fSecure) LogInfo("%s%s\n", strCaption, message.original);
     }
 
@@ -49,7 +49,7 @@ bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& 
 
 bool noui_ThreadSafeQuestion(const bilingual_str& /* ignored interactive message */, const std::string& message, unsigned int style)
 {
-    return noui_ThreadSafeMessageBox(Untranslated(message), /*caption=*/"", style);
+    return noui_ThreadSafeMessageBox(Untranslated(message), style);
 }
 
 void noui_InitMessage(const std::string& message)
@@ -64,9 +64,9 @@ void noui_connect()
     noui_InitMessageConn = uiInterface.InitMessage_connect(noui_InitMessage);
 }
 
-bool noui_ThreadSafeMessageBoxRedirect(const bilingual_str& message, const std::string& caption, unsigned int style)
+bool noui_ThreadSafeMessageBoxRedirect(const bilingual_str& message, unsigned int style)
 {
-    LogInfo("%s: %s", caption, message.original);
+    LogInfo("%s", message.original);
     return false;
 }
 

--- a/src/noui.h
+++ b/src/noui.h
@@ -10,7 +10,7 @@
 struct bilingual_str;
 
 /** Non-GUI handler, which logs and prints messages. */
-bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& caption, unsigned int style);
+bool noui_ThreadSafeMessageBox(const bilingual_str& message, unsigned int style);
 /** Non-GUI handler, which logs and prints questions. */
 bool noui_ThreadSafeQuestion(const bilingual_str& /* ignored interactive message */, const std::string& message, unsigned int style);
 /** Non-GUI handler, which only logs a message. */

--- a/src/noui.h
+++ b/src/noui.h
@@ -12,7 +12,7 @@ struct bilingual_str;
 /** Non-GUI handler, which logs and prints messages. */
 bool noui_ThreadSafeMessageBox(const bilingual_str& message, const std::string& caption, unsigned int style);
 /** Non-GUI handler, which logs and prints questions. */
-bool noui_ThreadSafeQuestion(const bilingual_str& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style);
+bool noui_ThreadSafeQuestion(const bilingual_str& /* ignored interactive message */, const std::string& message, unsigned int style);
 /** Non-GUI handler, which only logs a message. */
 void noui_InitMessage(const std::string& message);
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1587,7 +1587,7 @@ void BitcoinGUI::showModalOverlay()
         modalOverlay->toggleVisibility();
 }
 
-static bool ThreadSafeMessageBox(BitcoinGUI* gui, const bilingual_str& message, const std::string& caption, unsigned int style)
+static bool ThreadSafeMessageBox(BitcoinGUI* gui, const bilingual_str& message, unsigned int style)
 {
     bool modal = (style & CClientUIInterface::MODAL);
     // The SECURE flag has no effect in the Qt GUI.
@@ -1599,11 +1599,14 @@ static bool ThreadSafeMessageBox(BitcoinGUI* gui, const bilingual_str& message, 
     if (message.original != message.translated) {
         detailed_message = BitcoinGUI::tr("Original message:") + "\n" + QString::fromStdString(message.original);
     }
+    // The title is empty for node messages. The fallback title is usually set
+    // by `style`.
+    const QString title{};
 
     // In case of modal message, use blocking connection to wait for user to click a button
     bool invoked = QMetaObject::invokeMethod(gui, "message",
                                modal ? GUIUtil::blockingGUIThreadConnection() : Qt::QueuedConnection,
-                               Q_ARG(QString, QString::fromStdString(caption)),
+                               Q_ARG(QString, title),
                                Q_ARG(QString, QString::fromStdString(message.translated)),
                                Q_ARG(unsigned int, style),
                                Q_ARG(bool*, &ret),
@@ -1616,10 +1619,10 @@ void BitcoinGUI::subscribeToCoreSignals()
 {
     // Connect signals to client
     m_handler_message_box = m_node.handleMessageBox([this](const bilingual_str& message, unsigned int style) {
-        return ThreadSafeMessageBox(this, message, /*caption=*/"", style);
+        return ThreadSafeMessageBox(this, message, style);
     });
     m_handler_question = m_node.handleQuestion([this](const bilingual_str& message, const std::string& /*non_interactive_message*/, unsigned int style) {
-        return ThreadSafeMessageBox(this, message, /*caption=*/"", style);
+        return ThreadSafeMessageBox(this, message, style);
     });
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1615,8 +1615,8 @@ static bool ThreadSafeMessageBox(BitcoinGUI* gui, const bilingual_str& message, 
 void BitcoinGUI::subscribeToCoreSignals()
 {
     // Connect signals to client
-    m_handler_message_box = m_node.handleMessageBox([this](const bilingual_str& message, const std::string& caption, unsigned int style) {
-        return ThreadSafeMessageBox(this, message, caption, style);
+    m_handler_message_box = m_node.handleMessageBox([this](const bilingual_str& message, unsigned int style) {
+        return ThreadSafeMessageBox(this, message, /*caption=*/"", style);
     });
     m_handler_question = m_node.handleQuestion([this](const bilingual_str& message, const std::string& /*non_interactive_message*/, unsigned int style) {
         return ThreadSafeMessageBox(this, message, /*caption=*/"", style);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1618,8 +1618,8 @@ void BitcoinGUI::subscribeToCoreSignals()
     m_handler_message_box = m_node.handleMessageBox([this](const bilingual_str& message, const std::string& caption, unsigned int style) {
         return ThreadSafeMessageBox(this, message, caption, style);
     });
-    m_handler_question = m_node.handleQuestion([this](const bilingual_str& message, const std::string& /*non_interactive_message*/, const std::string& caption, unsigned int style) {
-        return ThreadSafeMessageBox(this, message, caption, style);
+    m_handler_question = m_node.handleQuestion([this](const bilingual_str& message, const std::string& /*non_interactive_message*/, unsigned int style) {
+        return ThreadSafeMessageBox(this, message, /*caption=*/"", style);
     });
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -41,8 +41,6 @@
 #include <util/translation.h>
 #include <validation.h>
 
-#include <functional>
-
 #include <QAction>
 #include <QActionGroup>
 #include <QApplication>
@@ -1617,8 +1615,12 @@ static bool ThreadSafeMessageBox(BitcoinGUI* gui, const bilingual_str& message, 
 void BitcoinGUI::subscribeToCoreSignals()
 {
     // Connect signals to client
-    m_handler_message_box = m_node.handleMessageBox(std::bind(ThreadSafeMessageBox, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-    m_handler_question = m_node.handleQuestion(std::bind(ThreadSafeMessageBox, this, std::placeholders::_1, std::placeholders::_3, std::placeholders::_4));
+    m_handler_message_box = m_node.handleMessageBox([this](const bilingual_str& message, const std::string& caption, unsigned int style) {
+        return ThreadSafeMessageBox(this, message, caption, style);
+    });
+    m_handler_question = m_node.handleQuestion([this](const bilingual_str& message, const std::string& /*non_interactive_message*/, const std::string& caption, unsigned int style) {
+        return ThreadSafeMessageBox(this, message, caption, style);
+    });
 }
 
 void BitcoinGUI::unsubscribeFromCoreSignals()

--- a/test/functional/feature_presegwit_node_upgrade.py
+++ b/test/functional/feature_presegwit_node_upgrade.py
@@ -38,7 +38,7 @@ class SegwitUpgradeTest(BitcoinTestFramework):
         # because the blockchain consists of 3 insufficiently validated blocks per segwit consensus rules.
         node.assert_start_raises_init_error(
             extra_args=["-testactivationheight=segwit@5"],
-            expected_msg=": Witness data for blocks after height 5 requires "
+            expected_msg="Witness data for blocks after height 5 requires "
             f"validation. Please restart with -reindex..{os.linesep}"
             "Please restart with -reindex or -reindex-chainstate to recover.",
         )

--- a/test/functional/feature_reindex_init.py
+++ b/test/functional/feature_reindex_init.py
@@ -21,7 +21,7 @@ class ReindexInitTest(BitcoinTestFramework):
         self.log.info("Removing the block index leads to init error")
         shutil.rmtree(node.blocks_path / "index")
         node.assert_start_raises_init_error(
-            expected_msg=f": Error initializing block database.{os.linesep}"
+            expected_msg=f"Error initializing block database.{os.linesep}"
             "Please restart with -reindex or -reindex-chainstate to recover.",
         )
 

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -124,7 +124,7 @@ class BlockchainTest(BitcoinTestFramework):
         self.log.info("A block tip of more than MAX_FUTURE_BLOCK_TIME in the future raises an error")
         self.nodes[0].assert_start_raises_init_error(
             extra_args=[f"-mocktime={TIME_RANGE_TIP - MAX_FUTURE_BLOCK_TIME - 1}"],
-            expected_msg=": The block database contains a block which appears to be from the future."
+            expected_msg="The block database contains a block which appears to be from the future."
             " This may be due to your computer's date and time being set incorrectly."
             f" Only rebuild the block database if you are sure that your computer's date and time are correct.{os.linesep}"
             "Please restart with -reindex or -reindex-chainstate to recover.",


### PR DESCRIPTION
Currently, the user interface (noui, gui) has a caption for each message. However, the caption has many issues:

* It is always hard-coded to the empty string.
* This is confusing and tedious when reading or maintaining the code.
* It is redundant, because `noui` will ignore the caption and set the logging prefix (error, warning, info) based on the `style`.
* The gui does prefer to set the title based on the caption, but since it the caption is always empty, the fallback will always be used.

Fix all issues by removing it.