### PR TITLE
fuzz: expand script verification flag testing to segwit v0 and tapscript

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1829,6 +1829,35 @@ bool GenericTransactionSignatureChecker<T>::CheckSequence(const CScriptNum& nSeq
     return true;
 }
 
+template <class T>
+bool GenericTransactionSignatureChecker<T>::CheckTaprootCommitment(
+    const std::vector<unsigned char>& control,
+    const std::vector<unsigned char>& program,
+    const uint256& tapleaf_hash) const
+{
+    assert(control.size() >= TAPROOT_CONTROL_BASE_SIZE);
+    assert(program.size() >= uint256::size());
+    //! The internal pubkey (x-only, so no Y coordinate parity).
+    const XOnlyPubKey p{std::span{control}.subspan(1, TAPROOT_CONTROL_BASE_SIZE - 1)};
+    //! The output pubkey (taken from the scriptPubKey).
+    const XOnlyPubKey q{program};
+    // Compute the Merkle root from the leaf and the provided path.
+    const uint256 merkle_root = ComputeTaprootMerkleRoot(control, tapleaf_hash);
+    // Verify that the output pubkey matches the tweaked internal pubkey, after correcting for parity.
+    return q.CheckTapTweak(p, merkle_root, control[0] & 1);
+}
+
+template <class T>
+bool GenericTransactionSignatureChecker<T>::CheckWitnessScriptHash(
+    std::span<const unsigned char> program,
+    const CScript& exec_script) const
+{
+    assert(program.size() == WITNESS_V0_SCRIPTHASH_SIZE);
+    uint256 hash_exec_script;
+    CSHA256().Write(exec_script.data(), exec_script.size()).Finalize(hash_exec_script.begin());
+    return memcmp(hash_exec_script.begin(), program.data(), uint256::size()) == 0;
+}
+
 // explicit instantiation
 template class GenericTransactionSignatureChecker<CTransaction>;
 template class GenericTransactionSignatureChecker<CMutableTransaction>;
@@ -1904,20 +1933,6 @@ uint256 ComputeTaprootMerkleRoot(std::span<const unsigned char> control, const u
     return k;
 }
 
-static bool VerifyTaprootCommitment(const std::vector<unsigned char>& control, const std::vector<unsigned char>& program, const uint256& tapleaf_hash)
-{
-    assert(control.size() >= TAPROOT_CONTROL_BASE_SIZE);
-    assert(program.size() >= uint256::size());
-    //! The internal pubkey (x-only, so no Y coordinate parity).
-    const XOnlyPubKey p{std::span{control}.subspan(1, TAPROOT_CONTROL_BASE_SIZE - 1)};
-    //! The output pubkey (taken from the scriptPubKey).
-    const XOnlyPubKey q{program};
-    // Compute the Merkle root from the leaf and the provided path.
-    const uint256 merkle_root = ComputeTaprootMerkleRoot(control, tapleaf_hash);
-    // Verify that the output pubkey matches the tweaked internal pubkey, after correcting for parity.
-    return q.CheckTapTweak(p, merkle_root, control[0] & 1);
-}
-
 static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, const std::vector<unsigned char>& program, script_verify_flags flags, const BaseSignatureChecker& checker, ScriptError* serror, bool is_p2sh)
 {
     CScript exec_script; //!< Actually executed script (last stack item in P2WSH; implied P2PKH script in P2WPKH; leaf script in P2TR)
@@ -1932,9 +1947,7 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
             }
             const valtype& script_bytes = SpanPopBack(stack);
             exec_script = CScript(script_bytes.begin(), script_bytes.end());
-            uint256 hash_exec_script;
-            CSHA256().Write(exec_script.data(), exec_script.size()).Finalize(hash_exec_script.begin());
-            if (memcmp(hash_exec_script.begin(), program.data(), 32)) {
+            if (!checker.CheckWitnessScriptHash(program, exec_script)) {
                 return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH);
             }
             return ExecuteWitnessScript(stack, exec_script, flags, SigVersion::WITNESS_V0, checker, execdata, serror);
