### PR TITLE
bench/test: clarify merkle bench and witness test intent

### DIFF
--- a/src/bench/merkle_root.cpp
+++ b/src/bench/merkle_root.cpp
@@ -25,8 +25,8 @@ static void MerkleRoot(benchmark::Bench& bench)
         bench.name(mutate ? "MerkleRootWithMutation" : "MerkleRoot").batch(hashes.size()).unit("leaf").run([&] {
             std::vector<uint256> leaves;
             leaves.reserve((hashes.size() + 1) & ~1ULL); // capacity rounded up to even
-            for (size_t s = 0; s < hashes.size(); s++) {
-                leaves.push_back(hashes[s]);
+            for (const auto& hash : hashes) {
+                leaves.push_back(hash);
             }
 
             bool mutated{false};

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -243,7 +243,8 @@ BOOST_AUTO_TEST_CASE(merkle_test_BlockWitness)
     uint256 blockWitness = BlockWitnessMerkleRoot(block);
 
     std::vector<uint256> hashes;
-    hashes.resize(vtx_count); // Note: leaving odd count to exercise old behavior
+    hashes.resize(vtx_count); // Odd count exercises leaf duplication in ComputeMerkleRoot (which can append one extra hash).
+    hashes[0] = uint256::ZERO; // The witness hash of the coinbase is 0.
     for (size_t pos{1}; pos < vtx_count; ++pos) {
         hashes[pos] = block.vtx[pos]->GetWitnessHash().ToUint256();
     }


### PR DESCRIPTION
Follow-up to #32497.

Clarify why the witness merkle test uses an odd leaf count (it exercises leaf duplication in `ComputeMerkleRoot()`), and make the coinbase witness hash initialization explicit.

Also simplify the leaf-copy loop in the `MerkleRoot` benchmark for readability.

No production code is changed in this follow-up, for simplicity and safety.