### PR TITLE
build: Fix debug prefix map for generated source files

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -211,7 +211,7 @@ CONFIGFLAGS="-DREDUCE_EXPORTS=ON -DBUILD_BENCH=OFF -DBUILD_GUI_TESTS=OFF -DBUILD
 # CFLAGS
 HOST_CFLAGS="-O2 -g"
 HOST_CFLAGS+=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
-HOST_CFLAGS+=" -fdebug-prefix-map=${DISTSRC}/src=."
+HOST_CFLAGS+=" -fdebug-prefix-map=${DISTSRC}=."
 case "$HOST" in
     *mingw*)  HOST_CFLAGS+=" -fno-ident" ;;
     *darwin*) unset HOST_CFLAGS ;;


### PR DESCRIPTION
This PR fixes an issue where debug paths were inconsistent for generated files residing in the build tree. #34414

Currently, the debug prefix map is restricted to `${DISTSRC}/src=.`. This configuration fails to correctly map generated files that exist outside of the `src` directory (e.g., Cap'n Proto definitions), resulting in inconsistent file paths during debugging.

**Changes:**
- Updated `HOST_CFLAGS` in `contrib/guix/libexec/build.sh` to map the entire `${DISTSRC}` to `.` instead of restricting it to `${DISTSRC}/src`.

This ensures all source files, including generated ones, have correct relative paths in the debug information.

