### PR TITLE
cluster_linearize: add tests and benchmarks for chain and tree-shaped clusters

### DIFF
--- a/src/bench/cluster_linearize.cpp
+++ b/src/bench/cluster_linearize.cpp
@@ -4,11 +4,13 @@
 
 #include <bench/bench.h>
 #include <cluster_linearize.h>
+#include <random.h>
 #include <test/util/cluster_linearize.h>
 #include <util/bitset.h>
 #include <util/strencodings.h>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstdint>
 #include <vector>
@@ -33,10 +35,41 @@ DepGraph<SetType> MakeWideGraph(DepGraphIndex ntx)
     return depgraph;
 }
 
+/** Construct a chain graph (tx0 -> tx1 -> tx2 -> ... -> tx_{n-1}). Each transaction
+ *  depends only on the previous one. Chain graphs have a unique topological order.
+ *  Uses FastRandomContext for deterministic but randomized feerates.
+ */
+template<typename SetType>
+DepGraph<SetType> MakeChainGraph(DepGraphIndex ntx, FastRandomContext& rng)
+{
+    DepGraph<SetType> depgraph;
+    for (DepGraphIndex i = 0; i < ntx; ++i) {
+        int64_t fee = rng.randbits<27>() + 100;
+        int32_t size = rng.randrange(1000) + 1;
+        depgraph.AddTransaction({fee, size});
+        if (i > 0) depgraph.AddDependencies(SetType::Singleton(i - 1), i);
+    }
+    return depgraph;
+}
+
 template<typename SetType>
 void BenchPostLinearizeWorstCase(DepGraphIndex ntx, benchmark::Bench& bench)
 {
     DepGraph<SetType> depgraph = MakeWideGraph<SetType>(ntx);
+    std::vector<DepGraphIndex> lin(ntx);
+    bench.run([&] {
+        for (DepGraphIndex i = 0; i < ntx; ++i) lin[i] = i;
+        PostLinearize(depgraph, lin);
+    });
+}
+
+template<typename SetType>
+void BenchPostLinearizeChain(DepGraphIndex ntx, benchmark::Bench& bench)
+{
+    std::array<unsigned char, 32> seed{};
+    for (int i = 0; i < 4; ++i) seed[i] = static_cast<unsigned char>((ntx >> (i * 8)) & 0xff);
+    FastRandomContext rng{uint256(seed)};
+    DepGraph<SetType> depgraph = MakeChainGraph<SetType>(ntx, rng);
     std::vector<DepGraphIndex> lin(ntx);
     bench.run([&] {
         for (DepGraphIndex i = 0; i < ntx; ++i) lin[i] = i;
@@ -89,6 +122,24 @@ void BenchLinearizeOptimallyPerCost(benchmark::Bench& bench, const std::string& 
     }
 }
 
+/** Benchmark Linearize on chain graphs of given sizes (total time to optimal). */
+void BenchLinearizeOptimallyChainTotal(benchmark::Bench& bench, const std::vector<DepGraphIndex>& chain_sizes)
+{
+    for (DepGraphIndex ntx : chain_sizes) {
+        std::array<unsigned char, 32> seed{};
+        for (int i = 0; i < 4; ++i) seed[i] = static_cast<unsigned char>((ntx >> (i * 8)) & 0xff);
+        FastRandomContext rng{uint256(seed)};
+        DepGraph<BitSet<64>> depgraph = MakeChainGraph<BitSet<64>>(ntx, rng);
+        auto bench_name = strprintf("LinearizeOptimallyChainTotal_%utx_%udep", depgraph.TxCount(), depgraph.CountDependencies());
+
+        uint64_t rng_seed = 0;
+        bench.name(bench_name).run([&] {
+            auto [_lin, optimal, _cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng_seed++, IndexTxOrder{});
+            assert(optimal);
+        });
+    }
+}
+
 } // namespace
 
 static void PostLinearize16TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<16>>(16, bench); }
@@ -97,6 +148,13 @@ static void PostLinearize48TxWorstCase(benchmark::Bench& bench) { BenchPostLinea
 static void PostLinearize64TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<64>>(64, bench); }
 static void PostLinearize75TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<75>>(75, bench); }
 static void PostLinearize99TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<99>>(99, bench); }
