### PR TITLE
ci: remove TODOs from retry

### DIFF
--- a/ci/retry/retry
+++ b/ci/retry/retry
@@ -4,8 +4,6 @@ __sleep_amount() {
   if [ -n "$constant_sleep" ]; then
     sleep_time=$constant_sleep
   else
-    #TODO: check for awk
-    #TODO: check if user would rather use one of the other possible dependencies: python, ruby, bc, dc
     sleep_time=`awk "BEGIN {t = $min_sleep * $(( (1<<($attempts -1)) )); print (t > $max_sleep ? $max_sleep : t)}"`
   fi
 }
@@ -43,7 +41,6 @@ retry()
 
     P="$1"
     for param in "${@:2}"; do P="$P '$param'"; done
-    #TODO: replace single quotes in each arg with '"'"' ?
     export RETRY_ATTEMPT=$attempts
     bash -c "$P"
     return_code=$?


### PR DESCRIPTION
TODOs are good targets for LLMs to generate PRs. Remove these TODOs, which aren't needed, to prevent that.