### PR TITLE
fuzz: set whitelist permissions on connman target

### DIFF
--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -79,6 +79,18 @@ FUZZ_TARGET(connman, .init = initialize_connman)
     CConnman::Options options;
     options.m_msgproc = &net_events;
     options.nMaxOutboundLimit = max_outbound_limit;
+
+    auto consume_whitelist = [&]() {
+        std::vector<NetWhitelistPermissions> result(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 3));
+        for (auto& entry : result) {
+            entry.m_flags = ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS);
+            entry.m_subnet = ConsumeSubNet(fuzzed_data_provider);
+        }
+        return result;
+    };
+    options.vWhitelistedRangeIncoming = consume_whitelist();
+    options.vWhitelistedRangeOutgoing = consume_whitelist();
+
     connman.Init(options);
 
     CNetAddr random_netaddr;


### PR DESCRIPTION
I noticed that `AddWhitelistPermissionFlags` was always being called with an empty `ranges` (whitelist permissions). This function is called when connecting to a node (`ConnectNode`), and if the connection is a manual one, it uses the `vWhitelistedRangeOutgoing` to populate the permissions. However, since we were not setting any whitelist permission on the target, this vector is always empty. This PR improves this target by populating both `vWhitelistedRangeIncoming` and `vWhitelistedRangeOutgoing`.