### PR TITLE
util: Fix UB in SetStdinEcho when ENOTTY

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -15,12 +15,6 @@
 # Tested on aarch64 and x86_64 with Ubuntu Noble system libs, using clang-16
 # and GCC, without gui.
 {
-   Suppress uninitialized bytes warning in compat code
-   Memcheck:Param
-   ioctl(TCSET{S,SW,SF})
-   fun:tcsetattr
-}
-{
    Suppress leaks on shutdown
    Memcheck:Leak
    ...

--- a/src/compat/stdin.cpp
+++ b/src/compat/stdin.cpp
@@ -43,7 +43,7 @@ void SetStdinEcho(bool enable)
         return;
     }
     if (!enable) {
-        tty.c_lflag &= ~ECHO;
+        tty.c_lflag &= static_cast<decltype(tty.c_lflag)>(~ECHO);
     } else {
         tty.c_lflag |= ECHO;
     }

--- a/src/compat/stdin.cpp
+++ b/src/compat/stdin.cpp
@@ -18,25 +18,38 @@
 // https://stackoverflow.com/questions/1413445/reading-a-password-from-stdcin
 void SetStdinEcho(bool enable)
 {
+    if (!StdinTerminal()) {
+        return;
+    }
 #ifdef WIN32
     HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
     DWORD mode;
-    GetConsoleMode(hStdin, &mode);
+    if (!GetConsoleMode(hStdin, &mode)) {
+        fputs("GetConsoleMode failed\n", stderr);
+        return;
+    }
     if (!enable) {
         mode &= ~ENABLE_ECHO_INPUT;
     } else {
         mode |= ENABLE_ECHO_INPUT;
     }
-    SetConsoleMode(hStdin, mode);
+    if (!SetConsoleMode(hStdin, mode)) {
+        fputs("SetConsoleMode failed\n", stderr);
+    }
 #else
     struct termios tty;
-    tcgetattr(STDIN_FILENO, &tty);
+    if (tcgetattr(STDIN_FILENO, &tty) != 0) {
+        fputs("tcgetattr failed\n", stderr);
+        return;
+    }
     if (!enable) {
         tty.c_lflag &= ~ECHO;
     } else {
         tty.c_lflag |= ECHO;
     }
-    (void)tcsetattr(STDIN_FILENO, TCSANOW, &tty);
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &tty) != 0) {
+        fputs("tcsetattr failed\n", stderr);
+    }
 #endif
 }
 

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -55,7 +55,6 @@ unsigned-integer-overflow:TxConfirmStats::EstimateMedianVal
 unsigned-integer-overflow:InsecureRandomContext::rand64
 unsigned-integer-overflow:InsecureRandomContext::SplitMix64
 unsigned-integer-overflow:bitset_detail::PopCount
-implicit-integer-sign-change:SetStdinEcho
 implicit-integer-sign-change:compressor.h
 implicit-integer-sign-change:crypto/
 implicit-integer-sign-change:TxConfirmStats::removeTx


### PR DESCRIPTION
The call to `tcgetattr` may fail with `ENOTTY`, leaving the struct possibly uninitialized (UB).

Fix this UB by returning early when `isatty` fails, or when `tcgetattr` fails. (Same for Windows)


This can be tested by a command that fails valgrind before the change and passes after:

```
echo 'pipe' | valgrind --quiet ./bld-cmake/bin/bitcoin-cli -stdinrpcpass uptime