### PR TITLE
refactor: Add [[nodiscard]] to functions returning bool+mutable ref

### DIFF
--- a/src/common/args.h
+++ b/src/common/args.h
@@ -417,7 +417,7 @@ public:
      * Get settings file path, or return false if read-write settings were
      * disabled with -nosettings.
      */
-    bool GetSettingsPath(fs::path* filepath = nullptr, bool temp = false, bool backup = false) const EXCLUSIVE_LOCKS_REQUIRED(!cs_args);
+    [[nodiscard]] bool GetSettingsPath(fs::path* filepath = nullptr, bool temp = false, bool backup = false) const EXCLUSIVE_LOCKS_REQUIRED(!cs_args);
 
     /**
      * Read settings file. Push errors to vector, or log them if null.

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -32,7 +32,7 @@
 using util::TrimString;
 using util::TrimStringView;
 
-static bool GetConfigOptions(std::istream& stream, const std::string& filepath, std::string& error, std::vector<std::pair<std::string, std::string>>& options, std::list<SectionInfo>& sections)
+[[nodiscard]] static bool GetConfigOptions(std::istream& stream, const std::string& filepath, std::string& error, std::vector<std::pair<std::string, std::string>>& options, std::list<SectionInfo>& sections)
 {
     std::string str, prefix;
     std::string::size_type pos;

--- a/src/external_signer.h
+++ b/src/external_signer.h
@@ -60,7 +60,7 @@ public:
     //! Sign PartiallySignedTransaction on the device.
     //! Calls `<command> signtransaction` and passes the PSBT via stdin.
     //! @param[in,out] psbt  PartiallySignedTransaction to be signed
-    bool SignTransaction(PartiallySignedTransaction& psbt, std::string& error);
+    [[nodiscard]] bool SignTransaction(PartiallySignedTransaction& psbt, std::string& error);
 };
 
 #endif // BITCOIN_EXTERNAL_SIGNER_H

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -167,7 +167,7 @@ public:
     virtual size_t getMempoolMaxUsage() = 0;
 
     //! Get header tip height and time.
-    virtual bool getHeaderTip(int& height, int64_t& block_time) = 0;
+    [[nodiscard]] virtual bool getHeaderTip(int& height, int64_t& block_time) = 0;
 
     //! Get num blocks.
     virtual int getNumBlocks() = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -100,7 +100,7 @@ public:
     virtual util::Result<CTxDestination> getNewDestination(OutputType type, const std::string& label) = 0;
 
     //! Get public key.
-    virtual bool getPubKey(const CScript& script, const CKeyID& address, CPubKey& pub_key) = 0;
+    [[nodiscard]] virtual bool getPubKey(const CScript& script, const CKeyID& address, CPubKey& pub_key) = 0;
 
     //! Sign message
     virtual SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) = 0;
@@ -172,7 +172,7 @@ public:
         CMutableTransaction& mtx) = 0;
 
     //! Sign bump transaction.
-    virtual bool signBumpTransaction(CMutableTransaction& mtx) = 0;
+    [[nodiscard]] virtual bool signBumpTransaction(CMutableTransaction& mtx) = 0;
 
     //! Commit bump transaction.
     virtual bool commitBumpTransaction(const Txid& txid,
@@ -190,7 +190,7 @@ public:
     virtual std::set<WalletTx> getWalletTxs() = 0;
 
     //! Try to get updated status for a particular transaction, if possible without blocking.
-    virtual bool tryGetTxStatus(const Txid& txid,
+    [[nodiscard]] virtual bool tryGetTxStatus(const Txid& txid,
         WalletTxStatus& tx_status,
         int& num_blocks,
         int64_t& block_time) = 0;
@@ -212,7 +212,7 @@ public:
     virtual WalletBalances getBalances() = 0;
 
     //! Get balances if possible without blocking.
-    virtual bool tryGetBalances(WalletBalances& balances, uint256& block_hash) = 0;
+    [[nodiscard]] virtual bool tryGetBalances(WalletBalances& balances, uint256& block_hash) = 0;
 
     //! Get balance.
     virtual CAmount getBalance() = 0;

--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -16,7 +16,7 @@ constexpr uint256 MUSIG_CHAINCODE{
     []() consteval { return uint256{"868087ca02a6f974c4598924c36b57762d32cb45717167e300622c7167e38965"_hex_u8}; }(),
 };
 
-static bool GetMuSig2KeyAggCache(const std::vector<CPubKey>& pubkeys, secp256k1_musig_keyagg_cache& keyagg_cache)
+[[nodiscard]] static bool GetMuSig2KeyAggCache(const std::vector<CPubKey>& pubkeys, secp256k1_musig_keyagg_cache& keyagg_cache)
 {
     // Parse the pubkeys
     std::vector<secp256k1_pubkey> secp_pubkeys;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -533,7 +533,7 @@ public:
     void CheckForStaleTipAndEvictPeers() override;
     util::Expected<void, std::string> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
-    bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+    [[nodiscard]] bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     std::vector<node::TxOrphanage::OrphanInfo> GetOrphanTransactions() override EXCLUSIVE_LOCKS_REQUIRED(!m_tx_download_mutex);
     PeerManagerInfo GetInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     std::vector<PrivateBroadcast::TxBroadcastInfo> GetPrivateBroadcastInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -113,7 +113,7 @@ public:
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;
 
     /** Get statistics from node state */
