### PR TITLE
consensus: disable min difficulty blocks on testnet4 after height 151,200

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -117,7 +117,7 @@ struct Params {
     /**
      * Block height at which the min difficulty blocks feature is disabled via hard fork.
      * Set to 0 to never disable (default behavior for testnet3, regtest).
-     * For testnet4, this is set to 201600 to fix the difficulty reset exploit.
+     * For testnet4, this is set to 151200 to fix the difficulty reset exploit.
      */
     int min_difficulty_fork_height{0};
     /**

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -115,7 +115,7 @@ struct Params {
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
     /**
-     * Block height at which the min difficulty blocks feature is disabled via soft fork.
+     * Block height at which the min difficulty blocks feature is disabled via hard fork.
      * Set to 0 to never disable (default behavior for testnet3, regtest).
      * For testnet4, this is set to 151200 to fix the difficulty reset exploit.
      */

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -115,7 +115,7 @@ struct Params {
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
     /**
-     * Block height at which the min difficulty blocks feature is disabled via hard fork.
+     * Block height at which the min difficulty blocks feature is disabled via soft fork.
      * Set to 0 to never disable (default behavior for testnet3, regtest).
      * For testnet4, this is set to 151200 to fix the difficulty reset exploit.
      */

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -119,7 +119,7 @@ struct Params {
      * Set to 0 to never disable (default behavior for testnet3, regtest).
      * For testnet4, this is set to 151200 to fix the difficulty reset exploit.
      */
-    int nMinDifficultyBlocksForkHeight{0};
+    int min_difficulty_fork_height{0};
     /**
       * Enforce BIP94 timewarp attack mitigation. On testnet4 this also enforces
       * the block storm mitigation.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -117,7 +117,7 @@ struct Params {
     /**
      * Block height at which the min difficulty blocks feature is disabled via hard fork.
      * Set to 0 to never disable (default behavior for testnet3, regtest).
-     * For testnet4, this is set to 151200 to fix the difficulty reset exploit.
+     * For testnet4, this is set to 201600 to fix the difficulty reset exploit.
      */
     int min_difficulty_fork_height{0};
     /**

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -115,6 +115,12 @@ struct Params {
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
     /**
+     * Block height at which the min difficulty blocks feature is disabled via hard fork.
+     * Set to 0 to never disable (default behavior for testnet3, regtest).
+     * For testnet4, this is set to 151200 to fix the difficulty reset exploit.
+     */
+    int nMinDifficultyBlocksForkHeight{0};
+    /**
       * Enforce BIP94 timewarp attack mitigation. On testnet4 this also enforces
       * the block storm mitigation.
       */

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -319,7 +319,7 @@ public:
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
-        consensus.min_difficulty_fork_height = 151200; // Hard fork to disable min difficulty blocks (epoch 75 boundary)
+        consensus.min_difficulty_fork_height = 201600; // Hard fork to disable min difficulty blocks (epoch 100 boundary)
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -319,7 +319,7 @@ public:
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
-        consensus.nMinDifficultyBlocksForkHeight = 151200; // Hard fork to disable min difficulty blocks (epoch 75 boundary)
+        consensus.min_difficulty_fork_height = 151200; // Hard fork to disable min difficulty blocks (epoch 75 boundary)
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -319,7 +319,7 @@ public:
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
-        consensus.min_difficulty_fork_height = 129024; // Hard fork to disable min difficulty blocks (epoch 100 boundary)
+        consensus.min_difficulty_fork_height = 151200; // Hard fork to disable min difficulty blocks (epoch 75 boundary)
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -319,7 +319,7 @@ public:
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
-        consensus.min_difficulty_fork_height = 201600; // Hard fork to disable min difficulty blocks (epoch 100 boundary)
+        consensus.min_difficulty_fork_height = 129024; // Hard fork to disable min difficulty blocks (epoch 100 boundary)
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -319,7 +319,7 @@ public:
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
-        consensus.min_difficulty_fork_height = 151200; // Hard fork to disable min difficulty blocks (epoch 75 boundary)
+        consensus.min_difficulty_fork_height = 151200; // Soft fork to disable min difficulty blocks (epoch 75 boundary)
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -319,6 +319,7 @@ public:
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
+        consensus.nMinDifficultyBlocksForkHeight = 151200; // Hard fork to disable min difficulty blocks (epoch 75 boundary)
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -319,7 +319,7 @@ public:
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
-        consensus.min_difficulty_fork_height = 151200; // Soft fork to disable min difficulty blocks (epoch 75 boundary)
+        consensus.min_difficulty_fork_height = 151200; // Hard fork to disable min difficulty blocks (epoch 75 boundary)
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -404,8 +404,13 @@ std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainma
         // Must release m_tip_block_mutex before locking cs_main, to avoid deadlocks.
         LOCK(::cs_main);
 
-        // On test networks return a minimum difficulty block after 20 minutes
-        if (!tip_changed && allow_min_difficulty) {
+        // On test networks return a minimum difficulty block after 20 minutes,
+        // but only if we haven't reached the fork height that disables this feature.
+        const auto& consensus = chainman.GetParams().GetConsensus();
+        const int nNextHeight = chainman.ActiveChain().Tip()->nHeight + 1;
+        const bool fAllowMinDifficulty = allow_min_difficulty &&
+            (consensus.nMinDifficultyBlocksForkHeight == 0 || nNextHeight < consensus.nMinDifficultyBlocksForkHeight);
+        if (!tip_changed && fAllowMinDifficulty) {
             const NodeClock::time_point tip_time{std::chrono::seconds{chainman.ActiveChain().Tip()->GetBlockTime()}};
             if (now > tip_time + 20min) {
                 tip_changed = true;

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -406,12 +406,14 @@ std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainma
 
         // On test networks return a minimum difficulty block after 20 minutes,
         // but only if we haven't reached the fork height that disables this feature.
-        const auto& consensus = chainman.GetParams().GetConsensus();
-        const int next_height = chainman.ActiveChain().Tip()->nHeight + 1;
-        if (!tip_changed && allow_min_difficulty && AllowMinDifficultyBlocks(consensus, next_height)) {
-            const NodeClock::time_point tip_time{std::chrono::seconds{chainman.ActiveChain().Tip()->GetBlockTime()}};
-            if (now > tip_time + 20min) {
-                tip_changed = true;
+        if (!tip_changed && allow_min_difficulty) {
+            const auto& consensus = chainman.GetParams().GetConsensus();
+            const int next_height = chainman.ActiveChain().Tip()->nHeight + 1;
+            if (AllowMinDifficultyBlocks(consensus, next_height)) {
+                const NodeClock::time_point tip_time{std::chrono::seconds{chainman.ActiveChain().Tip()->GetBlockTime()}};
+                if (now > tip_time + 20min) {
+                    tip_changed = true;
+                }
             }
         }
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -407,10 +407,8 @@ std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainma
         // On test networks return a minimum difficulty block after 20 minutes,
         // but only if we haven't reached the fork height that disables this feature.
         const auto& consensus = chainman.GetParams().GetConsensus();
-        const int nNextHeight = chainman.ActiveChain().Tip()->nHeight + 1;
-        const bool fAllowMinDifficulty = allow_min_difficulty &&
-            (consensus.nMinDifficultyBlocksForkHeight == 0 || nNextHeight < consensus.nMinDifficultyBlocksForkHeight);
-        if (!tip_changed && fAllowMinDifficulty) {
+        const int next_height = chainman.ActiveChain().Tip()->nHeight + 1;
+        if (!tip_changed && allow_min_difficulty && AllowMinDifficultyBlocks(consensus, next_height)) {
             const NodeClock::time_point tip_time{std::chrono::seconds{chainman.ActiveChain().Tip()->GetBlockTime()}};
             if (now > tip_time + 20min) {
                 tip_changed = true;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -34,10 +34,12 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 
     const int next_height = pindexLast->nHeight + 1;
 
-    // At the fork height, reset difficulty to compensate for the
-    // artificially high difficulty caused by min-difficulty blocks in testnet4.
-    if (auto fork_bits = GetMinDifficultyForkBits(params, next_height)) {
-        return *fork_bits;
+    if (params.fPowAllowMinDifficultyBlocks) {
+        // At the fork height, reset difficulty to compensate for the
+        // artificially high difficulty caused by min-difficulty blocks in testnet4.
+        if (auto fork_bits = GetMinDifficultyForkBits(params, next_height)) {
+            return *fork_bits;
+        }
     }
 
     const bool allow_min_difficulty_blocks = AllowMinDifficultyBlocks(params, next_height);
@@ -114,11 +116,13 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 // or decrease beyond the permitted limits.
 bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t height, uint32_t old_nbits, uint32_t new_nbits)
 {
-    if (AllowMinDifficultyBlocks(params, height)) return true;
+    if (params.fPowAllowMinDifficultyBlocks) {
+        if (AllowMinDifficultyBlocks(params, height)) return true;
 
-    // At the fork height, only the reset to difficulty 1,000,000 is valid
-    if (auto fork_bits = GetMinDifficultyForkBits(params, height)) {
-        return new_nbits == *fork_bits;
+        // At the fork height, only the reset to difficulty 1,000,000 is valid
+        if (auto fork_bits = GetMinDifficultyForkBits(params, height)) {
+            return new_nbits == *fork_bits;
+        }
     }
 
     if (height % params.DifficultyAdjustmentInterval() == 0) {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -18,30 +18,12 @@ bool AllowMinDifficultyBlocks(const Consensus::Params& params, int height)
     return height < params.min_difficulty_fork_height;
 }
 
-std::optional<unsigned int> GetMinDifficultyForkBits(const Consensus::Params& params, int height)
-{
-    if (!params.fPowAllowMinDifficultyBlocks) return std::nullopt;
-    if (params.min_difficulty_fork_height == 0 || height != params.min_difficulty_fork_height) return std::nullopt;
-    arith_uint256 target = UintToArith256(params.powLimit);
-    target /= 1000000;
-    return target.GetCompact();
-}
-
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     assert(pindexLast != nullptr);
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
     const int next_height = pindexLast->nHeight + 1;
-
-    if (params.fPowAllowMinDifficultyBlocks) {
-        // At the fork height, reset difficulty to compensate for the
-        // artificially high difficulty caused by min-difficulty blocks in testnet4.
-        if (auto fork_bits = GetMinDifficultyForkBits(params, next_height)) {
-            return *fork_bits;
-        }
-    }
-
     const bool allow_min_difficulty_blocks = AllowMinDifficultyBlocks(params, next_height);
 
     // Only change once per difficulty adjustment interval
@@ -116,14 +98,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 // or decrease beyond the permitted limits.
 bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t height, uint32_t old_nbits, uint32_t new_nbits)
 {
-    if (params.fPowAllowMinDifficultyBlocks) {
-        if (AllowMinDifficultyBlocks(params, height)) return true;
-
-        // At the fork height, only the reset to difficulty 1,000,000 is valid
-        if (auto fork_bits = GetMinDifficultyForkBits(params, height)) {
-            return new_nbits == *fork_bits;
-        }
-    }
+    if (AllowMinDifficultyBlocks(params, height)) return true;
 
     if (height % params.DifficultyAdjustmentInterval() == 0) {
         int64_t smallest_timespan = params.nPowTargetTimespan/4;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -11,31 +11,41 @@
 #include <uint256.h>
 #include <util/check.h>
 
+bool AllowMinDifficultyBlocks(const Consensus::Params& params, int height)
+{
+    if (!params.fPowAllowMinDifficultyBlocks) return false;
+    if (params.min_difficulty_fork_height == 0) return true;
+    return height < params.min_difficulty_fork_height;
+}
+
+std::optional<unsigned int> GetMinDifficultyForkBits(const Consensus::Params& params, int height)
+{
+    if (!params.fPowAllowMinDifficultyBlocks) return std::nullopt;
+    if (params.min_difficulty_fork_height == 0 || height != params.min_difficulty_fork_height) return std::nullopt;
+    arith_uint256 target = UintToArith256(params.powLimit);
+    target /= 1000000;
+    return target.GetCompact();
+}
+
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     assert(pindexLast != nullptr);
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
-    // Check if min difficulty blocks are allowed at this height.
-    // nMinDifficultyBlocksForkHeight == 0 means no fork (keep allowing min difficulty blocks).
-    // Otherwise, min difficulty blocks are disabled at and after the fork height.
-    const int nNextHeight = pindexLast->nHeight + 1;
-    const bool fAllowMinDifficultyBlocks = params.fPowAllowMinDifficultyBlocks &&
-        (params.nMinDifficultyBlocksForkHeight == 0 || nNextHeight < params.nMinDifficultyBlocksForkHeight);
+    const int next_height = pindexLast->nHeight + 1;
 
-    // At the fork height, reset difficulty to 1,000,000 to compensate for the
-    // artificially high difficulty caused by min-difficulty blocks.
-    // We use 1,000,000 instead of 1 (powLimit) to avoid a block storm.
-    if (params.nMinDifficultyBlocksForkHeight != 0 && nNextHeight == params.nMinDifficultyBlocksForkHeight) {
-        arith_uint256 target = UintToArith256(params.powLimit);
-        target /= 1000000;
-        return target.GetCompact();
+    // At the fork height, reset difficulty to compensate for the
+    // artificially high difficulty caused by min-difficulty blocks in testnet4.
+    if (auto fork_bits = GetMinDifficultyForkBits(params, next_height)) {
+        return *fork_bits;
     }
+
+    const bool allow_min_difficulty_blocks = AllowMinDifficultyBlocks(params, next_height);
 
     // Only change once per difficulty adjustment interval
     if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
     {
-        if (fAllowMinDifficultyBlocks)
+        if (allow_min_difficulty_blocks)
         {
             // Special difficulty rule for testnet:
             // If the new block's timestamp is more than 2* 10 minutes
@@ -104,17 +114,11 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 // or decrease beyond the permitted limits.
 bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t height, uint32_t old_nbits, uint32_t new_nbits)
 {
-    // Check if min difficulty blocks are allowed at this height.
-    // After the fork height, we enforce proper difficulty validation.
-    const bool fAllowMinDifficultyBlocks = params.fPowAllowMinDifficultyBlocks &&
-        (params.nMinDifficultyBlocksForkHeight == 0 || height < params.nMinDifficultyBlocksForkHeight);
-    if (fAllowMinDifficultyBlocks) return true;
+    if (AllowMinDifficultyBlocks(params, height)) return true;
 
-    // At the fork height, we reset to difficulty 1,000,000, so only that transition is valid
-    if (params.nMinDifficultyBlocksForkHeight != 0 && height == params.nMinDifficultyBlocksForkHeight) {
-        arith_uint256 fork_target = UintToArith256(params.powLimit);
-        fork_target /= 1000000;
-        return new_nbits == fork_target.GetCompact();
+    // At the fork height, only the reset to difficulty 1,000,000 is valid
+    if (auto fork_bits = GetMinDifficultyForkBits(params, height)) {
+        return new_nbits == *fork_bits;
     }
 
     if (height % params.DifficultyAdjustmentInterval() == 0) {

--- a/src/pow.h
+++ b/src/pow.h
@@ -29,7 +29,7 @@ std::optional<arith_uint256> DeriveTarget(unsigned int nBits, uint256 pow_limit)
 /**
  * Whether min-difficulty blocks are allowed at the given height.
  * Used for the testnet4 hard fork that disables min-difficulty blocks
- * at height 151,200 (consensus.min_difficulty_fork_height).
+ * at height 201,600 (consensus.min_difficulty_fork_height).
  * Returns false on networks where fPowAllowMinDifficultyBlocks is false (e.g. mainnet).
  */
 bool AllowMinDifficultyBlocks(const Consensus::Params& params, int height);

--- a/src/pow.h
+++ b/src/pow.h
@@ -29,7 +29,7 @@ std::optional<arith_uint256> DeriveTarget(unsigned int nBits, uint256 pow_limit)
 /**
  * Whether min-difficulty blocks are allowed at the given height.
  * Used for the testnet4 hard fork that disables min-difficulty blocks
- * at height 201,600 (consensus.min_difficulty_fork_height).
+ * at height 151,200 (consensus.min_difficulty_fork_height).
  * Returns false on networks where fPowAllowMinDifficultyBlocks is false (e.g. mainnet).
  */
 bool AllowMinDifficultyBlocks(const Consensus::Params& params, int height);

--- a/src/pow.h
+++ b/src/pow.h
@@ -26,6 +26,22 @@ class arith_uint256;
  */
 std::optional<arith_uint256> DeriveTarget(unsigned int nBits, uint256 pow_limit);
 
+/**
+ * Whether min-difficulty blocks are allowed at the given height.
+ * Used for the testnet4 hard fork that disables min-difficulty blocks
+ * at height 151,200 (consensus.min_difficulty_fork_height).
+ * Returns false on networks where fPowAllowMinDifficultyBlocks is false (e.g. mainnet).
+ */
+bool AllowMinDifficultyBlocks(const Consensus::Params& params, int height);
+
+/**
+ * At the testnet4 fork height where min-difficulty blocks are disabled,
+ * difficulty resets to powLimit / 1,000,000 to compensate for the artificially
+ * high difficulty caused by min-difficulty blocks, without causing a block storm.
+ * Returns the compact target if this height is the fork height, or std::nullopt otherwise.
+ */
+std::optional<unsigned int> GetMinDifficultyForkBits(const Consensus::Params& params, int height);
+
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 

--- a/src/pow.h
+++ b/src/pow.h
@@ -28,7 +28,7 @@ std::optional<arith_uint256> DeriveTarget(unsigned int nBits, uint256 pow_limit)
 
 /**
  * Whether min-difficulty blocks are allowed at the given height.
- * Used for the testnet4 soft fork that disables min-difficulty blocks
+ * Used for the testnet4 hard fork that disables min-difficulty blocks
  * at height 151,200 (consensus.min_difficulty_fork_height).
  * Returns false on networks where fPowAllowMinDifficultyBlocks is false (e.g. mainnet).
  */

--- a/src/pow.h
+++ b/src/pow.h
@@ -34,14 +34,6 @@ std::optional<arith_uint256> DeriveTarget(unsigned int nBits, uint256 pow_limit)
  */
 bool AllowMinDifficultyBlocks(const Consensus::Params& params, int height);
 
-/**
- * At the testnet4 fork height where min-difficulty blocks are disabled,
- * difficulty resets to powLimit / 1,000,000 to compensate for the artificially
- * high difficulty caused by min-difficulty blocks, without causing a block storm.
- * Returns the compact target if this height is the fork height, or std::nullopt otherwise.
- */
-std::optional<unsigned int> GetMinDifficultyForkBits(const Consensus::Params& params, int height);
-
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 

--- a/src/pow.h
+++ b/src/pow.h
@@ -28,7 +28,7 @@ std::optional<arith_uint256> DeriveTarget(unsigned int nBits, uint256 pow_limit)
 
 /**
  * Whether min-difficulty blocks are allowed at the given height.
- * Used for the testnet4 hard fork that disables min-difficulty blocks
+ * Used for the testnet4 soft fork that disables min-difficulty blocks
  * at height 151,200 (consensus.min_difficulty_fork_height).
  * Returns false on networks where fPowAllowMinDifficultyBlocks is false (e.g. mainnet).
  */

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_pre_fork)
 
     // Verify testnet4 has the expected fork height (epoch 100 boundary)
     const int fork_height = consensus.min_difficulty_fork_height;
-    BOOST_CHECK_EQUAL(fork_height, 201600);
+    BOOST_CHECK_EQUAL(fork_height, 129024);
     BOOST_CHECK(consensus.fPowAllowMinDifficultyBlocks);
 
     const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -239,34 +239,6 @@ BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_pre_fork)
     BOOST_CHECK_EQUAL(bits, pow_limit);
 }
 
-/* Test that at the fork height, difficulty resets to 1,000,000 */
-BOOST_AUTO_TEST_CASE(testnet4_difficulty_reset_at_fork)
-{
-    const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
-    const auto& consensus = chainParams->GetConsensus();
-    const int fork_height = consensus.min_difficulty_fork_height;
-
-    // Calculate expected difficulty: powLimit / 1,000,000
-    arith_uint256 expected_target = UintToArith256(consensus.powLimit);
-    expected_target /= 1000000;
-    const unsigned int expected_bits = expected_target.GetCompact();
-
-    // Create a mock chain so next block is at fork_height
-    CBlockIndex pindexPrev;
-    pindexPrev.nHeight = fork_height - 1;
-    pindexPrev.nTime = 1714777860;
-    pindexPrev.nBits = 0x1c00ffff;  // Some non-trivial (high) difficulty
-
-    // Block header doesn't matter for the reset - it happens unconditionally at fork height
-    CBlockHeader block;
-    block.nTime = pindexPrev.nTime + consensus.nPowTargetSpacing;
-
-    unsigned int bits = GetNextWorkRequired(&pindexPrev, &block, consensus);
-
-    // At fork height: difficulty should reset to 1,000,000
-    BOOST_CHECK_EQUAL(bits, expected_bits);
-}
-
 /* Test that testnet4 min-difficulty blocks are NOT allowed after the fork height */
 BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_post_fork)
 {
@@ -303,40 +275,23 @@ BOOST_AUTO_TEST_CASE(testnet4_permitted_difficulty_transition)
     const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();
     const unsigned int some_difficulty = 0x1c00ffff;
 
-    // Calculate the fork reset difficulty (1,000,000)
-    arith_uint256 fork_target = UintToArith256(consensus.powLimit);
-    fork_target /= 1000000;
-    const unsigned int fork_difficulty = fork_target.GetCompact();
-
     // Before fork: any transition should be permitted
     // because fPowAllowMinDifficultyBlocks is true and we're before fork
     BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height - 1, some_difficulty, pow_limit));
     BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height - 1, some_difficulty, some_difficulty));
     BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height - 1, pow_limit, some_difficulty));
 
-    // At fork: only transition to difficulty 1,000,000 is permitted
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height, some_difficulty, fork_difficulty));
-    BOOST_CHECK(!PermittedDifficultyTransition(consensus, fork_height, some_difficulty, pow_limit));
-    BOOST_CHECK(!PermittedDifficultyTransition(consensus, fork_height, some_difficulty, some_difficulty));
-
-    // After fork: strict rules apply
+    // At and after fork: strict rules apply
     // For non-retarget heights, difficulty must stay the same
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, fork_height, some_difficulty, pow_limit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height, some_difficulty, some_difficulty));
+
     BOOST_CHECK(!PermittedDifficultyTransition(consensus, fork_height + 1, some_difficulty, pow_limit));
     BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height + 1, some_difficulty, some_difficulty));
 
-    // Further after fork: same strict rules
     int non_retarget_height = fork_height + 800;
     BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, pow_limit));
     BOOST_CHECK(PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, some_difficulty));
-
-    // At the next retarget after the fork, the transition must be based on the
-    // fork reset difficulty (1,000,000), not the pre-fork difficulty.
-    const int next_retarget = fork_height + consensus.DifficultyAdjustmentInterval();
-    // Retarget from fork_difficulty: within factor of 4 is permitted
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, next_retarget, fork_difficulty, fork_difficulty));
-    // Transitioning from some unrelated pre-fork difficulty to fork_difficulty is not valid
-    // if it exceeds the 4x adjustment limit
-    BOOST_CHECK(!PermittedDifficultyTransition(consensus, next_retarget, fork_difficulty, pow_limit));
 }
 
 /* Test that regtest is unaffected by the fork (min_difficulty_fork_height = 0) */

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -216,14 +216,15 @@ BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_pre_fork)
     const auto& consensus = chainParams->GetConsensus();
 
     // Verify testnet4 has the expected fork height (epoch 75 boundary)
