### PR TITLE
kernel: add block locator to the C API

### DIFF
--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -142,6 +142,7 @@ struct Handle {
 struct btck_BlockTreeEntry: Handle<btck_BlockTreeEntry, CBlockIndex> {};
 struct btck_Block : Handle<btck_Block, std::shared_ptr<const CBlock>> {};
 struct btck_BlockValidationState : Handle<btck_BlockValidationState, BlockValidationState> {};
+struct btck_BlockLocator : Handle<btck_BlockLocator, CBlockLocator> {};
 
 namespace {
 
@@ -1393,4 +1394,33 @@ uint32_t btck_block_header_get_nonce(const btck_BlockHeader* header)
 void btck_block_header_destroy(btck_BlockHeader* header)
 {
     delete header;
+}
+
+btck_BlockLocator* btck_chainstate_manager_get_locator(const btck_ChainstateManager* chainstate_manager)
+{
+    try {
+        auto& chainman = btck_ChainstateManager::get(chainstate_manager).m_chainman;
+        const CBlockIndex* tip{
+            Assert(WITH_LOCK(chainman->GetMutex(), return chainman->ActiveTip()))};
+        return btck_BlockLocator::create(GetLocator(tip));
+    } catch (const std::exception& e) {
+        LogError("Failed to get block locator: %s", e.what());
+        return nullptr;
+    }
+}
+
+int btck_block_locator_to_bytes(const btck_BlockLocator* locator, btck_WriteBytes writer, void* user_data)
+{
+    try {
+        WriterStream ws{writer, user_data};
+        ws << btck_BlockLocator::get(locator);
+        return 0;
+    } catch (...) {
+        return -1;
+    }
+}
+
+void btck_block_locator_destroy(btck_BlockLocator* locator)
+{
+    delete locator;
 }

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -218,6 +218,15 @@ typedef struct btck_ChainstateManager btck_ChainstateManager;
 typedef struct btck_Block btck_Block;
 
 /**
+ * Opaque data structure for holding a block locator.
+ *
+ * A locator is an ordered list of block hashes spaced exponentially further
+ * back from the active chain tip. Peers use it to find their last common
+ * ancestor with the local chain without exchanging every block hash.
+ */
+typedef struct btck_BlockLocator btck_BlockLocator;
+
+/**
  * Opaque data structure for holding the state of a block during validation.
  *
  * Contains information indicating whether validation was successful, and if not
@@ -1193,6 +1202,35 @@ BITCOINKERNEL_API const btck_Chain* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chains
 BITCOINKERNEL_API const btck_BlockTreeEntry* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_get_block_tree_entry_by_hash(
     const btck_ChainstateManager* chainstate_manager,
     const btck_BlockHash* block_hash) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Get the active chain tip's block locator.
+ *
+ * @param[in] chainstate_manager Non-null.
+ * @return A new btck_BlockLocator, or null on error.
+ */
+BITCOINKERNEL_API btck_BlockLocator* BITCOINKERNEL_WARN_UNUSED_RESULT
+btck_chainstate_manager_get_locator(
+    const btck_ChainstateManager* chainstate_manager) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Serialize a block locator into bytes.
+ *
+ * @param[in] locator    Non-null.
+ * @param[in] writer     Non-null, callback to a write bytes function.
+ * @param[in] user_data  Holds a user-defined opaque structure that will be
+ *                       passed back through the writer callback.
+ * @return               0 on success.
+ */
+BITCOINKERNEL_API int btck_block_locator_to_bytes(
+    const btck_BlockLocator* locator,
+    btck_WriteBytes writer,
+    void* user_data) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * Destroy the block locator.
+ */
+BITCOINKERNEL_API void btck_block_locator_destroy(btck_BlockLocator* locator);
 
 /**
  * Destroy the chainstate manager.

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -1187,6 +1187,17 @@ public:
     MAKE_RANGE_METHOD(TxsSpentOutputs, BlockSpentOutputs, &BlockSpentOutputs::Count, &BlockSpentOutputs::GetTxSpentOutputs, *this)
 };
 
+class BlockLocator : UniqueHandle<btck_BlockLocator, btck_block_locator_destroy>
+{
+public:
+    explicit BlockLocator(btck_BlockLocator* ptr) : UniqueHandle{ptr} {}
+
+    std::vector<std::byte> ToBytes() const
+    {
+        return write_bytes(get(), btck_block_locator_to_bytes);
+    }
+};
+
 class ChainMan : UniqueHandle<btck_ChainstateManager, btck_chainstate_manager_destroy>
 {
 public:
@@ -1237,6 +1248,13 @@ public:
     BlockTreeEntry GetBestEntry() const
     {
         return btck_chainstate_manager_get_best_entry(get());
+    }
+
+    std::optional<BlockLocator> GetLocator() const
+    {
+        auto* locator{btck_chainstate_manager_get_locator(get())};
+        if (!locator) return std::nullopt;
+        return BlockLocator{locator};
     }
 
     std::optional<Block> ReadBlock(const BlockTreeEntry& entry) const

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -1177,3 +1177,59 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     fs::remove_all(test_directory.m_directory / "blocks" / "rev00000.dat");
     BOOST_CHECK_THROW(chainman->ReadBlockSpentOutputs(tip), std::runtime_error);
 }
+
+BOOST_AUTO_TEST_CASE(btck_block_locator_tests)
+{
+    // Serialized CBlockLocator format: 4-byte version | 1-byte compact count | count * 32-byte hashes.
+    auto locator_count{[](const std::vector<std::byte>& b) -> size_t {
+        return static_cast<uint8_t>(b[4]);
+    }};
+    auto locator_hash{[](const std::vector<std::byte>& b, size_t i) {
+        std::array<std::byte, 32> hash;
+        std::memcpy(hash.data(), b.data() + 5 + i * 32, 32);
+        return hash;
+    }};
+
+    // The genesis block is always the active tip on a fresh chainstate.
+    {
+        auto test_directory{TestDirectory{"locator_genesis_only"}};
+        auto notifications{std::make_shared<TestKernelNotifications>()};
+        auto context{create_context(notifications, ChainType::REGTEST)};
+        auto chainman{create_chainman(
+            test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
+            /*block_tree_db_in_memory=*/true, /*chainstate_db_in_memory=*/true,
+            context)};
+        auto locator{chainman->GetLocator()};
+        BOOST_REQUIRE(locator.has_value());
+        auto locator_bytes{locator->ToBytes()};
+        BOOST_CHECK_EQUAL(locator_count(locator_bytes), 1);
+        auto genesis_hash{chainman->GetBestEntry().GetHash().ToBytes()};
+        BOOST_CHECK(locator_hash(locator_bytes, 0) == genesis_hash);
+    }
+
+    // After IBD the locator must contain more than one hash and start at the new tip.
+    {
+        auto test_directory{TestDirectory{"locator_regtest"}};
+        auto notifications{std::make_shared<TestKernelNotifications>()};
+        auto context{create_context(notifications, ChainType::REGTEST)};
+        auto chainman{create_chainman(
+            test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
+            /*block_tree_db_in_memory=*/true, /*chainstate_db_in_memory=*/true,
+            context)};
+        for (const auto& raw_block : REGTEST_BLOCK_DATA) {
+            Block block{hex_string_to_byte_vec(raw_block)};
+            bool new_block{false};
+            BOOST_CHECK(chainman->ProcessBlock(block, &new_block));
+            BOOST_CHECK(new_block);
+        }
+
+        auto locator{chainman->GetLocator()};
+        BOOST_REQUIRE(locator.has_value());
+        auto locator_bytes{locator->ToBytes()};
+        BOOST_CHECK(locator_count(locator_bytes) > 1);
+
+        // Verify the tip hash independently rather than relying on GetBestEntry().
+        Block last_block{hex_string_to_byte_vec(REGTEST_BLOCK_DATA.back())};
+        BOOST_CHECK(locator_hash(locator_bytes, 0) == last_block.GetHash().ToBytes());
+    }
+}


### PR DESCRIPTION
The block locator is the primitive a node uses to announce its chain position to peers. When a node resumes after shutting down on a stale tip, it sends its locator so a peer can identify the fork point and serve the blocks needed to reach the best chain. Without this, callers of libbitcoinkernel have no canonical way to recover from a stale tip.

Adds three C API functions: `btck_chainstate_manager_get_locator` to retrieve the active tip's locator as a `btck_BlockLocator`, `btck_block_locator_to_bytes` to serialize it, and `btck_block_locator_destroy` to free it.

Includes a C++ convenience wrapper and Boost tests covering the genesis-only and post-IBD cases.

Motivated by kernel-node/pull/30 (edit: idea for the PR came from [rustaceanrob's comment](https://github.com/kernel-node/kernel-node/pull/30#issuecomment-4053578271) ), which needs this primitive to implement sync recovery in a Rust consumer of libbitcoinkernel.