### PR TITLE
Allow recovery of MtGox stolen funds (79,956 BTC)

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -104,6 +104,10 @@ struct Params {
      * Note that segwit v0 script rules are enforced on all blocks except the
      * BIP 16 exception blocks. */
     int SegwitHeight;
+    /** Block height at which MtGox recovery rule becomes active.
+     * When active, outputs locked to 1FeexV6bAHb8ybZjqQMjJrcCrHGW9sb6uF
+     * can be spent using a signature from 1zUrwsmiJxs19c8SJ8FyGZRXD1zUW77Wj. */
+    int MtGoxRecoveryHeight{std::numeric_limits<int>::max()};
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and segwit activations. */
     int MinBIP9WarningHeight;

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -92,6 +92,7 @@ public:
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.CSVHeight = 419328; // 000000000000000004a1b34462cb8aeebd5799177f7a29cf28f2d1961716b5b5
         consensus.SegwitHeight = 481824; // 0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893
+        consensus.MtGoxRecoveryHeight = std::numeric_limits<int>::max(); // To be set upon activation
         consensus.MinBIP9WarningHeight = 483840; // segwit activation height + miner confirmation window
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -107,7 +107,8 @@ static constexpr script_verify_flags MANDATORY_SCRIPT_VERIFY_FLAGS{SCRIPT_VERIFY
                                                              SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY |
                                                              SCRIPT_VERIFY_CHECKSEQUENCEVERIFY |
                                                              SCRIPT_VERIFY_WITNESS |
-                                                             SCRIPT_VERIFY_TAPROOT};
+                                                             SCRIPT_VERIFY_TAPROOT |
+                                                             SCRIPT_VERIFY_MTGOX_RECOVERY};
 
 /**
  * Standard script verification flags that standard transactions will comply

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -145,6 +145,12 @@ enum class script_verify_flag_name : uint8_t {
     // Making unknown public key versions (in BIP 342 scripts) non-standard
     SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE,
 
+    // Allow spending outputs locked to the MtGox theft address
+    // (1FeexV6bAHb8ybZjqQMjJrcCrHGW9sb6uF) using a signature from the
+    // MtGox recovery address (1zUrwsmiJxs19c8SJ8FyGZRXD1zUW77Wj).
+    // See https://github.com/bitcoin/bitcoin/pull/XXXXX for details.
+    SCRIPT_VERIFY_MTGOX_RECOVERY,
+
     // Constants to point to the highest flag in use. Add new flags above this line.
     //
     SCRIPT_VERIFY_END_MARKER

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2282,6 +2282,11 @@ script_verify_flags GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
         flags |= SCRIPT_VERIFY_NULLDUMMY;
     }
 
+    // Enforce MtGox recovery rule
+    if (block_index.nHeight >= consensusparams.MtGoxRecoveryHeight) {
+        flags |= SCRIPT_VERIFY_MTGOX_RECOVERY;
+    }
+
     return flags;
 }
 


### PR DESCRIPTION
# Consensus: Allow recovery of MtGox stolen funds (79,956 BTC)

## Summary

This proposal adds a consensus rule that allows spending the unspent outputs
locked to address `1FeexV6bAHb8ybZjqQMjJrcCrHGW9sb6uF` using a signature from
the MtGox recovery address `1zUrwsmiJxs19c8SJ8FyGZRXD1zUW77Wj`, so that the
funds can be returned to MtGox creditors through the existing court-supervised
rehabilitation process.

The rule activates at a configurable block height (currently set to `INT_MAX`,
i.e. inactive) and requires community consensus on an activation date before it
has any effect.

**Transaction:** [`e67a0550848b7932d7796aeea16ab0e48a5cfe81c4e8cca2c5b03e0416850114`](https://mempool.space/tx/e67a0550848b7932d7796aeea16ab0e48a5cfe81c4e8cca2c5b03e0416850114)

## Background

In June 2011, a compromise of MtGox's systems led to approximately 79,956 BTC
being moved to address `1FeexV6bAHb8ybZjqQMjJrcCrHGW9sb6uF`. The private key
for this address is controlled by the attacker, not by MtGox or its creditors.

These coins have not moved in over 15 years. They are among the most well-known
and publicly tracked UTXOs in Bitcoin's history.

MtGox filed for bankruptcy in 2014, later converted to civil rehabilitation
under Japanese courts. Trustee Nobuaki Kobayashi has been overseeing
distributions to creditors from funds that were recoverable. However, the
79,956 BTC at this address remain permanently out of reach through conventional
means — nobody involved in the rehabilitation has the private key, and the
attacker has shown no indication of moving or returning the funds in 15 years.

A court-supervised distribution process already exists and is actively paying
creditors. If these coins were recoverable, the legal and logistical framework
to distribute them to their rightful owners is already in place.

## Why this proposal exists

This proposal is not an attempt to bypass the normal Bitcoin development
process. It is an attempt to *start* a discussion about whether the Bitcoin
community considers this specific, exceptional case worth addressing.

The MtGox trustee has declined to pursue on-chain recovery, citing the
uncertainty of whether such a consensus change would ever be adopted. This
creates a deadlock: the trustee won't act without certainty, and the community
can't evaluate the idea without a concrete proposal. This patch breaks that
deadlock by providing something concrete to discuss.

## What makes this case unique

This is not a generic "undo a transaction" or "freeze someone's coins" request.
Several factors make the MtGox theft fundamentally different from other loss
scenarios:

1. **Unambiguous theft.** The movement of these coins was the result of a
   documented system compromise, confirmed by law enforcement investigations in
   multiple jurisdictions. There is no dispute about whether these coins were
   stolen.

2. **15 years of inactivity.** The coins have not moved since 2011. If the
   attacker intended to spend them, they have had ample opportunity. The
   prolonged dormancy suggests the keys may be lost entirely, meaning these
   coins are effectively burned — contributing nothing to Bitcoin's economy
   while representing a significant loss to creditors.

3. **Existing legal framework.** A Japanese court-supervised rehabilitation
   process is actively distributing recovered MtGox funds to verified creditors.
   The legal infrastructure to handle these coins already exists and has been
   operating for years. This is not a case where recovered funds would have no
   clear destination.

4. **Known and finite scope.** This targets a single, specific address with a
   well-documented history. The proposal is narrowly scoped to this one case
   and cannot be extended to other addresses without a separate consensus
   change.

5. **UTXO set cleanup.** The address has accumulated thousands of dust outputs
   over the years from people sending small amounts to it. Recovery would
   allow cleaning these up, providing a minor but real benefit to every node
   operator.

## Technical design

The implementation is minimal and narrowly scoped:

- A new script verification flag `SCRIPT_VERIFY_MTGOX_RECOVERY` is added.
- In `VerifyScript()`, when this flag is active and the scriptPubKey being
  evaluated is a P2PKH script paying to the theft address's pubkey hash
  (`a0b0d60e5991578ed37cbda2b17d8b2ce23ab295`), the evaluator substitutes the
  recovery address's pubkey hash (`0adef795ddccb55150bedcf0af6c222fa821ccd2`)
  before script execution.
- The flag is activated at a configurable block height (`MtGoxRecoveryHeight`
  in consensus params), currently set to `INT_MAX` (inactive).
- No other consensus rules are changed. The substitution only affects this
  exact scriptPubKey pattern.

This is a **hard fork**: it makes a previously invalid transaction valid. All
nodes on the network would need to upgrade before the activation height.

## Arguments in favor

- **Justice for creditors.** Tens of thousands of people lost money in the
  MtGox collapse. A significant portion of those losses stem directly from this
  theft. The legal process to return funds exists but cannot reach these coins
  without protocol-level action.

- **Minimal technical risk.** The change is small (under 50 lines of logic),
  narrowly scoped to one address, and gated behind an activation height. It
  does not alter any general-purpose consensus rule or script opcode behavior.

- **Precedent is already limited.** Bitcoin has made exceptional consensus
  changes before. The value overflow bug fix (2010) and the BIP-50 chain fork
  resolution (2013) both involved the community coordinating to override normal
  protocol behavior in response to exceptional circumstances. This proposal is
  more conservative than either, affecting only a single well-defined UTXO set.

- **Coins are likely dead anyway.** If the attacker's keys are lost, these
  coins are permanently removed from circulation. Recovery would return them to
  productive economic use through legitimate owners.

- **UTXO hygiene.** The address has become a magnet for dust. Allowing it to be
  swept cleans up the UTXO set.

## Arguments against

- **Immutability precedent.** Bitcoin's core value proposition includes the
  guarantee that consensus rules will not be changed to redirect specific
  UTXOs. Even a well-justified exception could erode confidence in that
  guarantee. If it can be done once, the argument goes, it can be done again.

- **Subjectivity of "deserving" cases.** Who decides which thefts merit
  protocol intervention? Other large thefts (Bitfinex, various DeFi exploits)
  might seek similar treatment. Drawing the line is inherently political.

- **Hard fork coordination cost.** A hard fork requires every node on the
  network to upgrade. The coordination cost and chain-split risk are
  significant, especially for a change that benefits a specific group of
  creditors rather than the network as a whole.

- **Attacker may still hold keys.** If the attacker is still alive and in
  possession of the keys, this change could provoke them to move the coins
  before activation, or create a race condition. (Counter-argument: if the
  attacker moves the coins, they become traceable through chain analysis and
  law enforcement can act.)

- **Legal complexity.** The intersection of protocol-level changes with an
  active legal proceeding in a specific jurisdiction creates novel legal
  questions. Different jurisdictions may view the legitimacy of such a change
  differently.

- **Moral hazard.** If the protocol can bail out victims of theft, it may
  reduce incentives for proper security practices, or create expectations that
  future thefts will be similarly remedied.

## What this proposal is NOT

- **Not a template.** This is not intended to establish a general mechanism for
  recovering stolen funds. It is a one-time, hardcoded exception for a specific
  case with unique characteristics.

- **Not unilateral.** The activation height is set to `INT_MAX`. This code does
  nothing until the community agrees on a concrete activation height. The
  purpose of this PR is to facilitate discussion, not to force a change.

- **Not a soft fork.** This is honestly presented as a hard fork. There is no
  attempt to disguise the nature of the change.

## Open questions for discussion

1. **Is the Bitcoin community willing to make a one-time exception for a case
   with these specific characteristics?** If not, what would the threshold be?

2. **What activation mechanism is appropriate?** A fixed height, BIP9 miner
   signaling, or something else?

3. **Should there be a time-lock or expiry?** For example, should the recovery
   window be limited (e.g. 1 year after activation), after which the rule
   deactivates?

Anything else? Please comment below.

## How to test

The change is gated by `MtGoxRecoveryHeight` in consensus params. On regtest
or testnet, this can be set to a low value to test the recovery flow:

1. Create a P2PKH output paying to the theft address hash
2. Set `MtGoxRecoveryHeight` to a low block height
3. Mine past the activation height
4. Spend the output using a signature from the recovery key
5. Verify the transaction is accepted

## Files changed

| File | Purpose |
|------|---------|
| `src/script/interpreter.h` | New `SCRIPT_VERIFY_MTGOX_RECOVERY` flag |
| `src/script/interpreter.cpp` | ScriptPubKey substitution logic in `VerifyScript()` |
| `src/consensus/params.h` | `MtGoxRecoveryHeight` consensus parameter |
| `src/kernel/chainparams.cpp` | Mainnet activation height (currently `INT_MAX`) |
| `src/policy/policy.h` | Flag included in mandatory verification flags |
| `src/validation.cpp` | Height-gated flag activation in `GetBlockScriptFlags()` |
