### PR TITLE
doc: Improve dependencies.md IPC documentation

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -35,7 +35,8 @@ Bitcoin Core requires one of the following compilers.
 
 | Dependency | Releases | Minimum required |
 | --- | --- | --- |
-| [Cap'n Proto](../depends/packages/capnp.mk) | [link](https://capnproto.org) | [0.7.1](https://github.com/bitcoin/bitcoin/pull/28907) |
+| [Cap'n Proto](../depends/packages/native_capnp.mk) ([IPC](multiprocess.md)) | [link](https://capnproto.org/) | [0.7.1](https://github.com/bitcoin/bitcoin/pull/33241) |
+| [libmultiprocess](../depends/packages/native_libmultiprocess.mk) ([IPC](multiprocess.md)) | [link](https://github.com/bitcoin-core/libmultiprocess/tags) | [v7.0-pre1](https://github.com/bitcoin/bitcoin/pull/33517) |
 | Python (scripts, tests) | [link](https://www.python.org) | [3.10](https://github.com/bitcoin/bitcoin/pull/30527) |
 | [Qt](../depends/packages/qt.mk) (gui) | [link](https://download.qt.io/archive/qt/) | [6.2](https://github.com/bitcoin/bitcoin/pull/30997) |
 | [qrencode](../depends/packages/qrencode.mk) (gui) | [link](https://fukuchi.org/works/qrencode/) | N/A |


### PR DESCRIPTION
Improve dependencies.md to document IPC dependencies better ([preview](https://github.com/ryanofsky/bitcoin/blob/pr/ipc-depdoc/doc/dependencies.md#build-1)). Specific changes are listed in the commit message.

This PR is based on #33623 by willcl-ark which made similar changes in the 29.x branch. This PR could also be backported to 30.x (it merges cleanly, and master and 30.x both have the same version requirements).