### PR TITLE
ci: Temporarily use clang in valgrind tasks

### DIFF
--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"
 export CONTAINER_NAME=ci_native_fuzz_valgrind
-export PACKAGES="libevent-dev libboost-dev libsqlite3-dev valgrind libcapnp-dev capnproto"
+export PACKAGES="clang llvm libclang-rt-dev libevent-dev libboost-dev libsqlite3-dev valgrind libcapnp-dev capnproto"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
@@ -17,5 +17,6 @@ export FUZZ_TESTS_CONFIG="--valgrind"
 export GOAL="all"
 export BITCOIN_CONFIG="\
  -DBUILD_FOR_FUZZING=ON \
- -DCMAKE_CXX_FLAGS='-Wno-error=array-bounds' \
+ -DCMAKE_C_COMPILER=clang \
+ -DCMAKE_CXX_COMPILER=clang++ \
 "

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"
 export CONTAINER_NAME=ci_native_valgrind
-export PACKAGES="valgrind python3-zmq libevent-dev libboost-dev libzmq3-dev libsqlite3-dev libcapnp-dev capnproto python3-pip"
+export PACKAGES="clang llvm libclang-rt-dev valgrind python3-zmq libevent-dev libboost-dev libzmq3-dev libsqlite3-dev libcapnp-dev capnproto python3-pip"
 export PIP_PACKAGES="--break-system-packages pycapnp"
 export USE_VALGRIND=1
 export NO_DEPENDS=1
@@ -17,7 +17,9 @@ export TEST_RUNNER_EXTRA="--exclude rpc_bind --exclude feature_bind_extra"
 export GOAL="install"
 # GUI disabled, because it only passes with a DEBUG=1 depends build
 export BITCOIN_CONFIG="\
-  --preset=dev-mode \
+ --preset=dev-mode \
  -DBUILD_GUI=OFF \
  -DWITH_USDT=OFF \
+ -DCMAKE_C_COMPILER=clang \
+ -DCMAKE_CXX_COMPILER=clang++ \
 "

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -15,7 +15,7 @@ export NO_DEPENDS=1
 # bind tests excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export TEST_RUNNER_EXTRA="--exclude rpc_bind --exclude feature_bind_extra"
 export GOAL="install"
-# TODO enable GUI
+# GUI disabled, because it only passes with a DEBUG=1 depends build
 export BITCOIN_CONFIG="\
   --preset=dev-mode \
  -DBUILD_GUI=OFF \

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -80,7 +80,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         after a timeout. Returns the utxo hash of the given node."""
 
         time_start = time.time()
-        while time.time() - time_start < 120:
+        while time.time() - time_start < 120 * self.options.timeout_factor:
             try:
                 # Any of these RPC calls could throw due to node crash
                 self.start_node(node_index)

--- a/test/sanitizer_suppressions/valgrind.supp
+++ b/test/sanitizer_suppressions/valgrind.supp
@@ -12,8 +12,10 @@
 #       --error-limit=no build/bin/test_bitcoin
 #
 # Note that suppressions may depend on OS and/or library versions.
-# Tested on aarch64 and x86_64 with Ubuntu Noble system libs, using clang-16
-# and GCC, without gui.
+# Tested on Debian Trixie system libs,
+# * using clang (only x86_64, see https://bugs.kde.org/show_bug.cgi?id=485276),
+# * and GCC (only -O1, see https://bugs.kde.org/show_bug.cgi?id=472329),
+# without gui (because it only passes with a DEBUG=1 depends build).
 {
    Suppress leaks on shutdown
    Memcheck:Leak


### PR DESCRIPTION
valgrind currently does not work on GCC compiled executables, due to an upstream bug. https://bugs.kde.org/show_bug.cgi?id=472329

So temporarily switch to clang, so that a long term solution can be figured out in the meantime.

