### PR TITLE
fuzz: assert we accept any PSBT serialization we create

### DIFF
--- a/src/test/fuzz/psbt.cpp
+++ b/src/test/fuzz/psbt.cpp
@@ -33,6 +33,17 @@ FUZZ_TARGET(psbt)
     }
     const PartiallySignedTransaction psbt = psbt_mut;
 
+    // A PSBT must roundtrip.
+    PartiallySignedTransaction psbt_roundtrip;
+    std::vector<uint8_t> psbt_ser;
+    VectorWriter{psbt_ser, 0, psbt};
+    SpanReader{psbt_ser} >> psbt_roundtrip;
+
+    // And be stable across roundtrips.
+    std::vector<uint8_t> roundtrip_ser;
+    VectorWriter{roundtrip_ser, 0, psbt_roundtrip};
+    Assert(psbt_ser == roundtrip_ser);
+
     const PSBTAnalysis analysis = AnalyzePSBT(psbt);
     (void)PSBTRoleName(analysis.next);
     for (const PSBTInputAnalysis& input_analysis : analysis.inputs) {


### PR DESCRIPTION
~~Invalid public keys were accepted in Musig2 partial signatures. Because we serialize invalid keys as the empty byte string, this would lead us to creating an invalid PSBT serializations.~~

~~This can be checked by reverting the first commit with the fix and simply running the target against the existing qa-assets corpus for the `psbt` harness.~~

This patch found the issue fixed in #34219 with a single run against the existing qa-assets corpus. It is useful to make sure there are no similar bugs, and we don't introduce roundtrip regressions outside of the specifc instance of accepting invalid public keys in Musig2 fields.

*(Edited on March 4 to only contain the fuzz harness patch)*