### PR TITLE
kernel: make logging callback global

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -168,7 +168,7 @@ int main(int argc, char* argv[])
 
     logging_set_options(logging_options);
 
-    Logger logger{std::make_unique<KernelLog>()};
+    logging_set_callback(std::make_unique<KernelLog>());
 
     ContextOptions options{};
     ChainParams params{has_regtest_flag ? ChainType::REGTEST : ChainType::MAINNET};

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -273,6 +273,37 @@ struct LoggingConnection {
     }
 };
 
+//! Manages kernel logging state.
+class KernelLogger
+{
+    std::unique_ptr<LoggingConnection> m_connection;
+
+public:
+    //! Replace the current callback. Clears any existing callback first. To unset, pass a nullptr callback.
+    bool SetCallback(btck_LogCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
+    {
+        m_connection.reset();
+
+        if (!callback) {
+            assert(!user_data && !user_data_destroy_callback);
+            return true;
+        }
+
+        try {
+            m_connection = std::make_unique<LoggingConnection>(callback, user_data, user_data_destroy_callback);
+        } catch (const std::exception&) {
+            return false;
+        }
+        return true;
+    }
+};
+
+KernelLogger& g_kernel_logger()
+{
+    static KernelLogger* logger{new KernelLogger};
+    return *logger;
+}
+
 class KernelNotifications final : public kernel::Notifications
 {
 private:
@@ -480,7 +511,6 @@ struct ChainMan {
 struct btck_Transaction : Handle<btck_Transaction, std::shared_ptr<const CTransaction>> {};
 struct btck_TransactionOutput : Handle<btck_TransactionOutput, CTxOut> {};
 struct btck_ScriptPubkey : Handle<btck_ScriptPubkey, CScript> {};
-struct btck_LoggingConnection : Handle<btck_LoggingConnection, LoggingConnection> {};
 struct btck_ContextOptions : Handle<btck_ContextOptions, ContextOptions> {};
 struct btck_Context : Handle<btck_Context, std::shared_ptr<const Context>> {};
 struct btck_ChainParameters : Handle<btck_ChainParameters, CChainParams> {};
@@ -769,21 +799,13 @@ void btck_logging_disable_category(btck_LogCategory category)
 
 void btck_logging_disable()
 {
+    g_kernel_logger().SetCallback(nullptr, nullptr, nullptr);
     LogInstance().DisableLogging();
 }
 
-btck_LoggingConnection* btck_logging_connection_create(btck_LogCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
+int btck_logging_set_callback(btck_LogCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
 {
-    try {
-        return btck_LoggingConnection::create(callback, user_data, user_data_destroy_callback);
-    } catch (const std::exception&) {
-        return nullptr;
-    }
-}
-
-void btck_logging_connection_destroy(btck_LoggingConnection* connection)
-{
-    delete connection;
+    return g_kernel_logger().SetCallback(callback, user_data, user_data_destroy_callback) ? 0 : 1;
 }
 
 btck_ChainParameters* btck_chain_parameters_create(const btck_ChainType chain_type)

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -130,19 +130,6 @@ typedef struct btck_ScriptPubkey btck_ScriptPubkey;
 typedef struct btck_TransactionOutput btck_TransactionOutput;
 
 /**
- * Opaque data structure for holding a logging connection.
- *
- * The logging connection can be used to manually stop logging.
- *
- * Messages that were logged before a connection is created are buffered in a
- * 1MB buffer. Logging can alternatively be permanently disabled by calling
- * @ref btck_logging_disable. Functions changing the logging settings are
- * global and change the settings for all existing btck_LoggingConnection
- * instances.
- */
-typedef struct btck_LoggingConnection btck_LoggingConnection;
-
-/**
  * Opaque data structure for holding the chain parameters.
  *
  * These are eventually placed into a kernel context through the kernel context
@@ -757,16 +744,14 @@ BITCOINKERNEL_API void btck_transaction_output_destroy(btck_TransactionOutput* t
  * @brief This disables the global internal logger. No log messages will be
  * buffered internally anymore once this is called and the buffer is cleared.
  * This function should only be called once and is not thread or re-entry safe.
- * Log messages will be buffered until this function is called, or a logging
- * connection is created. This must not be called while a logging connection
- * already exists.
+ * Log messages will be buffered until this function is called, or the logging
+ * callback is set. If a logging callback is set, it will be cleared and its
+ * user_data freed through the destroy callback if one was provided.
  */
 BITCOINKERNEL_API void btck_logging_disable();
 
 /**
- * @brief Set some options for the global internal logger. This changes global
- * settings and will override settings for all existing @ref
- * btck_LoggingConnection instances.
+ * @brief Set some options for the global internal logger.
  *
  * @param[in] options Sets formatting options of the log messages.
  */
@@ -775,9 +760,7 @@ BITCOINKERNEL_API void btck_logging_set_options(btck_LoggingOptions options);
 /**
  * @brief Set the log level of the global internal logger. This does not
  * enable the selected categories. Use @ref btck_logging_enable_category to
- * start logging from a specific, or all categories. This changes a global
- * setting and will override settings for all existing
- * @ref btck_LoggingConnection instances.
+ * start logging from a specific, or all categories.
  *
  * @param[in] category If btck_LogCategory_ALL is chosen, sets both the global fallback log level
  *                     used by all categories that don't have a specific level set, and also
@@ -790,45 +773,41 @@ BITCOINKERNEL_API void btck_logging_set_options(btck_LoggingOptions options);
 BITCOINKERNEL_API void btck_logging_set_level_category(btck_LogCategory category, btck_LogLevel level);
 
 /**
- * @brief Enable a specific log category for the global internal logger. This
- * changes a global setting and will override settings for all existing @ref
- * btck_LoggingConnection instances.
+ * @brief Enable a specific log category for the global internal logger.
  *
  * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be enabled.
  */
 BITCOINKERNEL_API void btck_logging_enable_category(btck_LogCategory category);
 
 /**
- * @brief Disable a specific log category for the global internal logger. This
- * changes a global setting and will override settings for all existing @ref
- * btck_LoggingConnection instances.
+ * @brief Disable a specific log category for the global internal logger.
  *
  * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be disabled.
  */
 BITCOINKERNEL_API void btck_logging_disable_category(btck_LogCategory category);
 
 /**
- * @brief Start logging messages through the provided callback. Log messages
- * produced before this function is first called are buffered and on calling this
- * function are logged immediately.
+ * @brief Set the logging callback for the global internal logger. This function
+ * is not thread-safe and must not be called concurrently. Log messages produced
+ * before this function is first called are buffered and on calling this function
+ * are logged immediately. Calling this function again replaces the previous
+ * callback. Any previously set user_data will be freed through its destroy
+ * callback if one was provided.
  *
- * @param[in] log_callback               Non-null, function through which messages will be logged.
+ * @param[in] log_callback               Nullable, function through which messages will be logged.
+ *                                       Null to clear the logging callback, in which case user_data
+ *                                       and user_data_destroy_callback must also be null.
  * @param[in] user_data                  Nullable, holds a user-defined opaque structure. Is passed back
  *                                       to the user through the callback. If the user_data_destroy_callback
  *                                       is also defined it is assumed that ownership of the user_data is passed
- *                                       to the created logging connection.
+ *                                       to the logger.
  * @param[in] user_data_destroy_callback Nullable, function for freeing the user data.
- * @return                               A new kernel logging connection, or null on error.
+ * @return                               Zero on success.
  */
-BITCOINKERNEL_API btck_LoggingConnection* BITCOINKERNEL_WARN_UNUSED_RESULT btck_logging_connection_create(
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_logging_set_callback(
     btck_LogCallback log_callback,
     void* user_data,
-    btck_DestroyCallback user_data_destroy_callback) BITCOINKERNEL_ARG_NONNULL(1);
-
-/**
- * Stop logging and destroy the logging connection.
- */
-BITCOINKERNEL_API void btck_logging_connection_destroy(btck_LoggingConnection* logging_connection);
+    btck_DestroyCallback user_data_destroy_callback);
 
 ///@}
 

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -836,17 +836,22 @@ concept Log = requires(T a, std::string_view message) {
 };
 
 template <Log T>
-class Logger : UniqueHandle<btck_LoggingConnection, btck_logging_connection_destroy>
+void logging_set_callback(std::unique_ptr<T> log)
 {
-public:
-    Logger(std::unique_ptr<T> log)
-        : UniqueHandle{btck_logging_connection_create(
-              +[](void* user_data, const char* message, size_t message_len) { static_cast<T*>(user_data)->LogMessage({message, message_len}); },
-              log.release(),
-              +[](void* user_data) { delete static_cast<T*>(user_data); })}
-    {
+    if (btck_logging_set_callback(
+            +[](void* user_data, const char* message, size_t message_len) { static_cast<T*>(user_data)->LogMessage({message, message_len}); },
+            log.release(),
+            +[](void* user_data) { delete static_cast<T*>(user_data); }) != 0) {
+        throw std::runtime_error("Failed to set logging callback");
     }
-};
+}
+
+inline void logging_set_callback(std::nullptr_t)
+{
+    if (btck_logging_set_callback(nullptr, nullptr, nullptr) != 0) {
+        throw std::runtime_error("Failed to clear logging callback");
+    }
+}
 
 class BlockTreeEntry : public View<btck_BlockTreeEntry>
 {

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -625,14 +625,12 @@ BOOST_AUTO_TEST_CASE(logging_tests)
     logging_enable_category(LogCategory::VALIDATION);
     logging_disable_category(LogCategory::VALIDATION);
 
-    // Check that connecting, connecting another, and then disconnecting and connecting a logger again works.
-    {
-        logging_set_level_category(LogCategory::KERNEL, LogLevel::TRACE_LEVEL);
-        logging_enable_category(LogCategory::KERNEL);
-        Logger logger{std::make_unique<TestLog>()};
-        Logger logger_2{std::make_unique<TestLog>()};
-    }
-    Logger logger{std::make_unique<TestLog>()};
+    // Check that setting, replacing, and clearing the logging callback works.
+    logging_set_level_category(LogCategory::KERNEL, LogLevel::TRACE_LEVEL);
+    logging_enable_category(LogCategory::KERNEL);
+    logging_set_callback(std::make_unique<TestLog>());
+    logging_set_callback(std::make_unique<TestLog>());
+    logging_set_callback(nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(btck_context_tests)
@@ -720,7 +718,7 @@ Context create_context(std::shared_ptr<TestKernelNotifications> notifications, C
 
 BOOST_AUTO_TEST_CASE(btck_chainman_tests)
 {
-    Logger logger{std::make_unique<TestLog>()};
+    logging_set_callback(std::make_unique<TestLog>());
     auto test_directory{TestDirectory{"chainman_test_bitcoin_kernel"}};
 
     { // test with default context


### PR DESCRIPTION
The underlying `LogInstance()` is a process-wide singleton, and all logging configuration (categories, levels, options) are already global. The per-connection `btck_LoggingConnection` handle gives the false impression of independent logger instances.

Fix this by explicitly making the entire kernel logging interface explicitly global, simplifying its usage. Replaces `btck_LoggingConnection` and its `{create,destroy}` functions with a single `btck_logging_set_callback` function. The `KernelLogger` class is introduced to hold global kernel logging state, which will be used in future work such as #34374.

To an extent, this approach is an alternative to #30342 which contextualizes logging. While I do believe contextualized logging would be a natural fit for the kernel interface, it seems there is currently (in my view) too little demand for the scope of changes necessary. That's why I've opened this PR as a much more straightforward way to fix kernel's current logging weirdness. If you believe kernel logging should be contextualized right away, please go review #30342 instead.