### PR TITLE
doc: fix a -> an grammar in comments

### DIFF
--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -169,7 +169,7 @@ void TxDownloadManagerImpl::DisconnectedPeer(NodeId nodeid)
 
 bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid, std::chrono::microseconds now)
 {
-    // If this is an orphan we are trying to resolve, consider this peer as a orphan resolution candidate instead.
+    // If this is an orphan we are trying to resolve, consider this peer as an orphan resolution candidate instead.
     // - is wtxid matching something in orphanage
     // - exists in orphanage
     // - peer can be an orphan resolution candidate

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -679,7 +679,7 @@ std::vector<TxOrphanage::OrphanInfo> TxOrphanageImpl::GetOrphanTransactions() co
     std::set<NodeId> this_orphan_announcers;
     while (it != index_by_wtxid.end()) {
         this_orphan_announcers.insert(it->m_announcer);
-        // If this is the last entry, or the next entry has a different wtxid, build a OrphanInfo.
+        // If this is the last entry, or the next entry has a different wtxid, build an OrphanInfo.
         if (std::next(it) == index_by_wtxid.end() || std::next(it)->m_tx->GetWitnessHash() != it->m_tx->GetWitnessHash()) {
             result.emplace_back(it->m_tx, std::move(this_orphan_announcers));
             this_orphan_announcers.clear();

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -1784,7 +1784,7 @@ void TxGraphImpl::GroupClusters(int level) noexcept
         }
     }
 
-    // Construct a an_clusters entry for every parent and child in the to-be-applied dependencies,
+    // Construct an an_clusters entry for every parent and child in the to-be-applied dependencies,
     // and an an_deps entry for each dependency to be applied.
     an_deps.reserve(clusterset.m_deps_to_add.size());
     for (const auto& [par, chl] : clusterset.m_deps_to_add) {


### PR DESCRIPTION
Fix "a" → "an" grammar before words starting with vowels in code comments:

- `src/txgraph.cpp`: "a an_clusters" → "an an_clusters"
- `src/node/txdownloadman_impl.cpp`: "a orphan" → "an orphan"
- `src/node/txorphanage.cpp`: "a OrphanInfo" → "an OrphanInfo"