### PR TITLE
rpc: Handle nullptr from createNewBlock in getblocktemplate

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -872,7 +872,9 @@ static RPCHelpMan getblocktemplate()
 
         // Create new block
         block_template = miner.createNewBlock();
-        CHECK_NONFATAL(block_template);
+        if (!block_template) {
+    	    throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Mining subsystem is not available");
+        }
 
 
         // Need to update only after we know createNewBlock succeeded


### PR DESCRIPTION
Fixes #34262

getblocktemplate currently asserts when miner.createNewBlock() returns nullptr. This can happen during shutdown or when the mining subsystem is unavailable.

Replace the assertion with proper error handling that returns RPC_CLIENT_NOT_CONNECTED instead, indicating the service is temporarily unavailable.