### PR TITLE
doc: mempool: fix  `removeUnchecked` incorrect comment

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -589,14 +589,7 @@ private:
     /* Helper for the public removeRecursive() */
     void removeRecursive(txiter to_remove, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    /** Before calling removeUnchecked for a given transaction,
-     *  UpdateForRemoveFromMempool must be called on the entire (dependent) set
-     *  of transactions being removed at the same time.  We use each
-     *  CTxMemPoolEntry's m_parents in order to walk ancestors of a
-     *  given transaction that is removed, so we can't remove intermediate
-     *  transactions in a chain before we've updated all the state for the
-     *  removal.
-     */
+    /* Removal from the mempool also triggers removal of the entry's Ref from txgraph. */
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 public:
     /** visited marks a CTxMemPoolEntry as having been traversed


### PR DESCRIPTION
`CTxMemPool::removeUnchecked` description comment is stale and incorrect; the behaviour being described no longer applies in the post-cluster world.  This PR is a simple fix that attempts to correctly describe what is being done in removeUnchecked.

