### PR TITLE
wallet: add private broadcast support for wallet transactions

### DIFF
--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -143,6 +143,11 @@ bilingual_str TransactionErrorString(const TransactionError err)
             return Untranslated("Unspendable output exceeds maximum configured by user (maxburnamount)");
         case TransactionError::INVALID_PACKAGE:
             return Untranslated("Transaction rejected due to invalid package");
+        case TransactionError::PRIVATE_BROADCAST_UNAVAILABLE:
+            return Untranslated("-privatebroadcast is enabled, but none of the Tor or I2P networks is "
+                                "reachable. Maybe the location of the Tor proxy couldn't be retrieved "
+                                "from the Tor daemon at startup. Check whether the Tor daemon is running "
+                                "and that -torcontrol, -torpassword and -i2psam are configured properly.");
         // no default case, so the compiler can warn about missing cases
     }
     assert(false);

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -3,10 +3,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/messages.h>
 #include <consensus/validation.h>
 #include <index/txindex.h>
 #include <net.h>
 #include <net_processing.h>
+#include <netbase.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/types.h>
@@ -42,6 +44,13 @@ TransactionError BroadcastTransaction(NodeContext& node,
     assert(node.chainman);
     assert(node.mempool);
     assert(node.peerman);
+
+    if (broadcast_method == TxBroadcast::NO_MEMPOOL_PRIVATE_BROADCAST &&
+        !g_reachable_nets.Contains(NET_ONION) &&
+        !g_reachable_nets.Contains(NET_I2P)) {
+        err_string = common::TransactionErrorString(TransactionError::PRIVATE_BROADCAST_UNAVAILABLE).original;
+        return TransactionError::PRIVATE_BROADCAST_UNAVAILABLE;
+    }
 
     Txid txid = tx->GetHash();
     Wtxid wtxid = tx->GetWitnessHash();

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -34,6 +34,7 @@ enum class TransactionError {
     MAX_FEE_EXCEEDED,
     MAX_BURN_EXCEEDED,
     INVALID_PACKAGE,
+    PRIVATE_BROADCAST_UNAVAILABLE,
 };
 
 struct BlockCreateOptions {

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -542,9 +542,15 @@ void SendCoinsDialog::sendButtonClicked([[maybe_unused]] bool checked)
         // Broadcast the transaction, unless an external signer was used and it
         // failed, or more signatures are needed.
         if (broadcast) {
-            // now send the prepared transaction
-            model->sendCoins(*m_current_transaction);
-            Q_EMIT coinsSent(m_current_transaction->getWtx()->GetHash());
+            try {
+                model->sendCoins(*m_current_transaction);
+            } catch (const std::runtime_error& e) {
+                QMessageBox::critical(this, tr("Send Coins"), QString::fromStdString(e.what()));
+                send_failure = true;
+            }
+            if (!send_failure) {
+                Q_EMIT coinsSent(m_current_transaction->getWtx()->GetHash());
+            }
         }
     }
     if (!send_failure) {

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -14,7 +14,6 @@
 #include <index/txospenderindex.h>
 #include <kernel/mempool_entry.h>
 #include <net_processing.h>
-#include <netbase.h>
 #include <node/mempool_persist_args.h>
 #include <node/types.h>
 #include <policy/rbf.h>
@@ -113,15 +112,6 @@ static RPCHelpMan sendrawtransaction()
             AssertLockNotHeld(cs_main);
             NodeContext& node = EnsureAnyNodeContext(request.context);
             const bool private_broadcast_enabled{gArgs.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)};
-            if (private_broadcast_enabled &&
-                !g_reachable_nets.Contains(NET_ONION) &&
-                !g_reachable_nets.Contains(NET_I2P)) {
-                throw JSONRPCError(RPC_MISC_ERROR,
-                                   "-privatebroadcast is enabled, but none of the Tor or I2P networks is "
-                                   "reachable. Maybe the location of the Tor proxy couldn't be retrieved "
-                                   "from the Tor daemon at startup. Check whether the Tor daemon is running "
-                                   "and that -torcontrol, -torpassword and -i2psam are configured properly.");
-            }
             const auto method = private_broadcast_enabled ? node::TxBroadcast::NO_MEMPOOL_PRIVATE_BROADCAST
                                                           : node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL;
             const TransactionError err = BroadcastTransaction(node,

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -395,6 +395,8 @@ RPCErrorCode RPCErrorFromTransactionError(TransactionError terr)
             return RPC_TRANSACTION_REJECTED;
         case TransactionError::ALREADY_IN_UTXO_SET:
             return RPC_VERIFY_ALREADY_IN_UTXO_SET;
+        case TransactionError::PRIVATE_BROADCAST_UNAVAILABLE:
+            return RPC_MISC_ERROR;
         default: break;
     }
     return RPC_TRANSACTION_ERROR;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -27,6 +27,8 @@
 #include <key.h>
 #include <key_io.h>
 #include <logging.h>
+#include <net.h>
+#include <netbase.h>
 #include <node/types.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
@@ -2143,7 +2145,10 @@ void MaybeResendWalletTxs(WalletContext& context)
 {
     for (const std::shared_ptr<CWallet>& pwallet : GetWallets(context)) {
         if (!pwallet->ShouldResend()) continue;
-        pwallet->ResubmitWalletTransactions(node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL, /*force=*/false);
+        const bool private_broadcast{gArgs.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)};
+        const auto method = private_broadcast ? node::TxBroadcast::NO_MEMPOOL_PRIVATE_BROADCAST
+                                              : node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL;
+        pwallet->ResubmitWalletTransactions(method, /*force=*/false);
         pwallet->SetNextResend();
     }
 }