-    BOOST_CHECK_EQUAL(consensus.nMinDifficultyBlocksForkHeight, 151200);
+    const int fork_height = consensus.min_difficulty_fork_height;
+    BOOST_CHECK_EQUAL(fork_height, 151200);
     BOOST_CHECK(consensus.fPowAllowMinDifficultyBlocks);
 
-    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+    const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();
 
-    // Create a mock chain at height 151,198 (so next block is 151,199, before fork)
+    // Create a mock chain so next block is fork_height - 1 (before fork)
     CBlockIndex pindexPrev;
-    pindexPrev.nHeight = 151198;
+    pindexPrev.nHeight = fork_height - 2;
     pindexPrev.nTime = 1714777860;  // Some base time
     pindexPrev.nBits = 0x1c00ffff;  // Some non-trivial difficulty
 
@@ -232,10 +233,10 @@ BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_pre_fork)
     CBlockHeader block;
     block.nTime = pindexPrev.nTime + consensus.nPowTargetSpacing * 2 + 1;  // >20 minutes later
 
-    unsigned int nBits = GetNextWorkRequired(&pindexPrev, &block, consensus);
+    unsigned int bits = GetNextWorkRequired(&pindexPrev, &block, consensus);
 
-    // Before fork (height 151,199): min-difficulty should be allowed
-    BOOST_CHECK_EQUAL(nBits, nProofOfWorkLimit);
+    // Before fork: min-difficulty should be allowed
+    BOOST_CHECK_EQUAL(bits, pow_limit);
 }
 
 /* Test that at the fork height, difficulty resets to 1,000,000 */
