### PR TITLE
build: avoid exporting secp256k1 symbols

### DIFF
--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -9,6 +9,11 @@ function(add_secp256k1 subdir)
   message("Configuring secp256k1 subtree...")
   set(BUILD_SHARED_LIBS OFF)
   set(CMAKE_EXPORT_COMPILE_COMMANDS OFF)
+
+  # Unconditionally prevent secp's symbols from being exported by our libs
+  set(CMAKE_C_VISIBILITY_PRESET hidden)
+  set(SECP256K1_ENABLE_API_VISIBILITY_ATTRIBUTES OFF CACHE BOOL "" FORCE)
+
   set(SECP256K1_ENABLE_MODULE_ECDH OFF CACHE BOOL "" FORCE)
   set(SECP256K1_ENABLE_MODULE_RECOVERY ON CACHE BOOL "" FORCE)
   set(SECP256K1_ENABLE_MODULE_MUSIG ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Take advantage of the [new secp256k1 option to avoid visibility attributes](https://github.com/bitcoin-core/secp256k1/pull/1696) on API functions.

While most users of a shared libsecp always want API functions exported so that they can actually be linked against, we always build it statically. When that static lib is linked into a (static or shared) libbitcoinkernel, by default its symbols end up exported there as well.

As libsecp is an implementation detail of the kernel (and any future Core lib), its symbols should never be exported.

[This was the intended use for the above PR](https://github.com/bitcoin-core/secp256k1/pull/1696#issuecomment-3028838988), looks like we just forgot to follow-up and actually hook it up.

This is most easily tested by building with `-DBUILD_KERNEL_LIB=ON -DBUILD_SHARED_LIBS=ON` (with or without `-DREDUCE_EXPORTS=ON`) and inspecting via:
```bash
nm -CD lib/libbitcoinkernel.so | grep secp
```

Before this change, secp's symbols will show up there. After, they should be absent.

This should finally solve secp symbol visibility once and for all :)