### PR TITLE
mempool: asynchronous mempool fee rate diagram updates via validation interface

### DIFF
--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -8,10 +8,13 @@
 #include <consensus/amount.h>
 #include <consensus/validation.h>
 #include <core_memusage.h>
+#include <kernel/mempool_removal_reason.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
 #include <primitives/transaction.h>
 #include <txgraph.h>
+#include <uint256.h>
+#include <util/feefrac.h>
 #include <util/overflow.h>
 #include <util/time.h>
 
@@ -19,6 +22,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <set>
 
 class CBlockIndex;
@@ -197,6 +201,20 @@ struct NewMempoolTransactionInfo {
           m_submitted_in_package{submitted_in_package},
           m_chainstate_is_current{chainstate_is_current},
           m_has_no_mempool_parents{has_no_mempool_parents} {}
+};
+
+struct MemPoolChunk {
+    FeePerWeight m_fee_rate;
+    std::vector<CTransactionRef> m_transactions;
+    int64_t m_sigops_cost{0};
+    std::optional<uint256> m_chunk_hash;
+};
+
+struct MemPoolChunksUpdate {
+    std::vector<MemPoolChunk> old_chunks;
+    std::vector<MemPoolChunk> new_chunks;
+    MemPoolRemovalReason reason;
+    std::optional<unsigned int> block_height{std::nullopt};
 };
 
 #endif // BITCOIN_KERNEL_MEMPOOL_ENTRY_H

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -7,6 +7,7 @@
 #include <primitives/transaction.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/hasher.h>
 
 #include <algorithm>
 #include <cassert>
