### PR TITLE
kernel: make logging struct-based

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -161,16 +161,6 @@ int main(int argc, char* argv[])
     std::filesystem::path abs_datadir{std::filesystem::absolute(argv[argc-1])};
     std::filesystem::create_directories(abs_datadir);
 
-    btck_LoggingOptions logging_options = {
-        .log_timestamps = true,
-        .log_time_micros = false,
-        .log_threadnames = false,
-        .log_sourcelocations = false,
-        .always_print_category_levels = true,
-    };
-
-    logging_set_options(logging_options);
-
     Logger logger{std::make_unique<KernelLog>()};
 
     ContextOptions options{};

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -44,9 +44,12 @@ std::vector<std::byte> hex_string_to_byte_vec(std::string_view hex)
 class KernelLog
 {
 public:
-    void LogMessage(std::string_view message)
+    void LogMessage(const LogEntry& entry)
     {
-        std::cout << "kernel: " << message;
+        std::cout << "kernel: " << entry.Timestamp().time_since_epoch().count()
+                  << " [" << log_category_get_name(entry.Category()) << ":"
+                  << log_level_get_name(entry.Level()) << "] "
+                  << entry.Message() << "\n";
     }
 };
 

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(bitcoinkernel
   ../util/fs.cpp
   ../util/fs_helpers.cpp
   ../util/hasher.cpp
+  ../util/log.cpp
   ../util/moneystr.cpp
   ../util/rbf.cpp
   ../util/serfloat.cpp

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -751,16 +751,6 @@ void btck_txid_destroy(btck_Txid* txid)
     delete txid;
 }
 
