### PR TITLE
test: Fix intermittent issue in feature_assumeutxo.py

### DIFF
--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -38,6 +38,7 @@ from test_framework.util import (
     assert_equal,
     assert_not_equal,
     assert_raises_rpc_error,
+    dumb_sync_blocks,
     ensure_for,
     sha256sum_file,
     try_rpc,
@@ -631,30 +632,17 @@ class AssumeutxoTest(BitcoinTestFramework):
 
         PAUSE_HEIGHT = FINAL_HEIGHT - 40
 
-        self.log.info("Restarting node to stop at height %d", PAUSE_HEIGHT)
-        self.restart_node(1, extra_args=[
-            f"-stopatheight={PAUSE_HEIGHT}", *self.extra_args[1]])
-
-        # Upon restart during snapshot tip sync, the node must remain in 'limited' mode.
+        self.log.info(f"Sync node up to height {PAUSE_HEIGHT}")
+        # During snapshot tip sync, the node must remain in 'limited' mode.
         self.assert_only_network_limited_service(n1)
-
-        # Finally connect the nodes and let them sync.
-        #
-        # Set `wait_for_connect=False` to avoid a race between performing connection
-        # assertions and the -stopatheight tripping.
-        self.connect_nodes(0, 1, wait_for_connect=False)
-
-        n1.wait_until_stopped(timeout=5)
+        dumb_sync_blocks(src=n0, dst=n1, height=PAUSE_HEIGHT)
 
         self.log.info("Checking that blocks are segmented on disk")
         assert self.has_blockfile(n1, "00000"), "normal blockfile missing"
         assert self.has_blockfile(n1, "00001"), "assumed blockfile missing"
         assert not self.has_blockfile(n1, "00002"), "too many blockfiles"
 
-        self.log.info("Restarted node before snapshot validation completed, reloading...")
-        self.restart_node(1, extra_args=self.extra_args[1])
-
-        # Upon restart, the node must remain in 'limited' mode
+        # The node must remain in 'limited' mode
         self.assert_only_network_limited_service(n1)
 
         # Send snapshot block to n1 out of order. This makes the test less

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -729,7 +729,7 @@ def dumb_sync_blocks(*, src, dst, height=None):
     height = height or src.getblockcount()
     for i in range(dst.getblockcount() + 1, height + 1):
         block_hash = src.getblockhash(i)
-        block = src.getblock(blockhash=block_hash, verbose=0)
+        block = src.getblock(blockhash=block_hash, verbosity=0)
         dst.submitblock(block)
     assert_equal(dst.getblockcount(), height)
 


### PR DESCRIPTION
The test has many issues:

* It fails intermittently, due to the use of `-stopatheight` (https://github.com/bitcoin/bitcoin/issues/33635)
* Using `-stopatheight` is expensive, because it requires two restarts, making the test slow

Fix all issues by using `dumb_sync_blocks` and avoid the two restarts.

Fixes https://github.com/bitcoin/bitcoin/issues/33635

Diff to test:

```diff
diff --git a/src/util/tokenpipe.cpp b/src/util/tokenpipe.cpp
index c982fa6fc4..1dc12ea1d5 100644
--- a/src/util/tokenpipe.cpp
+++ b/src/util/tokenpipe.cpp
@@ -4,2 +4,3 @@
 #include <util/tokenpipe.h>
+#include <util/time.h>
 
@@ -60,2 +61,3 @@ int TokenPipeEnd::TokenRead()
         ssize_t result = read(m_fd, &token, 1);
+        UninterruptibleSleep(999ms);
         if (result < 0) {
```

On master: Test fails
On this pull: Test passes
