### PR TITLE
util: Add util::NotNull<SmartPtrType>

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -19,6 +19,7 @@
 #include <util/check.h>
 #include <util/log.h>
 #include <util/overflow.h>
+#include <util/pointers.h>
 
 #include <cassert>
 #include <cstdint>
@@ -737,8 +738,8 @@ private:
         return base->PeekCoin(outpoint);
     }
 
-    //! Non-null. May have zero workers when input fetching is disabled.
-    std::shared_ptr<ThreadPool> m_thread_pool;
+    /// May have zero workers when input fetching is disabled.
+    util::NotNullSharedPtr<ThreadPool> m_thread_pool;
     std::vector<std::future<void>> m_futures{};
 
 protected:
@@ -749,11 +750,10 @@ protected:
     }
 
 public:
-    explicit CoinsViewOverlay(CCoinsView* in_base, std::shared_ptr<ThreadPool> thread_pool,
+    explicit CoinsViewOverlay(CCoinsView* in_base, util::NotNullSharedPtr<ThreadPool> thread_pool,
                               bool deterministic = false) noexcept
         : CCoinsViewCache{in_base, deterministic}, m_thread_pool{std::move(thread_pool)}
     {
-        Assert(m_thread_pool);
     }
 
     ~CoinsViewOverlay() noexcept override { StopFetching(); }

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -13,6 +13,7 @@
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/obfuscation.h>
+#include <util/pointers.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -193,7 +194,7 @@ class CDBWrapper
     friend const Obfuscation& dbwrapper_private::GetObfuscation(const CDBWrapper&);
 private:
     //! holds all leveldb-specific fields of this class
-    std::unique_ptr<LevelDBContext> m_db_context;
+    util::NotNullUniquePtr<LevelDBContext> m_db_context;
 
     //! the name of this database
     std::string m_name;
@@ -207,7 +208,7 @@ private:
     std::optional<std::string> ReadImpl(std::span<const std::byte> key) const;
     bool ExistsImpl(std::span<const std::byte> key) const;
     size_t EstimateSizeImpl(std::span<const std::byte> key1, std::span<const std::byte> key2) const;
-    auto& DBContext() const LIFETIMEBOUND { return *Assert(m_db_context); }
+    auto& DBContext() const LIFETIMEBOUND { return *m_db_context; }
 
 public:
     CDBWrapper(const DBParams& params);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -4060,12 +4060,12 @@ ServiceFlags CConnman::GetLocalServices() const
     return m_local_services;
 }
 
