### PR TITLE
test: node will not try to connect to anchors from an unreachable network

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -576,8 +576,9 @@ class TestNode():
             while remaining_expected and remaining_expected[-1] in log:
                 remaining_expected.pop()
             if not remaining_expected:
-                return
-            if time.time() >= time_end:
+                if time.time() >= time_end:
+                    return
+            elif time.time() >= time_end:
                 break
             time.sleep(0.05)
         remaining_expected = [e for e in remaining_expected if e not in log]


### PR DESCRIPTION
This PR adds a test to check that a node will not try to connect to an anchor from an unreachable network when initializing. It kills and can be tested with the following mutant:

```diff
diff --git a/src/net.cpp b/src/net.cpp
index 6b79e913e8..cd8aa4c502 100644
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2774,7 +2774,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
             if (anchor && !m_anchors.empty()) {
                 const CAddress addr = m_anchors.back();
                 m_anchors.pop_back();
-                if (!addr.IsValid() || IsLocal(addr) || !g_reachable_nets.Contains(addr) ||
+                if (!addr.IsValid() || IsLocal(addr) ||
                     !m_msgproc->HasAllDesirableServiceFlags(addr.nServices) ||
                     outbound_ipv46_peer_netgroups.contains(m_netgroupman.GetGroup(addr))) continue;
                 addrConnect = addr;
```

Also, it fixes a bug in `assert_debug_log` which has a timing asymmetry between expected and unexpected message
checking. When all expected messages were found early, the function would return immediately without waiting for the full timeout period. This created a race condition where unexpected messages appearing after the expected messages (but before the timeout) would not be detected.