### PR TITLE
index: batch db writes during initial sync

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -198,6 +198,24 @@ bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data
     return true;
 }
 
+bool BaseIndex::ProcessBlocks(const CBlockIndex* start, const CBlockIndex* end)
+{
+    // Collect all block indexes from [end...start] in order
+    std::vector<const CBlockIndex*> ordered_blocks;
+    ordered_blocks.reserve(end->nHeight - start->nHeight + 1);
+    for (const CBlockIndex* block = end; block && start->pprev != block; block = block->pprev) {
+        ordered_blocks.emplace_back(block);
+    }
+
+    // And process blocks in forward order: from start to end
+    for (auto it = ordered_blocks.rbegin(); it != ordered_blocks.rend(); ++it) {
+        if (m_interrupt) return false;
+        if (!ProcessBlock(*it)) return false; // error logged internally
+    }
+
+    return true;
+}
+
 void BaseIndex::Sync()
 {
     const CBlockIndex* pindex = m_best_block_index.load();
@@ -230,7 +248,13 @@ void BaseIndex::Sync()
                 return;
             }
 
-            if (!ProcessBlock(pindex_next)) return; // error logged internally
+            // For now, process a single block at time
+            if (!ProcessBlocks(/*start=*/pindex_next, /*end=*/pindex_next)) {
+                // If failed due to an interruption, we haven't processed the block.
+                if (m_interrupt) break;
+                // Otherwise this is an unrecoverable error and we want to stop.
+                return; // error logged internally
+            }
 
             // Update last processed block for next round
             pindex = pindex_next;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -204,18 +204,7 @@ void BaseIndex::Sync()
     if (!m_synced) {
         auto last_log_time{NodeClock::now()};
         auto last_locator_write_time{last_log_time};
-        while (true) {
-            if (m_interrupt) {
-                LogInfo("%s: m_interrupt set; exiting ThreadSync", GetName());
-
-                SetBestBlockIndex(pindex);
-                // No need to handle errors in Commit. If it fails, the error will be already be
-                // logged. The best way to recover is to continue, as index cannot be corrupted by
-                // a missed commit to disk for an advanced index state.
-                Commit();
-                return;
-            }
-
+        while (!m_interrupt) {
             const CBlockIndex* pindex_next = WITH_LOCK(cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain));
             // If pindex_next is null, it means pindex is the chain tip, so
             // commit data indexed so far.
@@ -259,6 +248,17 @@ void BaseIndex::Sync()
                 Commit();
             }
         }
+    }
+
+    if (m_interrupt) {
+        LogInfo("%s: m_interrupt set; exiting ThreadSync", GetName());
+
+        SetBestBlockIndex(pindex);
+        // No need to handle errors in Commit. If it fails, the error will be already be
+        // logged. The best way to recover is to continue, as index cannot be corrupted by
+        // a missed commit to disk for an advanced index state.
+        Commit();
+        return;
     }
 
     if (pindex) {

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -240,10 +240,11 @@ void BaseIndex::Sync()
                 FatalErrorf("Failed to rewind %s to a previous chain tip", GetName());
                 return;
             }
+
+            if (!ProcessBlock(pindex_next)) return; // error logged internally
+
+            // Update last processed block for next round
             pindex = pindex_next;
-
-
-            if (!ProcessBlock(pindex)) return; // error logged internally
 
             auto current_time{NodeClock::now()};
             if (current_time - last_log_time >= SYNC_LOG_INTERVAL) {

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -148,31 +148,38 @@ bool BaseIndex::Init()
     return true;
 }
 
