### PR TITLE
coins: delegate `CCoinsViewDB::HaveCoin` to `GetCoin`

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -333,21 +333,6 @@ std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) 
     return strValue;
 }
 
-bool CDBWrapper::ExistsImpl(std::span<const std::byte> key) const
-{
-    leveldb::Slice slKey(CharCast(key.data()), key.size());
-
-    std::string strValue;
-    leveldb::Status status = DBContext().pdb->Get(DBContext().readoptions, slKey, &strValue);
-    if (!status.ok()) {
-        if (status.IsNotFound())
-            return false;
-        LogError("LevelDB read failure: %s", status.ToString());
-        HandleError(status);
-    }
-    return true;
-}
-
 size_t CDBWrapper::EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const
 {
     leveldb::Slice slKey1(CharCast(key1.data()), key1.size());

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -162,10 +162,10 @@ public:
         try {
             SpanReader ssKey{GetKeyImpl()};
             ssKey >> key;
+            return true;
         } catch (const std::exception&) {
             return false;
         }
-        return true;
     }
 
     template<typename V> bool GetValue(V& value) {
@@ -174,10 +174,10 @@ public:
             m_scratch.write(GetValueImpl());
             dbwrapper_private::GetObfuscation(parent)(m_scratch);
             m_scratch >> value;
+            return true;
         } catch (const std::exception&) {
             return false;
         }
-        return true;
     }
 };
 
@@ -211,32 +211,28 @@ public:
     CDBWrapper(const CDBWrapper&) = delete;
     CDBWrapper& operator=(const CDBWrapper&) = delete;
 
-    template <typename K, typename V>
-    bool Read(const K& key, V& value) const
+    template <typename K>
+    std::optional<std::string> ReadRaw(const K& key) const
     {
         DataStream ssKey{};
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        std::optional<std::string> strValue{ReadImpl(ssKey)};
-        if (!strValue) {
-            return false;
-        }
+        return ReadImpl(ssKey);
+    }
+
+    template <typename K, typename V>
+    bool Read(const K& key, V& value) const
+    {
+        auto strValue{ReadRaw(key)};
+        if (!strValue) return false;
         try {
             std::span ssValue{MakeWritableByteSpan(*strValue)};
             m_obfuscation(ssValue);
             SpanReader{ssValue} >> value;
+            return true;
         } catch (const std::exception&) {
             return false;
         }
-        return true;
-    }
-
-    template <typename K, typename V>
-    void Write(const K& key, const V& value, bool fSync = false)
-    {
-        CDBBatch batch(*this);
-        batch.Write(key, value);
-        WriteBatch(batch, fSync);
     }
 
     template <typename K>
@@ -246,6 +242,14 @@ public:
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
         return ExistsImpl(ssKey);
+    }
+
+    template <typename K, typename V>
+    void Write(const K& key, const V& value, bool fSync = false)
+    {
+        CDBBatch batch(*this);
+        batch.Write(key, value);
+        WriteBatch(batch, fSync);
     }
 
     template <typename K>

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -200,7 +200,6 @@ private:
     inline static const std::string OBFUSCATION_KEY{"\000obfuscate_key", 14}; // explicit size to avoid truncation at leading \0
 
     std::optional<std::string> ReadImpl(std::span<const std::byte> key) const;
-    bool ExistsImpl(std::span<const std::byte> key) const;
     size_t EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const;
     auto& DBContext() const LIFETIMEBOUND { return *Assert(m_db_context); }
 
@@ -238,10 +237,7 @@ public:
     template <typename K>
     bool Exists(const K& key) const
     {
-        DataStream ssKey{};
-        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey << key;
-        return ExistsImpl(ssKey);
+        return !!ReadRaw(key);
     }
 
     template <typename K, typename V>

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1085,6 +1085,63 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     BOOST_CHECK_EQUAL(base.GetBestBlock(), block_hash);
 }
 
