### PR TITLE
test: throttle large orphan transactions while being sent in RPCs

### DIFF
--- a/.github/ci-test-each-commit-exec.py
+++ b/.github/ci-test-each-commit-exec.py
@@ -16,9 +16,24 @@ def run(cmd, **kwargs):
     except Exception as e:
         sys.exit(str(e))
 
+def debug_stats():
+    '''
+    p1 = run(["ss", "-tan"], capture_output=True, text=True)
+    p2 = run(["awk", "{print $1}"], input=p1.stdout, capture_output=True, text=True)
+    p3 = run(["sort"], input=p2.stdout, capture_output=True, text=True)
+    print(run(["uniq", "-c"], input=p3.stdout, capture_output=True, text=True).stdout)
+    print(run(["ss", "-tan", "state", "time-wait"], capture_output=True, text=True).stdout)
+    print(run(["cat", "/proc/net/sockstat"]).stdout)
+    print(run(["cat", "/proc/net/sockstat6"], stderr=subprocess.DEVNULL, text=True).stdout)
+    print(run(["cat", "/proc/loadavg"]).stdout)
+    print(run(["ss", "-tain"], capture_output=True, text=True).stdout)
+    '''
+    print(run(["vmstat"], capture_output=True, text=True).stdout)
+
 
 def main():
     print("Running tests on commit ...")
+    # debug_stats()
     run(["git", "log", "-1"])
 
     num_procs = int(run(["nproc"], stdout=subprocess.PIPE).stdout)

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -553,19 +553,30 @@ std::string HTTPRequest::ReadBody()
     struct evbuffer* buf = evhttp_request_get_input_buffer(req);
     if (!buf)
         return "";
-    size_t size = evbuffer_get_length(buf);
-    /** Trivial implementation: if this is ever a performance bottleneck,
-     * internal copying can be avoided in multi-segment buffers by using
-     * evbuffer_peek and an awkward loop. Though in that case, it'd be even
-     * better to not copy into an intermediate string but use a stream
-     * abstraction to consume the evbuffer on the fly in the parsing algorithm.
-     */
-    const char* data = (const char*)evbuffer_pullup(buf, size);
-    if (!data) // returns nullptr in case of empty buffer
+
+    size_t total_len = evbuffer_get_length(buf);
+    if (total_len == 0)
         return "";
-    std::string rv(data, size);
-    evbuffer_drain(buf, size);
-    return rv;
+    std::string result;
+    result.reserve(total_len);
+
+    struct evbuffer_iovec v[8];
+    int n;
+
+    while ((n = evbuffer_peek(buf, -1, nullptr, v, 8)) > 0) {
+        size_t drained = 0;
+
+        for (int i = 0; i < n; ++i) {
+            const char* data = static_cast<const char*>(v[i].iov_base);
+            size_t len = v[i].iov_len;
+
+            result.append(data, len);
+            drained += len;
+        }
+
+        evbuffer_drain(buf, drained);
+    }
+    return result;
 }
 
 void HTTPRequest::WriteHeader(const std::string& hdr, const std::string& value)

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -12,7 +12,7 @@ import time
 
 from test_framework.blocktools import MAX_STANDARD_TX_WEIGHT
 from test_framework.mempool_util import (
-    create_large_orphan,
+    LargeOrphanTransaction,
     DEFAULT_MIN_RELAY_TX_FEE,
     fill_mempool,
 )
@@ -435,13 +435,13 @@ class PackageRelayTest(BitcoinTestFramework):
         num_individual_dosers = 10
 
         self.log.info("Create very large orphans to be sent by DoSy peers (may take a while)")
-        large_orphans = [create_large_orphan() for _ in range(50)]
+        large_orphans = [LargeOrphanTransaction() for _ in range(50)]
         # Check to make sure these are orphans, within max standard size (to be accepted into the orphanage)
         for large_orphan in large_orphans:
