### PR TITLE
contrib: add initial zsh completion for bitcoin-cli

### DIFF
--- a/contrib/completions/zsh/_bitcoin-cli
+++ b/contrib/completions/zsh/_bitcoin-cli
@@ -1,0 +1,27 @@
+﻿#compdef bitcoin-cli
+
+# Minimal zsh completion for bitcoin-cli
+
+local -a commands
+commands=(
+  "getblockchaininfo:Show blockchain state"
+  "getnetworkinfo:Show network state"
+  "getwalletinfo:Show wallet information"
+  "sendtoaddress:Send to address"
+  "getnewaddress:Get new address"
+  "gettransaction:Get transaction"
+  "help:Show help"
+)
+
+_arguments -C \
+  '1:command:->cmd' \
+  '*::arg:->args'
+
+case $state in
+  cmd)
+    _describe -t commands 'bitcoin-cli commands' commands
+    ;;
+  args)
+    _files
+    ;;
+esac


### PR DESCRIPTION
Bitcoin Core currently provides shell completion scripts for bash and fish in contrib/completions/, but zsh (which is the default shell on macOS and widely used by developers) does not have any native completion support for Bitcoin Core command-line tools.

This means users of zsh do not get tab-completion for bitcoin-cli, making it harder to discover commands and increasing the chance of typing mistakes.

This was reported in Issue #33404:
“Add zsh completion scripts for Bitcoin Core command-line tools”

What was needed

A native zsh completion script (not bash-compat mode)

Located in contrib/completions/zsh/

A minimal, correct starting point that can be extended incrementally


What this PR does

Adds a new directory:
contrib/completions/zsh/

Adds an initial zsh completion script:
contrib/completions/zsh/_bitcoin-cli

Provides:

Subcommand completion for common bitcoin-cli commands

Basic argument and file-path completion

The implementation is intentionally conservative and minimal, and can be extended in follow-up PRs to reach feature parity with the bash completion.

Why this approach

Keeps the change small, reviewable, and safe

Avoids large auto-generated or brittle completion logic

Establishes the correct structure and location for future zsh completions

Fixes #33404
<img width="1024" height="1536" alt="ChatGPT Image Jan 21, 2026, 02_59_08 PM" src="https://github.com/user-attachments/assets/fa4675f0-4caf-4c92-9f60-f598059ef8a4" />

