### PR TITLE
p2p: prevent unsolicited addr relay token abuse

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4112,8 +4112,11 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                  vAddr.size(), num_proc, num_rate_limit, pfrom.GetId());
 
         m_addrman.Add(vAddrOk, pfrom.addr, /*time_penalty=*/2h);
-        if (vAddr.size() < 1000) peer.m_getaddr_sent = false;
-
+        // Reduce the token bucket by the addresses we didn't process from the GETADDR response.
+        if (peer.m_getaddr_sent) {
+            peer.m_addr_token_bucket -= std::max<double>(MAX_ADDR_TO_SEND - num_proc, 0);
+            peer.m_getaddr_sent = false;
+        }
         // AddrFetch: Require multiple addresses to avoid disconnecting on self-announcements
         if (pfrom.IsAddrFetchConn() && vAddr.size() > 1) {
             LogDebug(BCLog::NET, "addrfetch connection completed, %s\n", pfrom.DisconnectMsg(fLogIPs));
@@ -5533,6 +5536,8 @@ void PeerManagerImpl::MaybeSendAddr(CNode& node, Peer& peer, std::chrono::micros
     if (!peer.m_addr_relay_enabled) return;
 
     LOCK(peer.m_addr_send_times_mutex);
+    // True if this is the first time we are sending our local address to this peer.
+    bool initial_addr_send = (peer.m_next_local_addr_send == 0us);
     // Periodically advertise our local address to the peer.
     if (fListen && !m_chainman.IsInitialBlockDownload() &&
         peer.m_next_local_addr_send < current_time) {
@@ -5547,10 +5552,9 @@ void PeerManagerImpl::MaybeSendAddr(CNode& node, Peer& peer, std::chrono::micros
         }
         if (std::optional<CService> local_service = GetLocalAddrForPeer(node)) {
             CAddress local_addr{*local_service, peer.m_our_services, Now<NodeSeconds>()};
-            if (peer.m_next_local_addr_send == 0us) {
-                // Send the initial self-announcement in its own message. This makes sure
-                // rate-limiting with limited start-tokens doesn't ignore it if the first
-                // message ends up containing multiple addresses.
+            if (initial_addr_send && !peer.m_is_inbound) {
+                // Send the initial self-announcement in its own message. only for the 
+                // outbound connections
                 if (IsAddrCompatible(peer, local_addr)) {
                     std::vector<CAddress> self_announcement{local_addr};
                     if (peer.m_wants_addrv2) {
@@ -5559,7 +5563,7 @@ void PeerManagerImpl::MaybeSendAddr(CNode& node, Peer& peer, std::chrono::micros
                         MakeAndPushMessage(node, NetMsgType::ADDR, CAddress::V1_NETWORK(self_announcement));
                     }
                 }
-            } else {
+            } else if(!initial_addr_send) {
                 // All later self-announcements are sent together with the other addresses.
                 PushAddress(peer, local_addr);
             }
@@ -5595,6 +5599,24 @@ void PeerManagerImpl::MaybeSendAddr(CNode& node, Peer& peer, std::chrono::micros
         MakeAndPushMessage(node, NetMsgType::ADDRV2, CAddress::V2_NETWORK(peer.m_addrs_to_send));
     } else {
         MakeAndPushMessage(node, NetMsgType::ADDR, CAddress::V1_NETWORK(peer.m_addrs_to_send));
+    }
+
+    // Send our self-announcement in separate ADDR/ADDRV2 message from the
+    // GETADDR response. A legitimate node will have 1 addr relay token
+    // remaining after processing the GETADDR response buffer, which is enough
+    // to accept this self-announcement from a separate message.
+    if (initial_addr_send && peer.m_is_inbound) {
+        if (std::optional<CService> local_service = GetLocalAddrForPeer(node)) {
+            CAddress local_addr{*local_service, peer.m_our_services, Now<NodeSeconds>()};
+            if (IsAddrCompatible(peer, local_addr)) {
+                std::vector<CAddress> self_announcement{local_addr};
+                if (peer.m_wants_addrv2) {
+                    MakeAndPushMessage(node, NetMsgType::ADDRV2, CAddress::V2_NETWORK(self_announcement));
+                } else {
+                    MakeAndPushMessage(node, NetMsgType::ADDR, CAddress::V1_NETWORK(self_announcement));
+                }
+            }
+        }
     }
     peer.m_addrs_to_send.clear();
 

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -40,6 +40,7 @@ class AddrReceiver(P2PInterface):
     test_addr_contents = False
     _tokens = 1
     send_getaddr = True
+    _getaddr_pending = False
 
     def __init__(self, test_addr_contents=False, send_getaddr=True):
         super().__init__()
@@ -59,7 +60,9 @@ class AddrReceiver(P2PInterface):
 
     def on_getaddr(self, message):
         # When the node sends us a getaddr, it increments the addr relay tokens for the connection by 1000
+        # and set _getaddr_pending as true to truck when we will recive the response
         self._tokens += 1000
+        self._getaddr_pending = True
 
     @property
     def tokens(self):
@@ -337,6 +340,10 @@ class AddrTest(BitcoinTestFramework):
 
         peer.send_and_ping(self.setup_addr_msg(new_addrs, sequential_ips=False))
 
+        if peer._getaddr_pending:
+            num_proc = min(new_addrs,peer.tokens)
+            peer.increment_tokens(-(1000 - num_proc))
+            peer._getaddr_pending = False
         peerinfo = self.nodes[0].getpeerinfo()[0]
         addrs_processed = peerinfo['addr_processed']
         addrs_rate_limited = peerinfo['addr_rate_limited']

--- a/test/functional/p2p_addr_selfannouncement.py
+++ b/test/functional/p2p_addr_selfannouncement.py
@@ -33,11 +33,13 @@ class SelfAnnouncementReceiver(P2PInterface):
 
     expected = None
     addrv2_test = False
+    outbound = False
 
-    def __init__(self, *, expected, addrv2):
+    def __init__(self, *, expected, addrv2, outbound):
         super().__init__(support_addrv2=addrv2)
         self.expected = expected
         self.addrv2_test = addrv2
+        self.outbound = outbound
 
     def handle_addr_message(self, message):
         self.addr_messages_received += 1
@@ -46,12 +48,15 @@ class SelfAnnouncementReceiver(P2PInterface):
             if addr == self.expected:
                 self.self_announcements_received += 1
                 if self.self_announcements_received == 1:
-                    # If it's the first self-announcement, check that it is
-                    # in the first addr message we receive, and that this message
-                    # only contains one address. This also implies that it is
-                    # the first address we receive.
-                    assert_equal(self.addr_messages_received, 1)
-                    assert_equal(len(message.addrs), 1)
+                    # Check if the self-announcement will be received first if the
+                    # sender is our outbound connection, otherwise its supposed to
+                    # be the second msg after the response to GETADDR
+                    if self.outbound:
+                        assert_equal(self.addr_messages_received, 1)
+                        assert_equal(len(message.addrs), 1)
+                    else:
+                        assert_equal(self.addr_messages_received, 2)
+                        assert_equal(len(message.addrs), 1)
 
     def on_addrv2(self, message):
         assert (self.addrv2_test)
@@ -112,10 +117,10 @@ class AddrSelfAnnouncementTest(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log([f'Advertising address {IP_TO_ANNOUNCE}:{port}']):
             if outbound:
                 self.log.info(f"Check that we get an initial self-announcement on an outbound connection from the node ({connection_type}, {addr_version})")
-                addr_receiver = self.nodes[0].add_outbound_p2p_connection(SelfAnnouncementReceiver(expected=expected, addrv2=addrv2), p2p_idx=0, connection_type="outbound-full-relay")
+                addr_receiver = self.nodes[0].add_outbound_p2p_connection(SelfAnnouncementReceiver(expected=expected, addrv2=addrv2, outbound=outbound), p2p_idx=0, connection_type="outbound-full-relay")
             else:
                 self.log.info(f"Check that we get an initial self-announcement when connecting to a node and sending a GETADDR ({connection_type}, {addr_version})")
-                addr_receiver = self.nodes[0].add_p2p_connection(SelfAnnouncementReceiver(expected=expected, addrv2=addrv2))
+                addr_receiver = self.nodes[0].add_p2p_connection(SelfAnnouncementReceiver(expected=expected, addrv2=addrv2, outbound=outbound))
             addr_receiver.sync_with_ping()
 
         if outbound:


### PR DESCRIPTION
The current addr relay token logic opens an attack that allows a malicious outbound peer to abuse our unsolicited message relaying as mentioned on [#34717 (comment)](https://github.com/bitcoin/bitcoin/pull/34717#issuecomment-4020647442): 
>- We establish an outbound connection to a node X.
>- We increase the token counter to[ +1000 tokens](https://github.com/bitcoin/bitcoin/blob/d198635fa2d48b7618789aedf112783935015d77/src/net_processing.cpp#L3772) since we expect to receive up to 1000 addresses in response from node X.
>-  Node X sends a buffer containing only 1 address, to [bypasses](https://github.com/bitcoin/bitcoin/blob/d198635fa2d48b7618789aedf112783935015d77/src/net_processing.cpp#L4100) the initial `m_getaddr_sent` check (or this negligible protection disappears entirely if the variable is removed as proposed in this PR)
>- Node X then starts sending unsolicited messages of size 10, since it knows it can use up to 1000 tokens (each address they will consume 1 token and if the number of addresses in the buffer is less or equal to 10 our node will relay it).
>- Our node become an intermediate relay, unintentionally helping hide this malicious node, since its (our node) the one who will relay the unsolicited messages.
>- Our node they will consume all of its tokens with other nodes by forwarding malicious addresses instead of forwarding addresses for legitimate nodes.

This issue predates PR #34146, which introduced a new addr self-announcement  mechanism that rendered `m_getaddr_sent` entirely ineffective, leading PR #34717 to propose removing  it entirely.

Instead of removing `m_getaddr_sent`, this PR keeps it and improves the token handling logic.
The addr self-announcement is ordered to be sent after the `GETADDR` response, allowing the `GETADDR` sender to clearly distinguish between the response and the self-announcement, and safely assume the first incoming message is the legitimate response.
Once the `GETADDR` response is processed, the token bucket is adjusted to count only the addresses actually received.
