### PR TITLE
net: advertise CJDNS addresses when `-externalip` disables discovery

### DIFF
--- a/doc/release-notes-34812.md
+++ b/doc/release-notes-34812.md
@@ -1,0 +1,9 @@
+P2P and network changes
+-----------------------
+
+- Nodes configured with `-cjdnsreachable` now advertise their CJDNS address
+  even when `-externalip` is set. Previously, specifying `-externalip`
+  implicitly disabled local address discovery, which also suppressed the
+  node's CJDNS address. CJDNS addresses live on a separate overlay network
+  and do not conflict with a manually specified external IP. Setting
+  `-discover=0` explicitly still disables CJDNS address discovery. (#34812)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -571,7 +571,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-bind=<addr>[:<port>][=onion]", strprintf("Bind to given address and always listen on it (default: 0.0.0.0). Use [host]:port notation for IPv6. Append =onion to tag any incoming connections to that address and port as incoming Tor connections (default: 127.0.0.1:%u=onion, testnet3: 127.0.0.1:%u=onion, testnet4: 127.0.0.1:%u=onion, signet: 127.0.0.1:%u=onion, regtest: 127.0.0.1:%u=onion)", defaultChainParams->GetDefaultPort() + 1, testnetChainParams->GetDefaultPort() + 1, testnet4ChainParams->GetDefaultPort() + 1, signetChainParams->GetDefaultPort() + 1, regtestChainParams->GetDefaultPort() + 1), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-cjdnsreachable", "If set, then this host is configured for CJDNS (connecting to fc00::/8 addresses would lead us to the CJDNS network, see doc/cjdns.md) (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-connect=<ip>", "Connect only to the specified node; -noconnect disables automatic connections (the rules for this peer are the same as for -addnode). This option can be specified multiple times to connect to multiple nodes.", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
-    argsman.AddArg("-discover", "Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-discover", "Discover own IP addresses (default: 1 when listening and no -externalip or -proxy). When discovery is disabled implicitly by -externalip, CJDNS addresses are still discovered; set -discover=0 explicitly to disable discovery entirely", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-dns", strprintf("Allow DNS lookups for -addnode, -seednode and -connect (default: %u)", DEFAULT_NAME_LOOKUP), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-dnsseed", strprintf("Query for peer addresses via DNS lookup, if low on addresses (default: %u unless -connect used or -maxconnections=0)", DEFAULT_DNSSEED), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-externalip=<ip>", "Specify your own public address", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
@@ -786,6 +786,10 @@ static bool AppInitServers(NodeContext& node)
 // Parameter interaction based on rules
 void InitParameterInteraction(ArgsManager& args)
 {
+    // Reset on every call so that repeated invocations (e.g. in tests) start
+    // from a clean state.
+    fDiscoverSoftDisabled = false;
+
     // when specifying an explicit binding address, you want to listen on it
     // even when -connect or -proxy is specified
     if (!args.GetArgs("-bind").empty()) {
@@ -837,8 +841,10 @@ void InitParameterInteraction(ArgsManager& args)
 
     if (!args.GetArgs("-externalip").empty()) {
         // if an explicit public IP is specified, do not try to find others
-        if (args.SoftSetBoolArg("-discover", false))
+        if (args.SoftSetBoolArg("-discover", false)) {
+            fDiscoverSoftDisabled = true;
             LogInfo("parameter interaction: -externalip set -> setting -discover=0\n");
+        }
     }
 
     if (args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -115,6 +115,7 @@ static const uint64_t RANDOMIZER_ID_NETWORKKEY = 0x0e8a2b136c592a7dULL; // SHA25
 // Global state variables
 //
 bool fDiscover = true;
+bool fDiscoverSoftDisabled = false;
 bool fListen = true;
 GlobalMutex g_maplocalhost_mutex;
 std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(g_maplocalhost_mutex);
@@ -282,7 +283,7 @@ bool AddLocal(const CService& addr_, int nScore)
     if (!addr.IsRoutable())
         return false;
 
-    if (!fDiscover && nScore < LOCAL_MANUAL)
+    if (!fDiscover && nScore < LOCAL_MANUAL && !(fDiscoverSoftDisabled && addr.IsCJDNS()))
         return false;
 
     if (!g_reachable_nets.Contains(addr))
@@ -3416,10 +3417,15 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
 
 void Discover()
 {
-    if (!fDiscover)
-        return;
+    // When -externalip soft-disabled -discover, still discover CJDNS addresses.
+    const bool cjdns_only = !fDiscover;
+    if (cjdns_only && !(fDiscoverSoftDisabled && g_reachable_nets.Contains(NET_CJDNS))) return;
 
     for (const CNetAddr &addr: GetLocalAddresses()) {
+        // Use HasCJDNSPrefix() rather than IsCJDNS() because addr has not
+        // yet been through MaybeFlipIPv6toCJDNS() (that happens in AddLocal).
+        if (cjdns_only && !addr.HasCJDNSPrefix())
+            continue;
         if (AddLocal(addr, LOCAL_IF) && fLogIPs) {
             LogInfo("%s: %s\n", __func__, addr.ToStringAddr());
         }
@@ -3490,7 +3496,7 @@ bool CConnman::Bind(const CService& addr_, unsigned int flags, NetPermissionFlag
         return false;
     }
 
-    if (addr.IsRoutable() && fDiscover && !(flags & BF_DONT_ADVERTISE) && !NetPermissions::HasFlag(permissions, NetPermissionFlags::NoBan)) {
+    if (addr.IsRoutable() && (fDiscover || (fDiscoverSoftDisabled && addr.IsCJDNS())) && !(flags & BF_DONT_ADVERTISE) && !NetPermissions::HasFlag(permissions, NetPermissionFlags::NoBan)) {
         AddLocal(addr, LOCAL_BIND);
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -172,6 +172,11 @@ bool IsLocal(const CService& addr);
 CService GetLocalAddress(const CNode& peer);
 
 extern bool fDiscover;
+/** Whether -discover was disabled implicitly by -externalip rather than explicitly
+ *  by the user. In that case CJDNS local address discovery stays enabled, since
+ *  CJDNS addresses live on a separate overlay network and do not conflict with a
+ *  manually specified external IP. */
+extern bool fDiscoverSoftDisabled;
 extern bool fListen;
 
 /** Subversion as sent to the P2P network in `version` messages */

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -838,6 +838,47 @@ BOOST_AUTO_TEST_CASE(LocalAddress_nScore_Overflow)
     BOOST_CHECK(!IsLocal(addr));
 }
 
+BOOST_AUTO_TEST_CASE(addlocal_cjdns_without_discover)
+{
+    // Test that AddLocal() accepts CJDNS addresses when -externalip soft-disables
+    // -discover, but not when discovery is disabled outright. LOCAL_IF is the
+    // score used by Discover() and LOCAL_BIND the one used by CConnman::Bind().
+    g_reachable_nets.Add(NET_CJDNS);
+
+    CService cjdns_addr{MaybeFlipIPv6toCJDNS(Lookup("fc00:1122:3344:5566:7788:9900:aabb:ccdd", 8333, /*fAllowLookup=*/false).value())};
+    BOOST_REQUIRE(cjdns_addr.IsCJDNS());
+
+    CService ipv4_addr{UtilBuildAddress(0x003, 0x001, 0x001, 0x001), 8333}; // 3.1.1.1:8333
+    g_reachable_nets.Add(NET_IPV4);
+
+    for (const int score : {LOCAL_IF, LOCAL_BIND}) {
+        // With fDiscover=true both are accepted (sanity check).
+        fDiscover = true;
+        fDiscoverSoftDisabled = false;
+        BOOST_CHECK(AddLocal(cjdns_addr, score));
+        BOOST_CHECK(AddLocal(ipv4_addr, score));
+        RemoveLocal(cjdns_addr);
+        RemoveLocal(ipv4_addr);
+
+        // With fDiscover=false, both should be rejected.
+        fDiscover = false;
+        BOOST_CHECK(!AddLocal(cjdns_addr, score));
+        BOOST_CHECK(!AddLocal(ipv4_addr, score));
+
+        // When -externalip soft-disables -discover, CJDNS should still be
+        // accepted but IPv4 should not.
+        fDiscoverSoftDisabled = true;
+        BOOST_CHECK(AddLocal(cjdns_addr, score));
+        BOOST_CHECK(!AddLocal(ipv4_addr, score));
+        RemoveLocal(cjdns_addr);
+    }
+
+    // Cleanup
+    fDiscover = true;
+    fDiscoverSoftDisabled = false;
+    g_reachable_nets.Reset();
+}
+
 BOOST_AUTO_TEST_CASE(initial_advertise_from_version_message)
 {
     LOCK(NetEventsInterface::g_msgproc_mutex);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -148,6 +148,7 @@ BasicTestingSetup::BasicTestingSetup(const ChainType chainType, TestOpts opts)
 
     // Reset globals
     fDiscover = true;
+    fDiscoverSoftDisabled = false;
     fListen = true;
     SetRPCWarmupStarting();
     g_reachable_nets.Reset();

--- a/test/functional/feature_cjdns_externalip.py
+++ b/test/functional/feature_cjdns_externalip.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that CJDNS addresses are advertised when -externalip is set.
+
+When -externalip is specified, -discover is implicitly set to 0. This
+should not prevent CJDNS bound addresses from being added to
+localaddresses, since CJDNS operates on a separate overlay network.
+"""
+
+import ipaddress
+import subprocess
+import uuid
+
+from test_framework.test_framework import BitcoinTestFramework, SkipTest
+from test_framework.util import assert_equal, p2p_port
+
+
+DOCKER_NET_LABEL = 'org.bitcoincore.functional-test'
+DOCKER_NET_LABEL_VALUE = 'feature_cjdns_externalip'
+
+
+def docker_is_available():
+    """Return True if Docker is usable on this host."""
+    try:
+        subprocess.run(['docker', 'info'], capture_output=True, check=True)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def create_cjdns_interface(network_name, subnet, gateway):
+    """Create a Docker network with an fc00::/8 subnet.
+
+    This places an fc00:: address on a non-loopback bridge interface on
+    the host, which bitcoind can bind to.
+    """
+    subprocess.run(
+        ['docker', 'network', 'create', '--ipv6',
+         '--subnet', subnet, '--gateway', gateway,
+         '--label', f'{DOCKER_NET_LABEL}={DOCKER_NET_LABEL_VALUE}',
+         network_name],
+        capture_output=True, check=True)
+
+
+def remove_cjdns_interface(network_name):
+    if network_name is None:
+        return
+
+    try:
+        inspect_result = subprocess.run(
+            ['docker', 'network', 'inspect', '--format',
+             f'{{{{ index .Labels "{DOCKER_NET_LABEL}" }}}}', network_name],
+            capture_output=True, check=False, text=True)
+    except FileNotFoundError:
+        return
+
+    if inspect_result.returncode != 0:
+        return
+    if inspect_result.stdout.strip() != DOCKER_NET_LABEL_VALUE:
+        return
+
+    subprocess.run(
+        ['docker', 'network', 'rm', network_name],
+        capture_output=True, check=False)
+
+
+class CJDNSDiscoverWithExternalIPTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.bind_to_localhost_only = False
+        self.num_nodes = 1
+        unique_id = uuid.uuid4().hex
+        cjdns_prefix = f'fc00:{int(unique_id[:4], 16):x}:{int(unique_id[4:8], 16):x}::'
+        self.docker_net_name = f'bitcoin_cjdns_test_{unique_id[:16]}'
+        self.docker_net_subnet = f'{ipaddress.IPv6Address(cjdns_prefix)}/112'
+        self.cjdns_addr = str(ipaddress.IPv6Address(f'{cjdns_prefix}1'))
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_platform_not_linux()
+        if not docker_is_available():
+            raise SkipTest(
+                "Docker must be available to run this test.")
+
+    def shutdown(self):
+        try:
+            return super().shutdown()
+        finally:
+            remove_cjdns_interface(self.docker_net_name)
+
+    def get_local_cjdns_addrs(self):
+        """Return CJDNS entries from getnetworkinfo localaddresses."""
+        local_addrs = self.nodes[0].getnetworkinfo()['localaddresses']
+        return [a for a in local_addrs if a['address'] == self.cjdns_addr]
+
+    def run_test(self):
+        try:
+            create_cjdns_interface(self.docker_net_name, self.docker_net_subnet, self.cjdns_addr)
+        except subprocess.CalledProcessError:
+            raise SkipTest(
+                "Could not create a Docker IPv6 network (unsupported on this platform).")
+
+        # The test framework disables discovery by default in bitcoin.conf.
+        # Remove that default so -externalip can soft-disable discovery here.
+        self.nodes[0].replace_in_config([("discover=0\n", "")])
+
+        port = p2p_port(0)
+        bind_arg = f'-bind=[{self.cjdns_addr}]:{port}'
+
+        self.log.info("Test: CJDNS address is not advertised with explicit -discover=0")
+        self.restart_node(0, ['-discover=0', '-cjdnsreachable'])
+        assert_equal(self.get_local_cjdns_addrs(), [])
+
+        self.log.info("Test: CJDNS bound address is not advertised with explicit -discover=0")
+        self.restart_node(0, [bind_arg, '-discover=0', '-cjdnsreachable'])
+        assert_equal(self.get_local_cjdns_addrs(), [])
+
+        self.log.info("Test: CJDNS bound address is advertised with -discover (baseline)")
+        self.restart_node(0, [bind_arg, '-discover', '-cjdnsreachable'])
+        assert self.get_local_cjdns_addrs(), (
+            f"Baseline failed: {self.cjdns_addr} not in localaddresses")
+
+        self.log.info("Test: CJDNS bound address is still advertised with -externalip")
+        self.restart_node(0, [bind_arg, '-externalip=2.2.2.2', '-cjdnsreachable'])
+        local_addrs = self.nodes[0].getnetworkinfo()['localaddresses']
+        ext_addrs = [a for a in local_addrs if a['address'] == '2.2.2.2']
+        assert ext_addrs, "externalip address 2.2.2.2 not in localaddresses"
+        assert self.get_local_cjdns_addrs(), (
+            f"{self.cjdns_addr} missing from localaddresses when -externalip is set")
+
+
+if __name__ == '__main__':
+    CJDNSDiscoverWithExternalIPTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -90,6 +90,8 @@ EXTENDED_SCRIPTS = [
     'feature_pruning.py',
     'feature_dbcrash.py',
     'feature_index_prune.py',
+    # Requires Docker to create a bindable fc00::/8 address.
+    'feature_cjdns_externalip.py',
 ]
 
 # Special script to run each bench sanity check


### PR DESCRIPTION
Fixes #33471

When `-externalip` is set, `-discover` is implicitly disabled. This prevents CJDNS bound addresses from being added to `localaddresses`, so the node never advertises itself on the CJDNS network - even though outbound CJDNS connections work fine.

CJDNS addresses live on a separate overlay network and don't conflict with manually specified external IPs, so there is no reason to suppress them. This PR adds CJDNS exceptions to the three code paths in `net.cpp` that gate on `fDiscover`:

* `AddLocal()` — accept CJDNS regardless of `fDiscover`
* `Discover()` — don't skip CJDNS-prefixed interfaces when `!fDiscover`
* `Bind()` — call `AddLocal()` for CJDNS bound addresses when `!fDiscover`

**Note to reviewers:** the functional test (`feature_cjdns_externalip.py`) requires Docker to create an `fc00::/8` bridge interface and is skipped when Docker is unavailable. It is included so reviewers can easily verify the fix end-to-end, but can be easily dropped (it's in a separate commit) if the dependency is unwanted. Note that this test cannot be run in CI containers.