### PR TITLE
[RFC] cluster_linearize: add O(N) fast path for chain-shaped clusters

### DIFF
--- a/src/bench/cluster_linearize.cpp
+++ b/src/bench/cluster_linearize.cpp
@@ -4,11 +4,13 @@
 
 #include <bench/bench.h>
 #include <cluster_linearize.h>
+#include <random.h>
 #include <test/util/cluster_linearize.h>
 #include <util/bitset.h>
 #include <util/strencodings.h>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstdint>
 #include <vector>
@@ -33,10 +35,41 @@ DepGraph<SetType> MakeWideGraph(DepGraphIndex ntx)
     return depgraph;
 }
 
+/** Construct a chain graph (tx0 -> tx1 -> tx2 -> ... -> tx_{n-1}). Each transaction
+ *  depends only on the previous one. Chain graphs have a unique topological order.
+ *  Uses FastRandomContext for deterministic but randomized feerates.
+ */
+template<typename SetType>
+DepGraph<SetType> MakeChainGraph(DepGraphIndex ntx, FastRandomContext& rng)
+{
+    DepGraph<SetType> depgraph;
+    for (DepGraphIndex i = 0; i < ntx; ++i) {
+        int64_t fee = rng.randbits<27>() + 100;
+        int32_t size = rng.randrange(1000) + 1;
+        depgraph.AddTransaction({fee, size});
+        if (i > 0) depgraph.AddDependencies(SetType::Singleton(i - 1), i);
+    }
+    return depgraph;
+}
+
 template<typename SetType>
 void BenchPostLinearizeWorstCase(DepGraphIndex ntx, benchmark::Bench& bench)
 {
     DepGraph<SetType> depgraph = MakeWideGraph<SetType>(ntx);
+    std::vector<DepGraphIndex> lin(ntx);
+    bench.run([&] {
+        for (DepGraphIndex i = 0; i < ntx; ++i) lin[i] = i;
+        PostLinearize(depgraph, lin);
+    });
+}
+
+template<typename SetType>
+void BenchPostLinearizeChain(DepGraphIndex ntx, benchmark::Bench& bench)
+{
+    std::array<unsigned char, 32> seed{};
+    for (int i = 0; i < 4; ++i) seed[i] = static_cast<unsigned char>((ntx >> (i * 8)) & 0xff);
+    FastRandomContext rng{uint256(seed)};
+    DepGraph<SetType> depgraph = MakeChainGraph<SetType>(ntx, rng);
     std::vector<DepGraphIndex> lin(ntx);
     bench.run([&] {
         for (DepGraphIndex i = 0; i < ntx; ++i) lin[i] = i;
@@ -89,6 +122,24 @@ void BenchLinearizeOptimallyPerCost(benchmark::Bench& bench, const std::string& 
     }
 }
 
+/** Benchmark Linearize on chain graphs of given sizes (total time to optimal). */
+void BenchLinearizeOptimallyChainTotal(benchmark::Bench& bench, const std::vector<DepGraphIndex>& chain_sizes)
+{
+    for (DepGraphIndex ntx : chain_sizes) {
+        std::array<unsigned char, 32> seed{};
+        for (int i = 0; i < 4; ++i) seed[i] = static_cast<unsigned char>((ntx >> (i * 8)) & 0xff);
+        FastRandomContext rng{uint256(seed)};
+        DepGraph<BitSet<64>> depgraph = MakeChainGraph<BitSet<64>>(ntx, rng);
+        auto bench_name = strprintf("LinearizeOptimallyChainTotal_%utx_%udep", depgraph.TxCount(), depgraph.CountDependencies());
+
+        uint64_t rng_seed = 0;
+        bench.name(bench_name).run([&] {
+            auto [_lin, optimal, _cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng_seed++, IndexTxOrder{});
+            assert(optimal);
+        });
+    }
+}
+
 } // namespace
 
 static void PostLinearize16TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<16>>(16, bench); }
@@ -97,6 +148,13 @@ static void PostLinearize48TxWorstCase(benchmark::Bench& bench) { BenchPostLinea
 static void PostLinearize64TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<64>>(64, bench); }
 static void PostLinearize75TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<75>>(75, bench); }
 static void PostLinearize99TxWorstCase(benchmark::Bench& bench) { BenchPostLinearizeWorstCase<BitSet<99>>(99, bench); }
+
+static void PostLinearize16TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<16>>(16, bench); }
+static void PostLinearize32TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<32>>(32, bench); }
+static void PostLinearize48TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<48>>(48, bench); }
+static void PostLinearize64TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<64>>(64, bench); }
+static void PostLinearize75TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<75>>(75, bench); }
+static void PostLinearize99TxChain(benchmark::Bench& bench) { BenchPostLinearizeChain<BitSet<99>>(99, bench); }
 
 // Constructed from replayed historical mempool activity, selecting for clusters that are slow
 // to linearize from scratch, with increasing number of transactions (9 to 63).
@@ -150,6 +208,14 @@ static void LinearizeOptimallyPerCost(benchmark::Bench& bench)
     BenchLinearizeOptimallyPerCost(bench, "LinearizeOptimallySyntheticPerCost", CLUSTERS_SYNTHETIC);
 }
 
