### PR TITLE
refactor: separate log generation from log handling

### DIFF
--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -5,9 +5,9 @@
 #ifndef BITCOIN_CHECKQUEUE_H
 #define BITCOIN_CHECKQUEUE_H
 
-#include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
+#include <util/log.h>
 #include <util/threadnames.h>
 
 #include <algorithm>

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -5,9 +5,9 @@
 #include <coins.h>
 
 #include <consensus/consensus.h>
-#include <logging.h>
 #include <random.h>
 #include <uint256.h>
+#include <util/log.h>
 #include <util/trace.h>
 
 TRACEPOINT_SEMAPHORE(utxocache, add);

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -4,21 +4,6 @@
 
 #include <dbwrapper.h>
 
-#include <logging.h>
-#include <random.h>
-#include <serialize.h>
-#include <span.h>
-#include <streams.h>
-#include <util/fs.h>
-#include <util/fs_helpers.h>
-#include <util/obfuscation.h>
-#include <util/strencodings.h>
-
-#include <algorithm>
-#include <cassert>
-#include <cstdarg>
-#include <cstdint>
-#include <cstdio>
 #include <leveldb/cache.h>
 #include <leveldb/db.h>
 #include <leveldb/env.h>
@@ -29,6 +14,22 @@
 #include <leveldb/slice.h>
 #include <leveldb/status.h>
 #include <leveldb/write_batch.h>