-    virtual bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const = 0;
+    [[nodiscard]] virtual bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const = 0;
 
     virtual std::vector<node::TxOrphanage::OrphanInfo> GetOrphanTransactions() = 0;
 

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -195,7 +195,7 @@ public:
 
     enum Network GetNetwork() const;
     std::string ToStringAddr() const;
-    bool GetInAddr(struct in_addr* pipv4Addr) const;
+    [[nodiscard]] bool GetInAddr(struct in_addr* pipv4Addr) const;
     Network GetNetClass() const;
 
     //! For IPv4, mapped IPv4, SIIT translated IPv4, Teredo, 6to4 tunneled addresses, return the relevant IPv4 address as a uint32.
@@ -207,7 +207,7 @@ public:
     int GetReachabilityFrom(const CNetAddr& paddrPartner) const;
 
     explicit CNetAddr(const struct in6_addr& pipv6Addr, uint32_t scope = 0);
-    bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
+    [[nodiscard]] bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
     friend bool operator==(const CNetAddr& a, const CNetAddr& b);
     friend bool operator<(const CNetAddr& a, const CNetAddr& b);
@@ -537,7 +537,7 @@ public:
     CService(const struct in_addr& ipv4Addr, uint16_t port);
     explicit CService(const struct sockaddr_in& addr);
     uint16_t GetPort() const;
-    bool GetSockAddr(struct sockaddr* paddr, socklen_t* addrlen) const;
+    [[nodiscard]] bool GetSockAddr(struct sockaddr* paddr, socklen_t* addrlen) const;
     /**
      * Set CService from a network sockaddr.
      * @param[in] paddr Pointer to sockaddr structure

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -332,7 +332,7 @@ public:
      * @param[out] utxo The UTXO of this input
      * @return Whether the UTXO could be retrieved
      */
-    bool GetUTXO(CTxOut& utxo) const;
+    [[nodiscard]] bool GetUTXO(CTxOut& utxo) const;
     bool HasSignatures() const;
 
     explicit PSBTInput(uint32_t psbt_version, const Txid& prev_txid, uint32_t prev_out, std::optional<uint32_t> sequence = std::nullopt)

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -96,7 +96,7 @@ private:
     EditStatus editStatus = OK;
 
     /** Look up address book data given an address string. */
-    bool getAddressData(const QString &address, std::string* name, wallet::AddressPurpose* purpose) const;
+    [[nodiscard]] bool getAddressData(const QString& address, std::string* name, wallet::AddressPurpose* purpose) const;
 
     /** Notify listeners that data changed. */
     void emitDataChanged(int index);

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -383,7 +383,7 @@ class BIP32PubkeyProvider final : public PubkeyProvider
     // Whether ' or h is used in harded derivation
     bool m_apostrophe;
 
-    bool GetExtKey(const SigningProvider& arg, CExtKey& ret) const
+    [[nodiscard]] bool GetExtKey(const SigningProvider& arg, CExtKey& ret) const
     {
         CKey key;
         if (!arg.GetKey(m_root_extkey.pubkey.GetID(), key)) return false;
@@ -396,7 +396,7 @@ class BIP32PubkeyProvider final : public PubkeyProvider
     }
 
     // Derives the last xprv
