### PR TITLE
Bump default `-dbcache` to 1GiB

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -6,7 +6,7 @@ There are a few parameters that can be dialed down to reduce the memory usage of
 
 The size of some in-memory caches can be reduced. As caches trade off memory usage for performance, reducing these will usually have a negative effect on performance.
 
-- `-dbcache=<n>` - the UTXO database cache size, this defaults to `450`. The unit is MiB (1024).
+- `-dbcache=<n>` - the UTXO database cache size, this defaults to `1024`. The unit is MiB (1024).
   - The minimum value for `-dbcache` is 4.
   - A lower `-dbcache` makes initial sync time much longer. After the initial sync, the effect is less pronounced for most use-cases, unless fast validation of blocks is important, such as for mining.
 

--- a/doc/release-notes-34692.md
+++ b/doc/release-notes-34692.md
@@ -1,0 +1,8 @@
+Updated settings
+----------------
+
+- The default `-dbcache` value has been increased to `1024` MiB from `450` MiB.
+  This improves performance, but will use more memory.
+  Systems with less than 4 GiB of RAM may run out of memory.
+  To maintain the previous behavior, set `-dbcache=450`.
+  See [reduce-memory.md](reduce-memory.md) for further guidance on low-memory systems. (#34692)

--- a/src/kernel/caches.h
+++ b/src/kernel/caches.h
@@ -10,7 +10,7 @@
 #include <algorithm>
 
 //! Suggested default amount of cache reserved for the kernel (bytes)
-static constexpr size_t DEFAULT_KERNEL_CACHE{450_MiB};
+static constexpr size_t DEFAULT_KERNEL_CACHE{1024_MiB};
 //! Default LevelDB write batch size
 static constexpr size_t DEFAULT_DB_CACHE_BATCH{32_MiB};
 

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -30,7 +30,7 @@ struct CacheSizes {
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes = 0);
 constexpr bool ShouldWarnOversizedDbCache(size_t dbcache, size_t total_ram) noexcept
 {
-    const size_t cap{(total_ram < 2048_MiB) ? DEFAULT_DB_CACHE : (total_ram / 100) * 75};
+    const size_t cap{total_ram / 100 * 75};
     return dbcache > cap;
 }
 

--- a/src/test/caches_tests.cpp
+++ b/src/test/caches_tests.cpp
@@ -13,9 +13,9 @@ BOOST_AUTO_TEST_SUITE(caches_tests)
 
 BOOST_AUTO_TEST_CASE(oversized_dbcache_warning)
 {
-    // memory restricted setup - cap is DEFAULT_DB_CACHE (450 MiB)
+    // memory restricted setup - cap is 75%
     BOOST_CHECK(!ShouldWarnOversizedDbCache(/*dbcache=*/4_MiB, /*total_ram=*/1024_MiB));    // Under cap
-    BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/512_MiB, /*total_ram=*/1024_MiB));  // At cap
+    BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/768_MiB, /*total_ram=*/1024_MiB)); // At cap
     BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/1500_MiB, /*total_ram=*/1024_MiB)); // Over cap
 
     // 2 GiB RAM - cap is 75%


### PR DESCRIPTION
This is an alternative to #34692 that does not introduce detection of system resources.