### PR TITLE
iwyu: Fix patch to prefer `<cstdint>`

### DIFF
--- a/ci/test/01_iwyu.patch
+++ b/ci/test/01_iwyu.patch
@@ -535,7 +535,7 @@ See: https://github.com/include-what-you-use/include-what-you-use/blob/clang_21/
    { "<sys/ustat.h>", kPrivate, "<ustat.h>", kPublic },
    // Exports guaranteed by the C standard
 -  { "<stdint.h>", kPublic, "<inttypes.h>", kPublic },
-+  { "<stdint.h>", kPrivate, "<inttypes.h>", kPrivate },
++  { "<cstdint>", kPublic, "<cinttypes>", kPublic },
  };
  
  const IncludeMapEntry stdlib_c_include_map[] = {


### PR DESCRIPTION
The goal of the [patch](https://github.com/bitcoin/bitcoin/blob/master/ci/test/01_iwyu.patch) is to suggest C++ headers rather than their C counterparts. However, for fixed width integer types, the patched IWYU currently suggests `<cinttypes>` where `<cstdint>` is sufficient.

This PR fixes this behavior.