### PR TITLE
p2p: add validation checks for initial self-announcement

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5521,11 +5521,13 @@ void PeerManagerImpl::MaybeSendAddr(CNode& node, Peer& peer, std::chrono::micros
                 // Send the initial self-announcement in its own message. This makes sure
                 // rate-limiting with limited start-tokens doesn't ignore it if the first
                 // message ends up containing multiple addresses.
-                std::vector<CAddress> self_announcement {local_addr};
-                if (peer.m_wants_addrv2) {
-                    MakeAndPushMessage(node, NetMsgType::ADDRV2, CAddress::V2_NETWORK(self_announcement));
-                } else {
-                    MakeAndPushMessage(node, NetMsgType::ADDR, CAddress::V1_NETWORK(self_announcement));
+                if (IsAddrCompatible(peer, local_addr)) {
+                    std::vector<CAddress> self_announcement{local_addr};
+                    if (peer.m_wants_addrv2) {
+                        MakeAndPushMessage(node, NetMsgType::ADDRV2, CAddress::V2_NETWORK(self_announcement));
+                    } else {
+                        MakeAndPushMessage(node, NetMsgType::ADDR, CAddress::V1_NETWORK(self_announcement));
+                    }
                 }
             } else {
                 // All later self-announcements are sent together with the other addresses.


### PR DESCRIPTION
This is a follow up to #34146 . Adds validation check to the initial self-announcement code path. `IsAddrCompatible()` check can prevent sending non-routable addresses to peers that don't support addrv2.