### PR TITLE
test: avoid interface_ipc.py race and null pointer dereference

### DIFF
--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -71,7 +71,9 @@ class IPCInterfaceTest(BitcoinTestFramework):
     def run_deprecated_mining_test(self):
         self.log.info("Running deprecated mining interface test")
         async def async_routine():
-            ctx, init = await make_capnp_init_ctx(self)
+            node = self.nodes[0]
+            connection = await capnp.AsyncIoStream.create_unix_connection(node.ipc_socket_path)
+            init = capnp.TwoPartyClient(connection).bootstrap().cast_as(self.capnp_modules['init'].Init)
             self.log.debug("Calling deprecated makeMiningOld2 should raise an error")
             try:
                 await init.makeMiningOld2()


### PR DESCRIPTION
Avoid race condition in `run_deprecated_mining_test` caused by creating and immediately destroying an unused worker thread. This is leading to test failures reported by maflcko in #34711
