### PR TITLE
doc: clarify swapping impact on IBD performance

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -2,6 +2,15 @@
 
 There are a few parameters that can be dialed down to reduce the memory usage of `bitcoind`. This can be useful on embedded systems or small VPSes.
 
+## Swapping
+
+When the operating system is under memory pressure, it may swap memory pages from RAM to disk.
+If this becomes continuous ("thrashing"), `bitcoind` can slow to a crawl, especially during initial sync or reindex.
+
+If you see sustained swap I/O while `bitcoind` runs, restart with a lower `-dbcache`.
+If needed, also reduce `-maxmempool`, `-maxconnections`, or use `-blocksonly`.
+Bitcoin Core may warn at startup when `-dbcache` looks too large for the detected system memory.
+
 ## In-memory caches
 
 The size of some in-memory caches can be reduced. As caches trade off memory usage for performance, reducing these will usually have a negative effect on performance.


### PR DESCRIPTION
### Problem
Sustained [heavy swapping](https://en.wikipedia.org/wiki/Thrashing_(computer_science)) can grind execution to a halt, but today users get no direct warning from the node when this happens, and this caveat is not documented.

### Fix
We can’t easily detect heavy swap pressure in a reliable, cross-platform way, but we can document what swapping is and why it can severely degrade IBD performance.

---

Note: An earlier version of this PR attempted to detect and warn on heavy swapping (Linux-only), but it was changed to documentation based on review feedback.
