### PR TITLE
log: correct size output in disk space check

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1931,7 +1931,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                     "Approximately %u GB of data will be stored in this directory."
                 ),
                 fs::quoted(fs::PathToString(args.GetBlocksDirPath())),
-                chainparams.AssumedBlockchainSize()
+                (additional_bytes_needed / 1024 / 1024 / 1024)
             ));
         }
     }


### PR DESCRIPTION
The output should be the additional space needed, otherwise we are always warning that 810GB will be stored, even when a user is pruning.

For example on machine with ~20GB free disk, pruning to 40GB:
```bash
./build/bin/bitcoind -prune=40000
...
2026-01-15T11:45:33Z [warning] Disk space for "/root/.bitcoin/blocks" may not accommodate the block files. Approximately 810 GB of data will be stored in this directory.
Warning: Disk space for "/root/.bitcoin/blocks" may not accommodate the block files. Approximately 810 GB of data will be stored in this directory.
```

This PR:
```bash
./build/bin/bitcoind -prune=40000
...
2026-01-15T11:41:49Z [warning] Disk space for "/root/.bitcoin/blocks" may not accommodate the block files. Approximately 39 GB of data will be stored in this directory.
Warning: Disk space for "/root/.bitcoin/blocks" may not accommodate the block files. Approximately 39 GB of data will be stored in this directory.
```