### PR TITLE
ci: use latest versions of lint deps

### DIFF
--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -42,17 +42,17 @@ python3 --version
 
 ${CI_RETRY_EXE} pip3 install \
   lief==0.16.6 \
-  mypy==1.18.2 \
+  mypy==1.19.1 \
   pyzmq==27.1.0 \
-  ruff==0.13.2 \
-  vulture==2.14
+  ruff==0.15.5 \
+  vulture==2.15
 
 SHELLCHECK_VERSION=v0.11.0
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | \
     tar --xz -xf - --directory /tmp/
 mv "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/
 
-MLC_VERSION=v1
+MLC_VERSION=v1.2.0
 MLC_BIN=mlc-x86_64-linux
 curl -sL "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/${MLC_BIN}" -o "/usr/bin/mlc"
 chmod +x /usr/bin/mlc


### PR DESCRIPTION
Use the latest available versions, except for LIEF, which is changed with Guix.