### PR TITLE
refactor: rename remaining BIP14 subversion identifiers to user agent

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -550,12 +550,12 @@ public:
                 const std::string addr{peer["addr"].get_str()};
                 const std::string age{conn_time == 0 ? "" : ToString((time_now - conn_time) / 60)};
                 const std::string services{FormatServices(peer["servicesnames"])};
-                const std::string sub_version{peer["subver"].get_str()};
+                const std::string user_agent{peer["subver"].get_str()};
                 const std::string transport{peer["transport_protocol_type"].isNull() ? "v1" : peer["transport_protocol_type"].get_str()};
                 const bool is_addr_relay_enabled{peer["addr_relay_enabled"].isNull() ? false : peer["addr_relay_enabled"].get_bool()};
                 const bool is_bip152_hb_from{peer["bip152_hb_from"].get_bool()};
                 const bool is_bip152_hb_to{peer["bip152_hb_to"].get_bool()};
-                m_peers.push_back({addr, sub_version, conn_type, NETWORK_SHORT_NAMES[network_id], age, services, transport, min_ping, ping, addr_processed, addr_rate_limited, last_blck, last_recv, last_send, last_trxn, peer_id, mapped_as, version, is_addr_relay_enabled, is_bip152_hb_from, is_bip152_hb_to, is_outbound, is_tx_relay});
+                m_peers.push_back({addr, user_agent, conn_type, NETWORK_SHORT_NAMES[network_id], age, services, transport, min_ping, ping, addr_processed, addr_rate_limited, last_blck, last_recv, last_send, last_trxn, peer_id, mapped_as, version, is_addr_relay_enabled, is_bip152_hb_from, is_bip152_hb_to, is_outbound, is_tx_relay});
                 m_max_addr_length = std::max(addr.length() + 1, m_max_addr_length);
                 m_max_addr_processed_length = std::max(ToString(addr_processed).length(), m_max_addr_processed_length);
                 m_max_addr_rate_limited_length = std::max(ToString(addr_rate_limited).length(), m_max_addr_rate_limited_length);
@@ -733,7 +733,7 @@ public:
         "           peer selection (only displayed if the -asmap config option is set)\n"
         "  id       Peer index, in increasing order of peer connections since node startup\n"
         "  address  IP address and port of the peer\n"
-        "  version  Peer version and subversion concatenated, e.g. \"70016/Satoshi:21.0.0/\"\n\n"
+        "  version  Peer version and user agent concatenated, e.g. \"70016/Satoshi:21.0.0/\"\n\n"
         "* The peer counts table displays the number of peers for each reachable network as well as\n"
         "  the number of block relay peers and manual peers.\n\n"
         "* The local addresses table lists each local address broadcast by the node, the port, and the score.\n\n"

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -62,7 +62,7 @@ std::string FormatFullVersion()
 }
 
 /**
- * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki)
+ * Format the user agent string according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki)
  */
 std::string FormatUserAgent(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
 {

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -64,7 +64,7 @@ std::string FormatFullVersion()
 /**
  * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki)
  */
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
+std::string FormatUserAgent(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
 {
     std::string comments_str;
     if (!comments.empty()) comments_str = strprintf("(%s)", Join(comments, "; "));

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -32,7 +32,7 @@ extern const std::string UA_NAME;
 
 
 std::string FormatFullVersion();
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
+std::string FormatUserAgent(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 
 std::string CopyrightHolders(const std::string& strPrefix);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1638,10 +1638,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             return InitError(strprintf(_("User Agent comment (%s) contains unsafe characters."), cmt));
         uacomments.push_back(cmt);
     }
-    strSubVersion = FormatSubVersion(UA_NAME, CLIENT_VERSION, uacomments);
-    if (strSubVersion.size() > MAX_SUBVERSION_LENGTH) {
+    strUserAgent = FormatUserAgent(UA_NAME, CLIENT_VERSION, uacomments);
+    if (strUserAgent.size() > MAX_USER_AGENT_LENGTH) {
         return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),
-            strSubVersion.size(), MAX_SUBVERSION_LENGTH));
+            strUserAgent.size(), MAX_USER_AGENT_LENGTH));
     }
 
     // Requesting DNS seeds entails connecting to IPv4/IPv6, which -onlynet options may prohibit:

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -117,7 +117,7 @@ bool fDiscover = true;
 bool fListen = true;
 GlobalMutex g_maplocalhost_mutex;
 std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(g_maplocalhost_mutex);
