### PR TITLE
interfaces: typed receive-request APIs

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -53,6 +54,7 @@ namespace interfaces {
 class Handler;
 struct WalletAddress;
 struct WalletBalances;
+struct WalletReceiveRequest;
 struct WalletTx;
 struct WalletTxOut;
 struct WalletTxStatus;
@@ -122,10 +124,14 @@ public:
     virtual std::vector<WalletAddress> getAddresses() = 0;
 
     //! Get receive requests.
-    virtual std::vector<std::string> getAddressReceiveRequests() = 0;
+    virtual std::vector<WalletReceiveRequest> getReceiveRequests() = 0;
 
-    //! Save or remove receive request.
-    virtual bool setAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& value) = 0;
+    //! Add a new receive request. Wallet assigns ID and timestamp.
+    //! Returns the assigned ID on success, or nullopt on failure.
+    virtual std::optional<int64_t> addReceiveRequest(const WalletReceiveRequest& request) = 0;
+
+    //! Erase a receive request.
+    virtual bool eraseReceiveRequest(const CTxDestination& dest, int64_t id) = 0;
 
     //! Display address on external signer
     virtual util::Result<void> displayAddress(const CTxDestination& dest) = 0;
@@ -361,6 +367,17 @@ struct WalletAddress
         : dest(std::move(dest)), is_mine(is_mine), purpose(std::move(purpose)), name(std::move(name))
     {
     }
+};
+
+//! Information about one wallet receive request.
+struct WalletReceiveRequest
+{
+    int64_t id{0};
+    int64_t time{0};
+    std::string address;
+    std::string label;
+    std::string message;
+    CAmount amount{0};
 };
 
 //! Collection of wallet balances.

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -9,24 +9,19 @@
 #include <qt/optionsmodel.h>
 #include <qt/walletmodel.h>
 
-#include <clientversion.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
-#include <streams.h>
-#include <util/string.h>
 
 #include <utility>
 
 #include <QLatin1Char>
 #include <QLatin1String>
 