@@ -151,20 +152,9 @@ bool IsChildWithParentsTree(const Package& package)
 uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions)
 {
     // Create a vector of the wtxids.
-    std::vector<Wtxid> wtxids_copy;
-    std::transform(transactions.cbegin(), transactions.cend(), std::back_inserter(wtxids_copy),
+    std::vector<Wtxid> wtxids;
+    std::transform(transactions.cbegin(), transactions.cend(), std::back_inserter(wtxids),
         [](const auto& tx){ return tx->GetWitnessHash(); });
 
-    // Sort in ascending order
-    std::sort(wtxids_copy.begin(), wtxids_copy.end(), [](const auto& lhs, const auto& rhs) {
-        return std::lexicographical_compare(std::make_reverse_iterator(lhs.end()), std::make_reverse_iterator(lhs.begin()),
-                                            std::make_reverse_iterator(rhs.end()), std::make_reverse_iterator(rhs.begin()));
-    });
-
-    // Get sha256 hash of the wtxids concatenated in this order
-    HashWriter hashwriter;
-    for (const auto& wtxid : wtxids_copy) {
-        hashwriter << wtxid;
-    }
-    return hashwriter.GetSHA256();
+    return GetHashFromWitnesses(wtxids);
 }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(test_bitcoin
   key_tests.cpp
   logging_tests.cpp
   mempool_tests.cpp
+  mempool_update_tests.cpp
   merkle_tests.cpp
   merkleblock_tests.cpp
   miner_tests.cpp

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -9,6 +9,7 @@
 #include <streams.h>
 #include <test/util/random.h>
 #include <test/util/txmempool.h>
+#include <validationinterface.h>
 
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
@@ -67,8 +68,9 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
     auto rand_ctx(FastRandomContext(uint256{42}));
     CBlock block(BuildBlockTestCase(rand_ctx));
 
-    LOCK2(cs_main, pool.cs);
     TryAddToMempool(pool, entry.FromTx(block.vtx[2]));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    LOCK2(cs_main, pool.cs);
     BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
 
     // Do a simple ShortTxIDs RT
@@ -151,8 +153,9 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
     auto rand_ctx(FastRandomContext(uint256{42}));
     CBlock block(BuildBlockTestCase(rand_ctx));
 
-    LOCK2(cs_main, pool.cs);
     TryAddToMempool(pool, entry.FromTx(block.vtx[2]));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    LOCK2(cs_main, pool.cs);
     BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
 
     Txid txhash;
@@ -222,8 +225,9 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
     auto rand_ctx(FastRandomContext(uint256{42}));
     CBlock block(BuildBlockTestCase(rand_ctx));
 
-    LOCK2(cs_main, pool.cs);
     TryAddToMempool(pool, entry.FromTx(block.vtx[1]));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    LOCK2(cs_main, pool.cs);
     BOOST_CHECK_EQUAL(pool.get(block.vtx[1]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
 
     Txid txhash;
@@ -322,8 +326,9 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
     std::vector<std::pair<Wtxid, CTransactionRef>> extra_txn;
     extra_txn.resize(10);
 
-    LOCK2(cs_main, pool.cs);
     TryAddToMempool(pool, entry.FromTx(block.vtx[2]));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    LOCK2(cs_main, pool.cs);
     BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
     // Ensure the non_block_tx is actually not in the block
     for (const auto &block_tx : block.vtx) {

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -797,8 +797,8 @@ FUZZ_TARGET(txgraph)
             } else if (sims.size() == 2 && !sims[0].IsOversized() && !sims[1].IsOversized() && command-- == 0) {
                 // GetMainStagingDiagrams()
                 auto [real_main_diagram, real_staged_diagram] = real->GetMainStagingDiagrams();
-                auto real_sum_main = std::accumulate(real_main_diagram.begin(), real_main_diagram.end(), FeeFrac{});
-                auto real_sum_staged = std::accumulate(real_staged_diagram.begin(), real_staged_diagram.end(), FeeFrac{});
+                auto real_sum_main = std::accumulate(real_main_diagram.begin(), real_main_diagram.end(), FeeFrac{}, [](auto acc, const auto& next) { return acc + next.feerate; });
+                auto real_sum_staged = std::accumulate(real_staged_diagram.begin(), real_staged_diagram.end(), FeeFrac{}, [](auto acc, const auto& next) { return acc + next.feerate; });
                 auto real_gain = real_sum_staged - real_sum_main;
                 auto sim_gain = sims[1].SumAll() - sims[0].SumAll();
                 // Just check that the total fee gained/lost and size gained/lost according to the
@@ -807,10 +807,10 @@ FUZZ_TARGET(txgraph)
                 assert(sim_gain == real_gain);
                 // Check that the feerates in each diagram are monotonically decreasing.
                 for (size_t i = 1; i < real_main_diagram.size(); ++i) {
-                    assert(ByRatio{real_main_diagram[i]} <= ByRatio{real_main_diagram[i - 1]});
+                    assert(ByRatio{real_main_diagram[i].feerate} <= ByRatio{real_main_diagram[i - 1].feerate});
                 }
                 for (size_t i = 1; i < real_staged_diagram.size(); ++i) {
-                    assert(ByRatio{real_staged_diagram[i]} <= ByRatio{real_staged_diagram[i - 1]});
+                    assert(ByRatio{real_staged_diagram[i].feerate} <= ByRatio{real_staged_diagram[i - 1].feerate});
                 }
                 break;
             } else if (block_builders.size() < 4 && !main_sim.IsOversized() && command-- == 0) {
@@ -1266,34 +1266,45 @@ FUZZ_TARGET(txgraph)
             auto [main_cmp_diagram, stage_cmp_diagram] = real->GetMainStagingDiagrams();
             // Check that the feerates in each diagram are monotonically decreasing.
             for (size_t i = 1; i < main_cmp_diagram.size(); ++i) {
-                assert(ByRatio{main_cmp_diagram[i]} <= ByRatio{main_cmp_diagram[i - 1]});
+                assert(ByRatio{main_cmp_diagram[i].feerate} <= ByRatio{main_cmp_diagram[i - 1].feerate});
             }
             for (size_t i = 1; i < stage_cmp_diagram.size(); ++i) {
-                assert(ByRatio{stage_cmp_diagram[i]} <= ByRatio{stage_cmp_diagram[i - 1]});
+                assert(ByRatio{stage_cmp_diagram[i].feerate} <= ByRatio{stage_cmp_diagram[i - 1].feerate});
             }
             // Treat the diagrams as sets of chunk feerates, and sort them in the same way so that
             // std::set_difference can be used on them below. The exact ordering does not matter
             // here, but it has to be consistent with the one used in main_real_diagram and
             // stage_real_diagram).
-            std::ranges::sort(main_cmp_diagram, std::greater<ByRatioNegSize<FeeFrac>>{});
-            std::ranges::sort(stage_cmp_diagram, std::greater<ByRatioNegSize<FeeFrac>>{});
+            std::ranges::sort(main_cmp_diagram, TxGraph::Chunk::GreaterFeerate{});
+            std::ranges::sort(stage_cmp_diagram, TxGraph::Chunk::GreaterFeerate{});
+            // extract the chunk feerates from main and staging compare diagrams
+            std::vector<FeeFrac> main_cmp_diagram_feerates, stage_cmp_diagram_feerates;
+            main_cmp_diagram_feerates.reserve(main_cmp_diagram.size());
+            stage_cmp_diagram_feerates.reserve(stage_cmp_diagram.size());
+            for (const auto& chunk : main_cmp_diagram) {
+                main_cmp_diagram_feerates.emplace_back(chunk.feerate);
+            }
+            for (const auto& chunk : stage_cmp_diagram) {
+                stage_cmp_diagram_feerates.emplace_back(chunk.feerate);
+            }
             // Find the chunks that appear in main_diagram but are missing from main_cmp_diagram.
             // This is allowed, because GetMainStagingDiagrams omits clusters in main unaffected
             // by staging.
+
             std::vector<FeeFrac> missing_main_cmp;
             std::set_difference(main_real_diagram.begin(), main_real_diagram.end(),
-                                main_cmp_diagram.begin(), main_cmp_diagram.end(),
+                                main_cmp_diagram_feerates.begin(), main_cmp_diagram_feerates.end(),
                                 std::inserter(missing_main_cmp, missing_main_cmp.end()),
                                 std::greater<ByRatioNegSize<FeeFrac>>{});
-            assert(main_cmp_diagram.size() + missing_main_cmp.size() == main_real_diagram.size());
+            assert(main_cmp_diagram_feerates.size() + missing_main_cmp.size() == main_real_diagram.size());
             // Do the same for chunks in stage_diagram missing from stage_cmp_diagram.
             auto stage_real_diagram = get_diagram_fn(TxGraph::Level::TOP);
             std::vector<FeeFrac> missing_stage_cmp;
             std::set_difference(stage_real_diagram.begin(), stage_real_diagram.end(),
-                                stage_cmp_diagram.begin(), stage_cmp_diagram.end(),
+                                stage_cmp_diagram_feerates.begin(), stage_cmp_diagram_feerates.end(),
                                 std::inserter(missing_stage_cmp, missing_stage_cmp.end()),
                                 std::greater<ByRatioNegSize<FeeFrac>>{});
-            assert(stage_cmp_diagram.size() + missing_stage_cmp.size() == stage_real_diagram.size());
+            assert(stage_cmp_diagram_feerates.size() + missing_stage_cmp.size() == stage_real_diagram.size());
             // The missing chunks must be equal across main & staging (otherwise they couldn't have
             // been omitted).
             assert(missing_main_cmp == missing_stage_cmp);

--- a/src/test/mempool_update_tests.cpp
+++ b/src/test/mempool_update_tests.cpp
@@ -1,0 +1,535 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kernel/mempool_entry.h>
+#include <kernel/mempool_removal_reason.h>
+#include <random.h>
+#include <test/util/common.h>
+#include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
+#include <txmempool.h>
+#include <util/hasher.h>
+#include <util/time.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <optional>
+
+class MempoolUpdatesListener : public CValidationInterface
+{
+public:
+    std::vector<MemPoolChunksUpdate> updates;
+    void MempoolUpdated(const MemPoolChunksUpdate& update) override { updates.push_back(update); }
+    void Clear() { updates.clear(); }
+};
+
+struct MemPoolUpdateSetup : TestingSetup {
+    MempoolUpdatesListener listener;
+    CTxMemPool& mpool;
+    MemPoolUpdateSetup() : TestingSetup(ChainType::REGTEST), mpool{*Assert(m_node.mempool)}
+    {
+        m_node.validation_signals->RegisterValidationInterface(&listener);
+    }
+    ~MemPoolUpdateSetup()
+    {
+        m_node.validation_signals->UnregisterValidationInterface(&listener);
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(mempool_update_tests, MemPoolUpdateSetup)
+
+static FastRandomContext det_rand{true};
+
+static CMutableTransaction ConstructTx(CAmount value = 1 * COIN, std::optional<COutPoint> prev_out = std::nullopt)
+{
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    if (prev_out) {
+        tx.vin[0].prevout = prev_out.value();
+    } else {
+        tx.vin[0].prevout = COutPoint{Txid::FromUint256(det_rand.rand256()), 0};
+    }
+    tx.vout.resize(1);
+    tx.vout[0].nValue = value;
+    tx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+    return tx;
+}
+
+// Sort wtxids in reverse-byte lexicographic order to match the canonical
+// ordering used by GetHashFromWitnesses when computing chunk hashes.
+static std::vector<Wtxid> ExpectedWitnesses(const std::vector<CMutableTransaction>& txs)
+{
+    std::vector<Wtxid> wtxids;
+    wtxids.reserve(txs.size());
+    for (const auto& tx : txs) {
+        wtxids.emplace_back(CTransaction(tx).GetWitnessHash());
+    }
+    std::sort(wtxids.begin(), wtxids.end(), [](const auto& lhs, const auto& rhs) {
+        return std::lexicographical_compare(
+            std::make_reverse_iterator(lhs.end()), std::make_reverse_iterator(lhs.begin()),
+            std::make_reverse_iterator(rhs.end()), std::make_reverse_iterator(rhs.begin()));
+    });
+    return wtxids;
+}
+
+static std::vector<Wtxid> ChunkWtxids(const MemPoolChunk& chunk)
+{
+    std::vector<Wtxid> wtxids;
+    wtxids.reserve(chunk.m_transactions.size());
+    for (const auto& tx : chunk.m_transactions)
+        wtxids.emplace_back(tx->GetWitnessHash());
+    std::sort(wtxids.begin(), wtxids.end(), [](const auto& a, const auto& b) {
+        return std::lexicographical_compare(
+            std::make_reverse_iterator(a.end()), std::make_reverse_iterator(a.begin()),
+            std::make_reverse_iterator(b.end()), std::make_reverse_iterator(b.begin()));
+    });
+    return wtxids;
+}
+
+static uint256 ExpectedChunkHash(const std::vector<CMutableTransaction>& txs)
+{
+    auto witnesses = ExpectedWitnesses(txs);
+    return GetHashFromWitnesses(witnesses);
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_NormalAddition)
+{
+    TestMemPoolEntryHelper entry;
+    auto tx = ConstructTx();
+    CAmount fee{100};
+    auto tx_entry = entry.Fee(fee).FromTx(tx);
+    int32_t size{tx_entry.GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, tx_entry);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::REPLACED);
+    BOOST_CHECK(update.old_chunks.empty());
+    BOOST_CHECK_EQUAL(update.new_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.new_chunks[0]) == ExpectedWitnesses({tx}));
+    BOOST_CHECK(update.new_chunks[0].m_chunk_hash == ExpectedChunkHash({tx}));
+    BOOST_CHECK(update.new_chunks[0].m_fee_rate == expected_fee_rate);
+    listener.Clear();
+    // Child pays for low-fee parent
+    auto parent_tx = ConstructTx();
+    CAmount parent_fee{100};
+    auto parent_entry = entry.Fee(parent_fee).FromTx(parent_tx);
+    int32_t parent_size{parent_entry.GetAdjustedWeight()};
+    FeeFrac parent_fee_rate{parent_fee, parent_size};
+    // Child spends parent output and pays a high fee, boosting the package.
+    auto child_tx = ConstructTx(1 * COIN, COutPoint{parent_tx.GetHash(), 0});
+    CAmount child_fee{10000};
+    auto child_entry = entry.Fee(child_fee).FromTx(child_tx);
+    int32_t child_size{child_entry.GetAdjustedWeight()};
+    // Once child is added the two txs form a single chunk; fee rate is combined.
+    FeeFrac expected_cpfp_rate{parent_fee + child_fee, parent_size + child_size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, parent_entry);
+        TryAddToMempool(mpool, child_entry);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    // Two signals: one for parent, one for child.
+    BOOST_CHECK_EQUAL(listener.updates.size(), 2U);
+    // After the child is added the chunk merges parent+child
+    const auto& cpfp_update = listener.updates[1];
+    BOOST_CHECK(cpfp_update.reason == MemPoolRemovalReason::REPLACED);
+    BOOST_CHECK_EQUAL(cpfp_update.old_chunks.size(), 1U);
+    const auto& old_chunk = cpfp_update.old_chunks[0];
+    BOOST_CHECK(ChunkWtxids(old_chunk) == ExpectedWitnesses({parent_tx}));
+    BOOST_CHECK(old_chunk.m_chunk_hash == ExpectedChunkHash({parent_tx}));
+    BOOST_CHECK(old_chunk.m_fee_rate == parent_fee_rate);
+    BOOST_CHECK_EQUAL(cpfp_update.new_chunks.size(), 1U);
+    const auto& cpfp_chunk = cpfp_update.new_chunks[0];
+    BOOST_CHECK(ChunkWtxids(cpfp_chunk) == ExpectedWitnesses({parent_tx, child_tx}));
+    BOOST_CHECK(cpfp_chunk.m_chunk_hash == ExpectedChunkHash({parent_tx, child_tx}));
+    BOOST_CHECK(cpfp_chunk.m_fee_rate == expected_cpfp_rate);
+    listener.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_RBFReplacement)
+{
+    TestMemPoolEntryHelper entry;
+    COutPoint shared_input{Txid::FromUint256(det_rand.rand256()), 0};
+    auto original_tx = ConstructTx();
+    original_tx.vin[0].prevout = shared_input;
+    CAmount original_fee{1000};
+    auto original_entry = entry.Fee(original_fee).FromTx(original_tx);
+    FeeFrac expected_original_rate{original_fee, original_entry.GetAdjustedWeight()};
+    // Replacement pays higher fee to satisfy RBF rules.
+    auto replacement_tx = ConstructTx();
+    replacement_tx.vin[0].prevout = shared_input;
+    CAmount replacement_fee{5000};
+    auto replacement_entry = entry.Fee(replacement_fee).FromTx(replacement_tx);
+    FeeFrac expected_replacement_rate{replacement_fee, replacement_entry.GetAdjustedWeight()};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, original_entry);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    {
+        LOCK2(cs_main, mpool.cs);
+        auto changeset = mpool.GetChangeSet();
+        changeset->StageAddition(replacement_entry.GetSharedTx(), replacement_entry.GetFee(), replacement_entry.GetTime().count(),
+                                 replacement_entry.GetHeight(), replacement_entry.GetSequence(), replacement_entry.GetSpendsCoinbase(),
+                                 replacement_entry.GetSigOpCost(), replacement_entry.GetLockPoints());
+        auto conflict_iter = mpool.GetIter(original_entry.GetSharedTx()->GetHash());
+        Assert(conflict_iter.has_value());
+        changeset->StageRemoval(conflict_iter.value());
+        changeset->Apply();
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::REPLACED);
+    // Old diagram: original tx's chunk is gone.
+    BOOST_CHECK_EQUAL(update.old_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.old_chunks[0]) == ExpectedWitnesses({original_tx}));
+    BOOST_CHECK(update.old_chunks[0].m_chunk_hash == ExpectedChunkHash({original_tx}));
+    BOOST_CHECK(update.old_chunks[0].m_fee_rate == expected_original_rate);
+    // New diagram: replacement tx's chunk appears.
+    BOOST_CHECK_EQUAL(update.new_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.new_chunks[0]) == ExpectedWitnesses({replacement_tx}));
+    BOOST_CHECK(update.new_chunks[0].m_chunk_hash == ExpectedChunkHash({replacement_tx}));
+    BOOST_CHECK(update.new_chunks[0].m_fee_rate == expected_replacement_rate);
+    listener.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_ChunkHashDeterminism)
+{
+    TestMemPoolEntryHelper entry;
+    auto tx = ConstructTx();
+    const uint256 expected_hash = ExpectedChunkHash({tx});
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(tx).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    for (int round = 0; round < 2; ++round) {
+        {
+            LOCK2(cs_main, mpool.cs);
+            TryAddToMempool(mpool, entry.Fee(fee).FromTx(tx));
+        }
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+        listener.Clear();
+        {
+            LOCK(mpool.cs);
+            mpool.removeForBlock({MakeTransactionRef(tx)}, /*nBlockHeight=*/1);
+        }
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+        BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+        BOOST_CHECK_EQUAL(listener.updates[0].new_chunks.size(), 0U);
+        BOOST_CHECK_EQUAL(listener.updates[0].old_chunks.size(), 1U);
+        BOOST_CHECK(listener.updates[0].reason == MemPoolRemovalReason::BLOCK);
+        BOOST_CHECK(listener.updates[0].block_height.value() == 1);
+        const auto& chunk = listener.updates[0].old_chunks[0];
+        // Both rounds must produce the same witnesses and hash, matching the expected values.
+        BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({tx}));
+        BOOST_CHECK(chunk.m_chunk_hash == expected_hash);
+        BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_BlockConnection)
+{
+    TestMemPoolEntryHelper entry;
+    // Build a CPFP cluster: low-fee parent + high-fee child.
+    // Together they form one chunk with the combined package fee rate.
+    auto parent_tx = ConstructTx();
+    CAmount parent_fee{100};
+    auto parent_entry = entry.Fee(parent_fee).FromTx(parent_tx);
+    int32_t parent_size{parent_entry.GetAdjustedWeight()};
+    auto child_tx = ConstructTx(1 * COIN, COutPoint{parent_tx.GetHash(), 0});
+    CAmount child_fee{10000};
+    auto child_entry = entry.Fee(child_fee).FromTx(child_tx);
+    int32_t child_size{child_entry.GetAdjustedWeight()};
+    FeeFrac expected_cluster_rate{parent_fee + child_fee, parent_size + child_size};
+    FeeFrac expected_child_solo_rate{child_fee, child_size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, parent_entry);
+        TryAddToMempool(mpool, child_entry);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    // Mine the parent; child remains but is now its own solo chunk.
+    {
+        LOCK(mpool.cs);
+        mpool.removeForBlock({MakeTransactionRef(parent_tx)}, /*nBlockHeight=*/2);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::BLOCK);
+    BOOST_CHECK(listener.updates[0].block_height.value() == 2);
+    // Old diagram: the merged parent+child chunk.
+    BOOST_CHECK_EQUAL(update.old_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.old_chunks[0]) == ExpectedWitnesses({parent_tx, child_tx}));
+    BOOST_CHECK(update.old_chunks[0].m_chunk_hash == ExpectedChunkHash({parent_tx, child_tx}));
+    BOOST_CHECK(update.old_chunks[0].m_fee_rate == expected_cluster_rate);
+
+    // New diagram: child is now a solo chunk with its own fee rate.
+    BOOST_CHECK_EQUAL(update.new_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.new_chunks[0]) == ExpectedWitnesses({child_tx}));
+    BOOST_CHECK(update.new_chunks[0].m_chunk_hash == ExpectedChunkHash({child_tx}));
+    BOOST_CHECK(update.new_chunks[0].m_fee_rate == expected_child_solo_rate);
+
+    BOOST_CHECK(!mpool.exists(parent_tx.GetHash()));
+    BOOST_CHECK(mpool.exists(child_tx.GetHash()));
+    listener.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_BlockConflict)
+{
+    TestMemPoolEntryHelper entry;
+    COutPoint shared_input{Txid::FromUint256(det_rand.rand256()), 0};
+    auto mempool_tx = ConstructTx();
+    mempool_tx.vin[0].prevout = shared_input;
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(mempool_tx).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee).FromTx(mempool_tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+
+    // block_tx spends the same input; evicts mempool_tx as a conflict.
+    auto block_tx = ConstructTx();
+    block_tx.vin[0].prevout = shared_input;
+    block_tx.vout[0].nValue = 9 * COIN / 10;
+    {
+        LOCK(mpool.cs);
+        mpool.removeForBlock({MakeTransactionRef(block_tx)}, /*nBlockHeight=*/3);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    // One BLOCK update (empty staged set) and one CONFLICT update.
+    BOOST_CHECK_EQUAL(listener.updates.size(), 2U);
+    // Conflict notification comes after block.
+    const auto& update = listener.updates[1];
+    const auto& chunk = update.old_chunks[0];
+    BOOST_CHECK(update.new_chunks.empty());
+    BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({mempool_tx}));
+    BOOST_CHECK(chunk.m_chunk_hash == ExpectedChunkHash({mempool_tx}));
+    BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::CONFLICT);
+    BOOST_CHECK(!update.block_height.has_value());
+    BOOST_CHECK(!mpool.exists(mempool_tx.GetHash()));
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_Expiry)
+{
+    TestMemPoolEntryHelper entry;
+    auto old_tx = ConstructTx();
+    auto fresh_tx = ConstructTx();
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(old_tx).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    const auto old_time = Now<NodeSeconds>() - std::chrono::hours(25);
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee).Time(old_time).FromTx(old_tx));
+        TryAddToMempool(mpool, entry.Fee(1000).Time(Now<NodeSeconds>()).FromTx(fresh_tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    {
+        LOCK2(cs_main, mpool.cs);
+        mpool.Expire((Now<NodeSeconds>() - std::chrono::seconds(1)).time_since_epoch());
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK_EQUAL(update.old_chunks.size(), 1U);
+    const auto& chunk = update.old_chunks[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::EXPIRY);
+    BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({old_tx}));
+    BOOST_CHECK(chunk.m_chunk_hash == ExpectedChunkHash({old_tx}));
+    BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    BOOST_CHECK(update.new_chunks.empty());
+    BOOST_CHECK(!mpool.exists(old_tx.GetHash()));
+    BOOST_CHECK(mpool.exists(fresh_tx.GetHash()));
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_SizeLimit)
+{
+    TestMemPoolEntryHelper entry;
+    auto low_fee_tx = ConstructTx();
+    auto high_fee_tx = ConstructTx();
+    CAmount fee_low{1000};
+    CAmount fee_high{9000};
+    FeeFrac expected_fee_rate_low{fee_low, entry.Fee(fee_low).FromTx(low_fee_tx).GetAdjustedWeight()};
+    auto low_fee_entry = entry.Fee(fee_low).FromTx(low_fee_tx);
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee_high).FromTx(high_fee_tx));
+        TryAddToMempool(mpool, entry.Fee(fee_low).FromTx(low_fee_tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    // Trim to one tx worth of memory; evicts the low fee tx.
+    {
+        LOCK2(cs_main, mpool.cs);
+        mpool.TrimToSize(mpool.DynamicMemoryUsage() - low_fee_entry.DynamicMemoryUsage());
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK_EQUAL(update.old_chunks.size(), 1U);
+    const auto& chunk_low = update.old_chunks[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::SIZELIMIT);
+    BOOST_CHECK(ChunkWtxids(chunk_low) == ExpectedWitnesses({low_fee_tx}));
+    BOOST_CHECK(chunk_low.m_chunk_hash == ExpectedChunkHash({low_fee_tx}));
+    BOOST_CHECK(chunk_low.m_fee_rate == expected_fee_rate_low);
+    BOOST_CHECK(update.new_chunks.empty());
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_RemoveRecursive)
+{
+    TestMemPoolEntryHelper entry;
+    auto tx = ConstructTx();
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(tx).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee).FromTx(tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    {
+        LOCK(mpool.cs);
+        mpool.removeRecursive(CTransaction(tx), MemPoolRemovalReason::REORG);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    BOOST_CHECK_EQUAL(listener.updates[0].old_chunks.size(), 1U);
+    const auto& chunk = listener.updates[0].old_chunks[0];
+    BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({tx}));
+    BOOST_CHECK(chunk.m_chunk_hash == ExpectedChunkHash({tx}));
+    BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    BOOST_CHECK(listener.updates[0].new_chunks.empty());
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_Reorg)
+{
+    TestMemPoolEntryHelper entry;
+    auto tx_to_invalidate = ConstructTx();
+    auto valid_tx = ConstructTx();
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(tx_to_invalidate).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee).FromTx(tx_to_invalidate));
+        TryAddToMempool(mpool, entry.Fee(1000).FromTx(valid_tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    const Txid tx_to_invalidate_txid = tx_to_invalidate.GetHash();
+    {
+        LOCK2(cs_main, mpool.cs);
+        auto& chainstate = m_node.chainman->ActiveChainstate();
+        mpool.removeForReorg(chainstate.m_chain, [&](CTxMemPool::txiter it)
+                                                     EXCLUSIVE_LOCKS_REQUIRED(mpool.cs, ::cs_main) {
+                                                         AssertLockHeld(mpool.cs);
+                                                         AssertLockHeld(::cs_main);
+                                                         return it->GetTx().GetHash() == tx_to_invalidate_txid;
+                                                     });
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    BOOST_CHECK_EQUAL(listener.updates[0].old_chunks.size(), 1U);
+    const auto& chunk = listener.updates[0].old_chunks[0];
+    BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({tx_to_invalidate}));
+    BOOST_CHECK(chunk.m_chunk_hash == ExpectedChunkHash({tx_to_invalidate}));
+    BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    BOOST_CHECK(listener.updates[0].new_chunks.empty());
+    BOOST_CHECK(!mpool.exists(tx_to_invalidate.GetHash()));
+    BOOST_CHECK(mpool.exists(valid_tx.GetHash()));
+}
+
+// Simulate a scenario where a reorg causes a tx to be added to the mempool
+// and connected to a cluster; this connection causes mempool limits to be exceeded.
+// In production this happens in MaybeUpdateMempoolForReorg:
+// txs are added via AcceptToMemoryPool, then UpdateTransactionsFromBlock
+// connects the parent->child dependency.
+//
+// Here chain[1..cluster_limit] are in-mempool and connected to a tx in a block, but the
+// reorg does not include the parent of chain[1..cluster_limit].
+// chain[0] is then added independently as a cluster of 1. UpdateTransactionsFromBlock scans
+// the mempool for txs that spends an output of chain[1], finds chain[1], and calls AddDependency
+// merging both clusters into one of size cluster_limit+1, which exceeds the limit.
+// Trim() evicts the lowest-fee tail tx.
+BOOST_AUTO_TEST_CASE(MempoolUpdated_UpdateTransactionsFromBlock)
+{
+    TestMemPoolEntryHelper entry;
+    const int chain_len{static_cast<int>(mpool.m_opts.limits.cluster_count + 1)};
+    std::vector<CMutableTransaction> chain;
+    chain.reserve(chain_len);
+    std::vector<Txid> txids;
+    chain.push_back(ConstructTx()); // chain[0]: the re-added parent
+    for (int i = 1; i < chain_len; ++i) {
+        chain.push_back(ConstructTx(1 * COIN, COutPoint{chain[i - 1].GetHash(), 0}));
+    }
+    CAmount normal_fee{1000};
+    CAmount low_fee{100};
+    int32_t last_tx_size{0};
+    {
+        LOCK2(cs_main, mpool.cs);
+        for (int i = 1; i < chain_len; ++i) {
+            CAmount fee = (i == chain_len - 1) ? low_fee : normal_fee;
+            auto curr_entry = entry.Fee(fee).FromTx(chain[i]);
+            if (i == chain_len - 1) last_tx_size = curr_entry.GetAdjustedWeight();
+            TryAddToMempool(mpool, curr_entry);
+        }
+        auto root_entry = entry.Fee(normal_fee).FromTx(chain[0]);
+        TryAddToMempool(mpool, root_entry);
+        txids.push_back(chain[0].GetHash());
+    }
+    // Verify the two clusters are independent before UpdateTransactionsFromBlock.
+    BOOST_CHECK_EQUAL(WITH_LOCK(mpool.cs, return mpool.GetCluster(chain[0].GetHash()).size()), 1);
+    BOOST_CHECK_EQUAL(WITH_LOCK(mpool.cs, return mpool.GetCluster(chain[1].GetHash()).size()), chain_len - 1);
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    {
+        LOCK2(cs_main, mpool.cs);
+        // Scans mapNextTx for chain[0]'s outputs, finds chain[1], calls
+        // AddDependency(chain[0], chain[1]). Merged cluster = chain_len > limit.
+        // Trim() evicts the lowest-fee tail tx (chain.back()).
+        mpool.UpdateTransactionsFromBlock(txids);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    // Both clusters are now merged (minus the evicted tail tx).
+    BOOST_CHECK_EQUAL(WITH_LOCK(mpool.cs, return mpool.GetCluster(chain[0].GetHash()).size()), chain_len - 1);
+    BOOST_CHECK_EQUAL(WITH_LOCK(mpool.cs, return mpool.GetCluster(chain[1].GetHash()).size()), chain_len - 1);
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::SIZELIMIT);
+    // old_chunks: the merged cluster before eviction, includes the low-fee tail tx.
+    BOOST_CHECK(!update.old_chunks.empty());
+    const auto& evicted_chunk = update.old_chunks.back();
+    BOOST_CHECK(ChunkWtxids(evicted_chunk) == ExpectedWitnesses({chain.back()}));
+    BOOST_CHECK(evicted_chunk.m_chunk_hash == ExpectedChunkHash({chain.back()}));
+    BOOST_CHECK(evicted_chunk.m_fee_rate == FeeFrac(low_fee, last_tx_size));
+    // new_chunks: the merged cluster after eviction, excludes the low-fee tail tx.
+    BOOST_CHECK(!update.new_chunks.empty());
+    BOOST_CHECK_EQUAL(update.new_chunks.size(), update.old_chunks.size() - 1);
+    BOOST_CHECK(!mpool.exists(chain.back().GetHash()));
+    // All other txs must still be present.
+    for (int i = 0; i < chain_len - 1; ++i) {
+        BOOST_CHECK(mpool.exists(chain[i].GetHash()));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -220,7 +220,7 @@ public:
      *  the Cluster's QualityLevel improved as a result. */
     virtual std::pair<uint64_t, bool> Relinearize(TxGraphImpl& graph, int level, uint64_t max_cost) noexcept = 0;
     /** For every chunk in the cluster, append its FeeFrac to ret. */
-    virtual void AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept = 0;
+    virtual void AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept = 0;
     /** Add a TrimTxData entry (filling m_chunk_feerate, m_index, m_tx_size) for every
      *  transaction in the Cluster to ret. Implicit dependencies between consecutive transactions
      *  in the linearization are added to deps. Return the Cluster's total transaction size. */
@@ -298,7 +298,7 @@ public:
     void Merge(TxGraphImpl& graph, int level, Cluster& cluster) noexcept final;
     void ApplyDependencies(TxGraphImpl& graph, int level, std::span<std::pair<GraphIndex, GraphIndex>> to_apply) noexcept final;
     std::pair<uint64_t, bool> Relinearize(TxGraphImpl& graph, int level, uint64_t max_cost) noexcept final;
-    void AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept final;
+    void AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept final;
     uint64_t AppendTrimData(std::vector<TrimTxData>& ret, std::vector<std::pair<GraphIndex, GraphIndex>>& deps) const noexcept final;
     void GetAncestorRefs(const TxGraphImpl& graph, std::span<std::pair<Cluster*, DepGraphIndex>>& args, std::vector<TxGraph::Ref*>& output) noexcept final;
     void GetDescendantRefs(const TxGraphImpl& graph, std::span<std::pair<Cluster*, DepGraphIndex>>& args, std::vector<TxGraph::Ref*>& output) noexcept final;
@@ -355,7 +355,7 @@ public:
     void Merge(TxGraphImpl& graph, int level, Cluster& cluster) noexcept final;
     void ApplyDependencies(TxGraphImpl& graph, int level, std::span<std::pair<GraphIndex, GraphIndex>> to_apply) noexcept final;
     std::pair<uint64_t, bool> Relinearize(TxGraphImpl& graph, int level, uint64_t max_cost) noexcept final;
-    void AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept final;
+    void AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept final;
     uint64_t AppendTrimData(std::vector<TrimTxData>& ret, std::vector<std::pair<GraphIndex, GraphIndex>>& deps) const noexcept final;
     void GetAncestorRefs(const TxGraphImpl& graph, std::span<std::pair<Cluster*, DepGraphIndex>>& args, std::vector<TxGraph::Ref*>& output) noexcept final;
     void GetDescendantRefs(const TxGraphImpl& graph, std::span<std::pair<Cluster*, DepGraphIndex>>& args, std::vector<TxGraph::Ref*>& output) noexcept final;
@@ -821,7 +821,7 @@ public:
     bool IsOversized(Level level) noexcept final;
     std::strong_ordering CompareMainOrder(const Ref& a, const Ref& b) noexcept final;
     GraphIndex CountDistinctClusters(std::span<const Ref* const> refs, Level level) noexcept final;
-    std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> GetMainStagingDiagrams() noexcept final;
+    std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>> GetMainStagingDiagrams() noexcept final;
     std::vector<Ref*> Trim() noexcept final;
 
     std::unique_ptr<BlockBuilder> GetBlockBuilder() noexcept final;
@@ -1381,17 +1381,29 @@ void SingletonClusterImpl::Compact() noexcept
     // Nothing to compact; SingletonClusterImpl is constant size.
 }
 
-void GenericClusterImpl::AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept
+void GenericClusterImpl::AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept
 {
-    auto chunk_feerates = ChunkLinearization(m_depgraph, m_linearization);
-    ret.reserve(ret.size() + chunk_feerates.size());
-    ret.insert(ret.end(), chunk_feerates.begin(), chunk_feerates.end());
+    auto linchunking = ChunkLinearizationInfo(m_depgraph, m_linearization);
+    ret.reserve(ret.size() + linchunking.size());
+    LinearizationIndex pos{0};
+    for (auto& [chunk, chunk_feerate] : linchunking) {
+        auto chunk_tx_count = chunk.Count();
+        std::vector<TxGraph::Ref*> refs;
+        refs.reserve(chunk_tx_count);
+        for (unsigned j = 0; j < chunk_tx_count; ++j) {
+            auto cluster_idx = m_linearization[pos];
+            refs.emplace_back(graph.m_entries[m_mapping[cluster_idx]].m_ref);
+            ++pos;
+        }
+        ret.emplace_back(chunk_feerate, std::move(refs));
+    }
 }
 
-void SingletonClusterImpl::AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept
+void SingletonClusterImpl::AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept
 {
     if (GetTxCount()) {
-        ret.push_back(m_feerate);
+        const auto& entry = graph.m_entries[m_graph_index];
+        ret.emplace_back(m_feerate, std::vector<TxGraph::Ref*>{entry.m_ref});
     }
 }
 
@@ -2807,7 +2819,7 @@ TxGraph::GraphIndex TxGraphImpl::CountDistinctClusters(std::span<const Ref* cons
     return ret;
 }
 
-std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> TxGraphImpl::GetMainStagingDiagrams() noexcept
+std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>> TxGraphImpl::GetMainStagingDiagrams() noexcept
 {
     Assume(m_staging_clusterset.has_value());
     MakeAllAcceptable(0);
@@ -2817,20 +2829,20 @@ std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> TxGraphImpl::GetMainStagin
     // For all Clusters in main which conflict with Clusters in staging (i.e., all that are removed
     // by, or replaced in, staging), gather their chunk feerates.
     auto main_clusters = GetConflicts();
-    std::vector<FeeFrac> main_feerates, staging_feerates;
+    std::vector<Chunk> main_chunks, staging_chunks;
     for (Cluster* cluster : main_clusters) {
-        cluster->AppendChunkFeerates(main_feerates);
+        cluster->AppendChunks(*this, main_chunks);
     }
     // Do the same for the Clusters in staging themselves.
     for (int quality = 0; quality < int(QualityLevel::NONE); ++quality) {
         for (const auto& cluster : m_staging_clusterset->m_clusters[quality]) {
-            cluster->AppendChunkFeerates(staging_feerates);
+            cluster->AppendChunks(*this, staging_chunks);
         }
     }
     // Sort both by decreasing feerate to obtain diagrams, and return them.
-    std::ranges::sort(main_feerates, std::greater<ByRatioNegSize<FeeFrac>>{});
-    std::ranges::sort(staging_feerates, std::greater<ByRatioNegSize<FeeFrac>>{});
-    return std::make_pair(std::move(main_feerates), std::move(staging_feerates));
+    std::ranges::sort(main_chunks, Chunk::GreaterFeerate{});
+    std::ranges::sort(staging_chunks, Chunk::GreaterFeerate{});
+    return std::make_pair(std::move(main_chunks), std::move(staging_chunks));
 }
 
 void GenericClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
@@ -2904,6 +2916,19 @@ void GenericClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
     }
     // Verify that each element of m_depgraph occurred in m_linearization.
     assert(m_done == m_depgraph.Positions());
+    // Verify AppendChunks returns correct result.
+    std::vector<TxGraph::Chunk> chunks;
+    AppendChunks(graph, chunks);
+    LinearizationIndex pos{0};
+    assert(chunks.size() == linchunking.size());
+    for (unsigned i = 0; i < chunks.size(); ++i) {
+        for (auto ref : chunks[i].refs) {
+            auto cluster_idx = m_linearization[pos];
+            assert(ref == graph.m_entries[m_mapping[cluster_idx]].m_ref);
+            pos += 1;
+        }
+        assert(chunks[i].feerate == linchunking[i].feerate);
+    }
 }
 
 void SingletonClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
@@ -2926,6 +2951,11 @@ void SingletonClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) cons
                 assert(chunk_data.m_chunk_count == LinearizationIndex(-1));
             }
         }
