### PR TITLE
test: rename `assert_greater_than(_or_equal)` to `assert_gt`/`assert_ge`

### DIFF
--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -33,7 +33,7 @@ from test_framework.script import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     softfork_active,
 )
@@ -389,7 +389,7 @@ class BIP68Test(BitcoinTestFramework):
         # getblockchaininfo will show CSV as active at block 431 (144 * 3 -1) since it's returning whether CSV is active for the next block.
         min_activation_height = 432
         height = self.nodes[0].getblockcount()
-        assert_greater_than(min_activation_height - height, 2)
+        assert_gt(min_activation_height - height, 2)
         self.generate(self.wallet, min_activation_height - height - 2, sync_fun=self.no_op)
         assert not softfork_active(self.nodes[0], 'csv')
         self.generate(self.wallet, 1, sync_fun=self.no_op)

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -53,7 +53,7 @@ from test_framework.script_util import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
 )
 from test_framework.wallet_util import generate_keypair
@@ -895,7 +895,7 @@ class FullBlockTest(BitcoinTestFramework):
         tx.nLockTime = 0xffffffff  # this locktime is non-final
         tx.vin.append(CTxIn(COutPoint(out[18].txid_int, 0)))  # don't set nSequence
         tx.vout.append(CTxOut(0, CScript([OP_TRUE])))
-        assert_greater_than(SEQUENCE_FINAL, tx.vin[0].nSequence)
+        assert_gt(SEQUENCE_FINAL, tx.vin[0].nSequence)
         b62 = self.update_block(62, [tx])
         self.send_blocks([b62], success=False, reject_reason='bad-txns-nonfinal', reconnect=True)
 

--- a/test/functional/feature_blocksxor.py
+++ b/test/functional/feature_blocksxor.py
@@ -11,7 +11,7 @@ from test_framework.test_node import (
 )
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     util_xor,
 )
 from test_framework.wallet import MiniWallet
@@ -36,7 +36,7 @@ class BlocksXORTest(BitcoinTestFramework):
         block_files = list(node.blocks_path.glob('blk[0-9][0-9][0-9][0-9][0-9].dat'))
         undo_files  = list(node.blocks_path.glob('rev[0-9][0-9][0-9][0-9][0-9].dat'))
         assert_equal(len(block_files), len(undo_files))
-        assert_greater_than(len(block_files), 1)  # we want at least one full block file
+        assert_gt(len(block_files), 1)  # we want at least one full block file
 
         self.log.info("Shut down node and un-XOR block/undo files manually")
         self.stop_node(0)

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -16,8 +16,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_not_equal,
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises_rpc_error,
     satoshi_round,
 )
@@ -78,7 +78,7 @@ def check_raw_estimates(node, fees_seen):
     for i in range(1, 26):
         for _, e in node.estimaterawfee(i).items():
             feerate = float(e["feerate"])
-            assert_greater_than(feerate, 0)
+            assert_gt(feerate, 0)
 
             if feerate + delta < min(fees_seen) or feerate - delta > max(fees_seen):
                 raise AssertionError(
@@ -97,9 +97,9 @@ def check_smart_estimates(node, fees_seen):
     last_feerate = feerate_ceiling
     for i, e in enumerate(all_smart_estimates):  # estimate is for i+1
         feerate = float(e["feerate"])
-        assert_greater_than(feerate, 0)
-        assert_greater_than_or_equal(feerate, float(mempoolMinFee))
-        assert_greater_than_or_equal(feerate, float(minRelaytxFee))
+        assert_gt(feerate, 0)
+        assert_ge(feerate, float(mempoolMinFee))
+        assert_ge(feerate, float(minRelaytxFee))
 
         if feerate + delta < min(fees_seen) or feerate - delta > feerate_ceiling:
             raise AssertionError(
@@ -114,7 +114,7 @@ def check_smart_estimates(node, fees_seen):
         if i == 0:
             assert_equal(e["blocks"], 2)
         else:
-            assert_greater_than_or_equal(i + 1, e["blocks"])
+            assert_ge(i + 1, e["blocks"])
 
 
 def check_estimates(node, fees_seen):
@@ -261,7 +261,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         utxos_to_respend = []
         txids_to_replace = []
 
-        assert_greater_than_or_equal(len(utxos), 250)
+        assert_ge(len(utxos), 250)
         for _ in range(5):
             # Broadcast 45 low fee transactions that will need to be RBF'd
             txs = []

--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -8,7 +8,7 @@ import os
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
 )
 
@@ -65,7 +65,7 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
         self.sync_index(height=200)
         tip = self.nodes[0].getbestblockhash()
         for node in filter_nodes:
-            assert_greater_than(len(node.getblockfilter(tip)['filter']), 0)
+            assert_gt(len(node.getblockfilter(tip)['filter']), 0)
         for node in stats_nodes:
             assert node.gettxoutsetinfo(hash_type="muhash", hash_or_height=tip)['muhash']
 
@@ -83,14 +83,14 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
         self.log.info("check if we can access the tips blockfilter and coinstats when we have pruned some blocks")
         tip = self.nodes[0].getbestblockhash()
         for node in filter_nodes:
-            assert_greater_than(len(node.getblockfilter(tip)['filter']), 0)
+            assert_gt(len(node.getblockfilter(tip)['filter']), 0)
         for node in stats_nodes:
             assert node.gettxoutsetinfo(hash_type="muhash", hash_or_height=tip)['muhash']
 
         self.log.info("check if we can access the blockfilter and coinstats of a pruned block")
         height_hash = self.nodes[0].getblockhash(2)
         for node in filter_nodes:
-            assert_greater_than(len(node.getblockfilter(height_hash)['filter']), 0)
+            assert_gt(len(node.getblockfilter(height_hash)['filter']), 0)
         for node in stats_nodes:
             assert node.gettxoutsetinfo(hash_type="muhash", hash_or_height=height_hash)['muhash']
 
@@ -126,7 +126,7 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
 
         for i in range(3):
             pruneheight_3 = self.nodes[i].pruneblockchain(2000)
-            assert_greater_than(pruneheight_3, pruneheight_2)
+            assert_gt(pruneheight_3, pruneheight_2)
             self.stop_node(i)
 
         self.log.info("make sure we get an init error when starting the nodes again with the indices")

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -23,7 +23,7 @@ from test_framework.script import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     try_rpc,
 )
@@ -151,7 +151,7 @@ class PruneTest(BitcoinTestFramework):
         self.log.info("Success")
         usage = calc_usage(self.prunedir)
         self.log.info(f"Usage should be below target: {usage}")
-        assert_greater_than(550, usage)
+        assert_gt(550, usage)
 
     def create_chain_with_staleblocks(self):
         # Create stale blocks in manageable sized chunks
@@ -220,7 +220,7 @@ class PruneTest(BitcoinTestFramework):
 
         usage = calc_usage(self.prunedir)
         self.log.info(f"Usage should be below target: {usage}")
-        assert_greater_than(550, usage)
+        assert_gt(550, usage)
 
     def reorg_back(self):
         # Verify that a block on the old main chain fork has been pruned away

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -13,8 +13,8 @@ from test_framework.messages import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises_rpc_error,
     get_fee,
 )
@@ -340,7 +340,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         # These two transactions are approximately the same size. The replacement tx pays twice the fee.
         tx_to_replace = self.wallet.create_self_transfer_multi(utxos_to_spend=[confirmed_utxos[1], confirmed_utxos[2]], fee_per_output=2000)
         tx_replacement = self.wallet.create_self_transfer_multi(utxos_to_spend=[confirmed_utxos[1], unconfirmed_utxo], fee_per_output=4000)
-        assert_greater_than(tx_replacement['fee']*tx_to_replace['tx'].get_vsize(), tx_to_replace['fee']*tx_replacement['tx'].get_vsize())
+        assert_gt(tx_replacement['fee']*tx_to_replace['tx'].get_vsize(), tx_to_replace['fee']*tx_replacement['tx'].get_vsize())
 
         self.nodes[0].sendrawtransaction(tx_to_replace['hex'])
         assert_raises_rpc_error(-26, "insufficient feerate: does not improve feerate diagram", self.nodes[0].sendrawtransaction, tx_replacement['hex'])
@@ -504,7 +504,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
             # When incremental relay feerate is higher than min relay feerate, min relay feerate is automatically increased.
             min_relay_feerate = node.getmempoolinfo()["minrelaytxfee"]
-            assert_greater_than_or_equal(min_relay_feerate, incremental_setting_decimal)
+            assert_ge(min_relay_feerate, incremental_setting_decimal)
 
             low_feerate = min_relay_feerate * 2
             confirmed_utxo = self.wallet.get_utxo(confirmed_only=True)

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -38,7 +38,7 @@ from test_framework.script_util import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than_or_equal,
+    assert_ge,
     assert_is_hex_string,
     assert_raises_rpc_error,
 )
@@ -229,7 +229,7 @@ class SegWitTest(BitcoinTestFramework):
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         raw_tx = self.nodes[0].getrawtransaction(txid, True)
         tmpl = self.nodes[0].getblocktemplate({'rules': ['segwit']})
-        assert_greater_than_or_equal(tmpl['sizelimit'], 3999577)  # actual maximum size is lower due to minimum mandatory non-witness data
+        assert_ge(tmpl['sizelimit'], 3999577)  # actual maximum size is lower due to minimum mandatory non-witness data
         assert_equal(tmpl['weightlimit'], 4000000)
         assert_equal(tmpl['sigoplimit'], 80000)
         assert_equal(tmpl['transactions'][0]['txid'], txid)

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -12,7 +12,7 @@ from test_framework.netutil import test_ipv6_local
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than_or_equal,
+    assert_ge,
     assert_raises_process_error,
     assert_raises_rpc_error,
     get_auth_cookie,
@@ -430,7 +430,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         self.stop_node(0)  # stop the node so we time out
         start_time = time.time()
         assert_raises_process_error(1, "Could not connect to the server", self.nodes[0].cli('-rpcwait', '-rpcwaittimeout=5').echo)
