### PR TITLE
wallet: resubmit transactions with private broadcast if enabled

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -27,6 +27,7 @@
 #include <key.h>
 #include <key_io.h>
 #include <logging.h>
+#include <net.h>
 #include <node/types.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
@@ -2180,9 +2181,15 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
 
 void MaybeResendWalletTxs(WalletContext& context)
 {
+    ArgsManager& args{*Assert(context.args)};
+    const node::TxBroadcast broadcast_method{
+        args.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)
+        ? node::TxBroadcast::NO_MEMPOOL_PRIVATE_BROADCAST
+        : node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL};
+
     for (const std::shared_ptr<CWallet>& pwallet : GetWallets(context)) {
         if (!pwallet->ShouldResend()) continue;
-        pwallet->ResubmitWalletTransactions(node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL, /*force=*/false);
+        pwallet->ResubmitWalletTransactions(broadcast_method, /*force=*/false);
         pwallet->SetNextResend();
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2070,7 +2070,6 @@ bool CWallet::SubmitTxMemoryPoolAndRelay(CWalletTx& wtx,
         what = "for private broadcast without adding to the mempool";
         break;
     }
-    WalletLogPrintf("Submitting wtx %s %s\n", wtx.GetHash().ToString(), what);
     // We must set TxStateInMempool here. Even though it will also be set later by the
     // entered-mempool callback, if we did not there would be a race where a
     // user could call sendmoney in a loop and hit spurious out of funds errors
@@ -2082,6 +2081,9 @@ bool CWallet::SubmitTxMemoryPoolAndRelay(CWalletTx& wtx,
     // TransactionRemovedFromMempool fires.
     bool ret = chain().broadcastTransaction(wtx.tx, m_default_max_tx_fee, broadcast_method, err_string);
     if (ret) wtx.m_state = TxStateInMempool{};
+    WalletLogPrintf("Submit of wallet transaction txid=%s wtxid=%s %s: %s\n",
+                    wtx.GetHash().ToString(), wtx.GetWitnessHash().ToString(), what,
+                    ret ? "ok" : err_string);
     return ret;
 }
 

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -25,8 +25,20 @@ RESEND_TIMER_LIMIT = 36 * 60 * 60
 
 
 class ResendWalletTransactionsTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        parser.add_argument("--privatebroadcast", action="store_true", dest="privatebroadcast",
+                            help="Run bitcoind with -privatebroadcast=1", default=False)
+
     def set_test_params(self):
-        self.num_nodes = 2
+        self.extra_args = [
+            [f"-privatebroadcast={1 if self.options.privatebroadcast else 0}"],
+            [],
+        ]
+        self.num_nodes = len(self.extra_args)
+        if self.options.privatebroadcast:
+            self.disable_autoconnect = False
+            # Make Tor look reachable and any attempts to connect to fail fast.
+            self.extra_args[0].append("-proxy=127.0.0.1:1")
         self.noban_tx_relay = True  # Needed due to mocktime
 
     def skip_test_if_missing_module(self):
@@ -76,11 +88,15 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         self.log.info("Bump time & check that transaction is rebroadcast")
         # Transaction should be rebroadcast approximately 24 hours in the future,
         # but can range from 12-36. So bump 36 hours to be sure.
-        with node.assert_debug_log(['resubmit 1 unconfirmed transactions']):
+        expected_msgs = ["resubmit 1 unconfirmed transactions"]
+        if self.options.privatebroadcast:
+            expected_msgs.append(f"Requesting 3 new connections due to txid={txid}")
+        with node.assert_debug_log(expected_msgs):
             node.setmocktime(now + RESEND_TIMER_LIMIT)
             # Tell scheduler to call MaybeResendWalletTxs now.
             node.mockscheduler(60)
-            peer_second.wait_for_broadcast([txid])
+            if not self.options.privatebroadcast:
+                peer_second.wait_for_broadcast([txid])
 
         self.log.info("Chain of unconfirmed not-in-mempool txs are rebroadcast")
         # This tests that the node broadcasts the parent transaction before the child transaction.
@@ -112,7 +128,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
             # Sometimes we will get a signature that is a little bit shorter than we expect which causes the
             # feerate to be a bit higher, then the followup to be a bit lower. This results in a replacement
             # that can't be broadcast. We can just skip that and keep grinding.
-            if try_rpc(-26, "insufficient fee, rejecting replacement", node.sendrawtransaction, bumped["hex"]):
+            if try_rpc(-26, "insufficient fee, rejecting replacement", node.submitpackage, [bumped["hex"]]):
                 continue
             # The scheduler queue creates a copy of the added tx after
             # send/bumpfee and re-adds it to the wallet (undoing the next
@@ -131,9 +147,19 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         # Set correct m_best_block_time, which is used in ResubmitWalletTransactions
         node.syncwithvalidationinterfacequeue()
 
+        # Let the scheduler run, we advanced the clock since last run. This will cause
+        # private broadcast's internal retry mechanism to pick and try to resend the parent
+        # transaction (txid). That will see the transaction is in the mempool and will
+        # give up resending it.
+        node.mockscheduler(60)
+
         evict_time = block_time + 60 * 60 * DEFAULT_MEMPOOL_EXPIRY_HOURS + 5
         # Flush out currently scheduled resubmit attempt now so that there can't be one right between eviction and check.
-        with node.assert_debug_log(['resubmit 2 unconfirmed transactions'], timeout=2):
+        expected_msgs = ["resubmit 2 unconfirmed transactions"]
+        if self.options.privatebroadcast:
+            expected_msgs.append(f"Requesting 3 new connections due to txid={txid}")
+            expected_msgs.append(f"Requesting 3 new connections due to txid={child_txid}")
+        with node.assert_debug_log(expected_msgs, timeout=2):
             node.setmocktime(evict_time)
             node.mockscheduler(60)
 
@@ -143,12 +169,20 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-5, "Transaction not in mempool", node.getmempoolentry, txid)
         assert_raises_rpc_error(-5, "Transaction not in mempool", node.getmempoolentry, child_txid)
 
-        # Rebroadcast and check that parent and child are both in the mempool
-        with node.assert_debug_log(['resubmit 2 unconfirmed transactions'], timeout=2):
+        # Rebroadcast and, if not private broadcast, check that parent and child are both in the mempool
+        expected_msgs = [
+            f"Submit of wallet transaction txid={txid}",
+            f"Submit of wallet transaction txid={child_txid}",
+            # If private broadcast is enabled, then child_txid is refused for broadcast because
+            # it is not acceptable in the mempool because the parent is not in the mempool.
+            f"resubmit {1 if self.options.privatebroadcast else 2} unconfirmed transactions",
+        ]
+        with node.assert_debug_log(expected_msgs, timeout=2):
             node.setmocktime(evict_time + RESEND_TIMER_LIMIT)
             node.mockscheduler(60)
-        node.getmempoolentry(txid)
-        node.getmempoolentry(child_txid)
+        if not self.options.privatebroadcast:
+            node.getmempoolentry(txid)
+            node.getmempoolentry(child_txid)
 
         self.log.info("Test rebroadcast of transactions received by others")
         # clear mempool


### PR DESCRIPTION
The wallet keeps track of transactions related to it and periodically rebroadcasts them every 12-36 hours if they are not mined.

If `-privatebroadcast=1` and a transaction is submitted locally with the `sendrawtransaction` RPC and it is related to the wallet, then the rebroadcasts would use the send-to-all method. Change that to use the private broadcast method.