+        // Verify AppendChunks returns correct result.
+        std::vector<TxGraph::Chunk> chunks;
+        AppendChunks(graph, chunks);
+        assert(chunks.size() == 1);
+        assert((chunks.back() == TxGraph::Chunk{m_feerate, {entry.m_ref}}));
     }
 }
 

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -61,6 +61,24 @@ public:
      */
     class Ref;
 
+    /** Datatype representing a chunk along with its feerate and all the tx refs in the chunk. */
+    struct Chunk {
+        FeePerWeight feerate;
+        std::vector<Ref*> refs;
+        Chunk(const FeeFrac& f, std::vector<Ref*> r) noexcept : feerate{f.fee, f.size}, refs{std::move(r)} {}
+        bool operator==(const Chunk& other) const noexcept
+        {
+            return feerate == other.feerate && refs == other.refs;
+        }
+        /** Comparator for sorting chunks by descending feerate; ties broken by smaller size. */
+        struct GreaterFeerate {
+            bool operator()(const Chunk& a, const Chunk& b) const noexcept
+            {
+                return ByRatioNegSize{a.feerate} > ByRatioNegSize{b.feerate};
+            }
+        };
+    };
+
     enum class Level {
         TOP, //!< Refers to staging if it exists, main otherwise.
         MAIN //!< Always refers to the main graph, whether staging is present or not.
@@ -167,10 +185,9 @@ public:
      *  not be oversized. */
     virtual GraphIndex CountDistinctClusters(std::span<const Ref* const>, Level level) noexcept = 0;
     /** For both main and staging (which must both exist and not be oversized), return the combined
-     *  respective feerate diagrams, including chunks from all clusters, but excluding clusters
-     *  that appear identically in both. Use FeeFrac rather than FeePerWeight so CompareChunks is
-     *  usable without type-conversion. */
-    virtual std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> GetMainStagingDiagrams() noexcept = 0;
+     *  respective feerate diagrams, including chunks (feerate and refs) from all clusters, but
+     *  excluding clusters that appear identically in both. */
+    virtual std::pair<std::vector<Chunk>, std::vector<Chunk>> GetMainStagingDiagrams() noexcept = 0;
     /** Remove transactions (including their own descendants) according to a fast but best-effort
      *  strategy such that the TxGraph's cluster and size limits are respected. Applies to staging
      *  if it exists, and to main otherwise. Returns the list of all removed transactions in

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -999,7 +999,17 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
         return util::Error{Untranslated("cluster size limit exceeded")};
     }
 
-    return m_pool->m_txgraph->GetMainStagingDiagrams();
+    std::vector<FeeFrac> old_diagram, new_diagram;
+    auto diagrams = m_pool->m_txgraph->GetMainStagingDiagrams();
+    old_diagram.reserve(diagrams.first.size());
+    new_diagram.reserve(diagrams.second.size());
+    for (auto& chunk : diagrams.first) {
+        old_diagram.emplace_back(chunk.feerate);
+    }
+    for (auto& chunk : diagrams.second) {
+        new_diagram.emplace_back(chunk.feerate);
+    }
+    return std::make_pair(old_diagram, new_diagram);
 }
 
 CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -54,6 +54,24 @@ bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
     return true;
 }
 
+static std::vector<MemPoolChunk> MakeMemPoolChunks(const std::vector<TxGraph::Chunk>& chunks)
+{
+    std::vector<MemPoolChunk> result;
+    result.reserve(chunks.size());
+    for (const auto& chunk : chunks) {
+        std::vector<CTransactionRef> txs;
+        int64_t sigops{0};
+        txs.reserve(chunk.refs.size());
+        for (const auto& ref : chunk.refs) {
+            const auto& entry = static_cast<const CTxMemPoolEntry&>(*ref);
+            txs.emplace_back(entry.GetSharedTx());
+            sigops += entry.GetSigOpCost();
+        }
+        result.push_back({chunk.feerate, std::move(txs), sigops, std::nullopt});
+    }
+    return result;
+}
+
 std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> CTxMemPool::GetChildren(const CTxMemPoolEntry& entry) const
 {
     std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> ret;
@@ -92,24 +110,15 @@ std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> CTxMemPool::GetParents(const CT
 void CTxMemPool::addDependenciesFromBlock(const std::vector<Txid>& vHashesToUpdate)
 {
     AssertLockHeld(cs);
-
-    // Iterate in reverse, so that whenever we are looking at a transaction
-    // we are sure that all in-mempool descendants have already been processed.
+    // Iterate in reverse so that when processing a transaction, all its
+    // in-mempool descendants have already been processed.
     for (const Txid& hash : vHashesToUpdate | std::views::reverse) {
-        // calculate children from mapNextTx
         txiter it = mapTx.find(hash);
-        if (it == mapTx.end()) {
-            continue;
-        }
+        if (it == mapTx.end()) continue;
         auto iter = mapNextTx.lower_bound(COutPoint(hash, 0));
-        {
-            for (; iter != mapNextTx.end() && iter->first->hash == hash; ++iter) {
-                txiter childIter = iter->second;
-                assert(childIter != mapTx.end());
-                // Add dependencies that are discovered between transactions in the
-                // block and transactions that were in the mempool to txgraph.
-                m_txgraph->AddDependency(/*parent=*/*it, /*child=*/*childIter);
-            }
+        for (; iter != mapNextTx.end() && iter->first->hash == hash; ++iter) {
+            assert(iter->second != mapTx.end());
+            m_txgraph->AddDependency(/*parent=*/*it, /*child=*/*iter->second);
         }
     }
 }
