### PR TITLE
doc: clarify confusing `git range-diff` add/delete output

### DIFF
--- a/doc/productivity.md
+++ b/doc/productivity.md
@@ -191,7 +191,12 @@ Then a simple `git pr 12345` will fetch and check out that pr from upstream.
 
 ### Diff the diffs with `git range-diff`
 
-It is very common for contributors to rebase their pull requests, or make changes to commits (perhaps in response to review) that are not at the head of their branch. This poses a problem for reviewers as when the contributor force pushes, the reviewer is no longer sure that his previous reviews of commits are still valid (as the commit hashes can now be different even though the diff is semantically the same). [git range-diff](https://git-scm.com/docs/git-range-diff) (Git >= 2.19) can help solve this problem by diffing the diffs.
+It is very common for contributors to rebase their pull requests, or make changes to commits (perhaps in response to review) that are not at the head of their branch. This poses a problem for reviewers as when the contributor force pushes, the reviewer is no longer sure that their previous reviews of commits are still valid (as the commit hashes can now be different even though the diff is semantically the same). [git range-diff](https://git-scm.com/docs/git-range-diff) (Git >= 2.19) can help solve this problem by diffing the diffs.
+
+> [!NOTE]
+> If `git range-diff` cannot match a commit in the old range to a commit in the new range, it will show it as "removed" (`<`) and "added" (`>`), without showing the patch contents.
+> This does not mean there were no code changes.
+> It means the commit was considered unrelated, and should be reviewed in full like a new commit.
 
 For example, to identify the differences between your previously reviewed diffs P1-5, and the new diffs P1-2,N3-4 as illustrated below:
 ```
@@ -205,6 +210,12 @@ For example, to identify the differences between your previously reviewed diffs 
 You can do:
 ```sh
 git range-diff master previously-reviewed-head new-head
+```
+
+If you expected `git range-diff` to match a commit, but it shows it as a deletion and an addition, try re-running with a higher creation factor:
+
+```sh
+git range-diff --creation-factor=95 <old_range> <new_range>
 ```
 
 Note that `git range-diff` also works for rebases:


### PR DESCRIPTION
### Problem
Range diffs in git are useful after PR rebases, but it has an easy-to-misread failure mode: if it cannot match a commit between the old and new ranges, it will show the old commit as removed (<) and the new commit as added (>), without showing any patch contents for that commit.
It can look like there were no code changes when in reality the commit was just treated as unrelated and needs full re-review.

### Example

```bash
git fetch upstream ff338fdb53a66ab40a36e1277e7371941fc89840 dd76338a57b9b1169ac27f7b783d6d0d4c6e38ab
git range-diff ff338fdb53a6...dd76338a57b9
```

This produced output like:
```patch
1:  0ca4295f2e = 93:  139aa4b27e bench: add on-disk `HaveInputs` benchmark
2:  4b32181dbb <  -:  ---------- test: add `HaveInputs` call-path unit tests
-:  ---------- > 94:  277c57f0c5 test: add `HaveInputs` call-path unit tests
3:  8c57687f86 ! 95:  c0c94ec986 dbwrapper: have `Read` and `Exists` reuse `ReadRaw`
@@ Metadata
## Commit message ##
   dbwrapper: have `Read` and `Exists` reuse `ReadRaw`

-    `ExistsImpl` was removed since it duplicates `CDBWrapper::ReadImpl` (except that it copies the resulting string on success, but that will be needed for caching anyway).
+    `ExistsImpl` was removed since it duplicates `CDBWrapper::ReadImpl`.
```

Even though the subject matches, there is no diff shown because the commits did not match - the reviewer could think that only the commit message was changed.
This should be treated as **unmatched** rather than **unchanged**.
If you expected a match, you can try increasing the search effort:
```bash
git range-diff --creation-factor=95 ff338fdb53a6...dd76338a57b9
```
which would show for example:
```patch
1:  0ca4295f2e = 93:  139aa4b27e bench: add on-disk `HaveInputs` benchmark
2:  4b32181dbb ! 94:  277c57f0c5 test: add `HaveInputs` call-path unit tests
@@ Commit message
 
     The tests document that `HaveInputs()` consults the cache first and that a cache miss pulls from the backing view via `GetCoin()`.
 
+    Co-authored-by: Novo <eunovo9@gmail.com>
+
  ## src/test/coins_tests.cpp ##
 @@ src/test/coins_tests.cpp: BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
      }
  }
  
-+BOOST_AUTO_TEST_CASE(ccoins_haveinputs_cache_miss_uses_base_getcoin)
++BOOST_AUTO_TEST_CASE(ccoins_cache_behavior)
```

### Fix
This PR updates `doc/productivity.md` to raise awareness and document this pitfall and mentions `--creation-factor` as a knob to try when the output seems unexpectedly empty.