### PR TITLE
test: assert shift-by-zero identity for arith_uint256

### DIFF
--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -65,6 +65,14 @@ static std::string ArrayToString(const unsigned char A[], unsigned int width)
 
 BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
 {
+    BOOST_CHECK((ZeroL << 0) == ZeroL);
+    BOOST_CHECK((ZeroL >> 0) == ZeroL);
+    BOOST_CHECK((OneL << 0) == OneL);
+    BOOST_CHECK((OneL >> 0) == OneL);
+    BOOST_CHECK((R1L << 0) == R1L);
+    BOOST_CHECK((R1L >> 0) == R1L);
+    BOOST_CHECK((MaxL << 0) == MaxL);
+    BOOST_CHECK((MaxL >> 0) == MaxL);
     BOOST_CHECK(1 == 0+1);
     // constructor arith_uint256(vector<char>):
     BOOST_CHECK(R1L.ToString() == ArrayToString(R1Array,32));


### PR DESCRIPTION
This adds explicit unit test assertions that left- and right-shifting
arith_uint256 values by zero bits is identity-preserving.

While implicitly covered by existing loops, making this invariant
explicit improves clarity and guards against future regressions.