-        assert_greater_than_or_equal(time.time(), start_time + 5)
+        assert_ge(time.time(), start_time + 5)
 
         self.log.info("Test that only one of -addrinfo, -generate, -getinfo, -netinfo may be specified at a time")
         assert_raises_process_error(1, "Only one of -getinfo, -netinfo may be specified", self.nodes[0].cli('-getinfo', '-netinfo').send_cli)

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -21,8 +21,8 @@ from test_framework.messages import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
 )
 from test_framework.wallet import (
     MiniWallet,
@@ -110,7 +110,7 @@ class RESTTest (BitcoinTestFramework):
 
         # Check hex format response
         hex_response = self.test_rest_request(f"/tx/{txid}", req_type=ReqType.HEX, ret_type=RetType.OBJ)
-        assert_greater_than_or_equal(int(hex_response.getheader('content-length')),
+        assert_ge(int(hex_response.getheader('content-length')),
                                      json_obj['size']*2)
 
         spent = (json_obj['vin'][0]['txid'], json_obj['vin'][0]['vout'])  # get the vin to later check for utxo (should be spent by then)
@@ -239,7 +239,7 @@ class RESTTest (BitcoinTestFramework):
 
         # Check binary format
         response = self.test_rest_request(f"/block/{bb_hash}", req_type=ReqType.BIN, ret_type=RetType.OBJ)
-        assert_greater_than(int(response.getheader('content-length')), BLOCK_HEADER_SIZE)
+        assert_gt(int(response.getheader('content-length')), BLOCK_HEADER_SIZE)
         response_bytes = response.read()
 
         # Compare with block header
@@ -250,13 +250,13 @@ class RESTTest (BitcoinTestFramework):
 
         # Check block hex format
         response_hex = self.test_rest_request(f"/block/{bb_hash}", req_type=ReqType.HEX, ret_type=RetType.OBJ)
-        assert_greater_than(int(response_hex.getheader('content-length')), BLOCK_HEADER_SIZE*2)
+        assert_gt(int(response_hex.getheader('content-length')), BLOCK_HEADER_SIZE*2)
         response_hex_bytes = response_hex.read().strip(b'\n')
         assert_equal(response_bytes.hex().encode(), response_hex_bytes)
 
         # Compare with hex block header
         response_header_hex = self.test_rest_request(f"/headers/{bb_hash}", req_type=ReqType.HEX, ret_type=RetType.OBJ, query_params={"count": 1})
-        assert_greater_than(int(response_header_hex.getheader('content-length')), BLOCK_HEADER_SIZE*2)
+        assert_gt(int(response_header_hex.getheader('content-length')), BLOCK_HEADER_SIZE*2)
         response_header_hex_bytes = response_header_hex.read(BLOCK_HEADER_SIZE*2)
         assert_equal(response_bytes[:BLOCK_HEADER_SIZE].hex().encode(), response_header_hex_bytes)
 
@@ -344,7 +344,7 @@ class RESTTest (BitcoinTestFramework):
         json_obj = self.test_rest_request("/mempool/info")
         assert_equal(json_obj['size'], 3)
         # the size of the memory pool should be greater than 3x ~100 bytes
-        assert_greater_than(json_obj['bytes'], 300)
+        assert_gt(json_obj['bytes'], 300)
 
         mempool_info = self.nodes[0].getmempoolinfo()
         # pop unstable unbroadcastcount before check

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -8,7 +8,7 @@ import json
 import os
 from dataclasses import dataclass
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than_or_equal
+from test_framework.util import assert_equal, assert_ge
 from threading import Thread
 from typing import Optional
 import subprocess
@@ -102,7 +102,7 @@ class RPCInterfaceTest(BitcoinTestFramework):
 
         command = info['active_commands'][0]
         assert_equal(command['method'], 'getrpcinfo')
-        assert_greater_than_or_equal(command['duration'], 0)
+        assert_ge(command['duration'], 0)
         assert_equal(info['logpath'], os.path.join(self.nodes[0].chain_path, 'debug.log'))
 
     def test_batch_request(self, call_options):

--- a/test/functional/interface_usdt_coinselection.py
+++ b/test/functional/interface_usdt_coinselection.py
@@ -15,7 +15,7 @@ except ImportError:
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     bpf_cflags,
 )
@@ -191,7 +191,7 @@ class CoinSelectionTracepointTest(BitcoinTestFramework):
         events = self.get_tracepoints([1, 2, 3, 1, 4])
         success, use_aps, _algo, _waste, change_pos = self.determine_selection_from_usdt(events)
         assert_equal(success, True)
-        assert_greater_than(change_pos, -1)
+        assert_gt(change_pos, -1)
 
         self.log.info("Failing to fund results in 1 tracepoint")
         # We should have 1 tracepoints in the order

--- a/test/functional/interface_usdt_net.py
+++ b/test/functional/interface_usdt_net.py
@@ -19,7 +19,7 @@ from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     bpf_cflags,
 )
 
@@ -369,8 +369,8 @@ class NetTracepointTest(BitcoinTestFramework):
 
         assert_equal(EXPECTED_INBOUND_CONNECTIONS, len(inbound_connections))
         for inbound_connection in inbound_connections:
-            assert_greater_than(inbound_connection.conn.id, 0)
-            assert_greater_than(inbound_connection.existing, 0)
+            assert_gt(inbound_connection.conn.id, 0)
+            assert_gt(inbound_connection.existing, 0)
             assert_equal(b'inbound', inbound_connection.conn.conn_type)
             assert_equal(NETWORK_TYPE_UNROUTABLE, inbound_connection.conn.network)
 
@@ -410,8 +410,8 @@ class NetTracepointTest(BitcoinTestFramework):
 
         assert_equal(EXPECTED_OUTBOUND_CONNECTIONS, len(outbound_connections))
         for outbound_connection in outbound_connections:
-            assert_greater_than(outbound_connection.conn.id, 0)
-            assert_greater_than(outbound_connection.existing, 0)
+            assert_gt(outbound_connection.conn.id, 0)
+            assert_gt(outbound_connection.existing, 0)
             assert_equal(EXPECTED_CONNECTION_TYPE, outbound_connection.conn.conn_type.decode('utf-8'))
             assert_equal(NETWORK_TYPE_UNROUTABLE, outbound_connection.conn.network)
 
@@ -447,8 +447,8 @@ class NetTracepointTest(BitcoinTestFramework):
 
         assert_equal(EXPECTED_EVICTED_CONNECTIONS, len(evicted_connections))
         for evicted_connection in evicted_connections:
-            assert_greater_than(evicted_connection.conn.id, 0)
-            assert_greater_than(evicted_connection.time_established, 0)
+            assert_gt(evicted_connection.conn.id, 0)
+            assert_gt(evicted_connection.time_established, 0)
             assert_equal("inbound", evicted_connection.conn.conn_type.decode('utf-8'))
             assert_equal(NETWORK_TYPE_UNROUTABLE, evicted_connection.conn.network)
 
@@ -484,8 +484,8 @@ class NetTracepointTest(BitcoinTestFramework):
 
         assert_equal(EXPECTED_MISBEHAVING_CONNECTIONS, len(misbehaving_connections))
         for misbehaving_connection in misbehaving_connections:
-            assert_greater_than(misbehaving_connection.id, 0)
-            assert_greater_than(len(misbehaving_connection.message), 0)
+            assert_gt(misbehaving_connection.id, 0)
+            assert_gt(len(misbehaving_connection.message), 0)
             assert_equal(misbehaving_connection.message, b"headers message size = 2001")
 
         bpf.cleanup()
@@ -521,10 +521,10 @@ class NetTracepointTest(BitcoinTestFramework):
 
         assert_equal(EXPECTED_CLOSED_CONNECTIONS, len(closed_connections))
         for closed_connection in closed_connections:
-            assert_greater_than(closed_connection.conn.id, 0)
+            assert_gt(closed_connection.conn.id, 0)
             assert_equal("inbound", closed_connection.conn.conn_type.decode('utf-8'))
             assert_equal(0, closed_connection.conn.network)
-            assert_greater_than(closed_connection.time_established, 0)
+            assert_gt(closed_connection.time_established, 0)
 
         bpf.cleanup()
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -48,7 +48,7 @@ from test_framework.script_util import (
 )
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     sync_txindex,
 )
@@ -381,7 +381,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             rawtxs=[tx.serialize().hex()],
         )
         tx.vout[0].scriptPubKey = CScript([OP_RETURN, b"\xff" * (data_len + 1)])
