### PR TITLE
test: use `ModuleNotFoundError` in `interface_ipc.py`

### DIFF
--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -42,7 +42,7 @@ class CoinbaseTxData:
 # Test may be skipped and not have capnp installed
 try:
     import capnp  # type: ignore[import] # noqa: F401
-except ImportError:
+except ModuleNotFoundError:
     pass
 
 @asynccontextmanager


### PR DESCRIPTION
Change this so we catch the case where the capnp shared libs have been updated, and can no-longer be loaded by the Python module, resulting in a skipped test, even though pycapnp is installed. i.e:
```bash
stderr:
Traceback (most recent call last):
  File "/root/ci_scratch/build/test/functional/interface_ipc.py", line 20, in <module>
    import capnp  # type: ignore[import] # noqa: F401
    ^^^^^^^^^^^^
  File "/usr/local/lib64/python3.14/site-packages/capnp/__init__.py", line 36, in <module>
    from .version import version as __version__
  File "/usr/local/lib64/python3.14/site-packages/capnp/version.py", line 1, in <module>
    from .lib.capnp import _CAPNP_VERSION_MAJOR as LIBCAPNP_VERSION_MAJOR  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: libcapnpc.so.1.0.1: cannot open shared object file: No such file or directory
```

Failing in this way should make it clear that `pycapnp` needs to be reinstalled/rebuilt.

If  `pycapnp` is not installed, the test still skips as expected:
```bash
Remaining jobs: [interface_ipc.py]
1/1 - interface_ipc.py skipped (capnp module not available.)

TEST             | STATUS    | DURATION

interface_ipc.py | ○ Skipped | 0 s
```

Fixes: #34016.