### PR TITLE
fees: wallet: remove block policy fee estimator internals from wallet

### DIFF
--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -6,7 +6,6 @@
 #include <common/messages.h>
 #include <common/types.h>
 #include <node/types.h>
-#include <policy/fees/block_policy_estimator.h>
 #include <tinyformat.h>
 #include <util/fees.h>
 #include <util/strencodings.h>
@@ -38,23 +37,6 @@ std::string StringForFeeReason(FeeReason reason)
     if (reason_string == fee_reason_strings.end()) return "Unknown";
 
     return reason_string->second;
-}
-
-std::string StringForBlockPolicyEstimateReason(BlockPolicyEstimateReason reason)
-{
-    switch (reason) {
-    case BlockPolicyEstimateReason::NONE:
-        return "None";
-    case BlockPolicyEstimateReason::HALF_ESTIMATE:
-        return "Half Target 60% Threshold";
-    case BlockPolicyEstimateReason::FULL_ESTIMATE:
-        return "Target 85% Threshold";
-    case BlockPolicyEstimateReason::DOUBLE_ESTIMATE:
-        return "Double Target 95% Threshold";
-    case BlockPolicyEstimateReason::CONSERVATIVE:
-        return "Conservative Double Target longer horizon";
-    } // no default case, so the compiler can warn about missing cases
-    assert(false);
 }
 
 const std::vector<std::pair<std::string, FeeEstimateMode>>& FeeModeMap()

