### PR TITLE
[RFC] `BlockMap` and `CChain` Concurrency Improvement

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,6 +179,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   addrman.cpp
   banman.cpp
   bip324.cpp
+  blockmap.cpp
   blockencodings.cpp
   blockfilter.cpp
   consensus/tx_verify.cpp

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -37,8 +37,7 @@ struct TestBlockAndIndex {
 
         stream >> TX_WITH_WITNESS(block);
 
-        blockHash = block.GetHash();
-        blockindex.phashBlock = &blockHash;
+        blockindex.m_block_hash = block.GetHash();
         blockindex.nBits = 403014710;
     }
 };

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -102,7 +102,7 @@ void generateFakeBlock(const CChainParams& params,
     }
 
     // notify wallet
-    const auto& pindex = WITH_LOCK(::cs_main, return context.chainman->ActiveChain().Tip());
+    const auto& pindex = context.chainman->ActiveChain().Tip();
     wallet.blockConnected(ChainstateRole{}, kernel::MakeBlockInfo(pindex, &block));
 }
 

--- a/src/blockmap.cpp
+++ b/src/blockmap.cpp
@@ -1,0 +1,167 @@
+#include <blockmap.h>
+
+#include <chain.h>
+#include <primitives/block.h>
+#include <uint256.h>
+
+#include <memory>
+#include <utility>
+
+std::pair<BlockMap::iterator, bool> BlockMap::try_emplace(const uint256& hash)
+{
+    auto it = find(hash);
+    if (it != end()) {
+        return {it, false};
+    }
+
+    if (m_impl.read().recent.size() > MAX_RECENT_SIZE) {
+        promote_all_recent();
+    }
+
+    auto block_ptr = std::make_shared<CBlockIndex>(hash);
+    return try_emplace_impl(hash, std::move(block_ptr));
+}
+
+std::pair<BlockMap::iterator, bool> BlockMap::try_emplace(const uint256& hash, const CBlockHeader& header)
+{
+    auto it = find(hash);
+    if (it != end()) {
+        return {it, false};
+    }
+
+    if (m_impl.read().recent.size() > MAX_RECENT_SIZE) {
+        promote_all_recent();
+    }
+
+    auto block_ptr = std::make_shared<CBlockIndex>(header);
+    return try_emplace_impl(hash, std::move(block_ptr));
+}
+
+BlockMap::iterator BlockMap::find(const uint256& hash)
+{
+    const auto& impl = m_impl.read();
+
+    auto recent_it = impl.recent.find(hash);
+    if (recent_it != impl.recent.end()) {
+        auto& stable_map = impl.stable.read();
+
+        return iterator(stable_map.end(), stable_map.end(),
+                        recent_it, impl.recent.end());
+    }
+
+    const auto& stable_map = impl.stable.read();
+    auto stable_it = stable_map.find(hash);
+    if (stable_it != stable_map.end()) {
+        return iterator(stable_it, stable_map.end(),
+                        impl.recent.begin(), impl.recent.end());
+    }
+
+    return end();
+}
+
+BlockMap::const_iterator BlockMap::find(const uint256& hash) const
+{
+    const auto& impl = m_impl.read();
+
+    auto recent_it = impl.recent.find(hash);
+    if (recent_it != impl.recent.end()) {
+        auto& stable_map = impl.stable.read();
+
+        return const_iterator(stable_map.end(), stable_map.end(),
+                              recent_it, impl.recent.end());
+    }
+
+    const auto& stable_map = impl.stable.read();
+    auto stable_it = stable_map.find(hash);
+    if (stable_it != stable_map.end()) {
+        return const_iterator(stable_it, stable_map.end(),
+                              impl.recent.begin(), impl.recent.end());
+    }
+
+    return end();
+}
+
+bool BlockMap::contains(const uint256& hash) const
+{
+    const auto& impl = m_impl.read();
+
+    if (impl.recent.contains(hash)) {
+        return true;
+    }
+
+    return impl.stable.read().contains(hash);
+}
+
+size_t BlockMap::size() const
+{
+    const auto& impl = m_impl.read();
+    return impl.stable.read().size() + impl.recent.size();
+}
+
+bool BlockMap::empty() const
+{
+    const auto& impl = m_impl.read();
+    return impl.stable.read().empty() && impl.recent.empty();
+}
+
+void BlockMap::promote_all_recent()
+{
+    auto& impl = m_impl.write();
+
+    if (impl.recent.empty()) {
+        return;
+    }
+
+    impl.stable.write(
+        [&](const InnerMap& old_stable) {
+            InnerMap new_stable = old_stable;
+            for (const auto& [hash, block_ptr] : impl.recent) {
+                new_stable.emplace(hash, block_ptr);
+            }
+            return new_stable;
+        },
+        [&](InnerMap& stable_map) {
+            for (const auto& [hash, block_ptr] : impl.recent) {
+                stable_map.emplace(hash, block_ptr);
+            }
+        });
+
+    impl.recent.clear();
+}
+
+BlockMap::iterator BlockMap::erase(iterator pos)
+{
+    if (pos == end()) {
+        return end();
+    }
+
+    auto& impl = m_impl.write();
+
+    if (pos.m_in_stable) {
+        uint256 hash = pos.m_stable_it->first;
+
+        impl.stable.write(
+            [&](const InnerMap& old_stable) {
+                InnerMap new_stable = old_stable;
+                new_stable.erase(hash);
+                return new_stable;
+            },
+            [&](InnerMap& stable_map) {
+                stable_map.erase(hash);
+            });
+
+        auto& stable_map = impl.stable.read();
+        auto next_stable_it = stable_map.find(hash);
+        if (next_stable_it == stable_map.end()) {
+            next_stable_it = stable_map.begin();
+        }
+
+        return iterator(next_stable_it, stable_map.end(),
+                        impl.recent.begin(), impl.recent.end());
+    } else {
+        auto next_it = impl.recent.erase(pos.m_recent_it);
+        auto& stable_map = impl.stable.read();
+        return iterator(stable_map.end(), stable_map.end(),
+                        next_it, impl.recent.end());
+    }
+}

--- a/src/blockmap.h
+++ b/src/blockmap.h
@@ -1,0 +1,395 @@
+#ifndef BITCOIN_BLOCKMAP_H
+#define BITCOIN_BLOCKMAP_H
+
+#include <chain.h>
+#include <primitives/block.h>
+#include <uint256.h>
+#include <util/copy_on_write.h>
+#include <util/hasher.h>
+
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+
+class BlockMap
+{
+private:
+    using BlockPtr = std::shared_ptr<CBlockIndex>;
+    using InnerMap = std::unordered_map<uint256, BlockPtr, BlockHasher>;
+
+    struct Impl {
+        stlab::copy_on_write<InnerMap> stable;
+
+        InnerMap recent;
+
+        Impl() = default;
+        Impl(InnerMap stable_map, InnerMap recent_map) : stable(std::move(stable_map)), recent(std::move(recent_map)) {}
+    };
+
+    stlab::copy_on_write<Impl> m_impl;
+
+    static constexpr size_t MAX_RECENT_SIZE = 1000;
+
+public:
+    class const_iterator;
+    class iterator
+    {
+        friend class BlockMap;
+        friend class const_iterator;
+
+    private:
+        InnerMap::const_iterator m_stable_it;
+        InnerMap::const_iterator m_stable_end;
+        InnerMap::const_iterator m_recent_it;
+        InnerMap::const_iterator m_recent_end;
+        bool m_in_stable;
+
+        mutable std::pair<uint256, CBlockIndex*> m_cached_value;
+
+        void update_cache() const
+        {
+            if (m_in_stable) {
+                m_cached_value = {m_stable_it->first, m_stable_it->second.get()};
+            } else {
+                m_cached_value = {m_recent_it->first, m_recent_it->second.get()};
+            }
+        }
+
+        void advance_if_at_end()
+        {
+            if (m_in_stable && m_stable_it == m_stable_end) {
+                m_in_stable = false;
+            }
+        }
+
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = std::pair<const uint256, CBlockIndex*>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+
+    public:
+        iterator() : m_in_stable(false), m_cached_value({uint256(), nullptr}) {}
+
+        iterator(InnerMap::const_iterator stable_begin, InnerMap::const_iterator stable_end,
+                 InnerMap::const_iterator recent_begin, InnerMap::const_iterator recent_end,
+                 bool at_end = false)
+            : m_stable_it(stable_begin), m_stable_end(stable_end), m_recent_it(recent_begin), m_recent_end(recent_end), m_in_stable(!at_end && stable_begin != stable_end), m_cached_value({uint256(), nullptr})
+        {
+            if (at_end) {
+                m_in_stable = false;
+                m_recent_it = recent_end;
+            } else if (m_in_stable || m_recent_it != m_recent_end) {
+                update_cache();
+            }
+        }
+
+        reference operator*() const
+        {
+            return reinterpret_cast<const value_type&>(m_cached_value);
+        }
+
+        pointer operator->() const
+        {
+            return reinterpret_cast<const value_type*>(&m_cached_value);
+        }
+
+        iterator& operator++()
+        {
+            if (m_in_stable) {
+                ++m_stable_it;
+                advance_if_at_end();
+            } else {
+                ++m_recent_it;
+            }
+
+            bool at_end = m_in_stable ? false : (m_recent_it == m_recent_end);
+            if (!at_end) {
+                update_cache();
+            }
+
+            return *this;
+        }
+
+        iterator operator++(int)
+        {
+            iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        bool operator==(const iterator& other) const
+        {
+            if (m_in_stable != other.m_in_stable) return false;
+            if (m_in_stable) {
+                return m_stable_it == other.m_stable_it;
+            } else {
+                return m_recent_it == other.m_recent_it;
+            }
+        }
+
+        bool operator!=(const iterator& other) const
+        {
+            return !(*this == other);
+        }
+    };
+
+    class const_iterator
+    {
+    private:
+        InnerMap::const_iterator m_stable_it;
+        InnerMap::const_iterator m_stable_end;
+        InnerMap::const_iterator m_recent_it;
+        InnerMap::const_iterator m_recent_end;
+        bool m_in_stable;
+
+        mutable std::pair<uint256, CBlockIndex*> m_cached_value;
+
+        void update_cache() const
+        {
+            if (m_in_stable) {
+                m_cached_value = {m_stable_it->first, m_stable_it->second.get()};
+            } else {
+                m_cached_value = {m_recent_it->first, m_recent_it->second.get()};
+            }
+        }
+
+        void advance_if_at_end()
+        {
+            if (m_in_stable && m_stable_it == m_stable_end) {
+                m_in_stable = false;
+            }
+        }
+
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = std::pair<const uint256, const CBlockIndex*>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+
+    public:
+        const_iterator() : m_in_stable(false), m_cached_value({uint256(), nullptr}) {}
+
+        const_iterator(InnerMap::const_iterator stable_begin, InnerMap::const_iterator stable_end,
+                       InnerMap::const_iterator recent_begin, InnerMap::const_iterator recent_end,
+                       bool at_end = false)
+            : m_stable_it(stable_begin), m_stable_end(stable_end), m_recent_it(recent_begin), m_recent_end(recent_end), m_in_stable(!at_end && stable_begin != stable_end), m_cached_value({uint256(), nullptr})
+        {
+            if (at_end) {
+                m_in_stable = false;
+                m_recent_it = recent_end;
+            } else if (m_in_stable || m_recent_it != m_recent_end) {
+                update_cache();
+            }
+        }
+
+        const_iterator(const iterator& other)
+            : m_stable_it(other.m_stable_it),
+              m_stable_end(other.m_stable_end),
+              m_recent_it(other.m_recent_it),
+              m_recent_end(other.m_recent_end),
+              m_in_stable(other.m_in_stable),
+              m_cached_value(other.m_cached_value)
+        {
+        }
+
+        reference operator*() const
+        {
+            return reinterpret_cast<const value_type&>(m_cached_value);
+        }
+
+        pointer operator->() const
+        {
+            return reinterpret_cast<const value_type*>(&m_cached_value);
+        }
+
+        const_iterator& operator++()
+        {
+            if (m_in_stable) {
+                ++m_stable_it;
+                advance_if_at_end();
+            } else {
+                ++m_recent_it;
+            }
+
+            bool at_end = m_in_stable ? false : (m_recent_it == m_recent_end);
+            if (!at_end) {
+                update_cache();
+            }
+
+            return *this;
+        }
+
+        const_iterator operator++(int)
+        {
+            const_iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        bool operator==(const const_iterator& other) const
+        {
+            if (m_in_stable != other.m_in_stable) return false;
+            if (m_in_stable) {
+                return m_stable_it == other.m_stable_it;
+            } else {
+                return m_recent_it == other.m_recent_it;
+            }
+        }
+
+        bool operator!=(const const_iterator& other) const
+        {
+            return !(*this == other);
+        }
+    };
+
+    iterator begin()
+    {
+        auto& impl = m_impl.read();
+        auto& stable_map = impl.stable.read();
+        return iterator(
+            stable_map.begin(), stable_map.end(),
+            impl.recent.begin(), impl.recent.end(),
+            false);
+    }
+
+    iterator end()
+    {
+        auto& impl = m_impl.read();
+        auto& stable_map = impl.stable.read();
+        return iterator(
+            stable_map.begin(), stable_map.end(),
+            impl.recent.begin(), impl.recent.end(),
+            true);
+    }
+
+    const_iterator begin() const
+    {
+        auto& impl = m_impl.read();
+        auto& stable_map = impl.stable.read();
+        return const_iterator(
+            stable_map.begin(), stable_map.end(),
+            impl.recent.begin(), impl.recent.end(),
+            false);
+    }
+
+    const_iterator end() const
+    {
+        auto& impl = m_impl.read();
+        auto& stable_map = impl.stable.read();
+        return const_iterator(
+            stable_map.begin(), stable_map.end(),
+            impl.recent.begin(), impl.recent.end(),
+            true);
+    }
+
+    const_iterator cbegin() const
+    {
+        return begin();
+    }
+
+    const_iterator cend() const
+    {
+        return end();
+    }
+
+    BlockMap() = default;
+    BlockMap(const BlockMap&) = default;
+    BlockMap& operator=(const BlockMap&) = default;
+    BlockMap(BlockMap&&) noexcept = default;
+    BlockMap& operator=(BlockMap&&) noexcept = default;
+
+    /**
+     * Insert a new block index (default constructed).
+     * Returns a pair of (pointer, inserted).
+     * If block already exists, returns (pointer to exisitng, false).
+     */
+    std::pair<iterator, bool> try_emplace(const uint256& hash);
+
+    /**
+     * Insert a new block index constructed from CBlockHeader.
+     * Returns pair of (pointer, inserted).
+     * If block already exists, returns (pointer to existing, false).
+     */
+    std::pair<iterator, bool> try_emplace(const uint256& hash, const CBlockHeader& header);
+
+    CBlockIndex* operator[](const uint256& hash)
+    {
+        auto [it, inserted] = try_emplace(hash);
+        return it->second;
+    }
+
+    /**
+     * Find a block index by hash.
+     * Returns mutable pointer (for use under cs_main lock).
+     */
+    iterator find(const uint256& hash);
+
+    /**
+     * Find a block index by hash (const version).
+     * Safe to use with snapshots.
+     */
+    const_iterator find(const uint256& hash) const;
+
+    /**
+     * Chec if block exists in the map.
+     */
+    bool contains(const uint256& hash) const;
+
+    /**
+     * Check if the map is empty (no blocks in stable or recent).
+     */
+    bool empty() const;
+
+    /**
+     * Get total number of blocks.
+     */
+    size_t size() const;
+
+    /**
+     * Erase a block at iterator position.
+     * Returns iterator to the element following the erased element.
+     * If pos == end(), returns end().
+     * */
+    iterator erase(iterator pos);
+
+private:
+    template <typename BlockPtrType>
+    std::pair<iterator, bool> try_emplace_impl(const uint256& hash, BlockPtrType&& block_ptr)
+    {
+        auto& impl = m_impl.write();
+        const auto& stable_map = impl.stable.read();
+
+        auto stable_it = stable_map.find(hash);
+        if (stable_it != stable_map.end()) {
+            return {iterator(stable_it, stable_map.end(),
+                             impl.recent.begin(), impl.recent.end()),
+                    false};
+        }
+
+        auto recent_it = impl.recent.find(hash);
+        if (recent_it != impl.recent.end()) {
+            return {iterator(stable_map.end(), stable_map.end(),
+                             recent_it, impl.recent.end()),
+                    false};
+        }
+
+        auto [it, inserted] = impl.recent.emplace(hash, std::forward<BlockPtrType>(block_ptr));
+
+        return {iterator(stable_map.end(), stable_map.end(),
+                         it, impl.recent.end()),
+                inserted};
+    }
+
+    /**
+     * Promote all blocks from recent to stable.
+     * Called when recent exceeds MAX_RECENT_SIZE threshold.
+     */
+    void promote_all_recent();
+};
+
+
+#endif // BITCOIN_BLOCKMAP_H

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -4,6 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
+
+#include <sync.h>
 #include <tinyformat.h>
 #include <util/check.h>
 
@@ -13,8 +15,9 @@ std::string CBlockIndex::ToString() const
                      pprev, nHeight, hashMerkleRoot.ToString(), GetBlockHash().ToString());
 }
 
