### PR TITLE
ci, iwyu: Fix warnings in `src/primitives` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -215,7 +215,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_io.cpp|signet.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_io.cpp|signet.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 
@@ -227,6 +227,7 @@ if [[ "${RUN_IWYU}" == true ]]; then
              -p "${BASE_BUILD_DIR}" "${MAKEJOBS}" \
              -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
              -Xiwyu --max_line_length=160 \
+             -Xiwyu --check_also="*/primitives/*.h" \
              2>&1 | tee /tmp/iwyu_ci.out
     python3 "/include-what-you-use/fix_includes.py" --nosafe_headers < /tmp/iwyu_ci.out
     git diff -U0 | ./contrib/devtools/clang-format-diff.py -binary="clang-format-${TIDY_LLVM_V}" -p1 -i -v

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -8,6 +8,10 @@
 #include <hash.h>
 #include <tinyformat.h>
 
+#include <memory>
+#include <span>
+#include <sstream>
+
 uint256 CBlockHeader::GetHash() const
 {
     return (HashWriter{} << *this).GetHash();

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -11,6 +11,11 @@
 #include <uint256.h>
 #include <util/time.h>
 
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
  * requirements.  When they solve the proof-of-work, they broadcast the block

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -12,10 +12,10 @@
 #include <script/script.h>
 #include <serialize.h>
 #include <tinyformat.h>
-#include <uint256.h>
 
 #include <algorithm>
 #include <cassert>
+#include <span>
 #include <stdexcept>
 
 std::string COutPoint::ToString() const

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -11,8 +11,8 @@
 #include <primitives/transaction_identifier.h> // IWYU pragma: export
 #include <script/script.h>
 #include <serialize.h>
-#include <uint256.h>
 
+#include <compare>
 #include <cstddef>
 #include <cstdint>
 #include <ios>

--- a/src/primitives/transaction_identifier.h
+++ b/src/primitives/transaction_identifier.h
@@ -9,9 +9,12 @@
 #include <uint256.h>
 #include <util/types.h>
 
-#include <compare>
-#include <concepts>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
 #include <tuple>
+#include <type_traits>
 #include <variant>
 
 /** transaction_identifier represents the two canonical transaction identifier


### PR DESCRIPTION
This PR [continues](https://github.com/bitcoin/bitcoin/pull/33725#issuecomment-3466897433) the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).