-    bool GetDerivedExtKey(const SigningProvider& arg, CExtKey& xprv, CExtKey& last_hardened) const
+    [[nodiscard]] bool GetDerivedExtKey(const SigningProvider& arg, CExtKey& xprv, CExtKey& last_hardened) const
     {
         if (!GetExtKey(arg, xprv)) return false;
         for (auto entry : m_path) {

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -550,10 +550,7 @@ public:
         CExtPubKey xpub;
         CExtKey lh_xprv;
         // If we have the cache, just get the parent xpub
-        if (cache != nullptr) {
-            cache->GetCachedLastHardenedExtPubKey(m_expr_index, xpub);
-        }
-        if (!xpub.pubkey.IsValid()) {
+        if (!cache || !cache->GetCachedLastHardenedExtPubKey(m_expr_index, xpub) || !xpub.pubkey.IsValid()) {
             // Cache miss, or nor cache, or need privkey
             CExtKey xprv;
             if (!GetDerivedExtKey(arg, xprv, lh_xprv)) return false;

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -63,7 +63,7 @@ public:
      * @param[in] key_exp_pos Position of the key expression within the descriptor
      * @param[out] xpub The CExtPubKey to get from cache
      */
-    bool GetCachedLastHardenedExtPubKey(uint32_t key_exp_pos, CExtPubKey& xpub) const;
+    [[nodiscard]] bool GetCachedLastHardenedExtPubKey(uint32_t key_exp_pos, CExtPubKey& xpub) const;
 
     /** Retrieve all cached parent xpubs */
     ExtPubKeyMap GetCachedParentExtPubKeys() const;

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -37,7 +37,7 @@ public:
      * @param[in] key_exp_pos Position of the key expression within the descriptor
      * @param[out] xpub The CExtPubKey to get from cache
      */
-    bool GetCachedParentExtPubKey(uint32_t key_exp_pos, CExtPubKey& xpub) const;
+    [[nodiscard]] bool GetCachedParentExtPubKey(uint32_t key_exp_pos, CExtPubKey& xpub) const;
     /** Cache an xpub derived at an index
      *
      * @param[in] key_exp_pos Position of the key expression within the descriptor
@@ -51,7 +51,7 @@ public:
      * @param[in] der_index Derivation index of the xpub
      * @param[out] xpub The CExtPubKey to get from cache
      */
-    bool GetCachedDerivedExtPubKey(uint32_t key_exp_pos, uint32_t der_index, CExtPubKey& xpub) const;
+    [[nodiscard]] bool GetCachedDerivedExtPubKey(uint32_t key_exp_pos, uint32_t der_index, CExtPubKey& xpub) const;
     /** Cache a last hardened xpub
      *
      * @param[in] key_exp_pos Position of the key expression within the descriptor

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -12,6 +12,7 @@
 #include <script/script.h>
 #include <tinyformat.h>
 #include <uint256.h>
+#include <util/check.h>
 
 typedef std::vector<unsigned char> valtype;
 
@@ -2154,7 +2155,7 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
         std::vector<unsigned char> data;
         while (pc < scriptSig.end()) {
             opcodetype opcode;
-            scriptSig.GetOp(pc, opcode, data);
+            Assert(scriptSig.GetOp(pc, opcode, data));
         }
         CScript subscript(data.begin(), data.end());
         if (subscript.IsWitnessProgram(witnessversion, witnessprogram)) {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -398,7 +398,7 @@ private:
  */
 using CScriptBase = prevector<36, uint8_t>;
 
-bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet);
+[[nodiscard]] bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet);
 
 /** Serialized script, used inside transaction inputs and outputs */
 class CScript : public CScriptBase
@@ -493,12 +493,12 @@ public:
         return *this << std::as_bytes(b);
     }
 
-    bool GetOp(const_iterator& pc, opcodetype& opcodeRet, std::vector<unsigned char>& vchRet) const
+    [[nodiscard]] bool GetOp(const_iterator& pc, opcodetype& opcodeRet, std::vector<unsigned char>& vchRet) const
     {
         return GetScriptOp(pc, end(), opcodeRet, &vchRet);
     }
 
-    bool GetOp(const_iterator& pc, opcodetype& opcodeRet) const
+    [[nodiscard]] bool GetOp(const_iterator& pc, opcodetype& opcodeRet) const
     {
         return GetScriptOp(pc, end(), opcodeRet, nullptr);
     }

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -202,7 +202,7 @@ bool MutableTransactionSignatureCreator::CreateMuSig2AggregateSig(const std::vec
     return true;
 }
 
-static bool GetCScript(const SigningProvider& provider, const SignatureData& sigdata, const CScriptID& scriptid, CScript& script)
+[[nodiscard]] static bool GetCScript(const SigningProvider& provider, const SignatureData& sigdata, const CScriptID& scriptid, CScript& script)
 {
     if (provider.GetCScript(scriptid, script)) {
         return true;
@@ -218,7 +218,7 @@ static bool GetCScript(const SigningProvider& provider, const SignatureData& sig
     return false;
 }
 
-static bool GetPubKey(const SigningProvider& provider, const SignatureData& sigdata, const CKeyID& address, CPubKey& pubkey)
+[[nodiscard]] static bool GetPubKey(const SigningProvider& provider, const SignatureData& sigdata, const CKeyID& address, CPubKey& pubkey)
 {
     // Look for pubkey in all partial sigs
     const auto it = sigdata.signatures.find(address);

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -157,21 +157,21 @@ class SigningProvider
 {
 public:
     virtual ~SigningProvider() = default;
-    virtual bool GetCScript(const CScriptID &scriptid, CScript& script) const { return false; }
+    [[nodiscard]] virtual bool GetCScript(const CScriptID& scriptid, CScript& script) const { return false; }
     virtual bool HaveCScript(const CScriptID &scriptid) const { return false; }
-    virtual bool GetPubKey(const CKeyID &address, CPubKey& pubkey) const { return false; }
-    virtual bool GetKey(const CKeyID &address, CKey& key) const { return false; }
+    [[nodiscard]] virtual bool GetPubKey(const CKeyID& address, CPubKey& pubkey) const { return false; }
+    [[nodiscard]] virtual bool GetKey(const CKeyID& address, CKey& key) const { return false; }
     virtual bool HaveKey(const CKeyID &address) const { return false; }
-    virtual bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const { return false; }
-    virtual bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const { return false; }
-    virtual bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const { return false; }
+    [[nodiscard]] virtual bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const { return false; }
+    [[nodiscard]] virtual bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const { return false; }
+    [[nodiscard]] virtual bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const { return false; }
     virtual std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const { return {}; }
     virtual std::map<CPubKey, std::vector<CPubKey>> GetAllMuSig2ParticipantPubkeys() const {return {}; }
     virtual void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const {}
     virtual std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const { return std::nullopt; }
     virtual void DeleteMuSig2Session(const uint256& session_id) const {}
 
-    bool GetKeyByXOnly(const XOnlyPubKey& pubkey, CKey& key) const
+    [[nodiscard]] bool GetKeyByXOnly(const XOnlyPubKey& pubkey, CKey& key) const
     {
         for (const auto& id : pubkey.GetKeyIDs()) {
             if (GetKey(id, key)) return true;
@@ -179,7 +179,7 @@ public:
         return false;
     }
 
-    bool GetPubKeyByXOnly(const XOnlyPubKey& pubkey, CPubKey& out) const
+    [[nodiscard]] bool GetPubKeyByXOnly(const XOnlyPubKey& pubkey, CPubKey& out) const
     {
         for (const auto& id : pubkey.GetKeyIDs()) {
             if (GetPubKey(id, out)) return true;
@@ -187,7 +187,7 @@ public:
         return false;
     }
 
-    bool GetKeyOriginByXOnly(const XOnlyPubKey& pubkey, KeyOriginInfo& info) const
+    [[nodiscard]] bool GetKeyOriginByXOnly(const XOnlyPubKey& pubkey, KeyOriginInfo& info) const
     {
         for (const auto& id : pubkey.GetKeyIDs()) {
             if (GetKeyOrigin(id, info)) return true;
@@ -207,12 +207,12 @@ private:
 
 public:
     HidingSigningProvider(const SigningProvider* provider, bool hide_secret, bool hide_origin) : m_hide_secret(hide_secret), m_hide_origin(hide_origin), m_provider(provider) {}
-    bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
-    bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
-    bool GetKey(const CKeyID& keyid, CKey& key) const override;
-    bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
-    bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
-    bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
+    [[nodiscard]] bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
+    [[nodiscard]] bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
+    [[nodiscard]] bool GetKey(const CKeyID& keyid, CKey& key) const override;
+    [[nodiscard]] bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
+    [[nodiscard]] bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
+    [[nodiscard]] bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
     std::map<CPubKey, std::vector<CPubKey>> GetAllMuSig2ParticipantPubkeys() const override;
     void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const override;
@@ -230,13 +230,13 @@ struct FlatSigningProvider final : public SigningProvider
     std::map<CPubKey, std::vector<CPubKey>> aggregate_pubkeys; /** MuSig2 aggregate pubkeys */
     std::map<uint256, MuSig2SecNonce>* musig2_secnonces{nullptr};
 
-    bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
-    bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
-    bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
+    [[nodiscard]] bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
+    [[nodiscard]] bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
+    [[nodiscard]] bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
     bool HaveKey(const CKeyID &keyid) const override;
-    bool GetKey(const CKeyID& keyid, CKey& key) const override;
-    bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
-    bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
+    [[nodiscard]] bool GetKey(const CKeyID& keyid, CKey& key) const override;
+    [[nodiscard]] bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
+    [[nodiscard]] bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
     std::map<CPubKey, std::vector<CPubKey>> GetAllMuSig2ParticipantPubkeys() const override;
     void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const override;
@@ -309,14 +309,14 @@ public:
 
     virtual bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
     virtual bool AddKey(const CKey &key) { return AddKeyPubKey(key, key.GetPubKey()); }
-    virtual bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
+    [[nodiscard]] virtual bool GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const override;
     virtual bool HaveKey(const CKeyID &address) const override;
     virtual std::set<CKeyID> GetKeys() const;
-    virtual bool GetKey(const CKeyID &address, CKey &keyOut) const override;
+    [[nodiscard]] virtual bool GetKey(const CKeyID& address, CKey& keyOut) const override;
     virtual bool AddCScript(const CScript& redeemScript);
     virtual bool HaveCScript(const CScriptID &hash) const override;
     virtual std::set<CScriptID> GetCScripts() const;
-    virtual bool GetCScript(const CScriptID &hash, CScript& redeemScriptOut) const override;
+    [[nodiscard]] virtual bool GetCScript(const CScriptID& hash, CScript& redeemScriptOut) const override;
 };
 
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */
@@ -329,12 +329,12 @@ class MultiSigningProvider: public SigningProvider {
 public:
     void AddProvider(std::unique_ptr<SigningProvider> provider);
 
-    bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
-    bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
-    bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
-    bool GetKey(const CKeyID& keyid, CKey& key) const override;
-    bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
-    bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
+    [[nodiscard]] bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
+    [[nodiscard]] bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
+    [[nodiscard]] bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
+    [[nodiscard]] bool GetKey(const CKeyID& keyid, CKey& key) const override;
+    [[nodiscard]] bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
+    [[nodiscard]] bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
 };
 
 #endif // BITCOIN_SCRIPT_SIGNINGPROVIDER_H

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -902,7 +902,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     while (pc < t.vin[0].scriptSig.end()) {
         opcodetype opcode;
         CScript::const_iterator prev_pc = pc;
-        t.vin[0].scriptSig.GetOp(pc, opcode); // advance to next op
+        BOOST_REQUIRE(t.vin[0].scriptSig.GetOp(pc, opcode)); // advance to next op
         // for the sake of simplicity, we only replace single-byte push operations
         if (opcode >= 1 && opcode <= OP_PUSHDATA4)
             continue;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -185,8 +185,8 @@ public:
         CCoinsViewCursor(in_block_hash), pcursor(pcursorIn) {}
     ~CCoinsViewDBCursor() = default;
 
-    bool GetKey(COutPoint &key) const override;
-    bool GetValue(Coin &coin) const override;
+    [[nodiscard]] bool GetKey(COutPoint& key) const override;
+    [[nodiscard]] bool GetValue(Coin& coin) const override;
 
     bool Valid() const override;
     void Next() override;

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -60,7 +60,7 @@ Result CreateRateBumpTransaction(CWallet& wallet,
 //! Sign the new transaction,
 //! @return false if the tx couldn't be found or if it was
 //! impossible to create the signature(s)
-bool SignTransaction(CWallet& wallet, CMutableTransaction& mtx);
+[[nodiscard]] bool SignTransaction(CWallet& wallet, CMutableTransaction& mtx);
 
 //! Commit the bumpfee transaction.
 //! @return success in case of CWallet::CommitTransaction was successful,

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -133,7 +133,7 @@ public:
     virtual bool CanProvide(const CScript& script, SignatureData& sigdata) { return false; }
 
     /** Creates new signatures and adds them to the transaction. Returns whether all inputs were signed */
-    virtual bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const { return false; }
+    [[nodiscard]] virtual bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const { return false; }
     /** Sign a message with the given script */
     virtual SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const { return SigningResult::SIGNING_FAILED; };
     /** Adds script and derivation path information to a PSBT, and optionally signs it. */
@@ -213,9 +213,9 @@ public:
 
     // FillableSigningProvider overrides
     bool HaveKey(const CKeyID &address) const override;
-    bool GetKey(const CKeyID &address, CKey& keyOut) const override;
-    bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
-    bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
+    [[nodiscard]] bool GetKey(const CKeyID& address, CKey& keyOut) const override;
+    [[nodiscard]] bool GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const override;
+    [[nodiscard]] bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
 
     //! Load metadata (used by LoadWallet)
     virtual void LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata &metadata);
@@ -237,7 +237,7 @@ public:
     const CHDChain& GetHDChain() const { return m_hd_chain; }
 
     //! Fetches a pubkey from mapWatchKeys if it exists there
-    bool GetWatchPubKey(const CKeyID &address, CPubKey &pubkey_out) const;
+    [[nodiscard]] bool GetWatchPubKey(const CKeyID& address, CPubKey& pubkey_out) const;
 
     /**
      * Retrieves scripts that were imported by bugs into the legacy spkm and are
@@ -260,12 +260,12 @@ private:
 public:
     explicit LegacySigningProvider(const LegacyDataSPKM& spk_man) : m_spk_man(spk_man) {}
 
-    bool GetCScript(const CScriptID &scriptid, CScript& script) const override { return m_spk_man.GetCScript(scriptid, script); }
+    [[nodiscard]] bool GetCScript(const CScriptID& scriptid, CScript& script) const override { return m_spk_man.GetCScript(scriptid, script); }
     bool HaveCScript(const CScriptID &scriptid) const override { return m_spk_man.HaveCScript(scriptid); }
-    bool GetPubKey(const CKeyID &address, CPubKey& pubkey) const override { return m_spk_man.GetPubKey(address, pubkey); }
-    bool GetKey(const CKeyID &address, CKey& key) const override { return false; }
+    [[nodiscard]] bool GetPubKey(const CKeyID& address, CPubKey& pubkey) const override { return m_spk_man.GetPubKey(address, pubkey); }
+    [[nodiscard]] bool GetKey(const CKeyID& address, CKey& key) const override { return false; }
     bool HaveKey(const CKeyID &address) const override { return false; }
-    bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override { return m_spk_man.GetKeyOrigin(keyid, info); }
+    [[nodiscard]] bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override { return m_spk_man.GetKeyOrigin(keyid, info); }
 };
 
 class DescriptorScriptPubKeyMan : public ScriptPubKeyMan
@@ -376,7 +376,7 @@ public:
     // Fetch the SigningProvider for the given pubkey and always include private keys. This should only be called by signing code.
     std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CPubKey& pubkey) const;
 
-    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override;
+    [[nodiscard]] bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override;
     SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
     std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed = nullptr) const override;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -662,9 +662,9 @@ public:
     OutputType TransactionChangeType(const std::optional<OutputType>& change_type, const std::vector<CRecipient>& vecSend) const;
 
     /** Fetch the inputs and sign with SIGHASH_ALL. */
-    bool SignTransaction(CMutableTransaction& tx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    [[nodiscard]] bool SignTransaction(CMutableTransaction& tx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     /** Sign the tx given the input coins and sighash. */
-    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const;
+    [[nodiscard]] bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const;
     SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const;
 
     /**


### PR DESCRIPTION
Legacy code often used a function signature of the form `bool Get...(const& in, mut& in_out);` to implement a getter that optionally returns a value.

In modern code, this can be replaced by `std::optional<_> Get...(const& in);`.

However, some legacy code remains. To ensure that the "imaginary optional" is not unwrapped when the getter returns false, add a C++17 `[[nodiscard]]` attribute to all those legacy functions.

There were only a few places that ignored the return value. I've fixed them in separate commits.

This should be easy to review via `--word-diff-regex=.` and then confirming that the attribute was added to such a getter.