### PR TITLE
doc: Clarify why performance-move-const-arg.CheckTriviallyCopyableMove=false

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -37,7 +37,7 @@ CheckOptions:
  - key: modernize-deprecated-headers.CheckHeaderFile
    value: false
  - key: performance-move-const-arg.CheckTriviallyCopyableMove
-   value: false
+   value: false  # Disabled, to allow the bugprone-use-after-move rule on trivially copyable types, to catch logic bugs
  - key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
    value: false
  - key: bugprone-unused-return-value.CheckedReturnTypes


### PR DESCRIPTION
Without this doc, there is a risk that the setting will be turned off, see https://github.com/bitcoin/bitcoin/pull/34514.

The reason to disable it is to catch logic bugs, even on trivially copyable types:

```cpp
#include <utility>
void Eat(int&& food) { food = 0; };
int main() {
  int food{2};
  Eat(std::move(food));
  Eat(std::move(food));  // This should err
}
```