-static std::unique_ptr<Transport> MakeTransport(NodeId id, bool use_v2transport, bool inbound) noexcept
+static util::NotNullUniquePtr<Transport> MakeTransport(NodeId id, bool use_v2transport, bool inbound) noexcept
 {
     if (use_v2transport) {
-        return std::make_unique<V2Transport>(id, /*initiating=*/!inbound);
+        return util::NotNull{std::make_unique<V2Transport>(id, /*initiating=*/!inbound)};
     } else {
-        return std::make_unique<V1Transport>(id);
+        return util::NotNull{std::make_unique<V1Transport>(id)};
     }
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -30,6 +30,7 @@
 #include <sync.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/pointers.h>
 #include <util/sock.h>
 #include <util/threadinterrupt.h>
 
@@ -684,7 +685,7 @@ class CNode
 public:
     /** Transport serializer/deserializer. The receive side functions are only called under cs_vRecv, while
      * the sending side functions are only called under cs_vSend. */
-    const std::unique_ptr<Transport> m_transport;
+    const util::NotNullUniquePtr<Transport> m_transport;
 
     const NetPermissionFlags m_permission_flags;
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -126,6 +126,7 @@ add_executable(test_bitcoin
   txvalidationcache_tests.cpp
   uint256_tests.cpp
   util_check_tests.cpp
+  util_pointers_tests.cpp
   util_expected_tests.cpp
   util_string_tests.cpp
   util_tests.cpp

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -23,9 +23,9 @@
 
 namespace {
 
-std::shared_ptr<ThreadPool> MakeStartedThreadPool()
+util::NotNullSharedPtr<ThreadPool> MakeStartedThreadPool()
 {
-    auto pool{std::make_shared<ThreadPool>("fetch_test")};
+    util::NotNull pool{std::make_shared<ThreadPool>("fetch_test")};
     pool->Start(DEFAULT_PREVOUTFETCH_THREADS);
     return pool;
 }
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(fetch_unstarted_thread_pool)
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
-    auto thread_pool{std::make_shared<ThreadPool>("fetch_none")};
+    util::NotNull thread_pool{std::make_shared<ThreadPool>("fetch_none")};
     CoinsViewOverlay view{&main_cache, thread_pool};
     const auto reset_guard{view.StartFetching(block)};
     CheckCache(block, view);
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(fetch_interrupted_thread_pool_uses_normal_lookup)
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
 
-    auto thread_pool{std::make_shared<ThreadPool>("fetch_intr")};
+    util::NotNull thread_pool{std::make_shared<ThreadPool>("fetch_intr")};
     thread_pool->Start(DEFAULT_PREVOUTFETCH_THREADS);
     thread_pool->Interrupt();
     CoinsViewOverlay view{&main_cache, thread_pool};

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -90,7 +90,7 @@ public:
 
 // Reuse a single global thread pool across fuzz iterations. Creating and destroying a pool every
 // iteration leaks memory, since iterations can run faster than the OS can tear down the threads.
-std::shared_ptr<ThreadPool> g_thread_pool{std::make_shared<ThreadPool>("view_fuzz")};
+util::NotNull g_thread_pool{std::make_shared<ThreadPool>("view_fuzz")};
 
 void StartPoolIfNeeded()
 {

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -206,7 +206,7 @@ struct OverlayFetchScope
 
 // Reuse a single global thread pool across fuzz iterations. Creating and destroying a pool every
 // iteration leaks memory, since iterations can run faster than the OS can tear down the threads.
-std::shared_ptr<ThreadPool> g_thread_pool{std::make_shared<ThreadPool>("cache_fuzz")};
+util::NotNull g_thread_pool{std::make_shared<ThreadPool>("cache_fuzz")};
 
 void StartPoolIfNeeded()
 {

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -274,66 +274,70 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     // Now test ImprovesFeerateDiagram with various levels of "package rbf" feerates
 
     // It doesn't improve itself
-    auto changeset = pool.GetChangeSet();
-    changeset->StageRemoval(entry1);
-    changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
-    const auto res1 = ImprovesFeerateDiagram(*changeset);
-    BOOST_CHECK(res1.has_value());
-    BOOST_CHECK(res1.value().first == DiagramCheckError::FAILURE);
-    BOOST_CHECK(res1.value().second == "insufficient feerate: does not improve feerate diagram");
+    {
+        auto changeset{pool.GetChangeSet()};
+        changeset->StageRemoval(entry1);
+        changeset->StageRemoval(entry2);
+        changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
+        const auto res1 = ImprovesFeerateDiagram(*changeset);
+        BOOST_CHECK(res1.has_value());
+        BOOST_CHECK(res1.value().first == DiagramCheckError::FAILURE);
+        BOOST_CHECK(res1.value().second == "insufficient feerate: does not improve feerate diagram");
+    }
 
     // With one more satoshi it does
-    changeset.reset();
-    changeset = pool.GetChangeSet();
-    changeset->StageRemoval(entry1);
-    changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee+1, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
-    BOOST_CHECK(ImprovesFeerateDiagram(*changeset) == std::nullopt);
+    {
+        auto changeset{pool.GetChangeSet()};
+        changeset->StageRemoval(entry1);
+        changeset->StageRemoval(entry2);
+        changeset->StageAddition(tx1_conflict, tx1_fee + 1, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
+        BOOST_CHECK(ImprovesFeerateDiagram(*changeset) == std::nullopt);
+    }
 
-    changeset.reset();
     // With prioritisation of in-mempool conflicts, it affects the results of the comparison using the same args as just above
     pool.PrioritiseTransaction(entry1->GetSharedTx()->GetHash(), /*nFeeDelta=*/1);
-    changeset = pool.GetChangeSet();
-    changeset->StageRemoval(entry1);
-    changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee+1, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
-    const auto res2 = ImprovesFeerateDiagram(*changeset);
-    BOOST_CHECK(res2.has_value());
-    BOOST_CHECK(res2.value().first == DiagramCheckError::FAILURE);
-    BOOST_CHECK(res2.value().second == "insufficient feerate: does not improve feerate diagram");
-    changeset.reset();
-
+    {
+        auto changeset{pool.GetChangeSet()};
+        changeset->StageRemoval(entry1);
+        changeset->StageRemoval(entry2);
+        changeset->StageAddition(tx1_conflict, tx1_fee + 1, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
+        const auto res2 = ImprovesFeerateDiagram(*changeset);
+        BOOST_CHECK(res2.has_value());
+        BOOST_CHECK(res2.value().first == DiagramCheckError::FAILURE);
+        BOOST_CHECK(res2.value().second == "insufficient feerate: does not improve feerate diagram");
+    }
     pool.PrioritiseTransaction(entry1->GetSharedTx()->GetHash(), /*nFeeDelta=*/-1);
 
     // With fewer vbytes it does
     CMutableTransaction tx4{entry3.GetTx()};
     tx4.vin[0].scriptWitness = CScriptWitness(); // Clear out the witness, to reduce size
     auto entry4 = entry.FromTx(MakeTransactionRef(tx4));
-    changeset = pool.GetChangeSet();
-    changeset->StageRemoval(entry1);
-    changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee, 0, 1, 0, false, 4, LockPoints());
-    BOOST_CHECK(ImprovesFeerateDiagram(*changeset) == std::nullopt);
-    changeset.reset();
+    {
+        auto changeset{pool.GetChangeSet()};
+        changeset->StageRemoval(entry1);
+        changeset->StageRemoval(entry2);
+        changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(entry4.GetSharedTx(), tx2_fee, 0, 1, 0, false, 4, LockPoints());
+        BOOST_CHECK(ImprovesFeerateDiagram(*changeset) == std::nullopt);
+    }
 
     // Adding a grandchild makes the cluster size 3, which is also calculable
-    const auto tx5 = make_tx(/*inputs=*/ {tx2}, /*output_values=*/ {995 * CENT});
+    const auto tx5 = make_tx(/*inputs=*/{tx2}, /*output_values=*/{995 * CENT});
     TryAddToMempool(pool, entry.Fee(normal_fee).FromTx(tx5));
     const auto entry5 = pool.GetIter(tx5->GetHash()).value();
-
-    changeset = pool.GetChangeSet();
-    changeset->StageRemoval(entry1);
-    changeset->StageRemoval(entry2);
-    changeset->StageRemoval(entry5);
-    changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee + entry5->GetModifiedFee() + 1, 0, 1, 0, false, 4, LockPoints());
-    const auto res3 = ImprovesFeerateDiagram(*changeset);
-    BOOST_CHECK(res3 == std::nullopt);
+    {
+        auto changeset{pool.GetChangeSet()};
+        changeset->StageRemoval(entry1);
+        changeset->StageRemoval(entry2);
+        changeset->StageRemoval(entry5);
+        changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(entry4.GetSharedTx(), tx2_fee + entry5->GetModifiedFee() + 1, 0, 1, 0, false, 4, LockPoints());
+        const auto res3 = ImprovesFeerateDiagram(*changeset);
+        BOOST_CHECK(res3 == std::nullopt);
+    }
 }
 
 BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)

--- a/src/test/util_pointers_tests.cpp
+++ b/src/test/util_pointers_tests.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <sync.h>
+#include <test/util/common.h>
+#include <util/pointers.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <set>
+#include <type_traits>
+#include <unordered_set>
+
+BOOST_AUTO_TEST_SUITE(util_pointers_tests)
+
+static_assert(std::is_same_v<util::NotNullUniquePtr<int>, util::NotNull<std::unique_ptr<int>>>);
+static_assert(std::is_same_v<util::NotNullSharedPtr<int>, util::NotNull<std::shared_ptr<int>>>);
+
+template <class P>
+concept NotNullConstructible = requires { typename std::bool_constant<(util::NotNull{P{}}, true)>; };
+
+BOOST_AUTO_TEST_CASE(check_ctor)
+{
+    struct SomePtr {
+        constexpr bool operator==(std::nullptr_t) const { return false; }
+    };
+    struct NullPtr {
+        constexpr bool operator==(std::nullptr_t) const { return true; }
+    };
+
+    static_assert(NotNullConstructible<SomePtr>);
+    static_assert(!NotNullConstructible<NullPtr>);
+    static_assert(!NotNullConstructible<std::nullptr_t>);
+    static_assert(!NotNullConstructible<int*>);
+}
+
+BOOST_AUTO_TEST_CASE(check_ctor_conv)
+{
+    using Ptr = std::shared_ptr<int>;
+    using NNPtr = util::NotNullSharedPtr<int>;
+
+    // For context: std::shared_ptr's raw pointer constructor is explicit
+    static_assert(std::constructible_from<Ptr, int*>);
+    static_assert(!std::convertible_to<int*, Ptr>);
+
+    // util::NotNull's constructor is explicit
+    static_assert(std::constructible_from<NNPtr, Ptr>);
+    static_assert(!std::convertible_to<Ptr, NNPtr>);
+
+    // For context: std::reference_wrapper's constructor is implicit
+    using Ref = std::reference_wrapper<int>;
+    static_assert(std::constructible_from<Ref, int&>);
+    static_assert(std::convertible_to<int&, Ref>);
+
+    using NNUniqPtr = util::NotNullUniquePtr<int>;
+
+    // NNPtr can be copied, but NNUniqPtr can not:
+    static_assert(std::is_constructible_v<NNPtr, NNPtr&>);
+    static_assert(std::is_constructible_v<NNPtr, const NNPtr&>);
+    static_assert(!std::is_constructible_v<NNUniqPtr, NNUniqPtr&>);
+    static_assert(!std::is_constructible_v<NNUniqPtr, const NNUniqPtr&>);
+}
+
+template <class P>
+concept NullptrComparable = requires(P val) { val == nullptr; };
+template <class P>
+concept HasOperatorBool = requires(P val) { bool{val}; };
+
+BOOST_AUTO_TEST_CASE(check_nullptr_compare)
+{
+    // The deleted ctor for nullptr also disallows nullptr compare:
+    static_assert(NullptrComparable<std::shared_ptr<int>>);
+    static_assert(!NullptrComparable<util::NotNullSharedPtr<int>>);
+
+    static_assert(HasOperatorBool<std::shared_ptr<int>>);
+    static_assert(!HasOperatorBool<util::NotNullSharedPtr<int>>);
+}
+
+BOOST_AUTO_TEST_CASE(check_nocopy_ptr)
+{
+    using NoCopyPtr = std::unique_ptr<int>;
+    {
+        NoCopyPtr no_copy_ptr{new int{}};
+        util::NotNull no_copy{std::move(no_copy_ptr)};
+        NoCopyPtr extract{std::move(no_copy)};
+        (void)extract;
+    }
+    {
+        util::NotNull no_copy{NoCopyPtr{new int{}}};
+        NoCopyPtr extract{std::move(no_copy).get()};
+        (void)extract;
+    }
+    {
+        util::NotNull no_copy{NoCopyPtr{new int{}}};
+        auto extract{std::move(no_copy).get()};
+        static_assert(std::is_same_v<decltype(extract), NoCopyPtr>);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(check_derived)
+{
+    struct MyBase {
+        virtual ~MyBase() = default;
+    };
+    struct MyDerived : public MyBase {
+    };
+
+    util::NotNull p{std::make_shared<MyDerived>()};
+    util::NotNull q{std::make_shared<MyBase>()};
+    q = p;
+    const bool same_ptr{q == p};
+    BOOST_CHECK(same_ptr);
+
+    util::NotNull nn_derived{std::make_unique<MyDerived>()};
+    util::NotNull nn_base{std::make_unique<MyBase>()};
+    nn_base = std::move(nn_derived);
+    std::unique_ptr<MyBase> base_inner{std::move(nn_base)};
+}
+
+BOOST_AUTO_TEST_CASE(check_move)
+{
+    auto a{std::make_unique<int>()};
+    util::NotNull box{std::move(a)};
+    auto new_box{std::move(box)};
+
+    auto b{std::make_shared<int>()};
+    util::NotNull arc{b};
+    auto new_arc{std::move(arc)};
+}
+
+BOOST_AUTO_TEST_CASE(check_swap)
+{
+    util::NotNull box_a{std::make_unique<int>(1)};
+    util::NotNull box_b{std::make_unique<int>(2)};
+    static_assert(std::is_nothrow_swappable_v<decltype(box_a)>);
+    BOOST_CHECK_EQUAL(*box_a - *box_b, -1);
+    swap(box_a, box_b);
+    BOOST_CHECK_EQUAL(*box_a - *box_b, 1);
+}
+
+BOOST_AUTO_TEST_CASE(check_deref)
+{
+    util::NotNull p{std::make_unique<int>(2)};
+    *p = 3;
+    BOOST_CHECK_EQUAL(*p, 3);
+    *p.get() = 4;
+    BOOST_CHECK_EQUAL(*p, 4);
+}
+
+BOOST_AUTO_TEST_CASE(check_compare_set)
+{
+    auto a{std::make_shared<int>(1)};
+    auto b{std::make_shared<int>(2)};
+    std::set<util::NotNullSharedPtr<int>> uniq{};
+    uniq.emplace(a);
+    uniq.emplace(a);
+    uniq.emplace(b);
+    BOOST_CHECK_EQUAL(uniq.size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(check_hash_set)
+{
+    auto a{std::make_shared<int>(1)};
+    auto b{std::make_shared<int>(2)};
+    std::unordered_set<util::NotNullSharedPtr<int>> uniq{};
+    uniq.emplace(a);
+    uniq.emplace(a);
+    uniq.emplace(b);
+    BOOST_CHECK_EQUAL(uniq.size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(check_tsa)
+{
+    struct Thing {
+        Mutex mutex{};
+        int a GUARDED_BY(mutex){2};
+    };
+    const util::NotNull p{std::make_shared<Thing>()};
+    // Clang thread safety annotation (TSA) may not be able to derive that
+    // operator-> and operator* refer to the same object. So use a named
+    // reference before taking the lock.
+    Thing& ref{*p};
+    LOCK(ref.mutex);
+    BOOST_CHECK_EQUAL(ref.a, 2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -22,6 +22,7 @@
 #include <txgraph.h>
 #include <util/feefrac.h>
 #include <util/hasher.h>
+#include <util/pointers.h>
 #include <util/result.h>
 
 #include <boost/multi_index/hashed_index.hpp>
@@ -716,10 +717,11 @@ public:
         friend class CTxMemPool;
     };
 
-    std::unique_ptr<ChangeSet> GetChangeSet() EXCLUSIVE_LOCKS_REQUIRED(cs) {
+    util::NotNull<std::unique_ptr<ChangeSet>> GetChangeSet() EXCLUSIVE_LOCKS_REQUIRED(cs)
+    {
         Assume(!m_have_changeset);
         m_have_changeset = true;
-        return std::make_unique<ChangeSet>(this);
+        return util::NotNull{std::make_unique<ChangeSet>(this)};
     }
 
     bool m_have_changeset GUARDED_BY(cs){false};

--- a/src/util/pointers.h
+++ b/src/util/pointers.h
@@ -1,0 +1,117 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef BITCOIN_UTIL_POINTERS_H
+#define BITCOIN_UTIL_POINTERS_H
+
+#include <attributes.h>
+#include <util/check.h>
+
+#include <compare>
+#include <concepts>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <utility>
+
+namespace util {
+
+/// NotNull is intended to be used to denote that a smart pointer type can not
+/// hold a nullptr value.
+///
+/// The type is more useful, the earlier in the lifetime of a pointer it is
+/// used. So instead of passing an existing pointer into NotNull, it is
+/// recommended to use the type when creating the smart pointer. E.g.:
+///
+/// util::NotNull p{std::make_shared<Thing>()};
+///
+/// This makes it obvious that a pointer really is not null and that the
+/// constructor will not fail.
+///
+/// NotNull can *not* be used to denote a raw pointer can not be nullptr.
+/// The C++ language provides raw references for this use case, and the C++
+/// standard library provides std::reference_wrapper, where raw references can
+/// not be used.
+///
+/// This type is movable, meaning that the inner pointer *is* null after a
+/// move. Clang-tidy static analysis is used to enforce use-after-move
+/// violations, so that the null should never be observed. Moreover, the
+/// runtime Assume check in the get() member function will ensure the same.
+template <class T>
+    requires(!std::is_pointer_v<T>) && requires(T t) { { t != nullptr } -> std::convertible_to<bool>; }
+class NotNull
+{
+public:
+    template <std::convertible_to<T> U>
+        requires(!std::same_as<std::remove_cvref_t<U>, NotNull>)
+    constexpr explicit NotNull(U&& u) noexcept(std::is_nothrow_constructible_v<T, U&&>)
+        : m_ptr(std::forward<U>(u))
+    {
+        Assert(m_ptr != nullptr);
+    }
+
+    template <std::convertible_to<T> U>
+    constexpr NotNull(NotNull<U>&& other) noexcept(std::is_nothrow_constructible_v<T, U&&>)
+        : m_ptr(std::move(other).get())
+    {
+    }
+
+    template <std::convertible_to<T> U>
+    constexpr NotNull(const NotNull<U>& other) noexcept(std::is_nothrow_constructible_v<T, const U&>)
+        : m_ptr(other.get())
+    {
+    }
+
+    NotNull(std::nullptr_t) = delete;
+    NotNull& operator=(std::nullptr_t) = delete;
+
+    constexpr NotNull(NotNull&&) = default;
+    constexpr NotNull& operator=(NotNull&&) = default;
+    constexpr NotNull(const NotNull&) = default;
+    constexpr NotNull& operator=(const NotNull&) = default;
+
+    constexpr const T& get() const& noexcept LIFETIMEBOUND { return Assume(m_ptr); }
+    constexpr T&& get() && noexcept LIFETIMEBOUND { return std::move(Assume(m_ptr)); }
+
+    constexpr decltype(auto) operator->() const LIFETIMEBOUND { return get(); }
+    constexpr decltype(auto) operator*() const LIFETIMEBOUND { return *get(); }
+
+    constexpr operator T() const& { return get(); }
+    constexpr operator T() && noexcept { return std::move(*this).get(); }
+
+    template <class U>
+    constexpr auto operator<=>(const NotNull<U>& other) const
+    {
+        return std::compare_three_way{}(get(), other.get());
+    }
+    template <class U>
+    constexpr bool operator==(const NotNull<U>& other) const
+    {
+        return get() == other.get();
+    }
+
+private:
+    T m_ptr;
+};
+
+template <class T>
+NotNull(T) -> NotNull<T>;
+
+template <typename T, typename Deleter = std::default_delete<T>>
+using NotNullUniquePtr = NotNull<std::unique_ptr<T, Deleter>>;
+
+template <typename T>
+using NotNullSharedPtr = NotNull<std::shared_ptr<T>>;
+
+} // namespace util
+
+template <class T>
+struct std::hash<util::NotNull<T>> {
+    std::size_t operator()(const util::NotNull<T>& v) const noexcept
+    {
+        return std::hash<T>{}(v.get());
+    }
+};
+
+#endif // BITCOIN_UTIL_POINTERS_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1864,7 +1864,7 @@ void CoinsViews::InitCache(int32_t prevoutfetch_threads)
 {
     AssertLockHeld(::cs_main);
     m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
-    auto thread_pool{std::make_shared<ThreadPool>("prevout")};
+    util::NotNull thread_pool{std::make_shared<ThreadPool>("prevout")};
     if (prevoutfetch_threads > 0) {
         thread_pool->Start(prevoutfetch_threads);
         LogInfo("Block input prevout fetching uses %d additional threads", prevoutfetch_threads);


### PR DESCRIPTION
The C++ standard library lacks a type to denote a smart pointer is not null. For raw pointer there is `std::reference_wrapper`, or a plain reference.

Other third-party libraries provide such a type, such as `gsl::strict_not_null`.

Fix all issues by adding `util::NotNull<SmartPtrType>`, which documents (and checks) that the inner pointer is never null.

This type can be used when passing never-null smart pointers between functions. It removes the need to `Assert()` the pointer before dereference. For example, in a getter function:

```cpp
util::NotNull<std::unique_ptr<Stats>> GetStats()
{
    return util::NotNull{std::make_unique<Stats>()};
}

int main()
{
    auto stats{GetStats()};
    stats->foo; // This can never lead to a nullptr deref
    // Assert(stats)->foo; // This is redundant and won't compile
}
```

Fixes https://github.com/bitcoin/bitcoin/issues/24423