### PR TITLE
ci: remove gnu-getopt usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           # A workaround for "The `brew link` step did not complete successfully" error.
           brew install --quiet python@3 || brew link --overwrite python@3
-          brew install --quiet coreutils ninja pkgconf gnu-getopt ccache boost libevent zeromq qt@6 qrencode capnp
+          brew install --quiet coreutils ninja pkgconf ccache boost libevent zeromq qt@6 qrencode capnp
 
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"

--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -8,7 +8,7 @@ export LC_ALL=C
 
 set -o errexit -o pipefail -o xtrace
 
-export CI_RETRY_EXE="/ci_retry --"
+export CI_RETRY_EXE="/ci_retry"
 
 pushd "/"
 

--- a/ci/retry/retry
+++ b/ci/retry/retry
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-GETOPT_BIN=$IN_GETOPT_BIN
-GETOPT_BIN=${GETOPT_BIN:-getopt}
-
 __sleep_amount() {
   if [ -n "$constant_sleep" ]; then
     sleep_time=$constant_sleep
@@ -71,93 +68,10 @@ retry()
   exit $return_code
 }
 
-# If we're being sourced, don't worry about such things
-if [ "$BASH_SOURCE" == "$0" ]; then
-  # Prints the help text
-  help()
-  {
-    local retry=$(basename $0)
-    cat <<EOF
-Usage: $retry [options] -- execute command
-    -h, -?, --help
-    -v, --verbose                    Verbose output
-    -t, --tries=#                    Set max retries: Default 10
-    -s, --sleep=secs                 Constant sleep amount (seconds)
-    -m, --min=secs                   Exponential Backoff: minimum sleep amount (seconds): Default 0.3
-    -x, --max=secs                   Exponential Backoff: maximum sleep amount (seconds): Default 60
-    -f, --fail="script +cmds"        Fail Script: run in case of final failure
-EOF
-  }
-
-  # show help for no arguments if stdin is a terminal
-  if { [ -z "$1" ] && [ -t 0 ] ; } || [ "$1" == '-h' ] || [ "$1" == '-?' ] || [ "$1" == '--help' ]
-  then
-    help
-    exit 0
-  fi
-
-  $GETOPT_BIN --test > /dev/null
-  if [[ $? -ne 4 ]]; then
-      echo "I’m sorry, 'getopt --test' failed in this environment. Please load GNU getopt."
-      exit 1
-  fi
-
-  OPTIONS=vt:s:m:x:f:
-  LONGOPTIONS=verbose,tries:,sleep:,min:,max:,fail:
-
-  PARSED=$($GETOPT_BIN --options="$OPTIONS" --longoptions="$LONGOPTIONS" --name "$0" -- "$@")
-  if [[ $? -ne 0 ]]; then
-    # e.g. $? == 1
-    #  then getopt has complained about wrong arguments to stdout
-    exit 2
-  fi
-  # read getopt’s output this way to handle the quoting right:
-  eval set -- "$PARSED"
-
   max_tries=10
   min_sleep=0.3
   max_sleep=60.0
   constant_sleep=
   fail_script=
 
-  # now enjoy the options in order and nicely split until we see --
-  while true; do
-      case "$1" in
-          -v|--verbose)
-              VERBOSE=true
-              shift
-              ;;
-          -t|--tries)
-              max_tries="$2"
-              shift 2
-              ;;
-          -s|--sleep)
-              constant_sleep="$2"
-              shift 2
-              ;;
-          -m|--min)
-              min_sleep="$2"
-              shift 2
-              ;;
-          -x|--max)
-              max_sleep="$2"
-              shift 2
-              ;;
-          -f|--fail)
-              fail_script="$2"
-              shift 2
-              ;;
-          --)
-              shift
-              break
-              ;;
-          *)
-              echo "Programming error"
-              exit 3
-              ;;
-      esac
-  done
-
   retry "$max_tries" "$min_sleep" "$max_sleep" "$constant_sleep" "$fail_script" "$@"
-
-fi

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -62,7 +62,7 @@ export PREVIOUS_RELEASES_DIR=${PREVIOUS_RELEASES_DIR:-$BASE_ROOT_DIR/prev_releas
 export CI_BASE_PACKAGES=${CI_BASE_PACKAGES:-build-essential pkgconf curl ca-certificates ccache python3-dev rsync git procps bison e2fsprogs cmake ninja-build}
 export GOAL=${GOAL:-install}
 export DIR_QA_ASSETS=${DIR_QA_ASSETS:-${BASE_SCRATCH_DIR}/qa-assets}
-export CI_RETRY_EXE=${CI_RETRY_EXE:-"retry --"}
+export CI_RETRY_EXE=${CI_RETRY_EXE:-"retry"}
 
 # The --platform argument used with `docker build` and `docker run`.
 export CI_IMAGE_PLATFORM=${CI_IMAGE_PLATFORM:-"linux"} # Force linux, but use native arch by default

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -58,14 +58,6 @@ def main():
 
         # Modify PATH to prepend the retry script, needed for CI_RETRY_EXE
         os.environ["PATH"] = f"{os.environ['BASE_ROOT_DIR']}/ci/retry:{os.environ['PATH']}"
-        # GNU getopt is required for the CI_RETRY_EXE script
-        if os.getenv("CI_OS_NAME") == "macos":
-            prefix = run(
-                ["brew", "--prefix", "gnu-getopt"],
-                stdout=subprocess.PIPE,
-                text=True,
-            ).stdout.strip()
-            os.environ["IN_GETOPT_BIN"] = f"{prefix}/bin/getopt"
     else:
         CI_IMAGE_LABEL = "bitcoin-ci-test"
 


### PR DESCRIPTION
This is used for argument parsing in the `retry` script, however we don't use the script with any arguments. So remove the unused code, and the dependency on `gnu-getopt`.

This came up in the context of adding new CI jobs, where gnu-getopt might not be available, or working properly. It seemed easier to just remove the unused code, than look for more workarounds.