### PR TITLE
COPYING: Correct start date for "The Bitcoin Core developers" copyright line

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2009-2026 The Bitcoin Core developers
+Copyright (c) 2014-2026 The Bitcoin Core developers
 Copyright (c) 2009-2026 Bitcoin Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
## Summary

Corrects `2009` → `2014` for "The Bitcoin Core developers" in the COPYING file,
reflecting when that project name came into use.

Closes #34563

## Change

**Before:**
```
Copyright (c) 2009-2026 The Bitcoin Core developers
Copyright (c) 2009-2026 Bitcoin Developers
```

**After:**
```
Copyright (c) 2014-2026 The Bitcoin Core developers
Copyright (c) 2009-2026 Bitcoin Developers
```

## Rationale

The git history shows:
- Satoshi replaced his own name with "Bitcoin Developers" in his final v0.3.19
  release (Dec 2010, `fc73ad644f0b`)
- The project was known as "Bitcoin" with "Bitcoin Developers" until the v0.9.0
  rebrand to "Bitcoin Core" (March 2014; see #3203, #3408)
- In 2015, `3b00e7c23164` replaced "Bitcoin Developers" with "The Bitcoin Core
  developers" and backdated it to 2009
- #11318 (gmaxwell, 2017) partially addressed this by restoring "Bitcoin
  Developers" as a second line — sipa identified `3b00e7c` as having introduced
  the naming error. However, the start date was not corrected

This is a single-number fix consistent with the project's preference for
accurate copyright notices, as demonstrated by #11318. No change to the license
text itself.

This change reflects historical naming, not contributor scope — early
contributors' work is fully covered under "Bitcoin Developers."