### PR TITLE
ci, iwyu: Fix warnings in `src/util` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -209,7 +209,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives|univalue/(lib|test)|zmq)/.*\\.cpp|node/blockstorage\\.cpp|node/utxo_snapshot\\.cpp|core_io\\.cpp|signet\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/(((crypto|index|kernel|primitives|univalue/(lib|test)|zmq)/.*|common/license_info|node/blockstorage|node/utxo_snapshot|clientversion|core_io|signet)\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -209,7 +209,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(((crypto|index|kernel|primitives|univalue/(lib|test)|zmq)/.*|common/license_info|node/blockstorage|node/utxo_snapshot|clientversion|core_io|signet)\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/(((crypto|index|kernel|primitives|univalue/(lib|test)|util|zmq)/.*|common/license_info|node/blockstorage|node/utxo_snapshot|clientversion|core_io|signet)\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   common/config.cpp
   common/init.cpp
   common/interfaces.cpp
+  common/license_info.cpp
   common/messages.cpp
   common/netif.cpp
   common/pcp.cpp

--- a/src/bench/strencodings.cpp
+++ b/src/bench/strencodings.cpp
@@ -4,6 +4,7 @@
 
 #include <bench/bench.h>
 #include <consensus/consensus.h>
+#include <crypto/hex_base.h>
 #include <random.h>
 #include <span.h>
 #include <util/strencodings.h>

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -8,6 +8,7 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/license_info.h>
 #include <common/system.h>
 #include <compat/compat.h>
 #include <compat/stdin.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -8,6 +8,7 @@
 #include <clientversion.h>
 #include <coins.h>
 #include <common/args.h>
+#include <common/license_info.h>
 #include <common/system.h>
 #include <compat/compat.h>
 #include <consensus/amount.h>

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -10,6 +10,7 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/license_info.h>
 #include <common/system.h>
 #include <compat/compat.h>
 #include <core_io.h>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -8,6 +8,7 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/license_info.h>
 #include <common/system.h>
 #include <compat/compat.h>
 #include <interfaces/init.h>

--- a/src/bitcoin.cpp
+++ b/src/bitcoin.cpp
@@ -6,6 +6,7 @@
 
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/license_info.h>
 #include <common/system.h>
 #include <util/fs.h>
 #include <util/exec.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -9,6 +9,7 @@
 #include <clientversion.h>
 #include <common/args.h>
 #include <common/init.h>
+#include <common/license_info.h>
 #include <common/system.h>
 #include <compat/compat.h>
 #include <init.h>

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -6,10 +6,8 @@
 
 #include <clientversion.h>
 
-#include <util/string.h>
-#include <util/translation.h>
-
 #include <tinyformat.h>
+#include <util/string.h>
 
 #include <string>
 #include <vector>
@@ -69,35 +67,4 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
     std::string comments_str;
     if (!comments.empty()) comments_str = strprintf("(%s)", Join(comments, "; "));
     return strprintf("/%s:%s%s/", name, FormatVersion(nClientVersion), comments_str);
-}
-
-std::string CopyrightHolders(const std::string& strPrefix)
-{
-    const auto copyright_devs = strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION).translated;
-    std::string strCopyrightHolders = strPrefix + copyright_devs;
-
-    // Make sure Bitcoin Core copyright is not removed by accident
-    if (copyright_devs.find("Bitcoin Core") == std::string::npos) {
-        strCopyrightHolders += "\n" + strPrefix + "The Bitcoin Core developers";
-    }
-    return strCopyrightHolders;
-}
-
-std::string LicenseInfo()
-{
-    const std::string URL_SOURCE_CODE = "<https://github.com/bitcoin/bitcoin>";
-
-    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i"), 2009, COPYRIGHT_YEAR).translated + " ") + "\n" +
-           "\n" +
-           strprintf(_("Please contribute if you find %s useful. "
-                       "Visit %s for further information about the software."),
-                     CLIENT_NAME, "<" CLIENT_URL ">")
-               .translated +
-           "\n" +
-           strprintf(_("The source code is available from %s."), URL_SOURCE_CODE).translated +
-           "\n" +
-           "\n" +
-           _("This is experimental software.") + "\n" +
-           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s"), "COPYING", "<https://opensource.org/license/MIT>").translated +
-           "\n";
 }

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -34,11 +34,6 @@ extern const std::string UA_NAME;
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 
-std::string CopyrightHolders(const std::string& strPrefix);
-
-/** Returns licensing information (for -version) */
-std::string LicenseInfo();
-
 #endif // RC_INVOKED
 
 #endif // BITCOIN_CLIENTVERSION_H

--- a/src/common/license_info.cpp
+++ b/src/common/license_info.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
+#include <common/license_info.h>
+
+#include <tinyformat.h>
+#include <util/translation.h>
+
+#include <string>
+
+std::string CopyrightHolders(const std::string& strPrefix)
+{
+    const auto copyright_devs = strprintf(_(COPYRIGHT_HOLDERS), COPYRIGHT_HOLDERS_SUBSTITUTION).translated;
+    std::string strCopyrightHolders = strPrefix + copyright_devs;
+
+    // Make sure Bitcoin Core copyright is not removed by accident
+    if (copyright_devs.find("Bitcoin Core") == std::string::npos) {
+        strCopyrightHolders += "\n" + strPrefix + "The Bitcoin Core developers";
+    }
+    return strCopyrightHolders;
+}
+
+std::string LicenseInfo()
+{
+    const std::string URL_SOURCE_CODE = "<https://github.com/bitcoin/bitcoin>";
+
+    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i"), 2009, COPYRIGHT_YEAR).translated + " ") + "\n" +
+           "\n" +
+           strprintf(_("Please contribute if you find %s useful. "
+                       "Visit %s for further information about the software."),
+                     CLIENT_NAME, "<" CLIENT_URL ">")
+               .translated +
+           "\n" +
+           strprintf(_("The source code is available from %s."), URL_SOURCE_CODE).translated +
+           "\n" +
+           "\n" +
+           _("This is experimental software.") + "\n" +
+           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s"), "COPYING", "<https://opensource.org/license/MIT>").translated +
+           "\n";
+}

--- a/src/common/license_info.h
+++ b/src/common/license_info.h
@@ -1,0 +1,15 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef BITCOIN_COMMON_LICENSE_INFO_H
+#define BITCOIN_COMMON_LICENSE_INFO_H
+
+#include <string>
+
+std::string CopyrightHolders(const std::string& strPrefix);
+
+/** Returns licensing information (for -version) */
+std::string LicenseInfo();
+
+#endif // BITCOIN_COMMON_LICENSE_INFO_H

--- a/src/core_io.cpp
+++ b/src/core_io.cpp
@@ -11,10 +11,7 @@
 #include <consensus/validation.h>
 #include <crypto/hex_base.h>
 #include <key_io.h>
-// IWYU incorrectly suggests replacing this header
-// with forward declarations.
-// See https://github.com/include-what-you-use/include-what-you-use/issues/1886.
-#include <primitives/block.h> // IWYU pragma: keep
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/descriptor.h>
 #include <script/interpreter.h>

--- a/src/logging.h
+++ b/src/logging.h
@@ -8,6 +8,7 @@
 
 #include <crypto/siphash.h>
 #include <logging/categories.h> // IWYU pragma: export
+#include <span.h>
 #include <util/fs.h>
 #include <util/log.h> // IWYU pragma: export
 #include <util/stdmutex.h>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -7,6 +7,7 @@
 #include <qt/splashscreen.h>
 
 #include <clientversion.h>
+#include <common/license_info.h>
 #include <common/system.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -12,6 +12,7 @@
 
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/license_info.h>
 #include <init.h>
 #include <util/strencodings.h>
 

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -5,6 +5,7 @@
 #include <blockfilter.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/license_info.h>
 #include <common/messages.h>
 #include <common/settings.h>
 #include <common/system.h>

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -7,6 +7,7 @@
 #define BITCOIN_UINT256_H
 
 #include <crypto/common.h>
+#include <crypto/hex_base.h>
 #include <span.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -4,20 +4,18 @@
 
 #include <util/asmap.h>
 
-#include <clientversion.h>
 #include <hash.h>
-#include <serialize.h>
 #include <streams.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/log.h>
 
-#include <algorithm>
 #include <bit>
-#include <cassert>
 #include <cstddef>
 #include <cstdio>
 #include <span>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/util/bip32.cpp
+++ b/src/util/bip32.cpp
@@ -2,12 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <tinyformat.h>
 #include <util/bip32.h>
+
+#include <tinyformat.h>
 #include <util/strencodings.h>
 
 #include <cstdint>
 #include <cstdio>
+#include <optional>
 #include <sstream>
 
 bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath)

