### PR TITLE
ci: Extend diff context for clang-format

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -198,7 +198,7 @@ if [[ "${RUN_IWYU}" == true ]]; then
              -Xiwyu --check_also="*/primitives/*.h" \
              2>&1 | tee /tmp/iwyu_ci.out
     python3 "/include-what-you-use/fix_includes.py" --nosafe_headers < /tmp/iwyu_ci.out
-    git diff -U0 | ./contrib/devtools/clang-format-diff.py -binary="clang-format-${TIDY_LLVM_V}" -p1 -i -v
+    git diff -U1 | ./contrib/devtools/clang-format-diff.py -binary="clang-format-${TIDY_LLVM_V}" -p1 -i -v
   }
 
   run_iwyu "compile_commands_iwyu_errors.json"


### PR DESCRIPTION
This PR ensures `clang-format` can properly restore empty lines between header groups that were previously stripped by `fix_includes.py`.

Addresses [this](https://github.com/bitcoin/bitcoin/pull/34448#issuecomment-3876394168) comment.