-using util::ToString;
-
 RecentRequestsTableModel::RecentRequestsTableModel(WalletModel *parent) :
     QAbstractTableModel(parent), walletModel(parent)
 {
     // Load entries from wallet
-    for (const std::string& request : parent->wallet().getAddressReceiveRequests()) {
+    for (const auto& request : parent->wallet().getReceiveRequests()) {
         addNewRequest(request);
     }
 
@@ -151,7 +146,7 @@ bool RecentRequestsTableModel::removeRows(int row, int count, const QModelIndex 
         for (int i = 0; i < count; ++i)
         {
             const RecentRequestEntry* rec = &list[row+i];
-            if (!walletModel->wallet().setAddressReceiveRequest(DecodeDestination(rec->recipient.address.toStdString()), ToString(rec->id), ""))
+            if (!walletModel->wallet().eraseReceiveRequest(DecodeDestination(rec->recipient.address.toStdString()), rec->id))
                 return false;
         }
 
@@ -172,34 +167,32 @@ Qt::ItemFlags RecentRequestsTableModel::flags(const QModelIndex &index) const
 // called when adding a request from the GUI
 void RecentRequestsTableModel::addNewRequest(const SendCoinsRecipient &recipient)
 {
+    interfaces::WalletReceiveRequest request;
+    request.address = recipient.address.toStdString();
+    request.label = recipient.label.toStdString();
+    request.message = recipient.message.toStdString();
+    request.amount = recipient.amount;
+
+    auto id = walletModel->wallet().addReceiveRequest(request);
+    if (!id) return;
+
     RecentRequestEntry newEntry;
-    newEntry.id = ++nReceiveRequestsMaxId;
+    newEntry.id = *id;
     newEntry.date = QDateTime::currentDateTime();
     newEntry.recipient = recipient;
-
-    DataStream ss{};
-    ss << newEntry;
-
-    if (!walletModel->wallet().setAddressReceiveRequest(DecodeDestination(recipient.address.toStdString()), ToString(newEntry.id), ss.str()))
-        return;
-
     addNewRequest(newEntry);
 }
 
 // called from ctor when loading from wallet
-void RecentRequestsTableModel::addNewRequest(const std::string &recipient)
+void RecentRequestsTableModel::addNewRequest(const interfaces::WalletReceiveRequest &request)
 {
-    SpanReader ss{MakeByteSpan(recipient)};
-
     RecentRequestEntry entry;
-    ss >> entry;
-
-    if (entry.id == 0) // should not happen
-        return;
-
-    if (entry.id > nReceiveRequestsMaxId)
-        nReceiveRequestsMaxId = entry.id;
-
+    entry.id = request.id;
+    entry.date = QDateTime::fromSecsSinceEpoch(request.time);
+    entry.recipient.address = QString::fromStdString(request.address);
+    entry.recipient.label = QString::fromStdString(request.label);
+    entry.recipient.message = QString::fromStdString(request.message);
+    entry.recipient.amount = request.amount;
     addNewRequest(entry);
 }
 

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -7,11 +7,13 @@
 
 #include <qt/sendcoinsrecipient.h>
 
-#include <string>
-
 #include <QAbstractTableModel>
 #include <QStringList>
 #include <QDateTime>
+
+namespace interfaces {
+struct WalletReceiveRequest;
+}
 
 class WalletModel;
 
@@ -20,18 +22,9 @@ class RecentRequestEntry
 public:
     RecentRequestEntry() = default;
 
-    static const int CURRENT_VERSION = 1;
-    int nVersion{RecentRequestEntry::CURRENT_VERSION};
     int64_t id{0};
     QDateTime date;
     SendCoinsRecipient recipient;
-
-    SERIALIZE_METHODS(RecentRequestEntry, obj) {
-        unsigned int date_timet;
-        SER_WRITE(obj, date_timet = obj.date.toSecsSinceEpoch());
-        READWRITE(obj.nVersion, obj.id, date_timet, obj.recipient);
-        SER_READ(obj, obj.date = QDateTime::fromSecsSinceEpoch(date_timet));
-    }
 };
 
 class RecentRequestEntryLessThan
@@ -80,7 +73,7 @@ public:
 
     const RecentRequestEntry &entry(int row) const { return list[row]; }
     void addNewRequest(const SendCoinsRecipient &recipient);
-    void addNewRequest(const std::string &recipient);
+    void addNewRequest(const interfaces::WalletReceiveRequest &request);
     void addNewRequest(RecentRequestEntry &recipient);
 
 public Q_SLOTS:
@@ -90,7 +83,6 @@ private:
     WalletModel *walletModel;
     QStringList columns;
     QList<RecentRequestEntry> list;
-    int64_t nReceiveRequestsMaxId{0};
 
     /** Updates the column title to "Amount (DisplayUnit)" and emits headerDataChanged() signal for table headers to react. */
     void updateAmountColumnTitle();

--- a/src/qt/sendcoinsrecipient.h
+++ b/src/qt/sendcoinsrecipient.h
@@ -6,7 +6,6 @@
 #define BITCOIN_QT_SENDCOINSRECIPIENT_H
 
 #include <consensus/amount.h>
-#include <serialize.h>
 
 #include <string>
 
@@ -15,9 +14,9 @@
 class SendCoinsRecipient
 {
 public:
-    explicit SendCoinsRecipient() : amount(0), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) { }
+    explicit SendCoinsRecipient() : amount(0), fSubtractFeeFromAmount(false) { }
     explicit SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message):
-        address(addr), label(_label), amount(_amount), message(_message), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) {}
+        address(addr), label(_label), amount(_amount), message(_message), fSubtractFeeFromAmount(false) {}
 
     // If from an unauthenticated payment request, this is used for storing
     // the addresses, e.g. address-A<br />address-B<br />address-C.