-// Returns the next block to sync, or null if fully synced
-static const CBlockIndex* NextSyncBlock(const CBlockIndex* pindex_prev, const CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+struct BlockRange {
+    const CBlockIndex* first{nullptr};
+    const CBlockIndex* last{nullptr};
+};
+
+// Returns the next range of blocks to sync, or 'std::nullopt' if fully synced
+static std::optional<BlockRange> NextSyncRange(const CBlockIndex* pindex_prev, const CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
-    const CBlockIndex* first;
+    BlockRange range;
 
     if (!pindex_prev) {
         // Only the genesis block has no prev block
-        first = chain.Genesis();
+        range.first = chain.Genesis();
     } else {
-        first = chain.Next(pindex_prev);
-        if (!first) {
+        range.first = chain.Next(pindex_prev);
+        if (!range.first) {
             // If there is no next block, we might be synced
             if (pindex_prev == chain.Tip()) {
-                return nullptr;
+                return std::nullopt;
             }
 
             // Since block is not in the chain, return the next block in the chain AFTER the last common ancestor.
             // Caller will be responsible for rewinding back to the common ancestor.
-            first = chain.Next(chain.FindFork(pindex_prev));
+            range.first = chain.Next(chain.FindFork(pindex_prev));
         }
     }
 
-    Assume(first);
-    return first;
+    Assume(range.first);
+    // For now, process a single block at time
+    range.last = range.first;
+    return range;
 }
 
 bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data)
@@ -233,10 +240,10 @@ void BaseIndex::Sync()
         auto last_log_time{NodeClock::now()};
         auto last_locator_write_time{last_log_time};
         while (!m_interrupt) {
-            const CBlockIndex* pindex_next = WITH_LOCK(cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain));
-            // If pindex_next is null, it means pindex is the chain tip, so
+            auto block_range = WITH_LOCK(cs_main, return NextSyncRange(pindex, m_chainstate->m_chain));
+            // If range.first is null, it means pindex is the chain tip, so
             // commit data indexed so far.
-            if (!pindex_next) {
+            if (!block_range) {
                 SetBestBlockIndex(pindex);
                 // No need to handle errors in Commit. See rationale above.
                 Commit();
@@ -247,19 +254,18 @@ void BaseIndex::Sync()
                 // attached while m_synced is still false, and it would not be
                 // indexed.
                 LOCK(::cs_main);
-                pindex_next = NextSyncBlock(pindex, m_chainstate->m_chain);
-                if (!pindex_next) {
+                block_range = NextSyncRange(pindex, m_chainstate->m_chain);
+                if (!block_range) {
                     m_synced = true;
                     break;
                 }
             }
-            if (pindex_next->pprev != pindex && !Rewind(pindex, pindex_next->pprev)) {
+            if (block_range->first->pprev != pindex && !Rewind(pindex, block_range->first->pprev)) {
                 FatalErrorf("Failed to rewind %s to a previous chain tip", GetName());
                 return;
             }
 
-            // For now, process a single block at time
-            if (!ProcessBlocks(/*start=*/pindex_next, /*end=*/pindex_next)) {
+            if (!ProcessBlocks(block_range->first, block_range->last)) {
                 // If failed due to an interruption, we haven't processed the block.
                 if (m_interrupt) break;
                 // Otherwise this is an unrecoverable error and we want to stop.
@@ -267,7 +273,7 @@ void BaseIndex::Sync()
             }
 
             // Update last processed block for next round
-            pindex = pindex_next;
+            pindex = block_range->last;
 
             auto current_time{NodeClock::now()};
             if (current_time - last_log_time >= SYNC_LOG_INTERVAL) {

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -20,6 +20,7 @@
 #include <tinyformat.h>
 #include <uint256.h>
 #include <undo.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/log.h>
 #include <util/string.h>
@@ -147,22 +148,31 @@ bool BaseIndex::Init()
     return true;
 }
 
-static const CBlockIndex* NextSyncBlock(const CBlockIndex* pindex_prev, CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+// Returns the next block to sync, or null if fully synced
+static const CBlockIndex* NextSyncBlock(const CBlockIndex* pindex_prev, const CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
+    const CBlockIndex* first;
 
     if (!pindex_prev) {
-        return chain.Genesis();
+        // Only the genesis block has no prev block
+        first = chain.Genesis();
+    } else {
+        first = chain.Next(pindex_prev);
+        if (!first) {
+            // If there is no next block, we might be synced
+            if (pindex_prev == chain.Tip()) {
+                return nullptr;
+            }
+
+            // Since block is not in the chain, return the next block in the chain AFTER the last common ancestor.
+            // Caller will be responsible for rewinding back to the common ancestor.
+            first = chain.Next(chain.FindFork(pindex_prev));
+        }
     }
 
-    const CBlockIndex* pindex = chain.Next(pindex_prev);
-    if (pindex) {
-        return pindex;
-    }
-
-    // Since block is not in the chain, return the next block in the chain AFTER the last common ancestor.
-    // Caller will be responsible for rewinding back to the common ancestor.
-    return chain.Next(chain.FindFork(pindex_prev));
+    Assume(first);
+    return first;
 }
 
 bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data)

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -187,7 +187,7 @@ static std::optional<BlockRange> NextSyncRange(const CBlockIndex* pindex_prev, c
     return range;
 }
 
-bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data)
+bool BaseIndex::ProcessBlock(CDBBatch& db_batch, const CBlockIndex* pindex, const CBlock* block_data)
 {
     interfaces::BlockInfo block_info = kernel::MakeBlockInfo(pindex, block_data);
 
@@ -211,7 +211,7 @@ bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data
         block_info.undo_data = &block_undo;
     }
 
-    if (!CustomAppend(block_info)) {
+    if (!CustomAppend(db_batch, block_info)) {
         FatalErrorf("Failed to write block %s to index database",
                     pindex->GetBlockHash().ToString());
         return false;
@@ -220,7 +220,7 @@ bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data
     return true;
 }
 
-bool BaseIndex::ProcessBlocks(const CBlockIndex* start, const CBlockIndex* end)
+bool BaseIndex::ProcessBlocks(CDBBatch& db_batch, const CBlockIndex* start, const CBlockIndex* end)
 {
     // Collect all block indexes from [end...start] in order
     std::vector<const CBlockIndex*> ordered_blocks;
@@ -232,7 +232,7 @@ bool BaseIndex::ProcessBlocks(const CBlockIndex* start, const CBlockIndex* end)
     // And process blocks in forward order: from start to end
     for (auto it = ordered_blocks.rbegin(); it != ordered_blocks.rend(); ++it) {
         if (m_interrupt) return false;
-        if (!ProcessBlock(*it)) return false; // error logged internally
+        if (!ProcessBlock(db_batch, *it)) return false; // error logged internally
     }
 
     return true;
@@ -270,12 +270,14 @@ void BaseIndex::Sync()
                 return;
             }
 
-            if (!ProcessBlocks(block_range->first, block_range->last)) {
+            CDBBatch db_batch(GetDB());
+            if (!ProcessBlocks(db_batch, block_range->first, block_range->last)) {
                 // If failed due to an interruption, we haven't processed the block.
                 if (m_interrupt) break;
                 // Otherwise this is an unrecoverable error and we want to stop.
                 return; // error logged internally
             }
+            GetDB().WriteBatch(db_batch);
 
             // Update last processed block for next round
             pindex = block_range->last;
@@ -414,7 +416,9 @@ void BaseIndex::BlockConnected(const ChainstateRole& role, const std::shared_ptr
     }
 
     // Dispatch block to child class; errors are logged internally and abort the node.
-    if (ProcessBlock(pindex, block.get())) {
+    CDBBatch db_batch(GetDB());
+    if (ProcessBlock(db_batch, pindex, block.get())) {
+        GetDB().WriteBatch(db_batch);
         // Setting the best block index is intentionally the last step of this
         // function, so BlockUntilSyncedToCurrentChain callers waiting for the
         // best block index to be updated can rely on the block being fully

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -31,7 +31,7 @@
 #include <validation.h>
 #include <validationinterface.h>
 
-#include <cassert>
+#include <algorithm>
 #include <compare>
 #include <cstdint>
 #include <memory>
@@ -154,7 +154,7 @@ struct BlockRange {
 };
 
 // Returns the next range of blocks to sync, or 'std::nullopt' if fully synced
-static std::optional<BlockRange> NextSyncRange(const CBlockIndex* pindex_prev, const CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+static std::optional<BlockRange> NextSyncRange(const CBlockIndex* pindex_prev, const CChain& chain, const int range_max_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     BlockRange range;
@@ -176,9 +176,14 @@ static std::optional<BlockRange> NextSyncRange(const CBlockIndex* pindex_prev, c
         }
     }
 
+    // Compute window
     Assume(range.first);
-    // For now, process a single block at time
-    range.last = range.first;
+    const int start_height = range.first->nHeight;
+    const int tip_height = chain.Height();
+    // Compute the last height in the batch without exceeding the chain tip
+    const int batch_end_height = std::min(start_height + range_max_size - 1, tip_height);
+    range.last = chain[batch_end_height];
+
     return range;
 }
 
@@ -240,7 +245,7 @@ void BaseIndex::Sync()
         auto last_log_time{NodeClock::now()};
         auto last_locator_write_time{last_log_time};
         while (!m_interrupt) {
-            auto block_range = WITH_LOCK(cs_main, return NextSyncRange(pindex, m_chainstate->m_chain));
+            auto block_range = WITH_LOCK(cs_main, return NextSyncRange(pindex, m_chainstate->m_chain, m_num_blocks_batch));
             // If range.first is null, it means pindex is the chain tip, so
             // commit data indexed so far.
             if (!block_range) {
@@ -254,7 +259,7 @@ void BaseIndex::Sync()
                 // attached while m_synced is still false, and it would not be
                 // indexed.
                 LOCK(::cs_main);
-                block_range = NextSyncRange(pindex, m_chainstate->m_chain);
+                block_range = NextSyncRange(pindex, m_chainstate->m_chain, m_num_blocks_batch);
                 if (!block_range) {
                     m_synced = true;
                     break;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -113,11 +113,11 @@ private:
     /// Loop over disconnected blocks and call CustomRemove.
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
 
-    bool ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data = nullptr);
+    bool ProcessBlock(CDBBatch& db_batch, const CBlockIndex* pindex, const CBlock* block_data = nullptr);
 
     /// Processes blocks in the range [start, end]. Calling 'ProcessBlock'.
     /// Returns false on unrecoverable failure or during interruption.
-    bool ProcessBlocks(const CBlockIndex* start, const CBlockIndex* end);
+    bool ProcessBlocks(CDBBatch& db_batch, const CBlockIndex* start, const CBlockIndex* end);
 
     virtual bool AllowPrune() const = 0;
 
@@ -137,7 +137,7 @@ protected:
     [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockRef>& block) { return true; }
 
     /// Write update index entries for a newly connected block.
-    [[nodiscard]] virtual bool CustomAppend(const interfaces::BlockInfo& block) { return true; }
+    [[nodiscard]] virtual bool CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block) { return true; }
 
     /// Virtual method called internally by Commit that can be overridden to atomically
     /// commit more index state.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -108,6 +108,10 @@ private:
 
     bool ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data = nullptr);
 
+    /// Processes blocks in the range [start, end]. Calling 'ProcessBlock'.
+    /// Returns false on unrecoverable failure or during interruption.
+    bool ProcessBlocks(const CBlockIndex* start, const CBlockIndex* end);
+
     virtual bool AllowPrune() const = 0;
 
     template <typename... Args>

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -27,6 +27,10 @@ class CBlockIndex;
 class Chainstate;
 
 struct CBlockLocator;
+
+/** Range of blocks to process in batches */
+static constexpr int INDEX_BATCH_SIZE = 500;
+
 struct IndexSummary {
     std::string name;
     bool synced{false};
@@ -92,6 +96,9 @@ private:
 
     std::thread m_thread_sync;
     CThreadInterrupt m_interrupt;
+
+    /// Number of blocks to process in a batch
+    int m_num_blocks_batch{INDEX_BATCH_SIZE};
 
     /// Write the current index state (eg. chain block locator and subclass-specific items) to disk.
     ///
@@ -180,6 +187,9 @@ public:
 
     /// Stops the instance from staying in sync with blockchain updates.
     void Stop();
+
+    /// Number of blocks to process in a batch
+    void SetProcessingBatchSize(const int blocks_count) { m_num_blocks_batch = blocks_count; }
 
     /// Get a summary of the index and its state.
     IndexSummary GetSummary() const;

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -248,16 +248,16 @@ std::optional<uint256> BlockFilterIndex::ReadFilterHeader(int height, const uint
     return read_out.second.header;
 }
 
-bool BlockFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
+bool BlockFilterIndex::CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block)
 {
     BlockFilter filter(m_filter_type, *Assert(block.data), *Assert(block.undo_data));
     const uint256& header = filter.ComputeHeader(m_last_header);
-    bool res = Write(filter, block.height, header);
+    bool res = Write(batch, filter, block.height, header);
     if (res) m_last_header = header; // update last header
     return res;
 }
 
-bool BlockFilterIndex::Write(const BlockFilter& filter, uint32_t block_height, const uint256& filter_header)
+bool BlockFilterIndex::Write(CDBBatch& batch, const BlockFilter& filter, uint32_t block_height, const uint256& filter_header)
 {
     size_t bytes_written = WriteFilterToDisk(m_next_filter_pos, filter);
     if (bytes_written == 0) return false;
@@ -268,7 +268,7 @@ bool BlockFilterIndex::Write(const BlockFilter& filter, uint32_t block_height, c
     value.second.header = filter_header;
     value.second.pos = m_next_filter_pos;
 
-    m_db->Write(index_util::DBHeightKey(block_height), value);
+    batch.Write(index_util::DBHeightKey(block_height), value);
 
     m_next_filter_pos.nPos += bytes_written;
     return true;

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -24,6 +24,7 @@
 class BlockFilter;
 class CBlockIndex;
 enum class BlockFilterType : uint8_t;
+class CDBBatch;
 
 static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 
@@ -58,7 +59,7 @@ private:
 
     bool AllowPrune() const override { return true; }
 
-    bool Write(const BlockFilter& filter, uint32_t block_height, const uint256& filter_header);
+    bool Write(CDBBatch& batch, const BlockFilter& filter, uint32_t block_height, const uint256& filter_header);
 
     std::optional<uint256> ReadFilterHeader(int height, const uint256& expected_block_hash);
 
@@ -67,7 +68,7 @@ protected:
 
     bool CustomCommit(CDBBatch& batch) override;
 
-    bool CustomAppend(const interfaces::BlockInfo& block) override;
+    bool CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block) override;
 
     bool CustomRemove(const interfaces::BlockInfo& block) override;
 

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -106,7 +106,7 @@ CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t 
     m_db = std::make_unique<CoinStatsIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
 }
 
-bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
+bool CoinStatsIndex::CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block)
 {
     const CAmount block_subsidy{GetBlockSubsidy(block.height, Params().GetConsensus())};
     m_total_subsidy += block_subsidy;
@@ -210,7 +210,7 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 
     // Intentionally do not update DB_MUHASH here so it stays in sync with
     // DB_BEST_BLOCK, and the index is not corrupted if there is an unclean shutdown.
-    m_db->Write(index_util::DBHeightKey(block.height), value);
+    batch.Write(index_util::DBHeightKey(block.height), value);
     return true;
 }
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -56,7 +56,7 @@ protected:
 
     bool CustomCommit(CDBBatch& batch) override;
 
-    bool CustomAppend(const interfaces::BlockInfo& block) override;
+    bool CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block) override;
 
     bool CustomRemove(const interfaces::BlockInfo& block) override;
 

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -43,9 +43,6 @@ public:
     /// Read the disk location of the transaction data with the given hash. Returns false if the
     /// transaction hash is not indexed.
     bool ReadTxPos(const Txid& txid, CDiskTxPos& pos) const;
-
-    /// Write a batch of transaction positions to the DB.
-    void WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos);
 };
 
 TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
@@ -57,13 +54,11 @@ bool TxIndex::DB::ReadTxPos(const Txid& txid, CDiskTxPos& pos) const
     return Read(std::make_pair(DB_TXINDEX, txid.ToUint256()), pos);
 }
 
-void TxIndex::DB::WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos)
+static void WriteTxs(CDBBatch& batch, const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos)
 {
-    CDBBatch batch(*this);
     for (const auto& [txid, pos] : v_pos) {
         batch.Write(std::make_pair(DB_TXINDEX, txid.ToUint256()), pos);
     }
-    WriteBatch(batch);
 }
 
 TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
@@ -72,7 +67,7 @@ TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, 
 
 TxIndex::~TxIndex() = default;
 
-bool TxIndex::CustomAppend(const interfaces::BlockInfo& block)
+bool TxIndex::CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block)
 {
     // Exclude genesis block transaction because outputs are not spendable.
     if (block.height == 0) return true;
@@ -85,7 +80,7 @@ bool TxIndex::CustomAppend(const interfaces::BlockInfo& block)
         vPos.emplace_back(tx->GetHash(), pos);
         pos.nTxOffset += ::GetSerializeSize(TX_WITH_WITNESS(*tx));
     }
-    m_db->WriteTxs(vPos);
+    WriteTxs(batch, vPos);
     return true;
 }
 

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -34,7 +34,7 @@ private:
     bool AllowPrune() const override { return false; }
 
 protected:
