### PR TITLE
wallet/rpc/backup: allow importprunedfunds to import spending txs (#3…

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -81,7 +81,7 @@ RPCHelpMan importprunedfunds()
     unsigned int txnIndex = vIndex[it - vMatch.begin()];
 
     CTransactionRef tx_ref = MakeTransactionRef(tx);
-    if (pwallet->IsMine(*tx_ref)) {
+    if (pwallet->IsMine(*tx_ref)|| pwallet->IsFromMe(*tx_ref)) {
         pwallet->AddToWallet(std::move(tx_ref), TxStateConfirmed{merkleBlock.header.GetHash(), height, static_cast<int>(txnIndex)});
         return UniValue::VNULL;
     }


### PR DESCRIPTION
…4584)

Currently, importprunedfunds only imports transactions that credit wallet addresses.
This PR allows spending transactions (IsFromMe) to be imported as well.

Fixes #34584
