### PR TITLE
bench: add script verification benchmark for P2TR key path spends

### DIFF
--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -2,9 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <addresstype.h>
 #include <bench/bench.h>
-#include <hash.h>
 #include <key.h>
+#include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
@@ -12,6 +13,7 @@
 #include <span.h>
 #include <test/util/transaction_utils.h>
 #include <uint256.h>
+#include <util/translation.h>
 
 #include <array>
 #include <cassert>
@@ -24,32 +26,31 @@ static void VerifyScriptBench(benchmark::Bench& bench)
 {
     ECC_Context ecc_context{};
 
-    const script_verify_flags flags{SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH};
-    const int witnessversion = 0;
+    // Create deterministic key material needed for output script creation / signing
+    FlatSigningProvider keystore;
+    CPubKey pubkey;
+    {
+        CKey privkey;
+        privkey.Set(uint256::ONE.begin(), uint256::ONE.end(), /*fCompressedIn=*/true);
+        pubkey = privkey.GetPubKey();
+        CKeyID key_id = pubkey.GetID();
+        keystore.keys.emplace(key_id, privkey);
+        keystore.pubkeys.emplace(key_id, pubkey);
+    }
 
-    // Key pair.
-    CKey key;
-    static const std::array<unsigned char, 32> vchKey = {
-        {
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
-        }
-    };
-    key.Set(vchKey.begin(), vchKey.end(), false);
-    CPubKey pubkey = key.GetPubKey();
-    uint160 pubkeyHash;
-    CHash160().Write(pubkey).Finalize(pubkeyHash);
-
-    // Script.
-    CScript scriptPubKey = CScript() << witnessversion << ToByteVector(pubkeyHash);
-    CScript scriptSig;
-    CScript witScriptPubkey = CScript() << OP_DUP << OP_HASH160 << ToByteVector(pubkeyHash) << OP_EQUALVERIFY << OP_CHECKSIG;
+    // Create crediting and spending transactions
+    CScript scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(pubkey));
     const CMutableTransaction& txCredit = BuildCreditingTransaction(scriptPubKey, 1);
-    CMutableTransaction txSpend = BuildSpendingTransaction(scriptSig, CScriptWitness(), CTransaction(txCredit));
-    CScriptWitness& witness = txSpend.vin[0].scriptWitness;
-    witness.stack.emplace_back();
-    key.Sign(SignatureHash(witScriptPubkey, txSpend, 0, SIGHASH_ALL, txCredit.vout[0].nValue, SigVersion::WITNESS_V0), witness.stack.back());
-    witness.stack.back().push_back(static_cast<unsigned char>(SIGHASH_ALL));
-    witness.stack.push_back(ToByteVector(pubkey));
+    CMutableTransaction txSpend = BuildSpendingTransaction(/*scriptSig=*/{}, /*scriptWitness=*/{}, CTransaction(txCredit));
+
+    // Sign spending transaction
+    {
+        std::map<COutPoint, Coin> coins;
+        coins[txSpend.vin[0].prevout] = Coin(txCredit.vout[0], /*nHeightIn=*/100, /*fCoinBaseIn=*/false);
+        std::map<int, bilingual_str> input_errors;
+        bool complete = SignTransaction(txSpend, &keystore, coins, SIGHASH_ALL, input_errors);
+        assert(complete);
+    }
 
     // Benchmark.
     bench.run([&] {
@@ -58,7 +59,7 @@ static void VerifyScriptBench(benchmark::Bench& bench)
             txSpend.vin[0].scriptSig,
             txCredit.vout[0].scriptPubKey,
             &txSpend.vin[0].scriptWitness,
-            flags,
+            STANDARD_SCRIPT_VERIFY_FLAGS,
             MutableTransactionSignatureChecker(&txSpend, 0, txCredit.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL),
             &err);
         assert(err == SCRIPT_ERR_OK);

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -20,36 +20,45 @@
 #include <cstdint>
 #include <vector>
 
-// Microbenchmark for verification of a basic P2WPKH script. Can be easily
-// modified to measure performance of other types of scripts.
-static void VerifyScriptBench(benchmark::Bench& bench)
+enum class ScriptType {
+    P2WPKH, // segwitv0, witness-pubkey-hash (ECDSA signature)
+    P2TR,   // segwitv1, taproot key-path spend (Schnorr signature)
+};
+
+// Microbenchmark for verification of standard scripts.
+static void VerifyScriptBench(benchmark::Bench& bench, ScriptType script_type)
 {
     ECC_Context ecc_context{};
 
     // Create deterministic key material needed for output script creation / signing
-    FlatSigningProvider keystore;
-    CPubKey pubkey;
-    {
-        CKey privkey;
-        privkey.Set(uint256::ONE.begin(), uint256::ONE.end(), /*fCompressedIn=*/true);
-        pubkey = privkey.GetPubKey();
-        CKeyID key_id = pubkey.GetID();
-        keystore.keys.emplace(key_id, privkey);
-        keystore.pubkeys.emplace(key_id, pubkey);
-    }
+    CKey privkey;
+    privkey.Set(uint256::ONE.begin(), uint256::ONE.end(), /*fCompressedIn=*/true);
+    CPubKey pubkey = privkey.GetPubKey();
+    CKeyID key_id = pubkey.GetID();
 
-    // Create crediting and spending transactions
-    CScript scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(pubkey));
-    const CMutableTransaction& txCredit = BuildCreditingTransaction(scriptPubKey, 1);
+    FlatSigningProvider keystore;
+    keystore.keys.emplace(key_id, privkey);
+    keystore.pubkeys.emplace(key_id, pubkey);
+
+    // Create crediting and spending transactions with provided input type
+    CTxDestination dest;
+    switch (script_type) {
+    case ScriptType::P2WPKH: dest = WitnessV0KeyHash(pubkey); break;
+    case ScriptType::P2TR:   dest = WitnessV1Taproot(XOnlyPubKey{pubkey}); break;
+    default: assert(false);
+    }
+    const CMutableTransaction& txCredit = BuildCreditingTransaction(GetScriptForDestination(dest), 1);
     CMutableTransaction txSpend = BuildSpendingTransaction(/*scriptSig=*/{}, /*scriptWitness=*/{}, CTransaction(txCredit));
 
-    // Sign spending transaction
+    // Sign spending transaction, precompute transaction data
+    PrecomputedTransactionData txdata;
     {
         std::map<COutPoint, Coin> coins;
         coins[txSpend.vin[0].prevout] = Coin(txCredit.vout[0], /*nHeightIn=*/100, /*fCoinBaseIn=*/false);
         std::map<int, bilingual_str> input_errors;
         bool complete = SignTransaction(txSpend, &keystore, coins, SIGHASH_ALL, input_errors);
         assert(complete);
+        txdata.Init(txSpend, /*spent_outputs=*/{txCredit.vout[0]});
     }
 
     // Benchmark.
@@ -60,12 +69,15 @@ static void VerifyScriptBench(benchmark::Bench& bench)
             txCredit.vout[0].scriptPubKey,
             &txSpend.vin[0].scriptWitness,
             STANDARD_SCRIPT_VERIFY_FLAGS,
-            MutableTransactionSignatureChecker(&txSpend, 0, txCredit.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL),
+            MutableTransactionSignatureChecker(&txSpend, 0, txCredit.vout[0].nValue, txdata, MissingDataBehavior::ASSERT_FAIL),
             &err);
         assert(err == SCRIPT_ERR_OK);
         assert(success);
     });
 }
