### PR TITLE
test: replace bare asserts with assertion helpers in wallet_bumpfee.py

### DIFF
--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -320,11 +320,11 @@ def test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address):
         bumped_psbt = rbf_node.psbtbumpfee(rbfid)
         bumped_tx = rbf_node.bumpfee(rbfid)
     assert_equal(bumped_tx["errors"], [])
-    assert bumped_tx["fee"] > -rbftx["fee"]
+    assert_greater_than(bumped_tx["fee"], -rbftx["fee"])
     assert_equal(bumped_tx["origfee"], -rbftx["fee"])
     assert "psbt" not in bumped_tx
     assert_equal(bumped_psbt["errors"], [])
-    assert bumped_psbt["fee"] > -rbftx["fee"]
+    assert_greater_than(bumped_psbt["fee"], -rbftx["fee"])
     assert_equal(bumped_psbt["origfee"], -rbftx["fee"])
     assert "psbt" in bumped_psbt
     # check that bumped_tx propagates, original tx was evicted and has a wallet conflict
@@ -334,15 +334,15 @@ def test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address):
     assert rbfid not in rbf_node.getrawmempool()
     assert rbfid not in peer_node.getrawmempool()
     oldwtx = rbf_node.gettransaction(rbfid)
-    assert len(oldwtx["walletconflicts"]) > 0
+    assert_greater_than(len(oldwtx["walletconflicts"]), 0)
     # check wallet transaction replaces and replaced_by values
     bumpedwtx = rbf_node.gettransaction(bumped_tx["txid"])
     assert_equal(oldwtx["replaced_by_txid"], bumped_tx["txid"])
     assert_equal(bumpedwtx["replaces_txid"], rbfid)
     # if this is a new_outputs test, check that outputs were indeed replaced
     if mode == "new_outputs":
-        assert len(bumpedwtx["details"]) == 1
-        assert bumpedwtx["details"][0]["address"] == new_address
+        assert_equal(len(bumpedwtx["details"]), 1)
+        assert_equal(bumpedwtx["details"][0]["address"], new_address)
     self.clear_mempool()
 
 
@@ -718,7 +718,7 @@ def test_unconfirmed_not_spendable(self, rbf_node, rbf_node_address):
 
 def test_bumpfee_metadata(self, rbf_node, dest_address):
     self.log.info('Test that bumped txn metadata persists to new txn record')
-    assert rbf_node.getbalance() < 49
+    assert_greater_than(49, rbf_node.getbalance())
     self.generatetoaddress(rbf_node, 101, rbf_node.getnewaddress())
     rbfid = rbf_node.sendtoaddress(dest_address, 49, "comment value", "to value")
     bumped_tx = rbf_node.bumpfee(rbfid)


### PR DESCRIPTION
Replace 6 bare `assert` statements in `test/functional/wallet_bumpfee.py` with test framework helpers (`assert_greater_than`, `assert_equal`).

Bare asserts produce unhelpful `AssertionError` with no context on failure. The helpers print actual vs expected values.

**Changes:**
- `assert bumped_tx["fee"] > -rbftx["fee"]` → `assert_greater_than`
- `assert bumped_psbt["fee"] > -rbftx["fee"]` → `assert_greater_than`
- `assert len(oldwtx["walletconflicts"]) > 0` → `assert_greater_than`
- `assert len(bumpedwtx["details"]) == 1` → `assert_equal`
- `assert bumpedwtx["details"][0]["address"] == new_address` → `assert_equal`
- `assert rbf_node.getbalance() < 49` → `assert_greater_than(49, ...)`

No new imports needed — all helpers already imported. Each replacement preserves the exact same logical condition.

Part of #23119.