-void btck_logging_set_options(const btck_LoggingOptions options)
-{
-    LOCK(cs_main);
-    LogInstance().m_log_timestamps = options.log_timestamps;
-    LogInstance().m_log_time_micros = options.log_time_micros;
-    LogInstance().m_log_threadnames = options.log_threadnames;
-    LogInstance().m_log_sourcelocations = options.log_sourcelocations;
-    LogInstance().m_always_print_category_level = options.always_print_category_levels;
-}
-
 void btck_logging_set_level_category(btck_LogCategory category, btck_LogLevel level)
 {
     LOCK(cs_main);
@@ -779,11 +769,6 @@ void btck_logging_enable_category(btck_LogCategory category)
 void btck_logging_disable_category(btck_LogCategory category)
 {
     LogInstance().DisableCategory(get_bclog_flag(category));
-}
-
-void btck_logging_disable()
-{
-    LogInstance().DisableLogging();
 }
 
 btck_LoggingConnection* btck_logging_connection_create(btck_LogCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -149,7 +149,6 @@ struct btck_BlockValidationState : Handle<btck_BlockValidationState, BlockValida
 
 namespace {
 
-
 struct LogLevelMapping {
     util::log::Level bclog;
     std::string_view name;
@@ -157,10 +156,12 @@ struct LogLevelMapping {
 
 // Single source of truth for log level mappings (indexed by btck_LogLevel)
 constexpr auto LOG_LEVELS = [] {
-    std::array<LogLevelMapping, 3> a{};
+    std::array<LogLevelMapping, 5> a{};
     a[btck_LogLevel_TRACE] = {util::log::Level::Trace, "trace"};
     a[btck_LogLevel_DEBUG] = {util::log::Level::Debug, "debug"};
     a[btck_LogLevel_INFO] = {util::log::Level::Info, "info"};
+    a[btck_LogLevel_WARNING] = {util::log::Level::Warning, "warning"};
+    a[btck_LogLevel_ERROR] = {util::log::Level::Error, "error"};
     return a;
 }();
 
@@ -177,18 +178,20 @@ struct LogCategoryMapping {
 
 // Single source of truth for log category mappings (indexed by btck_LogCategory)
 constexpr auto LOG_CATEGORIES = [] {
-    std::array<LogCategoryMapping, 11> a{};
+    std::array<LogCategoryMapping, 13> a{};
     a[btck_LogCategory_ALL] = {BCLog::LogFlags::ALL, "all"};
     a[btck_LogCategory_BENCH] = {BCLog::LogFlags::BENCH, "bench"};
     a[btck_LogCategory_BLOCKSTORAGE] = {BCLog::LogFlags::BLOCKSTORAGE, "blockstorage"};
     a[btck_LogCategory_COINDB] = {BCLog::LogFlags::COINDB, "coindb"};
+    a[btck_LogCategory_ESTIMATEFEE] = {BCLog::LogFlags::ESTIMATEFEE, "estimatefee"};
+    a[btck_LogCategory_KERNEL] = {BCLog::LogFlags::KERNEL, "kernel"};
     a[btck_LogCategory_LEVELDB] = {BCLog::LogFlags::LEVELDB, "leveldb"};
     a[btck_LogCategory_MEMPOOL] = {BCLog::LogFlags::MEMPOOL, "mempool"};
     a[btck_LogCategory_PRUNE] = {BCLog::LogFlags::PRUNE, "prune"};
     a[btck_LogCategory_RAND] = {BCLog::LogFlags::RAND, "rand"};
     a[btck_LogCategory_REINDEX] = {BCLog::LogFlags::REINDEX, "reindex"};
+    a[btck_LogCategory_TXPACKAGES] = {BCLog::LogFlags::TXPACKAGES, "txpackages"};
     a[btck_LogCategory_VALIDATION] = {BCLog::LogFlags::VALIDATION, "validation"};
-    a[btck_LogCategory_KERNEL] = {BCLog::LogFlags::KERNEL, "kernel"};
     return a;
 }();
 

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -133,12 +133,6 @@ typedef struct btck_TransactionOutput btck_TransactionOutput;
  * Opaque data structure for holding a logging connection.
  *
  * The logging connection can be used to manually stop logging.
- *
- * Messages that were logged before a connection is created are buffered in a
- * 1MB buffer. Logging can alternatively be permanently disabled by calling
- * @ref btck_logging_disable. Functions changing the logging settings are
- * global and change the settings for all existing btck_LoggingConnection
- * instances.
  */
 typedef struct btck_LoggingConnection btck_LoggingConnection;
 
@@ -370,8 +364,11 @@ typedef struct {
 /**
  * Function signature for the global logging callback. All bitcoin kernel
  * internal logs will pass through this callback.
+ *
+ * @param[in] user_data User-defined data passed to btck_logging_connection_create.
+ * @param[in] entry     Log entry. Valid only for the duration of the callback.
  */
-typedef void (*btck_LogCallback)(void* user_data, const char* message, size_t message_len);
+typedef void (*btck_LogCallback)(void* user_data, const btck_LogEntry* entry);
 
 /**
  * Function signature for freeing user data.
@@ -834,11 +831,9 @@ BITCOINKERNEL_API void btck_logging_enable_category(btck_LogCategory category);
 BITCOINKERNEL_API void btck_logging_disable_category(btck_LogCategory category);
 
 /**
- * @brief Start logging messages through the provided callback. Log messages
- * produced before this function is first called are buffered and on calling this
- * function are logged immediately.
+ * @brief Start logging messages through the provided callback.
  *
- * @param[in] log_callback               Non-null, function through which messages will be logged.
+ * @param[in] log_callback               Non-null, function through which log entries will be delivered.
  * @param[in] user_data                  Nullable, holds a user-defined opaque structure. Is passed back
  *                                       to the user through the callback. If the user_data_destroy_callback
  *                                       is also defined it is assumed that ownership of the user_data is passed

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -436,13 +436,15 @@ typedef uint8_t btck_LogCategory;
 #define btck_LogCategory_BENCH ((btck_LogCategory)(1))
 #define btck_LogCategory_BLOCKSTORAGE ((btck_LogCategory)(2))
 #define btck_LogCategory_COINDB ((btck_LogCategory)(3))
-#define btck_LogCategory_LEVELDB ((btck_LogCategory)(4))
-#define btck_LogCategory_MEMPOOL ((btck_LogCategory)(5))
-#define btck_LogCategory_PRUNE ((btck_LogCategory)(6))
-#define btck_LogCategory_RAND ((btck_LogCategory)(7))
-#define btck_LogCategory_REINDEX ((btck_LogCategory)(8))
-#define btck_LogCategory_VALIDATION ((btck_LogCategory)(9))
-#define btck_LogCategory_KERNEL ((btck_LogCategory)(10))
+#define btck_LogCategory_ESTIMATEFEE ((btck_LogCategory)(4))
+#define btck_LogCategory_KERNEL ((btck_LogCategory)(5))
+#define btck_LogCategory_LEVELDB ((btck_LogCategory)(6))
+#define btck_LogCategory_MEMPOOL ((btck_LogCategory)(7))
+#define btck_LogCategory_PRUNE ((btck_LogCategory)(8))
+#define btck_LogCategory_RAND ((btck_LogCategory)(9))
+#define btck_LogCategory_REINDEX ((btck_LogCategory)(10))
+#define btck_LogCategory_TXPACKAGES ((btck_LogCategory)(11))
+#define btck_LogCategory_VALIDATION ((btck_LogCategory)(12))
 
 /**
  * The level at which logs should be produced.
@@ -451,6 +453,8 @@ typedef uint8_t btck_LogLevel;
 #define btck_LogLevel_TRACE ((btck_LogLevel)(0))
 #define btck_LogLevel_DEBUG ((btck_LogLevel)(1))
 #define btck_LogLevel_INFO ((btck_LogLevel)(2))
+#define btck_LogLevel_WARNING ((btck_LogLevel)(3))
+#define btck_LogLevel_ERROR ((btck_LogLevel)(4))
 
 /**
  * Options controlling the format of log messages.

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -323,6 +323,48 @@ typedef uint8_t btck_Warning;
 #define btck_Warning_UNKNOWN_NEW_RULES_ACTIVATED ((btck_Warning)(0))
 #define btck_Warning_LARGE_WORK_INVALID_CHAIN ((btck_Warning)(1))
 
+/**
+ * A collection of logging categories that may be encountered by kernel code.
+ */
+typedef uint8_t btck_LogCategory;
+#define btck_LogCategory_ALL ((btck_LogCategory)(0))
+#define btck_LogCategory_BENCH ((btck_LogCategory)(1))
+#define btck_LogCategory_BLOCKSTORAGE ((btck_LogCategory)(2))
+#define btck_LogCategory_COINDB ((btck_LogCategory)(3))
+#define btck_LogCategory_ESTIMATEFEE ((btck_LogCategory)(4))
+#define btck_LogCategory_KERNEL ((btck_LogCategory)(5))
+#define btck_LogCategory_LEVELDB ((btck_LogCategory)(6))
+#define btck_LogCategory_MEMPOOL ((btck_LogCategory)(7))
+#define btck_LogCategory_PRUNE ((btck_LogCategory)(8))
+#define btck_LogCategory_RAND ((btck_LogCategory)(9))
+#define btck_LogCategory_REINDEX ((btck_LogCategory)(10))
+#define btck_LogCategory_TXPACKAGES ((btck_LogCategory)(11))
+#define btck_LogCategory_VALIDATION ((btck_LogCategory)(12))
+
+/**
+ * The level at which logs should be produced.
+ */
+typedef uint8_t btck_LogLevel;
+#define btck_LogLevel_TRACE ((btck_LogLevel)(0))
+#define btck_LogLevel_DEBUG ((btck_LogLevel)(1))
+#define btck_LogLevel_INFO ((btck_LogLevel)(2))
+#define btck_LogLevel_WARNING ((btck_LogLevel)(3))
+#define btck_LogLevel_ERROR ((btck_LogLevel)(4))
+
+/**
+ * A log entry passed to the logging callback.
+ */
+typedef struct {
+    btck_StringView message;       //!< Log message.
+    btck_StringView file_name;     //!< Source file name.
+    btck_StringView function_name; //!< Source function name.
+    btck_StringView thread_name;   //!< Thread name.
+    int64_t timestamp_ns;          //!< Timestamp in nanoseconds since epoch.
+    uint32_t line;                 //!< Source line number.
+    btck_LogLevel level;           //!< Log level.
+    btck_LogCategory category;     //!< Log category.
+} btck_LogEntry;
+
 /** Callback function types */
 
 /**
@@ -427,34 +469,6 @@ typedef struct {
     btck_NotifyFlushError flush_error;      //!< An error encountered when flushing data to disk.
     btck_NotifyFatalError fatal_error;      //!< An unrecoverable system error encountered by the library.
 } btck_NotificationInterfaceCallbacks;
-
-/**
- * A collection of logging categories that may be encountered by kernel code.
- */
-typedef uint8_t btck_LogCategory;
-#define btck_LogCategory_ALL ((btck_LogCategory)(0))
-#define btck_LogCategory_BENCH ((btck_LogCategory)(1))
-#define btck_LogCategory_BLOCKSTORAGE ((btck_LogCategory)(2))
-#define btck_LogCategory_COINDB ((btck_LogCategory)(3))
-#define btck_LogCategory_ESTIMATEFEE ((btck_LogCategory)(4))
-#define btck_LogCategory_KERNEL ((btck_LogCategory)(5))
-#define btck_LogCategory_LEVELDB ((btck_LogCategory)(6))
-#define btck_LogCategory_MEMPOOL ((btck_LogCategory)(7))
-#define btck_LogCategory_PRUNE ((btck_LogCategory)(8))
-#define btck_LogCategory_RAND ((btck_LogCategory)(9))
-#define btck_LogCategory_REINDEX ((btck_LogCategory)(10))
-#define btck_LogCategory_TXPACKAGES ((btck_LogCategory)(11))
-#define btck_LogCategory_VALIDATION ((btck_LogCategory)(12))
-
-/**
- * The level at which logs should be produced.
- */
-typedef uint8_t btck_LogLevel;
-#define btck_LogLevel_TRACE ((btck_LogLevel)(0))
-#define btck_LogLevel_DEBUG ((btck_LogLevel)(1))
-#define btck_LogLevel_INFO ((btck_LogLevel)(2))
-#define btck_LogLevel_WARNING ((btck_LogLevel)(3))
-#define btck_LogLevel_ERROR ((btck_LogLevel)(4))
 
 /**
  * Options controlling the format of log messages.

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -468,19 +468,6 @@ typedef struct {
 } btck_NotificationInterfaceCallbacks;
 
 /**
- * Options controlling the format of log messages.
- *
- * Set fields as non-zero to indicate true.
- */
-typedef struct {
-    int log_timestamps;               //!< Prepend a timestamp to log messages.
-    int log_time_micros;              //!< Log timestamps in microsecond precision.
-    int log_threadnames;              //!< Prepend the name of the thread to log messages.
-    int log_sourcelocations;          //!< Prepend the source location to log messages.
-    int always_print_category_levels; //!< Prepend the log category and level to log messages.
-} btck_LoggingOptions;
-
-/**
  * A collection of status codes that may be issued by the script verify function.
  */
 typedef uint8_t btck_ScriptVerifyStatus;
@@ -775,25 +762,6 @@ BITCOINKERNEL_API void btck_transaction_output_destroy(btck_TransactionOutput* t
  * Logging-related functions.
  */
 ///@{
-
-/**
- * @brief This disables the global internal logger. No log messages will be
- * buffered internally anymore once this is called and the buffer is cleared.
- * This function should only be called once and is not thread or re-entry safe.
- * Log messages will be buffered until this function is called, or a logging
- * connection is created. This must not be called while a logging connection
- * already exists.
- */
-BITCOINKERNEL_API void btck_logging_disable();
-
-/**
- * @brief Set some options for the global internal logger. This changes global
- * settings and will override settings for all existing @ref
- * btck_LoggingConnection instances.
- *
- * @param[in] options Sets formatting options of the log messages.
- */
-BITCOINKERNEL_API void btck_logging_set_options(btck_LoggingOptions options);
 
 /**
  * @brief Set the log level of the global internal logger. This does not

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -304,6 +304,14 @@ typedef struct btck_Txid btck_Txid;
  */
 typedef struct btck_BlockHeader btck_BlockHeader;
 
+/**
+ * A non-owning view of a string with explicit length.
+ */
+typedef struct {
+    const char* data; //!< Pointer to string data (not necessarily null-terminated).
+    size_t size;      //!< Size of the string.
+} btck_StringView;
+
 /** Current sync state passed to tip changed callbacks. */
 typedef uint8_t btck_SynchronizationState;
 #define btck_SynchronizationState_INIT_REINDEX ((btck_SynchronizationState)(0))
@@ -829,6 +837,22 @@ BITCOINKERNEL_API btck_LoggingConnection* BITCOINKERNEL_WARN_UNUSED_RESULT btck_
  * Stop logging and destroy the logging connection.
  */
 BITCOINKERNEL_API void btck_logging_connection_destroy(btck_LoggingConnection* logging_connection);
+
+/**
+ * @brief Get the name of a log level.
+ *
+ * @param[in] level  The log level.
+ * @return           String name (e.g., "trace", "debug", "info", "warning", "error").
+ */
+BITCOINKERNEL_API btck_StringView btck_log_level_get_name(btck_LogLevel level);
+
+/**
+ * @brief Get the name of a log category.
+ *
+ * @param[in] category  The log category.
+ * @return              String name (e.g., "all", "bench", "validation").
+ */
+BITCOINKERNEL_API btck_StringView btck_log_category_get_name(btck_LogCategory category);
 
 ///@}
 

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -810,16 +810,6 @@ public:
     }
 };
 
-inline void logging_disable()
-{
-    btck_logging_disable();
-}
-
-inline void logging_set_options(const btck_LoggingOptions& logging_options)
-{
-    btck_logging_set_options(logging_options);
-}
-
 inline void logging_set_level_category(LogCategory category, LogLevel level)
 {
     btck_logging_set_level_category(static_cast<btck_LogCategory>(category), static_cast<btck_LogLevel>(level));

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -866,8 +866,8 @@ inline std::string_view log_category_get_name(LogCategory category)
 }
 
 template <typename T>
-concept Log = requires(T a, std::string_view message) {
-    { a.LogMessage(message) } -> std::same_as<void>;
+concept Log = requires(T a, const LogEntry& entry) {
+    { a.LogMessage(entry) } -> std::same_as<void>;
 };
 
 template <Log T>
@@ -876,7 +876,7 @@ class Logger : UniqueHandle<btck_LoggingConnection, btck_logging_connection_dest
 public:
     Logger(std::unique_ptr<T> log)
         : UniqueHandle{btck_logging_connection_create(
-              +[](void* user_data, const char* message, size_t message_len) { static_cast<T*>(user_data)->LogMessage({message, message_len}); },
+              +[](void* user_data, const btck_LogEntry* entry) { static_cast<T*>(user_data)->LogMessage(LogEntry{*entry}); },
               log.release(),
               +[](void* user_data) { delete static_cast<T*>(user_data); })}
     {

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -8,6 +8,7 @@
 #include <kernel/bitcoinkernel.h>
 
 #include <array>
+#include <chrono>
 #include <exception>
 #include <functional>
 #include <memory>
@@ -828,6 +829,24 @@ inline void logging_enable_category(LogCategory category)
 {
     btck_logging_enable_category(static_cast<btck_LogCategory>(category));
 }
+
+class LogEntry
+{
+private:
+    const btck_LogEntry* m_entry;
+
+public:
+    LogEntry(const btck_LogEntry& e) : m_entry{&e} {}
+
+    std::string_view Message() const { return {m_entry->message.data, m_entry->message.size}; }
+    std::string_view FileName() const { return {m_entry->file_name.data, m_entry->file_name.size}; }
+    std::string_view FunctionName() const { return {m_entry->function_name.data, m_entry->function_name.size}; }
+    std::string_view ThreadName() const { return {m_entry->thread_name.data, m_entry->thread_name.size}; }
+    std::chrono::sys_time<std::chrono::nanoseconds> Timestamp() const { return std::chrono::sys_time<std::chrono::nanoseconds>{std::chrono::nanoseconds{m_entry->timestamp_ns}}; }
+    uint32_t Line() const { return m_entry->line; }
+    LogLevel Level() const { return static_cast<LogLevel>(m_entry->level); }
+    LogCategory Category() const { return static_cast<LogCategory>(m_entry->category); }
+};
 
 inline void logging_disable_category(LogCategory category)
 {

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -830,6 +830,18 @@ inline void logging_disable_category(LogCategory category)
     btck_logging_disable_category(static_cast<btck_LogCategory>(category));
 }
 
+inline std::string_view log_level_get_name(LogLevel level)
+{
+    auto name{btck_log_level_get_name(static_cast<btck_LogLevel>(level))};
+    return {name.data, name.size};
+}
+
+inline std::string_view log_category_get_name(LogCategory category)
+{
+    auto name{btck_log_category_get_name(static_cast<btck_LogCategory>(category))};
+    return {name.data, name.size};
+}
+
 template <typename T>
 concept Log = requires(T a, std::string_view message) {
     { a.LogMessage(message) } -> std::same_as<void>;

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -27,19 +27,23 @@ enum class LogCategory : btck_LogCategory {
     BENCH = btck_LogCategory_BENCH,
     BLOCKSTORAGE = btck_LogCategory_BLOCKSTORAGE,
     COINDB = btck_LogCategory_COINDB,
+    ESTIMATEFEE = btck_LogCategory_ESTIMATEFEE,
+    KERNEL = btck_LogCategory_KERNEL,
     LEVELDB = btck_LogCategory_LEVELDB,
     MEMPOOL = btck_LogCategory_MEMPOOL,
     PRUNE = btck_LogCategory_PRUNE,
     RAND = btck_LogCategory_RAND,
     REINDEX = btck_LogCategory_REINDEX,
+    TXPACKAGES = btck_LogCategory_TXPACKAGES,
     VALIDATION = btck_LogCategory_VALIDATION,
-    KERNEL = btck_LogCategory_KERNEL
 };
 
 enum class LogLevel : btck_LogLevel {
     TRACE_LEVEL = btck_LogLevel_TRACE,
     DEBUG_LEVEL = btck_LogLevel_DEBUG,
-    INFO_LEVEL = btck_LogLevel_INFO
+    INFO_LEVEL = btck_LogLevel_INFO,
+    WARNING_LEVEL = btck_LogLevel_WARNING,
+    ERROR_LEVEL = btck_LogLevel_ERROR,
 };
 
 enum class ChainType : btck_ChainType {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -4,9 +4,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <logging.h>
+
 #include <memusage.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/string.h>
 #include <util/threadnames.h>
 #include <util/time.h>
@@ -42,6 +44,11 @@ BCLog::Logger& LogInstance()
  */
     static BCLog::Logger* g_logger{new BCLog::Logger()};
     return *g_logger;
+}
+
+util::log::Dispatcher& util::log::g_dispatcher()
+{
+    return LogInstance().GetDispatcher();
 }
 
 bool fLogIPs = DEFAULT_LOGIPS;

--- a/src/logging.h
+++ b/src/logging.h
@@ -11,6 +11,7 @@
 #include <tinyformat.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/source.h>
 #include <util/string.h>
 #include <util/time.h>
 
@@ -21,7 +22,6 @@
 #include <list>
 #include <memory>
 #include <mutex>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -36,26 +36,6 @@ static constexpr bool DEFAULT_LOGLEVELALWAYS = false;
 extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern bool fLogIPs;
-
-/// Like std::source_location, but allowing to override the function name.
-class SourceLocation
-{
-public:
-    /// The func argument must be constructed from the C++11 __func__ macro.
-    /// Ref: https://en.cppreference.com/w/cpp/language/function.html#func
-    /// Non-static string literals are not supported.
-    SourceLocation(const char* func,
-                   std::source_location loc = std::source_location::current())
-        : m_func{func}, m_loc{loc} {}
-
-    std::string_view file_name() const { return m_loc.file_name(); }
-    std::uint_least32_t line() const { return m_loc.line(); }
-    std::string_view function_name_short() const { return m_func; }
-
-private:
-    std::string_view m_func;
-    std::source_location m_loc;
-};
 
 struct SourceLocationEqual {
     bool operator()(const SourceLocation& lhs, const SourceLocation& rhs) const noexcept

--- a/src/logging.h
+++ b/src/logging.h
@@ -189,6 +189,9 @@ namespace BCLog {
         size_t m_cur_buffer_memusage GUARDED_BY(m_cs){0};
         size_t m_buffer_lines_discarded GUARDED_BY(m_cs){0};
 
+        //! Dispatches log entries to its registered callbacks.
+        util::log::Dispatcher m_dispatcher{};
+
         //! Manages the rate limiting of each log location.
         std::shared_ptr<LogRateLimiter> m_limiter GUARDED_BY(m_cs);
 
@@ -227,6 +230,9 @@ namespace BCLog {
 
         fs::path m_file_path;
         std::atomic<bool> m_reopen_file{false};
+
+        /** Get the Dispatcher that is used by this Logger to dispatch callbacks. */
+        util::log::Dispatcher& GetDispatcher() { return m_dispatcher; }
 
         /** Send a string to the log output */
         void LogPrintStr(std::string_view str, SourceLocation&& source_loc, BCLog::LogFlags category, BCLog::Level level, bool should_ratelimit)

--- a/src/logging.h
+++ b/src/logging.h
@@ -284,7 +284,6 @@ namespace BCLog {
         /** Disable logging
          * This offers a slight speedup and slightly smaller memory usage
          * compared to leaving the logging system in its default state.
-         * Mostly intended for libbitcoin-kernel apps that don't want any logging.
          * Should be used instead of StartLogging().
          */
         void DisableLogging() EXCLUSIVE_LOCKS_REQUIRED(!m_cs);

--- a/src/logging.h
+++ b/src/logging.h
@@ -11,7 +11,7 @@
 #include <tinyformat.h>
 #include <util/check.h>
 #include <util/fs.h>
-#include <util/source.h>
+#include <util/log.h> // IWYU pragma: export
 #include <util/string.h>
 #include <util/time.h>
 
@@ -99,13 +99,8 @@ namespace BCLog {
         PRIVBROADCAST = (CategoryMask{1} << 30),
         ALL         = ~NONE,
     };
-    enum class Level {
-        Trace = 0, // High-volume or detailed logging for development/debugging
-        Debug,     // Reasonably noisy logging, but still usable in production
-        Info,      // Default
-        Warning,
-        Error,
-    };
+
+    using Level = util::log::Level;
     constexpr auto DEFAULT_LOG_LEVEL{Level::Debug};
     constexpr size_t DEFAULT_MAX_LOG_BUFFER{1'000'000}; // buffer up to 1MB of log data prior to StartLogging
     constexpr uint64_t RATELIMIT_MAX_BYTES{1024 * 1024}; // maximum number of bytes per source location that can be logged within the RATELIMIT_WINDOW

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -122,6 +122,7 @@ add_executable(test_bitcoin
   uint256_tests.cpp
   util_check_tests.cpp
   util_expected_tests.cpp
+  util_log_tests.cpp
   util_string_tests.cpp
   util_tests.cpp
   util_threadnames_tests.cpp

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -615,15 +615,6 @@ BOOST_AUTO_TEST_CASE(btck_script_verify_tests)
 
 BOOST_AUTO_TEST_CASE(logging_tests)
 {
-    btck_LoggingOptions logging_options = {
-        .log_timestamps = true,
-        .log_time_micros = true,
-        .log_threadnames = false,
-        .log_sourcelocations = false,
-        .always_print_category_levels = true,
-    };
-
-    logging_set_options(logging_options);
     logging_set_level_category(LogCategory::BENCH, LogLevel::TRACE_LEVEL);
     logging_disable_category(LogCategory::BENCH);
     logging_enable_category(LogCategory::VALIDATION);

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -640,6 +640,8 @@ BOOST_AUTO_TEST_CASE(log_level_name_tests)
     BOOST_CHECK_EQUAL(log_level_get_name(LogLevel::TRACE_LEVEL), "trace");
     BOOST_CHECK_EQUAL(log_level_get_name(LogLevel::DEBUG_LEVEL), "debug");
     BOOST_CHECK_EQUAL(log_level_get_name(LogLevel::INFO_LEVEL), "info");
+    BOOST_CHECK_EQUAL(log_level_get_name(LogLevel::WARNING_LEVEL), "warning");
+    BOOST_CHECK_EQUAL(log_level_get_name(LogLevel::ERROR_LEVEL), "error");
 }
 
 BOOST_AUTO_TEST_CASE(log_category_name_tests)
@@ -648,12 +650,14 @@ BOOST_AUTO_TEST_CASE(log_category_name_tests)
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::BENCH), "bench");
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::BLOCKSTORAGE), "blockstorage");
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::COINDB), "coindb");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::ESTIMATEFEE), "estimatefee");
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::KERNEL), "kernel");
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::LEVELDB), "leveldb");
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::MEMPOOL), "mempool");
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::PRUNE), "prune");
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::RAND), "rand");
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::REINDEX), "reindex");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::TXPACKAGES), "txpackages");
     BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::VALIDATION), "validation");
 }
 

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -6,9 +6,9 @@
 #include <kernel/bitcoinkernel_wrapper.h>
 
 #define BOOST_TEST_MODULE Bitcoin Kernel Test Suite