+// Chain sizes for Linearize benchmarks (aligned with historical cluster size range).
+static const std::vector<DepGraphIndex> CHAIN_SIZES = {9, 16, 32, 48, 63};
+
+static void LinearizeOptimallyChainTotal(benchmark::Bench& bench)
+{
+    BenchLinearizeOptimallyChainTotal(bench, CHAIN_SIZES);
+}
+
 BENCHMARK(PostLinearize16TxWorstCase);
 BENCHMARK(PostLinearize32TxWorstCase);
 BENCHMARK(PostLinearize48TxWorstCase);
@@ -157,5 +223,13 @@ BENCHMARK(PostLinearize64TxWorstCase);
 BENCHMARK(PostLinearize75TxWorstCase);
 BENCHMARK(PostLinearize99TxWorstCase);
 
+BENCHMARK(PostLinearize16TxChain);
+BENCHMARK(PostLinearize32TxChain);
+BENCHMARK(PostLinearize48TxChain);
+BENCHMARK(PostLinearize64TxChain);
+BENCHMARK(PostLinearize75TxChain);
+BENCHMARK(PostLinearize99TxChain);
+
 BENCHMARK(LinearizeOptimallyTotal);
 BENCHMARK(LinearizeOptimallyPerCost);
+BENCHMARK(LinearizeOptimallyChainTotal);

--- a/src/bench/cluster_linearize.cpp
+++ b/src/bench/cluster_linearize.cpp
@@ -88,7 +88,7 @@ void BenchLinearizeOptimallyTotal(benchmark::Bench& bench, const std::string& na
         // Benchmark the total time to optimal.
         uint64_t rng_seed = 0;
         bench.name(bench_name).run([&] {
-            auto [_lin, optimal, _cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng_seed++, IndexTxOrder{});
+            auto [_lin, optimal, _cost, _is_chain] = Linearize(depgraph, /*max_iterations=*/10000000, rng_seed++, IndexTxOrder{});
             assert(optimal);
         });
     }
@@ -105,7 +105,7 @@ void BenchLinearizeOptimallyPerCost(benchmark::Bench& bench, const std::string& 
         // Determine the cost of 100 rng_seeds.
         uint64_t total_cost = 0;
         for (uint64_t iter = 0; iter < 100; ++iter) {
-            auto [_lin, optimal, cost] = Linearize(depgraph, /*max_iterations=*/10000000, /*rng_seed=*/iter, IndexTxOrder{});
+            auto [_lin, optimal, cost, _is_chain] = Linearize(depgraph, /*max_iterations=*/10000000, /*rng_seed=*/iter, IndexTxOrder{});
             total_cost += cost;
         }
 
@@ -113,13 +113,32 @@ void BenchLinearizeOptimallyPerCost(benchmark::Bench& bench, const std::string& 
         bench.name(bench_name).unit("cost").batch(total_cost).run([&] {
             uint64_t recompute_cost = 0;
             for (uint64_t iter = 0; iter < 100; ++iter) {
-                auto [_lin, optimal, cost] = Linearize(depgraph, /*max_iterations=*/10000000, /*rng_seed=*/iter, IndexTxOrder{});
+                auto [_lin, optimal, cost, _is_chain] = Linearize(depgraph, /*max_iterations=*/10000000, /*rng_seed=*/iter, IndexTxOrder{});
                 assert(optimal);
                 recompute_cost += cost;
             }
             assert(total_cost == recompute_cost);
         });
     }
+}
+
+/** Construct a chain graph with strictly increasing individual feerates (fee_i = i+1, size_i = 1).
+ *
+ * This is a pessimal feerate distribution for the SPF algorithm on chains: every transaction
+ * looks attractive in isolation (feerate i+1), but to include tx_i all its ancestors must be
+ * included too. As a result the only valid chunk with feerate greater than any strict prefix is
+ * the entire chain (feerate (N+1)/2), which SPF must discover through many improvement steps.
+ * TryLinearizeChain handles this in O(N) regardless of feerate distribution.
+ */
+template<typename SetType>
+DepGraph<SetType> MakeMonotoneChainGraph(DepGraphIndex ntx)
+{
+    DepGraph<SetType> depgraph;
+    for (DepGraphIndex i = 0; i < ntx; ++i) {
+        depgraph.AddTransaction({int64_t(i) + 1, 1});
+        if (i > 0) depgraph.AddDependencies(SetType::Singleton(i - 1), i);
+    }
+    return depgraph;
 }
 
 /** Benchmark Linearize on chain graphs of given sizes (total time to optimal). */
