### PR TITLE
mining: add coinbase locktime and sequence fields to getblocktemplate RPC

### DIFF
--- a/doc/release-notes-34419.md
+++ b/doc/release-notes-34419.md
@@ -1,0 +1,7 @@
+Updated RPCs
+------------
+
+- Added `coinbase_locktime` and `coinbase_sequence` to the `getblocktemplate`
+  response to prepare for a possible BIP54 deployment in the future. There is
+  no corresponding change for IPC clients, since `getCoinbaseTx()` already
+  includes these fields.

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -681,6 +681,8 @@ static RPCHelpMan getblocktemplate()
                     {RPCResult::Type::STR_HEX, "key", "values must be in the coinbase (keys may be ignored)"},
                 }},
                 {RPCResult::Type::NUM, "coinbasevalue", "maximum allowable input to coinbase transaction, including the generation award and transaction fees (in satoshis)"},
+                {RPCResult::Type::NUM, "coinbase_locktime", "locktime for the coinbase transaction"},
+                {RPCResult::Type::NUM, "coinbase_sequence", "sequence for the coinbase input"},
                 {RPCResult::Type::STR, "longpollid", "an id to include with a request to longpoll on an update to this template"},
                 {RPCResult::Type::STR, "target", "The hash target"},
                 {RPCResult::Type::NUM_TIME, "mintime", "The minimum timestamp appropriate for the next block time, expressed in " + UNIX_EPOCH_TIME + ". Adjusted for the proposed BIP94 timewarp rule."},
@@ -990,6 +992,8 @@ static RPCHelpMan getblocktemplate()
     result.pushKV("coinbaseaux", std::move(aux));
     const node::CoinbaseTx coinbase_tx{block_template->getCoinbaseTx()};
     result.pushKV("coinbasevalue", coinbase_tx.block_reward_remaining);
+    result.pushKV("coinbase_locktime", coinbase_tx.lock_time);
+    result.pushKV("coinbase_sequence", coinbase_tx.sequence);
     result.pushKV("longpollid", tip.GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", GetMinimumTime(pindexPrev, consensusParams.DifficultyAdjustmentInterval()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -988,7 +988,8 @@ static RPCHelpMan getblocktemplate()
     result.pushKV("previousblockhash", block.hashPrevBlock.GetHex());
     result.pushKV("transactions", std::move(transactions));
     result.pushKV("coinbaseaux", std::move(aux));
-    result.pushKV("coinbasevalue", block.vtx[0]->vout[0].nValue);
+    const node::CoinbaseTx coinbase_tx{block_template->getCoinbaseTx()};
+    result.pushKV("coinbasevalue", coinbase_tx.block_reward_remaining);
     result.pushKV("longpollid", tip.GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", GetMinimumTime(pindexPrev, consensusParams.DifficultyAdjustmentInterval()));

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -418,6 +418,8 @@ class MiningTest(BitcoinTestFramework):
         self.log.info("getblocktemplate: Test capability advertised")
         assert 'proposal' in tmpl['capabilities']
         assert 'coinbasetxn' not in tmpl
+        assert_equal(tmpl["coinbase_locktime"], int(tmpl["height"]) - 1)
+        assert_equal(tmpl["coinbase_sequence"], MAX_SEQUENCE_NONFINAL)
 
         next_height = int(tmpl["height"])
         coinbase_tx = create_coinbase(height=next_height)


### PR DESCRIPTION
[BIP54](https://github.com/bitcoin/bips/blob/master/bip-0054.md) proposes contraining the cointbase transaction `nLockTime` and `nSequence` fields. Our internal mining code has been doing this since #32155, but currently the fields are only communicated to IPC clients (see e.g. #33819).

This PR extends the `getblocktemplate` RPC to provide these fields.

Accompanying proposed extension to BIP54: https://github.com/bitcoin/bips/pull/2097

Even if BIP54 never activates, it makes sense to serve these new fields.