### PR TITLE
http: fix submission during shutdown race

### DIFF
--- a/src/test/fuzz/threadpool.cpp
+++ b/src/test/fuzz/threadpool.cpp
@@ -87,10 +87,10 @@ FUZZ_TARGET(threadpool, .init = setup_threadpool_test) EXCLUSIVE_LOCKS_REQUIRED(
         std::future<void> fut;
         if (will_throw) {
             expected_fail_tasks++;
-            fut = g_pool.Submit(ThrowTask{});
+            fut = *Assert(g_pool.Submit(ThrowTask{}));
         } else {
             expected_task_counter++;
-            fut = g_pool.Submit(CounterTask{task_counter});
+            fut = *Assert(g_pool.Submit(CounterTask{task_counter}));
         }
 
         // If caller wants to wait immediately, consume the future here (safe).


### PR DESCRIPTION
Fixes #34573.

As mentioned in https://github.com/bitcoin/bitcoin/issues/34573#issuecomment-3891596958, the ThreadPool PR (#33689) revealed an existing issue.

Before that PR, we were returning an incorrect error "Request rejected because http work queue depth exceeded" during shutdown for unhandled requests (we were not differentiating between "queue depth exceeded" and "server interrupted" errors). Now, with the ThreadPool inclusion, we return the proper error but we don't handle it properly.

This PR improves exactly that. Handling the missing error and properly returning it to the user.

The race can be reproduced as follows:

1) The server receives an http request.
2) Processing of the request is delayed, and shutdown is triggered in the meantime.
3) During shutdown, the libevent callback is unregistered and the threadpool interrupted.
4) The delayed request (step 2) resumes and tries to submit a task to the now-interrupted server.

Reproduction test can be found https://github.com/bitcoin/bitcoin/pull/34577#issuecomment-3902672521.

Also, to prevent this kind of issue from happening again, this PR changes task submission
to return the error as part of the function's return value using `util::Expected` instead of
throwing the exception. Unlike exceptions, which require extra try-catch blocks and can be
ignored, returning `Expected` forces callers to explicitly handle failures, and attributes
like `[[nodiscard]]` allow us catch unhandled ones at compile time.