@@ -117,11 +126,42 @@ void CTxMemPool::addDependenciesFromBlock(const std::vector<Txid>& vHashesToUpda
 void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<Txid>& vHashesToUpdate)
 {
     AssertLockHeld(cs);
+    Assume(!m_have_changeset);
+    // Add parent->child dependencies discovered between re-added transactions
+    // and existing mempool transactions on a staging graph, then check whether
+    // any clusters now exceed the size limit.
+    auto changeSet = GetChangeSet();
     addDependenciesFromBlock(vHashesToUpdate);
-    auto txs_to_remove = m_txgraph->Trim(); // Enforce cluster size limits.
-    for (auto txptr : txs_to_remove) {
-        const CTxMemPoolEntry& entry = *(static_cast<const CTxMemPoolEntry*>(txptr));
-        removeUnchecked(mapTx.iterator_to(entry), MemPoolRemovalReason::SIZELIMIT);
+    auto txs_to_remove = m_txgraph->Trim();
+    setEntries iters;
+    if (!txs_to_remove.empty()) {
+        // Clusters exceed the size limit after adding new dependencies.
+        // Abort the current staging graph (which contains the oversized clusters)
+        // and start fresh; an oversized graph cannot produce a valid fee rate diagram.
+        // Then evict the transactions discovered by Trim() and re-add dependencies.
+        // With the oversized txs gone, GetMainStagingDiagrams produces a correct
+        // before/after diff: old = pre-dependency clusters (main),
+        // new = post-dependency clusters without evicted txs (staging).
+        changeSet.reset();
+        changeSet = GetChangeSet();
+        for (auto txptr : txs_to_remove) {
+            m_txgraph->RemoveTransaction(*txptr);
+            iters.insert(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*txptr)));
+        }
+        // It is safe to add dependencies here without first evicting iters from
+        // mapTx/mapNextTx: AddDependency is a no-op when either parent or child
+        // is absent from the graph, so evicted txs are simply skipped.
+        addDependenciesFromBlock(vHashesToUpdate);
+    }
+    changeSet->SnapshotDiagrams();
+    auto& chunks = changeSet->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+    m_txgraph->CommitStaging();
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(
+        MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::SIZELIMIT});
+    RemoveStaged(iters, MemPoolRemovalReason::SIZELIMIT);
+    if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
+        LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after reorg.");
     }
 }
 