-std::string strSubVersion;
+std::string strUserAgent;
 
 size_t CSerializedNetMsg::GetMemoryUsage() const noexcept
 {
@@ -624,8 +624,8 @@ void CNode::CopyStats(CNodeStats& stats)
     X(m_addr_name);
     X(nVersion);
     {
-        LOCK(m_subver_mutex);
-        X(cleanSubVer);
+        LOCK(m_user_agent_mutex);
+        X(cleanUserAgent);
     }
     stats.fInbound = IsInboundConn();
     X(m_bip152_highbandwidth_to);

--- a/src/net.h
+++ b/src/net.h
@@ -64,7 +64,7 @@ static constexpr auto EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL = 5min;
 /** Maximum length of incoming protocol messages (no message over 4 MB is currently acceptable). */
 static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
 /** Maximum length of the user agent string in `version` message */
-static const unsigned int MAX_SUBVERSION_LENGTH = 256;
+static const unsigned int MAX_USER_AGENT_LENGTH = 256;
 /** Maximum number of automatic outgoing nodes over which we'll relay everything (blocks, tx, addrs, etc) */
 static const int MAX_OUTBOUND_FULL_RELAY_CONNECTIONS = 8;
 /** Maximum number of addnode outgoing nodes */
@@ -174,8 +174,8 @@ CService GetLocalAddress(const CNode& peer);
 extern bool fDiscover;
 extern bool fListen;
 
-/** Subversion as sent to the P2P network in `version` messages */
-extern std::string strSubVersion;
+/** UserAgent as sent to the P2P network in `version` messages */
+extern std::string strUserAgent;
 
 struct LocalServiceInfo {
     int nScore;
@@ -199,7 +199,7 @@ public:
     std::chrono::seconds m_connected;
     std::string m_addr_name;
     int nVersion;
-    std::string cleanSubVer;
+    std::string cleanUserAgent;
     bool fInbound;
     // We requested high bandwidth connection to peer
     bool m_bip152_highbandwidth_to;
@@ -721,12 +721,12 @@ public:
     //! Whether this peer is an inbound onion, i.e. connected via our Tor onion service.
     const bool m_inbound_onion;
     std::atomic<int> nVersion{0};
-    Mutex m_subver_mutex;
+    Mutex m_user_agent_mutex;
     /**
-     * cleanSubVer is a sanitized string of the user agent byte array we read
+     * cleanUserAgent is a sanitized string of the user agent byte array we read
      * from the wire. This cleaned string can safely be logged or displayed.
      */
-    std::string cleanSubVer GUARDED_BY(m_subver_mutex){};
+    std::string cleanUserAgent GUARDED_BY(m_user_agent_mutex){};
     const bool m_prefer_evict{false}; // This peer is preferred for eviction.
     bool HasPermission(NetPermissionFlags permission) const {
         return NetPermissions::HasFlag(m_permission_flags, permission);
@@ -963,7 +963,7 @@ public:
 
     void CloseSocketDisconnect() EXCLUSIVE_LOCKS_REQUIRED(!m_sock_mutex);
 
-    void CopyStats(CNodeStats& stats) EXCLUSIVE_LOCKS_REQUIRED(!m_subver_mutex, !m_addr_local_mutex, !cs_vSend, !cs_vRecv);
+    void CopyStats(CNodeStats& stats) EXCLUSIVE_LOCKS_REQUIRED(!m_user_agent_mutex, !m_addr_local_mutex, !cs_vSend, !cs_vRecv);
 
     std::string ConnectionTypeAsString() const { return ::ConnectionTypeAsString(m_conn_type); }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1563,7 +1563,7 @@ void PeerManagerImpl::PushNodeVersion(CNode& pnode, const Peer& peer)
         my_time = count_seconds(GetTime<std::chrono::seconds>());
         your_services = addr.nServices;
         your_addr = addr.IsRoutable() && !IsProxy(addr) && addr.IsAddrV1Compatible() ? CService{addr} : CService{};
-        my_user_agent = strSubVersion;
+        my_user_agent = strUserAgent;
         my_height = m_best_height;
         my_tx_relay = !RejectIncomingTxs(pnode);
     }
@@ -3565,7 +3565,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         uint64_t nNonce = 1;
         ServiceFlags nServices;
         int nVersion;
-        std::string cleanSubVer;
+        std::string cleanUserAgent;
         int starting_height = -1;
         bool fRelay = true;
 
@@ -3608,9 +3608,9 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             vRecv >> nNonce;
         }
         if (!vRecv.empty()) {
-            std::string strSubVer;
-            vRecv >> LIMITED_STRING(strSubVer, MAX_SUBVERSION_LENGTH);
-            cleanSubVer = SanitizeString(strSubVer);
+            std::string user_agent;
+            vRecv >> LIMITED_STRING(user_agent, MAX_USER_AGENT_LENGTH);
+            cleanUserAgent = SanitizeString(user_agent);
         }
         if (!vRecv.empty()) {
             vRecv >> starting_height;
@@ -3645,8 +3645,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         peer->m_their_services = nServices;
         pfrom.SetAddrLocal(addrMe);
         {
-            LOCK(pfrom.m_subver_mutex);
-            pfrom.cleanSubVer = cleanSubVer;
+            LOCK(pfrom.m_user_agent_mutex);
+            pfrom.cleanUserAgent = cleanUserAgent;
         }
         peer->m_starting_height = starting_height;
 
@@ -3669,7 +3669,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         const auto mapped_as{m_connman.GetMappedAS(pfrom.addr)};
         LogDebug(BCLog::NET, "receive version message: %s: version %d, blocks=%d, us=%s, txrelay=%d, peer=%d%s%s\n",
-                  cleanSubVer, pfrom.nVersion,
+                  cleanUserAgent, pfrom.nVersion,
                   peer->m_starting_height, addrMe.ToStringAddrPort(), fRelay, pfrom.GetId(),
                   pfrom.LogIP(fLogIPs), (mapped_as ? strprintf(", mapped_as=%d", mapped_as) : ""));
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -198,9 +198,9 @@ QString ClientModel::formatFullVersion() const
     return QString::fromStdString(FormatFullVersion());
 }
 
-QString ClientModel::formatSubVersion() const
+QString ClientModel::formatUserAgent() const
 {
-    return QString::fromStdString(strSubVersion);
+    return QString::fromStdString(strUserAgent);
 }
 
 bool ClientModel::isReleaseVersion() const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -83,7 +83,7 @@ public:
     QString getStatusBarWarnings() const;
 
     QString formatFullVersion() const;
-    QString formatSubVersion() const;
+    QString formatUserAgent() const;
     bool isReleaseVersion() const;
     QString formatClientStartupTime() const;
     QString dataDir() const;

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1303,7 +1303,7 @@
                 </widget>
                </item>
                <item row="6" column="1">
-                <widget class="QLabel" name="peerSubversion">
+                <widget class="QLabel" name="peerUserAgent">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -87,8 +87,8 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
             return GUIUtil::formatBytes(rec->nodeStats.nSendBytes);
         case Received:
             return GUIUtil::formatBytes(rec->nodeStats.nRecvBytes);
-        case Subversion:
-            return QString::fromStdString(rec->nodeStats.cleanSubVer);
+        case UserAgent:
+            return QString::fromStdString(rec->nodeStats.cleanUserAgent);
         } // no default case, so the compiler can warn about missing cases
         assert(false);
     } else if (role == Qt::TextAlignmentRole) {
@@ -106,7 +106,7 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
         case Sent:
         case Received:
             return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-        case Subversion:
+        case UserAgent:
             return {};
         } // no default case, so the compiler can warn about missing cases
         assert(false);

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -55,7 +55,7 @@ public:
         Ping,
         Sent,
         Received,
