### PR TITLE
Add nullptr-check to CChain::Contains(), tests

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -409,6 +409,7 @@ public:
     /** Efficiently check whether a block is present in this chain. */
     bool Contains(const CBlockIndex* pindex) const
     {
+        if (!pindex) return false;
         return (*this)[pindex->nHeight] == pindex;
     }
 

--- a/src/test/chain_tests.cpp
+++ b/src/test/chain_tests.cpp
@@ -41,6 +41,43 @@ const CBlockIndex* NaiveLastCommonAncestor(const CBlockIndex* a, const CBlockInd
 
 } // namespace
 
+BOOST_AUTO_TEST_CASE(cchain_basic_tests)
+{
+    // An empty chain
+    const auto chain_0 = CChain{};
+    // A chain with 2 blocks
+    auto chain_2 = CChain{};
+    auto genesis = CBlockIndex{};
+    genesis.nHeight = 0;
+    chain_2.SetTip(genesis);
+    auto bi1 = CBlockIndex{};
+    bi1.nHeight = 1;
+    chain_2.SetTip(bi1);
+
+    BOOST_CHECK_EQUAL(chain_0.Height(), -1);
+    BOOST_CHECK_EQUAL(chain_2.Height(), 1);
+
+    BOOST_CHECK_EQUAL(chain_0.Tip(), nullptr);
+    BOOST_CHECK_EQUAL(chain_2.Tip(), &bi1);
+
+    // Indexer accessor: call with valid and invalid (low & high) values
+    BOOST_CHECK_EQUAL(chain_2[0], &genesis);
+    BOOST_CHECK_EQUAL(chain_2[1], &bi1);
+    BOOST_CHECK_EQUAL(chain_2[-1], nullptr);
+    BOOST_CHECK_EQUAL(chain_2[2], nullptr);
+
+    // Contains: call with contained & non-contained blocks, and with nullptr
+    BOOST_CHECK_EQUAL(chain_2.Contains(&genesis), true);
+    BOOST_CHECK_EQUAL(chain_2.Contains(&bi1), true);
+    BOOST_CHECK_EQUAL(chain_0.Contains(&bi1), false);
+    // BOOST_CHECK_EQUAL(chain_0.Contains(nullptr), false); // fail with memory access violation
+
+    // Call with non-tip & tip blocks, and with nulltr
+    BOOST_CHECK_EQUAL(chain_2.Next(&genesis), &bi1);
+    BOOST_CHECK_EQUAL(chain_2.Next(&bi1), nullptr);
+    // BOOST_CHECK_EQUAL(chain_0.Next(nullptr), nullptr); // fail with memory access violation
+}
+
 BOOST_AUTO_TEST_CASE(chain_test)
 {
     FastRandomContext ctx;

--- a/src/test/chain_tests.cpp
+++ b/src/test/chain_tests.cpp
@@ -70,12 +70,12 @@ BOOST_AUTO_TEST_CASE(cchain_basic_tests)
     BOOST_CHECK_EQUAL(chain_2.Contains(&genesis), true);
     BOOST_CHECK_EQUAL(chain_2.Contains(&bi1), true);
     BOOST_CHECK_EQUAL(chain_0.Contains(&bi1), false);
-    // BOOST_CHECK_EQUAL(chain_0.Contains(nullptr), false); // fail with memory access violation
+    BOOST_CHECK_EQUAL(chain_0.Contains(nullptr), false);
 
     // Call with non-tip & tip blocks, and with nulltr
     BOOST_CHECK_EQUAL(chain_2.Next(&genesis), &bi1);
     BOOST_CHECK_EQUAL(chain_2.Next(&bi1), nullptr);
-    // BOOST_CHECK_EQUAL(chain_0.Next(nullptr), nullptr); // fail with memory access violation
+    BOOST_CHECK_EQUAL(chain_0.Next(nullptr), nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(chain_test)


### PR DESCRIPTION
Add unit tests to the `CChain` class, and add a nullptr-check to `CChain::Contains()` to avoid potential memory access violation by `nullptr` dereference.

The `CChain::Contains()` method (in `src/chain.h`) dereferences its input without checking. The `Next()` method also calls into this with a `nullptr` if invoked with `nullptr`. While most call sites have indirect guarantee that the input is not `nullptr`, it's not easy to establish this to all call sites with high confidence. These methods are publicly available. There is no known high-level use case to trigger this error, but the fix is easy, and makes the code safer.

Also, unit tests were added to the `CChain` class, filling a gap.

Changes:

- Add basic unit tests for `CChain` class methods
- Add a nullptr-check to `CChain::Contains()`

Alternative. I have considered changing `Contains()` to take a reference instead of pointer, however, when applying that to various methods, it grew to a much bigger changeset -- see #34440. Having in mind the friction of larger PRs, I think the present minimal one-check solution (with the tests) makes sense on its own.

This change is remotely related to and indirectly triggered by #32875 .
