### PR TITLE
doc: update Windows MSVC build guide to utilize winget to install build requirements

### DIFF
--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -6,25 +6,49 @@ For cross-compiling options, please see [`build-windows.md`](./build-windows.md)
 
 ## Preparation
 
-### 1. Visual Studio
+### 1. Install Required Dependencies
+
+The first step is to install the required build applications. The instructions below use WinGet to install the applications.
+
+WinGet is available on all supported Windows versions. The applications mentioned can also be installed manually.
+
+#### Visual Studio
 
 This guide relies on using CMake and vcpkg package manager provided with the Visual Studio installation.
-Here are requirements for the Visual Studio installation:
-1. Minimum required version: Visual Studio 2026 version 18.3.
-2. Installed components:
-- The "Desktop development with C++" workload.
 
-The commands in this guide should be executed in "Developer PowerShell for VS" or "Developer Command Prompt for VS".
+Minimum required version: Visual Studio 2026 version 18.3 with the "Desktop development with C++" workload.
+
+To install Visual Studio Community Edition with the necessary components, run:
+
+```powershell
+winget install --id Microsoft.VisualStudio.Community --override "--wait --quiet --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Component.Git --includeRecommended"
+```
+
+This installs:
+- Visual Studio
+- The "Desktop development with C++" workload (NativeDesktop)
+- Git component
+
+After installation, the commands in this guide should be executed in "Developer PowerShell for VS" or "Developer Command Prompt for VS".
 The former is assumed hereinafter.
 
-### 2. Git
+#### Python
 
-Download and install [Git for Windows](https://git-scm.com/downloads/win). Once installed, Git is available from PowerShell or the Command Prompt.
+Python is required for running the test suite.
 
-### 3. Clone Bitcoin Repository
+To install Python, run:
+
+```powershell
+winget install python3
+```
+
+### 2. Clone Bitcoin Repository
+
+`git` should already be installed as a component of Visual Studio. If not, download and install [Git for Windows](https://git-scm.com/downloads/win).
 
 Clone the Bitcoin Core repository to a directory. All build scripts and commands will run from this directory.
-```
+
+```powershell
 git clone https://github.com/bitcoin/bitcoin.git
 ```
 
@@ -38,7 +62,7 @@ The Bitcoin Core project supports the following vcpkg triplets:
 To facilitate build process, the Bitcoin Core project provides presets, which are used in this guide.
 
 Available presets can be listed as follows:
-```
+```powershell
 cmake --list-presets
 ```
 
@@ -52,7 +76,7 @@ In the following instructions, the "Debug" configuration can be specified instea
 
 Run `cmake -B build -LH` to see the full list of available options.
 
-### 4. Building with Static Linking with GUI
+### Building with Static Linking with GUI
 
 ```powershell
 cmake -B build --preset vs2026-static          # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
@@ -61,7 +85,7 @@ ctest --test-dir build --build-config Release  # Append "-j N" for N parallel te
 cmake --install build --config Release         # Optional.
 ```
 
-### 5. Building with Dynamic Linking without GUI
+### Building with Dynamic Linking without GUI
 
 ```powershell
 cmake -B build --preset vs2026 -DBUILD_GUI=OFF # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
@@ -69,7 +93,7 @@ cmake --build build --config Release           # Append "-j N" for N parallel jo
 ctest --test-dir build --build-config Release  # Append "-j N" for N parallel tests.
 ```
 
-### 6. vcpkg-specific Issues and Workarounds
+### vcpkg-specific Issues and Workarounds
 
 vcpkg installation during the configuration step might fail for various reasons unrelated to Bitcoin Core.
 
@@ -92,16 +116,16 @@ cmake -B build --preset vs2026-static -DVCPKG_INSTALLED_DIR="C:\path_without_spa
 
 ## Performance Notes
 
-### 7. vcpkg Manifest Default Features
+### vcpkg Manifest Default Features
 
 One can skip vcpkg manifest default features to speed up the configuration step.
 For example, the following invocation will skip all features except for "wallet" and "tests" and their dependencies:
-```
+```powershell
 cmake -B build --preset vs2026 -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet;tests" -DBUILD_GUI=OFF -DWITH_ZMQ=OFF
 ```
 
 Available features are listed in the [`vcpkg.json`](/vcpkg.json) file.
 
-### 8. Antivirus Software
+### Antivirus Software
 
 To improve the build process performance, one might add the Bitcoin repository directory to the Microsoft Defender Antivirus exclusions.


### PR DESCRIPTION
This PR updates the Windows MSVC build guide to bring it more in line with the macOS and Unix build guides. 

Currently the guide listed requirements but left users to manually do the download/installation. The macOS and the Unix guide utilize package managers to provide concrete installation commands that users can follow. By introducing  `winget`, the Windows MSVC build guide now also provides concrete installation commands.

The changes/commands can be tested on any windows machine, provided it run a  Windows 10 (version 1809 (build 17763)) or later (e.g. Windows 11 / Server 2025).