### PR TITLE
wallet: Follow-ups to create/load split (#32636)

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4304,7 +4304,7 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& walle
         return util::Error{Untranslated("Wallet file verification failed.") + Untranslated(" ") + error};
     }
 
-    // Make the local wallet
+    // Initialize the CWallet for the local wallet.
     std::shared_ptr<CWallet> local_wallet = CWallet::LoadExisting(empty_context, wallet_name, std::move(database), error, warnings);
     if (!local_wallet) {
         return util::Error{Untranslated("Wallet loading failed.") + Untranslated(" ") + error};

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -797,6 +797,19 @@ public:
     bool IsFromMe(const CTransaction& tx) const;
     CAmount GetDebit(const CTransaction& tx) const;
 
+    /**
+     * Pass-through to WalletBatch::LoadWallet() to initialize this CWallet from
+     * the records stored in CWallet::m_database. Primarily used by
+     * CWallet::LoadExisting.
+     *
+     * @param[out]  error       A bilingual_str that will indicate the reason
+     *                          for failure, if any.
+     * @param[out]  warnings    A vector of bilingual_str's that describe
+     *                          non-fatal issues encountered during loading.
+     * @return  A DBErrors indicating the success or failure state of the load.
+     *
+     * @pre m_database must be set.
+     */
     DBErrors PopulateWalletFromDB(bilingual_str& error, std::vector<bilingual_str>& warnings);
 
     /** Erases the provided transactions from the wallet. */
@@ -873,10 +886,24 @@ public:
 
     static bool LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContext& context, bilingual_str& error, std::vector<bilingual_str>& warnings);
 
-    /* Initializes, creates and returns a new CWallet; returns a null pointer in case of an error */
+    /**
+     * Create a new wallet.
+     *
+     * @return A shared pointer to a `CWallet` object corresponding to the
+     *         created wallet on success, `std::nullptr` is returned in case of
+     *         an error.
+     */
     static std::shared_ptr<CWallet> CreateNew(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings);
 
-    /* Initializes, loads, and returns a CWallet from an existing wallet; returns a null pointer in case of an error */
+    /**
+     * Load an existing wallet from `database`.
+     *
+     * @param[in] database  The database object from which to load an existing wallet.
+     *
+     * @return A shared pointer to a `CWallet` object corresponding to the
+     *         loaded wallet on success, `std::nullptr` is returned in case of
+     *         an error.
+     */
     static std::shared_ptr<CWallet> LoadExisting(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, bilingual_str& error, std::vector<bilingual_str>& warnings);
 
     /**

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -265,8 +265,14 @@ public:
 
     DBErrors LoadWallet(CWallet* pwallet);
 
-    //! Write the given client_version.
-    bool WriteVersion(int client_version) { return m_batch->Write(DBKeys::VERSION, CLIENT_VERSION); }
+    /**
+     * Write the given `client_version` to #m_batch, indicating the last version
+     * of client software to load this wallet.
+     *
+     * @param[in]   client_version  `CLIENT_VERSION` outside of test code.
+     * @return      A bool indicating whether or not the write succeeded.
+     */
+    bool WriteVersion(int client_version) { return m_batch->Write(DBKeys::VERSION, client_version); }
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);


### PR DESCRIPTION
This adds documentation for `PopulateWalletFromDB()` and improves documentation for `LoadExisting()` and `CreateNew()`, and makes `WalletBatch::WriteVersion(int client_version)` respect the argument that it's passed, addressing issues reviewers pointed in #32636.