### PR TITLE
rpc, net: remove `startingheight` field of `getpeerinfo` RPC and from node state

### DIFF
--- a/doc/release-notes-34796.md
+++ b/doc/release-notes-34796.md
@@ -1,0 +1,6 @@
+Updated RPCs
+------------
+
+- The `-deprecatedrpc=startingheight` configuration option has been removed.
+  The `getpeerinfo` RPC no longer returns the `startingheight` field, which
+  was previously deprecated in v31.0. (#34796)

--- a/src/net.h
+++ b/src/net.h
@@ -205,7 +205,6 @@ public:
     bool m_bip152_highbandwidth_to;
     // Peer requested high bandwidth connection
     bool m_bip152_highbandwidth_from;
-    int m_starting_height;
     uint64_t nSendBytes;
     mapMsgTypeSize mapSendBytesPerMsgType;
     uint64_t nRecvBytes;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -272,10 +272,6 @@ struct Peer {
     /** Set to true once initial VERSION message was sent (only relevant for outbound peers). */
     bool m_outbound_version_message_sent GUARDED_BY(NetEventsInterface::g_msgproc_mutex){false};
 
-    /** This peer's reported block height when we connected */
-    // TODO: remove in v32.0, only show reported height once in "receive version message: ..." debug log
-    std::atomic<int> m_starting_height{-1};
-
     /** The pong reply we're expecting, or 0 if no pong expected. */
     std::atomic<uint64_t> m_ping_nonce_sent{0};
     /** When the last ping was sent, or 0 if no ping was ever sent */
@@ -1804,7 +1800,6 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
     PeerRef peer = GetPeerRef(nodeid);
     if (peer == nullptr) return false;
     stats.their_services = peer->m_their_services;
-    stats.m_starting_height = peer->m_starting_height;
     // It is common for nodes with good ping times to suddenly become lagged,
     // due to a new block arriving or other large transfer.
     // Merely reporting pingtime might fool the caller into thinking the node was still responsive,
@@ -3106,8 +3101,7 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
     if (nCount == m_opts.max_headers_result && !have_headers_sync) {
         // Headers message had its maximum size; the peer may have more headers.
         if (MaybeSendGetHeaders(pfrom, GetLocator(pindexLast), peer)) {
-            LogDebug(BCLog::NET, "more getheaders (%d) to end to peer=%d (startheight:%d)\n",
-                    pindexLast->nHeight, pfrom.GetId(), peer.m_starting_height);
+            LogDebug(BCLog::NET, "more getheaders (%d) to end to peer=%d", pindexLast->nHeight, pfrom.GetId());
         }
     }
 
@@ -3675,7 +3669,6 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             LOCK(pfrom.m_subver_mutex);
             pfrom.cleanSubVer = cleanSubVer;
         }
-        peer.m_starting_height = starting_height;
 
         // Only initialize the Peer::TxRelay m_relay_txs data structure if:
         // - this isn't an outbound block-relay-only connection, and
@@ -3697,7 +3690,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         const auto mapped_as{m_connman.GetMappedAS(pfrom.addr)};
         LogDebug(BCLog::NET, "receive version message: %s: version %d, blocks=%d, us=%s, txrelay=%d, %s%s",
                   cleanSubVer.empty() ? "<no user agent>" : cleanSubVer, pfrom.nVersion,
-                  peer.m_starting_height, addrMe.ToStringAddrPort(), fRelay, pfrom.LogPeer(),
+                  starting_height, addrMe.ToStringAddrPort(), fRelay, pfrom.LogPeer(),
                   (mapped_as ? strprintf(", mapped_as=%d", mapped_as) : ""));
 
         if (pfrom.IsPrivateBroadcastConn()) {
@@ -3825,11 +3818,10 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
         auto new_peer_msg = [&]() {
             const auto mapped_as{m_connman.GetMappedAS(pfrom.addr)};
-            return strprintf("New %s peer connected: transport: %s, version: %d, blocks=%d, %s%s",
+            return strprintf("New %s peer connected: transport: %s, version: %d, %s%s",
                 pfrom.ConnectionTypeAsString(),
                 TransportTypeAsString(pfrom.m_transport->GetInfo().transport_type),
-                pfrom.nVersion.load(), peer.m_starting_height,
-                pfrom.LogPeer(),
+                pfrom.nVersion.load(), pfrom.LogPeer(),
                 (mapped_as ? strprintf(", mapped_as=%d", mapped_as) : ""));
         };
 
@@ -5807,7 +5799,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                 if (pindexStart->pprev)
                     pindexStart = pindexStart->pprev;
                 if (MaybeSendGetHeaders(node, GetLocator(pindexStart), peer)) {
-                    LogDebug(BCLog::NET, "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, node.GetId(), peer.m_starting_height);
+                    LogDebug(BCLog::NET, "initial getheaders (%d) to peer=%d", pindexStart->nHeight, node.GetId());
 
                     state.fSyncStarted = true;
                     peer.m_headers_sync_timeout = current_time + HEADERS_DOWNLOAD_TIMEOUT_BASE +

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -53,7 +53,6 @@ static const unsigned int MAX_HEADERS_RESULTS = 2000;
 struct CNodeStateStats {
     int nSyncHeight = -1;
     int nCommonHeight = -1;
-    int m_starting_height = -1;
     std::chrono::microseconds m_ping_wait;
     std::vector<int> vHeightInFlight;
     bool m_relay_txs;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -161,7 +161,6 @@ static RPCHelpMan getpeerinfo()
                     {RPCResult::Type::BOOL, "inbound", "Inbound (true) or Outbound (false)"},
                     {RPCResult::Type::BOOL, "bip152_hb_to", "Whether we selected peer as (compact blocks) high-bandwidth peer"},
                     {RPCResult::Type::BOOL, "bip152_hb_from", "Whether peer selected us as (compact blocks) high-bandwidth peer"},
-                    {RPCResult::Type::NUM, "startingheight", /*optional=*/true, "(DEPRECATED, returned only if config option -deprecatedrpc=startingheight is passed) The starting height (block) of the peer"},
                     {RPCResult::Type::NUM, "presynced_headers", "The current height of header pre-synchronization with this peer, or -1 if no low-work sync is in progress"},
                     {RPCResult::Type::NUM, "synced_headers", "The last header we have in common with this peer"},
                     {RPCResult::Type::NUM, "synced_blocks", "The last block we have in common with this peer"},
@@ -268,9 +267,6 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("inbound", stats.fInbound);
         obj.pushKV("bip152_hb_to", stats.m_bip152_highbandwidth_to);
         obj.pushKV("bip152_hb_from", stats.m_bip152_highbandwidth_from);
-        if (IsDeprecatedRPCEnabled("startingheight")) {
-            obj.pushKV("startingheight", statestats.m_starting_height);
-        }
         obj.pushKV("presynced_headers", statestats.presync_height);
         obj.pushKV("synced_headers", statestats.nSyncHeight);
         obj.pushKV("synced_blocks", statestats.nCommonHeight);

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -63,7 +63,7 @@ class NetTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.extra_args = [
-            ["-minrelaytxfee=0.00001000", "-deprecatedrpc=startingheight"],
+            ["-minrelaytxfee=0.00001000"],
             ["-minrelaytxfee=0.00000500"],
         ]
         # Specify a non-working proxy to make sure no actual connections to public IPs are attempted
@@ -174,7 +174,6 @@ class NetTest(BitcoinTestFramework):
                 "services": "0000000000000000",
                 "servicesnames": [],
                 "session_id": "" if not self.options.v2transport else no_version_peer.v2_state.peer['session_id'].hex(),
-                "startingheight": -1,
                 "subver": "",
                 "synced_blocks": -1,
                 "synced_headers": -1,


### PR DESCRIPTION
This PR completely removes the `startingheight` field in the `getpeerinfo` RPC, previously deprecated in v31.0 (see #34197). The second commit goes one step further: the only remaining usage for a `Peer`s `m_starting_height` field is for printing P2P debug messages. Considering that the information is untrusted and not deemed useful (see discussion #33990), remove the field and only print the starting height information once at reception of the `VERSION` message (suggested by ajtowns in https://github.com/bitcoin/bitcoin/pull/33990#issuecomment-3621363780), without saving it.