@@ -36,26 +35,6 @@ public:
     QString authenticatedMerchant;
 
     bool fSubtractFeeFromAmount; // memory only
-
-    static const int CURRENT_VERSION = 1;
-    int nVersion;
-
-    SERIALIZE_METHODS(SendCoinsRecipient, obj)
-    {
-        std::string address_str, label_str, message_str, auth_merchant_str;
-
-        SER_WRITE(obj, address_str = obj.address.toStdString());
-        SER_WRITE(obj, label_str = obj.label.toStdString());
-        SER_WRITE(obj, message_str = obj.message.toStdString());
-        SER_WRITE(obj, auth_merchant_str = obj.authenticatedMerchant.toStdString());
-
-        READWRITE(obj.nVersion, address_str, label_str, obj.amount, message_str, obj.sPaymentRequest, auth_merchant_str);
-
-        SER_READ(obj, obj.address = QString::fromStdString(address_str));
-        SER_READ(obj, obj.label = QString::fromStdString(label_str));
-        SER_READ(obj, obj.message = QString::fromStdString(message_str));
-        SER_READ(obj, obj.authenticatedMerchant = QString::fromStdString(auth_merchant_str));
-    }
 };
 
 #endif // BITCOIN_QT_SENDCOINSRECIPIENT_H

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -361,19 +361,14 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
     QCOMPARE(currentRowCount, initialRowCount+1);
 
     // Check addition to wallet
-    std::vector<std::string> requests = walletModel.wallet().getAddressReceiveRequests();
+    std::vector<interfaces::WalletReceiveRequest> requests = walletModel.wallet().getReceiveRequests();
     QCOMPARE(requests.size(), size_t{1});
-    RecentRequestEntry entry;
-    SpanReader{MakeByteSpan(requests[0])} >> entry;
-    QCOMPARE(entry.nVersion, int{1});
-    QCOMPARE(entry.id, int64_t{1});
-    QVERIFY(entry.date.isValid());
-    QCOMPARE(entry.recipient.address, address);
-    QCOMPARE(entry.recipient.label, QString{"TEST_LABEL_1"});
-    QCOMPARE(entry.recipient.amount, CAmount{1});
-    QCOMPARE(entry.recipient.message, QString{"TEST_MESSAGE_1"});
-    QCOMPARE(entry.recipient.sPaymentRequest, std::string{});
-    QCOMPARE(entry.recipient.authenticatedMerchant, QString{});
+    QCOMPARE(requests[0].id, int64_t{0});
+    QVERIFY(requests[0].time > 0);
+    QCOMPARE(QString::fromStdString(requests[0].address), address);
+    QCOMPARE(requests[0].label, std::string{"TEST_LABEL_1"});
+    QCOMPARE(requests[0].amount, CAmount{1});
+    QCOMPARE(requests[0].message, std::string{"TEST_MESSAGE_1"});
 
     // Check Remove button
     QTableView* table = receiveCoinsDialog.findChild<QTableView*>("recentRequestsView");
@@ -383,7 +378,7 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
     QCOMPARE(requestTableModel->rowCount({}), currentRowCount-1);
 
     // Check removal from wallet
-    QCOMPARE(walletModel.wallet().getAddressReceiveRequests().size(), size_t{0});
+    QCOMPARE(walletModel.wallet().getReceiveRequests().size(), size_t{0});
 }
 
 void TestGUIWatchOnly(interfaces::Node& node, TestChain100Setup& test)

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -8,6 +8,7 @@
 #include <consensus/amount.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
+#include <key_io.h>
 #include <node/types.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <primitives/transaction.h>
@@ -17,6 +18,7 @@
 #include <sync.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <util/ui_change_type.h>
 #include <wallet/coincontrol.h>
@@ -45,6 +47,7 @@ using interfaces::WalletBalances;
 using interfaces::WalletLoader;
 using interfaces::WalletMigrationResult;
 using interfaces::WalletOrderForm;
