### PR TITLE
fuzz: set fSuccessfullyConnected in connman harness

### DIFF
--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -89,6 +89,8 @@ FUZZ_TARGET(connman, .init = initialize_connman)
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100) {
         CNode& p2p_node{*ConsumeNodeAsUniquePtr(fuzzed_data_provider).release()};
+        // Simulate post-handshake state.
+        p2p_node.fSuccessfullyConnected = true;
         connman.AddTestNode(p2p_node);
     }
 


### PR DESCRIPTION
The connman fuzz harness never sets `fSuccessfullyConnected=true` on nodes added through `AddTestNode()`. `NodeFullyConnected()` gates `ForEachNode()` on that flag, making its callback unreachable in the current harness.
Set `fSuccessfullyConnected=true` before `AddTestNode()` to simulate a node that has completed the version handshake. 