### PR TITLE
refactor: extract BlockDownloadManager from PeerManagerImpl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,6 +214,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   net_processing.cpp
   netgroup.cpp
   node/abort.cpp
+  node/blockdownloadman_impl.cpp
   node/blockmanager_args.cpp
   node/blockstorage.cpp
   node/caches.cpp

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -34,6 +34,7 @@
 #include <node/connection_types.h>
 #include <node/protocol_version.h>
 #include <node/timeoffsets.h>
+#include <node/blockdownloadman.h>
 #include <node/txdownloadman.h>
 #include <node/txorphanage.h>
 #include <node/txreconciliation.h>
@@ -126,32 +127,18 @@ static const unsigned int MAX_LOCATOR_SZ = 101;
 static const unsigned int MAX_INV_SZ = 50000;
 /** Limit to avoid sending big packets. Not used in processing incoming GETDATA for compatibility */
 static const unsigned int MAX_GETDATA_SZ = 1000;
-/** Number of blocks that can be requested at any given time from a single peer. */
-static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
-/** Default time during which a peer must stall block download progress before being disconnected.
- * the actual timeout is increased temporarily if peers are disconnected for hitting the timeout */
-static constexpr auto BLOCK_STALLING_TIMEOUT_DEFAULT{2s};
-/** Maximum timeout for stalling block download. */
-static constexpr auto BLOCK_STALLING_TIMEOUT_MAX{64s};
 /** Maximum depth of blocks we're willing to serve as compact blocks to peers
  *  when requested. For older blocks, a regular BLOCK response will be sent. */
 static const int MAX_CMPCTBLOCK_DEPTH = 5;
 /** Maximum depth of blocks we're willing to respond to GETBLOCKTXN requests for. */
 static const int MAX_BLOCKTXN_DEPTH = 10;
 static_assert(MAX_BLOCKTXN_DEPTH <= MIN_BLOCKS_TO_KEEP, "MAX_BLOCKTXN_DEPTH too high");
-/** Size of the "block download window": how far ahead of our current height do we fetch?
- *  Larger windows tolerate larger download speed differences between peer, but increase the potential
- *  degree of disordering of blocks on disk (which make reindexing and pruning harder). We'll probably
- *  want to make this a per-peer adaptive value at some point. */
-static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 /** Block download timeout base, expressed in multiples of the block interval (i.e. 10 min) */
 static constexpr double BLOCK_DOWNLOAD_TIMEOUT_BASE = 1;
 /** Additional block download timeout per parallel downloading peer (i.e. 5 min) */
 static constexpr double BLOCK_DOWNLOAD_TIMEOUT_PER_PEER = 0.5;
 /** Maximum number of headers to announce when relaying blocks with headers message.*/
 static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
-/** Minimum blocks required to signal NODE_NETWORK_LIMITED */
-static const unsigned int NODE_NETWORK_LIMITED_MIN_BLOCKS = 288;
 /** Window, in blocks, for connecting to NODE_NETWORK_LIMITED peers */
 static const unsigned int NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS = 144;
 /** Average delay between local address broadcasts */