+using interfaces::WalletReceiveRequest;
 using interfaces::WalletTx;
 using interfaces::WalletTxOut;
 using interfaces::WalletTxStatus;
@@ -54,6 +57,7 @@ namespace wallet {
 // All members of the classes in this namespace are intentionally public, as the
 // classes themselves are private.
 namespace {
+
 //! Construct wallet tx struct.
 WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
 {
@@ -210,27 +214,49 @@ public:
         });
         return result;
     }
-    std::vector<std::string> getAddressReceiveRequests() override {
+    std::vector<WalletReceiveRequest> getReceiveRequests() override
+    {
         LOCK(m_wallet->cs_wallet);
-        return m_wallet->GetAddressReceiveRequests();
+        std::vector<WalletReceiveRequest> result;
+        for (const auto& [dest, entry] : m_wallet->m_address_book) {
+            for (const auto& [id, req] : entry.receive_requests) {
+                result.push_back({
+                    .id = req.id,
+                    .time = req.time,
+                    .address = EncodeDestination(dest),
+                    .label = req.label,
+                    .message = req.message,
+                    .amount = req.amount,
+                });
+            }
+        }
+        return result;
     }
-    bool setAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& value) override {
-        // Note: The setAddressReceiveRequest interface used by the GUI to store
-        // receive requests is a little awkward and could be improved in the
-        // future:
-        //
-        // - The same method is used to save requests and erase them, but
-        //   having separate methods could be clearer and prevent bugs.
-        //
-        // - Request ids are passed as strings even though they are generated as
-        //   integers.
-        //
-        // - Multiple requests can be stored for the same address, but it might
-        //   be better to only allow one request or only keep the current one.
+    std::optional<int64_t> addReceiveRequest(const WalletReceiveRequest& request) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        const CTxDestination dest = DecodeDestination(request.address);
+        if (!IsValidDestination(dest)) return std::nullopt;
+
+        ReceiveRequest req;
+        req.id = m_wallet->m_next_receive_request_id;
+        req.time = static_cast<unsigned int>(GetTime());
+        req.address = request.address;
+        req.label = request.label;
+        req.message = request.message;
+        req.amount = request.amount;
+
+        WalletBatch batch{m_wallet->GetDatabase()};
+        if (!m_wallet->SetAddressReceiveRequest(batch, dest, req)) {
+            return std::nullopt;
+        }
+        return req.id;
+    }
+    bool eraseReceiveRequest(const CTxDestination& dest, int64_t id) override
+    {
         LOCK(m_wallet->cs_wallet);
         WalletBatch batch{m_wallet->GetDatabase()};
-        return value.empty() ? m_wallet->EraseAddressReceiveRequest(batch, dest, id)
-                             : m_wallet->SetAddressReceiveRequest(batch, dest, id, value);
+        return m_wallet->EraseAddressReceiveRequest(batch, dest, id);
     }
     util::Result<void> displayAddress(const CTxDestination& dest) override
     {

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -321,18 +321,31 @@ BOOST_FIXTURE_TEST_CASE(LoadReceiveRequests, TestingSetup)
             WalletBatch batch{wallet->GetDatabase()};
             BOOST_CHECK(batch.WriteAddressPreviouslySpent(PKHash(), true));
             BOOST_CHECK(batch.WriteAddressPreviouslySpent(ScriptHash(), true));
-            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, PKHash(), "0", "val_rr00"));
-            BOOST_CHECK(wallet->EraseAddressReceiveRequest(batch, PKHash(), "0"));
-            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, PKHash(), "1", "val_rr10"));
-            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, PKHash(), "1", "val_rr11"));
-            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, ScriptHash(), "2", "val_rr20"));
+
+            ReceiveRequest req0{.id = 0, .time = 100, .address = "a0", .label = {}, .message = {}, .amount = 0};
+            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, PKHash(), req0));
+            BOOST_CHECK(wallet->EraseAddressReceiveRequest(batch, PKHash(), 0));
+
+            ReceiveRequest req1{.id = 1, .time = 101, .address = "a1", .label = "l1", .message = {}, .amount = 0};
+            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, PKHash(), req1));
+            // Overwrite with updated label
+            req1.label = "l1_updated";
+            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, PKHash(), req1));
+
+            ReceiveRequest req2{.id = 2, .time = 102, .address = "a2", .label = {}, .message = {}, .amount = 0};
+            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, ScriptHash(), req2));
         });
         TestLoadWallet(name, format, [](std::shared_ptr<CWallet> wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet) {
             BOOST_CHECK(wallet->IsAddressPreviouslySpent(PKHash()));
             BOOST_CHECK(wallet->IsAddressPreviouslySpent(ScriptHash()));
-            auto requests = wallet->GetAddressReceiveRequests();
-            auto erequests = {"val_rr11", "val_rr20"};
-            BOOST_CHECK_EQUAL_COLLECTIONS(requests.begin(), requests.end(), std::begin(erequests), std::end(erequests));
+            const auto& pk_reqs = wallet->m_address_book[PKHash()].receive_requests;
+            BOOST_CHECK_EQUAL(pk_reqs.size(), 1U);
+            BOOST_CHECK_EQUAL(pk_reqs.at(1).label, "l1_updated");
+            const auto& sh_reqs = wallet->m_address_book[ScriptHash()].receive_requests;
+            BOOST_CHECK_EQUAL(sh_reqs.size(), 1U);
+            BOOST_CHECK_EQUAL(sh_reqs.at(2).address, "a2");
+            // Verify cached next ID was computed from loaded data
+            BOOST_CHECK_EQUAL(wallet->m_next_receive_request_id, 3);
             RunWithinTxn(wallet->GetDatabase(), /*process_desc=*/"test", [](WalletBatch& batch){
                 BOOST_CHECK(batch.WriteAddressPreviouslySpent(PKHash(), false));
                 BOOST_CHECK(batch.EraseAddressData(ScriptHash()));
@@ -342,9 +355,63 @@ BOOST_FIXTURE_TEST_CASE(LoadReceiveRequests, TestingSetup)
         TestLoadWallet(name, format, [](std::shared_ptr<CWallet> wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet) {
             BOOST_CHECK(!wallet->IsAddressPreviouslySpent(PKHash()));
             BOOST_CHECK(!wallet->IsAddressPreviouslySpent(ScriptHash()));
-            auto requests = wallet->GetAddressReceiveRequests();
-            auto erequests = {"val_rr11"};
-            BOOST_CHECK_EQUAL_COLLECTIONS(requests.begin(), requests.end(), std::begin(erequests), std::end(erequests));
+            const auto& pk_reqs = wallet->m_address_book[PKHash()].receive_requests;
+            BOOST_CHECK_EQUAL(pk_reqs.size(), 1U);
+            BOOST_CHECK_EQUAL(pk_reqs.at(1).label, "l1_updated");
+        });
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(ReceiveRequestOperations, TestingSetup)
+{
+    for (DatabaseFormat format : DATABASE_FORMATS) {
+        const std::string name{strprintf("receive-request-ops-%i", format)};
+        TestLoadWallet(name, format, [](std::shared_ptr<CWallet> wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet) {
+            const std::string address = EncodeDestination(PKHash());
+            WalletBatch batch{wallet->GetDatabase()};
+
+            // Initially empty
+            BOOST_CHECK(wallet->m_address_book[PKHash()].receive_requests.empty());
+            BOOST_CHECK_EQUAL(wallet->m_next_receive_request_id, 0);
+
+            // Add a receive request using cached ID
+            ReceiveRequest req;
+            req.id = wallet->m_next_receive_request_id;
+            req.time = 12345;
+            req.address = address;
+            req.label = "label1";
+            req.message = "msg1";
+            req.amount = 1000;
+            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, PKHash(), req));
+
+            // Verify cached ID was advanced
+            BOOST_CHECK_EQUAL(wallet->m_next_receive_request_id, 1);
+
+            // Read it back and verify all fields
+            const auto& requests = wallet->m_address_book[PKHash()].receive_requests;
+            BOOST_CHECK_EQUAL(requests.size(), 1U);
+            BOOST_CHECK_EQUAL(requests.at(0).id, 0);
+            BOOST_CHECK_EQUAL(requests.at(0).time, 12345U);
+            BOOST_CHECK_EQUAL(requests.at(0).address, address);
+            BOOST_CHECK_EQUAL(requests.at(0).label, "label1");
+            BOOST_CHECK_EQUAL(requests.at(0).message, "msg1");
+            BOOST_CHECK_EQUAL(requests.at(0).amount, 1000);
+
+            // Second request gets next cached ID
+            ReceiveRequest req2;
+            req2.id = wallet->m_next_receive_request_id;
+            req2.time = 12346;
+            req2.address = address;
+            req2.label = "label2";
+            req2.amount = 2000;
+            BOOST_CHECK(wallet->SetAddressReceiveRequest(batch, PKHash(), req2));
+            BOOST_CHECK_EQUAL(wallet->m_next_receive_request_id, 2);
+            BOOST_CHECK_EQUAL(requests.size(), 2U);
+
+            // Erase works
+            BOOST_CHECK(wallet->EraseAddressReceiveRequest(batch, PKHash(), 0));
+            BOOST_CHECK_EQUAL(requests.size(), 1U);
+            BOOST_CHECK_EQUAL(requests.at(1).label, "label2");
         });
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2881,9 +2881,10 @@ void CWallet::LoadAddressPreviouslySpent(const CTxDestination& dest)
     m_address_book[dest].previously_spent = true;
 }
 
-void CWallet::LoadAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& request)
+void CWallet::LoadAddressReceiveRequest(const CTxDestination& dest, ReceiveRequest request)
 {
-    m_address_book[dest].receive_requests[id] = request;
+    if (request.id >= m_next_receive_request_id) m_next_receive_request_id = request.id + 1;
+    m_address_book[dest].receive_requests[request.id] = std::move(request);
 }
 
 bool CWallet::IsAddressPreviouslySpent(const CTxDestination& dest) const
@@ -2892,25 +2893,14 @@ bool CWallet::IsAddressPreviouslySpent(const CTxDestination& dest) const
     return false;
 }
 
-std::vector<std::string> CWallet::GetAddressReceiveRequests() const
+bool CWallet::SetAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, const ReceiveRequest& request)
 {
-    std::vector<std::string> values;
-    for (const auto& [dest, entry] : m_address_book) {
-        for (const auto& [id, request] : entry.receive_requests) {
-            values.emplace_back(request);
-        }
-    }
-    return values;
-}
-
-bool CWallet::SetAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, const std::string& id, const std::string& value)
-{
-    if (!batch.WriteAddressReceiveRequest(dest, id, value)) return false;
-    m_address_book[dest].receive_requests[id] = value;
+    if (!batch.WriteAddressReceiveRequest(dest, request)) return false;
+    LoadAddressReceiveRequest(dest, request);
     return true;
 }
 
