### PR TITLE
refactor: logging: Various API improvements

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -736,13 +736,12 @@ logging messages. They should be used as follows:
   most of the time, and it should be used for log messages that are
   useful for debugging and can reasonably be enabled on a production
   system (that has sufficient free storage space). They will be logged
-  if the program is started with `-debug=category` or `-debug=1`.
+  if the program is started with `-debug=category` or `-debug=1`, or
+  the category is enabled through the `logging` RPC.
 
 - `LogInfo(fmt, params...)` should only be used rarely, e.g. for startup
   messages or for infrequent and important events such as a new block tip
-  being found or a new outbound connection being made. These log messages
-  are unconditional, so care must be taken that they can't be used by an
-  attacker to fill up storage.
+  being found or a new outbound connection being made.
 
 - `LogError(fmt, params...)` should be used in place of `LogInfo` for
   severe problems that require the node (or a subsystem) to shut down
@@ -763,6 +762,13 @@ logging messages. They should be used as follows:
 Note that the format strings and parameters of `LogDebug` and `LogTrace`
 are only evaluated if the logging category is enabled, so you must be
 careful to avoid side-effects in those expressions.
+
+While `LogInfo`, `LogWarning` and `LogError` messages should be rare,
+in case there are circumstances where they are not, those messages
+are automatically rate-limited to prevent potential disk-filling
+attacks. For the cases where this protection is undesirable,
+rate-limiting can be avoided with the `util::log::NO_RATE_LIMIT` tag, eg
+`LogInfo(util::log::NO_RATE_LIMIT, "UpdateTip: new best=%s ...",...)`.
 
 ## General C++
 

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -14,7 +14,6 @@
 #include <common/settings.h>
 #include <cstdint>
 #include <hash.h>
-#include <logging.h>
 #include <logging/timer.h>
 #include <netbase.h>
 #include <netgroup.h>
@@ -24,6 +23,7 @@
 #include <univalue.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
+#include <util/log.h>
 #include <util/syserror.h>
 #include <util/translation.h>
 

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -9,7 +9,6 @@
 #include <addrman_impl.h>
 
 #include <hash.h>
-#include <logging.h>
 #include <logging/timer.h>
 #include <netaddress.h>
 #include <protocol.h>
@@ -19,6 +18,7 @@
 #include <tinyformat.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/time.h>
 
 #include <cmath>

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -5,13 +5,13 @@
 #ifndef BITCOIN_ADDRMAN_IMPL_H
 #define BITCOIN_ADDRMAN_IMPL_H
 
-#include <logging.h>
 #include <logging/timer.h>
 #include <netaddress.h>
 #include <protocol.h>
 #include <serialize.h>
 #include <sync.h>
 #include <uint256.h>
+#include <util/log.h>
 #include <util/time.h>
 
 #include <cstdint>

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -6,10 +6,10 @@
 #include <banman.h>
 
 #include <common/system.h>
-#include <logging.h>
 #include <netaddress.h>
 #include <node/interface_ui.h>
 #include <sync.h>
+#include <util/log.h>
 #include <util/time.h>
 #include <util/translation.h>
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -16,6 +16,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/init.h>
 #include <kernel/context.h>
+#include <logging.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <node/warnings.h>

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -9,10 +9,10 @@
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>
-#include <logging.h>
 #include <random.h>
 #include <streams.h>
 #include <txmempool.h>
+#include <util/log.h>
 #include <validation.h>
 
 #include <unordered_map>

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -219,7 +219,7 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
         return READ_STATUS_FAILED; // Possible Short ID collision
     }
 