-        assert_greater_than(tx.get_vsize(), int(MAX_STANDARD_TX_WEIGHT / 4))
+        assert_gt(tx.get_vsize(), int(MAX_STANDARD_TX_WEIGHT / 4))
         self.check_mempool_result(
             result_expected=[{"txid": tx.txid_hex, "allowed": False, "reject-reason": "tx-size"}],
             rawtxs=[tx.serialize().hex()],
@@ -418,7 +418,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         # Note it's only non-witness size that matters!
         assert_equal(len(tx.serialize_without_witness()), 64)
         assert_equal(MIN_STANDARD_TX_NONWITNESS_SIZE - 1, 64)
-        assert_greater_than(len(tx.serialize()), 64)
+        assert_gt(len(tx.serialize()), 64)
 
         self.check_mempool_result(
             result_expected=[{'txid': tx.txid_hex, 'allowed': False, 'reject-reason': 'tx-size-small'}],

--- a/test/functional/mempool_cluster.py
+++ b/test/functional/mempool_cluster.py
@@ -19,8 +19,8 @@ from test_framework.wallet import (
 )
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises_rpc_error,
 )
 
@@ -83,7 +83,7 @@ class MempoolClusterTest(BitcoinTestFramework):
             # The weight is always positive, except for the first iteration
             assert x['weight'] > 0 or x['fee'] == 0
             # Monotonically decreasing fee per weight
-            assert_greater_than_or_equal(last_val['fee'] * x['weight'], x['fee'] * last_val['weight'])
+            assert_ge(last_val['fee'] * x['weight'], x['fee'] * last_val['weight'])
             last_val = x
 
     def test_limit_enforcement(self, cluster_submitted, target_vsize_per_tx=None):
@@ -91,7 +91,7 @@ class MempoolClusterTest(BitcoinTestFramework):
         the cluster may change as a result of these transactions, so cluster_submitted is mutated accordingly
         """
         # Cluster has already been submitted and has at least 3 transactions, otherwise this test won't work.
-        assert_greater_than_or_equal(len(cluster_submitted), 3)
+        assert_ge(len(cluster_submitted), 3)
         node = self.nodes[0]
         last_result = cluster_submitted[-1]
 
@@ -195,7 +195,7 @@ class MempoolClusterTest(BitcoinTestFramework):
             utxo_from_cluster1 = cluster1[-1]["new_utxo"]
 
             # Make the next cluster, which contains the remaining transactions
-            assert_greater_than(max_cluster_count, num_txns_cluster1)
+            assert_gt(max_cluster_count, num_txns_cluster1)
             num_txns_cluster2 = max_cluster_count - num_txns_cluster1
             cluster2 = self.add_chain_cluster(node, num_txns_cluster2)
             for result in cluster2:
@@ -246,7 +246,7 @@ class MempoolClusterTest(BitcoinTestFramework):
             utxos_to_merge.append(singleton["new_utxo"])
             vsize_remaining -= singleton["tx"].get_vsize()
 
-        assert_greater_than_or_equal(vsize_remaining, 500)
+        assert_ge(vsize_remaining, 500)
 
         # Create a transaction spending from all clusters that exceeds the cluster size limit.
         tx_merger_too_big = self.wallet.create_self_transfer_multi(utxos_to_spend=utxos_to_merge, target_vsize=vsize_remaining + 4, fee_per_output=10000)

--- a/test/functional/mempool_ephemeral_dust.py
+++ b/test/functional/mempool_ephemeral_dust.py
@@ -13,7 +13,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mempool_util import assert_mempool_contents
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     assert_not_equal,
 )
@@ -152,7 +152,7 @@ class EphemeralDustTest(BitcoinTestFramework):
         sats_fee = 1
         dusty_tx, sweep_tx = self.create_ephemeral_dust_package(tx_version=3, dust_tx_fee=sats_fee)
         assert_equal(int(COIN * dusty_tx["fee"]), sats_fee) # has fees
-        assert_greater_than(dusty_tx["tx"].vout[0].nValue, 330) # main output is not dust
+        assert_gt(dusty_tx["tx"].vout[0].nValue, 330) # main output is not dust
         assert_equal(dusty_tx["tx"].vout[1].nValue, 0) # added one is dust
 
         # When base fee is non-0, we report dust like usual
@@ -239,7 +239,7 @@ class EphemeralDustTest(BitcoinTestFramework):
 
         # Doesn't spend in-mempool dust output from parent
         unspent_sweep_tx = self.wallet.create_self_transfer_multi(fee_per_output=2000, utxos_to_spend=[dusty_tx["new_utxos"][0]], version=3)
-        assert_greater_than(unspent_sweep_tx["fee"], sweep_tx["fee"])
+        assert_gt(unspent_sweep_tx["fee"], sweep_tx["fee"])
         res = self.nodes[0].submitpackage([dusty_tx["hex"], unspent_sweep_tx["hex"]])
         assert_equal(res["tx-results"][unspent_sweep_tx["wtxid"]]["error"], f"missing-ephemeral-spends, tx {unspent_sweep_tx['txid']} (wtxid={unspent_sweep_tx['wtxid']}) did not spend parent's ephemeral dust")
         assert_raises_rpc_error(-26, f"missing-ephemeral-spends, tx {unspent_sweep_tx['txid']} (wtxid={unspent_sweep_tx['wtxid']}) did not spend parent's ephemeral dust", self.nodes[0].sendrawtransaction, unspent_sweep_tx["hex"])

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -14,7 +14,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_fee_amount,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
 )
 from test_framework.wallet import (
@@ -55,7 +55,7 @@ class MempoolLimitTest(BitcoinTestFramework):
 
         # There is a gap, our parents will be minrate, with child bringing up descendant fee sufficiently to avoid
         # eviction even though parents cause eviction on their own
-        assert_greater_than(mempool_entry_minrate, mempoolmin_feerate)
+        assert_gt(mempool_entry_minrate, mempoolmin_feerate)
 
         package_hex = []
         # UTXOs to be spent by the ultimate child transaction
@@ -68,7 +68,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         num_big_parents = 3
         # Need to be large enough to trigger eviction
         # (note that the mempool usage of a tx is about three times its vsize)
-        assert_greater_than(parent_vsize * num_big_parents * 3, current_info["maxmempool"] - current_info["bytes"])
+        assert_gt(parent_vsize * num_big_parents * 3, current_info["maxmempool"] - current_info["bytes"])
 
         big_parent_txids = []
         big_parent_wtxids = []
@@ -106,7 +106,7 @@ class MempoolLimitTest(BitcoinTestFramework):
             assert_equal(len(package_res["tx-results"][wtxid]["fees"]["effective-includes"]), 1)
 
         # Maximum size must never be exceeded.
-        assert_greater_than(node.getmempoolinfo()["maxmempool"], node.getmempoolinfo()["bytes"])
+        assert_gt(node.getmempoolinfo()["maxmempool"], node.getmempoolinfo()["bytes"])
 
         # Package found in mempool still
         resulting_mempool_txids = node.getrawmempool()
@@ -123,7 +123,7 @@ class MempoolLimitTest(BitcoinTestFramework):
             for txid, entry in zip(mempool_txids, mempool_entries):
                 if txid == eviction:
                     evicted_feerate_btc_per_kvb = entry["fees"]["modified"] / (Decimal(entry["vsize"]) / 1000)
-                    assert_greater_than(evicted_feerate_btc_per_kvb, max_parent_feerate)
+                    assert_gt(evicted_feerate_btc_per_kvb, max_parent_feerate)
 
     def test_mid_package_replacement(self):
         node = self.nodes[0]
@@ -182,7 +182,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         assert len([tx_res for _, tx_res in res["tx-results"].items() if "error" in tx_res and tx_res["error"] == "bad-txns-inputs-missingorspent"])
 
         # Maximum size must never be exceeded.
-        assert_greater_than(node.getmempoolinfo()["maxmempool"], node.getmempoolinfo()["bytes"])
+        assert_gt(node.getmempoolinfo()["maxmempool"], node.getmempoolinfo()["bytes"])
 
         resulting_mempool_txids = node.getrawmempool()
         # The replacement should be successful.
@@ -259,7 +259,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         # Needs to be large enough to trigger eviction
         # (note that the mempool usage of a tx is about three times its vsize)
         target_vsize_each = 50000
-        assert_greater_than(target_vsize_each * 2 * 3, node.getmempoolinfo()["maxmempool"] - node.getmempoolinfo()["bytes"])
+        assert_gt(target_vsize_each * 2 * 3, node.getmempoolinfo()["maxmempool"] - node.getmempoolinfo()["bytes"])
         # Should be a true CPFP: parent's feerate is just below mempool min feerate
         parent_feerate = mempoolmin_feerate - Decimal("0.0000001")  # 0.01 sats/vbyte below min feerate
         # Parent + child is above mempool minimum feerate
@@ -272,9 +272,9 @@ class MempoolLimitTest(BitcoinTestFramework):
         # This package ranks below the lowest descendant package in the mempool
         package_fee = tx_parent_just_below["fee"] + tx_child_just_above["fee"]
         package_vsize = tx_parent_just_below["tx"].get_vsize() + tx_child_just_above["tx"].get_vsize()
-        assert_greater_than(worst_feerate_btcvb, package_fee / package_vsize)
-        assert_greater_than(mempoolmin_feerate, tx_parent_just_below["fee"] / (tx_parent_just_below["tx"].get_vsize()))
-        assert_greater_than(package_fee / package_vsize, mempoolmin_feerate / 1000)
+        assert_gt(worst_feerate_btcvb, package_fee / package_vsize)
+        assert_gt(mempoolmin_feerate, tx_parent_just_below["fee"] / (tx_parent_just_below["tx"].get_vsize()))
+        assert_gt(package_fee / package_vsize, mempoolmin_feerate / 1000)
         res = node.submitpackage([tx_parent_just_below["hex"], tx_child_just_above["hex"]])
         for wtxid in [tx_parent_just_below["wtxid"], tx_child_just_above["wtxid"]]:
             assert_equal(res["tx-results"][wtxid]["error"], "mempool full")

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -12,7 +12,7 @@ from test_framework.messages import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mempool_util import fill_mempool
 from test_framework.util import (
-    assert_greater_than_or_equal,
+    assert_ge,
     assert_equal,
 )
 from test_framework.wallet import (
@@ -143,7 +143,7 @@ class PackageRBFTest(BitcoinTestFramework):
         coin = self.coins.pop()
 
         package_hex1, package_txns1 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE, child_fee=DEFAULT_CHILD_FEE, heavy_child=True)
-        assert_greater_than_or_equal(1000, package_txns1[-1].get_vsize())
+        assert_ge(1000, package_txns1[-1].get_vsize())
         node.submitpackage(package_hex1)
         self.assert_mempool_contents(expected=package_txns1)
 

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -43,7 +43,7 @@ from test_framework.p2p import P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than_or_equal,
+    assert_ge,
     assert_raises_rpc_error,
 )
 from test_framework.wallet import MiniWallet, COIN
@@ -95,8 +95,8 @@ class MempoolPersistTest(BitcoinTestFramework):
 
         last_entry = self.nodes[0].getmempoolentry(txid=last_txid)
         tx_creation_time = last_entry['time']
-        assert_greater_than_or_equal(tx_creation_time, tx_creation_time_lower)
-        assert_greater_than_or_equal(tx_creation_time_higher, tx_creation_time)
+        assert_ge(tx_creation_time, tx_creation_time_lower)
+        assert_ge(tx_creation_time_higher, tx_creation_time)
 
         # disconnect nodes & make a txn that remains in the unbroadcast set.
         self.disconnect_nodes(0, 1)

--- a/test/functional/mempool_sigoplimit.py
+++ b/test/functional/mempool_sigoplimit.py
@@ -39,8 +39,8 @@ from test_framework.script_util import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises_rpc_error,
 )
 from test_framework.wallet import MiniWallet
@@ -91,7 +91,7 @@ class BytesPerSigOpTest(BitcoinTestFramework):
         tx = self.create_p2wsh_spending_tx(witness_script, CScript([OP_RETURN, b'X'*256]))
 
         # bump the tx to reach the sigop-limit equivalent size by padding the datacarrier output
-        assert_greater_than_or_equal(sigop_equivalent_vsize, tx.get_vsize())
+        assert_ge(sigop_equivalent_vsize, tx.get_vsize())
         vsize_to_pad = sigop_equivalent_vsize - tx.get_vsize()
         tx.vout[0].scriptPubKey = CScript([OP_RETURN, b'X'*(256+vsize_to_pad)])
         assert_equal(sigop_equivalent_vsize, tx.get_vsize())
@@ -122,7 +122,7 @@ class BytesPerSigOpTest(BitcoinTestFramework):
         # is much larger than the serialized vsize, i.e. we create a small child
         # tx by getting rid of the large padding output)
         tx.vout[0].scriptPubKey = CScript([OP_RETURN, b'test123'])
-        assert_greater_than(sigop_equivalent_vsize, tx.get_vsize())
+        assert_gt(sigop_equivalent_vsize, tx.get_vsize())
         self.nodes[0].sendrawtransaction(hexstring=tx.serialize().hex(), maxburnamount='1.0')
 
         # fetch parent tx, which doesn't contain any sigops
@@ -180,7 +180,7 @@ class BytesPerSigOpTest(BitcoinTestFramework):
         assert tx_parent.txid_hex in self.nodes[0].getrawmempool()
 
         # Transactions are tiny in weight
-        assert_greater_than(2000, tx_parent.get_weight() + tx_child.get_weight())
+        assert_gt(2000, tx_parent.get_weight() + tx_child.get_weight())
 
     def test_legacy_sigops_stdness(self):
         self.log.info("Test a transaction with too many legacy sigops in its inputs is non-standard.")

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -8,8 +8,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_not_equal,
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises_rpc_error,
     get_fee,
 )
@@ -64,7 +64,7 @@ class MempoolTRUC(BitcoinTestFramework):
         node = self.nodes[0]
         self.log.info("Test TRUC-specific maximum transaction vsize")
         tx_v3_heavy = self.wallet.create_self_transfer(target_vsize=TRUC_MAX_VSIZE + 1, version=3)
-        assert_greater_than_or_equal(tx_v3_heavy["tx"].get_vsize(), TRUC_MAX_VSIZE)
+        assert_ge(tx_v3_heavy["tx"].get_vsize(), TRUC_MAX_VSIZE)
         expected_error_heavy = f"TRUC-violation, version=3 tx {tx_v3_heavy['txid']} (wtxid={tx_v3_heavy['wtxid']}) is too big"
         assert_raises_rpc_error(-26, expected_error_heavy, node.sendrawtransaction, tx_v3_heavy["hex"])
         self.check_mempool([])
@@ -84,7 +84,7 @@ class MempoolTRUC(BitcoinTestFramework):
             target_vsize=TRUC_CHILD_MAX_VSIZE + 1,
             version=3
         )
-        assert_greater_than_or_equal(tx_v3_child_heavy["tx"].get_vsize(), TRUC_CHILD_MAX_VSIZE)
+        assert_ge(tx_v3_child_heavy["tx"].get_vsize(), TRUC_CHILD_MAX_VSIZE)
         expected_error_child_heavy = f"TRUC-violation, version=3 child tx {tx_v3_child_heavy['txid']} (wtxid={tx_v3_child_heavy['wtxid']}) is too big"
         assert_raises_rpc_error(-26, expected_error_child_heavy, node.sendrawtransaction, tx_v3_child_heavy["hex"])
         self.check_mempool([tx_v3_parent_normal["txid"]])
@@ -99,7 +99,7 @@ class MempoolTRUC(BitcoinTestFramework):
             target_vsize=TRUC_CHILD_MAX_VSIZE - 3,
             version=3
         )
-        assert_greater_than_or_equal(TRUC_CHILD_MAX_VSIZE, tx_v3_child_almost_heavy["tx"].get_vsize())
+        assert_ge(TRUC_CHILD_MAX_VSIZE, tx_v3_child_almost_heavy["tx"].get_vsize())
         self.check_mempool([tx_v3_parent_normal["txid"], tx_v3_child_almost_heavy["txid"]])
         assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 2)
         tx_v3_child_almost_heavy_rbf = self.wallet.send_self_transfer(
@@ -109,7 +109,7 @@ class MempoolTRUC(BitcoinTestFramework):
             target_vsize=875,
             version=3
         )
-        assert_greater_than_or_equal(tx_v3_child_almost_heavy["tx"].get_vsize() + tx_v3_child_almost_heavy_rbf["tx"].get_vsize(),
+        assert_ge(tx_v3_child_almost_heavy["tx"].get_vsize() + tx_v3_child_almost_heavy_rbf["tx"].get_vsize(),
                                      TRUC_CHILD_MAX_VSIZE)
         self.check_mempool([tx_v3_parent_normal["txid"], tx_v3_child_almost_heavy_rbf["txid"]])
         assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 2)
@@ -201,7 +201,7 @@ class MempoolTRUC(BitcoinTestFramework):
         tx_v2_from_v3 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block["new_utxo"], version=2)
         tx_v3_from_v2 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v2_block["new_utxo"], version=3)
         tx_v3_child_large = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block2["new_utxo"], target_vsize=1250, version=3)
-        assert_greater_than(node.getmempoolentry(tx_v3_child_large["txid"])["vsize"], TRUC_CHILD_MAX_VSIZE)
+        assert_gt(node.getmempoolentry(tx_v3_child_large["txid"])["vsize"], TRUC_CHILD_MAX_VSIZE)
         tx_chain_4 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_chain_3["new_utxo"], version=2)
         self.check_mempool([tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"], tx_chain_4["txid"]])
 
@@ -232,8 +232,8 @@ class MempoolTRUC(BitcoinTestFramework):
         )
 
         # Parent and child are within v3 limits, but cluster count limit is exceeded.
-        assert_greater_than_or_equal(TRUC_MAX_VSIZE, tx_v3_parent_large1["tx"].get_vsize())
-        assert_greater_than_or_equal(TRUC_CHILD_MAX_VSIZE, tx_v3_child_large1["tx"].get_vsize())
+        assert_ge(TRUC_MAX_VSIZE, tx_v3_parent_large1["tx"].get_vsize())
+        assert_ge(TRUC_CHILD_MAX_VSIZE, tx_v3_child_large1["tx"].get_vsize())
 
         assert_raises_rpc_error(-26, "too-large-cluster", node.sendrawtransaction, tx_v3_child_large1["hex"])
         self.check_mempool([tx_v3_parent_large1["txid"]])
@@ -245,8 +245,8 @@ class MempoolTRUC(BitcoinTestFramework):
         tx_v3_parent_large2 = self.wallet.send_self_transfer(from_node=node, target_vsize=parent_target_vsize, version=3)
         tx_v3_child_large2 = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_parent_large2["new_utxo"], target_vsize=child_target_vsize, version=3)
         # Parent and child are within TRUC limits
-        assert_greater_than_or_equal(TRUC_MAX_VSIZE, tx_v3_parent_large2["tx"].get_vsize())
-        assert_greater_than_or_equal(TRUC_CHILD_MAX_VSIZE, tx_v3_child_large2["tx"].get_vsize())
+        assert_ge(TRUC_MAX_VSIZE, tx_v3_parent_large2["tx"].get_vsize())
+        assert_ge(TRUC_CHILD_MAX_VSIZE, tx_v3_child_large2["tx"].get_vsize())
         assert_raises_rpc_error(-26, "too-large-cluster", node.sendrawtransaction, tx_v3_child_large2["hex"])
         self.log.info("Test that a decreased limitclustercount also applies to TRUC transactions")
         self.restart_node(0, extra_args=["-limitclustercount=1", "-acceptnonstdtxn=1"])
@@ -625,11 +625,11 @@ class MempoolTRUC(BitcoinTestFramework):
             tx_v3_child = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_0fee_parent["new_utxo"], fee_rate=high_feerate, version=3)
             total_v3_fee = tx_v3_child["fee"] + tx_v3_0fee_parent["fee"]
             total_v3_size = tx_v3_child["tx"].get_vsize() + tx_v3_0fee_parent["tx"].get_vsize()
-            assert_greater_than_or_equal(total_v3_fee, get_fee(total_v3_size, minrelayfeerate))
+            assert_ge(total_v3_fee, get_fee(total_v3_size, minrelayfeerate))
             if minrelayfeerate > 0:
-                assert_greater_than(get_fee(tx_v3_0fee_parent["tx"].get_vsize(), minrelayfeerate), 0)
+                assert_gt(get_fee(tx_v3_0fee_parent["tx"].get_vsize(), minrelayfeerate), 0)
                 # Always need to pay at least 1 satoshi for entry, even if minimum feerate is very low
-                assert_greater_than(total_v3_fee, 0)
+                assert_gt(total_v3_fee, 0)
                 # Also create a version where the child is at minrelaytxfee
                 tx_v3_child_minrelay = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_0fee_parent["new_utxo"], fee_rate=minrelayfeerate, version=3)
                 result_truc_minrelay = node.submitpackage([tx_v3_0fee_parent["hex"], tx_v3_child_minrelay["hex"]])
@@ -639,11 +639,11 @@ class MempoolTRUC(BitcoinTestFramework):
             tx_v2_child = self.wallet.create_self_transfer(utxo_to_spend=tx_v2_0fee_parent["new_utxo"], fee_rate=high_feerate, version=2)
             total_v2_fee = tx_v2_child["fee"] + tx_v2_0fee_parent["fee"]
             total_v2_size = tx_v2_child["tx"].get_vsize() + tx_v2_0fee_parent["tx"].get_vsize()
-            assert_greater_than_or_equal(total_v2_fee, get_fee(total_v2_size, minrelayfeerate))
+            assert_ge(total_v2_fee, get_fee(total_v2_size, minrelayfeerate))
             if minrelayfeerate > 0:
-                assert_greater_than(get_fee(tx_v2_0fee_parent["tx"].get_vsize(), minrelayfeerate), 0)
+                assert_gt(get_fee(tx_v2_0fee_parent["tx"].get_vsize(), minrelayfeerate), 0)
                 # Always need to pay at least 1 satoshi for entry, even if minimum feerate is very low
-                assert_greater_than(total_v2_fee, 0)
+                assert_gt(total_v2_fee, 0)
 
             result_truc = node.submitpackage([tx_v3_0fee_parent["hex"], tx_v3_child["hex"]], maxfeerate=0)
             assert_equal(result_truc["package_msg"], "success")

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -13,7 +13,7 @@ import time
 
 from test_framework.blocktools import create_empty_fork
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than_or_equal, assert_raises_rpc_error
+from test_framework.util import assert_equal, assert_ge, assert_raises_rpc_error
 from test_framework.wallet import MiniWallet
 from test_framework.mempool_util import DEFAULT_CLUSTER_LIMIT
 
@@ -164,7 +164,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
         # At least one parent must be dropped, but more may be dropped,
         # depending on the dynamic cost overhead.
         expected_parent_count = len(large_std_txs) - 1
-        assert_greater_than_or_equal(expected_parent_count * 2, len(mempool))
+        assert_ge(expected_parent_count * 2, len(mempool))
         expected_parent_count = len(mempool) // 2
 
         parent_presence = [tx["txid"] in mempool for tx in large_std_txs]

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -39,8 +39,8 @@ from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises_rpc_error,
     get_fee,
 )
@@ -159,8 +159,8 @@ class MiningTest(BitcoinTestFramework):
             assert_equal(tx_with_min_feerate["fee"], get_fee(tx_with_min_feerate["tx"].get_vsize(), blockmintxfee_btc_kvb))
             if blockmintxfee_sat_kvb >= 10:
                 lowerfee_btc_kvb = blockmintxfee_btc_kvb - Decimal(10)/COIN  # 0.01 sat/vbyte lower
-                assert_greater_than(blockmintxfee_btc_kvb, lowerfee_btc_kvb)
-                assert_greater_than_or_equal(lowerfee_btc_kvb, 0)
+                assert_gt(blockmintxfee_btc_kvb, lowerfee_btc_kvb)
+                assert_ge(lowerfee_btc_kvb, 0)
                 tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=lowerfee_btc_kvb, confirmed_only=True)
                 assert_equal(tx_below_min_feerate["fee"], get_fee(tx_below_min_feerate["tx"].get_vsize(), lowerfee_btc_kvb))
             else:  # go below zero fee by using modified fees
@@ -176,7 +176,7 @@ class MiningTest(BitcoinTestFramework):
             if blockmintxfee_btc_kvb > 0:
                 for txid in block_template_txids:
                     tx = node.getmempoolentry(txid)
-                    assert_greater_than(tx['fees']['base'], 0)
+                    assert_gt(tx['fees']['base'], 0)
 
             self.generate(self.wallet, 1, sync_fun=self.no_op)
             block = node.getblock(node.getbestblockhash(), verbosity=2)
@@ -214,7 +214,7 @@ class MiningTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(t)
         # The template will have an adjusted timestamp, which we then modify
         tmpl = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
-        assert_greater_than_or_equal(tmpl['curtime'], t + MAX_FUTURE_BLOCK_TIME - MAX_TIMEWARP)
+        assert_ge(tmpl['curtime'], t + MAX_FUTURE_BLOCK_TIME - MAX_TIMEWARP)
         # mintime and curtime should match
         assert_equal(tmpl['mintime'], tmpl['curtime'])
 
@@ -253,7 +253,7 @@ class MiningTest(BitcoinTestFramework):
         self.generate(prune_node, 400, sync_fun=self.no_op)
         pruned_block = prune_node.getblock(prune_node.getblockhash(2), verbosity=0)
         pruned_height = prune_node.pruneblockchain(400)
-        assert_greater_than_or_equal(pruned_height, 2)
+        assert_ge(pruned_height, 2)
         pruned_blockhash = prune_node.getblockhash(2)
 
         assert_raises_rpc_error(-1, 'Block not available (pruned data)', prune_node.getblock, pruned_blockhash)
@@ -283,7 +283,7 @@ class MiningTest(BitcoinTestFramework):
         self.log.info(f"Testing block template: contains {expected_tx_count} transactions, and total weight <= {expected_weight}")
         assert_equal(len(response["transactions"]), expected_tx_count)
         total_weight = sum(transaction["weight"] for transaction in response["transactions"])
-        assert_greater_than_or_equal(expected_weight, total_weight)
+        assert_ge(expected_weight, total_weight)
 
     def test_block_max_weight(self):
         self.log.info("Testing default and custom -blockmaxweight startup options.")

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -23,8 +23,8 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal
+    assert_gt,
+    assert_ge
 )
 
 ONE_MINUTE  = 60
@@ -235,7 +235,7 @@ class AddrTest(BitcoinTestFramework):
         peerinfo = self.nodes[0].getpeerinfo()
 
         # Confirm node received addr-related messages from receiver peer
-        assert_greater_than(self.sum_addr_messages(peerinfo[1]['bytesrecv_per_msg']), 0)
+        assert_gt(self.sum_addr_messages(peerinfo[1]['bytesrecv_per_msg']), 0)
         # And that peer received addresses
         assert_equal(receiver_peer.num_ipv4_received - initial_addrs_received, 2)
 
@@ -248,7 +248,7 @@ class AddrTest(BitcoinTestFramework):
         blackhole_peer.send_and_ping(msg_addr())
 
         # Confirm node has now received addr-related messages from blackhole peer
-        assert_greater_than(self.sum_addr_messages(peerinfo[1]['bytesrecv_per_msg']), 0)
+        assert_gt(self.sum_addr_messages(peerinfo[1]['bytesrecv_per_msg']), 0)
         assert_equal(self.nodes[0].getpeerinfo()[2]['addr_relay_enabled'], True)
 
         msg = self.setup_addr_msg(2)
@@ -421,7 +421,7 @@ class AddrTest(BitcoinTestFramework):
         nodes_received_addr = self.get_nodes_that_received_addr(peer, receiver_peer, addr_receivers, 0, TWO_HOURS)  # 10 intervals of 2 hours
         # Per RelayAddress, we would announce these addrs to 2 destinations per day.
         # Since it's at most one rotation, at most 4 nodes can receive ADDR.
-        assert_greater_than_or_equal(ADDR_DESTINATIONS_THRESHOLD, len(nodes_received_addr))
+        assert_ge(ADDR_DESTINATIONS_THRESHOLD, len(nodes_received_addr))
         self.nodes[0].disconnect_p2ps()
 
     def destination_rotates_more_than_once_over_several_days_test(self):
@@ -436,7 +436,7 @@ class AddrTest(BitcoinTestFramework):
         nodes_received_addr = self.get_nodes_that_received_addr(peer, receiver_peer, addr_receivers, ONE_DAY, ONE_HOUR)
         # Now that there should have been more than one rotation, more than
         # ADDR_DESTINATIONS_THRESHOLD nodes should have received ADDR.
-        assert_greater_than(len(nodes_received_addr), ADDR_DESTINATIONS_THRESHOLD)
+        assert_gt(len(nodes_received_addr), ADDR_DESTINATIONS_THRESHOLD)
         self.nodes[0].disconnect_p2ps()
 
 

--- a/test/functional/p2p_addr_selfannouncement.py
+++ b/test/functional/p2p_addr_selfannouncement.py
@@ -20,7 +20,7 @@ from test_framework.messages import (
 )
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than
+from test_framework.util import assert_equal, assert_gt
 
 IP_TO_ANNOUNCE = "42.42.42.42"
 ONE_DAY = 60 * 60 * 24
@@ -83,7 +83,7 @@ class AddrSelfAnnouncementTest(BitcoinTestFramework):
         # and an addr message containing the GETADDR response.
         assert_equal(addr_receiver.self_announcements_received, 1)
         assert_equal(addr_receiver.addr_messages_received, 2)
-        assert_greater_than(addr_receiver.addresses_received, 1)
+        assert_gt(addr_receiver.addresses_received, 1)
 
     def outbound_connection_open_assertions(self, addr_receiver):
         # We expect only the self-announcement.

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -26,7 +26,7 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than_or_equal,
+    assert_ge,
 )
 
 PEER_TIMEOUT = 3
@@ -163,8 +163,8 @@ class P2PLeakTest(BitcoinTestFramework):
         p2p_version_store = self.nodes[0].add_p2p_connection(P2PVersionStore())
         ver = p2p_version_store.version_received
         # Check that received time is within one hour of now
-        assert_greater_than_or_equal(ver.nTime, time.time() - 3600)
-        assert_greater_than_or_equal(time.time() + 3600, ver.nTime)
+        assert_ge(ver.nTime, time.time() - 3600)
+        assert_ge(time.time() + 3600, ver.nTime)
         assert_equal(ver.addrFrom.port, 0)
         assert_equal(ver.addrFrom.ip, '0.0.0.0')
         assert_equal(ver.nStartingHeight, 201)

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -43,8 +43,8 @@ from test_framework.script import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
 )
 from test_framework.wallet import (
     MiniWallet,
@@ -85,7 +85,7 @@ class PackageRelayTest(BitcoinTestFramework):
         self.sequence so that subsequent calls to this function result in unique transactions."""
 
         self.sequence -= 1
-        assert_greater_than(self.nodes[0].getmempoolinfo()["mempoolminfee"], Decimal(DEFAULT_MIN_RELAY_TX_FEE) / COIN)
+        assert_gt(self.nodes[0].getmempoolinfo()["mempoolminfee"], Decimal(DEFAULT_MIN_RELAY_TX_FEE) / COIN)
 
         return wallet.create_self_transfer(fee_rate=Decimal(DEFAULT_MIN_RELAY_TX_FEE) / COIN, sequence=self.sequence, utxo_to_spend=utxo_to_spend, confirmed_only=True)
 
@@ -438,9 +438,9 @@ class PackageRelayTest(BitcoinTestFramework):
         large_orphans = [create_large_orphan() for _ in range(50)]
         # Check to make sure these are orphans, within max standard size (to be accepted into the orphanage)
         for large_orphan in large_orphans:
-            assert_greater_than_or_equal(100000, large_orphan.get_vsize())
-            assert_greater_than(MAX_STANDARD_TX_WEIGHT, large_orphan.get_weight())
-            assert_greater_than_or_equal(3 * large_orphan.get_vsize(), 2 * 100000)
+            assert_ge(100000, large_orphan.get_vsize())
+            assert_gt(MAX_STANDARD_TX_WEIGHT, large_orphan.get_weight())
+            assert_ge(3 * large_orphan.get_vsize(), 2 * 100000)
             testres = node.testmempoolaccept([large_orphan.serialize().hex()])
             assert not testres[0]["allowed"]
             assert_equal(testres[0]["reject-reason"], "missing-inputs")
@@ -507,7 +507,7 @@ class PackageRelayTest(BitcoinTestFramework):
         batch_size = 51
         num_peers_shared = 60
         batch_single_doser = 100
-        assert_greater_than(num_peers_shared * batch_size + batch_single_doser, 3000)
+        assert_gt(num_peers_shared * batch_size + batch_single_doser, 3000)
         # 60 peers * 51 orphans = 3060 announcements
         shared_orphans = [self.create_small_orphan() for _ in range(batch_size)]
         self.log.info(f"Send the same {batch_size} orphans from {num_peers_shared} DoSy peers (may take a while)")

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -82,7 +82,7 @@ from test_framework.script_util import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_not_equal,
-    assert_greater_than_or_equal,
+    assert_ge,
     assert_equal,
     assert_raises_rpc_error,
     ensure_for,
@@ -844,7 +844,7 @@ class SegWitTest(BitcoinTestFramework):
         relayable_block.vtx[0].wit.vtxinwit[0].scriptWitness.stack.append(b'a' * 100_000)
 
         # Ensure it's relayable by weight
-        assert_greater_than_or_equal(MAX_BLOCK_WEIGHT, relayable_block.get_weight())
+        assert_ge(MAX_BLOCK_WEIGHT, relayable_block.get_weight())
 
         # Send over P2P and expect rejection for the same reason
         test_witness_block(self.nodes[0], self.test_node, relayable_block,

--- a/test/functional/p2p_v2_encrypted.py
+++ b/test/functional/p2p_v2_encrypted.py
@@ -16,7 +16,7 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     check_node_connections,
 )
 from test_framework.crypto.chacha20 import REKEY_INTERVAL
@@ -82,8 +82,8 @@ class P2PEncrypted(BitcoinTestFramework):
         self.log.info("Check if version is sent and verack is received in inbound/outbound connections")
         assert_equal(len(node0.getpeerinfo()), 5)  # check if above 5 connections are present in node0's getpeerinfo()
         for peer in node0.getpeerinfo():
-            assert_greater_than(peer['bytessent_per_msg']['version'], 0)
-            assert_greater_than(peer['bytesrecv_per_msg']['verack'], 0)
+            assert_gt(peer['bytessent_per_msg']['version'], 0)
+            assert_gt(peer['bytesrecv_per_msg']['verack'], 0)
 
         self.log.info("Testing whether blocks propagate - check if tips sync when number of blocks >= REKEY_INTERVAL")
         # tests whether rekeying (which happens every REKEY_INTERVAL packets) works correctly

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -51,8 +51,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_not_equal,
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises,
     assert_raises_rpc_error,
     assert_is_hex_string,
@@ -161,10 +161,10 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(sorted(res.keys()), sorted(['pruneheight', 'automatic_pruning'] + keys))
 
         # size_on_disk should be > 0
-        assert_greater_than(res['size_on_disk'], 0)
+        assert_gt(res['size_on_disk'], 0)
 
         # pruneheight should be greater or equal to 0
-        assert_greater_than_or_equal(res['pruneheight'], 0)
+        assert_ge(res['pruneheight'], 0)
 
         # check other pruning fields given that prune=1
         assert res['pruned']
@@ -202,7 +202,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(res['pruneheight'], 0)
         assert res['automatic_pruning']
         assert_equal(res['prune_target_size'], 576716800)
-        assert_greater_than(res['size_on_disk'], 0)
+        assert_gt(res['size_on_disk'], 0)
 
         assert_equal(res['bits'], nbits_str(REGTEST_N_BITS))
         assert_equal(res['target'], target_str(REGTEST_TARGET))
@@ -286,7 +286,7 @@ class BlockchainTest(BitcoinTestFramework):
         self.log.info("Check that verificationprogress is less than 1 when the block tip is old")
         future = 2 * 60 * 60
         self.nodes[0].setmocktime(self.nodes[0].getblockchaininfo()["time"] + future + 1)
-        assert_greater_than(1, self.nodes[0].getblockchaininfo()["verificationprogress"])
+        assert_gt(1, self.nodes[0].getblockchaininfo()["verificationprogress"])
 
         self.log.info("Check that verificationprogress is exactly 1 for a recent block tip")
         self.nodes[0].setmocktime(self.nodes[0].getblockchaininfo()["time"] + future)
@@ -294,7 +294,7 @@ class BlockchainTest(BitcoinTestFramework):
 
         self.log.info("Check that verificationprogress is less than 1 as soon as a new header comes in")
         self.nodes[0].submitheader(self.generateblock(self.nodes[0], output="raw(55)", transactions=[], submit=False, sync_fun=self.no_op)["hex"])
-        assert_greater_than(1, self.nodes[0].getblockchaininfo()["verificationprogress"])
+        assert_gt(1, self.nodes[0].getblockchaininfo()["verificationprogress"])
 
     def _test_y2106(self):
         self.log.info("Check that block timestamps work until year 2106")

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -9,8 +9,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
 )
 
 from test_framework.authproxy import JSONRPCException
