### PR TITLE
Update libmultiprocess subtree to be more stable with rust IPC client

### DIFF
--- a/doc/versions.md
+++ b/doc/versions.md
@@ -7,40 +7,55 @@ Library versions are tracked with simple
 Versioning policy is described in the [version.h](../include/mp/version.h)
 include.
 
-## v7
+## v8
 - Current unstable version in master branch.
-- Intended to be compatible with Bitcoin Core 30.1 and future releases.
+
+## v7.0
+- Adds SpawnProcess race fix, cmake `target_capnp_sources` option, ci and documentation improvements.
+- Used in Bitcoin Core master branch, pulled in by [#34363](https://github.com/bitcoin/bitcoin/pull/34363).
+
+## v7.0-pre1
+
+- Adds support for log levels to reduce logging and "thread busy" error to avoid a crash on misuse. Fixes intermittent mptest hang and makes other minor improvements.
+- Used in Bitcoin Core 30.1 and 30.2 releases and 30.x branch. Pulled in by [#33412](https://github.com/bitcoin/bitcoin/pull/33412), [#33518](https://github.com/bitcoin/bitcoin/pull/33518), and [#33519](https://github.com/bitcoin/bitcoin/pull/33519).
 
 ## v6.0
-- `EventLoop::addClient` and `EventLoop::removeClient` methods dropped,
+
+- Adds fixes for unclean shutdowns and thread sanitizer issues and adds CI scripts.
+- Drops `EventLoop::addClient` and `EventLoop::removeClient` methods,
   requiring clients to use new `EventLoopRef` class instead.
-- Compatible with Bitcoin Core 30.0 release.
+- Used in Bitcoin Core 30.0 release. Pulled in by [#31741](https://github.com/bitcoin/bitcoin/pull/31741), [#32641](https://github.com/bitcoin/bitcoin/pull/32641), [#32345](https://github.com/bitcoin/bitcoin/pull/32345), [#33241](https://github.com/bitcoin/bitcoin/pull/33241), and [#33322](https://github.com/bitcoin/bitcoin/pull/33322).
 
 ## v5.0
+- Adds build improvements and tidy/warning fixes.
+- Used in Bitcoin Core 29 releases, pulled in by [#31945](https://github.com/bitcoin/bitcoin/pull/31945).
+
+## v5.0-pre1
+- Adds many improvements to Bitcoin Core mining interface: splitting up type headers, fixing shutdown bugs, adding subtree build support.
 - Broke up `proxy-types.h` into `type-*.h` files requiring clients to explicitly
   include overloads needed for C++ ↔️ Cap'n Proto type conversions.
 - Now requires C++ 20 support.
-- Compatible with Bitcoin Core 29 releases.
+- Minimum required version for Bitcoin Core 29 releases, pulled in by [#30509](https://github.com/bitcoin/bitcoin/pull/30509), [#30510](https://github.com/bitcoin/bitcoin/pull/30510), [#31105](https://github.com/bitcoin/bitcoin/pull/31105), [#31740](https://github.com/bitcoin/bitcoin/pull/31740).
 
 ## v4.0
 - Added better cmake support, installing cmake package files so clients do not
   need to use pkgconfig.
-- Compatible with Bitcoin Core 28 releases.
+- Used in Bitcoin Core 28 releases, pulled in by [#30490](https://github.com/bitcoin/bitcoin/pull/30490) and [#30513](https://github.com/bitcoin/bitcoin/pull/30513).
 
 ## v3.0
 - Dropped compatibility with Cap'n Proto versions before 0.7.
-- Compatible with Bitcoin Core 27 releases.
+- Used in Bitcoin Core 27 releases, pulled in by [#28735](https://github.com/bitcoin/bitcoin/pull/28735), [#28907](https://github.com/bitcoin/bitcoin/pull/28907), and [#29276](https://github.com/bitcoin/bitcoin/pull/29276).
 
 ## v2.0
 - Changed `PassField` function signature.
 - Now requires C++17 support.
-- Compatible with Bitcoin Core 25 and 26 releases.
+- Used in Bitcoin Core 25 and 26 releases, pulled in by [#26672](https://github.com/bitcoin/bitcoin/pull/26672).
 
 ## v1.0
 - Dropped hardcoded includes in generated files, now requiring `include` and
   `includeTypes` annotations.
-- Compatible with Bitcoin Core 22, 23, and 24 releases.
+- Used in Bitcoin Core 22, 23, and 24 releases, pulled in by [#19160](https://github.com/bitcoin/bitcoin/pull/19160).
 
 ## v0.0
 - Initial version used in a downstream release.
-- Compatible with Bitcoin Core 21 releases.
+- Used in Bitcoin Core 21 releases, pulled in by [#16367](https://github.com/bitcoin/bitcoin/pull/16367), [#18588](https://github.com/bitcoin/bitcoin/pull/18588), and [#18677](https://github.com/bitcoin/bitcoin/pull/18677).

--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -48,6 +48,19 @@ struct ServerInvokeContext : InvokeContext
     ProxyServer& proxy_server;
     CallContext& call_context;
     int req;
+    //! For IPC methods that execute asynchronously, not on the event-loop
+    //! thread: lock preventing the event-loop thread from freeing the params or
+    //! results structs if the request is canceled while the worker thread is
+    //! reading params (`call_context.getParams()`) or writing results
+    //! (`call_context.getResults()`).
+    Lock* cancel_lock{nullptr};
+    //! For IPC methods that execute asynchronously, not on the event-loop
+    //! thread, this is set to true if the IPC call was canceled by the client
+    //! or canceled by a disconnection. If the call runs on the event-loop
+    //! thread, it can't be canceled. This should be accessed with cancel_lock
+    //! held if it is not null, since in the asynchronous case it is accessed
+    //! from multiple threads.
+    bool request_canceled{false};
 
     ServerInvokeContext(ProxyServer& proxy_server, CallContext& call_context, int req)
         : InvokeContext{*proxy_server.m_context.connection}, proxy_server{proxy_server}, call_context{call_context}, req{req}
@@ -82,11 +95,23 @@ template <>
 struct ProxyServer<Thread> final : public Thread::Server
 {
 public:
-    ProxyServer(ThreadContext& thread_context, std::thread&& thread);
+    ProxyServer(Connection& connection, ThreadContext& thread_context, std::thread&& thread);
     ~ProxyServer();
     kj::Promise<void> getName(GetNameContext context) override;
+
+    //! Run a callback function fn returning T on this thread. The function will
+    //! be queued and executed as soon as the thread is idle, and when fn
+    //! returns, the promise returned by this method will be fulfilled with the
+    //! value fn returned.
+    template<typename T, typename Fn>
+    kj::Promise<T> post(Fn&& fn);
+
+    EventLoopRef m_loop;
     ThreadContext& m_thread_context;
     std::thread m_thread;
+    //! Promise signaled when m_thread_context.waiter is ready and there is no
+    //! post() callback function waiting to execute.
+    kj::Promise<void> m_thread_ready{kj::READY_NOW};
 };
 
 //! Handler for kj::TaskSet failed task events.
@@ -322,7 +347,12 @@ public:
 //! thread is blocked waiting for server response, this is what allows the
 //! client to run the request in the same thread, the same way code would run in a
 //! single process, with the callback sharing the same thread stack as the original
-//! call.)
+//! call.) To support this, the clientInvoke function calls Waiter::wait() to
+//! block the client IPC thread while initial request is in progress. Then if
+//! there is a callback, it is executed with Waiter::post().
+//!
+//! The Waiter class is also used server-side by `ProxyServer<Thread>::post()`
+//! to execute IPC calls on worker threads.
 struct Waiter
 {
     Waiter() = default;
@@ -404,11 +434,11 @@ public:
     template <typename F>
     void onDisconnect(F&& f)
     {
-        // Add disconnect handler to local TaskSet to ensure it is cancelled and
+        // Add disconnect handler to local TaskSet to ensure it is canceled and
         // will never run after connection object is destroyed. But when disconnect
         // handler fires, do not call the function f right away, instead add it
         // to the EventLoop TaskSet to avoid "Promise callback destroyed itself"
-        // error in cases where f deletes this Connection object.
+        // error in the typical case where f deletes this Connection object.
         m_on_disconnect.add(m_network.onDisconnect().then(
             [f = std::forward<F>(f), this]() mutable { m_loop->m_task_set->add(kj::evalLater(kj::mv(f))); }));
     }
@@ -416,6 +446,9 @@ public:
     EventLoopRef m_loop;
     kj::Own<kj::AsyncIoStream> m_stream;
     LoggingErrorHandler m_error_handler{*m_loop};
+    //! TaskSet used to cancel the m_network.onDisconnect() handler for remote
+    //! disconnections, if the connection is closed locally first by deleting
+    //! this Connection object.
     kj::TaskSet m_on_disconnect{m_error_handler};
     ::capnp::TwoPartyVatNetwork m_network;
     std::optional<::capnp::RpcSystem<::capnp::rpc::twoparty::VatId>> m_rpc_system;
@@ -427,6 +460,11 @@ public:
     //! Collection of server-side IPC worker threads (ProxyServer<Thread> objects previously returned by
     //! ThreadMap.makeThread) used to service requests to clients.
     ::capnp::CapabilityServerSet<Thread> m_threads;
+
+    //! Canceler for canceling promises that we want to discard when the
+    //! connection is destroyed. This is used to interrupt method calls that are
+    //! still executing at time of disconnection.
+    kj::Canceler m_canceler;
 
     //! Cleanup functions to run if connection is broken unexpectedly.  List
     //! will be empty if all ProxyClient are destroyed cleanly before the
@@ -674,6 +712,70 @@ struct ThreadContext
     //! which could deadlock the thread.
     bool loop_thread = false;
 };
+
+template<typename T, typename Fn>
+kj::Promise<T> ProxyServer<Thread>::post(Fn&& fn)
+{
+    auto ready = kj::newPromiseAndFulfiller<void>(); // Signaled when waiter is ready to post again.
+    auto cancel_monitor_ptr = kj::heap<CancelMonitor>();
+    CancelMonitor& cancel_monitor = *cancel_monitor_ptr;
+    // Keep a reference to the ProxyServer<Thread> instance by assigning it to
+    // the self variable. ProxyServer instances are reference-counted and if the
+    // client drops its reference, this variable keeps the instance alive until
+    // the thread finishes executing. The self variable needs to be destroyed on
+    // the event loop thread so it is freed in a sync() call below.
+    auto self = thisCap();
+    auto ret = m_thread_ready.then([this, self = std::move(self), fn = std::forward<Fn>(fn), ready_fulfiller = kj::mv(ready.fulfiller), cancel_monitor_ptr = kj::mv(cancel_monitor_ptr)]() mutable {
+        auto result = kj::newPromiseAndFulfiller<T>(); // Signaled when fn() is called, with its return value.
+        bool posted = m_thread_context.waiter->post([this, self = std::move(self), fn = std::forward<Fn>(fn), ready_fulfiller = kj::mv(ready_fulfiller), result_fulfiller = kj::mv(result.fulfiller), cancel_monitor_ptr = kj::mv(cancel_monitor_ptr)]() mutable {
+            // Fulfill ready.promise now, as soon as the Waiter starts executing
+            // this lambda, so the next ProxyServer<Thread>::post() call can
+            // immediately call waiter->post(). It is important to do this
+            // before calling fn() because fn() can make an IPC call back to the
+            // client, which can make another IPC call to this server thread.
+            // (This typically happens when IPC methods take std::function
+            // parameters.) When this happens the second call to the server
+            // thread should not be blocked waiting for the first call.
+            m_loop->sync([ready_fulfiller = kj::mv(ready_fulfiller)]() mutable {
+                ready_fulfiller->fulfill();
+                ready_fulfiller = nullptr;
+            });
+            std::optional<T> result_value;
+            kj::Maybe<kj::Exception> exception{kj::runCatchingExceptions([&]{ result_value.emplace(fn(*cancel_monitor_ptr)); })};
+            m_loop->sync([this, &result_value, &exception, self = kj::mv(self), result_fulfiller = kj::mv(result_fulfiller), cancel_monitor_ptr = kj::mv(cancel_monitor_ptr)]() mutable {
+                // Destroy CancelMonitor here before fulfilling or rejecting the
+                // promise so it doesn't get triggered when the promise is
+                // destroyed.
+                cancel_monitor_ptr = nullptr;
+                // Send results to the fulfiller. Technically it would be ok to
+                // skip this if promise was canceled, but it's simpler to just
+                // do it unconditionally.
+                KJ_IF_MAYBE(e, exception) {
+                    assert(!result_value);
+                    result_fulfiller->reject(kj::mv(*e));
+                } else {
+                    assert(result_value);
+                    result_fulfiller->fulfill(kj::mv(*result_value));
+                    result_value.reset();
+                }
+                result_fulfiller = nullptr;
+                // Use evalLater to destroy the ProxyServer<Thread> self
+                // reference, if it is the last reference, because the
+                // ProxyServer<Thread> destructor needs to join the thread,
+                // which can't happen until this sync() block has exited.
+                m_loop->m_task_set->add(kj::evalLater([self = kj::mv(self)] {}));
+            });
+        });
+        // Assert that calling Waiter::post did not fail. It could only return
+        // false if a new function was posted before the previous one finished
+        // executing, but new functions are only posted when m_thread_ready is
+        // signaled, so this should never happen.
+        assert(posted);
+        return kj::mv(result.promise);
+    }).attach(kj::heap<CancelProbe>(cancel_monitor));
+    m_thread_ready = kj::mv(ready.promise);
+    return ret;
+}
 
 //! Given stream file descriptor, make a new ProxyClient object to send requests
 //! over the stream. Also create a new Connection object embedded in the

--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -153,6 +153,7 @@ public:
     ProxyServerBase(std::shared_ptr<Impl> impl, Connection& connection);
     virtual ~ProxyServerBase();
     void invokeDestroy();
+    using Interface_::Server::thisCap;
 
     /**
      * Implementation pointer that may or may not be owned and deleted when this

--- a/include/mp/version.h
+++ b/include/mp/version.h
@@ -5,22 +5,30 @@
 #ifndef MP_VERSION_H
 #define MP_VERSION_H
 
-//! Major version number. Should be incremented in the master branch before
-//! changes that introduce major new features or break API compatibility, if
-//! there are clients relying on the previous API. (If an API changes multiple
-//! times and nothing uses the intermediate changes, it is sufficient to
-//! increment this only once before the first change.)
+//! @file
+//! @brief Major and minor version numbers
+//!
+//! Versioning uses a cruder form of SemVer where the major number is
+//! incremented with all significant changes, regardless of whether they are
+//! backward compatible, and the minor number is treated like a patch level and
+//! only incremented when a fix or backport is applied to an old branch.
+
+//! Major version number. Should be incremented after any release or external
+//! usage of the library (like a subtree update) so the previous number
+//! identifies that release. Should also be incremented before any change that
+//! breaks backward compatibility or introduces nontrivial features, so
+//! downstream code can use it to detect compatibility.
 //!
 //! Each time this is incremented, a new stable branch should be created. E.g.
 //! when this is incremented to 8, a "v7" stable branch should be created
 //! pointing at the prior merge commit. The /doc/versions.md file should also be
 //! updated, noting any significant or incompatible changes made since the
-//! previous version, and backported to the stable branch before it is tagged.
-#define MP_MAJOR_VERSION 7
+//! previous version.
+#define MP_MAJOR_VERSION 8
 
 //! Minor version number. Should be incremented in stable branches after
-//! backporting changes. The /doc/versions.md file in the master and stable
-//! branches should also be updated to list the new minor version.
+//! backporting changes. The /doc/versions.md file should also be updated to
+//! list the new minor version.
 #define MP_MINOR_VERSION 0
 
 #endif // MP_VERSION_H

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -211,6 +211,7 @@ static void Generate(kj::StringPtr src_prefix,
     cpp_server << "#include <kj/async.h>\n";
     cpp_server << "#include <kj/common.h>\n";
     cpp_server << "#include <kj/exception.h>\n";
+    cpp_server << "#include <kj/tuple.h>\n";
     cpp_server << "#include <mp/proxy.h>\n";
     cpp_server << "#include <mp/util.h>\n";
     cpp_server << "#include <" << PROXY_TYPES << ">\n";

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -38,7 +38,7 @@
 
 namespace mp {
 
-thread_local ThreadContext g_thread_context;
+thread_local ThreadContext g_thread_context; // NOLINT(bitcoin-nontrivial-threadlocal)
 
 void LoggingErrorHandler::taskFailed(kj::Exception&& exception)
 {
@@ -87,6 +87,10 @@ Connection::~Connection()
     // event loop thread, and if there was a remote disconnect, this is called
     // by an onDisconnect callback directly from the event loop thread.
     assert(std::this_thread::get_id() == m_loop->m_thread_id);
+
+    // Try to cancel any calls that may be executing.
+    m_canceler.cancel("Interrupted by disconnect");
+
     // Shut down RPC system first, since this will garbage collect any
     // ProxyServer objects that were not freed before the connection was closed.
     // Typically all ProxyServer objects associated with this connection will be
@@ -362,8 +366,8 @@ ProxyClient<Thread>::~ProxyClient()
     }
 }
 
-ProxyServer<Thread>::ProxyServer(ThreadContext& thread_context, std::thread&& thread)
-    : m_thread_context(thread_context), m_thread(std::move(thread))
+ProxyServer<Thread>::ProxyServer(Connection& connection, ThreadContext& thread_context, std::thread&& thread)
+    : m_loop{*connection.m_loop}, m_thread_context(thread_context), m_thread(std::move(thread))
 {
     assert(m_thread_context.waiter.get() != nullptr);
 }
@@ -418,7 +422,7 @@ kj::Promise<void> ProxyServer<ThreadMap>::makeThread(MakeThreadContext context)
         // is just waiter getting set to null.)
         g_thread_context.waiter->wait(lock, [] { return !g_thread_context.waiter; });
     });
-    auto thread_server = kj::heap<ProxyServer<Thread>>(*thread_context.get_future().get(), std::move(thread));
+    auto thread_server = kj::heap<ProxyServer<Thread>>(m_connection, *thread_context.get_future().get(), std::move(thread));
     auto thread_client = m_connection.m_threads.add(kj::mv(thread_server));
     context.getResults().setResult(kj::mv(thread_client));
     return kj::READY_NOW;

--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -4,7 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the IPC (multiprocess) interface."""
 import asyncio
+import http.client
+import re
 
+from contextlib import ExitStack
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 from test_framework.ipc_util import (
@@ -81,10 +84,104 @@ class IPCInterfaceTest(BitcoinTestFramework):
                 assert_equal(e.type, "FAILED")
         asyncio.run(capnp.run(async_routine()))
 
+    def run_unclean_disconnect_test(self):
+        """Test behavior when disconnecting during an IPC call that later
+        returns a non-null interface pointer. Currently this behavior causes a
+        crash as reported https://github.com/bitcoin/bitcoin/issues/34250, but a
+        followup will change this behavior."""
+        node = self.nodes[0]
+        self.log.info("Running disconnect during BlockTemplate.waitNext")
+        timeout = self.rpc_timeout * 1000.0
+        disconnected_log_check = ExitStack()
+
+        async def async_routine():
+            ctx, init = await make_capnp_init_ctx(self)
+            self.log.debug("Create Mining proxy object")
+            mining = init.makeMining(ctx).result
+
+            self.log.debug("Create a template")
+            opts = self.capnp_modules['mining'].BlockCreateOptions()
+            template = (await mining.createNewBlock(ctx, opts)).result
+
+            self.log.debug("Wait for a new template")
+            waitoptions = self.capnp_modules['mining'].BlockWaitOptions()
+            waitoptions.timeout = timeout
+            waitoptions.feeThreshold = 1
+            with node.assert_debug_log(expected_msgs=["BlockTemplate.waitNext", "IPC server post request"], timeout=2):
+                promise = template.waitNext(ctx, waitoptions)
+                await asyncio.sleep(0.1)
+            disconnected_log_check.enter_context(node.assert_debug_log(expected_msgs=["IPC server: socket disconnected"], timeout=2))
+            del promise
+
+        asyncio.run(capnp.run(async_routine()))
+
+        # Wait for socket disconnected log message, then generate a block to
+        # cause the waitNext() call to return a new template. This will cause a
+        # crash and disconnect with error output.
+        disconnected_log_check.close()
+        try:
+            self.generate(node, 1)
+        except (http.client.RemoteDisconnected, BrokenPipeError, ConnectionResetError):
+            pass
+        node.wait_until_stopped(expected_ret_code=(-11, -6, 1, 66), expected_stderr=re.compile(""))
+        self.start_node(0)
+
+    def run_thread_busy_test(self):
+        """Test behavior when sending multiple calls to the same server thread
+        which used to cause a crash as reported
+        https://github.com/bitcoin/bitcoin/issues/33923 and currently causes a
+        thread busy error. A future change will make this just queue the calls
+        for execution and not trigger any error"""
+        node = self.nodes[0]
+        self.log.info("Running thread busy test")
+        timeout = self.rpc_timeout * 1000.0
+
+        async def async_routine():
+            ctx, init = await make_capnp_init_ctx(self)
+            self.log.debug("Create Mining proxy object")
+            mining = init.makeMining(ctx).result
+
+            self.log.debug("Create a template")
+            opts = self.capnp_modules['mining'].BlockCreateOptions()
+            template = (await mining.createNewBlock(ctx, opts)).result
+
+            self.log.debug("Wait for a new template")
+            waitoptions = self.capnp_modules['mining'].BlockWaitOptions()
+            waitoptions.timeout = timeout
+            waitoptions.feeThreshold = 1
+
+            # Make multiple waitNext calls where the first will start to
+            # execute, the second will be posted waiting to execute, and the
+            # third will fail to execute because the execution thread is busy.
+            with node.assert_debug_log(expected_msgs=["BlockTemplate.waitNext", "IPC server post request"], timeout=2):
+                promise1 = template.waitNext(ctx, waitoptions)
+                await asyncio.sleep(0.1)
+            with node.assert_debug_log(expected_msgs=["BlockTemplate.waitNext", "IPC server post request"], timeout=2):
+                promise2 = template.waitNext(ctx, waitoptions)
+                await asyncio.sleep(0.1)
+            try:
+                await template.waitNext(ctx, waitoptions)
+            except capnp.lib.capnp.KjException as e:
+                assert_equal(e.description, "remote exception: std::exception: thread busy")
+                assert_equal(e.type, "FAILED")
+            else:
+                raise AssertionError("Expected thread busy exception")
+
+            # Generate a new block to make the active waitNext calls return, then clean up.
+            with node.assert_debug_log(expected_msgs=["IPC server send response"], timeout=2):
+                self.generate(node, 1, sync_fun=self.no_op)
+            await ((await promise1).result).destroy(ctx)
+            await ((await promise2).result).destroy(ctx)
+            await template.destroy(ctx)
+
+        asyncio.run(capnp.run(async_routine()))
+
     def run_test(self):
         self.run_echo_test()
         self.run_mining_test()
         self.run_deprecated_mining_test()
+        self.run_unclean_disconnect_test()
+        self.run_thread_busy_test()
 
 if __name__ == '__main__':
     IPCInterfaceTest(__file__).main()

--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -4,8 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the IPC (multiprocess) interface."""
 import asyncio
-import http.client
-import re
 
 from contextlib import ExitStack
 from test_framework.test_framework import BitcoinTestFramework
@@ -86,9 +84,9 @@ class IPCInterfaceTest(BitcoinTestFramework):
 
     def run_unclean_disconnect_test(self):
         """Test behavior when disconnecting during an IPC call that later
-        returns a non-null interface pointer. Currently this behavior causes a
-        crash as reported https://github.com/bitcoin/bitcoin/issues/34250, but a
-        followup will change this behavior."""
+        returns a non-null interface pointer. This used to cause a crash as
+        reported https://github.com/bitcoin/bitcoin/issues/34250, but now just
+        results in a cancellation log message"""
         node = self.nodes[0]
         self.log.info("Running disconnect during BlockTemplate.waitNext")
         timeout = self.rpc_timeout * 1000.0
@@ -110,28 +108,22 @@ class IPCInterfaceTest(BitcoinTestFramework):
             with node.assert_debug_log(expected_msgs=["BlockTemplate.waitNext", "IPC server post request"], timeout=2):
                 promise = template.waitNext(ctx, waitoptions)
                 await asyncio.sleep(0.1)
-            disconnected_log_check.enter_context(node.assert_debug_log(expected_msgs=["IPC server: socket disconnected"], timeout=2))
+            disconnected_log_check.enter_context(node.assert_debug_log(expected_msgs=["IPC server: socket disconnected", "canceled while executing"], timeout=2))
             del promise
 
         asyncio.run(capnp.run(async_routine()))
 
         # Wait for socket disconnected log message, then generate a block to
-        # cause the waitNext() call to return a new template. This will cause a
-        # crash and disconnect with error output.
-        disconnected_log_check.close()
-        try:
+        # cause the waitNext() call to return a new template. Look for a
+        # canceled IPC log message after waitNext returns.
+        with node.assert_debug_log(expected_msgs=["interrupted (canceled)"], timeout=2):
+            disconnected_log_check.close()
             self.generate(node, 1)
-        except (http.client.RemoteDisconnected, BrokenPipeError, ConnectionResetError):
-            pass
-        node.wait_until_stopped(expected_ret_code=(-11, -6, 1, 66), expected_stderr=re.compile(""))
-        self.start_node(0)
 
     def run_thread_busy_test(self):
         """Test behavior when sending multiple calls to the same server thread
         which used to cause a crash as reported
-        https://github.com/bitcoin/bitcoin/issues/33923 and currently causes a
-        thread busy error. A future change will make this just queue the calls
-        for execution and not trigger any error"""
+        https://github.com/bitcoin/bitcoin/issues/33923."""
         node = self.nodes[0]
         self.log.info("Running thread busy test")
         timeout = self.rpc_timeout * 1000.0
@@ -151,27 +143,26 @@ class IPCInterfaceTest(BitcoinTestFramework):
             waitoptions.feeThreshold = 1
 
             # Make multiple waitNext calls where the first will start to
-            # execute, the second will be posted waiting to execute, and the
-            # third will fail to execute because the execution thread is busy.
+            # execute, and the second and third will be posted waiting to
+            # execute. Previously, the third call would fail calling
+            # mp::Waiter::post() because the waiting function slot is occupied,
+            # but now posts are queued.
             with node.assert_debug_log(expected_msgs=["BlockTemplate.waitNext", "IPC server post request"], timeout=2):
                 promise1 = template.waitNext(ctx, waitoptions)
                 await asyncio.sleep(0.1)
             with node.assert_debug_log(expected_msgs=["BlockTemplate.waitNext", "IPC server post request"], timeout=2):
                 promise2 = template.waitNext(ctx, waitoptions)
                 await asyncio.sleep(0.1)
-            try:
-                await template.waitNext(ctx, waitoptions)
-            except capnp.lib.capnp.KjException as e:
-                assert_equal(e.description, "remote exception: std::exception: thread busy")
-                assert_equal(e.type, "FAILED")
-            else:
-                raise AssertionError("Expected thread busy exception")
+            with node.assert_debug_log(expected_msgs=["BlockTemplate.waitNext", "IPC server post request"], timeout=2):
+                promise3 = template.waitNext(ctx, waitoptions)
+                await asyncio.sleep(0.1)
 
             # Generate a new block to make the active waitNext calls return, then clean up.
             with node.assert_debug_log(expected_msgs=["IPC server send response"], timeout=2):
                 self.generate(node, 1, sync_fun=self.no_op)
             await ((await promise1).result).destroy(ctx)
             await ((await promise2).result).destroy(ctx)
+            await ((await promise3).result).destroy(ctx)
             await template.destroy(ctx)
 
         asyncio.run(capnp.run(async_routine()))

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -6,7 +6,7 @@
 import asyncio
 from contextlib import AsyncExitStack
 from io import BytesIO
-import re
+import platform
 from test_framework.blocktools import NULL_OUTPOINT
 from test_framework.messages import (
     MAX_BLOCK_WEIGHT,
@@ -245,17 +245,15 @@ class IPCMiningTest(BitcoinTestFramework):
                 await mining.createNewBlock(ctx, opts)
                 raise AssertionError("createNewBlock unexpectedly succeeded")
             except capnp.lib.capnp.KjException as e:
-                if e.type == "DISCONNECTED":
-                    # The remote exception isn't caught currently and leads to a
-                    # std::terminate call. Just detect and restart in this case.
-                    # This bug is fixed with
-                    # https://github.com/bitcoin-core/libmultiprocess/pull/218
-                    assert_equal(e.description, "Peer disconnected.")
-                    self.nodes[0].wait_until_stopped(expected_ret_code=(-11, -6, 1, 66), expected_stderr=re.compile(""))
-                    self.start_node(0)
+                if e.description == "remote exception: unknown non-KJ exception of type: kj::Exception":
+                    # macOS + REDUCE_EXPORTS bug: Cap'n Proto fails to recognize
+                    # its own exception type and returns a generic error instead.
+                    # https://github.com/bitcoin/bitcoin/pull/34422#discussion_r2863852691
+                    # Assert this only occurs on Darwin until fixed.
+                    assert_equal(platform.system(), "Darwin")
                 else:
                     assert_equal(e.description, "remote exception: std::exception: block_reserved_weight (0) must be at least 2000 weight units")
-                    assert_equal(e.type, "FAILED")
+                assert_equal(e.type, "FAILED")
 
         asyncio.run(capnp.run(async_routine()))
 

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -33,6 +33,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     passFn @16 (context :Proxy.Context, fn :FooFn) -> (result :Int32);
     callFn @17 () -> ();
     callFnAsync @18 (context :Proxy.Context) -> ();
+    callIntFnAsync @21 (context :Proxy.Context, arg :Int32) -> (result :Int32);
 }
 
 interface FooCallback $Proxy.wrap("mp::test::FooCallback") {

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -83,7 +83,9 @@ public:
     std::shared_ptr<FooCallback> m_callback;
     void callFn() { assert(m_fn); m_fn(); }
     void callFnAsync() { assert(m_fn); m_fn(); }
+    int callIntFnAsync(int arg) { assert(m_int_fn); return m_int_fn(arg); }
     std::function<void()> m_fn;
+    std::function<int(int)> m_int_fn;
 };
 
 } // namespace test

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -8,7 +8,9 @@
 #include <atomic>
 #include <capnp/capability.h>
 #include <capnp/rpc.h>
+#include <cassert>
 #include <condition_variable>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <future>
@@ -16,9 +18,7 @@
 #include <kj/async-io.h>
 #include <kj/common.h>
 #include <kj/debug.h>
-#include <kj/exception.h>
 #include <kj/memory.h>
-#include <kj/string.h>
 #include <kj/test.h>
 #include <memory>
 #include <mp/proxy.h>
@@ -31,7 +31,6 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <system_error>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -98,7 +97,7 @@ public:
                   client_connection->m_rpc_system->bootstrap(ServerVatId().vat_id).castAs<messages::FooInterface>(),
                   client_connection.get(), /* destroy_connection= */ client_owns_connection);
               if (client_owns_connection) {
-                  client_connection.release();
+                  (void)client_connection.release();
               } else {
                   client_disconnect = [&] { loop.sync([&] { client_connection.reset(); }); };
               }
@@ -317,7 +316,7 @@ KJ_TEST("Calling IPC method, disconnecting and blocking during the call")
     signal.set_value();
 }
 
-KJ_TEST("Make simultaneous IPC calls to trigger 'thread busy' error")
+KJ_TEST("Make simultaneous IPC calls on single remote thread")
 {
     TestSetup setup;
     ProxyClient<messages::FooInterface>* foo = setup.client.get();
@@ -336,51 +335,39 @@ KJ_TEST("Make simultaneous IPC calls to trigger 'thread busy' error")
         request_thread = &tc.request_threads.at(foo->m_context.connection)->m_client;
     });
 
-    setup.server->m_impl->m_fn = [&] {
-        try
-        {
-            signal.get_future().get();
-        }
-        catch (const std::future_error& e)
-        {
-            KJ_EXPECT(e.code() == std::make_error_code(std::future_errc::future_already_retrieved));
-        }
+    // Call callIntFnAsync 3 times with n=100, 200, 300
+    std::atomic<int> expected = 100;
+
+    setup.server->m_impl->m_int_fn = [&](int n) {
+        assert(n == expected);
+        expected += 100;
+        return n;
     };
 
     auto client{foo->m_client};
-    bool caught_thread_busy = false;
-    // NOTE: '3' was chosen because it was the lowest number
-    // of simultaneous calls required to reliably catch a "thread busy" error
     std::atomic<size_t> running{3};
     foo->m_context.loop->sync([&]
     {
         for (size_t i = 0; i < running; i++)
         {
-            auto request{client.callFnAsyncRequest()};
+            auto request{client.callIntFnAsyncRequest()};
             auto context{request.initContext()};
             context.setCallbackThread(*callback_thread);
             context.setThread(*request_thread);
+            request.setArg(100 * (i+1));
             foo->m_context.loop->m_task_set->add(request.send().then(
-                [&](auto&& results) {
+                [&running, &tc, i](auto&& results) {
+                    assert(results.getResult() == static_cast<int32_t>(100 * (i+1)));
                     running -= 1;
                     tc.waiter->m_cv.notify_all();
-                },
-                [&](kj::Exception&& e) {
-                    KJ_EXPECT(std::string_view{e.getDescription().cStr()} ==
-                        "remote exception: std::exception: thread busy");
-                    caught_thread_busy = true;
-                    running -= 1;
-                    signal.set_value();
-                    tc.waiter->m_cv.notify_all();
-                }
-            ));
+                }));
         }
     });
     {
         Lock lock(tc.waiter->m_mutex);
         tc.waiter->wait(lock, [&running] { return running == 0; });
     }
-    KJ_EXPECT(caught_thread_busy);
+    KJ_EXPECT(expected == 400);
 }
 
 } // namespace test


### PR DESCRIPTION
Includes:

- https://github.com/bitcoin-core/libmultiprocess/pull/241
- https://github.com/bitcoin-core/libmultiprocess/pull/240
- https://github.com/bitcoin-core/libmultiprocess/pull/244
- https://github.com/bitcoin-core/libmultiprocess/pull/245

The main change is https://github.com/bitcoin-core/libmultiprocess/pull/240 which fixes issues with asynchronous requests (https://github.com/bitcoin/bitcoin/issues/33923) and unclean disconnects (https://github.com/bitcoin/bitcoin/issues/34250) that happen with the rust mining client. It also adds tests for these fixes which had some previous review in #34284 (that PR was closed to simplify dependencies between PRs).

The changes can be verified by running `test/lint/git-subtree-check.sh src/ipc/libmultiprocess` as described in [developer notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#subtrees) and [lint instructions](https://github.com/bitcoin/bitcoin/tree/master/test/lint#git-subtree-checksh)

Resolves #33923 and #34250
