### PR TITLE
script: remove unused `SCRIPT_ERR_LAST`

### DIFF
--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -86,8 +86,6 @@ typedef enum ScriptError_t
     SCRIPT_ERR_ERROR_COUNT
 } ScriptError;
 
-#define SCRIPT_ERR_LAST SCRIPT_ERR_ERROR_COUNT
-
 std::string ScriptErrorString(ScriptError error);
 
 #endif // BITCOIN_SCRIPT_SCRIPT_ERROR_H


### PR DESCRIPTION
It was introduced in ab9edbd6b6eb3efbca11f16fa467c3c0ef905708 and never used since. It seems it might have been intended to be exposed as part of a public library interface, which has since been superseded.

The only call site uses SCRIPT_ERR_ERROR_COUNT directly.