### PR TITLE
wallet: handle MiniMiner bump fee calculation failures

### DIFF
--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -22,6 +22,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/result.h>
 #include <util/time.h>
 #include <validation.h>
@@ -138,7 +139,7 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
     }
 
     // Check available balance
-    auto bal = WITH_LOCK(wallet.cs_wallet, return wallet::AvailableCoins(wallet).GetTotalAmount()); // Cache
+    auto bal = WITH_LOCK(wallet.cs_wallet, return Assert(wallet::AvailableCoins(wallet))->GetTotalAmount()); // Cache
     assert(bal == 49 * COIN * (chain_size - COINBASE_MATURITY));
 
     wallet::CCoinControl coin_control;
@@ -149,8 +150,11 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
         // Select inputs, each has 48 BTC
         wallet::CoinFilterParams filter_coins;
         filter_coins.max_count = preset_inputs->num_of_internal_inputs;
-        const auto& res = WITH_LOCK(wallet.cs_wallet,
-                                    return wallet::AvailableCoins(wallet, /*coinControl=*/nullptr, /*feerate=*/std::nullopt, filter_coins));
+        const auto res = WITH_LOCK(wallet.cs_wallet, {
+            auto available_coins{wallet::AvailableCoins(wallet, /*coinControl=*/nullptr, /*feerate=*/std::nullopt, filter_coins)};
+            Assert(available_coins);
+            return wallet::CoinsResult{*available_coins};
+        });
         for (int i=0; i < preset_inputs->num_of_internal_inputs; i++) {
             const auto& coin{res.coins.at(output_type)[i]};
             target += coin.txout.nValue;
@@ -198,13 +202,12 @@ static void AvailableCoins(benchmark::Bench& bench, const std::vector<OutputType
     }
 
     // Check available balance
-    auto bal = WITH_LOCK(wallet.cs_wallet, return wallet::AvailableCoins(wallet).GetTotalAmount()); // Cache
+    auto bal = WITH_LOCK(wallet.cs_wallet, return Assert(wallet::AvailableCoins(wallet))->GetTotalAmount()); // Cache
     assert(bal == 49 * COIN * (chain_size - COINBASE_MATURITY));
 
     bench.run([&] {
         LOCK(wallet.cs_wallet);
-        const auto& res = wallet::AvailableCoins(wallet);
-        assert(res.All().size() == (chain_size - COINBASE_MATURITY) * 2);
+        assert(Assert(wallet::AvailableCoins(wallet))->All().size() == (chain_size - COINBASE_MATURITY) * 2);
     });
 }
 

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -140,7 +140,7 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
     }
 
     // Check available balance
-    auto bal = WITH_LOCK(wallet.cs_wallet, return wallet::AvailableCoins(wallet).GetTotalAmount()); // Cache
+    auto bal = WITH_LOCK(wallet.cs_wallet, return Assert(wallet::AvailableCoins(wallet))->GetTotalAmount()); // Cache
     assert(bal == 49 * COIN * (chain_size - COINBASE_MATURITY));
 
     wallet::CCoinControl coin_control;
@@ -151,8 +151,11 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
         // Select inputs, each has 48 BTC
         wallet::CoinFilterParams filter_coins;
         filter_coins.max_count = preset_inputs->num_of_internal_inputs;
