### PR TITLE
util/log: Combine the warning/error log levels into a single alert level

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -723,7 +723,7 @@ pay attention to for reviewers of Bitcoin Core code.
 
 ## Logging
 
-The macros `LogInfo`, `LogDebug`, `LogTrace`, `LogWarning` and `LogError` are available for
+The macros `LogInfo`, `LogDebug`, `LogTrace`, and `LogAlert` are available for
 logging messages. They should be used as follows:
 
 - `LogDebug(BCLog::CATEGORY, fmt, params...)` is what you want
@@ -738,14 +738,11 @@ logging messages. They should be used as follows:
   are unconditional, so care must be taken that they can't be used by an
   attacker to fill up storage.
 
-- `LogError(fmt, params...)` should be used in place of `LogInfo` for
-  severe problems that require the node (or a subsystem) to shut down
-  entirely (e.g., insufficient storage space).
-
-- `LogWarning(fmt, params...)` should be used in place of `LogInfo` for
-  severe problems that the node admin should address, but are not
-  severe enough to warrant shutting down the node (e.g., system time
-  appears to be wrong, unknown soft fork appears to have activated).
+- `LogAlert(fmt, params...)` should be used in place of `LogInfo` for
+  severe problems that the node admin should address, including
+  fatal problems that result in the node shutting itself down (e.g.,
+  insufficient storage space, system time appears to be wrong, unknown
+  soft fork appears to have activated).
 
 - `LogTrace(BCLog::CATEGORY, fmt, params...)` should be used in place of
   `LogDebug` for log messages that would be unusable on a production
@@ -753,6 +750,9 @@ logging messages. They should be used as follows:
   intensive to process. These will be logged if the startup
   options `-debug=category -loglevel=category:trace` or `-debug=1
   -loglevel=trace` are selected.
+
+`LogError` and `LogWarning` are available as aliases for `LogAlert`
+for compatibility, but should not be used in new code.
 
 Note that the format strings and parameters of `LogDebug` and `LogTrace`
 are only evaluated if the logging category is enabled, so you must be

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -153,7 +153,7 @@ bool BCLog::Logger::WillLogCategory(BCLog::LogFlags category) const
 
 bool BCLog::Logger::WillLogCategoryLevel(BCLog::LogFlags category, BCLog::Level level) const
 {
-    // Log messages at Info, Warning and Error level unconditionally, so that
+    // Log messages at Info and Alert level unconditionally, so that
     // important troubleshooting information doesn't get lost.
     if (level >= BCLog::Level::Info) return true;
 
@@ -240,10 +240,8 @@ std::string BCLog::Logger::LogLevelToStr(BCLog::Level level)
         return "debug";
     case BCLog::Level::Info:
         return "info";
-    case BCLog::Level::Warning:
-        return "warning";
-    case BCLog::Level::Error:
-        return "error";
+    case BCLog::Level::Alert:
+        return "alert";
     }
     assert(false);
 }
@@ -266,10 +264,12 @@ static std::optional<BCLog::Level> GetLogLevel(std::string_view level_str)
         return BCLog::Level::Debug;
     } else if (level_str == "info") {
         return BCLog::Level::Info;
+    } else if (level_str == "alert") {
+        return BCLog::Level::Alert;
     } else if (level_str == "warning") {
-        return BCLog::Level::Warning;
+        return BCLog::Level::Alert;
     } else if (level_str == "error") {
-        return BCLog::Level::Error;
+        return BCLog::Level::Alert;
     } else {
         return std::nullopt;
     }
@@ -474,7 +474,7 @@ void BCLog::Logger::LogPrintStr_(std::string_view str, SourceLocation&& source_l
                              source_loc.file_name(), source_loc.line(), source_loc.function_name_short(),
                              m_limiter->m_max_bytes,
                              Ticks<std::chrono::seconds>(m_limiter->m_reset_window)),
-                         SourceLocation{__func__}, LogFlags::ALL, Level::Warning, /*should_ratelimit=*/false); // with should_ratelimit=false, this cannot lead to infinite recursion
+                         SourceLocation{__func__}, LogFlags::ALL, Level::Alert, /*should_ratelimit=*/false); // with should_ratelimit=false, this cannot lead to infinite recursion
         } else if (status == LogRateLimiter::Status::STILL_SUPPRESSED) {
             ratelimit = true;
         }