-#include <boost/test/included/unit_test.hpp>
-
 #include <test/kernel/block_data.h>
+
+#include <boost/test/included/unit_test.hpp>
 
 #include <charconv>
 #include <cstdint>
@@ -91,9 +91,13 @@ void check_equal(std::span<const std::byte> _actual, std::span<const std::byte> 
 class TestLog
 {
 public:
-    void LogMessage(std::string_view message)
+    void LogMessage(const LogEntry& entry)
     {
-        std::cout << "kernel: " << message;
+        // TODO: stream Timestamp() directly once minimum gcc version is bumped to 13.1 (required for std::format support)
+        std::cout << "kernel: " << entry.Timestamp().time_since_epoch().count()
+                  << " [" << log_category_get_name(entry.Category()) << ":"
+                  << log_level_get_name(entry.Level()) << "] "
+                  << entry.Message() << "\n";
     }
 };
 

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -635,6 +635,28 @@ BOOST_AUTO_TEST_CASE(logging_tests)
     Logger logger{std::make_unique<TestLog>()};
 }
 
+BOOST_AUTO_TEST_CASE(log_level_name_tests)
+{
+    BOOST_CHECK_EQUAL(log_level_get_name(LogLevel::TRACE_LEVEL), "trace");
+    BOOST_CHECK_EQUAL(log_level_get_name(LogLevel::DEBUG_LEVEL), "debug");
+    BOOST_CHECK_EQUAL(log_level_get_name(LogLevel::INFO_LEVEL), "info");
+}
+
+BOOST_AUTO_TEST_CASE(log_category_name_tests)
+{
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::ALL), "all");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::BENCH), "bench");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::BLOCKSTORAGE), "blockstorage");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::COINDB), "coindb");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::KERNEL), "kernel");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::LEVELDB), "leveldb");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::MEMPOOL), "mempool");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::PRUNE), "prune");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::RAND), "rand");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::REINDEX), "reindex");
+    BOOST_CHECK_EQUAL(log_category_get_name(LogCategory::VALIDATION), "validation");
+}
+
 BOOST_AUTO_TEST_CASE(btck_context_tests)
 {
     { // test default context

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -133,7 +133,7 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintStr, LogSetup)
     std::vector<std::string> expected;
     for (auto& [msg, category, level, prefix, loc] : cases) {
         expected.push_back(tfm::format("[%s:%s] [%s] %s%s", util::RemovePrefix(loc.file_name(), "./"), loc.line(), loc.function_name_short(), prefix, msg));
-        LogInstance().LogPrintStr(msg, std::move(loc), category, level, /*should_ratelimit=*/false);
+        LogInstance().LogPrintStr({.category = category, .message = msg, .source_loc = std::move(loc), .level = level, .should_ratelimit = false});
     }
     std::vector<std::string> log_lines{ReadDebugLogLines()};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());

