### PR TITLE
contrib: add ASmap attestation scripts

### DIFF
--- a/contrib/asmap/README.md
+++ b/contrib/asmap/README.md
@@ -1,4 +1,6 @@
-# ASMap Tool
+# ASMap Tools
+
+## asmap-tool
 
 Tool for performing various operations on textual and binary asmap files,
 particularly encoding/compressing the raw data to the binary format that can
@@ -80,4 +82,39 @@ bitcoin-cli getnodeaddresses 0 > addrs.json
 and pass in the address file as the third argument:
 ```
 python3 asmap-tool.py diff_addrs path/to/first.file path/to/second.file addrs.json
+```
+
+## ASmap Attestation
+
+### Creating an attestation
+
+Similar to [guix](../guix/README.md#attesting-to-build-outputs) attestation, one can attest to ASmaps. Attestations are collected in the [asmap.sigs](https://github.com/asmap/asmap.sigs) repo.
+
+To attest to an ASmap, you must have:
+- the result file `final_result.txt` containing the ASmap in text format
+- a PGP key added to the `builder-keys` dir in the [asmap.sigs](https://github.com/asmap/asmap.sigs) repo.
+
+Attesting to an ASmap output:
+```bash
+env ASMAP_SIGS_REPO=<path/to/asmap.sigs>\
+  ASMAP_FILE=<path/to/asmap_file.txt>\
+  ./asmap-attest
+```
+
+This will add a `SHA256SUMS` file and a `SHA256SUMS.asc` file under the `<EPOCH>/<SIGNER>` directory in `ASMAP_SIGS_REPO`. This process will encode the ASmap with `asmap-tool`, and write encoded ASmap files to the current directory.
+
+### Verifying attestations
+
+To verify attestations in the [asmap.sigs](https://github.com/asmap/asmap.sigs) repo, you should have the PGP keys in [asmap.sigs/builder-keys](https://github.com/asmap/asmap.sigs/tree/main/builder-keys) in your GPG keyring.
+
+To verify all attestations in the repo:
+```bash
+env ASMAP_SIGS_REPO=<path/to/asmap.sigs> ./asmap-verify
+```
+Optionally pass `SIGNER` and/or `EPOCH`:
+```bash
+env ASMAP_SIGS_REPO=<path/to/asmap.sigs>\
+  SIGNER=satoshi\
+  EPOCH=1777777777\
+  ./asmap-verify
 ```

--- a/contrib/asmap/asmap-attest
+++ b/contrib/asmap/asmap-attest
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+set -e -o pipefail
+
+################
+# Required non-builtin commands should be invocable
+################
+
+check_tools() {
+    for cmd in "$@"; do
+        if ! command -v "$cmd" > /dev/null 2>&1; then
+            echo "ERR: This script requires that '$cmd' is installed and available in your \$PATH"
+            exit 1
+        fi
+    done
+}
+
+check_tools cat env basename mkdir sha256sum python3 mktemp diff
+
+GPG=${GPG:-gpg}
+
+if [ -z "$NO_SIGN" ]; then
+    # shellcheck disable=SC2206
+    GPG_ARRAY=($GPG)
+    check_tools "${GPG_ARRAY[0]}"
+fi
+
+################
+# Usage
+################
+
+cmd_usage() {
+cat <<EOF
+Synopsis:
+
+    env ASMAP_SIGS_REPO=<path/to/asmap.sigs> \\
+        SIGNER=<gpg-key-name> \\
+        ASMAP_FILE=<path/to/final_result.txt> \\
+        [ EPOCH=1777777777 ] \\
+        [ NO_SIGN=1 ] \\
+      ./contrib/asmap/asmap-attest
+
+Example:
+
+    env ASMAP_SIGS_REPO=/home/user/asmap.sigs \\
+        SIGNER=satoshi \\
+        ASMAP_FILE=/home/user/kartograf/out/1772726379/final_result.txt \\
+      ./contrib/asmap/asmap-attest
+
+    Outputs:
+      \$PWD/final_result.dat                                         (encoded binary)
+      /home/user/asmap.sigs/1772726379/satoshi/SHA256SUMS          (attestation)
+      /home/user/asmap.sigs/1772726379/satoshi/SHA256SUMS.asc      (signature)
+
+Example w/o signing, just creating SHA256SUMS:
+
+    env ASMAP_SIGS_REPO=/home/user/asmap.sigs \\
+        SIGNER=satoshi \\
+        ASMAP_FILE=/home/user/kartograf/out/1772726379/final_result.txt \\
+        NO_SIGN=1 \\
+      ./contrib/asmap/asmap-attest
+
+Environment variables:
+
+    ASMAP_SIGS_REPO  Path to the asmap.sigs repository clone
+    SIGNER           GPG key name, must match a .gpg file under builder-keys/ in the sigs repo
+    ASMAP_FILE       Path to the input asmap text file to encode and attest
+    EPOCH            Unix timestamp to use as the output folder name;
+                     (default: derived from the parent directory of ASMAP_FILE)
+    NO_SIGN          If set and non-empty, skip GPG signing
+    GPG              Override the gpg binary (default: gpg)
+
+EOF
+}
+
+################
+# Required env vars should be non-empty
+################
+
+if [ -z "$ASMAP_SIGS_REPO" ] || [ -z "$SIGNER" ] || [ -z "$ASMAP_FILE" ]; then
+    cmd_usage
+    exit 1
+fi
+
+################
+# ASMAP_SIGS_REPO should exist as a directory
+################
+
+if [ ! -d "$ASMAP_SIGS_REPO" ]; then
+cat << EOF
+ERR: The specified ASMAP_SIGS_REPO is not an existing directory:
+
+    '$ASMAP_SIGS_REPO'
+
+Hint: Please clone the asmap.sigs repository and point to it with the
+      ASMAP_SIGS_REPO environment variable.
+
+EOF
+cmd_usage
+exit 1
+fi
+
+################
+# ASMAP_FILE should exist and be readable
+################
+
+if [ ! -f "$ASMAP_FILE" ]; then
+cat << EOF
+ERR: The specified ASMAP_FILE does not exist or is not a regular file:
+
+    '$ASMAP_FILE'
+
+EOF
+exit 1
+fi
+
+if [ ! -r "$ASMAP_FILE" ]; then
+cat << EOF
+ERR: The specified ASMAP_FILE is not readable:
+
+    '$ASMAP_FILE'
+
+EOF
+exit 1
+fi
+
+################
+# The SIGNER should have a corresponding .gpg key in builder-keys/
+################
+
+signer_key="$ASMAP_SIGS_REPO/builder-keys/${SIGNER}.gpg"
+if [ ! -f "$signer_key" ]; then
+cat << EOF
+ERR: No builder key found for signer '${SIGNER}':
+
+    '$signer_key'
+
+Hint: The SIGNER name must match a .gpg file under builder-keys/ in the
+      asmap.sigs repository (without the .gpg extension). Available signers:
+
+EOF
+    if [ -d "$ASMAP_SIGS_REPO/builder-keys" ]; then
+        for f in "$ASMAP_SIGS_REPO/builder-keys"/*.gpg; do
+            if [ -f "$f" ]; then
+                key_name="$(basename "$f" .gpg)"
+                echo "          ${key_name}"
+            fi
+        done
+    else
+        echo "          (builder-keys directory not found)"
+    fi
+    echo ""
+    exit 1
+fi
+
+if [ -n "$EPOCH" ]; then
+    run_id="$EPOCH"
+else
+    run_id="$(basename "$(dirname "$ASMAP_FILE")")"
+fi
+signer_dir="$ASMAP_SIGS_REPO/$run_id/$SIGNER"
+mkdir -p "$signer_dir"
+
+################
+# The GPG key should be usable
+################
+
+if [ -z "$NO_SIGN" ] && ! ${GPG} --dry-run --list-secret-keys "${SIGNER}" >/dev/null 2>&1; then
+    echo "ERR: GPG can't seem to find any secret key named '${SIGNER}'"
+    exit 1
+fi
+
+################
+# asmap-tool.py should be findable
+################
+
+ASMAP_TOOL="$(dirname "${BASH_SOURCE[0]}")/asmap-tool.py"
+if [ ! -f "$ASMAP_TOOL" ]; then
+    echo "ERR: Cannot find asmap-tool.py at expected location: '$ASMAP_TOOL'"
+    exit 1
+fi
+
+##############
+##  Encode  ##
+##############
+
+input_basename="$(basename "$ASMAP_FILE")"
+encoded_filled_basename="${run_id}_asmap.dat"
+encoded_unfilled_basename="${run_id}_asmap_unfilled.dat"
+
+encoded_filled_file="${PWD}/${encoded_filled_basename}"
+encoded_unfilled_file="${PWD}/${encoded_unfilled_basename}"
+
+echo "Encoding '$input_basename' using asmap-tool.py..."
+python3 "$ASMAP_TOOL" encode --fill "$ASMAP_FILE" "$encoded_filled_file"
+echo "Encoding complete (filled): '$encoded_filled_file'"
+python3 "$ASMAP_TOOL" encode "$ASMAP_FILE" "$encoded_unfilled_file"
+echo "Encoding complete (unfilled): '$encoded_unfilled_file'"
+echo ""
+
+##############
+##  Attest  ##
+##############
+
+input_hash="$(sha256sum "$ASMAP_FILE" | cut -d' ' -f1)"
+encoded_filled_hash="$(sha256sum "$encoded_filled_file" | cut -d' ' -f1)"
+encoded_unfilled_hash="$(sha256sum "$encoded_unfilled_file" | cut -d' ' -f1)"
+
+sha256sums_file="$signer_dir/SHA256SUMS"
+
+temp_sha256sums="$(mktemp)"
+cat > "$temp_sha256sums" <<EOF
+${input_hash}  ${input_basename}
+${encoded_filled_hash}  ${encoded_filled_basename}
+${encoded_unfilled_hash}  ${encoded_unfilled_basename}
+EOF
+
+if [ -e "$sha256sums_file" ]; then
+    if diff -u "$sha256sums_file" "$temp_sha256sums" >/dev/null 2>&1; then
+        echo "A SHA256SUMS file already exists for signer '${SIGNER}' and is up-to-date."
+        rm -f "$temp_sha256sums"
+    else
+        diff -u "$sha256sums_file" "$temp_sha256sums" || true
+        cat << EOF
+--
+
+ERR: A SHA256SUMS file already exists for signer '${SIGNER}' and attests
+     differently. See the diff above for details.
+
+Hint: You may wish to remove the existing attestation and its signature by
+      invoking:
+
+          rm '${sha256sums_file}'{,.asc}
+
+      Then try running this script again.
+
+EOF
+        rm -f "$temp_sha256sums"
+        exit 1
+    fi
+else
+    mv "$temp_sha256sums" "$sha256sums_file"
+fi
+
+##############
+##   Sign   ##
+##############
+
+if [ -z "$NO_SIGN" ]; then
+    if [ ! -e "$sha256sums_file".asc ]; then
+        ${GPG} --detach-sign \
+               --digest-algo sha256 \
+               --local-user "$SIGNER" \
+               --armor \
+               --output "$sha256sums_file".asc "$sha256sums_file"
+    else
+        echo "Signature '${sha256sums_file}.asc' already exists."
+    fi
+else
+    echo "Not signing SHA256SUMS as \$NO_SIGN is set"
+fi
+
+echo ""
+echo "Attestation complete. Results for run '${run_id}', signer '${SIGNER}':"
+echo "    ${sha256sums_file}   (attestation)"
+if [ -z "$NO_SIGN" ] && [ -e "$sha256sums_file".asc ]; then
+    echo "    ${sha256sums_file}.asc   (signature)"
+fi
+

--- a/contrib/asmap/asmap-verify
+++ b/contrib/asmap/asmap-verify
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+set -e -o pipefail
+
+################
+# Required non-builtin commands should be invocable
+################
+
+check_tools() {
+    for cmd in "$@"; do
+        if ! command -v "$cmd" > /dev/null 2>&1; then
+            echo "ERR: This script requires that '$cmd' is installed and available in your \$PATH"
+            exit 1
+        fi
+    done
+}
+
+check_tools cat diff gpg basename
+
+################
+# Usage
+################
+
+cmd_usage() {
+cat <<EOF
+Synopsis:
+
+    env ASMAP_SIGS_REPO=<path/to/asmap.sigs> \\
+        [ EPOCH=<unix_timestamp> ] \\
+        [ SIGNER=<signer> ] \\
+      ./contrib/asmap/asmap-verify
+
+Example verifying all epochs:
+
+    env ASMAP_SIGS_REPO=/home/user/asmap.sigs \\
+      ./contrib/asmap/asmap-verify
+
+Example verifying a specific epoch:
+
+    env ASMAP_SIGS_REPO=/home/user/asmap.sigs \\
+        EPOCH=1772726379 \\
+      ./contrib/asmap/asmap-verify
+
+Example using a specific signer's attestation as the compare base:
+
+    env ASMAP_SIGS_REPO=/home/user/asmap.sigs \\
+        SIGNER=satoshi \\
+      ./contrib/asmap/asmap-verify
+
+Environment variables:
+
+    ASMAP_SIGS_REPO  Path to the asmap.sigs repository clone
+    EPOCH            (optional) Only verify this epoch; default: verify all epochs
+    SIGNER           (optional) Use this signer's SHA256SUMS as the compare base;
+                     default: use the first one found
+
+EOF
+}
+
+################
+# Required env vars should be non-empty
+################
+
+if [ -z "$ASMAP_SIGS_REPO" ]; then
+    cmd_usage
+    exit 1
+fi
+
+################
+# ASMAP_SIGS_REPO should exist as a directory
+################
+
+if [ ! -d "$ASMAP_SIGS_REPO" ]; then
+cat << EOF
+ERR: The specified ASMAP_SIGS_REPO is not an existent directory:
+
+    '$ASMAP_SIGS_REPO'
+
+Hint: Please clone the asmap.sigs repository and point to it with the
+      ASMAP_SIGS_REPO environment variable.
+
+EOF
+cmd_usage
+exit 1
+fi
+
+builder_keys_dir="$ASMAP_SIGS_REPO/builder-keys"
+
+##############
+##  Verify  ##
+##############
+
+# Usage: verify <compare_base> <current_manifest>
+verify() {
+    local compare_base="$1"
+    local current_manifest="$2"
+    local signer_name
+    signer_name="$(basename "$(dirname "$current_manifest")")"
+
+    if ! gpg --quiet --batch \
+            --verify "${current_manifest}.asc" "$current_manifest" 1>&2; then
+        echo "ERR: Failed to verify GPG signature for signer '${signer_name}'"
+        echo "     Manifest:  '${current_manifest}'"
+        echo "     Signature: '${current_manifest}.asc'"
+        echo ""
+        echo "Hint: Either the signature is invalid or the public key is not in"
+        echo "      your GPG keyring. You can import it with:"
+        echo "          gpg --import '${builder_keys_dir}/${signer_name}.gpg'"
+        echo ""
+        failure=1
+    elif ! diff --report-identical "$compare_base" "$current_manifest" 1>&2; then
+        echo "ERR: The SHA256SUMS attestation differs from the compare base:"
+        echo "    base:    '${compare_base}'"
+        echo "    current: '${current_manifest}'"
+        echo ""
+        failure=1
+    else
+        echo "Verified: '${current_manifest}'"
+        echo ""
+    fi
+}
+
+# Determine which epoch(s) to verify
+if [ -n "$EPOCH" ]; then
+    epoch_dirs=( "$ASMAP_SIGS_REPO/$EPOCH" )
+    if [ ! -d "${epoch_dirs[0]}" ]; then
+        echo "ERR: No epoch directory found for EPOCH='${EPOCH}':"
+        echo "    '${epoch_dirs[0]}'"
+        echo ""
+        exit 1
+    fi
+else
+    shopt -s nullglob
+    epoch_dirs=( "$ASMAP_SIGS_REPO"/*/ )
+    shopt -u nullglob
+    # Exclude builder-keys and any other non-epoch dirs (not purely numeric)
+    filtered_epoch_dirs=()
+    for d in "${epoch_dirs[@]}"; do
+        dir_name="$(basename "$d")"
+        if [[ "$dir_name" =~ ^[0-9]+$ ]]; then
+            filtered_epoch_dirs+=("$d")
+        fi
+    done
+    epoch_dirs=("${filtered_epoch_dirs[@]}")
+fi
+
+if (( ${#epoch_dirs[@]} == 0 )); then
+    echo "ERR: No epoch directories found in '${ASMAP_SIGS_REPO}'"
+    echo ""
+    echo "Hint: Expected directories named with Unix timestamps, e.g.:"
+    echo "      '${ASMAP_SIGS_REPO}/1772726379/'"
+    echo ""
+    exit 1
+fi
+
+total_verified=0
+failure=""
+
+for epoch_dir in "${epoch_dirs[@]}"; do
+    epoch_name="$(basename "$epoch_dir")"
+    echo "===================="
+    echo "Epoch: ${epoch_name}"
+    echo "===================="
+    echo ""
+
+    shopt -s nullglob
+    all_manifests=( "${epoch_dir%/}"/*/SHA256SUMS )
+    shopt -u nullglob
+
+    if (( ${#all_manifests[@]} == 0 )); then
+        echo "WARN: No SHA256SUMS files found in epoch '${epoch_name}', skipping."
+        echo ""
+        continue
+    fi
+
+    # Pick compare base
+    compare_base="${all_manifests[0]}"
+    if [ -n "$SIGNER" ]; then
+        signer_manifest="${epoch_dir%/}/${SIGNER}/SHA256SUMS"
+        if [ -f "$signer_manifest" ]; then
+            echo "Using ${SIGNER}'s attestation as the compare base"
+            compare_base="$signer_manifest"
+        else
+            echo "Unable to find ${SIGNER}'s attestation for epoch '${epoch_name}', using the first one found"
+        fi
+    else
+        echo "No SIGNER provided, using the first attestation found as compare base"
+    fi
+    echo ""
+    echo "--------------------"
+    echo ""
+
+    for current_manifest in "${all_manifests[@]}"; do
+        if [ ! -e "${current_manifest}.asc" ]; then
+            signer_name="$(basename "$(dirname "$current_manifest")")"
+            echo "WARN: No signature file found for signer '${signer_name}' in epoch '${epoch_name}'"
+            echo "      Expected: '${current_manifest}.asc'"
+            echo ""
+            failure=1
+            continue
+        fi
+        verify "$compare_base" "$current_manifest"
+        total_verified=$(( total_verified + 1 ))
+    done
+
+    echo "DONE: Checked ${#all_manifests[@]} attestation(s) for epoch '${epoch_name}'"
+    echo ""
+done
+
+echo "===================="
+echo ""
+
+if (( total_verified == 0 )); then
+    echo "ERR: No attestations could be verified."
+    echo ""
+    exit 1
+fi
+
+if [ -n "$failure" ]; then
+    echo "FAIL: One or more verifications failed. See above for details."
+    echo ""
+    exit 1
+fi
+
+echo "OK: All ${total_verified} attestation(s) verified successfully."
+echo ""
+

--- a/contrib/asmap/asmap-verify
+++ b/contrib/asmap/asmap-verify
@@ -15,7 +15,13 @@ check_tools() {
     done
 }
 
-check_tools cat diff gpg basename
+check_tools cat diff basename
+
+GPG=${GPG:-gpg}
+
+# shellcheck disable=SC2206
+GPG_ARRAY=($GPG)
+check_tools "${GPG_ARRAY[0]}"
 
 ################
 # Usage
@@ -97,7 +103,7 @@ verify() {
     local signer_name
     signer_name="$(basename "$(dirname "$current_manifest")")"
 
-    if ! gpg --quiet --batch \
+    if ! ${GPG} --quiet --batch \
             --verify "${current_manifest}.asc" "$current_manifest" 1>&2; then
         echo "ERR: Failed to verify GPG signature for signer '${signer_name}'"
         echo "     Manifest:  '${current_manifest}'"
@@ -105,7 +111,7 @@ verify() {
         echo ""
         echo "Hint: Either the signature is invalid or the public key is not in"
         echo "      your GPG keyring. You can import it with:"
-        echo "          gpg --import '${builder_keys_dir}/${signer_name}.gpg'"
+        echo "         ${GPG} --import '${builder_keys_dir}/${signer_name}.gpg'"
         echo ""
         failure=1
     elif ! diff --report-identical "$compare_base" "$current_manifest" 1>&2; then


### PR DESCRIPTION
Before embedding an ASmap in Bitcoin Core, contributors should attest to the ASmap they create with a well-known PGP key. This allows us to verify that the ASmap file was the same across contributors, and that the contributor's submission This process is analogous to the Guix signing process and the scripts here are heavily inspired from [guix-attest](https://github.com/bitcoin/bitcoin/blob/master/contrib/guix/guix-attest) and [guix-verify](https://github.com/bitcoin/bitcoin/blob/master/contrib/guix/guix-verify). 

The attestation [repository](https://github.com/asmap/asmap.sigs) is currently under the "asmap" organization.

The `asmap-attest` script process is:
- take an ASmap as input
- encode it with the `asmap-tool` python script in this directory
- produce two encoded files: filled and unfilled binary ASmaps
- create an attestation file with the hash of the input ASmap and the hashes of both encoded files
- sign that file with the signer's PGP key
- write the attestation and signatures files to the attestation repository

This process writes 4 files in total: both encoded files to the local directory, an attestation file and its signature to the attestation repository (asmap.sigs) (unless the `NO_SIGN` env var is set) . The input ASmap file is usually around 33MB, the encoded files around 1.5MB (filled) and 1.8MB (unfilled), and the attestation file and signature are sub 1MB. 

The `asmap-verify` script validates the signatures in the repo. The user must add the signer's keys to their GPG keyring before verifying attestations.

No tests are added here. These scripts don't interface with any runtime functionality in the codebase.