### PR TITLE
test: Turn ElapseSteady into SteadyClockContext

### DIFF
--- a/src/test/fuzz/p2p_headers_presync.cpp
+++ b/src/test/fuzz/p2p_headers_presync.cpp
@@ -172,7 +172,7 @@ FUZZ_TARGET(p2p_headers_presync, .init = initialize)
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     // The steady clock is currently only used for logging, so a constant
     // time-point seems acceptable for now.
-    ElapseSteady elapse_steady{};
+    SteadyClockContext steady_ctx{};
 
     ChainstateManager& chainman = *g_testing_setup->m_node.chainman;
     CBlockHeader base{chainman.GetParams().GenesisBlock()};

--- a/src/test/util/time.h
+++ b/src/test/util/time.h
@@ -5,16 +5,30 @@
 #ifndef BITCOIN_TEST_UTIL_TIME_H
 #define BITCOIN_TEST_UTIL_TIME_H
 
+#include <util/check.h>
 #include <util/time.h>
 
-struct ElapseSteady {
+
+/// Helper to initialize the global MockableSteadyClock, let a duration elapse,
+/// and reset it after use in a test.
+class SteadyClockContext
+{
     MockableSteadyClock::mock_time_point::duration t{MockableSteadyClock::INITIAL_MOCK_TIME};
-    ElapseSteady()
+
+public:
+    /** Initialize with INITIAL_MOCK_TIME. */
+    explicit SteadyClockContext() { (*this) += 0s; }
+
+    /** Unset mocktime */
+    ~SteadyClockContext() { MockableSteadyClock::ClearMockTime(); }
+
+    SteadyClockContext(const SteadyClockContext&) = delete;
+    SteadyClockContext& operator=(const SteadyClockContext&) = delete;
+
+    /** Change mocktime by the given duration delta */
+    void operator+=(std::chrono::milliseconds d)
     {
-        (*this)(0s); // init
-    }
-    void operator()(std::chrono::milliseconds d)
-    {
+        Assert(d >= 0s); // Steady time can only increase monotonically.
         t += d;
         MockableSteadyClock::SetMockTime(t);
     }


### PR DESCRIPTION
`ElapseSteady` was introduced a while back, but is only used in one place. It makes more sense if this were a context manager, so that mocktime does not leak from one test into the next.

So turn it into a context manager, rename it and allow easy time advancement via e.g. `steady_ctx += 1h`.

