### PR TITLE
ci: remove `Valgrind fuzz` from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,12 +578,6 @@ jobs:
             timeout-minutes: 240
             file-env: './ci/test/00_setup_env_native_fuzz.sh'
 
-          - name: 'Valgrind, fuzz'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 240
-            file-env: './ci/test/00_setup_env_native_fuzz_with_valgrind.sh'
-
           - name: 'previous releases'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
             fallback-runner: 'ubuntu-24.04'


### PR DESCRIPTION
### Problem definition
The `Valgrind fuzz` job was introduced in e4b04630bcf59ea03c1373777a0167af699f92a4.
Since then, `ci/test/00_setup_env_native_fuzz_with_valgrind.sh` seems to regularly time out on forked repositories (which fall back to GitHub-hosted runners), hitting the 240 minute job timeout.

This means that every PR I push on my own branch (I do that sometimes to make sure it passes CI before I push to `bitcoin/bitcoin`) will always fail.

### Fix
Remove it from the CI matrix, similar to how the valgrind no-fuzz task is handled.
The setup script remains available for local testing.