@@ -212,8 +252,13 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
 void CTxMemPool::Apply(ChangeSet* changeset)
 {
     AssertLockHeld(cs);
+    if (changeset->m_fee_rate_diagrams.first.empty() && changeset->m_fee_rate_diagrams.second.empty()) {
+        changeset->SnapshotDiagrams();
+    }
+    auto& chunks = changeset->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
     m_txgraph->CommitStaging();
-
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::REPLACED});
     RemoveStaged(changeset->m_to_remove, MemPoolRemovalReason::REPLACED);
 
     for (size_t i=0; i<changeset->m_entry_vec.size(); ++i) {
@@ -331,9 +376,15 @@ void CTxMemPool::removeRecursive(CTxMemPool::txiter to_remove, MemPoolRemovalRea
     AssertLockHeld(cs);
     Assume(!m_have_changeset);
     auto descendants = m_txgraph->GetDescendants(*to_remove, TxGraph::Level::MAIN);
+    auto changeSet = GetChangeSet();
     for (auto tx: descendants) {
-        removeUnchecked(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*tx)), reason);
+        changeSet->StageRemoval(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*tx)));
     }
+    changeSet->SnapshotDiagrams();
+    auto& chunks = changeSet->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, reason});
+    RemoveStaged(changeSet->GetRemovals(), reason);
 }
 
 void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReason reason)
