### PR TITLE
cmake: Improve `install_name_tool` workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,13 @@ set(CLIENT_BUGREPORT "https://github.com/bitcoin/bitcoin/issues")
 #=============================
 # Language setup
 #=============================
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_HOST_APPLE)
+if(CMAKE_VERSION VERSION_LESS 4.2 AND CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_HOST_APPLE)
   # We do not use the install_name_tool when cross-compiling for macOS.
+  # However, CMake < 4.2 still searches for Apple's version of the tool,
+  # which causes an error during configuration.
+  # See:
+  # - https://gitlab.kitware.com/cmake/cmake/-/issues/27069
+  # - https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10955
   # So disable this tool check in further enable_language() commands.
   set(CMAKE_PLATFORM_HAS_INSTALLNAME FALSE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(CMAKE_VERSION VERSION_LESS 4.2 AND CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NO
   # - https://gitlab.kitware.com/cmake/cmake/-/issues/27069
   # - https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10955
   # So disable this tool check in further enable_language() commands.
-  set(CMAKE_PLATFORM_HAS_INSTALLNAME FALSE)
+  set(CMAKE_INSTALL_NAME_TOOL "${CMAKE_COMMAND} -E true")
 endif()
 enable_language(CXX)
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
We stopped using `install_name_tool` in 3bee51427a05075150721f0a05ead8f92e1ba019 (https://github.com/bitcoin/bitcoin/pull/29890), which [required](https://github.com/hebasto/bitcoin/pull/180) a CMake-specific hack:https://github.com/bitcoin/bitcoin/blob/b65ff0e5a1fd4ea2ae75e204729b8008c4ebb9ab/CMakeLists.txt#L72-L76

Due to recent changes in CMake, this hack has become problematic for the following reasons:
1. It is no longer needed when using CMake 4.2 or newer. See upstream [Issue #27069](https://gitlab.kitware.com/cmake/cmake/-/issues/27069) and [MR #10955](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10955).

2. It causes an [issue](https://github.com/bitcoin/bitcoin/issues/34513) when using CMake 4.0.5 or newer. See upstream [Issue #26814](https://gitlab.kitware.com/cmake/cmake/-/issues/26814) and [MR #10721](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10721).

This PR addresses both of these issues. Please see the individual commits for more details.

Fixes https://github.com/bitcoin/bitcoin/issues/34513.