### PR TITLE
test: Add missing resolve() to valgrind.supp file for test shell

### DIFF
--- a/ci/test/wrap-valgrind.sh
+++ b/ci/test/wrap-valgrind.sh
@@ -12,7 +12,7 @@ for b_name in "${BASE_OUTDIR}/bin"/*; do
       echo "Wrap $b ..."
       mv "$b" "${b}_orig"
       echo '#!/usr/bin/env bash' > "$b"
-      echo "exec valgrind --gen-suppressions=all --quiet --error-exitcode=1 --suppressions=${BASE_ROOT_DIR}/contrib/valgrind.supp \"${b}_orig\" \"\$@\"" >> "$b"
+      echo "exec valgrind --gen-suppressions=all --quiet --error-exitcode=1 --suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/valgrind.supp \"${b}_orig\" \"\$@\"" >> "$b"
       chmod +x "$b"
     done
 done

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -384,13 +384,13 @@ other input.
 
 Valgrind is a programming tool for memory debugging, memory leak detection, and
 profiling. The repo contains a Valgrind suppressions file
-([`valgrind.supp`](https://github.com/bitcoin/bitcoin/blob/master/contrib/valgrind.supp))
+([`valgrind.supp`](/test/sanitizer_suppressions/valgrind.supp))
 which includes known Valgrind warnings in our dependencies that cannot be fixed
 in-tree. Example use:
 
 ```shell
-$ valgrind --suppressions=contrib/valgrind.supp build/bin/test_bitcoin
-$ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
+$ valgrind --suppressions=test/sanitizer_suppressions/valgrind.supp build/bin/test_bitcoin
+$ valgrind --suppressions=test/sanitizer_suppressions/valgrind.supp --leak-check=full \
       --show-leak-kinds=all build/bin/test_bitcoin --log_level=test_suite
 $ valgrind -v --leak-check=full build/bin/bitcoind -printtoconsole
 $ ./build/test/functional/test_runner.py --valgrind

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -251,7 +251,7 @@ class Binaries:
     def __init__(self, paths, bin_dir, *, use_valgrind=False):
         self.paths = paths
         self.bin_dir = bin_dir
-        suppressions_file = pathlib.Path(__file__).parents[3] / "contrib" / "valgrind.supp"
+        suppressions_file = pathlib.Path(__file__).resolve().parents[3] / "contrib" / "valgrind.supp"
         self.valgrind_cmd = [
             "valgrind",
             f"--suppressions={suppressions_file}",

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -251,7 +251,7 @@ class Binaries:
     def __init__(self, paths, bin_dir, *, use_valgrind=False):
         self.paths = paths
         self.bin_dir = bin_dir
-        suppressions_file = pathlib.Path(__file__).resolve().parents[3] / "contrib" / "valgrind.supp"
+        suppressions_file = pathlib.Path(__file__).resolve().parents[3] / "test" / "sanitizer_suppressions" / "valgrind.supp"
         self.valgrind_cmd = [
             "valgrind",
             f"--suppressions={suppressions_file}",

--- a/test/sanitizer_suppressions/valgrind.supp
+++ b/test/sanitizer_suppressions/valgrind.supp
@@ -2,12 +2,12 @@
 # dependencies that cannot be fixed in-tree.
 #
 # Example use:
-# $ valgrind --suppressions=contrib/valgrind.supp build/bin/test_bitcoin
-# $ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
+# $ valgrind --suppressions=test/sanitizer_suppressions/valgrind.supp build/bin/test_bitcoin
+# $ valgrind --suppressions=test/sanitizer_suppressions/valgrind.supp --leak-check=full \
 #       --show-leak-kinds=all build/bin/test_bitcoin
 #
 # To create suppressions for found issues, use the --gen-suppressions=all option:
-# $ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
+# $ valgrind --suppressions=test/sanitizer_suppressions/valgrind.supp --leak-check=full \
 #       --show-leak-kinds=all --gen-suppressions=all --show-reachable=yes \
 #       --error-limit=no build/bin/test_bitcoin
 #


### PR DESCRIPTION
(see commit message for details)

Can be tested via:

```
./bld-cmake/test/functional/feature_framework_testshell.py --valgrind
```

Before:

```
bitcoind exited with status 1 during initialization. ==1735813== FATAL: can't open suppressions file "/b-c/b-c-2/bld-cmake/contrib/valgrind.supp"
```

After: (passes)


Also, move the suppression file to all the other suppression files.