### PR TITLE
wallet, test: improve wallet functional tests

### DIFF
--- a/test/functional/wallet_assumeutxo.py
+++ b/test/functional/wallet_assumeutxo.py
@@ -85,15 +85,16 @@ class AssumeutxoTest(BitcoinTestFramework):
         # Balance of w wallet is still 0 because n3 has not synced yet
         assert_equal(n3.getbalance(), 0)
 
+        n3.unloadwallet("w")
         self.log.info("Backup from before the snapshot height can't be loaded during background sync (pruned node)")
         assert_raises_rpc_error(-4, expected_error_message, n3.restorewallet, "w2", "backup_w2.dat")
 
     def test_restore_wallet_pruneheight(self, n3):
         self.log.info("Ensuring wallet can't be restored from a backup that was created before the pruneheight (pruned node)")
         self.complete_background_validation(n3)
-        # After background sync, pruneheight is reset to 0, so mine 500 blocks
+        # After background sync, pruneheight is reset to 0, so mine 200 blocks
         # and prune the chain again
-        self.generate(n3, nblocks=500, sync_fun=self.no_op)
+        self.generate(n3, nblocks=200, sync_fun=self.no_op)
         assert_equal(n3.pruneblockchain(FINAL_HEIGHT), 298)  # 298 is the height of the last block pruned (pruneheight 299)
         error_message = "Wallet loading failed. Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)"
         # This backup (backup_w2.dat) was created at height 199, so it can't be restored in a node with a pruneheight of 299

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -91,25 +91,6 @@ class WalletBackupTest(BitcoinTestFramework):
         self.sync_mempools()
         self.generate(self.nodes[3], 1)
 
-    # As above, this mirrors the original bash test.
-    def start_three(self, args=()):
-        self.start_node(0, self.extra_args[0] + list(args))
-        self.start_node(1, self.extra_args[1] + list(args))
-        self.start_node(2, self.extra_args[2] + list(args))
-        self.connect_nodes(0, 3)
-        self.connect_nodes(1, 3)
-        self.connect_nodes(2, 3)
-        self.connect_nodes(2, 0)
-
-    def stop_three(self):
-        self.stop_node(0)
-        self.stop_node(1)
-        self.stop_node(2)
-
-    def erase_three(self):
-        for node_num in range(3):
-            (self.nodes[node_num].wallets_path / self.default_wallet_name / self.wallet_data_filename).unlink()
-
     def restore_invalid_wallet(self):
         node = self.nodes[3]
         invalid_wallet_file = self.nodes[0].datadir_path / 'invalid_wallet_file.bak'
@@ -191,7 +172,7 @@ class WalletBackupTest(BitcoinTestFramework):
         self.log.info("Test loading backup on a pruned node when the backup was created close to the prune height of the restoring node")
         node = self.nodes[3]
         self.restart_node(3, ["-prune=1", "-fastprune=1"])
-        # Ensure the chain tip is at height 214, because this test assume it is.
+        # Ensure the chain tip is at height 214, because this test assumes it is.
         assert_equal(node.getchaintips()[0]["height"], 214)
         # We need a few more blocks so we can actually get above an realistic
         # minimal prune height


### PR DESCRIPTION
Relates to #34354 

While the actual fix of the issue is in another PR, this one improves the
affected tests by trying to reduce the chain notifications that
need to be processed while simulating erroneous wallet restoration
scenarios.