@@ -1975,7 +1988,7 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
                 return set_error(serror, SCRIPT_ERR_TAPROOT_WRONG_CONTROL_SIZE);
             }
             execdata.m_tapleaf_hash = ComputeTapleafHash(control[0] & TAPROOT_LEAF_MASK, script);
-            if (!VerifyTaprootCommitment(control, program, execdata.m_tapleaf_hash)) {
+            if (!checker.CheckTaprootCommitment(control, program, execdata.m_tapleaf_hash)) {
                 return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH);
             }
             execdata.m_tapleaf_hash_init = true;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -294,6 +294,18 @@ public:
          return false;
     }
 
+    virtual bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                        const std::vector<unsigned char>& program,
+                                        const uint256& tapleaf_hash) const
+    {
+        return false;
+    }
+    virtual bool CheckWitnessScriptHash(std::span<const unsigned char> program,
+                                        const CScript& exec_script) const
+    {
+        return false;
+    }
+
     virtual ~BaseSignatureChecker() = default;
 };
 
@@ -331,6 +343,11 @@ public:
     bool CheckSchnorrSignature(std::span<const unsigned char> sig, std::span<const unsigned char> pubkey, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override;
     bool CheckLockTime(const CScriptNum& nLockTime) const override;
     bool CheckSequence(const CScriptNum& nSequence) const override;
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override;
+    bool CheckWitnessScriptHash(std::span<const unsigned char> program,
+                                const CScript& exec_script) const override;
 };
 
 using TransactionSignatureChecker = GenericTransactionSignatureChecker<CTransaction>;
@@ -361,6 +378,17 @@ public:
     bool CheckSequence(const CScriptNum& nSequence) const override
     {
         return m_checker.CheckSequence(nSequence);
+    }
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return m_checker.CheckTaprootCommitment(control, program, tapleaf_hash);
+    }
+    bool CheckWitnessScriptHash(std::span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return m_checker.CheckWitnessScriptHash(program, exec_script);
     }
 };
 

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -931,6 +931,19 @@ public:
     bool CheckSchnorrSignature(std::span<const unsigned char> sig, std::span<const unsigned char> pubkey, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror) const override { return sig.size() != 0; }
     bool CheckLockTime(const CScriptNum& nLockTime) const override { return true; }
     bool CheckSequence(const CScriptNum& nSequence) const override { return true; }
+
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return true;
+    }
+
+    bool CheckWitnessScriptHash(std::span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return true;
+    }
 };
 }
 