--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -27,12 +27,9 @@ namespace common {
 std::string StringForFeeReason(FeeReason reason)
 {
     static const std::map<FeeReason, std::string> fee_reason_strings = {
-        {FeeReason::NONE, "None"},
-        {FeeReason::HALF_ESTIMATE, "Half Target 60% Threshold"},
-        {FeeReason::FULL_ESTIMATE, "Target 85% Threshold"},
-        {FeeReason::DOUBLE_ESTIMATE, "Double Target 95% Threshold"},
-        {FeeReason::CONSERVATIVE, "Conservative Double Target longer horizon"},
+        {FeeReason::FEE_RATE_ESTIMATOR, "Fee Rate Estimator"},
         {FeeReason::MEMPOOL_MIN, "Mempool Min Fee"},
+        {FeeReason::USER_SPECIFIED, "User Specified Fee"},
         {FeeReason::FALLBACK, "Fallback fee"},
         {FeeReason::REQUIRED, "Minimum Required Fee"},
     };
@@ -41,6 +38,23 @@ std::string StringForFeeReason(FeeReason reason)
     if (reason_string == fee_reason_strings.end()) return "Unknown";
 
     return reason_string->second;
+}
+
+std::string StringForBlockPolicyEstimateReason(BlockPolicyEstimateReason reason)
+{
+    switch (reason) {
+    case BlockPolicyEstimateReason::NONE:
+        return "None";
+    case BlockPolicyEstimateReason::HALF_ESTIMATE:
+        return "Half Target 60% Threshold";
+    case BlockPolicyEstimateReason::FULL_ESTIMATE:
+        return "Target 85% Threshold";
+    case BlockPolicyEstimateReason::DOUBLE_ESTIMATE:
+        return "Double Target 95% Threshold";
+    case BlockPolicyEstimateReason::CONSERVATIVE:
+        return "Conservative Double Target longer horizon";
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
 }
 
 const std::vector<std::pair<std::string, FeeEstimateMode>>& FeeModeMap()

--- a/src/common/messages.h
+++ b/src/common/messages.h
@@ -18,6 +18,7 @@ struct bilingual_str;
 
 enum class FeeEstimateMode;
 enum class FeeReason;
+enum class BlockPolicyEstimateReason;
 namespace node {
 enum class TransactionError;
 } // namespace node
@@ -26,6 +27,7 @@ namespace common {
 enum class PSBTError;
 bool FeeModeFromString(std::string_view mode_string, FeeEstimateMode& fee_estimate_mode);
 std::string StringForFeeReason(FeeReason reason);
+std::string StringForBlockPolicyEstimateReason(BlockPolicyEstimateReason reason);
 std::string FeeModes(const std::string& delimiter);
 std::string FeeModeInfo(std::pair<std::string, FeeEstimateMode>& mode);
 std::string FeeModesDetail(std::string default_info);

--- a/src/common/messages.h
+++ b/src/common/messages.h
@@ -18,7 +18,6 @@ struct bilingual_str;
 
 enum class FeeEstimateMode;
 enum class FeeReason;
-enum class BlockPolicyEstimateReason;
 namespace node {
 enum class TransactionError;
 } // namespace node
@@ -27,7 +26,6 @@ namespace common {
 enum class PSBTError;
 bool FeeModeFromString(std::string_view mode_string, FeeEstimateMode& fee_estimate_mode);
 std::string StringForFeeReason(FeeReason reason);
-std::string StringForBlockPolicyEstimateReason(BlockPolicyEstimateReason reason);
 std::string FeeModes(const std::string& delimiter);
 std::string FeeModeInfo(std::pair<std::string, FeeEstimateMode>& mode);
 std::string FeeModesDetail(std::string default_info);

--- a/src/policy/fees/block_policy_estimator.cpp
+++ b/src/policy/fees/block_policy_estimator.cpp
@@ -48,6 +48,23 @@ std::string StringForFeeEstimateHorizon(FeeEstimateHorizon horizon)
     assert(false);
 }
 
+std::string StringForBlockPolicyEstimateReason(BlockPolicyEstimateReason reason)
+{
+    switch (reason) {
+    case BlockPolicyEstimateReason::NONE:
+        return "None";
+    case BlockPolicyEstimateReason::HALF_ESTIMATE:
+        return "Half Target 60% Threshold";
+    case BlockPolicyEstimateReason::FULL_ESTIMATE:
+        return "Target 85% Threshold";
+    case BlockPolicyEstimateReason::DOUBLE_ESTIMATE:
+        return "Double Target 95% Threshold";
+    case BlockPolicyEstimateReason::CONSERVATIVE:
+        return "Conservative Double Target longer horizon";
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
+
 namespace {
 
 struct EncodedDoubleFormatter
@@ -872,11 +889,12 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
 {
     LOCK(m_cs_fee_estimator);
 
-    if (feeCalc) {
-        feeCalc->desiredTarget = confTarget;
-        feeCalc->returnedTarget = confTarget;
-        feeCalc->best_height = nBestSeenHeight;
-    }
+    FeeCalculation temp_fee_calc;
+    if (!feeCalc) feeCalc = &temp_fee_calc;
+
+    feeCalc->desiredTarget = confTarget;
+    feeCalc->returnedTarget = confTarget;
+    feeCalc->best_height = nBestSeenHeight;
 
     double median = -1;
     EstimationResult tempResult;
@@ -893,7 +911,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
     if ((unsigned int)confTarget > maxUsableEstimate) {
         confTarget = maxUsableEstimate;
     }
-    if (feeCalc) feeCalc->returnedTarget = confTarget;
+    feeCalc->returnedTarget = confTarget;
 
     if (confTarget <= 1) return CFeeRate(0); // error condition
 
@@ -917,40 +935,41 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
      * See: https://github.com/bitcoin/bitcoin/issues/11800#issuecomment-349697807
      */
     double halfEst = estimateCombinedFee(confTarget/2, HALF_SUCCESS_PCT, true, &tempResult);
-    if (feeCalc) {
-        feeCalc->est = tempResult;
-        feeCalc->reason = BlockPolicyEstimateReason::HALF_ESTIMATE;
-    }
+    feeCalc->est = tempResult;
+    feeCalc->reason = BlockPolicyEstimateReason::HALF_ESTIMATE;
     median = halfEst;
     double actualEst = estimateCombinedFee(confTarget, SUCCESS_PCT, true, &tempResult);
     if (actualEst > median) {
         median = actualEst;
-        if (feeCalc) {
-            feeCalc->est = tempResult;
-            feeCalc->reason = BlockPolicyEstimateReason::FULL_ESTIMATE;
-        }
+        feeCalc->est = tempResult;
+        feeCalc->reason = BlockPolicyEstimateReason::FULL_ESTIMATE;
     }
     double doubleEst = estimateCombinedFee(2 * confTarget, DOUBLE_SUCCESS_PCT, !conservative, &tempResult);
     if (doubleEst > median) {
         median = doubleEst;
-        if (feeCalc) {
-            feeCalc->est = tempResult;
-            feeCalc->reason = BlockPolicyEstimateReason::DOUBLE_ESTIMATE;
-        }
+        feeCalc->est = tempResult;
+        feeCalc->reason = BlockPolicyEstimateReason::DOUBLE_ESTIMATE;
     }
 
     if (conservative || median == -1) {
         double consEst =  estimateConservativeFee(2 * confTarget, &tempResult);
         if (consEst > median) {
             median = consEst;
-            if (feeCalc) {
-                feeCalc->est = tempResult;
-                feeCalc->reason = BlockPolicyEstimateReason::CONSERVATIVE;
-            }
+            feeCalc->est = tempResult;
+            feeCalc->reason = BlockPolicyEstimateReason::CONSERVATIVE;
         }
     }
 
     if (median < 0) return CFeeRate(0); // error condition
+
+    LogDebug(BCLog::ESTIMATEFEE, "estimateSmartFee Selected feerate :%g Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)",
+             median, feeCalc->returnedTarget, feeCalc->desiredTarget, StringForBlockPolicyEstimateReason(feeCalc->reason), feeCalc->est.decay,
+             feeCalc->est.pass.start, feeCalc->est.pass.end,
+             (feeCalc->est.pass.totalConfirmed + feeCalc->est.pass.inMempool + feeCalc->est.pass.leftMempool) > 0.0 ? 100 * feeCalc->est.pass.withinTarget / (feeCalc->est.pass.totalConfirmed + feeCalc->est.pass.inMempool + feeCalc->est.pass.leftMempool) : 0.0,
+             feeCalc->est.pass.withinTarget, feeCalc->est.pass.totalConfirmed, feeCalc->est.pass.inMempool, feeCalc->est.pass.leftMempool,
+             feeCalc->est.fail.start, feeCalc->est.fail.end,
+             (feeCalc->est.fail.totalConfirmed + feeCalc->est.fail.inMempool + feeCalc->est.fail.leftMempool) > 0.0 ? 100 * feeCalc->est.fail.withinTarget / (feeCalc->est.fail.totalConfirmed + feeCalc->est.fail.inMempool + feeCalc->est.fail.leftMempool) : 0.0,
+             feeCalc->est.fail.withinTarget, feeCalc->est.fail.totalConfirmed, feeCalc->est.fail.inMempool, feeCalc->est.fail.leftMempool);
 
     return CFeeRate(llround(median));
 }

--- a/src/policy/fees/block_policy_estimator.cpp
+++ b/src/policy/fees/block_policy_estimator.cpp
@@ -919,7 +919,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
     double halfEst = estimateCombinedFee(confTarget/2, HALF_SUCCESS_PCT, true, &tempResult);
     if (feeCalc) {
         feeCalc->est = tempResult;
-        feeCalc->reason = FeeReason::HALF_ESTIMATE;
+        feeCalc->reason = BlockPolicyEstimateReason::HALF_ESTIMATE;
     }
     median = halfEst;
     double actualEst = estimateCombinedFee(confTarget, SUCCESS_PCT, true, &tempResult);
@@ -927,7 +927,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
         median = actualEst;
         if (feeCalc) {
             feeCalc->est = tempResult;
-            feeCalc->reason = FeeReason::FULL_ESTIMATE;
+            feeCalc->reason = BlockPolicyEstimateReason::FULL_ESTIMATE;
         }
     }
     double doubleEst = estimateCombinedFee(2 * confTarget, DOUBLE_SUCCESS_PCT, !conservative, &tempResult);
@@ -935,7 +935,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
         median = doubleEst;
         if (feeCalc) {
             feeCalc->est = tempResult;
-            feeCalc->reason = FeeReason::DOUBLE_ESTIMATE;
+            feeCalc->reason = BlockPolicyEstimateReason::DOUBLE_ESTIMATE;
         }
     }
 
@@ -945,7 +945,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
             median = consEst;
             if (feeCalc) {
                 feeCalc->est = tempResult;
-                feeCalc->reason = FeeReason::CONSERVATIVE;
+                feeCalc->reason = BlockPolicyEstimateReason::CONSERVATIVE;
             }
         }
     }

--- a/src/policy/fees/block_policy_estimator.h
+++ b/src/policy/fees/block_policy_estimator.h
@@ -56,15 +56,12 @@ static constexpr auto ALL_FEE_ESTIMATE_HORIZONS = std::array{
 std::string StringForFeeEstimateHorizon(FeeEstimateHorizon horizon);
 
 /* Enumeration of reason for returned fee estimate */
-enum class FeeReason {
+enum class BlockPolicyEstimateReason {
     NONE,
     HALF_ESTIMATE,
     FULL_ESTIMATE,
     DOUBLE_ESTIMATE,
     CONSERVATIVE,
-    MEMPOOL_MIN,
-    FALLBACK,
-    REQUIRED,
 };
 
 /* Used to return detailed information about a feerate bucket */
@@ -90,7 +87,7 @@ struct EstimationResult
 struct FeeCalculation
 {
     EstimationResult est;
-    FeeReason reason = FeeReason::NONE;
+    BlockPolicyEstimateReason reason = BlockPolicyEstimateReason::NONE;
     int desiredTarget = 0;
     int returnedTarget = 0;
     unsigned int best_height{0};

--- a/src/policy/fees/block_policy_estimator.h
+++ b/src/policy/fees/block_policy_estimator.h
@@ -64,6 +64,8 @@ enum class BlockPolicyEstimateReason {
     CONSERVATIVE,
 };
 
+std::string StringForBlockPolicyEstimateReason(BlockPolicyEstimateReason reason);
+
 /* Used to return detailed information about a feerate bucket */
 struct EstimatorBucket
 {

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -21,11 +21,11 @@
 #include <key_io.h>
 #include <node/interface_ui.h>
 #include <node/types.h>
-#include <policy/fees/block_policy_estimator.h>
 #include <txmempool.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/fees.h>
+#include <wallet/types.h>
 #include <wallet/wallet.h>
 
 #include <array>

--- a/src/test/fuzz/fees.cpp
+++ b/src/test/fuzz/fees.cpp
@@ -8,12 +8,14 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/fees.h>
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
 using common::StringForFeeReason;
+using common::StringForBlockPolicyEstimateReason;
 
 FUZZ_TARGET(fees)
 {
@@ -26,6 +28,8 @@ FUZZ_TARGET(fees)
         const CAmount rounded_fee = fee_filter_rounder.round(current_minimum_fee);
         assert(MoneyRange(rounded_fee));
     }
-    const FeeReason fee_reason = fuzzed_data_provider.PickValueInArray({FeeReason::NONE, FeeReason::HALF_ESTIMATE, FeeReason::FULL_ESTIMATE, FeeReason::DOUBLE_ESTIMATE, FeeReason::CONSERVATIVE, FeeReason::MEMPOOL_MIN, FeeReason::FALLBACK, FeeReason::REQUIRED});
+    const FeeReason fee_reason = fuzzed_data_provider.PickValueInArray({FeeReason::FEE_RATE_ESTIMATOR, FeeReason::MEMPOOL_MIN, FeeReason::USER_SPECIFIED, FeeReason::FALLBACK, FeeReason::REQUIRED});
     (void)StringForFeeReason(fee_reason);
+    const BlockPolicyEstimateReason block_policy_fee_reason = fuzzed_data_provider.PickValueInArray({BlockPolicyEstimateReason::NONE, BlockPolicyEstimateReason::HALF_ESTIMATE, BlockPolicyEstimateReason::FULL_ESTIMATE, BlockPolicyEstimateReason::DOUBLE_ESTIMATE, BlockPolicyEstimateReason::CONSERVATIVE});
+    (void)StringForBlockPolicyEstimateReason(block_policy_fee_reason);
 }

--- a/src/test/fuzz/fees.cpp
+++ b/src/test/fuzz/fees.cpp
@@ -15,7 +15,6 @@
 #include <vector>
 
 using common::StringForFeeReason;
-using common::StringForBlockPolicyEstimateReason;
 
 FUZZ_TARGET(fees)
 {

--- a/src/util/fees.h
+++ b/src/util/fees.h
@@ -12,4 +12,13 @@ enum class FeeEstimateMode {
     CONSERVATIVE, //!< Force estimateSmartFee to use conservative estimates
 };
 
+/* Used to determine the reason a wallet selected a transaction fee rate */
+enum class FeeReason {
+    FEE_RATE_ESTIMATOR,
+    MEMPOOL_MIN,
+    USER_SPECIFIED,
+    FALLBACK,
+    REQUIRED,
+};
+
 #endif // BITCOIN_UTIL_FEES_H

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -7,7 +7,6 @@
 
 #include <outputtype.h>
 #include <policy/feerate.h>
-#include <policy/fees/block_policy_estimator.h>
 #include <primitives/transaction.h>
 #include <script/keyorigin.h>
 #include <script/signingprovider.h>

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -8,7 +8,6 @@
 #include <common/system.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
-#include <policy/fees/block_policy_estimator.h>
 #include <policy/policy.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
@@ -139,7 +138,7 @@ static CFeeRate EstimateFeeRate(const CWallet& wallet, const CWalletTx& wtx, con
     feerate += std::max(node_incremental_relay_fee, wallet_incremental_relay_fee);
 
     // Fee rate must also be at least the wallet's GetMinimumFeeRate
-    CFeeRate min_feerate(GetMinimumFeeRate(wallet, coin_control, /*feeCalc=*/nullptr));
+    CFeeRate min_feerate(GetMinimumFeeRate(wallet, coin_control).fee_rate);
 
     // Set the required fee rate for the replacement transaction in coin control.
     return std::max(feerate, min_feerate);

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -5,6 +5,7 @@
 
 #include <wallet/fees.h>
 
+#include <policy/fees/block_policy_estimator.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
@@ -16,9 +17,9 @@ CAmount GetRequiredFee(const CWallet& wallet, unsigned int nTxBytes)
 }
 
 
-CAmount GetMinimumFee(const CWallet& wallet, unsigned int nTxBytes, const CCoinControl& coin_control, FeeCalculation* feeCalc)
+CAmount GetMinimumFee(const MinimumFeeRateResult& min_fee_rate, unsigned int nTxBytes)
 {
-    return GetMinimumFeeRate(wallet, coin_control, feeCalc).GetFee(static_cast<int32_t>(nTxBytes));
+    return min_fee_rate.fee_rate.GetFee(static_cast<int32_t>(nTxBytes));
 }
 
 CFeeRate GetRequiredFeeRate(const CWallet& wallet)
@@ -26,7 +27,7 @@ CFeeRate GetRequiredFeeRate(const CWallet& wallet)
     return std::max(wallet.m_min_fee, wallet.chain().relayMinFee());
 }
 
-CFeeRate GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_control, FeeCalculation* feeCalc)
+MinimumFeeRateResult GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_control)
 {
     /* User control of how to calculate fee uses the following parameter precedence:
        1. coin_control.m_feerate
@@ -34,11 +35,12 @@ CFeeRate GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_contr
        3. m_confirm_target (user-set member variable of wallet)
        The first parameter that is set is used.
     */
-    CFeeRate feerate_needed;
+    MinimumFeeRateResult res;
     if (coin_control.m_feerate) { // 1.
-        feerate_needed = *(coin_control.m_feerate);
+        res.fee_rate = *(coin_control.m_feerate);
+        res.fee_reason = FeeReason::USER_SPECIFIED;
         // Allow to override automatic min/max check over coin control instance
-        if (coin_control.fOverrideFeeRate) return feerate_needed;
+        if (coin_control.fOverrideFeeRate) return res;
     }
     else { // 2. or 3.
         // We will use smart fee estimation
@@ -49,30 +51,34 @@ CFeeRate GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_contr
         if (coin_control.m_fee_mode == FeeEstimateMode::CONSERVATIVE) conservative_estimate = true;
         else if (coin_control.m_fee_mode == FeeEstimateMode::ECONOMICAL) conservative_estimate = false;
 
-        feerate_needed = wallet.chain().estimateSmartFee(target, conservative_estimate, feeCalc);
-        if (feerate_needed == CFeeRate(0)) {
+        FeeCalculation feeCalc;
+        res.fee_rate = wallet.chain().estimateSmartFee(target, conservative_estimate, &feeCalc);
+        res.returned_target = feeCalc.returnedTarget;
+        if (res.fee_rate == CFeeRate(0)) {
             // if we don't have enough data for estimateSmartFee, then use fallback fee
-            feerate_needed = wallet.m_fallback_fee;
-            if (feeCalc) feeCalc->reason = FeeReason::FALLBACK;
-
+            res.fee_rate = wallet.m_fallback_fee;
+            res.fee_reason = FeeReason::FALLBACK;
             // directly return if fallback fee is disabled (feerate 0 == disabled)
-            if (wallet.m_fallback_fee == CFeeRate(0)) return feerate_needed;
+            if (wallet.m_fallback_fee == CFeeRate(0)) return res;
+        } else {
+            res.fee_reason = FeeReason::FEE_RATE_ESTIMATOR;
         }
+
         // Obey mempool min fee when using smart fee estimation
         CFeeRate min_mempool_feerate = wallet.chain().mempoolMinFee();
-        if (feerate_needed < min_mempool_feerate) {
-            feerate_needed = min_mempool_feerate;
-            if (feeCalc) feeCalc->reason = FeeReason::MEMPOOL_MIN;
+        if (res.fee_rate < min_mempool_feerate) {
+            res.fee_rate = min_mempool_feerate;
+            res.fee_reason = FeeReason::MEMPOOL_MIN;
         }
     }
 
     // prevent user from paying a fee below the required fee rate
     CFeeRate required_feerate = GetRequiredFeeRate(wallet);
-    if (required_feerate > feerate_needed) {
-        feerate_needed = required_feerate;
-        if (feeCalc) feeCalc->reason = FeeReason::REQUIRED;
+    if (required_feerate > res.fee_rate) {
+        res.fee_rate = required_feerate;
+        res.fee_reason = FeeReason::REQUIRED;
     }
-    return feerate_needed;
+    return res;
 }
 
 CFeeRate GetDiscardRate(const CWallet& wallet)

--- a/src/wallet/fees.h
+++ b/src/wallet/fees.h
@@ -7,9 +7,9 @@
 #define BITCOIN_WALLET_FEES_H
 
 #include <consensus/amount.h>
+#include <wallet/types.h>
 
 class CFeeRate;
-struct FeeCalculation;
 
 namespace wallet {
 class CCoinControl;
@@ -22,10 +22,9 @@ class CWallet;
 CAmount GetRequiredFee(const CWallet& wallet, unsigned int nTxBytes);
 
 /**
- * Estimate the minimum fee considering user set parameters
- * and the required fee
+ * Return the minimum fee for this size given a fee rate result.
  */
-CAmount GetMinimumFee(const CWallet& wallet, unsigned int nTxBytes, const CCoinControl& coin_control, FeeCalculation* feeCalc);
+CAmount GetMinimumFee(const MinimumFeeRateResult& min_fee_rate, unsigned int nTxBytes);
 
 /**
  * Return the minimum required feerate taking into account the
@@ -37,7 +36,7 @@ CFeeRate GetRequiredFeeRate(const CWallet& wallet);
  * Estimate the minimum fee rate considering user set parameters
  * and the required fee
  */
-CFeeRate GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_control, FeeCalculation* feeCalc);
+MinimumFeeRateResult GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_control);
 
 /**
  * Return the maximum feerate for discarding change.

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -9,7 +9,6 @@
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <node/types.h>
-#include <policy/fees/block_policy_estimator.h>
 #include <primitives/transaction.h>
 #include <rpc/server.h>
 #include <scheduler.h>
@@ -471,11 +470,10 @@ public:
         int* returned_target,
         FeeReason* reason) override
     {
-        FeeCalculation fee_calc;
-        CAmount result;
-        result = GetMinimumFee(*m_wallet, tx_bytes, coin_control, &fee_calc);
-        if (returned_target) *returned_target = fee_calc.returnedTarget;
-        if (reason) *reason = fee_calc.reason;
+        auto min_fee_rate{GetMinimumFeeRate(*m_wallet, coin_control)};
+        auto result = GetMinimumFee(min_fee_rate, tx_bytes);
+        if (returned_target) *returned_target = min_fee_rate.returned_target;
+        if (reason) *reason = min_fee_rate.fee_reason;
         return result;
     }
     unsigned int getConfirmTarget() override { return m_wallet->m_confirm_target; }

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -195,7 +195,7 @@ UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vecto
     if (verbose) {
         UniValue entry(UniValue::VOBJ);
         entry.pushKV("txid", tx->GetHash().GetHex());
-        entry.pushKV("fee_reason", StringForFeeReason(res->fee_calc.reason));
+        entry.pushKV("fee_reason", StringForFeeReason(res->fee_reason));
         return entry;
     }
     return tx->GetHash().GetHex();
@@ -272,7 +272,7 @@ RPCMethod sendtoaddress()
                         RPCResult::Type::OBJ, "", "",
                         {
                             {RPCResult::Type::STR_HEX, "txid", "The transaction id."},
-                            {RPCResult::Type::STR, "fee_reason", "The transaction fee reason."}
+                            {RPCResult::Type::STR, "fee_reason", "The reason the wallet selected this fee rate (e.g. fee rate estimator, mempool minimum, fallback, or minimum required). It no longer exposes the block policy estimator's detailed threshold internals."}
                         },
                     },
                 },
@@ -380,7 +380,7 @@ RPCMethod sendmany()
                         {
                             {RPCResult::Type::STR_HEX, "txid", "The transaction id for the send. Only 1 transaction is created regardless of\n"
                 "the number of addresses."},
-                            {RPCResult::Type::STR, "fee_reason", "The transaction fee reason."}
+                            {RPCResult::Type::STR, "fee_reason", "The reason the wallet selected this fee rate (e.g. fee rate estimator, mempool minimum, fallback, or minimum required). It no longer exposes the block policy estimator's detailed threshold internals."}
                         },
                     },
                 },
@@ -1442,8 +1442,7 @@ RPCMethod sendall()
 
             const bool rbf{options.exists("replaceable") ? options["replaceable"].get_bool() : pwallet->m_signal_rbf};
 
-            FeeCalculation fee_calc_out;
-            CFeeRate fee_rate{GetMinimumFeeRate(*pwallet, coin_control, &fee_calc_out)};
+            auto [fee_rate, fee_reason, returned_target] = GetMinimumFeeRate(*pwallet, coin_control);
             // Do not, ever, assume that it's fine to change the fee rate if the user has explicitly
             // provided one
             if (coin_control.m_feerate && fee_rate > *coin_control.m_feerate) {
@@ -1451,14 +1450,14 @@ RPCMethod sendall()
                 auto msg{strprintf("Fee rate (%s) is lower than the minimum fee rate setting (%s).",
                     coin_control.m_feerate->ToString(feerate_format),
                     fee_rate.ToString(feerate_format))};
-                if (fee_calc_out.reason == FeeReason::REQUIRED) {
+                if (fee_reason == FeeReason::REQUIRED) {
                     msg += strprintf("\nConsider modifying -mintxfee (%s) or -minrelaytxfee (%s).",
                         pwallet->m_min_fee.ToString(feerate_format),
                         pwallet->chain().relayMinFee().ToString(feerate_format));
                 }
                 throw JSONRPCError(RPC_INVALID_PARAMETER, msg);
             }
-            if (fee_calc_out.reason == FeeReason::FALLBACK && !pwallet->m_allow_fallback_fee) {
+            if (fee_reason == FeeReason::FALLBACK && !pwallet->m_allow_fallback_fee) {
                 // eventually allow a fallback fee
                 throw JSONRPCError(RPC_WALLET_ERROR, "Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.");
             }

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1150,8 +1150,8 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     coin_selection_params.m_discard_feerate = GetDiscardRate(wallet);
 
     // Get the fee rate to use effective values in coin selection
-    FeeCalculation feeCalc;
-    coin_selection_params.m_effective_feerate = GetMinimumFeeRate(wallet, coin_control, &feeCalc);
+    auto min_fee_rate{GetMinimumFeeRate(wallet, coin_control)};
+    coin_selection_params.m_effective_feerate = min_fee_rate.fee_rate;
     // Do not, ever, assume that it's fine to change the fee rate if the user has explicitly
     // provided one
     if (coin_control.m_feerate && coin_selection_params.m_effective_feerate > *coin_control.m_feerate) {
@@ -1159,7 +1159,7 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         auto msg{strprintf(_("Fee rate (%s) is lower than the minimum fee rate setting (%s)."),
             coin_control.m_feerate->ToString(feerate_format),
             coin_selection_params.m_effective_feerate.ToString(feerate_format))};
-        if (feeCalc.reason == FeeReason::REQUIRED) {
+        if (min_fee_rate.fee_reason == FeeReason::REQUIRED) {
             msg += strprintf(_("\nConsider modifying %s (%s) or %s (%s)."),
                 "-mintxfee",
                 wallet.m_min_fee.ToString(feerate_format),
@@ -1168,7 +1168,7 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         }
         return util::Error{msg};
     }
-    if (feeCalc.reason == FeeReason::FALLBACK && !wallet.m_allow_fallback_fee) {
+    if (min_fee_rate.fee_reason == FeeReason::FALLBACK && !wallet.m_allow_fallback_fee) {
         // eventually allow a fallback fee
         return util::Error{strprintf(_("Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s."), "-fallbackfee")};
     }
@@ -1433,15 +1433,9 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     reservedest.KeepDestination();
 
     wallet.WalletLogPrintf("Coin Selection: Algorithm:%s, Waste Metric Score:%d\n", GetAlgorithmName(result.GetAlgo()), result.GetWaste());
-    wallet.WalletLogPrintf("Fee Calculation: Fee:%d Bytes:%u Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
-              current_fee, nBytes, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
-              feeCalc.est.pass.start, feeCalc.est.pass.end,
-              (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool) > 0.0 ? 100 * feeCalc.est.pass.withinTarget / (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool) : 0.0,
-              feeCalc.est.pass.withinTarget, feeCalc.est.pass.totalConfirmed, feeCalc.est.pass.inMempool, feeCalc.est.pass.leftMempool,
-              feeCalc.est.fail.start, feeCalc.est.fail.end,
-              (feeCalc.est.fail.totalConfirmed + feeCalc.est.fail.inMempool + feeCalc.est.fail.leftMempool) > 0.0 ? 100 * feeCalc.est.fail.withinTarget / (feeCalc.est.fail.totalConfirmed + feeCalc.est.fail.inMempool + feeCalc.est.fail.leftMempool) : 0.0,
-              feeCalc.est.fail.withinTarget, feeCalc.est.fail.totalConfirmed, feeCalc.est.fail.inMempool, feeCalc.est.fail.leftMempool);
-    return CreatedTransactionResult(tx, current_fee, change_pos, feeCalc);
+    wallet.WalletLogPrintf("Fee Calculation: Fee:%d Bytes:%u, Source: %s\n",
+                           current_fee, nBytes, StringForFeeReason(min_fee_rate.fee_reason));
+    return CreatedTransactionResult(tx, current_fee, change_pos, min_fee_rate.fee_reason);
 }
 
 util::Result<CreatedTransactionResult> CreateTransaction(

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -6,7 +6,6 @@
 #define BITCOIN_WALLET_SPEND_H
 
 #include <consensus/amount.h>
-#include <policy/fees/block_policy_estimator.h>
 #include <util/result.h>
 #include <wallet/coinselection.h>
 #include <wallet/transaction.h>

--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -2,12 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <policy/fees/block_policy_estimator.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <test/util/txmempool.h>
+#include <util/fees.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/fees.h>
@@ -115,11 +117,18 @@ FUZZ_TARGET(wallet_fees, .init = initialize_setup)
     if (fuzzed_data_provider.ConsumeBool()) {
         coin_control.m_fee_mode = fuzzed_data_provider.ConsumeBool() ? FeeEstimateMode::CONSERVATIVE : FeeEstimateMode::ECONOMICAL;
     }
-
-    FeeCalculation fee_calculation;
-    FeeCalculation* maybe_fee_calculation{fuzzed_data_provider.ConsumeBool() ? nullptr : &fee_calculation};
-    (void)GetMinimumFeeRate(wallet, coin_control, maybe_fee_calculation);
-    (void)GetMinimumFee(wallet, tx_bytes, coin_control, maybe_fee_calculation);
+    MinimumFeeRateResult min_fee_rate;
+    if (fuzzed_data_provider.ConsumeBool()) {
+        min_fee_rate.fee_rate = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        min_fee_rate.returned_target = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 999'000);
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        min_fee_rate.fee_reason = fuzzed_data_provider.PickValueInArray({FeeReason::FEE_RATE_ESTIMATOR, FeeReason::MEMPOOL_MIN, FeeReason::USER_SPECIFIED, FeeReason::FALLBACK, FeeReason::REQUIRED});
+    }
+    (void)GetMinimumFeeRate(wallet, coin_control);
+    (void)GetMinimumFee(min_fee_rate, tx_bytes);
 }
 } // namespace
 } // namespace wallet

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -4,7 +4,6 @@
 
 #include <consensus/amount.h>
 #include <key.h>
-#include <policy/fees/block_policy_estimator.h>
 #include <script/solver.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>

--- a/src/wallet/types.h
+++ b/src/wallet/types.h
@@ -14,10 +14,21 @@
 #ifndef BITCOIN_WALLET_TYPES_H
 #define BITCOIN_WALLET_TYPES_H
 
-#include <policy/fees/block_policy_estimator.h>
+#include <consensus/amount.h>
+#include <policy/feerate.h>
+#include <primitives/transaction.h>
+#include <util/fees.h>
 #include <util/translation.h>
 
+#include <optional>
+
 namespace wallet {
+struct MinimumFeeRateResult {
+    CFeeRate fee_rate;
+    FeeReason fee_reason = FeeReason::USER_SPECIFIED;
+    int returned_target = 0;
+};
+
 /**
  * Address purpose field that has been been stored with wallet sending and
  * receiving addresses since BIP70 payment protocol support was added in
@@ -36,11 +47,11 @@ struct CreatedTransactionResult
 {
     CTransactionRef tx;
     CAmount fee;
-    FeeCalculation fee_calc;
+    FeeReason fee_reason;
     std::optional<unsigned int> change_pos;
 
-    CreatedTransactionResult(CTransactionRef _tx, CAmount _fee, std::optional<unsigned int> _change_pos, const FeeCalculation& _fee_calc)
-            : tx(_tx), fee(_fee), fee_calc(_fee_calc), change_pos(_change_pos) {}
+    CreatedTransactionResult(CTransactionRef _tx, CAmount _fee, std::optional<unsigned int> _change_pos, FeeReason _fee_reason)
+        : tx(_tx), fee(_fee), fee_reason(_fee_reason), change_pos(_change_pos) {}
 };
 
 //! Machine-readable wallet error codes.


### PR DESCRIPTION
Part of #34075

#### Motivation
The wallet currently depends on `CBlockPolicyEstimator` internals through `FeeCalculation` and the old `FeeReason` enum returned by `estimateSmartFee`.

That enum mixed two different concepts:

* why the block policy estimator chose a specific estimate, such as the half-target, full-target, double-target, or conservative threshold;
* why the wallet selected the fee rate it will use, such as fallback fee, mempool minimum fee, user-specified fee, or minimum required fee.

This coupling makes wallet fee selection harder to reason about and exposes estimator-specific details through wallet code and wallet RPC output. This PR separates those concerns so the estimator owns its internal estimate reasons and the wallet reports only wallet-level fee selection reasons.

#### Key Changes
* Split wallet and estimator fee reasons:
  * Added a wallet-facing `FeeReason` enum in `src/util/fees.h` with `FEE_RATE_ESTIMATOR`, `MEMPOOL_MIN`, `USER_SPECIFIED`, `FALLBACK`, and `REQUIRED`.
  * Renamed the estimator reason enum to `BlockPolicyEstimateReason` and scoped it to estimator outputs: `NONE`, `HALF_ESTIMATE`, `FULL_ESTIMATE`, `DOUBLE_ESTIMATE`, and `CONSERVATIVE`.

* Stop passing estimator internals through wallet fee selection:
  * Replaced the `FeeCalculation*` output parameter in `wallet::GetMinimumFeeRate` with a `MinimumFeeRateResult` struct containing the selected fee rate, wallet fee reason, and returned target.
  * Updated wallet, Qt, RPC, interface, and test/fuzz callers to use the wallet fee reason instead of `FeeCalculation`.
  * Updated `CreatedTransactionResult` to store the wallet `FeeReason` instead of a full `FeeCalculation`.

* Keep wallet RPC `fee_reason` at wallet scope:
  * Verbose wallet RPC responses still use the existing `fee_reason` field name for compatibility.
  * The field now reports the wallet fee selection reason, not the block policy estimator's detailed threshold reason.
  * The help text for the affected wallet RPC responses was updated to describe this behavior.

* Move estimator reason stringification into the estimator:
  * Moved `StringForBlockPolicyEstimateReason` out of `src/common/messages.cpp` and into `src/policy/fees/block_policy_estimator.cpp`.
  * Implemented it with a `switch` without a `default` case so missing enum cases can be caught by compiler warnings.

* Move detailed estimator logging into `estimateSmartFee`:
  * `CBlockPolicyEstimator::estimateSmartFee` now always populates a local `FeeCalculation`, even when the caller does not pass one, so estimator debug logging remains available inside the estimator.
  * The detailed estimate debug log now lives in `estimateSmartFee`, where the estimator data originates.
  * Wallet transaction creation now logs only the selected fee, transaction size, and wallet fee reason.