--- a/src/util/bytevectorhash.cpp
+++ b/src/util/bytevectorhash.cpp
@@ -2,10 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <crypto/siphash.h>
-#include <random.h>
 #include <util/bytevectorhash.h>
 
+#include <crypto/siphash.h>
+#include <random.h>
+
+#include <span>
 #include <vector>
 
 ByteVectorHash::ByteVectorHash() :

--- a/src/util/chaintype.cpp
+++ b/src/util/chaintype.cpp
@@ -4,7 +4,8 @@
 
 #include <util/chaintype.h>
 
-#include <cassert>
+#include <util/check.h>
+
 #include <optional>
 #include <string>
 

--- a/src/util/chaintype.h
+++ b/src/util/chaintype.h
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 
 enum class ChainType {
     MAIN,

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -8,11 +8,14 @@
 #include <attributes.h>
 
 #include <atomic>
+// We use `util/check.h` to provide the `assert()` macro
+// to ensure that `NDEBUG` is not defined.
 #include <cassert> // IWYU pragma: export
 #include <source_location>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 
 constexpr bool G_FUZZING_BUILD{

--- a/src/util/exec.cpp
+++ b/src/util/exec.cpp
@@ -5,12 +5,17 @@
 #include <util/exec.h>
 
 #include <util/fs.h>
+#ifdef WIN32
 #include <util/subprocess.h>
+#endif
 
+#include <cstdlib>
 #include <string>
-#include <vector>
+#include <system_error>
 
 #ifdef WIN32
+#include <codecvt>
+#include <locale>
 #include <process.h>
 #include <windows.h>
 #else

--- a/src/util/expected.h
+++ b/src/util/expected.h
@@ -8,7 +8,6 @@
 #include <attributes.h>
 #include <util/check.h>
 
-#include <cassert>
 #include <exception>
 #include <utility>
 #include <variant>

--- a/src/util/feefrac.cpp
+++ b/src/util/feefrac.cpp
@@ -3,9 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <util/feefrac.h>
-#include <algorithm>
+
+#include <util/check.h>
+
 #include <array>
-#include <vector>
+#include <cstddef>
 
 std::partial_ordering CompareChunks(std::span<const FeeFrac> chunks0, std::span<const FeeFrac> chunks1)
 {

--- a/src/util/feefrac.h
+++ b/src/util/feefrac.h
@@ -5,13 +5,13 @@
 #ifndef BITCOIN_UTIL_FEEFRAC_H
 #define BITCOIN_UTIL_FEEFRAC_H
 
-#include <span.h>
 #include <util/check.h>
 #include <util/overflow.h>
 
 #include <compare>
 #include <cstdint>
-#include <vector>
+#include <span>
+#include <utility>
 
 /** Data structure storing a fee and size, ordered by increasing fee/size.
  *

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -3,22 +3,20 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <util/fs.h>
+
+#include <util/check.h>
 #include <util/syserror.h>
 
+#include <cerrno>
+#include <string>
+
 #ifndef WIN32
-#include <cstring>
 #include <fcntl.h>
-#include <sys/file.h>
-#include <sys/utsname.h>
 #include <unistd.h>
 #else
 #include <limits>
 #include <windows.h>
 #endif
-
-#include <cassert>
-#include <cerrno>
-#include <string>
 
 namespace fsbridge {
 

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -5,17 +5,18 @@
 #ifndef BITCOIN_UTIL_FS_H
 #define BITCOIN_UTIL_FS_H
 
-#include <tinyformat.h>
+// IWYU incorrectly suggests removing this header.
+// See https://github.com/include-what-you-use/include-what-you-use/issues/1931.
+#include <tinyformat.h> // IWYU pragma: keep
 
 #include <cstdio>
+// The `util/fs.h` header is designed to be a drop-in replacement for `filesystem`.
 #include <filesystem> // IWYU pragma: export
 #include <functional>
 #include <iomanip>
 #include <ios>
-#include <ostream>
 #include <string>
 #include <string_view>
-#include <system_error>
 #include <type_traits>
 #include <utility>
 

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -24,6 +24,7 @@
 #ifndef WIN32
 #include <fcntl.h>
 #include <sys/resource.h>
+#include <sys/types.h>
 #include <unistd.h>
 #else
 #include <io.h>

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -13,6 +13,7 @@
 #include <iosfwd>
 #include <limits>
 #include <optional>
+#include <string>
 
 #ifdef __APPLE__
 enum class FSType {

--- a/src/util/hasher.cpp
+++ b/src/util/hasher.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/hasher.h>
+
 #include <crypto/siphash.h>
 #include <random.h>
-#include <span.h>
-#include <util/hasher.h>
 
 SaltedUint256Hasher::SaltedUint256Hasher() : m_hasher{
     FastRandomContext().rand64(),

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -8,12 +8,11 @@
 #include <crypto/common.h>
 #include <crypto/siphash.h>
 #include <primitives/transaction.h>
-#include <span.h>
 #include <uint256.h>
 
-#include <concepts>
 #include <cstdint>
 #include <cstring>
+#include <span>
 
 class SaltedUint256Hasher
 {

--- a/src/util/obfuscation.h
+++ b/src/util/obfuscation.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_OBFUSCATION_H
 #define BITCOIN_UTIL_OBFUSCATION_H
 
-#include <cstdint>
+#include <crypto/hex_base.h>
 #include <span.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
@@ -13,6 +13,7 @@
 #include <array>
 #include <bit>
 #include <climits>
+#include <cstdint>
 #include <ios>
 #include <memory>
 

--- a/src/util/overflow.h
+++ b/src/util/overflow.h
@@ -5,7 +5,8 @@
 #ifndef BITCOIN_UTIL_OVERFLOW_H
 #define BITCOIN_UTIL_OVERFLOW_H
 
-#include <cassert>
+#include <util/check.h>
+
 #include <climits>
 #include <concepts>
 #include <limits>

--- a/src/util/rbf.cpp
+++ b/src/util/rbf.cpp
@@ -6,6 +6,8 @@
 
 #include <primitives/transaction.h>
 
+#include <vector>
+
 bool SignalsOptInRBF(const CTransaction &tx)
 {
     for (const CTxIn &txin : tx.vin) {

--- a/src/util/readwritefile.cpp
+++ b/src/util/readwritefile.cpp
@@ -9,7 +9,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <limits>
 #include <string>
 #include <utility>
 

--- a/src/util/readwritefile.h
+++ b/src/util/readwritefile.h
@@ -7,6 +7,7 @@
 
 #include <util/fs.h>
 
+#include <cstddef>
 #include <limits>
 #include <string>
 #include <utility>

--- a/src/util/signalinterrupt.h
+++ b/src/util/signalinterrupt.h
@@ -13,7 +13,6 @@
 #endif
 
 #include <atomic>
-#include <cstdlib>
 
 namespace util {
 /**

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -4,18 +4,23 @@
 
 #include <util/sock.h>
 
-#include <common/system.h>
 #include <compat/compat.h>
 #include <span.h>
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/log.h>
 #include <util/syserror.h>
 #include <util/threadinterrupt.h>
 #include <util/time.h>
 
+#include <algorithm>
+#include <compare>
+#include <exception>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
+#include <vector>
 
 #ifdef USE_POLL
 #include <poll.h>

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -6,14 +6,16 @@
 #define BITCOIN_UTIL_SOCK_H
 
 #include <compat/compat.h>
-#include <util/threadinterrupt.h>
 #include <util/time.h>
 
-#include <chrono>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <span>
 #include <string>
 #include <unordered_map>
+
+class CThreadInterrupt;
 
 /**
  * Maximum time to wait for I/O readiness.

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -7,14 +7,13 @@
 
 #include <crypto/hex_base.h>
 #include <span.h>
+#include <util/check.h>
 #include <util/overflow.h>
 
-#include <array>
-#include <cassert>
-#include <cstring>
+#include <compare>
 #include <limits>
 #include <optional>
-#include <ostream>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -9,11 +9,9 @@
 #ifndef BITCOIN_UTIL_STRENCODINGS_H
 #define BITCOIN_UTIL_STRENCODINGS_H
 
-#include <crypto/hex_base.h>
 #include <span.h>
 #include <util/string.h>
 
-#include <algorithm>
 #include <array>
 #include <bit>
 #include <charconv>
@@ -21,6 +19,7 @@
 #include <cstdint>
 #include <limits>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <system_error>

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -4,7 +4,10 @@
 
 #include <util/string.h>
 
+#include <iterator>
+#include <memory>
 #include <regex>
+#include <stdexcept>
 #include <string>
 
 namespace util {

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -5,13 +5,14 @@
 #ifndef BITCOIN_UTIL_STRING_H
 #define BITCOIN_UTIL_STRING_H
 
-#include <span.h>
-
+#include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
-#include <cstring>
+#include <initializer_list>
 #include <locale>
 #include <optional>
+#include <span>
 #include <sstream>
 #include <string>
 #include <string_view>

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -36,10 +36,10 @@ Documentation for C++ subprocessing library.
 #ifndef BITCOIN_UTIL_SUBPROCESS_H
 #define BITCOIN_UTIL_SUBPROCESS_H
 
+#include <util/check.h>
 #include <util/syserror.h>
 
 #include <algorithm>
-#include <cassert>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>

--- a/src/util/syserror.cpp
+++ b/src/util/syserror.cpp
@@ -4,8 +4,9 @@
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
-#include <tinyformat.h>
 #include <util/syserror.h>
+
+#include <tinyformat.h>
 
 #include <cstring>
 #include <string>

--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -11,7 +11,6 @@
 #include <exception>
 #include <functional>
 #include <string>
-#include <utility>
 
 void util::TraceThread(std::string_view thread_name, std::function<void()> thread_func)
 {

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -6,7 +6,7 @@
 #define BITCOIN_UTIL_THREAD_H
 
 #include <functional>
-#include <string>
+#include <string_view>
 
 namespace util {
 /**

--- a/src/util/threadinterrupt.h
+++ b/src/util/threadinterrupt.h
@@ -6,9 +6,9 @@
 #define BITCOIN_UTIL_THREADINTERRUPT_H
 
 #include <sync.h>
+#include <util/time.h>
 
 #include <atomic>
-#include <chrono>
 #include <condition_variable>
 
 /**

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -2,17 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/threadnames.h>
+
+#include <algorithm>
 #include <cstring>
 #include <string>
-#include <thread>
-#include <utility>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>
 #include <pthread_np.h>
 #endif
-
-#include <util/threadnames.h>
 
 #if __has_include(<sys/prctl.h>)
 #include <sys/prctl.h>

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -5,7 +5,6 @@
 
 #include <util/time.h>
 
-#include <compat/compat.h>
 #include <tinyformat.h>
 #include <util/check.h>
 #include <util/strencodings.h>
@@ -13,10 +12,17 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <compare>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <thread>
+
+#ifdef WIN32
+#include <winsock2.h>
+#else
+#include <sys/time.h>
+#endif
 
 static constexpr std::array<std::string_view, 7> weekdays{"Thu", "Fri", "Sat", "Sun", "Mon", "Tue", "Wed"}; // 1970-01-01 was a Thursday.
 static constexpr std::array<std::string_view, 12> months{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -9,9 +9,16 @@
 // The `util/time.h` header is designed to be a drop-in replacement for `chrono`.
 #include <chrono> // IWYU pragma: export
 #include <cstdint>
+#include <ctime>
 #include <optional>
 #include <string>
 #include <string_view>
+
+#ifdef WIN32
+#include <winsock2.h>
+#else
+#include <sys/time.h>
+#endif
 
 using namespace std::chrono_literals;
 

--- a/src/util/tokenpipe.cpp
+++ b/src/util/tokenpipe.cpp
@@ -1,15 +1,18 @@
 // Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#include <util/tokenpipe.h>
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
+
+#include <util/tokenpipe.h>
 
 #ifndef WIN32
 
 #include <cerrno>
-#include <fcntl.h>
 #include <optional>
+
+#include <fcntl.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 TokenPipeEnd TokenPipe::TakeReadEnd()

--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -6,9 +6,9 @@
 #define BITCOIN_UTIL_TRANSLATION_H
 
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/string.h>
 
-#include <cassert>
 #include <functional>
 #include <string>
 


### PR DESCRIPTION
This PR [continues](https://github.com/bitcoin/bitcoin/pull/33725#issuecomment-3466897433) the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).