### PR TITLE
test: Suppress another unsolicited `mock_process/*` output

### DIFF
--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -26,7 +26,18 @@ BOOST_FIXTURE_TEST_SUITE(system_tests, BasicTestingSetup)
 
 static std::vector<std::string> mock_executable(std::string name)
 {
-    return {boost::unit_test::framework::master_test_suite().argv[0], "--log_level=nothing", "--report_level=no", "--run_test=mock_process/" + name};
+    // Invoke the mock_process/* test case with all unsolicited output suppressed.
+    return {
+        boost::unit_test::framework::master_test_suite().argv[0],
+        // Disable false-positive memory leak dumps to stderr
+        // in debug builds when using the Windows UCRT.
+        "--detect_memory_leaks=0",
+        // Disable logging to stdout.
+        "--log_level=nothing",
+        // Disable the test report to stderr.
+        "--report_level=no",
+        "--run_test=mock_process/" + name,
+    };
 }
 
 BOOST_AUTO_TEST_CASE(run_command)


### PR DESCRIPTION
This is a follow-up to https://github.com/bitcoin/bitcoin/pull/33929.

The[ `mock_process/*`](https://github.com/bitcoin/bitcoin/blob/390e7d61bd531505bb3d13f38316c282b85ed1dd/src/test/mock_process.cpp#L10) test cases, which serve as helpers for [`system_tests`](https://github.com/bitcoin/bitcoin/blob/390e7d61bd531505bb3d13f38316c282b85ed1dd/src/test/system_tests.cpp#L23) rather than actual tests, are invoked in a way that suppresses unsolicited output to stdout or stderr to keep the test results reproducible.

However, in debug builds, the Windows CRT still prints false-positive memory leak dumps to stderr.

This PR handles this specific case and documents the other suppressions.