### PR TITLE
net: drop connection on unknown socket family in AcceptConnection

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1745,9 +1745,9 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     CService addr;
     if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr, len)) {
         LogWarning("Unknown socket family\n");
-    } else {
-        addr = MaybeFlipIPv6toCJDNS(addr);
+        return;
     }
+    addr = MaybeFlipIPv6toCJDNS(addr);
 
     const CService addr_bind{MaybeFlipIPv6toCJDNS(GetBindAddress(*sock))};
 


### PR DESCRIPTION
When `SetSockAddr()` fails in` AcceptConnection()`, the code logs a warning but continues processing the connection with a default empty CService address. This means ban checks, whitelist matching, and all downstream logic operate on an invalid address.

Return early on failure instead, consistent with other error paths in the same function.