### PR TITLE
index: improve TxoSpenderIndex readability and documentation

### DIFF
--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -56,6 +56,16 @@ protected:
 public:
     explicit TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
+    /**
+     * Search the index for a transaction that spends the given outpoint.
+     *
+     * @param[in] txo  The outpoint to search for.
+     *
+     * @return  std::nullopt               if the outpoint has not been spent on-chain.
+     *          std::optional{TxoSpender}  if the output has been spent on-chain. Contains the spending transaction
+     *                                     and the block it was confirmed in.
+     *          util::Unexpected{error}    if something unexpected happened (i.e. disk or deserialization error).
+     */
     util::Expected<std::optional<TxoSpender>, std::string> FindSpender(const COutPoint& txo) const;
 };
 

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -994,33 +994,50 @@ static RPCHelpMan gettxspendingprevout()
                     }
                 }
             }
-            // if search is not limited to the mempool and no spender was found for an outpoint, search the txospenderindex
-            // we call g_txospenderindex->BlockUntilSyncedToCurrentChain() only if g_txospenderindex is going to be used
+
+            // The index is only needed if on-chain search is enabled and at least one output was not found in the mempool
+            bool use_index = false;
+            if (!mempool_only && missing_from_mempool) {
+                // As we are going to use the index, let's wait until it is synced
+                use_index = g_txospenderindex && g_txospenderindex->BlockUntilSyncedToCurrentChain();
+            }
+
+            // Construct results
             UniValue result{UniValue::VARR};
-            bool txospenderindex_ready{mempool_only || !missing_from_mempool || (g_txospenderindex && g_txospenderindex->BlockUntilSyncedToCurrentChain())};
             for (auto& entry : prevouts) {
+                // Spent in mempool. Add output directly
                 if (!entry.output.isNull()) {
                     result.push_back(std::move(entry.output));
                     continue;
                 }
-                UniValue o{entry.input};
+
+                // Mempool-only mode. Return the input outpoint (which means: unspent).
                 if (mempool_only) {
-                    // do nothing, caller has selected to only query the mempool
-                } else if (!txospenderindex_ready) {
+                    result.push_back(entry.input);
+                    continue;
+                }
+
+                // No tx spending this output in the mempool, check on-chain via the index if possible
+                if (!use_index) {
                     throw JSONRPCError(RPC_MISC_ERROR, strprintf("No spending tx for the outpoint %s:%d in mempool, and txospenderindex is unavailable.", entry.prevout.hash.GetHex(), entry.prevout.n));
-                } else {
-                    // no spending tx in mempool, query txospender index
-                    const auto spender{g_txospenderindex->FindSpender(entry.prevout)};
-                    if (!spender) {
-                        throw JSONRPCError(RPC_MISC_ERROR, spender.error());
-                    }
-                    if (spender.value()) {
-                        o.pushKV("spendingtxid", spender.value()->tx->GetHash().GetHex());
-                        o.pushKV("blockhash", spender.value()->block_hash.GetHex());
-                        if (return_spending_tx) {
-                            o.pushKV("spendingtx", EncodeHexTx(*spender.value()->tx));
-                        }
-                    }
+                }
+
+                const auto spender{g_txospenderindex->FindSpender(entry.prevout)};
+                if (!spender) throw JSONRPCError(RPC_MISC_ERROR, spender.error());
+
+                const std::optional<TxoSpender>& op_spend_info = spender.value();
+                // If info is nullopt, it means this output was not spent. Return the input outpoint (which means: unspent).
+                if (!op_spend_info.has_value()) {
+                    result.push_back(entry.input);
+                    continue;
+                }
+
+                // Otherwise, this outpoint was spent on-chain
+                UniValue o {entry.input};
+                o.pushKV("spendingtxid", op_spend_info->tx->GetHash().GetHex());
+                o.pushKV("blockhash", op_spend_info->block_hash.GetHex());
+                if (return_spending_tx) {
+                    o.pushKV("spendingtx", EncodeHexTx(*op_spend_info->tx));
                 }
                 result.push_back(std::move(o));
             }


### PR DESCRIPTION
This should help future ourselves and other devs to maintain the code. The code here
took me a bit to grasp, so I imagine others could be in the same situation.

First, `TxoSpenderIndex::FindSpender` returns an `Expected<optional<TxoSpender>>` but
the two levels of the return type were undocumented, making it unclear what a returned
`nullopt` means. So added doc clarifying each return case.

Second, the result-building loop in `gettxspendingprevout` was not super readable
to me, mainly due to the nested if/else chain and missing comments on what is going on
along the process.

Hope this helps others, if not, I can close it. It was helpful to me.