### PR TITLE
test: Avoid empty errmsg in JSONRPCException

### DIFF
--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -51,11 +51,7 @@ log = logging.getLogger("BitcoinRPC")
 
 class JSONRPCException(Exception):
     def __init__(self, rpc_error, http_status=None):
-        try:
-            errmsg = '%(message)s (%(code)i)' % rpc_error
-        except (KeyError, TypeError):
-            errmsg = ''
-        super().__init__(errmsg)
+        super().__init__(f"{rpc_error} [http_status={http_status}]")
         self.error = rpc_error
         self.http_status = http_status
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -147,11 +147,10 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         except subprocess.CalledProcessError as e:
             self.log.exception(f"Called Process failed with stdout='{e.stdout}'; stderr='{e.stderr}';")
             self.success = TestStatus.FAILED
-        except JSONRPCException as e:
-            self.log.exception(f"Failure during setup: error={e.error}, http_status={e.http_status}")
-            self.success = TestStatus.FAILED
         except BaseException:
-            self.log.exception("Unexpected exception")
+            # The `exception` log will add the exception info to the message.
+            # https://docs.python.org/3/library/logging.html#logging.exception
+            self.log.exception("Unexpected exception:")
             self.success = TestStatus.FAILED
         finally:
             exit_code = self.shutdown()


### PR DESCRIPTION
It is unclear why the fallback should be an empty message, when it is better to include all rpc_error details that are available.

Also, include the http status.

This allows to revert commit 6354b4fd7fe819eb13274b212e426a7d10ca75d3, because it is no longer needed.


Can be tested by running this diff:

```diff
diff --git a/test/functional/wallet_disable.py b/test/functional/wallet_disable.py
index dbcccd4778..9717a2d248 100755
--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -18,9 +18,8 @@ class DisableWalletTest (BitcoinTestFramework):
         self.extra_args = [["-disablewallet"]]
         self.wallet_names = []
 
-    def run_test (self):
-        # Make sure wallet is really disabled
-        assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].getwalletinfo)
+    def run_test(self):
+        self.nodes[0].getwalletinfo()
         x = self.nodes[0].validateaddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
         assert x['isvalid'] == False
         x = self.nodes[0].validateaddress('mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
