### PR TITLE
util: Remove `FilterHeaderHasher`

### DIFF
--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -51,7 +51,7 @@ private:
 
     Mutex m_cs_headers_cache;
     /** cache of block hash to filter header, to avoid disk access when responding to getcfcheckpt. */
-    std::unordered_map<uint256, uint256, FilterHeaderHasher> m_headers_cache GUARDED_BY(m_cs_headers_cache);
+    std::unordered_map<uint256, uint256, BlockHasher> m_headers_cache GUARDED_BY(m_cs_headers_cache);
 
     // Last computed header to avoid disk reads on every new block.
     uint256 m_last_header{};

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -76,10 +76,6 @@ public:
     }
 };
 
-struct FilterHeaderHasher {
-    size_t operator()(const uint256& hash) const { return ReadLE64(hash.begin()); }
-};
-
 /**
  * We're hashing a nonce into the entries themselves, so we don't need extra
  * blinding in the set hash computation.


### PR DESCRIPTION
With respect to `std::unordered_map` documentation, the `Hash` type
defined in the template is over the `Key` and not `T`, the value. This
hasher is incorrectly named as the `FilterHeader` is the value within this map.
I consider this a bug as opposed to a refactor as the key and value
relationship is implied to be `filter header -> block hash` when it is
the opposite.

Further, the hasher for the key already exists via `BlockHasher`.

ref: https://en.cppreference.com/w/cpp/container/unordered_map.html