@@ -356,10 +407,15 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
             ++iter;
         }
         auto all_removes = m_txgraph->GetDescendantsUnion(to_remove, TxGraph::Level::MAIN);
+        auto changeSet = GetChangeSet();
         for (auto ref : all_removes) {
-            auto tx = mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref));
-            removeUnchecked(tx, reason);
+            changeSet->StageRemoval(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref)));
         }
+        changeSet->SnapshotDiagrams();
+        auto& chunks = changeSet->GetFeeRateDiagramChunks();
+        auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+        if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, reason});
+        RemoveStaged(changeSet->GetRemovals(), reason);
     }
 }
 
@@ -379,10 +435,16 @@ void CTxMemPool::removeForReorg(CChain& chain, std::function<bool(txiter)> check
 
     auto all_to_remove = m_txgraph->GetDescendantsUnion(to_remove, TxGraph::Level::MAIN);
 
+    auto changeSet = GetChangeSet();
     for (auto ref : all_to_remove) {
-        auto it = mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref));
-        removeUnchecked(it, MemPoolRemovalReason::REORG);
+        changeSet->StageRemoval(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref)));
     }
+    changeSet->SnapshotDiagrams();
+    auto& chunks = changeSet->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::REORG});
+    RemoveStaged(changeSet->GetRemovals(), MemPoolRemovalReason::REORG);
+
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         assert(TestLockPointValidity(chain, it->GetLockPoints()));
     }
@@ -416,12 +478,22 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     std::vector<RemovedMempoolTransactionInfo> txs_removed_for_block;
     if (mapTx.size() || mapNextTx.size() || mapDeltas.size()) {
         txs_removed_for_block.reserve(vtx.size());
-        for (const auto& tx : vtx) {
-            txiter it = mapTx.find(tx->GetHash());
-            if (it != mapTx.end()) {
-                txs_removed_for_block.emplace_back(*it);
-                removeUnchecked(it, MemPoolRemovalReason::BLOCK);
+        {
+            auto changeSet = GetChangeSet();
+            for (const auto& tx : vtx) {
+                txiter it = mapTx.find(tx->GetHash());
+                if (it != mapTx.end()) {
+                    txs_removed_for_block.emplace_back(*it);
+                    changeSet->StageRemoval(it);
+                }
             }
+            changeSet->SnapshotDiagrams();
+            auto& chunks = changeSet->GetFeeRateDiagramChunks();
+            auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+            if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::BLOCK, nBlockHeight});
+            RemoveStaged(changeSet->GetRemovals(), MemPoolRemovalReason::BLOCK);
+        }
+        for (const auto& tx : vtx) {
             removeConflicts(*tx);
             ClearPrioritisation(tx->GetHash());
         }
@@ -829,7 +901,15 @@ int CTxMemPool::Expire(std::chrono::seconds time)
     for (txiter removeit : toremove) {
         CalculateDescendants(removeit, stage);
     }
-    RemoveStaged(stage, MemPoolRemovalReason::EXPIRY);
+    auto changeSet = GetChangeSet();
+    for (auto it : stage) {
+        changeSet->StageRemoval(it);
+    }
+    changeSet->SnapshotDiagrams();
+    auto& chunks = changeSet->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::EXPIRY});
+    RemoveStaged(changeSet->GetRemovals(), MemPoolRemovalReason::EXPIRY);
     return stage.size();
 }
 
@@ -895,13 +975,15 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
             }
         }
 