@@ -243,15 +244,16 @@ BOOST_AUTO_TEST_CASE(testnet4_difficulty_reset_at_fork)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
     const auto& consensus = chainParams->GetConsensus();
+    const int fork_height = consensus.min_difficulty_fork_height;
 
     // Calculate expected difficulty: powLimit / 1,000,000
-    arith_uint256 expectedTarget = UintToArith256(consensus.powLimit);
-    expectedTarget /= 1000000;
-    const unsigned int nExpectedBits = expectedTarget.GetCompact();
+    arith_uint256 expected_target = UintToArith256(consensus.powLimit);
+    expected_target /= 1000000;
+    const unsigned int expected_bits = expected_target.GetCompact();
 
-    // Create a mock chain at height 151,199 (so next block is 151,200, at fork)
+    // Create a mock chain so next block is at fork_height
     CBlockIndex pindexPrev;
-    pindexPrev.nHeight = 151199;
+    pindexPrev.nHeight = fork_height - 1;
     pindexPrev.nTime = 1714777860;
     pindexPrev.nBits = 0x1c00ffff;  // Some non-trivial (high) difficulty
 
@@ -259,10 +261,10 @@ BOOST_AUTO_TEST_CASE(testnet4_difficulty_reset_at_fork)
     CBlockHeader block;
     block.nTime = pindexPrev.nTime + consensus.nPowTargetSpacing;
 