+
+static void PostLinearize16TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<16>>(16, bench); }
+static void PostLinearize32TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<32>>(32, bench); }
+static void PostLinearize48TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<48>>(48, bench); }
+static void PostLinearize64TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<64>>(64, bench); }
+static void PostLinearize75TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<75>>(75, bench); }
+static void PostLinearize99TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<99>>(99, bench); }
 
 // Constructed from replayed historical mempool activity, selecting for clusters that are slow
 // to linearize from scratch, with increasing number of transactions (9 to 63).
@@ -150,6 +208,14 @@ static void LinearizeOptimallyPerCost(benchmark::Bench& bench)
     BenchLinearizeOptimallyPerCost(bench, "LinearizeOptimallySyntheticPerCost", CLUSTERS_SYNTHETIC);
 }
 
+// Chain sizes for Linearize benchmarks (aligned with historical cluster size range).
+static const std::vector<DepGraphIndex> CHAIN_SIZES = {9, 16, 32, 48, 63};
+
+static void LinearizeOptimallyChainTotal(benchmark::Bench& bench)
+{
+    BenchLinearizeOptimallyChainTotal(bench, CHAIN_SIZES);
+}
+
 BENCHMARK(PostLinearize16TxWorstCase);
 BENCHMARK(PostLinearize32TxWorstCase);
 BENCHMARK(PostLinearize48TxWorstCase);
@@ -157,5 +223,13 @@ BENCHMARK(PostLinearize64TxWorstCase);
 BENCHMARK(PostLinearize75TxWorstCase);
 BENCHMARK(PostLinearize99TxWorstCase);
 
+BENCHMARK(PostLinearize16TxChain);
+BENCHMARK(PostLinearize32TxChain);
+BENCHMARK(PostLinearize48TxChain);
+BENCHMARK(PostLinearize64TxChain);
+BENCHMARK(PostLinearize75TxChain);
+BENCHMARK(PostLinearize99TxChain);
+
 BENCHMARK(LinearizeOptimallyTotal);
 BENCHMARK(LinearizeOptimallyPerCost);
+BENCHMARK(LinearizeOptimallyChainTotal);

--- a/src/test/cluster_linearize_tests.cpp
+++ b/src/test/cluster_linearize_tests.cpp
@@ -583,4 +583,84 @@ BOOST_AUTO_TEST_CASE(postlinearize_tree_optimal_tests)
     }
 }
 