@@ -2316,6 +2321,16 @@ void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::ve
     LOCK(cs_wallet);
     WalletLogPrintf("CommitTransaction:\n%s\n", util::RemoveSuffixView(tx->ToString(), "\n"));
 
+    const bool private_broadcast{gArgs.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)};
+    if (fBroadcastTransactions && private_broadcast &&
+        !g_reachable_nets.Contains(NET_ONION) &&
+        !g_reachable_nets.Contains(NET_I2P)) {
+        const std::string err_string{
+            common::TransactionErrorString(node::TransactionError::PRIVATE_BROADCAST_UNAVAILABLE).original};
+        WalletLogPrintf("CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", err_string);
+        throw std::runtime_error(std::string(__func__) + ": " + err_string);
+    }
+
     // Add tx to wallet, because if it has change it's also ours,
     // otherwise just for transaction history.
     CWalletTx* wtx = AddToWallet(tx, TxStateInactive{}, [&](CWalletTx& wtx, bool new_tx) {
@@ -2344,8 +2359,11 @@ void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::ve
     }
 
     std::string err_string;
-    if (!SubmitTxMemoryPoolAndRelay(*wtx, err_string, node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL)) {
+    const auto method = private_broadcast ? node::TxBroadcast::NO_MEMPOOL_PRIVATE_BROADCAST
+                                          : node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL;
+    if (!SubmitTxMemoryPoolAndRelay(*wtx, err_string, method)) {
         WalletLogPrintf("CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", err_string);
+        // Keep the committed wallet transaction so it can be retried later via rebroadcast.
         // TODO: if we expect the failure to be long term or permanent, instead delete wtx from the wallet and return failure.
     }
 }

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -28,8 +28,10 @@ from test_framework.netutil import (
 )
 from test_framework.script_util import build_malleated_tx_package
 from test_framework.socks5 import (
+    FAKE_ONION_ADDRESSES,
     Socks5Configuration,
     Socks5Server,
+    add_addresses_to_addrman,
 )
 from test_framework.test_framework import (
     BitcoinTestFramework,
@@ -39,7 +41,6 @@ from test_framework.util import (
     assert_greater_than_or_equal,
     assert_not_equal,
     assert_raises_rpc_error,
-    p2p_port,
     tor_port,
 )
 from test_framework.wallet import (
@@ -97,26 +98,7 @@ ADDRMAN_ADDRESSES = [
     "[200::1]",
     "[210::1]",
 
-    "testonlyad777777777777777777777777777777777777777775b6qd.onion",
-    "testonlyah77777777777777777777777777777777777777777z7ayd.onion",
-    "testonlyal77777777777777777777777777777777777777777vp6qd.onion",
-    "testonlyap77777777777777777777777777777777777777777r5qad.onion",
-    "testonlyat77777777777777777777777777777777777777777udsid.onion",
-    "testonlyax77777777777777777777777777777777777777777yciid.onion",
-    "testonlya777777777777777777777777777777777777777777rhgyd.onion",
-    "testonlybd77777777777777777777777777777777777777777rs4ad.onion",
-    "testonlybp77777777777777777777777777777777777777777zs2ad.onion",
-    "testonlybt777777777777777777777777777777777777777777x6id.onion",
-    "testonlybx777777777777777777777777777777777777777775styd.onion",
-    "testonlyb3777777777777777777777777777777777777777774ckid.onion",
-    "testonlycd77777777777777777777777777777777777777777733id.onion",
-    "testonlych77777777777777777777777777777777777777777t6kid.onion",
-    "testonlycl77777777777777777777777777777777777777777tt3ad.onion",
-    "testonlyct77777777777777777777777777777777777777777wvhyd.onion",
-    "testonlycx7777777777777777777777777777777777777777774bad.onion",
-    "testonlyc377777777777777777777777777777777777777777u6aid.onion",
-    "testonlydd777777777777777777777777777777777777777777u5ad.onion",
-    "testonlydh77777777777777777777777777777777777777777wgnyd.onion",
+    *FAKE_ONION_ADDRESSES,
 
     "testonlyad77777777777777777777777777777777777777777q.b32.i2p",
     "testonlyah77777777777777777777777777777777777777777q.b32.i2p",
@@ -168,12 +150,9 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         self.num_nodes = 2
 
     def setup_nodes(self):
-        # Start a SOCKS5 proxy server.
+        # Start a SOCKS5 proxy server with ephemeral port.
         socks5_server_config = Socks5Configuration()
-        # self.nodes[0] listens on p2p_port(0),
-        # self.nodes[1] listens on p2p_port(1),
-        # thus we tell the SOCKS5 server to listen on p2p_port(self.num_nodes) (self.num_nodes is 2)
-        socks5_server_config.addr = ("127.0.0.1", p2p_port(self.num_nodes))
+        socks5_server_config.addr = ("127.0.0.1", 0)  # Let OS assign port
         socks5_server_config.unauth = True
         socks5_server_config.auth = True
 
@@ -320,10 +299,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         wallet = MiniWallet(tx_originator)
 
         # Fill tx_originator's addrman.
-        for addr in ADDRMAN_ADDRESSES:
-            res = tx_originator.addpeeraddress(address=addr, port=8333, tried=False)
-            if not res["success"]:
-                self.log.debug(f"Could not add {addr} to tx_originator's addrman (collision?)")
+        add_addresses_to_addrman(tx_originator, ADDRMAN_ADDRESSES, self.log)
 
         self.wait_until(lambda: len(self.destinations) == NUM_INITIAL_CONNECTIONS)
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -312,6 +312,7 @@ BASE_SCRIPTS = [
     'feature_minchainwork.py',
     'rpc_estimatefee.py',
     'p2p_private_broadcast.py',
+    'wallet_private_broadcast.py',
     'rpc_getblockstats.py',
     'feature_port.py',
     'feature_bind_port_externalip.py',

--- a/test/functional/wallet_private_broadcast.py
+++ b/test/functional/wallet_private_broadcast.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test wallet transaction broadcast when -privatebroadcast is enabled.
+
+When -privatebroadcast is enabled, wallet transactions (sendtoaddress, sendmany,
+send, etc.) should be broadcast privately through Tor/I2P networks instead of
+being announced to all connected peers.
+
+Test coverage:
+- test_sendtoaddress_private_broadcast: New tx broadcasts via SOCKS5 proxy
+- test_error_when_tor_i2p_unavailable: Proper error when no anonymous network
+- test_rebroadcast_with_private_broadcast: Rebroadcast uses private method
+- test_rebroadcast_without_private_broadcast: Rebroadcast uses normal method
+
+Note: P2P-level private broadcast behavior (transaction returning from network,
+rebroadcast timing, etc.) is tested in p2p_private_broadcast.py.
+"""
+
+import time
+
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.socks5 import (
+    FAKE_ONION_ADDRESSES,
+    Socks5ProxyHelper,
+    add_addresses_to_addrman,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+    tor_port,
+)
+
+
+class WalletPrivateBroadcastTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.disable_autoconnect = False
+        self.extra_args = [[], []]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def setup_nodes(self):
+        """Set up SOCKS5 proxy and configure nodes for private broadcast testing."""
+        self.proxy = Socks5ProxyHelper(self.log)
+        self.proxy.start_simple_redirect("127.0.0.1", tor_port(1))
+
+        self.extra_args = [
+            [
+                "-privatebroadcast=1",
+                f"-proxy=127.0.0.1:{self.proxy.port}",
+                "-cjdnsreachable",
+                "-v2transport=0",
+                "-test=addrman",
+                "-debug=privatebroadcast",
+                "-debug=mempool",
+            ],
+            [
+                "-connect=0",
+                f"-bind=127.0.0.1:{tor_port(1)}=onion",
+                "-v2transport=0",
+                "-debug=mempool",
+            ],
+        ]
+        super().setup_nodes()
+
+    def setup_network(self):
+        self.setup_nodes()
+        # Don't connect nodes - private broadcast goes through SOCKS5
+
+    # =========================================================================
+    # Helper methods
+    # =========================================================================
+
+    def create_and_fund_wallets(self):
+        """Create wallets on both nodes and fund the sender."""
+        self.log.info("Creating and funding wallets")
+
+        self.nodes[0].createwallet(wallet_name="sender_wallet")
+        self.sender_wallet = self.nodes[0].get_wallet_rpc("sender_wallet")
+
+        self.nodes[1].createwallet(wallet_name="receiver_wallet")
+        self.receiver_wallet = self.nodes[1].get_wallet_rpc("receiver_wallet")
+
+        address = self.sender_wallet.getnewaddress()
+        self.generatetoaddress(self.nodes[0], 101, address, sync_fun=self.no_op)
+
+        balance = self.sender_wallet.getbalance()
+        assert_greater_than(balance, 0)
+        self.log.info(f"Sender wallet funded with {balance} BTC")
+
+    def reload_sender_wallet(self):
+        """Load the sender wallet and return its RPC interface."""
+        self.nodes[0].loadwallet("sender_wallet")
+        self.sender_wallet = self.nodes[0].get_wallet_rpc("sender_wallet")
+
+    def get_private_broadcast_args(self):
+        """Return node args for private broadcast mode with current proxy."""
+        return [
+            "-privatebroadcast=1",
+            f"-proxy=127.0.0.1:{self.proxy.port}",
+            "-cjdnsreachable",
+            "-v2transport=0",
+            "-test=addrman",
+            "-debug=privatebroadcast",
+            "-debug=mempool",
+        ]
+
+    def trigger_wallet_resubmit(self, node):
+        """Trigger MaybeResendWalletTxs by advancing time and mining a block.
+
+        Wallet resubmission requires:
+        1. A block at least 5 minutes newer than the transaction
+        2. Sufficient time passed (12-36 hours) for the resubmit timer
+        """
+        block_time = int(time.time()) + 6 * 60  # 6 minutes in the future
+        node.setmocktime(block_time)
+
+        best_block_hash = int(node.getbestblockhash(), 16)
+        block = create_block(best_block_hash, create_coinbase(node.getblockcount() + 1), block_time)
+        block.solve()
+        node.submitblock(block.serialize().hex())
+        node.syncwithvalidationinterfacequeue()
+
+        # Advance 36 hours to exceed maximum resubmit interval
+        node.setmocktime(block_time + 36 * 60 * 60)
+        node.mockscheduler(60)
+
+    def saturate_reachable_networks(self, node):
+        """Establish connections to all reachable networks to prevent race conditions.
+
+        Bitcoin Core's network-specific connection logic tries to maintain at least
+        one connection to each reachable network. This can race with private broadcast
+        connections through the SOCKS5 proxy. By pre-establishing connections to all
+        networks, we prevent unpredictable network-specific connections.
+        See https://github.com/bitcoin/bitcoin/issues/34387
+        """
+        node.addnode(node="20.0.0.1:8333", command="onetry")  # IPv4
+        node.addnode(node="[20::1]:8333", command="onetry")  # IPv6
+        node.addnode(node="testonlyp7jkg2rwd3gfdo7ptme3puk2xfvd3hka6qdnypf4gqy3jahid.onion:8333", command="onetry")  # Tor
+        node.addnode(node="[fc00::1]:8333", command="onetry")  # CJDNS
+
+    # =========================================================================
+    # Test methods
+    # =========================================================================
+
+    def test_sendtoaddress_private_broadcast(self):
+        """Test that sendtoaddress broadcasts via SOCKS5 proxy when -privatebroadcast enabled."""
+        self.log.info("Testing sendtoaddress with private broadcast...")
+
+        sender = self.nodes[0]
+        receiver = self.nodes[1]
+        dest = self.receiver_wallet.getnewaddress()
+        initial_destinations = len(self.proxy.destinations)
+
+        # Send transaction
+        self.txid_private = self.sender_wallet.sendtoaddress(dest, 1.0)
+        self.log.info(f"Sent transaction: {self.txid_private}")
+
+        # Verify NOT in sender's mempool (private broadcast skips local mempool)
+        assert_equal(len(sender.getrawmempool()), 0)
+        self.log.info("Transaction not in sender's mempool (expected)")
+
+        # Verify wallet logged private broadcast submission
+        self.wait_for_log_message(sender, f"Submitting wtx {self.txid_private} for private broadcast")
+        self.log.info("Wallet logged private broadcast submission")
+
+        # Verify SOCKS5 connection established
+        self.wait_until(lambda: len(self.proxy.destinations) > initial_destinations)
+        self.log.info("SOCKS5 connection established")
+
+        # Verify private broadcast: INV sent via proxy
+        self.wait_for_log_message(sender, f"P2P handshake completed, sending INV for txid={self.txid_private}")
+        self.log.info("Private broadcast INV sent via SOCKS5")
+
+        # Verify transaction reached receiver and was accepted to mempool
+        self.wait_until(lambda: self.txid_private in receiver.getrawmempool(), timeout=30)
+        self.wait_for_log_message(receiver, f"accepted {self.txid_private}")
+        self.log.info("Transaction accepted by receiver node")
+
+    def test_error_when_tor_i2p_unavailable(self):
+        """Test that wallet RPCs fail gracefully when Tor/I2P is not reachable."""
+        self.log.info("Testing error when Tor/I2P unavailable...")
+
+        # Stop proxy and restart with -privatebroadcast but broken Tor setup:
+        # - -listenonion allows startup (expects to get proxy from Tor later)
+        # - -torcontrol=127.0.0.1:1 fails (port 1 is privileged, nothing listens)
+        # - Result: No working Tor proxy, no I2P, private broadcast unavailable
+        self.proxy.stop()
+        self.restart_node(0, extra_args=[
+            "-privatebroadcast=1",
+            "-v2transport=0",
+            "-listenonion",
+            "-torcontrol=127.0.0.1:1",
+        ])
+        self.reload_sender_wallet()
+
+        dest = self.receiver_wallet.getnewaddress()
+
+        assert_raises_rpc_error(
+            -1,
+            "none of the Tor or I2P networks is reachable",
+            self.sender_wallet.sendtoaddress, dest, 0.1
+        )
+        self.log.info("sendtoaddress correctly rejected")
+
+    def test_rebroadcast_with_private_broadcast(self):
+        """Test that rebroadcast uses private broadcast method when -privatebroadcast enabled."""
+        self.log.info("Testing rebroadcast with -privatebroadcast...")
+
+        sender = self.nodes[0]
+
+        # Start new proxy and restart with -privatebroadcast
+        self.proxy = Socks5ProxyHelper(self.log)
+        self.proxy.start_simple_redirect("127.0.0.1", tor_port(1))
+
+        self.restart_node(0, extra_args=self.get_private_broadcast_args())
+        self.reload_sender_wallet()
+
+        # Verify the tx is still unconfirmed
+        tx_info = self.sender_wallet.gettransaction(self.txid_private)
+        assert_equal(tx_info["confirmations"], 0)
+
+        # Saturate network-specific connection logic before populating addrman
+        self.saturate_reachable_networks(sender)
+        add_addresses_to_addrman(sender, FAKE_ONION_ADDRESSES[:5], self.log)
+
+        # Track log to verify new private broadcast messages
+        log_pos = self.get_log_pos(sender)
+
+        # Trigger resubmission
+        self.trigger_wallet_resubmit(sender)
+
+        # Verify private broadcast was triggered for resubmission
+        self.wait_for_log_message(sender, f"Requesting 3 new connections due to txid={self.txid_private}", log_pos)
+        self.wait_until(lambda: len(self.proxy.destinations) >= 1)
+        self.log.info("Rebroadcast used private broadcast method")
+
+        # Cleanup
+        self.proxy.stop()
+
+    def test_rebroadcast_without_private_broadcast(self):
+        """Test that rebroadcast uses normal method when -privatebroadcast is off."""
+        self.log.info("Testing rebroadcast without -privatebroadcast...")
+
+        sender = self.nodes[0]
+
+        # Restart without -privatebroadcast
+        self.restart_node(0, extra_args=["-v2transport=0"])
+        self.reload_sender_wallet()
+        sender.setmocktime(0)
+
+        # Verify the tx is still unconfirmed
+        tx_info = self.sender_wallet.gettransaction(self.txid_private)
+        assert_equal(tx_info["confirmations"], 0)
+
+        # Track log to verify rebroadcast uses normal method
+        log_pos = self.get_log_pos(sender)
+
+        # Trigger resubmission - should use MEMPOOL_AND_BROADCAST_TO_ALL (normal path)
+        self.trigger_wallet_resubmit(sender)
+
+        # Verify normal submission was used (not private broadcast)
+        self.wait_for_log_message(sender, f"Submitting wtx {self.txid_private} to mempool and for broadcast to peers", log_pos)
+        self.log.info("Rebroadcast used normal broadcast method")
+
+    # =========================================================================
+    # Log helpers
+    # =========================================================================
+
+    def get_log_pos(self, node):
+        """Get current position in node's debug.log for tracking new messages."""
+        try:
+            with open(node.debug_log_path, 'r', encoding='utf-8') as f:
+                f.seek(0, 2)
+                return f.tell()
+        except FileNotFoundError:
+            return 0
+
+    def wait_for_log_message(self, node, message, start_pos=0, timeout=30):
+        """Wait for a message to appear in the node's debug.log."""
+        def check():
+            try:
+                with open(node.debug_log_path, 'r', encoding='utf-8') as f:
+                    if start_pos > 0:
+                        f.seek(start_pos)
+                    return message in f.read()
+            except FileNotFoundError:
+                return False
+        self.wait_until(check, timeout=timeout)
+
+    # =========================================================================
+    # Main test execution
+    # =========================================================================
+
+    def run_test(self):
+        # Saturate network-specific connection logic before populating addrman
+        self.saturate_reachable_networks(self.nodes[0])
+        add_addresses_to_addrman(self.nodes[0], FAKE_ONION_ADDRESSES[:5], self.log)
+        self.create_and_fund_wallets()
+
+        # Run tests in sequence (they share state via self.txid_private)
+        self.test_sendtoaddress_private_broadcast()
+        self.test_error_when_tor_i2p_unavailable()
+        self.test_rebroadcast_with_private_broadcast()
+        self.test_rebroadcast_without_private_broadcast()
+
+        self.log.info("All wallet private broadcast tests passed!")
+
+
+if __name__ == "__main__":
+    WalletPrivateBroadcastTest(__file__).main()


### PR DESCRIPTION
## Summary

Extends the private broadcast feature (#29415) to wallet transactions. When `-privatebroadcast=1` is enabled, wallet RPCs (`sendtoaddress`, `send`, `sendall`, `sendmany`) now broadcast transactions through short-lived Tor/I2P connections instead of announcing to all connected peers.

EDIT: The per-transaction private_broadcast flag in mapValue of the original proposal has been removed (rationale: https://github.com/bitcoin/bitcoin/pull/34533#pullrequestreview-3829186494). 

<details>
  <summary>Previous approach</summary>
  
## Key Changes

**Centralized availability check** (commit 1)
- Moves the Tor/I2P reachability check from `sendrawtransaction` RPC to `BroadcastTransaction()`
- All broadcast callers now get consistent error handling

**Wallet integration** (commit 2)
- `CommitTransaction()`: Uses private broadcast when enabled, fails loudly if Tor/I2P unavailable
- `ResubmitWalletTransactions()`: Rebroadcasts using the original broadcast method
- Persists a `private_broadcast` flag in the wallet transaction's `mapValue`

**Functional tests** (commits 3-4)
- Tests wallet send via SOCKS5 proxy
- Tests flag persistence across restarts
- Tests error handling when Tor/I2P unavailable

## Behavior Matrix

| Scenario | TX Flag | Node Setting | Expected Behavior | Tested |
|----------|---------------|--------------|-------------------|--------|
| New tx | Private | - | Via SOCKS5, flag set | Test 1 ✓ |
| Resubmit | Private | Public | Skip | Test 2 ✓ |
| Resubmit | Public | Private | Skip | Test 3 ✓ |
| Resubmit | Private | Private | Rebroadcast | Test 3 ✓ |
| New tx | Private | - (no Tor) | RPC error | Test 4 ✓ |
| Resubmit | Private | Private (no Tor) | Log error | Test 4 ✓ |

**Why skip on mode mismatch?** Rebroadcasting via a different method than originally used may allow correlation of transaction to origin, or may indicate origin has `-privatebroadcast` enabled.

</details>