### PR TITLE
ThreadPool follow-ups, proactive shutdown and HasReason dependency cleanup

### DIFF
--- a/src/ipc/test/ipc_tests.cpp
+++ b/src/ipc/test/ipc_tests.cpp
@@ -5,6 +5,7 @@
 #include <ipc/process.h>
 #include <ipc/test/ipc_test.h>
 
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <arith_uint256.h>
-#include <test/util/setup_common.h>
+#include <test/util/common.h>
 #include <uint256.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -10,6 +10,7 @@
 #include <test/util/random.h>
 #include <test/util/txmempool.h>
 
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -12,6 +12,7 @@
 #include <node/miner.h>
 #include <pow.h>
 #include <test/util/blockfilter.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <test/data/blockfilters.json.h>
-#include <test/util/setup_common.h>
+#include <test/util/common.h>
 
 #include <blockfilter.h>
 #include <core_io.h>

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -14,6 +14,7 @@
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
+#include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
 

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -13,6 +13,7 @@
 #include <random.h>
 #include <serialize.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -6,6 +6,7 @@
 #include <clientversion.h>
 #include <coins.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/poolresourcetester.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -17,6 +17,7 @@
 #include <crypto/muhash.h>
 #include <random.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <dbwrapper.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -5,6 +5,7 @@
 #include <common/args.h>
 #include <common/settings.h>
 #include <logging.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
 #include <util/strencodings.h>

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -8,6 +8,7 @@
 #include <headerssync.h>
 #include <net_processing.h>
 #include <pow.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <httpserver.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -5,6 +5,7 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <script/solver.h>
 #include <validation.h>

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -9,6 +9,7 @@
 #include <span.h>
 #include <streams.h>
 #include <secp256k1_extrakeys.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -6,6 +6,7 @@
 #include <logging.h>
 #include <logging/timer.h>
 #include <scheduler.h>
+#include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/merkle.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 

--- a/src/test/merkleblock_tests.cpp
+++ b/src/test/merkleblock_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <merkleblock.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -25,6 +25,7 @@
 #include <versionbits.h>
 #include <pow.h>
 
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 
 #include <memory>

--- a/src/test/minisketch_tests.cpp
+++ b/src/test/minisketch_tests.cpp
@@ -5,6 +5,7 @@
 #include <minisketch.h>
 #include <node/minisketchwrapper.h>
 #include <random.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -9,6 +9,7 @@
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
 #include <tinyformat.h>

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -15,6 +15,7 @@
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/net.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -10,6 +10,7 @@
 #include <protocol.h>
 #include <serialize.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 #include <util/translation.h>

--- a/src/test/node_init_tests.cpp
+++ b/src/test/node_init_tests.cpp
@@ -7,6 +7,7 @@
 #include <rpc/server.h>
 
 #include <boost/test/unit_test.hpp>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 
 using node::NodeContext;

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -10,6 +10,7 @@
 #include <pubkey.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>

--- a/src/test/pcp_tests.cpp
+++ b/src/test/pcp_tests.cpp
@@ -5,6 +5,7 @@
 #include <common/pcp.h>
 #include <netbase.h>
 #include <test/util/logging.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/time.h>
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -6,6 +6,7 @@
 #include <chainparams.h>
 #include <pow.h>
 #include <test/util/random.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/chaintype.h>
 

--- a/src/test/rest_tests.cpp
+++ b/src/test/rest_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <rest.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <sync.h>
-#include <test/util/setup_common.h>
+#include <test/util/common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -9,6 +9,7 @@
 #include <rpc/client.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
 #include <util/time.h>

--- a/src/test/script_parse_tests.cpp
+++ b/src/test/script_parse_tests.cpp
@@ -5,7 +5,7 @@
 #include <core_io.h>
 #include <script/script.h>
 #include <util/strencodings.h>