@@ -134,8 +153,29 @@ void BenchLinearizeOptimallyChainTotal(benchmark::Bench& bench, const std::vecto
 
         uint64_t rng_seed = 0;
         bench.name(bench_name).run([&] {
-            auto [_lin, optimal, _cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng_seed++, IndexTxOrder{});
+            auto [_lin, optimal, _cost, is_chain] = Linearize(depgraph, /*max_iterations=*/10000000, rng_seed++, IndexTxOrder{});
             assert(optimal);
+            assert(is_chain);
+        });
+    }
+}
+
+/** Benchmark Linearize on monotone chain graphs (worst-case feerate distribution for SPF).
+ *
+ * Without TryLinearizeChain, the SPF MakeTopological phase triggers an O(N²) cascade for
+ * strictly increasing feerates.  With TryLinearizeChain the result is produced in O(N).
+ */
+void BenchLinearizeOptimallyMonotoneChainTotal(benchmark::Bench& bench, const std::vector<DepGraphIndex>& chain_sizes)
+{
+    for (DepGraphIndex ntx : chain_sizes) {
+        DepGraph<BitSet<64>> depgraph = MakeMonotoneChainGraph<BitSet<64>>(ntx);
+        auto bench_name = strprintf("LinearizeOptimallyMonotoneChainTotal_%utx_%udep", depgraph.TxCount(), depgraph.CountDependencies());
+
+        uint64_t rng_seed = 0;
+        bench.name(bench_name).run([&] {
+            auto [_lin, optimal, _cost, is_chain] = Linearize(depgraph, /*max_iterations=*/10000000, rng_seed++, IndexTxOrder{});
+            assert(optimal);
+            assert(is_chain);
         });
     }
 }
@@ -216,6 +256,11 @@ static void LinearizeOptimallyChainTotal(benchmark::Bench& bench)
     BenchLinearizeOptimallyChainTotal(bench, CHAIN_SIZES);
 }
 
+static void LinearizeOptimallyMonotoneChainTotal(benchmark::Bench& bench)
+{
+    BenchLinearizeOptimallyMonotoneChainTotal(bench, CHAIN_SIZES);
+}
+
 BENCHMARK(PostLinearize16TxWorstCase);
 BENCHMARK(PostLinearize32TxWorstCase);
 BENCHMARK(PostLinearize48TxWorstCase);
@@ -233,3 +278,4 @@ BENCHMARK(PostLinearize99TxChain);
 BENCHMARK(LinearizeOptimallyTotal);
 BENCHMARK(LinearizeOptimallyPerCost);
 BENCHMARK(LinearizeOptimallyChainTotal);
+BENCHMARK(LinearizeOptimallyMonotoneChainTotal);

--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -1662,7 +1662,41 @@ public:
     }
 };
 
-/** Find or improve a linearization for a cluster.
+/** Check if a cluster forms a single chain and, if so, compute an optimal linearization for it.
+ *
+ * A cluster is a chain if every transaction has at most one direct parent and at most one direct
+ * child. Equivalently, the multiset of ancestor-set sizes of all transactions equals {1,...,N}.
+ *
+ * @param[in] depgraph   Dependency graph of the cluster.
+ * @return               An optimal linearization, or an empty vector if not a chain.
+ *
+ * Complexity: O(N) where N = depgraph.TxCount().
+ */
+template<typename SetType>
+std::vector<DepGraphIndex> TryLinearizeChain(const DepGraph<SetType>& depgraph) noexcept
+{
+    const auto n = depgraph.TxCount();
+    if (n == 0) return {};
+
+    // A cluster with N transactions is a chain iff the ancestor-set sizes form exactly {1,...,N}.
+    // Check this in O(N) using a presence array (Ancestors().Count() is O(1) for BitSets).
+    std::vector<bool> seen(n + 1, false);
+    for (auto i : depgraph.Positions()) {
+        auto sz = depgraph.Ancestors(i).Count();
+        if (sz > n || seen[sz]) return {};
+        seen[sz] = true;
+    }
+
+    // Build the linearization directly: the node with k ancestors occupies position k-1.
+    // For a chain this topological order is unique and already optimal.
+    std::vector<DepGraphIndex> result(n);
+    for (auto i : depgraph.Positions()) {
+        result[depgraph.Ancestors(i).Count() - 1] = i;
+    }
+    return result;
+}
+
+/** SPF-based implementation of cluster linearization. Called by Linearize() for non-chain clusters.
  *
  * @param[in] depgraph            Dependency graph of the cluster to be linearized.
  * @param[in] max_iterations      Upper bound on the amount of work that will be done.
@@ -1683,7 +1717,7 @@ public:
  *                                - How many optimization steps were actually performed.
  */
 template<typename SetType>