-    bool CustomAppend(const interfaces::BlockInfo& block) override;
+    bool CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block) override;
 
     BaseIndex::DB& GetDB() const override;
 

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -87,15 +87,13 @@ static DBKey CreateKey(std::pair<uint64_t, uint64_t> siphash_key, const COutPoin
     return DBKey(CreateKeyPrefix(siphash_key, vout), pos);
 }
 
-void TxoSpenderIndex::WriteSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items)
+void TxoSpenderIndex::WriteSpenderInfos(CDBBatch& batch, const std::vector<std::pair<COutPoint, CDiskTxPos>>& items)
 {
-    CDBBatch batch(*m_db);
     for (const auto& [outpoint, pos] : items) {
         DBKey key(CreateKey(m_siphash_key, outpoint, pos));
         // key is hash(spent outpoint) | disk pos, value is empty
         batch.Write(key, "");
     }
-    m_db->WriteBatch(batch);
 }
 
 
@@ -127,9 +125,9 @@ static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const
 }
 
 
-bool TxoSpenderIndex::CustomAppend(const interfaces::BlockInfo& block)
+bool TxoSpenderIndex::CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block)
 {
-    WriteSpenderInfos(BuildSpenderPositions(block));
+    WriteSpenderInfos(batch, BuildSpenderPositions(block));
     return true;
 }
 

