### PR TITLE
wallet: guard against negative bump fee discount from mempool race

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -800,7 +800,14 @@ util::Result<SelectionResult> ChooseSelectionResult(interfaces::Chain& chain, co
             return util::Error{_("Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.")};
         }
         CAmount bump_fee_overestimate = summed_bump_fees - combined_bump_fee.value();
-        if (bump_fee_overestimate) {
+        // Guard against negative values: the mempool state can change between the
+        // individual bump fee calculations (AvailableCoins) and the combined
+        // calculation here, since each MiniMiner only holds cs_main for its
+        // constructor.  If the combined fee ends up higher than the summed
+        // individual fees due to this race, the discount would be negative.
+        // In that case simply skip the discount — it is a waste-metric
+        // optimisation and not a correctness requirement.
+        if (bump_fee_overestimate > 0) {
             result.SetBumpFeeDiscount(bump_fee_overestimate);
         }
         result.RecalculateWaste(coin_selection_params.min_viable_change, coin_selection_params.m_cost_of_change, coin_selection_params.m_change_fee);


### PR DESCRIPTION
## Human View

The bump fee discount (`summed_bump_fees - combined_bump_fee`) can become negative when the mempool state changes between the two MiniMiner calculations. Each MiniMiner only holds `cs_main` for the duration of its constructor, so fee deltas, new transactions, or evictions in between cause the values to diverge.

When the combined fee exceeds the sum of individual fees, the difference is negative. The truthiness check `if (bump_fee_overestimate)` passes (non-zero), and `SetBumpFeeDiscount` hits `assert(discount >= 0)`, crashing the node.

**Fix:** Change the condition from `if (bump_fee_overestimate)` to `if (bump_fee_overestimate > 0)` so negative overestimates are simply skipped. The discount is a waste-metric optimisation, not a correctness requirement.

Fixes #34232

---

## AI View (DCCE Protocol v1.0)

### Metadata
- **Generator**: Claude (Anthropic) via Cursor IDE
- **Methodology**: AI-assisted development with human oversight and review

### AI Contribution Summary
- Solution design and implementation

### Verification Steps Performed
1. Reproduced the reported issue
2. Analyzed source code to identify root cause
3. Implemented and tested the fix

### Human Review Guidance
- Review the implementation for correctness and completeness
- Verify test coverage matches the described scenarios

Made with M7 [Cursor](https://cursor.com)
