### PR TITLE
ci: Always print low ccache hit rate notice

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -148,11 +148,9 @@ cmake --build "${BASE_BUILD_DIR}" "$MAKEJOBS" --target $GOAL || (
 )
 
 bash -c "${PRINT_CCACHE_STATISTICS}"
-if [ "$CI" = "true" ]; then
-  hit_rate=$(ccache -s | grep "Hits:" | head -1 | sed 's/.*(\(.*\)%).*/\1/')
-  if [ "${hit_rate%.*}" -lt 75 ]; then
-      echo "::notice title=low ccache hitrate::Ccache hit-rate in $CONTAINER_NAME was $hit_rate%"
-  fi
+hit_rate=$(ccache --show-stats | grep "Hits:" | head -1 | sed 's/.*(\(.*\)%).*/\1/')
+if [ "${hit_rate%.*}" -lt 75 ]; then
+  echo "::notice title=low ccache hitrate::Ccache hit-rate in $CONTAINER_NAME was $hit_rate%"
 fi
 du -sh "${DEPENDS_DIR}"/*/
 du -sh "${PREVIOUS_RELEASES_DIR}"


### PR DESCRIPTION
Looks like the hit rate is low, even on test changes such as https://github.com/bitcoin/bitcoin/actions/runs/21476546461/job/61867393974#step:10:3349

to make it easier to debug, unconditionally print the low hit rate notice