### PR TITLE
net: encapsulate TxRelay state and replace recursive mutexes

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5549,11 +5549,11 @@ class CompareInvMempoolOrder
 public:
     explicit CompareInvMempoolOrder(CTxMemPool* mempool) : m_mempool{mempool} {}
 
-    bool operator()(std::set<Wtxid>::iterator a, std::set<Wtxid>::iterator b)
+    bool operator()(const Wtxid& a, const Wtxid& b)
     {
         /* As std::make_heap produces a max-heap, we want the entries with the
          * higher mining score to sort later. */
-        return m_mempool->CompareMiningScoreWithTopology(*b, *a);
+        return m_mempool->CompareMiningScoreWithTopology(b, a);
     }
 };
 } // namespace
@@ -6000,7 +6000,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
 
         if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
             auto tx_inventory_batch{tx_relay->StartTxInventoryBatch(node.HasPermission(NetPermissionFlags::NoBan), current_time)};
-            if (tx_inventory_batch.m_inv_send_time_reached) {
+            if (tx_inventory_batch.InvSendTimeReached()) {
                 if (node.IsInboundConn()) {
                     tx_relay->SetNextInvSendTime(NextInvToInbounds(current_time, INBOUND_INVENTORY_BROADCAST_INTERVAL, node.m_network_key));
                 } else {
@@ -6009,9 +6009,9 @@ bool PeerManagerImpl::SendMessages(CNode& node)
             }
 
             // Respond to BIP35 mempool requests
-            if (tx_inventory_batch.m_send_trickle && tx_inventory_batch.m_send_mempool) {
+            if (tx_inventory_batch.SendTrickle() && tx_inventory_batch.SendMempool()) {
                 auto vtxinfo = m_mempool.infoAll();
-                const CFeeRate filterrate{tx_inventory_batch.m_fee_filter_received};
+                const CFeeRate filterrate{tx_inventory_batch.FeeFilterReceived()};
 
                 for (const auto& txinfo : vtxinfo) {
                     const Txid& txid{txinfo.tx->GetHash()};
@@ -6019,7 +6019,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                     const auto inv = peer.m_wtxid_relay ?
                                          CInv{MSG_WTX, wtxid.ToUint256()} :
                                          CInv{MSG_TX, txid.ToUint256()};
-                    tx_inventory_batch.m_tx_inventory_to_send.erase(wtxid);
+                    tx_inventory_batch.EraseQueued(wtxid);
 
                     // Don't send transactions that peers will not put into their mempool
                     if (txinfo.fee < filterrate.GetFee(txinfo.vsize)) {
@@ -6036,14 +6036,10 @@ bool PeerManagerImpl::SendMessages(CNode& node)
             }
 
             // Determine transactions to relay
-            if (tx_inventory_batch.m_send_trickle) {
+            if (tx_inventory_batch.SendTrickle()) {
                 // Produce a vector with all candidates for sending
-                std::vector<std::set<Wtxid>::iterator> vInvTx;
-                vInvTx.reserve(tx_inventory_batch.m_tx_inventory_to_send.size());
-                for (std::set<Wtxid>::iterator it = tx_inventory_batch.m_tx_inventory_to_send.begin(); it != tx_inventory_batch.m_tx_inventory_to_send.end(); it++) {
-                    vInvTx.push_back(it);
-                }
-                const CFeeRate filterrate{tx_inventory_batch.m_fee_filter_received};
+                std::vector<Wtxid> vInvTx{tx_inventory_batch.QueuedCandidates()};
+                const CFeeRate filterrate{tx_inventory_batch.FeeFilterReceived()};
                 // Topologically and fee-rate sort the inventory we send for privacy and priority reasons.
                 // A heap is used so that not all items need sorting if only a few are being sent.
                 CompareInvMempoolOrder compareInvMempoolOrder(&m_mempool);
@@ -6051,16 +6047,15 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                 // No reason to drain out at many times the network's capacity,
                 // especially since we have many peers and some will draw much shorter delays.
                 unsigned int nRelayedTransactions = 0;
-                size_t broadcast_max{INVENTORY_BROADCAST_TARGET + (tx_inventory_batch.m_tx_inventory_to_send.size()/1000)*5};
+                size_t broadcast_max{INVENTORY_BROADCAST_TARGET + (vInvTx.size()/1000)*5};
                 broadcast_max = std::min<size_t>(INVENTORY_BROADCAST_MAX, broadcast_max);
                 while (!vInvTx.empty() && nRelayedTransactions < broadcast_max) {
                     // Fetch the top element from the heap
                     std::pop_heap(vInvTx.begin(), vInvTx.end(), compareInvMempoolOrder);
-                    std::set<Wtxid>::iterator it = vInvTx.back();
+                    auto wtxid = vInvTx.back();
                     vInvTx.pop_back();
-                    auto wtxid = *it;
                     // Remove it from the to-be-sent set
-                    tx_inventory_batch.m_tx_inventory_to_send.erase(it);
+                    tx_inventory_batch.EraseQueued(wtxid);
                     // Not in the mempool anymore? don't bother sending it.
                     auto txinfo = m_mempool.info(wtxid);
                     if (!txinfo.tx) {
@@ -6091,7 +6086,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                     tx_relay->AddKnownTx(inv.hash);
                 }
 
-                tx_relay->ReturnTxInventory(std::move(tx_inventory_batch.m_tx_inventory_to_send));
+                tx_relay->ReturnTxInventory(std::move(tx_inventory_batch));
 
                 // Ensure we'll respond to GETDATA requests for anything we've just announced
                 const uint64_t mempool_sequence{WITH_LOCK(m_mempool.cs, return m_mempool.GetSequence())};

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -935,7 +935,7 @@ private:
 
     /** Determine whether or not a peer can request a transaction, and return it (or nullptr if not found or not allowed). */
     CTransactionRef FindTxForGetData(const Peer::TxRelay& tx_relay, const GenTxid& gtxid)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_most_recent_block_mutex, !tx_relay.m_tx_inventory_mutex);
+        EXCLUSIVE_LOCKS_REQUIRED(!m_most_recent_block_mutex);
 
     void ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic<bool>& interruptMsgProc)
         EXCLUSIVE_LOCKS_REQUIRED(!m_most_recent_block_mutex, peer.m_getdata_requests_mutex, NetEventsInterface::g_msgproc_mutex)
@@ -3659,7 +3659,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             pfrom.cleanSubVer = cleanSubVer;
         }
 
-        // Only initialize the Peer::TxRelay m_relay_txs data structure if:
+        // Only initialize the peer's transaction relay state if:
         // - this isn't an outbound block-relay-only connection, and
         // - this isn't an outbound feeler connection, and
         // - fRelay=true (the peer wishes to receive transaction announcements)
@@ -3825,13 +3825,12 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         if (auto tx_relay = peer.GetTxRelay()) {
-            // `TxRelay::m_tx_inventory_to_send` must be empty before the
-            // version handshake is completed as
-            // `TxRelay::m_next_inv_send_time` is first initialised in
-            // `SendMessages` after the verack is received. Any transactions
-            // received during the version handshake would otherwise
-            // immediately be advertised without random delay, potentially
-            // leaking the time of arrival to a spy.
+            // Transaction inventory must be empty before the version handshake
+            // is completed, as the first scheduled inventory send is initialised
+            // in `SendMessages` after the verack is received. Any transactions
+            // received during the version handshake would otherwise immediately
+            // be advertised without random delay, potentially leaking the time
+            // of arrival to a spy.
             Assume(tx_relay->IsInventoryPristine());
         }
 
@@ -6000,117 +5999,104 @@ bool PeerManagerImpl::SendMessages(CNode& node)
         }
 
         if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
-                LOCK(tx_relay->m_tx_inventory_mutex);
-                // Check whether periodic sends should happen
-                bool fSendTrickle = node.HasPermission(NetPermissionFlags::NoBan);
-                if (tx_relay->m_next_inv_send_time < current_time) {
-                    fSendTrickle = true;
-                    if (node.IsInboundConn()) {
-                        tx_relay->m_next_inv_send_time = NextInvToInbounds(current_time, INBOUND_INVENTORY_BROADCAST_INTERVAL, node.m_network_key);
-                    } else {
-                        tx_relay->m_next_inv_send_time = current_time + m_rng.rand_exp_duration(OUTBOUND_INVENTORY_BROADCAST_INTERVAL);
+            auto tx_inventory_batch{tx_relay->StartTxInventoryBatch(node.HasPermission(NetPermissionFlags::NoBan), current_time)};
+            if (tx_inventory_batch.m_inv_send_time_reached) {
+                if (node.IsInboundConn()) {
+                    tx_relay->SetNextInvSendTime(NextInvToInbounds(current_time, INBOUND_INVENTORY_BROADCAST_INTERVAL, node.m_network_key));
+                } else {
+                    tx_relay->SetNextInvSendTime(current_time + m_rng.rand_exp_duration(OUTBOUND_INVENTORY_BROADCAST_INTERVAL));
+                }
+            }
+
+            // Respond to BIP35 mempool requests
+            if (tx_inventory_batch.m_send_trickle && tx_inventory_batch.m_send_mempool) {
+                auto vtxinfo = m_mempool.infoAll();
+                const CFeeRate filterrate{tx_inventory_batch.m_fee_filter_received};
+
+                for (const auto& txinfo : vtxinfo) {
+                    const Txid& txid{txinfo.tx->GetHash()};
+                    const Wtxid& wtxid{txinfo.tx->GetWitnessHash()};
+                    const auto inv = peer.m_wtxid_relay ?
+                                         CInv{MSG_WTX, wtxid.ToUint256()} :
+                                         CInv{MSG_TX, txid.ToUint256()};
+                    tx_inventory_batch.m_tx_inventory_to_send.erase(wtxid);
+
+                    // Don't send transactions that peers will not put into their mempool
+                    if (txinfo.fee < filterrate.GetFee(txinfo.vsize)) {
+                        continue;
+                    }
+                    if (!tx_relay->IsTxRelevantAndUpdate(*txinfo.tx)) continue;
+                    tx_relay->AddKnownTx(inv.hash);
+                    vInv.push_back(inv);
+                    if (vInv.size() == MAX_INV_SZ) {
+                        MakeAndPushMessage(node, NetMsgType::INV, vInv);
+                        vInv.clear();
                     }
                 }
+            }
 
-                // Time to send but the peer has requested we not relay transactions.
-                if (fSendTrickle) {
-                    LOCK(tx_relay->m_bloom_filter_mutex);
-                    if (!tx_relay->m_relay_txs) tx_relay->m_tx_inventory_to_send.clear();
+            // Determine transactions to relay
+            if (tx_inventory_batch.m_send_trickle) {
+                // Produce a vector with all candidates for sending
+                std::vector<std::set<Wtxid>::iterator> vInvTx;
+                vInvTx.reserve(tx_inventory_batch.m_tx_inventory_to_send.size());
+                for (std::set<Wtxid>::iterator it = tx_inventory_batch.m_tx_inventory_to_send.begin(); it != tx_inventory_batch.m_tx_inventory_to_send.end(); it++) {
+                    vInvTx.push_back(it);
+                }
+                const CFeeRate filterrate{tx_inventory_batch.m_fee_filter_received};
+                // Topologically and fee-rate sort the inventory we send for privacy and priority reasons.
+                // A heap is used so that not all items need sorting if only a few are being sent.
+                CompareInvMempoolOrder compareInvMempoolOrder(&m_mempool);
+                std::make_heap(vInvTx.begin(), vInvTx.end(), compareInvMempoolOrder);
+                // No reason to drain out at many times the network's capacity,
+                // especially since we have many peers and some will draw much shorter delays.
+                unsigned int nRelayedTransactions = 0;
+                size_t broadcast_max{INVENTORY_BROADCAST_TARGET + (tx_inventory_batch.m_tx_inventory_to_send.size()/1000)*5};
+                broadcast_max = std::min<size_t>(INVENTORY_BROADCAST_MAX, broadcast_max);
+                while (!vInvTx.empty() && nRelayedTransactions < broadcast_max) {
+                    // Fetch the top element from the heap
+                    std::pop_heap(vInvTx.begin(), vInvTx.end(), compareInvMempoolOrder);
+                    std::set<Wtxid>::iterator it = vInvTx.back();
+                    vInvTx.pop_back();
+                    auto wtxid = *it;
+                    // Remove it from the to-be-sent set
+                    tx_inventory_batch.m_tx_inventory_to_send.erase(it);
+                    // Not in the mempool anymore? don't bother sending it.
+                    auto txinfo = m_mempool.info(wtxid);
+                    if (!txinfo.tx) {
+                        continue;
+                    }
+                    // TxRelay's known-inventory filter contains either txids or wtxids
+                    // depending on whether our peer supports wtxid-relay. Therefore, first
+                    // construct the inv and then use its hash for the filter check.
+                    const auto inv = peer.m_wtxid_relay ?
+                                         CInv{MSG_WTX, wtxid.ToUint256()} :
+                                         CInv{MSG_TX, txinfo.tx->GetHash().ToUint256()};
+                    // Check if not in the filter already
+                    if (tx_relay->TxInventoryKnownContains(inv.hash)) {
+                        continue;
+                    }
+                    // Peer told you to not send transactions at that feerate? Don't bother sending it.
+                    if (txinfo.fee < filterrate.GetFee(txinfo.vsize)) {
+                        continue;
+                    }
+                    if (!tx_relay->IsTxRelevantAndUpdate(*txinfo.tx)) continue;
+                    // Send
+                    vInv.push_back(inv);
+                    nRelayedTransactions++;
+                    if (vInv.size() == MAX_INV_SZ) {
+                        MakeAndPushMessage(node, NetMsgType::INV, vInv);
+                        vInv.clear();
+                    }
+                    tx_relay->AddKnownTx(inv.hash);
                 }
 
-                // Respond to BIP35 mempool requests
-                if (fSendTrickle && tx_relay->m_send_mempool) {
-                    auto vtxinfo = m_mempool.infoAll();
-                    tx_relay->m_send_mempool = false;
-                    const CFeeRate filterrate{tx_relay->m_fee_filter_received.load()};
+                tx_relay->ReturnTxInventory(std::move(tx_inventory_batch.m_tx_inventory_to_send));
 
-                    LOCK(tx_relay->m_bloom_filter_mutex);
-
-                    for (const auto& txinfo : vtxinfo) {
-                        const Txid& txid{txinfo.tx->GetHash()};
-                        const Wtxid& wtxid{txinfo.tx->GetWitnessHash()};
-                        const auto inv = peer.m_wtxid_relay ?
-                                             CInv{MSG_WTX, wtxid.ToUint256()} :
-                                             CInv{MSG_TX, txid.ToUint256()};
-                        tx_relay->m_tx_inventory_to_send.erase(wtxid);
-
-                        // Don't send transactions that peers will not put into their mempool
-                        if (txinfo.fee < filterrate.GetFee(txinfo.vsize)) {
-                            continue;
-                        }
-                        if (tx_relay->m_bloom_filter) {
-                            if (!tx_relay->m_bloom_filter->IsRelevantAndUpdate(*txinfo.tx)) continue;
-                        }
-                        tx_relay->m_tx_inventory_known_filter.insert(inv.hash);
-                        vInv.push_back(inv);
-                        if (vInv.size() == MAX_INV_SZ) {
-                            MakeAndPushMessage(node, NetMsgType::INV, vInv);
-                            vInv.clear();
-                        }
-                    }
-                }
-
-                // Determine transactions to relay
-                if (fSendTrickle) {
-                    // Produce a vector with all candidates for sending
-                    std::vector<std::set<Wtxid>::iterator> vInvTx;
-                    vInvTx.reserve(tx_relay->m_tx_inventory_to_send.size());
-                    for (std::set<Wtxid>::iterator it = tx_relay->m_tx_inventory_to_send.begin(); it != tx_relay->m_tx_inventory_to_send.end(); it++) {
-                        vInvTx.push_back(it);
-                    }
-                    const CFeeRate filterrate{tx_relay->m_fee_filter_received.load()};
-                    // Topologically and fee-rate sort the inventory we send for privacy and priority reasons.
-                    // A heap is used so that not all items need sorting if only a few are being sent.
-                    CompareInvMempoolOrder compareInvMempoolOrder(&m_mempool);
-                    std::make_heap(vInvTx.begin(), vInvTx.end(), compareInvMempoolOrder);
-                    // No reason to drain out at many times the network's capacity,
-                    // especially since we have many peers and some will draw much shorter delays.
-                    unsigned int nRelayedTransactions = 0;
-                    LOCK(tx_relay->m_bloom_filter_mutex);
-                    size_t broadcast_max{INVENTORY_BROADCAST_TARGET + (tx_relay->m_tx_inventory_to_send.size()/1000)*5};
-                    broadcast_max = std::min<size_t>(INVENTORY_BROADCAST_MAX, broadcast_max);
-                    while (!vInvTx.empty() && nRelayedTransactions < broadcast_max) {
-                        // Fetch the top element from the heap
-                        std::pop_heap(vInvTx.begin(), vInvTx.end(), compareInvMempoolOrder);
-                        std::set<Wtxid>::iterator it = vInvTx.back();
-                        vInvTx.pop_back();
-                        auto wtxid = *it;
-                        // Remove it from the to-be-sent set
-                        tx_relay->m_tx_inventory_to_send.erase(it);
-                        // Not in the mempool anymore? don't bother sending it.
-                        auto txinfo = m_mempool.info(wtxid);
-                        if (!txinfo.tx) {
-                            continue;
-                        }
-                        // `TxRelay::m_tx_inventory_known_filter` contains either txids or wtxids
-                        // depending on whether our peer supports wtxid-relay. Therefore, first
-                        // construct the inv and then use its hash for the filter check.
-                        const auto inv = peer.m_wtxid_relay ?
-                                             CInv{MSG_WTX, wtxid.ToUint256()} :
-                                             CInv{MSG_TX, txinfo.tx->GetHash().ToUint256()};
-                        // Check if not in the filter already
-                        if (tx_relay->m_tx_inventory_known_filter.contains(inv.hash)) {
-                            continue;
-                        }
-                        // Peer told you to not send transactions at that feerate? Don't bother sending it.
-                        if (txinfo.fee < filterrate.GetFee(txinfo.vsize)) {
-                            continue;
-                        }
-                        if (tx_relay->m_bloom_filter && !tx_relay->m_bloom_filter->IsRelevantAndUpdate(*txinfo.tx)) continue;
-                        // Send
-                        vInv.push_back(inv);
-                        nRelayedTransactions++;
-                        if (vInv.size() == MAX_INV_SZ) {
-                            MakeAndPushMessage(node, NetMsgType::INV, vInv);
-                            vInv.clear();
-                        }
-                        tx_relay->m_tx_inventory_known_filter.insert(inv.hash);
-                    }
-
-                    // Ensure we'll respond to GETDATA requests for anything we've just announced
-                    LOCK(m_mempool.cs);
-                    tx_relay->m_last_inv_sequence = m_mempool.GetSequence();
-                }
+                // Ensure we'll respond to GETDATA requests for anything we've just announced
+                const uint64_t mempool_sequence{WITH_LOCK(m_mempool.cs, return m_mempool.GetSequence())};
+                tx_relay->SetLastInvSequence(mempool_sequence);
+            }
         }
         if (!vInv.empty())
             MakeAndPushMessage(node, NetMsgType::INV, vInv);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -37,6 +37,7 @@
 #include <node/txdownloadman.h>
 #include <node/txorphanage.h>
 #include <node/txreconciliation.h>
+#include <node/txrelay.h>
 #include <node/warnings.h>
 #include <policy/feerate.h>
 #include <policy/fees/block_policy_estimator.h>
@@ -287,37 +288,7 @@ struct Peer {
       * to the peer. */
     std::chrono::microseconds m_next_send_feefilter GUARDED_BY(NetEventsInterface::g_msgproc_mutex){0};
 
-    struct TxRelay {
-        mutable RecursiveMutex m_bloom_filter_mutex;
-        /** Whether we relay transactions to this peer. */
-        bool m_relay_txs GUARDED_BY(m_bloom_filter_mutex){false};
-        /** A bloom filter for which transactions to announce to the peer. See BIP37. */
-        std::unique_ptr<CBloomFilter> m_bloom_filter PT_GUARDED_BY(m_bloom_filter_mutex) GUARDED_BY(m_bloom_filter_mutex){nullptr};
-
-        mutable RecursiveMutex m_tx_inventory_mutex;
-        /** A filter of all the (w)txids that the peer has announced to
-         *  us or we have announced to the peer. We use this to avoid announcing
-         *  the same (w)txid to a peer that already has the transaction. */
-        CRollingBloomFilter m_tx_inventory_known_filter GUARDED_BY(m_tx_inventory_mutex){50000, 0.000001};
-        /** Set of wtxids we still have to announce. For non-wtxid-relay peers,
-         *  we retrieve the txid from the corresponding mempool transaction when
-         *  constructing the `inv` message. We use the mempool to sort transactions
-         *  in dependency order before relay, so this does not have to be sorted. */
-        std::set<Wtxid> m_tx_inventory_to_send GUARDED_BY(m_tx_inventory_mutex);
-        /** Whether the peer has requested us to send our complete mempool. Only
-         *  permitted if the peer has NetPermissionFlags::Mempool or we advertise
-         *  NODE_BLOOM. See BIP35. */
-        bool m_send_mempool GUARDED_BY(m_tx_inventory_mutex){false};
-        /** The next time after which we will send an `inv` message containing
-         *  transaction announcements to this peer. */
-        std::chrono::microseconds m_next_inv_send_time GUARDED_BY(m_tx_inventory_mutex){0};
-        /** The mempool sequence num at which we sent the last `inv` message to this peer.
-         *  Can relay txs with lower sequence numbers than this (see CTxMempool::info_for_relay). */
-        uint64_t m_last_inv_sequence GUARDED_BY(m_tx_inventory_mutex){1};
-
-        /** Minimum fee rate with which to filter transaction announcements to this node. See BIP133. */
-        std::atomic<CAmount> m_fee_filter_received{0};
-    };
+    using TxRelay = node::TxRelay;
 
     /* Initializes a TxRelay struct for this peer. Can be called at most once for a peer. */
     TxRelay* SetTxRelay() EXCLUSIVE_LOCKS_REQUIRED(!m_tx_relay_mutex)
@@ -1156,8 +1127,7 @@ static void AddKnownTx(Peer& peer, const uint256& hash)
     auto tx_relay = peer.GetTxRelay();
     if (!tx_relay) return;
 
-    LOCK(tx_relay->m_tx_inventory_mutex);
-    tx_relay->m_tx_inventory_known_filter.insert(hash);
+    tx_relay->AddKnownTx(hash);
 }
 
 /** Whether this peer can serve us blocks. */
@@ -1838,11 +1808,11 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
     }
 
     if (auto tx_relay = peer->GetTxRelay(); tx_relay != nullptr) {
-        stats.m_relay_txs = WITH_LOCK(tx_relay->m_bloom_filter_mutex, return tx_relay->m_relay_txs);
-        stats.m_fee_filter_received = tx_relay->m_fee_filter_received.load();
-        LOCK(tx_relay->m_tx_inventory_mutex);
-        stats.m_last_inv_seq = tx_relay->m_last_inv_sequence;
-        stats.m_inv_to_send = tx_relay->m_tx_inventory_to_send.size();
+        stats.m_relay_txs = tx_relay->GetRelayTxs();
+        stats.m_fee_filter_received = tx_relay->GetFeeFilterReceived();
+        const auto inv_stats = tx_relay->GetInventoryStats();
+        stats.m_last_inv_seq = inv_stats.m_last_inv_seq;
+        stats.m_inv_to_send = inv_stats.m_inv_to_send;
     } else {
         stats.m_relay_txs = false;
         stats.m_fee_filter_received = 0;
@@ -2278,18 +2248,8 @@ void PeerManagerImpl::InitiateTxBroadcastToAll(const Txid& txid, const Wtxid& wt
         auto tx_relay = peer.GetTxRelay();
         if (!tx_relay) continue;
 
-        LOCK(tx_relay->m_tx_inventory_mutex);
-        // Only queue transactions for announcement once the version handshake
-        // is completed. The time of arrival for these transactions is
-        // otherwise at risk of leaking to a spy, if the spy is able to
-        // distinguish transactions received during the handshake from the rest
-        // in the announcement.
-        if (tx_relay->m_next_inv_send_time == 0s) continue;
-
         const uint256& hash{peer.m_wtxid_relay ? wtxid.ToUint256() : txid.ToUint256()};
-        if (!tx_relay->m_tx_inventory_known_filter.contains(hash)) {
-            tx_relay->m_tx_inventory_to_send.insert(wtxid);
-        }
+        tx_relay->PushInventory(hash, wtxid);
     }
 }
 
@@ -2466,24 +2426,19 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         } else if (inv.IsMsgWitnessBlk()) {
             MakeAndPushMessage(pfrom, NetMsgType::BLOCK, TX_WITH_WITNESS(*pblock));
         } else if (inv.IsMsgFilteredBlk()) {
-            bool sendMerkleBlock = false;
-            CMerkleBlock merkleBlock;
+            std::optional<CMerkleBlock> merkle_block;
             if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
-                LOCK(tx_relay->m_bloom_filter_mutex);
-                if (tx_relay->m_bloom_filter) {
-                    sendMerkleBlock = true;
-                    merkleBlock = CMerkleBlock(*pblock, *tx_relay->m_bloom_filter);
-                }
+                merkle_block = tx_relay->MakeMerkleBlock(*pblock);
             }
-            if (sendMerkleBlock) {
-                MakeAndPushMessage(pfrom, NetMsgType::MERKLEBLOCK, merkleBlock);
+            if (merkle_block) {
+                MakeAndPushMessage(pfrom, NetMsgType::MERKLEBLOCK, *merkle_block);
                 // CMerkleBlock just contains hashes, so also push any transactions in the block the client did not see
                 // This avoids hurting performance by pointlessly requiring a round-trip
                 // Note that there is currently no way for a node to request any single transactions we didn't send here -
                 // they must either disconnect and retry or request the full block.
                 // Thus, the protocol spec specified allows for us to provide duplicate txn here,
                 // however we MUST always provide at least what the remote peer needs
-                for (const auto& [tx_idx, _] : merkleBlock.vMatchedTxn)
+                for (const auto& [tx_idx, _] : merkle_block->vMatchedTxn)
                     MakeAndPushMessage(pfrom, NetMsgType::TX, TX_NO_WITNESS(*pblock->vtx[tx_idx]));
             }
             // else
@@ -2526,7 +2481,7 @@ CTransactionRef PeerManagerImpl::FindTxForGetData(const Peer::TxRelay& tx_relay,
     // If a tx was in the mempool prior to the last INV for this peer, permit the request.
     auto txinfo{std::visit(
         [&](const auto& id) {
-            return m_mempool.info_for_relay(id, WITH_LOCK(tx_relay.m_tx_inventory_mutex, return tx_relay.m_last_inv_sequence));
+            return m_mempool.info_for_relay(id, tx_relay.GetLastInvSequence());
         },
         gtxid)};
     if (txinfo.tx) {
@@ -3714,10 +3669,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             !pfrom.IsFeelerConn() &&
             (fRelay || (peer.m_our_services & NODE_BLOOM))) {
             auto* const tx_relay = peer.SetTxRelay();
-            {
-                LOCK(tx_relay->m_bloom_filter_mutex);
-                tx_relay->m_relay_txs = fRelay; // set to true after we get the first filter* message
-            }
+            tx_relay->SetRelayTxs(fRelay); // set to true after we get the first filter* message
             if (fRelay) pfrom.m_relays_txs = true;
         }
 
@@ -3759,7 +3711,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // - this is not an addr fetch connection;
             // - we are not in -blocksonly mode.
             const auto* tx_relay = peer.GetTxRelay();
-            if (tx_relay && WITH_LOCK(tx_relay->m_bloom_filter_mutex, return tx_relay->m_relay_txs) &&
+            if (tx_relay && tx_relay->GetRelayTxs() &&
                 !pfrom.IsAddrFetchConn() && !m_opts.ignore_incoming_txs) {
                 const uint64_t recon_salt = m_txreconciliation->PreRegisterPeer(pfrom.GetId());
                 MakeAndPushMessage(pfrom, NetMsgType::SENDTXRCNCL,
@@ -3880,10 +3832,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // received during the version handshake would otherwise
             // immediately be advertised without random delay, potentially
             // leaking the time of arrival to a spy.
-            Assume(WITH_LOCK(
-                tx_relay->m_tx_inventory_mutex,
-                return tx_relay->m_tx_inventory_to_send.empty() &&
-                       tx_relay->m_next_inv_send_time == 0s));
+            Assume(tx_relay->IsInventoryPristine());
         }
 
         if (pfrom.IsPrivateBroadcastConn()) {
@@ -4059,7 +4008,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         // This flag might also be false in other cases, but the RejectIncomingTxs check above
         // eliminates them, so that this flag fully represents what we are looking for.
         const auto* tx_relay = peer.GetTxRelay();
-        if (!tx_relay || !WITH_LOCK(tx_relay->m_bloom_filter_mutex, return tx_relay->m_relay_txs)) {
+        if (!tx_relay || !tx_relay->GetRelayTxs()) {
             LogDebug(BCLog::NET, "sendtxrcncl received which indicated no tx relay to us, %s", pfrom.DisconnectMsg());
             pfrom.fDisconnect = true;
             return;
@@ -4955,8 +4904,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
-            LOCK(tx_relay->m_tx_inventory_mutex);
-            tx_relay->m_send_mempool = true;
+            tx_relay->SetSendMempool();
         }
         return;
     }
@@ -5000,11 +4948,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // There is no excuse for sending a too-large filter
             Misbehaving(peer, "too-large bloom filter");
         } else if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
-            {
-                LOCK(tx_relay->m_bloom_filter_mutex);
-                tx_relay->m_bloom_filter.reset(new CBloomFilter(filter));
-                tx_relay->m_relay_txs = true;
-            }
+            tx_relay->SetBloomFilter(std::move(filter));
             pfrom.m_bloom_filter_loaded = true;
             pfrom.m_relays_txs = true;
         }
@@ -5026,10 +4970,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         if (vData.size() > MAX_SCRIPT_ELEMENT_SIZE) {
             bad = true;
         } else if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
-            LOCK(tx_relay->m_bloom_filter_mutex);
-            if (tx_relay->m_bloom_filter) {
-                tx_relay->m_bloom_filter->insert(vData);
-            } else {
+            if (!tx_relay->AddToBloomFilter(vData)) {
                 bad = true;
             }
         }
@@ -5048,11 +4989,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         auto tx_relay = peer.GetTxRelay();
         if (!tx_relay) return;
 
-        {
-            LOCK(tx_relay->m_bloom_filter_mutex);
-            tx_relay->m_bloom_filter = nullptr;
-            tx_relay->m_relay_txs = true;
-        }
+        tx_relay->ClearBloomFilter();
         pfrom.m_bloom_filter_loaded = false;
         pfrom.m_relays_txs = true;
         return;
@@ -5063,7 +5000,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         vRecv >> newFeeFilter;
         if (MoneyRange(newFeeFilter)) {
             if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
-                tx_relay->m_fee_filter_received = newFeeFilter;
+                tx_relay->SetFeeFilterReceived(newFeeFilter);
             }
             LogDebug(BCLog::NET, "received: feefilter of %s from peer=%d\n", CFeeRate(newFeeFilter).ToString(), pfrom.GetId());
         }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -138,9 +138,9 @@ public:
 
     /**
      * Initiate a transaction broadcast to eligible peers.
-     * Queue the witness transaction id to `Peer::TxRelay::m_tx_inventory_to_send`
-     * for each peer. Later, depending on `Peer::TxRelay::m_next_inv_send_time` and if
-     * the transaction is in the mempool, an `INV` about it may be sent to the peer.
+     * Queue the witness transaction id for each peer. Later, depending on the peer's
+     * scheduled inventory relay time and if the transaction is in the mempool, an
+     * `INV` about it may be sent to the peer.
      */
     virtual void InitiateTxBroadcastToAll(const Txid& txid, const Wtxid& wtxid) = 0;
 

--- a/src/node/txrelay.h
+++ b/src/node/txrelay.h
@@ -25,7 +25,9 @@
 
 namespace node {
 
-struct TxRelay {
+class TxRelay
+{
+private:
     mutable RecursiveMutex m_bloom_filter_mutex;
     /** Whether we relay transactions to this peer. */
     bool m_relay_txs GUARDED_BY(m_bloom_filter_mutex){false};
@@ -56,6 +58,7 @@ struct TxRelay {
     /** Minimum fee rate with which to filter transaction announcements to this node. See BIP133. */
     std::atomic<CAmount> m_fee_filter_received{0};
 
+public:
     bool GetRelayTxs() const EXCLUSIVE_LOCKS_REQUIRED(!m_bloom_filter_mutex)
     {
         return WITH_LOCK(m_bloom_filter_mutex, return m_relay_txs);
@@ -111,6 +114,12 @@ struct TxRelay {
         return WITH_LOCK(m_tx_inventory_mutex, return m_last_inv_sequence);
     }
 
+    void SetLastInvSequence(uint64_t sequence) EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        LOCK(m_tx_inventory_mutex);
+        m_last_inv_sequence = sequence;
+    }
+
     void SetSendMempool() EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
     {
         LOCK(m_tx_inventory_mutex);
@@ -126,6 +135,12 @@ struct TxRelay {
     {
         LOCK(m_tx_inventory_mutex);
         return {m_last_inv_sequence, m_tx_inventory_to_send.size()};
+    }
+
+    void SetNextInvSendTime(std::chrono::microseconds next_time) EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        LOCK(m_tx_inventory_mutex);
+        m_next_inv_send_time = next_time;
     }
 
     /** Queue a transaction for relay if the peer doesn't already know about
@@ -148,6 +163,64 @@ struct TxRelay {
     {
         LOCK(m_tx_inventory_mutex);
         return m_tx_inventory_to_send.empty() && m_next_inv_send_time == std::chrono::microseconds{0};
+    }
+
+    struct TxInventoryBatch {
+        bool m_send_trickle{false};
+        bool m_send_mempool{false};
+        bool m_inv_send_time_reached{false};
+        CAmount m_fee_filter_received{0};
+        std::set<Wtxid> m_tx_inventory_to_send;
+    };
+
+    TxInventoryBatch StartTxInventoryBatch(bool send_trickle, std::chrono::microseconds current_time)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        TxInventoryBatch batch;
+        batch.m_fee_filter_received = m_fee_filter_received.load();
+
+        LOCK(m_tx_inventory_mutex);
+        if (m_next_inv_send_time < current_time) {
+            send_trickle = true;
+            batch.m_inv_send_time_reached = true;
+            m_next_inv_send_time = current_time;
+        }
+        batch.m_send_trickle = send_trickle;
+        if (!send_trickle) return batch;
+
+        {
+            LOCK(m_bloom_filter_mutex);
+            if (!m_relay_txs) m_tx_inventory_to_send.clear();
+        }
+
+        batch.m_send_mempool = m_send_mempool;
+        m_send_mempool = false;
+        // New inventory can be queued while this batch is processed. Unsent
+        // entries from the batch are merged back by ReturnTxInventory(). If the
+        // caller unwinds before that, the batch's unsent entries are dropped;
+        // SendMessages() does not recover from that exceptional path.
+        batch.m_tx_inventory_to_send.swap(m_tx_inventory_to_send);
+        return batch;
+    }
+
+    void ReturnTxInventory(std::set<Wtxid> tx_inventory_to_send) EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        if (tx_inventory_to_send.empty()) return;
+
+        LOCK(m_tx_inventory_mutex);
+        m_tx_inventory_to_send.merge(tx_inventory_to_send);
+    }
+
+    bool TxInventoryKnownContains(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        LOCK(m_tx_inventory_mutex);
+        return m_tx_inventory_known_filter.contains(hash);
+    }
+
+    bool IsTxRelevantAndUpdate(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(!m_bloom_filter_mutex)
+    {
+        LOCK(m_bloom_filter_mutex);
+        return !m_bloom_filter || m_bloom_filter->IsRelevantAndUpdate(tx);
     }
 
     CAmount GetFeeFilterReceived() const

--- a/src/node/txrelay.h
+++ b/src/node/txrelay.h
@@ -1,0 +1,166 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_TXRELAY_H
+#define BITCOIN_NODE_TXRELAY_H
+
+#include <common/bloom.h>
+#include <consensus/amount.h>
+#include <merkleblock.h>
+#include <primitives/transaction.h>
+#include <primitives/transaction_identifier.h>
+#include <sync.h>
+#include <uint256.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <set>
+#include <span>
+#include <utility>
+
+namespace node {
+
+struct TxRelay {
+    mutable RecursiveMutex m_bloom_filter_mutex;
+    /** Whether we relay transactions to this peer. */
+    bool m_relay_txs GUARDED_BY(m_bloom_filter_mutex){false};
+    /** A bloom filter for which transactions to announce to the peer. See BIP37. */
+    std::unique_ptr<CBloomFilter> m_bloom_filter PT_GUARDED_BY(m_bloom_filter_mutex) GUARDED_BY(m_bloom_filter_mutex){nullptr};
+
+    mutable RecursiveMutex m_tx_inventory_mutex;
+    /** A filter of all the (w)txids that the peer has announced to
+     *  us or we have announced to the peer. We use this to avoid announcing
+     *  the same (w)txid to a peer that already has the transaction. */
+    CRollingBloomFilter m_tx_inventory_known_filter GUARDED_BY(m_tx_inventory_mutex){50000, 0.000001};
+    /** Set of wtxids we still have to announce. For non-wtxid-relay peers,
+     *  we retrieve the txid from the corresponding mempool transaction when
+     *  constructing the `inv` message. We use the mempool to sort transactions
+     *  in dependency order before relay, so this does not have to be sorted. */
+    std::set<Wtxid> m_tx_inventory_to_send GUARDED_BY(m_tx_inventory_mutex);
+    /** Whether the peer has requested us to send our complete mempool. Only
+     *  permitted if the peer has NetPermissionFlags::Mempool or we advertise
+     *  NODE_BLOOM. See BIP35. */
+    bool m_send_mempool GUARDED_BY(m_tx_inventory_mutex){false};
+    /** The next time after which we will send an `inv` message containing
+     *  transaction announcements to this peer. */
+    std::chrono::microseconds m_next_inv_send_time GUARDED_BY(m_tx_inventory_mutex){0};
+    /** The mempool sequence num at which we sent the last `inv` message to this peer.
+     *  Can relay txs with lower sequence numbers than this (see CTxMempool::info_for_relay). */
+    uint64_t m_last_inv_sequence GUARDED_BY(m_tx_inventory_mutex){1};
+
+    /** Minimum fee rate with which to filter transaction announcements to this node. See BIP133. */
+    std::atomic<CAmount> m_fee_filter_received{0};
+
+    bool GetRelayTxs() const EXCLUSIVE_LOCKS_REQUIRED(!m_bloom_filter_mutex)
+    {
+        return WITH_LOCK(m_bloom_filter_mutex, return m_relay_txs);
+    }
+
+    void SetRelayTxs(bool relay_txs) EXCLUSIVE_LOCKS_REQUIRED(!m_bloom_filter_mutex)
+    {
+        LOCK(m_bloom_filter_mutex);
+        m_relay_txs = relay_txs;
+    }
+
+    void SetBloomFilter(CBloomFilter filter) EXCLUSIVE_LOCKS_REQUIRED(!m_bloom_filter_mutex)
+    {
+        LOCK(m_bloom_filter_mutex);
+        m_bloom_filter = std::make_unique<CBloomFilter>(std::move(filter));
+        m_relay_txs = true;
+    }
+
+    /** Returns false if no bloom filter is set. */
+    bool AddToBloomFilter(std::span<const unsigned char> data) EXCLUSIVE_LOCKS_REQUIRED(!m_bloom_filter_mutex)
+    {
+        LOCK(m_bloom_filter_mutex);
+        if (!m_bloom_filter) return false;
+        m_bloom_filter->insert(data);
+        return true;
+    }
+
+    void ClearBloomFilter() EXCLUSIVE_LOCKS_REQUIRED(!m_bloom_filter_mutex)
+    {
+        LOCK(m_bloom_filter_mutex);
+        m_bloom_filter = nullptr;
+        m_relay_txs = true;
+    }
+
+    /** Compute a BIP37 merkle block from `block`, filtered through this
+     *  peer's bloom filter, or std::nullopt if no filter is set. Matched
+     *  transactions are added to the filter (see CMerkleBlock). */
+    std::optional<CMerkleBlock> MakeMerkleBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_bloom_filter_mutex)
+    {
+        LOCK(m_bloom_filter_mutex);
+        if (!m_bloom_filter) return std::nullopt;
+        return CMerkleBlock{block, *m_bloom_filter};
+    }
+
+    void AddKnownTx(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        LOCK(m_tx_inventory_mutex);
+        m_tx_inventory_known_filter.insert(hash);
+    }
+
+    uint64_t GetLastInvSequence() const EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        return WITH_LOCK(m_tx_inventory_mutex, return m_last_inv_sequence);
+    }
+
+    void SetSendMempool() EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        LOCK(m_tx_inventory_mutex);
+        m_send_mempool = true;
+    }
+
+    struct InventoryStats {
+        uint64_t m_last_inv_seq;
+        size_t m_inv_to_send;
+    };
+
+    InventoryStats GetInventoryStats() const EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        LOCK(m_tx_inventory_mutex);
+        return {m_last_inv_sequence, m_tx_inventory_to_send.size()};
+    }
+
+    /** Queue a transaction for relay if the peer doesn't already know about
+     *  it. Only queue transactions for announcement once the version handshake
+     *  is completed. The time of arrival for these transactions is otherwise
+     *  at risk of leaking to a spy, if the spy is able to distinguish
+     *  transactions received during the handshake from the rest in the
+     *  announcement. */
+    void PushInventory(const uint256& hash, const Wtxid& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        LOCK(m_tx_inventory_mutex);
+        if (m_next_inv_send_time == std::chrono::microseconds{0}) return;
+        if (!m_tx_inventory_known_filter.contains(hash)) {
+            m_tx_inventory_to_send.insert(wtxid);
+        }
+    }
+
+    /** Returns true if the inventory is empty and no send has been scheduled. */
+    bool IsInventoryPristine() const EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        LOCK(m_tx_inventory_mutex);
+        return m_tx_inventory_to_send.empty() && m_next_inv_send_time == std::chrono::microseconds{0};
+    }
+
+    CAmount GetFeeFilterReceived() const
+    {
+        return m_fee_filter_received.load();
+    }
+
+    void SetFeeFilterReceived(CAmount fee_filter_received)
+    {
+        m_fee_filter_received = fee_filter_received;
+    }
+};
+
+} // namespace node
+
+#endif // BITCOIN_NODE_TXRELAY_H

--- a/src/node/txrelay.h
+++ b/src/node/txrelay.h
@@ -22,6 +22,7 @@
 #include <set>
 #include <span>
 #include <utility>
+#include <vector>
 
 namespace node {
 
@@ -165,12 +166,30 @@ public:
         return m_tx_inventory_to_send.empty() && m_next_inv_send_time == std::chrono::microseconds{0};
     }
 
-    struct TxInventoryBatch {
+    class TxInventoryBatch
+    {
+        friend class TxRelay;
+
+        TxInventoryBatch() = default;
+
         bool m_send_trickle{false};
         bool m_send_mempool{false};
         bool m_inv_send_time_reached{false};
         CAmount m_fee_filter_received{0};
         std::set<Wtxid> m_tx_inventory_to_send;
+
+    public:
+        TxInventoryBatch(const TxInventoryBatch&) = delete;
+        TxInventoryBatch& operator=(const TxInventoryBatch&) = delete;
+        TxInventoryBatch(TxInventoryBatch&&) noexcept = default;
+        TxInventoryBatch& operator=(TxInventoryBatch&&) noexcept = default;
+
+        bool SendTrickle() const { return m_send_trickle; }
+        bool SendMempool() const { return m_send_mempool; }
+        bool InvSendTimeReached() const { return m_inv_send_time_reached; }
+        CAmount FeeFilterReceived() const { return m_fee_filter_received; }
+        std::vector<Wtxid> QueuedCandidates() const { return {m_tx_inventory_to_send.begin(), m_tx_inventory_to_send.end()}; }
+        void EraseQueued(const Wtxid& wtxid) { m_tx_inventory_to_send.erase(wtxid); }
     };
 
     TxInventoryBatch StartTxInventoryBatch(bool send_trickle, std::chrono::microseconds current_time)
@@ -203,12 +222,18 @@ public:
         return batch;
     }
 
-    void ReturnTxInventory(std::set<Wtxid> tx_inventory_to_send) EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    TxInventoryBatch StartTxInventoryBatch(bool send_trickle)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex, !m_bloom_filter_mutex)
     {
-        if (tx_inventory_to_send.empty()) return;
+        return StartTxInventoryBatch(send_trickle, std::chrono::microseconds::min());
+    }
+
+    void ReturnTxInventory(TxInventoryBatch&& batch) EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+    {
+        if (batch.m_tx_inventory_to_send.empty()) return;
 
         LOCK(m_tx_inventory_mutex);
-        m_tx_inventory_to_send.merge(tx_inventory_to_send);
+        m_tx_inventory_to_send.merge(batch.m_tx_inventory_to_send);
     }
 
     bool TxInventoryKnownContains(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)

--- a/src/node/txrelay.h
+++ b/src/node/txrelay.h
@@ -29,13 +29,13 @@ namespace node {
 class TxRelay
 {
 private:
-    mutable RecursiveMutex m_bloom_filter_mutex;
+    mutable Mutex m_bloom_filter_mutex ACQUIRED_AFTER(m_tx_inventory_mutex);
     /** Whether we relay transactions to this peer. */
     bool m_relay_txs GUARDED_BY(m_bloom_filter_mutex){false};
     /** A bloom filter for which transactions to announce to the peer. See BIP37. */
     std::unique_ptr<CBloomFilter> m_bloom_filter PT_GUARDED_BY(m_bloom_filter_mutex) GUARDED_BY(m_bloom_filter_mutex){nullptr};
 
-    mutable RecursiveMutex m_tx_inventory_mutex;
+    mutable Mutex m_tx_inventory_mutex ACQUIRED_BEFORE(m_bloom_filter_mutex);
     /** A filter of all the (w)txids that the peer has announced to
      *  us or we have announced to the peer. We use this to avoid announcing
      *  the same (w)txid to a peer that already has the transaction. */
@@ -193,7 +193,7 @@ public:
     };
 
     TxInventoryBatch StartTxInventoryBatch(bool send_trickle, std::chrono::microseconds current_time)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex, !m_bloom_filter_mutex)
     {
         TxInventoryBatch batch;
         batch.m_fee_filter_received = m_fee_filter_received.load();

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -120,6 +120,7 @@ add_executable(test_bitcoin
   txindex_tests.cpp
   txospenderindex_tests.cpp
   txpackage_tests.cpp
+  txrelay_tests.cpp
   txreconciliation_tests.cpp
   txrequest_tests.cpp
   txvalidation_tests.cpp

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -133,6 +133,7 @@ add_executable(fuzz
   tx_pool.cpp
   txgraph.cpp
   txorphan.cpp
+  txrelay.cpp
   txrequest.cpp
   utxo_snapshot.cpp
   utxo_total_supply.cpp

--- a/src/test/fuzz/txrelay.cpp
+++ b/src/test/fuzz/txrelay.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/bloom.h>
+#include <consensus/amount.h>
+#include <node/txrelay.h>
+#include <primitives/transaction_identifier.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/random.h>
+#include <uint256.h>
+
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+FUZZ_TARGET(txrelay)
+{
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    FuzzedDataProvider provider{buffer.data(), buffer.size()};
+    node::TxRelay tx_relay;
+
+    bool relay_txs{false};
+    bool bloom_filter_loaded{false};
+    CAmount fee_filter_received{0};
+
+    while (provider.remaining_bytes() > 0) {
+        CallOneOf(
+            provider,
+            [&] {
+                relay_txs = provider.ConsumeBool();
+                tx_relay.SetRelayTxs(relay_txs);
+            },
+            [&] {
+                tx_relay.SetBloomFilter(CBloomFilter{
+                    provider.ConsumeIntegralInRange<unsigned int>(1, 1000),
+                    provider.ConsumeFloatingPointInRange<double>(0.000001, 0.1),
+                    provider.ConsumeIntegral<unsigned int>(),
+                    provider.ConsumeIntegralInRange<unsigned char>(BLOOM_UPDATE_NONE, BLOOM_UPDATE_MASK)});
+                relay_txs = true;
+                bloom_filter_loaded = true;
+            },
+            [&] {
+                tx_relay.ClearBloomFilter();
+                relay_txs = true;
+                bloom_filter_loaded = false;
+            },
+            [&] {
+                const auto data{ConsumeRandomLengthByteVector(provider, /*max_length=*/32)};
+                assert(tx_relay.AddToBloomFilter(data) == bloom_filter_loaded);
+            },
+            [&] {
+                tx_relay.AddKnownTx(ConsumeUInt256(provider));
+            },
+            [&] {
+                tx_relay.SetSendMempool();
+                assert(tx_relay.StartTxInventoryBatch(/*send_trickle=*/true).SendMempool());
+            },
+            [&] {
+                fee_filter_received = provider.ConsumeIntegral<CAmount>();
+                tx_relay.SetFeeFilterReceived(fee_filter_received);
+            },
+            [&] {
+                tx_relay.SetNextInvSendTime(std::chrono::microseconds{provider.ConsumeIntegral<int64_t>()});
+            },
+            [&] {
+                const uint256 hash{ConsumeUInt256(provider)};
+                tx_relay.PushInventory(hash, Wtxid::FromUint256(hash));
+            },
+            [&] {
+                (void)tx_relay.GetInventoryStats();
+                (void)tx_relay.IsInventoryPristine();
+                (void)tx_relay.GetLastInvSequence();
+                assert(tx_relay.GetRelayTxs() == relay_txs);
+                assert(tx_relay.GetFeeFilterReceived() == fee_filter_received);
+            },
+            [&] {
+                auto batch{tx_relay.StartTxInventoryBatch(provider.ConsumeBool())};
+                for (const auto& wtxid : batch.QueuedCandidates()) {
+                    if (provider.ConsumeBool()) batch.EraseQueued(wtxid);
+                }
+                tx_relay.ReturnTxInventory(std::move(batch));
+            });
+    }
+}

--- a/src/test/txrelay_tests.cpp
+++ b/src/test/txrelay_tests.cpp
@@ -1,0 +1,289 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/txrelay.h>
+#include <primitives/block.h>
+#include <random.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <set>
+#include <thread>
+#include <utility>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+BOOST_FIXTURE_TEST_SUITE(txrelay_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(txrelay_bloom_filter_lifecycle)
+{
+    node::TxRelay tx_relay;
+    const std::vector<unsigned char> data{1, 2, 3};
+
+    BOOST_CHECK(!tx_relay.GetRelayTxs());
+    BOOST_CHECK(!tx_relay.AddToBloomFilter(data));
+
+    tx_relay.SetBloomFilter(CBloomFilter{10, 0.001, 0, BLOOM_UPDATE_NONE});
+    BOOST_CHECK(tx_relay.GetRelayTxs());
+    BOOST_CHECK(tx_relay.AddToBloomFilter(data));
+
+    tx_relay.ClearBloomFilter();
+    BOOST_CHECK(tx_relay.GetRelayTxs());
+    BOOST_CHECK(!tx_relay.AddToBloomFilter(data));
+}
+
+BOOST_AUTO_TEST_CASE(txrelay_inventory_gated_until_send_scheduled)
+{
+    node::TxRelay tx_relay;
+    const uint256 hash{uint256::ONE};
+    const Wtxid wtxid{Wtxid::FromUint256(hash)};
+
+    BOOST_CHECK(tx_relay.IsInventoryPristine());
+    tx_relay.PushInventory(hash, wtxid);
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 0U);
+    BOOST_CHECK(tx_relay.IsInventoryPristine());
+
+    tx_relay.SetNextInvSendTime(1us);
+    BOOST_CHECK(!tx_relay.IsInventoryPristine());
+
+    tx_relay.PushInventory(hash, wtxid);
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 1U);
+}
+
+BOOST_AUTO_TEST_CASE(txrelay_known_inventory_not_requeued)
+{
+    node::TxRelay tx_relay;
+    tx_relay.SetRelayTxs(true);
+    tx_relay.SetNextInvSendTime(1us);
+
+    const uint256 first_hash{uint256::ONE};
+    tx_relay.PushInventory(first_hash, Wtxid::FromUint256(first_hash));
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 1U);
+
+    const uint256 known_hash{uint256{2}};
+    tx_relay.AddKnownTx(known_hash);
+    tx_relay.PushInventory(known_hash, Wtxid::FromUint256(known_hash));
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 1U);
+}
+
+BOOST_AUTO_TEST_CASE(txrelay_state_accessors)
+{
+    node::TxRelay tx_relay;
+
+    BOOST_CHECK_EQUAL(tx_relay.GetLastInvSequence(), 1U);
+    tx_relay.SetLastInvSequence(42);
+    BOOST_CHECK_EQUAL(tx_relay.GetLastInvSequence(), 42U);
+
+    BOOST_CHECK(!tx_relay.StartTxInventoryBatch(/*send_trickle=*/true).SendMempool());
+    tx_relay.SetSendMempool();
+    BOOST_CHECK(tx_relay.StartTxInventoryBatch(/*send_trickle=*/true).SendMempool());
+    BOOST_CHECK(!tx_relay.StartTxInventoryBatch(/*send_trickle=*/true).SendMempool());
+
+    tx_relay.SetFeeFilterReceived(123);
+    BOOST_CHECK_EQUAL(tx_relay.GetFeeFilterReceived(), 123);
+}
+
+BOOST_AUTO_TEST_CASE(txrelay_inventory_batch_schedules_before_snapshot)
+{
+    node::TxRelay tx_relay;
+
+    auto batch{tx_relay.StartTxInventoryBatch(/*send_trickle=*/false, 1us)};
+    BOOST_CHECK(batch.SendTrickle());
+    BOOST_CHECK(batch.InvSendTimeReached());
+    tx_relay.SetNextInvSendTime(2us);
+
+    const uint256 hash{uint256::ONE};
+    tx_relay.PushInventory(hash, Wtxid::FromUint256(hash));
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 1U);
+
+    auto early_batch{tx_relay.StartTxInventoryBatch(/*send_trickle=*/false, 1us)};
+    BOOST_CHECK(!early_batch.SendTrickle());
+    BOOST_CHECK(!early_batch.InvSendTimeReached());
+}
+
+// StartTxInventoryBatch drops queued inventory at snapshot time when the peer
+// has disabled tx relay. This exercises the nested bloom-lock branch (the only
+// place both mutexes are held, in the m_tx_inventory_mutex -> m_bloom_filter_mutex
+// order).
+BOOST_AUTO_TEST_CASE(txrelay_inventory_batch_cleared_when_relay_disabled)
+{
+    node::TxRelay tx_relay;
+    tx_relay.SetNextInvSendTime(1us); // open the gate (PushInventory ignores the relay flag)
+
+    const uint256 hash{uint256::ONE};
+    tx_relay.PushInventory(hash, Wtxid::FromUint256(hash));
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 1U);
+
+    tx_relay.SetRelayTxs(false); // peer asked us not to relay transactions
+    auto batch{tx_relay.StartTxInventoryBatch(/*send_trickle=*/true)};
+    BOOST_CHECK_EQUAL(batch.QueuedCandidates().size(), 0U);
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 0U);
+}
+
+BOOST_AUTO_TEST_CASE(txrelay_inventory_batch_moves_and_returns_queued_inventory)
+{
+    node::TxRelay tx_relay;
+    tx_relay.SetRelayTxs(true);
+    tx_relay.SetNextInvSendTime(1us);
+
+    const uint256 hash{uint256::ONE};
+    tx_relay.PushInventory(hash, Wtxid::FromUint256(hash));
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 1U);
+
+    auto batch{tx_relay.StartTxInventoryBatch(/*send_trickle=*/true)};
+    BOOST_CHECK(batch.SendTrickle());
+    BOOST_CHECK_EQUAL(batch.QueuedCandidates().size(), 1U);
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 0U);
+
+    tx_relay.ReturnTxInventory(std::move(batch));
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 1U);
+
+    auto processed_batch{tx_relay.StartTxInventoryBatch(/*send_trickle=*/true)};
+    processed_batch.EraseQueued(Wtxid::FromUint256(hash));
+    tx_relay.ReturnTxInventory(std::move(processed_batch));
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 0U);
+}
+
+// Conservation invariant (single-threaded): across repeated snapshot/drain
+// rounds, the inventory the batch hands out is exactly what is pending, and the
+// union of everything "sent" (erased from a batch) with everything still queued
+// always equals the originally queued set. No wtxid is invented or dropped by
+// the StartTxInventoryBatch swap / ReturnTxInventory merge.
+BOOST_AUTO_TEST_CASE(txrelay_inventory_batch_conserves_inventory)
+{
+    node::TxRelay tx_relay;
+    tx_relay.SetRelayTxs(true);
+    tx_relay.SetNextInvSendTime(1us); // open the announcement gate
+
+    constexpr size_t N{200};
+    std::set<Wtxid> queued; // ground truth of what is still pending
+    for (size_t i = 0; i < N; ++i) {
+        const uint256 hash{m_rng.rand256()};
+        tx_relay.PushInventory(hash, Wtxid::FromUint256(hash));
+        queued.insert(Wtxid::FromUint256(hash));
+    }
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, queued.size());
+
+    std::set<Wtxid> sent;
+    for (int round = 0; round < 8 && !queued.empty(); ++round) {
+        auto batch{tx_relay.StartTxInventoryBatch(/*send_trickle=*/true)};
+
+        // The swap empties the live queue and hands us exactly what was pending.
+        BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 0U);
+        const auto candidates{batch.QueuedCandidates()};
+        BOOST_CHECK(std::set<Wtxid>(candidates.begin(), candidates.end()) == queued);
+
+        // "Send" a random subset by erasing it from the batch; the remainder is
+        // returned to the live queue.
+        for (const auto& wtxid : candidates) {
+            if (m_rng.randbool()) {
+                batch.EraseQueued(wtxid);
+                BOOST_CHECK(sent.insert(wtxid).second); // never sent twice
+                queued.erase(wtxid);
+            }
+        }
+        tx_relay.ReturnTxInventory(std::move(batch));
+
+        // Conservation after the round: live queue == ground-truth remainder.
+        BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, queued.size());
+    }
+
+    // The sent set and the remaining queue partition the original, no overlap.
+    auto final_batch{tx_relay.StartTxInventoryBatch(/*send_trickle=*/true)};
+    const auto remaining{final_batch.QueuedCandidates()};
+    BOOST_CHECK(std::set<Wtxid>(remaining.begin(), remaining.end()) == queued);
+    for (const auto& wtxid : remaining) BOOST_CHECK(!sent.contains(wtxid));
+}
+
+// Conservation invariant under concurrency: one thread keeps queuing inventory
+// via PushInventory() while another keeps draining via the snapshot/merge batch
+// (as SendMessages() does, holding no TxRelay mutex during the drain). Every
+// queued wtxid must be drained exactly once -- none lost to the swap, none
+// duplicated by the merge. Run under ThreadSanitizer to also check that the
+// only synchronization is TxRelay's own mutex (no data race introduced by
+// moving work out of the lock).
+BOOST_AUTO_TEST_CASE(txrelay_inventory_batch_conserves_under_concurrent_push)
+{
+    node::TxRelay tx_relay;
+    tx_relay.SetRelayTxs(true);
+    tx_relay.SetNextInvSendTime(1us); // open the announcement gate
+
+    // A fixed universe of distinct wtxids, each queued exactly once.
+    constexpr size_t N{2000};
+    std::set<Wtxid> expected;
+    while (expected.size() < N) expected.insert(Wtxid::FromUint256(m_rng.rand256()));
+    const std::vector<Wtxid> universe{expected.begin(), expected.end()};
+
+    std::atomic<bool> producer_done{false};
+
+    // Producer thread: queue every wtxid once, concurrently with the drainer.
+    // Performs no Boost.Test assertions (those run only on the main thread).
+    std::thread producer{[&] {
+        for (const auto& wtxid : universe) {
+            tx_relay.PushInventory(wtxid.ToUint256(), wtxid);
+        }
+        producer_done.store(true);
+    }};
+
+    // Drainer (main thread): repeatedly snapshot the queue and "send" every
+    // candidate by erasing it, recording what was drained. After the producer
+    // is done, keep draining until a post-join snapshot comes back empty --
+    // i.e. nothing is left pending or in flight.
+    std::set<Wtxid> drained;
+    auto drain_once = [&] {
+        auto batch{tx_relay.StartTxInventoryBatch(/*send_trickle=*/true)};
+        const auto candidates{batch.QueuedCandidates()};
+        for (const auto& wtxid : candidates) {
+            BOOST_CHECK(drained.insert(wtxid).second); // each drained at most once
+            batch.EraseQueued(wtxid);
+        }
+        tx_relay.ReturnTxInventory(std::move(batch)); // nothing left to return
+        return candidates.empty();
+    };
+
+    while (!producer_done.load()) drain_once();
+
+    producer.join();
+
+    while (!drain_once()) {}
+
+    // Every queued wtxid was drained exactly once; queue is empty at the end.
+    BOOST_CHECK(drained == expected);
+    BOOST_CHECK_EQUAL(drained.size(), N);
+    BOOST_CHECK_EQUAL(tx_relay.GetInventoryStats().m_inv_to_send, 0U);
+}
+
+// MakeMerkleBlock returns nullopt when no bloom filter is loaded, and a
+// CMerkleBlock filtered through the peer's bloom filter when one is.
+BOOST_AUTO_TEST_CASE(txrelay_make_merkle_block)
+{
+    node::TxRelay tx_relay;
+
+    CMutableTransaction coinbase;
+    coinbase.vin.resize(1);
+    coinbase.vin[0].prevout.SetNull();
+    coinbase.vout.resize(1);
+    CBlock block;
+    block.vtx.push_back(MakeTransactionRef(coinbase));
+    const Txid txid{block.vtx[0]->GetHash()};
+
+    // No filter loaded -> no merkle block.
+    BOOST_CHECK(!tx_relay.MakeMerkleBlock(block).has_value());
+
+    // A filter matching the coinbase -> a merkle block containing it.
+    CBloomFilter filter{10, 0.001, 0, BLOOM_UPDATE_ALL};
+    filter.insert(txid.ToUint256());
+    tx_relay.SetBloomFilter(filter);
+
+    const auto merkle_block{tx_relay.MakeMerkleBlock(block)};
+    BOOST_REQUIRE(merkle_block.has_value());
+    BOOST_REQUIRE_EQUAL(merkle_block->vMatchedTxn.size(), 1U);
+    BOOST_CHECK(merkle_block->vMatchedTxn[0].second == txid);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Part of #19303.

This PR refactors per-peer transaction relay state so `TxRelay` owns its guarded data and lock boundaries before replacing its `RecursiveMutex` members with plain `Mutex`.

Before this change, `Peer::TxRelay` was mostly a collection of public state inside `net_processing.cpp`. 
Callers directly locked its mutexes, inspected its fields, and mutated its containers. 
That made the mutex type change hard to review: replacing `RecursiveMutex` with `Mutex` is only clearly safe if outside code cannot accidentally recurse, take locks in the wrong order, or bypass the intended state transitions.

The main changes are:

- Move `Peer::TxRelay` into `node::TxRelay`.
- Route bloom-filter and transaction-inventory state changes through named `TxRelay` methods.
- Remove direct `TxRelay` field and mutex access from `net_processing.cpp`.
- Snapshot queued transaction inventory into a `TxInventoryBatch` in `SendMessages()`, process it without holding the `TxRelay` mutex, and merge unsent entries back afterward.
- Hide the batch backing storage behind a small semantic API.
- Add unit tests and a fuzz target for the extracted `TxRelay` behavior.
- Replace the two `RecursiveMutex` members with `Mutex` and annotate the inventory-before-bloom lock order.

No P2P behavior change is intended. The purpose is to move from "external code locks and mutates TxRelay internals" to "TxRelay owns its state transitions and locking contract."

The most important commit to review is the `SendMessages()` batch snapshot refactor, because that is where the lock ownership model changes. The final mutex replacement is intentionally small after the state has been encapsulated.