### PR TITLE
bench: add WalletBalanceManySpent for high-history wallet scenario

### DIFF
--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -3,28 +3,28 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <bench/wallet_bench_util.h>
+#include <consensus/consensus.h>
 #include <interfaces/chain.h>
 #include <kernel/chainparams.h>
-#include <primitives/block.h>
-#include <primitives/transaction.h>
-#include <sync.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
 #include <util/time.h>
-#include <validation.h>
 #include <wallet/receive.h>
+#include <wallet/spend.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
-#include <wallet/walletutil.h>
 
 #include <cassert>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
 
 namespace wallet {
+
 static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const bool add_mine)
 {
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
@@ -70,4 +70,124 @@ static void WalletBalanceWatch(benchmark::Bench& bench) { WalletBalance(bench, /
 BENCHMARK(WalletBalanceDirty);
 BENCHMARK(WalletBalanceClean);
 BENCHMARK(WalletBalanceWatch);
+
+static void WalletBalanceManySpent(benchmark::Bench& bench)
+{
+    constexpr int NUM_BLOCKS{500};
+    constexpr int OUTPUTS_PER_BLOCK{100};
+    constexpr CAmount OUTPUT_VALUE{50 * COIN / OUTPUTS_PER_BLOCK};
+    constexpr size_t TOTAL_WALLET_OUTPUTS{NUM_BLOCKS * OUTPUTS_PER_BLOCK};
+    constexpr size_t KEEP_UNSPENT{50};
+    constexpr size_t BATCH_SIZE{100};
+    constexpr CAmount FEE{1000};
+    constexpr size_t TXS_PER_BLOCK{10};
+    constexpr int FILLER_OUTPUTS{1};
+    constexpr CAmount FILLER_VALUE{50 * COIN};
+
+    // Benchmark GetBalance with many spent TXOs and few unspent TXOs.
+    // This scenario benefits from optimizations that separate definitely-spent
+    // outputs from potentially-spendable ones (such as m_unusable_txos).
+    //
+    // Target: many spent TXOs, few unspent TXOs.
+    const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
+    const auto& params = test_setup->m_node.chainman->GetParams();
+
+    NodeClockContext clock_ctx{params.GenesisBlock().Time()};
+    CWallet wallet{test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase()};
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        wallet.SetupDescriptorScriptPubKeyMans();
+    }
+    auto handler = test_setup->m_node.chain->handleNotifications({&wallet, [](CWallet*) {}});
+
+    const auto dest = getNewDestination(wallet, OutputType::BECH32);
+    const CScript wallet_script = GetScriptForDestination(dest);
+    // Burn script for outputs we don't want in the wallet
+    const CScript burn_script{CScript() << OP_TRUE};
+
+    // Phase 1: Create the configured wallet-owned output history.
+    for (int i = 0; i < NUM_BLOCKS; ++i) {
+        GenerateFakeBlock(params, test_setup->m_node, wallet, wallet_script, OUTPUTS_PER_BLOCK);
+    }
+
+    // Phase 2: Mature all wallet-owned coinbase outputs.
+    for (int i = 0; i < COINBASE_MATURITY; ++i) {
+        GenerateFakeBlock(params, test_setup->m_node, wallet, burn_script, FILLER_OUTPUTS);
+    }
+
+    // Phase 3: Spend most wallet outputs in batches.
+    std::vector<COutPoint> outputs_to_spend;
+    outputs_to_spend.reserve(TOTAL_WALLET_OUTPUTS);
+    {
+        LOCK(wallet.cs_wallet);
+        for (const auto& [_, coins] : AvailableCoins(wallet).coins) {
+            for (const auto& coin : coins) {
+                outputs_to_spend.push_back(coin.outpoint);
+            }
+        }
+    }
+
+    // Keep the configured small remainder unspent, and spend the rest.
+    assert(outputs_to_spend.size() == TOTAL_WALLET_OUTPUTS);
+    const size_t num_to_spend{outputs_to_spend.size() - KEEP_UNSPENT};
+
+    // Create spending transactions in configured-size batches.
+    std::vector<CTransactionRef> spending_txs;
+
+    for (size_t i{0}; i < num_to_spend; i += BATCH_SIZE) {
+        CMutableTransaction spend_tx;
+        const size_t batch_end{std::min(i + BATCH_SIZE, num_to_spend)};
+
+        CAmount total_value{0};
+        for (size_t j{i}; j < batch_end; ++j) {
+            spend_tx.vin.emplace_back(outputs_to_spend[j]);
+            total_value += OUTPUT_VALUE;
+        }
+
+        // Send to burn script so consolidation outputs don't add to wallet TXOs
+        spend_tx.vout.emplace_back(total_value - FEE, burn_script);
+
+        spending_txs.push_back(MakeTransactionRef(std::move(spend_tx)));
+    }
+
+    // Phase 4: Confirm all spending transactions in fake blocks.
+    // Coinbase outputs go to burn script to avoid adding wallet TXOs.
+    for (size_t i{0}; i < spending_txs.size(); i += TXS_PER_BLOCK) {
+        const size_t batch_end{std::min(i + TXS_PER_BLOCK, spending_txs.size())};
+        std::vector<CTransactionRef> block_txs{spending_txs.begin() + i, spending_txs.begin() + batch_end};
+        GenerateFakeBlock(params, test_setup->m_node, wallet, burn_script, FILLER_OUTPUTS, FILLER_VALUE, block_txs);
+    }
+
+    // Balance alone does not prove that the intended wallet output state was built.
+    size_t owned_outputs{0};
+    size_t spent_outputs{0};
+    {
+        LOCK(wallet.cs_wallet);
+        for (const auto& [outpoint, _] : wallet.GetTXOs()) {
+            ++owned_outputs;
+            spent_outputs += wallet.IsSpent(outpoint);
+        }
+    }
+    if (owned_outputs == TOTAL_WALLET_OUTPUTS) {
+        assert(spent_outputs == TOTAL_WALLET_OUTPUTS - KEEP_UNSPENT);
+    } else {
+        assert(owned_outputs == KEEP_UNSPENT);
+        assert(spent_outputs == 0);
+    }
+
+    CAmount expected_balance{0};
+    for (size_t i{0}; i < KEEP_UNSPENT; ++i) {
+        expected_balance += OUTPUT_VALUE;
+    }
+
+    bench.warmup(1).minEpochIterations(128).run([&] {
+        const auto bal{GetBalance(wallet)};
+        ankerl::nanobench::doNotOptimizeAway(bal);
+        assert(bal.m_mine_trusted == expected_balance);
+        assert(bal.m_mine_immature == 0);
+    });
+}
+
+BENCHMARK(WalletBalanceManySpent);
 } // namespace wallet

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -3,12 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <bench/wallet_bench_util.h>
+#include <consensus/consensus.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <kernel/chainparams.h>
-#include <primitives/block.h>
-#include <primitives/transaction.h>
-#include <sync.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
@@ -17,16 +16,19 @@
 #include <validation.h>
 #include <wallet/db.h>
 #include <wallet/receive.h>
+#include <wallet/spend.h>
 #include <wallet/sqlite.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
-#include <wallet/walletutil.h>
 
+#include <cassert>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
 
 namespace wallet {
+
 static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const bool add_mine)
 {
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
@@ -72,4 +74,124 @@ static void WalletBalanceWatch(benchmark::Bench& bench) { WalletBalance(bench, /
 BENCHMARK(WalletBalanceDirty);
 BENCHMARK(WalletBalanceClean);
 BENCHMARK(WalletBalanceWatch);
+
+static void WalletBalanceManySpent(benchmark::Bench& bench)
+{
+    constexpr int NUM_BLOCKS{500};
+    constexpr int OUTPUTS_PER_BLOCK{100};
+    constexpr CAmount OUTPUT_VALUE{50 * COIN / OUTPUTS_PER_BLOCK};
+    constexpr size_t TOTAL_WALLET_OUTPUTS{NUM_BLOCKS * OUTPUTS_PER_BLOCK};
+    constexpr size_t KEEP_UNSPENT{50};
+    constexpr size_t BATCH_SIZE{100};
+    constexpr CAmount FEE{1000};
+    constexpr size_t TXS_PER_BLOCK{10};
+    constexpr int FILLER_OUTPUTS{1};
+    constexpr CAmount FILLER_VALUE{50 * COIN};
+
+    // Benchmark GetBalance with many spent TXOs and few unspent TXOs.
+    // This scenario benefits from optimizations that separate definitely-spent
+    // outputs from potentially-spendable ones (such as m_unusable_txos).
+    //
+    // Target: many spent TXOs, few unspent TXOs.
+    const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
+    const auto& params = test_setup->m_node.chainman->GetParams();
+
+    FakeNodeClock clock{params.GenesisBlock().Time()};
+    CWallet wallet{test_setup->m_node.chain.get(), "", MakeInMemoryWalletDatabase()};
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        wallet.SetupDescriptorScriptPubKeyMans();
+    }
+    auto handler = test_setup->m_node.chain->handleNotifications({&wallet, [](CWallet*) {}});
+
+    const auto dest = getNewDestination(wallet, OutputType::BECH32);
+    const CScript wallet_script = GetScriptForDestination(dest);
+    // Burn script for outputs we don't want in the wallet
+    const CScript burn_script{CScript() << OP_TRUE};
+
+    // Phase 1: Create the configured wallet-owned output history.
+    for (int i = 0; i < NUM_BLOCKS; ++i) {
+        GenerateFakeBlock(params, test_setup->m_node, wallet, wallet_script, OUTPUTS_PER_BLOCK);
+    }
+
+    // Phase 2: Mature all wallet-owned coinbase outputs.
+    for (int i = 0; i < COINBASE_MATURITY; ++i) {
+        GenerateFakeBlock(params, test_setup->m_node, wallet, burn_script, FILLER_OUTPUTS);
+    }
+
+    // Phase 3: Spend most wallet outputs in batches.
+    std::vector<COutPoint> outputs_to_spend;
+    outputs_to_spend.reserve(TOTAL_WALLET_OUTPUTS);
+    {
+        LOCK(wallet.cs_wallet);
+        for (const auto& [_, coins] : AvailableCoins(wallet).coins) {
+            for (const auto& coin : coins) {
+                outputs_to_spend.push_back(coin.outpoint);
+            }
+        }
+    }
+
+    // Keep the configured small remainder unspent, and spend the rest.
+    assert(outputs_to_spend.size() == TOTAL_WALLET_OUTPUTS);
+    const size_t num_to_spend{outputs_to_spend.size() - KEEP_UNSPENT};
+
+    // Create spending transactions in configured-size batches.
+    std::vector<CTransactionRef> spending_txs;
+
+    for (size_t i{0}; i < num_to_spend; i += BATCH_SIZE) {
+        CMutableTransaction spend_tx;
+        const size_t batch_end{std::min(i + BATCH_SIZE, num_to_spend)};
+
+        CAmount total_value{0};
+        for (size_t j{i}; j < batch_end; ++j) {
+            spend_tx.vin.emplace_back(outputs_to_spend[j]);
+            total_value += OUTPUT_VALUE;
+        }
+
+        // Send to burn script so consolidation outputs don't add to wallet TXOs
+        spend_tx.vout.emplace_back(total_value - FEE, burn_script);
+
+        spending_txs.push_back(MakeTransactionRef(std::move(spend_tx)));
+    }
+
+    // Phase 4: Confirm all spending transactions in fake blocks.
+    // Coinbase outputs go to burn script to avoid adding wallet TXOs.
+    for (size_t i{0}; i < spending_txs.size(); i += TXS_PER_BLOCK) {
+        const size_t batch_end{std::min(i + TXS_PER_BLOCK, spending_txs.size())};
+        std::vector<CTransactionRef> block_txs{spending_txs.begin() + i, spending_txs.begin() + batch_end};
+        GenerateFakeBlock(params, test_setup->m_node, wallet, burn_script, FILLER_OUTPUTS, FILLER_VALUE, block_txs);
+    }
+
+    // Balance alone does not prove that the intended wallet output state was built.
+    size_t owned_outputs{0};
+    size_t spent_outputs{0};
+    {
+        LOCK(wallet.cs_wallet);
+        for (const auto& [outpoint, _] : wallet.GetTXOs()) {
+            ++owned_outputs;
+            spent_outputs += wallet.IsSpent(outpoint);
+        }
+    }
+    if (owned_outputs == TOTAL_WALLET_OUTPUTS) {
+        assert(spent_outputs == TOTAL_WALLET_OUTPUTS - KEEP_UNSPENT);
+    } else {
+        assert(owned_outputs == KEEP_UNSPENT);
+        assert(spent_outputs == 0);
+    }
+
+    CAmount expected_balance{0};
+    for (size_t i{0}; i < KEEP_UNSPENT; ++i) {
+        expected_balance += OUTPUT_VALUE;
+    }
+
+    bench.warmup(1).minEpochIterations(128).run([&] {
+        const auto bal{GetBalance(wallet)};
+        ankerl::nanobench::doNotOptimizeAway(bal);
+        assert(bal.m_mine_trusted == expected_balance);
+        assert(bal.m_mine_immature == 0);
+    });
+}
+
+BENCHMARK(WalletBalanceManySpent);
 } // namespace wallet

--- a/src/bench/wallet_bench_util.h
+++ b/src/bench/wallet_bench_util.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BENCH_WALLET_BENCH_UTIL_H
+#define BITCOIN_BENCH_WALLET_BENCH_UTIL_H
+
+#include <consensus/merkle.h>
+#include <kernel/chain.h>
+#include <kernel/chainparams.h>
+#include <kernel/types.h>
+#include <node/blockstorage.h>
+#include <node/context.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <sync.h>
+#include <uint256.h>
+#include <validation.h>
+#include <versionbits.h>
+#include <wallet/wallet.h>
+
+#include <vector>
+
+namespace wallet {
+
+struct TipBlock
+{
+    uint256 prev_block_hash{};
+    int64_t prev_block_time{0};
+    int tip_height{0};
+};
+
+inline TipBlock GetTip(const CChainParams& params, const node::NodeContext& context)
+{
+    {
+        LOCK(::cs_main);
+        if (const auto* tip{context.chainman->ActiveTip()}) {
+            return {tip->GetBlockHash(), tip->GetBlockTime(), tip->nHeight};
+        }
+    }
+    return {params.GenesisBlock().GetHash(), params.GenesisBlock().GetBlockTime(), 0};
+}
+
+/**
+ * Generate a fake block with customizable coinbase outputs and optional extra transactions.
+ * This is useful for benchmarks that need to quickly build wallet state without full validation.
+ */
+inline void GenerateFakeBlock(const CChainParams& params,
+                              const node::NodeContext& context,
+                              CWallet& wallet,
+                              const std::vector<CTxOut>& coinbase_outputs,
+                              const std::vector<CTransactionRef>& extra_txs = {})
+{
+    TipBlock tip{GetTip(params, context)};
+
+    CBlock block;
+    CMutableTransaction coinbase_tx;
+    coinbase_tx.vin.resize(1);
+    coinbase_tx.vin[0].prevout.SetNull();
+    coinbase_tx.vin[0].scriptSig = CScript() << ++tip.tip_height << OP_0;
+    coinbase_tx.vout = coinbase_outputs;
+
+    block.vtx = {MakeTransactionRef(std::move(coinbase_tx))};
+    block.vtx.insert(block.vtx.end(), extra_txs.begin(), extra_txs.end());
+
+    block.nVersion = VERSIONBITS_LAST_OLD_BLOCK_VERSION;
+    block.hashPrevBlock = tip.prev_block_hash;
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    block.nTime = ++tip.prev_block_time;
+    block.nBits = params.GenesisBlock().nBits;
+    block.nNonce = 0;
+
+    CBlockIndex* pindex{nullptr};
+    {
+        LOCK(::cs_main);
+        pindex = context.chainman->m_blockman.AddToBlockIndex(block, context.chainman->m_best_header);
+        context.chainman->ActiveChain().SetTip(*pindex);
+    }
+
+    wallet.blockConnected(kernel::ChainstateRole{}, kernel::MakeBlockInfo(pindex, &block));
+}
+
+inline void GenerateFakeBlock(const CChainParams& params,
+                              const node::NodeContext& context,
+                              CWallet& wallet,
+                              const CScript& coinbase_script,
+                              int num_coinbase_outputs,
+                              CAmount total_coinbase_value = 50 * COIN,
+                              const std::vector<CTransactionRef>& extra_txs = {})
+{
+    std::vector<CTxOut> coinbase_outputs;
+    coinbase_outputs.reserve(num_coinbase_outputs);
+    const CAmount per_output{total_coinbase_value / num_coinbase_outputs};
+    for (int i{0}; i < num_coinbase_outputs; ++i) {
+        coinbase_outputs.emplace_back(per_output, coinbase_script);
+    }
+    GenerateFakeBlock(params, context, wallet, coinbase_outputs, extra_txs);
+}
+
+} // namespace wallet
+
+#endif // BITCOIN_BENCH_WALLET_BENCH_UTIL_H

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -4,34 +4,25 @@
 
 #include <addresstype.h>
 #include <bench/bench.h>
-#include <chain.h>
+#include <bench/wallet_bench_util.h>
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
-#include <consensus/merkle.h>
 #include <interfaces/chain.h>
-#include <kernel/chain.h>
-#include <kernel/types.h>
-#include <node/blockstorage.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
-#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
-#include <uint256.h>
 #include <util/result.h>
 #include <util/time.h>
-#include <validation.h>
-#include <versionbits.h>
 #include <wallet/coincontrol.h>
 #include <wallet/coinselection.h>
 #include <wallet/spend.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
-#include <wallet/walletutil.h>
 
 #include <cassert>
 #include <cstdint>
@@ -41,70 +32,28 @@
 #include <utility>
 #include <vector>
 
-using kernel::ChainstateRole;
 using wallet::CWallet;
 using wallet::CreateMockableWalletDatabase;
 using wallet::WALLET_FLAG_DESCRIPTORS;
-
-struct TipBlock
-{
-    uint256 prev_block_hash;
-    int64_t prev_block_time;
-    int tip_height;
-};
-
-TipBlock getTip(const CChainParams& params, const node::NodeContext& context)
-{
-    auto tip = WITH_LOCK(::cs_main, return context.chainman->ActiveTip());
-    return (tip) ? TipBlock{tip->GetBlockHash(), tip->GetBlockTime(), tip->nHeight} :
-           TipBlock{params.GenesisBlock().GetHash(), params.GenesisBlock().GetBlockTime(), 0};
-}
 
 void generateFakeBlock(const CChainParams& params,
                        const node::NodeContext& context,
                        CWallet& wallet,
                        const CScript& coinbase_out_script)
 {
-    TipBlock tip{getTip(params, context)};
-
-    // Create block
-    CBlock block;
-    CMutableTransaction coinbase_tx;
-    coinbase_tx.vin.resize(1);
-    coinbase_tx.vin[0].prevout.SetNull();
-    coinbase_tx.vout.resize(2);
-    coinbase_tx.vout[0].scriptPubKey = coinbase_out_script;
-    coinbase_tx.vout[0].nValue = 48 * COIN;
-    coinbase_tx.vin[0].scriptSig = CScript() << ++tip.tip_height << OP_0;
-    coinbase_tx.vout[1].scriptPubKey = coinbase_out_script; // extra output
-    coinbase_tx.vout[1].nValue = 1 * COIN;
+    constexpr int NON_WALLET_OUTPUTS{50};
+    std::vector<CTxOut> coinbase_outputs;
+    coinbase_outputs.reserve(2 + NON_WALLET_OUTPUTS);
+    coinbase_outputs.emplace_back(48 * COIN, coinbase_out_script);
+    coinbase_outputs.emplace_back(1 * COIN, coinbase_out_script);
 
     // Fill the coinbase with outputs that don't belong to the wallet in order to benchmark
     // AvailableCoins' behavior with unnecessary TXOs
-    for (int i = 0; i < 50; ++i) {
-        coinbase_tx.vout.emplace_back(1 * COIN / 50, CScript(OP_TRUE));
+    for (int i{0}; i < NON_WALLET_OUTPUTS; ++i) {
+        coinbase_outputs.emplace_back(1 * COIN / NON_WALLET_OUTPUTS, CScript(OP_TRUE));
     }
 
-    block.vtx = {MakeTransactionRef(std::move(coinbase_tx))};
-
-    block.nVersion = VERSIONBITS_LAST_OLD_BLOCK_VERSION;
-    block.hashPrevBlock = tip.prev_block_hash;
-    block.hashMerkleRoot = BlockMerkleRoot(block);
-    block.nTime = ++tip.prev_block_time;
-    block.nBits = params.GenesisBlock().nBits;
-    block.nNonce = 0;
-
-    {
-        LOCK(::cs_main);
-        // Add it to the index
-        CBlockIndex* pindex{context.chainman->m_blockman.AddToBlockIndex(block, context.chainman->m_best_header)};
-        // add it to the chain
-        context.chainman->ActiveChain().SetTip(*pindex);
-    }
-
-    // notify wallet
-    const auto& pindex = WITH_LOCK(::cs_main, return context.chainman->ActiveChain().Tip());
-    wallet.blockConnected(ChainstateRole{}, kernel::MakeBlockInfo(pindex, &block));
+    wallet::GenerateFakeBlock(params, context, wallet, coinbase_outputs);
 }
 
 struct PreSelectInputs {

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -4,27 +4,19 @@
 
 #include <addresstype.h>
 #include <bench/bench.h>
-#include <chain.h>
+#include <bench/wallet_bench_util.h>
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
-#include <consensus/merkle.h>
-#include <kernel/chain.h>
-#include <kernel/types.h>
-#include <node/blockstorage.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
-#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
-#include <uint256.h>
 #include <util/check.h>
 #include <util/result.h>
-#include <validation.h>
-#include <versionbits.h>
 #include <wallet/coincontrol.h>
 #include <wallet/coinselection.h>
 #include <wallet/db.h>
@@ -33,7 +25,6 @@
 #include <wallet/test/util.h>
 #include <wallet/types.h>
 #include <wallet/wallet.h>
-#include <wallet/walletutil.h>
 
 #include <cstdint>
 #include <map>
@@ -43,70 +34,28 @@
 #include <utility>
 #include <vector>
 
-using kernel::ChainstateRole;
 using wallet::CWallet;
 using wallet::MakeInMemoryWalletDatabase;
 using wallet::WALLET_FLAG_DESCRIPTORS;
-
-struct TipBlock
-{
-    uint256 prev_block_hash;
-    int64_t prev_block_time;
-    int tip_height;
-};
-
-TipBlock getTip(const CChainParams& params, const node::NodeContext& context)
-{
-    auto tip = WITH_LOCK(::cs_main, return context.chainman->ActiveTip());
-    return (tip) ? TipBlock{tip->GetBlockHash(), tip->GetBlockTime(), tip->nHeight} :
-           TipBlock{params.GenesisBlock().GetHash(), params.GenesisBlock().GetBlockTime(), 0};
-}
 
 void generateFakeBlock(const CChainParams& params,
                        const node::NodeContext& context,
                        CWallet& wallet,
                        const CScript& coinbase_out_script)
 {
-    TipBlock tip{getTip(params, context)};
-
-    // Create block
-    CBlock block;
-    CMutableTransaction coinbase_tx;
-    coinbase_tx.vin.resize(1);
-    coinbase_tx.vin[0].prevout.SetNull();
-    coinbase_tx.vout.resize(2);
-    coinbase_tx.vout[0].scriptPubKey = coinbase_out_script;
-    coinbase_tx.vout[0].nValue = 48 * COIN;
-    coinbase_tx.vin[0].scriptSig = CScript() << ++tip.tip_height << OP_0;
-    coinbase_tx.vout[1].scriptPubKey = coinbase_out_script; // extra output
-    coinbase_tx.vout[1].nValue = 1 * COIN;
+    constexpr int NON_WALLET_OUTPUTS{50};
+    std::vector<CTxOut> coinbase_outputs;
+    coinbase_outputs.reserve(2 + NON_WALLET_OUTPUTS);
+    coinbase_outputs.emplace_back(48 * COIN, coinbase_out_script);
+    coinbase_outputs.emplace_back(1 * COIN, coinbase_out_script);
 
     // Fill the coinbase with outputs that don't belong to the wallet in order to benchmark
     // AvailableCoins' behavior with unnecessary TXOs
-    for (int i = 0; i < 50; ++i) {
-        coinbase_tx.vout.emplace_back(1 * COIN / 50, CScript(OP_TRUE));
+    for (int i{0}; i < NON_WALLET_OUTPUTS; ++i) {
+        coinbase_outputs.emplace_back(1 * COIN / NON_WALLET_OUTPUTS, CScript(OP_TRUE));
     }
 
-    block.vtx = {MakeTransactionRef(std::move(coinbase_tx))};
-
-    block.nVersion = VERSIONBITS_LAST_OLD_BLOCK_VERSION;
-    block.hashPrevBlock = tip.prev_block_hash;
-    block.hashMerkleRoot = BlockMerkleRoot(block);
-    block.nTime = ++tip.prev_block_time;
-    block.nBits = params.GenesisBlock().nBits;
-    block.nNonce = 0;
-
-    {
-        LOCK(::cs_main);
-        // Add it to the index
-        CBlockIndex* pindex{context.chainman->m_blockman.AddToBlockIndex(block, context.chainman->m_best_header)};
-        // add it to the chain
-        context.chainman->ActiveChain().SetTip(*pindex);
-    }
-
-    // notify wallet
-    const auto& pindex = WITH_LOCK(::cs_main, return context.chainman->ActiveChain().Tip());
-    wallet.blockConnected(ChainstateRole{}, kernel::MakeBlockInfo(pindex, &block));
+    wallet::GenerateFakeBlock(params, context, wallet, coinbase_outputs);
 }
 
 struct PreSelectInputs {


### PR DESCRIPTION
This PR introduces a new benchmark that measures `GetBalance()` performance on wallets with extensive transaction history where the majority of outputs have already been spent.

It was created to test #27865, which separates spent TXOs from spendable ones.
This pattern mirrors real-world usage in high-activity wallets such as Lightning nodes, exchanges, hot wallets, and payment processors.

**Setup:**
- Creates 500 blocks × 100 coinbase outputs = 50,000 wallet TXOs
- Matures all coinbases with COINBASE_MATURITY additional blocks
- Spends 49,950 outputs in batched transactions (confirmed in blocks)
- Consolidation outputs go to a burn script to avoid inflating wallet TXO count
                                                                                                                                         
To keep the setup time reasonable, the benchmark uses the fast “fake block” approach, similar to `wallet_create_tx.cpp`.