### PR TITLE
ci: use Alpine 3.23

### DIFF
--- a/ci/test/00_setup_env_native_alpine_musl.sh
+++ b/ci/test/00_setup_env_native_alpine_musl.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_alpine_musl
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/alpine:3.22"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/alpine:3.23"
 export CI_BASE_PACKAGES="build-base musl-dev pkgconf curl ccache make ninja git python3-dev py3-pip which patch xz procps rsync util-linux bison e2fsprogs cmake dash linux-headers"
 export PIP_PACKAGES="--break-system-packages pyzmq pycapnp"
 export DEP_OPTS="DEBUG=1"

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -32,7 +32,7 @@ if [ -n "${APT_LLVM_V}" ]; then
   )
 fi
 
-if [[ $CI_IMAGE_NAME_TAG == *alpine* ]]; then
+if command -v apk >/dev/null 2>&1; then
   ${CI_RETRY_EXE} apk update
   # shellcheck disable=SC2086
   ${CI_RETRY_EXE} apk add --no-cache $CI_BASE_PACKAGES $PACKAGES


### PR DESCRIPTION
Use the latest version of Alpine ([3.23](https://www.alpinelinux.org/posts/Alpine-3.23.0-released.html)) in the CI job.
This should fail for now (https://github.com/bitcoin-core/secp256k1/pull/1813), given the use of GCC `15.x`.