### PR TITLE
rpc: `uptime` should begin on application start

### DIFF
--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -127,8 +127,8 @@ std::optional<size_t> GetTotalRAM()
     return std::nullopt;
 }
 
-SteadyClock::duration GetUptime()
-{
-    static const auto g_startup_time{SteadyClock::now()};
-    return SteadyClock::now() - g_startup_time;
-}
+namespace {
+    const auto g_startup_time{SteadyClock::now()};
+} // namespace
+
+SteadyClock::duration GetUptime() { return SteadyClock::now() - g_startup_time; }

--- a/test/functional/rpc_uptime.py
+++ b/test/functional/rpc_uptime.py
@@ -26,8 +26,11 @@ class UptimeTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Mocktime must be in the range [0, 9223372036], not -1.", self.nodes[0].setmocktime, -1)
 
     def _test_uptime(self):
-        wait_time = 20_000
+        time.sleep(1) # Do some work before checking uptime
         uptime_before = self.nodes[0].uptime()
+        assert uptime_before > 0, "uptime should begin at app start"
+
+        wait_time = 20_000
         self.nodes[0].setmocktime(int(time.time()) + wait_time)
         uptime_after = self.nodes[0].uptime()
         self.nodes[0].setmocktime(0)


### PR DESCRIPTION
### Problem
#34328 switched uptime to use monotonic time, but `g_startup_time` was a function-local static in `GetUptime()`, meaning it was initialized on first call rather than at program start.
This caused the first uptime RPC to always return 0.

### Fix
Move `g_startup_time` to namespace scope so it initializes at program start, ensuring the first `uptime()` call returns actual elapsed time.

### Reproducer

Revert the fix and run the test or alternatively:

```bash
cmake -B build && cmake --build build --target bitcoind bitcoin-cli -j$(nproc)
./build/bin/bitcoind -regtest -daemon
sleep 10
./build/bin/bitcoin-cli -regtest uptime
./build/bin/bitcoin-cli -regtest stop
```

<details>
<summary>Before (uptime is initialized on first call)</summary>

```bash
Bitcoin Core starting
0
Bitcoin Core stopping
```

</details>

<details>
<summary>After (first uptime call is in-line with sleep)</summary>

```bash
Bitcoin Core starting
10
Bitcoin Core stopping
```
</details>

----

Fixes #34423, added reporter as coauthor.