### PR TITLE
test: Remove fixed TODO in address_to_scriptpubkey

### DIFF
--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -193,9 +193,7 @@ def address_to_scriptpubkey(address):
         return keyhash_to_p2pkh_script(payload)
     elif version == 196:  # testnet script hash
         return scripthash_to_p2sh_script(payload)
-    # TODO: also support other address formats
-    else:
-        assert False
+    raise ValueError(f"Unsupported address type: {address}")
 
 
 class TestFrameworkScript(unittest.TestCase):


### PR DESCRIPTION
After commit d178082996dc3000f42816f89afcf3fa4d31e159 added the bech32 format, the TODO about adding other formats can be removed.