### PR TITLE
wallet: Fix detection of symlinks on Windows

### DIFF
--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -32,6 +32,7 @@
 #else
 #include <io.h>
 #include <shlobj.h>
+#include <windows.h>
 #endif // WIN32
 
 #ifdef __APPLE__
@@ -342,3 +343,16 @@ FSType GetFilesystemType(const fs::path& path)
     return FSType::OTHER;
 }
 #endif
+
+bool IsSymlink(const fs::path& path)
+{
+#ifdef WIN32
+    DWORD file_attrs = GetFileAttributesW(path.wstring().c_str());
+    if (file_attrs == INVALID_FILE_ATTRIBUTES) {
+        throw fs::filesystem_error("Unable to get file attributes", fs::PathToString(path), std::make_error_code(std::errc::invalid_argument));
+    }
+    return (file_attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+#else
+    return fs::is_symlink(path);
+#endif
+}

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -106,4 +106,11 @@ bool IsDirWritable(const fs::path& dir_path);
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 
+/** Determine whether the given path is a symbolic link or a reparse point on Windows
+ *
+ * @param[in] path The path to check
+ * @return Whether path is a symlink or reparse point
+ */
+bool IsSymlink(const fs::path& path);
+
 #endif // BITCOIN_UTIL_FS_HELPERS_H

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -7,6 +7,7 @@
 #include <common/args.h>
 #include <util/fs.h>
 #include <util/log.h>
+#include <util/fs_helpers.h>
 #include <wallet/db.h>
 
 #include <algorithm>
@@ -29,6 +30,11 @@ std::vector<std::pair<fs::path, std::string>> ListDatabases(const fs::path& wall
         assert(!ec); // Loop should exit on error.
         try {
             const fs::path path{it->path().lexically_relative(wallet_dir)};
+
+            if (IsSymlink(it->path())) {
+                LogWarning("Not recursively searching symlink/reparse point at '%s'", fs::PathToString(it->path()));
+                it.disable_recursion_pending();
+            }
 
             if (it->status().type() == fs::file_type::directory) {
                 if (IsBDBFile(BDBDataFile(it->path()))) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2969,7 +2969,9 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     fs::file_type path_type = fs::symlink_status(wallet_path).type();
     if (!(path_type == fs::file_type::not_found || path_type == fs::file_type::directory ||
           (path_type == fs::file_type::symlink && fs::is_directory(wallet_path)) ||
-          (path_type == fs::file_type::regular && name_path.filename() == name_path))) {
+          // Windows cross compile does not detect symlinks, so we need to explicitly check
+          // whether a "regular file" is actually a symlink.
+          (path_type == fs::file_type::regular && name_path.filename() == name_path && !IsSymlink(wallet_path)))) {
         return util::Error{Untranslated(strprintf(
               "Invalid -wallet path '%s'. -wallet path should point to a directory where wallet.dat and "
               "database/log.?????????? files can be stored, a location where such a directory could be created, "

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -67,17 +67,12 @@ class MultiWalletTest(BitcoinTestFramework):
 
     def run_test(self):
         self.check_chmod = True
-        self.check_symlinks = True
         if platform.system() == 'Windows':
             # Additional context:
             # - chmod: Posix has one user per file while Windows has an ACL approach
-            # - symlinks: GCC 13 has FIXME notes for symlinks under Windows:
-            #   https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=libstdc%2B%2B-v3/src/filesystem/ops-common.h;h=ba377905a2e90f7baf30c900b090f1f732397e08;hb=refs/heads/releases/gcc-13#l124
-            self.log.warning('Skipping chmod+symlink checks on Windows: '
-                             'chmod works differently due to how access rights work and '
-                             'symlink behavior with regard to the standard library is non-standard on cross-built binaries.')
+            self.log.warning('Skipping chmod checks on Windows: '
+                             'chmod works differently due to how access rights work')
             self.check_chmod = False
-            self.check_symlinks = False
         elif os.geteuid() == 0:
             self.log.warning('Skipping checks involving chmod as they require non-root permissions.')
             self.check_chmod = False
@@ -105,21 +100,20 @@ class MultiWalletTest(BitcoinTestFramework):
         self.test_lock_file_closed(node)
 
     def test_scanning_main_dir_access(self, node):
-        if not self.check_chmod:
-            return
-
         self.log.info("Verify warning is emitted when failing to scan the wallets directory")
         self.start_node(0)
         with node.assert_debug_log(unexpected_msgs=['Error scanning directory entries under'], expected_msgs=[]):
             result = node.listwalletdir()
             assert_equal(result, {'wallets': [{'name': 'default_wallet', 'warnings': []}]})
-        os.chmod(data_dir(node, 'wallets'), 0)
-        with node.assert_debug_log(expected_msgs=['Error scanning directory entries under']):
-            result = node.listwalletdir()
-            assert_equal(result, {'wallets': []})
+
+        if self.check_chmod:
+            os.chmod(data_dir(node, 'wallets'), 0)
+            with node.assert_debug_log(expected_msgs=['Error scanning directory entries under']):
+                result = node.listwalletdir()
+                assert_equal(result, {'wallets': []})
+            # Restore permissions
+            os.chmod(data_dir(node, 'wallets'), stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
         self.stop_node(0)
-        # Restore permissions
-        os.chmod(data_dir(node, 'wallets'), stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
     def test_mixed_wallets(self, node):
         self.log.info("Test mixed wallets")
@@ -128,8 +122,7 @@ class MultiWalletTest(BitcoinTestFramework):
         os.mkdir(wallet_dir(node, 'w7'))
         os.symlink('w7', wallet_dir(node, 'w7_symlink'))
 
-        if self.check_symlinks:
-            os.symlink('..', wallet_dir(node, 'recursive_dir_symlink'))
+        os.symlink('..', wallet_dir(node, 'recursive_dir_symlink'))
 
         # rename wallet.dat to make sure plain wallet file paths (as opposed to
         # directory paths) can be loaded
@@ -172,32 +165,29 @@ class MultiWalletTest(BitcoinTestFramework):
         return empty_wallet, empty_created_wallet, wallet_names, in_wallet_dir
 
     def test_scanning_sub_dir(self, node, in_wallet_dir):
-        if not self.check_chmod:
-            return
-
         self.log.info("Test scanning for sub directories")
         # Baseline, no errors.
         with node.assert_debug_log(expected_msgs=[], unexpected_msgs=["Error while scanning wallet dir"]):
             walletlist = node.listwalletdir()['wallets']
         assert_equal(sorted(map(lambda w: w['name'], walletlist)), sorted(in_wallet_dir))
 
-        # "Permission denied" error.
-        os.mkdir(wallet_dir(node, 'no_access'))
-        os.chmod(wallet_dir(node, 'no_access'), 0)
-        with node.assert_debug_log(expected_msgs=["Error while scanning wallet dir"]):
-            walletlist = node.listwalletdir()['wallets']
-        # Need to ensure access is restored for cleanup
-        os.chmod(wallet_dir(node, 'no_access'), stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        if self.check_chmod:
+            # "Permission denied" error.
+            os.mkdir(wallet_dir(node, 'no_access'))
+            os.chmod(wallet_dir(node, 'no_access'), 0)
+            with node.assert_debug_log(expected_msgs=["Error while scanning wallet dir"]):
+                walletlist = node.listwalletdir()['wallets']
+            # Need to ensure access is restored for cleanup
+            os.chmod(wallet_dir(node, 'no_access'), stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
-        # Verify that we no longer emit errors after restoring permissions
-        with node.assert_debug_log(expected_msgs=[], unexpected_msgs=["Error while scanning wallet dir"]):
-            walletlist = node.listwalletdir()['wallets']
-        assert_equal(sorted(map(lambda w: w['name'], walletlist)), sorted(in_wallet_dir))
+            # Verify that we no longer emit errors after restoring permissions
+            with node.assert_debug_log(expected_msgs=[], unexpected_msgs=["Error while scanning wallet dir"]):
+                walletlist = node.listwalletdir()['wallets']
+            assert_equal(sorted(map(lambda w: w['name'], walletlist)), sorted(in_wallet_dir))
 
     def test_scanning_symlink_levels(self, node, in_wallet_dir):
-        if not self.check_symlinks:
+        if platform.system() == 'Windows':
             return
-
         self.log.info("Test for errors from too many levels of symbolic links")
         os.mkdir(wallet_dir(node, 'self_walletdat_symlink'))
         os.symlink('wallet.dat', wallet_dir(node, 'self_walletdat_symlink/wallet.dat'))
@@ -221,9 +211,8 @@ class MultiWalletTest(BitcoinTestFramework):
         self.stop_node(0, 'Warning: Ignoring duplicate -wallet w1.')
 
         # should not initialize if wallet file is a symlink
-        if self.check_symlinks:
-            os.symlink('w8', wallet_dir(node, 'w8_symlink'))
-            node.assert_start_raises_init_error(['-wallet=w8_symlink'], r'Error: Invalid -wallet path \'w8_symlink\'\. .*', match=ErrorMatch.FULL_REGEX)
+        os.symlink('w8', wallet_dir(node, 'w8_symlink'))
+        node.assert_start_raises_init_error(['-wallet=w8_symlink'], r'Error: Invalid -wallet path \'w8_symlink\'\. .*', match=ErrorMatch.FULL_REGEX)
 
         # should not initialize if the specified walletdir does not exist
         node.assert_start_raises_init_error(['-walletdir=bad'], 'Error: Specified -walletdir "bad" does not exist')
@@ -350,8 +339,7 @@ class MultiWalletTest(BitcoinTestFramework):
         # Fail to load duplicate wallets
         assert_raises_rpc_error(-35, "Wallet \"w1\" is already loaded.", node.loadwallet, wallet_names[0])
         # Fail to load if wallet file is a symlink
-        if self.check_symlinks:
-            assert_raises_rpc_error(-4, "Wallet file verification failed. Invalid -wallet path 'w8_symlink'", node.loadwallet, 'w8_symlink')
+        assert_raises_rpc_error(-4, "Wallet file verification failed. Invalid -wallet path 'w8_symlink'", node.loadwallet, 'w8_symlink')
 
         # Fail to load if a directory is specified that doesn't contain a wallet
         os.mkdir(wallet_dir(node, 'empty_wallet_dir'))


### PR DESCRIPTION
This PR implements symlink detection for Windows, since GCC [doesn't support symlinks on Windows](https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=libstdc%2B%2B-v3/src/filesystem/ops-common.h;h=ba377905a2e90f7baf30c900b090f1f732397e08;hb=refs/heads/releases/gcc-13#l124). This is used by the wallet's `ListDatabases` in order to detect symlinks and avoid recursing them. It's also used in wallet path validation since that is also checking whether paths are symlinks, and we should properly detect symlinks on Windows.

Under the hood, the `IsSymlink` function uses `std::filesystem::is_symlink` for non-Windows systems. On Windows, it checks a file's attributes to determine if it is a [reparse point](https://learn.microsoft.com/en-us/windows/win32/fileio/reparse-points). Strictly speaking, this will also catch files that aren't symlinks, such as directories that are Onedrive mounts. I think it's fine to not be recursively searching such directories.

This is based on #34418 for the multiwallet test and CI changes that it enables. The last commit also removes the skipping of the symlink checks so that we are testing that the symlink handling behavior on Windows matches that on Linux and MacOS.