### PR TITLE
refactor: avoid unreachable throw in `inline_check_non_fatal`

### DIFF
--- a/src/util/check.h
+++ b/src/util/check.h
@@ -71,8 +71,9 @@ T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const std::source_location& lo
     if (!val) {
         if constexpr (G_ABORT_ON_FAILED_ASSUME) {
             assertion_fail(loc, assertion);
+        } else {
+            throw NonFatalCheckError{assertion, loc};
         }
-        throw NonFatalCheckError{assertion, loc};
     }
     return std::forward<T>(val);
 }


### PR DESCRIPTION
In builds where `G_ABORT_ON_FAILED_ASSUME` is true, `inline_check_non_fatal` called `assertion_fail()` and then had a throw `NonFatalCheckError` that was never reachable, because `assertion_fail()` either aborts or throws and never returns.
Refactored `inline_check_non_fatal` to use `if constexpr (G_ABORT_ON_FAILED_ASSUME) { assertion_fail(...) } else { throw NonFatalCheckError(...) }` branch, removing the unreachable `throw`