### PR TITLE
ci: split vcpkg tools cache into restore/save

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,11 +259,13 @@ jobs:
         run: |
           echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> "$GITHUB_ENV"
 
-      - name: vcpkg tools cache
-        uses: actions/cache@v5
+      - name: Restore vcpkg tools cache
+        id: vcpkg-tools-cache
+        uses: actions/cache/restore@v5
         with:
           path: C:/vcpkg/downloads/tools
-          key: ${{ github.job }}-vcpkg-tools
+          key: ${{ github.job }}-vcpkg-tools-${{ github.run_id }}
+          restore-keys: ${{ github.job }}-vcpkg-tools-
 
       - name: Restore vcpkg binary cache
         uses: actions/cache/restore@v4
@@ -282,6 +284,13 @@ jobs:
         with:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ github.job }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
+
+      - name: Save vcpkg tools cache
+        uses: actions/cache/save@v5
+        if: github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && steps.vcpkg-tools-cache.outputs.cache-hit != 'true'
+        with:
+          path: C:/vcpkg/downloads/tools
+          key: ${{ github.job }}-vcpkg-tools-${{ github.run_id }}
 
       - name: Build
         run: |


### PR DESCRIPTION
The vcpkg tools cache was using the combined actions/cache action, which by default saves on every run regardless of branch. Split it into the restore/save pattern used by the other caches, so that saves only happen on default branch pushes.

This will have little impact in bitcoin/bitcoin (which uses few branches), but on forks, if you don't update master branch frequently (which saves all caches), then all cache space will eventually be taken up by multiple vckpg tools caches, resulting in bad cache hit rates in all other jobs.