### PR TITLE
cmake: Fix NetBSD-specific workaround for Boost

### DIFF
--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -32,12 +32,14 @@ function(add_boost_if_needed)
   find_package(Boost 1.74.0 REQUIRED CONFIG)
   mark_as_advanced(Boost_INCLUDE_DIR boost_headers_DIR)
   # Workaround for a bug in NetBSD pkgsrc.
-  # See: https://github.com/NetBSD/pkgsrc/issues/167.
+  # See https://gnats.netbsd.org/59856.
   if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
     get_filename_component(_boost_include_dir "${boost_headers_DIR}/../../../include/" ABSOLUTE)
-    set_target_properties(Boost::headers PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES ${_boost_include_dir}
-    )
+    if(_boost_include_dir MATCHES "^/usr/pkg/")
+      set_target_properties(Boost::headers PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${_boost_include_dir}
+      )
+    endif()
     unset(_boost_include_dir)
   endif()
   set_target_properties(Boost::headers PROPERTIES IMPORTED_GLOBAL TRUE)


### PR DESCRIPTION
The recently merged https://github.com/bitcoin/bitcoin/pull/34143 broke builds with depends on NetBSD due to a workaround introduced in 5a5ddbd78922236402df378c8588a7b0b3f83a13.

The upstream [bug](https://gnats.netbsd.org/59856) has been fixed, and the entire workaround can be removed once the fixed Boost package becomes generally available.

However, it seems prudent to amend the workaround now to have it workable in the 31.0 release.

Here are CI runs:
- broken: https://github.com/hebasto/bitcoin-core-nightly/actions/runs/21933683654
- fixed: https://github.com/hebasto/bitcoin-core-nightly/actions/runs/21933683654