### PR TITLE
test: Fix shutdown vptr race in BlockFilterIndexSync bench

### DIFF
--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -53,6 +53,9 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
         IndexSummary summary = filter_index.GetSummary();
         assert(summary.synced);
         assert(summary.best_block_hash == WITH_LOCK(::cs_main, return test_setup->m_node.chainman->ActiveTip()->GetBlockHash()));
+
+        // Shutdown sequence (c.f. Shutdown() in init.cpp)
+        filter_index.Stop();
     });
 }
 

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -64,14 +64,6 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
 
     BOOST_CHECK(block_index != new_block_index);
 
-    // It is not safe to stop and destroy the index until it finishes handling
-    // the last BlockConnected notification. The BlockUntilSyncedToCurrentChain()
-    // call above is sufficient to ensure this, but the
-    // SyncWithValidationInterfaceQueue() call below is also needed to ensure
-    // TSAN always sees the test thread waiting for the notification thread, and
-    // avoid potential false positive reports.
-    m_node.validation_signals->SyncWithValidationInterfaceQueue();
-
     // Shutdown sequence (c.f. Shutdown() in init.cpp)
     coin_stats_index.Stop();
 }

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -61,14 +61,6 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
         }
     }
 
-    // It is not safe to stop and destroy the index until it finishes handling
-    // the last BlockConnected notification. The BlockUntilSyncedToCurrentChain()
-    // call above is sufficient to ensure this, but the
-    // SyncWithValidationInterfaceQueue() call below is also needed to ensure
-    // TSAN always sees the test thread waiting for the notification thread, and
-    // avoid potential false positive reports.
-    m_node.validation_signals->SyncWithValidationInterfaceQueue();
-
     // shutdown sequence (c.f. Shutdown() in init.cpp)
     txindex.Stop();
 }

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -70,6 +70,7 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
         BOOST_CHECK_EQUAL((*tx_spender)->block_hash, tip_hash);
     }
 
+    // Shutdown sequence (c.f. Shutdown() in init.cpp)
     txospenderindex.Stop();
 }
 


### PR DESCRIPTION
Currently, the `BlockFilterIndexSync` may fail tsan.

Diff to reproduce:

```diff
diff --git a/src/validationinterface.cpp b/src/validationinterface.cpp
index c7be6ab..4cb8435 100644
--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -14,2 +14,3 @@
 #include <primitives/transaction.h>
+#include <random.h>
 #include <util/check.h>
@@ -156,2 +157,4 @@ void ValidationSignals::SyncWithValidationInterfaceQueue()
 
+static FastRandomContext g_rnd{};
+
 // Use a macro instead of a function for conditional logging to prevent
@@ -166,2 +169,3 @@ void ValidationSignals::SyncWithValidationInterfaceQueue()
             LOG_EVENT(fmt, local_name, __VA_ARGS__);           \
+            UninterruptibleSleep(1ms * g_rnd.randrange(95));   \
             event();                                           \
```

and then running the tsan CI pod: `MAKEJOBS="-j$(nproc)" FILE_ENV="./ci/test/00_setup_env_native_tsan.sh" ./ci/test_run_all.sh`

After about 3 runs, it will fail. It is also possible to run in a loop inside the pod: `while TSAN_OPTIONS="suppressions=$(pwd)/test/sanitizer_suppressions/tsan:halt_on_error=1:second_deadlock_stack=1" /ci_container_base/ci/scratch/build-x86_64-pc-linux-gnu/bin/bench_bitcoin -filter=BlockFilterIndexSync -sanity-check ; do true ; done`


The output will be:

