### PR TITLE
net: Reduce local network activity when networkactive=0

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2102,9 +2102,6 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     LogInfo("nBestHeight = %d", chain_active_height);
     if (node.peerman) node.peerman->SetBestBlock(chain_active_height, std::chrono::seconds{best_block_time});
 
-    // Map ports with NAT-PMP
-    StartMapPort(args.GetBoolArg("-natpmp", DEFAULT_NATPMP));
-
     CConnman::Options connOptions;
     connOptions.m_local_services = g_local_services;
     connOptions.m_max_automatic_connections = nMaxConnections;
@@ -2119,6 +2116,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.whitelist_forcerelay = args.GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY);
     connOptions.whitelist_relay = args.GetBoolArg("-whitelistrelay", DEFAULT_WHITELISTRELAY);
     connOptions.m_capture_messages = args.GetBoolArg("-capturemessages", false);
+    connOptions.m_mapport = EnableMapPort;
+    connOptions.m_mapport_enabled = args.GetBoolArg("-natpmp", DEFAULT_NATPMP);
 
     // Port to bind to if `-bind=addr` is provided without a `:port` suffix.
     const uint16_t default_bind_port =

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2118,6 +2118,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.m_capture_messages = args.GetBoolArg("-capturemessages", false);
     connOptions.m_mapport = EnableMapPort;
     connOptions.m_mapport_enabled = args.GetBoolArg("-natpmp", DEFAULT_NATPMP);
+    connOptions.m_tor_control = [&node](bool enable) {
+        if (node.tor_controller) node.tor_controller->SetNetworkActive(enable);
+    };
 
     // Port to bind to if `-bind=addr` is provided without a `:port` suffix.
     const uint16_t default_bind_port =

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -135,7 +135,7 @@ void StartThreadMapPort()
     }
 }
 
-void StartMapPort(bool enable)
+void EnableMapPort(bool enable)
 {
     if (enable) {
         StartThreadMapPort();

--- a/src/mapport.h
+++ b/src/mapport.h
@@ -7,7 +7,7 @@
 
 static constexpr bool DEFAULT_NATPMP = true;
 
-void StartMapPort(bool enable);
+void EnableMapPort(bool enable);
 void InterruptMapPort();
 void StopMapPort();
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3406,6 +3406,9 @@ void CConnman::SetNetworkActive(bool active)
     if (m_mapport) {
         m_mapport(m_mapport_enabled && active);
     }
+    if (m_tor_control) {
+        m_tor_control(active);
+    }
 
     if (m_client_interface) {
         m_client_interface->NotifyNetworkActiveChanged(fNetworkActive);
@@ -3622,6 +3625,9 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
 
     if (m_mapport) {
         m_mapport(m_mapport_enabled && fNetworkActive);
+    }
+    if (m_tor_control) {
+        m_tor_control(fNetworkActive);
     }
 
     return true;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3403,8 +3403,20 @@ void CConnman::SetNetworkActive(bool active)
 
     fNetworkActive = active;
 
+    if (m_mapport) {
+        m_mapport(m_mapport_enabled && active);
+    }
+
     if (m_client_interface) {
         m_client_interface->NotifyNetworkActiveChanged(fNetworkActive);
+    }
+}
+
+void CConnman::SetMapPortEnabled(bool enable)
+{
+    m_mapport_enabled = enable;
+    if (m_mapport) {
+        m_mapport(enable && fNetworkActive);
     }
 }
 
@@ -3606,6 +3618,10 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     if (m_netgroupman.UsingASMap()) {
         ASMapHealthCheck();
         scheduler.scheduleEvery([this] { ASMapHealthCheck(); }, ASMAP_HEALTH_CHECK_INTERVAL);
+    }
+
+    if (m_mapport) {
+        m_mapport(m_mapport_enabled && fNetworkActive);
     }
 
     return true;

--- a/src/net.h
+++ b/src/net.h
@@ -1098,6 +1098,8 @@ public:
         bool whitelist_forcerelay = DEFAULT_WHITELISTFORCERELAY;
         bool whitelist_relay = DEFAULT_WHITELISTRELAY;
         bool m_capture_messages = false;
+        std::function<void(bool)> m_mapport;
+        bool m_mapport_enabled = false;
     };
 
     void Init(const Options& connOptions) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex, !m_total_bytes_sent_mutex)