-    unsigned int nBits = GetNextWorkRequired(&pindexPrev, &block, consensus);
+    unsigned int bits = GetNextWorkRequired(&pindexPrev, &block, consensus);
 
-    // At fork (height 151,200): difficulty should reset to 1,000,000
-    BOOST_CHECK_EQUAL(nBits, nExpectedBits);
+    // At fork height: difficulty should reset to 1,000,000
+    BOOST_CHECK_EQUAL(bits, expected_bits);
 }
 
 /* Test that testnet4 min-difficulty blocks are NOT allowed after the fork height */
@@ -270,24 +272,25 @@ BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_post_fork)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
     const auto& consensus = chainParams->GetConsensus();
+    const int fork_height = consensus.min_difficulty_fork_height;
 
-    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+    const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();
 
-    // Create a mock chain at height 151,200 (so next block is 151,201, after fork)
+    // Create a mock chain so next block is fork_height + 1 (after fork)
     CBlockIndex pindexPrev;
-    pindexPrev.nHeight = 151200;
+    pindexPrev.nHeight = fork_height;
     pindexPrev.nTime = 1714777860;
     pindexPrev.nBits = 0x1c00ffff;
 
     CBlockHeader block;
     block.nTime = pindexPrev.nTime + consensus.nPowTargetSpacing * 2 + 1;
 
