### PR TITLE
ci: Set TEST_RUNNER_PORT_MIN in test-each after cirrus runner switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
     name: 'test ancestor commits'
     needs: runners
     runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' || 'ubuntu-24.04' }}
+    env:
+      TEST_RUNNER_PORT_MIN: "14000"  # Use a larger port, to avoid colliding with CIRRUS_CACHE_HOST port 12321.
     if: github.event_name == 'pull_request' && github.event.pull_request.commits != 1
     timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes.
     steps:

--- a/src/test/threadpool_tests.cpp
+++ b/src/test/threadpool_tests.cpp
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(stop_active_wait_drains_queue)
     }
     BOOST_CHECK_EQUAL(threadPool.WorkQueueSize(), num_tasks);
 
-    // Delay release so Stop() drain all tasks from the calling thread
+    // Delay release so Stop() drains all tasks from the calling thread
     std::thread unblocker([&blocker, &threadPool]() {
         while (threadPool.WorkQueueSize() > 0) {
             std::this_thread::yield();


### PR DESCRIPTION
This is needed after the recent switch to cirrus runners in the task in commit c8c9c1e61759f689615a304254fed33cda7f895e.

Otherwise, the CI will fail:

```
 node1 stderr Error: Unable to bind to 127.0.0.1:12321 on this computer. Bitcoin Core is probably already running.
```

(https://github.com/bitcoin/bitcoin/actions/runs/22398358349/job/64837827234?pr=31723#step:9:2605)

Also, include a random second commit, so that the CI task is run in this pull.