### PR TITLE
test: Fix P2PK script test

### DIFF
--- a/src/test/data/script_tests.json
+++ b/src/test/data/script_tests.json
@@ -1826,7 +1826,7 @@
 [
     "0x47 0x304402203e4516da7253cf068effec6b95c41221c0cf3a8e6ccb8cbf1725b562e9afde2c022054e1c258c2981cdfba5df1f46661fb6541c44f77ca0092f3600331abfffb125101 NOP8",
     "0x21 0x03363d90d447b00c9c99ceac05b6262ee053441c7e55552ffe526bad8f83ff4640 CHECKSIG",
-    "",
+    "P2SH",
     "OK",
     "P2PK with non-push scriptSig but with P2SH validation"
 ],

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -667,7 +667,7 @@ BOOST_AUTO_TEST_CASE(script_build)
                                 "P2SH(P2PK) with non-push scriptSig but no P2SH or SIGPUSHONLY", 0, true
                                ).PushSig(keys.key2).Opcode(OP_NOP8).PushRedeem());
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG,
-                                "P2PK with non-push scriptSig but with P2SH validation", 0
+                                "P2PK with non-push scriptSig but with P2SH validation", SCRIPT_VERIFY_P2SH
                                ).PushSig(keys.key2).Opcode(OP_NOP8));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG,
                                 "P2SH(P2PK) with non-push scriptSig but no SIGPUSHONLY", SCRIPT_VERIFY_P2SH, true


### PR DESCRIPTION
I found another script_tests case that isn't behaving the way it was meant to. It's a P2PK spend where we add an `OP_NOP8` to the scriptSig to make it non-push-only. The test should check that [`scriptSig.IsPushOnly()`](https://github.com/bitcoin/bitcoin/blob/691dc830c669061923a7eec677415013f75fd5d8/src/script/interpreter.cpp#L2055) is only enforced in P2SH mode when the scriptPubKey actually matches the P2SH pattern. To test this, we need to **turn on the P2SH flag**.