### PR TITLE
sqlite: Delete wallet.dat-journal on database close

### DIFF
--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -96,6 +96,10 @@ static inline bool exists(const path& p)
 {
     return std::filesystem::exists(p);
 }
+static inline bool exists(const path& p, std::error_code& ec) noexcept
+{
+    return std::filesystem::exists(p, ec);
+}
 
 // Allow explicit quoted stream I/O.
 static inline auto quoted(const std::string& s)

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -19,12 +19,14 @@
 #include <sqlite3.h>
 
 #include <cstdint>
+#include <fstream>
 #include <optional>
 #include <utility>
 #include <vector>
 
 namespace wallet {
 static constexpr int32_t WALLET_SCHEMA_VERSION = 0;
+static constexpr size_t SQLITE_JOURNAL_HEADER_SIZE = 28;
 
 static std::span<const std::byte> SpanFromBlob(sqlite3_stmt* stmt, int col)
 {
@@ -374,6 +376,31 @@ void SQLiteDatabase::Close()
         throw std::runtime_error(strprintf("SQLiteDatabase: Failed to close database: %s\n", sqlite3_errstr(res)));
     }
     m_db = nullptr;
+
+    std::error_code ec;
+    const fs::path journal_path = fs::PathFromString(Filename() + "-journal");
+    bool journal_exists = fs::exists(journal_path, ec);
+    if (ec) return;
+    if (journal_exists) {
+        // If the journal file is more than 0 bytes, check if the 28 byte header is zero'd
+        auto size = fs::file_size(journal_path, ec);
+        if (ec) return;
+        if (size > SQLITE_JOURNAL_HEADER_SIZE) {
+            std::ifstream file{journal_path.std_path(), std::ios::binary};
+            if (!file.is_open()) return;
+
+            char header[SQLITE_JOURNAL_HEADER_SIZE];
+            file.read(header, SQLITE_JOURNAL_HEADER_SIZE);
+            file.close();
+
+            if (std::any_of(header, header + SQLITE_JOURNAL_HEADER_SIZE, [](char c){ return c != 0; })) {
+                return;
+            }
+        }
+
+        // Journal file is truncated or zero'd header, so it can be safely deleted
+        fs::remove(journal_path);
+    }
 }
 
 bool SQLiteDatabase::HasActiveTxn()


### PR DESCRIPTION
The wallet.dat-journal file is SQLite's hot journal file. This file is either deleted, truncated, or has its header zeroed when a database transaction is committed. However, in `restorewallet`, we are assuming that sqlite decided to delete the journal file even though it may have truncated or zeroed its header instead.

This PR changes `SQLiteDatabase::Close()` to remove the journal file if it is 0 bytes, or if the header (first 28 bytes) is all 0's. Otherwise, it leaves the file untouched.

This fixes one of the issues described in #34354

An alternative is to have `RestoreWallet` specifically also delete the journal file. However, I thought that this solution would be more robust as I think there are other places where we expect the journal file to be deleted on a clean close of a wallet database.