@@ -53,13 +53,13 @@ class RpcMiscTest(BitcoinTestFramework):
 
         self.log.info("test getmemoryinfo")
         memory = node.getmemoryinfo()['locked']
-        assert_greater_than(memory['used'], 0)
-        assert_greater_than(memory['free'], 0)
-        assert_greater_than(memory['total'], 0)
-        # assert_greater_than_or_equal() for locked in case locking pages failed at some point
-        assert_greater_than_or_equal(memory['locked'], 0)
-        assert_greater_than(memory['chunks_used'], 0)
-        assert_greater_than(memory['chunks_free'], 0)
+        assert_gt(memory['used'], 0)
+        assert_gt(memory['free'], 0)
+        assert_gt(memory['total'], 0)
+        # assert_ge() for locked in case locking pages failed at some point
+        assert_ge(memory['locked'], 0)
+        assert_gt(memory['chunks_used'], 0)
+        assert_gt(memory['chunks_free'], 0)
         assert_equal(memory['used'] + memory['free'], memory['total'])
 
         self.log.info("test mallocinfo")

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -21,7 +21,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_approx,
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     p2p_port,
 )
@@ -311,10 +311,10 @@ class NetTest(BitcoinTestFramework):
         # Maximum possible addresses in AddrMan is 10000. The actual number will
         # usually be less due to bucket and bucket position collisions.
         node_addresses = self.nodes[0].getnodeaddresses(0, "ipv4")
