### PR TITLE
build: don't pass on boost dependency to kernel consumers

### DIFF
--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -89,7 +89,6 @@ target_link_libraries(bitcoinkernel
     secp256k1_objs
     $<$<PLATFORM_ID:Windows>:bcrypt>
     $<TARGET_NAME_IF_EXISTS:USDT::headers>
-  PUBLIC
     Boost::headers
 )
 


### PR DESCRIPTION
This is unnecessary now that the kernel now exports a (boost-less) API.

Noticed while slimming down boost dependencies in #34495.