### PR TITLE
ci: mount git directory as writable in linter

### DIFF
--- a/ci/lint.py
+++ b/ci/lint.py
@@ -31,7 +31,7 @@ def get_worktree_mounts(repo_root):
     main_gitdir = gitdir.parent.parent
     return [
         f"--volume={gitdir}:{gitdir}",
-        f"--volume={main_gitdir}:{main_gitdir}:ro",
+        f"--volume={main_gitdir}:{main_gitdir}",
     ]
 
 


### PR DESCRIPTION
On merges to master we set LINT_CI_SANITY_CHECK_COMMIT_SIG (when "GITHUB_REPOSITORY == bitcoin/bitcoin") which runs verify-commits.py.

This requires write access to the .git directory.
Make the mounted .git directory writable.

This is currently not run on PR branches or locally which caused a miss during review.

Ideally we can have the same checks running in PRs as on merges to master to avoid future discrepancies like this.