+#include <logging.h>
+#include <random.h>
+#include <serialize.h>
+#include <span.h>
+#include <streams.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
+#include <util/log.h>
+#include <util/obfuscation.h>
+#include <util/strencodings.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -57,7 +58,7 @@ public:
     // This code is adapted from posix_logger.h, which is why it is using vsprintf.
     // Please do not do this in normal code
     void Logv(const char * format, va_list ap) override {
-            if (!LogAcceptCategory(BCLog::LEVELDB, BCLog::Level::Debug)) {
+            if (!LogAcceptCategory(BCLog::LEVELDB, util::log::Level::Debug)) {
                 return;
             }
             char buffer[500];
@@ -276,7 +277,7 @@ CDBWrapper::~CDBWrapper()
 
 void CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
 {
-    const bool log_memory = LogAcceptCategory(BCLog::LEVELDB, BCLog::Level::Debug);
+    const bool log_memory = LogAcceptCategory(BCLog::LEVELDB, util::log::Level::Debug);
     double mem_before = 0;
     if (log_memory) {
         mem_before = DynamicMemoryUsage() / 1024.0 / 1024;

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -3,12 +3,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <stdexcept>
-
 #include <flatfile.h>
-#include <logging.h>
+
 #include <tinyformat.h>
 #include <util/fs_helpers.h>
+#include <util/log.h>
+
+#include <stdexcept>
 
 FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
     m_dir(std::move(dir)),

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -10,7 +10,6 @@
 #include <interfaces/chain.h>
 #include <interfaces/types.h>
 #include <kernel/types.h>
-#include <logging.h>
 #include <node/abort.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
@@ -22,6 +21,7 @@
 #include <uint256.h>
 #include <undo.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/string.h>
 #include <util/thread.h>
 #include <util/threadinterrupt.h>

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -14,7 +14,6 @@
 #include <index/db_key.h>
 #include <interfaces/chain.h>
 #include <interfaces/types.h>
-#include <logging.h>
 #include <serialize.h>
 #include <streams.h>
 #include <sync.h>
@@ -22,6 +21,7 @@
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/hasher.h>
+#include <util/log.h>
 #include <util/syserror.h>
 
 #include <cerrno>

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -17,7 +17,6 @@
 #include <interfaces/chain.h>
 #include <interfaces/types.h>
 #include <kernel/coinstats.h>
-#include <logging.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
@@ -26,6 +25,7 @@
 #include <undo.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <validation.h>
 
 #include <compare>

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -10,7 +10,6 @@
 #include <index/base.h>
 #include <index/disktxpos.h>
 #include <interfaces/chain.h>
-#include <logging.h>
 #include <node/blockstorage.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -18,6 +17,7 @@
 #include <streams.h>
 #include <uint256.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <validation.h>
 
 #include <cassert>

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -12,13 +12,13 @@
 #include <crypto/hex_base.h>
 #include <hash.h>
 #include <kernel/messagestartchars.h>
-#include <logging.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <uint256.h>
 #include <util/chaintype.h>
+#include <util/log.h>
 #include <util/strencodings.h>
 
 #include <algorithm>

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -8,7 +8,6 @@
 #include <coins.h>
 #include <crypto/muhash.h>
 #include <hash.h>
-#include <logging.h>
 #include <node/blockstorage.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
@@ -17,6 +16,7 @@
 #include <sync.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/overflow.h>
 #include <validation.h>
 

--- a/src/kernel/context.cpp
+++ b/src/kernel/context.cpp
@@ -5,8 +5,8 @@
 #include <kernel/context.h>
 
 #include <crypto/sha256.h>
-#include <logging.h>
 #include <random.h>
+#include <util/log.h>
 
 #include <mutex>
 #include <string>

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -602,3 +602,16 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     m_category_log_levels[flag] = level.value();
     return true;
 }
+
+bool util::log::ShouldLog(Category category, Level level)
+{
+    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
+}
+
+void util::log::Log(util::log::Entry entry)
+{
+    BCLog::Logger& logger{LogInstance()};
+    if (logger.Enabled()) {
+        logger.LogPrintStr(std::move(entry.message), std::move(entry.source_loc), static_cast<BCLog::LogFlags>(entry.category), entry.level, entry.should_ratelimit);
+    }
+}

--- a/src/logging.h
+++ b/src/logging.h
@@ -9,8 +9,6 @@
 #include <crypto/siphash.h>
 #include <logging/categories.h> // IWYU pragma: export
 #include <threadsafety.h>
-#include <tinyformat.h>
-#include <util/check.h>
 #include <util/fs.h>
 #include <util/log.h> // IWYU pragma: export
 #include <util/string.h>
@@ -22,11 +20,8 @@
 #include <functional>
 #include <list>
 #include <memory>
-#include <mutex>
-#include <source_location>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
@@ -303,19 +298,5 @@ static inline bool LogAcceptCategory(BCLog::LogFlags category, BCLog::Level leve
 
 /** Return true if str parses as a log category and set the flag */
 bool GetLogCategory(BCLog::LogFlags& flag, std::string_view str);
-
-template <typename... Args>
-inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, BCLog::Level level, bool should_ratelimit, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
-{
-    if (LogInstance().Enabled()) {
-        std::string log_msg;
-        try {
-            log_msg = tfm::format(fmt, args...);
-        } catch (tinyformat::format_error& fmterr) {
-            log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
-        }
-        LogInstance().LogPrintStr(log_msg, std::move(source_loc), flag, level, should_ratelimit);
-    }
-}
 
 #endif // BITCOIN_LOGGING_H

--- a/src/logging.h
+++ b/src/logging.h
@@ -318,35 +318,4 @@ inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags 
     }
 }
 
-// Allow __func__ to be used in any context without warnings:
-// NOLINTNEXTLINE(bugprone-lambda-function-name)
-#define LogPrintLevel_(category, level, should_ratelimit, ...) LogPrintFormatInternal(SourceLocation{__func__}, category, level, should_ratelimit, __VA_ARGS__)
-
-// Log unconditionally. Uses basic rate limiting to mitigate disk filling attacks.
-// Be conservative when using functions that unconditionally log to debug.log!
-// It should not be the case that an inbound peer can fill up a user's storage
-// with debug.log entries.
-#define LogInfo(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, /*should_ratelimit=*/true, __VA_ARGS__)
-#define LogWarning(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Warning, /*should_ratelimit=*/true, __VA_ARGS__)
-#define LogError(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Error, /*should_ratelimit=*/true, __VA_ARGS__)
-
-// Use a macro instead of a function for conditional logging to prevent
-// evaluating arguments when logging for the category is not enabled.
-
-// Log by prefixing the output with the passed category name and severity level. This logs conditionally if
-// the category is allowed. No rate limiting is applied, because users specifying -debug are assumed to be
-// developers or power users who are aware that -debug may cause excessive disk usage due to logging.
-#define detail_LogIfCategoryAndLevelEnabled(category, level, ...)     \
-    do {                                                              \
-        if (LogAcceptCategory((category), (level))) {                 \
-            bool rate_limit{level >= BCLog::Level::Info};             \
-            Assume(!rate_limit);/*Only called with the levels below*/ \
-            LogPrintLevel_(category, level, rate_limit, __VA_ARGS__); \
-        }                                                             \
-    } while (0)
-
-// Log conditionally, prefixing the output with the passed category name.
-#define LogDebug(category, ...) detail_LogIfCategoryAndLevelEnabled(category, BCLog::Level::Debug, __VA_ARGS__)
-#define LogTrace(category, ...) detail_LogIfCategoryAndLevelEnabled(category, BCLog::Level::Trace, __VA_ARGS__)
-
 #endif // BITCOIN_LOGGING_H

--- a/src/logging.h
+++ b/src/logging.h
@@ -11,6 +11,7 @@
 #include <tinyformat.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/log.h> // IWYU pragma: export
 #include <util/string.h>
 #include <util/time.h>
 
@@ -36,26 +37,6 @@ static constexpr bool DEFAULT_LOGLEVELALWAYS = false;
 extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern bool fLogIPs;
-
-/// Like std::source_location, but allowing to override the function name.
-class SourceLocation
-{
-public:
-    /// The func argument must be constructed from the C++11 __func__ macro.
-    /// Ref: https://en.cppreference.com/w/cpp/language/function.html#func
-    /// Non-static string literals are not supported.
-    SourceLocation(const char* func,
-                   std::source_location loc = std::source_location::current())
-        : m_func{func}, m_loc{loc} {}
-
-    std::string_view file_name() const { return m_loc.file_name(); }
-    std::uint_least32_t line() const { return m_loc.line(); }
-    std::string_view function_name_short() const { return m_func; }
-
-private:
-    std::string_view m_func;
-    std::source_location m_loc;
-};
 
 struct SourceLocationEqual {
     bool operator()(const SourceLocation& lhs, const SourceLocation& rhs) const noexcept

--- a/src/logging.h
+++ b/src/logging.h
@@ -7,6 +7,7 @@
 #define BITCOIN_LOGGING_H
 
 #include <crypto/siphash.h>
+#include <logging/categories.h> // IWYU pragma: export
 #include <threadsafety.h>
 #include <tinyformat.h>
 #include <util/check.h>
@@ -62,44 +63,6 @@ struct LogCategory {
 };
 
 namespace BCLog {
-    using CategoryMask = uint64_t;
-    enum LogFlags : CategoryMask {
-        NONE        = CategoryMask{0},
-        NET         = (CategoryMask{1} <<  0),
-        TOR         = (CategoryMask{1} <<  1),
-        MEMPOOL     = (CategoryMask{1} <<  2),
-        HTTP        = (CategoryMask{1} <<  3),
-        BENCH       = (CategoryMask{1} <<  4),
-        ZMQ         = (CategoryMask{1} <<  5),
-        WALLETDB    = (CategoryMask{1} <<  6),
-        RPC         = (CategoryMask{1} <<  7),
-        ESTIMATEFEE = (CategoryMask{1} <<  8),
-        ADDRMAN     = (CategoryMask{1} <<  9),
-        SELECTCOINS = (CategoryMask{1} << 10),
-        REINDEX     = (CategoryMask{1} << 11),
-        CMPCTBLOCK  = (CategoryMask{1} << 12),
-        RAND        = (CategoryMask{1} << 13),
-        PRUNE       = (CategoryMask{1} << 14),
-        PROXY       = (CategoryMask{1} << 15),
-        MEMPOOLREJ  = (CategoryMask{1} << 16),
-        LIBEVENT    = (CategoryMask{1} << 17),
-        COINDB      = (CategoryMask{1} << 18),
-        QT          = (CategoryMask{1} << 19),
-        LEVELDB     = (CategoryMask{1} << 20),
-        VALIDATION  = (CategoryMask{1} << 21),
-        I2P         = (CategoryMask{1} << 22),
-        IPC         = (CategoryMask{1} << 23),
-#ifdef DEBUG_LOCKCONTENTION
-        LOCK        = (CategoryMask{1} << 24),
-#endif
-        BLOCKSTORAGE = (CategoryMask{1} << 25),
-        TXRECONCILIATION = (CategoryMask{1} << 26),
-        SCAN        = (CategoryMask{1} << 27),
-        TXPACKAGES  = (CategoryMask{1} << 28),
-        KERNEL      = (CategoryMask{1} << 29),
-        PRIVBROADCAST = (CategoryMask{1} << 30),
-        ALL         = ~NONE,
-    };
     enum class Level {
         Trace = 0, // High-volume or detailed logging for development/debugging
         Debug,     // Reasonably noisy logging, but still usable in production

--- a/src/logging.h
+++ b/src/logging.h
@@ -63,13 +63,6 @@ struct LogCategory {
 };
 
 namespace BCLog {
-    enum class Level {
-        Trace = 0, // High-volume or detailed logging for development/debugging
-        Debug,     // Reasonably noisy logging, but still usable in production
-        Info,      // Default
-        Warning,
-        Error,
-    };
     constexpr auto DEFAULT_LOG_LEVEL{Level::Debug};
     constexpr size_t DEFAULT_MAX_LOG_BUFFER{1'000'000}; // buffer up to 1MB of log data prior to StartLogging
     constexpr uint64_t RATELIMIT_MAX_BYTES{1024 * 1024}; // maximum number of bytes per source location that can be logged within the RATELIMIT_WINDOW

--- a/src/logging/categories.h
+++ b/src/logging/categories.h
@@ -1,0 +1,54 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_LOGGING_CATEGORIES_H
+#define BITCOIN_LOGGING_CATEGORIES_H
+
+#include <cstdint>
+
+namespace BCLog {
+
+using CategoryMask = uint64_t;
+
+enum LogFlags : CategoryMask {
+    NONE = CategoryMask{0},
+    NET = (CategoryMask{1} << 0),
+    TOR = (CategoryMask{1} << 1),
+    MEMPOOL = (CategoryMask{1} << 2),
+    HTTP = (CategoryMask{1} << 3),
+    BENCH = (CategoryMask{1} << 4),
+    ZMQ = (CategoryMask{1} << 5),
+    WALLETDB = (CategoryMask{1} << 6),
+    RPC = (CategoryMask{1} << 7),
+    ESTIMATEFEE = (CategoryMask{1} << 8),
+    ADDRMAN = (CategoryMask{1} << 9),
+    SELECTCOINS = (CategoryMask{1} << 10),
+    REINDEX = (CategoryMask{1} << 11),
+    CMPCTBLOCK = (CategoryMask{1} << 12),
+    RAND = (CategoryMask{1} << 13),
+    PRUNE = (CategoryMask{1} << 14),
+    PROXY = (CategoryMask{1} << 15),
+    MEMPOOLREJ = (CategoryMask{1} << 16),
+    LIBEVENT = (CategoryMask{1} << 17),
+    COINDB = (CategoryMask{1} << 18),
+    QT = (CategoryMask{1} << 19),
+    LEVELDB = (CategoryMask{1} << 20),
+    VALIDATION = (CategoryMask{1} << 21),
+    I2P = (CategoryMask{1} << 22),
+    IPC = (CategoryMask{1} << 23),
+#ifdef DEBUG_LOCKCONTENTION
+    LOCK = (CategoryMask{1} << 24),
+#endif
+    BLOCKSTORAGE = (CategoryMask{1} << 25),
+    TXRECONCILIATION = (CategoryMask{1} << 26),
+    SCAN = (CategoryMask{1} << 27),
+    TXPACKAGES = (CategoryMask{1} << 28),
+    KERNEL = (CategoryMask{1} << 29),
+    PRIVBROADCAST = (CategoryMask{1} << 30),
+    ALL = ~NONE,
+};
+
+} // namespace BCLog
+
+#endif // BITCOIN_LOGGING_CATEGORIES_H

--- a/src/logging/timer.h
+++ b/src/logging/timer.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_LOGGING_TIMER_H
 #define BITCOIN_LOGGING_TIMER_H
 
-#include <logging.h>
+#include <util/log.h>
 #include <util/macros.h>
 #include <util/time.h>
 #include <util/types.h>

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -16,7 +16,6 @@
 #include <kernel/messagestartchars.h>
 #include <kernel/notifications_interface.h>
 #include <kernel/types.h>
-#include <logging.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -31,6 +30,7 @@
 #include <util/check.h>
 #include <util/expected.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/obfuscation.h>
 #include <util/overflow.h>
 #include <util/result.h>

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -9,7 +9,6 @@
 #include <coins.h>
 #include <consensus/params.h>
 #include <kernel/caches.h>
-#include <logging.h>
 #include <node/blockstorage.h>
 #include <sync.h>
 #include <threadsafety.h>
@@ -17,6 +16,7 @@
 #include <txdb.h>
 #include <uint256.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/signalinterrupt.h>
 #include <util/time.h>
 #include <util/translation.h>

--- a/src/node/utxo_snapshot.cpp
+++ b/src/node/utxo_snapshot.cpp
@@ -4,12 +4,12 @@
 
 #include <node/utxo_snapshot.h>
 
-#include <logging.h>
 #include <streams.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <uint256.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <validation.h>
 
 #include <cassert>

--- a/src/policy/truc_policy.cpp
+++ b/src/policy/truc_policy.cpp
@@ -6,7 +6,6 @@
 
 #include <coins.h>
 #include <consensus/amount.h>
-#include <logging.h>
 #include <tinyformat.h>
 #include <util/check.h>
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -12,12 +12,12 @@
 #include <crypto/chacha20.h>
 #include <crypto/sha256.h>
 #include <crypto/sha512.h>
-#include <logging.h>
 #include <randomenv.h>
 #include <span.h>
 #include <support/allocators/secure.h>
 #include <support/cleanse.h>
 #include <sync.h>
+#include <util/log.h>
 #include <util/time.h>
 
 #include <array>

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -6,12 +6,12 @@
 #include <script/sigcache.h>
 
 #include <crypto/sha256.h>
-#include <logging.h>
 #include <pubkey.h>
 #include <random.h>
 #include <script/interpreter.h>
 #include <span.h>
 #include <uint256.h>
+#include <util/log.h>
 
 #include <mutex>
 #include <shared_mutex>

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -7,7 +7,6 @@
 #include <consensus/merkle.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
-#include <logging.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
@@ -15,6 +14,7 @@
 #include <streams.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/log.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/streams.h
+++ b/src/streams.h
@@ -6,11 +6,11 @@
 #ifndef BITCOIN_STREAMS_H
 #define BITCOIN_STREAMS_H
 
-#include <logging.h>
 #include <serialize.h>
 #include <span.h>
 #include <support/allocators/zeroafterfree.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/obfuscation.h>
 #include <util/overflow.h>
 #include <util/syserror.h>

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -4,8 +4,8 @@
 
 #include <sync.h>
 
-#include <logging.h>
 #include <tinyformat.h>
+#include <util/log.h>
 #include <util/strencodings.h>
 #include <util/threadnames.h>
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -7,7 +7,6 @@
 #define BITCOIN_SYNC_H
 
 #ifdef DEBUG_LOCKCONTENTION
-#include <logging.h>
 #include <logging/timer.h>
 #endif
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -7,11 +7,11 @@
 
 #include <coins.h>
 #include <dbwrapper.h>
-#include <logging.h>
 #include <primitives/transaction.h>
 #include <random.h>
 #include <serialize.h>
 #include <uint256.h>
+#include <util/log.h>
 #include <util/vector.h>
 
 #include <cassert>

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -11,13 +11,13 @@
 #include <consensus/consensus.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
-#include <logging.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
 #include <random.h>
 #include <tinyformat.h>
 #include <util/check.h>
 #include <util/feefrac.h>
+#include <util/log.h>
 #include <util/moneystr.h>
 #include <util/overflow.h>
 #include <util/result.h>

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -6,11 +6,11 @@
 
 #include <clientversion.h>
 #include <hash.h>
-#include <logging.h>
 #include <serialize.h>
 #include <streams.h>
 #include <uint256.h>
 #include <util/fs.h>
+#include <util/log.h>
 
 #include <algorithm>
 #include <bit>

--- a/src/util/batchpriority.cpp
+++ b/src/util/batchpriority.cpp
@@ -4,7 +4,7 @@
 
 #include <util/batchpriority.h>
 
-#include <logging.h>
+#include <util/log.h>
 #include <util/syserror.h>
 
 #include <string>

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -5,8 +5,8 @@
 
 #include <util/exception.h>
 
-#include <logging.h>
 #include <tinyformat.h>
+#include <util/log.h>
 
 #include <exception>
 #include <iostream>

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -3,13 +3,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/fs_helpers.h>
-
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
-#include <logging.h>
+#include <util/fs_helpers.h>
+
 #include <sync.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/syserror.h>
 
 #include <cerrno>

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -5,8 +5,13 @@
 #ifndef BITCOIN_UTIL_LOG_H
 #define BITCOIN_UTIL_LOG_H
 
+#include <logging/categories.h> // IWYU pragma: export
+#include <tinyformat.h>
+#include <util/check.h>
+
 #include <cstdint>
 #include <source_location>
+#include <string>
 #include <string_view>
 
 /// Like std::source_location, but allowing to override the function name.
@@ -30,6 +35,9 @@ private:
 };
 
 namespace util::log {
+/** Opaque to util::log; interpreted by consumers (e.g., BCLog::LogFlags). */
+using Category = uint64_t;
+
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production
@@ -37,12 +45,44 @@ enum class Level {
     Warning,
     Error,
 };
+
+struct Entry {
+    Category category;
+    Level level;
+    bool should_ratelimit{false}; //!< Hint for consumers if this entry should be ratelimited
+    SourceLocation source_loc;
+    std::string message;
+};
+
+/** Return whether messages with specified category and level should be logged. Applications using
+ * the logging library need to provide this. */
+bool ShouldLog(Category category, Level level);
+
+/** Send message to be logged. Applications using the logging library need to provide this. */
+void Log(Entry entry);
 } // namespace util::log
 
 namespace BCLog {
 //! Alias for compatibility. Prefer util::log::Level over BCLog::Level in new code.
 using Level = util::log::Level;
 } // namespace BCLog
+
+template <typename... Args>
+inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, BCLog::Level level, bool should_ratelimit, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    std::string log_msg;
+    try {
+        log_msg = tfm::format(fmt, args...);
+    } catch (tinyformat::format_error& fmterr) {
+        log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
+    }
+    util::log::Log(util::log::Entry{
+        .category = flag,
+        .level = level,
+        .should_ratelimit = should_ratelimit,
+        .source_loc = std::move(source_loc),
+        .message = std::move(log_msg)});
+}
 
 // Allow __func__ to be used in any context without warnings:
 // NOLINTNEXTLINE(bugprone-lambda-function-name)
@@ -64,7 +104,7 @@ using Level = util::log::Level;
 // developers or power users who are aware that -debug may cause excessive disk usage due to logging.
 #define detail_LogIfCategoryAndLevelEnabled(category, level, ...)      \
     do {                                                               \
-        if (LogAcceptCategory((category), (level))) {                  \
+        if (util::log::ShouldLog((category), (level))) {               \
             bool rate_limit{level >= BCLog::Level::Info};              \
             Assume(!rate_limit); /*Only called with the levels below*/ \
             LogPrintLevel_(category, level, rate_limit, __VA_ARGS__);  \

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -29,4 +29,18 @@ private:
     std::source_location m_loc;
 };
 
+namespace util::log {
+enum class Level {
+    Trace = 0, // High-volume or detailed logging for development/debugging
+    Debug,     // Reasonably noisy logging, but still usable in production
+    Info,      // Default
+    Warning,
+    Error,
+};
+} // namespace util::log
+
+namespace BCLog {
+//! Alias for compatibility. Prefer util::log::Level over BCLog::Level in new code.
+using Level = util::log::Level;
+} // namespace BCLog
 #endif // BITCOIN_UTIL_LOG_H

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -1,0 +1,32 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_LOG_H
+#define BITCOIN_UTIL_LOG_H
+
+#include <cstdint>
+#include <source_location>
+#include <string_view>
+
+/// Like std::source_location, but allowing to override the function name.
+class SourceLocation
+{
+public:
+    /// The func argument must be constructed from the C++11 __func__ macro.
+    /// Ref: https://en.cppreference.com/w/cpp/language/function.html#func
+    /// Non-static string literals are not supported.
+    SourceLocation(const char* func,
+                   std::source_location loc = std::source_location::current())
+        : m_func{func}, m_loc{loc} {}
+
+    std::string_view file_name() const { return m_loc.file_name(); }
+    std::uint_least32_t line() const { return m_loc.line(); }
+    std::string_view function_name_short() const { return m_func; }
+
+private:
+    std::string_view m_func;
+    std::source_location m_loc;
+};
+
+#endif // BITCOIN_UTIL_LOG_H

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -43,4 +43,36 @@ namespace BCLog {
 //! Alias for compatibility. Prefer util::log::Level over BCLog::Level in new code.
 using Level = util::log::Level;
 } // namespace BCLog
+
+// Allow __func__ to be used in any context without warnings:
+// NOLINTNEXTLINE(bugprone-lambda-function-name)
+#define LogPrintLevel_(category, level, should_ratelimit, ...) LogPrintFormatInternal(SourceLocation{__func__}, category, level, should_ratelimit, __VA_ARGS__)
+
+// Log unconditionally. Uses basic rate limiting to mitigate disk filling attacks.
+// Be conservative when using functions that unconditionally log to debug.log!
+// It should not be the case that an inbound peer can fill up a user's storage
+// with debug.log entries.
+#define LogInfo(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, /*should_ratelimit=*/true, __VA_ARGS__)
+#define LogWarning(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Warning, /*should_ratelimit=*/true, __VA_ARGS__)
+#define LogError(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Error, /*should_ratelimit=*/true, __VA_ARGS__)
+
+// Use a macro instead of a function for conditional logging to prevent
+// evaluating arguments when logging for the category is not enabled.
+
+// Log by prefixing the output with the passed category name and severity level. This logs conditionally if
+// the category is allowed. No rate limiting is applied, because users specifying -debug are assumed to be
+// developers or power users who are aware that -debug may cause excessive disk usage due to logging.
+#define detail_LogIfCategoryAndLevelEnabled(category, level, ...)      \
+    do {                                                               \
+        if (LogAcceptCategory((category), (level))) {                  \
+            bool rate_limit{level >= BCLog::Level::Info};              \
+            Assume(!rate_limit); /*Only called with the levels below*/ \
+            LogPrintLevel_(category, level, rate_limit, __VA_ARGS__);  \
+        }                                                              \
+    } while (0)
+
+// Log conditionally, prefixing the output with the passed category name.
+#define LogDebug(category, ...) detail_LogIfCategoryAndLevelEnabled(category, BCLog::Level::Debug, __VA_ARGS__)
+#define LogTrace(category, ...) detail_LogIfCategoryAndLevelEnabled(category, BCLog::Level::Trace, __VA_ARGS__)
+
 #endif // BITCOIN_UTIL_LOG_H

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -2,11 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/sock.h>
+
 #include <common/system.h>
 #include <compat/compat.h>
-#include <logging.h>
+#include <span.h>
 #include <tinyformat.h>
-#include <util/sock.h>
+#include <util/log.h>
 #include <util/syserror.h>
 #include <util/threadinterrupt.h>
 #include <util/time.h>

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -11,6 +11,7 @@
 
 #include <chrono>
 #include <memory>
+#include <span>
 #include <string>
 #include <unordered_map>
 

--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -4,8 +4,8 @@
 
 #include <util/thread.h>
 
-#include <logging.h>
 #include <util/exception.h>
+#include <util/log.h>
 #include <util/threadnames.h>
 
 #include <exception>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -28,7 +28,6 @@
 #include <kernel/notifications_interface.h>
 #include <kernel/types.h>
 #include <kernel/warning.h>
-#include <logging.h>
 #include <logging/timer.h>
 #include <node/blockstorage.h>
 #include <node/utxo_snapshot.h>
@@ -53,6 +52,7 @@
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/hasher.h>
+#include <util/log.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
 #include <util/result.h>
@@ -2870,7 +2870,7 @@ static void UpdateTipLog(
     AssertLockHeld(::cs_main);
 
     // Disable rate limiting in LogPrintLevel_ so this source location may log during IBD.
-    LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, /*should_ratelimit=*/false, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+    LogPrintLevel_(BCLog::LogFlags::ALL, util::log::Level::Info, /*should_ratelimit=*/false, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
                    log(tip->nChainWork.getdouble()) / log(2.0), tip->m_chain_tx_count,

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -10,10 +10,10 @@
 #include <kernel/mempool_entry.h>
 #include <kernel/mempool_removal_reason.h>
 #include <kernel/types.h>
-#include <logging.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/task_runner.h>
 
 #include <future>


### PR DESCRIPTION
This is a mostly move-only change. It's a small refactoring that allows logging macros to be used by including a simple `util/log.h` header instead of the full `logging.h` logging implementation. Most of the changes here were cherry-picked from #34374.

Original motivation for this change was to reduce the size and complexity of #34374 (kernel structured logging PR) and reduce the number of conflicts it causes with other PRs. But this should also make sense as a standalone change to have a clearer separation of concerns between log generation and log handling, and avoid needing to depend on the whole logging framework in call sites that only emit log messages.

Recommended to review with `--color-moved=dimmed-zebra --color-moved-ws=ignore-all-space`