### PR TITLE
ci: [refactor] Drop last use of pwsh

### DIFF
--- a/.github/ci-windows-cross.py
+++ b/.github/ci-windows-cross.py
@@ -134,13 +134,13 @@ def run_unit_tests():
 
 def main():
     parser = argparse.ArgumentParser(description="Utility to run Windows CI steps.")
-    steps = [
-        "print_version",
-        "check_manifests",
-        "prepare_tests",
-        "run_unit_tests",
-        "run_functional_tests",
-    ]
+    steps = list(map(lambda f: f.__name__, [
+        print_version,
+        check_manifests,
+        prepare_tests,
+        run_unit_tests,
+        run_functional_tests,
+    ]))
     parser.add_argument("step", choices=steps, help="CI step to perform.")
     args = parser.parse_args()
 
@@ -149,16 +149,7 @@ def main():
         str(Path.cwd() / "previous_releases"),
     )
 
-    if args.step == "print_version":
-        print_version()
-    elif args.step == "check_manifests":
-        check_manifests()
-    elif args.step == "prepare_tests":
-        prepare_tests()
-    elif args.step == "run_unit_tests":
-        run_unit_tests()
-    elif args.step == "run_functional_tests":
-        run_functional_tests()
+    exec(f'{args.step}()')
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,16 +227,9 @@ jobs:
 
       - *CHECKOUT
 
-      - &SET_UP_VS
-        name: Set up VS Developer Prompt
-        shell: pwsh -Command "$PSVersionTable; $PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
-        run: |
-          $vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $installationPath = & $vswherePath -latest -property installationPath
-          & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -arch=x64 -no_logo && set" | foreach-object {
-            $name, $value = $_ -split '=', 2
-            echo "$name=$value" >> $env:GITHUB_ENV
-          }
+      - &IMPORT_VS_ENV
+        name: Import Visual Studio env vars
+        run: py -3 .github/ci-windows.py "standard" github_import_vs_env
 
       - name: Get tool information
         shell: pwsh
@@ -418,7 +411,7 @@ jobs:
       - name: Run bitcoind.exe
         run: py -3 .github/ci-windows-cross.py print_version
 
-      - *SET_UP_VS
+      - *IMPORT_VS_ENV
 
       - name: Check executable manifests
         run: py -3 .github/ci-windows-cross.py check_manifests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,14 +232,14 @@ jobs:
         run: py -3 .github/ci-windows.py "standard" github_import_vs_env
 
       - name: Get tool information
-        shell: pwsh
         run: |
-          cmake -version | Tee-Object -FilePath "cmake_version"
-          Write-Output "---"
-          msbuild -version | Tee-Object -FilePath "msbuild_version"
-          $env:VCToolsVersion | Tee-Object -FilePath "toolset_version"
+          set -o errexit -o pipefail -o xtrace -o nounset
+
+          cmake -version | tee cmake_version
+          echo '---'
+          msbuild.exe -version | tee msbuild_version
+          echo "${VCToolsVersion-}" | tee toolset_version
           py -3 --version
-          Write-Host "PowerShell version $($PSVersionTable.PSVersion.ToString())"
           bash --version
 
       - name: Using vcpkg with MSBuild


### PR DESCRIPTION
The use of pwsh was a bit confusing and inconsistent around the exit code. See also https://github.com/bitcoin/bitcoin/pull/32672

I think it is fine to drop it and purely use Bash/Python.

This also moves a bit of code from the github yaml to the python script.