### PR TITLE
refactor: remove unnecessary `std::move` for a few trivially copyable types

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -108,9 +108,9 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
            (bool)it->second.coin.IsCoinBase());
 }
 
-void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin) {
+void CCoinsViewCache::EmplaceCoinInternalDANGER(const COutPoint& outpoint, Coin&& coin) {
     const auto mem_usage{coin.DynamicMemoryUsage()};
-    auto [it, inserted] = cacheCoins.try_emplace(std::move(outpoint), std::move(coin));
+    auto [it, inserted] = cacheCoins.try_emplace(outpoint, std::move(coin));
     if (inserted) {
         CCoinsCacheEntry::SetDirty(*it, m_sentinel);
         ++m_dirty_count;

--- a/src/coins.h
+++ b/src/coins.h
@@ -471,7 +471,7 @@ public:
      * NOT FOR GENERAL USE. Used only when loading coins from a UTXO snapshot.
      * @sa ChainstateManager::PopulateAndValidateSnapshot()
      */
-    void EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin);
+    void EmplaceCoinInternalDANGER(const COutPoint& outpoint, Coin&& coin);
 
     /**
      * Spend a coin. Pass moveto in order to get the deleted data.

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -236,7 +236,7 @@ struct RPCArg {
         std::string description,
         RPCArgOptions opts = {})
         : m_names{std::move(name)},
-          m_type{std::move(type)},
+          m_type{type},
           m_fallback{std::move(fallback)},
           m_description{std::move(description)},
           m_opts{std::move(opts)}
@@ -252,7 +252,7 @@ struct RPCArg {
         std::vector<RPCArg> inner,
         RPCArgOptions opts = {})
         : m_names{std::move(name)},
-          m_type{std::move(type)},
+          m_type{type},
           m_inner{std::move(inner)},
           m_fallback{std::move(fallback)},
           m_description{std::move(description)},
@@ -338,7 +338,7 @@ struct RPCResult {
         std::string description,
         std::vector<RPCResult> inner = {},
         RPCResultOptions opts = {})
-        : m_type{std::move(type)},
+        : m_type{type},
           m_key_name{std::move(m_key_name)},
           m_inner{std::move(inner)},
           m_optional{optional},
@@ -366,7 +366,7 @@ struct RPCResult {
         std::string description,
         std::vector<RPCResult> inner = {},
         RPCResultOptions opts = {})
-        : m_type{std::move(type)},
+        : m_type{type},
           m_key_name{std::move(m_key_name)},
           m_inner{std::move(inner)},
           m_optional{optional},

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -193,7 +193,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
                     coin = newcoin;
                 }
                 if (COutPoint op(txid, 0); !stack.back()->map().contains(op) && !newcoin.out.scriptPubKey.IsUnspendable() && m_rng.randbool()) {
-                    stack.back()->EmplaceCoinInternalDANGER(std::move(op), std::move(newcoin));
+                    stack.back()->EmplaceCoinInternalDANGER(op, std::move(newcoin));
                 } else {
                     stack.back()->AddCoin(op, std::move(newcoin), /*possible_overwrite=*/!coin.IsSpent() || m_rng.randbool());
                 }
@@ -1109,11 +1109,11 @@ BOOST_AUTO_TEST_CASE(ccoins_emplace_duplicate_keeps_usage_balanced)
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
 
     const Coin coin1{CTxOut{m_rng.randrange(10), CScript{} << m_rng.randbytes(CScriptBase::STATIC_SIZE + 1)}, 1, false};
-    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin1});
+    cache.EmplaceCoinInternalDANGER(outpoint, Coin{coin1});
     cache.SelfTest();
 
     const Coin coin2{CTxOut{m_rng.randrange(20), CScript{} << m_rng.randbytes(CScriptBase::STATIC_SIZE + 2)}, 2, false};
