### PR TITLE
guix: introduce --exclude parameter to guix-clean

### DIFF
--- a/contrib/guix/guix-clean
+++ b/contrib/guix/guix-clean
@@ -9,14 +9,62 @@ set -e -o pipefail
 # shellcheck source=libexec/prelude.bash
 source "$(dirname "${BASH_SOURCE[0]}")/libexec/prelude.bash"
 
+print_help() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Clean the working tree using 'git clean -xdff', while preserving:
+  - Directories and files recorded in precious_dirs
+  - Any additional paths specified via --exclude
+
+Options:
+  --force                 Skip the interactive preview and prompt, run immediately
+  --exclude PATH          Exclude PATH (file or directory) from git clean (can be used multiple times)
+  --exclude=PATH          Same as --exclude PATH
+  -h, --help              Show this help message and exit
+EOF
+}
+
 # Parse supported args
 FORCE=0
-if [[ $* == "--force" ]]; then
-    FORCE=1
-elif [ $# != 0 ]; then
-    echo "Script only takes optional --force arg."
-    exit 1
-fi
+exclude_flags=()
+user_exclude_messages=()
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --force)
+            FORCE=1
+            shift
+            ;;
+        --exclude=*)
+            path=${1#--exclude=}
+            user_exclude_messages+=( "Avoiding user-specified path: ${path}" )
+            exclude_flags+=( --exclude="$path" )
+            shift
+            ;;
+        --exclude)
+            if [ "$#" -lt 2 ]; then
+                echo "guix-clean: --exclude requires a PATH argument" >&2
+                exit 1
+            fi
+            user_exclude_messages+=( "Avoiding user-specified path: $2" )
+            exclude_flags+=( --exclude="$2" )
+            shift 2
+            ;;
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+        *)
+            echo "guix-clean: unknown option '$1'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Now that all options are validated, print the user exclude messages (if any)
+for msg in "${user_exclude_messages[@]}"; do
+    echo "$msg"
+done
 
 ###################
 ## Sanity Checks ##
@@ -65,8 +113,6 @@ dir_under_git_root() {
 shopt -s nullglob
 found_precious_dirs_files=( "${version_base_prefix}"*/"${var_base_basename}/precious_dirs" ) # This expands to an array of directories...
 shopt -u nullglob
-
-exclude_flags=()
 
 for precious_dirs_file in "${found_precious_dirs_files[@]}"; do
     # Make sure the precious directories (e.g. SOURCES_PATH, BASE_CACHE, SDK_PATH)


### PR DESCRIPTION
## Summary
This is motivated by https://github.com/bitcoin/bitcoin/pull/34776#issuecomment-4026174587 and a follow-up to https://github.com/bitcoin/bitcoin/pull/34776.

The motivation is that when a user runs `contrib/guix/guix-clean` it will clean the whole directory or nothing leading the user to have to manually clear out these files. It would be useful to be able to exclude certain files.

It adds the `--exclude` and `--help`/`-h` parameters to `contrib/guix/guix-clean`

Right now, when a user runs that script, it will delete everything. It makes sense to allow the user to exclude any files or directories from being removed.

---

#### Help text
![Screenshot 2026-03-10 at 10 15 08 AM](https://github.com/user-attachments/assets/9dbbd9ce-1f70-4e0e-b4ab-99f7aba3ae01)
#### Multiple excludes
![Screenshot 2026-03-10 at 10 15 30 AM](https://github.com/user-attachments/assets/a315576b-4c07-43a8-a742-ddf6197741c0)
#### Unknown option
![Screenshot 2026-03-10 at 10 19 41 AM](https://github.com/user-attachments/assets/a282c0b9-eaa8-4e2c-ad2e-f4527e753c52)
#### Exclude with --force
![Screenshot 2026-03-10 at 10 19 53 AM](https://github.com/user-attachments/assets/2873aa5d-a6a7-4750-8336-e634bdff732e)