-        Subversion
+        UserAgent
     };
 
     enum {

--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -40,8 +40,8 @@ bool PeerTableSortProxy::lessThan(const QModelIndex& left_index, const QModelInd
         return left_stats.nSendBytes < right_stats.nSendBytes;
     case PeerTableModel::Received:
         return left_stats.nRecvBytes < right_stats.nRecvBytes;
-    case PeerTableModel::Subversion:
-        return left_stats.cleanSubVer.compare(right_stats.cleanSubVer) < 0;
+    case PeerTableModel::UserAgent:
+        return left_stats.cleanUserAgent.compare(right_stats.cleanUserAgent) < 0;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -659,7 +659,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
 
         if (!ui->peerWidget->horizontalHeader()->restoreState(m_peer_widget_header_state)) {
             ui->peerWidget->setColumnWidth(PeerTableModel::Address, ADDRESS_COLUMN_WIDTH);
-            ui->peerWidget->setColumnWidth(PeerTableModel::Subversion, SUBVERSION_COLUMN_WIDTH);
+            ui->peerWidget->setColumnWidth(PeerTableModel::UserAgent, USER_AGENT_COLUMN_WIDTH);
             ui->peerWidget->setColumnWidth(PeerTableModel::Ping, PING_COLUMN_WIDTH);
         }
         ui->peerWidget->horizontalHeader()->setSectionResizeMode(PeerTableModel::Age, QHeaderView::ResizeToContents);
@@ -718,7 +718,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
 
         // Provide initial values
         ui->clientVersion->setText(model->formatFullVersion());
-        ui->clientUserAgent->setText(model->formatSubVersion());
+        ui->clientUserAgent->setText(model->formatUserAgent());
         ui->dataDir->setText(model->dataDir());
         ui->blocksDir->setText(model->blocksDir());
         ui->startupTime->setText(model->formatClientStartupTime());
@@ -1176,7 +1176,7 @@ void RPCConsole::updateDetailWidget()
     ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.m_last_ping_time));
     ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.m_min_ping_time));
     ui->peerVersion->setText(stats->nodeStats.nVersion ? QString::number(stats->nodeStats.nVersion) : ts.na);