-    unsigned int nBits = GetNextWorkRequired(&pindexPrev, &block, consensus);
+    unsigned int bits = GetNextWorkRequired(&pindexPrev, &block, consensus);
 
-    // After fork (height 151,201): min-difficulty should NOT be allowed
+    // After fork: min-difficulty should NOT be allowed
     // Even with >20 min delay, should return previous block's difficulty
-    BOOST_CHECK_EQUAL(nBits, pindexPrev.nBits);
-    BOOST_CHECK(nBits != nProofOfWorkLimit);
+    BOOST_CHECK_EQUAL(bits, pindexPrev.nBits);
+    BOOST_CHECK(bits != pow_limit);
 }
 
 /* Test PermittedDifficultyTransition for testnet4 before and after fork */
@@ -295,57 +298,70 @@ BOOST_AUTO_TEST_CASE(testnet4_permitted_difficulty_transition)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
     const auto& consensus = chainParams->GetConsensus();
+    const int fork_height = consensus.min_difficulty_fork_height;
 
-    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+    const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();
     const unsigned int some_difficulty = 0x1c00ffff;
 
     // Calculate the fork reset difficulty (1,000,000)
-    arith_uint256 forkTarget = UintToArith256(consensus.powLimit);
-    forkTarget /= 1000000;
-    const unsigned int nForkDifficulty = forkTarget.GetCompact();
+    arith_uint256 fork_target = UintToArith256(consensus.powLimit);
+    fork_target /= 1000000;
+    const unsigned int fork_difficulty = fork_target.GetCompact();
 