-bool CWallet::EraseAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, const std::string& id)
+bool CWallet::EraseAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, int64_t id)
 {
     if (!batch.EraseAddressReceiveRequest(dest, id)) return false;
     m_address_book[dest].receive_requests.erase(id);
@@ -4050,7 +4040,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
         if (entry.purpose) batch.WritePurpose(address, PurposeToString(*entry.purpose));
         if (entry.label) batch.WriteName(address, *entry.label);
         for (const auto& [id, request] : entry.receive_requests) {
-            batch.WriteAddressReceiveRequest(dest, id, request);
+            batch.WriteAddressReceiveRequest(dest, request);
         }
         if (entry.previously_spent) batch.WriteAddressPreviouslySpent(dest, true);
     };

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -233,6 +233,29 @@ public:
 };
 
 /**
+ * Receive request data stored in the wallet database.
+ * SERIALIZE_METHODS preserves the legacy on-disk format for backward compatibility.
+ * Unused legacy fields (sPaymentRequest, authenticatedMerchant) are written as
+ * empty strings.
+ */
+struct ReceiveRequest
+{
+    int64_t id{0};
+    unsigned int time{0};
+    std::string address;
+    std::string label;
+    std::string message;
+    CAmount amount{0};
+
+    SERIALIZE_METHODS(ReceiveRequest, obj)
+    {
+        int outer_ver{1}, inner_ver{1};
+        std::string s_payment_request, authenticated_merchant;
+        READWRITE(outer_ver, obj.id, obj.time, inner_ver, obj.address, obj.label, obj.amount, obj.message, s_payment_request, authenticated_merchant);
+    }
+};
+
+/**
  * Address book data.
  */
 struct CAddressBookData