-    if (LogAcceptCategory(BCLog::CMPCTBLOCK, BCLog::Level::Debug)) {
+    if (util::log::ShouldDebugLog(BCLog::CMPCTBLOCK)) {
         const uint256 hash{block.GetHash()};
         uint32_t tx_missing_size{0};
         for (const auto& tx : vtx_missing) tx_missing_size += tx->ComputeTotalSize();

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -9,9 +9,9 @@
 #include <common/args.h>
 #include <consensus/params.h>
 #include <deploymentinfo.h>
-#include <logging.h>
 #include <tinyformat.h>
 #include <util/chaintype.h>
+#include <util/log.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -7,7 +7,6 @@
 
 #include <chainparamsbase.h>
 #include <common/settings.h>
-#include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <univalue.h>
@@ -15,6 +14,7 @@
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
+#include <util/log.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -5,12 +5,12 @@
 #include <common/args.h>
 
 #include <common/settings.h>
-#include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <univalue.h>
 #include <util/chaintype.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/string.h>
 
 #include <algorithm>

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -5,9 +5,9 @@
 #include <chainparams.h>
 #include <common/args.h>
 #include <common/init.h>
-#include <logging.h>
 #include <tinyformat.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/translation.h>
 
 #include <algorithm>

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -6,9 +6,9 @@
 
 #include <common/netif.h>
 
-#include <logging.h>
 #include <netbase.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/sock.h>
 #include <util/syserror.h>
 

--- a/src/common/pcp.cpp
+++ b/src/common/pcp.cpp
@@ -7,12 +7,12 @@
 #include <atomic>
 #include <common/netif.h>
 #include <crypto/common.h>
-#include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <random.h>
 #include <span.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/readwritefile.h>
 #include <util/sock.h>
 #include <util/strencodings.h>

--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -7,7 +7,7 @@
 
 #include <common/system.h>
 
-#include <logging.h>
+#include <util/log.h>
 #include <util/string.h>
 #include <util/time.h>
 

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -59,7 +59,7 @@ public:
     // This code is adapted from posix_logger.h, which is why it is using vsprintf.
     // Please do not do this in normal code
     void Logv(const char * format, va_list ap) override {
-            if (!LogAcceptCategory(BCLog::LEVELDB, util::log::Level::Debug)) {
+            if (!util::log::ShouldDebugLog(BCLog::LEVELDB)) {
                 return;
             }
             char buffer[500];
@@ -278,7 +278,7 @@ CDBWrapper::~CDBWrapper()
 
 void CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
 {
-    const bool log_memory = LogAcceptCategory(BCLog::LEVELDB, util::log::Level::Debug);
+    const bool log_memory = util::log::ShouldDebugLog(BCLog::LEVELDB);
     double mem_before = 0;
     if (log_memory) {
         mem_before = DynamicMemoryUsage() / double(1_MiB);

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -14,7 +14,6 @@
 #include <leveldb/slice.h>
 #include <leveldb/status.h>
 #include <leveldb/write_batch.h>
-#include <logging.h>
 #include <random.h>
 #include <serialize.h>
 #include <span.h>

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/args.h>
-#include <logging.h>
+#include <util/log.h>
 #include <walletinitinterface.h>
 
 class ArgsManager;

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -4,9 +4,9 @@
 
 #include <headerssync.h>
 
-#include <logging.h>
 #include <pow.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/time.h>
 #include <util/vector.h>
 

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -7,12 +7,12 @@
 #include <common/args.h>
 #include <crypto/hmac_sha256.h>
 #include <httpserver.h>
-#include <logging.h>
 #include <netaddress.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
+#include <util/log.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <walletinitinterface.h>

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -8,7 +8,6 @@
 #include <compat/endian.h>
 #include <crypto/sha256.h>
 #include <i2p.h>
-#include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <random.h>
@@ -16,6 +15,7 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/readwritefile.h>
 #include <util/sock.h>
 #include <util/strencodings.h>

--- a/src/index/db_key.h
+++ b/src/index/db_key.h
@@ -7,9 +7,9 @@
 
 #include <dbwrapper.h>
 #include <interfaces/types.h>
-#include <logging.h>
 #include <serialize.h>
 #include <uint256.h>
+#include <util/log.h>
 
 #include <cstdint>
 #include <ios>

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -7,12 +7,12 @@
 
 #include <common/settings.h>
 #include <consensus/amount.h>
-#include <logging.h>
 #include <net.h>
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <support/allocators/secure.h>
+#include <util/log.h>
 #include <util/translation.h>
 
 #include <cstddef>

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -33,8 +33,8 @@ namespace {
 
 mp::Log GetRequestedIPCLogLevel()
 {
-    if (LogAcceptCategory(BCLog::IPC, BCLog::Level::Trace)) return mp::Log::Trace;
-    if (LogAcceptCategory(BCLog::IPC, BCLog::Level::Debug)) return mp::Log::Debug;
+    if (util::log::ShouldTraceLog(BCLog::IPC)) return mp::Log::Trace;
+    if (util::log::ShouldDebugLog(BCLog::IPC)) return mp::Log::Debug;
 
     // Info, Warning, and Error are logged unconditionally
     return mp::Log::Info;

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -10,10 +10,10 @@
 #include <ipc/exception.h>
 #include <ipc/protocol.h>
 #include <kj/async.h>
-#include <logging.h>
 #include <mp/proxy-io.h>
 #include <mp/proxy-types.h>
 #include <mp/util.h>
+#include <util/log.h>
 #include <util/threadnames.h>
 
 #include <cassert>

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -9,9 +9,9 @@
 #include <ipc/capnp/protocol.h>
 #include <ipc/process.h>
 #include <ipc/protocol.h>
-#include <logging.h>
 #include <tinyformat.h>
 #include <util/fs.h>
+#include <util/log.h>
 
 #include <csignal>
 #include <cstdio>

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -4,10 +4,10 @@
 
 #include <ipc/process.h>
 #include <ipc/protocol.h>
-#include <logging.h>
 #include <mp/util.h>
 #include <tinyformat.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/strencodings.h>
 #include <util/syserror.h>
 

--- a/src/ipc/test/ipc_test.cpp
+++ b/src/ipc/test/ipc_test.cpp
@@ -3,16 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <interfaces/init.h>
+#include <ipc/capnp/mining.capnp.h>
 #include <ipc/capnp/protocol.h>
 #include <ipc/process.h>
 #include <ipc/protocol.h>
-#include <logging.h>
-#include <mp/proxy-types.h>
-#include <ipc/capnp/mining.capnp.h>
 #include <ipc/test/ipc_test.capnp.h>
 #include <ipc/test/ipc_test.capnp.proxy.h>
 #include <ipc/test/ipc_test.h>
+#include <mp/proxy-types.h>
 #include <tinyformat.h>
+#include <util/log.h>
 #include <validation.h>
 
 #include <future>

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -612,9 +612,14 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     return true;
 }
 
-bool util::log::ShouldLog(Category category, Level level)
+bool util::log::ShouldDebugLog(Category category)
 {
-    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), level);
+    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Debug);
+}
+
+bool util::log::ShouldTraceLog(Category category)
+{
+    return LogInstance().WillLogCategoryLevel(static_cast<BCLog::LogFlags>(category), util::log::Level::Trace);
 }
 
 void util::log::Log(util::log::Entry entry)

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -224,7 +224,7 @@ static const std::unordered_map<BCLog::LogFlags, std::string> LOG_CATEGORIES_BY_
     }(LOG_CATEGORIES_BY_STR)
 };
 
-std::optional<BCLog::LogFlags> GetLogCategory(std::string_view str)
+std::optional<BCLog::LogFlags> BCLog::Logger::GetLogCategory(std::string_view str)
 {
     if (str.empty() || str == "1" || str == "all") {
         return BCLog::ALL;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -572,8 +572,7 @@ void BCLog::LogRateLimiter::Reset()
     }
     for (const auto& [source_loc, stats] : source_locations) {
         if (stats.m_dropped_bytes == 0) continue;
-        LogPrintLevel_(
-            LogFlags::ALL, Level::Warning, /*should_ratelimit=*/false,
+        LogWarning(util::log::NO_RATE_LIMIT,
             "Restarting logging from %s:%d (%s): %d bytes were dropped during the last %ss.",
             source_loc.file_name(), source_loc.line(), source_loc.function_name_short(),
             stats.m_dropped_bytes, Ticks<std::chrono::seconds>(m_reset_window));

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -514,6 +514,8 @@ void BCLog::Logger::LogPrint_(util::log::Entry entry)
 
 void BCLog::Logger::ShrinkDebugFile()
 {
+    STDLOCK(m_cs);
+
     // Amount of debug.log to save at end when shrinking (must fit in memory)
     constexpr size_t RECENT_DEBUG_HISTORY_SIZE = 10 * 1000000;
 
@@ -535,7 +537,14 @@ void BCLog::Logger::ShrinkDebugFile()
         // Restart the file with some of the end
         std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);
         if (fseek(file, -((long)vch.size()), SEEK_END)) {
-            LogWarning("Failed to shrink debug log file: fseek(...) failed");
+            // LogWarning, except with m_cs held
+            LogPrint_({
+                .category = BCLog::ALL,
+                .level = Level::Warning,
+                .should_ratelimit = true,
+                .source_loc = SourceLocation{__func__},
+                .message = "Failed to shrink debug log file: fseek(...) failed",
+            });
             fclose(file);
             return;
         }

--- a/src/logging.h
+++ b/src/logging.h
@@ -275,6 +275,9 @@ namespace BCLog {
         static std::string LogLevelToStr(BCLog::Level level);
 
         bool DefaultShrinkDebugFile() const;
+
+        //! Return log flag if str parses as a log category.
+        static std::optional<BCLog::LogFlags> GetLogCategory(std::string_view str);
     };
 } // namespace BCLog
 
@@ -285,8 +288,5 @@ static inline bool LogAcceptCategory(BCLog::LogFlags category, BCLog::Level leve
 {
     return LogInstance().WillLogCategoryLevel(category, level);
 }
-
-/// Return log flag if str parses as a log category.
-std::optional<BCLog::LogFlags> GetLogCategory(std::string_view str);
 
 #endif // BITCOIN_LOGGING_H

--- a/src/logging.h
+++ b/src/logging.h
@@ -227,7 +227,7 @@ namespace BCLog {
          */
         void DisableLogging() EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
 
-        void ShrinkDebugFile();
+        void ShrinkDebugFile() EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
 
         std::unordered_map<LogFlags, Level> CategoryLevels() const EXCLUSIVE_LOCKS_REQUIRED(!m_cs)
         {

--- a/src/logging.h
+++ b/src/logging.h
@@ -276,7 +276,6 @@ namespace BCLog {
 
         bool DefaultShrinkDebugFile() const;
     };
-
 } // namespace BCLog
 
 BCLog::Logger& LogInstance();

--- a/src/logging.h
+++ b/src/logging.h
@@ -283,10 +283,4 @@ namespace BCLog {
 
 BCLog::Logger& LogInstance();
 
-/** Return true if log accepts specified category, at the specified level. */
-static inline bool LogAcceptCategory(BCLog::LogFlags category, BCLog::Level level)
-{
-    return LogInstance().WillLogCategoryLevel(category, level);
-}
-
 #endif // BITCOIN_LOGGING_H

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -8,11 +8,11 @@
 #include <common/netif.h>
 #include <common/pcp.h>
 #include <common/system.h>
-#include <logging.h>
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <random.h>
+#include <util/log.h>
 #include <util/thread.h>
 #include <util/threadinterrupt.h>
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2607,7 +2607,7 @@ void PeerManagerImpl::SendBlockTransactions(CNode& pfrom, Peer& peer, const CBlo
         resp.txn[i] = block.vtx[req.indexes[i]];
     }
 
-    if (LogAcceptCategory(BCLog::CMPCTBLOCK, BCLog::Level::Debug)) {
+    if (util::log::ShouldDebugLog(BCLog::CMPCTBLOCK)) {
         uint32_t tx_requested_size{0};
         for (const auto& tx : resp.txn) tx_requested_size += tx->ComputeTotalSize();
         LogDebug(BCLog::CMPCTBLOCK, "Peer %d sent us a GETBLOCKTXN for block %s, sending a BLOCKTXN with %u txns. (%u bytes)\n", pfrom.GetId(), block.GetHash().ToString(), resp.txn.size(), tx_requested_size);

--- a/src/net_types.cpp
+++ b/src/net_types.cpp
@@ -4,10 +4,10 @@
 
 #include <net_types.h>
 
-#include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <univalue.h>
+#include <util/log.h>
 
 static const char* BANMAN_JSON_VERSION_KEY{"version"};
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -8,9 +8,9 @@
 #include <netbase.h>
 
 #include <compat/compat.h>
-#include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
+#include <util/log.h>
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/netgroup.cpp
+++ b/src/netgroup.cpp
@@ -5,9 +5,9 @@
 #include <netgroup.h>
 
 #include <hash.h>
-#include <logging.h>
 #include <uint256.h>
 #include <util/asmap.h>
+#include <util/log.h>
 
 #include <cstddef>
 

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -9,10 +9,10 @@
 #include <index/txindex.h>
 #include <index/txospenderindex.h>
 #include <kernel/caches.h>
-#include <logging.h>
 #include <node/interface_ui.h>
 #include <tinyformat.h>
 #include <util/byte_units.h>
+#include <util/log.h>
 
 #include <algorithm>
 #include <string>

--- a/src/node/chainstatemanager_args.cpp
+++ b/src/node/chainstatemanager_args.cpp
@@ -7,12 +7,12 @@
 #include <arith_uint256.h>
 #include <common/args.h>
 #include <common/system.h>
-#include <logging.h>
 #include <node/coins_view_args.h>
 #include <node/database_args.h>
 #include <tinyformat.h>
 #include <uint256.h>
 #include <util/byte_units.h>
+#include <util/log.h>
 #include <util/result.h>
 #include <util/strencodings.h>
 #include <util/translation.h>

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -11,11 +11,11 @@
 #include <common/system.h>
 #include <kernel/context.h>
 #include <kernel/warning.h>
-#include <logging.h>
 #include <node/abort.h>
 #include <node/interface_ui.h>
 #include <node/warnings.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -11,11 +11,11 @@
 #include <common/messages.h>
 #include <consensus/amount.h>
 #include <kernel/chainparams.h>
-#include <logging.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <tinyformat.h>
 #include <txgraph.h>
+#include <util/log.h>
 #include <util/moneystr.h>
 #include <util/translation.h>
 

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -6,7 +6,6 @@
 
 #include <clientversion.h>
 #include <consensus/amount.h>
-#include <logging.h>
 #include <primitives/transaction.h>
 #include <random.h>
 #include <serialize.h>
@@ -16,6 +15,7 @@
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
+#include <util/log.h>
 #include <util/obfuscation.h>
 #include <util/signalinterrupt.h>
 #include <util/syserror.h>

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -15,13 +15,13 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
-#include <logging.h>
 #include <node/context.h>
 #include <node/kernel_notifications.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <pow.h>
 #include <primitives/transaction.h>
+#include <util/log.h>
 #include <util/moneystr.h>
 #include <util/signalinterrupt.h>
 #include <util/time.h>

--- a/src/node/minisketchwrapper.cpp
+++ b/src/node/minisketchwrapper.cpp
@@ -4,7 +4,7 @@
 
 #include <node/minisketchwrapper.h>
 
-#include <logging.h>
+#include <util/log.h>
 #include <util/time.h>
 
 #include <minisketch.h>

--- a/src/node/timeoffsets.cpp
+++ b/src/node/timeoffsets.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <logging.h>
 #include <node/timeoffsets.h>
 #include <node/warnings.h>
 #include <sync.h>
 #include <tinyformat.h>
+#include <util/log.h>
 #include <util/time.h>
 #include <util/translation.h>
 

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -7,8 +7,8 @@
 
 #include <chain.h>
 #include <consensus/validation.h>
-#include <logging.h>
 #include <txmempool.h>
+#include <util/log.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -5,12 +5,12 @@
 #include <node/txorphanage.h>
 
 #include <consensus/validation.h>
-#include <logging.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <util/feefrac.h>
-#include <util/time.h>
 #include <util/hasher.h>
+#include <util/log.h>
+#include <util/time.h>
 
 #include <boost/multi_index/indexed_by.hpp>
 #include <boost/multi_index/ordered_index.hpp>

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -5,8 +5,8 @@
 #include <node/txreconciliation.h>
 
 #include <common/system.h>
-#include <logging.h>
 #include <util/check.h>
+#include <util/log.h>
 
 #include <unordered_map>
 #include <variant>

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -6,8 +6,8 @@
 #include <noui.h>
 
 #include <btcsignals.h>
-#include <logging.h>
 #include <node/interface_ui.h>
+#include <util/log.h>
 #include <util/translation.h>
 
 #include <string>

--- a/src/policy/fees/block_policy_estimator.cpp
+++ b/src/policy/fees/block_policy_estimator.cpp
@@ -8,7 +8,6 @@
 #include <common/system.h>
 #include <consensus/amount.h>
 #include <kernel/mempool_entry.h>
-#include <logging.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <random.h>
@@ -18,6 +17,7 @@
 #include <tinyformat.h>
 #include <uint256.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/serfloat.h>
 #include <util/syserror.h>
 #include <util/time.h>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -15,7 +15,6 @@
 #include <interfaces/handler.h>
 #include <interfaces/init.h>
 #include <interfaces/node.h>
-#include <logging.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <noui.h>
@@ -33,6 +32,7 @@
 #include <qt/winshutdownmonitor.h>
 #include <uint256.h>
 #include <util/exception.h>
+#include <util/log.h>
 #include <util/string.h>
 #include <util/threadnames.h>
 #include <util/translation.h>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -14,8 +14,8 @@
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
-#include <logging.h>
 #include <policy/policy.h>
+#include <util/log.h>
 #include <validation.h>
 
 #include <cstdint>

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -7,7 +7,7 @@
 #include <script/interpreter.h>
 #include <script/signingprovider.h>
 
-#include <logging.h>
+#include <util/log.h>
 
 const SigningProvider& DUMMY_SIGNING_PROVIDER = SigningProvider();
 

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -13,7 +13,6 @@
 #include <script/script.h>
 #include <streams.h>
 #include <uint256.h>
-#include <util/check.h>
 #include <util/log.h>
 
 #include <algorithm>

--- a/src/test/fuzz/pcp.cpp
+++ b/src/test/fuzz/pcp.cpp
@@ -8,6 +8,7 @@
 #include <test/fuzz/util/net.h>
 
 #include <common/pcp.h>
+#include <logging.h>
 #include <util/check.h>
 #include <util/threadinterrupt.h>
 

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -382,7 +382,7 @@ void LogFromLocation(Location location, const std::string& message) {
         LogDebug(BCLog::LogFlags::HTTP, "%s\n", message);
         return;
     case Location::INFO_NOLIMIT:
-        LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, /*should_ratelimit=*/false, "%s\n", message);
+        LogInfo(util::log::NO_RATE_LIMIT, "%s\n", message);
         return;
     } // no default case, so the compiler can warn about missing cases
     assert(false);

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -166,7 +166,7 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros_CategoryName, LogSetup)
     const auto category_names = SplitString(concatenated_category_names, ',');
     for (const auto& category_name : category_names) {
         const auto trimmed_category_name = TrimString(category_name);
-        const auto category{*Assert(GetLogCategory(trimmed_category_name))};
+        const auto category{*Assert(BCLog::Logger::GetLogCategory(trimmed_category_name))};
         expected_category_names.emplace_back(category, trimmed_category_name);
     }
 

--- a/src/test/node_init_tests.cpp
+++ b/src/test/node_init_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <init.h>
 #include <interfaces/init.h>
+#include <logging.h>
 #include <rpc/server.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -6,13 +6,13 @@
 #define BITCOIN_TEST_UTIL_CHAINSTATE_H
 
 #include <clientversion.h>
-#include <logging.h>
 #include <node/context.h>
 #include <node/utxo_snapshot.h>
 #include <rpc/blockchain.h>
 #include <test/util/setup_common.h>
 #include <util/byte_units.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <validation.h>
 
 #include <univalue.h>

--- a/src/test/util/random.cpp
+++ b/src/test/util/random.cpp
@@ -4,10 +4,10 @@
 
 #include <test/util/random.h>
 
-#include <logging.h>
 #include <random.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/log.h>
 
 #include <cstdlib>
 #include <iostream>

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -10,7 +10,6 @@
 #include <common/args.h>
 #include <compat/compat.h>
 #include <crypto/hmac_sha256.h>
-#include <logging.h>
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
@@ -18,6 +17,7 @@
 #include <tinyformat.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <util/readwritefile.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -112,15 +112,15 @@ using Level = util::log::Level;
 
 // Allow __func__ to be used in any context without warnings:
 // NOLINTNEXTLINE(bugprone-lambda-function-name)
-#define LogPrintLevel_(category, level, ...) util::log::LogPrintFormatInternal(SourceLocation{__func__}, category, level, __VA_ARGS__)
+#define detail_LogWithSrcLoc(category, level, ...) util::log::LogPrintFormatInternal(SourceLocation{__func__}, category, level, __VA_ARGS__)
 
 // Log unconditionally. Uses basic rate limiting to mitigate disk filling attacks.
 // Be conservative when using functions that unconditionally log to debug.log!
 // It should not be the case that an inbound peer can fill up a user's storage
 // with debug.log entries.
-#define LogInfo(...) LogPrintLevel_(BCLog::LogFlags::ALL, util::log::Level::Info, __VA_ARGS__)
-#define LogWarning(...) LogPrintLevel_(BCLog::LogFlags::ALL, util::log::Level::Warning, __VA_ARGS__)
-#define LogError(...) LogPrintLevel_(BCLog::LogFlags::ALL, util::log::Level::Error, __VA_ARGS__)
+#define LogInfo(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Info, __VA_ARGS__)
+#define LogWarning(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Warning, __VA_ARGS__)
+#define LogError(...) detail_LogWithSrcLoc(BCLog::LogFlags::ALL, util::log::Level::Error, __VA_ARGS__)
 
 // Use a macro instead of a function for conditional logging to prevent
 // evaluating arguments when logging for the category is not enabled.
@@ -132,7 +132,7 @@ using Level = util::log::Level;
     do {                                                               \
         if (util::log::ShouldLog((category), (level))) {               \
             Assume((level) < util::log::Level::Info); /*Only called with the levels below*/ \
-            LogPrintLevel_((category), (level), util::log::NO_RATE_LIMIT, __VA_ARGS__);  \
+            detail_LogWithSrcLoc((category), (level), util::log::NO_RATE_LIMIT, __VA_ARGS__);  \
         }                                                              \
     } while (0)
 

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -43,6 +43,12 @@ namespace util::log {
 /** Opaque to util::log; interpreted by consumers (e.g., BCLog::LogFlags). */
 using Category = uint64_t;
 
+//! Structure and constant for tagging not to rate limit.
+struct NoRateLimitTag {
+    explicit NoRateLimitTag() = default;
+};
+inline constexpr NoRateLimitTag NO_RATE_LIMIT{};
+
 enum class Level {
     Trace = 0, // High-volume or detailed logging for development/debugging
     Debug,     // Reasonably noisy logging, but still usable in production
@@ -68,15 +74,9 @@ bool ShouldLog(Category category, Level level);
 
 /** Send message to be logged. Applications using the logging library need to provide this. */
 void Log(Entry entry);
-} // namespace util::log
-
-namespace BCLog {
-//! Alias for compatibility. Prefer util::log::Level over BCLog::Level in new code.
-using Level = util::log::Level;
-} // namespace BCLog
 
 template <typename... Args>
-inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, BCLog::Level level, bool should_ratelimit, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+inline void LogPrintFormatInternal_(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, bool should_ratelimit, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
     std::string log_msg;
     try {
@@ -92,17 +92,35 @@ inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags 
         .message = std::move(log_msg)});
 }
 
+template <typename... Args>
+inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    return LogPrintFormatInternal_(std::move(source_loc), flag, level, /*should_ratelimit=*/true, fmt, args...);
+}
+
+template <typename... Args>
+inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags flag, util::log::Level level, util::log::NoRateLimitTag, util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
+{
+    return LogPrintFormatInternal_(std::move(source_loc), flag, level, /*should_ratelimit=*/false, fmt, args...);
+}
+} // namespace util::log
+
+namespace BCLog {
+//! Alias for compatibility. Prefer util::log::Level over BCLog::Level in new code.
+using Level = util::log::Level;
+} // namespace BCLog
+
 // Allow __func__ to be used in any context without warnings:
 // NOLINTNEXTLINE(bugprone-lambda-function-name)
-#define LogPrintLevel_(category, level, should_ratelimit, ...) LogPrintFormatInternal(SourceLocation{__func__}, category, level, should_ratelimit, __VA_ARGS__)
+#define LogPrintLevel_(category, level, ...) util::log::LogPrintFormatInternal(SourceLocation{__func__}, category, level, __VA_ARGS__)
 
 // Log unconditionally. Uses basic rate limiting to mitigate disk filling attacks.
 // Be conservative when using functions that unconditionally log to debug.log!
 // It should not be the case that an inbound peer can fill up a user's storage
 // with debug.log entries.
-#define LogInfo(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Info, /*should_ratelimit=*/true, __VA_ARGS__)
-#define LogWarning(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Warning, /*should_ratelimit=*/true, __VA_ARGS__)
-#define LogError(...) LogPrintLevel_(BCLog::LogFlags::ALL, BCLog::Level::Error, /*should_ratelimit=*/true, __VA_ARGS__)
+#define LogInfo(...) LogPrintLevel_(BCLog::LogFlags::ALL, util::log::Level::Info, __VA_ARGS__)
+#define LogWarning(...) LogPrintLevel_(BCLog::LogFlags::ALL, util::log::Level::Warning, __VA_ARGS__)
+#define LogError(...) LogPrintLevel_(BCLog::LogFlags::ALL, util::log::Level::Error, __VA_ARGS__)
 
 // Use a macro instead of a function for conditional logging to prevent
 // evaluating arguments when logging for the category is not enabled.
@@ -113,14 +131,13 @@ inline void LogPrintFormatInternal(SourceLocation&& source_loc, BCLog::LogFlags 
 #define detail_LogIfCategoryAndLevelEnabled(category, level, ...)      \
     do {                                                               \
         if (util::log::ShouldLog((category), (level))) {               \
-            bool rate_limit{level >= BCLog::Level::Info};              \
-            Assume(!rate_limit); /*Only called with the levels below*/ \
-            LogPrintLevel_(category, level, rate_limit, __VA_ARGS__);  \
+            Assume((level) < util::log::Level::Info); /*Only called with the levels below*/ \
+            LogPrintLevel_((category), (level), util::log::NO_RATE_LIMIT, __VA_ARGS__);  \
         }                                                              \
     } while (0)
 
 // Log conditionally, prefixing the output with the passed category name.
-#define LogDebug(category, ...) detail_LogIfCategoryAndLevelEnabled(category, BCLog::Level::Debug, __VA_ARGS__)
-#define LogTrace(category, ...) detail_LogIfCategoryAndLevelEnabled(category, BCLog::Level::Trace, __VA_ARGS__)
+#define LogDebug(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::Level::Debug, __VA_ARGS__)
+#define LogTrace(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::Level::Trace, __VA_ARGS__)
 
 #endif // BITCOIN_UTIL_LOG_H

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -68,9 +68,13 @@ struct Entry {
     std::string message;
 };
 
-/** Return whether messages with specified category and level should be logged. Applications using
- * the logging library need to provide this. */
-bool ShouldLog(Category category, Level level);
+/// Return whether messages with specified category should be debug logged.
+/// Applications using the logging library need to provide this.
+bool ShouldDebugLog(Category category);
+
+/// Return whether messages with specified category should be trace logged.
+/// Applications using the logging library need to provide this.
+bool ShouldTraceLog(Category category);
 
 /** Send message to be logged. Applications using the logging library need to provide this. */
 void Log(Entry entry);
@@ -128,16 +132,15 @@ using Level = util::log::Level;
 // Log by prefixing the output with the passed category name and severity level. This logs conditionally if
 // the category is allowed. No rate limiting is applied, because users specifying -debug are assumed to be
 // developers or power users who are aware that -debug may cause excessive disk usage due to logging.
-#define detail_LogIfCategoryAndLevelEnabled(category, level, ...)      \
-    do {                                                               \
-        if (util::log::ShouldLog((category), (level))) {               \
-            Assume((level) < util::log::Level::Info); /*Only called with the levels below*/ \
-            detail_LogWithSrcLoc((category), (level), util::log::NO_RATE_LIMIT, __VA_ARGS__);  \
-        }                                                              \
+#define detail_LogIfCategoryAndLevelEnabled(category, shouldlog, level, ...)                  \
+    do {                                                                                      \
+        if (shouldlog(category)) {                                                            \
+            detail_LogWithSrcLoc((category), (level), util::log::NO_RATE_LIMIT, __VA_ARGS__); \
+        }                                                                                     \
     } while (0)
 
 // Log conditionally, prefixing the output with the passed category name.
-#define LogDebug(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::Level::Debug, __VA_ARGS__)
-#define LogTrace(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::Level::Trace, __VA_ARGS__)
+#define LogDebug(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::ShouldDebugLog, util::log::Level::Debug, __VA_ARGS__)
+#define LogTrace(category, ...) detail_LogIfCategoryAndLevelEnabled(category, util::log::ShouldTraceLog, util::log::Level::Trace, __VA_ARGS__)
 
 #endif // BITCOIN_UTIL_LOG_H

--- a/src/util/stdmutex.h
+++ b/src/util/stdmutex.h
@@ -40,6 +40,4 @@ public:
 // Provide STDLOCK(..) wrapper around StdMutex::Guard that checks the lock is not already held
 #define STDLOCK(cs) StdMutex::Guard UNIQUE_NAME(criticalblock){StdMutex::CheckNotHeld(cs)}
 
-using StdLockGuard = StdMutex::Guard; // TODO: remove, provided for backwards compat only
-
 #endif // BITCOIN_UTIL_STDMUTEX_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2864,8 +2864,8 @@ static void UpdateTipLog(
 
     AssertLockHeld(::cs_main);
 
-    // Disable rate limiting in LogPrintLevel_ so this source location may log during IBD.
-    LogPrintLevel_(BCLog::LogFlags::ALL, util::log::Level::Info, /*should_ratelimit=*/false, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+    // Disable rate limiting as this may log frequently during IBD.
+    LogInfo(util::log::NO_RATE_LIMIT, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
                    prefix, func_name,
                    tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
                    log(tip->nChainWork.getdouble()) / log(2.0), tip->m_chain_tx_count,

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -171,7 +171,7 @@ void ValidationSignals::SyncWithValidationInterfaceQueue()
     } while (0)
 
 #define LOG_MSG(fmt, ...) \
-    (ShouldLog(BCLog::VALIDATION, BCLog::Level::Debug) ? tfm::format((fmt), __VA_ARGS__) : std::string{})
+    (util::log::ShouldDebugLog(BCLog::VALIDATION) ? tfm::format((fmt), __VA_ARGS__) : std::string{})
 
 #define LOG_EVENT(fmt, ...) \
     LogDebug(BCLog::VALIDATION, fmt, __VA_ARGS__)

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -8,9 +8,9 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <interfaces/chain.h>
-#include <logging.h>
 #include <policy/feerate.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/moneystr.h>
 
 #include <numeric>

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -732,7 +732,7 @@ util::Result<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, c
             result.AddInput(*lowest_larger);
         }
 
-        if (LogAcceptCategory(BCLog::SELECTCOINS, BCLog::Level::Debug)) {
+        if (util::log::ShouldDebugLog(BCLog::SELECTCOINS)) {
             std::string log_message{"Coin selection best subset: "};
             for (unsigned int i = 0; i < applicable_groups.size(); i++) {
                 if (vfBest[i]) {

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -5,8 +5,8 @@
 
 #include <chainparams.h>
 #include <common/args.h>
-#include <logging.h>
 #include <util/fs.h>
+#include <util/log.h>
 #include <wallet/db.h>
 
 #include <algorithm>

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -4,8 +4,8 @@
 
 #include <compat/byteswap.h>
 #include <crypto/common.h>
-#include <logging.h>
 #include <streams.h>
+#include <util/log.h>
 #include <util/translation.h>
 #include <wallet/migrate.h>
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -4,7 +4,6 @@
 
 #include <hash.h>
 #include <key_io.h>
-#include <logging.h>
 #include <node/types.h>
 #include <outputtype.h>
 #include <script/descriptor.h>
@@ -13,6 +12,7 @@
 #include <script/solver.h>
 #include <util/bip32.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/time.h>

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -10,13 +10,13 @@
 #include <common/messages.h>
 #include <common/signmessage.h>
 #include <common/types.h>
-#include <logging.h>
 #include <musig.h>
 #include <node/types.h>
 #include <psbt.h>
 #include <script/descriptor.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
+#include <util/log.h>
 #include <util/result.h>
 #include <util/time.h>
 #include <wallet/crypter.h>

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -267,7 +267,7 @@ void SQLiteDatabase::Open(int additional_flags)
             throw std::runtime_error(strprintf("SQLiteDatabase: Failed to enable extended result codes: %s\n", sqlite3_errstr(ret)));
         }
         // Trace SQL statements if tracing is enabled with -debug=walletdb -loglevel=walletdb:trace
-        if (LogAcceptCategory(BCLog::WALLETDB, BCLog::Level::Trace)) {
+        if (util::log::ShouldTraceLog(BCLog::WALLETDB)) {
            ret = sqlite3_trace_v2(m_db, SQLITE_TRACE_STMT, TraceSqlCallback, this);
            if (ret != SQLITE_OK) {
                LogWarning("Failed to enable SQL tracing for %s", Filename());

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -8,10 +8,10 @@
 
 #include <chainparams.h>
 #include <crypto/common.h>
-#include <logging.h>
 #include <sync.h>
 #include <util/check.h>
 #include <util/fs_helpers.h>
+#include <util/log.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
 #include <wallet/db.h>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6,6 +6,7 @@
 #include <wallet/wallet.h>
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
+
 #include <addresstype.h>
 #include <blockfilter.h>
 #include <chain.h>
@@ -26,7 +27,6 @@
 #include <kernel/types.h>
 #include <key.h>
 #include <key_io.h>
-#include <logging.h>
 #include <node/types.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
@@ -55,6 +55,7 @@
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
+#include <util/log.h>
 #include <util/moneystr.h>
 #include <util/result.h>
 #include <util/string.h>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -12,7 +12,6 @@
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <kernel/cs_main.h>
-#include <logging.h>
 #include <node/types.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
@@ -26,6 +25,7 @@
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/hasher.h>
+#include <util/log.h>
 #include <util/result.h>
 #include <util/string.h>
 #include <util/time.h>

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -7,7 +7,7 @@
 #include <chainparams.h>
 #include <common/args.h>
 #include <key_io.h>
-#include <logging.h>
+#include <util/log.h>
 
 namespace wallet {
 fs::path GetWalletDir()

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -7,11 +7,11 @@
 #include <common/args.h>
 #include <kernel/mempool_entry.h>
 #include <kernel/types.h>
-#include <logging.h>
 #include <netbase.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <zmq/zmqabstractnotifier.h>
 #include <zmq/zmqpublishnotifier.h>
 #include <zmq/zmqutil.h>

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -6,7 +6,6 @@
 
 #include <chain.h>
 #include <crypto/common.h>
-#include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <primitives/transaction.h>
@@ -14,6 +13,7 @@
 #include <streams.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <zmq/zmqutil.h>
 
 #include <zmq.h>

--- a/src/zmq/zmqutil.cpp
+++ b/src/zmq/zmqutil.cpp
@@ -5,7 +5,6 @@
 #include <zmq/zmqutil.h>
 
 #include <logging.h>
-#include <util/check.h>
 
 #include <zmq.h>
 

--- a/src/zmq/zmqutil.cpp
+++ b/src/zmq/zmqutil.cpp
@@ -4,7 +4,7 @@
 
 #include <zmq/zmqutil.h>
 
-#include <logging.h>
+#include <util/log.h>
 
 #include <zmq.h>
 


### PR DESCRIPTION
`ShrinkDebugFile` now takes the logging mutex for its entire run; though it's only called in init so shouldn't have any races in the first place.

Adds a `NO_RATE_LIMIT` tag that can be used with info/warning/error logs to avoid rate-limiting. This allows `LogPrintLevel_` to be restricted to being an internal API.

The `GetLogCategory` function is moved out of the global namespace.

`ShouldLog` is split into separate `ShouldDebugLog` and `ShouldTraceLog` so that filtering checks are somewhat more enforced via function signature checks.

Redundant `LogAcceptCategory` function is removed.

More files are pointed at util/log.h instead of logging.h.