### PR TITLE
doc: Fix grammar in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ about Git.
 ### Creating the Pull Request
 
 The title of the pull request should be prefixed by the component or area that
-the pull request affects. Valid areas as:
+the pull request affects. Valid areas are:
 
   - `consensus` for changes to consensus critical code
   - `doc` for changes to the documentation


### PR DESCRIPTION
## Summary
Fix grammatical error in the contributing guidelines.

## Changes
- Change "Valid areas as:" to "Valid areas are:" for proper grammar

This is a minor documentation improvement to enhance readability.