-    ui->peerSubversion->setText(!stats->nodeStats.cleanSubVer.empty() ? QString::fromStdString(stats->nodeStats.cleanSubVer) : ts.na);
+    ui->peerUserAgent->setText(!stats->nodeStats.cleanUserAgent.empty() ? QString::fromStdString(stats->nodeStats.cleanUserAgent) : ts.na);
     ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type, /*prepend_direction=*/true));
     ui->peerTransportType->setText(QString::fromStdString(TransportTypeAsString(stats->nodeStats.m_transport_type)));
     if (stats->nodeStats.m_transport_type == TransportProtocolType::V2) {

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -153,7 +153,7 @@ private:
     enum ColumnWidths
     {
         ADDRESS_COLUMN_WIDTH = 200,
-        SUBVERSION_COLUMN_WIDTH = 150,
+        USER_AGENT_COLUMN_WIDTH = 150,
         PING_COLUMN_WIDTH = 80,
         BANSUBNET_COLUMN_WIDTH = 200,
         BANTIME_COLUMN_WIDTH = 250

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -264,7 +264,7 @@ static RPCHelpMan getpeerinfo()
         // Use the sanitized form of subver here, to avoid tricksy remote peers from
         // corrupting or modifying the JSON output by putting special characters in
         // their ver message.
-        obj.pushKV("subver", stats.cleanSubVer);
+        obj.pushKV("subver", stats.cleanUserAgent);
         obj.pushKV("inbound", stats.fInbound);
         obj.pushKV("bip152_hb_to", stats.m_bip152_highbandwidth_to);
         obj.pushKV("bip152_hb_from", stats.m_bip152_highbandwidth_from);
@@ -693,7 +693,7 @@ static RPCHelpMan getnetworkinfo()
     LOCK(cs_main);
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("version",       CLIENT_VERSION);
-    obj.pushKV("subversion",    strSubVersion);
+    obj.pushKV("subversion",    strUserAgent);
     obj.pushKV("protocolversion",PROTOCOL_VERSION);
     NodeContext& node = EnsureAnyNodeContext(request.context);
     if (node.connman) {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -157,7 +157,7 @@ static RPCHelpMan getpeerinfo()
                     {RPCResult::Type::NUM, "minping", /*optional=*/true, "The minimum observed ping time in seconds, if any"},
                     {RPCResult::Type::NUM, "pingwait", /*optional=*/true, "The duration in seconds of an outstanding ping (if non-zero)"},
                     {RPCResult::Type::NUM, "version", "The peer version, such as 70001"},
-                    {RPCResult::Type::STR, "subver", "The string version"},
+                    {RPCResult::Type::STR, "subver", "The peer user agent string"},
                     {RPCResult::Type::BOOL, "inbound", "Inbound (true) or Outbound (false)"},
                     {RPCResult::Type::BOOL, "bip152_hb_to", "Whether we selected peer as (compact blocks) high-bandwidth peer"},
                     {RPCResult::Type::BOOL, "bip152_hb_from", "Whether peer selected us as (compact blocks) high-bandwidth peer"},
@@ -261,7 +261,7 @@ static RPCHelpMan getpeerinfo()
             obj.pushKV("pingwait", Ticks<SecondsDouble>(statestats.m_ping_wait));
         }
         obj.pushKV("version", stats.nVersion);
-        // Use the sanitized form of subver here, to avoid tricksy remote peers from
+        // Use the sanitized form of the user agent string here, to avoid tricksy remote peers from
         // corrupting or modifying the JSON output by putting special characters in
         // their ver message.
         obj.pushKV("subver", stats.cleanUserAgent);
@@ -639,7 +639,7 @@ static RPCHelpMan getnetworkinfo()
                     RPCResult::Type::OBJ, "", "",
                     {
                         {RPCResult::Type::NUM, "version", "the server version"},
-                        {RPCResult::Type::STR, "subversion", "the server subversion string"},
+                        {RPCResult::Type::STR, "subversion", "the server user agent string"},
                         {RPCResult::Type::NUM, "protocolversion", "the protocol version"},
                         {RPCResult::Type::STR_HEX, "localservices", "the services we offer to the network"},
                         {RPCResult::Type::ARR, "localservicesnames", "the services we offer to the network, in human-readable form",

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -63,7 +63,7 @@ FUZZ_TARGET(string)
     (void)FeeModeFromString(random_string_1, fee_estimate_mode);
     const auto width{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 1000)};
     (void)FormatParagraph(random_string_1, width, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, width));
-    (void)FormatSubVersion(random_string_1, fuzzed_data_provider.ConsumeIntegral<int>(), random_string_vector);
+    (void)FormatUserAgent(random_string_1, fuzzed_data_provider.ConsumeIntegral<int>(), random_string_vector);
     (void)GetDescriptorChecksum(random_string_1);
     (void)HelpExampleCli(random_string_1, random_string_2);
     (void)HelpExampleRpc(random_string_1, random_string_2);

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -44,7 +44,7 @@ void ConnmanTestMsg::Handshake(CNode& node,
                 int64_t{},                                      // ignored service bits
                 CNetAddr::V1(CService{}),                       // ignored
                 uint64_t{1},                                    // dummy nonce
-                std::string{},                                  // dummy subver
+                std::string{},                                  // dummy user agent
                 int32_t{},                                      // dummy starting_height
                 relay_txs),
     };

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -919,16 +919,16 @@ BOOST_AUTO_TEST_CASE(test_FormatParagraph)
     BOOST_CHECK_EQUAL(FormatParagraph("Testing that normal newlines do not get indented.\nLike here.", 79), "Testing that normal newlines do not get indented.\nLike here.");
 }
 
-BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
+BOOST_AUTO_TEST_CASE(test_FormatUserAgent)
 {
     std::vector<std::string> comments;
     comments.emplace_back("comment1");
     std::vector<std::string> comments2;
     comments2.emplace_back("comment1");
     comments2.push_back(SanitizeString(std::string("Comment2; .,_?@-; !\"#$%&'()*+/<=>[]\\^`{|}~"), SAFE_CHARS_UA_COMMENT)); // Semicolon is discouraged but not forbidden by BIP-0014
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>()),std::string("/Test:9.99.0/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments),std::string("/Test:9.99.0(comment1)/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2),std::string("/Test:9.99.0(comment1; Comment2; .,_?@-; )/"));
+    BOOST_CHECK_EQUAL(FormatUserAgent("Test", 99900, std::vector<std::string>()),std::string("/Test:9.99.0/"));
+    BOOST_CHECK_EQUAL(FormatUserAgent("Test", 99900, comments),std::string("/Test:9.99.0(comment1)/"));
+    BOOST_CHECK_EQUAL(FormatUserAgent("Test", 99900, comments2),std::string("/Test:9.99.0(comment1; Comment2; .,_?@-; )/"));
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseFixedPoint)

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -33,10 +33,10 @@ class IncludeConfTest(BitcoinTestFramework):
             f.write("uacomment=main\nincludeconf=relative.conf\n")
         self.restart_node(0)
 
-        self.log.info("-includeconf works from config file. subversion should end with 'main; relative)/'")
+        self.log.info("-includeconf works from config file. User agent should end with 'main; relative)/'")
 
-        subversion = self.nodes[0].getnetworkinfo()["subversion"]
-        assert subversion.endswith("main; relative)/")
+        user_agent = self.nodes[0].getnetworkinfo()["subversion"]
+        assert user_agent.endswith("main; relative)/")
 
         self.log.info("-includeconf cannot be used as command-line arg")
         self.stop_node(0)
@@ -49,13 +49,13 @@ class IncludeConfTest(BitcoinTestFramework):
             expected_msg='Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf="relative2.conf"',
         )
 
-        self.log.info("-includeconf cannot be used recursively. subversion should end with 'main; relative)/'")
+        self.log.info("-includeconf cannot be used recursively. User agent should end with 'main; relative)/'")
         with open(self.nodes[0].datadir_path / "relative.conf", "a") as f:
             f.write("includeconf=relative2.conf\n")
         self.start_node(0)
 
-        subversion = self.nodes[0].getnetworkinfo()["subversion"]
-        assert subversion.endswith("main; relative)/")
+        user_agent = self.nodes[0].getnetworkinfo()["subversion"]
+        assert user_agent.endswith("main; relative)/")
         self.stop_node(0, expected_stderr="warning: -includeconf cannot be used from included files; ignoring -includeconf=relative2.conf")
 
         self.log.info("-includeconf cannot contain invalid arg")
@@ -69,7 +69,7 @@ class IncludeConfTest(BitcoinTestFramework):
         (self.nodes[0].datadir_path / "relative.conf").unlink()
         self.nodes[0].assert_start_raises_init_error(expected_msg="Error: Error reading configuration file: Failed to include configuration file relative.conf")
 
