### PR TITLE
test: use IP_PORTRANGE_HIGH on FreeBSD for dynamic port allocation

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -181,3 +181,22 @@ def format_addr_port(addr, port):
         return f"[{addr}]:{port}"
     else:
         return f"{addr}:{port}"
+
+
+def set_ephemeral_port_range(sock):
+    '''On FreeBSD, set socket to use the high ephemeral port range (49152-65535).
+
+    FreeBSD's default ephemeral port range (10000-65535) overlaps with the test
+    framework's static port range starting at TEST_RUNNER_PORT_MIN (default=11000).
+    Using IP_PORTRANGE_HIGH avoids this overlap when binding to port 0 for dynamic
+    port allocation.
+    '''
+    if sys.platform.startswith('freebsd'):
+        # Constants from FreeBSD's netinet/in.h and netinet6/in6.h
+        IP_PORTRANGE = 19
+        IPV6_PORTRANGE = 14
+        IP_PORTRANGE_HIGH = 1  # Same value for both IPv4 and IPv6
+        if sock.family == socket.AF_INET6:
+            sock.setsockopt(socket.IPPROTO_IPV6, IPV6_PORTRANGE, IP_PORTRANGE_HIGH)
+        else:
+            sock.setsockopt(socket.IPPROTO_IP, IP_PORTRANGE, IP_PORTRANGE_HIGH)

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -22,9 +22,11 @@ P2PTxInvStore: A p2p interface class that inherits from P2PDataStore, and keeps
 
 import asyncio
 from collections import defaultdict
+import ipaddress
 from io import BytesIO
 import logging
 import platform
+import socket
 import struct
 import sys
 import threading
@@ -75,6 +77,9 @@ from test_framework.messages import (
     NODE_WITNESS,
     MAGIC_BYTES,
     sha256,
+)
+from test_framework.netutil import (
+    set_ephemeral_port_range,
 )
 from test_framework.util import (
     assert_not_equal,
@@ -793,8 +798,22 @@ class NetworkThread(threading.Thread):
             # connections, we can accomplish this by providing different
             # `proto` functions
 
-            listener = await cls.network_event_loop.create_server(peer_protocol, addr, port)
-            port = listener.sockets[0].getsockname()[1]
+            if port == 0:
+                # Manually create the socket in order to set the range to be
+                # used for the port before the bind() call.
+                if ipaddress.ip_address(addr).version == 4:
+                    address_family = socket.AF_INET
+                else:
+                    address_family = socket.AF_INET6
+                s = socket.socket(address_family)
+                set_ephemeral_port_range(s)
+                s.bind((addr, 0))
+                s.listen()
+                listener = await cls.network_event_loop.create_server(peer_protocol, sock=s)
+                port = listener.sockets[0].getsockname()[1]
+            else:
+                listener = await cls.network_event_loop.create_server(peer_protocol, addr, port)
+
             logger.debug("Listening server on %s:%d should be started" % (addr, port))
             cls.listeners[(addr, port)] = listener
 

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -11,7 +11,8 @@ import queue
 import logging
 
 from .netutil import (
-    format_addr_port
+    format_addr_port,
+    set_ephemeral_port_range,
 )
 
 logger = logging.getLogger("TestFramework.socks5")
@@ -202,6 +203,10 @@ class Socks5Server():
         self.conf = conf
         self.s = socket.socket(conf.af)
         self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # When using dynamic port allocation (port=0), ensure we don't get a
+        # port that conflicts with the test framework's static port range.
+        if conf.addr[1] == 0:
+            set_ephemeral_port_range(self.s)
         self.s.bind(conf.addr)
         # When port=0, the OS assigns an available port. Update conf.addr
         # to reflect the actual bound address so callers can use it.


### PR DESCRIPTION
Reopening #34336. I’ve now tested it on FreeBSD and confirmed it works.

On FreeBSD, the default ephemeral port range (10000-65535) overlaps with the test framework's static port range (11000-26000), possibly causing intermittent "address already in use" failures when tests use dynamic port allocation (`port=0`).

This PR adds a helper that sets `IP_PORTRANGE_HIGH` via `setsockopt()` before binding, requesting ports from 49152-65535 instead, which avoids the overlap, as suggested in https://github.com/bitcoin/bitcoin/issues/34331#issuecomment-3767161843 by @maflcko .

From FreeBSD's [sys/netinet/in.h](https://cgit.freebsd.org/src/tree/sys/netinet/in.h):                                                          
  ```c
  #define IP_PORTRANGE         19
  #define IP_PORTRANGE_HIGH    1
  #define IPPORT_EPHEMERALFIRST 10000  /* default range start */
  #define IPPORT_HIFIRSTAUTO   49152   /* high range start */
```

See also: FreeBSD https://man.freebsd.org/cgi/man.cgi?query=ip&sektion=4 man page.

Fixes #34331