### PR TITLE
ci, iwyu: Fix warnings in `src/zmq` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -215,7 +215,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_io.cpp|signet.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives|zmq)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_io.cpp|signet.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -108,6 +108,9 @@ IncludeCategories:
   - Regex:           '^<Q'
     Priority:        2
     CaseSensitive:   true
+  - Regex:           '^<zmq.h>$'
+    Priority:        2
+    CaseSensitive:   true
   - Regex:           '^<[^>.]*>'
     Priority:        3
     CaseSensitive:   false

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -11,14 +11,13 @@
 #include <netbase.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
-#include <validationinterface.h>
+#include <util/check.h>
 #include <zmq/zmqabstractnotifier.h>
 #include <zmq/zmqpublishnotifier.h>
 #include <zmq/zmqutil.h>
 
 #include <zmq.h>
 
-#include <cassert>
 #include <map>
 #include <string>
 #include <utility>

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -8,16 +8,15 @@
 #include <primitives/transaction.h>
 #include <validationinterface.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <list>
 #include <memory>
 #include <vector>
 
-class CBlock;
 class CBlockIndex;
 class CZMQAbstractNotifier;
-struct NewMempoolTransactionInfo;
 
 class CZMQNotificationInterface final : public CValidationInterface
 {

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -5,38 +5,29 @@
 #include <zmq/zmqpublishnotifier.h>
 
 #include <chain.h>
-#include <chainparams.h>
 #include <crypto/common.h>
-#include <kernel/cs_main.h>
 #include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
-#include <node/blockstorage.h>
-#include <primitives/block.h>
 #include <primitives/transaction.h>
-#include <rpc/server.h>
 #include <serialize.h>
 #include <streams.h>
-#include <sync.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <zmq/zmqutil.h>
 
 #include <zmq.h>
 
-#include <cassert>
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <map>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
-
-namespace Consensus {
-struct Params;
-}
 
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;
 

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -10,10 +10,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <utility>
 #include <vector>
 
 class CBlockIndex;
-class CTransaction;
 
 class CZMQAbstractPublishNotifier : public CZMQAbstractNotifier
 {

--- a/src/zmq/zmqrpc.cpp
+++ b/src/zmq/zmqrpc.cpp
@@ -6,13 +6,15 @@
 
 #include <rpc/server.h>
 #include <rpc/util.h>
+#include <univalue.h>
 #include <zmq/zmqabstractnotifier.h>
 #include <zmq/zmqnotificationinterface.h>
 
-#include <univalue.h>
-
 #include <list>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 class JSONRPCRequest;
 

--- a/src/zmq/zmqutil.cpp
+++ b/src/zmq/zmqutil.cpp
@@ -5,6 +5,8 @@
 #include <zmq/zmqutil.h>
 
 #include <logging.h>
+#include <util/check.h>
+
 #include <zmq.h>
 
 #include <cerrno>


### PR DESCRIPTION
This PR [continues](https://github.com/bitcoin/bitcoin/pull/33725#issuecomment-3466897433) the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).

Additionally, this adds a new include category to `src/.clang-format`.