-        self.log.info("multiple -includeconf args can be used from the base config file. subversion should end with 'main; relative; relative2)/'")
+        self.log.info("multiple -includeconf args can be used from the base config file. User agent should end with 'main; relative; relative2)/'")
         with open(self.nodes[0].datadir_path / "relative.conf", "w") as f:
             # Restore initial file contents
             f.write("uacomment=relative\n")
@@ -79,8 +79,8 @@ class IncludeConfTest(BitcoinTestFramework):
 
         self.start_node(0)
 
-        subversion = self.nodes[0].getnetworkinfo()["subversion"]
-        assert subversion.endswith("main; relative; relative2)/")
+        user_agent = self.nodes[0].getnetworkinfo()["subversion"]
+        assert user_agent.endswith("main; relative; relative2)/")
 
 if __name__ == '__main__':
     IncludeConfTest(__file__).main()

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -24,7 +24,7 @@ from test_framework.messages import (
 from test_framework.p2p import (
     P2PInterface,
     P2P_SERVICES,
-    P2P_SUBVERSION,
+    P2P_USER_AGENT,
     P2P_VERSION,
     p2p_lock,
 )
@@ -239,7 +239,7 @@ class FilterTest(BitcoinTestFramework):
         # Send version with relay=False
         version_without_fRelay = msg_version()
         version_without_fRelay.nVersion = P2P_VERSION
-        version_without_fRelay.strSubVer = P2P_SUBVERSION
+        version_without_fRelay.user_agent = P2P_USER_AGENT
         version_without_fRelay.nServices = P2P_SERVICES
         version_without_fRelay.relay = 0
         filter_peer_without_nrelay.send_without_ping(version_without_fRelay)

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -19,7 +19,7 @@ from test_framework.messages import (
 )
 from test_framework.p2p import (
     P2PInterface,
-    P2P_SUBVERSION,
+    P2P_USER_AGENT,
     P2P_SERVICES,
     P2P_VERSION_RELAY,
 )
@@ -105,7 +105,7 @@ class P2PLeakTest(BitcoinTestFramework):
     def create_old_version(self, nversion):
         old_version_msg = msg_version()
         old_version_msg.nVersion = nversion
-        old_version_msg.strSubVer = P2P_SUBVERSION
+        old_version_msg.user_agent = P2P_USER_AGENT
         old_version_msg.nServices = P2P_SERVICES
         old_version_msg.relay = P2P_VERSION_RELAY
         return old_version_msg

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -294,7 +294,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             assert_equal(peer.last_message["version"].nTime, 0)
             assert_equal(peer.last_message["version"].addrTo, dummy_address)
             assert_equal(peer.last_message["version"].addrFrom, dummy_address)
-            assert_equal(peer.last_message["version"].strSubVer, "/pynode:0.0.1/")
+            assert_equal(peer.last_message["version"].user_agent, "/pynode:0.0.1/")
             assert_equal(peer.last_message["version"].nStartingHeight, 0)
             assert_equal(peer.last_message["version"].relay, 0)
             assert_equal(peer.last_message["tx"].tx.txid_hex, tx["txid"])

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -15,7 +15,7 @@ from test_framework.messages import (
 from test_framework.p2p import (
     P2PInterface,
     P2P_SERVICES,
-    P2P_SUBVERSION,
+    P2P_USER_AGENT,
     P2P_VERSION,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -92,7 +92,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer = self.nodes[0].add_p2p_connection(SendTxrcnclReceiver(), send_version=False, wait_for_verack=False)
         pre_wtxid_version_msg = msg_version()
         pre_wtxid_version_msg.nVersion = 70015
-        pre_wtxid_version_msg.strSubVer = P2P_SUBVERSION
+        pre_wtxid_version_msg.user_agent = P2P_USER_AGENT
         pre_wtxid_version_msg.nServices = P2P_SERVICES
         pre_wtxid_version_msg.relay = 1
         peer.send_without_ping(pre_wtxid_version_msg)
@@ -104,7 +104,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer = self.nodes[0].add_p2p_connection(SendTxrcnclReceiver(), send_version=False, wait_for_verack=False)
         no_txrelay_version_msg = msg_version()
         no_txrelay_version_msg.nVersion = P2P_VERSION
-        no_txrelay_version_msg.strSubVer = P2P_SUBVERSION
+        no_txrelay_version_msg.user_agent = P2P_USER_AGENT
         no_txrelay_version_msg.nServices = P2P_SERVICES
         no_txrelay_version_msg.relay = 0
         peer.send_without_ping(no_txrelay_version_msg)
@@ -117,7 +117,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer = self.nodes[0].add_p2p_connection(SendTxrcnclReceiver(), send_version=False, wait_for_verack=False)
         no_txrelay_version_msg = msg_version()
         no_txrelay_version_msg.nVersion = P2P_VERSION
-        no_txrelay_version_msg.strSubVer = P2P_SUBVERSION
+        no_txrelay_version_msg.user_agent = P2P_USER_AGENT
         no_txrelay_version_msg.nServices = P2P_SERVICES
         no_txrelay_version_msg.relay = 0
         peer.send_without_ping(no_txrelay_version_msg)
@@ -204,7 +204,7 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(), send_version=False, wait_for_verack=False)
         old_version_msg = msg_version()
         old_version_msg.nVersion = 70015
-        old_version_msg.strSubVer = P2P_SUBVERSION
+        old_version_msg.user_agent = P2P_USER_AGENT
         old_version_msg.nServices = P2P_SERVICES
         old_version_msg.relay = 1
         peer.send_without_ping(old_version_msg)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1140,7 +1140,7 @@ class CMerkleBlock:
 # Objects that correspond to messages on the wire
 class msg_version:
     __slots__ = ("addrFrom", "addrTo", "nNonce", "relay", "nServices",
-                 "nStartingHeight", "nTime", "nVersion", "strSubVer")
+                 "nStartingHeight", "nTime", "nVersion", "user_agent")
     msgtype = b"version"
 
     def __init__(self):
@@ -1150,7 +1150,7 @@ class msg_version:
         self.addrTo = CAddress()
         self.addrFrom = CAddress()
         self.nNonce = random.getrandbits(64)
-        self.strSubVer = ''
+        self.user_agent = ''
         self.nStartingHeight = -1
         self.relay = 0
 
@@ -1164,7 +1164,7 @@ class msg_version:
         self.addrFrom = CAddress()
         self.addrFrom.deserialize(f, with_time=False)
         self.nNonce = int.from_bytes(f.read(8), "little")
-        self.strSubVer = deser_string(f).decode('utf-8')
+        self.user_agent = deser_string(f).decode('utf-8')
 
         self.nStartingHeight = int.from_bytes(f.read(4), "little", signed=True)
 
@@ -1180,16 +1180,16 @@ class msg_version:
         r += self.addrTo.serialize(with_time=False)
         r += self.addrFrom.serialize(with_time=False)
         r += self.nNonce.to_bytes(8, "little")
-        r += ser_string(self.strSubVer.encode('utf-8'))
+        r += ser_string(self.user_agent.encode('utf-8'))
         r += self.nStartingHeight.to_bytes(4, "little", signed=True)
         r += self.relay.to_bytes(1, "little")
         return r
 
     def __repr__(self):
-        return 'msg_version(nVersion=%i nServices=%i nTime=%s addrTo=%s addrFrom=%s nNonce=0x%016X strSubVer=%s nStartingHeight=%i relay=%i)' \
+        return 'msg_version(nVersion=%i nServices=%i nTime=%s addrTo=%s addrFrom=%s nNonce=0x%016X user_agent=%s nStartingHeight=%i relay=%i)' \
             % (self.nVersion, self.nServices, time.ctime(self.nTime),
                repr(self.addrTo), repr(self.addrFrom), self.nNonce,
-               self.strSubVer, self.nStartingHeight, self.relay)
+               self.user_agent, self.nStartingHeight, self.relay)
 
 
 class msg_verack:

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -103,7 +103,7 @@ P2P_VERSION = 70016
 # The services that this test framework offers in its `version` message
 P2P_SERVICES = NODE_NETWORK | NODE_WITNESS
 # The P2P user agent string that this test framework sends in its `version` message
