### PR TITLE
subprocess: Fix `-Wunused-private-field` when building with clang-cl on Windows

### DIFF
--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -738,6 +738,7 @@ private:
   Popen* popen_ = nullptr;
 };
 
+#ifndef __USING_WINDOWS__
 /*!
  * A helper class to Popen.
  * This takes care of all the fork-exec logic
@@ -759,6 +760,7 @@ private:
   Popen* parent_ = nullptr;
   int err_wr_pipe_ = -1;
 };
+#endif
 
 // Fwd Decl.
 class Streams;
@@ -932,7 +934,9 @@ class Popen
 {
 public:
   friend struct detail::ArgumentDeducer;
+#ifndef __USING_WINDOWS__
   friend class detail::Child;
+#endif
 
   template <typename... Args>
   Popen(const std::string& cmd_args, Args&& ...args):
@@ -1275,8 +1279,8 @@ namespace detail {
   }
 
 
-  inline void Child::execute_child() {
 #ifndef __USING_WINDOWS__
+  inline void Child::execute_child() {
     int sys_ret = -1;
     auto& stream = parent_->stream_;
 
@@ -1336,8 +1340,8 @@ namespace detail {
     // Calling application would not get this
     // exit failure
     _exit (EXIT_FAILURE);
-#endif
   }
+#endif
 
 
   inline void Streams::setup_comm_channels()

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -1024,6 +1024,9 @@ private:
 #ifdef __USING_WINDOWS__
   HANDLE process_handle_;
   std::future<void> cleanup_future_;
+#else
+  // Pid of the child process
+  int child_pid_ = -1;
 #endif
 
   std::string exe_name_;
@@ -1033,9 +1036,6 @@ private:
   // Command provided as sequence
   std::vector<std::string> vargs_;
   std::vector<char*> cargv_;
-
-  // Pid of the child process
-  int child_pid_ = -1;
 
   int retcode_ = -1;
 };


### PR DESCRIPTION
This PR is a prerequisite for https://github.com/bitcoin/bitcoin/pull/31507.

It resolves `-Wunused-private-field` warnings triggered in `src/util/subprocess.h` when compiling with clang-cl on Windows:
```
D:\a\bitcoin\bitcoin\src\util/subprocess.h(759,10): warning : private field 'parent_' is not used [-Wunused-private-field] [D:\a\bitcoin\bitcoin\build\src\util\bitcoin_util.vcxproj]
D:\a\bitcoin\bitcoin\src\util/subprocess.h(760,7): warning : private field 'err_wr_pipe_' is not used [-Wunused-private-field] [D:\a\bitcoin\bitcoin\build\src\util\bitcoin_util.vcxproj]
D:\a\bitcoin\bitcoin\src\util/subprocess.h(1038,7): warning : private field 'child_pid_' is not used [-Wunused-private-field] [D:\a\bitcoin\bitcoin\build\src\util\bitcoin_util.vcxproj]
```

Only the second commit has been [submitted](https://github.com/arun11299/cpp-subprocess/pull/127) upstream. The first commit is specific to this repository and not applicable upstream.