### PR TITLE
wallet: don't back-date locktime below input locktime

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -104,8 +104,21 @@ static UniValue FinishTransaction(const std::shared_ptr<CWallet> pwallet, const 
 
     if (can_anti_fee_snipe) {
         LOCK(pwallet->cs_wallet);
+        // Find the highest nLockTime of all the wallet-owned input transactions so that
+        // this transaction does not use a lower value.
+        // Setting a lower nLockTime would make the "signed earlier but broadcast later"
+        // explanation unrealistic, and may act as a wallet fingerprint.
+        // We can only inspect the nLockTime of wallet-owned inputs.
+        // When spending external inputs, their original nLockTime is unknown,
+        // so the selected value may still be lower.
+        unsigned int max_input_locktime{0};
+        for (const CTxIn& tx_in : rawTx.vin) {
+            if (const CWalletTx* wtx{pwallet->GetWalletTx(tx_in.prevout.hash)}) {
+                max_input_locktime = std::max(max_input_locktime, wtx->tx->nLockTime);
+            }
+        }
         FastRandomContext rng_fast;
-        DiscourageFeeSniping(rawTx, rng_fast, pwallet->chain(), pwallet->GetLastBlockHash(), pwallet->GetLastBlockHeight());
+        DiscourageFeeSniping(rawTx, rng_fast, pwallet->chain(), pwallet->GetLastBlockHash(), pwallet->GetLastBlockHeight(), max_input_locktime);
     }
 
     // Make a blank psbt

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -983,7 +983,8 @@ static bool IsCurrentForAntiFeeSniping(interfaces::Chain& chain, const uint256& 
 }
 
 void DiscourageFeeSniping(CMutableTransaction& tx, FastRandomContext& rng_fast,
-                                 interfaces::Chain& chain, const uint256& block_hash, int block_height)
+                                 interfaces::Chain& chain, const uint256& block_hash, int block_height,
+                                 unsigned int min_allowed_locktime)
 {
     // All inputs must be added by now
     assert(!tx.vin.empty());
@@ -1014,8 +1015,14 @@ void DiscourageFeeSniping(CMutableTransaction& tx, FastRandomContext& rng_fast,
         // that transactions that are delayed after signing for whatever reason,
         // e.g. high-latency mix networks and some CoinJoin implementations, have
         // better privacy.
-        if (rng_fast.randrange(10) == 0) {
-            tx.nLockTime = std::max(0, int(tx.nLockTime) - int(rng_fast.randrange(100)));
+        // Only pick an nLockTime further back if min_allowed_locktime is lower than the
+        // current block height; otherwise, we already picked the earliest possible nLockTime.
+        if (static_cast<int>(min_allowed_locktime) < block_height && rng_fast.randrange(10) == 0) {
+            // Calculate how far back we can set nLockTime: at most 100 blocks, but constrained
+            // by min_allowed_locktime to make sure we don't go below the minimum value
+            int locktime_range = std::min(100, int(block_height - min_allowed_locktime));
+            tx.nLockTime = std::max(int(min_allowed_locktime), int(tx.nLockTime) - int(rng_fast.randrange(locktime_range)));
+            Assert(tx.nLockTime >= min_allowed_locktime);
         }
     } else {
         // If our chain is lagging behind, we can't discourage fee sniping nor help
@@ -1286,7 +1293,20 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         use_anti_fee_sniping = false;
     }
     if (use_anti_fee_sniping) {
-        DiscourageFeeSniping(txNew, rng_fast, wallet.chain(), wallet.GetLastBlockHash(), wallet.GetLastBlockHeight());
+        // Find the highest nLockTime of all the wallet-owned input transactions so that
+        // this transaction does not use a lower value.
+        // Setting a lower nLockTime would make the "signed earlier but broadcast later"
+        // explanation unrealistic, and may act as a wallet fingerprint.
+        // We can only inspect the nLockTime of wallet-owned inputs.
+        // When spending external inputs, their original nLockTime is unknown,
+        // so the selected value may still be lower.
+        unsigned int max_input_locktime{0};
+        for (const auto& coin : selected_coins) {
+            if (const CWalletTx* coin_wtx{wallet.GetWalletTx(coin->outpoint.hash)}) {
+                max_input_locktime = std::max(max_input_locktime, coin_wtx->tx->nLockTime);
+            }
+        }
+        DiscourageFeeSniping(txNew, rng_fast, wallet.chain(), wallet.GetLastBlockHash(), wallet.GetLastBlockHeight(), max_input_locktime);
     }
 
     // Calculate the transaction fee

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -216,8 +216,9 @@ struct CreatedTransactionResult
 /**
  * Set a height-based locktime for new transactions (uses the height of the
  * current chain tip unless we are not synced with the current chain
+ *
  */
-void DiscourageFeeSniping(CMutableTransaction& tx, FastRandomContext& rng_fast, interfaces::Chain& chain, const uint256& block_hash, int block_height);
+void DiscourageFeeSniping(CMutableTransaction& tx, FastRandomContext& rng_fast, interfaces::Chain& chain, const uint256& block_hash, int block_height, unsigned int min_allowed_locktime);
 
 /**
  * Create a new transaction paying the recipients with a set of coins

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -47,7 +47,8 @@ class CreateTxWalletTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
-        assert 0 < tx['locktime'] <= 201
+        # The nlocktime should be within 100 blocks of the block height
+        assert 101 <= tx['locktime'] <= 201
 
     def test_tx_size_too_large(self):
         # More than 10kB of outputs, so that we hit -maxtxfee with a high feerate

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -9,6 +9,7 @@ from test_framework.messages import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than_or_equal,
     assert_raises_rpc_error,
 )
 from test_framework.blocktools import (
@@ -49,6 +50,35 @@ class CreateTxWalletTest(BitcoinTestFramework):
         tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
         # The nlocktime should be within 100 blocks of the block height
         assert 101 <= tx['locktime'] <= 201
+
+        self.log.info('Test that sendtoaddress sets the transaction locktime no lower than any input locktime')
+        wallet_rpc = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].createwallet("anti_fee_sniping_test")
+        test_wallet = self.nodes[0].get_wallet_rpc("anti_fee_sniping_test")
+        # Create 100 parent transactions, all with the same
+        # explicit backdated nLockTime. This avoids relying on the random
+        # anti fee sniping behavior and provides several inputs to spend from.
+        num_parents = 100
+        tip_height = self.nodes[0].getblockcount()
+        parent_locktime = tip_height - 80
+        for _ in range(num_parents):
+            wallet_rpc.send(outputs=[{test_wallet.getnewaddress(): 10}], locktime=parent_locktime)
+        self.generate(self.nodes[0], 5)
+        tip_height = self.nodes[0].getblockcount()
+        # Spend parents one by one until we observe a backdated
+        # nLockTime on a child transaction. Backdating happens randomly, so
+        # retry until the locktime is less than the current block height.
+        child_nlocktime = tip_height
+        num_tries = 0
+        while child_nlocktime == tip_height:
+            child_txid = test_wallet.sendtoaddress(wallet_rpc.getnewaddress(), 9)
+            child_nlocktime = test_wallet.gettransaction(txid=child_txid, verbose=True)["decoded"]["locktime"]
+            num_tries += 1
+            if num_tries >= num_parents:
+                raise AssertionError("RPC call sendtoaddress() did not produce a backdated nLockTime")
+        # Child nlocktime should be >= parent nlocktime
+        assert_greater_than_or_equal(child_nlocktime, parent_locktime)
+        test_wallet.unloadwallet()
 
     def test_tx_size_too_large(self):
         # More than 10kB of outputs, so that we hit -maxtxfee with a high feerate

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -532,6 +532,7 @@ class WalletSendTest(BitcoinTestFramework):
 
         # Check tx creation size limits
         self.test_weight_limits()
+        self.test_fee_sniping_respects_input_locktime()
 
     def test_weight_limits(self):
         self.log.info("Test weight limits")
@@ -563,6 +564,31 @@ class WalletSendTest(BitcoinTestFramework):
 
         self.nodes[1].unloadwallet("test_weight_limits")
 
+    def test_fee_sniping_respects_input_locktime(self):
+        self.log.info("Test that send sets the anti-fee-sniping locktime no lower than any input locktime")
+        self.nodes[1].createwallet("test_fee_sniping")
+        wallet = self.nodes[1].get_wallet_rpc("test_fee_sniping")
+        tip_height = self.nodes[0].getblockcount()
+        # Create a parent transaction with an explicit backdated nLockTime
+        parent_nlocktime = tip_height - 80
+        self.nodes[0].send(outputs=[{wallet.getnewaddress(): 10}], locktime=parent_nlocktime)
+        self.sync_mempools()
+        # Create child transactions until we observe a backdated nLockTime.
+        # Backdating happens randomly, so retry until the locktime is less than
+        # the current block height.
+        utxos = wallet.listunspent(0, 0)
+        child_nlocktime = tip_height
+        while child_nlocktime == tip_height:
+            # We set add_to_wallet=False, so that the transaction won't get added to the wallet or broadcasted.
+            # This way we can continue creating transactions spending the same input, until we find one with
+            # a backdated nlocktime
+            child_hex = wallet.send([{wallet.getnewaddress(): 9}], inputs=utxos, add_to_wallet=False)["hex"]
+            child_nlocktime = wallet.decoderawtransaction(child_hex)["locktime"]
+            # Child nlocktime should be within 100 blocks of tip
+            assert_greater_than_or_equal(child_nlocktime, tip_height - 100)
+        # Child nlocktime should be >= parent nlocktime
+        assert_greater_than_or_equal(child_nlocktime, parent_nlocktime)
+        self.nodes[1].unloadwallet("test_fee_sniping")
 
 if __name__ == '__main__':
     WalletSendTest(__file__).main()

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -12,6 +12,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_greater_than_or_equal,
+    assert_not_equal,
     assert_raises_rpc_error,
 )
 
@@ -453,6 +454,29 @@ class SendallTest(BitcoinTestFramework):
         utxos[0]["sequence"] = SEQUENCE_FINAL
         txid = self.wallet.sendall(recipients=[self.remainder_target], inputs=utxos)["txid"]
         assert_equal(self.wallet.gettransaction(txid=txid, verbose=True)["decoded"]["locktime"], 0)
+
+        self.log.info("Test sendall sets the anti-fee-sniping locktime no lower than any input locktime")
+        # Create a parent transaction with an explicit backdated nLockTime.
+        self.add_utxos([1])
+        tip_height = self.nodes[0].getblockcount()
+        parent_nlocktime = tip_height - 80
+        self.wallet.send(outputs=[{self.wallet.getnewaddress(): 0.9}], locktime=parent_nlocktime)
+        # Keep creating transactions with sendall until we observe a backdated
+        # nLockTime on a child transaction. Backdating happens randomly due
+        # to the anti fee sniping logic, so retry until the locktime is less
+        # than the current block height.
+        parent_utxos = self.wallet.listunspent(0, 0)
+        child_nlocktime = tip_height
+        while child_nlocktime == tip_height:
+            # We set add_to_wallet=False, so that the transaction won't get added to the wallet or broadcasted.
+            # This way we can continue creating transactions spending the same input, until we find one with
+            # a backdated nlocktime
+            child_hex = self.wallet.sendall(recipients=[self.remainder_target], inputs=parent_utxos, add_to_wallet=False)["hex"]
+            child_nlocktime = self.nodes[0].decoderawtransaction(child_hex)["locktime"]
+            # Child nlocktime should be within 100 blocks of tip
+            assert_greater_than_or_equal(child_nlocktime, self.nodes[0].getblockcount() - 100)
+        # Child nlocktime should be >= parent nlocktime
+        assert_greater_than_or_equal(child_nlocktime, parent_nlocktime)
 
     # This tests needs to be the last one otherwise @cleanup will fail with "Transaction too large" error
     def sendall_fails_with_transaction_too_large(self):

--- a/test/functional/wallet_sendmany.py
+++ b/test/functional/wallet_sendmany.py
@@ -5,7 +5,10 @@
 """Test the sendmany RPC command."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_raises_rpc_error
+from test_framework.util import (
+    assert_greater_than_or_equal,
+    assert_raises_rpc_error,
+)
 
 
 class SendmanyTest(BitcoinTestFramework):
@@ -36,6 +39,37 @@ class SendmanyTest(BitcoinTestFramework):
         self.log.info("Test valid mixing of string destinations with numeric indexes in SFFO argument")
         self.def_wallet.sendmany(dummy='', amounts={addr_1: 1, addr_2: 1}, subtractfeefrom=[0, addr_2])
 
+    def test_anti_fee_sniping(self):
+        self.log.info('Test that sendmany sets the transaction locktime no lower than any input locktime')
+        self.generate(self.nodes[0], 250)
+        wallet_rpc = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].createwallet("anti_fee_sniping_test")
+        test_wallet = self.nodes[0].get_wallet_rpc("anti_fee_sniping_test")
+        # Create 100 parent transactions, all with the same
+        # explicit backdated nLockTime. This avoids relying on the random
+        # anti fee sniping behavior and provides several inputs to spend from.
+        num_parents = 100
+        tip_height = self.nodes[0].getblockcount()
+        parent_locktime = tip_height - 80
+        for _ in range(num_parents):
+            wallet_rpc.send(outputs=[{test_wallet.getnewaddress(): 10}], locktime=parent_locktime)
+        self.generate(self.nodes[0], 5)
+        tip_height = self.nodes[0].getblockcount()
+        # Spend parents one by one until we observe a backdated
+        # nLockTime on a child transaction. Backdating happens randomly, so
+        # retry until the locktime is less than the current block height.
+        child_nlocktime = tip_height
+        num_tries = 0
+        while child_nlocktime == tip_height:
+            child_txid = test_wallet.sendmany("", {wallet_rpc.getnewaddress(): 6, wallet_rpc.getnewaddress(): 3})
+            child_nlocktime = test_wallet.gettransaction(txid=child_txid, verbose=True)["decoded"]["locktime"]
+            num_tries += 1
+            if num_tries >= num_parents:
+                raise AssertionError("RPC call sendmany() did not produce a backdated nLockTime")
+        # Child nlocktime should be >= parent nlocktime
+        assert_greater_than_or_equal(child_nlocktime, parent_locktime)
+        test_wallet.unloadwallet()
+
     def run_test(self):
         self.nodes[0].createwallet("activewallet")
         self.wallet = self.nodes[0].get_wallet_rpc("activewallet")
@@ -43,6 +77,7 @@ class SendmanyTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 101)
 
         self.test_sffo_repeated_address()
+        self.test_anti_fee_sniping()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #26527

The Bitcoin Core wallet implements an anti-fee-sniping mechanism that sets a transaction's nLockTime to the current block height, and occasionally to an earlier height.

Previously, when creating a transaction, the wallet could choose an nLockTime that was lower than the nLockTime of one of its inputs. This creates an unrealistic "transaction signed earlier but only broadcast now" scenario and may act as a wallet fingerprint.

This PR fixes the issue by adding a `min_allowed_locktime` parameter to `DiscourageFeeSniping`. When creating a transaction, the wallet now sets this minimum to the highest locktime among all parent transactions. This ensures that while the locktime can still be backdated for anti-fee-sniping, it won't go below any input's locktime.

`DiscourageFeeSniping` is invoked by the following RPCs:
- `sendall`
- `send`
- `sendtoaddress`
- `sendmany`
- `fundrawtransaction`
- `walletcreatefundedpsbt`

Tests are added for `sendall`, `send`, `sendtoaddress` and `sendmany`.

`fundrawtransaction` and `walletcreatefundedpsbt` can't hit this edge case, because they don't use the anti-fee-sniping logic and instead always set nLockTime to 0 unless explicitly provided by the user.