-P2P_SUBVERSION = "/python-p2p-tester:0.0.3/"
+P2P_USER_AGENT = "/python-p2p-tester:0.0.3/"
 # Value for relay that this test framework sends in its `version` message
 P2P_VERSION_RELAY = 1
 # Delay after receiving a tx inv before requesting transactions from non-preferred peers, in seconds
@@ -486,7 +486,7 @@ class P2PInterface(P2PConnection):
         # Send a version msg
         vt = msg_version()
         vt.nVersion = P2P_VERSION
-        vt.strSubVer = P2P_SUBVERSION
+        vt.user_agent = P2P_USER_AGENT
         vt.relay = P2P_VERSION_RELAY
         vt.nServices = services
         vt.addrTo.ip = self.dstaddr

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -584,15 +584,15 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         if not wait_for_connect:
             return
 
-        # Use subversion as peer id. Test nodes have their node number appended to the user agent string
-        from_connection_subver = from_connection.getnetworkinfo()['subversion']
-        to_connection_subver = to_connection.getnetworkinfo()['subversion']
+        # Use the user agent string as peer id. Test nodes have their node number appended to it.
+        from_connection_user_agent = from_connection.getnetworkinfo()['subversion']
+        to_connection_user_agent = to_connection.getnetworkinfo()['subversion']
 
