### PR TITLE
doc: Update asmap-data repository rule for file inclusion

### DIFF
--- a/doc/asmap-data.md
+++ b/doc/asmap-data.md
@@ -41,9 +41,9 @@ To overcome this, multiple users can start the download process at the exact
 same time which leads to a high likelihood that their downloaded data will be
 similar enough that they receive the same output at the end of the process.
 This process is regularly coordinated at the [asmap-data](https://github.com/asmap/asmap-data)
-project. If enough participants have joined the effort (5 or more is recommended) and a majority of the
-participants have received the same result, the resulting ASMap file is added
-to the repository for public use. Files will not be merged to the repository
+project. If the result hash that was observed by the most participants is signed
+by 5 participants or more, the resulting ASMap file is added to the repository for
+public use. Files will not be merged to the repository
 without at least two additional reviewers confirming that the process described
 above was followed as expected and that the encoding step yielded the same
 file hash. New files are created on an ongoing basis but without any central planning


### PR DESCRIPTION
This updates the decision rule for file inclusion in the asmap-data repository after a collaborative run following discussion in the latest run: https://github.com/bitcoin-core/asmap-data/issues/44

The change is small but does a few things:
- No minimum number of participants recommended anymore
- Minimum number of matches set to 5 (which was previously the number of recommended min participants)
- The result that is taken does not need to see a match between the majority of participants, it only needs to have the most matches
- Participants that saw a match should sign for it

I also thought about adding an explicit tie-breaker if there are two results with the same number of matches but since both results are equally valid I think it won't be needed (?)