### PR TITLE
doc: Extend Windows build  msvc doc to use winget for VS 2022 install

### DIFF
--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -14,7 +14,15 @@ Here are requirements for the Visual Studio installation:
 2. Installed components:
 - The "Desktop development with C++" workload.
 
-The commands in this guide should be executed in "Developer PowerShell for VS 2022" or "Developer Command Prompt for VS 2022".
+You can install Visual Studio 2022 Community edition together with the required workload using **winget**.
+Run the following command in an **elevated** PowerShell or Command Prompt:
+
+```powershell
+winget install --id Microsoft.VisualStudio.2022.Community `
+ --override "--wait --quiet --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended"
+```
+
+The commands in this guide should be executed in `Developer PowerShell for VS 2022` or `Developer Command Prompt for VS 2022`.
 The former is assumed hereinafter.
 
 ### 2. Git


### PR DESCRIPTION
This PR adds a simple copy and paste-able instruction to meet the requirements to build on Windows (sans git). 

With the introduction of Visual Studio 2026, Microsoft made is not so easy to find the community edition of visual studio 2022 on it's download page. The professional and Enterprise 2022 versions are behind a login and need a license / microsoft account. The 2022 community edition version is stil available to install via winget. 
This PR extends the documentation to include the relevant winget command. 

Also, moving to Visual Studio 2026 (Community edition) is currently not an option, it ships with a [unusable vcpkg version](https://developercommunity.visualstudio.com/t/10998815).