### PR TITLE
test: use `IP_PORTRANGE_HIGH` on FreeBSD for dynamic port allocation

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -181,3 +181,17 @@ def format_addr_port(addr, port):
         return f"[{addr}]:{port}"
     else:
         return f"{addr}:{port}"
+
+
+def set_freebsd_high_port_range(sock):
+    '''On FreeBSD, set socket to use the high ephemeral port range (49152-65535).
+
+    FreeBSD's default ephemeral port range (10000-65535) overlaps with the test
+    framework's static port range (11000-26000). Using IP_PORTRANGE_HIGH avoids
+    this overlap when binding to port 0 for dynamic port allocation.
+    '''
+    if sys.platform.startswith('freebsd'):
+        # Constants from FreeBSD's netinet/in.h
+        IP_PORTRANGE = 19
+        IP_PORTRANGE_HIGH = 1
+        sock.setsockopt(socket.IPPROTO_IP, IP_PORTRANGE, IP_PORTRANGE_HIGH)

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -11,7 +11,8 @@ import queue
 import logging
 
 from .netutil import (
-    format_addr_port
+    format_addr_port,
+    set_freebsd_high_port_range,
 )
 
 logger = logging.getLogger("TestFramework.socks5")
@@ -202,6 +203,10 @@ class Socks5Server():
         self.conf = conf
         self.s = socket.socket(conf.af)
         self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # When using dynamic port allocation (port=0), ensure we don't get a
+        # port that conflicts with the test framework's static port range.
+        if conf.addr[1] == 0:
+            set_freebsd_high_port_range(self.s)
         self.s.bind(conf.addr)
         # When port=0, the OS assigns an available port. Update conf.addr
         # to reflect the actual bound address so callers can use it.


### PR DESCRIPTION
On FreeBSD, the default ephemeral port range (10000-65535) overlaps with the test framework's static port range (11000-26000), possibly causing intermittent "address already in use" failures when tests use dynamic port allocation (`port=0`).

This PR adds a helper that sets `IP_PORTRANGE_HIGH` via `setsockopt()` before binding, requesting ports from 49152-65535 instead, which avoids the overlap, as suggested in https://github.com/bitcoin/bitcoin/issues/34331#issuecomment-3767161843 by @maflcko .

From FreeBSD's [sys/netinet/in.h](https://cgit.freebsd.org/src/tree/sys/netinet/in.h):                                                          
  ```c
  #define IP_PORTRANGE         19
  #define IP_PORTRANGE_HIGH    1
  #define IPPORT_EPHEMERALFIRST 10000  /* default range start */
  #define IPPORT_HIFIRSTAUTO   49152   /* high range start */
```

See also: FreeBSD https://man.freebsd.org/cgi/man.cgi?query=ip&sektion=4 man page.

I’ll leave the PR as a draft since I haven’t tested it on FreeBSD yet and would like to gather feedback on the approach.

Fixes #34331