### PR TITLE
bench: use larger payload in HexStrBench

### DIFF
--- a/src/bench/strencodings.cpp
+++ b/src/bench/strencodings.cpp
@@ -3,7 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <bench/data/block413567.raw.h>
+#include <consensus/consensus.h>
+#include <random.h>
 #include <span.h>
 #include <util/strencodings.h>
 
@@ -11,7 +12,8 @@
 
 static void HexStrBench(benchmark::Bench& bench)
 {
-    auto const& data = benchmark::data::block413567;
+    FastRandomContext rng{/*fDeterministic=*/true};
+    auto data{rng.randbytes<std::byte>(MAX_BLOCK_WEIGHT)};
     bench.batch(data.size()).unit("byte").run([&] {
         auto hex = HexStr(data);
         ankerl::nanobench::doNotOptimizeAway(hex);


### PR DESCRIPTION
### Context
Split out of https://github.com/bitcoin/bitcoin/pull/32554
Inspired by https://github.com/bitcoin/bitcoin/pull/32457#discussion_r2081323234
 
### Problem
`HexStrBench` uses the bytes from the embedded block fixture as a random source of bytes to measure `HexStr` performance against.
This coupling makes block benchmark migrations in #32554 slightly more work than necessary.

### Fix
We can use deterministic pseudo-random bytes instead so this benchmark keeps stable input without fixture coupling.
Use `MAX_BLOCK_WEIGHT` so the benchmark stays in the same size range and keeps measured work above harness overhead.
This changes the benchmark baseline because input size moves from about 1 MB to 4 MB.