### PR TITLE
node: allocate index caches proportional to usage patterns

### DIFF
--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -58,16 +58,25 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
 {
     size_t total_cache{CalculateDbCacheBytes(args)};
 
+    // Allocate proportional to usage pattern benefit:
+    // - txindex (10%): serves getrawtransaction RPCs with mostly unique,
+    //   non-repetitive lookups across the entire blockchain.
+    // - blockfilterindex (5%): serves BIP 157 light clients that repeatedly
+    //   query recent blocks, benefiting most from LevelDB cache.
+    // - txospenderindex (5%): serves gettxspendingprevout RPCs with very
+    //   specific, rarely repeated outpoint queries.
+    // - coinstatsindex: intentionally not included here, since usage pattern
+    //   does not seem to suggest it would be necessary to cache.
     IndexCacheSizes index_sizes;
-    index_sizes.tx_index = std::min(total_cache / 8, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? MAX_TX_INDEX_CACHE : 0);
-    total_cache -= index_sizes.tx_index;
-    index_sizes.txospender_index = std::min(total_cache / 8, args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX) ? MAX_TXOSPENDER_INDEX_CACHE : 0);
-    total_cache -= index_sizes.txospender_index;
+    index_sizes.tx_index = std::min(total_cache * 10 / 100, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? MAX_TX_INDEX_CACHE : 0);
+    index_sizes.txospender_index = std::min(total_cache * 5 / 100, args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX) ? MAX_TXOSPENDER_INDEX_CACHE : 0);
     if (n_indexes > 0) {
-        size_t max_cache = std::min(total_cache / 8, MAX_FILTER_INDEX_CACHE);
+        size_t max_cache = std::min(total_cache * 5 / 100, MAX_FILTER_INDEX_CACHE);
         index_sizes.filter_index = max_cache / n_indexes;
         total_cache -= index_sizes.filter_index * n_indexes;
     }
+    total_cache -= index_sizes.tx_index;
+    total_cache -= index_sizes.txospender_index;
     return {index_sizes, kernel::CacheSizes{total_cache}};
 }
 

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -62,7 +62,9 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
     // - txindex (10%): serves getrawtransaction RPCs with mostly unique,
     //   non-repetitive lookups across the entire blockchain.
     // - blockfilterindex (5%): serves BIP 157 light clients that repeatedly
-    //   query recent blocks, benefiting most from LevelDB cache.
+    //   query recent blocks, benefiting from LevelDB cache, but the
+    //   working set for a typical 2-week offline gap is ~200kiB, well within 5%
+    //   of the total cache.
     // - txospenderindex (5%): serves gettxspendingprevout RPCs with very
     //   specific, rarely repeated outpoint queries.
     // - coinstatsindex: intentionally not included here, since usage pattern


### PR DESCRIPTION
The current cache allocation for optional indexes (txindex, txospenderindex, blockfilterindex) uses a sequential total_cache / 8 approach where each index gets 1/8 of the remaining budget after the previous index has been allocated. This means the order in which indexes appear in the code silently determines how much cache each one gets.

|Index|Current share of total|
|---|---|
|txindex	|~12%|
|txospenderindex|~11%|
|blockfilterindex	|~10%|

This is unintuitive, undocumented, and probably doesn't reflect actual usage patterns. This PR replaces the sequential 1/8 allocation with explicit percentages based on how the indexes are typically used. The current values are an educated guess, and subject to further benchmark and research of typical client usage patterns.

|Index|Allocation|Rationale|
|---|---|---|
|txindex |10% |Serves getrawtransaction RPCs with mostly unique lookups across the entire blockchain: low cache reuse|
|txospenderindex|5%|Serves gettxspendingprevout RPCs with very specific outpoint queries: likely the least repetitive access pattern|
|blockfilterindex|5%|Serves BIP 157 light clients that repeatedly query the same recent blocks: highest cache benefit|

UPDATE: blockfilterindex allocation changed from 15% to 5% in the course of the discussion

This is a continuation of  the related discussion: https://github.com/bitcoin/bitcoin/pull/24539#discussion_r2809088034 and https://github.com/bitcoin/bitcoin/pull/31483.

Further feedback and input is very much appreciated.