### PR TITLE
wallet: allow importprunedfunds for spending transactions

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -81,9 +81,9 @@ RPCMethod importprunedfunds()
 
     unsigned int txnIndex = vIndex[it - vMatch.begin()];
 
-    CTransactionRef tx_ref = MakeTransactionRef(tx);
-    if (pwallet->IsMine(*tx_ref)) {
-        pwallet->AddToWallet(std::move(tx_ref), TxStateConfirmed{merkleBlock.header.GetHash(), height, static_cast<int>(txnIndex)});
+    const CTransactionRef tx_ref = MakeTransactionRef(tx);
+    auto tx_state = TxStateConfirmed{merkleBlock.header.GetHash(), height, static_cast<int>(txnIndex)};
+    if (pwallet->AddToWalletIfInvolvingMe(tx_ref, tx_state, /*rescanning_old_block=*/false)) {
         return UniValue::VNULL;
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -342,23 +342,6 @@ private:
     void AddToSpends(const COutPoint& outpoint, const Txid& txid) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void AddToSpends(const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    /**
-     * Add a transaction to the wallet, or update it.  confirm.block_* should
-     * be set when the transaction was known to be included in a block.  When
-     * block_hash.IsNull(), then wallet state is not updated in AddToWallet, but
-     * notifications happen and cached balances are marked dirty.
-     *
-     * TODO: One exception to this is that the abandoned state is cleared under the
-     * assumption that any further notification of a transaction that was considered
-     * abandoned is an indication that it is not safe to be considered abandoned.
-     * Abandoned state should probably be more carefully tracked via different
-     * chain notifications or by checking mempool presence when necessary.
-     *
-     * Should be called with rescanning_old_block set to true, if the transaction is
-     * not discovered in real time, but during a rescan of old blocks.
-     */
-    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const SyncTxState& state, bool rescanning_old_block) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-
     /** Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
     void MarkConflicted(const uint256& hashBlock, int conflicting_height, const Txid& hashTx);
 
@@ -630,6 +613,23 @@ public:
      * @return the recently added wtx pointer or nullptr if there was a db write error.
      */
     CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool rescanning_old_block = false);
+
+    /**
+     * Add a transaction to the wallet, or update it.  confirm.block_* should
+     * be set when the transaction was known to be included in a block.  When
+     * block_hash.IsNull(), then wallet state is not updated in AddToWallet, but
+     * notifications happen and cached balances are marked dirty.
+     *
+     * TODO: One exception to this is that the abandoned state is cleared under the
+     * assumption that any further notification of a transaction that was considered
+     * abandoned is an indication that it is not safe to be considered abandoned.
+     * Abandoned state should probably be more carefully tracked via different
+     * chain notifications or by checking mempool presence when necessary.
+     *
+     * Should be called with rescanning_old_block set to true, if the transaction is
+     * not discovered in real time, but during a rescan of old blocks.
+     */
+    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const SyncTxState& state, bool rescanning_old_block) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool LoadToWallet(CWalletTx&& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx) override;
     void blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) override;

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -16,6 +16,7 @@ from test_framework.util import (
     assert_equal,
     assert_not_equal,
     assert_raises_rpc_error,
+    find_vout_for_address,
     wallet_importprivkey,
 )
 from test_framework.wallet_util import generate_keypair
@@ -117,6 +118,21 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
         w1.removeprunedfunds(txnid3)
         assert txnid3 not in [tx['txid'] for tx in w1.listtransactions()]
+
+        # Import a spending transaction with no wallet outputs (issue #21647)
+        txid = self.nodes[0].sendtoaddress(address3, 0.1)
+        vout = find_vout_for_address(self.nodes[0], txid, address3)
+        self.generate(self.nodes[0], 1)
+        external_addr = self.nodes[0].getnewaddress()
+        spend_txid = w1.sendall(recipients=[external_addr], inputs=[{"txid": txid, "vout": vout}])["txid"]
+        self.sync_mempools()
+        self.generate(self.nodes[0], 1)
+        spend_raw = w1.gettransaction(spend_txid)['hex']
+        spend_proof = self.nodes[0].gettxoutproof([spend_txid])
+        w1.removeprunedfunds(spend_txid)
+        assert not [tx for tx in w1.listtransactions() if tx['txid'] == spend_txid]
+        w1.importprunedfunds(spend_raw, spend_proof)
+        assert [tx for tx in w1.listtransactions() if tx['txid'] == spend_txid]
 
         # Check various RPC parameter validation errors
         assert_raises_rpc_error(-22, "TX decode failed", w1.importprunedfunds, b'invalid tx'.hex(), proof1)


### PR DESCRIPTION
`importprunedfunds` only allowed importing transactions that credit the wallet
(checked via `IsMine`), rejecting transactions that spend from it. This could
leave a pruned wallet showing an incorrect balance: if a spending transaction
was removed with `removeprunedfunds`, it couldn't be re-imported and would fail
with "No addresses in wallet correspond to included transaction".

This routes the import through `AddToWalletIfInvolvingMe()`, which already
checks both `IsMine()` and `IsFromMe()`, so spending transactions are accepted
and the involvement check is no longer duplicated in `importprunedfunds`. A
functional test imports a transaction that spends from the wallet but has no
outputs to it (entire UTXO sent externally).

Fixes #21647