--- a/src/test/util_log_tests.cpp
+++ b/src/test/util_log_tests.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/setup_common.h>
+#include <util/log.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <vector>
+
+using namespace util::log;
+
+BOOST_AUTO_TEST_SUITE(util_log_tests)
+
+BOOST_AUTO_TEST_CASE(dispatcher_enabled)
+{
+    Dispatcher dispatcher{};
+
+    // No callbacks registered - should not be enabled
+    BOOST_CHECK(!dispatcher.Enabled());
+
+    // Register a callback - should now be enabled
+    auto handle = dispatcher.RegisterCallback([](const Entry&) {});
+    BOOST_CHECK(dispatcher.Enabled());
+
+    // Unregister the callback - should no longer be enabled
+    dispatcher.UnregisterCallback(handle);
+    BOOST_CHECK(!dispatcher.Enabled());
+}
+
+BOOST_AUTO_TEST_CASE(dispatcher_callback_receives_entry)
+{
+    Dispatcher dispatcher{};
+
+    std::vector<Entry> received_entries;
+    auto handle = dispatcher.RegisterCallback([&](const Entry& entry) {
+        received_entries.push_back(entry);
+    });
+
+    const uint64_t test_category{42};
+    auto before = std::chrono::system_clock::now();
+    auto line = __LINE__ + 1; // capture the line number of the log statement below
+    dispatcher.Log(Level::Info, /*category=*/test_category, {__func__}, /*should_ratelimit=*/true, "test message %d", 123);
+    auto after = std::chrono::system_clock::now();
+
+    BOOST_REQUIRE_EQUAL(received_entries.size(), 1);
+    const auto& entry = received_entries[0];
+
+    BOOST_CHECK_EQUAL(static_cast<int>(entry.level), static_cast<int>(Level::Info));
+    BOOST_CHECK_EQUAL(entry.category, test_category);
+    BOOST_CHECK_EQUAL(entry.message, "test message 123");
+    BOOST_CHECK(entry.source_loc.file_name().ends_with(__FILE__));
+    BOOST_CHECK_EQUAL(entry.source_loc.function_name_short(), __func__);
+    BOOST_CHECK_EQUAL(entry.source_loc.line(), line);
+    BOOST_CHECK(entry.timestamp >= before && entry.timestamp <= after);
+    BOOST_CHECK(entry.should_ratelimit);
+
+    dispatcher.UnregisterCallback(handle);
+}
+
+BOOST_AUTO_TEST_CASE(dispatcher_multiple_callbacks)
+{
+    Dispatcher dispatcher{};
+
+    int callback1_count{0};
+    int callback2_count{0};
+
+    BOOST_CHECK(!dispatcher.Enabled());
+    auto handle1 = dispatcher.RegisterCallback([&](const Entry&) {
+        ++callback1_count;
+    });
+    auto handle2 = dispatcher.RegisterCallback([&](const Entry&) {
+        ++callback2_count;
+    });
+    BOOST_CHECK(dispatcher.Enabled());
+
+    dispatcher.Log(Level::Info, /*category=*/0, __func__, /*should_ratelimit=*/false, "test");
+
+    // Both callbacks should have been called
+    BOOST_CHECK_EQUAL(callback1_count, 1);
+    BOOST_CHECK_EQUAL(callback2_count, 1);
+
+    // Unregister first callback
+    dispatcher.UnregisterCallback(handle1);
+
+    dispatcher.Log(Level::Info, /*category=*/0, __func__, /*should_ratelimit=*/false, "test");
+
+    // Only second callback should have been called
+    BOOST_CHECK_EQUAL(callback1_count, 1);
+    BOOST_CHECK_EQUAL(callback2_count, 2);
+
+    dispatcher.UnregisterCallback(handle2);
+    BOOST_CHECK(!dispatcher.Enabled());
+}
+
+BOOST_AUTO_TEST_CASE(dispatcher_skips_when_not_enabled)
+{
+    Dispatcher dispatcher{};
+    BOOST_CHECK(!dispatcher.Enabled());
+
+    // No callbacks registered, Log should be a no-op (and not crash)
+    dispatcher.Log(Level::Info, /*category=*/0, __func__, /*should_ratelimit=*/false, "this should not crash");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   fs.cpp
   fs_helpers.cpp
   hasher.cpp
+  log.cpp
   moneystr.cpp
   rbf.cpp
   readwritefile.cpp

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/log.h>
+
+#include <threadsafety.h>
+
+#include <iterator>
+#include <utility>
+
+namespace util::log {
+
+Dispatcher::CallbackHandle Dispatcher::RegisterCallback(Callback callback)
+{
+    StdLockGuard lock{m_mutex};
+    m_callbacks.push_back(std::move(callback));
+    m_callback_count.fetch_add(1, std::memory_order_release);
+    return std::prev(m_callbacks.end());
+}
+
+void Dispatcher::UnregisterCallback(CallbackHandle handle)
+{
+    StdLockGuard lock{m_mutex};
+    m_callbacks.erase(handle);
+    m_callback_count.fetch_sub(1, std::memory_order_release);
+}
+
+} // namespace util::log

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -1,0 +1,23 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_LOG_H
+#define BITCOIN_UTIL_LOG_H
+
+#include <util/source.h> // IWYU pragma: export
+
+
+namespace util::log {
+
+enum class Level {
+    Trace = 0, // High-volume or detailed logging for development/debugging
+    Debug,     // Reasonably noisy logging, but still usable in production
+    Info,      // Default
+    Warning,
+    Error,
+};
+
+} // namespace util::log
+
+#endif // BITCOIN_UTIL_LOG_H

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -112,6 +112,14 @@ private:
     std::atomic<size_t> m_callback_count{0};
 };
 