@@ -563,7 +563,7 @@ void BCLog::LogRateLimiter::Reset()
     for (const auto& [source_loc, stats] : source_locations) {
         if (stats.m_dropped_bytes == 0) continue;
         LogPrintLevel_(
-            LogFlags::ALL, Level::Warning, /*should_ratelimit=*/false,
+            LogFlags::ALL, Level::Alert, /*should_ratelimit=*/false,
             "Restarting logging from %s:%d (%s): %d bytes were dropped during the last %ss.",
             source_loc.file_name(), source_loc.line(), source_loc.function_name_short(),
             stats.m_dropped_bytes, Ticks<std::chrono::seconds>(m_reset_window));

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -146,13 +146,13 @@ bool BlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, s
                 pindexNew->nTx            = diskindex.nTx;
 
                 if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, consensusParams)) {
-                    LogError("%s: CheckProofOfWork failed: %s\n", __func__, pindexNew->ToString());
+                    LogAlert("%s: CheckProofOfWork failed: %s", __func__, pindexNew->ToString());
                     return false;
                 }
 
                 pcursor->Next();
             } else {
-                LogError("%s: failed to read value\n", __func__);
+                LogAlert("%s: failed to read value", __func__);
                 return false;
             }
         } else {
@@ -460,7 +460,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
     for (CBlockIndex* pindex : vSortedByHeight) {
         if (m_interrupt) return false;
         if (previous_index && pindex->nHeight > previous_index->nHeight + 1) {
-            LogError("%s: block index is non-contiguous, index of height %d missing\n", __func__, previous_index->nHeight + 1);
+            LogAlert("%s: block index is non-contiguous, index of height %d missing", __func__, previous_index->nHeight + 1);
             return false;
         }
         previous_index = pindex;
@@ -701,7 +701,7 @@ bool BlockManager::ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index
     // Open history file to read
     AutoFile file{OpenUndoFile(pos, true)};
     if (file.IsNull()) {
-        LogError("OpenUndoFile failed for %s while reading block undo", pos.ToString());
+        LogAlert("OpenUndoFile failed for %s while reading block undo", pos.ToString());
         return false;
     }
     BufferedReader filein{std::move(file)};
@@ -718,11 +718,11 @@ bool BlockManager::ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index
 
         // Verify checksum
         if (hashChecksum != verifier.GetHash()) {
-            LogError("Checksum mismatch at %s while reading block undo", pos.ToString());
+            LogAlert("Checksum mismatch at %s while reading block undo", pos.ToString());
             return false;
         }
     } catch (const std::exception& e) {
-        LogError("Deserialize or I/O error - %s at %s while reading block undo", e.what(), pos.ToString());
+        LogAlert("Deserialize or I/O error - %s at %s while reading block undo", e.what(), pos.ToString());
         return false;
     }
 
@@ -895,7 +895,7 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
         // a reindex. A flush error might also leave some of the data files
         // untrimmed.
         if (!FlushBlockFile(last_blockfile, /*fFinalize=*/true, finalize_undo)) {
-            LogWarning(
+            LogAlert(
                           "Failed to flush previous block file %05i (finalize=1, finalize_undo=%i) before opening new block file %05i\n",
                           last_blockfile, finalize_undo, nFile);
         }
@@ -975,14 +975,14 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
         FlatFilePos pos;
         const auto blockundo_size{static_cast<uint32_t>(GetSerializeSize(blockundo))};
         if (!FindUndoPos(state, block.nFile, pos, blockundo_size + UNDO_DATA_DISK_OVERHEAD)) {
-            LogError("FindUndoPos failed for %s while writing block undo", pos.ToString());
+            LogAlert("FindUndoPos failed for %s while writing block undo", pos.ToString());
             return false;
         }
 
         // Open history file to append
         AutoFile file{OpenUndoFile(pos)};
         if (file.IsNull()) {
-            LogError("OpenUndoFile failed for %s while writing block undo", pos.ToString());
+            LogAlert("OpenUndoFile failed for %s while writing block undo", pos.ToString());
             return FatalError(m_opts.notifications, state, _("Failed to write undo data."));
         }
         {
@@ -1003,7 +1003,7 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
 
         // Make sure that the file is closed before we call `FlushUndoFile`.
         if (file.fclose() != 0) {
-            LogError("Failed to close block undo file %s: %s", pos.ToString(), SysErrorString(errno));
+            LogAlert("Failed to close block undo file %s: %s", pos.ToString(), SysErrorString(errno));
             return FatalError(m_opts.notifications, state, _("Failed to close block undo file."));
         }
 
@@ -1019,7 +1019,7 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
             // fact it is. Note though, that a failed flush might leave the data
             // file untrimmed.
             if (!FlushUndoFile(pos.nFile, true)) {
-                LogWarning("Failed to flush undo file %05i\n", pos.nFile);
+                LogAlert("Failed to flush undo file %05i", pos.nFile);
             }
         } else if (pos.nFile == cursor.file_num && block.nHeight > cursor.undo_height) {
             cursor.undo_height = block.nHeight;
@@ -1047,7 +1047,7 @@ bool BlockManager::ReadBlock(CBlock& block, const FlatFilePos& pos, const std::o
         // Read block
         SpanReader{*block_data} >> TX_WITH_WITNESS(block);
     } catch (const std::exception& e) {
-        LogError("Deserialize or I/O error - %s at %s while reading block", e.what(), pos.ToString());
+        LogAlert("Deserialize or I/O error - %s at %s while reading block", e.what(), pos.ToString());
         return false;
     }
 
@@ -1055,18 +1055,18 @@ bool BlockManager::ReadBlock(CBlock& block, const FlatFilePos& pos, const std::o
 
     // Check the header
     if (!CheckProofOfWork(block_hash, block.nBits, GetConsensus())) {
-        LogError("Errors in block header at %s while reading block", pos.ToString());
+        LogAlert("Errors in block header at %s while reading block", pos.ToString());
         return false;
     }
 
     // Signet only: check block solution
     if (GetConsensus().signet_blocks && !CheckSignetBlockSolution(block, GetConsensus())) {
-        LogError("Errors in block solution at %s while reading block", pos.ToString());
+        LogAlert("Errors in block solution at %s while reading block", pos.ToString());
         return false;
     }
 
     if (expected_hash && block_hash != *expected_hash) {
-        LogError("GetHash() doesn't match index at %s while reading block (%s != %s)",
+        LogAlert("GetHash() doesn't match index at %s while reading block (%s != %s)",
                  pos.ToString(), block_hash.ToString(), expected_hash->ToString());
         return false;
     }
@@ -1086,12 +1086,12 @@ BlockManager::ReadRawBlockResult BlockManager::ReadRawBlock(const FlatFilePos& p
         // If nPos is less than STORAGE_HEADER_BYTES, we can't read the header that precedes the block data
         // This would cause an unsigned integer underflow when trying to position the file cursor
         // This can happen after pruning or default constructed positions
-        LogError("Failed for %s while reading raw block storage header", pos.ToString());
+        LogAlert("Failed for %s while reading raw block storage header", pos.ToString());
         return util::Unexpected{ReadRawError::IO};
     }
     AutoFile filein{OpenBlockFile({pos.nFile, pos.nPos - STORAGE_HEADER_BYTES}, /*fReadOnly=*/true)};
     if (filein.IsNull()) {
-        LogError("OpenBlockFile failed for %s while reading raw block", pos.ToString());
+        LogAlert("OpenBlockFile failed for %s while reading raw block", pos.ToString());
         return util::Unexpected{ReadRawError::IO};
     }
 
@@ -1102,13 +1102,13 @@ BlockManager::ReadRawBlockResult BlockManager::ReadRawBlock(const FlatFilePos& p
         filein >> blk_start >> blk_size;
 
         if (blk_start != GetParams().MessageStart()) {
-            LogError("Block magic mismatch for %s: %s versus expected %s while reading raw block",
+            LogAlert("Block magic mismatch for %s: %s versus expected %s while reading raw block",
                 pos.ToString(), HexStr(blk_start), HexStr(GetParams().MessageStart()));
             return util::Unexpected{ReadRawError::IO};
         }
 
         if (blk_size > MAX_SIZE) {
-            LogError("Block data is larger than maximum deserialization size for %s: %s versus %s while reading raw block",
+            LogAlert("Block data is larger than maximum deserialization size for %s: %s versus %s while reading raw block",
                 pos.ToString(), blk_size, MAX_SIZE);
             return util::Unexpected{ReadRawError::IO};
         }
@@ -1126,7 +1126,7 @@ BlockManager::ReadRawBlockResult BlockManager::ReadRawBlock(const FlatFilePos& p
         filein.read(data);
         return data;
     } catch (const std::exception& e) {
-        LogError("Read from block file failed: %s for %s while reading raw block", e.what(), pos.ToString());
+        LogAlert("Read from block file failed: %s for %s while reading raw block", e.what(), pos.ToString());
         return util::Unexpected{ReadRawError::IO};
     }
 }
@@ -1136,12 +1136,12 @@ FlatFilePos BlockManager::WriteBlock(const CBlock& block, int nHeight)
     const unsigned int block_size{static_cast<unsigned int>(GetSerializeSize(TX_WITH_WITNESS(block)))};
     FlatFilePos pos{FindNextBlockPos(block_size + STORAGE_HEADER_BYTES, nHeight, block.GetBlockTime())};
     if (pos.IsNull()) {
-        LogError("FindNextBlockPos failed for %s while writing block", pos.ToString());
+        LogAlert("FindNextBlockPos failed for %s while writing block", pos.ToString());
         return FlatFilePos();
     }
     AutoFile file{OpenBlockFile(pos, /*fReadOnly=*/false)};
     if (file.IsNull()) {
-        LogError("OpenBlockFile failed for %s while writing block", pos.ToString());
+        LogAlert("OpenBlockFile failed for %s while writing block", pos.ToString());
         m_opts.notifications.fatalError(_("Failed to write block."));
         return FlatFilePos();
     }
@@ -1156,7 +1156,7 @@ FlatFilePos BlockManager::WriteBlock(const CBlock& block, int nHeight)
     }
 
     if (file.fclose() != 0) {
-        LogError("Failed to close block file %s: %s", pos.ToString(), SysErrorString(errno));
+        LogAlert("Failed to close block file %s: %s", pos.ToString(), SysErrorString(errno));
         m_opts.notifications.fatalError(_("Failed to close file when writing block."));
         return FlatFilePos();
     }
@@ -1304,7 +1304,7 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
                 return;
             }
         } else {
-            LogWarning("Could not open blocks file %s", fs::PathToString(path));
+            LogAlert("Could not open blocks file %s", fs::PathToString(path));
         }
     }
 

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -146,14 +146,16 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros, LogSetup)
     LogTrace(BCLog::NET, "foo6: %s", "bar6"); // not logged
     LogDebug(BCLog::NET, "foo7: %s", "bar7");
     LogInfo("foo8: %s", "bar8");
-    LogWarning("foo9: %s", "bar9");
+    LogAlert("foo9: %s", "bar9");
     LogError("foo10: %s", "bar10");
+    LogWarning("foo11: %s", "bar11");
     std::vector<std::string> log_lines{ReadDebugLogLines()};
     std::vector<std::string> expected = {
         "[net] foo7: bar7",
         "foo8: bar8",
-        "[warning] foo9: bar9",
-        "[error] foo10: bar10",
+        "[alert] foo9: bar9",
+        "[alert] foo10: bar10",
+        "[alert] foo11: bar11",
     };
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
@@ -194,8 +196,9 @@ BOOST_FIXTURE_TEST_CASE(logging_SeverityLevels, LogSetup)
     LogInfo("info_%s", 1);
     LogTrace(BCLog::HTTP, "trace_%s. This log level is lower than the global one.", 2);
     LogDebug(BCLog::HTTP, "debug_%s", 3);
-    LogWarning("warn_%s", 4);
+    LogAlert("alert_%s", 4);
     LogError("err_%s", 5);
+    LogWarning("warn_%s", 6);
 
     // Category-specific log level
     LogDebug(BCLog::NET, "debug_%s. This log level is the same as the global one but lower than the category-specific one, which takes precedence.", 6);
@@ -203,8 +206,9 @@ BOOST_FIXTURE_TEST_CASE(logging_SeverityLevels, LogSetup)
     std::vector<std::string> expected = {
         "info_1",
         "[http] debug_3",
-        "[warning] warn_4",
-        "[error] err_5",
+        "[alert] alert_4",
+        "[alert] err_5",
+        "[alert] warn_6",
     };
     std::vector<std::string> log_lines{ReadDebugLogLines()};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
@@ -413,7 +417,7 @@ void TestLogFromLocation(Location location, const std::string& message,
 
     if (status == Status::NEWLY_SUPPRESSED) {
         BOOST_REQUIRE_EQUAL(log_lines.size(), 2);
-        BOOST_CHECK(log_lines[0].starts_with("[*] [warning] Excessive logging detected"));
+        BOOST_CHECK(log_lines[0].starts_with("[*] [alert] Excessive logging detected"));
         log_lines.erase(log_lines.begin());
     }
     BOOST_REQUIRE_EQUAL(log_lines.size(), 1);
@@ -451,7 +455,7 @@ BOOST_FIXTURE_TEST_CASE(logging_filesize_rate_limit, LogSetup)
     TestLogFromLocation(Location::INFO_2, "c", Status::UNSUPPRESSED, /*suppressions_active=*/true);
     {
         scheduler.MockForwardAndSync(time_window);
-        BOOST_CHECK(ReadDebugLogLines().back().starts_with("[warning] Restarting logging"));
+        BOOST_CHECK(ReadDebugLogLines().back().starts_with("[alert] Restarting logging"));
     }
     // Check that logging from previously suppressed location is unsuppressed again.
     TestLogFromLocation(Location::INFO_1, log_message, Status::UNSUPPRESSED, /*suppressions_active=*/false);

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -42,8 +42,7 @@ enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production
     Info,      // Default
-    Warning,
-    Error,
+    Alert,
 };
 
 struct Entry {
@@ -93,8 +92,11 @@ inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags 
 // It should not be the case that an inbound peer can fill up a user's storage
 // with debug.log entries.
 #define LogInfo(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, /*should_ratelimit=*/true, __VA_ARGS__)
-#define LogWarning(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Warning, /*should_ratelimit=*/true, __VA_ARGS__)
-#define LogError(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Error, /*should_ratelimit=*/true, __VA_ARGS__)
+#define LogAlert(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Alert, /*should_ratelimit=*/true, __VA_ARGS__)
+
+// Compatibility aliases
+#define LogWarning(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Alert, /*should_ratelimit=*/true, __VA_ARGS__)
+#define LogError(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Alert, /*should_ratelimit=*/true, __VA_ARGS__)
 
 // Use a macro instead of a function for conditional logging to prevent
 // evaluating arguments when logging for the category is not enabled.

--- a/test/functional/feature_coinstatsindex_compatibility.py
+++ b/test/functional/feature_coinstatsindex_compatibility.py
@@ -52,7 +52,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         shutil.rmtree(node.chain_path / "indexes" / "coinstatsindex")
         shutil.copytree(legacy_node.chain_path / "indexes" / "coinstats", node.chain_path / "indexes" / "coinstats")
         old_version_path = node.chain_path / "indexes" / "coinstats"
-        msg = f'[warning] Old version of coinstatsindex found at {old_version_path}. This folder can be safely deleted unless you plan to downgrade your node to version 29 or lower.'
+        msg = f'[alert] Old version of coinstatsindex found at {old_version_path}. This folder can be safely deleted unless you plan to downgrade your node to version 29 or lower.'
         with node.assert_debug_log(expected_msgs=[msg]):
             self.start_node(0, ['-coinstatsindex'])
         self.wait_until(lambda: node.getindexinfo()['coinstatsindex']['synced'] is True)

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -129,7 +129,7 @@ class ConfArgsTest(BitcoinTestFramework):
         with open(inc_conf_file_path, 'w') as conf:
             conf.write('reindex=1\n')
 
-        with self.nodes[0].assert_debug_log(expected_msgs=["[warning] reindex=1 is set in the configuration file, which will significantly slow down startup. Consider removing or commenting out this option for better performance, unless there is currently a condition which makes rebuilding the indexes necessary"]):
+        with self.nodes[0].assert_debug_log(expected_msgs=["[alert] reindex=1 is set in the configuration file, which will significantly slow down startup. Consider removing or commenting out this option for better performance, unless there is currently a condition which makes rebuilding the indexes necessary"]):
             self.start_node(0)
         self.stop_node(0)
 
@@ -229,7 +229,7 @@ class ConfArgsTest(BitcoinTestFramework):
                 )
 
     def test_log_buffer(self):
-        with self.nodes[0].assert_debug_log(expected_msgs=["[warning] Parsed potentially confusing double-negative -listen=0\n"]):
+        with self.nodes[0].assert_debug_log(expected_msgs=["[alert] Parsed potentially confusing double-negative -listen=0\n"]):
             self.start_node(0, extra_args=['-nolisten=0'])
         self.stop_node(0)
 


### PR DESCRIPTION
There's little benefit in having two error levels that the node operator should pay attention to when the only difference between them is that one means the node is about to shut down -- the admin can easily see that just by looking at whether the node did shutdown. So this PR replaces LogWarning and LogError with LogAlert, which hopefully emphasises that the point of using that level is to alert the node operator.

Leaves LogWarning and LogError available as deprecated aliases to reduce code churn and avoid invalidating PRs.

Left as draft pending #34038 as the "warning" and "error" levels are currently exposed to users via the `-loglevel` config option.