### PR TITLE
kernel: doc: explain return value for `btck_WriteBytes` callback

### DIFF
--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -349,6 +349,8 @@ typedef void (*btck_ValidationInterfaceBlockDisconnected)(void* user_data, btck_
 
 /**
  * Function signature for serializing data.
+ *
+ * Returns 0 to indicate success.
  */
 typedef int (*btck_WriteBytes)(const void* bytes, size_t size, void* userdata);
 


### PR DESCRIPTION
Note that this is the only callback type with a non-void return type. Probably it would make sense to document the parameters of callbacks as well on the long-term (Doxygen style?), but this IMHO the most critical missing documentation, where likely other bitcoinkernel users working with the C API could trip over too.

Background: I've been working on btck bindings for [Zig](https://ziglang.org/) for a while [1]. Overall I found the C API header `bitcoinkernel.h` very well-documented and to a large degree self-explanatory, but for implementing a `btck_WriteBytes` callback (needed for various `btck_..._to_bytes` serialization functions) I had to look into the [kernel implementation](https://github.com/bitcoin/bitcoin/blob/e98d36715eace5ee54a10f2931adcbbc5f6b0a15/src/kernel/bitcoinkernel.cpp#L86) to figure out what return value is expected.

[1] still not public and put on hold for the last few months due to lib(std)c++ build system / linking issues (needing ugly workarounds, hopefully improved with Zig's upcoming 0.16 release); now continued, hopefully ready to be published in a first presentable version soon(tm)