### PR TITLE
test: Rename wallet in restore attempt in wallet_assumeutxo

### DIFF
--- a/test/functional/wallet_assumeutxo.py
+++ b/test/functional/wallet_assumeutxo.py
@@ -96,7 +96,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         assert_equal(n3.pruneblockchain(FINAL_HEIGHT), 298)  # 298 is the height of the last block pruned (pruneheight 299)
         error_message = "Wallet loading failed. Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)"
         # This backup (backup_w2.dat) was created at height 199, so it can't be restored in a node with a pruneheight of 299
-        assert_raises_rpc_error(-4, error_message, n3.restorewallet, "w2", "backup_w2.dat")
+        assert_raises_rpc_error(-4, error_message, n3.restorewallet, "w2_pruneheight", "backup_w2.dat")
 
         self.log.info("Ensuring wallet can be restored from a backup that was created at the pruneheight (pruned node)")
         # This backup (backup_w.dat) was created at height 299, so it can be restored in a node with a pruneheight of 299


### PR DESCRIPTION
I hope this fixes #34354

Based on this error from the logs `filesystem error: cannot remove: The process cannot access the file because it is being used by another process` it looks like there still exists a wallet file by the same name from the previous test case hasn't been cleaned up yet by it's process fully. This should be fixed by giving the failing `restorewallet` case a different wallet name and this shouldn't have any further effects on the rest of the test because is expected to fail anyway. The following (successful) call already uses a different wallet name.