### PR TITLE
guix: Update storage requirement for HOSTS and added warning for Guix overhead

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -154,18 +154,37 @@ avail_KiB="$(df -Pk "$VERSION_BASE" | sed 1d | tr -s ' ' | cut -d' ' -f4)"
 total_required_KiB=0
 for host in $HOSTS; do
     case "$host" in
-        *darwin*) required_KiB=440000 ;;
-        *mingw*)  required_KiB=7600000 ;;
-        *)        required_KiB=6400000 ;;
+        *darwin*)  required_KiB=3000000 ;;
+        *mingw*)   required_KiB=9000000 ;;
+        *riscv64*) required_KiB=6300000 ;;
+        *)         required_KiB=4400000 ;;
     esac
     total_required_KiB=$((total_required_KiB+required_KiB))
 done
+
+total_required_KiB=$((total_required_KiB+5500000)) # output directory
 
 if (( total_required_KiB > avail_KiB )); then
     total_required_GiB=$((total_required_KiB / 1048576))
     avail_GiB=$((avail_KiB / 1048576))
     echo "Performing a Bitcoin Core Guix build for the selected HOSTS requires ${total_required_GiB} GiB, however, only ${avail_GiB} GiB is available. Please free up some disk space before performing the build."
     exit 1
+fi
+
+total_required_KiB=$((total_required_KiB+9500000)) # guix overhead
+
+if (( total_required_KiB > avail_KiB )); then
+    total_required_GiB=$((total_required_KiB / 1048576))
+    avail_GiB=$((avail_KiB / 1048576))
+cat << EOF
+
+WARN: Available disk space (${avail_GiB} GiB) may be insufficient for the
+      estimated total of ${total_required_GiB} GiB (build directories, output,
+      and Guix environment overhead).
+
+The build will proceed, but may fail mid-way if disk space runs out.
+
+EOF
 fi
 
 ################


### PR DESCRIPTION
This is an alternative to #33889

The lasttime the storage requirements were updated is 4 years ago in #22075 and do not match the current needs of a Guix build. This PR updates the storage requirements to align with recent builds.

The current code is quite off for certain hosts (the total equals out overall), but the check also ignores the output directory which takes up an additional 5 GiB of disk space:

<details>

Comparing real usage against the script's estimates:

| Host                  | Real KiB  | Estimate KiB | Delta          |
| --------------------- | --------- | ------------ | -------------- |
| `aarch64-linux-gnu`   | 3,875,896 | 6,400,000    | **-2,524,104** |
| `arm-linux-gnueabihf` | 2,983,008 | 6,400,000    | **-3,416,992** |
| `riscv64-linux-gnu`   | 5,712,668 | 6,400,000    | -687,332       |
| `x86_64-linux-gnu`    | 3,978,648 | 6,400,000    | **-2,421,352** |
| `powerpc64-linux-gnu` | 4,026,948 | 6,400,000    | -2,373,052     |
| `x86_64-w64-mingw32`  | 8,022,644 | 7,600,000    | +422,644       |
| `x86_64-apple-darwin` | 2,714,848 | 440,000      | **+2,274,848** |
| `arm64-apple-darwin`  | 2,659,824 | 440,000      | **+2,219,824** |
| `output dir ` | 5,500,000 | 0 | **+5,500,000**|


</details>

This PR makes the following changes: 
- Updates the required KiB per category to current needs + 10% margin
- it adds an extra category for `riscv64` (was way off * category )
- adds output directory storage requirements 

This all totals to 42 GiB (using all hosts) :
<details>

Output for #34550 on Guix 1.5.0 

| Host                  |  Real KiB | Estimate      | Margin     |
| --------------------- | ---------------- | ------------- | ---------- |
| `aarch64-linux-gnu`   | ~3,880,000       | 4,400,000     | +13%       |
| `arm-linux-gnueabihf` | ~3,041,000       | 4,400,000     | +45%       |
| `powerpc64-linux-gnu` | ~4,089,000       | 4,400,000     | +8%        |
| `x86_64-linux-gnu`    | ~3,985,000       | 4,400,000     | +10%       |
| `riscv64-linux-gnu`   | ~5,767,000       | 6,300,000     | +9%        |
| `x86_64-w64-mingw32`  | ~8,074,000       | 9,000,000     | +11%       |
| `x86_64-apple-darwin` | ~2,726,000       | 3,000,000     | +10%       |
| `arm64-apple-darwin`  | ~2,726,000       | 3,000,000     | +10%       |
| **output**            | ~4,929,000 | 5,500,000 | +10% |

Output for #34627 on Guix 1.4.0 

| Host                  |  Real KiB | Estimate      | Margin     |
| --------------------- | ---------------- | ------------- | ---------- |
| `aarch64-linux-gnu`   | ~3,934,232       | 4,400,000     | +12%       |
| `arm-linux-gnueabihf` | ~3,040,552       | 4,400,000     | +45%       |
| `powerpc64-linux-gnu` | ~4,084,480       | 4,400,000     | +8%        |
| `x86_64-linux-gnu`    | ~4,036,900       | 4,400,000     | +9%       |
| `riscv64-linux-gnu`   | ~5,764,512       | 6,300,000     | +9%        |
| `x86_64-w64-mingw32`  | ~8,087,164       | 9,000,000     | +11%       |
| `x86_64-apple-darwin` | ~2,762,992       | 3,000,000     | +9%       |
| `arm64-apple-darwin`  | ~2,707,800       | 3,000,000     | +11%       |
| **output**            | ~5,048,228 | 5,500,000 | +9% |

</details>

Additionally, maybe more controversial (happy to drop), I've added a second check to warm users if they do not have enough free space to store the guix overhead (`/gnu` store) which is an additional 8,7 GiB.  This check only warns and does not stop the build. 

<details> <summary> New warning message:</summary>

```terminal
Found macOS SDK at '/root/SDK/Xcode-26.1.1-17B100-extracted-SDK-with-libcxx-head
ers', using...

WARN: Available disk space (42 GiB) may be insufficient for the
      estimated total of 51 GiB (build directories, output,
      and Guix environment overhead).

The build will proceed, but may fail mid-way if disk space runs out.

Checking that we can connect to the guix-daemon...
```
</details>

NB.
Could not find a good reason for the change  in disk usage, even older V29 build take up roughly the same size as recent builds.