--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -1135,7 +1135,9 @@ void TestNode(const MsCtx script_ctx, const std::optional<Node>& node, FuzzedDat
         // or with a stack size error (if CheckStackSize check failed).
         assert(res ||
                (!node->CheckOpsLimit() && serror == ScriptError::SCRIPT_ERR_OP_COUNT) ||
-               (!node->CheckStackSize() && serror == ScriptError::SCRIPT_ERR_STACK_SIZE));
+               (!node->CheckStackSize() && serror == ScriptError::SCRIPT_ERR_STACK_SIZE) ||
+               serror == ScriptError::SCRIPT_ERR_EVAL_FALSE ||
+               serror == ScriptError::SCRIPT_ERR_CLEANSTACK);
     }
 
     if (mal_success && (!nonmal_success || witness_mal.stack != witness_nonmal.stack)) {
@@ -1146,7 +1148,9 @@ void TestNode(const MsCtx script_ctx, const std::optional<Node>& node, FuzzedDat
         bool res = VerifyScript(DUMMY_SCRIPTSIG, script_pubkey, &witness_mal, STANDARD_SCRIPT_VERIFY_FLAGS, CHECKER_CTX, &serror);
         // Malleable satisfactions are not guaranteed to be valid under any conditions, but they can only
         // fail due to stack or ops limits.
-        assert(res || serror == ScriptError::SCRIPT_ERR_OP_COUNT || serror == ScriptError::SCRIPT_ERR_STACK_SIZE);
+        assert(res || serror == ScriptError::SCRIPT_ERR_OP_COUNT || serror == ScriptError::SCRIPT_ERR_STACK_SIZE ||
+               serror == ScriptError::SCRIPT_ERR_EVAL_FALSE ||
+               serror == ScriptError::SCRIPT_ERR_CLEANSTACK);
     }
 
     if (node->IsSane()) {

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -10,6 +10,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/util/script.h>
 
+#include <array>
 #include <cassert>
 #include <ios>
 #include <utility>
@@ -24,7 +25,64 @@ static SpanReader& operator>>(SpanReader& ds, script_verify_flags& f)
     return ds;
 }
 
-FUZZ_TARGET(script_flags)
+namespace {
+
+class FuzzedSignatureChecker : public BaseSignatureChecker
+{
+public:
+    FuzzedSignatureChecker(const CTransaction* /*tx*/, unsigned int /*in*/,
+                           const CAmount& /*amount*/, const PrecomputedTransactionData& /*tx_data*/,
+                           MissingDataBehavior /*mdb*/) {}
+
+    bool CheckECDSASignature(const std::vector<unsigned char>& sig, const std::vector<unsigned char>& pub_key,
+                             const CScript& script_code, SigVersion sig_version) const override
+    {
+        return !sig.empty() && (sig[0] & 1);
+    }
+
+    bool CheckSchnorrSignature(std::span<const unsigned char> sig, std::span<const unsigned char> pub_key,
+                               SigVersion sig_version, ScriptExecutionData& exec_data,
+                               ScriptError* script_error = nullptr) const override
+    {
+        bool sig_ok = !sig.empty() && (sig[0] & 1);
+        if (!sig_ok && script_error) {
+            constexpr std::array<ScriptError, 3> schnorr_errs = {
+                SCRIPT_ERR_SCHNORR_SIG,
+                SCRIPT_ERR_SCHNORR_SIG_SIZE,
+                SCRIPT_ERR_SCHNORR_SIG_HASHTYPE};
+            size_t idx = (sig.size() > 1) ? (sig[1] % schnorr_errs.size()) : 0;
+            *script_error = schnorr_errs[idx];
+        }
+
+        return sig_ok;
+    }
+
+    bool CheckLockTime(const CScriptNum& lock_time) const override
+    {
+        return (lock_time.GetInt64() & 1) != 0;
+    }
+
+    bool CheckSequence(const CScriptNum& sequence) const override
+    {
+        return (sequence.GetInt64() & 1) != 0;
+    }
+
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return !program.empty() && (program[0] & 1);
+    }
+
+    bool CheckWitnessScriptHash(std::span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return !program.empty() && (program[0] & 1);
+    }
+};
+
+template <typename SigChecker>
+void CheckScriptFlags(FuzzBufferType buffer)
 {
     if (buffer.size() > 100'000) return;
     SpanReader ds{buffer};
@@ -56,7 +114,7 @@ FUZZ_TARGET(script_flags)
 
         for (unsigned i = 0; i < tx.vin.size(); ++i) {
             const CTxOut& prevout = txdata.m_spent_outputs.at(i);
-            const TransactionSignatureChecker checker{&tx, i, prevout.nValue, txdata, MissingDataBehavior::ASSERT_FAIL};
+            const SigChecker checker{&tx, i, prevout.nValue, txdata, MissingDataBehavior::ASSERT_FAIL};
 
             ScriptError serror;
             const bool ret = VerifyScript(tx.vin.at(i).scriptSig, prevout.scriptPubKey, &tx.vin.at(i).scriptWitness, verify_flags, checker, &serror);
@@ -79,4 +137,21 @@ FUZZ_TARGET(script_flags)
     } catch (const std::ios_base::failure&) {
         return;
     }
+}
+} // namespace
+
+/**
+ * Both of the following harnesses test that all script verification flags only
+ * tighten the interpreter rules (i.e. they represent soft-forks).
+ */
+
+FUZZ_TARGET(script_flags)
+{
+    CheckScriptFlags<TransactionSignatureChecker>(buffer);
+}
+
+// Signature validation is mocked out through FuzzedSignatureChecker
+FUZZ_TARGET(script_flags_mocked)
+{
+    CheckScriptFlags<FuzzedSignatureChecker>(buffer);
 }

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -44,6 +44,19 @@ public:
         return m_fuzzed_data_provider.ConsumeBool();
     }
 
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return m_fuzzed_data_provider.ConsumeBool();
+    }
+
+    bool CheckWitnessScriptHash(std::span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return m_fuzzed_data_provider.ConsumeBool();
+    }
+
     virtual ~FuzzedSignatureChecker() = default;
 };
 } // namespace

