### PR TITLE
ci: add FreeBSD Clang cross job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,12 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_mac_cross_intel.sh'
 
+          - name: 'FreeBSD Cross'
+            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+            fallback-runner: 'ubuntu-24.04'
+            timeout-minutes: 120
+            file-env: './ci/test/00_setup_env_freebsd_cross.sh'
+
           - name: 'No wallet'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
             fallback-runner: 'ubuntu-24.04'

--- a/ci/test/00_setup_env_freebsd_cross.sh
+++ b/ci/test/00_setup_env_freebsd_cross.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_freebsd_cross
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export APT_LLVM_V="22"
+export FREEBSD_VERSION=15.0
+export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} lld"
+export HOST=x86_64-unknown-freebsd
+export DEP_OPTS="build_CC=clang build_CXX=clang++ AR=llvm-ar-${APT_LLVM_V} STRIP=llvm-strip-${APT_LLVM_V} NM=llvm-nm-${APT_LLVM_V} RANLIB=llvm-ranlib-${APT_LLVM_V}"
+export GOAL="install"
+export BITCOIN_CONFIG="\
+ --preset=dev-mode \
+ -DREDUCE_EXPORTS=ON \
+ -DWITH_USDT=OFF \
+"
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -104,4 +104,16 @@ if [ -n "$XCODE_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${OSX_SDK_BASENAME}" ]
   tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
 fi
 
+FREEBSD_SDK_BASENAME="freebsd-${HOST}-${FREEBSD_VERSION}"
+
+if [ -n "$FREEBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" ]; then
+  FREEBSD_SDK_FILENAME="base-${FREEBSD_VERSION}.txz"
+  FREEBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${FREEBSD_SDK_FILENAME}"
+  if [ ! -f "$FREEBSD_SDK_PATH" ]; then
+    ${CI_RETRY_EXE} curl --location --fail "https://download.freebsd.org/releases/amd64/${FREEBSD_VERSION}-RELEASE/base.txz" -o "$FREEBSD_SDK_PATH"
+  fi
+  mkdir -p "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}"
+  tar -C "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" -xf "$FREEBSD_SDK_PATH"
+fi
+
 echo -n "done" > "${CFG_DONE}"

--- a/depends/builders/freebsd.mk
+++ b/depends/builders/freebsd.mk
@@ -7,3 +7,9 @@ build_freebsd_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CON
 # freebsd host on freebsd builder: override freebsd host preferences.
 freebsd_CC = clang
 freebsd_CXX = clang++
+
+i686_freebsd_CFLAGS += -m32
+i686_freebsd_CXXFLAGS += -m32
+
+x86_64_freebsd_CFLAGS += -m64
+x86_64_freebsd_CXXFLAGS += -m64

--- a/depends/hosts/freebsd.mk
+++ b/depends/hosts/freebsd.mk
@@ -1,31 +1,38 @@
+FREEBSD_VERSION ?= 15.0
+FREEBSD_SDK=$(SDK_PATH)/freebsd-$(host)-$(FREEBSD_VERSION)/
+
+# We can't just use $(shell command -v clang) because GNU Make handles builtins
+# in a special way and doesn't know that `command` is a POSIX-standard builtin
+# prior to 1af314465e5dfe3e8baa839a32a72e83c04f26ef, first released in v4.2.90.
+# At the time of writing, GNU Make v4.2.1 is still being used in supported
+# distro releases.
+#
+# Source: https://lists.gnu.org/archive/html/bug-make/2017-11/msg00017.html
+clang_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang")
+clangxx_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang++")
+
+freebsd_AR=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-ar")
+freebsd_NM=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-nm")
+freebsd_OBJCOPY=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-objcopy")
+freebsd_OBJDUMP=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-objdump")
+freebsd_RANLIB=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-ranlib")
+freebsd_STRIP=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-strip")
+
+
+freebsd_CC=$(clang_prog) --target=$(host) \
+              --sysroot=$(FREEBSD_SDK)
+
+freebsd_CXX=$(clangxx_prog) --target=$(host) \
+              --sysroot=$(FREEBSD_SDK) -stdlib=libc++
+
 freebsd_CFLAGS=
 freebsd_CXXFLAGS=
+freebsd_LDFLAGS=-fuse-ld=lld
 
 freebsd_release_CFLAGS=-O2
 freebsd_release_CXXFLAGS=$(freebsd_release_CFLAGS)
 
 freebsd_debug_CFLAGS=-O1 -g
 freebsd_debug_CXXFLAGS=$(freebsd_debug_CFLAGS)
-
-ifeq (86,$(findstring 86,$(build_arch)))
-i686_freebsd_CC=clang -m32
-i686_freebsd_CXX=clang++ -m32
-i686_freebsd_AR=ar
-i686_freebsd_RANLIB=ranlib
-i686_freebsd_NM=nm
-i686_freebsd_STRIP=strip
-
-x86_64_freebsd_CC=clang -m64
-x86_64_freebsd_CXX=clang++ -m64
-x86_64_freebsd_AR=ar
-x86_64_freebsd_RANLIB=ranlib
-x86_64_freebsd_NM=nm
-x86_64_freebsd_STRIP=strip
-else
-i686_freebsd_CC=$(default_host_CC) -m32
-i686_freebsd_CXX=$(default_host_CXX) -m32
-x86_64_freebsd_CC=$(default_host_CC) -m64
-x86_64_freebsd_CXX=$(default_host_CXX) -m64
-endif
 
 freebsd_cmake_system_name=FreeBSD

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -5,6 +5,7 @@ boost_packages = boost
 libevent_packages = libevent
 
 qrencode_linux_packages = qrencode
+qrencode_freebsd_packages = qrencode
 qrencode_darwin_packages = qrencode
 qrencode_mingw32_packages = qrencode
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -156,6 +156,7 @@ ifneq ($(LTO),)
 $(package)_config_opts_linux += -ltcg
 endif
 $(package)_config_opts_freebsd := $$($(package)_config_opts_linux)
+$(package)_config_opts_freebsd += -no-feature-inotify
 
 $(package)_config_opts_mingw32 := -no-dbus
 $(package)_config_opts_mingw32 += -no-feature-freetype


### PR DESCRIPTION
Alternative to #33562, which was adding a native FreeBSD job; however that had issues with permissions/caching, as well as potential determinism issues. This adds a FreeBSD cross job using Linux and Clang.

Would close #33438. The same changes here could also be used to produce FreeBSD binaries out of Guix.