### PR TITLE
test: fully reset the state of CConnman in tests

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -1241,7 +1241,7 @@ public:
         /// Wait for the number of needed connections to become greater than 0.
         void NumToOpenWait() const;
 
-    private:
+    protected:
         /**
          * Check if private broadcast can be done to IPv4 or IPv6 peers and if so via which proxy.
          * If private broadcast connections should not be opened to IPv4 or IPv6, then this will
@@ -1251,6 +1251,8 @@ public:
 
         /// Number of `ConnectionType::PRIVATE_BROADCAST` connections to open.
         std::atomic_size_t m_num_to_open{0};
+
+        friend struct ConnmanTestMsg;
     } m_private_broadcast;
 
     bool CheckIncomingNonce(uint64_t nonce);

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -72,8 +72,7 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
 
     auto& node{g_setup->m_node};
     auto& connman{static_cast<ConnmanTestMsg&>(*node.connman)};
-    connman.ResetAddrCache();
-    connman.ResetMaxOutboundCycle();
+    connman.Reset();
     auto& chainman{static_cast<TestChainstateManager&>(*node.chainman)};
     const auto block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
     SetMockTime(1610000000); // any time to successfully reset ibd

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -62,8 +62,7 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
 
     auto& node{g_setup->m_node};
     auto& connman{static_cast<ConnmanTestMsg&>(*node.connman)};
-    connman.ResetAddrCache();
-    connman.ResetMaxOutboundCycle();
+    connman.Reset();
     auto& chainman{static_cast<TestChainstateManager&>(*node.chainman)};
     const auto block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
     SetMockTime(1610000000); // any time to successfully reset ibd

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -80,6 +80,12 @@ void ConnmanTestMsg::ResetMaxOutboundCycle()
     nMaxOutboundTotalBytesSentInCycle = 0;
 }
 
+void ConnmanTestMsg::Reset()
+{
+    ResetAddrCache();
+    ResetMaxOutboundCycle();
+}
+
 void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, std::span<const uint8_t> msg_bytes, bool& complete) const
 {
     assert(node.ReceiveMsgBytes(msg_bytes, complete));

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -84,6 +84,8 @@ void ConnmanTestMsg::Reset()
 {
     ResetAddrCache();
     ResetMaxOutboundCycle();
+    m_private_broadcast.m_outbound_tor_ok_at_least_once.store(false);
+    m_private_broadcast.m_num_to_open.store(0);
 }
 
 void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, std::span<const uint8_t> msg_bytes, bool& complete) const

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -49,6 +49,8 @@ struct ConnmanTestMsg : public CConnman {
 
     void ResetAddrCache();
     void ResetMaxOutboundCycle();
+    /// Reset the internal state.
+    void Reset();
 
     std::vector<CNode*> TestNodes()
     {


### PR DESCRIPTION
Member variables of `CConnman::m_private_broadcast` (introduced in
https://github.com/bitcoin/bitcoin/pull/29415) could influence the tests
which creates non-determinism if the same instance of `CConnman` is used
for repeated test iterations.

So, reset the state of `CConnman::m_private_broadcast` from
`ConnmanTestMsg::Reset()`. Currently this affects the fuzz tests
`process_message` and `process_messages`.

Reported in https://github.com/bitcoin/bitcoin/issues/34476#issuecomment-3849088794