-#include <test/util/setup_common.h>
+#include <test/util/common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -10,6 +10,7 @@
 #include <script/script.h>
 #include <script/signingprovider.h>
 #include <script/solver.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -19,6 +19,7 @@
 #include <streams.h>
 #include <test/util/json.h>
 #include <test/util/random.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
 #include <util/fs.h>
@@ -26,7 +27,6 @@
 #include <util/string.h>
 
 #include <cstdint>
-#include <fstream>
 #include <string>
 #include <vector>
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -5,6 +5,7 @@
 #include <hash.h>
 #include <serialize.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -11,6 +11,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <test/data/sighash.json.h>
+#include <test/util/common.h>
 #include <test/util/json.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <common/system.h>
 #include <compat/compat.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/sock.h>
 #include <util/threadinterrupt.h>

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -5,6 +5,7 @@
 #include <flatfile.h>
 #include <node/blockstorage.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/fs.h>

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <sync.h>
-#include <test/util/setup_common.h>
+#include <test/util/common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -6,6 +6,7 @@
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <common/run_command.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
 #include <util/string.h>

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -26,6 +26,7 @@
 #include <script/signingprovider.h>
 #include <script/solver.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/json.h>
 #include <test/util/random.h>
 #include <test/util/script.h>

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -8,6 +8,7 @@
 #include <node/txdownloadman_impl.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <validation.h>

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <index/txospenderindex.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -11,6 +11,7 @@
 #include <script/script.h>
 #include <serialize.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>

--- a/src/test/txreconciliation_tests.cpp
+++ b/src/test/txreconciliation_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <node/txreconciliation.h>
 
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -11,6 +11,7 @@
 #include <primitives/transaction.h>
 #include <random.h>
 #include <script/script.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/txmempool.h>
 #include <validation.h>

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <primitives/transaction_identifier.h>
 #include <streams.h>
-#include <test/util/setup_common.h>
+#include <test/util/common.h>
 #include <uint256.h>
 #include <util/strencodings.h>
 

--- a/src/test/util/common.h
+++ b/src/test/util/common.h
@@ -1,0 +1,39 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_COMMON_H
+#define BITCOIN_TEST_UTIL_COMMON_H
+
+#include <ostream>
+#include <optional>
+#include <string>
+
+// Make types usable in BOOST_CHECK_* @{
+namespace std {
+template <typename T> requires std::is_enum_v<T>
+inline std::ostream& operator<<(std::ostream& os, const T& e)
+{
+    return os << static_cast<std::underlying_type_t<T>>(e);
+}
+
+template <typename T>
+inline std::ostream& operator<<(std::ostream& os, const std::optional<T>& v)
+{
+    return v ? os << *v
+             : os << "std::nullopt";
+}
+} // namespace std
+
+template <typename T>
+concept HasToString = requires(const T& t) { t.ToString(); };
+
+template <HasToString T>
+inline std::ostream& operator<<(std::ostream& os, const T& obj)
+{
+    return os << obj.ToString();
+}
+
+// @}
+
+#endif // BITCOIN_TEST_UTIL_COMMON_H

--- a/src/test/util/common.h
+++ b/src/test/util/common.h
@@ -9,6 +9,22 @@
 #include <optional>
 #include <string>
 
+/**
+ * BOOST_CHECK_EXCEPTION predicates to check the specific validation error.
+ * Use as
+ * BOOST_CHECK_EXCEPTION(code that throws, exception type, HasReason("foo"));
+ */
+class HasReason
+{
+public:
+    explicit HasReason(std::string_view reason) : m_reason(reason) {}
+    bool operator()(std::string_view s) const { return s.find(m_reason) != std::string_view::npos; }
+    bool operator()(const std::exception& e) const { return (*this)(e.what()); }
+
+private:
+    const std::string m_reason;
+};
+
 // Make types usable in BOOST_CHECK_* @{
 namespace std {
 template <typename T> requires std::is_enum_v<T>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -620,26 +620,3 @@ CBlock getBlock13b8a()
     stream >> TX_WITH_WITNESS(block);
     return block;
 }