-        def find_conn(node, peer_subversion, inbound):
-            return next(filter(lambda peer: peer['subver'] == peer_subversion and peer['inbound'] == inbound, node.getpeerinfo()), None)
+        def find_conn(node, peer_user_agent, inbound):
+            return next(filter(lambda peer: peer['subver'] == peer_user_agent and peer['inbound'] == inbound, node.getpeerinfo()), None)
 
-        self.wait_until(lambda: find_conn(from_connection, to_connection_subver, inbound=False) is not None)
-        self.wait_until(lambda: find_conn(to_connection, from_connection_subver, inbound=True) is not None)
+        self.wait_until(lambda: find_conn(from_connection, to_connection_user_agent, inbound=False) is not None)
+        self.wait_until(lambda: find_conn(to_connection, from_connection_user_agent, inbound=True) is not None)
 
         def check_bytesrecv(peer, msg_type, min_bytes_recv):
             assert peer is not None, "Error: peer disconnected"
@@ -604,8 +604,8 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         #
         # As the flag fSuccessfullyConnected is not exposed, check it by
         # waiting for a pong, which can only happen after the flag was set.
-        self.wait_until(lambda: check_bytesrecv(find_conn(from_connection, to_connection_subver, inbound=False), 'pong', 29))
-        self.wait_until(lambda: check_bytesrecv(find_conn(to_connection, from_connection_subver, inbound=True), 'pong', 29))
+        self.wait_until(lambda: check_bytesrecv(find_conn(from_connection, to_connection_user_agent, inbound=False), 'pong', 29))
+        self.wait_until(lambda: check_bytesrecv(find_conn(to_connection, from_connection_user_agent, inbound=True), 'pong', 29))
 
     def disconnect_nodes(self, a, b):
         def disconnect_nodes_helper(node_a, node_b):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -29,7 +29,7 @@ from .authproxy import (
     serialization_fallback,
 )
 from .messages import NODE_P2P_V2
-from .p2p import P2P_SERVICES, P2P_SUBVERSION
+from .p2p import P2P_SERVICES, P2P_USER_AGENT
 from .util import (
     MAX_NODES,
     assert_equal,
@@ -816,7 +816,7 @@ class TestNode():
             dst_addr_and_port = f"{p2p_conn.dstaddr}:{p2p_conn.dstport}"
             info = [peer for peer in self.getpeerinfo() if peer["addr"] == our_addr_and_port and peer["addrbind"] == dst_addr_and_port]
             assert_equal(len(info), 1)
-            assert_equal(info[0]["subver"], P2P_SUBVERSION)
+            assert_equal(info[0]["subver"], P2P_USER_AGENT)
 
         return p2p_conn
 
@@ -885,7 +885,7 @@ class TestNode():
 
     def num_test_p2p_connections(self):
         """Return number of test framework p2p connections to the node."""
-        return len([peer for peer in self.getpeerinfo() if peer['subver'] == P2P_SUBVERSION])
+        return len([peer for peer in self.getpeerinfo() if peer['subver'] == P2P_USER_AGENT])
 
     def disconnect_p2ps(self):
         """Close all p2p connections to the node.

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -131,7 +131,7 @@ class TestNode():
             "-debugexclude=libevent",
             "-debugexclude=leveldb",
             "-debugexclude=rand",
-            "-uacomment=testnode%d" % i,  # required for subversion uniqueness across peers
+            "-uacomment=testnode%d" % i,  # required for user agent uniqueness across peers
         ]
         if uses_wallet is not None and not uses_wallet:
             self.args.append("-disablewallet")


### PR DESCRIPTION
### Problem
[BIP14](https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki) defines the `sub_version_num` field in `version` messages as a user-agent string, but there are still internal and user-facing references to "subver/subversion" (as noted in https://github.com/bitcoin/bitcoin/pull/34389#discussion_r2721151800).

### Fix
The first commit performs the bulk of the mechanical work via a `scripted-diff` that (with a leading preflight check to make sure the target names don't collide), renaming internal identifiers from `*SubVersion*`/`subver*` to `*UserAgent*`/`user_agent`. I have verified the mechanical renames via to produce the same binary (except for the `test_FormatSubVersion` unit test name).

The second commit follows up with the remaining non-mechanical cleanup, adjusting user-facing descriptions, comments, and local variable names to use "user agent" and explicitly referencing BIP14 as justification.

For compatibility, the RPC keys (`subver`, `subversion`) are intentionally left unchanged.