### PR TITLE
build: Temporarily remove confusing and brittle `-fdebug-prefix-map`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,9 +488,8 @@ try_append_cxx_flags("-fno-extended-identifiers" TARGET core_interface SKIP_LINK
 # which can cause issues with coverage builds, particularly when using
 # Clang in the OSS-Fuzz environment due to its use of other options
 # and a third party script, or with GCC.
-try_append_cxx_flags("-fdebug-prefix-map=A=B" TARGET core_interface SKIP_LINK
-  IF_CHECK_PASSED "-fdebug-prefix-map=${PROJECT_SOURCE_DIR}/src=."
-)
+# Set `-fmacro-prefix-map`, so that source file names are expanded without the
+# src prefix.
 try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
   IF_CHECK_PASSED "-fmacro-prefix-map=${PROJECT_SOURCE_DIR}/src=."
 )

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -211,6 +211,7 @@ CONFIGFLAGS="-DREDUCE_EXPORTS=ON -DBUILD_BENCH=OFF -DBUILD_GUI_TESTS=OFF -DBUILD
 # CFLAGS
 HOST_CFLAGS="-O2 -g"
 HOST_CFLAGS+=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
+HOST_CFLAGS+=" -fdebug-prefix-map=${DISTSRC}/src=."
 case "$HOST" in
     *mingw*)  HOST_CFLAGS+=" -fno-ident" ;;
     *darwin*) unset HOST_CFLAGS ;;


### PR DESCRIPTION
The compiler option `-fdebug-prefix-map` is unconditionally set by the build system. This is problematic for many reasons:

* Users and devs have no easy way to disable it without modifying the build system source code
* The mapping is broken since the cmake migration, and requires manual fixups such as https://github.com/bitcoin/bitcoin/issues/31204 or https://github.com/bitcoin/bitcoin/issues/31957

Fix all issues by temporarily removing it.

Though, the option is kept for the guix build, so that no change in behavior is observed for the release binaries.

Fixes https://github.com/bitcoin/bitcoin/issues/31957
Fixes https://github.com/bitcoin/bitcoin/issues/31204


The option can be added back in the future, if there is any need to. Though, adding it back should ideally work out of the box, or at least provide easy workarounds for all commonly used tooling.