-        assert_greater_than(len(node_addresses), 5000)
-        assert_greater_than(10000, len(node_addresses))
+        assert_gt(len(node_addresses), 5000)
+        assert_gt(10000, len(node_addresses))
         for a in node_addresses:
-            assert_greater_than(a["time"], 1527811200)  # 1st June 2018
+            assert_gt(a["time"], 1527811200)  # 1st June 2018
             assert_equal(a["services"], P2P_SERVICES)
             assert a["address"] in imported_addrs
             assert_equal(a["port"], 8333)

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -34,7 +34,7 @@ from test_framework.script import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     sync_txindex,
 )
@@ -244,7 +244,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # check that verbosity 2 for a mempool tx will fallback to verbosity 1
         # Do this with a pruned chain, as a regression test for https://github.com/bitcoin/bitcoin/pull/29003
         self.generate(self.nodes[2], 400)
-        assert_greater_than(self.nodes[2].pruneblockchain(250), 0)
+        assert_gt(self.nodes[2].pruneblockchain(250), 0)
         mempool_tx = self.wallet.send_self_transfer(from_node=self.nodes[2])['txid']
         gottx = self.nodes[2].getrawtransaction(txid=mempool_tx, verbosity=2)
         assert 'fee' not in gottx

--- a/test/functional/test_framework/mempool_util.py
+++ b/test/functional/test_framework/mempool_util.py
@@ -21,7 +21,7 @@ from .script import (
 )
 from .util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     create_lots_of_big_transactions,
     gen_return_txouts,
 )
