### PR TITLE
node: Persist private broadcast transactions over node restarts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -228,6 +228,8 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/mini_miner.cpp
   node/minisketchwrapper.cpp
   node/peerman_args.cpp
+  node/private_broadcast_persist.cpp
+  node/private_broadcast_persist_args.cpp
   node/psbt.cpp
   node/timeoffsets.cpp
   node/transaction.cpp

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -32,6 +32,7 @@
 #include <netmessagemaker.h>
 #include <node/blockstorage.h>
 #include <node/connection_types.h>
+#include <node/private_broadcast_persist.h>
 #include <node/protocol_version.h>
 #include <node/timeoffsets.h>
 #include <node/txdownloadman.h>
@@ -545,6 +546,8 @@ public:
     void SendPings() override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void InitiateTxBroadcastToAll(const Txid& txid, const Wtxid& wtxid) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void InitiateTxBroadcastPrivate(const CTransactionRef& tx) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+    void DumpPrivateBroadcast(const fs::path& dump_path) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+    void LoadPrivateBroadcast(const fs::path& load_path) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void SetBestBlock(int height, std::chrono::seconds time) override
     {
         m_best_height = height;
@@ -2244,6 +2247,16 @@ void PeerManagerImpl::InitiateTxBroadcastPrivate(const CTransactionRef& tx)
     } else {
         LogDebug(BCLog::PRIVBROADCAST, "Ignoring unnecessary request to schedule an already scheduled transaction: %s", txstr);
     }
