### PR TITLE
test: fix assert_array_result empty-expected match counting

### DIFF
--- a/test/functional/feature_framework_unit_tests.py
+++ b/test/functional/feature_framework_unit_tests.py
@@ -30,6 +30,7 @@ TEST_FRAMEWORK_MODULES = [
     "script",
     "script_util",
     "segwit_addr",
+    "util",
     "wallet_util",
 ]
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -19,6 +19,7 @@ import re
 import shlex
 import time
 import types
+import unittest
 
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
@@ -213,16 +214,25 @@ def assert_array_result(object_array, to_match, expected, should_not_find=False)
                 all_match = False
         if not all_match:
             continue
-        elif should_not_find:
-            num_matched = num_matched + 1
+        num_matched += 1
+        if should_not_find:
+            continue
         for key, value in expected.items():
             if item[key] != value:
                 raise AssertionError("%s : expected %s=%s" % (str(item), str(key), str(value)))
-            num_matched = num_matched + 1
     if num_matched == 0 and not should_not_find:
         raise AssertionError("No objects matched %s" % (str(to_match)))
     if num_matched > 0 and should_not_find:
         raise AssertionError("Objects were found %s" % (str(to_match)))
+
+
+class TestFrameworkUtil(unittest.TestCase):
+    def test_assert_array_result_empty_expected(self):
+        assert_array_result([{"key": 1}], {"key": 1}, {})
+
+    def test_assert_array_result_empty_expected_without_match_raises(self):
+        with self.assertRaisesRegex(AssertionError, "No objects matched"):
+            assert_array_result([{"key": 2}], {"key": 1}, {})
 
 
 # Utility functions


### PR DESCRIPTION
## Motivation

assert_array_result() can fail incorrectly when expected is empty.
In that case, a row that matches to_match is not counted, and the helper raises
"No objects matched" even though a match exists.

## What changed

1. Update assert_array_result() to increment num_matched immediately after a to_match hit.
2. Preserve existing should_not_find behavior.
3. Add regression tests in test_framework.util for:
   1. a matching row with expected={} (passes)
   2. no matching row with expected={} (raises)
4. Add test_framework.util to feature_framework_unit_tests.py so the new tests run in the framework unit test suite.

## Why this is correct

Match detection should depend on to_match, not on whether expected has keys.
The updated logic counts matches when match truth is established. This fixes the
empty-expected false negative while leaving the negative-search path unchanged.

## Test plan

```bash
test/lint/lint-python.py
python3 test/functional/feature_framework_unit_tests.py
build-codex/test/functional/test_runner.py wallet_listreceivedby.py --jobs=1 --failfast
```

## Notes

This patch is intentionally small and keeps behavior change and regression tests
in the same patch.