@@ -109,13 +109,13 @@ def fill_mempool(test_framework, node, *, tx_sync_fun=None):
 
     test_framework.log.debug("The tx should be evicted by now")
     # The number of transactions created should be greater than the ones present in the mempool
-    assert_greater_than(tx_batch_size * num_of_batches, len(node.getrawmempool()))
+    assert_gt(tx_batch_size * num_of_batches, len(node.getrawmempool()))
     # Initial tx created should not be present in the mempool anymore as it had a lower fee rate
     assert tx_to_be_evicted_id not in node.getrawmempool()
 
     test_framework.log.debug("Check that mempoolminfee is larger than minrelaytxfee")
     assert_equal(node.getmempoolinfo()['minrelaytxfee'], minrelayfee)
-    assert_greater_than(node.getmempoolinfo()['mempoolminfee'], minrelayfee)
+    assert_gt(node.getmempoolinfo()['mempoolminfee'], minrelayfee)
 
 def tx_in_orphanage(node, tx: CTransaction) -> bool:
     """Returns true if the transaction is in the orphanage."""

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -84,12 +84,12 @@ def assert_not_equal(thing1, thing2, *, error_message=""):
         raise AssertionError(f"Both values are {thing1}{f', {error_message}' if error_message else ''}")
 
 
-def assert_greater_than(thing1, thing2):
+def assert_gt(thing1, thing2):
     if thing1 <= thing2:
         raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))
 
 
-def assert_greater_than_or_equal(thing1, thing2):
+def assert_ge(thing1, thing2):
     if thing1 < thing2:
         raise AssertionError("%s < %s" % (str(thing1), str(thing2)))
 

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -51,7 +51,7 @@ from test_framework.script_util import (
 )
 from test_framework.util import (
     assert_equal,
-    assert_greater_than_or_equal,
+    assert_ge,
     get_fee,
 )
 from test_framework.wallet_util import generate_keypair
