### PR TITLE
lint: Temporarily revert to vulture==2.14

### DIFF
--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -45,7 +45,7 @@ ${CI_RETRY_EXE} pip3 install \
   mypy==1.19.1 \
   pyzmq==27.1.0 \
   ruff==0.15.5 \
-  vulture==2.15
+  vulture==2.14
 
 SHELLCHECK_VERSION=v0.11.0
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | \


### PR DESCRIPTION
To work around https://github.com/bitcoin/bitcoin/issues/34810