-void CChain::SetTip(CBlockIndex& block)
+void CChain::SetTip(CBlockIndex& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
 {
+    LOCK(m_mutex);
     CBlockIndex* pindex = &block;
     vChain.resize(pindex->nHeight + 1);
     while (pindex && vChain[pindex->nHeight] != pindex) {
@@ -47,19 +50,31 @@ CBlockLocator GetLocator(const CBlockIndex* index)
     return CBlockLocator{LocatorEntries(index)};
 }
 
-const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
+const CBlockIndex* CChain::FindFork(const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+{
+    LOCK(m_mutex);
     if (pindex == nullptr) {
         return nullptr;
     }
-    if (pindex->nHeight > Height())
-        pindex = pindex->GetAncestor(Height());
-    while (pindex && !Contains(pindex))
+
+    int height = int(vChain.size()) - 1;
+    if (pindex->nHeight > height)
+        pindex = pindex->GetAncestor(height);
+
+    while (pindex) {
+        if (pindex->nHeight >= 0 && pindex->nHeight < (int)vChain.size() &&
+            vChain[pindex->nHeight] == pindex) {
+            break;
+        }
         pindex = pindex->pprev;
+    }
+
     return pindex;
 }
 
-CBlockIndex* CChain::FindEarliestAtLeast(int64_t nTime, int height) const
+CBlockIndex* CChain::FindEarliestAtLeast(int64_t nTime, int height) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
 {
+    LOCK(m_mutex);
     std::pair<int64_t, int> blockparams = std::make_pair(nTime, height);
     std::vector<CBlockIndex*>::const_iterator lower = std::lower_bound(vChain.begin(), vChain.end(), blockparams,
         [](CBlockIndex* pBlock, const std::pair<int64_t, int>& blockparams) -> bool { return pBlock->GetBlockTimeMax() < blockparams.first || pBlock->nHeight < blockparams.second; });

--- a/src/chain.h
+++ b/src/chain.h
@@ -93,8 +93,7 @@ enum BlockStatus : uint32_t {
 class CBlockIndex
 {
 public:
-    //! pointer to the hash of the block, if any. Memory is owned by this CBlockIndex
-    const uint256* phashBlock{nullptr};
+    uint256 m_block_hash;
 
     //! pointer to the index of the predecessor of this block
     CBlockIndex* pprev{nullptr};
@@ -151,13 +150,19 @@ public:
     //! (memory only) Maximum nTime in the chain up to and including this block.
     unsigned int nTimeMax{0};
 
-    explicit CBlockIndex(const CBlockHeader& block)
-        : nVersion{block.nVersion},
-          hashMerkleRoot{block.hashMerkleRoot},
-          nTime{block.nTime},
-          nBits{block.nBits},
-          nNonce{block.nNonce}
+    explicit CBlockIndex(const uint256& hash)
+        : m_block_hash{hash}
     {
+    }
+
+    explicit CBlockIndex(const CBlockHeader& block)
+        : CBlockIndex(block.GetHash())
+    {
+        nVersion = block.nVersion;
+        hashMerkleRoot = block.hashMerkleRoot;
+        nTime = block.nTime;
+        nBits = block.nBits;
+        nNonce = block.nNonce;
     }
 
     FlatFilePos GetBlockPos() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
@@ -197,8 +202,7 @@ public:
 
     uint256 GetBlockHash() const
     {
-        assert(phashBlock != nullptr);
-        return *phashBlock;
+        return m_block_hash;
     }
 
     /**

--- a/src/chain.h
+++ b/src/chain.h
@@ -13,6 +13,7 @@
 #include <primitives/block.h>
 #include <serialize.h>
 #include <sync.h>
+#include <threadsafety.h>
 #include <uint256.h>
 #include <util/time.h>
 
@@ -383,7 +384,8 @@ public:
 class CChain
 {
 private:
-    std::vector<CBlockIndex*> vChain;
+    std::vector<CBlockIndex*> vChain GUARDED_BY(m_mutex);
+    mutable Mutex m_mutex;
 
 public:
     CChain() = default;
@@ -391,63 +393,80 @@ public:
     CChain& operator=(const CChain&) = delete;
 
     /** Returns the index entry for the genesis block of this chain, or nullptr if none. */
-    CBlockIndex* Genesis() const
+    CBlockIndex* Genesis() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
+        LOCK(m_mutex);
         return vChain.size() > 0 ? vChain[0] : nullptr;
     }
 
     /** Returns the index entry for the tip of this chain, or nullptr if none. */
-    CBlockIndex* Tip() const
+    CBlockIndex* Tip() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
+        LOCK(m_mutex);
         return vChain.size() > 0 ? vChain[vChain.size() - 1] : nullptr;
     }
 
     /** Returns the index entry at a particular height in this chain, or nullptr if no such height exists. */
-    CBlockIndex* operator[](int nHeight) const
+    CBlockIndex* operator[](int nHeight) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
+        LOCK(m_mutex);
         if (nHeight < 0 || nHeight >= (int)vChain.size())
             return nullptr;
         return vChain[nHeight];
     }
 
     /** Efficiently check whether a block is present in this chain. */
-    bool Contains(const CBlockIndex* pindex) const
+    bool Contains(const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
-        return (*this)[pindex->nHeight] == pindex;
+        LOCK(m_mutex);
+        if (pindex->nHeight < 0 || pindex->nHeight >= (int)vChain.size())
+            return false;
+        return vChain[pindex->nHeight] == pindex;
     }
 
     /** Find the successor of a block in this chain, or nullptr if the given index is not found or is the tip. */
-    CBlockIndex* Next(const CBlockIndex* pindex) const
+    CBlockIndex* Next(const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
-        if (Contains(pindex))
-            return (*this)[pindex->nHeight + 1];
-        else
+        LOCK(m_mutex);
+
+        if (pindex->nHeight < 0 || pindex->nHeight >= (int)vChain.size())
             return nullptr;
+
+        if (vChain[pindex->nHeight] != pindex)
+            return nullptr;
+
+        // Check if there's a next block
+        if (pindex->nHeight + 1 >= (int)vChain.size())
+            return nullptr;
+
+        return vChain[pindex->nHeight + 1];
     }
 
     /** Return the maximal height in the chain. Is equal to chain.Tip() ? chain.Tip()->nHeight : -1. */
-    int Height() const
+    int Height() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
+        LOCK(m_mutex);
         return int(vChain.size()) - 1;
     }
 
     /** Check whether this chain's tip exists, has enough work, and is recent. */
-    bool IsTipRecent(const arith_uint256& min_chain_work, std::chrono::seconds max_tip_age) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    bool IsTipRecent(const arith_uint256& min_chain_work, std::chrono::seconds max_tip_age) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
-        const auto tip{Tip()};
+        LOCK(m_mutex);
+        const auto tip = vChain.size() > 0 ? vChain[vChain.size() - 1] : nullptr;
         return tip &&
                tip->nChainWork >= min_chain_work &&
                tip->Time() >= Now<NodeSeconds>() - max_tip_age;
     }
 
     /** Set/initialize a chain with a given tip. */
-    void SetTip(CBlockIndex& block);
+    void SetTip(CBlockIndex& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Find the last common block between this chain and a block index entry. */
-    const CBlockIndex* FindFork(const CBlockIndex* pindex) const;
+    const CBlockIndex* FindFork(const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Find the earliest block with timestamp equal or greater than the given time and height equal or greater than the given height. */
-    CBlockIndex* FindEarliestAtLeast(int64_t nTime, int height) const;
+    CBlockIndex* FindEarliestAtLeast(int64_t nTime, int height) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 };
 
 /** Get a locator for a block index entry. */

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -390,10 +390,7 @@ void BaseIndex::ChainStateFlushed(const ChainstateRole& role, const CBlockLocato
 
     const uint256& locator_tip_hash = locator.vHave.front();
     const CBlockIndex* locator_tip_index;
-    {
-        LOCK(cs_main);
-        locator_tip_index = m_chainstate->m_blockman.LookupBlockIndex(locator_tip_hash);
-    }
+    locator_tip_index = m_chainstate->m_blockman.LookupBlockIndex(locator_tip_hash);
 
     if (!locator_tip_index) {
         FatalErrorf("First block (hash=%s) in locator was not found",

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -118,7 +118,6 @@ bool BaseIndex::Init()
 
     const auto locator{GetDB().ReadBestBlock()};
 
-    LOCK(cs_main);
     CChain& index_chain = m_chainstate->m_chain;
 
     if (locator.IsNull()) {

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -420,21 +420,14 @@ void BaseIndex::ChainStateFlushed(const ChainstateRole& role, const CBlockLocato
 
 bool BaseIndex::BlockUntilSyncedToCurrentChain() const
 {
-    AssertLockNotHeld(cs_main);
-
     if (!m_synced) {
         return false;
     }
 
-    {
-        // Skip the queue-draining stuff if we know we're caught up with
-        // m_chain.Tip().
-        LOCK(cs_main);
-        const CBlockIndex* chain_tip = m_chainstate->m_chain.Tip();
-        const CBlockIndex* best_block_index = m_best_block_index.load();
-        if (best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
-            return true;
-        }
+    const CBlockIndex* chain_tip = m_chainstate->m_chain.Tip();
+    const CBlockIndex* best_block_index = m_best_block_index.load();
+    if (best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
+        return true;
     }
 
     LogInfo("%s is catching up on block notifications", GetName());

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -147,10 +147,8 @@ bool BaseIndex::Init()
     return true;
 }
 
-static const CBlockIndex* NextSyncBlock(const CBlockIndex* pindex_prev, CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+static const CBlockIndex* NextSyncBlock(const CBlockIndex* pindex_prev, CChain& chain)
 {
-    AssertLockHeld(cs_main);
-
     if (!pindex_prev) {
         return chain.Genesis();
     }
@@ -216,7 +214,7 @@ void BaseIndex::Sync()
                 return;
             }
 
-            const CBlockIndex* pindex_next = WITH_LOCK(cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain));
+            const CBlockIndex* pindex_next = NextSyncBlock(pindex, m_chainstate->m_chain);
             // If pindex_next is null, it means pindex is the chain tip, so
             // commit data indexed so far.
             if (!pindex_next) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2343,13 +2343,9 @@ bool StartIndexBackgroundSync(NodeContext& node)
             if (summary.synced) continue;
 
             // Get the last common block between the index best block and the active chain
-            const CBlockIndex* pindex = nullptr;
-            {
-                LOCK(::cs_main);
-                pindex = chainman.m_blockman.LookupBlockIndex(summary.best_block_hash);
-                if (!index_chain.Contains(pindex)) {
-                    pindex = index_chain.FindFork(pindex);
-                }
+            const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(summary.best_block_hash);
+            if (!index_chain.Contains(pindex)) {
+                pindex = index_chain.FindFork(pindex);
             }
             if (!pindex) {
                 pindex = index_chain.Genesis();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1964,7 +1964,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         return false;
     }
 
-    int chain_active_height = WITH_LOCK(cs_main, return chainman.ActiveChain().Height());
+    int chain_active_height = chainman.ActiveChain().Height();
 
     // On first startup, warn on low block storage space
     if (!do_reindex && !do_reindex_chainstate && chain_active_height <= 1) {

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(bitcoinkernel
   disconnected_transactions.cpp
   mempool_removal_reason.cpp
   ../arith_uint256.cpp
+  ../blockmap.cpp
   ../chain.cpp
   ../coins.cpp
   ../compressor.cpp

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1169,7 +1169,7 @@ int32_t btck_block_tree_entry_get_height(const btck_BlockTreeEntry* entry)
 
 const btck_BlockHash* btck_block_tree_entry_get_block_hash(const btck_BlockTreeEntry* entry)
 {
-    return btck_BlockHash::ref(btck_BlockTreeEntry::get(entry).phashBlock);
+    return btck_BlockHash::ref(&btck_BlockTreeEntry::get(entry).m_block_hash);
 }
 
 int btck_block_tree_entry_equals(const btck_BlockTreeEntry* entry1, const btck_BlockTreeEntry* entry2)

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1035,8 +1035,7 @@ btck_ChainstateManager* btck_chainstate_manager_create(
 
 const btck_BlockTreeEntry* btck_chainstate_manager_get_block_tree_entry_by_hash(const btck_ChainstateManager* chainman, const btck_BlockHash* block_hash)
 {
-    auto block_index = WITH_LOCK(btck_ChainstateManager::get(chainman).m_chainman->GetMutex(),
-                                 return btck_ChainstateManager::get(chainman).m_chainman->m_blockman.LookupBlockIndex(btck_BlockHash::get(block_hash)));
+    auto block_index = btck_ChainstateManager::get(chainman).m_chainman->m_blockman.LookupBlockIndex(btck_BlockHash::get(block_hash));
     if (!block_index) {
         LogDebug(BCLog::KERNEL, "A block with the given hash is not indexed.");
         return nullptr;

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1320,19 +1320,16 @@ const btck_Chain* btck_chainstate_manager_get_active_chain(const btck_Chainstate
 
 int btck_chain_get_height(const btck_Chain* chain)
 {
-    LOCK(::cs_main);
     return btck_Chain::get(chain).Height();
 }
 
 const btck_BlockTreeEntry* btck_chain_get_by_height(const btck_Chain* chain, int height)
 {
-    LOCK(::cs_main);
     return btck_BlockTreeEntry::ref(btck_Chain::get(chain)[height]);
 }
 
 int btck_chain_contains(const btck_Chain* chain, const btck_BlockTreeEntry* entry)
 {
-    LOCK(::cs_main);
     return btck_Chain::get(chain).Contains(&btck_BlockTreeEntry::get(entry)) ? 1 : 0;
 }
 

--- a/src/kernel/chain.cpp
+++ b/src/kernel/chain.cpp
@@ -17,9 +17,9 @@ using kernel::ChainstateRole;
 namespace kernel {
 interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data)
 {
-    interfaces::BlockInfo info{index ? *index->phashBlock : uint256::ZERO};
+    interfaces::BlockInfo info{index ? index->m_block_hash : uint256::ZERO};
     if (index) {
-        info.prev_hash = index->pprev ? index->pprev->phashBlock : nullptr;
+        info.prev_hash = index->pprev ? &index->pprev->m_block_hash : nullptr;
         info.height = index->nHeight;
         info.chain_time_max = index->GetBlockTimeMax();
         LOCK(::cs_main);

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -13,12 +13,10 @@
 #include <script/script.h>
 #include <span.h>
 #include <streams.h>
-#include <sync.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/log.h>
 #include <util/overflow.h>
-#include <validation.h>
 
 #include <map>
 #include <memory>
@@ -149,7 +147,7 @@ static bool ComputeUTXOStats(CCoinsView* view, CCoinsStats& stats, T hash_obj, c
 
 std::optional<CCoinsStats> ComputeUTXOStats(CoinStatsHashType hash_type, CCoinsView* view, node::BlockManager& blockman, const std::function<void()>& interruption_point)
 {
-    CBlockIndex* pindex = WITH_LOCK(::cs_main, return blockman.LookupBlockIndex(view->GetBestBlock()));
+    CBlockIndex* pindex = blockman.LookupBlockIndex(view->GetBestBlock());
     CCoinsStats stats{Assert(pindex)->nHeight, pindex->GetBlockHash()};
 
     bool success = [&]() -> bool {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3026,7 +3026,7 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
     }
 
     // Do these headers connect to something in our block index?
-    const CBlockIndex *chain_start_header{WITH_LOCK(::cs_main, return m_chainman.m_blockman.LookupBlockIndex(headers[0].hashPrevBlock))};
+    const CBlockIndex* chain_start_header = m_chainman.m_blockman.LookupBlockIndex(headers[0].hashPrevBlock);
     bool headers_connect_blockindex{chain_start_header != nullptr};
 
     if (!headers_connect_blockindex) {
@@ -4867,7 +4867,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
         LogDebug(BCLog::NET, "received block %s peer=%d\n", pblock->GetHash().ToString(), pfrom.GetId());
 
-        const CBlockIndex* prev_block{WITH_LOCK(m_chainman.GetMutex(), return m_chainman.m_blockman.LookupBlockIndex(pblock->hashPrevBlock))};
+        const CBlockIndex* prev_block = m_chainman.m_blockman.LookupBlockIndex(pblock->hashPrevBlock);
 
         // Check for possible mutation if it connects to something we know so we can check for DEPLOYMENT_SEGWIT being active
         if (prev_block && IsBlockMutated(/*block=*/*pblock,

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2635,9 +2635,8 @@ bool PeerManagerImpl::CheckHeadersPoW(const std::vector<CBlockHeader>& headers, 
 arith_uint256 PeerManagerImpl::GetAntiDoSWorkThreshold()
 {
     arith_uint256 near_chaintip_work = 0;
-    LOCK(cs_main);
+    const CBlockIndex* tip = m_chainman.ActiveChain().Tip();
     if (m_chainman.ActiveChain().Tip() != nullptr) {
-        const CBlockIndex *tip = m_chainman.ActiveChain().Tip();
         // Use a 144 block buffer, so that we'll accept headers that fork from
         // near our tip.
         near_chaintip_work = tip->nChainWork - std::min<arith_uint256>(144*GetBlockProof(*tip), tip->nChainWork);

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -202,7 +202,7 @@ std::vector<CBlockIndex*> BlockManager::GetAllBlockIndices()
     std::vector<CBlockIndex*> rv;
     rv.reserve(m_block_index.size());
     for (auto& [_, block_index] : m_block_index) {
-        rv.push_back(&block_index);
+        rv.push_back(block_index);
     }
     return rv;
 }
@@ -211,14 +211,14 @@ CBlockIndex* BlockManager::LookupBlockIndex(const uint256& hash)
 {
     AssertLockHeld(cs_main);
     BlockMap::iterator it = m_block_index.find(hash);
-    return it == m_block_index.end() ? nullptr : &it->second;
+    return it == m_block_index.end() ? nullptr : it->second;
 }
 
 const CBlockIndex* BlockManager::LookupBlockIndex(const uint256& hash) const
 {
     AssertLockHeld(cs_main);
     BlockMap::const_iterator it = m_block_index.find(hash);
-    return it == m_block_index.end() ? nullptr : &it->second;
+    return it == m_block_index.end() ? nullptr : it->second;
 }
 
 CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block, CBlockIndex*& best_header)
@@ -227,19 +227,18 @@ CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block, CBlockInde
 
     auto [mi, inserted] = m_block_index.try_emplace(block.GetHash(), block);
     if (!inserted) {
-        return &mi->second;
+        return mi->second;
     }
-    CBlockIndex* pindexNew = &(*mi).second;
+    CBlockIndex* pindexNew = mi->second;
 
     // We assign the sequence id to blocks only when the full data is available,
     // to avoid miners withholding blocks but broadcasting headers, to get a
     // competitive advantage.
     pindexNew->nSequenceId = SEQ_ID_INIT_FROM_DISK;
 
-    pindexNew->m_block_hash = ((*mi).first);
     BlockMap::iterator miPrev = m_block_index.find(block.hashPrevBlock);
     if (miPrev != m_block_index.end()) {
-        pindexNew->pprev = &(*miPrev).second;
+        pindexNew->pprev = (*miPrev).second;
         pindexNew->nHeight = pindexNew->pprev->nHeight + 1;
         pindexNew->BuildSkip();
     }
@@ -261,7 +260,7 @@ void BlockManager::PruneOneBlockFile(const int fileNumber)
     LOCK(cs_LastBlockFile);
 
     for (auto& entry : m_block_index) {
-        CBlockIndex* pindex = &entry.second;
+        CBlockIndex* pindex = entry.second;
         if (pindex->nFile == fileNumber) {
             pindex->nStatus &= ~BLOCK_HAVE_DATA;
             pindex->nStatus &= ~BLOCK_HAVE_UNDO;
@@ -413,10 +412,7 @@ CBlockIndex* BlockManager::InsertBlockIndex(const uint256& hash)
     }
 
     const auto [mi, inserted]{m_block_index.try_emplace(hash)};
-    CBlockIndex* pindex = &(*mi).second;
-    if (inserted) {
-        pindex->m_block_hash = ((*mi).first);
-    }
+    CBlockIndex* pindex = (*mi).second;
     return pindex;
 }
 
@@ -554,8 +550,8 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     LogInfo("Checking all blk files are present...");
     std::set<int> setBlkDataFiles;
     for (const auto& [_, block_index] : m_block_index) {
-        if (block_index.nStatus & BLOCK_HAVE_DATA) {
-            setBlkDataFiles.insert(block_index.nFile);
+        if (block_index->nStatus & BLOCK_HAVE_DATA) {
+            setBlkDataFiles.insert(block_index->nFile);
         }
     }
     for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++) {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -236,7 +236,7 @@ CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block, CBlockInde
     // competitive advantage.
     pindexNew->nSequenceId = SEQ_ID_INIT_FROM_DISK;
 
-    pindexNew->phashBlock = &((*mi).first);
+    pindexNew->m_block_hash = ((*mi).first);
     BlockMap::iterator miPrev = m_block_index.find(block.hashPrevBlock);
     if (miPrev != m_block_index.end()) {
         pindexNew->pprev = &(*miPrev).second;
@@ -415,7 +415,7 @@ CBlockIndex* BlockManager::InsertBlockIndex(const uint256& hash)
     const auto [mi, inserted]{m_block_index.try_emplace(hash)};
     CBlockIndex* pindex = &(*mi).second;
     if (inserted) {
-        pindex->phashBlock = &((*mi).first);
+        pindex->m_block_hash = ((*mi).first);
     }
     return pindex;
 }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -6,6 +6,7 @@
 #define BITCOIN_NODE_BLOCKSTORAGE_H
 
 #include <attributes.h>
+#include <blockmap.h>
 #include <chain.h>
 #include <dbwrapper.h>
 #include <flatfile.h>
@@ -20,7 +21,6 @@
 #include <uint256.h>
 #include <util/expected.h>
 #include <util/fs.h>
-#include <util/hasher.h>
 #include <util/obfuscation.h>
 
 #include <algorithm>
@@ -127,12 +127,6 @@ static constexpr uint32_t STORAGE_HEADER_BYTES{std::tuple_size_v<MessageStartCha
 
 /** Total overhead when writing undo data: header (8 bytes) plus checksum (32 bytes) */
 static constexpr uint32_t UNDO_DATA_DISK_OVERHEAD{STORAGE_HEADER_BYTES + uint256::size()};
-
-// Because validation code takes pointers to the map's CBlockIndex objects, if
-// we ever switch to another associative container, we need to either use a
-// container that has stable addressing (true of all std associative
-// containers), or make the key a `std::unique_ptr<CBlockIndex>`
-using BlockMap = std::unordered_map<uint256, CBlockIndex, BlockHasher>;
 
 struct CBlockIndexWorkComparator {
     bool operator()(const CBlockIndex* pa, const CBlockIndex* pb) const;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -297,6 +297,8 @@ private:
     const FlatFileSeq m_block_file_seq;
     const FlatFileSeq m_undo_file_seq;
 
+    mutable Mutex m_block_index_mutex;
+
 protected:
     std::vector<CBlockFileInfo> m_blockfile_info;
 
@@ -323,7 +325,7 @@ public:
      */
     std::atomic_bool m_blockfiles_indexed{true};
 
-    BlockMap m_block_index GUARDED_BY(cs_main);
+    BlockMap m_block_index;
 
     /**
      * The height of the base block of an assumeutxo snapshot, if one is in use.
@@ -339,7 +341,7 @@ public:
      */
     std::optional<int> m_snapshot_height;
 
-    std::vector<CBlockIndex*> GetAllBlockIndices() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    std::vector<CBlockIndex*> GetAllBlockIndices();
 
     /**
      * All pairs A->B, where A (or one of its ancestors) misses transactions, but B has transactions.
@@ -360,15 +362,15 @@ public:
      */
     void ScanAndUnlinkAlreadyPrunedFiles() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    CBlockIndex* AddToBlockIndex(const CBlockHeader& block, CBlockIndex*& best_header) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    CBlockIndex* AddToBlockIndex(const CBlockHeader& block, CBlockIndex*& best_header) EXCLUSIVE_LOCKS_REQUIRED(!m_block_index_mutex);
     /** Create a new block index entry for a given block hash */
-    CBlockIndex* InsertBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    CBlockIndex* InsertBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(!m_block_index_mutex);
 
     //! Mark one block file as pruned (modify associated database entries)
     void PruneOneBlockFile(int fileNumber) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    CBlockIndex* LookupBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    const CBlockIndex* LookupBlockIndex(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    CBlockIndex* LookupBlockIndex(const uint256& hash);
+    const CBlockIndex* LookupBlockIndex(const uint256& hash) const;
 
     /** Get block file info entry for one block file */
     CBlockFileInfo* GetBlockFileInfo(size_t n);
@@ -468,6 +470,11 @@ public:
     bool ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index) const;
 
     void CleanupBlockRevFiles() const;
+
+    BlockMap GetBlockIndexSnapshot() const
+    {
+        return m_block_index;
+    }
 };
 
 // Calls ActivateBestChain() even if no blocks are imported.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -580,7 +580,7 @@ public:
         if (!block_filter_index) return std::nullopt;
 
         BlockFilter filter;
-        const CBlockIndex* index{WITH_LOCK(::cs_main, return chainman().m_blockman.LookupBlockIndex(block_hash))};
+        const CBlockIndex* index = chainman().m_blockman.LookupBlockIndex(block_hash);
         if (index == nullptr || !block_filter_index->LookupFilter(index, filter)) return std::nullopt;
         return filter.GetFilter().MatchAny(filter_set);
     }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -305,12 +305,11 @@ public:
     }
     int getNumBlocks() override
     {
-        LOCK(::cs_main);
         return chainman().ActiveChain().Height();
     }
     uint256 getBestBlockHash() override
     {
-        const CBlockIndex* tip = WITH_LOCK(::cs_main, return chainman().ActiveChain().Tip());
+        const CBlockIndex* tip = chainman().ActiveChain().Tip();
         return tip ? tip->GetBlockHash() : chainman().GetParams().GenesisBlock().GetHash();
     }
     int64_t getLastBlockTime() override
@@ -553,7 +552,6 @@ public:
     }
     uint256 getBlockHash(int height) override
     {
-        LOCK(::cs_main);
         return Assert(chainman().ActiveChain()[height])->GetBlockHash();
     }
     bool haveBlockOnDisk(int height) override
@@ -782,7 +780,10 @@ public:
     }
     void waitForNotificationsIfTipChanged(const uint256& old_tip) override
     {
-        if (!old_tip.IsNull() && old_tip == WITH_LOCK(::cs_main, return chainman().ActiveChain().Tip()->GetBlockHash())) return;
+        if (!old_tip.IsNull()) {
+            const CBlockIndex* tip = chainman().ActiveChain().Tip();
+            if (tip && old_tip == tip->GetBlockHash()) return;
+        }
         validation_signals().SyncWithValidationInterfaceQueue();
     }
     void waitForNotifications() override

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -70,7 +70,7 @@ void RegenerateCommitments(CBlock& block, ChainstateManager& chainman)
     tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
     block.vtx.at(0) = MakeTransactionRef(tx);
 
-    const CBlockIndex* prev_block = WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(block.hashPrevBlock));
+    const CBlockIndex* prev_block = chainman.m_blockman.LookupBlockIndex(block.hashPrevBlock);
     chainman.GenerateCoinbaseCommitment(block, prev_block);
 
     block.hashMerkleRoot = BlockMerkleRoot(block);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -336,7 +336,7 @@ static bool rest_spent_txouts(const std::any& context, HTTPRequest* req, const s
         return false;
     }
 
-    const CBlockIndex* pblockindex = WITH_LOCK(cs_main, return chainman->m_blockman.LookupBlockIndex(*hash));
+    const CBlockIndex* pblockindex = chainman->m_blockman.LookupBlockIndex(*hash);
     if (!pblockindex) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -1104,7 +1104,6 @@ static bool rest_blockhash_by_height(const std::any& context, HTTPRequest* req,
         ChainstateManager* maybe_chainman = GetChainman(context, req);
         if (!maybe_chainman) return false;
         ChainstateManager& chainman = *maybe_chainman;
-        LOCK(cs_main);
         const CChain& active_chain = chainman.ActiveChain();
         if (*blockheight > active_chain.Height()) {
             return RESTERR(req, HTTP_NOT_FOUND, "Block height out of range");

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -219,18 +219,15 @@ static bool rest_headers(const std::any& context,
     ChainstateManager* maybe_chainman = GetChainman(context, req);
     if (!maybe_chainman) return false;
     ChainstateManager& chainman = *maybe_chainman;
-    {
-        LOCK(cs_main);
-        CChain& active_chain = chainman.ActiveChain();
-        tip = active_chain.Tip();
-        const CBlockIndex* pindex{chainman.m_blockman.LookupBlockIndex(*hash)};
-        while (pindex != nullptr && active_chain.Contains(pindex)) {
-            headers.push_back(pindex);
-            if (headers.size() == *parsed_count) {
-                break;
-            }
-            pindex = active_chain.Next(pindex);
+    CChain& active_chain = chainman.ActiveChain();
+    tip = active_chain.Tip();
+    const CBlockIndex* pindex{chainman.m_blockman.LookupBlockIndex(*hash)};
+    while (pindex != nullptr && active_chain.Contains(pindex)) {
+        headers.push_back(pindex);
+        if (headers.size() == *parsed_count) {
+            break;
         }
+        pindex = active_chain.Next(pindex);
     }
 
     switch (rf) {
@@ -544,19 +541,16 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
 
     std::vector<const CBlockIndex*> headers;
     headers.reserve(*parsed_count);
-    {
-        ChainstateManager* maybe_chainman = GetChainman(context, req);
-        if (!maybe_chainman) return false;
-        ChainstateManager& chainman = *maybe_chainman;
-        LOCK(cs_main);
-        CChain& active_chain = chainman.ActiveChain();
-        const CBlockIndex* pindex{chainman.m_blockman.LookupBlockIndex(*block_hash)};
-        while (pindex != nullptr && active_chain.Contains(pindex)) {
-            headers.push_back(pindex);
-            if (headers.size() == *parsed_count)
-                break;
-            pindex = active_chain.Next(pindex);
-        }
+    ChainstateManager* maybe_chainman = GetChainman(context, req);
+    if (!maybe_chainman) return false;
+    ChainstateManager& chainman = *maybe_chainman;
+    CChain& active_chain = chainman.ActiveChain();
+    const CBlockIndex* pindex{chainman.m_blockman.LookupBlockIndex(*block_hash)};
+    while (pindex != nullptr && active_chain.Contains(pindex)) {
+        headers.push_back(pindex);
+        if (headers.size() == *parsed_count)
+            break;
+        pindex = active_chain.Next(pindex);
     }
 
     bool index_ready = index->BlockUntilSyncedToCurrentChain();

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1616,7 +1616,7 @@ static RPCHelpMan getchaintips()
     for (const CBlockIndex* block : setTips) {
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("height", block->nHeight);
-        obj.pushKV("hash", block->phashBlock->GetHex());
+        obj.pushKV("hash", block->m_block_hash.GetHex());
 
         const int branchLen = block->nHeight - active_chain.FindFork(block)->nHeight;
         obj.pushKV("branchlen", branchLen);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1596,9 +1596,9 @@ static RPCHelpMan getchaintips()
     std::set<const CBlockIndex*> setPrevs;
 
     for (const auto& [_, block_index] : chainman.BlockIndex()) {
-        if (!active_chain.Contains(&block_index)) {
-            setOrphans.insert(&block_index);
-            setPrevs.insert(block_index.pprev);
+        if (!active_chain.Contains(block_index)) {
+            setOrphans.insert(block_index);
+            setPrevs.insert(block_index->pprev);
         }
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -5,6 +5,7 @@
 
 #include <rpc/blockchain.h>
 
+#include <blockmap.h>
 #include <blockfilter.h>
 #include <chain.h>
 #include <chainparams.h>
@@ -1577,8 +1578,8 @@ static RPCHelpMan getchaintips()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    LOCK(cs_main);
     CChain& active_chain = chainman.ActiveChain();
+    BlockMap block_index_snapshot = chainman.BlockIndexSnapshot();
 
     /*
      * Idea: The set of chain tips is the active chain tip, plus orphan blocks which do not have another orphan building off of them.
@@ -1591,7 +1592,7 @@ static RPCHelpMan getchaintips()
     std::set<const CBlockIndex*> setOrphans;
     std::set<const CBlockIndex*> setPrevs;
 
-    for (const auto& [_, block_index] : chainman.BlockIndex()) {
+    for (const auto& [_, block_index] : block_index_snapshot) {
         if (!active_chain.Contains(block_index)) {
             setOrphans.insert(block_index);
             setPrevs.insert(block_index->pprev);
@@ -1617,20 +1618,30 @@ static RPCHelpMan getchaintips()
         const int branchLen = block->nHeight - active_chain.FindFork(block)->nHeight;
         obj.pushKV("branchlen", branchLen);
 
+        uint32_t block_status;
+        bool is_valid_fork;
+        bool is_valid_header;
+        {
+            LOCK(cs_main);
+            block_status = block->nStatus;
+            is_valid_fork = block->IsValid(BLOCK_VALID_SCRIPTS);
+            is_valid_header = block->IsValid(BLOCK_VALID_TREE);
+        }
+
         std::string status;
         if (active_chain.Contains(block)) {
             // This block is part of the currently active chain.
             status = "active";
-        } else if (block->nStatus & BLOCK_FAILED_VALID) {
+        } else if (block_status & BLOCK_FAILED_VALID) {
             // This block or one of its ancestors is invalid.
             status = "invalid";
         } else if (!block->HaveNumChainTxs()) {
             // This block cannot be connected because full block data for it or one of its parents is missing.
             status = "headers-only";
-        } else if (block->IsValid(BLOCK_VALID_SCRIPTS)) {
+        } else if (is_valid_fork) {
             // This block is fully validated, but no longer part of the active chain. It was probably the active block once, but was reorganized.
             status = "valid-fork";
-        } else if (block->IsValid(BLOCK_VALID_TREE)) {
+        } else if (is_valid_header) {
             // The headers for this block are valid, but it has not been validated. It was probably never part of the most-work chain.
             status = "valid-headers";
         } else {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -541,7 +541,7 @@ static RPCHelpMan getblockfrompeer()
     const uint256& block_hash{ParseHashV(request.params[0], "blockhash")};
     const NodeId peer_id{request.params[1].getInt<int64_t>()};
 
-    const CBlockIndex* const index = WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(block_hash););
+    const CBlockIndex* const index = chainman.m_blockman.LookupBlockIndex(block_hash);
 
     if (!index) {
         throw JSONRPCError(RPC_MISC_ERROR, "Block header missing");
@@ -1672,12 +1672,9 @@ static RPCHelpMan preciousblock()
     CBlockIndex* pblockindex;
 
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    {
-        LOCK(cs_main);
-        pblockindex = chainman.m_blockman.LookupBlockIndex(hash);
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        }
+    pblockindex = chainman.m_blockman.LookupBlockIndex(hash);
+    if (!pblockindex) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
     }
 
     BlockValidationState state;
@@ -1693,15 +1690,12 @@ static RPCHelpMan preciousblock()
 }
 
 void InvalidateBlock(ChainstateManager& chainman, const uint256 block_hash) {
-    BlockValidationState state;
-    CBlockIndex* pblockindex;
-    {
-        LOCK(chainman.GetMutex());
-        pblockindex = chainman.m_blockman.LookupBlockIndex(block_hash);
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        }
+    CBlockIndex* pblockindex = chainman.m_blockman.LookupBlockIndex(block_hash);
+    if (!pblockindex) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
     }
+
+    BlockValidationState state;
     chainman.ActiveChainstate().InvalidateBlock(state, pblockindex);
 
     if (state.IsValid()) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -639,14 +639,9 @@ static RPCHelpMan getblockheader()
     if (!request.params[1].isNull())
         fVerbose = request.params[1].get_bool();
 
-    const CBlockIndex* pblockindex;
-    const CBlockIndex* tip;
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    {
-        LOCK(cs_main);
-        pblockindex = chainman.m_blockman.LookupBlockIndex(hash);
-        tip = chainman.ActiveChain().Tip();
-    }
+    const CBlockIndex* pblockindex = chainman.m_blockman.LookupBlockIndex(hash);
+    const CBlockIndex* tip = chainman.ActiveChain().Tip();
 
     if (!pblockindex) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
@@ -843,14 +838,11 @@ static RPCHelpMan getblock()
     const CBlockIndex* pblockindex;
     const CBlockIndex* tip;
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    {
-        LOCK(cs_main);
-        pblockindex = chainman.m_blockman.LookupBlockIndex(hash);
-        tip = chainman.ActiveChain().Tip();
+    pblockindex = chainman.m_blockman.LookupBlockIndex(hash);
+    tip = chainman.ActiveChain().Tip();
 
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        }
+    if (!pblockindex) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
     }
 
     const std::vector<std::byte> block_data{GetRawBlockChecked(chainman.m_blockman, *pblockindex)};
@@ -1826,7 +1818,6 @@ static RPCHelpMan getchaintxstats()
         pindex = chainman.ActiveChain().Tip();
     } else {
         uint256 hash(ParseHashV(request.params[1], "blockhash"));
-        LOCK(cs_main);
         pindex = chainman.m_blockman.LookupBlockIndex(hash);
         if (!pindex) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
@@ -2757,20 +2748,17 @@ static RPCHelpMan getdescriptoractivity()
 
     std::set<const CBlockIndex*, CompareByHeightAscending> blockindexes_sorted;
 
-    {
-        // Validate all given blockhashes, and ensure blocks are along a single chain.
-        LOCK(::cs_main);
-        for (const UniValue& blockhash : request.params[0].get_array().getValues()) {
-            uint256 bhash = ParseHashV(blockhash, "blockhash");
-            CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(bhash);
-            if (!pindex) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-            }
-            if (!chainman.ActiveChain().Contains(pindex)) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Block is not in main chain");
-            }
-            blockindexes_sorted.insert(pindex);
+    // Validate all given blockhashes, and ensure blocks are along a single chain.
+    for (const UniValue& blockhash : request.params[0].get_array().getValues()) {
+        uint256 bhash = ParseHashV(blockhash, "blockhash");
+        CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(bhash);
+        if (!pindex) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
         }
+        if (!chainman.ActiveChain().Contains(pindex)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Block is not in main chain");
+        }
+        blockindexes_sorted.insert(pindex);
     }
 
     std::set<CScript> scripts_to_watch;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -125,7 +125,6 @@ static int ComputeNextBlockAndDepth(const CBlockIndex& tip, const CBlockIndex& b
 
 static const CBlockIndex* ParseHashOrHeight(const UniValue& param, ChainstateManager& chainman)
 {
-    LOCK(::cs_main);
     CChain& active_chain = chainman.ActiveChain();
 
     if (param.isNum()) {
@@ -260,7 +259,6 @@ static RPCHelpMan getblockcount()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    LOCK(cs_main);
     return chainman.ActiveChain().Height();
 },
     };
@@ -281,7 +279,6 @@ static RPCHelpMan getbestblockhash()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    LOCK(cs_main);
     return chainman.ActiveChain().Tip()->GetBlockHash().GetHex();
 },
     };
@@ -583,7 +580,6 @@ static RPCHelpMan getblockhash()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    LOCK(cs_main);
     const CChain& active_chain = chainman.ActiveChain();
 
     int nHeight = request.params[0].getInt<int>();
@@ -1816,7 +1812,6 @@ static RPCHelpMan getchaintxstats()
     int blockcount = 30 * 24 * 60 * 60 / chainman.GetParams().GetConsensus().nPowTargetSpacing; // By default: 1 month
 
     if (request.params[1].isNull()) {
-        LOCK(cs_main);
         pindex = chainman.ActiveChain().Tip();
     } else {
         uint256 hash(ParseHashV(request.params[1], "blockhash"));
@@ -2591,22 +2586,19 @@ static RPCHelpMan scanblocks()
         // set the start-height
         const CBlockIndex* start_index = nullptr;
         const CBlockIndex* stop_block = nullptr;
-        {
-            LOCK(cs_main);
-            CChain& active_chain = chainman.ActiveChain();
-            start_index = active_chain.Genesis();
-            stop_block = active_chain.Tip(); // If no stop block is provided, stop at the chain tip.
-            if (!request.params[2].isNull()) {
-                start_index = active_chain[request.params[2].getInt<int>()];
-                if (!start_index) {
-                    throw JSONRPCError(RPC_MISC_ERROR, "Invalid start_height");
-                }
+        CChain& active_chain = chainman.ActiveChain();
+        start_index = active_chain.Genesis();
+        stop_block = active_chain.Tip(); // If no stop block is provided, stop at the chain tip.
+        if (!request.params[2].isNull()) {
+            start_index = active_chain[request.params[2].getInt<int>()];
+            if (!start_index) {
+                throw JSONRPCError(RPC_MISC_ERROR, "Invalid start_height");
             }
-            if (!request.params[3].isNull()) {
-                stop_block = active_chain[request.params[3].getInt<int>()];
-                if (!stop_block || stop_block->nHeight < start_index->nHeight) {
-                    throw JSONRPCError(RPC_MISC_ERROR, "Invalid stop_height");
-                }
+        }
+        if (!request.params[3].isNull()) {
+            stop_block = active_chain[request.params[3].getInt<int>()];
+            if (!stop_block || stop_block->nHeight < start_index->nHeight) {
+                throw JSONRPCError(RPC_MISC_ERROR, "Invalid stop_height");
             }
         }
         CHECK_NONFATAL(start_index);
@@ -2643,7 +2635,7 @@ static RPCHelpMan scanblocks()
             // split the lookup range in chunks if we are deeper than 'amount_per_chunk' blocks from the stopping block
             int start_block = !end_range ? start_index->nHeight : start_index->nHeight + 1; // to not include the previous round 'end_range' block
             end_range = (start_block + amount_per_chunk < stop_block->nHeight) ?
-                    WITH_LOCK(::cs_main, return chainman.ActiveChain()[start_block + amount_per_chunk]) :
+                    chainman.ActiveChain()[start_block + amount_per_chunk] :
                     stop_block;
 
             if (index->LookupFilterRange(start_block, end_range, filters)) {
@@ -3081,7 +3073,7 @@ static RPCHelpMan dumptxoutset()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    const CBlockIndex* tip{WITH_LOCK(::cs_main, return node.chainman->ActiveChain().Tip())};
+    const CBlockIndex* tip{node.chainman->ActiveChain().Tip()};
     const CBlockIndex* target_index{nullptr};
     const auto snapshot_type{self.Arg<std::string_view>("type")};
     const UniValue options{request.params[2].isNull() ? UniValue::VOBJ : request.params[2]};
@@ -3153,7 +3145,7 @@ static RPCHelpMan dumptxoutset()
             disable_network.emplace(connman);
         }
 
-        invalidate_index = WITH_LOCK(::cs_main, return node.chainman->ActiveChain().Next(target_index));
+        invalidate_index = node.chainman->ActiveChain().Next(target_index);
         temporary_rollback.emplace(*node.chainman, *invalidate_index);
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -457,7 +457,6 @@ static RPCHelpMan getmininginfo()
     NodeContext& node = EnsureAnyNodeContext(request.context);
     const CTxMemPool& mempool = EnsureMemPool(node);
     ChainstateManager& chainman = EnsureChainman(node);
-    LOCK(cs_main);
     const CChain& active_chain = chainman.ActiveChain();
     CBlockIndex& tip{*CHECK_NONFATAL(active_chain.Tip())};
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -68,7 +68,6 @@ static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& 
     TxToUniv(tx, /*block_hash=*/uint256(), entry, /*include_hex=*/true, txundo, verbosity);
 
     if (!hashBlock.IsNull()) {
-        LOCK(cs_main);
 
         entry.pushKV("blockhash", hashBlock.GetHex());
         const CBlockIndex* pindex = active_chainstate.m_blockman.LookupBlockIndex(hashBlock);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -335,7 +335,6 @@ static RPCHelpMan getrawtransaction()
 
     UniValue result(UniValue::VOBJ);
     if (blockindex) {
-        LOCK(cs_main);
         result.pushKV("in_active_chain", chainman.ActiveChain().Contains(blockindex));
     }
     // If request is verbosity >= 1 but no blockhash was given, then look up the blockindex

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -59,7 +59,6 @@ static RPCHelpMan gettxoutproof()
             uint256 hashBlock;
             ChainstateManager& chainman = EnsureAnyChainman(request.context);
             if (!request.params[1].isNull()) {
-                LOCK(cs_main);
                 hashBlock = ParseHashV(request.params[1], "blockhash");
                 pblockindex = chainman.m_blockman.LookupBlockIndex(hashBlock);
                 if (!pblockindex) {
@@ -91,7 +90,6 @@ static RPCHelpMan gettxoutproof()
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
                 }
 
-                LOCK(cs_main);
                 pblockindex = chainman.m_blockman.LookupBlockIndex(hashBlock);
                 if (!pblockindex) {
                     throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -348,7 +348,7 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, BuildChainTestingSetup)
 
     std::promise<void> promise;
     std::shared_future<void> blocker(promise.get_future());
-    int blocking_height = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip()->nHeight);
+    int blocking_height = m_node.chainman->ActiveChain().Tip()->nHeight;
 
     IndexReorgCrash index(interfaces::MakeChain(m_node), blocker, blocking_height);
     BOOST_REQUIRE(index.Init());

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -223,7 +223,7 @@ BOOST_FIXTURE_TEST_CASE(blockmanager_readblock_hash_mismatch, TestingSetup)
         const auto tip{m_node.chainman->ActiveTip()};
         index.nStatus = tip->nStatus;
         index.nDataPos = tip->nDataPos;
-        index.phashBlock = &uint256::ONE; // mismatched block hash
+        index.m_block_hash = uint256::ONE; // mismatched block hash
     }
 
     ASSERT_DEBUG_LOG("GetHash() doesn't match index");

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -22,11 +22,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
     CoinStatsIndex coin_stats_index{interfaces::MakeChain(m_node), 1 << 20, true};
     BOOST_REQUIRE(coin_stats_index.Init());
 
-    const CBlockIndex* block_index;
-    {
-        LOCK(cs_main);
-        block_index = m_node.chainman->ActiveChain().Tip();
-    }
+    const CBlockIndex* block_index = m_node.chainman->ActiveChain().Tip();
 
     // CoinStatsIndex should not be found before it is started.
     BOOST_CHECK(!coin_stats_index.LookUpStats(*block_index));
@@ -38,11 +34,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
     coin_stats_index.Sync();
 
     // Check that CoinStatsIndex works for genesis block.
-    const CBlockIndex* genesis_block_index;
-    {
-        LOCK(cs_main);
-        genesis_block_index = m_node.chainman->ActiveChain().Genesis();
-    }
+    const CBlockIndex* genesis_block_index = m_node.chainman->ActiveChain().Genesis();
     BOOST_CHECK(coin_stats_index.LookUpStats(*genesis_block_index));
 
     // Check that CoinStatsIndex updates with new blocks.
@@ -55,11 +47,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
     // Let the CoinStatsIndex to catch up again.
     BOOST_CHECK(coin_stats_index.BlockUntilSyncedToCurrentChain());
 
-    const CBlockIndex* new_block_index;
-    {
-        LOCK(cs_main);
-        new_block_index = m_node.chainman->ActiveChain().Tip();
-    }
+    const CBlockIndex* new_block_index = m_node.chainman->ActiveChain().Tip();
+
     BOOST_CHECK(coin_stats_index.LookUpStats(*new_block_index));
 
     BOOST_CHECK(block_index != new_block_index);

--- a/src/test/fuzz/block_index.cpp
+++ b/src/test/fuzz/block_index.cpp
@@ -86,7 +86,7 @@ FUZZ_TARGET(block_index, .init = init_block_index)
     for (int i = 0; i < blocks_count; i++) {
         CBlockHeader header{ConsumeBlockHeader(fuzzed_data_provider)};
         blocks.push_back(std::make_unique<CBlockIndex>(std::move(header)));
-        blocks.back()->phashBlock = &g_block_hash;
+        blocks.back()->m_block_hash = g_block_hash;
         blocks_info.push_back(blocks.back().get());
     }
 

--- a/src/test/fuzz/chain.cpp
+++ b/src/test/fuzz/chain.cpp
@@ -20,7 +20,7 @@ FUZZ_TARGET(chain)
     }
 
     const uint256 zero{};
-    disk_block_index->phashBlock = &zero;
+    disk_block_index->m_block_hash = zero;
     {
         LOCK(::cs_main);
         (void)disk_block_index->ConstructBlockHash();
@@ -59,7 +59,7 @@ FUZZ_TARGET(chain)
     }
 
     CBlockIndex block_index{block_header};
-    block_index.phashBlock = &zero;
+    block_index.m_block_hash = zero;
     (void)block_index.GetBlockHash();
     (void)block_index.ToString();
 }

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -62,7 +62,7 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
     SetMockTime(ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast()));
 
     const uint256 genesis_hash = genesis_header.GetHash();
-    start_index.phashBlock = &genesis_hash;
+    start_index.m_block_hash = genesis_hash;
 
     const HeadersSyncParams params{
         .commitment_period = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, Params().HeadersSync().commitment_period * 2),

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -492,7 +492,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
         while (m_node.chainman->ActiveChain().Tip()->nHeight < 209999) {
             CBlockIndex* prev = m_node.chainman->ActiveChain().Tip();
             CBlockIndex* next = new CBlockIndex();
-            next->phashBlock = new uint256(m_rng.rand256());
+            next->m_block_hash = m_rng.rand256();
             m_node.chainman->ActiveChainstate().CoinsTip().SetBestBlock(next->GetBlockHash());
             next->pprev = prev;
             next->nHeight = prev->nHeight + 1;
@@ -504,7 +504,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
         while (m_node.chainman->ActiveChain().Tip()->nHeight < 210000) {
             CBlockIndex* prev = m_node.chainman->ActiveChain().Tip();
             CBlockIndex* next = new CBlockIndex();
-            next->phashBlock = new uint256(m_rng.rand256());
+            next->m_block_hash = m_rng.rand256();
             m_node.chainman->ActiveChainstate().CoinsTip().SetBestBlock(next->GetBlockHash());
             next->pprev = prev;
             next->nHeight = prev->nHeight + 1;
@@ -534,7 +534,6 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
             CBlockIndex* del = m_node.chainman->ActiveChain().Tip();
             m_node.chainman->ActiveChain().SetTip(*Assert(del->pprev));
             m_node.chainman->ActiveChainstate().CoinsTip().SetBestBlock(del->pprev->GetBlockHash());
-            delete del->phashBlock;
             delete del;
         }
     }

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
         vHashMain[i] = ArithToUint256(i); // Set the hash equal to the height, so we can quickly check the distances.
         vBlocksMain[i].nHeight = i;
         vBlocksMain[i].pprev = i ? &vBlocksMain[i - 1] : nullptr;
-        vBlocksMain[i].phashBlock = &vHashMain[i];
+        vBlocksMain[i].m_block_hash = vHashMain[i];
         vBlocksMain[i].BuildSkip();
         BOOST_CHECK_EQUAL((int)UintToArith256(vBlocksMain[i].GetBlockHash()).GetLow64(), vBlocksMain[i].nHeight);
         BOOST_CHECK(vBlocksMain[i].pprev == nullptr || vBlocksMain[i].nHeight == vBlocksMain[i].pprev->nHeight + 1);
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
         vHashSide[i] = ArithToUint256(i + 50000 + (arith_uint256(1) << 128)); // Add 1<<128 to the hashes, so GetLow64() still returns the height.
         vBlocksSide[i].nHeight = i + 50000;
         vBlocksSide[i].pprev = i ? &vBlocksSide[i - 1] : (vBlocksMain.data()+49999);
-        vBlocksSide[i].phashBlock = &vHashSide[i];
+        vBlocksSide[i].m_block_hash = vHashSide[i];
         vBlocksSide[i].BuildSkip();
         BOOST_CHECK_EQUAL((int)UintToArith256(vBlocksSide[i].GetBlockHash()).GetLow64(), vBlocksSide[i].nHeight);
         BOOST_CHECK(vBlocksSide[i].pprev == nullptr || vBlocksSide[i].nHeight == vBlocksSide[i].pprev->nHeight + 1);
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(findearliestatleast_test)
         vHashMain[i] = ArithToUint256(i); // Set the hash equal to the height
         vBlocksMain[i].nHeight = i;
         vBlocksMain[i].pprev = i ? &vBlocksMain[i - 1] : nullptr;
-        vBlocksMain[i].phashBlock = &vHashMain[i];
+        vBlocksMain[i].m_block_hash = vHashMain[i];
         vBlocksMain[i].BuildSkip();
         if (i < 10) {
             vBlocksMain[i].nTime = i;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -387,12 +387,9 @@ TestChain100Setup::TestChain100Setup(
     // Generate a 100-block chain:
     this->mineBlocks(COINBASE_MATURITY);
 
-    {
-        LOCK(::cs_main);
-        assert(
-            m_node.chainman->ActiveChain().Tip()->GetBlockHash().ToString() ==
-            "0c8c5f79505775a0f6aed6aca2350718ceb9c6f2c878667864d5c7a6d8ffa2a6");
-    }
+    assert(
+        m_node.chainman->ActiveChain().Tip()->GetBlockHash().ToString() ==
+        "0c8c5f79505775a0f6aed6aca2350718ceb9c6f2c878667864d5c7a6d8ffa2a6");
 }
 
 void TestChain100Setup::mineBlocks(int num_blocks)

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -138,7 +138,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     // Create a snapshot-based chainstate.
     //
     CBlockIndex* snapshot_base{WITH_LOCK(manager.GetMutex(), return manager.ActiveChain()[manager.ActiveChain().Height() / 2])};
-    Chainstate& c2{WITH_LOCK(::cs_main, return manager.AddChainstate(std::make_unique<Chainstate>(nullptr, manager.m_blockman, manager, *snapshot_base->phashBlock)))};
+    Chainstate& c2{WITH_LOCK(::cs_main, return manager.AddChainstate(std::make_unique<Chainstate>(nullptr, manager.m_blockman, manager, snapshot_base->GetBlockHash())))};
     chainstates.push_back(&c2);
     c2.InitCoinsDB(
         /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
@@ -525,7 +525,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_loadblockindex, TestChain100Setup)
     }
 
     // Note: cs2's tip is not set when ActivateExistingSnapshot is called.
-    Chainstate& cs2{WITH_LOCK(::cs_main, return chainman.AddChainstate(std::make_unique<Chainstate>(nullptr, chainman.m_blockman, chainman, *assumed_base->phashBlock)))};
+    Chainstate& cs2{WITH_LOCK(::cs_main, return chainman.AddChainstate(std::make_unique<Chainstate>(nullptr, chainman.m_blockman, chainman, assumed_base->GetBlockHash())))};
 
     // Set tip of the fully validated chain to be the validated tip
     cs1.m_chain.SetTip(*validated_tip);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -137,7 +137,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
 
     // Create a snapshot-based chainstate.
     //
-    CBlockIndex* snapshot_base{WITH_LOCK(manager.GetMutex(), return manager.ActiveChain()[manager.ActiveChain().Height() / 2])};
+    CBlockIndex* snapshot_base{manager.ActiveChain()[manager.ActiveChain().Height() / 2]};
     Chainstate& c2{WITH_LOCK(::cs_main, return manager.AddChainstate(std::make_unique<Chainstate>(nullptr, manager.m_blockman, manager, snapshot_base->GetBlockHash())))};
     chainstates.push_back(&c2);
     c2.InitCoinsDB(

--- a/src/util/copy_on_write.h
+++ b/src/util/copy_on_write.h
@@ -1,0 +1,260 @@
+// Copyright (c) 2013 Adobe
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file COPYING for license details or
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// Original source: https://github.com/stlab/stlab-copy-on-write
+
+#ifndef BITCOIN_UTIL_COPY_ON_WRITE_H
+#define BITCOIN_UTIL_COPY_ON_WRITE_H
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+namespace stlab {
+
+template <typename T>
+class copy_on_write
+{
+    struct model {
+        std::atomic<std::size_t> _count{1};
+
+        model() noexcept(std::is_nothrow_constructible_v<T>) = default;
+
+        template <class... Args>
+        explicit model(Args&&... args) noexcept(std::is_nothrow_constructible_v<T, Args&&...>) : _value(std::forward<Args>(args)...)
+        {
+        }
+
+        T _value;
+    };
+
+    model* _self;
+
+    template <class U>
+    using disable_copy = std::enable_if_t<!std::is_same_v<std::decay_t<U>, copy_on_write>>*;
+
+    template <typename U>
+    using disable_copy_assign =
+        std::enable_if_t<!std::is_same_v<std::decay_t<U>, copy_on_write>, copy_on_write&>;
+
+    auto default_model() noexcept(std::is_nothrow_constructible_v<T>) -> model*
+    {
+        static model default_s;
+        return &default_s;
+    }
+
+public:
+    using element_type = T;
+
+    copy_on_write() noexcept(std::is_nothrow_constructible_v<T>)
+    {
+        _self = default_model();
+
+        _self->_count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    template <class U>
+    copy_on_write(U&& x, disable_copy<U> = nullptr) : _self(new model(std::forward<U>(x)))
+    {
+    }
+
+    template <class U, class V, class... Args>
+    copy_on_write(U&& x, V&& y, Args&&... args) : _self(new model(std::forward<U>(x), std::forward<V>(y), std::forward<Args>(args)...))
+    {
+    }
+
+    copy_on_write(const copy_on_write& x) noexcept : _self(x._self)
+    {
+        assert(_self && "FATAL (sparent) : using a moved copy_on_write object");
+        _self->_count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    copy_on_write(copy_on_write&& x) noexcept : _self{std::exchange(x._self, nullptr)}
+    {
+        assert(_self && "WARNING (sparent) : using a moved copy_on_write object");
+    }
+
+    ~copy_on_write()
+    {
+        assert(!_self || ((_self->_count > 0) && "FATAL (sparent) : double delete"));
+        if (_self && (_self->_count.fetch_sub(1, std::memory_order_release) == 1)) {
+            std::atomic_thread_fence(std::memory_order_acquire);
+            if constexpr (std::is_default_constructible_v<element_type>) {
+                assert(_self != default_model());
+            }
+            delete _self;
+        }
+    }
+
+    auto operator=(const copy_on_write& x) noexcept -> copy_on_write&
+    {
+        assert(this != &x && "self-assignment is not allowed");
+        return *this = copy_on_write(x);
+    }
+
+    auto operator=(copy_on_write&& x) noexcept -> copy_on_write&
+    {
+        auto tmp{std::move(x)};
+        swap(*this, tmp);
+        return *this;
+    }
+
+    template <class U>
+    auto operator=(U&& x) -> disable_copy_assign<U>
+    {
+        if (_self && unique()) {
+            _self->_value = std::forward<U>(x);
+            return *this;
+        }
+        return *this = copy_on_write(std::forward<U>(x));
+    }
+
+    auto write() -> element_type&
+    {
+        if (!unique()) *this = copy_on_write(read());
+        return _self->_value;
+    }
+
+    template <class Transform, class Inplace>
+    auto write(Transform transform, Inplace inplace) -> element_type&
+    {
+        static_assert(std::is_invocable_r_v<T, Transform, const T&>,
+                      "Transform must be invocable with const T&");
+        static_assert(std::is_invocable_r_v<void, Inplace, T&>,
+                      "Inplace must be invocable with T&");
+
+        if (!unique()) {
+            *this = copy_on_write(transform(read()));
+        } else {
+            inplace(_self->_value);
+        }
+        return _self->_value;
+    }
+
+    [[nodiscard]] auto read() const noexcept -> const element_type&
+    {
+        assert(_self && "FATAL (sparent): using a moved copy_on_write object");
+        return _self->_value;
+    }
+
+    operator const element_type&() const noexcept { return read(); }
+
+    auto operator*() const noexcept -> const element_type& { return read(); }
+
+    auto operator->() const noexcept -> const element_type* { return &read(); }
+
+    [[nodiscard]] auto unique() const noexcept -> bool
+    {
+        assert(_self && "FATAL (sparent) : using a moved copy_on_write object");
+        return _self->_count.load(std::memory_order_acquire) == 1;
+    }
+
+    [[nodiscard]] auto identity(const copy_on_write& x) const noexcept -> bool
+    {
+        assert((_self && x._self) && "FATAL (sparent) : using a moved copy_on_write object");
+        return _self == x._self;
+    }
+
+    friend inline void swap(copy_on_write& x, copy_on_write& y) noexcept
+    {
+        std::swap(x._self, y._self);
+    }
+
+    friend inline auto operator<(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !x.identity(y) && (*x < *y);
+    }
+
+    friend inline auto operator<(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return *x < y;
+    }
+
+    friend inline auto operator<(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return x < *y;
+    }
+
+    friend inline auto operator>(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return y < x;
+    }
+
+    friend inline auto operator>(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return y < x;
+    }
+
+    friend inline auto operator>(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return y < x;
+    }
+
+    friend inline auto operator<=(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(y < x);
+    }
+
+    friend inline auto operator<=(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return !(y < x);
+    }
+
+    friend inline auto operator<=(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(y < x);
+    }
+
+    friend inline auto operator>=(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(x < y);
+    }
+
+    friend inline auto operator>=(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return !(x < y);
+    }
+
+    friend inline auto operator>=(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(x < y);
+    }
+
+    friend inline auto operator==(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return x.identity(y) || (*x == *y);
+    }
+
+    friend inline auto operator==(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return *x == y;
+    }
+
+    friend inline auto operator==(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return x == *y;
+    }
+
+    friend inline auto operator!=(const copy_on_write& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(x == y);
+    }
+
+    friend inline auto operator!=(const copy_on_write& x, const element_type& y) noexcept -> bool
+    {
+        return !(x == y);
+    }
+
+    friend inline auto operator!=(const element_type& x, const copy_on_write& y) noexcept -> bool
+    {
+        return !(x == y);
+    }
+};
+} // namespace stlab
+
+#endif // BITCOIN_UTIL_COPY_ON_WRITE_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2257,7 +2257,7 @@ script_verify_flags GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
     // For simplicity, always leave P2SH+WITNESS+TAPROOT on except for the two
     // violating blocks.
     script_verify_flags flags{SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT};
-    const auto it{consensusparams.script_flag_exceptions.find(*Assert(block_index.phashBlock))};
+    const auto it{consensusparams.script_flag_exceptions.find(block_index.GetBlockHash())};
     if (it != consensusparams.script_flag_exceptions.end()) {
         flags = it->second;
     }
@@ -2296,7 +2296,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     assert(pindex);
 
     uint256 block_hash{block.GetHash()};
-    assert(*pindex->phashBlock == block_hash);
+    assert(pindex->GetBlockHash() == block_hash);
 
     const auto time_start{SteadyClock::now()};
     const CChainParams& params{m_chainman.GetParams()};
@@ -4506,7 +4506,7 @@ BlockValidationState TestBlockValidity(
     BlockValidationState state;
     CBlockIndex* tip{Assert(chainstate.m_chain.Tip())};
 
-    if (block.hashPrevBlock != *Assert(tip->phashBlock)) {
+    if (block.hashPrevBlock != tip->GetBlockHash()) {
         state.Invalid({}, "inconclusive-not-best-prevblk");
         return state;
     }
@@ -4547,10 +4547,8 @@ BlockValidationState TestBlockValidity(
     // We don't want ConnectBlock to update the actual chainstate, so create
     // a cache on top of it, along with a dummy block index.
     CBlockIndex index_dummy{block};
-    uint256 block_hash(block.GetHash());
     index_dummy.pprev = tip;
     index_dummy.nHeight = tip->nHeight + 1;
-    index_dummy.phashBlock = &block_hash;
     CCoinsViewCache view_dummy(&chainstate.CoinsTip());
 
     // Set fJustCheck to true in order to update, and not clear, validation caches.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -8,6 +8,7 @@
 #include <validation.h>
 
 #include <arith_uint256.h>
+#include <blockmap.h>
 #include <chain.h>
 #include <checkqueue.h>
 #include <clientversion.h>
@@ -84,7 +85,6 @@ using kernel::Notifications;
 
 using fsbridge::FopenFn;
 using node::BlockManager;
-using node::BlockMap;
 using node::CBlockIndexHeightOnlyComparator;
 using node::CBlockIndexWorkComparator;
 using node::SnapshotMetadata;
@@ -2352,8 +2352,8 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         BlockMap::const_iterator it{m_blockman.m_block_index.find(m_chainman.AssumedValidBlock())};
         if (it == m_blockman.m_block_index.end()) {
             script_check_reason = "assumevalid hash not in headers";
-        } else if (it->second.GetAncestor(pindex->nHeight) != pindex) {
-            script_check_reason = (pindex->nHeight > it->second.nHeight) ? "block height above assumevalid height" : "block not in assumevalid chain";
+        } else if ((*it).second->GetAncestor(pindex->nHeight) != pindex) {
+            script_check_reason = (pindex->nHeight > (*it).second->nHeight) ? "block height above assumevalid height" : "block not in assumevalid chain";
         } else if (m_chainman.m_best_header->GetAncestor(pindex->nHeight) != pindex) {
             script_check_reason = "block not in best header chain";
         } else if (m_chainman.m_best_header->nChainWork < m_chainman.MinimumChainWork()) {
@@ -3576,7 +3576,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
     {
         LOCK(cs_main);
         for (auto& entry : m_blockman.m_block_index) {
-            CBlockIndex* candidate = &entry.second;
+            CBlockIndex* candidate = entry.second;
             // We don't need to put anything in our active chain into the
             // multimap, because those candidates will be found and considered
             // as we disconnect.
@@ -3697,8 +3697,8 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
         // Loop back over all block index entries and add any missing entries
         // to setBlockIndexCandidates.
         for (auto& [_, block_index] : m_blockman.m_block_index) {
-            if (block_index.IsValid(BLOCK_VALID_TRANSACTIONS) && block_index.HaveNumChainTxs() && !setBlockIndexCandidates.value_comp()(&block_index, m_chain.Tip())) {
-                setBlockIndexCandidates.insert(&block_index);
+            if (block_index->IsValid(BLOCK_VALID_TRANSACTIONS) && block_index->HaveNumChainTxs() && !setBlockIndexCandidates.value_comp()(block_index, m_chain.Tip())) {
+                setBlockIndexCandidates.insert(block_index);
             }
         }
 
@@ -3733,9 +3733,9 @@ void Chainstate::SetBlockFailureFlags(CBlockIndex* invalid_block)
     AssertLockHeld(cs_main);
 
     for (auto& [_, block_index] : m_blockman.m_block_index) {
-        if (invalid_block != &block_index && block_index.GetAncestor(invalid_block->nHeight) == invalid_block) {
-            block_index.nStatus |= BLOCK_FAILED_VALID;
-            m_blockman.m_dirty_blockindex.insert(&block_index);
+        if (invalid_block != block_index && block_index->GetAncestor(invalid_block->nHeight) == invalid_block) {
+            block_index->nStatus |= BLOCK_FAILED_VALID;
+            m_blockman.m_dirty_blockindex.insert(block_index);
         }
     }
 }
@@ -3747,13 +3747,13 @@ void Chainstate::ResetBlockFailureFlags(CBlockIndex *pindex) {
 
     // Remove the invalidity flag from this block and all its descendants and ancestors.
     for (auto& [_, block_index] : m_blockman.m_block_index) {
-        if ((block_index.nStatus & BLOCK_FAILED_VALID) && (block_index.GetAncestor(nHeight) == pindex || pindex->GetAncestor(block_index.nHeight) == &block_index)) {
-            block_index.nStatus &= ~BLOCK_FAILED_VALID;
-            m_blockman.m_dirty_blockindex.insert(&block_index);
-            if (block_index.IsValid(BLOCK_VALID_TRANSACTIONS) && block_index.HaveNumChainTxs() && setBlockIndexCandidates.value_comp()(m_chain.Tip(), &block_index)) {
-                setBlockIndexCandidates.insert(&block_index);
+        if ((block_index->nStatus & BLOCK_FAILED_VALID) && (block_index->GetAncestor(nHeight) == pindex || pindex->GetAncestor(block_index->nHeight) == block_index)) {
+            block_index->nStatus &= ~BLOCK_FAILED_VALID;
+            m_blockman.m_dirty_blockindex.insert(block_index);
+            if (block_index->IsValid(BLOCK_VALID_TRANSACTIONS) && block_index->HaveNumChainTxs() && setBlockIndexCandidates.value_comp()(m_chain.Tip(), block_index)) {
+                setBlockIndexCandidates.insert(block_index);
             }
-            if (&block_index == m_chainman.m_best_invalid) {
+            if (block_index == m_chainman.m_best_invalid) {
                 // Reset invalid block marker if it was pointing to one of those.
                 m_chainman.m_best_invalid = nullptr;
             }
@@ -4225,7 +4225,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
     if (hash != GetConsensus().hashGenesisBlock) {
         if (miSelf != m_blockman.m_block_index.end()) {
             // Block header is already known.
-            CBlockIndex* pindex = &(miSelf->second);
+            CBlockIndex* pindex = (*miSelf).second;
             if (ppindex)
                 *ppindex = pindex;
             if (pindex->nStatus & BLOCK_FAILED_VALID) {
@@ -4248,7 +4248,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             LogDebug(BCLog::VALIDATION, "header %s has prev block not found: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_MISSING_PREV, "prev-blk-not-found");
         }
-        pindexPrev = &((*mi).second);
+        pindexPrev = (*mi).second;
         if (pindexPrev->nStatus & BLOCK_FAILED_VALID) {
             LogDebug(BCLog::VALIDATION, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
@@ -4826,14 +4826,14 @@ bool Chainstate::ReplayBlocks()
         LogError("ReplayBlocks(): reorganization to unknown block requested\n");
         return false;
     }
-    pindexNew = &(m_blockman.m_block_index[hashHeads[0]]);
+    pindexNew = m_blockman.m_block_index[hashHeads[0]];
 
     if (!hashHeads[1].IsNull()) { // The old tip is allowed to be 0, indicating it's the first flush.
         if (!m_blockman.m_block_index.contains(hashHeads[1])) {
             LogError("ReplayBlocks(): reorganization from unknown block requested\n");
             return false;
         }
-        pindexOld = &(m_blockman.m_block_index[hashHeads[1]]);
+        pindexOld = m_blockman.m_block_index[hashHeads[1]];
         pindexFork = LastCommonAncestor(pindexOld, pindexNew);
         assert(pindexFork != nullptr);
     }
@@ -5187,10 +5187,10 @@ void ChainstateManager::CheckBlockIndex() const
     std::multimap<const CBlockIndex*, const CBlockIndex*> forward;
     for (auto& [_, block_index] : m_blockman.m_block_index) {
         // Only save indexes in forward that are not part of the best header chain.
-        if (!best_hdr_chain.Contains(&block_index)) {
+        if (!best_hdr_chain.Contains(block_index)) {
             // Only genesis, which must be part of the best header chain, can have a nullptr parent.
-            assert(block_index.pprev);
-            forward.emplace(block_index.pprev, &block_index);
+            assert(block_index->pprev);
+            forward.emplace(block_index->pprev, block_index);
         }
     }
     assert(forward.size() + best_hdr_chain.Height() + 1 == m_blockman.m_block_index.size());
@@ -6274,8 +6274,9 @@ void ChainstateManager::RecalculateBestHeader()
     AssertLockHeld(cs_main);
     m_best_header = ActiveChain().Tip();
     for (auto& entry : m_blockman.m_block_index) {
-        if (!(entry.second.nStatus & BLOCK_FAILED_VALID) && m_best_header->nChainWork < entry.second.nChainWork) {
-            m_best_header = &entry.second;
+        CBlockIndex* block_index = entry.second;
+        if (!(block_index->nStatus & BLOCK_FAILED_VALID) && m_best_header->nChainWork < block_index->nChainWork) {
+            m_best_header = block_index;
         }
     }
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -1159,9 +1159,9 @@ public:
     //! should use CurrentChainstate() instead.
     //! @{
     Chainstate& ActiveChainstate() const;
-    CChain& ActiveChain() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex()) { return ActiveChainstate().m_chain; }
-    int ActiveHeight() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex()) { return ActiveChain().Height(); }
-    CBlockIndex* ActiveTip() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex()) { return ActiveChain().Tip(); }
+    CChain& ActiveChain() const { return ActiveChainstate().m_chain; }
+    int ActiveHeight() const { return ActiveChain().Height(); }
+    CBlockIndex* ActiveTip() const { return ActiveChain().Tip(); }
     //! @}
 
     /**

--- a/src/validation.h
+++ b/src/validation.h
@@ -8,6 +8,7 @@
 
 #include <arith_uint256.h>
 #include <attributes.h>
+#include <blockmap.h>
 #include <chain.h>
 #include <checkqueue.h>
 #include <coins.h>
@@ -1176,7 +1177,7 @@ public:
      */
     void UpdateIBDStatus() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    node::BlockMap& BlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    BlockMap& BlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
         return m_blockman.m_block_index;

--- a/src/validation.h
+++ b/src/validation.h
@@ -1183,6 +1183,11 @@ public:
         return m_blockman.m_block_index;
     }
 
+    BlockMap BlockIndexSnapshot()
+    {
+        return m_blockman.GetBlockIndexSnapshot();
+    }
+
     /**
      * Track versionbit status
      */

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -260,7 +260,7 @@ static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lock
         const uint256& hash = inserted.first->first;
         block = &inserted.first->second;
         block->nTime = blockTime;
-        block->phashBlock = &hash;
+        block->m_block_hash = hash;
         state = TxStateConfirmed{hash, block->nHeight, /*index=*/0};
     }
     return wallet.AddToWallet(MakeTransactionRef(tx), state, [&](CWalletTx& wtx, bool /* new_tx */) {

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -255,10 +255,10 @@ static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lock
     CBlockIndex* block = nullptr;
     if (blockTime > 0) {
         LOCK(cs_main);
-        auto inserted = chainman.BlockIndex().emplace(std::piecewise_construct, std::make_tuple(GetRandHash()), std::make_tuple());
+        auto inserted = chainman.BlockIndex().try_emplace(GetRandHash());
         assert(inserted.second);
         const uint256& hash = inserted.first->first;
-        block = &inserted.first->second;
+        block = inserted.first->second;
         block->nTime = blockTime;
         block->m_block_hash = hash;
         state = TxStateConfirmed{hash, block->nHeight, /*index=*/0};

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -20,7 +20,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "qt/sendcoinsdialog -> qt/walletmodel -> qt/sendcoinsdialog",
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel",
     "wallet/wallet -> wallet/walletdb -> wallet/wallet",
-    "kernel/coinstats -> validation -> kernel/coinstats",
+    "kernel/coinstats -> node/blockstorage -> validation -> kernel/coinstats",
     "versionbits -> versionbits_impl -> versionbits",
 
     # Temporary, removed in followup https://github.com/bitcoin/bitcoin/pull/24230


### PR DESCRIPTION
## RFC: `BlockMap` and `CChain` Concurrency Improvement

Follow-up to https://github.com/bitcoin/bitcoin/pull/34424.

This RFC applies a `stable` and `recent` + copy-on-write design to `BlockMap`, adds an internal Mutex to `CChain` and demonstrates how `cs_main` locks can be removed.

### Motivation

The current `BlockMap` and `CChain` are protected by `cs_main`, creating bottlenecks for multi-threaded access.

### BlockMap Design

**TL;DR:** Split the block index into `stable` (bulk of history) + `recent` (~1,000 blocks). Use nested `stlab::copy_on_write` so updates copy only `recent`, keeping `stable` shared. 

### Changes

1. Stores block hash directly in CBlockIndex (required due to loss of address stability)
2. Implements copy-on-write `BlockMap` with `stable` + `recent` architecture
3. Adds internal mutex to `CChain`
4. Removes `cs_main` locks across multiple call sites, using `getchaintips` as an illustrative example

*Note: the lock removals in this RFC are non-exhaustive*
---
### Request for Comments

If you have opinions on the following design decisions, please weigh in:
- Storing block hashes directly in `CBlockIndex` is required due to loss of address stability from the copy-on-write design, is the memory cost an acceptable tradeoff?
- Are there simpler alternatives to copy-on-write here? A plain mutex might be sufficient, but full BlockMap iteration would hold the lock for extended periods.