### PR TITLE
fuzz: pull the latest FuzzedDataProvider.h from upstream

### DIFF
--- a/src/test/fuzz/FuzzedDataProvider.h
+++ b/src/test/fuzz/FuzzedDataProvider.h
@@ -314,7 +314,6 @@ T FuzzedDataProvider::PickValueInArray(const std::array<T, size> &array) {
 
 template <typename T>
 T FuzzedDataProvider::PickValueInArray(std::initializer_list<const T> list) {
-  // TODO(Dor1s): switch to static_assert once C++14 is allowed.
   if (!list.size())
     abort();
 
@@ -381,13 +380,13 @@ TS FuzzedDataProvider::ConvertUnsignedToSigned(TU value) {
   static_assert(!std::numeric_limits<TU>::is_signed,
                 "Source type must be unsigned.");
 
-  // TODO(Dor1s): change to `if constexpr` once C++17 becomes mainstream.
-  if (std::numeric_limits<TS>::is_modulo)
+  if constexpr (std::numeric_limits<TS>::is_modulo)
     return static_cast<TS>(value);
 
   // Avoid using implementation-defined unsigned to signed conversions.
   // To learn more, see https://stackoverflow.com/questions/13150449.
-  if (value <= std::numeric_limits<TS>::max()) {
+  constexpr auto TS_max = static_cast<TU>(std::numeric_limits<TS>::max());
+  if (value <= TS_max) {
     return static_cast<TS>(value);
   } else {
     constexpr auto TS_min = std::numeric_limits<TS>::min();


### PR DESCRIPTION
Pulls down the latest version of https://github.com/llvm/llvm-project/blob/main/compiler-rt/include/fuzzer/FuzzedDataProvider.h, after https://github.com/llvm/llvm-project/pull/177794 was merged upstream.

just a note that in C++20 unsigned‑to‑signed conversion is no longer implementation defined so this is effectively a no‑op in Core and this is mainly an upstream cleanup update