### PR TITLE
ci: Fix LLVM repository signature failure

### DIFF
--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -29,6 +29,10 @@ if [ -n "${APT_LLVM_V}" ]; then
     # shellcheck disable=SC2034
     source /etc/os-release
     echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${APT_LLVM_V} main" > "/etc/apt/sources.list.d/llvm-toolchain-${VERSION_CODENAME}-${APT_LLVM_V}.list"
+    # Temporarily work around Sequoia PGP policy deadline for legacy repositories.
+    # See https://github.com/llvm/llvm-project/issues/153385.
+    sed -i 's/\(sha1\.second_preimage_resistance =\).*/\1 9999-01-01/' /usr/share/apt/default-sequoia.config && \
+    apt-get update && \
   )
 fi
 


### PR DESCRIPTION
The LLVM apt repository uses legacy SHA1 signatures which are now rejected by the stricter Sequoia PGP policy.

This change extends the `sha1.second_preimage_resistance` cutoff date to 9999-01-01 in the default Sequoia config. This effectively whitelists the legacy signature algorithm, preventing "OpenPGP signature verification failed" errors during `apt-get update`.

See https://github.com/llvm/llvm-project/issues/153385.