### PR TITLE
doc: Explain that low-effort pull requests may be closed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,13 @@ The codebase is maintained using the "contributor workflow" where everyone
 without exception contributes patch proposals using "pull requests" (PRs). This
 facilitates social contribution, easy testing and peer review.
 
+Pull request authors must fully and confidently understand their own changes
+and must have tested them. Contributors should mention which tests cover their
+changes, or include the manual steps they used to confirm the change.
+Contributors are expected to be prepared to clearly motivate and explain their
+changes. If there is doubt, the pull request may be closed.
+Please refer to the [peer review](#peer-review) section below for more details.
+
 To contribute a patch, the workflow is as follows:
 
   1. Fork repository ([only for the first time](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo))
@@ -337,6 +344,11 @@ high chance of being rejected. It is up to the PR author to convince the
 reviewers that the changes warrant the review effort, and if reviewers are
 "Concept NACK'ing" the PR, the author may need to present arguments and/or do
 research backing their suggested changes.
+
+Moreover, if there is reasonable doubt that the pull request author does not
+fully understand the changes they are submitting themselves, or if it becomes
+clear that they have not tested the changes on a basic level themselves, the
+pull request may be closed immediately.
 
 #### Conceptual Review
 


### PR DESCRIPTION
Lately, there seems to be a rise in low-effort pull requests. For example, where a contributor does not seem to understand the changes they are submitting, or it becomes clear that they have not tested the changes at all.

I don't think such pull requests are helpful, as they extract precious review time, which could be better spent on reviewing pull requests by reviewers who care about understanding the changes they are submitting, and who ensure their changes are sound and tested.

So document that such low-effort pull request may be closed.