### PR TITLE
util: Drop *BSD headers in `batchpriority.cpp`

### DIFF
--- a/src/util/batchpriority.cpp
+++ b/src/util/batchpriority.cpp
@@ -2,15 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/batchpriority.h>
+
 #include <logging.h>
 #include <util/syserror.h>
 
-#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
-#include <pthread.h>
-#include <pthread_np.h>
-#endif
+#include <string>
 
 #ifndef WIN32
+#include <pthread.h>
 #include <sched.h>
 #endif
 


### PR DESCRIPTION
Currently, there are issues with headers in `batchpriority.cpp`:
1. `SCHED_BATCH` is not defined on all supported *BSD platforms.
2. `pthread.h` is necessary on other platforms.

This PR addresses both issues and fixes other includes.