### PR TITLE
net: don't perform network activity when networkactive=0

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2044,8 +2044,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     LogInfo("nBestHeight = %d", chain_active_height);
     if (node.peerman) node.peerman->SetBestBlock(chain_active_height, std::chrono::seconds{best_block_time});
 
-    // Map ports with NAT-PMP
-    StartMapPort(args.GetBoolArg("-natpmp", DEFAULT_NATPMP));
+    // Only start NAT-PMP port mapping if network is active
+    if (args.GetBoolArg("-networkactive", true)) {
+        StartMapPort(args.GetBoolArg("-natpmp", DEFAULT_NATPMP));
+    }
 
     CConnman::Options connOptions;
     connOptions.m_local_services = g_local_services;
@@ -2138,7 +2140,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                     "for the automatically created Tor onion service."),
                                   onion_service_target.ToStringAddrPort()));
         }
-        StartTorControl(onion_service_target);
+        // Only start Tor control if network is active
+        if (args.GetBoolArg("-networkactive", true)) {
+            StartTorControl(onion_service_target);
+        }
     }
 
     if (connOptions.bind_on_any) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2572,6 +2572,13 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
     }
 
     while (!m_interrupt_net->interrupted()) {
+        // Wait if the network is inactive
+        if (!fNetworkActive) {
+            do {
+                if (!m_interrupt_net->sleep_for(1s)) return;
+            } while (!fNetworkActive);
+        }
+
         if (add_addr_fetch) {
             add_addr_fetch = false;
             const auto& seed{SpanPopBack(seed_nodes)};


### PR DESCRIPTION
## Problem
When starting bitcoind with `-networkactive=0`, the node still performs various network activities despite the user explicitly requesting that the P2P network be inactive. This results in unnecessary log messages and network overhead:

- `[addrman] Selected IP:PORT from tried` - Address manager selections
- `[net:error] Could not get best interface for default route` - Gateway detection attempts
- `[tor] Error connecting to Tor control socket` - Tor control connection attempts
- `[tor] Not connected to Tor control port` - Tor reconnection attempts
- `[net] portmap: Could not determine IPv4/IPv6 default gateway` - UPnP/NAT-PMP attempts

This defeats the purpose of the `-networkactive` flag, which is documented as "Enable all P2P network activity (default: 1)".

### Steps to Reproduce
1. Start bitcoind with `bitcoind.exe -networkactive=0`
2. Observe logs - despite the flag being set to disable network activity, addrman selections and network-related errors are logged

### Expected Behavior
No network activity should occur when `-networkactive=0` is set at startup. The node should remain idle until network is activated via RPC command `setnetworkactive true`.

## Solution
This PR ensures that when `networkactive=0`, no network initialization or activity occurs by:

### 1. **ThreadOpenConnections (src/net.cpp)**
Added a check at the beginning of the main while loop to pause all outbound connection logic when `fNetworkActive` is false. This prevents:
- Address selection from addrman
- Connection attempts to peers
- Feeler connections
- Block relay connection attempts

This check follows the existing pattern used for DNS seed querying (lines 2345-2349) and uses the same synchronization mechanism (`fNetworkActive` atomic flag and `sleep_for` with interruption support).

### 2. **StartMapPort (src/init.cpp)**
Made NAT-PMP port mapping startup conditional on `-networkactive` being true. This prevents:
- Port mapping initialization
- Gateway detection attempts
- Related network errors and log spam

### 3. **StartTorControl (src/init.cpp)**
Made Tor control thread startup conditional on `-networkactive` being true. This prevents:
- Tor control socket connection attempts
- Tor-related error logs
- Unnecessary event loop setup

## Testing
The fix has been verified to:
- Compile without errors or warnings
- Follow existing code patterns and conventions used in the same functions
- Use the same argument parsing method as existing code (`args.GetBoolArg("-networkactive", true)`)
- Respect the interruption mechanism used throughout the codebase

### Manual Testing
```bash
# Start with networkactive=0 - should see no network activity logs
bitcoind -networkactive=0

# Start with networkactive=1 (default) - normal behavior
bitcoind
```

Affected Code Paths
`src/net.cpp: CConnman::ThreadOpenConnections()` - Main connection management loop
`src/init.cpp` Bitcoin Core initialization - MapPort and TorControl startup

Notes
This change is backward compatible - default behavior (networkactive=1) is unchanged
Dynamic network activation via setnetworkactive true RPC will resume ThreadOpenConnections activity
MapPort and TorControl remain stopped if started with networkactive=0 (can be addressed in follow-up if needed for dynamic activation)

Fixes #34190