### PR TITLE
net: Enable local address discovery when bind=0.0.0.0 is used

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2141,7 +2141,25 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         StartTorControl(onion_service_target);
     }
 
-    if (connOptions.bind_on_any) {
+    bool discover_on_any = connOptions.bind_on_any;
+    if (!discover_on_any) {
+        for (const auto& bind_addr : connOptions.vBinds) {
+            if (bind_addr.IsBindAny()) {
+                discover_on_any = true;
+                break;
+            }
+        }
+    }
+    if (!discover_on_any) {
+        for (const auto& white_bind : connOptions.vWhiteBinds) {
+            if (white_bind.m_service.IsBindAny()) {
+                discover_on_any = true;
+                break;
+            }
+        }
+    }
+
+    if (discover_on_any) {
         // Only add all IP addresses of the machine if we would be listening on
         // any address - 0.0.0.0 (IPv4) and :: (IPv6).
         Discover();


### PR DESCRIPTION
### Motivation
The `Discover()` function in `init.cpp` was only being called if `bind_on_any` was true. However, `bind_on_any` is set to false if an explicit `-bind` argument is provided, even if that argument is `-bind=0.0.0.0` (which effectively binds to all interfaces).

This behavior prevented local address discovery when a user explicitly configured `-bind=0.0.0.0`, which is common in containerized environments or when users want to be explicit about interface binding.

Fixes #31293.

### Solution
Updated the logic in `init.cpp` to check if any of the provided bind addresses (either via `-bind` or `-whitebind`) are "any" addresses (0.0.0.0 or ::). If so, we enable discovery.

### Testing
- Validated that `Discover()` is called when `-bind=0.0.0.0` is used.
- Verified standard behavior (no bind, specific bind) remains unchanged.