### PR TITLE
ci: Treat SHA1 LLVM signing key as warning

### DIFF
--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -22,6 +22,11 @@ if [ -n "$DPKG_ADD_ARCH" ]; then
 fi
 
 if [ -n "${APT_LLVM_V}" ]; then
+  # Temporarily work around Sequoia PGP policy deadline for legacy repositories.
+  # See https://github.com/llvm/llvm-project/issues/153385.
+  if [ -f /usr/share/apt/default-sequoia.config ]; then
+    sed -i 's/\(sha1\.second_preimage_resistance =\).*/\1 9999-01-01/' /usr/share/apt/default-sequoia.config
+  fi
   ${CI_RETRY_EXE} apt-get update
   ${CI_RETRY_EXE} apt-get install curl -y
   curl "https://apt.llvm.org/llvm-snapshot.gpg.key" | tee "/etc/apt/trusted.gpg.d/apt.llvm.org.asc"


### PR DESCRIPTION
The current SHA1 LLVM signing key is considered not secure since
2026-02-01T00:00:00Z which makes this run fail when downloading
packages.

See: https://github.com/llvm/llvm-project/issues/153385

Apply the fix from the issue to temporarily to treat this error as a
warning, until the upstream key can be updated.

This PR should be reverted once the upstream key is updated.