### PR TITLE
refactor: use explicit `&util::TraceThread` function pointer in thread spawns

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1454,7 +1454,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     auto& scheduler = *node.scheduler;
 
     // Start the lightweight task scheduler thread
-    scheduler.m_service_thread = std::thread(util::TraceThread, "scheduler", [&] { scheduler.serviceQueue(); });
+    scheduler.m_service_thread = std::thread(&util::TraceThread, "scheduler", [&] { scheduler.serviceQueue(); });
 
     // Gather some entropy once per minute.
     scheduler.scheduleEvery([]{

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -247,7 +247,7 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
     // from blocking due to queue overrun.
     if (opts.setup_validation_interface) {
         m_node.scheduler = std::make_unique<CScheduler>();
-        m_node.scheduler->m_service_thread = std::thread(util::TraceThread, "scheduler", [&] { m_node.scheduler->serviceQueue(); });
+        m_node.scheduler->m_service_thread = std::thread(&util::TraceThread, "scheduler", [&] { m_node.scheduler->serviceQueue(); });
         m_node.validation_signals =
             // Use synchronous task runner while fuzzing to avoid non-determinism
             EnableFuzzDeterminism() ?


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->
Replace implicit function-to-pointer decay with explicit `&util::TraceThread`  expressions in two thread spawn call sites.

**Why:** 
While both forms work the same way, using explicit `&` is slightly more friendly to the compile, makes the code easy to understand what is happening, and the rest of the project already follows this style for thread spawns. This aligns these two occurrences with that convention.
All  threads which uses `util::TraceThread`  to spawn now use the explicit `&` form
**Verified no remaining inconsistent spawns:**

```bash
# no remaining inconsistent spawns
$ grep -rn "std::thread(util::TraceThread" src/ | wc -l
0
# all occurrences now use explicit & form
$ grep -rn "util::TraceThread" src/ 
```




<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