+/** Construct a random chain-structured dependency graph.
+ *  A chain structure means: tx0 -> tx1 -> tx2 -> ... -> tx_{n-1}
+ *  Each transaction depends only on the previous one.
+ *  Uses random feerates for transactions.
+ */
+template<typename SetType>
+DepGraph<SetType> MakeRandomChainGraph(DepGraphIndex ntx, InsecureRandomContext& rng)
+{
+    DepGraph<SetType> depgraph;
+
+    // Add transactions with random feerates
+    for (DepGraphIndex i = 0; i < ntx; ++i) {
+        int64_t fee = rng.randbits<27>() + 100;  // Random fee: 100 to 100 + (2^27 - 1)
+        int32_t size = rng.randrange(1000) + 1;  // Random size: 1 to 1000
+        depgraph.AddTransaction({fee, size});
+    }
+
+    // Create chain: tx0 -> tx1 -> tx2 -> ... -> tx_{n-1}
+    for (DepGraphIndex i = 1; i < ntx; ++i) {
+        depgraph.AddDependencies(SetType::Singleton(i - 1), i);
+    }
+
+    return depgraph;
+}
+
+/** Test that PostLinearize finds optimal linearization for chain-structured graphs.
+ *  Chain graphs are a special case of tree graphs (each transaction has at most one parent),
+ *  so PostLinearize should find optimal linearization.
+ */
+BOOST_AUTO_TEST_CASE(postlinearize_chain_optimal_tests)
+{
+    FastRandomContext rng;
+
+    // Test with different chain sizes
+    for (DepGraphIndex ntx : {5, 10, 15, 20, 25, 30, 40, 50}) {
+        for (int iter = 0; iter < 10; ++iter) {
+            InsecureRandomContext chain_rng(rng.rand64());
+            DepGraph<BitSet<64>> depgraph = MakeRandomChainGraph<BitSet<64>>(ntx, chain_rng);
+
+            SanityCheck(depgraph);
+
+            // Create a topological linearization as input to PostLinearize
+            // For chain graphs, the topological order is simply [0, 1, 2, ..., n-1]
+            std::vector<DepGraphIndex> topo_lin(ntx);
+            for (DepGraphIndex i = 0; i < ntx; ++i) {
+                topo_lin[i] = i;
+            }
+
+            // Apply PostLinearize
+            std::vector<DepGraphIndex> post_lin = topo_lin;
+            PostLinearize(depgraph, post_lin);
+            SanityCheck(depgraph, post_lin);
+
+            // Find optimal linearization using Linearize
+            auto [opt_lin, optimal, cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng.rand64(), IndexTxOrder{});
+            BOOST_CHECK(optimal);
+            SanityCheck(depgraph, opt_lin);
+
+            // Compare chunk diagrams: PostLinearize result should be equal to optimal
+            auto post_chunks = ChunkLinearization(depgraph, post_lin);
+            auto opt_chunks = ChunkLinearization(depgraph, opt_lin);
+            auto cmp = CompareChunks(post_chunks, opt_chunks);
+
+            // PostLinearize should produce optimal result for chain graphs
+            BOOST_CHECK_MESSAGE(std::is_eq(cmp),
+                "PostLinearize should find optimal linearization for chain-structured graphs. "
+                "ntx=" << ntx << ", iter=" << iter);
+
+            // Verify that running PostLinearize again doesn't change the result
+            std::vector<DepGraphIndex> post_post_lin = post_lin;
+            PostLinearize(depgraph, post_post_lin);
+            auto post_post_chunks = ChunkLinearization(depgraph, post_post_lin);
+            auto cmp_post = CompareChunks(post_post_chunks, post_chunks);
+            BOOST_CHECK_MESSAGE(std::is_eq(cmp_post),
+                "PostLinearize should be idempotent on chain-structured graphs. "
+                "ntx=" << ntx << ", iter=" << iter);
+        }
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/cluster_linearize_tests.cpp
+++ b/src/test/cluster_linearize_tests.cpp
@@ -3,11 +3,15 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <cluster_linearize.h>
+#include <random.h>
 #include <test/util/cluster_linearize.h>
 #include <test/util/setup_common.h>
 #include <util/bitset.h>
+#include <util/feefrac.h>
 #include <util/strencodings.h>
 
+#include <algorithm>
+#include <numeric>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -474,6 +478,109 @@ BOOST_AUTO_TEST_CASE(depgraph_optimal_tests)
     TestOptimalLinearization("855f8024008024816501807c81020284629b030383078631048044895c000002048078100100000000068315856a020000000004800784130300000000028167800c04000000000281758a14010000000885249a1a0100010004852ca63e020000010300"_hex_u8, {6, 1, 12, 5, 11, 3, 4, 10, 0, 8, 9, 7, 2});
     TestOptimalLinearization("855f97230080678a4f018210925d02856113038105892b04854e996105805a8a480000000000000283028b7a01000000000002846d9f080200000000000283189656030000000000018277862e0400000000000185508d200500000000000000"_hex_u8, {3, 0, 10, 7, 2, 1, 4, 8, 6, 5, 11, 9});
     TestOptimalLinearization("866faa23008646b71501851f96130282588f1103804d851c0000000003822097600100000003850a8f310200000003856e9201000000038656935f01000003855b8f5f020000018743923a0000000a812b810b010000098403a328020000068712970203000005833e98400400000200"_hex_u8, {11, 14, 1, 10, 4, 3, 5, 13, 9, 7, 6, 12, 8, 0, 2});
+}
+
+/** Construct a random tree-structured dependency graph.
+ *  A tree structure means: either all transactions have at most one parent (upright tree),
+ *  or all transactions have at most one child (reverse tree).
+ *  Uses random feerates for transactions.
+ */
+template<typename SetType>
+DepGraph<SetType> MakeRandomTreeGraph(DepGraphIndex ntx, InsecureRandomContext& rng, bool upright_tree)
+{
+    DepGraph<SetType> depgraph;
+
+    // Add transactions with random feerates
+    for (DepGraphIndex i = 0; i < ntx; ++i) {
+        int64_t fee = rng.randbits<27>() + 100;  // Random fee: 100 to 100 + (2^27 - 1)
+        int32_t size = rng.randrange(1000) + 1;  // Random size: 1 to 1000
+        depgraph.AddTransaction({fee, size});
+    }
+
+    if (upright_tree) {
+        // Upright tree: each transaction has at most one parent.
+        // Root (0) has no parent; each node i in [1, ntx) has exactly one parent in [0, i).
+        // This yields exactly ntx-1 edges and no cycles (parent < i), so the result is a tree.
+        for (DepGraphIndex i = 1; i < ntx; ++i) {
+            DepGraphIndex parent = rng.randrange(i);  // Parent in [0, i)
+            depgraph.AddDependencies(SetType::Singleton(parent), i);
+        }
+    } else {
+        // Reverse tree: each transaction has at most one child.
+        // Mirror of the upright tree: node i picks a random child from [0, i).
+        // Since child < i, no cycles are possible. Multiple nodes may pick the same
+        // child, producing genuine branching (a node with multiple parents, one child).
+        for (DepGraphIndex i = 1; i < ntx; ++i) {
+            DepGraphIndex child = rng.randrange(i);  // child in [0, i)
+            depgraph.AddDependencies(SetType::Singleton(i), child);
+        }
+    }
+
+    return depgraph;
+}
+
+/** Test that PostLinearize finds optimal linearization for tree-structured graphs.
+ *  This test verifies the guarantee stated in PostLinearize's documentation:
+ *  "If the input has a tree shape (either all transactions have at most one child,
+ *   or all transactions have at most one parent), the result is optimal."
+ */
+BOOST_AUTO_TEST_CASE(postlinearize_tree_optimal_tests)
+{
+    FastRandomContext rng;
+
+    // Test with different tree sizes and structures
+    for (DepGraphIndex ntx : {5, 10, 15, 20, 25, 30}) {
+        for (int iter = 0; iter < 10; ++iter) {
+            // Test both upright tree (each tx has at most one parent) and reverse tree (each tx has at most one child)
+            for (bool upright : {true, false}) {
+                InsecureRandomContext tree_rng(rng.rand64());
+                DepGraph<BitSet<64>> depgraph = MakeRandomTreeGraph<BitSet<64>>(ntx, tree_rng, upright);
+
+                SanityCheck(depgraph);
+                // Tree must have exactly ntx-1 edges
+                BOOST_CHECK_EQUAL(depgraph.CountDependencies(), ntx - 1);
+
+                // Build a topological linearization: ancestors before descendants.
+                // Sort by ancestor count (ascending); use index as tie-breaker for deterministic order.
+                std::vector<DepGraphIndex> topo_lin(ntx);
+                std::iota(topo_lin.begin(), topo_lin.end(), DepGraphIndex{0});
+                std::sort(topo_lin.begin(), topo_lin.end(), [&](DepGraphIndex a, DepGraphIndex b) {
+                    const auto na = depgraph.Ancestors(a).Count();
+                    const auto nb = depgraph.Ancestors(b).Count();
+                    return na < nb || (na == nb && a < b);
+                });
+
+                // Apply PostLinearize
+                std::vector<DepGraphIndex> post_lin = topo_lin;
+                PostLinearize(depgraph, post_lin);
+                SanityCheck(depgraph, post_lin);
+
+                // Find optimal linearization using Linearize
+                auto [opt_lin, optimal, cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng.rand64(), IndexTxOrder{});
+                BOOST_CHECK(optimal);
+                SanityCheck(depgraph, opt_lin);
+
+                // Compare chunk diagrams: PostLinearize result should be equal to optimal
+                auto post_chunks = ChunkLinearization(depgraph, post_lin);
+                auto opt_chunks = ChunkLinearization(depgraph, opt_lin);
+                auto cmp = CompareChunks(post_chunks, opt_chunks);
+
+                // PostLinearize should produce optimal result for tree graphs
+                BOOST_CHECK_MESSAGE(std::is_eq(cmp),
+                    "PostLinearize should find optimal linearization for tree-structured graphs. "
+                    "ntx=" << ntx << ", upright=" << upright << ", iter=" << iter);
+
+                // Verify that running PostLinearize again doesn't change the result
+                std::vector<DepGraphIndex> post_post_lin = post_lin;
+                PostLinearize(depgraph, post_post_lin);
+                auto post_post_chunks = ChunkLinearization(depgraph, post_post_lin);
+                auto cmp_post = CompareChunks(post_post_chunks, post_chunks);
+                BOOST_CHECK_MESSAGE(std::is_eq(cmp_post),
+                    "PostLinearize should be idempotent on tree-structured graphs. "
+                    "ntx=" << ntx << ", upright=" << upright << ", iter=" << iter);
+            }
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
                                                                                 
## Summary                                                                       
                                                                                 
This PR adds correctness tests and benchmarks specifically targeting chain and tree-shaped
cluster topologies, which are both common in real-world mempools and structurally special
with respect to `PostLinearize`.                                                 
                                                                                 
**Commits:**                                                                     
- `a11760f9` cluster_linearize: add chain cluster benchmarks for PostLinearize and Linearize
- `4b7e2b28` cluster_linearize: test PostLinearize optimality on random tree-shaped clusters
- `0725aa05` cluster_linearize: test PostLinearize optimality on random chain clusters
                                                                                 
---                                                                              
                                                                                 
## Motivation                                                                    
                                                                                 
`PostLinearize` gives an optimality guarantee for clusters with a **tree shape**: if every
transaction has at most one direct parent, or every transaction has at most one direct child,
the result is provably optimal. A chain (tx_0 → tx_1 → ... → tx_{N-1}) satisfies *both*
conditions simultaneously.                                                       
                                                                                 
These structural guarantees lacked dedicated test coverage and chain-specific benchmarks,
making it hard to observe the effect of topology-aware optimizations on linearization
performance.                                                                     
                                                                                 
---                                                                              
                                                                                 
## Changes                                                                       
                                                                                 
### Tests (`src/test/cluster_linearize_tests.cpp`)                               
                                                                                 
#### `postlinearize_tree_optimal_tests`                                          
                                                                                 
Adds `MakeRandomTreeGraph()`, which generates random tree-shaped dependency graphs in two
orientations:                                                                    
                                                                                 
- **Upright tree**: transaction i picks a random parent from [0, i), so every node has at
  most one direct parent.                                                        
- **Reverse tree**: transaction i picks a random child from [0, i), so every node has at
  most one direct child.                                                         
                                                                                 
For random trees of sizes 5..30, the test verifies:                              
1. `PostLinearize` produces a linearization of equal quality to the exhaustive `Linearize()`
   result (as guaranteed by `PostLinearize`'s interface for tree-shaped inputs). 
2. **Idempotency**: a second `PostLinearize` pass produces no change.            
                                                                                 
#### `postlinearize_chain_optimal_tests`                                         
                                                                                 
Adds `MakeRandomChainGraph()`, which generates random linear chain dependency graphs
(tx_0 → tx_1 → ... → tx_{N-1}) with randomized feerates.                         
                                                                                 
For chains of sizes 5..50, the test verifies:                                    
1. `PostLinearize` produces a linearization of equal quality to the exhaustive `Linearize()`
   result. A chain satisfies both tree-shape conditions simultaneously, so optimality is
   guaranteed.                                                                   
2. **Idempotency**: a second `PostLinearize` pass produces no change.            
                                                                                 
### Benchmarks (`src/bench/cluster_linearize.cpp`)                               
                                                                                 
Adds `MakeChainGraph()` to build deterministic random chain dependency graphs    
(tx_0 → tx_1 → ... → tx_{N-1}) with randomized feerates seeded deterministically from the
cluster size, and two sets of chain-specific benchmarks:                         
                                                                                 
- **`PostLinearizeChain{16,32,48,64,75,99}Tx`**: measure `PostLinearize` throughput on
  chain-shaped clusters across a range of sizes.                                 
- **`LinearizeOptimallyChainTotal_{9,16,32,48,63}tx`**: measure the total time for
  `Linearize` to reach an optimal result on chain-shaped clusters.               
                                                                                 
Chain clusters are a common real-world mempool pattern (each transaction spending an output
of the previous one). Dedicated benchmarks make it easy to observe the effect of 
topology-specific linearization optimizations as they are developed.             