@@ -1136,6 +1138,8 @@ public:
         whitelist_forcerelay = connOptions.whitelist_forcerelay;
         whitelist_relay = connOptions.whitelist_relay;
         m_capture_messages = connOptions.m_capture_messages;
+        m_mapport = connOptions.m_mapport;
+        m_mapport_enabled = connOptions.m_mapport_enabled;
     }
 
     // test only
@@ -1167,6 +1171,7 @@ public:
     bool GetNetworkActive() const { return fNetworkActive; };
     bool GetUseAddrmanOutgoing() const { return m_use_addrman_outgoing; };
     void SetNetworkActive(bool active);
+    void SetMapPortEnabled(bool enable);
 
     /**
      * Open a new P2P connection and initialize it with the PeerManager at `m_msgproc`.
@@ -1617,6 +1622,8 @@ private:
 
     std::vector<ListenSocket> vhListenSocket;
     std::atomic<bool> fNetworkActive{true};
+    std::function<void(bool)> m_mapport;
+    std::atomic_bool m_mapport_enabled{false};
     bool fAddressesInitialized{false};
     std::reference_wrapper<AddrMan> addrman;
     const NetGroupManager& m_netgroupman;

--- a/src/net.h
+++ b/src/net.h
@@ -1100,6 +1100,7 @@ public:
         bool m_capture_messages = false;
         std::function<void(bool)> m_mapport;
         bool m_mapport_enabled = false;
+        std::function<void(bool)> m_tor_control;
     };
 
     void Init(const Options& connOptions) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex, !m_total_bytes_sent_mutex)
@@ -1140,6 +1141,7 @@ public:
         m_capture_messages = connOptions.m_capture_messages;
         m_mapport = connOptions.m_mapport;
         m_mapport_enabled = connOptions.m_mapport_enabled;
+        m_tor_control = connOptions.m_tor_control;
     }
 
     // test only
@@ -1624,6 +1626,7 @@ private:
     std::atomic<bool> fNetworkActive{true};
     std::function<void(bool)> m_mapport;
     std::atomic_bool m_mapport_enabled{false};
+    std::function<void(bool)> m_tor_control;
     bool fAddressesInitialized{false};
     std::reference_wrapper<AddrMan> addrman;
     const NetGroupManager& m_netgroupman;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -28,7 +28,6 @@
 #include <kernel/context.h>
 #include <key.h>
 #include <logging.h>
-#include <mapport.h>
 #include <net.h>
 #include <net_processing.h>
 #include <net_types.h>
@@ -199,7 +198,9 @@ public:
         });
         args().WriteSettingsFile();
     }
-    void mapPort(bool enable) override { StartMapPort(enable); }
+    void mapPort(bool enable) override {
+        if (m_context->connman) m_context->connman->SetMapPortEnabled(enable);
+    }
     std::optional<Proxy> getProxy(Network net) override { return GetProxy(net); }
     size_t getNodeCount(ConnectionDirection flags) override
     {

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -387,11 +387,56 @@ void TorController::Join()
     }
 }
 
+void TorController::SetNetworkActive(bool active)
+{
+    if (m_network_active.exchange(active) != active) {
+        m_network_active_change_count.fetch_add(1);
+    }
+}
+
+bool TorController::SleepWithNetworkPolling(std::chrono::milliseconds timeout, uint64_t expected_change_count)
+{
+    constexpr auto POLL_INTERVAL{std::chrono::milliseconds{100}};
+
+    for (auto remaining{timeout}; remaining > 0ms;) {
+        if (m_network_active_change_count.load() != expected_change_count) {
+            return true;
+        }
+        const auto sleep_time{std::min(remaining, POLL_INTERVAL)};
+        if (!m_interrupt.sleep_for(sleep_time)) {
+            return false;
+        }
+        remaining -= sleep_time;
+        if (m_network_active_change_count.load() != expected_change_count) {
+            return true;
+        }
+    }
+    return true;
+}
+
 void TorController::ThreadControl()
 {
     LogDebug(BCLog::TOR, "Entering Tor control thread");
+    bool was_network_active{false};
 
     while (!m_interrupt) {
+        const bool network_active{m_network_active.load()};
+        if (network_active && !was_network_active) {
+            m_reconnect_timeout = RECONNECT_TIMEOUT_START;
+        }
+        was_network_active = network_active;
+
+        if (!network_active) {
+            if (m_conn.IsConnected()) {
+                disconnected_cb(m_conn);
+            }
+            const auto change_count{m_network_active_change_count.load()};
+            if (!SleepWithNetworkPolling(std::chrono::milliseconds{100}, change_count) && m_interrupt) {
+                break;
+            }
+            continue;
+        }
+
         // Try to connect if not connected already
         if (!m_conn.IsConnected()) {
             LogDebug(BCLog::TOR, "Attempting to connect to Tor control port %s", m_tor_control_center);
@@ -403,8 +448,12 @@ void TorController::ThreadControl()
                 }
                 // Wait before retrying with exponential backoff
                 LogDebug(BCLog::TOR, "Retrying in %.1f seconds", m_reconnect_timeout.count());
-                if (!m_interrupt.sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(m_reconnect_timeout))) {
+                const auto change_count{m_network_active_change_count.load()};
+                if (!SleepWithNetworkPolling(std::chrono::duration_cast<std::chrono::milliseconds>(m_reconnect_timeout), change_count) && m_interrupt) {
                     break;
+                }
+                if (!m_network_active) {
+                    continue;
                 }
                 m_reconnect_timeout = std::min(m_reconnect_timeout * RECONNECT_TIMEOUT_EXP, RECONNECT_TIMEOUT_MAX);
                 continue;
@@ -737,6 +786,11 @@ void TorController::disconnected_cb(TorControlConnection& _conn)
     m_service = CService();
     if (!m_reconnect)
         return;
+    if (!m_network_active) {
+        LogDebug(BCLog::TOR, "Network inactive, not reconnecting to Tor control port");
+        _conn.Disconnect();
+        return;
+    }
 
     LogDebug(BCLog::TOR, "Not connected to Tor control port %s, will retry", m_tor_control_center);
     _conn.Disconnect();

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -387,11 +387,53 @@ void TorController::Join()
     }
 }
 
+void TorController::SetNetworkActive(bool active)
+{
+    if (m_network_active.exchange(active) != active) {
+        m_network_active_change_count.fetch_add(1);
+    }
+}
+
+bool TorController::SleepWithNetworkPolling(std::chrono::milliseconds timeout, uint64_t expected_change_count)
+{
+    constexpr auto POLL_INTERVAL{std::chrono::milliseconds{100}};
+
+    for (auto remaining{timeout}; remaining > 0ms;) {
+        if (m_network_active_change_count.load() != expected_change_count) {
+            return true;
+        }
+        const auto sleep_time{std::min(remaining, POLL_INTERVAL)};
+        if (!m_interrupt.sleep_for(sleep_time)) {
+            return false;
+        }
+        remaining -= sleep_time;
+    }
+    return true;
+}
+
 void TorController::ThreadControl()
 {
     LogDebug(BCLog::TOR, "Entering Tor control thread");
+    bool was_network_active{false};
 
     while (!m_interrupt) {
+        const bool network_active{m_network_active.load()};
+        if (network_active && !was_network_active) {
+            m_reconnect_timeout = RECONNECT_TIMEOUT_START;
+        }
+        was_network_active = network_active;
+
+        if (!network_active) {
+            if (m_conn.IsConnected()) {
+                disconnected_cb(m_conn);
+            }
+            const auto change_count{m_network_active_change_count.load()};
+            if (!SleepWithNetworkPolling(std::chrono::milliseconds{100}, change_count) && m_interrupt) {
+                break;
+            }
+            continue;
+        }
+
         // Try to connect if not connected already
         if (!m_conn.IsConnected()) {
             LogDebug(BCLog::TOR, "Attempting to connect to Tor control port %s", m_tor_control_center);
@@ -403,8 +445,12 @@ void TorController::ThreadControl()
                 }
                 // Wait before retrying with exponential backoff
                 LogDebug(BCLog::TOR, "Retrying in %.1f seconds", m_reconnect_timeout.count());
-                if (!m_interrupt.sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(m_reconnect_timeout))) {
+                const auto change_count{m_network_active_change_count.load()};
+                if (!SleepWithNetworkPolling(std::chrono::duration_cast<std::chrono::milliseconds>(m_reconnect_timeout), change_count) && m_interrupt) {
                     break;
+                }
+                if (!m_network_active) {
+                    continue;
                 }
                 m_reconnect_timeout = std::min(m_reconnect_timeout * RECONNECT_TIMEOUT_EXP, RECONNECT_TIMEOUT_MAX);
                 continue;
@@ -737,6 +783,11 @@ void TorController::disconnected_cb(TorControlConnection& _conn)
     m_service = CService();
     if (!m_reconnect)
         return;
+    if (!m_network_active) {
+        LogDebug(BCLog::TOR, "Network inactive, not reconnecting to Tor control port");
+        _conn.Disconnect();
+        return;
+    }
 
     LogDebug(BCLog::TOR, "Not connected to Tor control port %s, will retry", m_tor_control_center);
     _conn.Disconnect();

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -13,6 +13,8 @@
 #include <util/sock.h>
 #include <util/threadinterrupt.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <deque>
 #include <functional>
@@ -136,7 +138,12 @@ public:
 
     /** Wait for the controller thread to exit */
     void Join();