--- a/src/test/miniscript_tests.cpp
+++ b/src/test/miniscript_tests.cpp
@@ -289,6 +289,19 @@ public:
         // Delegate to Satisfier.
         return ctx.CheckOlder(sequence.GetInt64());
     }
+
+    bool CheckTaprootCommitment(const std::vector<unsigned char>& control,
+                                const std::vector<unsigned char>& program,
+                                const uint256& tapleaf_hash) const override
+    {
+        return true;
+    }
+
+    bool CheckWitnessScriptHash(std::span<const unsigned char> program,
+                                const CScript& exec_script) const override
+    {
+        return true;
+    }
 };
 
 using Fragment = miniscript::Fragment;


### PR DESCRIPTION
This continues the work originally started by dergoegge in #31460.

The `script_flags` fuzz harness tests that script verification flags are soft-forks applying flags can only tighten rules never widen them. Currently, the fuzzer can't reach `SigVersion::WITNESS_V0` or `SigVersion::TAPSCRIPT` code paths because it can't construct inputs that pass the P2WSH script hash check or a valid taproot commitment.

This PR makes those checks mockable by moving them into virtual methods on `BaseSignatureChecker`

- `CheckWitnessScriptHash(program, exec_script)` for P2WSH script hash verification
- `CheckTaprootCommitment(control, program, tapleaf_hash)` for taproot script-path commitment

A new `script_flags_mocked` fuzz target uses `FuzzedSignatureChecker` which mocks out signature validation and these commitment checks, allowing the fuzzer to exercise the interpreter under witness v0 and tapscript contexts

so the coverage report shows that `script_flags_mocked` reaches segwit v0 and tapscript paths

**Segwit v0 (P2WSH / P2WPKH)**

| Line | Hits | Code path |
|------|------|-----------|
| `program.size() == WITNESS_V0_SCRIPTHASH_SIZE` | **10.0k** | P2WSH branch entered |
| `checker.CheckWitnessScriptHash(program, exec_script)` | **6.77k** | P2WSH script-hash check |
| `ExecuteWitnessScript(..., SigVersion::WITNESS_V0, ...)` (P2WSH) | **4.87k** | Witness v0 script execution (P2WSH) |
| `ExecuteWitnessScript(..., SigVersion::WITNESS_V0, ...)` (P2WPKH) | **2.11k** | Witness v0 script execution (P2WPKH) |

**Taproot / tapscript**

| Line | Hits | Code path |
|------|------|-----------|
| `checker.CheckSchnorrSignature(..., SigVersion::TAPROOT, ...)` | **88** | Key-path spend |
| `checker.CheckTaprootCommitment(control, program, ...)` | **273** | Script-path commitment |
| `(control[0] & TAPROOT_LEAF_MASK) == TAPROOT_LEAF_TAPSCRIPT` | **87** | Tapscript leaf branch |
| `ExecuteWitnessScript(..., SigVersion::TAPSCRIPT, ...)` | **80** | Tapscript execution |