### PR TITLE
rpc: add wtxid lookup support to getrawtransaction

### DIFF
--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -172,4 +172,9 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
     }
     return nullptr;
 }
+
+CTransactionRef GetTransaction(const CTxMemPool& mempool, const Wtxid& hash)
+{
+    return mempool.get(hash);
+}
 } // namespace node

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -71,6 +71,18 @@ static const CAmount DEFAULT_MAX_BURN_AMOUNT{0};
  * @returns                    The tx if found, otherwise nullptr
  */
 CTransactionRef GetTransaction(const CBlockIndex* block_index, const CTxMemPool* mempool, const Txid& hash, const BlockManager& blockman, uint256& hashBlock);
+
+/**
+ * Return a mempool transaction with a given witness hash.
+ *
+ * @param[in] mempool   mempool reference
+ * @param[in] hash      the wtxid
+ * @returns             the tx if found, otherwise nullptr
+ *
+ * @note -txindex does not support lookups by wtxid. Lookups using a block hash
+ *       are possible, but have not been implemented.
+ */
+CTransactionRef GetTransaction(const CTxMemPool& mempool, const Wtxid& hash);
 } // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -228,7 +228,7 @@ static RPCHelpMan getrawtransaction()
                 "If verbosity is 1, returns a JSON Object with information about the transaction.\n"
                 "If verbosity is 2, returns a JSON Object with information about the transaction, including fee and prevout information.",
                 {
-                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                    {"txid|wtxid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id (txid or wtxid)"},
                     {"verbosity|verbose", RPCArg::Type::NUM, RPCArg::Default{0}, "0 for hex-encoded data, 1 for a JSON object, and 2 for JSON object with fee and prevout",
                      RPCArgOptions{.skip_type_check = true}},
                     {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "The block in which to look for the transaction"},
@@ -283,11 +283,10 @@ static RPCHelpMan getrawtransaction()
 {
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
-
-    auto txid{Txid::FromUint256(ParseHashV(request.params[0], "parameter 1"))};
+    const uint256 hash{ParseHashV(request.params[0], "parameter 1")};
     const CBlockIndex* blockindex = nullptr;
 
-    if (txid.ToUint256() == chainman.GetParams().GenesisBlock().hashMerkleRoot) {
+    if (hash == chainman.GetParams().GenesisBlock().hashMerkleRoot) {
         // Special exception for the genesis block coinbase transaction
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "The genesis block coinbase is not considered an ordinary transaction and cannot be retrieved");
     }
@@ -310,7 +309,11 @@ static RPCHelpMan getrawtransaction()
     }
 
     uint256 hash_block;
-    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), txid, chainman.m_blockman, hash_block);
+    const Txid txid{Txid::FromUint256(hash)};
+    CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), txid, chainman.m_blockman, hash_block);
+    if (!tx && node.mempool && !blockindex) {
+        tx = node.mempool->get(Wtxid::FromUint256(hash));
+    }
     if (!tx) {
         std::string errmsg;
         if (blockindex) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -627,6 +627,15 @@ CTransactionRef CTxMemPool::get(const Txid& hash) const
     return i->GetSharedTx();
 }
 
+CTransactionRef CTxMemPool::get(const Wtxid& hash) const
+{
+    LOCK(cs);
+    const auto& wtxid_map{mapTx.get<index_by_wtxid>()};
+    const auto it{wtxid_map.find(hash)};
+    if (it == wtxid_map.end()) return nullptr;
+    return it->GetSharedTx();
+}
+
 void CTxMemPool::PrioritiseTransaction(const Txid& hash, const CAmount& nFeeDelta)
 {
     {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -514,7 +514,21 @@ public:
 
     const CTxMemPoolEntry* GetEntry(const Txid& txid) const LIFETIMEBOUND EXCLUSIVE_LOCKS_REQUIRED(cs);
 
+    /**
+     * Return a mempool transaction with a given hash.
+     *
+     * @param[in] hash      the txid
+     * @returns             the tx if found, otherwise nullptr
+     */
     CTransactionRef get(const Txid& hash) const;
+
+    /**
+     * Return a mempool transaction with a given witness hash.
+     *
+     * @param[in] hash      the wtxid
+     * @returns             the tx if found, otherwise nullptr
+     */
+    CTransactionRef get(const Wtxid& hash) const;
 
     template <TxidOrWtxid T>
     TxMempoolInfo info(const T& id) const

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -91,6 +91,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.decoderawtransaction_tests()
         self.transaction_version_number_tests()
         self.getrawtransaction_verbosity_tests()
+        self.getrawtransaction_wtxid_tests()
 
     def getrawtransaction_tests(self):
         tx = self.wallet.send_self_transfer(from_node=self.nodes[0])
@@ -496,6 +497,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx = tx.serialize().hex()
         decrawtx = self.nodes[0].decoderawtransaction(rawtx)
         assert_equal(decrawtx['version'], 0xffffffff)
+
+    def getrawtransaction_wtxid_tests(self):
+        #Test wtxid lookup in mempool
+        self.log.info("Test wtxid lookup in mempool")
+        mempool_tx = self.wallet.send_self_transfer(from_node=self.nodes[0])
+        wtxid = self.nodes[0].getmempoolentry(mempool_tx['txid'])['wtxid']
+        assert_equal(self.nodes[0].getrawtransaction(wtxid), mempool_tx['hex'])
 
 if __name__ == '__main__':
     RawTransactionsTest(__file__).main()


### PR DESCRIPTION
`getrawtransaction()` now accepts a wtxid in addition to a txid. If the initial txid lookup fails, the hash is retried as a wtxid against the mempool. Wtxid lookup is mempool-only since the txindex indexes by txid.

## Use case

If you have a wtxid and want to look up the transaction, there's currently no way to do it without scanning the whole mempool. To find a transaction by wtxid, you'd have to call `getrawmempool true` and iterate through every result to match it. There's no direct lookup. 

This adds wtxid lookup support to `getrawtransaction`.

Closes #34013
