### PR TITLE
test: support mainnet base58 in address_to_scriptpubkey

### DIFF
--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -3,7 +3,12 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the scantxoutset rpc call."""
-from test_framework.address import address_to_scriptpubkey
+from test_framework.address import (
+    address_to_scriptpubkey,
+    base58_to_byte,
+    keyhash_to_p2pkh_script,
+    scripthash_to_p2sh_script,
+)
 from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
@@ -39,9 +44,15 @@ class ScantxoutsetTest(BitcoinTestFramework):
         pubk1, spk_P2SH_SEGWIT, addr_P2SH_SEGWIT = getnewdestination("p2sh-segwit")
         pubk2, spk_LEGACY, addr_LEGACY = getnewdestination("legacy")
         pubk3, spk_BECH32, addr_BECH32 = getnewdestination("bech32")
+        mainnet_p2pkh_addr = "1BoatSLRHtKNngkdXEeobR76b53LETtpyT"
+        mainnet_p2sh_addr = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"
+
         self.sendtodestination(spk_P2SH_SEGWIT, 0.001)
         self.sendtodestination(spk_LEGACY, 0.002)
         self.sendtodestination(spk_BECH32, 0.004)
+        self.log.info("Exercise address_to_scriptpubkey via string destinations with mainnet Base58 inputs.")
+        self.sendtodestination(mainnet_p2pkh_addr, 0.003)
+        self.sendtodestination(mainnet_p2sh_addr, 0.006)
 
         #send to child keys of tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK
         self.sendtodestination("mkHV1C6JLheLoUSSZYk7x3FH5tnx9bu7yc", 0.008)  # (m/0'/0'/0')
@@ -73,6 +84,17 @@ class ScantxoutsetTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].scantxoutset("start", ["combo(" + pubk1.hex() + ")", "combo(" + pubk2.hex() + ")", "combo(" + pubk3.hex() + ")"])['total_amount'], Decimal("0.007"))
         assert_equal(self.nodes[0].scantxoutset("start", ["addr(" + addr_P2SH_SEGWIT + ")", "addr(" + addr_LEGACY + ")", "addr(" + addr_BECH32 + ")"])['total_amount'], Decimal("0.007"))
         assert_equal(self.nodes[0].scantxoutset("start", ["addr(" + addr_P2SH_SEGWIT + ")", "addr(" + addr_LEGACY + ")", "combo(" + pubk3.hex() + ")"])['total_amount'], Decimal("0.007"))
+
+        mainnet_p2pkh_payload, mainnet_p2pkh_version = base58_to_byte(mainnet_p2pkh_addr)
+        assert_equal(mainnet_p2pkh_version, 0)
+        mainnet_p2pkh_spk = keyhash_to_p2pkh_script(mainnet_p2pkh_payload)
+
+        mainnet_p2sh_payload, mainnet_p2sh_version = base58_to_byte(mainnet_p2sh_addr)
+        assert_equal(mainnet_p2sh_version, 5)
+        mainnet_p2sh_spk = scripthash_to_p2sh_script(mainnet_p2sh_payload)
+
+        assert_equal(self.nodes[0].scantxoutset("start", [f"raw({mainnet_p2pkh_spk.hex()})"])['total_amount'], Decimal("0.003"))
+        assert_equal(self.nodes[0].scantxoutset("start", [f"raw({mainnet_p2sh_spk.hex()})"])['total_amount'], Decimal("0.006"))
 
         self.log.info("Test range validation.")
         assert_raises_rpc_error(-8, "End of range is too high", self.nodes[0].scantxoutset, "start", [{"desc": "desc", "range": -1}])

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -86,7 +86,8 @@ def base58_to_byte(s):
     n = 0
     for c in s:
         n *= 58
-        assert c in b58chars
+        if c not in b58chars:
+            raise ValueError(f"Invalid Base58 character '{c}'")
         digit = b58chars.index(c)
         n += digit
     h = '%x' % n
@@ -185,17 +186,20 @@ def bech32_to_bytes(address):
 
 def address_to_scriptpubkey(address):
     """Converts a given address to the corresponding output script (scriptPubKey)."""
-    version, payload = bech32_to_bytes(address)
-    if version is not None:
-        return program_to_witness_script(version, payload) # testnet segwit scriptpubkey
+    wit_ver, wit_payload = bech32_to_bytes(address)
+    if wit_ver is not None:
+        return program_to_witness_script(wit_ver, wit_payload)
+
     payload, version = base58_to_byte(address)
-    if version == 111:  # testnet pubkey hash
+    if version in (0, 111):  # mainnet/testnet pubkey hash
+        if len(payload) != 20:
+            raise ValueError(f"Invalid base58 payload length for P2PKH: {len(payload)}")
         return keyhash_to_p2pkh_script(payload)
-    elif version == 196:  # testnet script hash
+    if version in (5, 196):  # mainnet/testnet script hash
+        if len(payload) != 20:
+            raise ValueError(f"Invalid base58 payload length for P2SH: {len(payload)}")
         return scripthash_to_p2sh_script(payload)
-    # TODO: also support other address formats
-    else:
-        assert False
+    raise ValueError(f"Unsupported base58 address version byte: {version}")
 
 
 class TestFrameworkScript(unittest.TestCase):
@@ -230,3 +234,31 @@ class TestFrameworkScript(unittest.TestCase):
         check_bech32_decode(bytes.fromhex('616211ab00dffe0adcb6ce258d6d3fd8cbd901e2'), 0)
         check_bech32_decode(bytes.fromhex('b6a7c98b482d7fb21c9fa8e65692a0890410ff22'), 0)
         check_bech32_decode(bytes.fromhex('f0c2109cb1008cfa7b5a09cc56f7267cd8e50929'), 0)
+
+    def test_address_to_scriptpubkey_base58(self):
+        payload_p2pkh = bytes.fromhex('1f8ea1702a7bd4941bca0941b852c4bbfedb2e05')
+        payload_p2sh = bytes.fromhex('3a0b05f4d7f66c3ba7009f453530296c845cc9cf')
+
+        for version in (0, 111):
+            address = byte_to_base58(payload_p2pkh, version)
+            assert_equal(address_to_scriptpubkey(address), keyhash_to_p2pkh_script(payload_p2pkh))
+
+        for version in (5, 196):
+            address = byte_to_base58(payload_p2sh, version)
+            assert_equal(address_to_scriptpubkey(address), scripthash_to_p2sh_script(payload_p2sh))
+
+    def test_address_to_scriptpubkey_invalid_base58(self):
+        invalid_version_addr = byte_to_base58(bytes.fromhex('11' * 20), 42)
+        with self.assertRaisesRegex(ValueError, "Unsupported base58 address version byte: 42"):
+            address_to_scriptpubkey(invalid_version_addr)
+
+        invalid_p2pkh_len_addr = byte_to_base58(bytes.fromhex('11' * 19), 0)
+        with self.assertRaisesRegex(ValueError, "Invalid base58 payload length for P2PKH: 19"):
+            address_to_scriptpubkey(invalid_p2pkh_len_addr)
+
+        invalid_p2sh_len_addr = byte_to_base58(bytes.fromhex('11' * 21), 5)
+        with self.assertRaisesRegex(ValueError, "Invalid base58 payload length for P2SH: 21"):
+            address_to_scriptpubkey(invalid_p2sh_len_addr)
+
+        with self.assertRaisesRegex(ValueError, "Invalid Base58 character '0'"):
+            address_to_scriptpubkey("0")

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -186,6 +186,9 @@ def bech32_to_bytes(address):
 
 def address_to_scriptpubkey(address):
     """Converts a given address to the corresponding output script (scriptPubKey)."""
+    if address == "":
+        raise ValueError("Empty address")
+
     wit_ver, wit_payload = bech32_to_bytes(address)
     if wit_ver is not None:
         return program_to_witness_script(wit_ver, wit_payload)
@@ -248,6 +251,9 @@ class TestFrameworkScript(unittest.TestCase):
             assert_equal(address_to_scriptpubkey(address), scripthash_to_p2sh_script(payload_p2sh))
 
     def test_address_to_scriptpubkey_invalid_base58(self):
+        with self.assertRaisesRegex(ValueError, "Empty address"):
+            address_to_scriptpubkey("")
+
         invalid_version_addr = byte_to_base58(bytes.fromhex('11' * 20), 42)
         with self.assertRaisesRegex(ValueError, "Unsupported base58 address version byte: 42"):
             address_to_scriptpubkey(invalid_version_addr)


### PR DESCRIPTION
## Summary
- Extend `test/functional/test_framework/address.py::address_to_scriptpubkey` to support mainnet Base58 version bytes:
  - P2PKH: `0`
  - P2SH: `5`
- Replace assert-based Base58 character validation with explicit `ValueError`.
- Add explicit `ValueError` handling for:
  - empty input
  - unsupported Base58 version bytes
  - invalid payload lengths

## Motivation
`address_to_scriptpubkey` supported Bech32 and testnet Base58, but not mainnet Base58 (`0`, `5`), despite being a shared helper in functional tests.

This change closes that gap and makes failure modes explicit and testable.

## Tests
- `cd test/functional && python3 -m unittest test_framework.address`
- `test/functional/feature_framework_unit_tests.py`
- `python3 -m ruff check --select=B006,B008,E101,E401,E402,E701,E702,E703,E711,E713,E714,E721,E722,E742,E743,F401,F402,F403,F404,F405,F406,F407,F541,F601,F602,F621,F631,F632,F811,F821,F822,F823,F841,PLE,W191,W291,W292,W293,W605 test/functional/test_framework/address.py`