-        setEntries stage;
+        auto changeSet = GetChangeSet();
         for (auto ref : worst_chunk) {
-            stage.insert(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref)));
+            changeSet->StageRemoval(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref)));
         }
-        for (auto e : stage) {
-            removeUnchecked(e, MemPoolRemovalReason::SIZELIMIT);
-        }
+        changeSet->SnapshotDiagrams();
+        auto& chunks = changeSet->GetFeeRateDiagramChunks();
+        auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+        if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::SIZELIMIT});
+        RemoveStaged(changeSet->GetRemovals(), MemPoolRemovalReason::SIZELIMIT);
         if (pvNoSpendsRemaining) {
             for (const CTransaction& tx : txn) {
                 for (const CTxIn& txin : tx.vin) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -998,18 +998,22 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
     if (!CheckMemPoolPolicyLimits()) {
         return util::Error{Untranslated("cluster size limit exceeded")};
     }
-
     std::vector<FeeFrac> old_diagram, new_diagram;
-    auto diagrams = m_pool->m_txgraph->GetMainStagingDiagrams();
-    old_diagram.reserve(diagrams.first.size());
-    new_diagram.reserve(diagrams.second.size());
-    for (auto& chunk : diagrams.first) {
+    m_fee_rate_diagrams = m_pool->m_txgraph->GetMainStagingDiagrams();
+    old_diagram.reserve(m_fee_rate_diagrams.first.size());
+    new_diagram.reserve(m_fee_rate_diagrams.second.size());
+    for (auto& chunk : m_fee_rate_diagrams.first) {
         old_diagram.emplace_back(chunk.feerate);
     }
-    for (auto& chunk : diagrams.second) {
+    for (auto& chunk : m_fee_rate_diagrams.second) {
         new_diagram.emplace_back(chunk.feerate);
     }
     return std::make_pair(old_diagram, new_diagram);
+}
+
+const std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>>& CTxMemPool::ChangeSet::GetFeeRateDiagramChunks() const
+{
+    return m_fee_rate_diagrams;
 }
 
 CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -88,7 +88,8 @@ std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> CTxMemPool::GetParents(const CT
     return ret;
 }
 
-void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<Txid>& vHashesToUpdate)
+
+void CTxMemPool::addDependenciesFromBlock(const std::vector<Txid>& vHashesToUpdate)
 {
     AssertLockHeld(cs);
 
@@ -111,7 +112,12 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<Txid>& vHashesToU
             }
         }
     }
+}
 
