### PR TITLE
test: Fixup TODO comment in feature_dbcrash.py; remove unnecessary sleep

### DIFF
--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -76,8 +76,8 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
     def restart_node(self, node_index, expected_tip):
         """Start up a given node id, wait for the tip to reach the given block hash, and calculate the utxo hash.
 
-        Exceptions on startup should indicate node crash (due to -dbcrashratio), in which case we try again. Give up
-        after 60 seconds. Returns the utxo hash of the given node."""
+        Exceptions during startup or subsequent RPC calls should indicate a node crash (due to -dbcrashratio), in which case we try again. Give up
+        after a timeout. Returns the utxo hash of the given node."""
 
         time_start = time.time()
         while time.time() - time_start < 120:
@@ -93,12 +93,11 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
                 # should raise an exception if bitcoind doesn't exit.
                 self.wait_for_node_exit(node_index, timeout=10)
             self.crashed_on_restart += 1
-            time.sleep(1)
 
         # If we got here, bitcoind isn't coming back up on restart.  Could be a
         # bug in bitcoind, or we've gotten unlucky with our dbcrash ratio --
         # perhaps we generated a test case that blew up our cache?
-        # TODO: If this happens a lot, we should try to restart without -dbcrashratio
+        # If this happens, the test should try to restart without -dbcrashratio
         # and make sure that recovery happens.
         raise AssertionError(f"Unable to successfully restart node {node_index} in allotted time")
 


### PR DESCRIPTION
Fixup some stale comments:

* The `60 seconds` is outdated. It should say 120 seconds. However, just clarify that there is a timeout.
* The TODO seems to imply that a timeout (failure to restart) can happen. However, I don't think we've seen it happen. So there isn't anything to do right now. Just remove the `TODO`, but keep the advice.

Also, remove an unnecessary `time.sleep(1)`. If there is a need for it, a comment should explain why.