### PR TITLE
refactor: Use aliasing shared_ptr in Sock::Wait

### DIFF
--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -138,10 +138,12 @@ bool Sock::IsSelectable() const
 
 bool Sock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
 {
-    // We need a `shared_ptr` owning `this` for `WaitMany()`, but don't want
+    // We need a `shared_ptr` holding `this` for `WaitMany()`, but don't want
     // `this` to be destroyed when the `shared_ptr` goes out of scope at the
-    // end of this function. Create it with a custom noop deleter.
-    std::shared_ptr<const Sock> shared{this, [](const Sock*) {}};
+    // end of this function.
+    // Create it with an aliasing shared_ptr that points to `this` without
+    // owning it.
+    std::shared_ptr<const Sock> shared{std::shared_ptr<const Sock>{}, this};
 
     EventsPerSock events_per_sock{std::make_pair(shared, Events{requested})};
 


### PR DESCRIPTION
Currently, a no-op lambda is used as the deleter for the temporary shared pointer helper in `Sock::Wait`. This is perfectly fine, but has a few style issues:

* The lambda needs to be allocated on the heap
* It triggers a false-positive upstream GCC-16-trunk bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123912

Fix all issues by just using an aliasing shared pointer, which points to `this`, but is otherwise empty (sits on the stack without any heap allocations).