-    // Before fork (height 151,199): any transition should be permitted
+    // Before fork: any transition should be permitted
     // because fPowAllowMinDifficultyBlocks is true and we're before fork
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151199, some_difficulty, nProofOfWorkLimit));
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151199, some_difficulty, some_difficulty));
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151199, nProofOfWorkLimit, some_difficulty));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height - 1, some_difficulty, pow_limit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height - 1, some_difficulty, some_difficulty));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height - 1, pow_limit, some_difficulty));
 
-    // At fork (height 151,200): only transition to difficulty 1,000,000 is permitted
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151200, some_difficulty, nForkDifficulty));
-    BOOST_CHECK(!PermittedDifficultyTransition(consensus, 151200, some_difficulty, nProofOfWorkLimit));
-    BOOST_CHECK(!PermittedDifficultyTransition(consensus, 151200, some_difficulty, some_difficulty));
+    // At fork: only transition to difficulty 1,000,000 is permitted
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height, some_difficulty, fork_difficulty));
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, fork_height, some_difficulty, pow_limit));
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, fork_height, some_difficulty, some_difficulty));
 
     // After fork: strict rules apply
     // For non-retarget heights, difficulty must stay the same
-    int non_retarget_height = 151201;  // Not divisible by 2016
-    BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, nProofOfWorkLimit));
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, some_difficulty));
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, fork_height + 1, some_difficulty, pow_limit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, fork_height + 1, some_difficulty, some_difficulty));
 
     // Further after fork: same strict rules
-    non_retarget_height = 152000;
-    BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, nProofOfWorkLimit));
+    int non_retarget_height = fork_height + 800;
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, pow_limit));
     BOOST_CHECK(PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, some_difficulty));
+
+    // At the next retarget after the fork, the transition must be based on the
+    // fork reset difficulty (1,000,000), not the pre-fork difficulty.
+    const int next_retarget = fork_height + consensus.DifficultyAdjustmentInterval();
+    // Retarget from fork_difficulty: within factor of 4 is permitted
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, next_retarget, fork_difficulty, fork_difficulty));
+    // Transitioning from some unrelated pre-fork difficulty to fork_difficulty is not valid
+    // if it exceeds the 4x adjustment limit
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, next_retarget, fork_difficulty, pow_limit));
 }
 
-/* Test that regtest is unaffected by the fork (nMinDifficultyBlocksForkHeight = 0) */
+/* Test that regtest is unaffected by the fork (min_difficulty_fork_height = 0) */
 BOOST_AUTO_TEST_CASE(regtest_min_difficulty_unaffected)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::REGTEST);
     const auto& consensus = chainParams->GetConsensus();
 
-    // Verify regtest has no fork (nMinDifficultyBlocksForkHeight = 0 means disabled)
-    BOOST_CHECK_EQUAL(consensus.nMinDifficultyBlocksForkHeight, 0);
+    // Verify regtest has no fork (min_difficulty_fork_height = 0 means disabled)
+    BOOST_CHECK_EQUAL(consensus.min_difficulty_fork_height, 0);
     BOOST_CHECK(consensus.fPowAllowMinDifficultyBlocks);
 
+    // Use testnet4's fork height to verify regtest is unaffected at those same heights
+    const auto testnet4Params = CreateChainParams(*m_node.args, ChainType::TESTNET4);
+    const int testnet4_fork_height = testnet4Params->GetConsensus().min_difficulty_fork_height;
+
     // PermittedDifficultyTransition should always return true for regtest
-    // regardless of height (even at heights > 151,200)
-    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+    // regardless of height (even at heights around the testnet4 fork)
+    const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();
     const unsigned int some_difficulty = 0x1c00ffff;
 
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151199, some_difficulty, nProofOfWorkLimit));
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151200, some_difficulty, nProofOfWorkLimit));
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151201, some_difficulty, nProofOfWorkLimit));
-    BOOST_CHECK(PermittedDifficultyTransition(consensus, 200000, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, testnet4_fork_height - 1, some_difficulty, pow_limit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, testnet4_fork_height, some_difficulty, pow_limit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, testnet4_fork_height + 1, some_difficulty, pow_limit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, 200000, some_difficulty, pow_limit));
 }
 
 /* Test that mainnet is unaffected (fPowAllowMinDifficultyBlocks = false) */
@@ -356,15 +372,16 @@ BOOST_AUTO_TEST_CASE(mainnet_min_difficulty_unaffected)
 
     // Mainnet doesn't allow min-difficulty blocks at all
     BOOST_CHECK(!consensus.fPowAllowMinDifficultyBlocks);
