### PR TITLE
test: Remove confusing assert_debug_log in wallet_reindex.py

### DIFF
--- a/test/functional/wallet_reindex.py
+++ b/test/functional/wallet_reindex.py
@@ -60,10 +60,8 @@ class WalletReindexTest(BitcoinTestFramework):
         assert_equal(wallet_watch_only.gettransaction(tx_id)['confirmations'], 50)
         assert_equal(wallet_watch_only.getbalances()['mine']['trusted'], 2)
 
-        # Reindex and wait for it to finish
-        with node.assert_debug_log(expected_msgs=["initload thread exit"]):
-            self.restart_node(0, extra_args=['-reindex=1', f'-mocktime={self.node_time}'])
-        node.syncwithvalidationinterfacequeue()
+        self.log.info("Reindex ...")  # restart_node waits for it to finish
+        self.restart_node(0, extra_args=[ f'-mocktime={self.node_time}'])
 
         # Verify the transaction is still 'confirmed' after reindex
         wallet_watch_only = node.get_wallet_rpc('watch_only')


### PR DESCRIPTION
The `wallet_reindex.py` test has many issues:

* It uses a `assert_debug_log` to ensure the reindex happened via `initload thread exit`. However, no other test uses this pattern, because `restart_node` already achieves the same internally (via `getmempoolinfo.loaded`).
* The `assert_debug_log` may intermittently fail, because the `initload thread exit` log may happen at any time after the inner thread function (lambda) is fully done.
* The test uses an `node.syncwithvalidationinterfacequeue()` without any explanation. No other test uses this pattern, because all wallet RPCs, in particular the next one (`gettransaction`) call it internally (via `BlockUntilSyncedToCurrentChain`).

Fix all issues by removing all confusing, useless, and brittle calls.

Example failure: https://github.com/bitcoin/bitcoin/actions/runs/22671604602/job/65716917459?pr=34419#step:11:22339

```
...
 node0 2026-03-04T13:55:23.784715Z (mocktime: 2026-03-04T22:15:17Z) [scheduler] [validationinterface.cpp:185] [operator()] [validation] UpdatedBlockTip: new block hash=24b5cc4c1352bc8841ecbe67a43827acd1adc609bd26b2691e80e89b97eff135 fork block hash=24a4dc8be9c157ac31913397d8bb1653900e12b55539c234039559fdeb6dd2fb (in IBD=true) 
 node0 2026-03-04T13:55:23.784851Z (mocktime: 2026-03-04T22:15:17Z) [initload] [util/thread.cpp:22] [TraceThread] initload thread exit 
 test  2026-03-04T13:55:23.813824Z TestFramework (ERROR): Unexpected exception: 
                                   Traceback (most recent call last):
                                     File "/home/admin/actions-runner/_work/_temp/test/functional/test_framework/test_framework.py", line 142, in main
                                       self.run_test()
                                     File "/home/admin/actions-runner/_work/_temp/build/test/functional/wallet_reindex.py", line 90, in run_test
                                       self.birthtime_test(node, miner_wallet)
                                     File "/home/admin/actions-runner/_work/_temp/build/test/functional/wallet_reindex.py", line 64, in birthtime_test
                                       with node.assert_debug_log(expected_msgs=["initload thread exit"]):
                                     File "/usr/lib/python3.12/contextlib.py", line 144, in __exit__
                                       next(self.gen)
                                     File "/home/admin/actions-runner/_work/_temp/test/functional/test_framework/test_node.py", line 607, in assert_debug_log
                                       self._raise_assertion_error(f'Expected message(s) {remaining_expected!s} '
                                     File "/home/admin/actions-runner/_work/_temp/test/functional/test_framework/test_node.py", line 241, in _raise_assertion_error
                                       raise AssertionError(self._node_msg(msg))
                                   AssertionError: [node 0] Expected message(s) ['initload thread exit'] not found in log:
```

Diff to reproduce failure:

```diff
diff --git a/src/util/thread.cpp b/src/util/thread.cpp
index 0fde73c4e2..de4c05e752 100644
--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -8,2 +8,3 @@
 #include <util/log.h>
+#include <util/time.h>
 #include <util/threadnames.h>
@@ -21,2 +22,3 @@ void util::TraceThread(std::string_view thread_name, std::function<void()> threa
         thread_func();
+    UninterruptibleSleep(999ms);
         LogInfo("%s thread exit", thread_name);
diff --git a/test/functional/wallet_reindex.py b/test/functional/wallet_reindex.py
index 71ab69e01b..649df4301a 100755
--- a/test/functional/wallet_reindex.py
+++ b/test/functional/wallet_reindex.py
@@ -62,2 +62,3 @@ class WalletReindexTest(BitcoinTestFramework):
 
+        import time; time.sleep(1) # Wait for previous initload thread to exit fully
         # Reindex and wait for it to finish
```

Before on master: Test fails
After on this pull: Test passes