-std::tuple<std::vector<DepGraphIndex>, bool, uint64_t> Linearize(
+std::tuple<std::vector<DepGraphIndex>, bool, uint64_t> LinearizeSPF(
     const DepGraph<SetType>& depgraph,
     uint64_t max_iterations,
     uint64_t rng_seed,
@@ -1720,6 +1754,49 @@ std::tuple<std::vector<DepGraphIndex>, bool, uint64_t> Linearize(
         } while (forest.GetCost() < max_iterations);
     }
     return {forest.GetLinearization(fallback_order), optimal, forest.GetCost()};
+}
+
+/** Find or improve a linearization for a cluster.
+ *
+ * For chain-shaped clusters (every transaction has at most one parent and at most one child),
+ * an O(N) fast path (TryLinearizeChain) is tried first, producing an optimal linearization
+ * directly without invoking the SPF algorithm.  For all other clusters the SPF algorithm
+ * (LinearizeSPF) is used.
+ *
+ * @param[in] depgraph            Dependency graph of the cluster to be linearized.
+ * @param[in] max_iterations      Upper bound on the amount of work that will be done (SPF path).
+ * @param[in] rng_seed            A random number seed to control search order (SPF path).
+ * @param[in] fallback_order      A comparator to order transactions, used to sort equal-feerate
+ *                                chunks and transactions (SPF path).
+ * @param[in] old_linearization   An existing linearization for the cluster, or empty (SPF path).
+ * @param[in] is_topological      (Only relevant if old_linearization is not empty) Whether
+ *                                old_linearization is topologically valid (SPF path).
+ * @return                        A tuple of:
+ *                                - The resulting linearization. It is guaranteed to be at least as
+ *                                  good (in the feerate diagram sense) as old_linearization.
+ *                                - A boolean indicating whether the result is guaranteed to be
+ *                                  optimal with minimal chunks.
+ *                                - How many optimization steps were actually performed.
+ *                                - A boolean indicating whether the chain fast path was used.
+ *                                  When true, the result is already optimal and PostLinearize is
+ *                                  not needed.
+ */
+template<typename SetType>
+std::tuple<std::vector<DepGraphIndex>, bool, uint64_t, bool> Linearize(
+    const DepGraph<SetType>& depgraph,
+    uint64_t max_iterations,
+    uint64_t rng_seed,
+    const StrongComparator<DepGraphIndex> auto& fallback_order,
+    std::span<const DepGraphIndex> old_linearization = {},
+    bool is_topological = true) noexcept
+{
+    // Fast path: O(N) optimal linearization for chain-shaped clusters, bypassing SPF entirely.
+    if (auto chain_lin = TryLinearizeChain(depgraph); !chain_lin.empty()) {
+        return {std::move(chain_lin), /*optimal=*/true, /*cost=*/0, /*is_chain=*/true};
+    }
+    // General path: SPF algorithm.
+    auto [lin, optimal, cost] = LinearizeSPF(depgraph, max_iterations, rng_seed, fallback_order, old_linearization, is_topological);
+    return {std::move(lin), optimal, cost, /*is_chain=*/false};
 }
 
 /** Improve a given linearization.

--- a/src/test/cluster_linearize_tests.cpp
+++ b/src/test/cluster_linearize_tests.cpp
@@ -583,4 +583,84 @@ BOOST_AUTO_TEST_CASE(postlinearize_tree_optimal_tests)
     }
 }
 
+/** Construct a random chain-structured dependency graph.
+ *  A chain structure means: tx0 -> tx1 -> tx2 -> ... -> tx_{n-1}
+ *  Each transaction depends only on the previous one.
+ *  Uses random feerates for transactions.
+ */
+template<typename SetType>
+DepGraph<SetType> MakeRandomChainGraph(DepGraphIndex ntx, InsecureRandomContext& rng)
+{
+    DepGraph<SetType> depgraph;
+
+    // Add transactions with random feerates
+    for (DepGraphIndex i = 0; i < ntx; ++i) {
+        int64_t fee = rng.randbits<27>() + 100;  // Random fee: 100 to 100 + (2^27 - 1)
+        int32_t size = rng.randrange(1000) + 1;  // Random size: 1 to 1000
+        depgraph.AddTransaction({fee, size});
+    }
+
+    // Create chain: tx0 -> tx1 -> tx2 -> ... -> tx_{n-1}
+    for (DepGraphIndex i = 1; i < ntx; ++i) {
+        depgraph.AddDependencies(SetType::Singleton(i - 1), i);
+    }
+
+    return depgraph;
+}
+
+/** Test that PostLinearize finds optimal linearization for chain-structured graphs.
+ *  Chain graphs are a special case of tree graphs (each transaction has at most one parent),
+ *  so PostLinearize should find optimal linearization.
+ */
+BOOST_AUTO_TEST_CASE(postlinearize_chain_optimal_tests)
+{
+    FastRandomContext rng;
+
+    // Test with different chain sizes
+    for (DepGraphIndex ntx : {5, 10, 15, 20, 25, 30, 40, 50}) {
+        for (int iter = 0; iter < 10; ++iter) {
+            InsecureRandomContext chain_rng(rng.rand64());
+            DepGraph<BitSet<64>> depgraph = MakeRandomChainGraph<BitSet<64>>(ntx, chain_rng);
+
+            SanityCheck(depgraph);
+
+            // Create a topological linearization as input to PostLinearize
+            // For chain graphs, the topological order is simply [0, 1, 2, ..., n-1]
+            std::vector<DepGraphIndex> topo_lin(ntx);
+            for (DepGraphIndex i = 0; i < ntx; ++i) {
+                topo_lin[i] = i;
+            }
+
+            // Apply PostLinearize
+            std::vector<DepGraphIndex> post_lin = topo_lin;
+            PostLinearize(depgraph, post_lin);
+            SanityCheck(depgraph, post_lin);
+
+            // Find optimal linearization using Linearize
+            auto [opt_lin, optimal, cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng.rand64(), IndexTxOrder{});
+            BOOST_CHECK(optimal);
+            SanityCheck(depgraph, opt_lin);
+
+            // Compare chunk diagrams: PostLinearize result should be equal to optimal
+            auto post_chunks = ChunkLinearization(depgraph, post_lin);
+            auto opt_chunks = ChunkLinearization(depgraph, opt_lin);
+            auto cmp = CompareChunks(post_chunks, opt_chunks);
+
+            // PostLinearize should produce optimal result for chain graphs
+            BOOST_CHECK_MESSAGE(std::is_eq(cmp),
+                "PostLinearize should find optimal linearization for chain-structured graphs. "
+                "ntx=" << ntx << ", iter=" << iter);
+
+            // Verify that running PostLinearize again doesn't change the result
+            std::vector<DepGraphIndex> post_post_lin = post_lin;
+            PostLinearize(depgraph, post_post_lin);
+            auto post_post_chunks = ChunkLinearization(depgraph, post_post_lin);
+            auto cmp_post = CompareChunks(post_post_chunks, post_chunks);
+            BOOST_CHECK_MESSAGE(std::is_eq(cmp_post),
+                "PostLinearize should be idempotent on chain-structured graphs. "
+                "ntx=" << ntx << ", iter=" << iter);
+        }
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/cluster_linearize_tests.cpp
+++ b/src/test/cluster_linearize_tests.cpp
@@ -3,11 +3,15 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <cluster_linearize.h>
+#include <random.h>
 #include <test/util/cluster_linearize.h>
 #include <test/util/setup_common.h>
 #include <util/bitset.h>
+#include <util/feefrac.h>
 #include <util/strencodings.h>
 
+#include <algorithm>
+#include <numeric>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -474,6 +478,109 @@ BOOST_AUTO_TEST_CASE(depgraph_optimal_tests)
     TestOptimalLinearization("855f8024008024816501807c81020284629b030383078631048044895c000002048078100100000000068315856a020000000004800784130300000000028167800c04000000000281758a14010000000885249a1a0100010004852ca63e020000010300"_hex_u8, {6, 1, 12, 5, 11, 3, 4, 10, 0, 8, 9, 7, 2});
     TestOptimalLinearization("855f97230080678a4f018210925d02856113038105892b04854e996105805a8a480000000000000283028b7a01000000000002846d9f080200000000000283189656030000000000018277862e0400000000000185508d200500000000000000"_hex_u8, {3, 0, 10, 7, 2, 1, 4, 8, 6, 5, 11, 9});
     TestOptimalLinearization("866faa23008646b71501851f96130282588f1103804d851c0000000003822097600100000003850a8f310200000003856e9201000000038656935f01000003855b8f5f020000018743923a0000000a812b810b010000098403a328020000068712970203000005833e98400400000200"_hex_u8, {11, 14, 1, 10, 4, 3, 5, 13, 9, 7, 6, 12, 8, 0, 2});
+}
+
+/** Construct a random tree-structured dependency graph.
+ *  A tree structure means: either all transactions have at most one parent (upright tree),
+ *  or all transactions have at most one child (reverse tree).
+ *  Uses random feerates for transactions.
+ */
+template<typename SetType>
+DepGraph<SetType> MakeRandomTreeGraph(DepGraphIndex ntx, InsecureRandomContext& rng, bool upright_tree)
+{
+    DepGraph<SetType> depgraph;
+
+    // Add transactions with random feerates
+    for (DepGraphIndex i = 0; i < ntx; ++i) {
+        int64_t fee = rng.randbits<27>() + 100;  // Random fee: 100 to 100 + (2^27 - 1)
+        int32_t size = rng.randrange(1000) + 1;  // Random size: 1 to 1000
+        depgraph.AddTransaction({fee, size});
+    }
+
+    if (upright_tree) {
+        // Upright tree: each transaction has at most one parent.
+        // Root (0) has no parent; each node i in [1, ntx) has exactly one parent in [0, i).
+        // This yields exactly ntx-1 edges and no cycles (parent < i), so the result is a tree.
+        for (DepGraphIndex i = 1; i < ntx; ++i) {
+            DepGraphIndex parent = rng.randrange(i);  // Parent in [0, i)
+            depgraph.AddDependencies(SetType::Singleton(parent), i);
+        }
+    } else {
+        // Reverse tree: each transaction has at most one child.
+        // Mirror of the upright tree: node i picks a random child from [0, i).
+        // Since child < i, no cycles are possible. Multiple nodes may pick the same
+        // child, producing genuine branching (a node with multiple parents, one child).
+        for (DepGraphIndex i = 1; i < ntx; ++i) {
+            DepGraphIndex child = rng.randrange(i);  // child in [0, i)
+            depgraph.AddDependencies(SetType::Singleton(i), child);
+        }
+    }
+
+    return depgraph;
+}
+
+/** Test that PostLinearize finds optimal linearization for tree-structured graphs.
+ *  This test verifies the guarantee stated in PostLinearize's documentation:
+ *  "If the input has a tree shape (either all transactions have at most one child,
+ *   or all transactions have at most one parent), the result is optimal."
+ */
+BOOST_AUTO_TEST_CASE(postlinearize_tree_optimal_tests)
+{
+    FastRandomContext rng;
+
+    // Test with different tree sizes and structures
+    for (DepGraphIndex ntx : {5, 10, 15, 20, 25, 30}) {
+        for (int iter = 0; iter < 10; ++iter) {
+            // Test both upright tree (each tx has at most one parent) and reverse tree (each tx has at most one child)
+            for (bool upright : {true, false}) {
+                InsecureRandomContext tree_rng(rng.rand64());
+                DepGraph<BitSet<64>> depgraph = MakeRandomTreeGraph<BitSet<64>>(ntx, tree_rng, upright);
+
+                SanityCheck(depgraph);
+                // Tree must have exactly ntx-1 edges
+                BOOST_CHECK_EQUAL(depgraph.CountDependencies(), ntx - 1);
+
+                // Build a topological linearization: ancestors before descendants.
+                // Sort by ancestor count (ascending); use index as tie-breaker for deterministic order.
+                std::vector<DepGraphIndex> topo_lin(ntx);
+                std::iota(topo_lin.begin(), topo_lin.end(), DepGraphIndex{0});
+                std::sort(topo_lin.begin(), topo_lin.end(), [&](DepGraphIndex a, DepGraphIndex b) {
+                    const auto na = depgraph.Ancestors(a).Count();
+                    const auto nb = depgraph.Ancestors(b).Count();
+                    return na < nb || (na == nb && a < b);
+                });
+
+                // Apply PostLinearize
+                std::vector<DepGraphIndex> post_lin = topo_lin;
+                PostLinearize(depgraph, post_lin);
+                SanityCheck(depgraph, post_lin);
+
+                // Find optimal linearization using Linearize
+                auto [opt_lin, optimal, cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng.rand64(), IndexTxOrder{});
+                BOOST_CHECK(optimal);
+                SanityCheck(depgraph, opt_lin);
+
+                // Compare chunk diagrams: PostLinearize result should be equal to optimal
+                auto post_chunks = ChunkLinearization(depgraph, post_lin);
+                auto opt_chunks = ChunkLinearization(depgraph, opt_lin);
+                auto cmp = CompareChunks(post_chunks, opt_chunks);
+
+                // PostLinearize should produce optimal result for tree graphs
+                BOOST_CHECK_MESSAGE(std::is_eq(cmp),
+                    "PostLinearize should find optimal linearization for tree-structured graphs. "
+                    "ntx=" << ntx << ", upright=" << upright << ", iter=" << iter);
+
+                // Verify that running PostLinearize again doesn't change the result
+                std::vector<DepGraphIndex> post_post_lin = post_lin;
+                PostLinearize(depgraph, post_post_lin);
+                auto post_post_chunks = ChunkLinearization(depgraph, post_post_lin);
+                auto cmp_post = CompareChunks(post_post_chunks, post_chunks);
+                BOOST_CHECK_MESSAGE(std::is_eq(cmp_post),
+                    "PostLinearize should be idempotent on tree-structured graphs. "
+                    "ntx=" << ntx << ", upright=" << upright << ", iter=" << iter);
+            }
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/cluster_linearize_tests.cpp
+++ b/src/test/cluster_linearize_tests.cpp
@@ -92,7 +92,7 @@ void TestOptimalLinearization(std::span<const uint8_t> enc, std::initializer_lis
                 is_topological = false;
                 break;
             }
-            std::tie(lin, opt, cost) = Linearize(depgraph, 1000000000000, rng.rand64(), IndexTxOrder{}, lin, is_topological);
+            std::tie(lin, opt, cost, std::ignore) = Linearize(depgraph, 1000000000000, rng.rand64(), IndexTxOrder{}, lin, is_topological);
             BOOST_CHECK(opt);
             BOOST_CHECK(cost <= MaxOptimalLinearizationIters(depgraph.TxCount()));
             SanityCheck(depgraph, lin);
@@ -556,7 +556,7 @@ BOOST_AUTO_TEST_CASE(postlinearize_tree_optimal_tests)
                 SanityCheck(depgraph, post_lin);
 
                 // Find optimal linearization using Linearize
-                auto [opt_lin, optimal, cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng.rand64(), IndexTxOrder{});
+                auto [opt_lin, optimal, cost, _is_chain] = Linearize(depgraph, /*max_iterations=*/10000000, rng.rand64(), IndexTxOrder{});
                 BOOST_CHECK(optimal);
                 SanityCheck(depgraph, opt_lin);
 
@@ -637,8 +637,9 @@ BOOST_AUTO_TEST_CASE(postlinearize_chain_optimal_tests)
             SanityCheck(depgraph, post_lin);
 
             // Find optimal linearization using Linearize
-            auto [opt_lin, optimal, cost] = Linearize(depgraph, /*max_iterations=*/10000000, rng.rand64(), IndexTxOrder{});
+            auto [opt_lin, optimal, cost, is_chain] = Linearize(depgraph, /*max_iterations=*/10000000, rng.rand64(), IndexTxOrder{});
             BOOST_CHECK(optimal);
+            BOOST_CHECK(is_chain);
             SanityCheck(depgraph, opt_lin);
 
             // Compare chunk diagrams: PostLinearize result should be equal to optimal

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -1044,7 +1044,7 @@ FUZZ_TARGET(clusterlin_linearize)
 
     // Invoke Linearize().
     iter_count &= 0x7ffff;
-    auto [linearization, optimal, cost] = Linearize(depgraph, iter_count, rng_seed, IndexTxOrder{}, old_linearization, /*is_topological=*/claim_topological_input);
+    auto [linearization, optimal, cost, _is_chain] = Linearize(depgraph, iter_count, rng_seed, IndexTxOrder{}, old_linearization, /*is_topological=*/claim_topological_input);
     SanityCheck(depgraph, linearization);
     auto chunking = ChunkLinearization(depgraph, linearization);
 
@@ -1145,7 +1145,7 @@ FUZZ_TARGET(clusterlin_linearize)
 
         // Redo from scratch with a different rng_seed. The resulting linearization should be
         // deterministic, if both are optimal.
-        auto [linearization2, optimal2, cost2] = Linearize(depgraph, MaxOptimalLinearizationIters(depgraph.TxCount()) + 1, rng_seed ^ 0x1337, IndexTxOrder{});
+        auto [linearization2, optimal2, cost2, _is_chain2] = Linearize(depgraph, MaxOptimalLinearizationIters(depgraph.TxCount()) + 1, rng_seed ^ 0x1337, IndexTxOrder{});
         assert(optimal2);
         assert(linearization2 == linearization);
     }
@@ -1236,7 +1236,7 @@ FUZZ_TARGET(clusterlin_postlinearize_tree)
 
     // Try to find an even better linearization directly. This must not change the diagram for the
     // same reason.
-    auto [opt_linearization, _optimal, _cost] = Linearize(depgraph_tree, 100000, rng_seed, IndexTxOrder{}, post_linearization);
+    auto [opt_linearization, _optimal, _cost, _is_chain] = Linearize(depgraph_tree, 100000, rng_seed, IndexTxOrder{}, post_linearization);
     auto opt_chunking = ChunkLinearization(depgraph_tree, opt_linearization);
     auto cmp_opt = CompareChunks(opt_chunking, post_chunking);
     assert(cmp_opt == 0);

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -1099,7 +1099,7 @@ FUZZ_TARGET(txgraph)
                 auto txid_b = sims[0].GetRef(b)->m_txid;
                 return txid_a <=> txid_b;
             };
-            auto [sim_lin, sim_optimal, _cost] = Linearize(sims[0].graph, 300000, rng.rand64(), fallback_order_sim, vec1);
+            auto [sim_lin, sim_optimal, _cost, _is_chain] = Linearize(sims[0].graph, 300000, rng.rand64(), fallback_order_sim, vec1);
             PostLinearize(sims[0].graph, sim_lin);
             auto sim_diagram = ChunkLinearization(sims[0].graph, sim_lin);
             auto cmp = CompareChunks(real_diagram, sim_diagram);

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -2161,17 +2161,20 @@ std::pair<uint64_t, bool> GenericClusterImpl::Relinearize(TxGraphImpl& graph, in
     Assume(!NeedsSplitting());
     // No work is required for Clusters which are already optimally linearized.
     if (IsOptimal()) return {0, false};
-    // Invoke the actual linearization algorithm (passing in the existing one).
+    // Invoke the linearization algorithm (passing in the existing one).
+    // For chain-shaped clusters Linearize() uses an O(N) fast path and signals is_chain=true,
+    // indicating that the result is already optimal — PostLinearize is not needed.
     uint64_t rng_seed = graph.m_rng.rand64();
     const auto fallback_order = [&](DepGraphIndex a, DepGraphIndex b) noexcept {
         const auto ref_a = graph.m_entries[m_mapping[a]].m_ref;
         const auto ref_b = graph.m_entries[m_mapping[b]].m_ref;
         return graph.m_fallback_order(*ref_a, *ref_b);
     };
-    auto [linearization, optimal, cost] = Linearize(m_depgraph, max_iters, rng_seed, fallback_order, m_linearization, /*is_topological=*/IsTopological());
+    auto [linearization, optimal, cost, is_chain] = Linearize(m_depgraph, max_iters, rng_seed, fallback_order, m_linearization, /*is_topological=*/IsTopological());
     // Postlinearize to improve the linearization (if optimal, only the sub-chunk order).
     // This also guarantees that all chunks are connected (even when non-optimal).
-    PostLinearize(m_depgraph, linearization);
+    // Skipped for chains: TryLinearizeChain already produces an optimal, connected result.
+    if (!is_chain) PostLinearize(m_depgraph, linearization);
     // Update the linearization.
     m_linearization = std::move(linearization);
     // Update the Cluster's quality.


### PR DESCRIPTION
This PR relies on PR https://github.com/bitcoin/bitcoin/pull/34625
## Summary                                                                       
                                                                                 
This PR adds `TryLinearizeChain()`, an O(N) specialised linearizer for chain-shaped
clusters, and a benchmark targeting the feerate distribution that triggers the worst-case
behaviour of the general SFL algorithm on chains.                                
                                                                                 
**Commits:**                                                                     
- `ad15466be1e4` cluster_linearize: add O(N) fast path for chain-shaped clusters 
- `72bf0faf820c` cluster_linearize: benchmark Linearize on worst-case chain feerate distribution
                                                                                 
---                                                                              
                                                                                 
## Motivation                                                                    
                                                                                 
Instrumentation added to a running node revealed that **virtually most cluster seen in the
mempool is chain-shaped** — each transaction spends an output of the previous one. This is
consistent with widespread use of CPFP (Child-Pays-For-Parent) fee bumping, where a
low-feerate parent transaction is paired with a high-feerate child that spends one of its
outputs, forming a two-transaction chain; longer chains arise from repeated CPFP stacking or
batch-payment patterns.                                                          
                                                                                 
Because chain clusters dominate in practice, a topology-specific O(N) fast path has
disproportionately large impact compared with optimising for rarer topologies.   
                                                                                 
The general `Linearize()` function uses the Spanning Forest Linearization (SFL) algorithm, whose
`MakeTopological()` phase merges chunks iteratively. For a chain cluster with N transactions
and strictly increasing individual feerates (fee_i = i+1), `MakeTopological` triggers a
cascade that merges the entire chain into one chunk step-by-step. At merge step k, two
operations each scan the growing top-part chunk of size k:                       
                                                                                 
- `UpdateChunk` iterates over all k transactions to write their `chunk_rep` (unconditionally,
  regardless of any inner-loop conditions).                                      
- `MergeChunks` iterates over all k transactions to locate the dependency connecting top and
  bottom chunks.                                                                 
                                                                                 
This accumulates O(1+2+...+(N-1)) = O(N²) loop iterations across the full cascade.
An O(N) specialised path avoids the SFL overhead entirely for chain-shaped clusters.
                                                                                 
---                                                                              
                                                                                 
## Algorithm                                                                     
                                                                                 
### Detection (`TryLinearizeChain`)                                              
                                                                                 
A cluster with N transactions is a chain if and only if its ancestor-set sizes form exactly
{1, 2, ..., N}. This is checked in O(N) using a boolean presence array;          
`Ancestors(i).Count()` is O(1) for the fixed-size `BitSet<64>` used here.        
                                                                                 
### Topological order                                                            
                                                                                 
The node with k ancestors occupies position k−1 in the unique topological order. Recovered
in O(N) by a single mapping pass.                                                
                                                                                 
### Why PostLinearize is not needed                                              
                                                                                 
The topological order of a chain cluster is unique, and every adjacent pair has a dependency,
so `ChunkLinearizationInfo`'s unconditional merge and `PostLinearize`'s merge/swap behave
identically (the swap branch never triggers). The topological order itself is the optimal
linearization, and `PostLinearize` can be safely skipped.                        
                                                                                 
The result is returned early from `Linearize()` before the SFL machinery is initialised:
                                                                                 
```cpp                                                                           
// In Linearize():                                                               
if (auto chain_lin = TryLinearizeChain(depgraph); !chain_lin.empty()) {          
    return {std::move(chain_lin), /*optimal=*/true, /*cost=*/0, /*is_chain=*/true};
}                                                                                
```                                                                              
                                                                                 
The fourth return value (`is_chain`) allows the caller (`Relinearize()`) to skip the
`PostLinearize()` pass, which is redundant for chains: `TryLinearizeChain` already
produces an optimal, connected linearization.                                    
                                                                                 
---                                                                              
                                                                                 
## Benchmark results                                                             
                                                                                 
### `LinearizeOptimallyMonotoneChainTotal` — increasing feerates (SFL worst case)
                                                                                 
`MakeMonotoneChainGraph` builds a chain with fee_i = i+1, size_i = 1. For the SFL
algorithm, every prefix of the chain has feerate (k+1)/2 (strictly increasing with length),
so `MakeTopological` must merge the entire chain into a single chunk through N−1 steps.
Each step scans the growing top-part chunk (via `UpdateChunk`'s unconditional `chunk_rep`
write loop and `MergeChunks`'s dep-search loop), accumulating O(N²) iterations in total.
`TryLinearizeChain` eliminates this entirely.                                    
                                                                                 
| Size | Before (ns/op) | After (ns/op) | Speedup |                              
|------|---------------|--------------|---------|                                
| 9 tx | 973 | 48 | **20×** |                                                    
| 16 tx | 1,772 | 72 | **25×** |                                                 
| 32 tx | 3,880 | 129 | **30×** |                                                
| 48 tx | 6,205 | 185 | **34×** |                                                
| 63 tx | 8,551 | 238 | **36×** |                                                
                                                                                 
Instructions per call after optimisation:                                        
                                                                                 
| N | Total instructions | Instructions/tx |                                     
|---|-------------------|----------------|                                       
| 9 | 954 | 106 |                                                                
| 16 | 1,360 | 85 |                                                              
| 32 | 2,295 | 72 |                                                              
| 48 | 3,230 | 67 |                                                              
| 63 | 4,100 | 65 |                                                              
                                                                                 
The "after" timings confirm that `TryLinearizeChain` runs in O(N) regardless of feerate
distribution (~65–106 instructions per transaction at N=9..63, constant converging as N
grows). The speedup grows with N because the baseline trends towards O(N²) while the
optimised path remains O(N).                                                     
