### PR TITLE
validation: follow-up nits for lock-free `IsInitialBlockDownload()`

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1934,13 +1934,8 @@ void Chainstate::InitCoinsCache(size_t cache_size_bytes)
     m_coins_views->InitCache();
 }
 
-// This function must be marked `const` so that `CValidationInterface` clients
-// (which are given a `const Chainstate*`) can call it.
-//
-// It is lock-free and depends on `m_cached_is_ibd`, which is latched by
-// `UpdateIBDStatus()`.
-//
-bool ChainstateManager::IsInitialBlockDownload() const
+// Lock-free: depends on `m_cached_is_ibd`, which is latched by `UpdateIBDStatus()`.
+bool ChainstateManager::IsInitialBlockDownload() const noexcept
 {
     return m_cached_is_ibd.load(std::memory_order_relaxed);
 }
@@ -3322,6 +3317,7 @@ static SynchronizationState GetSynchronizationState(bool init, bool blockfiles_i
 
 void ChainstateManager::UpdateIBDStatus()
 {
+    AssertLockHeld(cs_main);
     if (!m_cached_is_ibd.load(std::memory_order_relaxed)) return;
     if (m_blockman.LoadingBlocks()) return;
     if (!CurrentChainstate().m_chain.IsTipRecent(MinimumChainWork(), m_options.max_tip_age)) return;

--- a/src/validation.h
+++ b/src/validation.h
@@ -1182,7 +1182,7 @@ public:
     mutable VersionBitsCache m_versionbitscache;
 
     /** Check whether we are doing an initial block download (synchronizing from disk or network) */
-    bool IsInitialBlockDownload() const;
+    bool IsInitialBlockDownload() const noexcept;
 
     /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
     double GuessVerificationProgress(const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(GetMutex());


### PR DESCRIPTION
Innocent follow-up to #34253:
* Add `AssertLockHeld(cs_main)` to `ChainstateManager::UpdateIBDStatus()` given it's already annotated with `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`.
* Fix outdated comment about constness of `ChainstateManager::IsInitialBlockDownload()` (compilation and build passes without it).
* And since we're touching it, we might as well mark `ChainstateManager::IsInitialBlockDownload()` as `noexcept` now.