-    BOOST_CHECK_EQUAL(consensus.nMinDifficultyBlocksForkHeight, 0);
+    BOOST_CHECK_EQUAL(consensus.min_difficulty_fork_height, 0);
 
     // PermittedDifficultyTransition enforces strict rules on mainnet
     const unsigned int some_difficulty = 0x1c00ffff;
-    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+    const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();
 
     // Non-retarget height: difficulty must stay same
+    // (chose an arbitrary non-divisible by 2016 block height)
     int non_retarget_height = 150001;
-    BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, pow_limit));
     BOOST_CHECK(PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, some_difficulty));
 }
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -209,4 +209,163 @@ BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
     sanity_check_chainparams(*m_node.args, ChainType::SIGNET);
 }
 
+/* Test that testnet4 min-difficulty blocks are allowed before the fork height */
+BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_pre_fork)
+{
+    const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
+    const auto& consensus = chainParams->GetConsensus();
+
+    // Verify testnet4 has the expected fork height (epoch 75 boundary)
+    BOOST_CHECK_EQUAL(consensus.nMinDifficultyBlocksForkHeight, 151200);
+    BOOST_CHECK(consensus.fPowAllowMinDifficultyBlocks);
+
+    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+
+    // Create a mock chain at height 151,198 (so next block is 151,199, before fork)
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 151198;
+    pindexPrev.nTime = 1714777860;  // Some base time
+    pindexPrev.nBits = 0x1c00ffff;  // Some non-trivial difficulty
+
+    // Create a block header with timestamp >20 minutes after previous block
+    // This should trigger the min-difficulty rule before the fork
+    CBlockHeader block;
+    block.nTime = pindexPrev.nTime + consensus.nPowTargetSpacing * 2 + 1;  // >20 minutes later
+
+    unsigned int nBits = GetNextWorkRequired(&pindexPrev, &block, consensus);
+
+    // Before fork (height 151,199): min-difficulty should be allowed
+    BOOST_CHECK_EQUAL(nBits, nProofOfWorkLimit);
+}
+
+/* Test that at the fork height, difficulty resets to 1,000,000 */
+BOOST_AUTO_TEST_CASE(testnet4_difficulty_reset_at_fork)
+{
+    const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
+    const auto& consensus = chainParams->GetConsensus();
+
+    // Calculate expected difficulty: powLimit / 1,000,000
+    arith_uint256 expectedTarget = UintToArith256(consensus.powLimit);
+    expectedTarget /= 1000000;
+    const unsigned int nExpectedBits = expectedTarget.GetCompact();
+
+    // Create a mock chain at height 151,199 (so next block is 151,200, at fork)
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 151199;
+    pindexPrev.nTime = 1714777860;
+    pindexPrev.nBits = 0x1c00ffff;  // Some non-trivial (high) difficulty
+
+    // Block header doesn't matter for the reset - it happens unconditionally at fork height
+    CBlockHeader block;
+    block.nTime = pindexPrev.nTime + consensus.nPowTargetSpacing;
+
+    unsigned int nBits = GetNextWorkRequired(&pindexPrev, &block, consensus);
+
+    // At fork (height 151,200): difficulty should reset to 1,000,000
+    BOOST_CHECK_EQUAL(nBits, nExpectedBits);
+}
+
+/* Test that testnet4 min-difficulty blocks are NOT allowed after the fork height */
+BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_post_fork)
+{
+    const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
+    const auto& consensus = chainParams->GetConsensus();
+
+    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+
+    // Create a mock chain at height 151,200 (so next block is 151,201, after fork)
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 151200;
+    pindexPrev.nTime = 1714777860;
+    pindexPrev.nBits = 0x1c00ffff;
+
+    CBlockHeader block;
+    block.nTime = pindexPrev.nTime + consensus.nPowTargetSpacing * 2 + 1;
+
+    unsigned int nBits = GetNextWorkRequired(&pindexPrev, &block, consensus);
+
+    // After fork (height 151,201): min-difficulty should NOT be allowed
+    // Even with >20 min delay, should return previous block's difficulty
+    BOOST_CHECK_EQUAL(nBits, pindexPrev.nBits);
+    BOOST_CHECK(nBits != nProofOfWorkLimit);
+}
+
+/* Test PermittedDifficultyTransition for testnet4 before and after fork */
+BOOST_AUTO_TEST_CASE(testnet4_permitted_difficulty_transition)
+{
+    const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
+    const auto& consensus = chainParams->GetConsensus();
+
+    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+    const unsigned int some_difficulty = 0x1c00ffff;
+
+    // Calculate the fork reset difficulty (1,000,000)
+    arith_uint256 forkTarget = UintToArith256(consensus.powLimit);
+    forkTarget /= 1000000;
+    const unsigned int nForkDifficulty = forkTarget.GetCompact();
+
+    // Before fork (height 151,199): any transition should be permitted
+    // because fPowAllowMinDifficultyBlocks is true and we're before fork
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151199, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151199, some_difficulty, some_difficulty));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151199, nProofOfWorkLimit, some_difficulty));
+
+    // At fork (height 151,200): only transition to difficulty 1,000,000 is permitted
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151200, some_difficulty, nForkDifficulty));
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, 151200, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, 151200, some_difficulty, some_difficulty));
+
+    // After fork: strict rules apply
+    // For non-retarget heights, difficulty must stay the same
+    int non_retarget_height = 151201;  // Not divisible by 2016
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, some_difficulty));
+
+    // Further after fork: same strict rules
+    non_retarget_height = 152000;
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, some_difficulty));
+}
+
+/* Test that regtest is unaffected by the fork (nMinDifficultyBlocksForkHeight = 0) */
+BOOST_AUTO_TEST_CASE(regtest_min_difficulty_unaffected)
+{
+    const auto chainParams = CreateChainParams(*m_node.args, ChainType::REGTEST);
+    const auto& consensus = chainParams->GetConsensus();
+
+    // Verify regtest has no fork (nMinDifficultyBlocksForkHeight = 0 means disabled)
+    BOOST_CHECK_EQUAL(consensus.nMinDifficultyBlocksForkHeight, 0);
+    BOOST_CHECK(consensus.fPowAllowMinDifficultyBlocks);
+
+    // PermittedDifficultyTransition should always return true for regtest
+    // regardless of height (even at heights > 151,200)
+    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+    const unsigned int some_difficulty = 0x1c00ffff;
+
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151199, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151200, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, 151201, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, 200000, some_difficulty, nProofOfWorkLimit));
+}
+
+/* Test that mainnet is unaffected (fPowAllowMinDifficultyBlocks = false) */
+BOOST_AUTO_TEST_CASE(mainnet_min_difficulty_unaffected)
+{
+    const auto chainParams = CreateChainParams(*m_node.args, ChainType::MAIN);
+    const auto& consensus = chainParams->GetConsensus();
+
+    // Mainnet doesn't allow min-difficulty blocks at all
+    BOOST_CHECK(!consensus.fPowAllowMinDifficultyBlocks);
+    BOOST_CHECK_EQUAL(consensus.nMinDifficultyBlocksForkHeight, 0);
+
+    // PermittedDifficultyTransition enforces strict rules on mainnet
+    const unsigned int some_difficulty = 0x1c00ffff;
+    const unsigned int nProofOfWorkLimit = UintToArith256(consensus.powLimit).GetCompact();
+
+    // Non-retarget height: difficulty must stay same
+    int non_retarget_height = 150001;
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, nProofOfWorkLimit));
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, some_difficulty));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -215,9 +215,9 @@ BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_pre_fork)
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
     const auto& consensus = chainParams->GetConsensus();
 