-        const auto& res = WITH_LOCK(wallet.cs_wallet,
-                                    return wallet::AvailableCoins(wallet, /*coinControl=*/nullptr, /*feerate=*/std::nullopt, filter_coins));
+        const auto res = WITH_LOCK(wallet.cs_wallet, {
+            auto available_coins{wallet::AvailableCoins(wallet, /*coinControl=*/nullptr, /*feerate=*/std::nullopt, filter_coins)};
+            Assert(available_coins);
+            return wallet::CoinsResult{*available_coins};
+        });
         for (int i=0; i < preset_inputs->num_of_internal_inputs; i++) {
             const auto& coin{res.coins.at(output_type)[i]};
             target += coin.txout.nValue;
@@ -200,13 +203,12 @@ static void AvailableCoins(benchmark::Bench& bench, const std::vector<OutputType
     }
 
     // Check available balance
-    auto bal = WITH_LOCK(wallet.cs_wallet, return wallet::AvailableCoins(wallet).GetTotalAmount()); // Cache
+    auto bal = WITH_LOCK(wallet.cs_wallet, return Assert(wallet::AvailableCoins(wallet))->GetTotalAmount()); // Cache
     assert(bal == 49 * COIN * (chain_size - COINBASE_MATURITY));
 
     bench.run([&] {
         LOCK(wallet.cs_wallet);
-        const auto& res = wallet::AvailableCoins(wallet);
-        assert(res.All().size() == (chain_size - COINBASE_MATURITY) * 2);
+        assert(Assert(wallet::AvailableCoins(wallet))->All().size() == (chain_size - COINBASE_MATURITY) * 2);
     });
 }
 

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -95,24 +95,30 @@ FUZZ_TARGET(mini_miner, .init = initialize_miner)
     CAmount sum_fees = 0;
     {
         node::MiniMiner mini_miner{pool, outpoints};
-        assert(mini_miner.IsReadyToCalculate());
+        const bool ready = mini_miner.IsReadyToCalculate();
         const auto bump_fees = mini_miner.CalculateBumpFees(target_feerate);
-        for (const auto& outpoint : outpoints) {
-            auto it = bump_fees.find(outpoint);
-            assert(it != bump_fees.end());
-            assert(it->second >= 0);
-            sum_fees += it->second;
+        if (!ready) {
+            assert(bump_fees.empty());
+        } else {
+            for (const auto& outpoint : outpoints) {
+                auto it = bump_fees.find(outpoint);
+                assert(it != bump_fees.end());
+                assert(it->second >= 0);
+                sum_fees += it->second;
+            }
         }
         assert(!mini_miner.IsReadyToCalculate());
     }
     {
         node::MiniMiner mini_miner{pool, outpoints};
-        assert(mini_miner.IsReadyToCalculate());
+        const bool ready = mini_miner.IsReadyToCalculate();
         total_bumpfee = mini_miner.CalculateTotalBumpFees(target_feerate);
-        assert(total_bumpfee.has_value());
+        assert(total_bumpfee.has_value() == ready);
         assert(!mini_miner.IsReadyToCalculate());
     }
     // Overlapping ancestry across multiple outpoints can only reduce the total bump fee.
-    assert (sum_fees >= *total_bumpfee);
+    if (total_bumpfee.has_value()) {
+        assert(sum_fees >= *total_bumpfee);
+    }
 }
 } // namespace

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -101,24 +101,30 @@ FUZZ_TARGET(mini_miner, .init = initialize_miner)
     CAmount sum_fees = 0;
     {
         node::MiniMiner mini_miner{pool, outpoints};
-        assert(mini_miner.IsReadyToCalculate());
+        const bool ready = mini_miner.IsReadyToCalculate();
         const auto bump_fees = mini_miner.CalculateBumpFees(target_feerate);
-        for (const auto& outpoint : outpoints) {
-            auto it = bump_fees.find(outpoint);
-            assert(it != bump_fees.end());
-            assert(it->second >= 0);
-            sum_fees += it->second;
+        if (!ready) {
+            assert(bump_fees.empty());
+        } else {
+            for (const auto& outpoint : outpoints) {
+                auto it = bump_fees.find(outpoint);
+                assert(it != bump_fees.end());
+                assert(it->second >= 0);
+                sum_fees += it->second;
+            }
         }
         assert(!mini_miner.IsReadyToCalculate());
     }
     {
         node::MiniMiner mini_miner{pool, outpoints};
-        assert(mini_miner.IsReadyToCalculate());
+        const bool ready = mini_miner.IsReadyToCalculate();
         total_bumpfee = mini_miner.CalculateTotalBumpFees(target_feerate);
-        assert(total_bumpfee.has_value());
+        assert(total_bumpfee.has_value() == ready);
         assert(!mini_miner.IsReadyToCalculate());
     }
     // Overlapping ancestry across multiple outpoints can only reduce the total bump fee.
-    assert (sum_fees >= *total_bumpfee);
+    if (total_bumpfee.has_value()) {
+        assert(sum_fees >= *total_bumpfee);
+    }
 }
 } // namespace

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -625,6 +625,17 @@ BOOST_FIXTURE_TEST_CASE(calculate_cluster, TestChain100Setup)
     TryAddToMempool(pool, entry.Fee(CENT).FromTx(tx_501));
     const auto cluster_501 = pool.GatherClusters(last_txs);
     BOOST_CHECK_EQUAL(cluster_501.size(), 0);
