### PR TITLE
doc: Document IWYU workaround

### DIFF
--- a/src/core_io.cpp
+++ b/src/core_io.cpp
@@ -10,6 +10,9 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <key_io.h>
+// IWYU incorrectly suggests replacing this header
+// with forward declarations.
+// See https://github.com/include-what-you-use/include-what-you-use/issues/1886.
 #include <primitives/block.h> // IWYU pragma: keep
 #include <primitives/transaction.h>
 #include <script/descriptor.h>


### PR DESCRIPTION
This PR addresses the following comments:
- https://github.com/bitcoin/bitcoin/pull/34079#discussion_r2640003086:
  > it would be good to reduce and report this bug upstream. Otherwise, wide-spread use of iwyu in this code-base seems risky.

- https://github.com/bitcoin/bitcoin/pull/34079#discussion_r2640035350:
  > Would have been good if it was documented, rather than adding undocumented workarounds for buggy tools.