### PR TITLE
guix: re-enable riscv exported symbol checking

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -23,6 +23,7 @@
              (guix build-system python)
              (guix build-system pyproject)
              (guix build-system trivial)
+             (guix download)
              (guix gexp)
              (guix git-download)
              ((guix licenses) #:prefix license:)
@@ -38,13 +39,36 @@ FILE-NAME found in ./patches relative to the current file."
 
 (define building-on (string-append "--build=" (list-ref (string-split (%current-system) #\-) 0) "-guix-linux-gnu"))
 
+(define (base-binutils target)
+  (package
+    (inherit (cross-binutils target)) ;; 2.44
+    (version "2.46.0")
+    (source (origin
+              (method url-fetch)
+              (uri (string-append "mirror://gnu/binutils/binutils-"
+                          version ".tar.bz2"))
+              (sha256
+               (base32
+                "04nd9vl7c1pxjbc9wh3ckddzhz5g82xyjqq9y9kf171a59im4c8g"))))
+    (arguments
+      (substitute-keyword-arguments (package-arguments (cross-binutils target))
+        ((#:configure-flags flags)
+          #~(append #$flags
+            (list "--enable-gprofng=no")))))
+    (native-inputs
+      (modify-inputs
+        (package-native-inputs (cross-binutils target))
+        (delete "bison")))
+  )
+)
+
 (define (make-cross-toolchain target
                               base-gcc-for-libc
                               base-kernel-headers
                               base-libc
                               base-gcc)
   "Create a cross-compilation toolchain package for TARGET"
-  (let* ((xbinutils (cross-binutils target))
+  (let* ((xbinutils (base-binutils target))
          ;; 1. Build a cross-compiling gcc without targeting any libc, derived
          ;; from BASE-GCC-FOR-LIBC
          (xgcc-sans-libc (cross-gcc target
@@ -119,7 +143,7 @@ desirable for building Bitcoin Core release binaries."
 
 (define (make-mingw-pthreads-cross-toolchain target)
   "Create a cross-compilation toolchain package for TARGET"
-  (let* ((xbinutils (binutils-mingw-patches (cross-binutils target)))
+  (let* ((xbinutils (binutils-mingw-patches (base-binutils target)))
          (machine (substring target 0 (string-index target #\-)))
          (pthreads-xlibc (winpthreads-patches (make-mingw-w64 machine
                                          #:xgcc (cross-gcc target #:xgcc base-gcc)

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -202,7 +202,7 @@ def check_exported_symbols(binary) -> bool:
         if not symbol.exported:
             continue
         name = symbol.name
-        if binary.header.machine_type == lief.ELF.ARCH.RISCV or name in IGNORE_EXPORTS:
+        if name in IGNORE_EXPORTS:
             continue
         print(f'{filename}: export of symbol {name} not allowed!')
         ok = False


### PR DESCRIPTION
Switching to binutils `2.46.0` fixes the spurious exported symbols (2.45.1 was still broken).

The relevant upstream change is https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=9e10fcf71c1101fb6422d0f52de5e615ed8df71d.

Fixes #28095.