### PR TITLE
iwyu: Update mappings

### DIFF
--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -9,7 +9,9 @@
   { "symbol": ["AT_HWCAP", "private", "<sys/auxv.h>", "public"] },
   { "symbol": ["AT_HWCAP2", "private", "<sys/auxv.h>", "public"] },
 
-  # IWYU bug.
+  # Workarounds for IWYU issues.
+  # See: https://github.com/include-what-you-use/include-what-you-use/issues/1616.
+  { "symbol": ["std::pair", "private", "<utility>", "public"] },
   # See: https://github.com/include-what-you-use/include-what-you-use/issues/1863.
   { "symbol": ["std::vector", "private", "<vector>", "public"] },
 ]

--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -6,6 +6,7 @@
   { "include": [ "<tmmintrin.h>", "private", "<immintrin.h>", "public" ] },
 
   # libc symbols.
+  # See: https://github.com/include-what-you-use/include-what-you-use/issues/1809.
   { "symbol": ["AT_HWCAP", "private", "<sys/auxv.h>", "public"] },
   { "symbol": ["AT_HWCAP2", "private", "<sys/auxv.h>", "public"] },
 

--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -9,11 +9,6 @@
   { "symbol": ["AT_HWCAP", "private", "<sys/auxv.h>", "public"] },
   { "symbol": ["AT_HWCAP2", "private", "<sys/auxv.h>", "public"] },
 
-  # Fixed in https://github.com/include-what-you-use/include-what-you-use/pull/1706.
-  { "symbol": ["SEEK_CUR", "private", "<cstdio>", "public"] },
-  { "symbol": ["SEEK_END", "private", "<cstdio>", "public"] },
-  { "symbol": ["SEEK_SET", "private", "<cstdio>", "public"] },
-
   # IWYU bug.
   # See: https://github.com/include-what-you-use/include-what-you-use/issues/1863.
   { "symbol": ["std::vector", "private", "<vector>", "public"] },

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -8,7 +8,6 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <iterator>
 #include <span>
 #include <utility>
 

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -24,7 +24,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <exception>
-#include <iterator>
 #include <span>
 #include <string>
 #include <utility>


### PR DESCRIPTION
This PR:
1. Removes mappings that have been [backported](https://github.com/include-what-you-use/include-what-you-use/pull/1706) upstream.
2. Adds a new temporary mapping to work around upstream [issue](https://github.com/include-what-you-use/include-what-you-use/issues/1616).
3. Document the existing mappings for libc symbols.