### PR TITLE
net: keep finished private broadcast txs in memory

### DIFF
--- a/doc/release-notes-34707.md
+++ b/doc/release-notes-34707.md
@@ -1,0 +1,9 @@
+P2P and network changes
+-----------------------
+
+- Transactions submitted via private broadcast are now retained in memory after
+  they are received back from the network, rather than being removed. They can
+  still be removed manually using the `abortprivatebroadcast` RPC. The
+  `getprivatebroadcastinfo` RPC now returns a `received_by_us` object for
+  transactions that have been received back from the network, containing the
+  peer `address` and `time` of reception. (#34707)

--- a/doc/release-notes-34707.md
+++ b/doc/release-notes-34707.md
@@ -1,0 +1,10 @@
+P2P and network changes
+-----------------------
+
+- Transactions submitted via private broadcast are now retained in the private broadcast queue after
+  they are received back from the network, rather than being removed. They can
+  still be removed manually using the `abortprivatebroadcast` RPC, and are
+  evicted oldest first if room is needed for a new transaction. The
+  `getprivatebroadcastinfo` RPC now returns a `received_by_us` object for
+  transactions that have been received back from the network, containing the
+  peer `address` and `time` of reception. (#34707)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4404,7 +4404,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         const uint256& hash = peer.m_wtxid_relay ? wtxid.ToUint256() : txid.ToUint256();
         AddKnownTx(peer, hash);
 
-        if (const auto num_broadcasted{m_tx_for_private_broadcast.Remove(ptx)}) {
+        if (const auto num_broadcasted{m_tx_for_private_broadcast.MarkReceived(ptx, CService{pfrom.addr})}) {
             LogDebug(BCLog::PRIVBROADCAST, "Received our privately broadcast transaction (txid=%s) from the "
                                            "network from %s; stopping private broadcast attempts",
                      txid.ToString(), pfrom.LogPeer());

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4711,7 +4711,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         const uint256& hash = peer.m_wtxid_relay ? wtxid.ToUint256() : txid.ToUint256();
         AddKnownTx(peer, hash);
 
-        if (const auto num_broadcasted{m_tx_for_private_broadcast.Remove(ptx)}) {
+        if (const auto num_broadcasted{m_tx_for_private_broadcast.MarkReceived(ptx, CService{pfrom.addr})}) {
             LogDebug(BCLog::PRIVBROADCAST, "Received our privately broadcast transaction (txid=%s) from the "
                                            "network from %s; stopping private broadcast attempts",
                      txid.ToString(), pfrom.LogPeer());

--- a/src/private_broadcast.cpp
+++ b/src/private_broadcast.cpp
@@ -6,14 +6,24 @@
 #include <util/check.h>
 
 #include <algorithm>
+#include <ranges>
 
 
 bool PrivateBroadcast::Add(const CTransactionRef& tx)
     EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
 {
     LOCK(m_mutex);
-    const bool inserted{m_transactions.try_emplace(tx).second};
-    return inserted;
+    const auto [it, inserted]{m_transactions.try_emplace(tx)};
+    if (!inserted) {
+        auto& state{it->second};
+        if (!state.received_by_us.has_value()) {
+            return false;
+        }
+        state.time_added = NodeClock::now();
+        state.received_by_us.reset();
+        state.send_statuses.clear();
+    }
+    return true;
 }
 
 std::optional<size_t> PrivateBroadcast::Remove(const CTransactionRef& tx)
@@ -28,17 +38,30 @@ std::optional<size_t> PrivateBroadcast::Remove(const CTransactionRef& tx)
     return std::nullopt;
 }
 
+std::optional<size_t> PrivateBroadcast::MarkReceived(const CTransactionRef& tx, const CService& received_from)
+    EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+{
+    LOCK(m_mutex);
+    const auto it{m_transactions.find(tx)};
+    if (it == m_transactions.end() || it->second.received_by_us.has_value()) return std::nullopt;
+    it->second.received_by_us.emplace(received_from, NodeClock::now());
+    const auto p{DerivePriority(it->second.send_statuses)};
+    return p.num_confirmed;
+}
+
 std::optional<CTransactionRef> PrivateBroadcast::PickTxForSend(const NodeId& will_send_to_nodeid, const CService& will_send_to_address)
     EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
 {
     LOCK(m_mutex);
 
-    const auto it{std::ranges::max_element(
-            m_transactions,
+    auto pending{m_transactions | std::views::filter([](const auto& el) {
+        return !el.second.received_by_us.has_value();
+    })};
+    const auto it{std::ranges::max_element(pending,
             [](const auto& a, const auto& b) { return a < b; },
             [](const auto& el) { return DerivePriority(el.second.send_statuses); })};
 
-    if (it != m_transactions.end()) {
+    if (it != pending.end()) {
         auto& [tx, state]{*it};
         state.send_statuses.emplace_back(will_send_to_nodeid, will_send_to_address, NodeClock::now());
         return tx;
@@ -83,7 +106,9 @@ bool PrivateBroadcast::HavePendingTransactions()
     EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
 {
     LOCK(m_mutex);
-    return !m_transactions.empty();
+    return std::ranges::any_of(m_transactions | std::views::values, [](const TxBroadcastStatus& status) {
+        return !status.received_by_us.has_value();
+    });
 }
 
 std::vector<CTransactionRef> PrivateBroadcast::GetStale() const
@@ -93,6 +118,7 @@ std::vector<CTransactionRef> PrivateBroadcast::GetStale() const
     const auto now{NodeClock::now()};
     std::vector<CTransactionRef> stale;
     for (const auto& [tx, state] : m_transactions) {
+        if (state.received_by_us.has_value()) continue;
         const Priority p{DerivePriority(state.send_statuses)};
         if (p.num_confirmed == 0) {
             if (state.time_added < now - INITIAL_STALE_DURATION) stale.push_back(tx);
@@ -116,7 +142,12 @@ std::vector<PrivateBroadcast::TxBroadcastInfo> PrivateBroadcast::GetBroadcastInf
         for (const auto& status : state.send_statuses) {
             peers.emplace_back(PeerSendInfo{.address = status.address, .sent = status.picked, .received = status.confirmed});
         }
-        entries.emplace_back(TxBroadcastInfo{.tx = tx, .time_added = state.time_added, .peers = std::move(peers)});
+        entries.emplace_back(TxBroadcastInfo{
+            .tx = tx,
+            .time_added = state.time_added,
+            .peers = std::move(peers),
+            .received_by_us = state.received_by_us,
+        });
     }
 
     return entries;

--- a/src/private_broadcast.cpp
+++ b/src/private_broadcast.cpp
@@ -17,13 +17,22 @@ PrivateBroadcast::AddResult PrivateBroadcast::Add(const CTransactionRef& tx)
     if (const auto it{m_transactions.find(tx)}; it != m_transactions.end()) {
         if (IsPending(it->second)) return AddResult::AlreadyPresent;
 
-        // An exhausted transaction can be explicitly retried by adding it again.
+        // An exhausted or received transaction can be explicitly retried by adding it again.
         it->second.time_added = NodeClock::now();
         it->second.send_statuses.clear();
+        it->second.received_by_us.reset();
         return AddResult::Added;
     }
 
-    if (m_transactions.size() >= m_max_transactions) return AddResult::QueueFull;
+    if (m_transactions.size() >= m_max_transactions) {
+        // Make room by dropping the oldest transaction that is no longer being broadcast.
+        auto finished{m_transactions | std::views::filter([this](const auto& entry) { return !IsPending(entry.second); })};
+        const auto oldest{std::ranges::min_element(finished, {}, [](const auto& entry) { return entry.second.time_added; })};
+
+        if (oldest == finished.end()) return AddResult::QueueFull;
+
+        m_transactions.erase(oldest.base());
+    }
 
     m_transactions.try_emplace(tx);
     return AddResult::Added;
@@ -39,6 +48,17 @@ std::optional<size_t> PrivateBroadcast::Remove(const CTransactionRef& tx)
         return p.num_confirmed;
     }
     return std::nullopt;
+}
+
+std::optional<size_t> PrivateBroadcast::MarkReceived(const CTransactionRef& tx, const CService& received_from)
+    EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+{
+    LOCK(m_mutex);
+    const auto it{m_transactions.find(tx)};
+    if (it == m_transactions.end() || it->second.received_by_us.has_value()) return std::nullopt;
+    it->second.received_by_us.emplace(received_from, NodeClock::now());
+    const auto p{DerivePriority(it->second.send_statuses)};
+    return p.num_confirmed;
 }
 
 std::optional<CTransactionRef> PrivateBroadcast::PickTxForSend(const NodeId& will_send_to_nodeid, const CService& will_send_to_address)
@@ -136,8 +156,14 @@ std::vector<PrivateBroadcast::TxBroadcastInfo> PrivateBroadcast::GetBroadcastInf
         for (const auto& status : state.send_statuses) {
             peers.emplace_back(PeerSendInfo{.address = status.address, .sent = status.picked, .received = status.confirmed});
         }
-        const size_t attempts_remaining{m_max_send_attempts - std::min(state.send_statuses.size(), m_max_send_attempts)};
-        entries.emplace_back(TxBroadcastInfo{.tx = tx, .time_added = state.time_added, .attempts_remaining = attempts_remaining, .peers = std::move(peers)});
+        const size_t attempts_remaining{IsPending(state) ? m_max_send_attempts - state.send_statuses.size() : 0};
+        entries.emplace_back(TxBroadcastInfo{
+            .tx = tx,
+            .time_added = state.time_added,
+            .attempts_remaining = attempts_remaining,
+            .peers = std::move(peers),
+            .received_by_us = state.received_by_us,
+        });
     }
 
     return entries;
@@ -145,7 +171,7 @@ std::vector<PrivateBroadcast::TxBroadcastInfo> PrivateBroadcast::GetBroadcastInf
 
 bool PrivateBroadcast::IsPending(const TxSendStatus& status) const
 {
-    return status.send_statuses.size() < m_max_send_attempts;
+    return !status.received_by_us.has_value() && status.send_statuses.size() < m_max_send_attempts;
 }
 
 PrivateBroadcast::Priority PrivateBroadcast::DerivePriority(const std::vector<SendStatus>& sent_to)

--- a/src/private_broadcast.h
+++ b/src/private_broadcast.h
@@ -20,6 +20,7 @@
  * Store a list of transactions to be broadcast privately. Supports the following operations:
  * - Add a new transaction
  * - Remove a transaction
+ * - Record that a transaction was received back from the network
  * - Pick a transaction for sending to one recipient
  * - Query which transaction has been picked for sending to a given recipient node
  * - Mark that a given recipient node has confirmed receipt of a transaction
@@ -44,17 +45,24 @@ public:
         std::optional<NodeClock::time_point> received;
     };
 
+    struct Received {
+        CService from;
+        NodeClock::time_point when;
+    };
+
     struct TxBroadcastInfo {
         CTransactionRef tx;
         NodeClock::time_point time_added;
         std::vector<PeerSendInfo> peers;
+        std::optional<Received> received_by_us;
     };
 
     /**
-     * Add a transaction to the storage.
+     * Add a transaction to the storage, or reset a transaction's state if the
+     * transaction has been marked received.
      * @param[in] tx The transaction to add.
-     * @retval true The transaction was added.
-     * @retval false The transaction was already present.
+     * @retval true The transaction was added or reset.
+     * @retval false The transaction was already present and not marked received.
      */
     bool Add(const CTransactionRef& tx)
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
@@ -63,10 +71,23 @@ public:
      * Forget a transaction.
      * @param[in] tx Transaction to forget.
      * @retval !nullopt The number of times the transaction was sent and confirmed
-     * by the recipient (if the transaction existed and was removed).
+     * by a recipient (if the transaction existed and was removed).
      * @retval nullopt The transaction was not in the storage.
      */
     std::optional<size_t> Remove(const CTransactionRef& tx)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /**
+     * Record that a transaction was received back from the network.
+     * The transaction remains in storage but will not be picked for sending
+     * again unless it is re-added via Add().
+     * @param[in] tx Transaction received from the network.
+     * @param[in] received_from Peer address we received the transaction from.
+     * @retval !nullopt The number of times the transaction was sent and confirmed
+     * by a recipient (if the transaction was found and marked as received).
+     * @retval nullopt The transaction was not in the storage or was already marked received.
+     */
+    std::optional<size_t> MarkReceived(const CTransactionRef& tx, const CService& received_from)
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /**
@@ -186,12 +207,13 @@ private:
      */
     std::optional<TxAndSendStatusForNode> GetSendStatusByNode(const NodeId& nodeid)
         EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
-    struct TxSendStatus {
-        const NodeClock::time_point time_added{NodeClock::now()};
+    struct TxBroadcastStatus {
+        NodeClock::time_point time_added{NodeClock::now()};
         std::vector<SendStatus> send_statuses;
+        std::optional<Received> received_by_us;
     };
     mutable Mutex m_mutex;
-    std::unordered_map<CTransactionRef, TxSendStatus, CTransactionRefHash, CTransactionRefComp>
+    std::unordered_map<CTransactionRef, TxBroadcastStatus, CTransactionRefHash, CTransactionRefComp>
         m_transactions GUARDED_BY(m_mutex);
 };
 

--- a/src/private_broadcast.h
+++ b/src/private_broadcast.h
@@ -20,6 +20,7 @@
  * Store a list of transactions to be broadcast privately. Supports the following operations:
  * - Add a new transaction
  * - Remove a transaction
+ * - Record that a transaction was received back from the network
  * - Pick a transaction for sending to one recipient
  * - Query which transaction has been picked for sending to a given recipient node
  * - Mark that a given recipient node has confirmed receipt of a transaction
@@ -39,7 +40,8 @@ public:
     static constexpr auto STALE_DURATION{1min};
 
     /// Maximum number of transactions tracked simultaneously.
-    /// Additions that would exceed this are rejected (see Add()).
+    /// Additions that would exceed this evict the oldest transaction that is no
+    /// longer pending, or are rejected if there is none (see Add()).
     static constexpr size_t MAX_TRANSACTIONS{10'000};
 
     /// Maximum number of send attempts for a transaction. Once this limit is
@@ -61,31 +63,43 @@ public:
         std::optional<NodeClock::time_point> received;
     };
 
+    struct Received {
+        CService from;
+        NodeClock::time_point when;
+    };
+
     struct TxBroadcastInfo {
         CTransactionRef tx;
         NodeClock::time_point time_added;
-        /// Number of additional send attempts allowed for this transaction (0 if exhausted).
+        /// Number of additional send attempts allowed for this transaction (0 if
+        /// exhausted or already received back from the network).
         size_t attempts_remaining;
         std::vector<PeerSendInfo> peers;
+        std::optional<Received> received_by_us;
     };
 
     /// Outcome of Add().
     enum class AddResult {
-        //! The transaction was newly added or reset after exhausting its send attempts.
+        //! The transaction was newly added or reset after exhausting its send
+        //! attempts or being received back from the network.
         Added,
-        //! The transaction was already present with send attempts remaining; no change.
+        //! The transaction was already present and still pending; no change.
         AlreadyPresent,
-        //! Rejected: the queue is already at MAX_TRANSACTIONS.
+        //! Rejected: the queue is at MAX_TRANSACTIONS and every transaction in
+        //! it is still pending, so there is nothing that can be evicted.
         QueueFull,
     };
 
     /**
-     * Add a transaction to the storage, or reset an exhausted transaction so it
-     * can be broadcast again.
+     * Add a transaction to the storage, or reset an exhausted or received
+     * transaction so it can be broadcast again.
+     * If the queue is at MAX_TRANSACTIONS, the oldest transaction that is no
+     * longer pending is evicted to make room. Pending transactions are never
+     * evicted.
      * @param[in] tx The transaction to add.
      * @return Whether the transaction was newly added or reset, was already
-     * present with send attempts remaining, or was rejected because the queue is
-     * full (see AddResult).
+     * present and still pending, or was rejected because the queue is full
+     * (see AddResult).
      */
     [[nodiscard]] AddResult Add(const CTransactionRef& tx)
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
@@ -94,10 +108,23 @@ public:
      * Forget a transaction.
      * @param[in] tx Transaction to forget.
      * @retval !nullopt The number of times the transaction was sent and confirmed
-     * by the recipient (if the transaction existed and was removed).
+     * by a recipient (if the transaction existed and was removed).
      * @retval nullopt The transaction was not in the storage.
      */
     std::optional<size_t> Remove(const CTransactionRef& tx)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /**
+     * Record that a transaction was received back from the network.
+     * The transaction remains in storage but will not be picked for sending
+     * again unless it is re-added via Add().
+     * @param[in] tx Transaction received from the network.
+     * @param[in] received_from Peer address we received the transaction from.
+     * @retval !nullopt The number of times the transaction was sent and confirmed
+     * by a recipient (if the transaction was found and marked as received).
+     * @retval nullopt The transaction was not in the storage or was already marked received.
+     */
+    std::optional<size_t> MarkReceived(const CTransactionRef& tx, const CService& received_from)
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /**
@@ -109,8 +136,8 @@ public:
      * transaction to one node would be a privacy leak.
      * @param[in] will_send_to_address Address of the peer to which this transaction
      * will be sent.
-     * @return Most urgent transaction or nullopt if there are no transactions
-     * with send attempts remaining.
+     * @return Most urgent transaction or nullopt if there are no pending
+     * transactions.
      */
     std::optional<CTransactionRef> PickTxForSend(const NodeId& will_send_to_nodeid, const CService& will_send_to_address)
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
@@ -140,14 +167,14 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /**
-     * Check if there are transactions with send attempts remaining.
+     * Check if there are transactions that still need to be broadcast.
      */
     bool HavePendingTransactions()
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /**
-     * Get the transactions that have not been broadcast recently and have send
-     * attempts remaining.
+     * Get the transactions that have not been broadcast recently and are still
+     * pending (not yet received back, with send attempts remaining).
      */
     std::vector<CTransactionRef> GetStale() const
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
@@ -228,6 +255,7 @@ private:
     struct TxSendStatus {
         NodeClock::time_point time_added{NodeClock::now()};
         std::vector<SendStatus> send_statuses;
+        std::optional<Received> received_by_us;
     };
     bool IsPending(const TxSendStatus& status) const;
     /// Cap on the number of simultaneously tracked transactions (see Add()).

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -148,7 +148,7 @@ static RPCMethod getprivatebroadcastinfo()
         RPCResult{
             RPCResult::Type::OBJ, "", "",
             {
-                {RPCResult::Type::ARR, "transactions", "",
+                {RPCResult::Type::ARR, "transactions", "Transactions currently in the private broadcast queue",
                     {
                         {RPCResult::Type::OBJ, "", "",
                             {
@@ -164,6 +164,11 @@ static RPCMethod getprivatebroadcastinfo()
                                                 {RPCResult::Type::NUM_TIME, "sent", "The time this transaction was picked for sending to this peer via private broadcast (seconds since epoch)"},
                                                 {RPCResult::Type::NUM_TIME, "received", /*optional=*/true, "The time this peer acknowledged reception of the transaction (seconds since epoch)"},
                                             }},
+                                    }},
+                                {RPCResult::Type::OBJ, "received_by_us", /*optional=*/true, "Information about how this transaction was received back from the network",
+                                    {
+                                        {RPCResult::Type::STR, "address", "The peer address from which this transaction was received back from the network"},
+                                        {RPCResult::Type::NUM_TIME, "time", "The time this transaction was received back from the network (seconds since epoch)"},
                                     }},
                             }},
                     }},
@@ -196,6 +201,12 @@ static RPCMethod getprivatebroadcastinfo()
                     peers.push_back(std::move(p));
                 }
                 o.pushKV("peers", std::move(peers));
+                if (tx_info.received_by_us.has_value()) {
+                    UniValue r(UniValue::VOBJ);
+                    r.pushKV("address", tx_info.received_by_us->from.ToStringAddrPort());
+                    r.pushKV("time", TicksSinceEpoch<std::chrono::seconds>(tx_info.received_by_us->when));
+                    o.pushKV("received_by_us", std::move(r));
+                }
                 transactions.push_back(std::move(o));
             }
 

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -148,13 +148,14 @@ static RPCMethod getprivatebroadcastinfo()
     return RPCMethod{
         "getprivatebroadcastinfo",
         "Returns information about transactions tracked for private broadcast.\n"
-        "Transactions that have reached the send-attempt limit remain in the result with attempts_remaining=0.\n"
+        "Transactions that have reached the send-attempt limit, or that have been received back from\n"
+        "the network, remain in the result with attempts_remaining=0.\n"
         "This method is only available when running with -privatebroadcast enabled.\n",
         {},
         RPCResult{
             RPCResult::Type::OBJ, "", "",
             {
-                {RPCResult::Type::ARR, "transactions", "",
+                {RPCResult::Type::ARR, "transactions", "Transactions currently in the private broadcast queue",
                     {
                         {RPCResult::Type::OBJ, "", "",
                             {
@@ -162,7 +163,7 @@ static RPCMethod getprivatebroadcastinfo()
                                 {RPCResult::Type::STR_HEX, "wtxid", "The transaction witness hash in hex"},
                                 {RPCResult::Type::STR_HEX, "hex", "The serialized, hex-encoded transaction data"},
                                 {RPCResult::Type::NUM_TIME, "time_added", "The time this transaction was added to the private broadcast queue (seconds since epoch)"},
-                                {RPCResult::Type::NUM, "attempts_remaining", "The number of additional private broadcast send attempts allowed for this transaction"},
+                                {RPCResult::Type::NUM, "attempts_remaining", "The number of additional private broadcast send attempts allowed for this transaction, 0 if it will not be sent again unless re-added"},
                                 {RPCResult::Type::ARR, "peers", "Per-peer send and acknowledgment information for this transaction",
                                     {
                                         {RPCResult::Type::OBJ, "", "",
@@ -171,6 +172,11 @@ static RPCMethod getprivatebroadcastinfo()
                                                 {RPCResult::Type::NUM_TIME, "sent", "The time this transaction was picked for sending to this peer via private broadcast (seconds since epoch)"},
                                                 {RPCResult::Type::NUM_TIME, "received", /*optional=*/true, "The time this peer acknowledged reception of the transaction (seconds since epoch)"},
                                             }},
+                                    }},
+                                {RPCResult::Type::OBJ, "received_by_us", /*optional=*/true, "Information about how this transaction was received back from the network",
+                                    {
+                                        {RPCResult::Type::STR, "address", "The peer address from which this transaction was received back from the network"},
+                                        {RPCResult::Type::NUM_TIME, "time", "The time this transaction was received back from the network (seconds since epoch)"},
                                     }},
                             }},
                     }},
@@ -208,6 +214,12 @@ static RPCMethod getprivatebroadcastinfo()
                     peers.push_back(std::move(p));
                 }
                 o.pushKV("peers", std::move(peers));
+                if (tx_info.received_by_us.has_value()) {
+                    UniValue r(UniValue::VOBJ);
+                    r.pushKV("address", tx_info.received_by_us->from.ToStringAddrPort());
+                    r.pushKV("time", TicksSinceEpoch<std::chrono::seconds>(tx_info.received_by_us->when));
+                    o.pushKV("received_by_us", std::move(r));
+                }
                 transactions.push_back(std::move(o));
             }
 

--- a/src/test/fuzz/private_broadcast.cpp
+++ b/src/test/fuzz/private_broadcast.cpp
@@ -63,6 +63,21 @@ FUZZ_TARGET(private_broadcast)
         return entry.second < max_send_attempts;
     }};
 
+    // Forget the sends recorded for a transaction that is no longer tracked or whose state
+    // was reset. Returns how many of those nodes had confirmed reception.
+    const auto forget_sends{[&nodes_sent_to, &nodes_that_confirmed_reception](const CTransactionRef& tx) {
+        size_t num_confirmed{0};
+        for (auto it = nodes_sent_to.begin(); it != nodes_sent_to.end();) {
+            if (CTransactionRefComp{}(it->second, tx)) {
+                if (nodes_that_confirmed_reception.erase(it->first) > 0) ++num_confirmed;
+                it = nodes_sent_to.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        return num_confirmed;
+    }};
+
     const auto ExistentOrNewNodeId = [&next_nodeid, &fdp](){
         if (next_nodeid == 0 || fdp.ConsumeBool()) {
             return next_nodeid++;
@@ -91,17 +106,29 @@ FUZZ_TARGET(private_broadcast)
                     } else {
                         Assert(res == PrivateBroadcast::AddResult::Added);
                         tx_it->second = 0;
-                        for (auto it = nodes_sent_to.begin(); it != nodes_sent_to.end();) {
-                            if (CTransactionRefComp{}(it->second, tx)) {
-                                nodes_that_confirmed_reception.erase(it->first);
-                                it = nodes_sent_to.erase(it);
-                            } else {
-                                ++it;
-                            }
-                        }
+                        forget_sends(tx);
                     }
                 } else if (transactions.size() >= cap) {
-                    Assert(res == PrivateBroadcast::AddResult::QueueFull);
+                    if (std::ranges::all_of(transactions, is_pending)) {
+                        Assert(res == PrivateBroadcast::AddResult::QueueFull);
+                    } else {
+                        Assert(res == PrivateBroadcast::AddResult::Added);
+
+                        // Find the evicted transaction: the only one no longer in the queue.
+                        const auto info{pb.GetBroadcastInfo()};
+                        std::unordered_set<CTransactionRef, CTransactionRefHash, CTransactionRefComp> in_queue;
+                        in_queue.reserve(info.size());
+                        for (const auto& e : info) in_queue.insert(e.tx);
+                        const auto evicted{std::ranges::find_if(transactions, [&in_queue](const auto& entry) {
+                            return !in_queue.contains(entry.first);
+                        })};
+                        Assert(evicted != transactions.end());
+                        Assert(!is_pending(*evicted)); // pending transactions are never evicted
+
+                        forget_sends(evicted->first);
+                        transactions.erase(evicted);
+                        transactions.emplace(tx, 0);
+                    }
                 } else {
                     Assert(res == PrivateBroadcast::AddResult::Added);
                     transactions.emplace(tx, 0);
@@ -114,20 +141,7 @@ FUZZ_TARGET(private_broadcast)
                 const auto transactions_it{PickIterator(fdp, transactions)};
                 const CTransactionRef& tx{transactions_it->first};
 
-                size_t num_nodes_that_confirmed_tx{0};
-
-                // Remove relevant entries from nodes_sent_to[] and nodes_that_confirmed_reception[] if any.
-                for (auto it = nodes_sent_to.begin(); it != nodes_sent_to.end();) {
-                    const NodeId nodeid{it->first};
-                    if (CTransactionRefComp{}(it->second, tx)) {
-                        it = nodes_sent_to.erase(it);
-                        if (nodes_that_confirmed_reception.erase(nodeid) > 0) {
-                            ++num_nodes_that_confirmed_tx;
-                        }
-                    } else {
-                        ++it;
-                    }
-                }
+                const size_t num_nodes_that_confirmed_tx{forget_sends(tx)};
 
                 const auto opt_num_confirmed{pb.Remove(tx)};
 

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -10,9 +10,9 @@
 #include <algorithm>
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(private_broadcast_tests, BasicTestingSetup)
+namespace {
 
-static CTransactionRef MakeDummyTx(uint32_t id, size_t num_witness)
+CTransactionRef MakeDummyTx(uint32_t id, size_t num_witness)
 {
     CMutableTransaction mtx;
     mtx.vin.resize(1);
@@ -24,15 +24,26 @@ static CTransactionRef MakeDummyTx(uint32_t id, size_t num_witness)
     return MakeTransactionRef(mtx);
 }
 
+auto FindTxInfo(const std::vector<PrivateBroadcast::TxBroadcastInfo>& infos, const CTransactionRef& tx)
+{
+    const auto it{std::ranges::find(infos, tx->GetWitnessHash(), [](const auto& info) { return info.tx->GetWitnessHash(); })};
+    BOOST_REQUIRE(it != infos.end());
+    return it;
+}
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(private_broadcast_tests, BasicTestingSetup)
+
 BOOST_AUTO_TEST_CASE(basic)
 {
     SetMockTime(Now<NodeSeconds>());
 
     PrivateBroadcast pb;
     const NodeId recipient1{1};
-    in_addr ipv4Addr;
-    ipv4Addr.s_addr = 0xa0b0c001;
-    const CService addr1{ipv4Addr, 1111};
+    in_addr ipv4_addr;
+    ipv4_addr.s_addr = 0xa0b0c001;
+    const CService addr1{ipv4_addr, 1111};
 
     // No transactions initially.
     BOOST_CHECK(!pb.PickTxForSend(/*will_send_to_nodeid=*/recipient1, /*will_send_to_address=*/addr1).has_value());
@@ -52,16 +63,11 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_REQUIRE(tx1->GetWitnessHash() != tx2->GetWitnessHash());
 
     BOOST_CHECK(pb.Add(tx2));
-    const auto find_tx_info{[](auto& infos, const CTransactionRef& tx) -> const PrivateBroadcast::TxBroadcastInfo& {
-        const auto it{std::ranges::find(infos, tx->GetWitnessHash(), [](const auto& info) { return info.tx->GetWitnessHash(); })};
-        BOOST_REQUIRE(it != infos.end());
-        return *it;
-    }};
     const auto check_peer_counts{[&](size_t tx1_peer_count, size_t tx2_peer_count) {
         const auto infos{pb.GetBroadcastInfo()};
         BOOST_CHECK_EQUAL(infos.size(), 2);
-        BOOST_CHECK_EQUAL(find_tx_info(infos, tx1).peers.size(), tx1_peer_count);
-        BOOST_CHECK_EQUAL(find_tx_info(infos, tx2).peers.size(), tx2_peer_count);
+        BOOST_CHECK_EQUAL(FindTxInfo(infos, tx1)->peers.size(), tx1_peer_count);
+        BOOST_CHECK_EQUAL(FindTxInfo(infos, tx2)->peers.size(), tx2_peer_count);
     }};
 
     check_peer_counts(/*tx1_peer_count=*/0, /*tx2_peer_count=*/0);
@@ -71,7 +77,7 @@ BOOST_AUTO_TEST_CASE(basic)
 
     // A second pick must return the other transaction.
     const NodeId recipient2{2};
-    const CService addr2{ipv4Addr, 2222};
+    const CService addr2{ipv4_addr, 2222};
     const auto tx_for_recipient2{pb.PickTxForSend(/*will_send_to_nodeid=*/recipient2, /*will_send_to_address=*/addr2).value()};
     BOOST_CHECK(tx_for_recipient2 == tx1 || tx_for_recipient2 == tx2);
     BOOST_CHECK_NE(tx_for_recipient1, tx_for_recipient2);
@@ -109,13 +115,15 @@ BOOST_AUTO_TEST_CASE(basic)
     const auto infos{pb.GetBroadcastInfo()};
     BOOST_CHECK_EQUAL(infos.size(), 2);
     {
-        const auto& peers{find_tx_info(infos, tx_for_recipient1).peers};
+        const auto info_it{FindTxInfo(infos, tx_for_recipient1)};
+        const auto& peers{info_it->peers};
         BOOST_CHECK_EQUAL(peers.size(), 1);
         BOOST_CHECK_EQUAL(peers[0].address.ToStringAddrPort(), addr1.ToStringAddrPort());
         BOOST_CHECK(peers[0].received.has_value());
     }
     {
-        const auto& peers{find_tx_info(infos, tx_for_recipient2).peers};
+        const auto info_it{FindTxInfo(infos, tx_for_recipient2)};
+        const auto& peers{info_it->peers};
         BOOST_CHECK_EQUAL(peers.size(), 1);
         BOOST_CHECK_EQUAL(peers[0].address.ToStringAddrPort(), addr2.ToStringAddrPort());
         BOOST_CHECK(!peers[0].received.has_value());
@@ -135,7 +143,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_CHECK(!pb.Remove(tx_for_recipient2).has_value());
 
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), 0);
-    const CService addr_nonexistent{ipv4Addr, 3333};
+    const CService addr_nonexistent{ipv4_addr, 3333};
     BOOST_CHECK(!pb.PickTxForSend(/*will_send_to_nodeid=*/nonexistent_recipient, /*will_send_to_address=*/addr_nonexistent).has_value());
 }
 

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -165,4 +165,66 @@ BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
     BOOST_CHECK_EQUAL(stale_state[0], tx);
 }
 
+BOOST_AUTO_TEST_CASE(mark_received)
+{
+    PrivateBroadcast pb;
+
+    const auto missing_tx{MakeDummyTx(/*id=*/999, /*num_witness=*/0)};
+    const auto tx{MakeDummyTx(/*id=*/42, /*num_witness=*/0)};
+    in_addr ipv4_addr;
+    ipv4_addr.s_addr = 0xa0b0c003;
+    const CService received_from{ipv4_addr, 3333};
+
+    // Missing transaction returns nullopt.
+    BOOST_CHECK(!pb.MarkReceived(missing_tx, received_from).has_value());
+
+    BOOST_REQUIRE(pb.Add(tx));
+
+    const NodeId recipient1{1};
+    const CService addr1{ipv4_addr, 1111};
+    BOOST_REQUIRE(pb.PickTxForSend(/*will_send_to_nodeid=*/recipient1, /*will_send_to_address=*/addr1).has_value());
+    const NodeId recipient2{2};
+    const CService addr2{ipv4_addr, 2222};
+    BOOST_REQUIRE(pb.PickTxForSend(/*will_send_to_nodeid=*/recipient2, /*will_send_to_address=*/addr2).has_value());
+    pb.NodeConfirmedReception(recipient1);
+
+    // MarkReceived succeeds and returns the number of confirmed sends.
+    BOOST_CHECK_EQUAL(pb.MarkReceived(tx, received_from).value(), 1);
+
+    {
+        const auto infos{pb.GetBroadcastInfo()};
+        const auto info{FindTxInfo(infos, tx)};
+        BOOST_CHECK(info->received_by_us.has_value());
+        BOOST_CHECK_EQUAL(info->received_by_us->from.ToStringAddrPort(), received_from.ToStringAddrPort());
+    }
+    BOOST_CHECK(!pb.HavePendingTransactions());
+    BOOST_CHECK(!pb.PickTxForSend(/*will_send_to_nodeid=*/recipient2, /*will_send_to_address=*/addr2).has_value());
+
+    // Subsequent MarkReceived returns nullopt and does not overwrite.
+    in_addr ipv4_addr2;
+    ipv4_addr2.s_addr = 0xa0b0c099;
+    const CService received_from2{ipv4_addr2, 4444};
+    BOOST_CHECK(!pb.MarkReceived(tx, received_from2).has_value());
+
+    {
+        const auto infos{pb.GetBroadcastInfo()};
+        const auto info{FindTxInfo(infos, tx)};
+        BOOST_CHECK_EQUAL(info->received_by_us->from.ToStringAddrPort(), received_from.ToStringAddrPort());
+        BOOST_CHECK(!pb.HavePendingTransactions());
+    }
+
+    // Re-adding after received clears the received state, resets time_added,
+    // and makes it pending again.
+    SetMockTime(Now<NodeSeconds>() + PrivateBroadcast::INITIAL_STALE_DURATION + 1min);
+    BOOST_CHECK(pb.Add(tx));
+    BOOST_CHECK(pb.HavePendingTransactions());
+    const auto infos{pb.GetBroadcastInfo()};
+    const auto info{FindTxInfo(infos, tx)};
+    BOOST_CHECK(!info->received_by_us.has_value());
+
+    // The re-added tx should NOT be immediately stale despite the elapsed time,
+    // because time_added was reset.
+    BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -308,4 +308,111 @@ BOOST_AUTO_TEST_CASE(rejection_at_cap)
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), num_cap);
 }
 
+BOOST_AUTO_TEST_CASE(eviction_at_cap)
+{
+    FakeNodeClock clock{};
+
+    constexpr size_t num_cap{3};
+    PrivateBroadcast pb{num_cap, /*max_send_attempts=*/1};
+
+    in_addr ipv4_addr;
+    ipv4_addr.s_addr = 0xa0b0c001;
+    const CService addr{ipv4_addr, 1111};
+
+    const auto present{[&pb](const CTransactionRef& tx) {
+        const auto infos{pb.GetBroadcastInfo()};
+        return std::ranges::any_of(infos, [&tx](const auto& info) { return info.tx->GetWitnessHash() == tx->GetWitnessHash(); });
+    }};
+
+    const auto exhausted{MakeDummyTx(/*id=*/0, /*num_witness=*/0)};
+    BOOST_REQUIRE_EQUAL(pb.Add(exhausted), PrivateBroadcast::AddResult::Added);
+    BOOST_REQUIRE_EQUAL(pb.PickTxForSend(/*will_send_to_nodeid=*/0, /*will_send_to_address=*/addr).value(), exhausted);
+    clock += 1min;
+
+    const auto pending{MakeDummyTx(/*id=*/1, /*num_witness=*/0)};
+    BOOST_REQUIRE_EQUAL(pb.Add(pending), PrivateBroadcast::AddResult::Added);
+    clock += 1min;
+
+    const auto received{MakeDummyTx(/*id=*/2, /*num_witness=*/0)};
+    BOOST_REQUIRE_EQUAL(pb.Add(received), PrivateBroadcast::AddResult::Added);
+    BOOST_REQUIRE(pb.MarkReceived(received, addr).has_value());
+    clock += 1min;
+
+    // At the cap the oldest transaction that is no longer pending is evicted.
+    BOOST_CHECK_EQUAL(pb.Add(MakeDummyTx(/*id=*/3, /*num_witness=*/0)), PrivateBroadcast::AddResult::Added);
+    BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), num_cap);
+    BOOST_CHECK(!present(exhausted));
+
+    // `received` is evicted next, even though `pending` is older: transactions that are
+    // still pending are never evicted.
+    BOOST_CHECK_EQUAL(pb.Add(MakeDummyTx(/*id=*/4, /*num_witness=*/0)), PrivateBroadcast::AddResult::Added);
+    BOOST_CHECK(!present(received));
+    BOOST_CHECK(present(pending));
+}
+
+BOOST_AUTO_TEST_CASE(mark_received)
+{
+    FakeNodeClock clock{};
+
+    PrivateBroadcast pb;
+
+    const auto missing_tx{MakeDummyTx(/*id=*/999, /*num_witness=*/0)};
+    const auto tx{MakeDummyTx(/*id=*/42, /*num_witness=*/0)};
+    in_addr ipv4_addr;
+    ipv4_addr.s_addr = 0xa0b0c003;
+    const CService received_from{ipv4_addr, 3333};
+
+    // Missing transaction returns nullopt.
+    BOOST_CHECK(!pb.MarkReceived(missing_tx, received_from).has_value());
+
+    BOOST_REQUIRE_EQUAL(pb.Add(tx), PrivateBroadcast::AddResult::Added);
+
+    const NodeId recipient1{1};
+    const CService addr1{ipv4_addr, 1111};
+    BOOST_REQUIRE(pb.PickTxForSend(/*will_send_to_nodeid=*/recipient1, /*will_send_to_address=*/addr1).has_value());
+    const NodeId recipient2{2};
+    const CService addr2{ipv4_addr, 2222};
+    BOOST_REQUIRE(pb.PickTxForSend(/*will_send_to_nodeid=*/recipient2, /*will_send_to_address=*/addr2).has_value());
+    pb.NodeConfirmedReception(recipient1);
+
+    // MarkReceived succeeds and returns the number of confirmed sends.
+    BOOST_CHECK_EQUAL(pb.MarkReceived(tx, received_from).value(), 1);
+
+    {
+        const auto infos{pb.GetBroadcastInfo()};
+        const auto info{FindTxInfo(infos, tx)};
+        BOOST_CHECK(info->received_by_us.has_value());
+        BOOST_CHECK_EQUAL(info->received_by_us->from.ToStringAddrPort(), received_from.ToStringAddrPort());
+    }
+    BOOST_CHECK(!pb.HavePendingTransactions());
+    // Use a fresh node id: sending more than one transaction to the same node is not allowed.
+    BOOST_CHECK(!pb.PickTxForSend(/*will_send_to_nodeid=*/3, /*will_send_to_address=*/addr2).has_value());
+
+    // Subsequent MarkReceived returns nullopt and does not overwrite.
+    in_addr ipv4_addr2;
+    ipv4_addr2.s_addr = 0xa0b0c099;
+    const CService received_from2{ipv4_addr2, 4444};
+    BOOST_CHECK(!pb.MarkReceived(tx, received_from2).has_value());
+
+    {
+        const auto infos{pb.GetBroadcastInfo()};
+        const auto info{FindTxInfo(infos, tx)};
+        BOOST_CHECK_EQUAL(info->received_by_us->from.ToStringAddrPort(), received_from.ToStringAddrPort());
+        BOOST_CHECK(!pb.HavePendingTransactions());
+    }
+
+    // Re-adding after received clears the received state, resets time_added,
+    // and makes it pending again.
+    clock += PrivateBroadcast::INITIAL_STALE_DURATION + 1min;
+    BOOST_CHECK_EQUAL(pb.Add(tx), PrivateBroadcast::AddResult::Added);
+    BOOST_CHECK(pb.HavePendingTransactions());
+    const auto infos{pb.GetBroadcastInfo()};
+    const auto info{FindTxInfo(infos, tx)};
+    BOOST_CHECK(!info->received_by_us.has_value());
+
+    // The re-added tx should NOT be immediately stale despite the elapsed time,
+    // because time_added was reset.
+    BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -22,9 +22,9 @@ std::ostream& operator<<(std::ostream& os, PrivateBroadcast::AddResult r)
     assert(false);
 }
 
-BOOST_FIXTURE_TEST_SUITE(private_broadcast_tests, BasicTestingSetup)
+namespace {
 
-static CTransactionRef MakeDummyTx(uint32_t id, size_t num_witness)
+CTransactionRef MakeDummyTx(uint32_t id, size_t num_witness)
 {
     CMutableTransaction mtx;
     mtx.vin.resize(1);
@@ -36,15 +36,26 @@ static CTransactionRef MakeDummyTx(uint32_t id, size_t num_witness)
     return MakeTransactionRef(mtx);
 }
 
+auto FindTxInfo(const std::vector<PrivateBroadcast::TxBroadcastInfo>& infos, const CTransactionRef& tx)
+{
+    const auto it{std::ranges::find(infos, tx->GetWitnessHash(), [](const auto& info) { return info.tx->GetWitnessHash(); })};
+    BOOST_REQUIRE(it != infos.end());
+    return it;
+}
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(private_broadcast_tests, BasicTestingSetup)
+
 BOOST_AUTO_TEST_CASE(basic)
 {
     FakeNodeClock clock{};
 
     PrivateBroadcast pb;
     const NodeId recipient1{1};
-    in_addr ipv4Addr;
-    ipv4Addr.s_addr = 0xa0b0c001;
-    const CService addr1{ipv4Addr, 1111};
+    in_addr ipv4_addr;
+    ipv4_addr.s_addr = 0xa0b0c001;
+    const CService addr1{ipv4_addr, 1111};
 
     // No transactions initially.
     BOOST_CHECK(!pb.PickTxForSend(/*will_send_to_nodeid=*/recipient1, /*will_send_to_address=*/addr1).has_value());
@@ -64,16 +75,11 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_REQUIRE(tx1->GetWitnessHash() != tx2->GetWitnessHash());
 
     BOOST_CHECK_EQUAL(pb.Add(tx2), PrivateBroadcast::AddResult::Added);
-    const auto find_tx_info{[](auto& infos, const CTransactionRef& tx) -> const PrivateBroadcast::TxBroadcastInfo& {
-        const auto it{std::ranges::find(infos, tx->GetWitnessHash(), [](const auto& info) { return info.tx->GetWitnessHash(); })};
-        BOOST_REQUIRE(it != infos.end());
-        return *it;
-    }};
     const auto check_peer_counts{[&](size_t tx1_peer_count, size_t tx2_peer_count) {
         const auto infos{pb.GetBroadcastInfo()};
         BOOST_CHECK_EQUAL(infos.size(), 2);
-        BOOST_CHECK_EQUAL(find_tx_info(infos, tx1).peers.size(), tx1_peer_count);
-        BOOST_CHECK_EQUAL(find_tx_info(infos, tx2).peers.size(), tx2_peer_count);
+        BOOST_CHECK_EQUAL(FindTxInfo(infos, tx1)->peers.size(), tx1_peer_count);
+        BOOST_CHECK_EQUAL(FindTxInfo(infos, tx2)->peers.size(), tx2_peer_count);
     }};
 
     check_peer_counts(/*tx1_peer_count=*/0, /*tx2_peer_count=*/0);
@@ -83,7 +89,7 @@ BOOST_AUTO_TEST_CASE(basic)
 
     // A second pick must return the other transaction.
     const NodeId recipient2{2};
-    const CService addr2{ipv4Addr, 2222};
+    const CService addr2{ipv4_addr, 2222};
     const auto tx_for_recipient2{pb.PickTxForSend(/*will_send_to_nodeid=*/recipient2, /*will_send_to_address=*/addr2).value()};
     BOOST_CHECK(tx_for_recipient2 == tx1 || tx_for_recipient2 == tx2);
     BOOST_CHECK_NE(tx_for_recipient1, tx_for_recipient2);
@@ -121,13 +127,15 @@ BOOST_AUTO_TEST_CASE(basic)
     const auto infos{pb.GetBroadcastInfo()};
     BOOST_CHECK_EQUAL(infos.size(), 2);
     {
-        const auto& peers{find_tx_info(infos, tx_for_recipient1).peers};
+        const auto info_it{FindTxInfo(infos, tx_for_recipient1)};
+        const auto& peers{info_it->peers};
         BOOST_CHECK_EQUAL(peers.size(), 1);
         BOOST_CHECK_EQUAL(peers[0].address.ToStringAddrPort(), addr1.ToStringAddrPort());
         BOOST_CHECK(peers[0].received.has_value());
     }
     {
-        const auto& peers{find_tx_info(infos, tx_for_recipient2).peers};
+        const auto info_it{FindTxInfo(infos, tx_for_recipient2)};
+        const auto& peers{info_it->peers};
         BOOST_CHECK_EQUAL(peers.size(), 1);
         BOOST_CHECK_EQUAL(peers[0].address.ToStringAddrPort(), addr2.ToStringAddrPort());
         BOOST_CHECK(!peers[0].received.has_value());
@@ -147,7 +155,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_CHECK(!pb.Remove(tx_for_recipient2).has_value());
 
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), 0);
-    const CService addr_nonexistent{ipv4Addr, 3333};
+    const CService addr_nonexistent{ipv4_addr, 3333};
     BOOST_CHECK(!pb.PickTxForSend(/*will_send_to_nodeid=*/nonexistent_recipient, /*will_send_to_address=*/addr_nonexistent).has_value());
 }
 
@@ -212,8 +220,7 @@ BOOST_AUTO_TEST_CASE(send_attempt_limit)
     BOOST_CHECK(pb.HavePendingTransactions());
     BOOST_CHECK(pb.GetStale().empty());
     const auto reset_info{pb.GetBroadcastInfo()};
-    const auto reset_tx_info{std::ranges::find(reset_info, tx->GetWitnessHash(), [](const auto& entry) { return entry.tx->GetWitnessHash(); })};
-    BOOST_REQUIRE(reset_tx_info != reset_info.end());
+    const auto reset_tx_info{FindTxInfo(reset_info, tx)};
     BOOST_CHECK(reset_tx_info->peers.empty());
     BOOST_CHECK_EQUAL(reset_tx_info->attempts_remaining, max_attempts);
     BOOST_REQUIRE_EQUAL(pb.PickTxForSend(/*will_send_to_nodeid=*/node_id++, address).value(), tx);

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -439,10 +439,13 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         self.log.info("Waiting for normal broadcast to another peer")
         other_peer.wait_for_inv([inv])
 
-        self.log.info("Checking getprivatebroadcastinfo no longer reports the transaction after it is received back")
+        self.log.info("Checking getprivatebroadcastinfo reports receive metadata after it is received back")
         pbinfo = tx_originator.getprivatebroadcastinfo()
-        pending = [t for t in pbinfo["transactions"] if t["txid"] == txs[0]["txid"] and t["wtxid"] == txs[0]["wtxid"]]
-        assert_equal(len(pending), 0)
+        info = [t for t in pbinfo["transactions"] if t["wtxid"] == txs[0]["wtxid"]]
+        assert_equal(len(info), 1)
+        assert "received_by_us" in info[0]
+        assert "address" in info[0]["received_by_us"]
+        assert "time" in info[0]["received_by_us"]
 
         self.log.info("Sending a transaction that is already in the mempool")
         skip_destinations = len(self.destinations)

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -316,10 +316,13 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         self.log.info("Waiting for normal broadcast to another peer")
         other_peer.wait_for_inv([inv])
 
-        self.log.info("Checking getprivatebroadcastinfo no longer reports the transaction after it is received back")
+        self.log.info("Checking getprivatebroadcastinfo reports receive metadata after it is received back")
         pbinfo = tx_originator.getprivatebroadcastinfo()
-        pending = [t for t in pbinfo["transactions"] if t["txid"] == txs[0]["txid"] and t["wtxid"] == txs[0]["wtxid"]]
-        assert_equal(len(pending), 0)
+        info = [t for t in pbinfo["transactions"] if t["wtxid"] == txs[0]["wtxid"]]
+        assert_equal(len(info), 1)
+        assert "received_by_us" in info[0]
+        assert "address" in info[0]["received_by_us"]
+        assert "time" in info[0]["received_by_us"]
 
         self.log.info("Sending a transaction that is already in the mempool")
         skip_destinations = len(self.destinations)


### PR DESCRIPTION
Follow up from #34329.

Private broadcast transaction data is removed from memory when either 1) the tx is received back from another peer and inserted into our mempool or 2) the tx is no longer acceptable to our mempool.

We want to persist this data to be able to verify that transactions have been received back, and to use that information for statistical analysis. Also see https://github.com/bitcoin/bitcoin/issues/30471.

This PR changes the behavior of the private broadcast queue to keep received txs in memory. The peer's address we received the tx from and the time is now also returned via `getprivatebroadcastinfo` RPC.

Mempool rejected txs are still removed from the queue as before.