### PR TITLE
wallet: skip APS when no partial spend exists

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1235,6 +1235,28 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
            result.GetWaste(),
            result.GetSelectedValue());
 
+    // Check for partial spend: spending some but not all UTXOs from any scriptPubKey
+    bool has_partial_spend{false};
+    if (coin_control.m_allow_other_inputs) {
+        std::map<CScript, std::pair<size_t, size_t>> spk_counts; // {available, selected}
+        for (const auto& coin : available_coins.All()) {
+            spk_counts[coin.txout.scriptPubKey].first++;
+        }
+        // Also count preset inputs as available (they're wallet UTXOs too)
+        for (const auto& coin : preset_inputs.All()) {
+            spk_counts[coin.txout.scriptPubKey].first++;
+        }
+        for (const auto& coin : result.GetInputSet()) {
+            spk_counts[coin->txout.scriptPubKey].second++;
+        }
+        for (const auto& [spk, counts] : spk_counts) {
+            if (counts.second > 0 && counts.second < counts.first) {
+                has_partial_spend = true;
+                break;
+            }
+        }
+    }
+
     // vouts to the payees
     txNew.vout.reserve(vecSend.size() + 1); // + 1 because of possible later insert
     for (const auto& recipient : vecSend)
@@ -1428,7 +1450,7 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
               feeCalc.est.fail.start, feeCalc.est.fail.end,
               (feeCalc.est.fail.totalConfirmed + feeCalc.est.fail.inMempool + feeCalc.est.fail.leftMempool) > 0.0 ? 100 * feeCalc.est.fail.withinTarget / (feeCalc.est.fail.totalConfirmed + feeCalc.est.fail.inMempool + feeCalc.est.fail.leftMempool) : 0.0,
               feeCalc.est.fail.withinTarget, feeCalc.est.fail.totalConfirmed, feeCalc.est.fail.inMempool, feeCalc.est.fail.leftMempool);
-    return CreatedTransactionResult(tx, current_fee, change_pos, feeCalc);
+    return CreatedTransactionResult(tx, current_fee, change_pos, feeCalc, has_partial_spend);
 }
 
 util::Result<CreatedTransactionResult> CreateTransaction(
@@ -1456,8 +1478,8 @@ util::Result<CreatedTransactionResult> CreateTransaction(
            res && res->change_pos.has_value() ? int32_t(*res->change_pos) : -1);
     if (!res) return res;
     const auto& txr_ungrouped = *res;
-    // try with avoidpartialspends unless it's enabled already
-    if (txr_ungrouped.fee > 0 /* 0 means non-functional fee rate estimation */ && wallet.m_max_aps_fee > -1 && !coin_control.m_avoid_partial_spends) {
+    // try with avoidpartialspends unless it's enabled already, or if there's no partial spend to avoid
+    if (txr_ungrouped.fee > 0 /* 0 means non-functional fee rate estimation */ && wallet.m_max_aps_fee > -1 && !coin_control.m_avoid_partial_spends && txr_ungrouped.has_partial_spend) {
         TRACEPOINT(coin_selection, attempting_aps_create_tx, wallet.GetName().c_str());
         CCoinControl tmp_cc = coin_control;
         tmp_cc.m_avoid_partial_spends = true;

--- a/src/wallet/types.h
+++ b/src/wallet/types.h
@@ -37,9 +37,11 @@ struct CreatedTransactionResult
     CAmount fee;
     FeeCalculation fee_calc;
     std::optional<unsigned int> change_pos;
+    /** Whether the selection spends only some UTXOs from any scriptPubKey (relevant for APS) */
+    bool has_partial_spend{false};
 
-    CreatedTransactionResult(CTransactionRef _tx, CAmount _fee, std::optional<unsigned int> _change_pos, const FeeCalculation& _fee_calc)
-            : tx(_tx), fee(_fee), fee_calc(_fee_calc), change_pos(_change_pos) {}
+    CreatedTransactionResult(CTransactionRef _tx, CAmount _fee, std::optional<unsigned int> _change_pos, const FeeCalculation& _fee_calc, bool _has_partial_spend = false)
+            : tx(_tx), fee(_fee), fee_calc(_fee_calc), change_pos(_change_pos), has_partial_spend(_has_partial_spend) {}
 };
 
 } // namespace wallet


### PR DESCRIPTION
Fixes #25150

APS (Avoid Partial Spends) runs a second coin selection pass to fully spend
UTXOs sharing a scriptPubKey. This currently runs unconditionally, even when
the first selection has no partial spend. Running APS unnecessarily wastes
computation and can produce a worse result when there was nothing to fix.

Detect partial spends by comparing selected vs available UTXO counts per
scriptPubKey, reusing available_coins. Skip APS if none found.

Test updated to create partial spend scenarios so tracepoints fire.

---

*Supersedes #34362 which was corrupted by a shallow clone force-push.*