### PR TITLE
[RFC] CChain Concurrency Improvement (Base + Tail Architecture)

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -14,12 +14,15 @@
 #include <serialize.h>
 #include <sync.h>
 #include <uint256.h>
+#include <util/copy_on_write.h>
 #include <util/time.h>
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 /**
@@ -376,35 +379,149 @@ public:
     std::string ToString() = delete;
 };
 
-/** An in-memory indexed chain of blocks. */
+/** An in-memory indexed chain of blocks.
+ *
+ * CChain is a regular type supporting copy construction and assignment with
+ * value semantics. Copies share underlying data through copy-on-write, making
+ * them efficient to snapshot.
+ *
+ * THREAD SAFETY:
+ * CChain itself provides NO thread safety guarantees. Concurrent access to the
+ * same CChain object required external synchronization. However, once copied,
+ * each CChain instance is independent and can be safely used by different
+ * threads without coordination.
+ *
+ * PERFORMANCE CHARACTERISTICS:
+ * - Copying: O(1) - increment a reference count, no data duplication
+ * - Reading: (Height, Tip, operator[]): O(1) - direct access to shared data
+ * - SetTip:
+ *   Unique:
+ *      AppendToTail O(1), MergeTailIntoBase O(n) every MAX_TAIL_SIZE ops,
+ *      HandleReorg O(n)
+ *   Shared:
+ *      AppendToTail O(MAX_TAIL_SIZE), MergeTailIntoBase O(n) every
+ *      MAX_TAIL_SIZE ops, HandleReorg O(n)
+ *   Amortized: O(n) per operation in both cases
+ *
+ * COPY-ON-WRITE BEHAVIOR:
+ * When you copy a CChain, both instances share the same underlying data. A
+ * physical copy only occurs when one instance is modified via SetTip. Even
+ * then, under normal operations, only the tail of the chain is copied, not the
+ * entire history.
+ *
+ * TYPICAL USAGE PATTERN:
+ *      // Get a snapshot with O(1) copy
+ *      CChain snapshot = original_chain;
+ *      // Use snapshot without holding locks
+ *      int height = snapshot.Height();
+ *      // Meanwhile, original_chain can be modified independently without
+ *      // affecting the snapshot
+ *
+ * EXAMPLE - Safe concurrent access:
+ *      CChain snapshot;
+ *      {
+ *          LOCK(cs_main);
+ *          snapshot = chainstate.m_chain; // O(1) copy
+ *      }
+ *      // Lock released
+ *      ProcessBlocks(snapshot); // Safe to use without locks
+ * */
 class CChain
 {
 private:
-    std::vector<CBlockIndex*> vChain;
+    struct Impl {
+        stlab::copy_on_write<std::vector<CBlockIndex*>> base;
+        std::vector<CBlockIndex*> tail;
+
+        Impl() = default;
+
+        Impl(std::vector<CBlockIndex*> base_vec, std::vector<CBlockIndex*> tail_vec)
+            : base(std::move(base_vec)), tail(std::move(tail_vec)) {}
+    };
+
+    stlab::copy_on_write<Impl> m_impl;
+
+    static constexpr size_t MAX_TAIL_SIZE = 1000;
+
+    void HandleReorg(Impl& impl,
+                     CBlockIndex& block)
+    {
+        auto& new_base = impl.base.write();
+        new_base.resize(block.nHeight + 1);
+
+        CBlockIndex* index = &block;
+        while (index && new_base[index->nHeight] != index) {
+            new_base[index->nHeight] = index;
+            index = index->pprev;
+        }
+
+        impl.tail.clear();
+    }
+
+    void MergeTailIntoBase(Impl& impl, CBlockIndex& block)
+    {
+        auto& mutable_base = impl.base.write();
+        mutable_base.reserve(mutable_base.size() + impl.tail.size() + 1);
+        mutable_base.insert(mutable_base.end(), impl.tail.begin(), impl.tail.end());
+        mutable_base.push_back(&block);
+
+        impl.tail.clear();
+    }
+
+    void AppendToTail(Impl& impl, CBlockIndex& block)
+    {
+        impl.tail.push_back(&block);
+    }
 
 public:
     CChain() = default;
-    CChain(const CChain&) = delete;
-    CChain& operator=(const CChain&) = delete;
+
+    CChain(const CChain& other) = default;
+    CChain& operator=(const CChain& other) = default;
+    CChain(CChain&&) noexcept = default;
+    CChain& operator=(CChain&&) noexcept = default;
 
     /** Returns the index entry for the genesis block of this chain, or nullptr if none. */
     CBlockIndex* Genesis() const
     {
-        return vChain.size() > 0 ? vChain[0] : nullptr;
+        const auto& impl = m_impl.read();
+        const auto& base = impl.base.read();
+        if (!base.empty()) return base[0];
+        const auto& tail = impl.tail;
+        if (!tail.empty()) return tail[0];
+        return nullptr;
     }
 
     /** Returns the index entry for the tip of this chain, or nullptr if none. */
     CBlockIndex* Tip() const
     {
-        return vChain.size() > 0 ? vChain[vChain.size() - 1] : nullptr;
+        const auto& impl = m_impl.read();
+        const auto& tail = impl.tail;
+        if (!tail.empty()) return tail.back();
+        const auto& base = impl.base.read();
+        if (!base.empty()) return base.back();
+        return nullptr;
     }
 
     /** Returns the index entry at a particular height in this chain, or nullptr if no such height exists. */
     CBlockIndex* operator[](int nHeight) const
     {
-        if (nHeight < 0 || nHeight >= (int)vChain.size())
-            return nullptr;
-        return vChain[nHeight];
+        if (nHeight < 0) return nullptr;
+
+        const auto& impl = m_impl.read();
+        const auto& base = impl.base.read();
+
+        if (nHeight < (int)base.size()) {
+            return base[nHeight];
+        }
+
+        size_t tail_idx = nHeight - base.size();
+        const auto& tail = impl.tail;
+        if (tail_idx < tail.size()) {
+            return tail[tail_idx];
+        }
+
+        return nullptr;
     }
 
     /** Efficiently check whether a block is present in this chain. */
@@ -425,7 +542,10 @@ public:
     /** Return the maximal height in the chain. Is equal to chain.Tip() ? chain.Tip()->nHeight : -1. */
     int Height() const
     {
-        return int(vChain.size()) - 1;
+        const auto& impl = m_impl.read();
+        const auto& base = impl.base.read();
+        const auto& tail = impl.tail;
+        return int(base.size() + tail.size()) - 1;
     }
 
     /** Set/initialize a chain with a given tip. */

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -56,7 +56,7 @@ UniValue CreateUTXOSnapshot(
     const fs::path& tmppath);
 
 //! Return height of highest block that has been pruned, or std::nullopt if no blocks have been pruned
-std::optional<int> GetPruneHeight(const node::BlockManager& blockman, const CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+std::optional<int> GetPruneHeight(const node::BlockManager& blockman, CChain chain) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 void CheckBlockDataAvailability(node::BlockManager& blockman, const CBlockIndex& blockindex, bool check_for_undo) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 #endif // BITCOIN_RPC_BLOCKCHAIN_H

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -62,7 +62,8 @@ using util::ToString;
  * If 'height' is -1, compute the estimate from current chain tip.
  * If 'height' is a valid block height, compute the estimate at the time when a given block was found.
  */
-static UniValue GetNetworkHashPS(int lookup, int height, const CChain& active_chain) {
+static UniValue GetNetworkHashPS(int lookup, int height, const CChain active_chain)
+{
     if (lookup < -1 || lookup == 0) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid nblocks. Must be a positive number or -1.");
     }
@@ -128,8 +129,7 @@ static RPCHelpMan getnetworkhashps()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    LOCK(cs_main);
-    return GetNetworkHashPS(self.Arg<int>("nblocks"), self.Arg<int>("height"), chainman.ActiveChain());
+    return GetNetworkHashPS(self.Arg<int>("nblocks"), self.Arg<int>("height"), chainman.ActiveChainSnapshot());
 },
     };
 }

