### PR TITLE
fuzz: Exclude too expensive inputs in miniscript_string target

### DIFF
--- a/src/test/fuzz/util/descriptor.cpp
+++ b/src/test/fuzz/util/descriptor.cpp
@@ -4,6 +4,11 @@
 
 #include <test/fuzz/util/descriptor.h>
 
+#include <key.h>
+#include <key_io.h>
+#include <pubkey.h>
+#include <util/strencodings.h>
+
 #include <ranges>
 #include <stack>
 

--- a/src/test/fuzz/util/descriptor.h
+++ b/src/test/fuzz/util/descriptor.h
@@ -5,18 +5,20 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_DESCRIPTOR_H
 #define BITCOIN_TEST_FUZZ_UTIL_DESCRIPTOR_H
 
-#include <key_io.h>
-#include <util/strencodings.h>
-#include <script/descriptor.h>
-#include <test/fuzz/fuzz.h>
-
-#include <functional>
+#include <array>
+#include <cinttypes>
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
 
 /**
- * Converts a mocked descriptor string to a valid one. Every key in a mocked descriptor key is
+ * Converts a mocked descriptor string to a valid one. Every key in a mocked descriptor is
  * represented by 2 hex characters preceded by the '%' character. We parse the two hex characters
  * as an index in a list of pre-generated keys. This list contains keys of the various types
- * accepted in descriptor keys expressions.
+ * accepted in descriptor key expressions.
  */
 class MockedDescriptorConverter {
 private:


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/30498

Accepting "expensive" fuzz inputs which have no real use-case is problematic, because it prevents the fuzz engine from spending time on the next useful fuzz input.

For example this one will take several seconds (the flamegraph shows the time is spent in minscipt `NoDupCheck`):

```
curl -fLO 'https://raw.githubusercontent.com/bitcoin-core/qa-assets/eac1c57614d7823bcd6079814749f72018aea438/fuzz_corpora/miniscript_string/41bae50cffd1741150a1b330d02ab09f46ff8cd1'
FUZZ=miniscript_string /usr/bin/time   ./bld-cmake/bin/fuzz  ./41bae50cffd1741150a1b330d02ab09f46ff8cd1
```

Inspecting the inputs shows that it has many sub frags, so rejecting based on `HasTooManySubFrag` should be sufficient.