@@ -263,13 +286,11 @@ struct CAddressBookData
     bool previously_spent{false};
 
     /**
-     * Map containing data about previously generated receive requests
-     * requesting funds to be sent to this address. Only present for IsMine
-     * addresses. Map keys are decimal numbers uniquely identifying each
-     * request, and map values are serialized RecentRequestEntry objects
-     * containing BIP21 URI information including message and amount.
+     * Map of receive requests for this address, keyed by unique request ID.
+     * Only present for IsMine addresses. Values contain BIP21 URI information
+     * including label, message, and amount.
      */
-    std::map<std::string, std::string> receive_requests{};
+    std::map<int64_t, ReceiveRequest> receive_requests{};
 
     /** Accessor methods. */
     bool IsChange() const { return !label.has_value(); }
@@ -505,6 +526,9 @@ public:
     std::map<CTxDestination, CAddressBookData> m_address_book GUARDED_BY(cs_wallet);
     const CAddressBookData* FindAddressBookEntry(const CTxDestination&, bool allow_change = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    /** Next available receive request ID, computed on wallet load. */
+    int64_t m_next_receive_request_id GUARDED_BY(cs_wallet) = 0;
+
     /** Set of Coins owned by this wallet that we won't try to spend from. A
      * Coin may be locked if it has already been used to fund a transaction
      * that hasn't confirmed yet. We wouldn't consider the Coin spent already,
@@ -585,9 +609,6 @@ public:
 
     //! Marks destination as previously spent.
     void LoadAddressPreviouslySpent(const CTxDestination& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    //! Appends payment request to destination.
-    void LoadAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& request) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-
     //! Holds a timestamp at which point the wallet is scheduled (externally) to be relocked. Caller must arrange for actual relocking to occur via Lock().
     int64_t nRelockTime GUARDED_BY(cs_wallet){0};
 
@@ -808,9 +829,9 @@ public:
     bool IsAddressPreviouslySpent(const CTxDestination& dest) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool SetAddressPreviouslySpent(WalletBatch& batch, const CTxDestination& dest, bool used) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    std::vector<std::string> GetAddressReceiveRequests() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool SetAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, const std::string& id, const std::string& value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool EraseAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, const std::string& id) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void LoadAddressReceiveRequest(const CTxDestination& dest, ReceiveRequest request) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool SetAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, const ReceiveRequest& request) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool EraseAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, int64_t id) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     unsigned int GetKeyPoolSize() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -13,10 +13,12 @@
 #include <protocol.h>
 #include <script/script.h>
 #include <serialize.h>
+#include <streams.h>
 #include <sync.h>
 #include <util/bip32.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/strencodings.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <wallet/migrate.h>
@@ -965,8 +967,17 @@ static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) E
             pwallet->LoadAddressPreviouslySpent(dest);
         } else if (strKey.starts_with("rr")) {
             // Load "rr##" keys where ## is a decimal number, and strValue
-            // is a serialized RecentRequestEntry object.
-            pwallet->LoadAddressReceiveRequest(dest, strKey.substr(2), strValue);
+            // is a serialized receive request.
+            auto id = ToIntegral<int64_t>(strKey.substr(2));
+            if (!id || *id < 0) return DBErrors::NONCRITICAL_ERROR;
+            try {
+                ReceiveRequest req;
+                SpanReader{MakeByteSpan(strValue)} >> req;
+                req.id = *id;
+                pwallet->LoadAddressReceiveRequest(dest, std::move(req));
+            } catch (const std::exception& e) {
+                pwallet->WalletLogPrintf("Warning: could not deserialize receive request '%s': %s\n", strKey, e.what());
+            }
         }
         return DBErrors::LOAD_OK;
     });
@@ -1223,14 +1234,16 @@ bool WalletBatch::WriteAddressPreviouslySpent(const CTxDestination& dest, bool p
     return previously_spent ? WriteIC(key, std::string("1")) : EraseIC(key);
 }
 
-bool WalletBatch::WriteAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& receive_request)
+bool WalletBatch::WriteAddressReceiveRequest(const CTxDestination& dest, const ReceiveRequest& request)
 {
-    return WriteIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(EncodeDestination(dest), "rr" + id)), receive_request);
+    DataStream ss{};
+    ss << request;
+    return WriteIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(EncodeDestination(dest), "rr" + util::ToString(request.id))), ss.str());
 }
 
-bool WalletBatch::EraseAddressReceiveRequest(const CTxDestination& dest, const std::string& id)
+bool WalletBatch::EraseAddressReceiveRequest(const CTxDestination& dest, int64_t id)
 {
-    return EraseIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(EncodeDestination(dest), "rr" + id)));
+    return EraseIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(EncodeDestination(dest), "rr" + util::ToString(id))));
 }
 
 bool WalletBatch::EraseAddressData(const CTxDestination& dest)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -25,6 +25,7 @@ namespace wallet {
 class CMasterKey;
 class CWallet;
 class CWalletTx;
+struct ReceiveRequest;
 struct WalletContext;
 
 // Logs information about the database, including available engines, features, and other capabilities
@@ -255,8 +256,8 @@ public:
     bool EraseLockedUTXO(const COutPoint& output);
 
     bool WriteAddressPreviouslySpent(const CTxDestination& dest, bool previously_spent);
-    bool WriteAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& receive_request);
-    bool EraseAddressReceiveRequest(const CTxDestination& dest, const std::string& id);
+    bool WriteAddressReceiveRequest(const CTxDestination& dest, const ReceiveRequest& request);
+    bool EraseAddressReceiveRequest(const CTxDestination& dest, int64_t id);
     bool EraseAddressData(const CTxDestination& dest);
 
     bool WriteActiveScriptPubKeyMan(uint8_t type, const uint256& id, bool internal);


### PR DESCRIPTION
Right now, `RecentRequestsTableModel` deserializes raw blobs it gets back from `getAddressReceiveRequests()` using `SpanReader` with no `try/catch`. If anything in the wallet DB is malformed, the GUI crashes on startup — there's no recovery path.

This PR replaces the two raw-string methods (`getAddressReceiveRequests()` / `setAddressReceiveRequest()`) with typed ones:

- `getReceiveRequests()` returns a `vector<WalletReceiveRequest>` instead of opaque blobs
- `addReceiveRequest()` lets the wallet assign the ID and timestamp
- `eraseReceiveRequest()` is now its own method instead of overloading the setter with an empty string

Serialization still happens the same way — I added `RecipientData` / `RequestEntryData` structs in `wallet/interfaces.cpp` that are byte-identical to the Qt-side ones, so the DB format doesn't change. The difference is that deserialization is now wrapped in `try/catch` at the wallet layer, so bad entries get logged and skipped rather than taking down the GUI.

Closes #34629