--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 struct CDiskTxPos;
+class CDBBatch;
 
 static constexpr bool DEFAULT_TXOSPENDERINDEX{false};
 
@@ -40,14 +41,14 @@ private:
     std::unique_ptr<BaseIndex::DB> m_db;
     std::pair<uint64_t, uint64_t> m_siphash_key;
     bool AllowPrune() const override { return false; }
-    void WriteSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
+    void WriteSpenderInfos(CDBBatch& batch, const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
     void EraseSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
     util::Expected<TxoSpender, std::string> ReadTransaction(const CDiskTxPos& pos) const;
 
 protected:
     interfaces::Chain::NotifyOptions CustomOptions() override;
 
-    bool CustomAppend(const interfaces::BlockInfo& block) override;
+    bool CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block) override;
 
     bool CustomRemove(const interfaces::BlockInfo& block) override;
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -351,6 +351,7 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, BuildChainTestingSetup)
     int blocking_height = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip()->nHeight);
 
     IndexReorgCrash index(interfaces::MakeChain(m_node), blocker, blocking_height);
+    index.SetProcessingBatchSize(1);
     BOOST_REQUIRE(index.Init());
     BOOST_REQUIRE(index.StartBackgroundSync());
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -385,4 +385,46 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, BuildChainTestingSetup)
     index.Stop();
 }
 