+    {
+        std::vector<COutPoint> cluster_limit_outpoints;
+        cluster_limit_outpoints.reserve(last_txs.size());
+        for (const auto& txid : last_txs) {
+            cluster_limit_outpoints.emplace_back(txid, 0);
+        }
+        node::MiniMiner mini_miner(pool, cluster_limit_outpoints);
+        BOOST_CHECK(!mini_miner.IsReadyToCalculate());
+        BOOST_CHECK(mini_miner.CalculateBumpFees(CFeeRate(CENT)).empty());
+        BOOST_CHECK(!mini_miner.CalculateTotalBumpFees(CFeeRate(CENT)).has_value());
+    }
 
     /* Zig Zag cluster:
      * txp0     txp1     txp2    ...  txp30  txp31

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -409,7 +409,7 @@ public:
 
         // And fetch the wallet available coins
         if (coin_control.m_allow_other_inputs) {
-            total_amount += AvailableCoins(*m_wallet, &coin_control).GetTotalAmount();
+            total_amount += Assert(AvailableCoins(*m_wallet, &coin_control))->GetTotalAmount();
         }
 
         return total_amount;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -411,7 +411,7 @@ public:
 
         // And fetch the wallet available coins
         if (coin_control.m_allow_other_inputs) {
-            total_amount += AvailableCoins(*m_wallet, &coin_control).GetTotalAmount();
+            total_amount += Assert(AvailableCoins(*m_wallet, &coin_control))->GetTotalAmount();
         }
 
         return total_amount;

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -599,7 +599,7 @@ RPCMethod listunspent()
         cctl.m_include_unsafe_inputs = include_unsafe;
         filter_coins.check_version_trucness = false;
         LOCK(pwallet->cs_wallet);
-        vecOutputs = AvailableCoins(*pwallet, &cctl, /*feerate=*/std::nullopt, filter_coins).All();
+        vecOutputs = CHECK_NONFATAL(AvailableCoins(*pwallet, &cctl, /*feerate=*/std::nullopt, filter_coins))->All();
     }
 
     LOCK(pwallet->cs_wallet);

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -600,7 +600,7 @@ RPCMethod listunspent()
         cctl.m_include_unsafe_inputs = include_unsafe;
         filter_coins.check_version_trucness = false;
         LOCK(pwallet->cs_wallet);