@@ -202,13 +189,6 @@ static constexpr auto PRIVATE_BROADCAST_MAX_CONNECTION_LIFETIME{3min};
 
 // Internal stuff
 namespace {
-/** Blocks that are in flight, and that are in the queue to be downloaded. */
-struct QueuedBlock {
-    /** BlockIndex. We must have this since we only request blocks when we've already validated the header. */
-    const CBlockIndex* pindex;
-    /** Optional, used for CMPCTBLOCK downloads */
-    std::unique_ptr<PartiallyDownloadedBlock> partialBlock;
-};
 
 /**
  * Data structure for an individual peer. This struct is not protected by
@@ -435,23 +415,6 @@ using PeerRef = std::shared_ptr<Peer>;
  * and we're no longer holding the node's locks.
  */
 struct CNodeState {
-    //! The best known block we know this peer has announced.
-    const CBlockIndex* pindexBestKnownBlock{nullptr};
-    //! The hash of the last unknown block this peer has announced.
-    uint256 hashLastUnknownBlock{};
-    //! The last full block we both have.
-    const CBlockIndex* pindexLastCommonBlock{nullptr};
-    //! The best header we have sent our peer.
-    const CBlockIndex* pindexBestHeaderSent{nullptr};
-    //! Whether we've started headers synchronization with this peer.
-    bool fSyncStarted{false};
-    //! Since when we're stalling block download progress (in microseconds), or 0.
-    std::chrono::microseconds m_stalling_since{0us};
-    std::list<QueuedBlock> vBlocksInFlight;
-    //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
-    std::chrono::microseconds m_downloading_since{0us};
-    //! Whether we consider this a preferred download peer.
-    bool fPreferredDownload{false};
     /** Whether this peer wants invs or cmpctblocks (when possible) for block announcements. */
     bool m_requested_hb_cmpctblocks{false};
     /** Whether this peer will send us cmpctblocks if we request them. */
@@ -785,6 +748,10 @@ private:
     Mutex m_tx_download_mutex ACQUIRED_BEFORE(m_mempool.cs);
     node::TxDownloadManager m_txdownloadman GUARDED_BY(m_tx_download_mutex);
 
+    /** Tracks block download state: in-flight blocks, request scheduling, stalling detection.
+     *  Synchronized by cs_main. */
+    node::BlockDownloadManager m_blockdownloadman;
+
     std::unique_ptr<TxReconciliationTracker> m_txreconciliation;
 
     /** The height of the best chain */
@@ -829,31 +796,14 @@ private:
 
     std::map<uint64_t, std::chrono::microseconds> m_next_inv_to_inbounds_per_network_key GUARDED_BY(g_msgproc_mutex);
 
-    /** Number of nodes with fSyncStarted. */
-    int nSyncStarted GUARDED_BY(cs_main) = 0;
-
     /** Hash of the last block we received via INV */
     uint256 m_last_block_inv_triggering_headers_sync GUARDED_BY(g_msgproc_mutex){};
-
-    /**
-     * Sources of received blocks, saved to be able punish them when processing
-     * happens afterwards.
-     * Set mapBlockSource[hash].second to false if the node should not be
-     * punished if the block is invalid.
-     */
-    std::map<uint256, std::pair<NodeId, bool>> mapBlockSource GUARDED_BY(cs_main);
 
     /** Number of peers with wtxid relay. */
     std::atomic<int> m_wtxid_relay_peers{0};
 
     /** Number of outbound peers with m_chain_sync.m_protect. */
     int m_outbound_peers_with_protect_from_disconnect GUARDED_BY(cs_main) = 0;
-
-    /** Number of preferable block download peers. */
-    int m_num_preferred_download_peers GUARDED_BY(cs_main){0};
-
-    /** Stalling timeout for blocks in IBD */
-    std::atomic<std::chrono::seconds> m_block_stalling_timeout{BLOCK_STALLING_TIMEOUT_DEFAULT};
 
     /**
      * For sending `inv`s to inbound peers, we use a single (exponentially
@@ -895,73 +845,6 @@ private:
     /** Height of the highest block announced using BIP 152 high-bandwidth mode. */
     int m_highest_fast_announce GUARDED_BY(::cs_main){0};
 
-    /** Have we requested this block from a peer */
-    bool IsBlockRequested(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
-    /** Have we requested this block from an outbound peer */
-    bool IsBlockRequestedFromOutbound(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_peer_mutex);
-
-    /** Remove this block from our tracked requested blocks. Called if:
-     *  - the block has been received from a peer
-     *  - the request for the block has timed out
-     * If "from_peer" is specified, then only remove the block if it is in
-     * flight from that peer (to avoid one peer's network traffic from
-     * affecting another's state).
-     */
-    void RemoveBlockRequest(const uint256& hash, std::optional<NodeId> from_peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
-    /* Mark a block as in flight
-     * Returns false, still setting pit, if the block was already in flight from the same peer
-     * pit will only be valid as long as the same cs_main lock is being held
-     */
-    bool BlockRequested(NodeId nodeid, const CBlockIndex& block, std::list<QueuedBlock>::iterator** pit = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
-    bool TipMayBeStale() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
-    /** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
-     *  at most count entries.
-     */
-    void FindNextBlocksToDownload(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
-    /** Request blocks for the background chainstate, if one is in use. */
-    void TryDownloadingHistoricalBlocks(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, const CBlockIndex* from_tip, const CBlockIndex* target_block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
-    /**
-    * \brief Find next blocks to download from a peer after a starting block.
-    *
-    * \param vBlocks      Vector of blocks to download which will be appended to.
-    * \param peer         Peer which blocks will be downloaded from.
-    * \param state        Pointer to the state of the peer.
-    * \param pindexWalk   Pointer to the starting block to add to vBlocks.
-    * \param count        Maximum number of blocks to allow in vBlocks. No more
-    *                     blocks will be added if it reaches this size.
-    * \param nWindowEnd   Maximum height of blocks to allow in vBlocks. No
-    *                     blocks will be added above this height.
-    * \param activeChain  Optional pointer to a chain to compare against. If
-    *                     provided, any next blocks which are already contained
-    *                     in this chain will not be appended to vBlocks, but
-    *                     instead will be used to update the
-    *                     state->pindexLastCommonBlock pointer.
-    * \param nodeStaller  Optional pointer to a NodeId variable that will receive
-    *                     the ID of another peer that might be causing this peer
-    *                     to stall. This is set to the ID of the peer which
-    *                     first requested the first in-flight block in the
-    *                     download window. It is only set if vBlocks is empty at
-    *                     the end of this function call and if increasing
-    *                     nWindowEnd by 1 would cause it to be non-empty (which
-    *                     indicates the download might be stalled because every
-    *                     block in the window is in flight and no other peer is
-    *                     trying to download the next block).
-    */
-    void FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, const Peer& peer, CNodeState *state, const CBlockIndex *pindexWalk, unsigned int count, int nWindowEnd, const CChain* activeChain=nullptr, NodeId* nodeStaller=nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
-    /* Multimap used to preserve insertion order */
-    typedef std::multimap<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator>> BlockDownloadMap;
-    BlockDownloadMap mapBlocksInFlight GUARDED_BY(cs_main);
-
-    /** When our tip was last updated. */
-    std::atomic<std::chrono::seconds> m_last_tip_update{0s};
-
     /** Determine whether or not a peer can request a transaction, and return it (or nullptr if not found or not allowed). */
     CTransactionRef FindTxForGetData(const Peer::TxRelay& tx_relay, const GenTxid& gtxid)
         EXCLUSIVE_LOCKS_REQUIRED(!m_most_recent_block_mutex, !tx_relay.m_tx_inventory_mutex);
@@ -996,9 +879,6 @@ private:
     /** Stack of nodes which we have set to announce using compact blocks */
     std::list<NodeId> lNodesAnnouncingHeaderAndIDs GUARDED_BY(cs_main);
 
-    /** Number of peers from which we're downloading blocks. */
-    int m_peers_downloading_from GUARDED_BY(cs_main) = 0;
-
     void AddToCompactExtraTransactions(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(g_msgproc_mutex);
 
     /** Orphan/conflicted/etc transactions that are kept for compact block reconstruction.
@@ -1008,10 +888,6 @@ private:
     /** Offset into vExtraTxnForCompact to insert the next tx */
     size_t vExtraTxnForCompactIt GUARDED_BY(g_msgproc_mutex) = 0;
 
-    /** Check whether the last unknown block a peer advertised is not yet known. */
-    void ProcessBlockAvailability(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    /** Update tracking information about which blocks a peer is assumed to have. */
-    void UpdateBlockAvailability(NodeId nodeid, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool CanDirectFetch() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
@@ -1192,95 +1068,6 @@ std::chrono::microseconds PeerManagerImpl::NextInvToInbounds(std::chrono::micros
     return timer;
 }
 
-bool PeerManagerImpl::IsBlockRequested(const uint256& hash)
-{
-    return mapBlocksInFlight.contains(hash);
-}
-
-bool PeerManagerImpl::IsBlockRequestedFromOutbound(const uint256& hash)
-{
-    for (auto range = mapBlocksInFlight.equal_range(hash); range.first != range.second; range.first++) {
-        auto [nodeid, block_it] = range.first->second;
-        PeerRef peer{GetPeerRef(nodeid)};
-        if (peer && !peer->m_is_inbound) return true;
-    }
-
-    return false;
-}
-
-void PeerManagerImpl::RemoveBlockRequest(const uint256& hash, std::optional<NodeId> from_peer)
-{
-    auto range = mapBlocksInFlight.equal_range(hash);
-    if (range.first == range.second) {
-        // Block was not requested from any peer
-        return;
-    }
-
-    // We should not have requested too many of this block
-    Assume(mapBlocksInFlight.count(hash) <= MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK);
-
-    while (range.first != range.second) {
-        const auto& [node_id, list_it]{range.first->second};
-
-        if (from_peer && *from_peer != node_id) {
-            range.first++;
-            continue;
-        }
-
-        CNodeState& state = *Assert(State(node_id));
-
-        if (state.vBlocksInFlight.begin() == list_it) {
-            // First block on the queue was received, update the start download time for the next one
-            state.m_downloading_since = std::max(state.m_downloading_since, GetTime<std::chrono::microseconds>());
-        }
-        state.vBlocksInFlight.erase(list_it);
-
-        if (state.vBlocksInFlight.empty()) {
-            // Last validated block on the queue for this peer was received.
-            m_peers_downloading_from--;
-        }
-        state.m_stalling_since = 0us;
-
-        range.first = mapBlocksInFlight.erase(range.first);
-    }
-}
-
-bool PeerManagerImpl::BlockRequested(NodeId nodeid, const CBlockIndex& block, std::list<QueuedBlock>::iterator** pit)
-{
-    const uint256& hash{block.GetBlockHash()};
-
-    CNodeState *state = State(nodeid);
-    assert(state != nullptr);
-
-    Assume(mapBlocksInFlight.count(hash) <= MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK);
-
-    // Short-circuit most stuff in case it is from the same node
-    for (auto range = mapBlocksInFlight.equal_range(hash); range.first != range.second; range.first++) {
-        if (range.first->second.first == nodeid) {
-            if (pit) {
-                *pit = &range.first->second.second;
-            }
-            return false;
-        }
-    }
-
-    // Make sure it's not being fetched already from same peer.
-    RemoveBlockRequest(hash, nodeid);
-
-    std::list<QueuedBlock>::iterator it = state->vBlocksInFlight.insert(state->vBlocksInFlight.end(),
-            {&block, std::unique_ptr<PartiallyDownloadedBlock>(pit ? new PartiallyDownloadedBlock(&m_mempool) : nullptr)});
-    if (state->vBlocksInFlight.size() == 1) {
-        // We're starting a block download (batch) from this peer.
-        state->m_downloading_since = GetTime<std::chrono::microseconds>();
-        m_peers_downloading_from++;
-    }
-    auto itInFlight = mapBlocksInFlight.insert(std::make_pair(hash, std::make_pair(nodeid, it)));
-    if (pit) {
-        *pit = &itInFlight->second.second;
-    }
-    return true;
-}
-
 void PeerManagerImpl::MaybeSetPeerAsAnnouncingHeaderAndIDs(NodeId nodeid)
 {
     AssertLockHeld(cs_main);
@@ -1340,16 +1127,6 @@ void PeerManagerImpl::MaybeSetPeerAsAnnouncingHeaderAndIDs(NodeId nodeid)
     }
 }
 
-bool PeerManagerImpl::TipMayBeStale()
-{
-    AssertLockHeld(cs_main);
-    const Consensus::Params& consensusParams = m_chainparams.GetConsensus();
-    if (m_last_tip_update.load() == 0s) {
-        m_last_tip_update = GetTime<std::chrono::seconds>();
-    }
-    return m_last_tip_update.load() < GetTime<std::chrono::seconds>() - std::chrono::seconds{consensusParams.nPowTargetSpacing * 3} && mapBlocksInFlight.empty();
-}
-
 int64_t PeerManagerImpl::ApproximateBestBlockDepth() const
 {
     return (GetTime<std::chrono::seconds>() - m_best_block_time.load()).count() / m_chainparams.GetConsensus().nPowTargetSpacing;
@@ -1358,200 +1135,6 @@ int64_t PeerManagerImpl::ApproximateBestBlockDepth() const
 bool PeerManagerImpl::CanDirectFetch()
 {
     return m_chainman.ActiveChain().Tip()->Time() > NodeClock::now() - m_chainparams.GetConsensus().PowTargetSpacing() * 20;
-}
-
-static bool PeerHasHeader(CNodeState *state, const CBlockIndex *pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
-{
-    if (state->pindexBestKnownBlock && pindex == state->pindexBestKnownBlock->GetAncestor(pindex->nHeight))
-        return true;
-    if (state->pindexBestHeaderSent && pindex == state->pindexBestHeaderSent->GetAncestor(pindex->nHeight))
-        return true;
-    return false;
-}
-
-void PeerManagerImpl::ProcessBlockAvailability(NodeId nodeid) {
-    CNodeState *state = State(nodeid);
-    assert(state != nullptr);
-
-    if (!state->hashLastUnknownBlock.IsNull()) {
-        const CBlockIndex* pindex = m_chainman.m_blockman.LookupBlockIndex(state->hashLastUnknownBlock);
-        if (pindex && pindex->nChainWork > 0) {
-            if (state->pindexBestKnownBlock == nullptr || pindex->nChainWork >= state->pindexBestKnownBlock->nChainWork) {
-                state->pindexBestKnownBlock = pindex;
-            }
-            state->hashLastUnknownBlock.SetNull();
-        }
-    }
-}
-
-void PeerManagerImpl::UpdateBlockAvailability(NodeId nodeid, const uint256 &hash) {
-    CNodeState *state = State(nodeid);
-    assert(state != nullptr);
-
-    ProcessBlockAvailability(nodeid);
-
-    const CBlockIndex* pindex = m_chainman.m_blockman.LookupBlockIndex(hash);
-    if (pindex && pindex->nChainWork > 0) {
-        // An actually better block was announced.
-        if (state->pindexBestKnownBlock == nullptr || pindex->nChainWork >= state->pindexBestKnownBlock->nChainWork) {
-            state->pindexBestKnownBlock = pindex;
-        }
-    } else {
-        // An unknown block was announced; just assume that the latest one is the best one.
-        state->hashLastUnknownBlock = hash;
-    }
-}
-
-// Logic for calculating which blocks to download from a given peer, given our current tip.
-void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller)
-{
-    if (count == 0)
-        return;
-
-    vBlocks.reserve(vBlocks.size() + count);
-    CNodeState *state = State(peer.m_id);
-    assert(state != nullptr);
-
-    // Make sure pindexBestKnownBlock is up to date, we'll need it.
-    ProcessBlockAvailability(peer.m_id);
-
-    if (state->pindexBestKnownBlock == nullptr || state->pindexBestKnownBlock->nChainWork < m_chainman.ActiveChain().Tip()->nChainWork || state->pindexBestKnownBlock->nChainWork < m_chainman.MinimumChainWork()) {
-        // This peer has nothing interesting.
-        return;
-    }
-
-    // When syncing with AssumeUtxo and the snapshot has not yet been validated,
-    // abort downloading blocks from peers that don't have the snapshot block in their best chain.
-    // We can't reorg to this chain due to missing undo data until validation completes,
-    // so downloading blocks from it would be futile.
-    const CBlockIndex* snap_base{m_chainman.CurrentChainstate().SnapshotBase()};
-    if (snap_base && m_chainman.CurrentChainstate().m_assumeutxo == Assumeutxo::UNVALIDATED &&
-        state->pindexBestKnownBlock->GetAncestor(snap_base->nHeight) != snap_base) {
-        LogDebug(BCLog::NET, "Not downloading blocks from peer=%d, which doesn't have the snapshot block in its best chain.\n", peer.m_id);
-        return;
-    }
-
-    // Determine the forking point between the peer's chain and our chain:
-    // pindexLastCommonBlock is required to be an ancestor of pindexBestKnownBlock, and will be used as a starting point.
-    // It is being set to the fork point between the peer's best known block and the current tip, unless it is already set to
-    // an ancestor with more work than the fork point.
-    auto fork_point = LastCommonAncestor(state->pindexBestKnownBlock, m_chainman.ActiveTip());
-    if (state->pindexLastCommonBlock == nullptr ||
-        fork_point->nChainWork > state->pindexLastCommonBlock->nChainWork ||
-        state->pindexBestKnownBlock->GetAncestor(state->pindexLastCommonBlock->nHeight) != state->pindexLastCommonBlock) {
-        state->pindexLastCommonBlock = fork_point;
-    }
-    if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
-        return;
-
-    const CBlockIndex *pindexWalk = state->pindexLastCommonBlock;
-    // Never fetch further than the best block we know the peer has, or more than BLOCK_DOWNLOAD_WINDOW + 1 beyond the last
-    // linked block we have in common with this peer. The +1 is so we can detect stalling, namely if we would be able to
-    // download that next block if the window were 1 larger.
-    int nWindowEnd = state->pindexLastCommonBlock->nHeight + BLOCK_DOWNLOAD_WINDOW;
-
-    FindNextBlocks(vBlocks, peer, state, pindexWalk, count, nWindowEnd, &m_chainman.ActiveChain(), &nodeStaller);
-}
-
-void PeerManagerImpl::TryDownloadingHistoricalBlocks(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, const CBlockIndex *from_tip, const CBlockIndex* target_block)
-{
-    Assert(from_tip);
-    Assert(target_block);
-
-    if (vBlocks.size() >= count) {
-        return;
-    }
-
-    vBlocks.reserve(count);
-    CNodeState *state = Assert(State(peer.m_id));
-
-    if (state->pindexBestKnownBlock == nullptr || state->pindexBestKnownBlock->GetAncestor(target_block->nHeight) != target_block) {
-        // This peer can't provide us the complete series of blocks leading up to the
-        // assumeutxo snapshot base.
-        //
-        // Presumably this peer's chain has less work than our ActiveChain()'s tip, or else we
-        // will eventually crash when we try to reorg to it. Let other logic
-        // deal with whether we disconnect this peer.
-        //
-        // TODO at some point in the future, we might choose to request what blocks
-        // this peer does have from the historical chain, despite it not having a
-        // complete history beneath the snapshot base.
-        return;
-    }
-
-    FindNextBlocks(vBlocks, peer, state, from_tip, count, std::min<int>(from_tip->nHeight + BLOCK_DOWNLOAD_WINDOW, target_block->nHeight));
-}
-
-void PeerManagerImpl::FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, const Peer& peer, CNodeState *state, const CBlockIndex *pindexWalk, unsigned int count, int nWindowEnd, const CChain* activeChain, NodeId* nodeStaller)
-{
-    std::vector<const CBlockIndex*> vToFetch;
-    int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
-    bool is_limited_peer = IsLimitedPeer(peer);
-    NodeId waitingfor = -1;
-    while (pindexWalk->nHeight < nMaxHeight) {
-        // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
-        // pindexBestKnownBlock) into vToFetch. We fetch 128, because CBlockIndex::GetAncestor may be as expensive
-        // as iterating over ~100 CBlockIndex* entries anyway.
-        int nToFetch = std::min(nMaxHeight - pindexWalk->nHeight, std::max<int>(count - vBlocks.size(), 128));
-        vToFetch.resize(nToFetch);
-        pindexWalk = state->pindexBestKnownBlock->GetAncestor(pindexWalk->nHeight + nToFetch);
-        vToFetch[nToFetch - 1] = pindexWalk;
-        for (unsigned int i = nToFetch - 1; i > 0; i--) {
-            vToFetch[i - 1] = vToFetch[i]->pprev;
-        }
-
-        // Iterate over those blocks in vToFetch (in forward direction), adding the ones that
-        // are not yet downloaded and not in flight to vBlocks. In the meantime, update
-        // pindexLastCommonBlock as long as all ancestors are already downloaded, or if it's
-        // already part of our chain (and therefore don't need it even if pruned).
-        for (const CBlockIndex* pindex : vToFetch) {
-            if (!pindex->IsValid(BLOCK_VALID_TREE)) {
-                // We consider the chain that this peer is on invalid.
-                return;
-            }
-
-            if (!CanServeWitnesses(peer) && DeploymentActiveAt(*pindex, m_chainman, Consensus::DEPLOYMENT_SEGWIT)) {
-                // We wouldn't download this block or its descendants from this peer.
-                return;
-            }
-
-            if (pindex->nStatus & BLOCK_HAVE_DATA || (activeChain && activeChain->Contains(*pindex))) {
-                if (activeChain && pindex->HaveNumChainTxs()) {
-                    state->pindexLastCommonBlock = pindex;
-                }
-                continue;
-            }
-
-            // Is block in-flight?
-            if (IsBlockRequested(pindex->GetBlockHash())) {
-                if (waitingfor == -1) {
-                    // This is the first already-in-flight block.
-                    waitingfor = mapBlocksInFlight.lower_bound(pindex->GetBlockHash())->second.first;
-                }
-                continue;
-            }
-
-            // The block is not already downloaded, and not yet in flight.
-            if (pindex->nHeight > nWindowEnd) {
-                // We reached the end of the window.
-                if (vBlocks.size() == 0 && waitingfor != peer.m_id) {
-                    // We aren't able to fetch anything, but we would be if the download window was one larger.
-                    if (nodeStaller) *nodeStaller = waitingfor;
-                }
-                return;
-            }
-
-            // Don't request blocks that go further than what limited peers can provide
-            if (is_limited_peer && (state->pindexBestKnownBlock->nHeight - pindex->nHeight >= static_cast<int>(NODE_NETWORK_LIMITED_MIN_BLOCKS) - 2 /* two blocks buffer for possible races */)) {
-                continue;
-            }
-
-            vBlocks.push_back(pindex);
-            if (vBlocks.size() == count) {
-                return;
-            }
-        }
-    }
 }
 
 } // namespace
@@ -1619,6 +1202,15 @@ void PeerManagerImpl::InitializeNode(const CNode& node, ServiceFlags our_service
     {
         LOCK(cs_main); // For m_node_states
         m_node_states.try_emplace(m_node_states.end(), nodeid);
+        // Register with block download manager using conservative defaults.
+        // The preferred_download flag is updated during VERSION processing when
+        // we know the peer's capabilities.
+        m_blockdownloadman.ConnectedPeer(nodeid, {
+            /*m_is_inbound=*/node.IsInboundConn(),
+            /*m_preferred_download=*/false,
+            /*m_can_serve_witnesses=*/false,
+            /*m_is_limited_peer=*/false
+        });
     }
     WITH_LOCK(m_tx_download_mutex, m_txdownloadman.CheckIsEmpty(nodeid));
 
@@ -1703,28 +1295,12 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
     CNodeState *state = State(nodeid);
     assert(state != nullptr);
 
-    if (state->fSyncStarted)
-        nSyncStarted--;
-
-    for (const QueuedBlock& entry : state->vBlocksInFlight) {
-        auto range = mapBlocksInFlight.equal_range(entry.pindex->GetBlockHash());
-        while (range.first != range.second) {
-            auto [node_id, list_it] = range.first->second;
-            if (node_id != nodeid) {
-                range.first++;
-            } else {
-                range.first = mapBlocksInFlight.erase(range.first);
-            }
-        }
-    }
+    m_blockdownloadman.DisconnectedPeer(nodeid);
     {
         LOCK(m_tx_download_mutex);
         m_txdownloadman.DisconnectedPeer(nodeid);
     }
     if (m_txreconciliation) m_txreconciliation->ForgetPeer(nodeid);
-    m_num_preferred_download_peers -= state->fPreferredDownload;
-    m_peers_downloading_from -= (!state->vBlocksInFlight.empty());
-    assert(m_peers_downloading_from >= 0);
     m_outbound_peers_with_protect_from_disconnect -= state->m_chain_sync.m_protect;
     assert(m_outbound_peers_with_protect_from_disconnect >= 0);
 
@@ -1732,9 +1308,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
 
     if (m_node_states.empty()) {
         // Do a consistency check after the last peer is removed.
-        assert(mapBlocksInFlight.empty());
-        assert(m_num_preferred_download_peers == 0);
-        assert(m_peers_downloading_from == 0);
+        m_blockdownloadman.CheckIsEmpty();
         assert(m_outbound_peers_with_protect_from_disconnect == 0);
         assert(m_wtxid_relay_peers == 0);
         WITH_LOCK(m_tx_download_mutex, m_txdownloadman.CheckIsEmpty());
@@ -1815,9 +1389,11 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
         const CNodeState* state = State(nodeid);
         if (state == nullptr)
             return false;
-        stats.nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
-        stats.nCommonHeight = state->pindexLastCommonBlock ? state->pindexLastCommonBlock->nHeight : -1;
-        for (const QueuedBlock& queue : state->vBlocksInFlight) {
+        const CBlockIndex* best_known = m_blockdownloadman.GetBestKnownBlock(nodeid);
+        const CBlockIndex* last_common = m_blockdownloadman.GetLastCommonBlock(nodeid);
+        stats.nSyncHeight = best_known ? best_known->nHeight : -1;
+        stats.nCommonHeight = last_common ? last_common->nHeight : -1;
+        for (const auto& queue : m_blockdownloadman.GetBlocksInFlight(nodeid)) {
             if (queue.pindex)
                 stats.vHeightInFlight.push_back(queue.pindex->nHeight);
         }
@@ -1996,10 +1572,10 @@ util::Expected<void, std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, co
     LOCK(cs_main);
 
     // Forget about all prior requests
-    RemoveBlockRequest(block_index.GetBlockHash(), std::nullopt);
+    m_blockdownloadman.RemoveBlockRequest(block_index.GetBlockHash(), std::nullopt);
 
     // Mark block as in-flight
-    if (!BlockRequested(peer_id, block_index)) return util::Unexpected{"Already requested from this peer"};
+    if (!m_blockdownloadman.BlockRequested(peer_id, block_index)) return util::Unexpected{"Already requested from this peer"};
 
     // Construct message to request the block
     const uint256& hash{block_index.GetBlockHash()};
@@ -2037,6 +1613,7 @@ PeerManagerImpl::PeerManagerImpl(CConnman& connman, AddrMan& addrman,
       m_chainman(chainman),
       m_mempool(pool),
       m_txdownloadman(node::TxDownloadOptions{pool, m_rng, opts.deterministic_rng}),
+      m_blockdownloadman(node::BlockDownloadOptions{chainman}),
       m_warnings{warnings},
       m_opts{opts}
 {
@@ -2094,14 +1671,14 @@ void PeerManagerImpl::BlockConnected(
 {
     // Update this for all chainstate roles so that we don't mistakenly see peers
     // helping us do background IBD as having a stale tip.
-    m_last_tip_update = GetTime<std::chrono::seconds>();
+    m_blockdownloadman.SetLastTipUpdate(GetTime<std::chrono::seconds>());
 
     // In case the dynamic timeout was doubled once or more, reduce it slowly back to its default value
-    auto stalling_timeout = m_block_stalling_timeout.load();
+    auto stalling_timeout = m_blockdownloadman.GetBlockStallingTimeout();
     Assume(stalling_timeout >= BLOCK_STALLING_TIMEOUT_DEFAULT);
     if (stalling_timeout != BLOCK_STALLING_TIMEOUT_DEFAULT) {
         const auto new_timeout = std::max(std::chrono::duration_cast<std::chrono::seconds>(stalling_timeout * 0.85), BLOCK_STALLING_TIMEOUT_DEFAULT);
-        if (m_block_stalling_timeout.compare_exchange_strong(stalling_timeout, new_timeout)) {
+        if (m_blockdownloadman.CompareExchangeBlockStallingTimeout(stalling_timeout, new_timeout)) {
             LogDebug(BCLog::NET, "Decreased stalling timeout to %d seconds\n", count_seconds(new_timeout));
         }
     }
@@ -2160,18 +1737,18 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
 
         if (pnode->GetCommonVersion() < INVALID_CB_NO_BAN_VERSION || pnode->fDisconnect)
             return;
-        ProcessBlockAvailability(pnode->GetId());
+        m_blockdownloadman.ProcessBlockAvailability(pnode->GetId());
         CNodeState &state = *State(pnode->GetId());
         // If the peer has, or we announced to them the previous block already,
         // but we don't think they have this one, go ahead and announce it
-        if (state.m_requested_hb_cmpctblocks && !PeerHasHeader(&state, pindex) && PeerHasHeader(&state, pindex->pprev)) {
+        if (state.m_requested_hb_cmpctblocks && !m_blockdownloadman.PeerHasHeader(pnode->GetId(), pindex) && m_blockdownloadman.PeerHasHeader(pnode->GetId(), pindex->pprev)) {
 
             LogDebug(BCLog::NET, "%s sending header-and-ids %s to peer=%d\n", "PeerManager::NewPoWValidBlock",
                     hashBlock.ToString(), pnode->GetId());
 
             const CSerializedNetMsg& ser_cmpctblock{lazy_ser.get()};
             PushMessage(*pnode, ser_cmpctblock.Copy());
-            state.pindexBestHeaderSent = pindex;
+            m_blockdownloadman.SetBestHeaderSent(pnode->GetId(), pindex);
         }
     });
 }
@@ -2223,14 +1800,14 @@ void PeerManagerImpl::BlockChecked(const std::shared_ptr<const CBlock>& block, c
     LOCK(cs_main);
 
     const uint256 hash(block->GetHash());
-    std::map<uint256, std::pair<NodeId, bool>>::iterator it = mapBlockSource.find(hash);
+    auto block_source = m_blockdownloadman.GetBlockSource(hash);
 
     // If the block failed validation, we know where it came from and we're still connected
     // to that peer, maybe punish.
     if (state.IsInvalid() &&
-        it != mapBlockSource.end() &&
-        State(it->second.first)) {
-            MaybePunishNodeForBlock(/*nodeid=*/ it->second.first, state, /*via_compact_block=*/ !it->second.second);
+        block_source.has_value() &&
+        State(block_source->first)) {
+            MaybePunishNodeForBlock(/*nodeid=*/ block_source->first, state, /*via_compact_block=*/ !block_source->second);
     }
     // Check that:
     // 1. The block is valid
@@ -2240,13 +1817,13 @@ void PeerManagerImpl::BlockChecked(const std::shared_ptr<const CBlock>& block, c
     //    just check that there are currently no other blocks in flight.
     else if (state.IsValid() &&
              !m_chainman.IsInitialBlockDownload() &&
-             mapBlocksInFlight.count(hash) == mapBlocksInFlight.size()) {
-        if (it != mapBlockSource.end()) {
-            MaybeSetPeerAsAnnouncingHeaderAndIDs(it->second.first);
+             m_blockdownloadman.CountBlocksInFlight(hash) == m_blockdownloadman.GetTotalBlocksInFlight()) {
+        if (block_source.has_value()) {
+            MaybeSetPeerAsAnnouncingHeaderAndIDs(block_source->first);
         }
     }
-    if (it != mapBlockSource.end())
-        mapBlockSource.erase(it);
+    if (block_source.has_value())
+        m_blockdownloadman.EraseBlockSource(hash);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -2691,7 +2268,7 @@ void PeerManagerImpl::HandleUnconnectingHeaders(CNode& pfrom, Peer& peer,
     // Set hashLastUnknownBlock for this peer, so that if we
     // eventually get the headers - even from a different peer -
     // we can use this peer to download.
-    WITH_LOCK(cs_main, UpdateBlockAvailability(pfrom.GetId(), headers.back().GetHash()));
+    WITH_LOCK(cs_main, m_blockdownloadman.UpdateBlockAvailability(pfrom.GetId(), headers.back().GetHash()));
 }
 
 bool PeerManagerImpl::CheckHeadersAreContinuous(const std::vector<CBlockHeader>& headers) const
@@ -2876,7 +2453,7 @@ void PeerManagerImpl::HeadersDirectFetchBlocks(CNode& pfrom, const Peer& peer, c
         // Calculate all the blocks we'd need to switch to last_header, up to a limit.
         while (pindexWalk && !m_chainman.ActiveChain().Contains(*pindexWalk) && vToFetch.size() <= MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             if (!(pindexWalk->nStatus & BLOCK_HAVE_DATA) &&
-                    !IsBlockRequested(pindexWalk->GetBlockHash()) &&
+                    !m_blockdownloadman.IsBlockRequested(pindexWalk->GetBlockHash()) &&
                     (!DeploymentActiveAt(*pindexWalk, m_chainman, Consensus::DEPLOYMENT_SEGWIT) || CanServeWitnesses(peer))) {
                 // We don't have this block, and it's not yet in flight.
                 vToFetch.push_back(pindexWalk);
@@ -2896,13 +2473,13 @@ void PeerManagerImpl::HeadersDirectFetchBlocks(CNode& pfrom, const Peer& peer, c
             std::vector<CInv> vGetData;
             // Download as much as possible, from earliest to latest.
             for (const CBlockIndex* pindex : vToFetch | std::views::reverse) {
-                if (nodestate->vBlocksInFlight.size() >= MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+                if (m_blockdownloadman.GetBlocksInFlight(pfrom.GetId()).size() >= MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
                     // Can't download any more from this peer
                     break;
                 }
                 uint32_t nFetchFlags = GetFetchFlags(peer);
                 vGetData.emplace_back(MSG_BLOCK | nFetchFlags, pindex->GetBlockHash());
-                BlockRequested(pfrom.GetId(), *pindex);
+                m_blockdownloadman.BlockRequested(pfrom.GetId(), *pindex);
                 LogDebug(BCLog::NET, "Requesting block %s from peer=%d",
                          pindex->GetBlockHash().ToString(), pfrom.GetId());
             }
@@ -2915,7 +2492,7 @@ void PeerManagerImpl::HeadersDirectFetchBlocks(CNode& pfrom, const Peer& peer, c
                 if (!m_opts.ignore_incoming_txs &&
                         nodestate->m_provides_cmpctblocks &&
                         vGetData.size() == 1 &&
-                        mapBlocksInFlight.size() == 1 &&
+                        m_blockdownloadman.GetTotalBlocksInFlight() == 1 &&
                         last_header.pprev->IsValid(BLOCK_VALID_CHAIN)) {
                     // In any case, we want to download using a compact block, not a regular one
                     vGetData[0] = CInv(MSG_CMPCT_BLOCK, vGetData[0].hash);
@@ -2937,7 +2514,7 @@ void PeerManagerImpl::UpdatePeerStateForReceivedHeaders(CNode& pfrom, Peer& peer
     LOCK(cs_main);
     CNodeState *nodestate = State(pfrom.GetId());
 
-    UpdateBlockAvailability(pfrom.GetId(), last_header.GetBlockHash());
+    m_blockdownloadman.UpdateBlockAvailability(pfrom.GetId(), last_header.GetBlockHash());
 
     // From here, pindexBestKnownBlock should be guaranteed to be non-null,
     // because it is set in UpdateBlockAvailability. Some nullptr checks
@@ -2947,12 +2524,14 @@ void PeerManagerImpl::UpdatePeerStateForReceivedHeaders(CNode& pfrom, Peer& peer
         nodestate->m_last_block_announcement = GetTime();
     }
 
+    const CBlockIndex* best_known = m_blockdownloadman.GetBestKnownBlock(pfrom.GetId());
+
     // If we're in IBD, we want outbound peers that will serve us a useful
     // chain. Disconnect peers that are on chains with insufficient work.
     if (m_chainman.IsInitialBlockDownload() && !may_have_more_headers) {
         // If the peer has no more headers to give us, then we know we have
         // their tip.
-        if (nodestate->pindexBestKnownBlock && nodestate->pindexBestKnownBlock->nChainWork < m_chainman.MinimumChainWork()) {
+        if (best_known && best_known->nChainWork < m_chainman.MinimumChainWork()) {
             // This peer has too little work on their headers chain to help
             // us sync -- disconnect if it is an outbound disconnection
             // candidate.
@@ -2973,8 +2552,8 @@ void PeerManagerImpl::UpdatePeerStateForReceivedHeaders(CNode& pfrom, Peer& peer
     // Note that outbound block-relay peers are excluded from this protection, and
     // thus always subject to eviction under the bad/lagging chain logic.
     // See ChainSyncTimeoutState.
-    if (!pfrom.fDisconnect && pfrom.IsFullOutboundConn() && nodestate->pindexBestKnownBlock != nullptr) {
-        if (m_outbound_peers_with_protect_from_disconnect < MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT && nodestate->pindexBestKnownBlock->nChainWork >= m_chainman.ActiveChain().Tip()->nChainWork && !nodestate->m_chain_sync.m_protect) {
+    if (!pfrom.fDisconnect && pfrom.IsFullOutboundConn() && best_known != nullptr) {
+        if (m_outbound_peers_with_protect_from_disconnect < MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT && best_known->nChainWork >= m_chainman.ActiveChain().Tip()->nChainWork && !nodestate->m_chain_sync.m_protect) {
             LogDebug(BCLog::NET, "Protecting outbound peer=%d from eviction\n", pfrom.GetId());
             nodestate->m_chain_sync.m_protect = true;
             ++m_outbound_peers_with_protect_from_disconnect;
@@ -3458,10 +3037,10 @@ void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlo
         // from, we can erase the block request now anyway (as we just stored
         // this block to disk).
         LOCK(cs_main);
-        RemoveBlockRequest(block->GetHash(), std::nullopt);
+        m_blockdownloadman.RemoveBlockRequest(block->GetHash(), std::nullopt);
     } else {
         LOCK(cs_main);
-        mapBlockSource.erase(block->GetHash());
+        m_blockdownloadman.EraseBlockSource(block->GetHash());
     }
 }
 
@@ -3472,34 +3051,21 @@ void PeerManagerImpl::ProcessCompactBlockTxns(CNode& pfrom, Peer& peer, const Bl
     {
         LOCK(cs_main);
 
-        auto range_flight = mapBlocksInFlight.equal_range(block_transactions.blockhash);
-        size_t already_in_flight = std::distance(range_flight.first, range_flight.second);
-        bool requested_block_from_this_peer{false};
+        auto flight_info = m_blockdownloadman.FindBlockInFlight(block_transactions.blockhash, pfrom.GetId());
+        bool first_in_flight = flight_info.first_in_flight;
 
-        // Multimap ensures ordering of outstanding requests. It's either empty or first in line.
-        bool first_in_flight = already_in_flight == 0 || (range_flight.first->second.first == pfrom.GetId());
-
-        while (range_flight.first != range_flight.second) {
-            auto [node_id, block_it] = range_flight.first->second;
-            if (node_id == pfrom.GetId() && block_it->partialBlock) {
-                requested_block_from_this_peer = true;
-                break;
-            }
-            range_flight.first++;
-        }
-
-        if (!requested_block_from_this_peer) {
+        if (!flight_info.queued_block) {
             LogDebug(BCLog::NET, "Peer %d sent us block transactions for block we weren't expecting\n", pfrom.GetId());
             return;
         }
 
-        PartiallyDownloadedBlock& partialBlock = *range_flight.first->second.second->partialBlock;
+        PartiallyDownloadedBlock& partialBlock = *flight_info.queued_block->partialBlock;
 
         if (partialBlock.header.IsNull()) {
             // It is possible for the header to be empty if a previous call to FillBlock wiped the header, but left
             // the PartiallyDownloadedBlock pointer around (i.e. did not call RemoveBlockRequest). In this case, we
             // should not call LookupBlockIndex below.
-            RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId());
+            m_blockdownloadman.RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId());
             Misbehaving(peer, "previous compact block reconstruction attempt failed");
             LogDebug(BCLog::NET, "Peer %d sent compact block transactions multiple times", pfrom.GetId());
             return;
@@ -3510,7 +3076,7 @@ void PeerManagerImpl::ProcessCompactBlockTxns(CNode& pfrom, Peer& peer, const Bl
         ReadStatus status = partialBlock.FillBlock(*pblock, block_transactions.txn,
                                                    /*segwit_active=*/DeploymentActiveAfter(prev_block, m_chainman, Consensus::DEPLOYMENT_SEGWIT));
         if (status == READ_STATUS_INVALID) {
-            RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId()); // Reset in-flight state in case Misbehaving does not result in a disconnect
+            m_blockdownloadman.RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId()); // Reset in-flight state in case Misbehaving does not result in a disconnect
             Misbehaving(peer, "invalid compact block/non-matching block transactions");
             return;
         } else if (status == READ_STATUS_FAILED) {
@@ -3523,25 +3089,25 @@ void PeerManagerImpl::ProcessCompactBlockTxns(CNode& pfrom, Peer& peer, const Bl
                 invs.emplace_back(MSG_BLOCK | GetFetchFlags(peer), block_transactions.blockhash);
                 MakeAndPushMessage(pfrom, NetMsgType::GETDATA, invs);
             } else {
-                RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId());
+                m_blockdownloadman.RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId());
                 LogDebug(BCLog::NET, "Peer %d sent us a compact block but it failed to reconstruct, waiting on first download to complete\n", pfrom.GetId());
                 return;
             }
         } else {
             // Block is okay for further processing
-            RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId()); // it is now an empty pointer
+            m_blockdownloadman.RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId()); // it is now an empty pointer
             fBlockRead = true;
-            // mapBlockSource is used for potentially punishing peers and
+            // Block source tracking is used for potentially punishing peers and
             // updating which peers send us compact blocks, so the race
             // between here and cs_main in ProcessNewBlock is fine.
             // BIP 152 permits peers to relay compact blocks after validating
             // the header only; we should not punish peers if the block turns
             // out to be invalid.
-            mapBlockSource.emplace(block_transactions.blockhash, std::make_pair(pfrom.GetId(), false));
+            m_blockdownloadman.SetBlockSource(block_transactions.blockhash, pfrom.GetId(), /*punish_on_invalid=*/false);
         }
     } // Don't hold cs_main when we call into ProcessNewBlock
     if (fBlockRead) {
-        // Since we requested this block (it was in mapBlocksInFlight), force it to be processed,
+        // Since we requested this block (it was in flight), force it to be processed,
         // even if it would not be a candidate for new tip (missing previous block, chain not long enough, etc)
         // This bypasses some anti-DoS logic in AcceptBlock (eg to prevent
         // disk-space attacks), but this should be safe due to the
@@ -3773,9 +3339,13 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         // Potentially mark this peer as a preferred download peer.
         {
             LOCK(cs_main);
-            CNodeState* state = State(pfrom.GetId());
-            state->fPreferredDownload = (!pfrom.IsInboundConn() || pfrom.HasPermission(NetPermissionFlags::NoBan)) && !pfrom.IsAddrFetchConn() && CanServeBlocks(peer);
-            m_num_preferred_download_peers += state->fPreferredDownload;
+            bool preferred = (!pfrom.IsInboundConn() || pfrom.HasPermission(NetPermissionFlags::NoBan)) && !pfrom.IsAddrFetchConn() && CanServeBlocks(peer);
+            m_blockdownloadman.ConnectedPeer(pfrom.GetId(), {
+                /*m_is_inbound=*/pfrom.IsInboundConn(),
+                /*m_preferred_download=*/preferred,
+                /*m_can_serve_witnesses=*/CanServeWitnesses(peer),
+                /*m_is_limited_peer=*/IsLimitedPeer(peer)
+            });
         }
 
         // Attempt to initialize address relay for outbound peers and use result
@@ -3913,9 +3483,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
         {
             LOCK2(::cs_main, m_tx_download_mutex);
-            const CNodeState* state = State(pfrom.GetId());
             m_txdownloadman.ConnectedPeer(pfrom.GetId(), node::TxDownloadConnectionInfo {
-                .m_preferred = state->fPreferredDownload,
+                .m_preferred = m_blockdownloadman.IsPreferredDownload(pfrom.GetId()),
                 .m_relay_permissions = pfrom.HasPermission(NetPermissionFlags::Relay),
                 .m_wtxid_relay = peer.m_wtxid_relay,
             });
@@ -4137,8 +3706,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 const bool fAlreadyHave = AlreadyHaveBlock(inv.hash);
                 LogDebug(BCLog::NET, "got inv: %s %s peer=%d", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
 
-                UpdateBlockAvailability(pfrom.GetId(), inv.hash);
-                if (!fAlreadyHave && !m_chainman.m_blockman.LoadingBlocks() && !IsBlockRequested(inv.hash)) {
+                m_blockdownloadman.UpdateBlockAvailability(pfrom.GetId(), inv.hash);
+                if (!fAlreadyHave && !m_chainman.m_blockman.LoadingBlocks() && !m_blockdownloadman.IsBlockRequested(inv.hash)) {
                     // Headers-first is the primary method of announcement on
                     // the network. If a node fell back to sending blocks by
                     // inv, it may be for a re-org, or because we haven't
@@ -4176,14 +3745,13 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // block to sync with as well, to sync quicker in the case where
             // our initial peer is unresponsive (but less bandwidth than we'd
             // use if we turned on sync with all peers).
-            CNodeState& state{*Assert(State(pfrom.GetId()))};
-            if (state.fSyncStarted || (!peer.m_inv_triggered_getheaders_before_sync && *best_block != m_last_block_inv_triggering_headers_sync)) {
+            if (m_blockdownloadman.GetSyncStarted(pfrom.GetId()) || (!peer.m_inv_triggered_getheaders_before_sync && *best_block != m_last_block_inv_triggering_headers_sync)) {
                 if (MaybeSendGetHeaders(pfrom, GetLocator(m_chainman.m_best_header), peer)) {
                     LogDebug(BCLog::NET, "getheaders (%d) %s to peer=%d\n",
                             m_chainman.m_best_header->nHeight, best_block->ToString(),
                             pfrom.GetId());
                 }
-                if (!state.fSyncStarted) {
+                if (!m_blockdownloadman.GetSyncStarted(pfrom.GetId())) {
                     peer.m_inv_triggered_getheaders_before_sync = true;
                     // Update the last block hash that triggered a new headers
                     // sync, so that we don't turn on headers sync with more
@@ -4404,7 +3972,6 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             return;
         }
 
-        CNodeState *nodestate = State(pfrom.GetId());
         const CBlockIndex* pindex = nullptr;
         if (locator.IsNull())
         {
@@ -4448,7 +4015,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         // without the new block. By resetting the BestHeaderSent, we ensure we
         // will re-announce the new block via headers (or compact blocks again)
         // in the SendMessages logic.
-        nodestate->pindexBestHeaderSent = pindex ? pindex : m_chainman.ActiveChain().Tip();
+        m_blockdownloadman.SetBestHeaderSent(pfrom.GetId(), pindex ? pindex : m_chainman.ActiveChain().Tip());
         MakeAndPushMessage(pfrom, NetMsgType::HEADERS, TX_WITH_WITNESS(vHeaders));
         return;
     }
@@ -4597,7 +4164,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
         {
         LOCK(cs_main);
-        UpdateBlockAvailability(pfrom.GetId(), pindex->GetBlockHash());
+        m_blockdownloadman.UpdateBlockAvailability(pfrom.GetId(), pindex->GetBlockHash());
 
         CNodeState *nodestate = State(pfrom.GetId());
 
@@ -4610,20 +4177,12 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         if (pindex->nStatus & BLOCK_HAVE_DATA) // Nothing to do here
             return;
 
-        auto range_flight = mapBlocksInFlight.equal_range(pindex->GetBlockHash());
-        size_t already_in_flight = std::distance(range_flight.first, range_flight.second);
-        bool requested_block_from_this_peer{false};
+        auto flight_info = m_blockdownloadman.FindBlockInFlight(pindex->GetBlockHash(), pfrom.GetId());
+        size_t already_in_flight = flight_info.already_in_flight;
+        bool requested_block_from_this_peer = flight_info.requested_from_peer;
 
         // Multimap ensures ordering of outstanding requests. It's either empty or first in line.
-        bool first_in_flight = already_in_flight == 0 || (range_flight.first->second.first == pfrom.GetId());
-
-        while (range_flight.first != range_flight.second) {
-            if (range_flight.first->second.first == pfrom.GetId()) {
-                requested_block_from_this_peer = true;
-                break;
-            }
-            range_flight.first++;
-        }
+        bool first_in_flight = flight_info.first_in_flight;
 
         if (pindex->nChainWork <= m_chainman.ActiveChain().Tip()->nChainWork || // We know something better
                 pindex->nTx != 0) { // We had this block at some point, but pruned it
@@ -4645,10 +4204,10 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         // We want to be a bit conservative just to be extra careful about DoS
         // possibilities in compact block processing...
         if (pindex->nHeight <= m_chainman.ActiveChain().Height() + 2) {
-            if ((already_in_flight < MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK && nodestate->vBlocksInFlight.size() < MAX_BLOCKS_IN_TRANSIT_PER_PEER) ||
+            if ((already_in_flight < MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK && m_blockdownloadman.GetBlocksInFlight(pfrom.GetId()).size() < MAX_BLOCKS_IN_TRANSIT_PER_PEER) ||
                  requested_block_from_this_peer) {
-                std::list<QueuedBlock>::iterator* queuedBlockIt = nullptr;
-                if (!BlockRequested(pfrom.GetId(), *pindex, &queuedBlockIt)) {
+                std::list<node::QueuedBlock>::iterator* queuedBlockIt = nullptr;
+                if (!m_blockdownloadman.BlockRequested(pfrom.GetId(), *pindex, &queuedBlockIt, &m_mempool)) {
                     if (!(*queuedBlockIt)->partialBlock)
                         (*queuedBlockIt)->partialBlock.reset(new PartiallyDownloadedBlock(&m_mempool));
                     else {
@@ -4661,7 +4220,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 PartiallyDownloadedBlock& partialBlock = *(*queuedBlockIt)->partialBlock;
                 ReadStatus status = partialBlock.InitData(cmpctblock, vExtraTxnForCompact);
                 if (status == READ_STATUS_INVALID) {
-                    RemoveBlockRequest(pindex->GetBlockHash(), pfrom.GetId()); // Reset in-flight state in case Misbehaving does not result in a disconnect
+                    m_blockdownloadman.RemoveBlockRequest(pindex->GetBlockHash(), pfrom.GetId()); // Reset in-flight state in case Misbehaving does not result in a disconnect
                     Misbehaving(peer, "invalid compact block");
                     return;
                 } else if (status == READ_STATUS_FAILED) {
@@ -4672,7 +4231,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                         MakeAndPushMessage(pfrom, NetMsgType::GETDATA, vInv);
                     } else {
                         // Give up for this peer and wait for other peer(s)
-                        RemoveBlockRequest(pindex->GetBlockHash(), pfrom.GetId());
+                        m_blockdownloadman.RemoveBlockRequest(pindex->GetBlockHash(), pfrom.GetId());
                     }
                     return;
                 }
@@ -4691,7 +4250,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                     MakeAndPushMessage(pfrom, NetMsgType::GETBLOCKTXN, req);
                 } else if (pfrom.m_bip152_highbandwidth_to &&
                     (!pfrom.IsInboundConn() ||
-                    IsBlockRequestedFromOutbound(blockhash) ||
+                    m_blockdownloadman.IsBlockRequestedFromOutbound(blockhash) ||
                     already_in_flight < MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK - 1)) {
                     // ... or it's a hb relay peer and:
                     // - peer is outbound, or
@@ -4701,7 +4260,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                     MakeAndPushMessage(pfrom, NetMsgType::GETBLOCKTXN, req);
                 } else {
                     // Give up for this peer and wait for other peer(s)
-                    RemoveBlockRequest(pindex->GetBlockHash(), pfrom.GetId());
+                    m_blockdownloadman.RemoveBlockRequest(pindex->GetBlockHash(), pfrom.GetId());
                 }
             } else {
                 // This block is either already in flight from a different
@@ -4758,7 +4317,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // block that is in flight from some other peer.
             {
                 LOCK(cs_main);
-                mapBlockSource.emplace(pblock->GetHash(), std::make_pair(pfrom.GetId(), false));
+                m_blockdownloadman.SetBlockSource(pblock->GetHash(), pfrom.GetId(), /*punish_on_invalid=*/false);
             }
             // Setting force_processing to true means that we bypass some of
             // our anti-DoS protections in AcceptBlock, which filters
@@ -4776,7 +4335,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 // process from some other peer.  We do this after calling
                 // ProcessNewBlock so that a malleated cmpctblock announcement
                 // can't be used to interfere with block relay.
-                RemoveBlockRequest(pblock->GetHash(), std::nullopt);
+                m_blockdownloadman.RemoveBlockRequest(pblock->GetHash(), std::nullopt);
             }
         }
         return;
@@ -4857,7 +4416,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                            /*check_witness_root=*/DeploymentActiveAfter(prev_block, m_chainman, Consensus::DEPLOYMENT_SEGWIT))) {
             LogDebug(BCLog::NET, "Received mutated block from peer=%d\n", peer.m_id);
             Misbehaving(peer, "mutated block");
-            WITH_LOCK(cs_main, RemoveBlockRequest(pblock->GetHash(), peer.m_id));
+            WITH_LOCK(cs_main, m_blockdownloadman.RemoveBlockRequest(pblock->GetHash(), peer.m_id));
             return;
         }
 
@@ -4868,12 +4427,12 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             LOCK(cs_main);
             // Always process the block if we requested it, since we may
             // need it even when it's not a candidate for a new best tip.
-            forceProcessing = IsBlockRequested(hash);
-            RemoveBlockRequest(hash, pfrom.GetId());
-            // mapBlockSource is only used for punishing peers and setting
+            forceProcessing = m_blockdownloadman.IsBlockRequested(hash);
+            m_blockdownloadman.RemoveBlockRequest(hash, pfrom.GetId());
+            // Block source tracking is only used for punishing peers and setting
             // which peers send us compact blocks, so the race between here and
             // cs_main in ProcessNewBlock is fine.
-            mapBlockSource.emplace(hash, std::make_pair(pfrom.GetId(), true));
+            m_blockdownloadman.SetBlockSource(hash, pfrom.GetId(), /*punish_on_invalid=*/true);
 
             // Check claimed work on this block against our anti-dos thresholds.
             if (prev_block && prev_block->nChainWork + GetBlockProof(*pblock) >= GetAntiDoSWorkThreshold()) {
@@ -5222,21 +4781,22 @@ void PeerManagerImpl::ConsiderEviction(CNode& pto, Peer& peer, std::chrono::seco
 
     CNodeState &state = *State(pto.GetId());
 
-    if (!state.m_chain_sync.m_protect && pto.IsOutboundOrBlockRelayConn() && state.fSyncStarted) {
+    if (!state.m_chain_sync.m_protect && pto.IsOutboundOrBlockRelayConn() && m_blockdownloadman.GetSyncStarted(pto.GetId())) {
         // This is an outbound peer subject to disconnection if they don't
         // announce a block with as much work as the current tip within
         // CHAIN_SYNC_TIMEOUT + HEADERS_RESPONSE_TIME seconds (note: if
         // their chain has more work than ours, we should sync to it,
         // unless it's invalid, in which case we should find that out and
         // disconnect from them elsewhere).
-        if (state.pindexBestKnownBlock != nullptr && state.pindexBestKnownBlock->nChainWork >= m_chainman.ActiveChain().Tip()->nChainWork) {
+        const CBlockIndex* peer_best_known = m_blockdownloadman.GetBestKnownBlock(pto.GetId());
+        if (peer_best_known != nullptr && peer_best_known->nChainWork >= m_chainman.ActiveChain().Tip()->nChainWork) {
             // The outbound peer has sent us a block with at least as much work as our current tip, so reset the timeout if it was set
             if (state.m_chain_sync.m_timeout != 0s) {
                 state.m_chain_sync.m_timeout = 0s;
                 state.m_chain_sync.m_work_header = nullptr;
                 state.m_chain_sync.m_sent_getheaders = false;
             }
-        } else if (state.m_chain_sync.m_timeout == 0s || (state.m_chain_sync.m_work_header != nullptr && state.pindexBestKnownBlock != nullptr && state.pindexBestKnownBlock->nChainWork >= state.m_chain_sync.m_work_header->nChainWork)) {
+        } else if (state.m_chain_sync.m_timeout == 0s || (state.m_chain_sync.m_work_header != nullptr && peer_best_known != nullptr && peer_best_known->nChainWork >= state.m_chain_sync.m_work_header->nChainWork)) {
             // At this point we know that the outbound peer has either never sent us a block/header or they have, but its tip is behind ours
             // AND
             // we are noticing this for the first time (m_timeout is 0)
@@ -5252,7 +4812,7 @@ void PeerManagerImpl::ConsiderEviction(CNode& pto, Peer& peer, std::chrono::seco
             // message to give the peer a chance to update us.
             if (state.m_chain_sync.m_sent_getheaders) {
                 // They've run out of time to catch up!
-                LogInfo("Outbound peer has old chain, best known block = %s, %s", state.pindexBestKnownBlock != nullptr ? state.pindexBestKnownBlock->GetBlockHash().ToString() : "<none>", pto.DisconnectMsg());
+                LogInfo("Outbound peer has old chain, best known block = %s, %s", peer_best_known != nullptr ? peer_best_known->GetBlockHash().ToString() : "<none>", pto.DisconnectMsg());
                 pto.fDisconnect = true;
             } else {
                 assert(state.m_chain_sync.m_work_header);
@@ -5263,7 +4823,7 @@ void PeerManagerImpl::ConsiderEviction(CNode& pto, Peer& peer, std::chrono::seco
                 MaybeSendGetHeaders(pto,
                         GetLocator(state.m_chain_sync.m_work_header->pprev),
                         peer);
-                LogDebug(BCLog::NET, "sending getheaders to outbound peer=%d to verify chain work (current best known block:%s, benchmark blockhash: %s)\n", pto.GetId(), state.pindexBestKnownBlock != nullptr ? state.pindexBestKnownBlock->GetBlockHash().ToString() : "<none>", state.m_chain_sync.m_work_header->GetBlockHash().ToString());
+                LogDebug(BCLog::NET, "sending getheaders to outbound peer=%d to verify chain work (current best known block:%s, benchmark blockhash: %s)\n", pto.GetId(), peer_best_known != nullptr ? peer_best_known->GetBlockHash().ToString() : "<none>", state.m_chain_sync.m_work_header->GetBlockHash().ToString());
                 state.m_chain_sync.m_sent_getheaders = true;
                 // Bump the timeout to allow a response, which could clear the timeout
                 // (if the response shows the peer has synced), reset the timeout (if
@@ -5308,16 +4868,18 @@ void PeerManagerImpl::EvictExtraOutboundPeers(NodeClock::time_point now)
             // at all.
             // Note that we only request blocks from a peer if we learn of a
             // valid headers chain with at least as much work as our tip.
+            // Only query the block download manager after the null check: a
+            // peer unknown to m_node_states is also unknown to the manager.
             CNodeState *node_state = State(pnode->GetId());
             if (node_state == nullptr ||
-                (now - pnode->m_connected >= MINIMUM_CONNECT_TIME && node_state->vBlocksInFlight.empty())) {
+                (now - pnode->m_connected >= MINIMUM_CONNECT_TIME && m_blockdownloadman.GetBlocksInFlight(pnode->GetId()).empty())) {
                 pnode->fDisconnect = true;
                 LogDebug(BCLog::NET, "disconnecting extra block-relay-only peer=%d (last block received at time %d)\n",
                          pnode->GetId(), count_seconds(pnode->m_last_block_time));
                 return true;
             } else {
                 LogDebug(BCLog::NET, "keeping block-relay-only peer=%d chosen for eviction (connect time: %d, blocks_in_flight: %d)\n",
-                         pnode->GetId(), TicksSinceEpoch<std::chrono::seconds>(pnode->m_connected), node_state->vBlocksInFlight.size());
+                         pnode->GetId(), TicksSinceEpoch<std::chrono::seconds>(pnode->m_connected), m_blockdownloadman.GetBlocksInFlight(pnode->GetId()).size());
             }
             return false;
         });
@@ -5361,14 +4923,14 @@ void PeerManagerImpl::EvictExtraOutboundPeers(NodeClock::time_point now)
                 // it time for new information to have arrived.
                 // Also don't disconnect any peer we're trying to download a
                 // block from.
-                CNodeState &state = *State(pnode->GetId());
-                if (now - pnode->m_connected > MINIMUM_CONNECT_TIME && state.vBlocksInFlight.empty()) {
+                const auto& peer_blocks_in_flight = m_blockdownloadman.GetBlocksInFlight(pnode->GetId());
+                if (now - pnode->m_connected > MINIMUM_CONNECT_TIME && peer_blocks_in_flight.empty()) {
                     LogDebug(BCLog::NET, "disconnecting extra outbound peer=%d (last block announcement received at time %d)\n", pnode->GetId(), oldest_block_announcement);
                     pnode->fDisconnect = true;
                     return true;
                 } else {
                     LogDebug(BCLog::NET, "keeping outbound peer=%d chosen for eviction (connect time: %d, blocks_in_flight: %d)\n",
-                             pnode->GetId(), TicksSinceEpoch<std::chrono::seconds>(pnode->m_connected), state.vBlocksInFlight.size());
+                             pnode->GetId(), TicksSinceEpoch<std::chrono::seconds>(pnode->m_connected), peer_blocks_in_flight.size());
                     return false;
                 }
             });
@@ -5396,9 +4958,9 @@ void PeerManagerImpl::CheckForStaleTipAndEvictPeers()
     if (now > m_stale_tip_check_time) {
         // Check whether our tip is stale, and if so, allow using an extra
         // outbound peer
-        if (!m_chainman.m_blockman.LoadingBlocks() && m_connman.GetNetworkActive() && m_connman.GetUseAddrmanOutgoing() && TipMayBeStale()) {
+        if (!m_chainman.m_blockman.LoadingBlocks() && m_connman.GetNetworkActive() && m_connman.GetUseAddrmanOutgoing() && m_blockdownloadman.TipMayBeStale(now, m_chainparams.GetConsensus().nPowTargetSpacing)) {
             LogInfo("Potential stale tip detected, will try using extra outbound peer (last tip update: %d seconds ago)\n",
-                      count_seconds(now - m_last_tip_update.load()));
+                      count_seconds(now - m_blockdownloadman.GetLastTipUpdate()));
             m_connman.SetTryNewOutboundPeer(true);
         } else if (m_connman.GetTryNewOutboundPeer()) {
             m_connman.SetTryNewOutboundPeer(false);
@@ -5540,9 +5102,9 @@ void PeerManagerImpl::MaybeSendSendHeaders(CNode& node, Peer& peer)
     // because of the state tracking done.
     if (!peer.m_sent_sendheaders && node.GetCommonVersion() >= SENDHEADERS_VERSION) {
         LOCK(cs_main);
-        CNodeState &state = *State(node.GetId());
-        if (state.pindexBestKnownBlock != nullptr &&
-                state.pindexBestKnownBlock->nChainWork > m_chainman.MinimumChainWork()) {
+        const CBlockIndex* best_known = m_blockdownloadman.GetBestKnownBlock(node.GetId());
+        if (best_known != nullptr &&
+                best_known->nChainWork > m_chainman.MinimumChainWork()) {
             // Tell our peer we prefer to receive headers rather than inv's
             // We send this to non-NODE NETWORK peers as well, because even
             // non-NODE NETWORK peers can announce blocks (such as pruning
@@ -5853,7 +5415,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
         // block download from this peer -- this mostly affects behavior while
         // in IBD (once out of IBD, we sync from all peers).
         bool sync_blocks_and_headers_from_peer = false;
-        if (state.fPreferredDownload) {
+        if (m_blockdownloadman.IsPreferredDownload(node.GetId())) {
             sync_blocks_and_headers_from_peer = true;
         } else if (CanServeBlocks(peer) && !node.IsAddrFetchConn()) {
             // Typically this is an inbound peer. If we don't have any outbound
@@ -5865,14 +5427,14 @@ bool PeerManagerImpl::SendMessages(CNode& node)
             // the latest blocks is from an inbound peer, we have to be sure to
             // eventually download it (and not just wait indefinitely for an
             // outbound peer to have it).
-            if (m_num_preferred_download_peers == 0 || mapBlocksInFlight.empty()) {
+            if (m_blockdownloadman.GetNumPreferredDownload() == 0 || !m_blockdownloadman.HasBlocksInFlight()) {
                 sync_blocks_and_headers_from_peer = true;
             }
         }
 
-        if (!state.fSyncStarted && CanServeBlocks(peer) && !m_chainman.m_blockman.LoadingBlocks()) {
+        if (!m_blockdownloadman.GetSyncStarted(node.GetId()) && CanServeBlocks(peer) && !m_chainman.m_blockman.LoadingBlocks()) {
             // Only actively request headers from a single peer, unless we're close to today.
-            if ((nSyncStarted == 0 && sync_blocks_and_headers_from_peer) || m_chainman.m_best_header->Time() > NodeClock::now() - 24h) {
+            if ((m_blockdownloadman.GetNumSyncStarted() == 0 && sync_blocks_and_headers_from_peer) || m_chainman.m_best_header->Time() > NodeClock::now() - 24h) {
                 const CBlockIndex* pindexStart = m_chainman.m_best_header;
                 /* If possible, start at the block preceding the currently
                    best known header.  This ensures that we always get a
@@ -5886,7 +5448,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                 if (MaybeSendGetHeaders(node, GetLocator(pindexStart), peer)) {
                     LogDebug(BCLog::NET, "initial getheaders (%d) to peer=%d", pindexStart->nHeight, node.GetId());
 
-                    state.fSyncStarted = true;
+                    m_blockdownloadman.SetSyncStarted(node.GetId(), true);
                     peer.m_headers_sync_timeout = current_time + HEADERS_DOWNLOAD_TIMEOUT_BASE +
                         (
                          // Convert HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER to microseconds before scaling
@@ -5894,7 +5456,6 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                          std::chrono::microseconds{HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER} *
                          Ticks<std::chrono::seconds>(NodeClock::now() - m_chainman.m_best_header->Time()) / consensusParams.nPowTargetSpacing
                         );
-                    nSyncStarted++;
                 }
             }
         }
@@ -5916,7 +5477,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                                  (!state.m_requested_hb_cmpctblocks || peer.m_blocks_for_headers_relay.size() > 1)) ||
                                  peer.m_blocks_for_headers_relay.size() > MAX_BLOCKS_TO_ANNOUNCE);
             const CBlockIndex *pBestIndex = nullptr; // last header queued for delivery
-            ProcessBlockAvailability(node.GetId()); // ensure pindexBestKnownBlock is up-to-date
+            m_blockdownloadman.ProcessBlockAvailability(node.GetId()); // ensure pindexBestKnownBlock is up-to-date
 
             if (!fRevertToInv) {
                 bool fFoundStartingHeader = false;
@@ -5950,9 +5511,9 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                     if (fFoundStartingHeader) {
                         // add this to the headers message
                         vHeaders.emplace_back(pindex->GetBlockHeader());
-                    } else if (PeerHasHeader(&state, pindex)) {
+                    } else if (m_blockdownloadman.PeerHasHeader(node.GetId(), pindex)) {
                         continue; // keep looking for the first new block
-                    } else if (pindex->pprev == nullptr || PeerHasHeader(&state, pindex->pprev)) {
+                    } else if (pindex->pprev == nullptr || m_blockdownloadman.PeerHasHeader(node.GetId(), pindex->pprev)) {
                         // Peer doesn't have this header but they do have the prior one.
                         // Start sending headers.
                         fFoundStartingHeader = true;
@@ -5988,7 +5549,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                         CBlockHeaderAndShortTxIDs cmpctblock{block, m_rng.rand64()};
                         MakeAndPushMessage(node, NetMsgType::CMPCTBLOCK, cmpctblock);
                     }
-                    state.pindexBestHeaderSent = pBestIndex;
+                    m_blockdownloadman.SetBestHeaderSent(node.GetId(), pBestIndex);
                 } else if (peer.m_prefers_headers) {
                     if (vHeaders.size() > 1) {
                         LogDebug(BCLog::NET, "%s: %u headers, range (%s, %s), to peer=%d\n", __func__,
@@ -6000,7 +5561,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                                 vHeaders.front().GetHash().ToString(), node.GetId());
                     }
                     MakeAndPushMessage(node, NetMsgType::HEADERS, TX_WITH_WITNESS(vHeaders));
-                    state.pindexBestHeaderSent = pBestIndex;
+                    m_blockdownloadman.SetBestHeaderSent(node.GetId(), pBestIndex);
                 } else
                     fRevertToInv = true;
             }
@@ -6022,7 +5583,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                     }
 
                     // If the peer's chain has this block, don't inv it back.
-                    if (!PeerHasHeader(&state, pindex)) {
+                    if (!m_blockdownloadman.PeerHasHeader(node.GetId(), pindex)) {
                         peer.m_blocks_for_inv_relay.push_back(hashToAnnounce);
                         LogDebug(BCLog::NET, "%s: sending inv peer=%d hash=%s\n", __func__,
                             node.GetId(), hashToAnnounce.ToString());
@@ -6168,8 +5729,9 @@ bool PeerManagerImpl::SendMessages(CNode& node)
             MakeAndPushMessage(node, NetMsgType::INV, vInv);
 
         // Detect whether we're stalling
-        auto stalling_timeout = m_block_stalling_timeout.load();
-        if (state.m_stalling_since.count() && state.m_stalling_since < current_time - stalling_timeout) {
+        auto stalling_timeout = m_blockdownloadman.GetBlockStallingTimeout();
+        auto peer_stalling_since = m_blockdownloadman.GetStallingSince(node.GetId());
+        if (peer_stalling_since.count() && peer_stalling_since < current_time - stalling_timeout) {
             // Stalling only triggers when the block download window cannot move. During normal steady state,
             // the download window should be much larger than the to-be-downloaded set of blocks, so disconnection
             // should only happen during initial block download.
@@ -6178,7 +5740,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
             // Increase timeout for the next peer so that we don't disconnect multiple peers if our own
             // bandwidth is insufficient.
             const auto new_timeout = std::min(2 * stalling_timeout, BLOCK_STALLING_TIMEOUT_MAX);
-            if (stalling_timeout != new_timeout && m_block_stalling_timeout.compare_exchange_strong(stalling_timeout, new_timeout)) {
+            if (stalling_timeout != new_timeout && m_blockdownloadman.CompareExchangeBlockStallingTimeout(stalling_timeout, new_timeout)) {
                 LogDebug(BCLog::NET, "Increased stalling timeout temporarily to %d seconds\n", count_seconds(new_timeout));
             }
             return true;
@@ -6188,20 +5750,21 @@ bool PeerManagerImpl::SendMessages(CNode& node)
         // We compensate for other peers to prevent killing off peers due to our own downstream link
         // being saturated. We only count validated in-flight blocks so peers can't advertise non-existing block hashes
         // to unreasonably increase our timeout.
-        if (state.vBlocksInFlight.size() > 0) {
-            QueuedBlock &queuedBlock = state.vBlocksInFlight.front();
-            int nOtherPeersWithValidatedDownloads = m_peers_downloading_from - 1;
-            if (current_time > state.m_downloading_since + std::chrono::seconds{consensusParams.nPowTargetSpacing} * (BLOCK_DOWNLOAD_TIMEOUT_BASE + BLOCK_DOWNLOAD_TIMEOUT_PER_PEER * nOtherPeersWithValidatedDownloads)) {
+        const auto& node_blocks_in_flight = m_blockdownloadman.GetBlocksInFlight(node.GetId());
+        if (!node_blocks_in_flight.empty()) {
+            const node::QueuedBlock &queuedBlock = node_blocks_in_flight.front();
+            int nOtherPeersWithValidatedDownloads = m_blockdownloadman.GetPeersDownloadingFrom() - 1;
+            if (current_time > m_blockdownloadman.GetDownloadingSince(node.GetId()) + std::chrono::seconds{consensusParams.nPowTargetSpacing} * (BLOCK_DOWNLOAD_TIMEOUT_BASE + BLOCK_DOWNLOAD_TIMEOUT_PER_PEER * nOtherPeersWithValidatedDownloads)) {
                 LogInfo("Timeout downloading block %s, %s", queuedBlock.pindex->GetBlockHash().ToString(), node.DisconnectMsg());
                 node.fDisconnect = true;
                 return true;
             }
         }
         // Check for headers sync timeouts
-        if (state.fSyncStarted && peer.m_headers_sync_timeout < std::chrono::microseconds::max()) {
+        if (m_blockdownloadman.GetSyncStarted(node.GetId()) && peer.m_headers_sync_timeout < std::chrono::microseconds::max()) {
             // Detect whether this is a stalling initial-headers-sync peer
             if (m_chainman.m_best_header->Time() <= NodeClock::now() - 24h) {
-                if (current_time > peer.m_headers_sync_timeout && nSyncStarted == 1 && (m_num_preferred_download_peers - state.fPreferredDownload >= 1)) {
+                if (current_time > peer.m_headers_sync_timeout && m_blockdownloadman.GetNumSyncStarted() == 1 && (m_blockdownloadman.GetNumPreferredDownload() - (m_blockdownloadman.IsPreferredDownload(node.GetId()) ? 1 : 0) >= 1)) {
                     // Disconnect a peer (without NetPermissionFlags::NoBan permission) if it is our only sync peer,
                     // and we have others we could be using instead.
                     // Note: If all our peers are inbound, then we won't
@@ -6218,8 +5781,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                         // Note: this will also result in at least one more
                         // getheaders message to be sent to
                         // this peer (eventually).
-                        state.fSyncStarted = false;
-                        nSyncStarted--;
+                        m_blockdownloadman.SetSyncStarted(node.GetId(), false);
                         peer.m_headers_sync_timeout = 0us;
                     }
                 }
@@ -6238,37 +5800,37 @@ bool PeerManagerImpl::SendMessages(CNode& node)
         // Message: getdata (blocks)
         //
         std::vector<CInv> vGetData;
-        if (CanServeBlocks(peer) && ((sync_blocks_and_headers_from_peer && !IsLimitedPeer(peer)) || !m_chainman.IsInitialBlockDownload()) && state.vBlocksInFlight.size() < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+        if (CanServeBlocks(peer) && ((sync_blocks_and_headers_from_peer && !IsLimitedPeer(peer)) || !m_chainman.IsInitialBlockDownload()) && node_blocks_in_flight.size() < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             std::vector<const CBlockIndex*> vToDownload;
             NodeId staller = -1;
-            auto get_inflight_budget = [&state]() {
-                return std::max(0, MAX_BLOCKS_IN_TRANSIT_PER_PEER - static_cast<int>(state.vBlocksInFlight.size()));
+            auto get_inflight_budget = [&node_blocks_in_flight]() {
+                return std::max(0, MAX_BLOCKS_IN_TRANSIT_PER_PEER - static_cast<int>(node_blocks_in_flight.size()));
             };
 
             // If there are multiple chainstates, download blocks for the
             // current chainstate first, to prioritize getting to network tip
             // before downloading historical blocks.
-            FindNextBlocksToDownload(peer, get_inflight_budget(), vToDownload, staller);
+            m_blockdownloadman.FindNextBlocksToDownload(node.GetId(), get_inflight_budget(), vToDownload, staller);
             auto historical_blocks{m_chainman.GetHistoricalBlockRange()};
             if (historical_blocks && !IsLimitedPeer(peer)) {
                 // If the first needed historical block is not an ancestor of the last,
                 // we need to start requesting blocks from their last common ancestor.
                 const CBlockIndex* from_tip = LastCommonAncestor(historical_blocks->first, historical_blocks->second);
-                TryDownloadingHistoricalBlocks(
-                    peer,
+                m_blockdownloadman.TryDownloadingHistoricalBlocks(
+                    node.GetId(),
                     get_inflight_budget(),
                     vToDownload, from_tip, historical_blocks->second);
             }
             for (const CBlockIndex *pindex : vToDownload) {
                 uint32_t nFetchFlags = GetFetchFlags(peer);
                 vGetData.emplace_back(MSG_BLOCK | nFetchFlags, pindex->GetBlockHash());
-                BlockRequested(node.GetId(), *pindex);
+                m_blockdownloadman.BlockRequested(node.GetId(), *pindex);
                 LogDebug(BCLog::NET, "Requesting block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
                     pindex->nHeight, node.GetId());
             }
-            if (state.vBlocksInFlight.empty() && staller != -1) {
-                if (State(staller)->m_stalling_since == 0us) {
-                    State(staller)->m_stalling_since = current_time;
+            if (node_blocks_in_flight.empty() && staller != -1) {
+                if (m_blockdownloadman.GetStallingSince(staller) == 0us) {
+                    m_blockdownloadman.SetStallingSince(staller, current_time);
                     LogDebug(BCLog::NET, "Stall started peer=%d\n", staller);
                 }
             }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -43,8 +43,6 @@ static constexpr bool DEFAULT_TXRECONCILIATION_ENABLE{false};
 static const uint32_t DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN{100};
 static const bool DEFAULT_PEERBLOOMFILTERS = false;
 static const bool DEFAULT_PEERBLOCKFILTERS = false;
-/** Maximum number of outstanding CMPCTBLOCK requests for the same block. */
-static const unsigned int MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK = 3;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
  *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;

--- a/src/node/blockdownloadman.h
+++ b/src/node/blockdownloadman.h
@@ -1,0 +1,226 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_BLOCKDOWNLOADMAN_H
+#define BITCOIN_NODE_BLOCKDOWNLOADMAN_H
+
+#include <kernel/cs_main.h>
+#include <net.h>
+#include <uint256.h>
+
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+class CBlockIndex;
+class ChainstateManager;
+class CTxMemPool;
+class PartiallyDownloadedBlock;
+
+/** Default time during which a peer must stall block download progress before being disconnected.
+ * The actual timeout is increased temporarily if peers are disconnected for hitting the timeout */
+static constexpr auto BLOCK_STALLING_TIMEOUT_DEFAULT{2s};
+/** Maximum timeout for stalling block download. */
+static constexpr auto BLOCK_STALLING_TIMEOUT_MAX{64s};
+/** Number of blocks that can be requested at any given time from a single peer. */
+static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
+/** Size of the "block download window": how far ahead of our current height do we fetch?
+ *  Larger windows tolerate larger download speed differences between peer, but increase the potential
+ *  degree of disordering of blocks on disk (which make reindexing and pruning harder). We'll probably
+ *  want to make this a per-peer adaptive value at some point. */
+static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
+/** Minimum blocks required to signal NODE_NETWORK_LIMITED */
+static const unsigned int NODE_NETWORK_LIMITED_MIN_BLOCKS = 288;
+/** Maximum number of outstanding CMPCTBLOCK requests for the same block. */
+static const unsigned int MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK = 3;
+
+namespace node {
+class BlockDownloadManagerImpl;
+
+/** Blocks that are in flight, and that are in the queue to be downloaded. */
+struct QueuedBlock {
+    /** BlockIndex. We must have this since we only request blocks when we've already validated the header. */
+    const CBlockIndex* pindex;
+    /** Optional, used for CMPCTBLOCK downloads */
+    std::unique_ptr<PartiallyDownloadedBlock> partialBlock;
+};
+
+struct BlockDownloadOptions {
+    /** Reference to ChainstateManager for chain state access and LookupBlockIndex. */
+    ChainstateManager& m_chainman;
+};
+
+struct BlockDownloadConnectionInfo {
+    /** Whether this is an inbound peer. */
+    bool m_is_inbound;
+    /** Whether this peer is preferred for download. */
+    bool m_preferred_download;
+    /** Whether this peer can serve witness data (NODE_WITNESS). */
+    bool m_can_serve_witnesses;
+    /** Whether this peer can only serve limited recent blocks (pruned). */
+    bool m_is_limited_peer;
+};
+
+/**
+ * Class responsible for tracking block download state: which blocks are
+ * in-flight, which peers are downloading from, request scheduling, stalling
+ * detection, and source tracking.
+ *
+ * This class is not thread-safe. Access must be synchronized using an
+ * external mutex.
+ */
+class BlockDownloadManager {
+    const std::unique_ptr<BlockDownloadManagerImpl> m_impl;
+
+public:
+    explicit BlockDownloadManager(const BlockDownloadOptions& options);
+    ~BlockDownloadManager();
+
+    /** Register a new peer for block download tracking. */
+    void ConnectedPeer(NodeId nodeid, const BlockDownloadConnectionInfo& info) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Clean up all block download state for a disconnected peer. */
+    void DisconnectedPeer(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Have we requested this block from any peer? */
+    bool IsBlockRequested(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Have we requested this block from an outbound peer? */
+    bool IsBlockRequestedFromOutbound(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Remove this block from our tracked requested blocks.
+     *  If from_peer is specified, only remove the block if it is in flight from that peer. */
+    void RemoveBlockRequest(const uint256& hash, std::optional<NodeId> from_peer) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Mark a block as in flight from a given peer.
+     *  Returns false (still setting pit) if the block was already in flight from the same peer.
+     *  pit will only be valid as long as the same cs_main lock is being held. */
+    bool BlockRequested(NodeId nodeid, const CBlockIndex& block,
+                        std::list<QueuedBlock>::iterator** pit = nullptr,
+                        CTxMemPool* mempool = nullptr) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Check whether the tip might be stale based on last update time and in-flight state.
+     *  nPowTargetSpacing is used to determine the staleness threshold. */
+    bool TipMayBeStale(std::chrono::seconds now, int64_t n_pow_target_spacing) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Record that the tip was updated. */
+    void SetLastTipUpdate(std::chrono::seconds time);
+
+    /** Get the last tip update time. */
+    std::chrono::seconds GetLastTipUpdate() const;
+
+    /** Check whether the last unknown block a peer advertised is not yet known. */
+    void ProcessBlockAvailability(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Update tracking information about which blocks a peer is assumed to have. */
+    void UpdateBlockAvailability(NodeId nodeid, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Calculate which blocks to download from a given peer, given our current tip.
+     *  Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks.
+     *  Sets nodeStaller to a stalling peer NodeId if applicable, or -1. */
+    void FindNextBlocksToDownload(NodeId nodeid, unsigned int count,
+                                  std::vector<const CBlockIndex*>& vBlocks,
+                                  NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Request blocks for the background chainstate, if one is in use. */
+    void TryDownloadingHistoricalBlocks(NodeId nodeid, unsigned int count,
+                                        std::vector<const CBlockIndex*>& vBlocks,
+                                        const CBlockIndex* from_tip,
+                                        const CBlockIndex* target_block) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the best known block for a peer (or nullptr). */
+    const CBlockIndex* GetBestKnownBlock(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the best header we have sent a peer (or nullptr). */
+    const CBlockIndex* GetBestHeaderSent(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Set the best header we have sent a peer. */
+    void SetBestHeaderSent(NodeId nodeid, const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the last common block with a peer (or nullptr). */
+    const CBlockIndex* GetLastCommonBlock(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get whether we have started syncing headers with this peer. */
+    bool GetSyncStarted(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Mark that we've started syncing headers with this peer, incrementing the global counter. */
+    void SetSyncStarted(NodeId nodeid, bool started) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the global number of peers with sync started. */
+    int GetNumSyncStarted() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the stalling timeout for blocks. */
+    std::chrono::seconds GetBlockStallingTimeout() const;
+
+    /** Atomically compare-and-exchange the stalling timeout.
+     *  Returns true on success (value was expected, now set to desired). */
+    bool CompareExchangeBlockStallingTimeout(std::chrono::seconds& expected, std::chrono::seconds desired);
+
+    /** Get the number of preferred download peers. */
+    int GetNumPreferredDownload() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the number of peers we are downloading blocks from. */
+    int GetPeersDownloadingFrom() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Whether blocks are in flight from any peer. */
+    bool HasBlocksInFlight() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get total number of blocks in flight (across all hashes and peers). */
+    size_t GetTotalBlocksInFlight() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the blocks-in-flight list for a peer. */
+    const std::list<QueuedBlock>& GetBlocksInFlight(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the downloading-since time for a peer. */
+    std::chrono::microseconds GetDownloadingSince(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the stalling-since time for a peer. */
+    std::chrono::microseconds GetStallingSince(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Set the stalling-since time for a peer. */
+    void SetStallingSince(NodeId nodeid, std::chrono::microseconds time) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get whether a peer is a preferred download peer. */
+    bool IsPreferredDownload(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get block source information for a given block hash. */
+    std::optional<std::pair<NodeId, bool>> GetBlockSource(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Record the source of a received block. */
+    void SetBlockSource(const uint256& hash, NodeId nodeid, bool punish_on_invalid) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Remove a block source entry. */
+    void EraseBlockSource(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Get the count of blocks in flight matching a hash. */
+    size_t CountBlocksInFlight(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Check that all data structures are empty. Used for post-disconnect assertions. */
+    void CheckIsEmpty() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Check whether a peer has a particular header. */
+    bool PeerHasHeader(NodeId nodeid, const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    /** Result of looking up in-flight block information. */
+    struct BlockInFlightInfo {
+        /** How many peers have this block in flight. */
+        size_t already_in_flight{0};
+        /** Whether the first entry (if any) is from the specified peer. */
+        bool first_in_flight{false};
+        /** Whether the specified peer has this block in flight. */
+        bool requested_from_peer{false};
+        /** Pointer to this peer's QueuedBlock, set only if that entry has a
+         *  partialBlock (valid while the same cs_main lock is held). */
+        QueuedBlock* queued_block{nullptr};
+    };
+
+    /** Find detailed in-flight information for a block hash + specific peer. */
+    BlockInFlightInfo FindBlockInFlight(const uint256& hash, NodeId peer_id) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+};
+} // namespace node
+#endif // BITCOIN_NODE_BLOCKDOWNLOADMAN_H

--- a/src/node/blockdownloadman_impl.cpp
+++ b/src/node/blockdownloadman_impl.cpp
@@ -1,0 +1,644 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/blockdownloadman_impl.h>
+#include <node/blockdownloadman.h>
+
+#include <blockencodings.h>
+#include <chain.h>
+#include <deploymentstatus.h>
+#include <logging.h>
+#include <node/blockstorage.h>
+#include <primitives/block.h>
+#include <txmempool.h>
+#include <util/check.h>
+#include <validation.h>
+
+namespace node {
+
+// ---------------------------------------------------------------------------
+// BlockDownloadManager pimpl forwarding wrappers
+// ---------------------------------------------------------------------------
+
+BlockDownloadManager::BlockDownloadManager(const BlockDownloadOptions& options)
+    : m_impl{std::make_unique<BlockDownloadManagerImpl>(options)}
+{}
+
+BlockDownloadManager::~BlockDownloadManager() = default;
+
+void BlockDownloadManager::ConnectedPeer(NodeId nodeid, const BlockDownloadConnectionInfo& info)
+{
+    m_impl->ConnectedPeer(nodeid, info);
+}
+
+void BlockDownloadManager::DisconnectedPeer(NodeId nodeid)
+{
+    m_impl->DisconnectedPeer(nodeid);
+}
+
+bool BlockDownloadManager::IsBlockRequested(const uint256& hash) const
+{
+    return m_impl->IsBlockRequested(hash);
+}
+
+bool BlockDownloadManager::IsBlockRequestedFromOutbound(const uint256& hash) const
+{
+    return m_impl->IsBlockRequestedFromOutbound(hash);
+}
+
+void BlockDownloadManager::RemoveBlockRequest(const uint256& hash, std::optional<NodeId> from_peer)
+{
+    m_impl->RemoveBlockRequest(hash, from_peer);
+}
+
+bool BlockDownloadManager::BlockRequested(NodeId nodeid, const CBlockIndex& block,
+                                          std::list<QueuedBlock>::iterator** pit,
+                                          CTxMemPool* mempool)
+{
+    return m_impl->BlockRequested(nodeid, block, pit, mempool);
+}
+
+bool BlockDownloadManager::TipMayBeStale(std::chrono::seconds now, int64_t n_pow_target_spacing)
+{
+    return m_impl->TipMayBeStale(now, n_pow_target_spacing);
+}
+
+void BlockDownloadManager::SetLastTipUpdate(std::chrono::seconds time)
+{
+    m_impl->m_last_tip_update = time;
+}
+
+std::chrono::seconds BlockDownloadManager::GetLastTipUpdate() const
+{
+    return m_impl->m_last_tip_update.load();
+}
+
+void BlockDownloadManager::ProcessBlockAvailability(NodeId nodeid)
+{
+    m_impl->ProcessBlockAvailability(nodeid);
+}
+
+void BlockDownloadManager::UpdateBlockAvailability(NodeId nodeid, const uint256& hash)
+{
+    m_impl->UpdateBlockAvailability(nodeid, hash);
+}
+
+void BlockDownloadManager::FindNextBlocksToDownload(NodeId nodeid, unsigned int count,
+                                                    std::vector<const CBlockIndex*>& vBlocks,
+                                                    NodeId& nodeStaller)
+{
+    m_impl->FindNextBlocksToDownload(nodeid, count, vBlocks, nodeStaller);
+}
+
+void BlockDownloadManager::TryDownloadingHistoricalBlocks(NodeId nodeid, unsigned int count,
+                                                          std::vector<const CBlockIndex*>& vBlocks,
+                                                          const CBlockIndex* from_tip,
+                                                          const CBlockIndex* target_block)
+{
+    m_impl->TryDownloadingHistoricalBlocks(nodeid, count, vBlocks, from_tip, target_block);
+}
+
+const CBlockIndex* BlockDownloadManager::GetBestKnownBlock(NodeId nodeid) const
+{
+    const auto* state = m_impl->GetPeerState(nodeid);
+    return state ? state->pindexBestKnownBlock : nullptr;
+}
+
+const CBlockIndex* BlockDownloadManager::GetBestHeaderSent(NodeId nodeid) const
+{
+    const auto* state = m_impl->GetPeerState(nodeid);
+    return state ? state->pindexBestHeaderSent : nullptr;
+}
+
+void BlockDownloadManager::SetBestHeaderSent(NodeId nodeid, const CBlockIndex* pindex)
+{
+    auto* state = m_impl->GetPeerState(nodeid);
+    if (state) state->pindexBestHeaderSent = pindex;
+}
+
+const CBlockIndex* BlockDownloadManager::GetLastCommonBlock(NodeId nodeid) const
+{
+    const auto* state = m_impl->GetPeerState(nodeid);
+    return state ? state->pindexLastCommonBlock : nullptr;
+}
+
+bool BlockDownloadManager::GetSyncStarted(NodeId nodeid) const
+{
+    const auto* state = m_impl->GetPeerState(nodeid);
+    return state ? state->fSyncStarted : false;
+}
+
+void BlockDownloadManager::SetSyncStarted(NodeId nodeid, bool started)
+{
+    auto* state = m_impl->GetPeerState(nodeid);
+    if (!state) return;
+    if (state->fSyncStarted && !started) {
+        m_impl->nSyncStarted--;
+    } else if (!state->fSyncStarted && started) {
+        m_impl->nSyncStarted++;
+    }
+    state->fSyncStarted = started;
+}
+
+int BlockDownloadManager::GetNumSyncStarted() const
+{
+    return m_impl->nSyncStarted;
+}
+
+std::chrono::seconds BlockDownloadManager::GetBlockStallingTimeout() const
+{
+    return m_impl->m_block_stalling_timeout.load();
+}
+
+bool BlockDownloadManager::CompareExchangeBlockStallingTimeout(std::chrono::seconds& expected, std::chrono::seconds desired)
+{
+    return m_impl->m_block_stalling_timeout.compare_exchange_strong(expected, desired);
+}
+
+int BlockDownloadManager::GetNumPreferredDownload() const
+{
+    return m_impl->m_num_preferred_download_peers;
+}
+
+int BlockDownloadManager::GetPeersDownloadingFrom() const
+{
+    return m_impl->m_peers_downloading_from;
+}
+
+bool BlockDownloadManager::HasBlocksInFlight() const
+{
+    return !m_impl->mapBlocksInFlight.empty();
+}
+
+size_t BlockDownloadManager::GetTotalBlocksInFlight() const
+{
+    return m_impl->mapBlocksInFlight.size();
+}
+
+const std::list<QueuedBlock>& BlockDownloadManager::GetBlocksInFlight(NodeId nodeid) const
+{
+    const auto* state = m_impl->GetPeerState(nodeid);
+    Assert(state);
+    return state->vBlocksInFlight;
+}
+
+std::chrono::microseconds BlockDownloadManager::GetDownloadingSince(NodeId nodeid) const
+{
+    const auto* state = m_impl->GetPeerState(nodeid);
+    return state ? state->m_downloading_since : std::chrono::microseconds{0};
+}
+
+std::chrono::microseconds BlockDownloadManager::GetStallingSince(NodeId nodeid) const
+{
+    const auto* state = m_impl->GetPeerState(nodeid);
+    return state ? state->m_stalling_since : std::chrono::microseconds{0};
+}
+
+void BlockDownloadManager::SetStallingSince(NodeId nodeid, std::chrono::microseconds time)
+{
+    auto* state = m_impl->GetPeerState(nodeid);
+    if (state) state->m_stalling_since = time;
+}
+
+bool BlockDownloadManager::IsPreferredDownload(NodeId nodeid) const
+{
+    const auto* state = m_impl->GetPeerState(nodeid);
+    return state ? state->fPreferredDownload : false;
+}
+
+std::optional<std::pair<NodeId, bool>> BlockDownloadManager::GetBlockSource(const uint256& hash) const
+{
+    auto it = m_impl->mapBlockSource.find(hash);
+    if (it != m_impl->mapBlockSource.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+void BlockDownloadManager::SetBlockSource(const uint256& hash, NodeId nodeid, bool punish_on_invalid)
+{
+    m_impl->mapBlockSource.emplace(hash, std::make_pair(nodeid, punish_on_invalid));
+}
+
+void BlockDownloadManager::EraseBlockSource(const uint256& hash)
+{
+    m_impl->mapBlockSource.erase(hash);
+}
+
+size_t BlockDownloadManager::CountBlocksInFlight(const uint256& hash) const
+{
+    return m_impl->mapBlocksInFlight.count(hash);
+}
+
+void BlockDownloadManager::CheckIsEmpty() const
+{
+    m_impl->CheckIsEmpty();
+}
+
+bool BlockDownloadManager::PeerHasHeader(NodeId nodeid, const CBlockIndex* pindex) const
+{
+    const auto* state = m_impl->GetPeerState(nodeid);
+    if (!state) return false;
+    return m_impl->PeerHasHeader(*state, pindex);
+}
+
+BlockDownloadManager::BlockInFlightInfo BlockDownloadManager::FindBlockInFlight(const uint256& hash, NodeId peer_id) const
+{
+    BlockInFlightInfo result;
+    auto range = m_impl->mapBlocksInFlight.equal_range(hash);
+    result.already_in_flight = std::distance(range.first, range.second);
+    result.first_in_flight = result.already_in_flight == 0 || (range.first->second.first == peer_id);
+
+    for (auto it = range.first; it != range.second; ++it) {
+        if (it->second.first == peer_id) {
+            result.requested_from_peer = true;
+            if (it->second.second->partialBlock) {
+                result.queued_block = &*it->second.second;
+            }
+            break;
+        }
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// BlockDownloadManagerImpl
+// ---------------------------------------------------------------------------
+
+BlockDownloadManagerImpl::PeerBlockDownloadState* BlockDownloadManagerImpl::GetPeerState(NodeId nodeid)
+{
+    auto it = m_peer_info.find(nodeid);
+    return it != m_peer_info.end() ? &it->second : nullptr;
+}
+
+const BlockDownloadManagerImpl::PeerBlockDownloadState* BlockDownloadManagerImpl::GetPeerState(NodeId nodeid) const
+{
+    auto it = m_peer_info.find(nodeid);
+    return it != m_peer_info.end() ? &it->second : nullptr;
+}
+
+void BlockDownloadManagerImpl::ConnectedPeer(NodeId nodeid, const BlockDownloadConnectionInfo& info)
+{
+    auto [it, inserted] = m_peer_info.try_emplace(nodeid, info);
+    auto& state = it->second;
+    if (!inserted) {
+        // Re-registration: update connection info.
+        state.m_connection_info = info;
+    }
+    // Set preferred download flag and update counter (handles both first
+    // registration and re-registration).
+    if (info.m_preferred_download && !state.fPreferredDownload) {
+        state.fPreferredDownload = true;
+        m_num_preferred_download_peers++;
+    }
+}
+
+void BlockDownloadManagerImpl::DisconnectedPeer(NodeId nodeid)
+{
+    auto it = m_peer_info.find(nodeid);
+    if (it == m_peer_info.end()) return;
+
+    auto& state = it->second;
+
+    if (state.fSyncStarted) {
+        nSyncStarted--;
+    }
+
+    // Remove all in-flight block entries for this peer from the global map.
+    for (const QueuedBlock& entry : state.vBlocksInFlight) {
+        auto range = mapBlocksInFlight.equal_range(entry.pindex->GetBlockHash());
+        while (range.first != range.second) {
+            auto [node_id, list_it] = range.first->second;
+            if (node_id != nodeid) {
+                range.first++;
+            } else {
+                range.first = mapBlocksInFlight.erase(range.first);
+            }
+        }
+    }
+
+    m_num_preferred_download_peers -= state.fPreferredDownload;
+    m_peers_downloading_from -= (!state.vBlocksInFlight.empty());
+    assert(m_peers_downloading_from >= 0);
+
+    m_peer_info.erase(it);
+}
+
+bool BlockDownloadManagerImpl::IsBlockRequested(const uint256& hash) const
+{
+    return mapBlocksInFlight.contains(hash);
+}
+
+bool BlockDownloadManagerImpl::IsBlockRequestedFromOutbound(const uint256& hash) const
+{
+    for (auto range = mapBlocksInFlight.equal_range(hash); range.first != range.second; range.first++) {
+        auto [nodeid, block_it] = range.first->second;
+        const auto* state = GetPeerState(nodeid);
+        if (state && !state->m_connection_info.m_is_inbound) return true;
+    }
+    return false;
+}
+
+void BlockDownloadManagerImpl::RemoveBlockRequest(const uint256& hash, std::optional<NodeId> from_peer)
+{
+    auto range = mapBlocksInFlight.equal_range(hash);
+    if (range.first == range.second) {
+        // Block was not requested from any peer
+        return;
+    }
+
+    // We should not have requested too many of this block
+    Assume(mapBlocksInFlight.count(hash) <= MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK);
+
+    while (range.first != range.second) {
+        const auto& [node_id, list_it]{range.first->second};
+
+        if (from_peer && *from_peer != node_id) {
+            range.first++;
+            continue;
+        }
+
+        auto* state = Assert(GetPeerState(node_id));
+
+        if (state->vBlocksInFlight.begin() == list_it) {
+            // First block on the queue was received, update the start download time for the next one
+            state->m_downloading_since = std::max(state->m_downloading_since, GetTime<std::chrono::microseconds>());
+        }
+        state->vBlocksInFlight.erase(list_it);
+
+        if (state->vBlocksInFlight.empty()) {
+            // Last validated block on the queue for this peer was received.
+            m_peers_downloading_from--;
+        }
+        state->m_stalling_since = 0us;
+
+        range.first = mapBlocksInFlight.erase(range.first);
+    }
+}
+
+bool BlockDownloadManagerImpl::BlockRequested(NodeId nodeid, const CBlockIndex& block,
+                                              std::list<QueuedBlock>::iterator** pit,
+                                              CTxMemPool* mempool)
+{
+    const uint256& hash{block.GetBlockHash()};
+
+    // A pit request creates a PartiallyDownloadedBlock, which needs the mempool.
+    Assume(!pit || mempool);
+
+    auto* state = Assert(GetPeerState(nodeid));
+
+    Assume(mapBlocksInFlight.count(hash) <= MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK);
+
+    // Short-circuit most stuff in case it is from the same node
+    for (auto range = mapBlocksInFlight.equal_range(hash); range.first != range.second; range.first++) {
+        if (range.first->second.first == nodeid) {
+            if (pit) {
+                *pit = &range.first->second.second;
+            }
+            return false;
+        }
+    }
+
+    // Make sure it's not being fetched already from same peer.
+    RemoveBlockRequest(hash, nodeid);
+
+    std::list<QueuedBlock>::iterator it = state->vBlocksInFlight.insert(state->vBlocksInFlight.end(),
+            {&block, std::unique_ptr<PartiallyDownloadedBlock>(pit ? new PartiallyDownloadedBlock(mempool) : nullptr)});
+    if (state->vBlocksInFlight.size() == 1) {
+        // We're starting a block download (batch) from this peer.
+        state->m_downloading_since = GetTime<std::chrono::microseconds>();
+        m_peers_downloading_from++;
+    }
+    auto itInFlight = mapBlocksInFlight.insert(std::make_pair(hash, std::make_pair(nodeid, it)));
+    if (pit) {
+        *pit = &itInFlight->second.second;
+    }
+    return true;
+}
+
+bool BlockDownloadManagerImpl::TipMayBeStale(std::chrono::seconds now, int64_t n_pow_target_spacing)
+{
+    if (m_last_tip_update.load() == 0s) {
+        m_last_tip_update = now;
+        return false;
+    }
+    return m_last_tip_update.load() < now - std::chrono::seconds{n_pow_target_spacing * 3} && mapBlocksInFlight.empty();
+}
+
+void BlockDownloadManagerImpl::ProcessBlockAvailability(NodeId nodeid)
+{
+    auto* state = Assert(GetPeerState(nodeid));
+
+    if (!state->hashLastUnknownBlock.IsNull()) {
+        const CBlockIndex* pindex = m_opts.m_chainman.m_blockman.LookupBlockIndex(state->hashLastUnknownBlock);
+        if (pindex && pindex->nChainWork > 0) {
+            if (state->pindexBestKnownBlock == nullptr || pindex->nChainWork >= state->pindexBestKnownBlock->nChainWork) {
+                state->pindexBestKnownBlock = pindex;
+            }
+            state->hashLastUnknownBlock.SetNull();
+        }
+    }
+}
+
+void BlockDownloadManagerImpl::UpdateBlockAvailability(NodeId nodeid, const uint256& hash)
+{
+    auto* state = Assert(GetPeerState(nodeid));
+
+    ProcessBlockAvailability(nodeid);
+
+    const CBlockIndex* pindex = m_opts.m_chainman.m_blockman.LookupBlockIndex(hash);
+    if (pindex && pindex->nChainWork > 0) {
+        // An actually better block was announced.
+        if (state->pindexBestKnownBlock == nullptr || pindex->nChainWork >= state->pindexBestKnownBlock->nChainWork) {
+            state->pindexBestKnownBlock = pindex;
+        }
+    } else {
+        // An unknown block was announced; just assume that the latest one is the best one.
+        state->hashLastUnknownBlock = hash;
+    }
+}
+
+void BlockDownloadManagerImpl::FindNextBlocksToDownload(NodeId nodeid, unsigned int count,
+                                                        std::vector<const CBlockIndex*>& vBlocks,
+                                                        NodeId& nodeStaller)
+{
+    if (count == 0) return;
+
+    vBlocks.reserve(vBlocks.size() + count);
+    auto* state = Assert(GetPeerState(nodeid));
+
+    // Make sure pindexBestKnownBlock is up to date, we'll need it.
+    ProcessBlockAvailability(nodeid);
+
+    if (state->pindexBestKnownBlock == nullptr ||
+        state->pindexBestKnownBlock->nChainWork < m_opts.m_chainman.ActiveChain().Tip()->nChainWork ||
+        state->pindexBestKnownBlock->nChainWork < m_opts.m_chainman.MinimumChainWork()) {
+        // This peer has nothing interesting.
+        return;
+    }
+
+    // When syncing with AssumeUtxo and the snapshot has not yet been validated,
+    // abort downloading blocks from peers that don't have the snapshot block in their best chain.
+    // We can't reorg to this chain due to missing undo data until validation completes,
+    // so downloading blocks from it would be futile.
+    const CBlockIndex* snap_base{m_opts.m_chainman.CurrentChainstate().SnapshotBase()};
+    if (snap_base && m_opts.m_chainman.CurrentChainstate().m_assumeutxo == Assumeutxo::UNVALIDATED &&
+        state->pindexBestKnownBlock->GetAncestor(snap_base->nHeight) != snap_base) {
+        LogDebug(BCLog::NET, "Not downloading blocks from peer=%d, which doesn't have the snapshot block in its best chain.\n", nodeid);
+        return;
+    }
+
+    // Determine the forking point between the peer's chain and our chain:
+    // pindexLastCommonBlock is required to be an ancestor of pindexBestKnownBlock, and will be used as a starting point.
+    // It is being set to the fork point between the peer's best known block and the current tip, unless it is already set to
+    // an ancestor with more work than the fork point.
+    auto fork_point = LastCommonAncestor(state->pindexBestKnownBlock, m_opts.m_chainman.ActiveTip());
+    if (state->pindexLastCommonBlock == nullptr ||
+        fork_point->nChainWork > state->pindexLastCommonBlock->nChainWork ||
+        state->pindexBestKnownBlock->GetAncestor(state->pindexLastCommonBlock->nHeight) != state->pindexLastCommonBlock) {
+        state->pindexLastCommonBlock = fork_point;
+    }
+    if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
+        return;
+
+    const CBlockIndex* pindexWalk = state->pindexLastCommonBlock;
+    // Never fetch further than the best block we know the peer has, or more than BLOCK_DOWNLOAD_WINDOW + 1 beyond the last
+    // linked block we have in common with this peer. The +1 is so we can detect stalling, namely if we would be able to
+    // download that next block if the window were 1 larger.
+    int nWindowEnd = state->pindexLastCommonBlock->nHeight + BLOCK_DOWNLOAD_WINDOW;
+
+    FindNextBlocks(vBlocks, nodeid, *state, pindexWalk, count, nWindowEnd, &m_opts.m_chainman.ActiveChain(), &nodeStaller);
+}
+
+void BlockDownloadManagerImpl::TryDownloadingHistoricalBlocks(NodeId nodeid, unsigned int count,
+                                                              std::vector<const CBlockIndex*>& vBlocks,
+                                                              const CBlockIndex* from_tip,
+                                                              const CBlockIndex* target_block)
+{
+    Assert(from_tip);
+    Assert(target_block);
+
+    if (vBlocks.size() >= count) {
+        return;
+    }
+
+    vBlocks.reserve(count);
+    auto* state = Assert(GetPeerState(nodeid));
+
+    if (state->pindexBestKnownBlock == nullptr ||
+        state->pindexBestKnownBlock->GetAncestor(target_block->nHeight) != target_block) {
+        // This peer can't provide us the complete series of blocks leading up to the
+        // assumeutxo snapshot base.
+        //
+        // Presumably this peer's chain has less work than our ActiveChain()'s tip, or else we
+        // will eventually crash when we try to reorg to it. Let other logic
+        // deal with whether we disconnect this peer.
+        //
+        // TODO at some point in the future, we might choose to request what blocks
+        // this peer does have from the historical chain, despite it not having a
+        // complete history beneath the snapshot base.
+        return;
+    }
+
+    FindNextBlocks(vBlocks, nodeid, *state, from_tip, count,
+                   std::min<int>(from_tip->nHeight + BLOCK_DOWNLOAD_WINDOW, target_block->nHeight));
+}
+
+void BlockDownloadManagerImpl::FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks,
+                                              NodeId nodeid,
+                                              PeerBlockDownloadState& state,
+                                              const CBlockIndex* pindexWalk,
+                                              unsigned int count, int nWindowEnd,
+                                              const CChain* activeChain,
+                                              NodeId* nodeStaller)
+{
+    std::vector<const CBlockIndex*> vToFetch;
+    int nMaxHeight = std::min<int>(state.pindexBestKnownBlock->nHeight, nWindowEnd + 1);
+    bool is_limited_peer = state.m_connection_info.m_is_limited_peer;
+    NodeId waitingfor = -1;
+    while (pindexWalk->nHeight < nMaxHeight) {
+        // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
+        // pindexBestKnownBlock) into vToFetch. We fetch 128, because CBlockIndex::GetAncestor may be as expensive
+        // as iterating over ~100 CBlockIndex* entries anyway.
+        int nToFetch = std::min(nMaxHeight - pindexWalk->nHeight, std::max<int>(count - vBlocks.size(), 128));
+        vToFetch.resize(nToFetch);
+        pindexWalk = state.pindexBestKnownBlock->GetAncestor(pindexWalk->nHeight + nToFetch);
+        vToFetch[nToFetch - 1] = pindexWalk;
+        for (unsigned int i = nToFetch - 1; i > 0; i--) {
+            vToFetch[i - 1] = vToFetch[i]->pprev;
+        }
+
+        // Iterate over those blocks in vToFetch (in forward direction), adding the ones that
+        // are not yet downloaded and not in flight to vBlocks. In the meantime, update
+        // pindexLastCommonBlock as long as all ancestors are already downloaded, or if it's
+        // already part of our chain (and therefore don't need it even if pruned).
+        for (const CBlockIndex* pindex : vToFetch) {
+            if (!pindex->IsValid(BLOCK_VALID_TREE)) {
+                // We consider the chain that this peer is on invalid.
+                return;
+            }
+
+            if (!state.m_connection_info.m_can_serve_witnesses &&
+                DeploymentActiveAt(*pindex, m_opts.m_chainman, Consensus::DEPLOYMENT_SEGWIT)) {
+                // We wouldn't download this block or its descendants from this peer.
+                return;
+            }
+
+            if (pindex->nStatus & BLOCK_HAVE_DATA || (activeChain && activeChain->Contains(*pindex))) {
+                if (activeChain && pindex->HaveNumChainTxs()) {
+                    state.pindexLastCommonBlock = pindex;
+                }
+                continue;
+            }
+
+            // Is block in-flight?
+            if (IsBlockRequested(pindex->GetBlockHash())) {
+                if (waitingfor == -1) {
+                    // This is the first already-in-flight block.
+                    waitingfor = mapBlocksInFlight.lower_bound(pindex->GetBlockHash())->second.first;
+                }
+                continue;
+            }
+
+            // The block is not already downloaded, and not yet in flight.
+            if (pindex->nHeight > nWindowEnd) {
+                // We reached the end of the window.
+                if (vBlocks.size() == 0 && waitingfor != nodeid) {
+                    // We aren't able to fetch anything, but we would be if the download window was one larger.
+                    if (nodeStaller) *nodeStaller = waitingfor;
+                }
+                return;
+            }
+
+            // Don't request blocks that go further than what limited peers can provide
+            if (is_limited_peer && (state.pindexBestKnownBlock->nHeight - pindex->nHeight >= static_cast<int>(NODE_NETWORK_LIMITED_MIN_BLOCKS) - 2 /* two blocks buffer for possible races */)) {
+                continue;
+            }
+
+            vBlocks.push_back(pindex);
+            if (vBlocks.size() == count) {
+                return;
+            }
+        }
+    }
+}
+
+bool BlockDownloadManagerImpl::PeerHasHeader(const PeerBlockDownloadState& state, const CBlockIndex* pindex) const
+{
+    if (state.pindexBestKnownBlock && pindex == state.pindexBestKnownBlock->GetAncestor(pindex->nHeight))
+        return true;
+    if (state.pindexBestHeaderSent && pindex == state.pindexBestHeaderSent->GetAncestor(pindex->nHeight))
+        return true;
+    return false;
+}
+
+void BlockDownloadManagerImpl::CheckIsEmpty() const
+{
+    assert(m_peer_info.empty());
+    assert(mapBlocksInFlight.empty());
+    assert(m_num_preferred_download_peers == 0);
+    assert(m_peers_downloading_from == 0);
+}
+
+} // namespace node

--- a/src/node/blockdownloadman_impl.h
+++ b/src/node/blockdownloadman_impl.h
@@ -1,0 +1,132 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_BLOCKDOWNLOADMAN_IMPL_H
+#define BITCOIN_NODE_BLOCKDOWNLOADMAN_IMPL_H
+
+#include <node/blockdownloadman.h>
+
+#include <chain.h>
+#include <kernel/cs_main.h>
+#include <uint256.h>
+
+#include <atomic>
+#include <chrono>
+#include <list>
+#include <map>
+#include <optional>
+#include <vector>
+
+class CBlockIndex;
+class ChainstateManager;
+
+namespace node {
+class BlockDownloadManagerImpl {
+public:
+    BlockDownloadOptions m_opts;
+
+    /** Per-peer block download state. */
+    struct PeerBlockDownloadState {
+        /** Connection info provided at registration time (updated on re-registration). */
+        BlockDownloadConnectionInfo m_connection_info;
+
+        /** The best known block we know this peer has announced. */
+        const CBlockIndex* pindexBestKnownBlock{nullptr};
+        /** The hash of the last unknown block this peer has announced. */
+        uint256 hashLastUnknownBlock{};
+        /** The last full block we both have. */
+        const CBlockIndex* pindexLastCommonBlock{nullptr};
+        /** The best header we have sent our peer. */
+        const CBlockIndex* pindexBestHeaderSent{nullptr};
+        /** Whether we've started headers synchronization with this peer. */
+        bool fSyncStarted{false};
+        /** Since when we're stalling block download progress (in microseconds), or 0. */
+        std::chrono::microseconds m_stalling_since{0us};
+        /** Blocks in flight from this peer. */
+        std::list<QueuedBlock> vBlocksInFlight;
+        /** When the first entry in vBlocksInFlight started downloading. */
+        std::chrono::microseconds m_downloading_since{0us};
+        /** Whether we consider this a preferred download peer. */
+        bool fPreferredDownload{false};
+
+        explicit PeerBlockDownloadState(const BlockDownloadConnectionInfo& info)
+            : m_connection_info{info} {}
+    };
+
+    /** Per-peer download state map. */
+    std::map<NodeId, PeerBlockDownloadState> m_peer_info GUARDED_BY(::cs_main);
+
+    /* Multimap used to preserve insertion order */
+    using BlockDownloadMap = std::multimap<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator>>;
+    BlockDownloadMap mapBlocksInFlight GUARDED_BY(::cs_main);
+
+    /**
+     * Sources of received blocks, saved to be able to punish them when processing
+     * happens afterwards.
+     * Set mapBlockSource[hash].second to false if the node should not be
+     * punished if the block is invalid.
+     */
+    std::map<uint256, std::pair<NodeId, bool>> mapBlockSource GUARDED_BY(::cs_main);
+
+    /** Number of peers with fSyncStarted. */
+    int nSyncStarted GUARDED_BY(::cs_main){0};
+
+    /** Default time during which a peer must stall block download progress before being disconnected. */
+    std::atomic<std::chrono::seconds> m_block_stalling_timeout{BLOCK_STALLING_TIMEOUT_DEFAULT};
+
+    /** When our tip was last updated. */
+    std::atomic<std::chrono::seconds> m_last_tip_update{0s};
+
+    /** Number of preferred block download peers. */
+    int m_num_preferred_download_peers GUARDED_BY(::cs_main){0};
+
+    /** Number of peers from which we're downloading blocks. */
+    int m_peers_downloading_from GUARDED_BY(::cs_main){0};
+
+    explicit BlockDownloadManagerImpl(const BlockDownloadOptions& options)
+        : m_opts{options} {}
+
+    // Helper to look up per-peer state (returns nullptr if not found).
+    PeerBlockDownloadState* GetPeerState(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    const PeerBlockDownloadState* GetPeerState(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    void ConnectedPeer(NodeId nodeid, const BlockDownloadConnectionInfo& info) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void DisconnectedPeer(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    bool IsBlockRequested(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool IsBlockRequestedFromOutbound(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void RemoveBlockRequest(const uint256& hash, std::optional<NodeId> from_peer) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool BlockRequested(NodeId nodeid, const CBlockIndex& block,
+                        std::list<QueuedBlock>::iterator** pit,
+                        CTxMemPool* mempool) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    bool TipMayBeStale(std::chrono::seconds now, int64_t n_pow_target_spacing) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    void ProcessBlockAvailability(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void UpdateBlockAvailability(NodeId nodeid, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    void FindNextBlocksToDownload(NodeId nodeid, unsigned int count,
+                                  std::vector<const CBlockIndex*>& vBlocks,
+                                  NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    void TryDownloadingHistoricalBlocks(NodeId nodeid, unsigned int count,
+                                        std::vector<const CBlockIndex*>& vBlocks,
+                                        const CBlockIndex* from_tip,
+                                        const CBlockIndex* target_block) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    void FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks,
+                        NodeId nodeid,
+                        PeerBlockDownloadState& state,
+                        const CBlockIndex* pindexWalk,
+                        unsigned int count, int nWindowEnd,
+                        const CChain* activeChain = nullptr,
+                        NodeId* nodeStaller = nullptr) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    bool PeerHasHeader(const PeerBlockDownloadState& state, const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    void CheckIsEmpty() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+};
+} // namespace node
+
+#endif // BITCOIN_NODE_BLOCKDOWNLOADMAN_IMPL_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(test_bitcoin
   bip32_tests.cpp
   bip324_tests.cpp
   blockchain_tests.cpp
+  blockdownload_tests.cpp
   blockencodings_tests.cpp
   blockfilter_index_tests.cpp
   blockfilter_tests.cpp

--- a/src/test/blockdownload_tests.cpp
+++ b/src/test/blockdownload_tests.cpp
@@ -1,0 +1,466 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <arith_uint256.h>
+#include <blockencodings.h>
+#include <chain.h>
+#include <consensus/validation.h>
+#include <node/blockdownloadman.h>
+#include <node/blockdownloadman_impl.h>
+#include <pow.h>
+#include <primitives/block.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+using node::BlockDownloadConnectionInfo;
+using node::BlockDownloadManager;
+using node::BlockDownloadOptions;
+
+BOOST_FIXTURE_TEST_SUITE(blockdownload_tests, TestingSetup)
+
+// Test the full peer lifecycle: registration, sync state, blocks in flight,
+// and disconnection with correct counter maintenance. Also covers sync-started
+// idempotency and explicit unsetting.
+BOOST_AUTO_TEST_CASE(peer_lifecycle)
+{
+    LOCK(cs_main);
+    BlockDownloadManager bdm(BlockDownloadOptions{*m_node.chainman});
+
+    const NodeId peer1{0}, peer2{1};
+    BlockDownloadConnectionInfo info1{/*m_is_inbound=*/false, /*m_preferred_download=*/true,
+                                      /*m_can_serve_witnesses=*/true,
+                                      /*m_is_limited_peer=*/false};
+    BlockDownloadConnectionInfo info2{/*m_is_inbound=*/true, /*m_preferred_download=*/false,
+                                      /*m_can_serve_witnesses=*/true,
+                                      /*m_is_limited_peer=*/false};
+
+    // Register peers
+    bdm.ConnectedPeer(peer1, info1);
+    bdm.ConnectedPeer(peer2, info2);
+
+    // Check initial state — peer1 is preferred, peer2 is not
+    BOOST_CHECK_EQUAL(bdm.GetNumSyncStarted(), 0);
+    BOOST_CHECK_EQUAL(bdm.GetNumPreferredDownload(), 1);
+    BOOST_CHECK_EQUAL(bdm.GetPeersDownloadingFrom(), 0);
+    BOOST_CHECK(!bdm.HasBlocksInFlight());
+
+    // Set sync started for both peers
+    bdm.SetSyncStarted(peer1, true);
+    bdm.SetSyncStarted(peer2, true);
+    BOOST_CHECK_EQUAL(bdm.GetNumSyncStarted(), 2);
+    BOOST_CHECK(bdm.GetSyncStarted(peer1));
+    BOOST_CHECK(bdm.GetSyncStarted(peer2));
+
+    // Setting same value again should not change count (idempotency)
+    bdm.SetSyncStarted(peer1, true);
+    BOOST_CHECK_EQUAL(bdm.GetNumSyncStarted(), 2);
+
+    // Explicitly unset sync for peer2
+    bdm.SetSyncStarted(peer2, false);
+    BOOST_CHECK_EQUAL(bdm.GetNumSyncStarted(), 1);
+    BOOST_CHECK(!bdm.GetSyncStarted(peer2));
+
+    // Request a block from peer1 — should update in-flight counters
+    const CBlockIndex* genesis = m_node.chainman->ActiveChain().Genesis();
+    BOOST_REQUIRE(genesis != nullptr);
+    bdm.BlockRequested(peer1, *genesis);
+    BOOST_CHECK(bdm.HasBlocksInFlight());
+    BOOST_CHECK_EQUAL(bdm.GetPeersDownloadingFrom(), 1);
+    BOOST_CHECK(bdm.IsBlockRequested(genesis->GetBlockHash()));
+
+    // Disconnect peer1 — should clean up sync, preferred, and in-flight state
+    bdm.DisconnectedPeer(peer1);
+    BOOST_CHECK_EQUAL(bdm.GetNumSyncStarted(), 0);
+    BOOST_CHECK_EQUAL(bdm.GetNumPreferredDownload(), 0);
+    BOOST_CHECK_EQUAL(bdm.GetPeersDownloadingFrom(), 0);
+    BOOST_CHECK(!bdm.HasBlocksInFlight());
+
+    // Disconnect peer2
+    bdm.DisconnectedPeer(peer2);
+    bdm.CheckIsEmpty();
+}
+
+// Test that block source attribution (which peer sent a block) can be
+// set, queried, and erased, and that unrelated hashes are not affected.
+BOOST_AUTO_TEST_CASE(block_source_tracking)
+{
+    LOCK(cs_main);
+    BlockDownloadManager bdm(BlockDownloadOptions{*m_node.chainman});
+
+    uint256 hash1 = uint256::ONE;
+    uint256 hash2{ArithToUint256(arith_uint256{2})};
+    NodeId peer1{0};
+
+    // Initially no source
+    BOOST_CHECK(!bdm.GetBlockSource(hash1).has_value());
+
+    // Set source
+    bdm.SetBlockSource(hash1, peer1, /*punish_on_invalid=*/true);
+    auto source = bdm.GetBlockSource(hash1);
+    BOOST_CHECK(source.has_value());
+    BOOST_CHECK_EQUAL(source->first, peer1);
+    BOOST_CHECK_EQUAL(source->second, true);
+
+    // No source for different hash
+    BOOST_CHECK(!bdm.GetBlockSource(hash2).has_value());
+
+    // Erase source
+    bdm.EraseBlockSource(hash1);
+    BOOST_CHECK(!bdm.GetBlockSource(hash1).has_value());
+}
+
+// Test last tip update get/set and TipMayBeStale logic: lazy initialization,
+// recent vs old tip, and staleness threshold.
+BOOST_AUTO_TEST_CASE(stalling_and_tip_staleness)
+{
+    LOCK(cs_main);
+    BlockDownloadManager bdm(BlockDownloadOptions{*m_node.chainman});
+
+    int64_t pow_spacing = 600; // 10 minutes
+    auto now = GetTime<std::chrono::seconds>();
+
+    // Last tip update: initially zero, then set/read back
+    BOOST_CHECK(bdm.GetLastTipUpdate() == std::chrono::seconds{0});
+
+    // First call with last_tip_update at 0 initializes it to now and returns false
+    BOOST_CHECK(!bdm.TipMayBeStale(now, pow_spacing));
+
+    // Set a recent tip update — not stale
+    bdm.SetLastTipUpdate(now);
+    BOOST_CHECK(bdm.GetLastTipUpdate() == now);
+    BOOST_CHECK(!bdm.TipMayBeStale(now, pow_spacing));
+
+    // Set an old tip update — stale (no blocks in flight)
+    bdm.SetLastTipUpdate(now - std::chrono::seconds{pow_spacing * 4});
+    BOOST_CHECK(bdm.TipMayBeStale(now, pow_spacing));
+}
+
+// Test basic block request flow: requesting a block marks it in-flight,
+// updates counters, detects outbound requests, rejects duplicate requests
+// from the same peer, and cleans up on removal.
+BOOST_AUTO_TEST_CASE(block_requested_basic)
+{
+    LOCK(cs_main);
+    BlockDownloadManager bdm(BlockDownloadOptions{*m_node.chainman});
+
+    NodeId peer1{0};
+    bdm.ConnectedPeer(peer1, {/*m_is_inbound=*/false, /*m_preferred_download=*/true,
+                               /*m_can_serve_witnesses=*/true,
+                               /*m_is_limited_peer=*/false});
+
+    // Use the genesis block as our test block
+    const CBlockIndex* genesis = m_node.chainman->ActiveChain().Genesis();
+    BOOST_REQUIRE(genesis != nullptr);
+
+    // Initially not requested
+    BOOST_CHECK(!bdm.IsBlockRequested(genesis->GetBlockHash()));
+
+    // Request it
+    bool first = bdm.BlockRequested(peer1, *genesis);
+    BOOST_CHECK(first);
+    BOOST_CHECK(bdm.IsBlockRequested(genesis->GetBlockHash()));
+    // peer1 is NOT inbound (m_is_inbound=false), so it IS outbound
+    BOOST_CHECK(bdm.IsBlockRequestedFromOutbound(genesis->GetBlockHash()));
+    BOOST_CHECK_EQUAL(bdm.GetPeersDownloadingFrom(), 1);
+    BOOST_CHECK_EQUAL(bdm.CountBlocksInFlight(genesis->GetBlockHash()), 1u);
+
+    // Request same block from same peer — returns false
+    bool second = bdm.BlockRequested(peer1, *genesis);
+    BOOST_CHECK(!second);
+
+    // Remove the request
+    bdm.RemoveBlockRequest(genesis->GetBlockHash(), std::nullopt);
+    BOOST_CHECK(!bdm.IsBlockRequested(genesis->GetBlockHash()));
+    BOOST_CHECK_EQUAL(bdm.GetPeersDownloadingFrom(), 0);
+
+    bdm.DisconnectedPeer(peer1);
+    bdm.CheckIsEmpty();
+}
+
+// Test that RemoveBlockRequest with a specific peer only removes that
+// peer's request, leaving requests from other peers intact.
+BOOST_AUTO_TEST_CASE(remove_block_request_from_specific_peer)
+{
+    LOCK(cs_main);
+    BlockDownloadManager bdm(BlockDownloadOptions{*m_node.chainman});
+
+    NodeId peer1{0}, peer2{1};
+    bdm.ConnectedPeer(peer1, {false, false, true, false});
+    bdm.ConnectedPeer(peer2, {true, false, true, false});
+
+    const CBlockIndex* genesis = m_node.chainman->ActiveChain().Genesis();
+
+    // Request from peer1
+    bdm.BlockRequested(peer1, *genesis);
+    BOOST_CHECK(bdm.IsBlockRequested(genesis->GetBlockHash()));
+
+    // Try to remove from peer2 — should not remove
+    bdm.RemoveBlockRequest(genesis->GetBlockHash(), peer2);
+    BOOST_CHECK(bdm.IsBlockRequested(genesis->GetBlockHash()));
+
+    // Remove from peer1 — should remove
+    bdm.RemoveBlockRequest(genesis->GetBlockHash(), peer1);
+    BOOST_CHECK(!bdm.IsBlockRequested(genesis->GetBlockHash()));
+
+    bdm.DisconnectedPeer(peer1);
+    bdm.DisconnectedPeer(peer2);
+    bdm.CheckIsEmpty();
+}
+
+// Test FindBlockInFlight: verify all BlockInFlightInfo fields across
+// different scenarios — no in-flight blocks, single request without
+// partialBlock, and multi-peer requests with partialBlock.
+BOOST_AUTO_TEST_CASE(find_block_in_flight)
+{
+    LOCK(cs_main);
+    BlockDownloadManager bdm(BlockDownloadOptions{*m_node.chainman});
+
+    NodeId peer1{0}, peer2{1}, peer3{2};
+    bdm.ConnectedPeer(peer1, {/*m_is_inbound=*/false, /*m_preferred_download=*/false,
+                               /*m_can_serve_witnesses=*/true,
+                               /*m_is_limited_peer=*/false});
+    bdm.ConnectedPeer(peer2, {true, false, true, false});
+    bdm.ConnectedPeer(peer3, {true, false, true, false});
+
+    const CBlockIndex* genesis = m_node.chainman->ActiveChain().Genesis();
+    BOOST_REQUIRE(genesis != nullptr);
+    const uint256& hash = genesis->GetBlockHash();
+
+    // No block in flight — already_in_flight is 0, first_in_flight is true (vacuous)
+    auto info = bdm.FindBlockInFlight(hash, peer1);
+    BOOST_CHECK_EQUAL(info.already_in_flight, 0u);
+    BOOST_CHECK(info.first_in_flight);
+    BOOST_CHECK(!info.requested_from_peer);
+    BOOST_CHECK(info.queued_block == nullptr);
+
+    // Request from peer1 without pit (no partialBlock)
+    bdm.BlockRequested(peer1, *genesis);
+
+    info = bdm.FindBlockInFlight(hash, peer1);
+    BOOST_CHECK_EQUAL(info.already_in_flight, 1u);
+    BOOST_CHECK(info.first_in_flight);
+    BOOST_CHECK(info.requested_from_peer);
+    BOOST_CHECK(info.queued_block == nullptr);
+
+    // Request from peer2 with pit — creates a partialBlock
+    std::list<node::QueuedBlock>::iterator* pit = nullptr;
+    bdm.BlockRequested(peer2, *genesis, &pit, m_node.mempool.get());
+
+    // From peer1's perspective: still first in flight, no partialBlock
+    info = bdm.FindBlockInFlight(hash, peer1);
+    BOOST_CHECK_EQUAL(info.already_in_flight, 2u);
+    BOOST_CHECK(info.first_in_flight);
+    BOOST_CHECK(info.requested_from_peer);
+    BOOST_CHECK(info.queued_block == nullptr);
+
+    // From peer2's perspective: not first in flight, has partialBlock
+    info = bdm.FindBlockInFlight(hash, peer2);
+    BOOST_CHECK_EQUAL(info.already_in_flight, 2u);
+    BOOST_CHECK(!info.first_in_flight);
+    BOOST_CHECK(info.requested_from_peer);
+    BOOST_CHECK(info.queued_block != nullptr);
+
+    // From peer3's perspective: not involved at all
+    info = bdm.FindBlockInFlight(hash, peer3);
+    BOOST_CHECK_EQUAL(info.already_in_flight, 2u);
+    BOOST_CHECK(!info.first_in_flight);
+    BOOST_CHECK(!info.requested_from_peer);
+    BOOST_CHECK(info.queued_block == nullptr);
+
+    bdm.DisconnectedPeer(peer1);
+    bdm.DisconnectedPeer(peer2);
+    bdm.DisconnectedPeer(peer3);
+    bdm.CheckIsEmpty();
+}
+
+// Test that TipMayBeStale returns false when blocks are in flight,
+// even if the last tip update is old enough to trigger staleness.
+BOOST_AUTO_TEST_CASE(tip_not_stale_with_blocks_in_flight)
+{
+    LOCK(cs_main);
+    BlockDownloadManager bdm(BlockDownloadOptions{*m_node.chainman});
+
+    NodeId peer1{0};
+    bdm.ConnectedPeer(peer1, {false, false, true, false});
+
+    int64_t pow_spacing = 600;
+    auto now = GetTime<std::chrono::seconds>();
+
+    // Initialize lazy tip update
+    bdm.TipMayBeStale(now, pow_spacing);
+
+    // Set an old tip update — stale when no blocks are in flight
+    bdm.SetLastTipUpdate(now - std::chrono::seconds{pow_spacing * 4});
+    BOOST_CHECK(bdm.TipMayBeStale(now, pow_spacing));
+
+    // Put a block in flight
+    const CBlockIndex* genesis = m_node.chainman->ActiveChain().Genesis();
+    bdm.BlockRequested(peer1, *genesis);
+    BOOST_CHECK(bdm.HasBlocksInFlight());
+
+    // Tip should NOT be stale — blocks in flight means we're making progress
+    BOOST_CHECK(!bdm.TipMayBeStale(now, pow_spacing));
+
+    // Remove the in-flight block — staleness returns
+    bdm.RemoveBlockRequest(genesis->GetBlockHash(), std::nullopt);
+    BOOST_CHECK(bdm.TipMayBeStale(now, pow_spacing));
+
+    bdm.DisconnectedPeer(peer1);
+    bdm.CheckIsEmpty();
+}
+
+// Test two-phase peer registration: ConnectedPeer is called first with
+// preferred=false (from InitializeNode), then re-called with preferred=true
+// (from VERSION handler). Verify the preferred counter does not double-count.
+BOOST_AUTO_TEST_CASE(connected_peer_reregistration)
+{
+    LOCK(cs_main);
+    BlockDownloadManager bdm(BlockDownloadOptions{*m_node.chainman});
+
+    NodeId peer1{0};
+
+    // Phase 1: initial registration with preferred=false
+    bdm.ConnectedPeer(peer1, {/*m_is_inbound=*/false, /*m_preferred_download=*/false,
+                               /*m_can_serve_witnesses=*/true,
+                               /*m_is_limited_peer=*/false});
+    BOOST_CHECK_EQUAL(bdm.GetNumPreferredDownload(), 0);
+
+    // Phase 2: re-registration with preferred=true (VERSION handler)
+    bdm.ConnectedPeer(peer1, {false, /*m_preferred_download=*/true, true, false});
+    BOOST_CHECK_EQUAL(bdm.GetNumPreferredDownload(), 1);
+
+    // Phase 3: re-registration again with preferred=true — should be idempotent
+    bdm.ConnectedPeer(peer1, {false, true, true, false});
+    BOOST_CHECK_EQUAL(bdm.GetNumPreferredDownload(), 1);
+
+    bdm.DisconnectedPeer(peer1);
+    bdm.CheckIsEmpty();
+}
+
+// Test CompareExchangeBlockStallingTimeout CAS semantics: fails when the
+// expected value does not match current (updating expected to actual),
+// succeeds when it does match.
+BOOST_AUTO_TEST_CASE(compare_exchange_stalling_timeout)
+{
+    BlockDownloadManager bdm(BlockDownloadOptions{*m_node.chainman});
+
+    // Initial value is default
+    BOOST_CHECK(bdm.GetBlockStallingTimeout() == BLOCK_STALLING_TIMEOUT_DEFAULT);
+
+    // CAS with wrong expected value — should fail
+    auto wrong = std::chrono::seconds{999};
+    BOOST_CHECK(!bdm.CompareExchangeBlockStallingTimeout(wrong, std::chrono::seconds{10}));
+    // On failure, expected is updated to the actual current value
+    BOOST_CHECK(wrong == BLOCK_STALLING_TIMEOUT_DEFAULT);
+    // Value unchanged
+    BOOST_CHECK(bdm.GetBlockStallingTimeout() == BLOCK_STALLING_TIMEOUT_DEFAULT);
+
+    // CAS with correct expected value — should succeed
+    auto expected = BLOCK_STALLING_TIMEOUT_DEFAULT;
+    BOOST_CHECK(bdm.CompareExchangeBlockStallingTimeout(expected, std::chrono::seconds{4}));
+    BOOST_CHECK(bdm.GetBlockStallingTimeout() == std::chrono::seconds{4});
+}
+
+// Test block download scheduling against headers-only blocks: peers that have
+// announced nothing yield no requests; announced headers are scheduled in
+// height order, capped by count and skipping blocks already in flight; and
+// historical download refuses peers that cannot serve the target chain.
+BOOST_FIXTURE_TEST_CASE(find_next_blocks_to_download, TestChain100Setup)
+{
+    ChainstateManager& chainman = *m_node.chainman;
+
+    // Build 5 headers-only successors of the current tip (no block data).
+    const CBlockIndex* tip = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip());
+    std::vector<CBlockHeader> headers;
+    uint256 prev_hash{tip->GetBlockHash()};
+    uint32_t prev_time{static_cast<uint32_t>(tip->GetBlockTime())};
+    for (size_t i = 0; i < 5; ++i) {
+        CBlockHeader header;
+        header.nVersion = 0x20000000;
+        header.hashPrevBlock = prev_hash;
+        header.hashMerkleRoot = ArithToUint256(arith_uint256{i + 1});
+        header.nTime = ++prev_time;
+        header.nBits = tip->nBits;
+        header.nNonce = 0;
+        while (!CheckProofOfWork(header.GetHash(), header.nBits, chainman.GetConsensus())) {
+            ++header.nNonce;
+        }
+        prev_hash = header.GetHash();
+        headers.push_back(header);
+    }
+    BlockValidationState state;
+    BOOST_REQUIRE(chainman.ProcessNewBlockHeaders(headers, /*min_pow_checked=*/true, state));
+
+    LOCK(cs_main);
+    BlockDownloadManager bdm(BlockDownloadOptions{chainman});
+
+    const NodeId peer1{0}, peer2{1};
+    bdm.ConnectedPeer(peer1, {/*m_is_inbound=*/false, /*m_preferred_download=*/true,
+                              /*m_can_serve_witnesses=*/true,
+                              /*m_is_limited_peer=*/false});
+    bdm.ConnectedPeer(peer2, {false, true, true, false});
+
+    // A peer that has not announced anything yields no requests.
+    std::vector<const CBlockIndex*> blocks;
+    NodeId staller{-1};
+    bdm.FindNextBlocksToDownload(peer1, /*count=*/16, blocks, staller);
+    BOOST_CHECK(blocks.empty());
+
+    // Announce the last header: all 5 blocks are scheduled in height order,
+    // and the last common block becomes the old tip.
+    bdm.UpdateBlockAvailability(peer1, headers.back().GetHash());
+    BOOST_REQUIRE(bdm.GetBestKnownBlock(peer1) != nullptr);
+    BOOST_CHECK_EQUAL(bdm.GetBestKnownBlock(peer1)->nHeight, tip->nHeight + 5);
+
+    bdm.FindNextBlocksToDownload(peer1, /*count=*/16, blocks, staller);
+    BOOST_REQUIRE_EQUAL(blocks.size(), 5u);
+    for (size_t i = 0; i < blocks.size(); ++i) {
+        BOOST_CHECK_EQUAL(blocks[i]->GetBlockHash().ToString(), headers[i].GetHash().ToString());
+    }
+    BOOST_CHECK(bdm.GetLastCommonBlock(peer1) == tip);
+
+    // The count limit caps the schedule.
+    blocks.clear();
+    bdm.FindNextBlocksToDownload(peer1, /*count=*/2, blocks, staller);
+    BOOST_REQUIRE_EQUAL(blocks.size(), 2u);
+
+    // Blocks already in flight (from any peer) are skipped.
+    const CBlockIndex* first_index{chainman.m_blockman.LookupBlockIndex(headers[0].GetHash())};
+    BOOST_REQUIRE(first_index != nullptr);
+    bdm.BlockRequested(peer2, *first_index);
+    blocks.clear();
+    bdm.FindNextBlocksToDownload(peer1, /*count=*/16, blocks, staller);
+    BOOST_REQUIRE_EQUAL(blocks.size(), 4u);
+    BOOST_CHECK_EQUAL(blocks[0]->GetBlockHash().ToString(), headers[1].GetHash().ToString());
+
+    // count == 0 is a no-op.
+    blocks.clear();
+    bdm.FindNextBlocksToDownload(peer1, /*count=*/0, blocks, staller);
+    BOOST_CHECK(blocks.empty());
+
+    bdm.RemoveBlockRequest(first_index->GetBlockHash(), std::nullopt);
+
+    // Historical download: peer2 has not announced the target block's chain,
+    // so it cannot serve the blocks leading up to it.
+    const CBlockIndex* target{chainman.m_blockman.LookupBlockIndex(headers.back().GetHash())};
+    BOOST_REQUIRE(target != nullptr);
+    blocks.clear();
+    bdm.TryDownloadingHistoricalBlocks(peer2, /*count=*/16, blocks, tip, target);
+    BOOST_CHECK(blocks.empty());
+
+    // peer1 announced the chain containing the target, so the full range of
+    // historical blocks up to the target is scheduled.
+    blocks.clear();
+    bdm.TryDownloadingHistoricalBlocks(peer1, /*count=*/16, blocks, tip, target);
+    BOOST_REQUIRE_EQUAL(blocks.size(), 5u);
+
+    bdm.DisconnectedPeer(peer1);
+    bdm.DisconnectedPeer(peer2);
+    bdm.CheckIsEmpty();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(fuzz
   block_header.cpp
   block_index.cpp
   block_index_tree.cpp
+  blockdownloadman.cpp
   blockfilter.cpp
   bloom_filter.cpp
   buffered_file.cpp

--- a/src/test/fuzz/blockdownloadman.cpp
+++ b/src/test/fuzz/blockdownloadman.cpp
@@ -1,0 +1,330 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chain.h>
+#include <consensus/validation.h>
+#include <hash.h>
+#include <node/blockdownloadman.h>
+#include <node/context.h>
+#include <pow.h>
+#include <primitives/block.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/mining.h>
+#include <test/util/script.h>
+#include <test/util/setup_common.h>
+#include <test/util/time.h>
+#include <txmempool.h>
+#include <uint256.h>
+#include <util/check.h>
+#include <util/time.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <optional>
+#include <vector>
+
+using node::BlockDownloadConnectionInfo;
+using node::BlockDownloadManager;
+using node::BlockDownloadOptions;
+
+namespace {
+
+const TestingSetup* g_setup;
+
+// Limit the total number of peers because we don't expect coverage to change much with lots more peers.
+constexpr NodeId NUM_PEERS{8};
+
+// All block index entries known to the fixture chainstate: the active chain
+// (blocks with data), a headers-only extension of the tip, and a headers-only
+// fork branching from below the tip.
+std::vector<const CBlockIndex*> ALL_BLOCKS;
+
+void MineHeadersOnlyChain(ChainstateManager& chainman, const CBlockIndex* fork_base, int length)
+{
+    std::vector<CBlockHeader> headers;
+    uint256 prev_hash{fork_base->GetBlockHash()};
+    uint32_t prev_time{static_cast<uint32_t>(fork_base->GetBlockTime())};
+    for (int i = 0; i < length; ++i) {
+        CBlockHeader header;
+        header.nVersion = 0x20000000;
+        header.hashPrevBlock = prev_hash;
+        // Distinct merkle roots give each header chain distinct block hashes.
+        header.hashMerkleRoot = (HashWriter{} << prev_hash << i).GetHash();
+        header.nTime = ++prev_time;
+        header.nBits = fork_base->nBits;
+        header.nNonce = 0;
+        while (!CheckProofOfWork(header.GetHash(), header.nBits, chainman.GetConsensus())) {
+            ++header.nNonce;
+        }
+        prev_hash = header.GetHash();
+        headers.push_back(header);
+    }
+    BlockValidationState state;
+    Assert(chainman.ProcessNewBlockHeaders(headers, /*min_pow_checked=*/true, state));
+    LOCK(cs_main);
+    for (const auto& header : headers) {
+        ALL_BLOCKS.push_back(Assert(chainman.m_blockman.LookupBlockIndex(header.GetHash())));
+    }
+}
+
+void initialize_blockdownloadman()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+    auto& chainman = *g_setup->m_node.chainman;
+    SetMockTime(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip()->Time()));
+
+    // Mine 20 blocks (with data) on top of the genesis block.
+    for (int i = 0; i < 20; ++i) {
+        MineBlock(g_setup->m_node, {.coinbase_output_script = P2WSH_OP_TRUE});
+    }
+    g_setup->m_node.validation_signals->SyncWithValidationInterfaceQueue();
+
+    const CBlockIndex* tip = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip());
+    Assert(tip->nHeight == 20);
+    {
+        LOCK(cs_main);
+        for (int height = 0; height <= tip->nHeight; ++height) {
+            ALL_BLOCKS.push_back(chainman.ActiveChain()[height]);
+        }
+    }
+    // A headers-only extension of the active tip and a headers-only fork from
+    // below the tip: download candidates with more chain work than the tip.
+    MineHeadersOnlyChain(chainman, tip, /*length=*/24);
+    MineHeadersOnlyChain(chainman, tip->GetAncestor(14), /*length=*/12);
+
+    // Freeze time so that runs are deterministic.
+    SetMockTime(tip->Time());
+}
+
+FUZZ_TARGET(blockdownloadman, .init = initialize_blockdownloadman)
+{
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
+
+    auto& chainman = *g_setup->m_node.chainman;
+    CTxMemPool* mempool = g_setup->m_node.mempool.get();
+
+    BlockDownloadManager bdm{BlockDownloadOptions{chainman}};
+
+    // Mirror of the registration state, used to respect the documented
+    // preconditions (most per-peer methods require a registered peer) and to
+    // cross-check the manager's global counters.
+    struct PeerMirror {
+        bool registered{false};
+        bool preferred{false};
+        bool sync_started{false};
+    };
+    std::array<PeerMirror, NUM_PEERS> peers;
+
+    auto rand_block = [&]() -> const CBlockIndex* {
+        return ALL_BLOCKS[fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, ALL_BLOCKS.size() - 1)];
+    };
+    // Usually a known block hash, sometimes an arbitrary one.
+    auto rand_hash = [&]() -> uint256 {
+        if (fuzzed_data_provider.ConsumeBool()) return ConsumeUInt256(fuzzed_data_provider);
+        return rand_block()->GetBlockHash();
+    };
+    auto check_scheduled_blocks = [&](const std::vector<const CBlockIndex*>& blocks, unsigned int count) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        Assert(blocks.size() <= count);
+        for (size_t i = 0; i < blocks.size(); ++i) {
+            // Scheduled blocks are never already stored or already in flight,
+            // and are returned in ascending height order.
+            Assert(!(blocks[i]->nStatus & BLOCK_HAVE_DATA));
+            Assert(!bdm.IsBlockRequested(blocks[i]->GetBlockHash()));
+            if (i > 0) Assert(blocks[i - 1]->nHeight < blocks[i]->nHeight);
+        }
+    };
+
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 500)
+    {
+        NodeId rand_peer = fuzzed_data_provider.ConsumeIntegralInRange<NodeId>(0, NUM_PEERS - 1);
+        auto& mirror = peers[rand_peer];
+
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] { // Initial registration or re-registration
+                BlockDownloadConnectionInfo info{
+                    .m_is_inbound = fuzzed_data_provider.ConsumeBool(),
+                    .m_preferred_download = fuzzed_data_provider.ConsumeBool(),
+                    .m_can_serve_witnesses = fuzzed_data_provider.ConsumeBool(),
+                    .m_is_limited_peer = fuzzed_data_provider.ConsumeBool(),
+                };
+                LOCK(cs_main);
+                bdm.ConnectedPeer(rand_peer, info);
+                mirror.registered = true;
+                // The preferred flag latches: re-registration can set but never clear it.
+                mirror.preferred = mirror.preferred || info.m_preferred_download;
+            },
+            [&] {
+                LOCK(cs_main);
+                bdm.DisconnectedPeer(rand_peer);
+                mirror = PeerMirror{};
+            },
+            [&] {
+                if (!mirror.registered) return;
+                LOCK(cs_main);
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    bdm.UpdateBlockAvailability(rand_peer, rand_hash());
+                } else {
+                    bdm.ProcessBlockAvailability(rand_peer);
+                }
+            },
+            [&] { // BlockRequested, respecting the net_processing call-site precondition
+                if (!mirror.registered) return;
+                const CBlockIndex& block{*rand_block()};
+                LOCK(cs_main);
+                const auto flight_info = bdm.FindBlockInFlight(block.GetBlockHash(), rand_peer);
+                if (!flight_info.requested_from_peer &&
+                    flight_info.already_in_flight >= MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK) {
+                    return;
+                }
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    std::list<node::QueuedBlock>::iterator* pit{nullptr};
+                    bdm.BlockRequested(rand_peer, block, &pit, mempool);
+                    Assert(pit != nullptr);
+                    Assert((*pit)->pindex == &block);
+                } else {
+                    bdm.BlockRequested(rand_peer, block);
+                }
+                Assert(bdm.IsBlockRequested(block.GetBlockHash()));
+            },
+            [&] {
+                std::optional<NodeId> from_peer;
+                if (fuzzed_data_provider.ConsumeBool()) from_peer = rand_peer;
+                LOCK(cs_main);
+                bdm.RemoveBlockRequest(rand_hash(), from_peer);
+            },
+            [&] {
+                if (!mirror.registered) return;
+                std::vector<const CBlockIndex*> blocks;
+                NodeId staller{-1};
+                const unsigned int count{fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 32)};
+                LOCK(cs_main);
+                bdm.FindNextBlocksToDownload(rand_peer, count, blocks, staller);
+                check_scheduled_blocks(blocks, count);
+            },
+            [&] {
+                if (!mirror.registered) return;
+                std::vector<const CBlockIndex*> blocks;
+                const unsigned int count{fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 32)};
+                // Mimic the call site: from_tip is the last common ancestor of
+                // a chain tip and the target block.
+                const CBlockIndex* target{rand_block()};
+                const CBlockIndex* from_tip{LastCommonAncestor(rand_block(), target)};
+                LOCK(cs_main);
+                bdm.TryDownloadingHistoricalBlocks(rand_peer, count, blocks, from_tip, target);
+                check_scheduled_blocks(blocks, count);
+            },
+            [&] { // Availability getters consistency
+                LOCK(cs_main);
+                const CBlockIndex* best_known = bdm.GetBestKnownBlock(rand_peer);
+                if (best_known) {
+                    Assert(mirror.registered);
+                    Assert(bdm.PeerHasHeader(rand_peer, best_known));
+                }
+                (void)bdm.GetLastCommonBlock(rand_peer);
+                (void)bdm.GetBestHeaderSent(rand_peer);
+            },
+            [&] {
+                const CBlockIndex* header_sent{fuzzed_data_provider.ConsumeBool() ? rand_block() : nullptr};
+                LOCK(cs_main);
+                bdm.SetBestHeaderSent(rand_peer, header_sent);
+                if (mirror.registered) Assert(bdm.GetBestHeaderSent(rand_peer) == header_sent);
+            },
+            [&] {
+                if (!mirror.registered) return;
+                const bool started{fuzzed_data_provider.ConsumeBool()};
+                LOCK(cs_main);
+                bdm.SetSyncStarted(rand_peer, started);
+                mirror.sync_started = started;
+                Assert(bdm.GetSyncStarted(rand_peer) == started);
+            },
+            [&] {
+                const auto time{std::chrono::microseconds{fuzzed_data_provider.ConsumeIntegral<uint32_t>()}};
+                LOCK(cs_main);
+                bdm.SetStallingSince(rand_peer, time);
+                if (mirror.registered) Assert(bdm.GetStallingSince(rand_peer) == time);
+            },
+            [&] {
+                const uint256 hash{rand_hash()};
+                LOCK(cs_main);
+                bdm.SetBlockSource(hash, rand_peer, /*punish_on_invalid=*/fuzzed_data_provider.ConsumeBool());
+                Assert(bdm.GetBlockSource(hash).has_value());
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    bdm.EraseBlockSource(hash);
+                    Assert(!bdm.GetBlockSource(hash).has_value());
+                }
+            },
+            [&] {
+                const auto now{std::chrono::seconds{fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, 4'000'000'000)}};
+                if (fuzzed_data_provider.ConsumeBool()) bdm.SetLastTipUpdate(now);
+                LOCK(cs_main);
+                const bool stale{bdm.TipMayBeStale(now, /*n_pow_target_spacing=*/fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(1, 3600))};
+                // A stale tip implies that nothing is in flight.
+                if (stale) Assert(!bdm.HasBlocksInFlight());
+            },
+            [&] { // Stalling timeout CAS semantics
+                auto expected{fuzzed_data_provider.ConsumeBool() ?
+                                  bdm.GetBlockStallingTimeout() :
+                                  std::chrono::seconds{fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, 100)}};
+                const auto expected_initial{expected};
+                const auto desired{std::chrono::seconds{fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(1, 64)}};
+                const auto current{bdm.GetBlockStallingTimeout()};
+                const bool success{bdm.CompareExchangeBlockStallingTimeout(expected, desired)};
+                Assert(success == (expected_initial == current));
+                if (success) {
+                    Assert(bdm.GetBlockStallingTimeout() == desired);
+                } else {
+                    Assert(expected == current);
+                }
+            },
+            [&] { // In-flight query consistency
+                const uint256 hash{rand_hash()};
+                LOCK(cs_main);
+                const auto info = bdm.FindBlockInFlight(hash, rand_peer);
+                Assert(info.already_in_flight == bdm.CountBlocksInFlight(hash));
+                Assert((info.already_in_flight > 0) == bdm.IsBlockRequested(hash));
+                if (info.queued_block) Assert(info.requested_from_peer);
+                if (info.requested_from_peer) Assert(info.already_in_flight > 0);
+                if (info.already_in_flight == 0) Assert(info.first_in_flight);
+                if (bdm.IsBlockRequestedFromOutbound(hash)) Assert(bdm.IsBlockRequested(hash));
+            });
+
+        // The global counters must agree with the per-peer state.
+        LOCK(cs_main);
+        size_t total_in_flight{0};
+        int downloading_from{0};
+        int preferred{0};
+        int sync_started{0};
+        for (NodeId peer = 0; peer < NUM_PEERS; ++peer) {
+            if (!peers[peer].registered) continue;
+            const auto& in_flight = bdm.GetBlocksInFlight(peer);
+            total_in_flight += in_flight.size();
+            downloading_from += !in_flight.empty();
+            preferred += peers[peer].preferred;
+            sync_started += peers[peer].sync_started;
+        }
+        Assert(total_in_flight == bdm.GetTotalBlocksInFlight());
+        Assert(downloading_from == bdm.GetPeersDownloadingFrom());
+        Assert(preferred == bdm.GetNumPreferredDownload());
+        Assert(sync_started == bdm.GetNumSyncStarted());
+        Assert(bdm.HasBlocksInFlight() == (total_in_flight > 0));
+    }
+    // Disconnect everybody, check that all data structures are empty.
+    LOCK(cs_main);
+    for (NodeId peer = 0; peer < NUM_PEERS; ++peer) {
+        bdm.DisconnectedPeer(peer);
+    }
+    bdm.CheckIsEmpty();
+}
+
+} // namespace


### PR DESCRIPTION
### Motivation

`net_processing.cpp` is the largest file in the codebase (~6200 lines) and `PeerManagerImpl` mixes several largely independent subsystems into a single class: transaction relay, address gossip, headers sync, compactblocks, and block download. This makes the file difficult to review, test in isolation, and reason about lock ordering.

 #30110 successfully extracted transaction download logic into `TxDownloadManager`. This PR applies the same approach to block download, continuing the incremental decomposition of `PeerManagerImpl`.
 
### What this PR does

Extract all block download state and scheduling logic into a new `BlockDownloadManager` module:

**Global state moved** (from `PeerManagerImpl`): `mapBlocksInFlight`, `mapBlockSource`, `nSyncStarted`, `m_block_stalling_timeout`, `m_last_tip_update`, `m_num_preferred_download_peers`, `m_peers_downloading_from`.

**Per-peer state moved** (from `CNodeState`): `pindexBestKnownBlock`, `hashLastUnknownBlock`, `pindexLastCommonBlock`, `pindexBestHeaderSent`, `fSyncStarted`, `vBlocksInFlight`, `m_downloading_since`, `m_stalling_since`, `fPreferredDownload`.

**Methods moved** (from `PeerManagerImpl`): `FindNextBlocksToDownload`, `TryDownloadingHistoricalBlocks`, `ProcessBlockAvailability`, `UpdateBlockAvailability`, `BlockRequested`, `RemoveBlockRequest`, `IsBlockRequested`, `IsBlockRequestedFromOutbound`, `TipMayBeStale`.

### The result:
* `net_processing.cpp` shrinks from 6193 to 5751 lines (−442 net)
* `CNodeState` loses 10 fields, retaining only compact block relay and chain sync timeout state
* Block download logic becomes unit-testable and fuzz-testable in isolation (8 unit test cases and 1 fuzz target added)

### Design

Follows the `TxDownloadManager` pimpl pattern:
* `blockdownloadman.h` — public interface
* `blockdownloadman_impl.h` — implementation class with per-peer state
* `blockdownloadman_impl.cpp` — implementation

 Unlike `TxDownloadManager`, no new mutex is introduced. Block download is inherently tied to chain state through `CBlockIndex*` pointers, so `cs_main` remains the synchronizing lock. The extraction is for code organization and testability, not lock granularity.
 
A fuzz target is included to exercise the extracted manager directly, covering peer lifecycle, availability updates, in-flight request tracking, scheduling, stalling state, and counter consistency.
 
 ### Commits

1. **Add BlockDownloadManager class with pimpl skeleton**: all new module files, no call sites changed
2. **Add unit tests**: exercises the module in isolation
3. **Migrate call sites**: ~150 call sites in `net_processing.cpp` rewired through `m_blockdownloadman`, pure mechanical replacement
4. **Add fuzz target**: exercises `BlockDownloadManager` state transitions and invariants through the new module boundary