@@ -271,7 +271,7 @@ class MiniWallet:
         (the utxo with the largest value is taken).
         """
         tx = self.create_self_transfer(fee_rate=0)["tx"]
-        assert_greater_than_or_equal(tx.vout[0].nValue, amount + fee)
+        assert_ge(tx.vout[0].nValue, amount + fee)
         tx.vout[0].nValue -= (amount + fee)           # change output -> MiniWallet
         tx.vout.append(CTxOut(amount, scriptPubKey))  # arbitrary output -> to be returned
         txid = self.sendrawtransaction(from_node=from_node, tx_hex=tx.serialize().hex())

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     sha256sum_file,
 )
 
@@ -401,7 +401,7 @@ class ToolWalletTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         assert_equal(send_res["complete"], True)
         tx = wallet.gettransaction(txid=send_res["txid"], verbose=True)
-        assert_greater_than(tx["decoded"]["size"], 70000)
+        assert_gt(tx["decoded"]["size"], 70000)
 
         self.stop_node(0)
 

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -61,7 +61,7 @@ from test_framework.descriptors import (
 )
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
 )
 
@@ -308,8 +308,8 @@ class AddressTypeTest(BitcoinTestFramework):
             new_balances = self.get_balances()
             self.log.debug("Check new balances: {}".format(new_balances))
             # We don't know what fee was set, so we can only check bounds on the balance of the sending node
-            assert_greater_than(new_balances[from_node], to_send * 10)
-            assert_greater_than(to_send * 11, new_balances[from_node])
+            assert_gt(new_balances[from_node], to_send * 10)
+            assert_gt(to_send * 11, new_balances[from_node])
             for n, to_node in enumerate(range(from_node + 1, from_node + 4)):
                 to_node %= 4
                 assert_equal(new_balances[to_node], old_balances[to_node] + to_send * 10 * (2 + n))

--- a/test/functional/wallet_assumeutxo.py
+++ b/test/functional/wallet_assumeutxo.py
@@ -11,7 +11,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import COIN
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     ensure_for,
 )
@@ -78,7 +78,7 @@ class AssumeutxoTest(BitcoinTestFramework):
     def test_backup_during_background_sync_pruned_node(self, n3, dump_output, expected_error_message):
         self.log.info("Backup from the snapshot height can be loaded during background sync (pruned node)")
         loaded = n3.loadtxoutset(dump_output['path'])
-        assert_greater_than(n3.pruneblockchain(START_HEIGHT), 0)
+        assert_gt(n3.pruneblockchain(START_HEIGHT), 0)
         self.validate_snapshot_import(n3, loaded, dump_output['base_hash'])
         n3.restorewallet("w", "backup_w.dat")
         # Balance of w wallet is still 0 because n3 has not synced yet

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -25,7 +25,7 @@ from test_framework.messages import ser_string
 
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
 )
 
@@ -393,7 +393,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
                     self.log.debug("Checking descriptor cache was upgraded")
                     # Fetch all records with the walletdescriptorlhcache prefix
                     lh_cache_recs = conn.execute(f"SELECT value FROM main where key >= x'{ser_string(b'walletdescriptorlhcache').hex()}' AND key < x'{ser_string(b'walletdescriptorlhcachf').hex()}'").fetchall()
-                    assert_greater_than(len(lh_cache_recs), 0)
+                    assert_gt(len(lh_cache_recs), 0)
 
             self.inspect_sqlite_db(down_backup_path, check_upgraded_records, old_flags)
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -26,7 +26,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_fee_amount,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     get_fee,
     find_vout_for_address,
@@ -265,7 +265,7 @@ class BumpFeeTest(BitcoinTestFramework):
         new_change_pos = find_vout_for_address(rbf_node, new_txid, change_addr)
         new_change_value = new_tx["decoded"]["vout"][new_change_pos]["value"]
 
-        assert_greater_than(change_value, new_change_value)
+        assert_gt(change_value, new_change_value)
 
 
     def test_single_output(self):
@@ -408,7 +408,7 @@ def test_notmine_bumpfee(self, rbf_node, peer_node, dest_address):
         psbt = peer_node.walletprocesspsbt(psbt["psbt"])
         res = rbf_node.testmempoolaccept([psbt["hex"]])
         assert res[0]["allowed"]
-        assert_greater_than(res[0]["fees"]["base"], old_fee)
+        assert_gt(res[0]["fees"]["base"], old_fee)
 
     self.log.info("Test that psbtbumpfee works for non-owned inputs")
     psbt = rbf_node.psbtbumpfee(txid=rbfid)
@@ -499,7 +499,7 @@ def test_small_output_with_feerate_succeeds(self, rbf_node, dest_address):
 
     # input(s) have been added
     final_input_list = rbf_node.getrawtransaction(rbfid, 1)["vin"]
-    assert_greater_than(len(final_input_list), 1)
+    assert_gt(len(final_input_list), 1)
     # Original input is in final set
     assert [txin for txin in final_input_list
             if txin["txid"] == original_txin["txid"]
@@ -545,7 +545,7 @@ def test_settxfee(self, rbf_node, dest_address):
     actual_feerate = bumped_tx["fee"] * 1000 / rbf_node.getrawtransaction(bumped_tx["txid"], True)["vsize"]
     # Assert that the difference between the requested feerate and the actual
     # feerate of the bumped transaction is small.
-    assert_greater_than(Decimal("0.00001000"), abs(requested_feerate - actual_feerate))
+    assert_gt(Decimal("0.00001000"), abs(requested_feerate - actual_feerate))
     rbf_node.settxfee(Decimal("0.00000000"))  # unset paytxfee
 
     # check that settxfee respects -maxtxfee
@@ -642,7 +642,7 @@ def test_watchonly_psbt(self, peer_node, rbf_node, dest_address):
 
     # Bump fee, obnoxiously high to add additional watchonly input
     bumped_psbt = watcher.psbtbumpfee(original_txid, fee_rate=HIGH)
-    assert_greater_than(len(watcher.decodepsbt(bumped_psbt['psbt'])["tx"]["vin"]), 1)
+    assert_gt(len(watcher.decodepsbt(bumped_psbt['psbt'])["tx"]["vin"]), 1)
     assert "txid" not in bumped_psbt
     assert_equal(bumped_psbt["origfee"], -watcher.gettransaction(original_txid)["fee"])
     assert not watcher.finalizepsbt(bumped_psbt["psbt"])["complete"]

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -22,8 +22,8 @@ from test_framework.util import (
     assert_approx,
     assert_equal,
     assert_fee_amount,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises_rpc_error,
     count_bytes,
     get_fee,
@@ -738,7 +738,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
 
-        assert_greater_than(len(dec_tx['vin']), 0) # at least one vin
+        assert_gt(len(dec_tx['vin']), 0) # at least one vin
         assert_equal(len(dec_tx['vout']), 2) # one change output added
 
     def test_watchonly(self):
@@ -769,7 +769,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(res_dec["vin"][0]["txid"], self.watchonly_utxo['txid'])
 
         assert "fee" in result.keys()
-        assert_greater_than(result["changepos"], -1)
+        assert_gt(result["changepos"], -1)
 
         wwatch.unloadwallet()
 
@@ -788,7 +788,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(len(res_dec["vin"]), 1)
         assert res_dec["vin"][0]["txid"] == self.watchonly_utxo['txid']
 
-        assert_greater_than(result["fee"], 0)
+        assert_gt(result["fee"], 0)
         assert_equal(result["changepos"], -1)
         assert_equal(result["fee"] + res_dec["vout"][0]["value"], self.watchonly_amount)
 
@@ -976,17 +976,17 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(share[1], 0)
 
         # The other 3 outputs are smaller as a result of subtractFeeFromOutputs.
-        assert_greater_than(share[0], 0)
-        assert_greater_than(share[2], 0)
-        assert_greater_than(share[3], 0)
+        assert_gt(share[0], 0)
+        assert_gt(share[2], 0)
+        assert_gt(share[3], 0)
 
         # Outputs 2 and 3 take the same share of the fee.
         assert_equal(share[2], share[3])
 
         # Output 0 takes at least as much share of the fee, and no more than 2
         # satoshis more, than outputs 2 and 3.
-        assert_greater_than_or_equal(share[0], share[2])
-        assert_greater_than_or_equal(share[2] + Decimal(2e-8), share[0])
+        assert_ge(share[0], share[2])
+        assert_ge(share[2] + Decimal(2e-8), share[0])
 
         # The fee is the same in both transactions.
         assert_equal(result[0]['fee'], result[1]['fee'])
@@ -1092,10 +1092,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(signed_tx["complete"], True)
         # Reducing the weight should have a lower fee
         funded_tx2 = wallet.fundrawtransaction(raw_tx, input_weights=[{"txid": ext_utxo["txid"], "vout": ext_utxo["vout"], "weight": low_input_weight}], fee_rate=2)
-        assert_greater_than(funded_tx["fee"], funded_tx2["fee"])
+        assert_gt(funded_tx["fee"], funded_tx2["fee"])
         # Increasing the weight should have a higher fee
         funded_tx2 = wallet.fundrawtransaction(raw_tx, input_weights=[{"txid": ext_utxo["txid"], "vout": ext_utxo["vout"], "weight": high_input_weight}], fee_rate=2)
-        assert_greater_than(funded_tx2["fee"], funded_tx["fee"])
+        assert_gt(funded_tx2["fee"], funded_tx["fee"])
         # The provided weight should override the calculated weight when solving data is provided
         funded_tx3 = wallet.fundrawtransaction(raw_tx, solving_data={"descriptors": [desc]}, input_weights=[{"txid": ext_utxo["txid"], "vout": ext_utxo["vout"], "weight": high_input_weight}], fee_rate=2)
         assert_equal(funded_tx2["fee"], funded_tx3["fee"])
@@ -1409,7 +1409,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         overhead_fees = feerate * len(tx) / 2 / 1000
         cost_of_change = change_tx["fee"] - no_change_tx["fee"]
         fees = no_change_tx["fee"]
-        assert_greater_than(fees, 0.01)
+        assert_gt(fees, 0.01)
 
         def do_fund_send(target):
             create_tx = tester.createrawtransaction([], [{funds.getnewaddress(): target}])
@@ -1427,7 +1427,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # The target value must be at most 2 - cost_of_change - not_input_fees - min_change (these are all
         # included in the target before ApproximateBestSubset).
         upper_bound = Decimal("2.0") - cost_of_change - overhead_fees - Decimal("0.01")
-        assert_greater_than_or_equal(upper_bound, lower_bound)
+        assert_ge(upper_bound, lower_bound)
         do_fund_send(lower_bound)
         do_fund_send(upper_bound)
 
@@ -1505,10 +1505,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.log.info("Craft a replacement adding inputs with highest depth possible")
         funded_tx2 = wallet.fundrawtransaction(raw_tx2, {'add_inputs': True, 'minconf': 2, 'fee_rate': 10})['hex']
         tx2_inputs = self.nodes[0].decoderawtransaction(funded_tx2)['vin']
-        assert_greater_than_or_equal(len(tx2_inputs), 2)
+        assert_ge(len(tx2_inputs), 2)
         for vin in tx2_inputs:
             if vin['txid'] != unconfirmed_txid:
-                assert_greater_than_or_equal(self.nodes[0].gettxout(vin['txid'], vin['vout'])['confirmations'], 2)
+                assert_ge(self.nodes[0].gettxout(vin['txid'], vin['vout'])['confirmations'], 2)
 
         final_tx2 = wallet.signrawtransactionwithwallet(funded_tx2)['hex']
         txid2 = self.nodes[0].sendrawtransaction(final_tx2)
@@ -1540,7 +1540,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         funded = wallet.fundrawtransaction(hexstring=tx, fee_rate=10)
 
         watchonly_funded = watchonly.fundrawtransaction(hexstring=tx, fee_rate=10)
-        assert_greater_than(watchonly_funded["fee"], funded["fee"])
+        assert_gt(watchonly_funded["fee"], funded["fee"])
 
 if __name__ == '__main__':
     RawTransactionsTest(__file__).main()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -24,7 +24,7 @@ from test_framework.script import hash160
 from test_framework.script_util import key_to_p2pkh_script, key_to_p2pk_script, script_to_p2sh_script, script_to_p2wsh_script
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
     find_vout_for_address,
     sha256sum_file,
@@ -170,7 +170,7 @@ class WalletMigrationTest(BitcoinTestFramework):
             # if the wallet has private keys and is not blank
             if wallet_info["private_keys_enabled"] and not wallet_info["blank"]:
                 lh_cache_recs = conn.execute(f"SELECT value FROM main where key >= x'{ser_string(b'walletdescriptorlhcache').hex()}' AND key < x'{ser_string(b'walletdescriptorlhcachf').hex()}'").fetchall()
-                assert_greater_than(len(lh_cache_recs), 0)
+                assert_gt(len(lh_cache_recs), 0)
 
         inspect_path = os.path.join(self.options.tmpdir, os.path.basename(f"{migrated_wallet_name}_inspect.dat"))
         wallet.backupwallet(inspect_path)

--- a/test/functional/wallet_musig.py
+++ b/test/functional/wallet_musig.py
@@ -10,7 +10,7 @@ from test_framework.key import H_POINT
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
 )
 
 PRIVKEY_RE = re.compile(r"^tr\((.+?)/.+\)#.{8}$")
@@ -303,7 +303,7 @@ class WalletMuSigTest(BitcoinTestFramework):
         assert_equal(finalized["complete"], True)
         witness = self.nodes[0].decodepsbt(finalized["psbt"])["inputs"][0]["final_scriptwitness"]
         if scriptpath:
-            assert_greater_than(len(witness), 1)
+            assert_gt(len(witness), 1)
         else:
             assert_equal(len(witness), 1)
         finalized = self.nodes[0].finalizepsbt(comb_psig_psbt)

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -19,7 +19,7 @@ import shutil
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
         assert_equal,
-        assert_greater_than,
+        assert_gt,
         assert_not_equal,
         assert_raises_rpc_error
 )
@@ -100,7 +100,7 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         # Restart to ensure node and wallet are flushed
         self.restart_node(0)
         wallet = node.get_wallet_rpc("reorg_crash")
-        assert_greater_than(wallet.getbalances()["mine"]["immature"], 0)
+        assert_gt(wallet.getbalances()["mine"]["immature"], 0)
 
         # Disconnect tip and sync wallet state
         tip = wallet.getbestblockhash()
@@ -127,7 +127,7 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         # coinbase. This was rescanned and now un-abandoned.
         wallet = node.get_wallet_rpc("reorg_crash")
         assert_equal(wallet.gettransaction(coinbase_tx_id)['details'][0]['abandoned'], False)
-        assert_greater_than(wallet.getbalances()["mine"]["immature"], 0)
+        assert_gt(wallet.getbalances()["mine"]["immature"], 0)
 
         # Previously, a bug caused the node to crash if two block disconnection events occurred consecutively.
         # Ensure this is no longer the case by simulating a new reorg.
@@ -140,7 +140,7 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         # And finally, verify the state if the block ends up being into the best chain again
         node.reconsiderblock(tip)
         assert_equal(wallet.gettransaction(coinbase_tx_id)['details'][0]['abandoned'], False)
-        assert_greater_than(wallet.getbalances()["mine"]["immature"], 0)
+        assert_gt(wallet.getbalances()["mine"]["immature"], 0)
 
     def run_test(self):
         # Send a tx from which to conflict outputs later

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -14,8 +14,8 @@ from test_framework.util import (
     assert_not_equal,
     assert_equal,
     assert_fee_amount,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises_rpc_error,
     count_bytes,
 )
@@ -152,7 +152,7 @@ class WalletSendTest(BitcoinTestFramework):
                 decoded_tx = from_wallet.gettransaction(txid=res["txid"], verbose=True)["decoded"]
                 # the locktime should be within 100 blocks of the
                 # block height
-                assert_greater_than_or_equal(decoded_tx["locktime"], from_wallet.getblockcount() - 100)
+                assert_ge(decoded_tx["locktime"], from_wallet.getblockcount() - 100)
 
         if expect_sign:
             assert_equal(res["complete"], True)
@@ -178,7 +178,7 @@ class WalletSendTest(BitcoinTestFramework):
                 if subtract_fee_from_outputs:
                     assert_equal(from_balance_before - from_balance, amount)
                 else:
-                    assert_greater_than(from_balance_before - from_balance, amount)
+                    assert_gt(from_balance_before - from_balance, amount)
             else:
                 assert next((out for out in tx["vout"] if out["scriptPubKey"]["asm"] == "OP_RETURN 35"), None)
         else:
@@ -418,7 +418,7 @@ class WalletSendTest(BitcoinTestFramework):
 
         self.log.info("Lock unspents...")
         utxo1 = w0.listunspent()[0]
-        assert_greater_than(utxo1["amount"], 1)
+        assert_gt(utxo1["amount"], 1)
         res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, inputs=[utxo1], add_to_wallet=False, lock_unspents=True)
         assert res["complete"]
         locked_coins = w0.listlockunspent()

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -10,8 +10,8 @@ from test_framework.messages import SEQUENCE_FINAL
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_gt,
+    assert_ge,
     assert_raises_rpc_error,
 )
 
@@ -55,7 +55,7 @@ class SendallTest(BitcoinTestFramework):
         for a in amounts:
             self.def_wallet.sendtoaddress(self.wallet.getnewaddress(), a)
         self.generate(self.nodes[0], 1)
-        assert_greater_than(self.wallet.getbalances()["mine"]["trusted"], 0)
+        assert_gt(self.wallet.getbalances()["mine"]["trusted"], 0)
         return self.wallet.getbalances()["mine"]["trusted"]
 
     # Helper schema for success cases
@@ -174,7 +174,7 @@ class SendallTest(BitcoinTestFramework):
         self.def_wallet.sendtoaddress(dust_wallet.getnewaddress(), 0.00000400)
         self.def_wallet.sendtoaddress(dust_wallet.getnewaddress(), 0.00000300)
         self.generate(self.nodes[0], 1)
-        assert_greater_than(dust_wallet.getbalances()["mine"]["trusted"], 0)
+        assert_gt(dust_wallet.getbalances()["mine"]["trusted"], 0)
 
         assert_raises_rpc_error(-6, "Total value of UTXO pool too low to pay for transaction."
                 + " Try using lower feerate or excluding uneconomic UTXOs with 'send_max' option.",
@@ -213,7 +213,7 @@ class SendallTest(BitcoinTestFramework):
         self.assert_tx_has_output(tx_from_wallet, self.remainder_target)
 
         self.generate(self.nodes[0], 1)
-        assert_greater_than(self.wallet.getbalances()["mine"]["trusted"], 0)
+        assert_gt(self.wallet.getbalances()["mine"]["trusted"], 0)
 
     @cleanup
     def sendall_fails_on_missing_input(self):
@@ -379,7 +379,7 @@ class SendallTest(BitcoinTestFramework):
         self.log.info("Test that sendall spends unconfirmed change")
         self.add_utxos([17])
         self.wallet.sendtoaddress(self.remainder_target, 10)
-        assert_greater_than(self.wallet.getbalances()["mine"]["trusted"], 6)
+        assert_gt(self.wallet.getbalances()["mine"]["trusted"], 6)
         self.test_sendall_success(sendall_args = [self.remainder_target])
 
         assert_equal(self.wallet.getbalance(), 0)
@@ -430,7 +430,7 @@ class SendallTest(BitcoinTestFramework):
         child_tx = self.wallet.decoderawtransaction(child_hex)
         lower_parent_feerate_amount = child_tx["vout"][0]["value"]
 
-        assert_greater_than(higher_parent_feerate_amount, lower_parent_feerate_amount)
+        assert_gt(higher_parent_feerate_amount, lower_parent_feerate_amount)
 
     @cleanup
     def sendall_anti_fee_sniping(self):
@@ -440,7 +440,7 @@ class SendallTest(BitcoinTestFramework):
 
         # the locktime should be within 100 blocks of the
         # block height
-        assert_greater_than_or_equal(tx_from_wallet["decoded"]["locktime"], tx_from_wallet["blockheight"] - 100)
+        assert_ge(tx_from_wallet["decoded"]["locktime"], tx_from_wallet["blockheight"] - 100)
 
         self.log.info("Testing sendall does not do anti-fee-sniping when locktime is specified")
         self.add_utxos([10,11])

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -13,7 +13,7 @@ import sys
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
 )
 
@@ -202,7 +202,7 @@ class WalletSignerTest(BitcoinTestFramework):
 
         # Bump fee
         res = hww.bumpfee(orig_tx_id)
-        assert_greater_than(res["fee"], res["origfee"])
+        assert_gt(res["fee"], res["origfee"])
         assert_equal(res["errors"], [])
 
 

--- a/test/functional/wallet_spend_unconfirmed.py
+++ b/test/functional/wallet_spend_unconfirmed.py
@@ -7,7 +7,7 @@ from decimal import Decimal, getcontext
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    assert_greater_than_or_equal,
+    assert_ge,
     assert_equal,
     find_vout_for_address,
 )
@@ -50,11 +50,11 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
     def assert_undershoots_target(self, tx):
         resulting_fee_rate = self.calc_fee_rate(tx)
-        assert_greater_than_or_equal(self.target_fee_rate, resulting_fee_rate)
+        assert_ge(self.target_fee_rate, resulting_fee_rate)
 
     def assert_beats_target(self, tx):
         resulting_fee_rate = self.calc_fee_rate(tx)
-        assert_greater_than_or_equal(resulting_fee_rate, self.target_fee_rate)
+        assert_ge(resulting_fee_rate, self.target_fee_rate)
 
     # Meta-Test: try feerate testing function on confirmed UTXO
     def test_target_feerate_confirmed(self):
@@ -104,8 +104,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([parent_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -131,8 +131,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([gp_tx, p_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -159,8 +159,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([p_one_tx, p_two_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -189,11 +189,11 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([p_high_tx, p_low_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
 
         resulting_bumped_ancestry_fee_rate = self.calc_set_fee_rate([p_low_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_bumped_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_bumped_ancestry_fee_rate)
+        assert_ge(resulting_bumped_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_bumped_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -218,11 +218,11 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([p_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
         resulting_ancestry_fee_rate_with_high_feerate_gp = self.calc_set_fee_rate([gp_tx, p_tx, ancestor_aware_tx])
         # Check that we bumped the parent without relying on the grandparent
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate_with_high_feerate_gp, self.target_fee_rate*1.1)
+        assert_ge(resulting_ancestry_fee_rate_with_high_feerate_gp, self.target_fee_rate*1.1)
 
         wallet.unloadwallet()
 
@@ -249,8 +249,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([gp_tx, p_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -271,8 +271,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([parent_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -297,8 +297,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([parent_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -319,18 +319,18 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([parent_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         bumped_ancestor_aware_txid = wallet.bumpfee(txid=to_be_rbfed_ancestor_aware_txid, options={"fee_rate": self.target_fee_rate * 2} )["txid"]
         bumped_ancestor_aware_tx = wallet.gettransaction(txid=bumped_ancestor_aware_txid, verbose=True)
         self.assert_spends_only_parents(ancestor_aware_tx, [parent_txid])
 
         resulting_bumped_fee_rate = self.calc_fee_rate(bumped_ancestor_aware_tx)
-        assert_greater_than_or_equal(resulting_bumped_fee_rate, 2*self.target_fee_rate)
+        assert_ge(resulting_bumped_fee_rate, 2*self.target_fee_rate)
         resulting_bumped_ancestry_fee_rate = self.calc_set_fee_rate([parent_tx, bumped_ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_bumped_ancestry_fee_rate, 2*self.target_fee_rate)
-        assert_greater_than_or_equal(2*self.target_fee_rate*1.01, resulting_bumped_ancestry_fee_rate)
+        assert_ge(resulting_bumped_ancestry_fee_rate, 2*self.target_fee_rate)
+        assert_ge(2*self.target_fee_rate*1.01, resulting_bumped_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -351,8 +351,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([two_output_parent_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -379,8 +379,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([parent_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -407,13 +407,13 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         self.assert_beats_target(ancestor_aware_tx)
         # Child is only paying for itself…
         resulting_fee_rate = self.calc_fee_rate(ancestor_aware_tx)
-        assert_greater_than_or_equal(1.05 * self.target_fee_rate, resulting_fee_rate)
+        assert_ge(1.05 * self.target_fee_rate, resulting_fee_rate)
         # …because sibling bumped to parent to ~50 s/vB, while our target is 30 s/vB
         resulting_ancestry_fee_rate_sibling = self.calc_set_fee_rate([parent_tx, sibling_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate_sibling, self.target_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate_sibling, self.target_fee_rate)
         # and our resulting "ancestry feerate" is therefore BELOW target feerate
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([parent_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(self.target_fee_rate, resulting_ancestry_fee_rate)
+        assert_ge(self.target_fee_rate, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 
@@ -430,7 +430,7 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         ancestor_aware_tx = wallet.gettransaction(txid=ancestor_aware_txid, verbose=True)
         self.assert_spends_only_parents(ancestor_aware_tx, [confirmed_parent_txid, unconfirmed_parent_txid])
         resulting_fee_rate = self.calc_fee_rate(ancestor_aware_tx)
-        assert_greater_than_or_equal(resulting_fee_rate, self.target_fee_rate)
+        assert_ge(resulting_fee_rate, self.target_fee_rate)
 
         wallet.unloadwallet()
 
@@ -457,8 +457,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         self.assert_beats_target(ancestor_aware_tx)
         resulting_ancestry_fee_rate = self.calc_set_fee_rate([parent_tx, ancestor_aware_tx])
-        assert_greater_than_or_equal(resulting_ancestry_fee_rate, self.target_fee_rate)
-        assert_greater_than_or_equal(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
+        assert_ge(resulting_ancestry_fee_rate, self.target_fee_rate)
+        assert_ge(self.target_fee_rate*1.01, resulting_ancestry_fee_rate)
 
         wallet.unloadwallet()
 

--- a/test/functional/wallet_v3_txs.py
+++ b/test/functional/wallet_v3_txs.py
@@ -26,7 +26,7 @@ from test_framework.blocktools import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_gt,
     assert_raises_rpc_error,
 )
 
@@ -140,7 +140,7 @@ class WalletV3Test(BitcoinTestFramework):
         self.send_tx(self.charlie, [], outputs, version_a)
 
         assert_equal(self.bob.getbalances()["mine"]["trusted"], 0)
-        assert_greater_than(self.bob.getbalances()["mine"]["untrusted_pending"], 0)
+        assert_gt(self.bob.getbalances()["mine"]["untrusted_pending"], 0)
 
         outputs = {self.alice.getnewaddress() : 1.0}
 
@@ -161,7 +161,7 @@ class WalletV3Test(BitcoinTestFramework):
         self.send_tx(self.charlie, [], outputs, version_a)
 
         assert_equal(self.bob.getbalances()["mine"]["trusted"], 0)
-        assert_greater_than(self.bob.getbalances()["mine"]["untrusted_pending"], 0)
+        assert_gt(self.bob.getbalances()["mine"]["untrusted_pending"], 0)
 
         outputs = {self.alice.getnewaddress() : 1.0}
 
@@ -566,7 +566,7 @@ class WalletV3Test(BitcoinTestFramework):
         self.send_tx(self.charlie, [], outputs, 1)
 
         assert_equal(self.bob.getbalances()["mine"]["trusted"], 0)
-        assert_greater_than(self.bob.getbalances()["mine"]["untrusted_pending"], 0)
+        assert_gt(self.bob.getbalances()["mine"]["untrusted_pending"], 0)
 
         outputs = {self.alice.getnewaddress() : 1.0}
 


### PR DESCRIPTION
### Problem

The functional test framework's `assert_greater_than` and `assert_greater_than_or_equal` helper names are verbose, discouraging their use despite providing better error messages for debugging intermittent failures.
They're also using a different nomenclature for comparison than what we're used to on C++ side.

### Fix

Rename them to `assert_gt` and `assert_ge` via a scripted diff to align with the C++ `BOOST_CHECK_GT`/`BOOST_CHECK_GE` naming.

Discussed in https://github.com/bitcoin/bitcoin/pull/34328#discussion_r2705415238