+/**
+ * Return a reference to the global dispatcher.
+ *
+ * This function is declared here but implemented differently by different binaries, see e.g.
+ * logging.cpp and bitcoinkernel.cpp.
+ */
+Dispatcher& g_dispatcher();
+
 } // namespace util::log
 
 #endif // BITCOIN_UTIL_LOG_H

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -5,8 +5,17 @@
 #ifndef BITCOIN_UTIL_LOG_H
 #define BITCOIN_UTIL_LOG_H
 
+#include <threadsafety.h>
+#include <tinyformat.h>
 #include <util/source.h> // IWYU pragma: export
+#include <util/string.h>
+#include <util/threadnames.h>
 
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <list>
+#include <string>
 
 namespace util::log {
 
@@ -16,6 +25,91 @@ enum class Level {
     Info,      // Default
     Warning,
     Error,
+};
+
+/** Log entry passed to registered callbacks. */
+struct Entry {
+    //! Opaque to util::log; interpreted by consumers (e.g., BCLog::LogFlags).
+    uint64_t category;
+    std::string message;
+    SourceLocation source_loc;
+    std::chrono::system_clock::time_point timestamp{std::chrono::system_clock::now()};
+    std::string thread_name{util::ThreadGetInternalName()};
+    Level level;
+    bool should_ratelimit{false}; //!< Hint for consumers if this entry should be ratelimited
+};
+
+/**
+ * Dispatcher is responsible for producing logs. It forwards log entries to one or
+ * multiple logging sinks (e.g. BCLog::Logger) through its registered callbacks.
+ *
+ * Log consumption (including printing and rate limiting) should be implemented by the sink.
+ */
+class Dispatcher
+{
+public:
+    //! Type for callbacks invoked for each log entry.
+    using Callback = std::function<void(const Entry&)>;
+    //! Type for opaque handles returned by RegisterCallback(), used to unregister.
+    using CallbackHandle = std::list<Callback>::iterator;
+
+    /**
+     * Register a callback to receive log entries.
+     * @param[in] callback  Invoked for each log entry.
+     * @return Handle to use with UnregisterCallback().
+     */
+    [[nodiscard]] CallbackHandle RegisterCallback(Callback callback) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /**
+     * Unregister a previously registered callback.
+     * @param[in] handle  Handle previously returned by RegisterCallback().
+     */
+    void UnregisterCallback(CallbackHandle handle) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** @return true if any callbacks are registered. */
+    bool Enabled() const { return m_callback_count.load(std::memory_order_acquire) > 0; }
+
+    /**
+     * Format message and dispatch to all registered callbacks.
+     * @param[in] level             Severity level.
+     * @param[in] category          Opaque category identifier.
+     * @param[in] loc               Source location of the log call.
+     * @param[in] should_ratelimit  Hint for consumers if this entry should be ratelimited.
+     * @param[in] fmt               Format string.
+     * @param[in] args              Format arguments.
+     */
+    template <typename... Args>
+    void Log(Level level, uint64_t category, SourceLocation&& loc, bool should_ratelimit,
+             util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        std::string log_msg;
+        try {
+            log_msg = tfm::format(fmt, args...);
+        } catch (const tinyformat::format_error& fmterr) {
+            log_msg = "Error \"" + std::string{fmterr.what()} + "\" while formatting log message: " + fmt.fmt;
+        }
+
+        Entry entry{
+            .category = category,
+            .message = std::move(log_msg),
+            .source_loc = std::move(loc),
+            .level = level,
+            .should_ratelimit = should_ratelimit,
+        };
+
+        StdLockGuard lock{m_mutex};
+        for (const auto& callback : m_callbacks) {
+            callback(entry);
+        }
+    }
+
+private:
+    mutable StdMutex m_mutex;
+    //! Callbacks to be executed when an eligible log statement is produced.
+    std::list<Callback> m_callbacks GUARDED_BY(m_mutex);
+    //! Lock-free size of m_callbacks for fast checks.
+    std::atomic<size_t> m_callback_count{0};
 };
 
 } // namespace util::log

