### PR TITLE
test: Sync mempools and wait for txospender index to be synced in rpc_gettxspendingprevout

### DIFF
--- a/test/functional/rpc_gettxspendingprevout.py
+++ b/test/functional/rpc_gettxspendingprevout.py
@@ -77,6 +77,8 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         txidA, txidB, txidC, txidD, txidE, txidF, txidG, txidH = [tx["txid"] for tx in txs]
 
         self.sync_mempools()
+        self.wait_until(lambda: node0.getindexinfo()["txospenderindex"]["synced"])
+        self.wait_until(lambda: node1.getindexinfo()["txospenderindex"]["synced"])
         mempool = node0.getrawmempool()
         assert_equal(len(mempool), 8)
         for tx in txs:

--- a/test/functional/rpc_gettxspendingprevout.py
+++ b/test/functional/rpc_gettxspendingprevout.py
@@ -76,6 +76,7 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         txs = [txA, txB, txC, txD, txE, txF, txG, txH]
         txidA, txidB, txidC, txidD, txidE, txidF, txidG, txidH = [tx["txid"] for tx in txs]
 
+        self.sync_mempools()
         mempool = node0.getrawmempool()
         assert_equal(len(mempool), 8)
         for tx in txs:


### PR DESCRIPTION
On slower runs, the txospender index may not be synced yet when the tests of its behavior begin, causing intermittent failures. Wait for them to be synced before starting the tests.

The tests also query mempool txs from other nodes, make sure mempools are synced before doing so.

The first commit with the following diff reproduces #34735:

```
diff --git a/src/index/txospenderindex.cpp b/src/index/txospenderindex.cpp
index d451bb1e0a4..e786f05a98c 100644
--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -129,6 +129,7 @@ static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const
 
 bool TxoSpenderIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
+    UninterruptibleSleep(100ms);
     WriteSpenderInfos(BuildSpenderPositions(block));
     return true;
 }
```

Fixes #34735 