### PR TITLE
ci: add Chimera Linux LTO config

### DIFF
--- a/ci/test/00_setup_env_native_chimera_lto.sh
+++ b/ci/test/00_setup_env_native_chimera_lto.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+# This config is experimental, and may not be reproducible, given
+# the use of a rolling distro.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_native_chimera_musl
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/chimeralinux/chimera"
+export CI_BASE_PACKAGES="ccache chimerautils chimerautils-extra clang cmake curl e2fsprogs git gmake gtar linux-headers ninja pkgconf procps python-devel python-pip rsync util-linux util-linux-lscpu xz"
+export PIP_PACKAGES="--break-system-packages pyzmq pycapnp"
+export DEP_OPTS="build_CC=clang build_CXX=clang++ build_TAR=gtar AR=llvm-ar CC=clang CXX=clang++ NM=llvm-nm RANLIB=llvm-ranlib STRIP=llvm-strip NO_QT=1"
+export GOAL="install"
+export BITCOIN_CONFIG="\
+ --preset=dev-mode \
+ -DBUILD_GUI=OFF \
+ -DREDUCE_EXPORTS=ON \
+ -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+"


### PR DESCRIPTION
Adds a CI config based on using [Chimera Linux](https://chimera-linux.org/). This might be interesting for any of the following:
* Chimera is based on LLVM & musl libc - we test both of these in isolation, but not together.
* No GNU components. I don't think we have an existing Linux CI job that doesn't have a gcc/stdlibc++ install. This exercises the depends logic for a fully LLVM/Clang/lld only build, including building the native tools (related to #33902).
* We don't currently have a job with LTO enabled (here using CMakes `CMAKE_INTERPROCEDURAL_OPTIMIZATION`, which is `-flto=thin` for LLVM/Clang). I think this is worth having generally (we do use LTO in some other places, like oss-fuzz). If runtime is too much of an issue, then it could also be dropped. (Chimera itself is also compiled with LTO).

QT in depends doesn't build (#32744), so is excluded for now.

Chimera has pointed out at least a few quirks, i.e #34390, #34408 and https://github.com/bitcoin/bitcoin/pull/29963#discussion_r2707922298.