-    // Verify testnet4 has the expected fork height (epoch 75 boundary)
+    // Verify testnet4 has the expected fork height (epoch 100 boundary)
     const int fork_height = consensus.min_difficulty_fork_height;
-    BOOST_CHECK_EQUAL(fork_height, 151200);
+    BOOST_CHECK_EQUAL(fork_height, 201600);
     BOOST_CHECK(consensus.fPowAllowMinDifficultyBlocks);
 
     const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();
@@ -334,8 +334,7 @@ BOOST_AUTO_TEST_CASE(mainnet_min_difficulty_unaffected)
     const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();
 
     // Non-retarget height: difficulty must stay same
-    // (chose an arbitrary non-divisible by 2016 block height)
-    int non_retarget_height = 150001;
+    int non_retarget_height = consensus.DifficultyAdjustmentInterval() + 1;
     BOOST_CHECK(!PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, pow_limit));
     BOOST_CHECK(PermittedDifficultyTransition(consensus, non_retarget_height, some_difficulty, some_difficulty));
 }

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -215,9 +215,9 @@ BOOST_AUTO_TEST_CASE(testnet4_min_difficulty_pre_fork)
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::TESTNET4);
     const auto& consensus = chainParams->GetConsensus();
 
-    // Verify testnet4 has the expected fork height (epoch 100 boundary)
+    // Verify testnet4 has the expected fork height (epoch 75 boundary)
     const int fork_height = consensus.min_difficulty_fork_height;
-    BOOST_CHECK_EQUAL(fork_height, 129024);
+    BOOST_CHECK_EQUAL(fork_height, 151200);
     BOOST_CHECK(consensus.fPowAllowMinDifficultyBlocks);
 
     const unsigned int pow_limit = UintToArith256(consensus.powLimit).GetCompact();


### PR DESCRIPTION
  ## Summary                                                                                                                                
                                                                                                                                            
  Disable the min-difficulty block rule on testnet4 after block height 151,200 (epoch 75 boundary).

## Motivation                                                                                                                             
                                                                                                                                            
Testnet4's min-difficulty rule (allowing difficulty-1 blocks after 20 minutes) is being exploited, causing ~85-90% of blocks to be CPU-mined min-difficulty blocks. This results in a race of CPU miners broadcasting blocks at exactly the second that it's acceptable. This race is so intense that CPU miners have figured out sending empty blocks, as they propagate faster than those that contain transactions, resulting in a network where transactions are confirmed at only the remaining ASIC blocks, that have ~1 hour average block times.                                                                                                     
                                                                                                                                            
  After the fork:                                                                                                                           
  - Min-difficulty blocks will no longer be allowed
  - Normal difficulty retargeting resumes                                                                                                   
                                                                                                                                            
  ## Changes                                                                                                                                
                                                                                                                                            
  - Add `nMinDifficultyBlocksForkHeight` consensus parameter (default 0 = disabled)                                                         
  - Set fork height to 151,200 for testnet4 (epoch 75 boundary, ~20,000 blocks from current height ~130,000)                                
  - Modify `GetNextWorkRequired()` to disable min-difficulty rule at fork height 151,200                                            
  - Modify `PermittedDifficultyTransition()` to enforce the new rules                                                                       
  - Modify `WaitAndCreateNewBlock()` in miner to respect the fork                                                                           
  - Add unit tests covering pre-fork, at-fork, and post-fork behavior                                                                       
                                                                                                                                            
  ## Test Plan                                                                                                                              
                                                                                                                                            
  - `./build/bin/test_bitcoin --run_test=pow_tests` - all 21 tests pass                                                                     
                                                                                                                                            
  ## Discussion                                                                                                                             
                                                                                                                                            
  [bitcoin-dev mailing list thread #1](https://groups.google.com/g/bitcoindev/c/iVLHJ1HWhoU)
  [bitcoin-dev mailing list thread #2](https://groups.google.com/g/bitcoindev/c/Jsv1VYpewuU)     
  [Bitcointalk thread](https://bitcointalk.org/index.php?topic=5569103.0)     