-    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin2});
+    cache.EmplaceCoinInternalDANGER(outpoint, Coin{coin2});
     cache.SelfTest();
 
     BOOST_CHECK(cache.AccessCoin(outpoint) == coin1);
@@ -1132,7 +1132,7 @@ BOOST_AUTO_TEST_CASE(ccoins_reset_guard)
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
 
     const Coin coin{CTxOut{m_rng.randrange(10), CScript{} << m_rng.randbytes(CScriptBase::STATIC_SIZE + 1)}, 1, false};
-    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin});
+    cache.EmplaceCoinInternalDANGER(outpoint, Coin{coin});
     BOOST_CHECK_EQUAL(cache.GetDirtyCount(), 1U);
 
     uint256 cache_best_block{m_rng.rand256()};

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -48,7 +48,7 @@ void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
         for (const auto& in : tx->vin) {
             Coin coin{};
             if (!spent) coin.out.nValue = 1;
-            cache.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
+            cache.EmplaceCoinInternalDANGER(in.prevout, std::move(coin));
         }
     }
 

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -115,7 +115,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                     const bool possible_overwrite{coins_view_cache.PeekCoin(outpoint) || fuzzed_data_provider.ConsumeBool()};
                     coins_view_cache.AddCoin(outpoint, std::move(coin), possible_overwrite);
                 } else {
-                    coins_view_cache.EmplaceCoinInternalDANGER(std::move(outpoint), std::move(coin));
+                    coins_view_cache.EmplaceCoinInternalDANGER(outpoint, std::move(coin));
                 }
             },
             [&] {

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -2710,9 +2710,9 @@ void TxGraphImpl::CommitStaging() noexcept
     m_main_clusterset.m_deps_to_add = std::move(m_staging_clusterset->m_deps_to_add);
     m_main_clusterset.m_to_remove = std::move(m_staging_clusterset->m_to_remove);
     m_main_clusterset.m_group_data = std::move(m_staging_clusterset->m_group_data);
-    m_main_clusterset.m_oversized = std::move(m_staging_clusterset->m_oversized);
-    m_main_clusterset.m_txcount = std::move(m_staging_clusterset->m_txcount);
-    m_main_clusterset.m_txcount_oversized = std::move(m_staging_clusterset->m_txcount_oversized);
+    m_main_clusterset.m_oversized = m_staging_clusterset->m_oversized;
+    m_main_clusterset.m_txcount = m_staging_clusterset->m_txcount;
+    m_main_clusterset.m_txcount_oversized = m_staging_clusterset->m_txcount_oversized;
     // Delete the old staging graph, after all its information was moved to main.
     m_staging_clusterset.reset();
     Compact();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5812,7 +5812,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                     return util::Error{Untranslated(strprintf("Bad snapshot data after deserializing %d coins - bad tx out value",
                               coins_count - coins_left))};
                 }
-                coins_cache.EmplaceCoinInternalDANGER(std::move(outpoint), std::move(coin));
+                coins_cache.EmplaceCoinInternalDANGER(outpoint, std::move(coin));
 
                 --coins_left;
                 ++coins_processed;


### PR DESCRIPTION
Inspired by https://github.com/bitcoin/bitcoin/pull/34320#discussion_r2751764873.

**Problem:** A few code paths use rvalue references or `std::move()` for types where moving provides no benefit.

`EmplaceCoinInternalDANGER` took `COutPoint&&`, forcing callers to pass trivially copyable outpoints as rvalues even though the cache stores its own key.

Some call sites also use `std::move()` on enum and primitive values, where it only adds noise.
> [!NOTE]
> `CheckTriviallyCopyableMove` remains `false` since `std::move()` on trivially copyable types can still be useful as intent documentation, for example to signal that a value should not be reused after a call.

**Fix:** Take trivially copyable arguments by const reference where the callee only needs to store its own copy, and pass existing values directly at the call sites.

Also remove `std::move()` from enum and primitive assignments where it has no semantic effect.