### PR TITLE
fuzz: Exclude too expensive inputs in descriptor_parse targets

### DIFF
--- a/src/test/fuzz/util/descriptor.cpp
+++ b/src/test/fuzz/util/descriptor.cpp
@@ -7,12 +7,15 @@
 #include <key.h>
 #include <key_io.h>
 #include <pubkey.h>
+#include <span.h>
 #include <util/strencodings.h>
 
 #include <ranges>
 #include <stack>
+#include <vector>
 
-void MockedDescriptorConverter::Init() {
+void MockedDescriptorConverter::Init()
+{
     // The data to use as a private key or a seed for an xprv.
     std::array<std::byte, 32> key_data{std::byte{1}};
     // Generate keys of all kinds and store them in the keys array.

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -50,23 +50,12 @@ void initialize_spkm()
     MOCKED_DESC_CONVERTER.Init();
 }
 
-/**
- * Deriving "expensive" descriptors will consume useful fuzz compute. The
- * compute is better spent on a smaller subset of descriptors, which still
- * covers all real end-user settings.
- */
-static bool IsTooExpensive(std::span<const uint8_t> desc)
-{
-    return HasDeepDerivPath(desc) || HasTooManySubFrag(desc) || HasTooManyWrappers(desc);
-}
-
 static std::optional<std::pair<WalletDescriptor, FlatSigningProvider>> CreateWalletDescriptor(FuzzedDataProvider& fuzzed_data_provider)
 {
     const std::string mocked_descriptor{fuzzed_data_provider.ConsumeRandomLengthString()};
-    if (IsTooExpensive(MakeUCharSpan(mocked_descriptor))) return {};
     const auto desc_str{MOCKED_DESC_CONVERTER.GetDescriptor(mocked_descriptor)};
     if (!desc_str.has_value()) return std::nullopt;
-    if (HasTooLargeLeafSize(MakeUCharSpan(*desc_str))) return {};
+    if (IsTooExpensive(MakeUCharSpan(*desc_str))) return {};
 
     FlatSigningProvider keys;
     std::string error;


### PR DESCRIPTION
Accepting "expensive" fuzz inputs which have no real use-case is problematic, because it prevents the fuzz engine from spending time on the next useful fuzz input.

For example, those will take several seconds (!) and the flamegraph shows that base58 encoding is the cause:

```
curl -fLO 'https://github.com/bitcoin-core/qa-assets/raw/b5ad78e070e4cf36beb415d7b490d948d70ba73f/fuzz_corpora/mocked_descriptor_parse/f5abf41608addcef3538da61d8096c2050235032'
curl -fLO 'https://github.com/bitcoin-core/qa-assets/raw/b5ad78e070e4cf36beb415d7b490d948d70ba73f/fuzz_corpora/descriptor_parse/78cb3175467f53b467b949883ee6072e92dbb267'

FUZZ=mocked_descriptor_parse ./bld-cmake/bin/fuzz ./f5abf41608addcef3538da61d8096c2050235032
FUZZ=descriptor_parse ./bld-cmake/bin/fuzz ./78cb3175467f53b467b949883ee6072e92dbb267
```

This will also break 32-bit fuzzing, see https://github.com/bitcoin/bitcoin/issues/34110#issuecomment-3759461248.

Fix all issues by checking for `HasTooLargeLeafSize`.

Sorry for creating several pull requests to fix this class of issue, but I think this one should be the last one. :sweat_smile: 