### PR TITLE
doc: fix broken bpftrace installation link

### DIFF
--- a/contrib/tracing/README.md
+++ b/contrib/tracing/README.md
@@ -22,7 +22,7 @@ corresponding packages. See [installing bpftrace] and [installing BCC] for more
 information. For development there exist a [bpftrace Reference Guide], a
 [BCC Reference Guide], and a [bcc Python Developer Tutorial].
 
-[installing bpftrace]: https://github.com/iovisor/bpftrace/blob/master/INSTALL.md
+[installing bpftrace]: https://github.com/bpftrace/bpftrace/blob/master/README.md#quick-start
 [installing BCC]: https://github.com/iovisor/bcc/blob/master/INSTALL.md
 [bpftrace Reference Guide]: https://github.com/iovisor/bpftrace/blob/master/docs/reference_guide.md
 [BCC Reference Guide]: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md


### PR DESCRIPTION
The bpftrace project has moved from the `iovisor` organization to its own
`bpftrace` organization on GitHub. The old installation documentation link
(`https://github.com/iovisor/bpftrace/blob/master/INSTALL.md`) is now broken (404).

The project also restructured their documentation - installation instructions
are now in the README.md under the "Quick Start" section rather than a
separate INSTALL.md file.