+// Ensure the initial sync batch window behaves as expected.
+// Tests sync from the genesis block and from a higher block to mimic a restart.
+// Note: Test runs in /tmp by default, which is usually cached, so timings are not
+// a meaningful benchmark (use -testdatadir to run it elsewhere).
+BOOST_FIXTURE_TEST_CASE(initial_sync_batch_window, BuildChainTestingSetup)
+{
+    constexpr int MINE_BLOCKS = 173;
+    constexpr int BATCH_SIZE = 30;
+
+    int expected_tip = 100; // pre-mined blocks
+    for (int round = 0; round < 2; round++) { // two rounds to test sync from genesis and from a higher block
+        mineBlocks(MINE_BLOCKS); // Generate blocks
+        const int tip_height = WITH_LOCK(::cs_main, return m_node.chainman->ActiveChain().Height());
+        BOOST_REQUIRE(tip_height == MINE_BLOCKS + expected_tip);
+        expected_tip = tip_height;
+
+        BlockFilterIndex filter_index(interfaces::MakeChain(m_node), BlockFilterType::BASIC, 1 << 20, /*f_memory=*/false);
+        filter_index.SetProcessingBatchSize(BATCH_SIZE);
+        BOOST_REQUIRE(filter_index.Init());
+        BOOST_CHECK(!filter_index.BlockUntilSyncedToCurrentChain());
+
+        // Ensure we can sync up to the tip
+        filter_index.Sync();
+        const auto& summary{filter_index.GetSummary()};
+        BOOST_CHECK(summary.synced);
+        BOOST_CHECK_EQUAL(summary.best_block_height, expected_tip);
+
+        {
+            // Verify all blocks up to the tip exist, always start from genesis to verify nothing was overwritten
+            LOCK(::cs_main);
+            const auto& chain = m_node.chainman->ActiveChain();
+            uint256 last_header;
+            for (auto pblock = chain.Genesis(); pblock; pblock = chain.Next(pblock)) {
+                CheckFilterLookups(filter_index, pblock, last_header, m_node.chainman->m_blockman);
+            }
+        }
+
+        filter_index.Interrupt();
+        filter_index.Stop();
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -327,7 +327,7 @@ public:
     bool AllowPrune() const override { return false; }
     BaseIndex::DB& GetDB() const override { return *m_db; }
 
-    bool CustomAppend(const interfaces::BlockInfo& block) override
+    bool CustomAppend(CDBBatch& db_batch, const interfaces::BlockInfo& block) override
     {
         // Simulate a delay so new blocks can get connected during the initial sync
         if (block.height == m_blocking_height) m_blocker.wait();

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -14,10 +14,12 @@
 #include <test/util/blockfilter.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <util/fs_helpers.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 #include <future>
+#include <latch>
 
 using node::BlockAssembler;
 using node::BlockManager;
@@ -341,6 +343,24 @@ public:
     }
 };
 
+template <typename F>
+static bool WaitUntil(F fn, const std::chrono::milliseconds timeout)
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!fn()) {
+        if (std::chrono::steady_clock::now() > deadline) return false;
+        std::this_thread::sleep_for(100ms);
+    }
+    return true;
+}
+
+static void WaitForHeight(const BaseIndex* index, const int height, const std::chrono::milliseconds timeout)
+{
+    if (!WaitUntil([index, height]() { return index->GetSummary().best_block_height == height; }, timeout)) {
+        BOOST_FAIL(strprintf("Timeout waiting for index height %d (current: %d)", height, index->GetSummary().best_block_height));
+    }
+}
+
 BOOST_FIXTURE_TEST_CASE(index_reorg_crash, BuildChainTestingSetup)
 {
     // Enable mock time
@@ -355,19 +375,8 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, BuildChainTestingSetup)
     BOOST_REQUIRE(index.Init());
     BOOST_REQUIRE(index.StartBackgroundSync());
 
