### PR TITLE
fuzz: register PeerManager in process_message(s)

### DIFF
--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -45,7 +45,6 @@ void ResetChainman(TestingSetup& setup)
         options.include_dummy_extranonce = true;
         MineBlock(setup.m_node, options);
     }
-    setup.m_node.validation_signals->SyncWithValidationInterfaceQueue();
 }
 } // namespace
 
@@ -100,6 +99,9 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     if (!LIMIT_TO_MESSAGE_TYPE.empty() && random_message_type != LIMIT_TO_MESSAGE_TYPE) {
         return;
     }
+
+    node.validation_signals->RegisterValidationInterface(node.peerman.get());
+
     CNode& p2p_node = *ConsumeNodeAsUniquePtr(fuzzed_data_provider).release();
 
     connman.AddTestNode(p2p_node);
@@ -125,6 +127,7 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
         node.peerman->SendMessages(p2p_node);
     }
     node.validation_signals->SyncWithValidationInterfaceQueue();
+    node.validation_signals->UnregisterValidationInterface(node.peerman.get());
     node.connman->StopNodes();
     if (block_index_size != WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())) {
         // Reuse the global chainman, but reset it when it is dirty

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -40,7 +40,6 @@ void ResetChainman(TestingSetup& setup)
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
         MineBlock(setup.m_node, options);
     }
-    setup.m_node.validation_signals->SyncWithValidationInterfaceQueue();
 }
 } // namespace
 
@@ -84,6 +83,8 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
     connman.SetMsgProc(node.peerman.get());
     connman.SetAddrman(*node.addrman);
 
+    node.validation_signals->RegisterValidationInterface(node.peerman.get());
+
     LOCK(NetEventsInterface::g_msgproc_mutex);
 
     std::vector<CNode*> peers;
@@ -125,6 +126,7 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
         }
     }
     node.validation_signals->SyncWithValidationInterfaceQueue();
+    node.validation_signals->UnregisterValidationInterface(node.peerman.get());
     node.connman->StopNodes();
     if (block_index_size != WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())) {
         // Reuse the global chainman, but reset it when it is dirty


### PR DESCRIPTION
This lets CValidationInterface callbacks be hit (just `BlockChecked` using the corpus from qa-assets). Also remove no-op SyncWithValidationInterfaceQueue since there are no validation interfaces registered in ResetChainman.