+void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<Txid>& vHashesToUpdate)
+{
+    AssertLockHeld(cs);
+    addDependenciesFromBlock(vHashesToUpdate);
     auto txs_to_remove = m_txgraph->Trim(); // Enforce cluster size limits.
     for (auto txptr : txs_to_remove) {
         const CTxMemPoolEntry& entry = *(static_cast<const CTxMemPoolEntry*>(txptr));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -790,7 +790,8 @@ void CTxMemPool::RemoveUnbroadcastTx(const Txid& txid, const bool unchecked) {
     }
 }
 
-void CTxMemPool::RemoveStaged(setEntries &stage, MemPoolRemovalReason reason) {
+void CTxMemPool::RemoveStaged(const setEntries& stage, MemPoolRemovalReason reason)
+{
     AssertLockHeld(cs);
     for (txiter it : stage) {
         removeUnchecked(it, reason);
@@ -994,10 +995,15 @@ std::vector<CTxMemPool::txiter> CTxMemPool::GatherClusters(const std::vector<Txi
 util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::ChangeSet::CalculateChunksForRBF()
 {
     LOCK(m_pool->cs);
-
     if (!CheckMemPoolPolicyLimits()) {
         return util::Error{Untranslated("cluster size limit exceeded")};
     }
+    return SnapshotDiagrams();
+}
+
+std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> CTxMemPool::ChangeSet::SnapshotDiagrams()
+{
+    LOCK(m_pool->cs);
     std::vector<FeeFrac> old_diagram, new_diagram;
     m_fee_rate_diagrams = m_pool->m_txgraph->GetMainStagingDiagrams();
     old_diagram.reserve(m_fee_rate_diagrams.first.size());

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -586,6 +586,9 @@ private:
 
     /* Removal from the mempool also triggers removal of the entry's Ref from txgraph. */
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+    void addDependenciesFromBlock(const std::vector<Txid>& vHashesToUpdate) EXCLUSIVE_LOCKS_REQUIRED(cs);
+
 public:
     /*
      * CTxMemPool::ChangeSet:

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -579,7 +579,7 @@ private:
      *  also be in the set, unless this transaction is being removed for being
      *  in a block.
      */
-    void RemoveStaged(setEntries& stage, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void RemoveStaged(const setEntries& stage, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /* Helper for the public removeRecursive() */
     void removeRecursive(txiter to_remove, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -680,6 +680,7 @@ public:
 
     private:
         void ProcessDependencies();
+        std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> SnapshotDiagrams();
 
         CTxMemPool* m_pool;
         CTxMemPool::indexed_transaction_set m_to_add;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -671,6 +671,8 @@ public:
          */
         util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CalculateChunksForRBF();
 
+        const std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>>& GetFeeRateDiagramChunks() const;
+
         size_t GetTxCount() const { return m_entry_vec.size(); }
         const CTransaction& GetAddedTxn(size_t index) const { return m_entry_vec.at(index)->GetTx(); }
 
@@ -684,6 +686,7 @@ public:
         std::vector<CTxMemPool::txiter> m_entry_vec; // track the added transactions' insertion order
         // map from the m_to_add index to the ancestors for the transaction
         std::map<CTxMemPool::txiter, CTxMemPool::setEntries, CompareIteratorByHash> m_ancestors;
+        std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>> m_fee_rate_diagrams;
         CTxMemPool::setEntries m_to_remove;
         bool m_dependencies_processed{false};
 

--- a/src/util/hasher.cpp
+++ b/src/util/hasher.cpp
@@ -5,7 +5,11 @@
 #include <util/hasher.h>
 
 #include <crypto/siphash.h>
+#include <hash.h>
 #include <random.h>
+
+#include <algorithm>
+#include <iterator>
 
 SaltedUint256Hasher::SaltedUint256Hasher() : m_hasher{
     FastRandomContext().rand64(),
@@ -35,4 +39,19 @@ SaltedSipHasher::SaltedSipHasher() :
 size_t SaltedSipHasher::operator()(const std::span<const unsigned char>& script) const
 {
     return CSipHasher(m_k0, m_k1).Write(script).Finalize();
+}
+
+uint256 GetHashFromWitnesses(std::vector<Wtxid> wtxids)
+{
+    // Sort in ascending order
+    std::sort(wtxids.begin(), wtxids.end(), [](const auto& lhs, const auto& rhs) {
+        return std::lexicographical_compare(
+            std::make_reverse_iterator(lhs.end()), std::make_reverse_iterator(lhs.begin()),
+            std::make_reverse_iterator(rhs.end()), std::make_reverse_iterator(rhs.begin()));
+    });
+
+    // Get sha256 hash of the wtxids concatenated in this order
+    HashWriter hw;
+    for (const auto& wtxid : wtxids) hw << wtxid;
+    return hw.GetSHA256();
 }

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstring>
 #include <span>
+#include <vector>
 
 class SaltedUint256Hasher
 {
@@ -115,5 +116,8 @@ public:
 
     size_t operator()(const std::span<const unsigned char>& script) const;
 };
+
+/** Sorts (a local copy of) a set of wtxids and hashes them into a single hash. */
+uint256 GetHashFromWitnesses(std::vector<Wtxid> wtxids);
 
 #endif // BITCOIN_UTIL_HASHER_H

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -13,6 +13,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <util/check.h>
+#include <util/hasher.h>
 #include <util/log.h>
 #include <util/task_runner.h>
 
@@ -237,6 +238,29 @@ void ValidationSignals::MempoolTransactionsRemovedForBlock(const std::vector<Rem
                           txs_removed_for_block.size());
     auto event = [txs_removed_for_block, nBlockHeight, this] {
         m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.MempoolTransactionsRemovedForBlock(txs_removed_for_block, nBlockHeight); });
+    };
+    ENQUEUE_AND_LOG_EVENT(std::move(event), std::move(log_msg));
+}
+
+void ValidationSignals::MempoolUpdated(MemPoolChunksUpdate mempool_chunks)
+{
+    auto compute_hash = [](MemPoolChunk& chunk) {
+        std::vector<Wtxid> wtxids;
+        wtxids.reserve(chunk.m_transactions.size());
+        for (const auto& tx : chunk.m_transactions)
+            wtxids.emplace_back(tx->GetWitnessHash());
+        chunk.m_chunk_hash = GetHashFromWitnesses(wtxids);
+    };
+    for (auto& chunk : mempool_chunks.old_chunks)
+        compute_hash(chunk);
+    for (auto& chunk : mempool_chunks.new_chunks)
+        compute_hash(chunk);
+    auto log_msg = LOG_MSG("%s: old chunks=%s new chunks=%s reason for removal=%s", __func__,
+                           mempool_chunks.old_chunks.size(),
+                           mempool_chunks.new_chunks.size(),
+                           RemovalReasonToString(mempool_chunks.reason));
+    auto event = [mempool_chunks, this] {
+        m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.MempoolUpdated(mempool_chunks); });
     };
     ENQUEUE_AND_LOG_EVENT(std::move(event), std::move(log_msg));
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -30,6 +30,7 @@ struct CBlockLocator;
 enum class MemPoolRemovalReason;
 struct RemovedMempoolTransactionInfo;
 struct NewMempoolTransactionInfo;
+struct MemPoolChunksUpdate;
 
 /**
  * Implement this to subscribe to events generated in validation and mempool
@@ -115,6 +116,13 @@ protected:
      * Called on a background thread.
      */
     virtual void MempoolTransactionsRemovedForBlock(const std::vector<RemovedMempoolTransactionInfo>& txs_removed_for_block, unsigned int nBlockHeight) {}
+    /**
+     * Notifies listeners of each mempool update via a MemPoolChunksUpdate
+     * describing the chunks that left and entered the mempool.
+     *
+     * Called on a background thread.
+     */
+    virtual void MempoolUpdated(const MemPoolChunksUpdate& mempool_chunks) {}
     /**
      * Notifies listeners of a block being connected.
      *
@@ -225,6 +233,7 @@ public:
     void MempoolTransactionsRemovedForBlock(const std::vector<RemovedMempoolTransactionInfo>&, unsigned int nBlockHeight);
     void BlockConnected(const kernel::ChainstateRole&, std::shared_ptr<const CBlock>, const CBlockIndex* pindex);
     void BlockDisconnected(std::shared_ptr<const CBlock>, const CBlockIndex* pindex);
+    void MempoolUpdated(MemPoolChunksUpdate);
     void ChainStateFlushed(const kernel::ChainstateRole&, const CBlockLocator&);
     void BlockChecked(const std::shared_ptr<const CBlock>&, const BlockValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -443,11 +443,11 @@ class ZMQTest (BitcoinTestFramework):
         mempool_seq += 1
         assert_equal((bump_txid, "A", mempool_seq), seq.receive_sequence())
         mempool_seq += 1
-        # Conflict announced first, then block
+        # Block txs seq slots consumed first, then conflict evicted, then block announced
+        mempool_seq += len(more_tx)
         assert_equal((bump_txid, "R", mempool_seq), seq.receive_sequence())
         mempool_seq += 1
         assert_equal((tip, "C", None), seq.receive_sequence())
-        mempool_seq += len(more_tx)
         # Last tx
         assert_equal((orig_txid_2, "A", mempool_seq), seq.receive_sequence())
         mempool_seq += 1


### PR DESCRIPTION
#### Motivation

Now that we have the full linearization of mempool clusters, whenever a cluster in the mempool gets updated  either due to replacement, eviction for various reasons, or block connection, we now have the previous linearization of the affected cluster and the new linearization of the new clusters available.

This brings two advantages the ability for outside observers to make decisions based on fee rate diagram updates without direct access to the mempool, and reduced lock contention.

It can used primarily for:
1. Making `CBlockPolicyEstimator` package aware
2. Preventing redundant block template builds in the proposed block template manager [BlockTemplateManager Proposal](https://github.com/bitcoin/bitcoin/issues/33389).

During the development of cluster mempool those usage was discussed.
Note: This is not the motivation behind cluster mempool just a part of it. 

See discussion in [Package aware fee estimator](https://delvingbitcoin.org/t/package-aware-fee-estimator-post-cluster-mempool/312/2?u=ismaelsadeeq) and [Determining BlockTemplate Fee Increase Using Fee Rate Diagram](https://delvingbitcoin.org/t/determining-blocktemplate-fee-increase-using-fee-rate-diagram/2052/3).


Currently the fee estimator is asynchronous but not package-aware.
After this PR it is possible to make it package-aware, a follow-up branch on top of this does exactly that see [commit](https://github.com/ismaelsadeeq/bitcoin/commit/fd88b167529aca80a4f65ed6aa77ec9372a41bce).

For the mining interface, the node every 1 seconds rebuilds a block template regardless of whether any significant mempool change occurred to the top block.

Even after cluster mempool, building a block template is not free since we have to pause the node (holding `cs_main`). 

With this notification, a proposed block template manager that observes the mempool update will only rebuild after an inflow in the mempool top block template warrants it.  Redundant builds where no significant fee rate change occurred are eliminated.

And doing this becomes even more useful because of proposed improvements like mempool-based fee rate estimation, which also builds a block template. Right now, it uses a constant 7-second interval and rebuilds regardless of whether an inflow affects the top block template or not. This will fix that.

A proposed [sendtemplate](https://github.com/bitcoin/bitcoin/pull/33191) in the p2p layer also builds a block template. I propose that it also use the proposed block template manager, which should be built on top of this, so that redundant block template builds are eliminated.

There is a different approach to determining updates in the top block template, but that still requires some direct interaction with the mempool. Since the fee estimator needs this notification anyway and we already have it, the block template manager can use it too and not interact with the mempool at all, it becomes a purely passive observer.


#### Changes


  - Added `TxGraph::Chunk`, a new struct carrying a chunk fee rate plus the transaction `TxGraph::Ref`s in that chunk. This lets before/after fee-rate
  diagrams carry enough information to build mempool chunk notifications.

  - Added `MemPoolChunk` (`kernel/mempool_entry.h`), representing a mempool chunk with:
    - `m_fee_rate` — chunk fee rate.
    - `m_transactions` — transactions in the chunk.
    - `m_sigops_cost` — total sigops cost for the chunk.
    - `m_chunk_hash` — deterministic hash identifying the chunk transaction set, computed before dispatching the validation callback.

  - Added `MemPoolChunksUpdate` (`kernel/mempool_entry.h`), carrying:
    - `old_chunks` — chunks before the update.
    - `new_chunks` — chunks after the update.
    - `reason` — `MemPoolRemovalReason` identifying the update type.
    - `block_height` — set only for block-connected removals; defaults to `std::nullopt`.

  - Added a new `CValidationInterface::MempoolUpdated` callback receiving a `MemPoolChunksUpdate`.

  - Added `GetHashFromWitnesses` (`src/util/hasher.{h,cpp}`), which sorts a vector of `Wtxid`s deterministically and hashes them to produce a stable chunk
  hash. `GetPackageHash` in `src/policy/packages.cpp` now uses this helper.

  - Changed `TxGraph::GetMainStagingDiagrams()` to return chunk objects instead of fee-rate-only diagrams.

  - Cached the fee-rate diagram chunks inside `CTxMemPool::ChangeSet`, so the same snapshot can be reused for RBF feerate checks and later notification
  emission without recomputing a different diagram.

  - Extracted the dependency addition logic in `UpdateTransactionsFromBlock` into the private helper `addDependenciesFromBlock`.

  `MempoolUpdated` is emitted for mempool update paths including:

  - Transaction addition and RBF replacement: emitted in `CTxMemPool::ChangeSet::Apply` with reason `REPLACED`.
  - Block connection: emitted in `removeForBlock` with reason `BLOCK`; `block_height` carries the connecting block height.
  - Reorg removals: emitted in `removeForReorg` with reason `REORG`.
  - Recursive removals: emitted in `removeRecursive` with the caller-supplied reason, such as `CONFLICT`, `EXPIRY`, or `REORG`.
  - Expiry: emitted in `Expire` with reason `EXPIRY`.
  - Size-limit eviction: emitted in `TrimToSize` with reason `SIZELIMIT`.
  - Post-reorg dependency update: emitted in `UpdateTransactionsFromBlock` with reason `SIZELIMIT`.

  The before/after chunks are snapshotted from the txgraph staging state before committing the staging graph. The mempool entries are removed afterward
  through `RemoveStaged`.

  Note on `UpdateTransactionsFromBlock`:

  A naive single-pass approach that adds dependencies and trims directly can leave the staging graph oversized, and oversized clusters cannot produce a valid
  fee-rate diagram. The implementation therefore uses a two-stage approach:

  - Phase 1: create txgraph staging, call `addDependenciesFromBlock` to register newly discovered parent-child relationships, then call `Trim()`.

  - If `Trim()` returns no transactions, no cluster exceeded the limit. The code snapshots the diagram, commits staging, emits `MempoolUpdated(SIZELIMIT)`,
  and finishes.

  - If `Trim()` returns transactions to evict, the oversized staging graph is discarded. A fresh staging graph is opened, the evicted txs are removed from
  txgraph staging, dependencies are added again, the diagram is snapshotted, staging is committed, `MempoolUpdated(SIZELIMIT)` is emitted, and then
  `RemoveStaged` fully removes the evicted entries from the mempool.

  Reorgs are rare, and reorgs that exceed the cluster size limit are rarer still, so the common optimistic path only applies dependencies once.

  Added `mempool_update_tests`, a unit test suite covering the `MempoolUpdated` emission paths and validating chunk contents, fee rates, block height
  propagation, and deterministic chunk hashes.

  Chunk hashes are computed in `ValidationSignals::MempoolUpdated` before the event is queued, so subscribers receive chunks with populated hashes while the
  mempool mutation path avoids carrying hash computation logic directly.