-        vecOutputs = AvailableCoins(*pwallet, &cctl, /*feerate=*/std::nullopt, filter_coins).All();
+        vecOutputs = CHECK_NONFATAL(AvailableCoins(*pwallet, &cctl, /*feerate=*/std::nullopt, filter_coins))->All();
     }
 
     LOCK(pwallet->cs_wallet);

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1477,7 +1477,11 @@ RPCMethod sendall()
             } else {
                 CoinFilterParams coins_params;
                 coins_params.min_amount = 0;
-                for (const COutput& output : AvailableCoins(*pwallet, &coin_control, fee_rate, coins_params).All()) {
+                auto available_coins_res = AvailableCoins(*pwallet, &coin_control, fee_rate, coins_params);
+                if (!available_coins_res) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(available_coins_res).original);
+                }
+                for (const COutput& output : available_coins_res->All()) {
                     if (send_max && fee_rate.GetFee(output.input_bytes) > output.txout.nValue) {
                         continue;
                     }

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1490,7 +1490,11 @@ RPCMethod sendall()
             } else {
                 CoinFilterParams coins_params;
                 coins_params.min_amount = 0;
-                for (const COutput& output : AvailableCoins(*pwallet, &coin_control, fee_rate, coins_params).All()) {
+                auto available_coins_res = AvailableCoins(*pwallet, &coin_control, fee_rate, coins_params);
+                if (!available_coins_res) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(available_coins_res).original);
+                }
+                for (const COutput& output : available_coins_res->All()) {
                     if (send_max && fee_rate.GetFee(output.input_bytes) > output.txout.nValue) {
                         continue;
                     }

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -271,8 +271,12 @@ util::Result<CoinsResult> FetchSelectedInputs(const CWallet& wallet, const CCoin
 {
     CoinsResult result;
     const bool can_grind_r = wallet.CanGrindR();
-    std::map<COutPoint, CAmount> map_of_bump_fees = wallet.chain().calculateIndividualBumpFees(coin_control.ListSelected(), coin_selection_params.m_effective_feerate);
-    for (const COutPoint& outpoint : coin_control.ListSelected()) {
+    const auto selected_inputs{coin_control.ListSelected()};
+    const auto map_of_bump_fees = wallet.chain().calculateIndividualBumpFees(selected_inputs, coin_selection_params.m_effective_feerate);
+    if (map_of_bump_fees.empty() && !selected_inputs.empty()) {
+        return util::Error{_("Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.")};
+    }
+    for (const COutPoint& outpoint : selected_inputs) {
         int64_t input_bytes = coin_control.GetInputWeight(outpoint).value_or(-1);
         if (input_bytes != -1) {
             input_bytes = GetVirtualTransactionSize(input_bytes, 0, 0);
@@ -317,7 +321,7 @@ util::Result<CoinsResult> FetchSelectedInputs(const CWallet& wallet, const CCoin
     return result;
 }
 
-CoinsResult AvailableCoins(const CWallet& wallet,
+util::Result<CoinsResult> AvailableCoins(const CWallet& wallet,
                            const CCoinControl* coinControl,
                            std::optional<CFeeRate> feerate,
                            const CoinFilterParams& params)
@@ -513,7 +517,10 @@ CoinsResult AvailableCoins(const CWallet& wallet,
     }
 
     if (feerate.has_value()) {
-        std::map<COutPoint, CAmount> map_of_bump_fees = wallet.chain().calculateIndividualBumpFees(outpoints, feerate.value());
+        const auto map_of_bump_fees = wallet.chain().calculateIndividualBumpFees(outpoints, feerate.value());
+        if (map_of_bump_fees.empty() && !outpoints.empty()) {
+            return util::Error{_("Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.")};
+        }
 
         for (auto& [_, outputs] : result.coins) {
             for (auto& output : outputs) {
@@ -554,7 +561,7 @@ std::map<CTxDestination, std::vector<COutput>> ListCoins(const CWallet& wallet)
     CCoinControl coin_control;
     CoinFilterParams coins_params;
     coins_params.skip_locked = false;
-    for (const COutput& coin : AvailableCoins(wallet, &coin_control, /*feerate=*/std::nullopt, coins_params).All()) {
+    for (const COutput& coin : Assert(AvailableCoins(wallet, &coin_control, /*feerate=*/std::nullopt, coins_params))->All()) {
         CTxDestination address;
         if (!ExtractDestination(FindNonChangeParentOutput(wallet, coin.outpoint).scriptPubKey, address)) {
             // For backwards compatibility, we convert P2PK output scripts into PKHash destinations
@@ -1216,7 +1223,9 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     // allowed (coins automatically selected by the wallet)
     CoinsResult available_coins;
     if (coin_control.m_allow_other_inputs) {
-        available_coins = AvailableCoins(wallet, &coin_control, coin_selection_params.m_effective_feerate);
+        auto res_available_coins = AvailableCoins(wallet, &coin_control, coin_selection_params.m_effective_feerate);
+        if (!res_available_coins) return util::Error{util::ErrorString(res_available_coins)};
+        available_coins = *res_available_coins;
     }
 
     // Choose coins to use

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -267,8 +267,14 @@ util::Result<CoinsResult> FetchSelectedInputs(const CWallet& wallet, const CCoin
 {
     CoinsResult result;
     const bool can_grind_r = wallet.CanGrindR();
-    std::map<COutPoint, CAmount> map_of_bump_fees = wallet.chain().calculateIndividualBumpFees(coin_control.ListSelected(), coin_selection_params.m_effective_feerate);
-    for (const COutPoint& outpoint : coin_control.ListSelected()) {
+    const auto selected_inputs{coin_control.ListSelected()};
+    const auto map_of_bump_fees = wallet.chain().calculateIndividualBumpFees(selected_inputs, coin_selection_params.m_effective_feerate);
+    // calculateIndividualBumpFees() either returns an entry per requested outpoint or gives up
+    // entirely, so an empty result for a non-empty request means the calculation failed.
+    if (map_of_bump_fees.empty() && !selected_inputs.empty()) {
+        return util::Error{_("Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.")};
+    }
+    for (const COutPoint& outpoint : selected_inputs) {
         int64_t input_bytes = coin_control.GetInputWeight(outpoint).value_or(-1);
         if (input_bytes != -1) {
             input_bytes = GetVirtualTransactionSize(input_bytes, 0, 0);
@@ -313,10 +319,10 @@ util::Result<CoinsResult> FetchSelectedInputs(const CWallet& wallet, const CCoin
     return result;
 }
 
-CoinsResult AvailableCoins(const CWallet& wallet,
-                           const CCoinControl* coinControl,
-                           std::optional<CFeeRate> feerate,
-                           const CoinFilterParams& params)
+util::Result<CoinsResult> AvailableCoins(const CWallet& wallet,
+                                         const CCoinControl* coinControl,
+                                         std::optional<CFeeRate> feerate,
+                                         const CoinFilterParams& params)
 {
     AssertLockHeld(wallet.cs_wallet);
 
@@ -509,7 +515,12 @@ CoinsResult AvailableCoins(const CWallet& wallet,
     }
 
     if (feerate.has_value()) {
-        std::map<COutPoint, CAmount> map_of_bump_fees = wallet.chain().calculateIndividualBumpFees(outpoints, feerate.value());
+        const auto map_of_bump_fees = wallet.chain().calculateIndividualBumpFees(outpoints, feerate.value());
+        // calculateIndividualBumpFees() either returns an entry per requested outpoint or gives
+        // up entirely, so an empty result for a non-empty request means the calculation failed.
+        if (map_of_bump_fees.empty() && !outpoints.empty()) {
+            return util::Error{_("Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.")};
+        }
 
         for (auto& [_, outputs] : result.coins) {
             for (auto& output : outputs) {
@@ -550,7 +561,7 @@ std::map<CTxDestination, std::vector<COutput>> ListCoins(const CWallet& wallet)
     CCoinControl coin_control;
     CoinFilterParams coins_params;
     coins_params.skip_locked = false;
-    for (const COutput& coin : AvailableCoins(wallet, &coin_control, /*feerate=*/std::nullopt, coins_params).All()) {
+    for (const COutput& coin : Assert(AvailableCoins(wallet, &coin_control, /*feerate=*/std::nullopt, coins_params))->All()) {
         CTxDestination address;
         if (!ExtractDestination(FindNonChangeParentOutput(wallet, coin.outpoint).scriptPubKey, address)) {
             // For backwards compatibility, we convert P2PK output scripts into PKHash destinations
@@ -1213,7 +1224,9 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     // allowed (coins automatically selected by the wallet)
     CoinsResult available_coins;
     if (coin_control.m_allow_other_inputs) {
-        available_coins = AvailableCoins(wallet, &coin_control, coin_selection_params.m_effective_feerate);
+        auto res_available_coins = AvailableCoins(wallet, &coin_control, coin_selection_params.m_effective_feerate);
+        if (!res_available_coins) return util::Error{util::ErrorString(res_available_coins)};
+        available_coins = std::move(*res_available_coins);
     }
 
     // Choose coins to use

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -94,10 +94,10 @@ struct CoinFilterParams {
 /**
  * Populate the CoinsResult struct with vectors of available COutputs, organized by OutputType.
  */
-CoinsResult AvailableCoins(const CWallet& wallet,
-                           const CCoinControl* coinControl = nullptr,
-                           std::optional<CFeeRate> feerate = std::nullopt,
-                           const CoinFilterParams& params = {}) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+util::Result<CoinsResult> AvailableCoins(const CWallet& wallet,
+                                         const CCoinControl* coinControl = nullptr,
+                                         std::optional<CFeeRate> feerate = std::nullopt,
+                                         const CoinFilterParams& params = {}) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 /**
  * Find non-change parent output.

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -93,10 +93,10 @@ struct CoinFilterParams {
 /**
  * Populate the CoinsResult struct with vectors of available COutputs, organized by OutputType.
  */
-CoinsResult AvailableCoins(const CWallet& wallet,
-                           const CCoinControl* coinControl = nullptr,
-                           std::optional<CFeeRate> feerate = std::nullopt,
-                           const CoinFilterParams& params = {}) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+util::Result<CoinsResult> AvailableCoins(const CWallet& wallet,
+                                         const CCoinControl* coinControl = nullptr,
+                                         std::optional<CFeeRate> feerate = std::nullopt,
+                                         const CoinFilterParams& params = {}) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 /**
  * Find non-change parent output.

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -70,7 +70,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_duplicated_preset_inputs_test, TestChain100Setup)
     auto wallet = CreateSyncedWallet(*m_node.chain, WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()), coinbaseKey);
 
     LOCK(wallet->cs_wallet);
-    auto available_coins = AvailableCoins(*wallet);
+    auto available_coins = *Assert(AvailableCoins(*wallet));
     std::vector<COutput> coins = available_coins.All();
     // Preselect the first 3 UTXO (150 BTC total)
     std::set<COutPoint> preset_inputs = {coins[0].outpoint, coins[1].outpoint, coins[2].outpoint};

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -87,7 +87,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_duplicated_preset_inputs_test, TestChain100Setup)
     auto wallet = CreateSyncedWallet(*m_node.chain, WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()), coinbaseKey);
 
     LOCK(wallet->cs_wallet);
-    auto available_coins = AvailableCoins(*wallet);
+    auto available_coins = *Assert(AvailableCoins(*wallet));
     std::vector<COutput> coins = available_coins.All();
     // Preselect the first 3 UTXO (150 BTC total)
     std::set<COutPoint> preset_inputs = {coins[0].outpoint, coins[1].outpoint, coins[2].outpoint};

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -408,7 +408,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 1U);
 
     // Check initial balance from one mature coinbase transaction.
-    BOOST_CHECK_EQUAL(50 * COIN, WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).GetTotalAmount()));
+    BOOST_CHECK_EQUAL(50 * COIN, WITH_LOCK(wallet->cs_wallet, return Assert(AvailableCoins(*wallet))->GetTotalAmount()));
 
     // Add a transaction creating a change address, and confirm ListCoins still
     // returns the coin associated with the change address underneath the
@@ -426,7 +426,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     // Lock both coins. Confirm number of available coins drops to 0.
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK_EQUAL(AvailableCoins(*wallet).Size(), 2U);
+        BOOST_CHECK_EQUAL(Assert(AvailableCoins(*wallet))->Size(), 2U);
     }
     for (const auto& group : list) {
         for (const auto& coin : group.second) {
@@ -436,7 +436,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     }
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK_EQUAL(AvailableCoins(*wallet).Size(), 0U);
+        BOOST_CHECK_EQUAL(Assert(AvailableCoins(*wallet))->Size(), 0U);
     }
     // Confirm ListCoins still returns same result as before, despite coins
     // being locked.
@@ -457,7 +457,7 @@ void TestCoinsResult(ListCoinsTest& context, OutputType out_type, CAmount amount
     CWalletTx& wtx = context.AddTx(CRecipient{*dest, amount, /*fSubtractFeeFromAmount=*/true});
     CoinFilterParams filter;
     filter.skip_locked = false;
-    CoinsResult available_coins = AvailableCoins(*context.wallet, nullptr, std::nullopt, filter);
+    CoinsResult available_coins = *Assert(AvailableCoins(*context.wallet, nullptr, std::nullopt, filter));
     // Lock outputs so they are not spent in follow-up transactions
     for (uint32_t i = 0; i < wtx.tx->vout.size(); i++) context.wallet->LockCoin({wtx.GetHash(), i}, /*persist=*/false);
     for (const auto& [type, size] : expected_coins_sizes) BOOST_CHECK_EQUAL(size, available_coins.coins[type].size());
@@ -471,7 +471,11 @@ BOOST_FIXTURE_TEST_CASE(BasicOutputTypesTest, ListCoinsTest)
     // Verify our wallet has one usable coinbase UTXO before starting
     // This UTXO is a P2PK, so it should show up in the Other bucket
     expected_coins_sizes[OutputType::UNKNOWN] = 1U;
-    CoinsResult available_coins = WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet));
+    CoinsResult available_coins;
+    {
+        LOCK(wallet->cs_wallet);
+        available_coins = *Assert(AvailableCoins(*wallet));
+    }
     BOOST_CHECK_EQUAL(available_coins.Size(), expected_coins_sizes[OutputType::UNKNOWN]);
     BOOST_CHECK_EQUAL(available_coins.coins[OutputType::UNKNOWN].size(), expected_coins_sizes[OutputType::UNKNOWN]);
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -440,7 +440,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 1U);
 
     // Check initial balance from one mature coinbase transaction.
-    BOOST_CHECK_EQUAL(50 * COIN, WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).GetTotalAmount()));
+    BOOST_CHECK_EQUAL(50 * COIN, WITH_LOCK(wallet->cs_wallet, return Assert(AvailableCoins(*wallet))->GetTotalAmount()));
 
     // Add a transaction creating a change address, and confirm ListCoins still
     // returns the coin associated with the change address underneath the
@@ -458,7 +458,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     // Lock both coins. Confirm number of available coins drops to 0.
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK_EQUAL(AvailableCoins(*wallet).Size(), 2U);
+        BOOST_CHECK_EQUAL(Assert(AvailableCoins(*wallet))->Size(), 2U);
     }
     for (const auto& group : list) {
         for (const auto& coin : group.second) {
@@ -468,7 +468,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     }
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK_EQUAL(AvailableCoins(*wallet).Size(), 0U);
+        BOOST_CHECK_EQUAL(Assert(AvailableCoins(*wallet))->Size(), 0U);
     }
     // Confirm ListCoins still returns same result as before, despite coins
     // being locked.
@@ -489,7 +489,7 @@ void TestCoinsResult(ListCoinsTest& context, OutputType out_type, CAmount amount
     CWalletTx& wtx = context.AddTx(CRecipient{*dest, amount, /*fSubtractFeeFromAmount=*/true});
     CoinFilterParams filter;
     filter.skip_locked = false;
-    CoinsResult available_coins = AvailableCoins(*context.wallet, nullptr, std::nullopt, filter);
+    CoinsResult available_coins = *Assert(AvailableCoins(*context.wallet, nullptr, std::nullopt, filter));
     // Lock outputs so they are not spent in follow-up transactions
     for (uint32_t i = 0; i < wtx.GetTx()->vout.size(); i++) context.wallet->LockCoin({wtx.GetHash(), i}, /*persist=*/false);
     for (const auto& [type, size] : expected_coins_sizes) BOOST_CHECK_EQUAL(size, available_coins.coins[type].size());
@@ -503,7 +503,11 @@ BOOST_FIXTURE_TEST_CASE(BasicOutputTypesTest, ListCoinsTest)
     // Verify our wallet has one usable coinbase UTXO before starting
     // This UTXO is a P2PK, so it should show up in the Other bucket
     expected_coins_sizes[OutputType::UNKNOWN] = 1U;
-    CoinsResult available_coins = WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet));
+    CoinsResult available_coins;
+    {
+        LOCK(wallet->cs_wallet);
+        available_coins = *Assert(AvailableCoins(*wallet));
+    }
     BOOST_CHECK_EQUAL(available_coins.Size(), expected_coins_sizes[OutputType::UNKNOWN]);
     BOOST_CHECK_EQUAL(available_coins.coins[OutputType::UNKNOWN].size(), expected_coins_sizes[OutputType::UNKNOWN]);
 

--- a/test/functional/wallet_spend_unconfirmed.py
+++ b/test/functional/wallet_spend_unconfirmed.py
@@ -9,6 +9,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_greater_than_or_equal,
     assert_equal,
+    assert_raises_rpc_error,
     find_vout_for_address,
 )
 
@@ -462,6 +463,68 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         wallet.unloadwallet()
 
+    def test_unconfirmed_cluster_limit_error(self):
+        self.log.info("Check that hitting the unconfirmed cluster limit returns a descriptive error")
+        # Confirm any leftovers from previous test cases so this scenario starts from an empty mempool.
+        self.generate(self.nodes[0], 1)
+
+        self.nodes[0].createwallet("cluster_limit_wallet")
+        wallet = self.nodes[0].get_wallet_rpc("cluster_limit_wallet")
+
+        self.generatetoaddress(self.nodes[0], 701, wallet.getnewaddress())
+        address = wallet.getnewaddress()
+        for _ in range(501):
+            result = wallet.send(outputs=[{address: 1}], options={"fee_rate": 10})
+            assert "txid" in result
+
+        error_msg = (
+            "Failed to calculate bump fees, because unconfirmed UTXOs depend on "
+            "an enormous cluster of unconfirmed transactions."
+        )
+
+        unconfirmed_inputs = []
+        seen_txids = set()
+        for utxo in wallet.listunspent(minconf=0, maxconf=0, include_unsafe=True):
+            if utxo["txid"] in seen_txids:
+                continue
+            seen_txids.add(utxo["txid"])
+            unconfirmed_inputs.append({"txid": utxo["txid"], "vout": utxo["vout"]})
+        assert_greater_than_or_equal(len(unconfirmed_inputs), 501)
+
+        assert_raises_rpc_error(
+            -4,
+            error_msg,
+            wallet.send,
+            outputs=[{address: 1}],
+            options={
+                "inputs": unconfirmed_inputs[:501],
+                "include_unsafe": True,
+                "add_inputs": False,
+                "fee_rate": 10,
+            },
+        )
+
+        assert_raises_rpc_error(
+            -4,
+            error_msg,
+            wallet.send,
+            outputs=[{address: 1}],
+            options={"fee_rate": 10},
+        )
+
+        assert_raises_rpc_error(
+            -4,
+            error_msg,
+            wallet.sendall,
+            recipients=[address],
+            fee_rate=10,
+        )
+
+        self.generate(self.nodes[0], 1)
+        assert "txid" in wallet.send(outputs=[{address: 1}], options={"fee_rate": 10})
+
+        wallet.unloadwallet()
+
 
     def run_test(self):
         self.log.info("Starting UnconfirmedInputTest!")
@@ -500,6 +563,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         self.test_confirmed_and_unconfirmed_parent()
 
         self.test_external_input_unconfirmed_low()
+
+        self.test_unconfirmed_cluster_limit_error()
 
 if __name__ == '__main__':
     UnconfirmedInputTest(__file__).main()

--- a/test/functional/wallet_spend_unconfirmed.py
+++ b/test/functional/wallet_spend_unconfirmed.py
@@ -9,6 +9,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_greater_than_or_equal,
     assert_equal,
+    assert_raises_rpc_error,
     find_vout_for_address,
 )
 
@@ -462,6 +463,73 @@ class UnconfirmedInputTest(BitcoinTestFramework):
 
         wallet.unloadwallet()
 
+    def test_unconfirmed_cluster_limit_error(self):
+        self.log.info("Check that hitting the unconfirmed cluster limit returns a descriptive error")
+        # Confirm any leftovers from previous test cases so this scenario starts from an empty mempool.
+        self.generate(self.nodes[0], 1)
+
+        self.nodes[0].createwallet("cluster_limit_wallet")
+        wallet = self.nodes[0].get_wallet_rpc("cluster_limit_wallet")
+
+        # Fund the wallet with enough mature coinbase outputs for the transactions below.
+        self.generatetoaddress(self.nodes[0], 701, wallet.getnewaddress())
+
+        # Bump fees cannot be calculated once the mempool transactions gathered for the requested
+        # inputs exceed the cluster limit of 500, so create one unconfirmed transaction more.
+        address = wallet.getnewaddress()
+        for _ in range(501):
+            result = wallet.send(outputs=[{address: 1}], options={"fee_rate": 10})
+            assert "txid" in result
+
+        error_msg = (
+            "Failed to calculate bump fees, because unconfirmed UTXOs depend on "
+            "an enormous cluster of unconfirmed transactions."
+        )
+
+        # Take a single output per transaction, so that spending them reaches all 501.
+        unconfirmed_inputs = []
+        seen_txids = set()
+        for utxo in wallet.listunspent(minconf=0, maxconf=0, include_unsafe=True):
+            if utxo["txid"] in seen_txids:
+                continue
+            seen_txids.add(utxo["txid"])
+            unconfirmed_inputs.append({"txid": utxo["txid"], "vout": utxo["vout"]})
+        assert_greater_than_or_equal(len(unconfirmed_inputs), 501)
+
+        assert_raises_rpc_error(
+            -4,
+            error_msg,
+            wallet.send,
+            outputs=[{address: 1}],
+            options={
+                "inputs": unconfirmed_inputs[:501],
+                "include_unsafe": True,
+                "add_inputs": False,
+                "fee_rate": 10,
+            },
+        )
+
+        assert_raises_rpc_error(
+            -4,
+            error_msg,
+            wallet.send,
+            outputs=[{address: 1}],
+            options={"fee_rate": 10},
+        )
+
+        assert_raises_rpc_error(
+            -4,
+            error_msg,
+            wallet.sendall,
+            recipients=[address],
+            fee_rate=10,
+        )
+
+        self.generate(self.nodes[0], 1)
+        assert "txid" in wallet.send(outputs=[{address: 1}], options={"fee_rate": 10})
+
+        wallet.unloadwallet()
+
 
     def run_test(self):
         self.log.info("Starting UnconfirmedInputTest!")
@@ -500,6 +568,8 @@ class UnconfirmedInputTest(BitcoinTestFramework):
         self.test_confirmed_and_unconfirmed_parent()
 
         self.test_external_input_unconfirmed_low()
+
+        self.test_unconfirmed_cluster_limit_error()
 
 if __name__ == '__main__':
     UnconfirmedInputTest(__file__).main()


### PR DESCRIPTION
Fixes #29711.

When MiniMiner cannot calculate individual bump fees, wallet funding can
index missing bump-fee entries and return `map::at` to users.

Treat an empty bump-fee map for non-empty requested outpoints as a
calculation failure. Make `AvailableCoins` return
`util::Result<CoinsResult>` so transaction creation and `sendall` can
propagate the wallet error instead of leaking an internal exception.

Add a functional regression test in `wallet_spend_unconfirmed.py`
covering the large unconfirmed set scenario from #29711. The test checks
auto-selected inputs, manually selected inputs, and `sendall`, and verifies
that spending succeeds again after mining a block.

Tested:
- `cmake --build build`
- `build/bin/test_bitcoin --catch_system_errors=no`
- `build/bin/test_bitcoin --run_test=miniminer_tests --catch_system_errors=no`
- `build/bin/test_bitcoin --run_test=spend_tests --catch_system_errors=no`
- `build/bin/test_bitcoin --run_test=coinselector_tests/bump_fee_test --catch_system_errors=no`
- `build/bin/test_bitcoin --run_test=wallet_tests/ListCoinsTest --catch_system_errors=no`
- `build/bin/test_bitcoin --run_test=wallet_tests/BasicOutputTypesTest --catch_system_errors=no`
- `python3 build/test/functional/test_runner.py wallet_spend_unconfirmed.py wallet_sendall.py wallet_send.py wallet_fundrawtransaction.py wallet_bumpfee.py wallet_create_tx.py wallet_basic.py`
- `build/bin/bench_bitcoin -filter='WalletAvailableCoins|WalletCreateTxUseOnlyPresetInputs|WalletCreateTxUsePresetInputsAndCoinSelection' -sanity-check`