### PR TITLE
ci, iwyu: Fix warnings in `src/univalue` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -213,7 +213,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives|zmq)/.*\\.cpp|node/blockstorage.cpp|node/utxo_snapshot.cpp|core_io.cpp|signet.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives|univalue/(lib|test)|zmq)/.*\\.cpp|node/blockstorage\\.cpp|node/utxo_snapshot\\.cpp|core_io\\.cpp|signet\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -7,7 +7,6 @@
 
 #include <iomanip>
 #include <map>
-#include <memory>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/src/univalue/lib/univalue_get.cpp
+++ b/src/univalue/lib/univalue_get.cpp
@@ -5,11 +5,7 @@
 
 #include <univalue.h>
 
-#include <cerrno>
-#include <cstdint>
-#include <cstdlib>
 #include <cstring>
-#include <limits>
 #include <locale>
 #include <sstream>
 #include <stdexcept>

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -6,7 +6,6 @@
 #include <univalue_utffilter.h>
 
 #include <cstdint>
-#include <cstdio>
 #include <cstring>
 #include <string>
 #include <string_view>

--- a/src/univalue/lib/univalue_write.cpp
+++ b/src/univalue/lib/univalue_write.cpp
@@ -5,7 +5,6 @@
 #include <univalue.h>
 #include <univalue_escapes.h>
 
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -8,7 +8,6 @@
 #include <cassert>
 #include <cstdint>
 #include <map>
-#include <memory>
 #include <stdexcept>
 #include <string>
 #include <string_view>

--- a/src/univalue/test/unitester.cpp
+++ b/src/univalue/test/unitester.cpp
@@ -63,8 +63,9 @@
 
 #include <array>
 #include <cassert>
-#include <cstdio>
 #include <string>
+#include <string_view>
+#include <tuple>
 
 static std::string rtrim(std::string s)
 {


### PR DESCRIPTION
This PR continues the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).