### PR TITLE
wallet: only log `txid` when `-debug=wallet` is explicit

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -176,6 +176,7 @@ static const std::map<std::string, BCLog::LogFlags, std::less<>> LOG_CATEGORIES_
     {"http", BCLog::HTTP},
     {"bench", BCLog::BENCH},
     {"zmq", BCLog::ZMQ},
+    {"wallet", BCLog::WALLET},
     {"walletdb", BCLog::WALLETDB},
     {"rpc", BCLog::RPC},
     {"estimatefee", BCLog::ESTIMATEFEE},

--- a/src/logging.h
+++ b/src/logging.h
@@ -117,6 +117,7 @@ namespace BCLog {
         TXPACKAGES  = (CategoryMask{1} << 28),
         KERNEL      = (CategoryMask{1} << 29),
         PRIVBROADCAST = (CategoryMask{1} << 30),
+        WALLET      = (CategoryMask{1} << 31),
         ALL         = ~NONE,
     };
     enum class Level {

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -114,7 +114,7 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
 // deleter here.
 static void WalletToolReleaseWallet(CWallet* wallet)
 {
-    wallet->WalletLogPrintf("Releasing wallet\n");
+    wallet->WalletLogInfo("Releasing wallet\n");
     wallet->Close();
     delete wallet;
 }

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -175,8 +175,8 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
 
         if (!ExtractDestination(txout.scriptPubKey, address) && !txout.scriptPubKey.IsUnspendable())
         {
-            wallet.WalletLogInfo("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
-                                    wtx.GetHash().ToString());
+            wallet.WalletLogInfo("CWalletTx::GetAmounts: Unknown transaction type found");
+            wallet.WalletLogDebug("  txid=%s", wtx.GetHash().ToString());
             address = CNoDestination();
         }
 

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -175,7 +175,7 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
 
         if (!ExtractDestination(txout.scriptPubKey, address) && !txout.scriptPubKey.IsUnspendable())
         {
-            wallet.WalletLogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
+            wallet.WalletLogInfo("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
                                     wtx.GetHash().ToString());
             address = CNoDestination();
         }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -291,7 +291,7 @@ bool LegacyDataSPKM::LoadCScript(const CScript& redeemScript)
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
     {
         std::string strAddr = EncodeDestination(ScriptHash(redeemScript));
-        WalletLogPrintf("%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n", __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
+        WalletLogInfo("%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n", __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
         return true;
     }
 
@@ -1071,7 +1071,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
     if (IsMine(script)) {
         int32_t index = m_map_script_pub_keys[script];
         if (index >= m_wallet_descriptor.next_index) {
-            WalletLogPrintf("%s: Detected a used keypool item at index %d, mark all keypool items up to this item as used\n", __func__, index);
+            WalletLogInfo("%s: Detected a used keypool item at index %d, mark all keypool items up to this item as used\n", __func__, index);
             auto out_keys = std::make_unique<FlatSigningProvider>();
             std::vector<CScript> scripts_temp;
             while (index >= m_wallet_descriptor.next_index) {
@@ -1085,7 +1085,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
             }
         }
         if (!TopUp()) {
-            WalletLogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);
+            WalletLogInfo("%s: Topping up keypool failed (locked wallet)\n", __func__);
         }
     }
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -150,7 +150,7 @@ public:
 
     /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
     template <typename... Params>
-    void WalletLogPrintf(util::ConstevalFormatString<sizeof...(Params)> wallet_fmt, const Params&... params) const
+    void WalletLogInfo(util::ConstevalFormatString<sizeof...(Params)> wallet_fmt, const Params&... params) const
     {
         LogInfo("[%s] %s", m_storage.LogName(), tfm::format(wallet_fmt, params...));
     };

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1395,8 +1395,8 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     // accidental reuse.
     reservedest.KeepDestination();
 
-    wallet.WalletLogPrintf("Coin Selection: Algorithm:%s, Waste Metric Score:%d\n", GetAlgorithmName(result.GetAlgo()), result.GetWaste());
-    wallet.WalletLogPrintf("Fee Calculation: Fee:%d Bytes:%u Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
+    wallet.WalletLogInfo("Coin Selection: Algorithm:%s, Waste Metric Score:%d\n", GetAlgorithmName(result.GetAlgo()), result.GetWaste());
+    wallet.WalletLogInfo("Fee Calculation: Fee:%d Bytes:%u Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
               current_fee, nBytes, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
               feeCalc.est.pass.start, feeCalc.est.pass.end,
               (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool) > 0.0 ? 100 * feeCalc.est.pass.withinTarget / (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool) : 0.0,
@@ -1453,7 +1453,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(
                txr_grouped.has_value() ? txr_grouped->fee : 0,
                txr_grouped.has_value() && txr_grouped->change_pos.has_value() ? int32_t(*txr_grouped->change_pos) : -1);
         if (txr_grouped) {
-            wallet.WalletLogPrintf("Fee non-grouped = %lld, grouped = %lld, using %s\n",
+            wallet.WalletLogInfo("Fee non-grouped = %lld, grouped = %lld, using %s\n",
                 txr_ungrouped.fee, txr_grouped->fee, use_aps ? "grouped" : "non-grouped");
             if (use_aps) return txr_grouped;
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -238,7 +238,7 @@ static std::set<std::string> g_unloading_wallet_set GUARDED_BY(g_wallet_release_
 static void FlushAndDeleteWallet(CWallet* wallet)
 {
     const std::string name = wallet->GetName();
-    wallet->WalletLogPrintf("Releasing wallet %s..\n", name);
+    wallet->WalletLogInfo("Releasing wallet %s..\n", name);
     delete wallet;
     // Wallet is now released, notify WaitForDeleteWallet, if any.
     {
@@ -641,7 +641,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
                 if (!EncryptMasterKey(strNewWalletPassphrase, plain_master_key, master_key)) {
                     return false;
                 }
-                WalletLogPrintf("Wallet passphrase changed to an nDeriveIterations of %i\n", master_key.nDeriveIterations);
+                WalletLogInfo("Wallet passphrase changed to an nDeriveIterations of %i\n", master_key.nDeriveIterations);
 
                 WalletBatch(GetDatabase()).WriteMasterKey(master_key_id, master_key);
                 if (fWasLocked)
@@ -810,7 +810,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     if (!EncryptMasterKey(strWalletPassphrase, plain_master_key, master_key)) {
         return false;
     }
-    WalletLogPrintf("Encrypting Wallet with an nDeriveIterations of %i\n", master_key.nDeriveIterations);
+    WalletLogInfo("Encrypting Wallet with an nDeriveIterations of %i\n", master_key.nDeriveIterations);
 
     {
         LOCK2(m_relock_mutex, cs_wallet);
@@ -965,7 +965,7 @@ bool CWallet::MarkReplaced(const Txid& originalHash, const Txid& newHash)
 
     bool success = true;
     if (!batch.WriteTx(wtx)) {
-        WalletLogPrintf("%s: Updating batch tx %s failed\n", __func__, wtx.GetHash().ToString());
+        WalletLogInfo("%s: Updating batch tx %s failed\n", __func__, wtx.GetHash().ToString());
         success = false;
     }
 
@@ -1090,7 +1090,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     }
 
     //// debug print
-    WalletLogPrintf("AddToWallet %s  %s%s %s\n", hash.ToString(), (fInsertedNew ? "new" : ""), (fUpdated ? "update" : ""), TxStateString(state));
+    WalletLogInfo("AddToWallet %s  %s%s %s\n", hash.ToString(), (fInsertedNew ? "new" : ""), (fUpdated ? "update" : ""), TxStateString(state));
 
     // Write to disk
     if (fInsertedNew || fUpdated)
@@ -1182,7 +1182,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(txin.prevout);
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
-                        WalletLogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
+                        WalletLogInfo("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
                         MarkConflicted(conf->confirmed_block_hash, conf->confirmed_block_height, range.first->second);
                     }
                     range.first++;
@@ -1802,7 +1802,7 @@ int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& r
     int start_height = 0;
     uint256 start_block;
     bool start = chain().findFirstBlockWithTimeAndHeight(startTime - TIMESTAMP_WINDOW, 0, FoundBlock().hash(start_block).height(start_height));
-    WalletLogPrintf("%s: Rescanning last %i blocks\n", __func__, start ? WITH_LOCK(cs_wallet, return GetLastBlockHeight()) - start_height + 1 : 0);
+    WalletLogInfo("%s: Rescanning last %i blocks\n", __func__, start ? WITH_LOCK(cs_wallet, return GetLastBlockHeight()) - start_height + 1 : 0);
 
     if (start) {
         // TODO: this should take into account failure by ScanResult::USER_ABORT
@@ -1852,7 +1852,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
     std::unique_ptr<FastWalletRescanFilter> fast_rescan_filter;
     if (chain().hasBlockFilterIndex(BlockFilterType::BASIC)) fast_rescan_filter = std::make_unique<FastWalletRescanFilter>(*this);
 
-    WalletLogPrintf("Rescan started from block %s... (%s)\n", start_block.ToString(),
+    WalletLogInfo("Rescan started from block %s... (%s)\n", start_block.ToString(),
                     fast_rescan_filter ? "fast variant using block filters" : "slow variant inspecting all blocks");
 
     fAbortRescan = false;
@@ -1877,7 +1877,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         bool next_interval = reserver.now() >= current_time + INTERVAL_TIME;
         if (next_interval) {
             current_time = reserver.now();
-            WalletLogPrintf("Still rescanning. At block %d. Progress=%f\n", block_height, progress_current);
+            WalletLogInfo("Still rescanning. At block %d. Progress=%f\n", block_height, progress_current);
         }
 
         bool fetch_block{true};
@@ -1930,7 +1930,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                 result.last_scanned_height = block_height;
 
                 if (!loc.IsNull()) {
-                    WalletLogPrintf("Saving scan progress %d.\n", block_height);
+                    WalletLogInfo("Saving scan progress %d.\n", block_height);
                     WalletBatch batch(GetDatabase());
                     batch.WriteBestBlock(loc);
                 }
@@ -1973,18 +1973,18 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         }
     }
     if (!max_height) {
-        WalletLogPrintf("Scanning current mempool transactions.\n");
+        WalletLogInfo("Scanning current mempool transactions.\n");
         WITH_LOCK(cs_wallet, chain().requestMempoolTransactions(*this));
     }
     ShowProgress(strprintf("[%s] %s", DisplayName(), _("Rescanning…")), 100); // hide progress dialog in GUI
     if (block_height && fAbortRescan) {
-        WalletLogPrintf("Rescan aborted at block %d. Progress=%f\n", block_height, progress_current);
+        WalletLogInfo("Rescan aborted at block %d. Progress=%f\n", block_height, progress_current);
         result.status = ScanResult::USER_ABORT;
     } else if (block_height && chain().shutdownRequested()) {
-        WalletLogPrintf("Rescan interrupted by shutdown request at block %d. Progress=%f\n", block_height, progress_current);
+        WalletLogInfo("Rescan interrupted by shutdown request at block %d. Progress=%f\n", block_height, progress_current);
         result.status = ScanResult::USER_ABORT;
     } else {
-        WalletLogPrintf("Rescan completed in %15dms\n", Ticks<std::chrono::milliseconds>(reserver.now() - start_time));
+        WalletLogInfo("Rescan completed in %15dms\n", Ticks<std::chrono::milliseconds>(reserver.now() - start_time));
     }
     return result;
 }
@@ -2017,7 +2017,7 @@ bool CWallet::SubmitTxMemoryPoolAndRelay(CWalletTx& wtx,
         what = "for private broadcast without adding to the mempool";
         break;
     }
-    WalletLogPrintf("Submitting wtx %s %s\n", wtx.GetHash().ToString(), what);
+    WalletLogInfo("Submitting wtx %s %s\n", wtx.GetHash().ToString(), what);
     // We must set TxStateInMempool here. Even though it will also be set later by the
     // entered-mempool callback, if we did not there would be a race where a
     // user could call sendmoney in a loop and hit spurious out of funds errors
@@ -2117,7 +2117,7 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
     } // cs_wallet
 
     if (submitted_tx_count > 0) {
-        WalletLogPrintf("%s: resubmit %u unconfirmed transactions\n", __func__, submitted_tx_count);
+        WalletLogInfo("%s: resubmit %u unconfirmed transactions\n", __func__, submitted_tx_count);
     }
 }
 
@@ -2298,7 +2298,7 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
 void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm)
 {
     LOCK(cs_wallet);
-    WalletLogPrintf("CommitTransaction:\n%s\n", util::RemoveSuffixView(tx->ToString(), "\n"));
+    WalletLogInfo("CommitTransaction:\n%s\n", util::RemoveSuffixView(tx->ToString(), "\n"));
 
     // Add tx to wallet, because if it has change it's also ours,
     // otherwise just for transaction history.
@@ -2329,7 +2329,7 @@ void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::ve
 
     std::string err_string;
     if (!SubmitTxMemoryPoolAndRelay(*wtx, err_string, node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL)) {
-        WalletLogPrintf("CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", err_string);
+        WalletLogInfo("CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", err_string);
         // TODO: if we expect the failure to be long term or permanent, instead delete wtx from the wallet and return failure.
     }
 }
@@ -2434,11 +2434,11 @@ bool CWallet::SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
 
     const std::string& encoded_dest = EncodeDestination(address);
     if (new_purpose && !batch.WritePurpose(encoded_dest, PurposeToString(*new_purpose))) {
-        WalletLogPrintf("Error: fail to write address book 'purpose' entry\n");
+        WalletLogInfo("Error: fail to write address book 'purpose' entry\n");
         return false;
     }
     if (!batch.WriteName(encoded_dest, strName)) {
-        WalletLogPrintf("Error: fail to write address book 'name' entry\n");
+        WalletLogInfo("Error: fail to write address book 'name' entry\n");
         return false;
     }
 
@@ -2471,24 +2471,24 @@ bool CWallet::DelAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
         // NOTE: This isn't a problem for sending addresses because they don't have any data that needs to be kept.
         // When adding new address data, it should be considered here whether to retain or delete it.
         if (IsMine(address)) {
-            WalletLogPrintf("%s called with IsMine address, NOT SUPPORTED. Please report this bug! %s\n", __func__, CLIENT_BUGREPORT);
+            WalletLogInfo("%s called with IsMine address, NOT SUPPORTED. Please report this bug! %s\n", __func__, CLIENT_BUGREPORT);
             return false;
         }
         // Delete data rows associated with this address
         if (!batch.EraseAddressData(address)) {
-            WalletLogPrintf("Error: cannot erase address book entry data\n");
+            WalletLogInfo("Error: cannot erase address book entry data\n");
             return false;
         }
 
         // Delete purpose entry
         if (!batch.ErasePurpose(dest)) {
-            WalletLogPrintf("Error: cannot erase address book entry purpose\n");
+            WalletLogInfo("Error: cannot erase address book entry purpose\n");
             return false;
         }
 
         // Delete name entry
         if (!batch.EraseName(dest)) {
-            WalletLogPrintf("Error: cannot erase address book entry name\n");
+            WalletLogInfo("Error: cannot erase address book entry name\n");
             return false;
         }
 
@@ -2790,7 +2790,7 @@ unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx, bool rescanning_old
                 nTimeSmart = std::max(latestEntry, std::min(blocktime, latestNow));
             }
         } else {
-            WalletLogPrintf("%s: found %s in block %s not in index\n", __func__, wtx.GetHash().ToString(), block_hash->ToString());
+            WalletLogInfo("%s: found %s in block %s not in index\n", __func__, wtx.GetHash().ToString(), block_hash->ToString());
         }
     }
     return nTimeSmart;
@@ -3114,7 +3114,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     walletInstance->m_spend_zero_conf_change = args.GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);
     walletInstance->m_signal_rbf = args.GetBoolArg("-walletrbf", DEFAULT_WALLET_RBF);
 
-    walletInstance->WalletLogPrintf("Wallet completed loading in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
+    walletInstance->WalletLogInfo("Wallet completed loading in %15dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
 
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
@@ -3135,9 +3135,9 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     {
         LOCK(walletInstance->cs_wallet);
         walletInstance->SetBroadcastTransactions(args.GetBoolArg("-walletbroadcast", DEFAULT_WALLETBROADCAST));
-        walletInstance->WalletLogPrintf("setKeyPool.size() = %u\n",      walletInstance->GetKeyPoolSize());
-        walletInstance->WalletLogPrintf("mapWallet.size() = %u\n",       walletInstance->mapWallet.size());
-        walletInstance->WalletLogPrintf("m_address_book.size() = %u\n",  walletInstance->m_address_book.size());
+        walletInstance->WalletLogInfo("setKeyPool.size() = %u\n",      walletInstance->GetKeyPoolSize());
+        walletInstance->WalletLogInfo("mapWallet.size() = %u\n",       walletInstance->mapWallet.size());
+        walletInstance->WalletLogInfo("m_address_book.size() = %u\n",  walletInstance->m_address_book.size());
     }
 
     return walletInstance;
@@ -3240,7 +3240,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         }
 
         chain.initMessage(_("Rescanning…"));
-        walletInstance->WalletLogPrintf("Rescanning last %i blocks (from block %i)...\n", *tip_height - rescan_height, rescan_height);
+        walletInstance->WalletLogInfo("Rescanning last %i blocks (from block %i)...\n", *tip_height - rescan_height, rescan_height);
 
         {
             WalletRescanReserver reserver(*walletInstance);
@@ -3661,7 +3661,7 @@ void CWallet::LoadActiveScriptPubKeyMan(uint256 id, OutputType type, bool intern
     // Legacy wallets have only one ScriptPubKeyManager and it's active for all output and change types.
     Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
 
-    WalletLogPrintf("Setting spkMan to active: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
+    WalletLogInfo("Setting spkMan to active: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
     auto& spk_mans = internal ? m_internal_spk_managers : m_external_spk_managers;
     auto& spk_mans_other = internal ? m_external_spk_managers : m_internal_spk_managers;
     auto spk_man = m_spk_managers.at(id).get();
@@ -3679,7 +3679,7 @@ void CWallet::DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool intern
 {
     auto spk_man = GetScriptPubKeyMan(type, internal);
     if (spk_man != nullptr && spk_man->GetID() == id) {
-        WalletLogPrintf("Deactivate spkMan: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
+        WalletLogInfo("Deactivate spkMan: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
         WalletBatch batch(GetDatabase());
         if (!batch.EraseActiveScriptPubKeyMan(static_cast<uint8_t>(type), internal)) {
             throw std::runtime_error(std::string(__func__) + ": erasing active ScriptPubKeyMan id failed");
@@ -3734,7 +3734,7 @@ util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWall
 
     auto spk_man = GetDescriptorScriptPubKeyMan(desc);
     if (spk_man) {
-        WalletLogPrintf("Update existing descriptor: %s\n", desc.descriptor->ToString());
+        WalletLogInfo("Update existing descriptor: %s\n", desc.descriptor->ToString());
         if (auto spkm_res = spk_man->UpdateWalletDescriptor(desc); !spkm_res) {
             return util::Error{util::ErrorString(spkm_res)};
         }
@@ -3789,7 +3789,7 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
 {
     AssertLockHeld(cs_wallet);
 
-    WalletLogPrintf("Migrating wallet storage database from BerkeleyDB to SQLite.\n");
+    WalletLogInfo("Migrating wallet storage database from BerkeleyDB to SQLite.\n");
 
     if (m_database->Format() == "sqlite") {
         error = _("Error: This wallet already uses SQLite");
@@ -4130,7 +4130,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             options.create_flags |= WALLET_FLAG_KEY_ORIGIN_METADATA;
         }
         if (data->watch_descs.size() > 0) {
-            wallet.WalletLogPrintf("Making a new watchonly wallet containing the watched scripts\n");
+            wallet.WalletLogInfo("Making a new watchonly wallet containing the watched scripts\n");
 
             DatabaseStatus status;
             std::vector<bilingual_str> warnings;
@@ -4169,7 +4169,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/true, warnings);
         }
         if (data->solvable_descs.size() > 0) {
-            wallet.WalletLogPrintf("Making a new watchonly wallet containing the unwatched solvable scripts\n");
+            wallet.WalletLogInfo("Making a new watchonly wallet containing the unwatched solvable scripts\n");
 
             DatabaseStatus status;
             std::vector<bilingual_str> warnings;
@@ -4215,7 +4215,7 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             error = util::ErrorString(res_migration);
             return false;
         }
-        wallet.WalletLogPrintf("Wallet migration complete.\n");
+        wallet.WalletLogInfo("Wallet migration complete.\n");
         return true;
     });
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -933,7 +933,7 @@ public:
 
     /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
     template <typename... Params>
-    void WalletLogPrintf(util::ConstevalFormatString<sizeof...(Params)> wallet_fmt, const Params&... params) const
+    void WalletLogInfo(util::ConstevalFormatString<sizeof...(Params)> wallet_fmt, const Params&... params) const
     {
         LogInfo("[%s] %s", LogName(), tfm::format(wallet_fmt, params...));
     };

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -938,6 +938,13 @@ public:
         LogInfo("[%s] %s", LogName(), tfm::format(wallet_fmt, params...));
     };
 
+    /** Prepends the wallet name in debug logging output to ease debugging in multi-wallet use cases */
+    template <typename... Params>
+    void WalletLogDebug(util::ConstevalFormatString<sizeof...(Params)> wallet_fmt, const Params&... params) const
+    {
+        LogDebug(BCLog::WALLET, "[%s] %s", LogName(), tfm::format(wallet_fmt, params...));
+    };
+
     //! Returns all unique ScriptPubKeyMans in m_internal_spk_managers and m_external_spk_managers
     std::set<ScriptPubKeyMan*> GetActiveScriptPubKeyMans() const;
     bool IsActiveScriptPubKeyMan(const ScriptPubKeyMan& spkm) const;

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -22,7 +22,7 @@ namespace WalletTool {
 // deleter here.
 static void WalletToolReleaseWallet(CWallet* wallet)
 {
-    wallet->WalletLogPrintf("Releasing wallet\n");
+    wallet->WalletLogInfo("Releasing wallet\n");
     wallet->Close();
     delete wallet;
 }


### PR DESCRIPTION
Extracted from: https://github.com/bitcoin/bitcoin/pull/34267#discussion_r2693741105

### Problem

All wallet logging was written to `debug.log` by default, so it can leak sensitive wallet context (`txids` and full transaction strings) when shared.
Also, `WalletLogPrintf` is a leftover name from the removed `LogPrintf` API and does not reflect the current behavior (unconditional info-level logging).

### Fix

After a refactor commit to rename `WalletLogPrintf` to `WalletLogInfo` (`scripted-diff` only) to reflect that it logs unconditionally at info level, redact txids and full transaction strings from info-level wallet logs, and add a new `-debug=wallet` category for sensitive context (txid/full tx string) logged as indented follow-up lines via the new `WalletLogDebug()`.

### Reproducer

We can easily exercises the common create wallet, mine, and send paths to demonstrate the info-level redaction vs `-debug=wallet` behavior.
It does not attempt to trigger rare error paths (e.g. database write failures, unexpected script types, conflicts/double-spends, broadcast failures, rescans/migrations), which would require additional setup and can be deduced from the code.

Build and run this once "before" and once "after", then compare grepped log output.

```bash
cmake -B build >/dev/null 2>&1 && cmake --build build --target bitcoind bitcoin-cli -j$(nproc) >/dev/null 2>&1

DATA_DIR=$(mktemp -d)

./build/bin/bitcoind -regtest -datadir="$DATA_DIR" -daemon -connect=0 -fallbackfee=0.0002 >/dev/null 2>&1
./build/bin/bitcoin-cli -regtest -datadir="$DATA_DIR" -rpcwait getblockchaininfo >/dev/null

./build/bin/bitcoin-cli -regtest -datadir="$DATA_DIR" createwallet w0 >/dev/null
./build/bin/bitcoin-cli -regtest -datadir="$DATA_DIR" createwallet w1 >/dev/null
ADDR0=$(./build/bin/bitcoin-cli -regtest -datadir="$DATA_DIR" -rpcwallet=w0 getnewaddress)
./build/bin/bitcoin-cli -regtest -datadir="$DATA_DIR" -rpcwallet=w0 generatetoaddress 101 "$ADDR0" >/dev/null
ADDR1=$(./build/bin/bitcoin-cli -regtest -datadir="$DATA_DIR" -rpcwallet=w1 getnewaddress)
./build/bin/bitcoin-cli -regtest -datadir="$DATA_DIR" -rpcwallet=w0 sendtoaddress "$ADDR1" 1 >/dev/null
./build/bin/bitcoin-cli -regtest -datadir="$DATA_DIR" -rpcwallet=w1 -rpcwait getbalances >/dev/null

rg -n "CommitTransaction|AddToWallet|Submitting wtx|txid=|CTransaction\\(" "$DATA_DIR/regtest/debug.log" || true

./build/bin/bitcoin-cli -regtest -datadir="$DATA_DIR" stop >/dev/null
```

<details>
<summary>Before (info-level wallet logs include txids and transaction dump)</summary>

```bash
113:2026-01-19T12:51:04Z [w0] AddToWallet d9a81836a9a2e8158ca6aa49278b70305a07614df420d980abe2028366407731  new Confirmed (block=24fd805ca35464a95530674f8434c3af34111409e5e3477ae4ba4b46f085baac, height=1, index=0)
...
411:2026-01-19T12:51:05Z [w0] AddToWallet 3d72f6d5f6829a070b0d9766a672b158b6a1fd87bea0f6959ab0ec4b44ebb7ef  new Confirmed (block=2e937f886897ccd9345fc859ebedde9be981a831aa55786286dae69b21a36007, height=101, index=0)
417:2026-01-19T12:51:05Z [w0] CommitTransaction:
418:CTransaction(hash=14daa63ec9, ver=2, vin.size=1, vout.size=2, nLockTime=3)
423:2026-01-19T12:51:05Z [w0] AddToWallet 14daa63ec9de552d7260ab2cd3e993ba41cd1eadc2e525eec8e017b26ebd5a4c  newupdate Inactive (abandoned=0)
424:2026-01-19T12:51:05Z [w0] Submitting wtx 14daa63ec9de552d7260ab2cd3e993ba41cd1eadc2e525eec8e017b26ebd5a4c to mempool and for broadcast to peers
425:2026-01-19T12:51:05Z [w0] AddToWallet 14daa63ec9de552d7260ab2cd3e993ba41cd1eadc2e525eec8e017b26ebd5a4c   InMempool
426:2026-01-19T12:51:05Z [w1] AddToWallet 14daa63ec9de552d7260ab2cd3e993ba41cd1eadc2e525eec8e017b26ebd5a4c  new InMempool
```
</details>

<details>
<summary>After (info-level wallet logs redact txids and transaction dump)</summary>

```bash
115:2026-01-19T12:52:46Z [w0] AddToWallet new Confirmed (block=7f0cdb7a15da25963eb2276592aefb99596011a3288f08a8598c87046e5d1f2f, height=1, index=0)
...
411:2026-01-19T12:52:47Z [w0] AddToWallet new Confirmed (block=0a02dcb2e58029c5e665bad29ae90f69f813527bb41f6c74e7600ada7194019c, height=101, index=0)
417:2026-01-19T12:52:47Z [w0] CommitTransaction
418:2026-01-19T12:52:47Z [w0] AddToWallet newupdate Inactive (abandoned=0)
419:2026-01-19T12:52:47Z [w0] Submitting wtx to mempool and for broadcast to peers
420:2026-01-19T12:52:47Z [w0] AddToWallet  InMempool
421:2026-01-19T12:52:47Z [w1] AddToWallet new InMempool
```
</details>

<details>
<summary>After with <code>-debug=wallet</code> (txids and transaction dump only in <code>[wallet]</code> debug lines)</summary>

Adding wallet debug logging:
```bash
./build/bin/bitcoind -regtest -datadir="$DATA_DIR" -daemon -connect=0 -fallbackfee=0.0002 -debug=wallet >/dev/null 2>&1
```

```bash
114:2026-01-19T12:54:47Z [w0] AddToWallet new Confirmed (block=511c1230d47d8d70c87f01b1b2274a4c04a8304f826f500af90ac36d3953544d, height=1, index=0)
115:2026-01-19T12:54:47Z [wallet] [w0]   txid=7d8e6900d4f3815291f5c80c24067d71867e605bc1ac96bc302174fc7c22c38f
...
512:2026-01-19T12:54:47Z [w0] AddToWallet new Confirmed (block=2c1aa6e5312f1b0213e5d8a32807baba845e5b1f19998e9ae5366ccc6ffce3b0, height=101, index=0)
513:2026-01-19T12:54:47Z [wallet] [w0]   txid=eb8521e70116f366541ab8202375b3ec145e29e7271779baa4eff066ccd1e9ac
519:2026-01-19T12:54:47Z [w0] CommitTransaction
520:2026-01-19T12:54:47Z [wallet] [w0]   CTransaction(hash=b56f816d0c, ver=2, vin.size=1, vout.size=2, nLockTime=101)
525:2026-01-19T12:54:47Z [w0] AddToWallet newupdate Inactive (abandoned=0)
526:2026-01-19T12:54:47Z [wallet] [w0]   txid=b56f816d0cf7fdc5ae34eb09bcfdfefe66e57e3f76be86e46ffebd046eaa8ed2
527:2026-01-19T12:54:47Z [w0] Submitting wtx to mempool and for broadcast to peers
528:2026-01-19T12:54:47Z [wallet] [w0]   txid=b56f816d0cf7fdc5ae34eb09bcfdfefe66e57e3f76be86e46ffebd046eaa8ed2
529:2026-01-19T12:54:47Z [w0] AddToWallet  InMempool
530:2026-01-19T12:54:47Z [wallet] [w0]   txid=b56f816d0cf7fdc5ae34eb09bcfdfefe66e57e3f76be86e46ffebd046eaa8ed2
531:2026-01-19T12:54:47Z [w1] AddToWallet new InMempool
532:2026-01-19T12:54:47Z [wallet] [w1]   txid=b56f816d0cf7fdc5ae34eb09bcfdfefe66e57e3f76be86e46ffebd046eaa8ed2
```

</details>
