### PR TITLE
ci: bump cirruslabs actions versions

### DIFF
--- a/.github/actions/restore-caches/action.yml
+++ b/.github/actions/restore-caches/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Restore Ccache cache
       id: ccache-cache
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@v5
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ env.CONTAINER_NAME }}-${{ github.run_id }}
@@ -14,7 +14,7 @@ runs:
 
     - name: Restore depends sources cache
       id: depends-sources
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@v5
       with:
         path: ${{ env.SOURCES_PATH }}
         key: depends-sources-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
@@ -23,7 +23,7 @@ runs:
 
     - name: Restore built depends cache
       id: depends-built
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@v5
       with:
         path: ${{ env.BASE_CACHE }}
         key: depends-built-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
@@ -32,7 +32,7 @@ runs:
 
     - name: Restore previous releases cache
       id: previous-releases
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@v5
       with:
         path: ${{ env.PREVIOUS_RELEASES_DIR }}
         key: previous-releases-${{ env.CONTAINER_NAME }}-${{ env.PREVIOUS_RELEASES_HASH }}

--- a/.github/actions/save-caches/action.yml
+++ b/.github/actions/save-caches/action.yml
@@ -11,28 +11,28 @@ runs:
         echo "previous releases direct cache hit to primary key: ${{ env.previous-releases-cache-hit }}"
 
     - name: Save Ccache cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@v5
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) }}
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ env.CONTAINER_NAME }}-${{ github.run_id }}
 
     - name: Save depends sources cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@v5
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.depends-sources-cache-hit != 'true') }}
       with:
         path: ${{ env.SOURCES_PATH }}
         key: depends-sources-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
 
     - name: Save built depends cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@v5
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.depends-built-cache-hit != 'true' )}}
       with:
         path: ${{ env.BASE_CACHE }}
         key: depends-built-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
 
     - name: Save previous releases cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@v5
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.previous-releases-cache-hit != 'true' )}}
       with:
         path: ${{ env.PREVIOUS_RELEASES_DIR }}


### PR DESCRIPTION
Fix CI deprecation warnings of form: `Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: cirruslabs/cache/restore@v4.`

As these are hiding in `.github/actions/**/*.yml` they were forgotten by the (two) previous PR(s) 😢 

https://github.com/bitcoin/bitcoin/pull/34802
https://github.com/bitcoin/bitcoin/pull/34344