### PR TITLE
wallet: rpc: Improve error message for low feerates.

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1435,7 +1435,16 @@ RPCHelpMan sendall()
             // Do not, ever, assume that it's fine to change the fee rate if the user has explicitly
             // provided one
             if (coin_control.m_feerate && fee_rate > *coin_control.m_feerate) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Fee rate (%s) is lower than the minimum fee rate setting (%s)", coin_control.m_feerate->ToString(FeeRateFormat::SAT_VB), fee_rate.ToString(FeeRateFormat::SAT_VB)));
+                const auto feerate_format = FeeRateFormat::SAT_VB;
+                auto msg{strprintf("Fee rate (%s) is lower than the minimum fee rate setting (%s).",
+                    coin_control.m_feerate->ToString(feerate_format),
+                    fee_rate.ToString(feerate_format))};
+                if (fee_calc_out.reason == FeeReason::REQUIRED) {
+                    msg += strprintf("\nConsider modifying -mintxfee (%s) or -minrelaytxfee (%s).",
+                        pwallet->m_min_fee.ToString(feerate_format),
+                        pwallet->chain().relayMinFee().ToString(feerate_format));
+                }
+                throw JSONRPCError(RPC_INVALID_PARAMETER, msg);
             }
             if (fee_calc_out.reason == FeeReason::FALLBACK && !pwallet->m_allow_fallback_fee) {
                 // eventually allow a fallback fee

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1153,7 +1153,18 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     // Do not, ever, assume that it's fine to change the fee rate if the user has explicitly
     // provided one
     if (coin_control.m_feerate && coin_selection_params.m_effective_feerate > *coin_control.m_feerate) {
-        return util::Error{strprintf(_("Fee rate (%s) is lower than the minimum fee rate setting (%s)"), coin_control.m_feerate->ToString(FeeRateFormat::SAT_VB), coin_selection_params.m_effective_feerate.ToString(FeeRateFormat::SAT_VB))};
+        const auto feerate_format = FeeRateFormat::SAT_VB;
+        auto msg{strprintf(_("Fee rate (%s) is lower than the minimum fee rate setting (%s)."),
+            coin_control.m_feerate->ToString(feerate_format),
+            coin_selection_params.m_effective_feerate.ToString(feerate_format))};
+        if (feeCalc.reason == FeeReason::REQUIRED) {
+            msg += strprintf(_("\nConsider modifying %s (%s) or %s (%s)."),
+                "-mintxfee",
+                wallet.m_min_fee.ToString(feerate_format),
+                "-minrelaytxfee",
+                wallet.chain().relayMinFee().ToString(feerate_format));
+        }
+        return util::Error{msg};
     }
     if (feeCalc.reason == FeeReason::FALLBACK && !wallet.m_allow_fallback_fee) {
         // eventually allow a fallback fee


### PR DESCRIPTION
Giving the user a hint about what action to take when they encounter an error related to a feerate that is below the minimum. I encountered this myself not knowing about `-mintxfee` and the manpage was slightly less than clear,

```
       -mintxfee=<amt>

              Fee rates (in BTC/kvB) smaller than this are considered zero fee for  transaction  creation
              (default: 0.00001)
```