### PR TITLE
depends: cleanup meta files

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -24,3 +24,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm -rf share
+endef

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -169,6 +169,7 @@ $(package)_config_env_darwin += OBJCXX="$$($(package)_cxx)"
 
 $(package)_cmake_opts := -DCMAKE_PREFIX_PATH=$(host_prefix)
 $(package)_cmake_opts += -DQT_FEATURE_cxx20=ON
+$(package)_cmake_opts += -DQT_GENERATE_SBOM=OFF
 ifneq ($(V),)
 $(package)_cmake_opts += --log-level=STATUS
 endif


### PR DESCRIPTION
1 followup to #34650, to disable sbom generation.
1 commit to Boost, to cleanup `.natvis` files that end up in share.