-            assert_greater_than_or_equal(100000, large_orphan.get_vsize())
-            assert_greater_than(MAX_STANDARD_TX_WEIGHT, large_orphan.get_weight())
-            assert_greater_than_or_equal(3 * large_orphan.get_vsize(), 2 * 100000)
-            testres = node.testmempoolaccept([large_orphan.serialize().hex()])
+            assert_greater_than_or_equal(100000, large_orphan.get.get_vsize())
+            assert_greater_than(MAX_STANDARD_TX_WEIGHT, large_orphan.get.get_weight())
+            assert_greater_than_or_equal(3 * large_orphan.get.get_vsize(), 2 * 100000)
+            testres = node.testmempoolaccept([large_orphan.to_send.serialize().hex()])
             assert not testres[0]["allowed"]
             assert_equal(testres[0]["reject-reason"], "missing-inputs")
 
@@ -451,9 +451,9 @@ class PackageRelayTest(BitcoinTestFramework):
         # Connect 10 peers and have each of them send a large orphan.
         for large_orphan in large_orphans[:num_individual_dosers]:
             peer_doser_individual = node.add_p2p_connection(P2PInterface())
-            peer_doser_individual.send_and_ping(msg_tx(large_orphan))
+            peer_doser_individual.send_and_ping(msg_tx(large_orphan.to_send))
             node.bumpmocktime(NONPREF_PEER_TX_DELAY + TXID_RELAY_DELAY)
-            peer_doser_individual.wait_for_getdata([large_orphan.vin[0].prevout.hash])
+            peer_doser_individual.wait_for_getdata([large_orphan.get.vin[0].prevout.hash])
 
         # Make sure that these transactions are going through the orphan handling codepaths.
         # Subsequent rounds will not wait for getdata because the time mocking will cause the
@@ -485,7 +485,7 @@ class PackageRelayTest(BitcoinTestFramework):
 
         self.log.info("Send another round of very large orphans from a DoSy peer")
         for large_orphan in large_orphans[num_individual_dosers:]:
