### PR TITLE
doc: Update Guix installation instructions for Debian/Ubuntu

### DIFF
--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -70,7 +70,7 @@ distros, please see: https://repology.org/project/guix/versions
 ### Debian / Ubuntu
 
 **Note:** As of early 2026, the `guix` package has been removed from Debian
-repositories and Ubuntu repositories will likely follow. See
+repositories and from Ubuntu 25.10 (Questing) and later. See
 https://lwn.net/Articles/1035491/ for details.
 
 Debian/Ubuntu users may use any other installation option mentioned in this document.

--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -69,13 +69,15 @@ distros, please see: https://repology.org/project/guix/versions
 
 ### Debian / Ubuntu
 
-Guix is available as a distribution package in various versions of [Debian
-](https://packages.debian.org/search?keywords=guix) and [Ubuntu
-](https://packages.ubuntu.com/search?keywords=guix).
+**Note:** As of early 2026, the `guix` package has been removed from Debian
+repositories and Ubuntu repositories will likely follow. See
+https://lwn.net/Articles/1035491/ for details.
 
-To install:
+Debian/Ubuntu users may use any other installation option mentioned in this document.
+
+If you previously installed `guix` via `apt`, you can remove it with:
 ```sh
-sudo apt install guix
+sudo apt purge guix
 ```
 
 ### Arch Linux


### PR DESCRIPTION
 The `guix` package was removed from Debian repositories due to security 
 vulnerabilities (CVE-2025-46415, CVE-2025-46416) affecting guix-daemon. 
 See https://lwn.net/Articles/1035491/
     
 Ubuntu and Debian derivatives will likely follow.
     
 Updates the Debian/Ubuntu section to warn users and redirect to alternative 
 installation methods already documented in the file.


 Fixes #33982