+
+    /** Enable or disable Tor control connectivity based on networkactive. */
+    void SetNetworkActive(bool active);
 private:
+    bool SleepWithNetworkPolling(std::chrono::milliseconds timeout, uint64_t expected_change_count);
+
     CThreadInterrupt m_interrupt;
     std::thread m_thread;
     const std::string m_tor_control_center;
@@ -153,6 +160,8 @@ private:
     std::vector<uint8_t> m_client_nonce;
 
     /// \anchor torcontrol
+    std::atomic_bool m_network_active{false};
+    std::atomic<uint64_t> m_network_active_change_count{0};
     void ThreadControl();
 
 public:

--- a/test/functional/feature_mapport.py
+++ b/test/functional/feature_mapport.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that mapport respects networkactive state.
+
+Verifies that NAT-PMP port mapping does not run when network is inactive,
+and properly starts/stops when network state is toggled via setnetworkactive RPC.
+"""
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class MapPortNetworkActiveTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("Test that mapport does not run when networkactive=0 at startup")
+        with node.assert_debug_log(
+            expected_msgs=[], unexpected_msgs=["portmap:"], timeout=2
+        ):
+            self.restart_node(0, extra_args=["-natpmp=1", "-networkactive=0", "-debug=net"])
+            assert_equal(node.getnetworkinfo()["networkactive"], False)
+            time.sleep(2)
+
+        self.log.info("Test that mapport starts when network is activated")
+        with node.assert_debug_log(expected_msgs=["portmap:"], timeout=5):
+            node.setnetworkactive(True)
+        assert_equal(node.getnetworkinfo()["networkactive"], True)
+
+        self.log.info("Test that mapport stops when network is deactivated")
+        node.setnetworkactive(False)
+        assert_equal(node.getnetworkinfo()["networkactive"], False)
+        with node.assert_debug_log(
+            expected_msgs=[], unexpected_msgs=["portmap:"], timeout=2
+        ):
+            time.sleep(2)
+
+        self.log.info("Test that mapport resumes when network is reactivated")
+        with node.assert_debug_log(expected_msgs=["portmap:"], timeout=5):
+            node.setnetworkactive(True)
+        assert_equal(node.getnetworkinfo()["networkactive"], True)
+
+
+if __name__ == "__main__":
+    MapPortNetworkActiveTest(__file__).main()

--- a/test/functional/feature_torcontrol.py
+++ b/test/functional/feature_torcontrol.py
@@ -78,6 +78,8 @@ class MockTorControlServer:
                     continue
         finally:
             conn.close()
+            if self.conn is conn:
+                self.conn = None
 
     def send_raw(self, data):
         if self.conn:
@@ -256,12 +258,69 @@ class TorControlTest(BitcoinTestFramework):
 
         mock_tor.stop()
 
+    def test_networkactive(self):
+        self.log.info("Test that Tor control respects networkactive state")
+
+        tor_port = p2p_port(self.num_nodes + 3)
+        mock_tor = MockTorControlServer(tor_port)
+        mock_tor.start()
+
+        self.restart_node(0, extra_args=[
+            f"-torcontrol=127.0.0.1:{tor_port}",
+            "-listenonion=1",
+            "-networkactive=0",
+            "-debug=tor",
+        ])
+
+        ensure_for(duration=2, f=lambda: len(mock_tor.received_commands) == 0)
+
+        with self.nodes[0].assert_debug_log(expected_msgs=["SetNetworkActive: true\n"]):
+            self.nodes[0].setnetworkactive(state=True)
+
+        self.wait_until(lambda: len(mock_tor.received_commands) >= 4, timeout=10)
+        assert_equal(mock_tor.received_commands[0], "PROTOCOLINFO 1")
+
+        with self.nodes[0].assert_debug_log(expected_msgs=["SetNetworkActive: false\n"]):
+            self.nodes[0].setnetworkactive(state=False)
+
+        self.wait_until(lambda: mock_tor.conn is None or mock_tor.conn.fileno() == -1, timeout=5)
+
+        # Clean up
+        mock_tor.stop()
+
+    def test_networkactive_reactivation_resets_backoff(self):
+        self.log.info("Test that re-activating the network resets torcontrol reconnect backoff")
+
+        tor_port = p2p_port(self.num_nodes + 4)
+        node = self.nodes[0]
+
+        with node.assert_debug_log(expected_msgs=["Retrying in 3.4 seconds"], timeout=10):
+            self.restart_node(0, extra_args=[
+                f"-torcontrol=127.0.0.1:{tor_port}",
+                "-listenonion=1",
+                "-debug=tor",
+            ])
+
+        with node.assert_debug_log(expected_msgs=["SetNetworkActive: false\n"]):
+            node.setnetworkactive(state=False)
+
+        # Give the Tor control thread time to observe the inactive state.
+        ensure_for(duration=2, f=lambda: not node.getnetworkinfo()["networkactive"])
+
+        with node.assert_debug_log(expected_msgs=[
+            "SetNetworkActive: true\n",
+            "Retrying in 1.0 seconds",
+        ], timeout=2):
+            node.setnetworkactive(state=True)
+
     def run_test(self):
         self.test_basic()
         self.test_partial_data()
         self.test_pow_fallback()
         self.test_oversized_line()
         self.test_overmany_lines()
+        self.test_networkactive()
+        self.test_networkactive_reactivation_resets_backoff()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -530,7 +530,14 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             # the RPC should throw.
             "-torcontrol=127.0.0.1:1",
             "-listenonion",
+            "-networkactive=0",
+            "-debug=tor",
         ])
+        with tx_originator.assert_debug_log(expected_msgs=[
+            "Initiating connection to Tor control port 127.0.0.1:1 failed",
+            "Retrying in 1.5 seconds",
+        ], timeout=5):
+            tx_originator.setnetworkactive(True)
         assert_raises_rpc_error(-1, "none of the Tor or I2P networks is reachable",
                                 tx_originator.sendrawtransaction, hexstring=txs[0]["hex"], maxfeerate=0.1)
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -339,6 +339,7 @@ BASE_SCRIPTS = [
     'feature_chain_tiebreaks.py',
     'feature_fastprune.py',
     'feature_framework_miniwallet.py',
+    'feature_mapport.py',
     'mempool_unbroadcast.py',
     'mempool_compatibility.py',
     'mempool_accept_wtxid.py',


### PR DESCRIPTION
Fixes #34190

When networkactive=0 is set, NAT-PMP port mapping and Tor control connections still run in the background, mapping ports and logging retry attempts despite the node being "inactive."

This wires both subsystems to CConnman::SetNetworkActive so they start and stop with the network state:

- mapport: `EnableMapPort` is injected as a callback via CConnman::Options. SetNetworkActive and SetMapPortEnabled both gate on network state.

- torcontrol: `TorController` is injected similarly through a CConnman::Options callback. The controller thread stays alive while networkactive=0, but idles without connecting or reconnecting to the Tor control port. Re-enabling the network wakes the controller promptly and resets reconnect backoff.