### PR TITLE
net: prevent signed integer overflow in AddLocal nScore update

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -29,6 +29,7 @@
 #include <random.h>
 #include <scheduler.h>
 #include <util/fs.h>
+#include <util/overflow.h>
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/thread.h>
@@ -294,7 +295,7 @@ bool AddLocal(const CService& addr_, int nScore)
         const auto [it, is_newly_added] = mapLocalHost.emplace(addr, LocalServiceInfo());
         LocalServiceInfo &info = it->second;
         if (is_newly_added || nScore >= info.nScore) {
-            info.nScore = nScore + (is_newly_added ? 0 : 1);
+            info.nScore = is_newly_added ? nScore : SaturatingAdd(nScore, 1);
             info.nPort = addr.GetPort();
         }
     }


### PR DESCRIPTION
When `AddLocal()` is called for an address already in mapLocalHost, it increments nScore by 1. If nScore is at INT_MAX, this is signed integer overflow (undefined behavior).

Use `SaturatingAdd `from` util/overflow.h` to cap at INT_MAX instead.

This is the same class of bug addressed for `SeenLocal()` in #[34028](https://github.com/bitcoin/bitcoin/pull/34028/changes/3fc5948e1feeb13babeeb7c4e32c97dc35f630d5), but in a different call site.