--- a/src/util/copy_on_write.h
+++ b/src/util/copy_on_write.h
@@ -1,0 +1,260 @@
+// Copyright (c) 2013 Adobe
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file COPYING for license details or
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// Original source: https://github.com/stlab/stlab-copy-on-write
+
+#ifndef BITCOIN_UTIL_COPY_ON_WRITE_H
+#define BITCOIN_UTIL_COPY_ON_WRITE_H
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+namespace stlab {
+
+template <typename T>
+class copy_on_write
+{
+    struct model {
+        std::atomic<std::size_t> _count{1};
+
+        model() noexcept(std::is_nothrow_constructible_v<T>) = default;
+
+        template <class... Args>
+        explicit model(Args&&... args) noexcept(std::is_nothrow_constructible_v<T, Args&&...>) : _value(std::forward<Args>(args)...)
+        {
+        }
+
+        T _value;
+    };
+
+    model* _self;
+
+    template <class U>
+    using disable_copy = std::enable_if_t<!std::is_same_v<std::decay_t<U>, copy_on_write>>*;
+
+    template <typename U>
+    using disable_copy_assign =
+        std::enable_if_t<!std::is_same_v<std::decay_t<U>, copy_on_write>, copy_on_write&>;
+
+    auto default_model() noexcept(std::is_nothrow_constructible_v<T>) -> model*
+    {
+        static model default_s;
+        return &default_s;
+    }
+
+public:
+    using element_type = T;
+
+    copy_on_write() noexcept(std::is_nothrow_constructible_v<T>)
+    {
+        _self = default_model();
+
+        _self->_count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    template <class U>
+    copy_on_write(U&& x, disable_copy<U> = nullptr) : _self(new model(std::forward<U>(x)))
+    {
+    }
+
+    template <class U, class V, class... Args>
+    copy_on_write(U&& x, V&& y, Args&&... args) : _self(new model(std::forward<U>(x), std::forward<V>(y), std::forward<Args>(args)...))
+    {
+    }
+
+    copy_on_write(const copy_on_write& x) noexcept : _self(x._self)
+    {
+        assert(_self && "FATAL (sparent) : using a moved copy_on_write object");
+        _self->_count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    copy_on_write(copy_on_write&& x) noexcept : _self{std::exchange(x._self, nullptr)}
+    {
+        assert(_self && "WARNING (sparent) : using a moved copy_on_write object");
+    }
+
+    ~copy_on_write()
+    {
+        assert(!_self || ((_self->_count > 0) && "FATAL (sparent) : double delete"));
+        if (_self && (_self->_count.fetch_sub(1, std::memory_order_release) == 1)) {
+            std::atomic_thread_fence(std::memory_order_acquire);
+            if constexpr (std::is_default_constructible_v<element_type>) {
+                assert(_self != default_model());
+            }
+            delete _self;
+        }
+    }
+
+    auto operator=(const copy_on_write& x) noexcept -> copy_on_write&
+    {
+        assert(this != &x && "self-assignment is not allowed");
+        return *this = copy_on_write(x);
+    }
+
+    auto operator=(copy_on_write&& x) noexcept -> copy_on_write&
+    {
+        auto tmp{std::move(x)};
+        swap(*this, tmp);
+        return *this;
+    }
+
+    template <class U>
+    auto operator=(U&& x) -> disable_copy_assign<U>
+    {
+        if (_self && unique()) {
+            _self->_value = std::forward<U>(x);
+            return *this;
+        }
+        return *this = copy_on_write(std::forward<U>(x));
+    }
+
+    auto write() -> element_type&
+    {
+        if (!unique()) *this = copy_on_write(read());
+        return _self->_value;
+    }
+
+    template <class Transform, class Inplace>
+    auto write(Transform transform, Inplace inplace) -> element_type&
+    {
+        static_assert(std::is_invocable_r_v<T, Transform, const T&>,
+                      "Transform must be invocable with const T&");
+        static_assert(std::is_invocable_r_v<void, Inplace, T&>,
+                      "Inplace must be invocable with T&");
+
+        if (!unique()) {
+            *this = copy_on_write(transform(read()));
+        } else {
+            inplace(_self->_value);
+        }
+        return _self->_value;
+    }
+
+    [[nodiscard]] auto read() const noexcept -> const element_type&
+    {
+        assert(_self && "FATAL (sparent): using a moved copy_on_write object");
+        return _self->_value;
+    }
+
+    operator const element_type&() const noexcept { return read(); }
+
+    auto operator*() const noexcept -> const element_type& { return read(); }
+
+    auto operator->() const noexcept -> const element_type* { return &read(); }
+
+    [[nodiscard]] auto unique() const noexcept -> bool
+    {
+        assert(_self && "FATAL (sparent) : using a moved copy_on_write object");
+        return _self->_count.load(std::memory_order_acquire) == 1;
+    }
+
+    [[nodiscard]] auto identity(const copy_on_write& x) const noexcept -> bool
+    {
+        assert((_self && x._self) && "FATAL (sparent) : using a moved copy_on_write object");
+        return _self == x._self;
+    }
+
+    friend inline void swap(copy_on_write& x, copy_on_write& y) noexcept
+    {
+        std::swap(x._self, y._self);
+    }
+
+    friend inline auto operator<(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !x.identity(y) && (*x < *y);
+    }
+
+    friend inline auto operator<(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return *x < y;
+    }
+
+    friend inline auto operator<(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return x < *y;
+    }
+
+    friend inline auto operator>(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return y < x;
+    }
+
+    friend inline auto operator>(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return y < x;
+    }
+
+    friend inline auto operator>(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return y < x;
+    }
+
+    friend inline auto operator<=(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(y < x);
+    }
+
+    friend inline auto operator<=(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return !(y < x);
+    }
+
+    friend inline auto operator<=(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(y < x);
+    }
+
+    friend inline auto operator>=(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(x < y);
+    }
+
+    friend inline auto operator>=(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return !(x < y);
+    }
+
+    friend inline auto operator>=(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(x < y);
+    }
+
+    friend inline auto operator==(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return x.identity(y) || (*x == *y);
+    }
+
+    friend inline auto operator==(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return *x == y;
+    }
+
+    friend inline auto operator==(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return x == *y;
+    }
+
+    friend inline auto operator!=(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(x == y);
+    }
+
+    friend inline auto operator!=(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return !(x == y);
+    }
+
+    friend inline auto operator!=(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(x == y);
+    }
+};
+} // namespace stlab
+
+#endif // BITCOIN_UTIL_COPY_ON_WRITE_H

--- a/src/validation.h
+++ b/src/validation.h
@@ -1153,8 +1153,13 @@ public:
     //! @{
     Chainstate& ActiveChainstate() const;
     CChain& ActiveChain() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex()) { return ActiveChainstate().m_chain; }
-    int ActiveHeight() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex()) { return ActiveChain().Height(); }
-    CBlockIndex* ActiveTip() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex()) { return ActiveChain().Tip(); }
+    CChain ActiveChainSnapshot() const
+    {
+        LOCK(GetMutex());
+        return ActiveChainstate().m_chain;
+    }
+    int ActiveHeight() const { return ActiveChainSnapshot().Height(); }
+    CBlockIndex* ActiveTip() const { return ActiveChainSnapshot().Tip(); }
     //! @}
 
     node::BlockMap& BlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)


### PR DESCRIPTION
## RFC: CChain Concurrency Improvement

This PR implements a copy-on-write based CChain design to enable concurrent access.

### Motivation

Current CChain uses a single vector protected by `cs_main`, creating bottlenecks for multi-threaded access. This PR lays the groundwork for removing `cs_main` locks by enabling consistent snapshots without holding locks.

### Design

See full design document: [CChain Concurrency](https://github.com/alexanderwiederin/bitcoinkernel-proposals/blob/master/cchain-concurrency.md) (**Out of date after mutex removal** - will be updated soon)

**TL;DR:** Split chain into base (bulk of history) + tail (recent ~1,000 blocks). Use nested `stlab::copy_on_write` so updates copy only tail, keeping base shared.

*Thanks to @purplekarrot for pointing me to `stlab::copy_on_write` and making design suggestions.*

### Changes

- Implements copy-on-write based CChain with value semantics
- Removes `cs_main` locks from RPC methods (where possible)
- All validation locks remain in place (`cs_main` still held during validation)
- API unchanged - backward compatible

### Request for Comments

1. Is the nested copy-on-write architecture sound?
2. Is `MAX_TAIL_SIZE = 1000` reasonable?
3. What are the concerns for future lock removal?
4. Is the added complexity worth the benefit?