+}
+
+void PeerManagerImpl::DumpPrivateBroadcast(const fs::path& dump_path) const
+{
+    node::DumpPrivateBroadcast(m_tx_for_private_broadcast, dump_path);
+}
+
+void PeerManagerImpl::LoadPrivateBroadcast(const fs::path& load_path)
+{
+    node::LoadPrivateBroadcast(m_tx_for_private_broadcast, load_path);
 }
 
 void PeerManagerImpl::RelayAddress(NodeId originator,

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -11,6 +11,7 @@
 #include <node/txorphanage.h>
 #include <protocol.h>
 #include <threadsafety.h>
+#include <util/fs.h>
 #include <util/expected.h>
 #include <validationinterface.h>
 
@@ -131,6 +132,12 @@ public:
      * asynchronously via short-lived connections to peers on privacy networks.
      */
     virtual void InitiateTxBroadcastPrivate(const CTransactionRef& tx) = 0;
+
+    /** Dump private broadcast state to disk. */
+    virtual void DumpPrivateBroadcast(const fs::path& dump_path) const = 0;
+
+    /** Load private broadcast state from disk. */
+    virtual void LoadPrivateBroadcast(const fs::path& load_path) = 0;
 
     /** Send ping message to all peers */
     virtual void SendPings() = 0;

--- a/src/node/private_broadcast_persist.cpp
+++ b/src/node/private_broadcast_persist.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/private_broadcast_persist.h>
+
+#include <clientversion.h>
+#include <logging.h>
+#include <private_broadcast.h>
+#include <random.h>
+#include <serialize.h>
+#include <streams.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
+#include <util/obfuscation.h>
+#include <util/syserror.h>
+
+#include <cstdint>
+#include <exception>
+#include <stdexcept>
+#include <vector>
+
+using fsbridge::FopenFn;
+
+namespace node {
+
+static const uint64_t PRIVATE_BROADCAST_DUMP_VERSION{1};
+static const uint64_t MAX_PRIVATE_BROADCAST_TXS{100000};
+
+void LoadPrivateBroadcast(PrivateBroadcast& pb, const fs::path& load_path, FopenFn mockable_fopen_function)
+{
+    if (load_path.empty()) return;
+
+    AutoFile file{mockable_fopen_function(load_path, "rb")};
+    if (file.IsNull()) {
+        LogDebug(BCLog::PRIVBROADCAST, "Failed to open private broadcast file. Continuing anyway.\n");
+        return;
+    }
+
+    try {
+        uint64_t version;
+        file >> version;
+        if (version != PRIVATE_BROADCAST_DUMP_VERSION) return;
+
+        Obfuscation obfuscation;
+        file >> obfuscation;
+        file.SetObfuscation(obfuscation);
+
+        uint64_t total_to_load{0};
+        file >> total_to_load;
+        LogDebug(BCLog::PRIVBROADCAST, "Loading %u private broadcast transactions from file...\n", total_to_load);
+
+        total_to_load = std::min<uint64_t>(total_to_load, MAX_PRIVATE_BROADCAST_TXS);
+
+        for (uint64_t i = 0; i < total_to_load; ++i) {
+            CTransactionRef tx;
+            file >> TX_WITH_WITNESS(tx);
+            pb.Add(tx);
+        }
+    } catch (const std::exception& e) {
+        LogInfo("Failed to deserialize private broadcast data on file: %s. Continuing anyway.\n", e.what());
+    }
+}
+
+void DumpPrivateBroadcast(const PrivateBroadcast& pb, const fs::path& dump_path, FopenFn mockable_fopen_function, bool skip_file_commit)
+{
+    const auto infos{pb.GetBroadcastInfo()};
+    std::vector<CTransactionRef> txs;
+    txs.reserve(infos.size());
+    for (const auto& info : infos) txs.push_back(info.tx);
+
+    const fs::path file_fspath{dump_path + ".new"};
+    AutoFile file{mockable_fopen_function(file_fspath, "wb")};
+    if (file.IsNull()) return;
+
+    try {
+        file << PRIVATE_BROADCAST_DUMP_VERSION;
+
+        const Obfuscation obfuscation{FastRandomContext{}.randbytes<Obfuscation::KEY_SIZE>()};
+        file << obfuscation;
+        file.SetObfuscation(obfuscation);
+
+        file << uint64_t{txs.size()};
+        LogDebug(BCLog::PRIVBROADCAST, "Writing %u private broadcast transactions to file...\n", txs.size());
+        for (const auto& tx : txs) {
+            file << TX_WITH_WITNESS(tx);
+        }
+
+        if (!skip_file_commit && !file.Commit()) {
+            (void)file.fclose();
+            throw std::runtime_error("Commit failed");
+        }
+        if (file.fclose() != 0) {
+            throw std::runtime_error(
+                strprintf("Error closing %s: %s", fs::PathToString(file_fspath), SysErrorString(errno)));
+        }
+        if (!RenameOver(dump_path + ".new", dump_path)) {
+            throw std::runtime_error("Rename failed");
+        }
+    } catch (const std::exception& e) {
+        LogInfo("Failed to dump private broadcast: %s. Continuing anyway.\n", e.what());
+        (void)file.fclose();
+    }
+}
+
+} // namespace node

--- a/src/node/private_broadcast_persist.h
+++ b/src/node/private_broadcast_persist.h
@@ -1,0 +1,25 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_PRIVATE_BROADCAST_PERSIST_H
+#define BITCOIN_NODE_PRIVATE_BROADCAST_PERSIST_H
+
+#include <util/fs.h>
+
+class PrivateBroadcast;
+
+namespace node {
+
+/** Dump the private broadcast state to a file. */
+void DumpPrivateBroadcast(const PrivateBroadcast& pb, const fs::path& dump_path,
+                          fsbridge::FopenFn mockable_fopen_function = fsbridge::fopen,
+                          bool skip_file_commit = false);
+
+/** Import the file and attempt to add its contents to the private broadcast state. */
+void LoadPrivateBroadcast(PrivateBroadcast& pb, const fs::path& load_path,
+                          fsbridge::FopenFn mockable_fopen_function = fsbridge::fopen);
+
+} // namespace node
+
+#endif // BITCOIN_NODE_PRIVATE_BROADCAST_PERSIST_H

--- a/src/node/private_broadcast_persist_args.cpp
+++ b/src/node/private_broadcast_persist_args.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/private_broadcast_persist_args.h>
+
+#include <common/args.h>
+#include <util/fs.h>
+
+namespace node {
+
+fs::path PrivateBroadcastPath(const ArgsManager& argsman)
+{
+    return argsman.GetDataDirNet() / "privatebroadcast.dat";
+}
+
+} // namespace node

--- a/src/node/private_broadcast_persist_args.h
+++ b/src/node/private_broadcast_persist_args.h
@@ -1,0 +1,19 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_PRIVATE_BROADCAST_PERSIST_ARGS_H
+#define BITCOIN_NODE_PRIVATE_BROADCAST_PERSIST_ARGS_H
+
+#include <util/fs.h>
+
+class ArgsManager;
+
+namespace node {
+
+/** Location of the private broadcast persistence file. */
+fs::path PrivateBroadcastPath(const ArgsManager& argsman);
+
+} // namespace node
+
+#endif // BITCOIN_NODE_PRIVATE_BROADCAST_PERSIST_ARGS_H

--- a/src/private_broadcast.h
+++ b/src/private_broadcast.h
@@ -30,6 +30,14 @@
 class PrivateBroadcast
 {
 public:
+    struct TxBroadcastInfo {
+        CTransactionRef tx;
+        size_t num_sent{0};
+        std::optional<NodeClock::time_point> last_sent{};
+        size_t num_peer_reception_acks{0};
+        std::optional<NodeClock::time_point> last_peer_reception_ack{};
+    };
+
     /**
      * Add a transaction to the storage.
      * @param[in] tx The transaction to add.
@@ -93,6 +101,12 @@ public:
      * Get the transactions that have not been broadcast recently.
      */
     std::vector<CTransactionRef> GetStale() const
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /**
+     * Get stats about all transactions currently being privately broadcast.
+     */
+    std::vector<TxBroadcastInfo> GetBroadcastInfo() const
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
 private:

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -133,6 +133,7 @@ add_executable(fuzz
   utxo_snapshot.cpp
   utxo_total_supply.cpp
   validation_load_mempool.cpp
+  private_broadcast_persist.cpp
   vecdeque.cpp
   versionbits.cpp
 )

--- a/src/test/fuzz/private_broadcast_persist.cpp
+++ b/src/test/fuzz/private_broadcast_persist.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/private_broadcast_persist.h>
+
+#include <node/private_broadcast_persist_args.h>
+#include <private_broadcast.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+
+#include <cstdint>
+#include <vector>
+
+using node::DumpPrivateBroadcast;
+using node::LoadPrivateBroadcast;
+using node::PrivateBroadcastPath;
+
+namespace {
+const TestingSetup* g_setup;
+} // namespace
+
+void initialize_private_broadcast_persist()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+}
+
+FUZZ_TARGET(private_broadcast_persist, .init = initialize_private_broadcast_persist)
+{
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    FuzzedFileProvider fuzzed_file_provider{fuzzed_data_provider};
+
+    auto fuzzed_fopen = [&](const fs::path&, const char*) {
+        return fuzzed_file_provider.open();
+    };
+
+    PrivateBroadcast pb;
+    LoadPrivateBroadcast(pb, PrivateBroadcastPath(g_setup->m_args), fuzzed_fopen);
+    DumpPrivateBroadcast(pb, PrivateBroadcastPath(g_setup->m_args), fuzzed_fopen, /*skip_file_commit=*/true);
+}


### PR DESCRIPTION
Follow-up from #29415 

Currently private broadcast transactions are stored in peer manager and do not persist over restarts. A submitted transaction can be lost if the node restarts before it is privately broadcast.

This change dumps the set of private broadcast transactions to a `privatebroadcast.dat` file on shutdown, and adds the transactions back to the private broadcast data structure on restart.