### PR TITLE
ci: Enable pipefail in 03_test_script.sh

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-set -o errexit -o xtrace
+set -o errexit -o xtrace -o pipefail
 
 if [ "${DANGER_RUN_CI_ON_HOST}" != "1" ]; then
   echo "This script will make unsafe local and global modifications, so it can only be run inside a container and requires DANGER_RUN_CI_ON_HOST=1"
@@ -136,10 +136,30 @@ cmake --build "${BASE_BUILD_DIR}" "$MAKEJOBS" --target $GOAL || (
 )
 
 ccache --version | head -n 1 && ccache --show-stats --verbose
-hit_rate=$(ccache --show-stats | grep "Hits:" | head -1 | sed 's/.*(\(.*\)%).*/\1/')
-if [ "${hit_rate%.*}" -lt 75 ]; then
-  echo "::notice title=low ccache hitrate::Ccache hit-rate in $CONTAINER_NAME was $hit_rate%"
-fi
+ccache --print-stats | python3 -c '
+import os
+import sys
+
+for line in sys.stdin:
+    key, value = line.split("\t", 1)
+    # "primary storage" fallback only needed for ccache version 4.5.1
+    if key in ("local_storage_hit", "primary_storage_hit"):
+        hits = int(value)
+    elif key in ("local_storage_miss", "primary_storage_miss"):
+        miss = int(value)
+
+calls = hits + miss
+# codegen has no calls, so skip that here
+if calls:
+    rate = (hits / calls * 100)
+    print(f"{rate:.2f}")
+    if rate < 75:
+        container = os.environ["CONTAINER_NAME"]
+        print(
+            "::notice title=low ccache hitrate::"
+            f"Ccache hit-rate in {container} was {rate:.2f}%"
+        )
+'
 du -sh "${DEPENDS_DIR}"/*/
 du -sh "${PREVIOUS_RELEASES_DIR}"
 
@@ -217,12 +237,14 @@ if [[ "${RUN_IWYU}" == true ]]; then
 
   run_iwyu() {
     mv "${BASE_BUILD_DIR}/$1" "${BASE_BUILD_DIR}/compile_commands.json"
-    python3 "/include-what-you-use/iwyu_tool.py" \
+    {
+      python3 "/include-what-you-use/iwyu_tool.py" \
              -p "${BASE_BUILD_DIR}" "${MAKEJOBS}" \
              -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
              -Xiwyu --max_line_length=160 \
              -Xiwyu --check_also="*/primitives/*.h" \
-             2>&1 | tee /tmp/iwyu_ci.out
+             2>&1 || true
+    } | tee /tmp/iwyu_ci.out
     python3 "/include-what-you-use/fix_includes.py" --nosafe_headers < /tmp/iwyu_ci.out
     git diff -U1 | ./contrib/devtools/clang-format-diff.py -binary="clang-format-${IWYU_LLVM_V}" -p1 -i -v
   }


### PR DESCRIPTION
The CI script is problematic, because it is written in Bash, without pipefail enabled. Thus, some failures are silently ignored.

Enabling pipefail is a bit tedious, because:

* The IWYU task has no (`--verbose`) ccache output, so the pipe fails after `grep` [1]. Also, right now on master, the if silently skips: `ci/test/03_test_script.sh: line 122: [: : integer expression expected`.
* The Alpine task has `Hits:` twice in the output, so the pipe fails after `head -1` [2]

Not sure what the easiest way to fix this would be. Some options are:

* Just use `tail -1` and `0` as fallback: `hit_rate=$(ccache --show-stats | grep "Hits:" | tail -1 | sed 's/.*(\(.*\)%).*/\1/' || echo "0")`
* Properly parse, using Python and `--print-stats` (this pull)

[1]

```
+ ccache --version
+ head -n 1
ccache version 4.11.2
+ ccache --show-stats --verbose
Cache directory:    /home/admin/actions-runner/_work/_temp/ccache_dir
Config file:        /home/admin/actions-runner/_work/_temp/ccache_dir/ccache.conf
System config file: /etc/ccache.conf
Stats updated:      Tue Feb 17 08:40:20 2026
Local storage:
  Cache size (GB):  0.0 / 2.0 ( 0.00%)
  Files:              0
  Hits:               0
  Misses:             0
  Reads:              0
  Writes:             0
++ ccache --show-stats
++ grep Hits:
++ head -1
++ sed 's/.*(\(.*\)%).*/\1/'
+ hit_rate=
Command '['docker', 'exec', '--env', 'DANGER_RUN_CI_ON_HOST=1', 'f5e8f319c22101ada5be9d4c5fd7d883ce37b830e86ec64627cb7d2b96749053', '/home/admin/actions-runner/_work/_temp/ci/test/03_test_script.sh']' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```

[2]

```
+ ccache --version
+ head -n 1
ccache version 4.12.1
+ ccache --show-stats --verbose
Cache directory:    /home/admin/actions-runner/_work/_temp/ccache_dir
Config file:        /home/admin/actions-runner/_work/_temp/ccache_dir/ccache.conf
System config file: /etc/ccache.conf
Stats updated:      Tue Feb 17 08:40:35 2026
Cacheable calls:     873 / 873 (100.0%)
  Hits:              846 / 873 (96.91%)
    Direct:          822 / 846 (97.16%)
    Preprocessed:     24 / 846 ( 2.84%)
  Misses:             27 / 873 ( 3.09%)
Successful lookups:
  Direct:            822 / 873 (94.16%)
  Preprocessed:       24 /  51 (47.06%)
Local storage:
  Cache size (GB):   2.0 / 2.0 (99.95%)
  Files:            2580
  Cleanups:           13
  Hits:              846 / 873 (96.91%)
  Misses:             27 / 873 ( 3.09%)
  Reads:            1772
  Writes:             52
++ ccache --show-stats
++ grep Hits:
++ head -1
++ sed 's/.*(\(.*\)%).*/\1/'
+ hit_rate=96.91
Command '['docker', 'exec', '--env', 'DANGER_RUN_CI_ON_HOST=1', '272a66a48206f1f6096612e196127ce46ea4dbff5dc14be3a4a20c4ee523956f', '/home/admin/actions-runner/_work/_temp/ci/test/03_test_script.sh']' returned non-zero exit status 141.
Error: Process completed with exit code 1.
```