### PR TITLE
test: Revert "Fix 'RuntimeError: Event loop is closed' on Windows"

### DIFF
--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -740,8 +740,6 @@ class NetworkThread(threading.Thread):
 
         NetworkThread.listeners = {}
         NetworkThread.protos = {}
-        if platform.system() == 'Windows':
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         NetworkThread.network_event_loop = asyncio.new_event_loop()
 
     def run(self):


### PR DESCRIPTION
This reverts commit f55932678facea2c36bc0708994dbef327a7df09, because it is no longer needed with recent Python 3.13.

Python 3.13 is the minimum required version on Windows, according to https://github.com/bitcoin/bitcoin/issues/29897#issuecomment-2940318094 to avoid intermittent test failures.