### PR TITLE
wallet: remove most asserts of `WALLET_FLAG_DESCRIPTORS` flag

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -806,9 +806,6 @@ void CWallet::AddToSpends(const CWalletTx& wtx)
 
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 {
-    // Only descriptor wallets can be encrypted
-    Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-
     if (HasEncryptionKeys())
         return false;
 
@@ -3681,10 +3678,6 @@ void CWallet::AddActiveScriptPubKeyManWithDb(WalletBatch& batch, uint256 id, Out
 
 void CWallet::LoadActiveScriptPubKeyMan(uint256 id, OutputType type, bool internal)
 {
-    // Activating ScriptPubKeyManager for a given output and change type is incompatible with legacy wallets.
-    // Legacy wallets have only one ScriptPubKeyManager and it's active for all output and change types.
-    Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-
     WalletLogPrintf("Setting spkMan to active: id = %s, type = %s, internal = %s\n", id.ToString(), FormatOutputType(type), internal ? "true" : "false");
     auto& spk_mans = internal ? m_internal_spk_managers : m_external_spk_managers;
     auto& spk_mans_other = internal ? m_external_spk_managers : m_internal_spk_managers;
@@ -3753,8 +3746,6 @@ std::optional<bool> CWallet::IsInternalScriptPubKeyMan(ScriptPubKeyMan* spk_man)
 util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWalletDescriptor(WalletDescriptor& desc, const FlatSigningProvider& signing_provider, const std::string& label, bool internal)
 {
     AssertLockHeld(cs_wallet);
-
-    Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
 
     auto spk_man = GetDescriptorScriptPubKeyMan(desc);
     if (spk_man) {
@@ -4496,8 +4487,6 @@ std::set<CExtPubKey> CWallet::GetActiveHDPubKeys() const
 {
     AssertLockHeld(cs_wallet);
 
-    Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-
     std::set<CExtPubKey> active_xpubs;
     for (const auto& spkm : GetActiveScriptPubKeyMans()) {
         const DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
@@ -4515,8 +4504,6 @@ std::set<CExtPubKey> CWallet::GetActiveHDPubKeys() const
 
 std::optional<CKey> CWallet::GetKey(const CKeyID& keyid) const
 {
-    Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-
     for (const auto& spkm : GetAllScriptPubKeyMans()) {
         const DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
         assert(desc_spkm);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -563,7 +563,7 @@ const CWalletTx* CWallet::GetWalletTx(const Txid& hash) const
 
 void CWallet::UpgradeDescriptorCache()
 {
-    if (!IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS) || IsLocked() || IsWalletFlagSet(WALLET_FLAG_LAST_HARDENED_XPUB_CACHED)) {
+    if (IsLocked() || IsWalletFlagSet(WALLET_FLAG_LAST_HARDENED_XPUB_CACHED)) {
         return;
     }
 
@@ -628,8 +628,10 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
                 continue; // try another master key
             }
             if (Unlock(plain_master_key)) {
-                // Now that we've unlocked, upgrade the descriptor cache
-                UpgradeDescriptorCache();
+                if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+                    // Now that we've unlocked, upgrade the descriptor cache
+                    UpgradeDescriptorCache();
+                }
                 return true;
             }
         }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1183,7 +1183,9 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     // Upgrade all of the descriptor caches to cache the last hardened xpub
     // This operation is not atomic, but if it fails, only new entries are added so it is backwards compatible
     try {
-        pwallet->UpgradeDescriptorCache();
+        if (pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+            pwallet->UpgradeDescriptorCache();
+        }
     } catch (...) {
         result = DBErrors::CORRUPT;
     }


### PR DESCRIPTION
Reasons:
1. Few of the wallet methods are descriptors specific as suggested
by their names, these assertions seems redundant within them.
2. Since the legacy wallet can't be loaded anymore, few of these
assertions are outdated now.
3. Seeing too many of these assertions in the `CWallet` class while
reading the code is cognitively loaded, and after a while becomes
annoying for the reader.

Note: Such assertions in the migration specific functions have been
left untouched because they seem necessary there.
