### PR TITLE
test: assert_debug_log timeouts follow-up

### DIFF
--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -83,13 +83,13 @@ class ConfArgsTest(BitcoinTestFramework):
         self.log.debug('Verifying that disabling of the config file means garbage inside of it does ' \
             'not prevent the node from starting, and message about existing config file is logged')
         ignored_file_message = [f'Data directory "{self.nodes[0].datadir_path}" contains a "bitcoin.conf" file which is explicitly ignored using -noconf.']
-        with self.nodes[0].assert_debug_log(timeout=60, expected_msgs=ignored_file_message):
+        with self.nodes[0].assert_debug_log(expected_msgs=ignored_file_message):
             self.start_node(0, extra_args=settings + ['-noconf'])
         self.stop_node(0)
 
         self.log.debug('Verifying no message appears when removing config file')
         os.remove(conf_path)
-        with self.nodes[0].assert_debug_log(timeout=60, expected_msgs=[], unexpected_msgs=ignored_file_message):
+        with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=ignored_file_message):
             self.start_node(0, extra_args=settings + ['-noconf'])
         self.stop_node(0)
 
@@ -342,7 +342,7 @@ class ConfArgsTest(BitcoinTestFramework):
                 "Loaded 0 addresses from peers.dat",
                 "DNS seeding disabled",
                 "Fixed seeds are disabled",
-        ]):
+        ], timeout=2):
             self.start_node(0, extra_args=['-dnsseed=0', '-fixedseeds=0'])
         self.stop_node(0)
 
@@ -386,7 +386,7 @@ class ConfArgsTest(BitcoinTestFramework):
         # If the user did not disable -dnsseed, but it was soft-disabled because they provided -connect,
         # they shouldn't see a warning about -dnsseed being ignored.
         with self.nodes[0].assert_debug_log(expected_msgs=addcon_thread_started,
-                unexpected_msgs=dnsseed_ignored):
+                unexpected_msgs=dnsseed_ignored, timeout=2):
             self.restart_node(0, extra_args=['-connect=fakeaddress1', UNREACHABLE_PROXY_ARG])
 
         # We have to supply expected_msgs as it's a required argument
@@ -394,7 +394,7 @@ class ConfArgsTest(BitcoinTestFramework):
         # These cases test for -connect being supplied but only to disable it
         for connect_arg in ['-connect=0', '-noconnect']:
             with self.nodes[0].assert_debug_log(expected_msgs=addcon_thread_started,
-                    unexpected_msgs=seednode_ignored):
+                    unexpected_msgs=seednode_ignored, timeout=2):
                 self.restart_node(0, extra_args=[connect_arg, '-seednode=fakeaddress2'])
 
             # Make sure -noconnect soft-disables -listen and -dnsseed.

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -179,6 +179,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         self.log.info('Send the block that includes the previous orphan ... ')
         with node.assert_debug_log(["Erased 1 orphan transaction(s) included or conflicted by block"]):
             node.p2ps[0].send_blocks_and_test([block_A], node, success=True)
+            node.syncwithvalidationinterfacequeue()
 
         self.log.info('Test that a transaction in the orphan pool conflicts with a new tip block causes erase this transaction from the orphan pool')
         tx_withhold_until_block_B = CTransaction()
@@ -205,6 +206,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         self.log.info('Send the block that includes a transaction which conflicts with the previous orphan ... ')
         with node.assert_debug_log(["Erased 1 orphan transaction(s) included or conflicted by block"]):
             node.p2ps[0].send_blocks_and_test([block_B], node, success=True)
+            node.syncwithvalidationinterfacequeue()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Small fixups that fell through. See the commit messages for details.

Can be tested via:

```diff
diff --git a/src/util/thread.cpp b/src/util/thread.cpp
index 0fde73c..4fcfe4f 100644
--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -8,2 +8,3 @@
 #include <util/log.h>
+#include <util/time.h>
 #include <util/threadnames.h>
@@ -18,2 +19,3 @@ void util::TraceThread(std::string_view thread_name, std::function<void()> threa
     util::ThreadRename(std::string{thread_name});
+    UninterruptibleSleep(999ms);
     try {
diff --git a/src/validationinterface.cpp b/src/validationinterface.cpp
index c7be6ab..3237aec 100644
--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -14,2 +14,3 @@
 #include <primitives/transaction.h>
+#include <random.h>
 #include <util/check.h>
@@ -156,2 +157,4 @@ void ValidationSignals::SyncWithValidationInterfaceQueue()
 
+static FastRandomContext g_rnd{};
+
 // Use a macro instead of a function for conditional logging to prevent
@@ -166,2 +169,3 @@ void ValidationSignals::SyncWithValidationInterfaceQueue()
             LOG_EVENT(fmt, local_name, __VA_ARGS__);           \
+            if(g_rnd.randrange(2)<1)UninterruptibleSleep(55ms);\
             event();                                           \
```

With this diff and without the changes here, the touched tests fail.
With this diff and with the changes here, the touched tests pass.

Fixes https://github.com/bitcoin/bitcoin/issues/34621