### PR TITLE
contrib: Remove valgrind suppression for bug 472219

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -56,9 +56,3 @@
    ...
    fun:_ZN5BCLog6Logger12StartLoggingEv
 }
-{
-   Suppress https://bugs.kde.org/show_bug.cgi?id=472219 - fixed in Valgrind 3.22.
-   Memcheck:Param
-   ppoll(ufds.events)
-   obj:/lib/ld-musl-aarch64.so.1
-}


### PR DESCRIPTION
Now that several Alpine releases are out, it seems fine to remove this suppression.

This should work since Alpine 3.19: https://pkgs.alpinelinux.org/packages?name=valgrind&branch=v3.19&repo=&arch=aarch64, which just dropped out of `main` support (https://alpinelinux.org/releases/)