### PR TITLE
lint: detect arch for mlc binary

### DIFF
--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -47,13 +47,12 @@ ${CI_RETRY_EXE} pip3 install \
   ruff==0.15.5
 
 SHELLCHECK_VERSION=v0.11.0
-curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | \
+curl --fail -L "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.$(uname --machine).tar.xz" | \
     tar --xz -xf - --directory /tmp/
 mv "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/
 
 MLC_VERSION=v1.2.0
-MLC_BIN=mlc-x86_64-linux
-curl -sL "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/${MLC_BIN}" -o "/usr/bin/mlc"
+curl --fail -L "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/mlc-$(uname --machine)-linux" -o "/usr/bin/mlc"
 chmod +x /usr/bin/mlc
 
 popd || exit


### PR DESCRIPTION
In testing #34547 it has been observed that the lint container does not run on aarch64-linux without `qemu binfmt` (or similar).

This is because some tools are hardcoded to download x64 linux binaries. This has meant the linter works fine on:

- x64 linux
- aarch64 MacOS (via Rosetta)
- platforms using qemu

But does not work on e.g. aarch64-linux _without qemu_.

`shellcheck`` offer many platforms: https://github.com/koalaman/shellcheck/releases/tag/v0.11.0 and `mlc` offers are least x64 and aarch64 linux https://github.com/becheran/mlc/releases/tag/v1.2.0.

Try to download the correct binary for the platform using `uname` detection. This should see the linter work on native aarch64 + amd64, whilst maintaining current (emulated) compatibility.