### PR TITLE
miniscript: correct and_v() properties

### DIFF
--- a/src/script/miniscript.cpp
+++ b/src/script/miniscript.cpp
@@ -144,7 +144,7 @@ Type ComputeType(Fragment fragment, Type x, Type y, Type z, const std::vector<Ty
             (y & "KVB"_mst).If(x << "V"_mst) | // B=V_x*B_y, V=V_x*V_y, K=V_x*K_y
             (x & "n"_mst) | (y & "n"_mst).If(x << "z"_mst) | // n=n_x+z_x*n_y
             ((x | y) & "o"_mst).If((x | y) << "z"_mst) | // o=o_x*z_y+z_x*o_y
-            (x & y & "dmz"_mst) | // d=d_x*d_y, m=m_x*m_y, z=z_x*z_y
+            (x & y & "mz"_mst) | // m=m_x*m_y, z=z_x*z_y
             ((x | y) & "s"_mst) | // s=s_x+s_y
             "f"_mst.If((y << "f"_mst) || (x << "s"_mst)) | // f=f_y+s_x
             (y & "ux"_mst) | // u=u_y, x=x_y


### PR DESCRIPTION
`and_v()` must never be 'd'. This is not a bug fix since this was unreachable in valid Miniscripts: the first sub of an `and_v()` must be of type V, which conflicts with (i.e. never has) property 'd'.