### PR TITLE
test: use ephemeral ports in p2p_private_broadcast.py

### DIFF
--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -36,7 +36,6 @@ from test_framework.test_framework import (
     BitcoinTestFramework,
 )
 from test_framework.util import (
-    MAX_NODES,
     assert_equal,
     assert_not_equal,
     assert_raises_rpc_error,
@@ -181,9 +180,6 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         self.socks5_server = Socks5Server(socks5_server_config)
         self.socks5_server.start()
 
-        # Tor ports are the highest among p2p/rpc/tor, so this should be the first available port.
-        ports_base = tor_port(MAX_NODES) + 1
-
         self.destinations = []
 
         self.destinations_lock = threading.Lock()
@@ -215,9 +211,12 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
                         actual_to_addr = addr
                         actual_to_port = port
 
+                    # Use port=0 to let the OS assign an available port. This
+                    # avoids "address already in use" errors when tests run
+                    # concurrently or ports are still in TIME_WAIT state.
                     self.network_thread.listen(
                         addr="127.0.0.1",
-                        port=ports_base + i,
+                        port=0,
                         p2p=listener,
                         callback=on_listen_done)
                     # Wait until the callback has been called.


### PR DESCRIPTION
The test `p2p_private_broadcast.py` gets some Python P2P nodes to listen and instructs the SOCKS5 proxy to redirect connections to them instead of to the requested addresses. This way the `bitcoind` which uses the proxy is tricked to think it has connected to real routable internet IP addresses or `.onion` addresses.

Picking the ports where to Python P2P nodes to listen however is tricky to be done in a non-conflicting way, given that other tests may run in parallel. https://github.com/bitcoin/bitcoin/pull/34186 made it possible to let the OS select a free port, so use that in
`p2p_private_broadcast.py`.

---

_Suggested in https://github.com/bitcoin/bitcoin/pull/29415#discussion_r2654849875_