```
Running with -sanity-check option, output is being suppressed as benchmark results will be useless.
Running with -sanity-check option, output is being suppressed as benchmark results will be useless.
==================
WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=100168)
  Write of size 8 at 0x7fffbe828aa8 by main thread:
    #0 BaseIndex::~BaseIndex() /ci_container_base/src/index/base.cpp:99:1 (bench_bitcoin+0x33c201) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #1 BlockFilterIndex::~BlockFilterIndex() /ci_container_base/src/index/blockfilterindex.h:40:7 (bench_bitcoin+0x266000) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #2 BlockFilterIndexSync(ankerl::nanobench::Bench&)::$_0::operator()() const /ci_container_base/src/bench/index_blockfilter.cpp:56:5 (bench_bitcoin+0x2659a1) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #3 ankerl::nanobench::Bench& ankerl::nanobench::Bench::run<BlockFilterIndexSync(ankerl::nanobench::Bench&)::$_0>(BlockFilterIndexSync(ankerl::nanobench::Bench&)::$_0&&) /ci_container_base/src/bench/nanobench.h:1221:13 (bench_bitcoin+0x2659a1)
    #4 BlockFilterIndexSync(ankerl::nanobench::Bench&) /ci_container_base/src/bench/index_blockfilter.cpp:46:33 (bench_bitcoin+0x26565a) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #5 std::__1::__invoke_result_impl<void, void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&>::type std::__1::__invoke[abi:dee230000]<void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&>(void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&) /cxx_build/include/c++/v1/__type_traits/invoke.h:90:27 (bench_bitcoin+0x21b394) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #6 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:dee230000]<void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&>(void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&) /cxx_build/include/c++/v1/__type_traits/invoke.h:350:5 (bench_bitcoin+0x21b394)
    #7 void std::__1::__invoke_r[abi:dee230000]<void, void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&>(void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&) /cxx_build/include/c++/v1/__type_traits/invoke.h:356:10 (bench_bitcoin+0x21b394)
    #8 std::__1::__function::__func<void (*)(ankerl::nanobench::Bench&), void (ankerl::nanobench::Bench&)>::operator()(ankerl::nanobench::Bench&) /cxx_build/include/c++/v1/__functional/function.h:172:12 (bench_bitcoin+0x21b394)
    #9 std::__1::__function::__value_func<void (ankerl::nanobench::Bench&)>::operator()[abi:dee230000](ankerl::nanobench::Bench&) const /cxx_build/include/c++/v1/__functional/function.h:273:12 (bench_bitcoin+0x1cc77d) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #10 std::__1::function<void (ankerl::nanobench::Bench&)>::operator()(ankerl::nanobench::Bench&) const /cxx_build/include/c++/v1/__functional/function.h:754:10 (bench_bitcoin+0x1cc77d)
    #11 benchmark::BenchRunner::RunAll(benchmark::Args const&) /ci_container_base/src/bench/bench.cpp:121:13 (bench_bitcoin+0x1cc77d)
    #12 main /ci_container_base/src/bench/bench_bitcoin.cpp:135:9 (bench_bitcoin+0x1c5a76) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)

  Previous read of size 8 at 0x7fffbe828aa8 by thread T1:
    #0 ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_1::operator()() const::'lambda'(CValidationInterface&)::operator()(CValidationInterface&) const /ci_container_base/src/validationinterface.cpp:231:79 (bench_bitcoin+0x885feb) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #1 void ValidationSignalsImpl::Iterate<ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_1::operator()() const::'lambda'(CValidationInterface&)>(ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_1::operator()() const::'lambda'(CValidationInterface&)&&) /ci_container_base/src/validationinterface.cpp:91:17 (bench_bitcoin+0x885feb)
    #2 ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_1::operator()() const /ci_container_base/src/validationinterface.cpp:231:22 (bench_bitcoin+0x885feb)
    #3 ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_0::operator()() const /ci_container_base/src/validationinterface.cpp:233:27 (bench_bitcoin+0x885feb)
    #4 std::__1::__invoke_result_impl<void, ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_0&>::type std::__1::__invoke[abi:dee230000]<ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_0&>(ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_0&) /cxx_build/include/c++/v1/__type_traits/invoke.h:90:27 (bench_bitcoin+0x885feb)
    #5 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:dee230000]<ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_0&>(ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_0&) /cxx_build/include/c++/v1/__type_traits/invoke.h:350:5 (bench_bitcoin+0x885feb)
    #6 void std::__1::__invoke_r[abi:dee230000]<void, ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_0&>(ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_0&) /cxx_build/include/c++/v1/__type_traits/invoke.h:356:10 (bench_bitcoin+0x885feb)
    #7 std::__1::__function::__func<ValidationSignals::MempoolTransactionsRemovedForBlock(std::__1::vector<RemovedMempoolTransactionInfo, std::__1::allocator<RemovedMempoolTransactionInfo>> const&, unsigned int)::$_0, void ()>::operator()() /cxx_build/include/c++/v1/__functional/function.h:172:12 (bench_bitcoin+0x885feb)
    #8 std::__1::__function::__value_func<void ()>::operator()[abi:dee230000]() const /cxx_build/include/c++/v1/__functional/function.h:273:12 (bench_bitcoin+0xddec83) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #9 std::__1::function<void ()>::operator()() const /cxx_build/include/c++/v1/__functional/function.h:754:10 (bench_bitcoin+0xddec83)
    #10 SerialTaskRunner::ProcessQueue() /ci_container_base/src/scheduler.cpp:173:5 (bench_bitcoin+0xddec83)
    #11 SerialTaskRunner::MaybeScheduleProcessQueue()::$_0::operator()() const /ci_container_base/src/scheduler.cpp:142:41 (bench_bitcoin+0xde08e5) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #12 std::__1::__invoke_result_impl<void, SerialTaskRunner::MaybeScheduleProcessQueue()::$_0&>::type std::__1::__invoke[abi:dee230000]<SerialTaskRunner::MaybeScheduleProcessQueue()::$_0&>(SerialTaskRunner::MaybeScheduleProcessQueue()::$_0&) /cxx_build/include/c++/v1/__type_traits/invoke.h:90:27 (bench_bitcoin+0xde08e5)
    #13 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:dee230000]<SerialTaskRunner::MaybeScheduleProcessQueue()::$_0&>(SerialTaskRunner::MaybeScheduleProcessQueue()::$_0&) /cxx_build/include/c++/v1/__type_traits/invoke.h:350:5 (bench_bitcoin+0xde08e5)
    #14 void std::__1::__invoke_r[abi:dee230000]<void, SerialTaskRunner::MaybeScheduleProcessQueue()::$_0&>(SerialTaskRunner::MaybeScheduleProcessQueue()::$_0&) /cxx_build/include/c++/v1/__type_traits/invoke.h:356:10 (bench_bitcoin+0xde08e5)
    #15 std::__1::__function::__func<SerialTaskRunner::MaybeScheduleProcessQueue()::$_0, void ()>::operator()() /cxx_build/include/c++/v1/__functional/function.h:172:12 (bench_bitcoin+0xde08e5)
    #16 std::__1::__function::__value_func<void ()>::operator()[abi:dee230000]() const /cxx_build/include/c++/v1/__functional/function.h:273:12 (bench_bitcoin+0xddda36) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #17 std::__1::function<void ()>::operator()() const /cxx_build/include/c++/v1/__functional/function.h:754:10 (bench_bitcoin+0xddda36)
    #18 CScheduler::serviceQueue() /ci_container_base/src/scheduler.cpp:60:17 (bench_bitcoin+0xddda36)
    #19 ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2::operator()() const /ci_container_base/src/test/util/setup_common.cpp:250:114 (bench_bitcoin+0x2dcaa8) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #20 std::__1::__invoke_result_impl<void, ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2&>::type std::__1::__invoke[abi:dee230000]<ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2&>(ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2&) /cxx_build/include/c++/v1/__type_traits/invoke.h:90:27 (bench_bitcoin+0x2dcaa8)
    #21 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:dee230000]<ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2&>(ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2&) /cxx_build/include/c++/v1/__type_traits/invoke.h:350:5 (bench_bitcoin+0x2dcaa8)
    #22 void std::__1::__invoke_r[abi:dee230000]<void, ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2&>(ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2&) /cxx_build/include/c++/v1/__type_traits/invoke.h:356:10 (bench_bitcoin+0x2dcaa8)
    #23 std::__1::__function::__func<ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2, void ()>::operator()() /cxx_build/include/c++/v1/__functional/function.h:172:12 (bench_bitcoin+0x2dcaa8)
    #24 std::__1::__function::__value_func<void ()>::operator()[abi:dee230000]() const /cxx_build/include/c++/v1/__functional/function.h:273:12 (bench_bitcoin+0xef2b0b) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #25 std::__1::function<void ()>::operator()() const /cxx_build/include/c++/v1/__functional/function.h:754:10 (bench_bitcoin+0xef2b0b)
    #26 util::TraceThread(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>) /ci_container_base/src/util/thread.cpp:21:9 (bench_bitcoin+0xef2b0b)
    #27 std::__1::__invoke_result_impl<void, void (*)(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>), char const*, ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2>::type std::__1::__invoke[abi:dee230000]<void (*)(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>), char const*, ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2>(void (*&&)(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>), char const*&&, ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2&&) /cxx_build/include/c++/v1/__type_traits/invoke.h:90:27 (bench_bitcoin+0x2dc652) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #28 void std::__1::__thread_execute[abi:dee230000]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>), char const*, ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2, 0ul, 1ul, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>), char const*, ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2>&, std::__1::__integer_sequence<unsigned long, 0ul, 1ul, 2ul>) /cxx_build/include/c++/v1/__thread/thread.h:161:3 (bench_bitcoin+0x2dc652)
    #29 void* std::__1::__thread_proxy[abi:dee230000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>), char const*, ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2>>(void*) /cxx_build/include/c++/v1/__thread/thread.h:169:3 (bench_bitcoin+0x2dc652)

  Location is stack of main thread.

  Thread T1 'b-scheduler' (tid=100170, running) created by main thread at:
    #0 pthread_create <null> (bench_bitcoin+0x13dc4e) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #1 std::__1::__libcpp_thread_create[abi:dee230000](unsigned long*, void* (*)(void*), void*) /cxx_build/include/c++/v1/__thread/support/pthread.h:182:10 (bench_bitcoin+0x2d3531) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #2 std::__1::thread::thread[abi:dee230000]<void (&)(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>), char const (&) [10], ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2, 0>(void (&)(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>), char const (&) [10], ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts)::$_2&&) /cxx_build/include/c++/v1/__thread/thread.h:218:16 (bench_bitcoin+0x2d3531)
    #3 ChainTestingSetup::ChainTestingSetup(ChainType, TestOpts) /ci_container_base/src/test/util/setup_common.cpp:250:46 (bench_bitcoin+0x2d3531)
    #4 TestingSetup::TestingSetup(ChainType, TestOpts) /ci_container_base/src/test/util/setup_common.cpp:344:7 (bench_bitcoin+0x2d4c1f) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #5 TestChain100Setup::TestChain100Setup(ChainType, TestOpts) /ci_container_base/src/test/util/setup_common.cpp:380:7 (bench_bitcoin+0x2d560a) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #6 std::__1::unique_ptr<TestChain100Setup, std::__1::default_delete<TestChain100Setup>> std::__1::make_unique[abi:dee230000]<TestChain100Setup, ChainType const&, TestOpts&, 0>(ChainType const&, TestOpts&) /cxx_build/include/c++/v1/__memory/unique_ptr.h:756:30 (bench_bitcoin+0x224eed) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #7 std::__1::unique_ptr<TestChain100Setup, std::__1::default_delete<TestChain100Setup>> MakeNoLogFileContext<TestChain100Setup>(ChainType, TestOpts) /ci_container_base/src/test/util/setup_common.h:259:12 (bench_bitcoin+0x224ce2) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #8 BlockFilterIndexSync(ankerl::nanobench::Bench&) /ci_container_base/src/bench/index_blockfilter.cpp:33:29 (bench_bitcoin+0x26530f) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #9 std::__1::__invoke_result_impl<void, void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&>::type std::__1::__invoke[abi:dee230000]<void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&>(void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&) /cxx_build/include/c++/v1/__type_traits/invoke.h:90:27 (bench_bitcoin+0x21b394) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #10 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:dee230000]<void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&>(void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&) /cxx_build/include/c++/v1/__type_traits/invoke.h:350:5 (bench_bitcoin+0x21b394)
    #11 void std::__1::__invoke_r[abi:dee230000]<void, void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&>(void (*&)(ankerl::nanobench::Bench&), ankerl::nanobench::Bench&) /cxx_build/include/c++/v1/__type_traits/invoke.h:356:10 (bench_bitcoin+0x21b394)
    #12 std::__1::__function::__func<void (*)(ankerl::nanobench::Bench&), void (ankerl::nanobench::Bench&)>::operator()(ankerl::nanobench::Bench&) /cxx_build/include/c++/v1/__functional/function.h:172:12 (bench_bitcoin+0x21b394)
    #13 std::__1::__function::__value_func<void (ankerl::nanobench::Bench&)>::operator()[abi:dee230000](ankerl::nanobench::Bench&) const /cxx_build/include/c++/v1/__functional/function.h:273:12 (bench_bitcoin+0x1cc77d) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)
    #14 std::__1::function<void (ankerl::nanobench::Bench&)>::operator()(ankerl::nanobench::Bench&) const /cxx_build/include/c++/v1/__functional/function.h:754:10 (bench_bitcoin+0x1cc77d)
    #15 benchmark::BenchRunner::RunAll(benchmark::Args const&) /ci_container_base/src/bench/bench.cpp:121:13 (bench_bitcoin+0x1cc77d)
    #16 main /ci_container_base/src/bench/bench_bitcoin.cpp:135:9 (bench_bitcoin+0x1c5a76) (BuildId: d6021b6fabe0b72ef5741922cc8e7f71ce6eac0c)

SUMMARY: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) /ci_container_base/src/index/base.cpp:99:1 in BaseIndex::~BaseIndex()
==================
```

Fix this by following the shutdown sequence of first stopping the index and then desctructing it, instead of doing both at the same time (stopping inside the desctructor).

Also, apply the comment `// Shutdown sequence (c.f. Shutdown() in init.cpp)` consistently, while touching this topic of the codebase.

Also, remove the unused `SyncWithValidationInterfaceQueue`, which is redundant to the prior `BlockUntilSyncedToCurrentChain`. See also the last comment in the pull request that introduced this: https://github.com/bitcoin/bitcoin/pull/26188#issuecomment-1274258156

> I think anything is fine here. Either keep both or delete both.

Given that devs did not apply the redundant sync in two new cases, it seems fine to remove it.