-    auto func_wait_until = [&](int height, std::chrono::milliseconds timeout) {
-        auto deadline = std::chrono::steady_clock::now() + timeout;
-        while (index.GetSummary().best_block_height < height) {
-            if (std::chrono::steady_clock::now() > deadline) {
-                BOOST_FAIL(strprintf("Timeout waiting for index height %d (current: %d)", height, index.GetSummary().best_block_height));
-                return;
-            }
-            std::this_thread::sleep_for(100ms);
-        }
-    };
-
     // Wait until the index is one block before the fork point
-    func_wait_until(blocking_height - 1, /*timeout=*/5s);
+    WaitForHeight(&index, blocking_height - 1, /*timeout=*/5s);
 
     // Create a fork to trigger the reorg
     std::vector<std::shared_ptr<CBlock>> fork;
@@ -381,7 +390,7 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, BuildChainTestingSetup)
     // Unblock the index thread so it can process the reorg
     promise.set_value();
     // Wait for the index to reach the new tip
-    func_wait_until(blocking_height + 2, 5s);
+    WaitForHeight(&index, blocking_height + 2, 5s);
     index.Stop();
 }
 
@@ -425,6 +434,83 @@ BOOST_FIXTURE_TEST_CASE(initial_sync_batch_window, BuildChainTestingSetup)
         filter_index.Interrupt();
         filter_index.Stop();
     }
