### PR TITLE
test: Fix script_assets_tests no-op on Windows CI

### DIFF
--- a/.github/ci-windows-cross.py
+++ b/.github/ci-windows-cross.py
@@ -80,6 +80,13 @@ def prepare_tests():
     ]
     run(cmd_download_prev_rel)
     run([sys.executable, "-m", "pip", "install", "pyzmq"])
+    dir_unit_test_data = Path.cwd() / "qa-assets" / "unit_test_data"
+    dir_unit_test_data.mkdir(parents=True, exist_ok=True)
+    import urllib.request
+    urllib.request.urlretrieve(
+        "https://github.com/bitcoin-core/qa-assets/raw/main/unit_test_data/script_assets_test.json",
+        dir_unit_test_data / "script_assets_test.json",
+    )
 
 
 def run_functional_tests():
@@ -118,6 +125,7 @@ def run_functional_tests():
 
 def run_unit_tests():
     # Can't use ctest here like other jobs as we don't have a CMake build tree.
+    os.environ["DIR_UNIT_TEST_DATA"] = str(Path.cwd() / "qa-assets" / "unit_test_data")
     commands = [
         ["./bin/test_bitcoin-qt.exe"],
         # Intentionally run sequentially here, to catch test case failures caused by dirty global state from prior test cases:

--- a/.github/ci-windows.py
+++ b/.github/ci-windows.py
@@ -128,6 +128,13 @@ def check_manifests(ci_type):
 def prepare_tests(ci_type):
     if ci_type == "standard":
         run([sys.executable, "-m", "pip", "install", "pyzmq"])
+        dir_unit_test_data = Path.cwd() / "qa-assets" / "unit_test_data"
+        dir_unit_test_data.mkdir(parents=True, exist_ok=True)
+        import urllib.request
+        urllib.request.urlretrieve(
+            "https://github.com/bitcoin-core/qa-assets/raw/main/unit_test_data/script_assets_test.json",
+            dir_unit_test_data / "script_assets_test.json",
+        )
     elif ci_type == "fuzz":
         repo_dir = str(Path.cwd() / "qa-assets")
         clone_cmd = [
@@ -160,6 +167,8 @@ def run_tests(ci_type):
         }
         for var, exe in test_envs.items():
             os.environ[var] = str(release_bin / exe)
+
+        os.environ["DIR_UNIT_TEST_DATA"] = str(Path.cwd() / "qa-assets" / "unit_test_data")
 
         ctest_cmd = [
             "ctest",


### PR DESCRIPTION
Resolves #34670

Since the switch to Python for Windows CI, the `qa-assets` files were not properly fetched during the test preparation phase, and the `DIR_UNIT_TEST_DATA` env variable was missing, causing `script_assets_tests` to skip or fail as a no-op on Windows test runners.

This PR adds the standard `urllib.request` retrieval to both `.github/ci-windows.py` and `.github/ci-windows-cross.py` during `prepare_tests` and sets `DIR_UNIT_TEST_DATA` in `run_unit_tests` and `run_tests` respectively to restore parity with the Bash pipelines.