### PR TITLE
net: guard RemoveLocal() log with fLogIPs

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -310,7 +310,9 @@ bool AddLocal(const CNetAddr &addr, int nScore)
 void RemoveLocal(const CService& addr)
 {
     LOCK(g_maplocalhost_mutex);
-    LogInfo("RemoveLocal(%s)\n", addr.ToStringAddrPort());
+    if (fLogIPs) {
+        LogInfo("RemoveLocal(%s)\n", addr.ToStringAddrPort());
+    }
     mapLocalHost.erase(addr);
 }
 


### PR DESCRIPTION
`RemoveLocal()` logs the local IP address unconditionally via `LogInfo()`. Other logging in net.cpp respects the fLogIPs flag to avoid leaking IP addresses when the user has not opted in with -logips.

Gate the log behind fLogIPs for consistency.

Relates to [#34458](https://github.com/bitcoin/bitcoin/pull/34458). 