### PR TITLE
guix: remove double export of `TZ`

### DIFF
--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -289,7 +289,7 @@ INFO: Codesigning ${VERSION:?not set} for platform triple ${HOST:?not set}:
 EOF
 
 
-        # Run the build script 'contrib/guix/libexec/build.sh' in the build
+        # Run the build script 'contrib/guix/libexec/codesign.sh' in the build
         # container specified by 'contrib/guix/manifest.scm'.
         #
         # Explanation of `guix shell` flags:

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -4,6 +4,9 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 export LC_ALL=C
 set -e -o pipefail
+
+# Environment variables for determinism
+export TAR_OPTIONS="--owner=0 --group=0 --numeric-owner --mtime='@${SOURCE_DATE_EPOCH}' --sort=name"
 export TZ=UTC
 
 # Although Guix _does_ set umask when building its own packages (in our case,
@@ -156,10 +159,6 @@ case "$HOST" in
         )
         ;;
 esac
-
-# Environment variables for determinism
-export TAR_OPTIONS="--owner=0 --group=0 --numeric-owner --mtime='@${SOURCE_DATE_EPOCH}' --sort=name"
-export TZ="UTC"
 
 ####################
 # Depends Building #


### PR DESCRIPTION
Remove a double export of `TZ` and fix a typo.