### PR TITLE
depends: Remove no longer necessary `dsymutil`

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -5,7 +5,6 @@ build_darwin_RANLIB:=$(shell xcrun -f ranlib)
 build_darwin_STRIP:=$(shell xcrun -f strip)
 build_darwin_OBJDUMP:=$(shell xcrun -f objdump)
 build_darwin_NM:=$(shell xcrun -f nm)
-build_darwin_DSYMUTIL:=$(shell xcrun -f dsymutil)
 build_darwin_SHA256SUM=shasum -a 256
 build_darwin_DOWNLOAD=curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
 
@@ -17,7 +16,6 @@ darwin_RANLIB:=$(shell xcrun -f ranlib)
 darwin_STRIP:=$(shell xcrun -f strip)
 darwin_OBJDUMP:=$(shell xcrun -f objdump)
 darwin_NM:=$(shell xcrun -f nm)
-darwin_DSYMUTIL:=$(shell xcrun -f dsymutil)
 
 x86_64_darwin_CFLAGS += -arch x86_64
 x86_64_darwin_CXXFLAGS += -arch x86_64

--- a/depends/builders/default.mk
+++ b/depends/builders/default.mk
@@ -13,7 +13,7 @@ build_$(build_os)_$1 ?= $$(default_build_$1)
 build_$(build_arch)_$(build_os)_$1 ?= $$(build_$(build_os)_$1)
 build_$1=$$(build_$(build_arch)_$(build_os)_$1)
 endef
-$(foreach var,CC CXX AR TAR RANLIB NM STRIP SHA256SUM DOWNLOAD OBJDUMP DSYMUTIL TOUCH,$(eval $(call add_build_tool_func,$(var))))
+$(foreach var,CC CXX AR TAR RANLIB NM STRIP SHA256SUM DOWNLOAD OBJDUMP TOUCH,$(eval $(call add_build_tool_func,$(var))))
 define add_build_flags_func
 build_$(build_arch)_$(build_os)_$1 += $(build_$(build_os)_$1)
 build_$1=$$(build_$(build_arch)_$(build_os)_$1)

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -17,7 +17,6 @@ clang_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang")
 clangxx_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang++")
 
 darwin_AR=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-ar")
-darwin_DSYMUTIL=$(shell $(SHELL) $(.SHELLFLAGS) "command -v dsymutil")
 darwin_NM=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-nm")
 darwin_OBJCOPY=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-objcopy")
 darwin_OBJDUMP=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-objdump")

--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -39,5 +39,5 @@ host_$1 = $$($(host_arch)_$(host_os)_$1)
 host_$(release_type)_$1 = $$($(host_arch)_$(host_os)_$(release_type)_$1)
 endef
 
-$(foreach tool,CC CXX AR RANLIB STRIP NM OBJCOPY OBJDUMP DSYMUTIL,$(eval $(call add_host_tool_func,$(tool))))
+$(foreach tool,CC CXX AR RANLIB STRIP NM OBJCOPY OBJDUMP,$(eval $(call add_host_tool_func,$(tool))))
 $(foreach flags,CFLAGS CXXFLAGS CPPFLAGS LDFLAGS, $(eval $(call add_host_flags_func,$(flags))))


### PR DESCRIPTION
I can't see where `dsymutil` is used. For example, a shared library under LTO builds fine:
```
cmake -B build --toolchain depends/arm64-apple-darwin/toolchain.cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DBUILD_KERNEL_LIB=ON -DBUILD_SHARED_LIBS=ON
cmake --build build -t libbitcoinkernel
```