-            peer_doser.send_and_ping(msg_tx(large_orphan))
+            peer_doser.send_and_ping(msg_tx(large_orphan.to_send))
 
         # Something was evicted; the orphanage does not contain all large orphans + the 1p1c child
         self.wait_until(lambda: len(node.getorphantxs()) < len(large_orphans) + 1)

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -7,7 +7,7 @@ import time
 
 from test_framework.blocktools import MAX_STANDARD_TX_WEIGHT
 from test_framework.mempool_util import (
-    create_large_orphan,
+    LargeOrphanTransaction,
     tx_in_orphanage,
 )
 from test_framework.messages import (
@@ -626,11 +626,11 @@ class OrphanHandlingTest(BitcoinTestFramework):
         peer_doser = node.add_p2p_connection(P2PInterface())
 
         # Each of the num_peers peers creates a distinct set of orphans
-        large_orphans = [create_large_orphan() for _ in range(60)]
+        large_orphans = [LargeOrphanTransaction() for _ in range(60)]
 
         # Check to make sure these are orphans, within max standard size (to be accepted into the orphanage)
         for large_orphan in large_orphans:
-            testres = node.testmempoolaccept([large_orphan.serialize().hex()])
+            testres = node.testmempoolaccept([large_orphan.to_send.serialize().hex()])
             assert not testres[0]["allowed"]
             assert_equal(testres[0]["reject-reason"], "missing-inputs")
 
@@ -641,9 +641,9 @@ class OrphanHandlingTest(BitcoinTestFramework):
         # Connect 20 peers and have each of them send a large orphan.
         for large_orphan in large_orphans[:num_individual_dosers]:
             peer_doser_individual = node.add_p2p_connection(P2PInterface())
-            peer_doser_individual.send_and_ping(msg_tx(large_orphan))
+            peer_doser_individual.send_and_ping(msg_tx(large_orphan.to_send))
             node.bumpmocktime(NONPREF_PEER_TX_DELAY + TXID_RELAY_DELAY + 1)
-            peer_doser_individual.wait_for_getdata([large_orphan.vin[0].prevout.hash])
+            peer_doser_individual.wait_for_getdata([large_orphan.get.vin[0].prevout.hash])
 
         # Make sure that these transactions are going through the orphan handling codepaths.
         # Subsequent rounds will not wait for getdata because the time mocking will cause the
@@ -673,7 +673,7 @@ class OrphanHandlingTest(BitcoinTestFramework):
 
         self.log.info("Send another round of very large orphans from a DoSy peer")
         for large_orphan in large_orphans[num_individual_dosers:]:
-            peer_doser.send_and_ping(msg_tx(large_orphan))
+            peer_doser.send_and_ping(msg_tx(large_orphan.to_send))
 
         self.log.info("Provide the top ancestor. The whole package should be re-evaluated after enough time.")
         peer_normal.send_and_ping(msg_tx(ancestor_package[0]["tx"]))

--- a/test/functional/test_framework/mempool_util.py
+++ b/test/functional/test_framework/mempool_util.py
@@ -122,12 +122,25 @@ def tx_in_orphanage(node, tx: CTransaction) -> bool:
     found = [o for o in node.getorphantxs(verbosity=1) if o["txid"] == tx.txid_hex and o["wtxid"] == tx.wtxid_hex]
     return len(found) == 1
 
-def create_large_orphan():
-    """Create huge orphan transaction"""
-    tx = CTransaction()
-    # Nonexistent UTXO
-    tx.vin = [CTxIn(COutPoint(random.randrange(1 << 256), random.randrange(1, 100)))]
-    tx.wit.vtxinwit = [CTxInWitness()]
-    tx.wit.vtxinwit[0].scriptWitness.stack = [CScript(b'X' * 390000)]
-    tx.vout = [CTxOut(100, CScript([OP_RETURN, b'a' * 20]))]
-    return tx
+class LargeOrphanTransaction:
+    """Create huge orphan transaction of serialized size around 780KB"""
+    def __init__(self):
+        tx = CTransaction()
+        # Nonexistent UTXO
+        tx.vin = [CTxIn(COutPoint(random.randrange(1 << 256), random.randrange(1, 100)))]
+        tx.wit.vtxinwit = [CTxInWitness()]
+        tx.wit.vtxinwit[0].scriptWitness.stack = [CScript(b'X' * 390000)]
+        tx.vout = [CTxOut(100, CScript([OP_RETURN, b'a' * 20]))]
+        self.__obj = tx
+
+    """Should be used only when the orphan is not supposed to be sent over the network"""
+    @property
+    def get(self):
+        return self.__obj
+
+    """Should be used only when the orphan is supposed to be sent over the network"""
+    @property
+    def to_send(self):
+        # Commented so that this delay doesn't take effect
+        # time.sleep(0.05)
+        return self.__obj


### PR DESCRIPTION
Addresses #34731

Reasons why I don't believe it is a deadlock issue based on the debug logs and debugger thread backtrace output shared in the issue:
- The HTTP worker threads (b-http_pool_x) are waiting on the condition variable and not on the mutex that signals that these threads are idle & waiting for work to be assigned to them.
- The HTTP thread (b-http) is epoll waiting that means it is waiting for a request (or a part of it) to be received.
- The added logs show that the first few testmempool RPCs were successful and the next one timed out. But the logs don't show a request for it being logged unlike in the previous ones, hinting that the server never received such a request (or in full) and thus never processed it. Even then the functional test client timed out, which means that it did send it (at least a part of it).
- The large orphan transactions being sent are each 780KB in size that are sent sequentially by the test. It tries to send 60 of them in a loop amounting to 46MB of data over a single HTTP connection that is reused.

More details are shared in the first commit message.

This PR throttles the RPCs on client side. I've not been able to reproduce this intermittent issue and thus I don't gurantee that this fixes the issue altogether. 

Note: A previous approach in this PR tried to not reuse the HTTP connection for the RPCs in this test instead. But I noticed a CI run where this affected test took around 75mins to complete that led me to move to this approach where the HTTP connection is reused like before but with some throttling.


<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
