### PR TITLE
subprocess: replace __USING_WINDOWS__ with WIN32

### DIFF
--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -55,16 +55,12 @@ Documentation for C++ subprocessing library.
 #include <string>
 #include <vector>
 
-#if (defined _MSC_VER) || (defined __MINGW32__)
-  #define __USING_WINDOWS__
-#endif
-
-#ifdef __USING_WINDOWS__
+#ifdef WIN32
   #include <codecvt>
 #endif
 
 extern "C" {
-#ifdef __USING_WINDOWS__
+#ifdef WIN32
   #include <windows.h>
   #include <io.h>
   #include <cwchar>
@@ -171,7 +167,7 @@ public:
 //--------------------------------------------------------------------
 namespace util
 {
-#ifdef __USING_WINDOWS__
+#ifdef WIN32
   inline void quote_argument(const std::wstring &argument, std::wstring &command_line,
                       bool force)
   {
@@ -332,7 +328,7 @@ namespace util
   }
 
 
-#ifndef __USING_WINDOWS__
+#ifndef WIN32
   /*!
    * Function: set_clo_on_exec
    * Sets/Resets the FD_CLOEXEC flag on the provided file descriptor
@@ -424,7 +420,7 @@ namespace util
   static inline
   int read_atmost_n(FILE* fp, char* buf, size_t read_upto)
   {
-#ifdef __USING_WINDOWS__
+#ifdef WIN32
     return (int)fread(buf, 1, read_upto, fp);
 #else
     int fd = subprocess_fileno(fp);
@@ -497,7 +493,7 @@ namespace util
     return total_bytes_read;
   }
 
-#ifndef __USING_WINDOWS__
+#ifndef WIN32
   /*!
    * Function: wait_for_child_exit
    * Waits for the process with pid `pid` to exit
@@ -598,7 +594,7 @@ struct input
   }
   explicit input(IOTYPE typ) {
     assert (typ == PIPE && "STDOUT/STDERR not allowed");
-#ifndef __USING_WINDOWS__
+#ifndef WIN32
     std::tie(rd_ch_, wr_ch_) = util::pipe_cloexec();
 #endif
   }
@@ -631,7 +627,7 @@ struct output
   }
   explicit output(IOTYPE typ) {
     assert (typ == PIPE && "STDOUT/STDERR not allowed");
-#ifndef __USING_WINDOWS__
+#ifndef WIN32
     std::tie(rd_ch_, wr_ch_) = util::pipe_cloexec();
 #endif
   }
@@ -663,7 +659,7 @@ struct error
   explicit error(IOTYPE typ) {
     assert ((typ == PIPE || typ == STDOUT) && "STDERR not allowed");
     if (typ == PIPE) {
-#ifndef __USING_WINDOWS__
+#ifndef WIN32
       std::tie(rd_ch_, wr_ch_) = util::pipe_cloexec();
 #endif
     } else {
@@ -738,7 +734,7 @@ private:
   Popen* popen_ = nullptr;
 };
 
-#ifndef __USING_WINDOWS__
+#ifndef WIN32
 /*!
  * A helper class to Popen.
  * This takes care of all the fork-exec logic
@@ -882,7 +878,7 @@ public:// Yes they are public
   std::shared_ptr<FILE> output_ = nullptr;
   std::shared_ptr<FILE> error_  = nullptr;
 
-#ifdef __USING_WINDOWS__
+#ifdef WIN32
   HANDLE g_hChildStd_IN_Rd = nullptr;
   HANDLE g_hChildStd_IN_Wr = nullptr;
   HANDLE g_hChildStd_OUT_Rd = nullptr;
@@ -932,7 +928,7 @@ class Popen
 {
 public:
   friend struct detail::ArgumentDeducer;
-#ifndef __USING_WINDOWS__
+#ifndef WIN32
   friend class detail::Child;
 #endif
 
@@ -1010,7 +1006,7 @@ private:
 private:
   detail::Streams stream_;
 
-#ifdef __USING_WINDOWS__
+#ifdef WIN32
   HANDLE process_handle_;
   std::future<void> cleanup_future_;
 #else
@@ -1049,7 +1045,7 @@ inline void Popen::populate_c_argv()
 
 inline int Popen::wait() noexcept(false)
 {
-#ifdef __USING_WINDOWS__
+#ifdef WIN32
   int ret = WaitForSingleObject(process_handle_, INFINITE);
 
   // WaitForSingleObject with INFINITE should only return when process has signaled
@@ -1082,7 +1078,7 @@ inline int Popen::wait() noexcept(false)
 
 inline void Popen::execute_process() noexcept(false)
 {
-#ifdef __USING_WINDOWS__
+#ifdef WIN32
   if (exe_name_.length()) {
     this->vargs_.insert(this->vargs_.begin(), this->exe_name_);
     this->populate_c_argv();
@@ -1262,7 +1258,7 @@ namespace detail {
   }
 
 
-#ifndef __USING_WINDOWS__
+#ifndef WIN32
   inline void Child::execute_child() {
     int sys_ret = -1;
     auto& stream = parent_->stream_;
@@ -1329,7 +1325,7 @@ namespace detail {
 
   inline void Streams::setup_comm_channels()
   {
-#ifdef __USING_WINDOWS__
+#ifdef WIN32
     util::configure_pipe(&this->g_hChildStd_IN_Rd, &this->g_hChildStd_IN_Wr, &this->g_hChildStd_IN_Wr);
     this->input(util::file_from_handle(this->g_hChildStd_IN_Wr, "w"));
     this->write_to_child_ = subprocess_fileno(this->input());


### PR DESCRIPTION
## Summary
Motivated by https://github.com/bitcoin/bitcoin/pull/34385#pullrequestreview-3826616188

In `subprocess.h` we are now renaming `__USING_WINDOWS__` with `WIN32`

In the rest of the codebase, we are using `WIN32`, so it makes sense to update `subprocess.h` to match that.

---

Use the following `grep` to assert there is no `__USING_WINDOWS__` in the codebase
```
grep -nri --exclude-dir=build "WIN32" ./ -I
rep -nri --exclude-dir=build "__USING_WINDOWS__" ./ -I
```