-
-std::ostream& operator<<(std::ostream& os, const arith_uint256& num)
-{
-    return os << num.ToString();
-}
-
-std::ostream& operator<<(std::ostream& os, const uint160& num)
-{
-    return os << num.ToString();
-}
-
-std::ostream& operator<<(std::ostream& os, const uint256& num)
-{
-    return os << num.ToString();
-}
-
-std::ostream& operator<<(std::ostream& os, const Txid& txid) {
-    return os << txid.ToString();
-}
-
-std::ostream& operator<<(std::ostream& os, const Wtxid& wtxid) {
-    return os << wtxid.ToString();
-}

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -261,20 +261,4 @@ std::unique_ptr<T> MakeNoLogFileContext(const ChainType chain_type = ChainType::
 
 CBlock getBlock13b8a();
 
-/**
- * BOOST_CHECK_EXCEPTION predicates to check the specific validation error.
- * Use as
- * BOOST_CHECK_EXCEPTION(code that throws, exception type, HasReason("foo"));
- */
-class HasReason
-{
-public:
-    explicit HasReason(std::string_view reason) : m_reason(reason) {}
-    bool operator()(std::string_view s) const { return s.find(m_reason) != std::string_view::npos; }
-    bool operator()(const std::exception& e) const { return (*this)(e.what()); }
-
-private:
-    const std::string m_reason;
-};
-
 #endif // BITCOIN_TEST_UTIL_SETUP_COMMON_H

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -261,29 +261,6 @@ std::unique_ptr<T> MakeNoLogFileContext(const ChainType chain_type = ChainType::
 
 CBlock getBlock13b8a();
 
-// Make types usable in BOOST_CHECK_* @{
-namespace std {
-template <typename T> requires std::is_enum_v<T>
-inline std::ostream& operator<<(std::ostream& os, const T& e)
-{
-    return os << static_cast<std::underlying_type_t<T>>(e);
-}
-
-template <typename T>
-inline std::ostream& operator<<(std::ostream& os, const std::optional<T>& v)
-{
-    return v ? os << *v
-             : os << "std::nullopt";
-}
-} // namespace std
-
-std::ostream& operator<<(std::ostream& os, const arith_uint256& num);
-std::ostream& operator<<(std::ostream& os, const uint160& num);
-std::ostream& operator<<(std::ostream& os, const uint256& num);
-std::ostream& operator<<(std::ostream& os, const Txid& txid);
-std::ostream& operator<<(std::ostream& os, const Wtxid& wtxid);
-// @}
-
 /**
  * BOOST_CHECK_EXCEPTION predicates to check the specific validation error.
  * Use as

--- a/src/test/util_check_tests.cpp
+++ b/src/test/util_check_tests.cpp
@@ -5,7 +5,7 @@
 #include <util/check.h>
 
 #include <boost/test/unit_test.hpp>
-#include <test/util/setup_common.h>
+#include <test/util/common.h>
 
 BOOST_AUTO_TEST_SUITE(util_check_tests)
 

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <test/util/common.h>
-#include <test/util/setup_common.h>
+#include <tinyformat.h>
 
 using namespace util;
 using util::detail::CheckNumFormatSpecifiers;

--- a/src/test/util_string_tests.cpp
+++ b/src/test/util_string_tests.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 
 using namespace util;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -9,6 +9,7 @@
 #include <script/parsing.h>
 #include <span.h>
 #include <sync.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -10,6 +10,7 @@
 #include <node/miner.h>
 #include <pow.h>
 #include <random.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -11,6 +11,7 @@
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/chainstate.h>
+#include <test/util/common.h>
 #include <test/util/coins.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -12,6 +12,7 @@
 #include <rpc/blockchain.h>
 #include <sync.h>
 #include <test/util/chainstate.h>
+#include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -5,6 +5,7 @@
 #include <sync.h>
 #include <test/util/coins.h>
 #include <test/util/random.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -6,6 +6,7 @@
 #include <chainparams.h>
 #include <consensus/params.h>
 #include <test/util/random.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/chaintype.h>
 #include <versionbits.h>

--- a/src/util/threadpool.h
+++ b/src/util/threadpool.h
@@ -105,8 +105,8 @@ public:
     {
         assert(num_workers > 0);
         LOCK(m_mutex);
+        if (m_interrupt) throw std::runtime_error("Thread pool has been interrupted or is stopping");
         if (!m_workers.empty()) throw std::runtime_error("Thread pool already started");
-        m_interrupt = false; // Reset
 
         // Create workers
         m_workers.reserve(num_workers);
@@ -122,6 +122,7 @@ public:
      * Any remaining tasks in the queue will be processed before returning.
      *
      * Must be called from a controller (non-worker) thread.
+     * Concurrent calls to Start() will be rejected while Stop() is in progress.
      */
     void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
@@ -139,9 +140,12 @@ public:
         }
         m_cv.notify_all();
         for (auto& worker : threads_to_join) worker.join();
+
         // Since we currently wait for tasks completion, sanity-check empty queue
-        WITH_LOCK(m_mutex, Assume(m_work_queue.empty()));
-        // Note: m_interrupt is left true until next Start()
+        LOCK(m_mutex);
+        Assume(m_work_queue.empty());
+        // Re-allow Start() now that all workers have exited
+        m_interrupt = false;
     }
 
     enum class SubmitError {
@@ -202,6 +206,10 @@ public:
      *
      * Wakes all worker threads so they can drain the queue and exit.
      * Unlike Stop(), this function does not wait for threads to finish.
+     *
+     * Note: The next step in the pool lifecycle is calling Stop(), which
+     *       releases any dangling resources and resets the pool state
+     *       for shutdown or restart.
      */
     void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -7,6 +7,7 @@
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <random.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
 #include <util/fs.h>
@@ -14,7 +15,6 @@
 #include <wallet/walletutil.h>
 
 #include <cstddef>
-#include <fstream>
 #include <memory>
 #include <span>
 #include <string>

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -17,6 +17,7 @@
 #include <policy/policy.h>
 #include <rpc/server.h>
 #include <script/solver.h>
+#include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>

--- a/src/wallet/test/wallet_transaction_tests.cpp
+++ b/src/wallet/test/wallet_transaction_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/transaction.h>
 
+#include <test/util/common.h>
 #include <wallet/test/wallet_test_fixture.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
+#include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
 

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -191,7 +191,7 @@ class AuthServiceProxy():
         content_type = http_response.getheader('Content-Type')
         if content_type != 'application/json':
             raise JSONRPCException(
-                {'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)},
+                {'code': -342, 'message': f"non-JSON HTTP response with \'{http_response.status} {http_response.reason}\' from server: {http_response.read().decode()}"},
                 http_response.status)
 
         data = http_response.read()


### PR DESCRIPTION
A few follow-ups to #33689, includes:

1) `ThreadPool` active-wait during shutdown:
Instead of just waiting for workers to finish processing tasks, `Stop()` now helps them actively.
This speeds up the JSON-RPC and REST server shutdown, resulting in a faster node shutdown when many requests remain unhandled. This wasn't included in the original PR due to the behavior change this introduces.

2) Decouple `HasReason` from the unit test framework machinery
This avoids providing the entire unit test framework dependency to low-level tests that only require access to the `HasReason` utility class. Examples are: `reverselock_tests.cpp`, `sync_tests.cpp`, `util_check_tests.cpp`, `util_string_tests.cpp`, `script_parse_tests.cpp` and `threadpool_tests.cpp`. These tests no longer gain access to unnecessary components like the chainstate, node context, caches, etc. It includes l0rinc's `threadpool_tests.cpp` `HasReason` changes.

3) Include response body in non-JSON HTTP error messages
Straight from pinheadmz [comment](https://github.com/bitcoin/bitcoin/pull/33689#discussion_r2783817192), it makes debugging CI issues easier.