### PR TITLE
test: fix intermittent feature blockfile assertion

### DIFF
--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -649,7 +649,12 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.log.info("Checking that blocks are segmented on disk")
         assert self.has_blockfile(n1, "00000"), "normal blockfile missing"
         assert self.has_blockfile(n1, "00001"), "assumed blockfile missing"
-        assert not self.has_blockfile(n1, "00002"), "too many blockfiles"
+        # With -fastprune, block files are 64 KiB. Asserting "not blk00002" caused
+        # intermittent failures because the background chainstate may or may not have
+        # rolled to a third file before shutdown. Accept both outcomes so we only
+        # need to ensure both chainstates wrote to disk (00000 and 00001).
+        if self.has_blockfile(n1, "00002"):
+            self.log.info("normal chainstate rolled to blk00002.dat before shutdown")
 
         self.log.info("Restarted node before snapshot validation completed, reloading...")
         self.restart_node(1, extra_args=self.extra_args[1])


### PR DESCRIPTION
intermittent `feature_assumeutxo.py` failures were a race  with `-fastprune 64 KiB blockfiles`,
the `normal chainstate` can fill `blk00000.dat` and roll to `blk00002.dat` while the `snapshot chainstate` writes `blk00001.dat` before `-stopatheight` trips...The test now only asserts that both chainstates wrote to disk `blk00000` and `blk00001`, tolerates `blk00002.dat` when it appears, and logs it. Behavior is unchanged; we just stop failing on a benign rollover..
i believe this should fix #33635