### PR TITLE
test: Fix intermittent failure in `feature_assumevalid.py` by ensuring invalid block was processed before checking debug.log

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -164,6 +164,7 @@ class AssumeValidTest(BitcoinTestFramework):
             self.send_blocks_until_disconnected(p2p0)
             self.wait_until(lambda: self.nodes[0].getblockcount() >= COINBASE_MATURITY + 1)
             assert_equal(self.nodes[0].getblockcount(), COINBASE_MATURITY + 1)
+            self.wait_until(lambda: next(filter(lambda x: x["hash"] == self.blocks[-1].hash_hex, self.nodes[0].getchaintips()))["status"] == "invalid")
 
 
         # nodes[1]


### PR DESCRIPTION
Prior to merging a PR, I run 4 different build configurations and their tests in parallel, and consistently one of those will have `feature_assumevalid.py` fail. The failure is because the `assert_debug_log` context exits before the invalid block is processed, so the lines it is looking for don't appear in the part of the log that it is examining.

This PR should resolve that issue by waiting for `getchaintips` to report that the invalid chain is invalid before exiting the `assert_debug_log` context.