### PR TITLE
test: Add missing timeout_factor to zmq socket

### DIFF
--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -174,7 +174,7 @@ class ZMQTest (BitcoinTestFramework):
 
         # set subscriber's desired timeout for the test
         for sub in subscribers:
-            sub.socket.set(zmq.RCVTIMEO, recv_timeout*1000)
+            sub.socket.set(zmq.RCVTIMEO, int(recv_timeout * self.options.timeout_factor * 1000))
 
         self.connect_nodes(0, 1)
         if sync_blocks:


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/34189

Otherwise, the test may intermittently fail on slow CI systems that have `--timeout-factor=` properly set.

It can be tested by running `./bld-cmake/test/functional/interface_zmq.py --timeout-factor=10` with this diff:

```diff
diff --git a/src/validationinterface.cpp b/src/validationinterface.cpp
index c7be6abc3a..b14cf2aee6 100644
--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -166,2 +166,3 @@ void ValidationSignals::SyncWithValidationInterfaceQueue()
             LOG_EVENT(fmt, local_name, __VA_ARGS__);           \
+            UninterruptibleSleep(45ms); \
             event();                                           \
diff --git a/test/functional/interface_zmq.py b/test/functional/interface_zmq.py
index 6717007626..eee377daea 100755
--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -176,3 +176,3 @@ class ZMQTest (BitcoinTestFramework):
         for sub in subscribers:
-            sub.socket.set(zmq.RCVTIMEO, recv_timeout*1000)
+            sub.socket.set(zmq.RCVTIMEO, int(recv_timeout * 1000))
 
@@ -271,3 +271,3 @@ class ZMQTest (BitcoinTestFramework):
             [(topic, address) for topic in ["hashblock", "hashtx"]],
-            recv_timeout=2)  # 2 second timeout to check end of notifications
+            recv_timeout=0.2)  # 2 second timeout to check end of notifications
         self.disconnect_nodes(0, 1)
```

Before this pull: Test fails with `zmq.error.Again: Resource temporarily unavailable`

After this pull: Test passes