+BOOST_AUTO_TEST_CASE(ccoins_cache_behavior)
+{
+    class CCoinsViewSpy final : public CoinsViewEmpty
+    {
+    public:
+        const COutPoint expected;
+        mutable size_t getcoin_calls{0};
+
+        explicit CCoinsViewSpy(const COutPoint& out) : expected{out} {}
+
+        std::optional<Coin> GetCoin(const COutPoint& out) const override
+        {
+            BOOST_CHECK(out == expected);
+            ++getcoin_calls;
+            return Coin{CTxOut{1, CScript{}}, 1, false};
+        }
+
+        bool HaveCoin(const COutPoint& out) const override
+        {
+            BOOST_CHECK(out == expected);
+            BOOST_FAIL("Base HaveCoin should never be called");
+            return false;
+        }
+    };
+
+    const COutPoint prevout{Txid::FromUint256(m_rng.rand256()), 0};
+    CCoinsViewSpy base{prevout};
+    CCoinsViewCache cache{&base};
+
+    CMutableTransaction mtx;
+    mtx.vin.emplace_back(prevout);
+    const CTransaction tx{mtx};
+    BOOST_CHECK(!tx.IsCoinBase());
+
+    BOOST_CHECK(cache.HaveInputs(tx));
+    BOOST_CHECK_EQUAL(base.getcoin_calls, 1);
+
+    BOOST_CHECK(cache.HaveInputs(tx));
+    BOOST_CHECK(cache.GetCoin(prevout));
+    BOOST_CHECK(!cache.AccessCoin(prevout).IsSpent());
+    BOOST_CHECK(cache.HaveCoin(prevout));
+    BOOST_CHECK_EQUAL(base.getcoin_calls, 1);
+
+    const COutPoint prefilled_prevout{Txid::FromUint256(m_rng.rand256()), 0};
+    cache.AddCoin(prefilled_prevout, Coin{CTxOut{1, CScript{}}, 1, false}, /*possible_overwrite=*/false);
+    BOOST_CHECK(cache.HaveCoinInCache(prefilled_prevout));
+
+    CMutableTransaction prefilled_mtx;
+    prefilled_mtx.vin.emplace_back(prefilled_prevout);
+    const CTransaction prefilled_tx{prefilled_mtx};
+    BOOST_CHECK(!prefilled_tx.IsCoinBase());
+    BOOST_CHECK(cache.HaveInputs(prefilled_tx));
+
+    BOOST_CHECK(cache.SpendCoin(prevout));
+    BOOST_CHECK(!cache.HaveCoinInCache(prevout));
+}
+
 BOOST_AUTO_TEST_CASE(coins_resource_is_used)
 {
     CCoinsMapMemoryResource resource;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -101,7 +101,7 @@ std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const
 
 bool CCoinsViewDB::HaveCoin(const COutPoint& outpoint) const
 {
-    return m_db->Exists(CoinEntry(&outpoint));
+    return !!GetCoin(outpoint);
 }
 
 uint256 CCoinsViewDB::GetBestBlock() const {


### PR DESCRIPTION
Split out of https://github.com/bitcoin/bitcoin/pull/34132#discussion_r2692307054.

**Problem:** `CCoinsViewDB::HaveCoin()` currently answers a different question from the cache-backed coins view path.
It calls `CDBWrapper::Exists()`, which only checks whether LevelDB has a value for the coin key, while `GetCoin()` tries to read the value as an unspent `Coin`.
This makes the direct DB view's `HaveCoin()` semantics diverge from `CCoinsViewCache::HaveCoin()`, which fetches through `GetCoin()` on cache misses.
The separate `CDBWrapper::ExistsImpl()` read path also duplicates `ReadImpl()` even though the remaining `CDBWrapper::Exists()` callers are infrequent metadata checks.

**Fix:** Make `CCoinsViewDB::HaveCoin()` delegate to `GetCoin()`, so it reports whether the outpoint can be read as an unspent `Coin` (not just whether the database contains any value).
Also have `CDBWrapper::Read()` and `Exists()` share a `ReadRaw()` helper instead of keeping separate LevelDB read implementations.

**Testing:** Add a unit test documenting that `CCoinsViewCache::HaveInputs()` checks the cache first and calls the backing view's `GetCoin()`, not `HaveCoin()`, on cache miss.
