### PR TITLE
qa: Fix Windows logging bug

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -809,7 +809,7 @@ class TestHandler:
                     status = "Passed"
                 elif proc.returncode == TEST_EXIT_SKIPPED:
                     status = "Skipped"
-                    skip_reason = re.search(r"Test Skipped: (.*)", stdout).group(1)
+                    skip_reason = re.search(r"Test Skipped: (.*)", stdout).group(1).strip()
                 else:
                     status = "Failed"
 


### PR DESCRIPTION
The regex `(.*)` was capturing `\r` from subprocess output on Windows, causing the closing parenthesis in logs to wrap to the next line.

For [example](https://github.com/hebasto/bitcoin/actions/runs/20993438084/job/60350204808):
```
208/454 - feature_bip68_sequence.py passed, Duration: 10 s
209/454 - rpc_bind.py --ipv4 skipped (not on a Linux system
)
210/454 - rpc_bind.py --ipv6 skipped (not on a Linux system
)
211/454 - rpc_packages.py passed, Duration: 8 s
212/454 - rpc_bind.py --nonloopback skipped (not on a Linux system
)
213/454 - p2p_feefilter.py passed, Duration: 4 s
```

Stripping whitespace from the regex match fixes the formatting. [See](https://github.com/hebasto/bitcoin/actions/runs/20993564177/job/60350024373):
```
208/454 - feature_bip68_sequence.py passed, Duration: 9 s
209/454 - rpc_bind.py --ipv4 skipped (not on a Linux system)
210/454 - rpc_bind.py --ipv6 skipped (not on a Linux system)
211/454 - rpc_bind.py --nonloopback skipped (not on a Linux system)
212/454 - rpc_packages.py passed, Duration: 7 s
```