+}
+
+// A BaseIndex subclass that simulates delays during 'CustomAppend'.
+// This allows testing more complex scenarios, such as reorgs during initial sync.
+class IndexBlockSim : public BaseIndex
+{
+    std::unique_ptr<BaseIndex::DB> m_db;
+    std::latch m_reached_block{1};
+    std::latch m_continue_sync{1};
+    int m_blocking_height;
+    // Guards against dup notifications when the blocking height is reprocessed during reorgs
+    std::atomic<bool> m_has_notified{false};
+
+public:
+    IndexBlockSim(const fs::path& parent_dir, std::unique_ptr<interfaces::Chain> chain, bool f_memory, const int blocking_height) :
+        BaseIndex(std::move(chain), "sim_index"), m_blocking_height(blocking_height)
+    {
+        const fs::path path = parent_dir / "index" / fs::PathFromString(GetName());
+        TryCreateDirectories(path);
+        m_db = std::make_unique<BaseIndex::DB>(path / "db", /*n_cache_size=*/0, f_memory, /*f_wipe=*/false);
+    }
+
+    void wait_at_blocking_point() const { m_reached_block.wait(); }
+    void allow_continue() { m_continue_sync.count_down(); }
+
+protected:
+    bool CustomAppend(CDBBatch& batch, const interfaces::BlockInfo& block) override {
+        if (block.height == m_blocking_height && !m_has_notified.exchange(true)) {
+            m_reached_block.count_down(); // notify waiters
+            m_continue_sync.wait(); // pause at the blocking height
+        }
+        return BaseIndex::CustomAppend(batch, block);
+    }
+
+    bool AllowPrune() const override { return false; }
+    BaseIndex::DB& GetDB() const override { return *m_db; }
+};
+
+// Tests that indexes can complete its initial sync even if a reorg occurs mid-sync.
+// The index is paused at a specific block while a fork is introduced a few blocks before the tip.
+// Once unblocked, the index should continue syncing and correctly reach the new chain tip.
+BOOST_FIXTURE_TEST_CASE(initial_sync_reorg, BuildChainTestingSetup)
+{
+    const auto& chainman = m_node.chainman;
+
+    // Create a filter index that will block during initial sync
+    const int start_tip_height = WITH_LOCK(::cs_main, return chainman->ActiveChain().Height());
+    const int blocking_height = start_tip_height - 1;
+    IndexBlockSim index(m_args.GetDataDirNet(), interfaces::MakeChain(m_node), /*f_memory=*/true, blocking_height);
+    index.SetProcessingBatchSize(1);
+    BOOST_REQUIRE(index.Init());
+    BOOST_REQUIRE(index.StartBackgroundSync());
+    // Wait for the index to reach the blocking point
+    index.wait_at_blocking_point();
+
+    // Create a fork starting 3 blocks before the tip
+    const CBlockIndex* fork_point = WITH_LOCK(cs_main, return chainman->ActiveChain()[chainman->ActiveChain().Height() - 3]);
+    constexpr int fork_length = 5;
+    std::vector<std::shared_ptr<CBlock>> fork_chain;
+    BOOST_REQUIRE(BuildChain(fork_point, CScript() << OP_TRUE, fork_length, fork_chain));
+    for (const auto& block : fork_chain) {
+        BOOST_REQUIRE(chainman->ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
+    }
+    // Ensure we have fully processed the fork
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    const CBlockIndex* tip_block = WITH_LOCK(cs_main, return chainman->ActiveChain().Tip());
+    BOOST_CHECK(start_tip_height != tip_block->nHeight);
+
+    // Unblock the index and let it finish syncing
+    index.allow_continue();
+    index.Stop(); // Wait for background thread to stop
+
+    // Verify index is fully synced with the current tip
+    const auto& summary = index.GetSummary();
+    BOOST_CHECK(index.GetSummary().synced);
+    BOOST_CHECK_EQUAL(summary.best_block_height, tip_block->nHeight);
+    BOOST_CHECK_EQUAL(summary.best_block_hash, tip_block->GetBlockHash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -513,4 +513,42 @@ BOOST_FIXTURE_TEST_CASE(initial_sync_reorg, BuildChainTestingSetup)
     BOOST_CHECK_EQUAL(summary.best_block_hash, tip_block->GetBlockHash());
 }
 
+// Verifies that the index persists its sync progress when interrupted during initial sync.
+// The index should resume from the last processed batch rather than restarting from genesis.
+BOOST_FIXTURE_TEST_CASE(shutdown_during_initial_sync, BuildChainTestingSetup)
+{
+    // The index will be interrupted at block 45. Due to the batch size of 10,
+    // the last synced block will be block 39 after interruption (end of batch range [30-39]).
+    constexpr int SHUTDOWN_HEIGHT = 45;
+    constexpr int BATCH_SIZE = 10;
+    constexpr int EXPECTED_LAST_SYNCED_BLOCK = 39;
+    const auto& dir = m_args.GetDataDirNet();
+
+    {
+        // Create a filter index that will block during initial sync
+        IndexBlockSim index(dir, interfaces::MakeChain(m_node), /*f_memory=*/false, /*blocking_height=*/SHUTDOWN_HEIGHT);
+        index.SetProcessingBatchSize(BATCH_SIZE);
+        BOOST_REQUIRE(index.Init());
+        BOOST_REQUIRE(index.StartBackgroundSync());
+
+        // Wait for the index to reach the blocking point
+        index.wait_at_blocking_point();
+
+        // Now mimic shutdown by interrupting the index and unblock sync
+        index.Interrupt();
+        index.allow_continue();
+        index.Stop(); // Wait for background thread to stop
+
+        // Check index ended with height at end of the last completed batch
+        BOOST_CHECK_EQUAL(index.GetSummary().best_block_height, EXPECTED_LAST_SYNCED_BLOCK);
+    }
+
+    {
+        // Check the index will resume from the last locator
+        IndexBlockSim index(dir, interfaces::MakeChain(m_node), /*f_memory=*/false, /*blocking_height=*/SHUTDOWN_HEIGHT);
+        BOOST_REQUIRE(index.Init());
+        BOOST_CHECK_EQUAL(index.GetSummary().best_block_height, EXPECTED_LAST_SYNCED_BLOCK);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Pending on #34897 review. Please go there first.

---------------------------------

Decouples part of #26966.

Right now, index initial sync writes to disk for every block, which is not the best for HDD. This change batches those, so disk writes are less frequent during initial sync. This also cuts down `cs_main` contention by reducing the number of `NextBlockSync` calls (instead of calling it for every block, we will call it once per block window), making the node more responsive (IBD and validation) while indexes sync up. On top of that, it lays the groundwork for the bigger speedups, since part of the parallelization pre-work is already in place.

Just as a small summary:

* Batch DB writes instead of flushing per block, which improves sync time on HDD due to the reduced number of disk write operations.
* Reduce `cs_main` lock contention, which improves the overall node responsiveness (and primarily IBD) while the indexes threads are syncing.
* Lays the groundwork for the real speedups, since part of #26966 parallelization pre-work is introduced here as well.
* Reduces the number of generated LDB files. See l0rinc's [comment](https://github.com/bitcoin/bitcoin/pull/34489#issuecomment-3876972773).