--- a/src/util/source.h
+++ b/src/util/source.h
@@ -1,0 +1,32 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_SOURCE_H
+#define BITCOIN_UTIL_SOURCE_H
+
+#include <cstdint>
+#include <source_location>
+#include <string_view>
+
+/// Like std::source_location, but allowing to override the function name.
+class SourceLocation
+{
+public:
+    /// The func argument must be constructed from the C++11 __func__ macro.
+    /// Ref: https://en.cppreference.com/w/cpp/language/function.html#func
+    /// Non-static string literals are not supported.
+    SourceLocation(const char* func,
+                   std::source_location loc = std::source_location::current())
+        : m_func{func}, m_loc{loc} {}
+
+    std::string_view file_name() const { return m_loc.file_name(); }
+    std::uint_least32_t line() const { return m_loc.line(); }
+    std::string_view function_name_short() const { return m_func; }
+
+private:
+    std::string_view m_func;
+    std::source_location m_loc;
+};
+
+#endif // BITCOIN_UTIL_SOURCE_H


### PR DESCRIPTION
The `bitcoinkernel` library (#27587) [exposes](https://github.com/bitcoin/bitcoin/blob/b26762bdcb941096ccc6f53c3fb5a7786ad735e7/src/kernel/bitcoinkernel.h#L698-L778) functionality to interface with kernel logging. This includes registering callbacks for log statements, level/category filtering, string formatting options, and more.

This PR improves kernel logging by making it struct-based instead of string-based. Rather than adding this functionality onto an already large `BCLog::Logger` class, the PR first separates log generation (i.e. producing the log message via `LogInfo(msg)`) from log consumption (i.e. formatting, ratelimiting, printing the message) by moving all log generation code to `util/log.h`. While not strictly necessary for adding struct-based logging, it better separates concerns and is a prerequisite for follow-up work in #34374 that completely removes `kernel`'s dependency on `logging.cpp`.

**Approach:**

1. **Separate log generation**: Add a minimal `util::log::Dispatcher` that is used to generate logs, and forwards struct-based log entries to registered callbacks. No formatting, rate-limiting, or output handling - that's the consumer's responsibility.
 
1. **Register `BCLog::Logger` on Dispatcher**: Register a callback on the global Dispatcher to receive entries and handle node-specific concerns (formatting, rate-limiting, file output) without changing most of its logic. Route logging macros through this global dispatcher.
 
1. **Update bitcoinkernel C API**: Replace the string-based callback with `btck_LogEntry` containing full metadata and remove `btck_LoggingOptions` and related functions.

Note: with this change, `bitcoinkernel` logging callbacks are no longer routed through `BCLog::Logger`. This means that they are no longer buffered (i.e. log messages produced before a logging callback is registered) are dropped, and there is no longer a need for `btck_logging_disable`. In practice, this means users can no longer see the log message produced during the static [context initialization](https://github.com/bitcoin/bitcoin/blob/01651324f4e540f6b96cff31e89752c3f9417293/src/kernel/context.cpp#L20).

Carve-out of #34374 to narrow the focus while maintaining tangible benefits (i.e. having struct-based logging).

