### PR TITLE
wallet: limit anti fee sniping locktime backdating when spending unconfirmed UTXOs

### DIFF
--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -217,7 +217,7 @@ struct CreatedTransactionResult
  * Set a height-based locktime for new transactions (uses the height of the
  * current chain tip unless we are not synced with the current chain
  */
-void DiscourageFeeSniping(CMutableTransaction& tx, FastRandomContext& rng_fast, interfaces::Chain& chain, const uint256& block_hash, int block_height);
+void DiscourageFeeSniping(CMutableTransaction& tx, FastRandomContext& rng_fast, interfaces::Chain& chain, const uint256& block_hash, int block_height, unsigned int min_locktime);
 
 /**
  * Create a new transaction paying the recipients with a set of coins

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -47,7 +47,8 @@ class CreateTxWalletTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
-        assert 0 < tx['locktime'] <= 201
+        # The nlocktime should be within 100 blocks of the block height
+        assert 101 <= tx['locktime'] <= 201
 
     def test_tx_size_too_large(self):
         # More than 10kB of outputs, so that we hit -maxtxfee with a high feerate


### PR DESCRIPTION
Fixes #26527

The Bitcoin Core wallet implements an anti fee sniping mechanism that sets a transaction’s nLockTime to the current block height, and occasionally to an earlier height.

When the wallet spends unconfirmed UTXOs, this logic can currently choose a locktime for the child transaction that is earlier than the locktime of its unconfirmed parent. This creates an unrealistic “transaction signed earlier but only broadcast now” scenario and may act as a wallet fingerprint.

This PR fixes the issue by preventing a transaction’s nLockTime from being set to a value earlier than the nLockTime of any unconfirmed parent. This is done by passing a minimum nLockTime to `DiscourageFeeSniping` when spending unconfirmed inputs, set to the maximum nLockTime of the unconfirmed parents, or 0 if there are none.

`DiscourageFeeSniping` is currently invoked by the following RPCs:
- `sendall`
- `send`
- `sendtoaddress`
- `sendmany`
- `fundrawtransaction`
- `walletcreatefundedpsbt`

Tests are added for this behavior for the `sendall` and `send` RPCs. These are the only RPCs that can hit this case, since `sendtoaddress` and `sendmany` don’t spend unconfirmed inputs, and `fundrawtransaction` and `walletcreatefundedpsbt` don’t apply fee sniping (instead, they always set `nLockTime` to 0 unless explicitly provided by the user).

You can cherry-pick the two commits adding tests on master and see them intermittently failing (this might take a couple of re-tries to see).