+
+static void VerifyScriptP2WPKH(benchmark::Bench& bench) { VerifyScriptBench(bench, ScriptType::P2WPKH); }
+static void VerifyScriptP2TR(benchmark::Bench& bench)   { VerifyScriptBench(bench, ScriptType::P2TR);   }
 
 static void VerifyNestedIfScript(benchmark::Bench& bench)
 {
@@ -88,5 +100,6 @@ static void VerifyNestedIfScript(benchmark::Bench& bench)
     });
 }
 
-BENCHMARK(VerifyScriptBench);
+BENCHMARK(VerifyScriptP2WPKH);
+BENCHMARK(VerifyScriptP2TR);
 BENCHMARK(VerifyNestedIfScript);


### PR DESCRIPTION
We currently benchmark Schnorr signature verification only in the context of block validation ([`ConectBlock*`](https://github.com/bitcoin/bitcoin/blob/8bb77f348ef390b7f7c7fb6b57fdc7e86ddb4ce7/src/bench/connectblock.cpp#L107) benchmarks), but not individually for single inputs [1]. This PR adds a script verification benchmark for P2TR key path spends accordingly, by generalizing the already existing one for P2WPKH spends.

This should make it easier to quantify potential performance improvements like e.g. https://github.com/bitcoin-core/secp256k1/pull/1777, which allows to plug in our HW-optimized SHA256 functions to be used in libsecp256k1 (see the linked example commit https://github.com/furszy/bitcoin-core/commit/f68bef06d95a589859f98fc898dd80ab2e35eb39). IIRC from last CoreDev, the main speedup from this is expected for ECDSA signing though (as this involves quite a lot of hashing), but it still makes sense to have verification benchmarks available for both signature types as well.

(An alternative way could be to add benchmarks for the signing/verifying member functions `CKey::Sign{,Schnorr}`, `CPubKey::Verify` and `XOnlyPubKey::VerifySchnorr` directly, if we prefer that.) 

[1] this claim can be practically verified by putting an `assert(false);` into `XOnlyPubKey::VerifySchnorr`: the three benchmarks crashing are `ConnectBlockAllSchnorr`, `ConnectBlockMixedEcdsaSchnorr` and `SignTransactionSchnorr` (as signing includes verification)