### PR TITLE
coins: tighten cache entry state invariants

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -96,9 +96,8 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
         Assume(TrySub(cachedCoinsUsage, it->second.coin.DynamicMemoryUsage()));
     }
     it->second.coin = std::move(coin);
-    CCoinsCacheEntry::SetDirty(*it, m_sentinel);
+    CCoinsCacheEntry::SetDirty(*it, m_sentinel, fresh);
     ++m_dirty_count;
-    if (fresh) CCoinsCacheEntry::SetFresh(*it, m_sentinel);
     cachedCoinsUsage += it->second.coin.DynamicMemoryUsage();
     TRACEPOINT(utxocache, add,
            outpoint.hash.data(),
@@ -208,13 +207,12 @@ void CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& in
                 } else {
                     entry.coin = it->second.coin;
                 }
-                CCoinsCacheEntry::SetDirty(*itUs, m_sentinel);
-                ++m_dirty_count;
-                cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
                 // We can mark it FRESH in the parent if it was FRESH in the child
                 // Otherwise it might have just been flushed from the parent's cache
                 // and already exist in the grandparent
-                if (it->second.IsFresh()) CCoinsCacheEntry::SetFresh(*itUs, m_sentinel);
+                CCoinsCacheEntry::SetDirty(*itUs, m_sentinel, it->second.IsFresh());
+                ++m_dirty_count;
+                cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
             }
         } else {
             // Found the entry in the parent cache

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -189,29 +189,26 @@ void CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& in
 {
     for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
         assert(it->second.IsDirty());
+        if (it->second.IsFresh() && it->second.coin.IsSpent()) throw std::logic_error("A FRESH coin was not removed when it was spent");
         auto [itUs, inserted]{cacheCoins.try_emplace(it->first)};
         if (inserted) {
-            if (it->second.IsFresh() && it->second.coin.IsSpent()) {
-                cacheCoins.erase(itUs); // TODO fresh coins should have been removed at spend
+            // The parent cache does not have an entry, while the child cache does.
+            // Move the data up and mark it as dirty.
+            CCoinsCacheEntry& entry{itUs->second};
+            assert(entry.coin.DynamicMemoryUsage() == 0);
+            if (cursor.WillErase(*it)) {
+                // Since this entry will be erased,
+                // we can move the coin into us instead of copying it
+                entry.coin = std::move(it->second.coin);
             } else {
-                // The parent cache does not have an entry, while the child cache does.
-                // Move the data up and mark it as dirty.
-                CCoinsCacheEntry& entry{itUs->second};
-                assert(entry.coin.DynamicMemoryUsage() == 0);
-                if (cursor.WillErase(*it)) {
-                    // Since this entry will be erased,
-                    // we can move the coin into us instead of copying it
-                    entry.coin = std::move(it->second.coin);
-                } else {
-                    entry.coin = it->second.coin;
-                }
-                // We can mark it FRESH in the parent if it was FRESH in the child
-                // Otherwise it might have just been flushed from the parent's cache
-                // and already exist in the grandparent
-                CCoinsCacheEntry::SetDirty(*itUs, m_sentinel, it->second.IsFresh());
-                ++m_dirty_count;
-                cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
+                entry.coin = it->second.coin;
             }
+            // We can mark it FRESH in the parent if it was FRESH in the child
+            // Otherwise it might have just been flushed from the parent's cache
+            // and already exist in the grandparent
+            CCoinsCacheEntry::SetDirty(*itUs, m_sentinel, it->second.IsFresh());
+            ++m_dirty_count;
+            cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
         } else {
             // Found the entry in the parent cache
             if (it->second.IsFresh() && !itUs->second.coin.IsSpent()) {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -188,9 +188,7 @@ void CCoinsViewCache::SetBestBlock(const uint256& in_block_hash)
 void CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& in_block_hash)
 {
     for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
-        if (!it->second.IsDirty()) { // TODO a cursor can only contain dirty entries
-            continue;
-        }
+        assert(it->second.IsDirty());
         auto [itUs, inserted]{cacheCoins.try_emplace(it->first)};
         if (inserted) {
             if (it->second.IsFresh() && it->second.coin.IsSpent()) {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -96,7 +96,7 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
         Assume(TrySub(cachedCoinsUsage, it->second.coin.DynamicMemoryUsage()));
     }
     it->second.coin = std::move(coin);
-    CCoinsCacheEntry::SetDirty(*it, m_sentinel, fresh);
+    CCoinsCacheEntry::SetDirty(*it, m_sentinel, it->second.IsFresh() || fresh);
     ++m_dirty_count;
     cachedCoinsUsage += it->second.coin.DynamicMemoryUsage();
     TRACEPOINT(utxocache, add,
@@ -111,7 +111,7 @@ void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coi
     const auto mem_usage{coin.DynamicMemoryUsage()};
     auto [it, inserted] = cacheCoins.try_emplace(std::move(outpoint), std::move(coin));
     if (inserted) {
-        CCoinsCacheEntry::SetDirty(*it, m_sentinel);
+        CCoinsCacheEntry::SetDirty(*it, m_sentinel, /*fresh=*/false);
         ++m_dirty_count;
         cachedCoinsUsage += mem_usage;
     }
@@ -145,7 +145,7 @@ bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
     if (it->second.IsFresh()) {
         cacheCoins.erase(it);
     } else {
-        CCoinsCacheEntry::SetDirty(*it, m_sentinel);
+        CCoinsCacheEntry::SetDirty(*it, m_sentinel, /*fresh=*/false);
         ++m_dirty_count;
         it->second.coin.Clear();
     }
@@ -237,7 +237,7 @@ void CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& in
                 }
                 cachedCoinsUsage += itUs->second.coin.DynamicMemoryUsage();
                 if (!itUs->second.IsDirty()) {
-                    CCoinsCacheEntry::SetDirty(*itUs, m_sentinel);
+                    CCoinsCacheEntry::SetDirty(*itUs, m_sentinel, /*fresh=*/false);
                     ++m_dirty_count;
                 }
                 // NOTE: It isn't safe to mark the coin as FRESH in the parent
@@ -268,8 +268,8 @@ void CCoinsViewCache::Sync()
     base->BatchWrite(cursor, m_block_hash);
     Assume(m_dirty_count == 0);
     if (m_sentinel.second.Next() != &m_sentinel) {
-        /* BatchWrite must clear flags of all entries */
-        throw std::logic_error("Not all unspent flagged entries were cleared");
+        /* BatchWrite must clear the state of all unspent entries */
+        throw std::logic_error("Not all unspent dirty entries were cleared");
     }
 }
 
@@ -339,13 +339,13 @@ void CCoinsViewCache::SanityCheck() const
         // Count the number of entries we expect in the linked list.
         if (entry.IsDirty()) ++count_dirty;
     }
-    // Iterate over the linked list of flagged entries.
+    // Iterate over the linked list of dirty entries.
     size_t count_linked = 0;
     for (auto it = m_sentinel.second.Next(); it != &m_sentinel; it = it->second.Next()) {
         // Verify linked list integrity.
         assert(it->second.Next()->second.Prev() == it);
         assert(it->second.Prev()->second.Next() == it);
-        // Verify they are actually flagged.
+        // Verify they are actually dirty.
         assert(it->second.IsDirty());
         // Count the number of entries actually in the list.
         ++count_linked;

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -131,6 +131,10 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool 
 bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
     CCoinsMap::iterator it = FetchCoin(outpoint);
     if (it == cacheCoins.end()) return false;
+    if (it->second.coin.IsSpent()) {
+        Assume(it->second.IsDirty() && !it->second.IsFresh());
+        return false;
+    }
     Assume(TrySub(m_dirty_count, it->second.IsDirty()));
     Assume(TrySub(cachedCoinsUsage, it->second.coin.DynamicMemoryUsage()));
     TRACEPOINT(utxocache, spent,

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -143,6 +143,10 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool 
 bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
     CCoinsMap::iterator it = FetchCoin(outpoint);
     if (it == cacheCoins.end()) return false;
+    if (it->second.coin.IsSpent()) {
+        Assume(it->second.IsDirty() && !it->second.IsFresh());
+        return false;
+    }
     Assume(TrySub(m_dirty_count, it->second.IsDirty()));
     Assume(TrySub(cachedCoinsUsage, it->second.coin.DynamicMemoryUsage()));
     TRACEPOINT(utxocache, spent,

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -200,9 +200,7 @@ void CCoinsViewCache::SetBestBlock(const uint256& in_block_hash)
 void CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& in_block_hash)
 {
     for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
-        if (!it->second.IsDirty()) { // TODO a cursor can only contain dirty entries
-            continue;
-        }
+        assert(it->second.IsDirty());
         auto [itUs, inserted]{cacheCoins.try_emplace(it->first)};
         if (inserted) {
             if (it->second.IsFresh() && it->second.coin.IsSpent()) {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -201,29 +201,26 @@ void CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& in
 {
     for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
         assert(it->second.IsDirty());
+        if (it->second.IsFresh() && it->second.coin.IsSpent()) throw std::logic_error("A FRESH coin was not removed when it was spent");
         auto [itUs, inserted]{cacheCoins.try_emplace(it->first)};
         if (inserted) {
-            if (it->second.IsFresh() && it->second.coin.IsSpent()) {
-                cacheCoins.erase(itUs); // TODO fresh coins should have been removed at spend
+            // The parent cache does not have an entry, while the child cache does.
+            // Move the data up and mark it as dirty.
+            CCoinsCacheEntry& entry{itUs->second};
+            assert(entry.coin.DynamicMemoryUsage() == 0);
+            if (cursor.WillErase(*it)) {
+                // Since this entry will be erased,
+                // we can move the coin into us instead of copying it
+                entry.coin = std::move(it->second.coin);
             } else {
-                // The parent cache does not have an entry, while the child cache does.
-                // Move the data up and mark it as dirty.
-                CCoinsCacheEntry& entry{itUs->second};
-                assert(entry.coin.DynamicMemoryUsage() == 0);
-                if (cursor.WillErase(*it)) {
-                    // Since this entry will be erased,
-                    // we can move the coin into us instead of copying it
-                    entry.coin = std::move(it->second.coin);
-                } else {
-                    entry.coin = it->second.coin;
-                }
-                // We can mark it FRESH in the parent if it was FRESH in the child
-                // Otherwise it might have just been flushed from the parent's cache
-                // and already exist in the grandparent
-                CCoinsCacheEntry::SetDirty(*itUs, m_sentinel, it->second.IsFresh());
-                ++m_dirty_count;
-                cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
+                entry.coin = it->second.coin;
             }
+            // We can mark it FRESH in the parent if it was FRESH in the child
+            // Otherwise it might have just been flushed from the parent's cache
+            // and already exist in the grandparent
+            CCoinsCacheEntry::SetDirty(*itUs, m_sentinel, it->second.IsFresh());
+            ++m_dirty_count;
+            cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
         } else {
             // Found the entry in the parent cache
             if (it->second.IsFresh() && !itUs->second.coin.IsSpent()) {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -108,7 +108,7 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
         Assume(TrySub(cachedCoinsUsage, it->second.coin.DynamicMemoryUsage()));
     }
     it->second.coin = std::move(coin);
-    CCoinsCacheEntry::SetDirty(*it, m_sentinel, fresh);
+    CCoinsCacheEntry::SetDirty(*it, m_sentinel, it->second.IsFresh() || fresh);
     ++m_dirty_count;
     cachedCoinsUsage += it->second.coin.DynamicMemoryUsage();
     TRACEPOINT(utxocache, add,
@@ -123,7 +123,7 @@ void CCoinsViewCache::EmplaceCoinInternalDANGER(const COutPoint& outpoint, Coin&
     const auto mem_usage{coin.DynamicMemoryUsage()};
     auto [it, inserted] = cacheCoins.try_emplace(outpoint, std::move(coin));
     if (inserted) {
-        CCoinsCacheEntry::SetDirty(*it, m_sentinel);
+        CCoinsCacheEntry::SetDirty(*it, m_sentinel, /*fresh=*/false);
         ++m_dirty_count;
         cachedCoinsUsage += mem_usage;
     }
@@ -157,7 +157,7 @@ bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
     if (it->second.IsFresh()) {
         cacheCoins.erase(it);
     } else {
-        CCoinsCacheEntry::SetDirty(*it, m_sentinel);
+        CCoinsCacheEntry::SetDirty(*it, m_sentinel, /*fresh=*/false);
         ++m_dirty_count;
         it->second.coin.Clear();
     }
@@ -249,7 +249,7 @@ void CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& in
                 }
                 cachedCoinsUsage += itUs->second.coin.DynamicMemoryUsage();
                 if (!itUs->second.IsDirty()) {
-                    CCoinsCacheEntry::SetDirty(*itUs, m_sentinel);
+                    CCoinsCacheEntry::SetDirty(*itUs, m_sentinel, /*fresh=*/false);
                     ++m_dirty_count;
                 }
                 // NOTE: It isn't safe to mark the coin as FRESH in the parent
@@ -280,8 +280,8 @@ void CCoinsViewCache::Sync()
     base->BatchWrite(cursor, m_block_hash);
     Assume(m_dirty_count == 0);
     if (m_sentinel.second.Next() != &m_sentinel) {
-        /* BatchWrite must clear flags of all entries */
-        throw std::logic_error("Not all unspent flagged entries were cleared");
+        /* BatchWrite must clear the state of all unspent entries */
+        throw std::logic_error("Not all unspent dirty entries were cleared");
     }
 }
 
@@ -351,13 +351,13 @@ void CCoinsViewCache::SanityCheck() const
         // Count the number of entries we expect in the linked list.
         if (entry.IsDirty()) ++count_dirty;
     }
-    // Iterate over the linked list of flagged entries.
+    // Iterate over the linked list of dirty entries.
     size_t count_linked = 0;
     for (auto it = m_sentinel.second.Next(); it != &m_sentinel; it = it->second.Next()) {
         // Verify linked list integrity.
         assert(it->second.Next()->second.Prev() == it);
         assert(it->second.Prev()->second.Next() == it);
-        // Verify they are actually flagged.
+        // Verify they are actually dirty.
         assert(it->second.IsDirty());
         // Count the number of entries actually in the list.
         ++count_linked;

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -108,9 +108,8 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
         Assume(TrySub(cachedCoinsUsage, it->second.coin.DynamicMemoryUsage()));
     }
     it->second.coin = std::move(coin);
-    CCoinsCacheEntry::SetDirty(*it, m_sentinel);
+    CCoinsCacheEntry::SetDirty(*it, m_sentinel, fresh);
     ++m_dirty_count;
-    if (fresh) CCoinsCacheEntry::SetFresh(*it, m_sentinel);
     cachedCoinsUsage += it->second.coin.DynamicMemoryUsage();
     TRACEPOINT(utxocache, add,
            outpoint.hash.data(),
@@ -220,13 +219,12 @@ void CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& in
                 } else {
                     entry.coin = it->second.coin;
                 }
-                CCoinsCacheEntry::SetDirty(*itUs, m_sentinel);
-                ++m_dirty_count;
-                cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
                 // We can mark it FRESH in the parent if it was FRESH in the child
                 // Otherwise it might have just been flushed from the parent's cache
                 // and already exist in the grandparent
-                if (it->second.IsFresh()) CCoinsCacheEntry::SetFresh(*itUs, m_sentinel);
+                CCoinsCacheEntry::SetDirty(*itUs, m_sentinel, it->second.IsFresh());
+                ++m_dirty_count;
+                cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
             }
         } else {
             // Found the entry in the parent cache

--- a/src/coins.h
+++ b/src/coins.h
@@ -123,21 +123,6 @@ private:
     CoinsCachePair* m_next{nullptr};
     uint8_t m_flags{0};
 
-    //! Adding a flag requires a reference to the sentinel of the flagged pair linked list.
-    static void AddFlags(uint8_t flags, CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept
-    {
-        Assume(flags & (DIRTY | FRESH));
-        if (!pair.second.m_flags) {
-            Assume(!pair.second.m_prev && !pair.second.m_next);
-            pair.second.m_prev = sentinel.second.m_prev;
-            pair.second.m_next = &sentinel;
-            sentinel.second.m_prev = &pair;
-            pair.second.m_prev->second.m_next = &pair;
-        }
-        Assume(pair.second.m_prev && pair.second.m_next);
-        pair.second.m_flags |= flags;
-    }
-
 public:
     Coin coin; // The actual cached data.
 
@@ -171,16 +156,25 @@ public:
 
     static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel, bool fresh = false) noexcept
     {
-        AddFlags(DIRTY | (fresh ? FRESH : 0), pair, sentinel);
+        if (!pair.second.m_flags) {
+            Assume(!pair.second.m_prev && !pair.second.m_next);
+            pair.second.m_prev = sentinel.second.m_prev;
+            pair.second.m_next = &sentinel;
+            sentinel.second.m_prev = &pair;
+            pair.second.m_prev->second.m_next = &pair;
+        }
+        Assume(pair.second.m_prev && pair.second.m_next);
+        pair.second.m_flags |= DIRTY | (fresh ? FRESH : 0);
     }
 
     void SetClean() noexcept
     {
-        if (!m_flags) return;
-        m_next->second.m_prev = m_prev;
-        m_prev->second.m_next = m_next;
-        m_flags = 0;
-        m_prev = m_next = nullptr;
+        if (m_flags) {
+            m_next->second.m_prev = m_prev;
+            m_prev->second.m_next = m_next;
+            m_flags = 0;
+            m_prev = m_next = nullptr;
+        }
     }
     bool IsDirty() const noexcept { return m_flags & DIRTY; }
     bool IsFresh() const noexcept { return m_flags & FRESH; }

--- a/src/coins.h
+++ b/src/coins.h
@@ -169,8 +169,11 @@ public:
         SetClean();
     }
 
-    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(DIRTY, pair, sentinel); }
-    static void SetFresh(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(FRESH, pair, sentinel); }
+    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel, bool fresh = false) noexcept
+    {
+        AddFlags(DIRTY | (fresh ? FRESH : 0), pair, sentinel);
+    }
+    static void SetFresh(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(FRESH, pair, sentinel); } // TODO also remove from tests
 
     void SetClean() noexcept
     {

--- a/src/coins.h
+++ b/src/coins.h
@@ -173,7 +173,6 @@ public:
     {
         AddFlags(DIRTY | (fresh ? FRESH : 0), pair, sentinel);
     }
-    static void SetFresh(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(FRESH, pair, sentinel); } // TODO also remove from tests
 
     void SetClean() noexcept
     {
@@ -186,14 +185,12 @@ public:
     bool IsDirty() const noexcept { return m_flags & DIRTY; }
     bool IsFresh() const noexcept { return m_flags & FRESH; }
 
-    //! Only call Next when this entry is DIRTY, FRESH, or both
     CoinsCachePair* Next() const noexcept
     {
         Assume(m_flags);
         return m_next;
     }
 
-    //! Only call Prev when this entry is DIRTY, FRESH, or both
     CoinsCachePair* Prev() const noexcept
     {
         Assume(m_flags);

--- a/src/coins.h
+++ b/src/coins.h
@@ -110,42 +110,21 @@ struct CCoinsCacheEntry
 {
 private:
     /**
-     * These are used to create a doubly linked list of flagged entries.
-     * They are set in SetDirty, SetFresh, and unset in SetClean.
-     * A flagged entry is any entry that is either DIRTY, FRESH, or both.
+     * These are used to create a doubly linked list of dirty entries.
+     * They are set in SetDirty and unset in SetClean.
+     * A dirty entry may also be fresh.
      *
-     * DIRTY entries are tracked so that only modified entries can be passed to
+     * Dirty entries are tracked so that only modified entries can be passed to
      * the parent cache for batch writing. This is a performance optimization
      * compared to giving all entries in the cache to the parent and having the
      * parent scan for only modified entries.
      */
     CoinsCachePair* m_prev{nullptr};
     CoinsCachePair* m_next{nullptr};
-    uint8_t m_flags{0};
+    bool m_fresh{false};
 
 public:
     Coin coin; // The actual cached data.
-
-    enum Flags {
-        /**
-         * DIRTY means the CCoinsCacheEntry is potentially different from the
-         * version in the parent cache. Failure to mark a coin as DIRTY when
-         * it is potentially different from the parent cache will cause a
-         * consensus failure, since the coin's state won't get written to the
-         * parent when the cache is flushed.
-         */
-        DIRTY = (1 << 0),
-        /**
-         * FRESH means the parent cache does not have this coin or that it is a
-         * spent coin in the parent cache. If a FRESH coin in the cache is
-         * later spent, it can be deleted entirely and doesn't ever need to be
-         * flushed to the parent. This is a performance optimization. Marking a
-         * coin as FRESH when it exists unspent in the parent cache will cause a
-         * consensus failure, since it might not be deleted from the parent
-         * when this cache is flushed.
-         */
-        FRESH = (1 << 1),
-    };
 
     CCoinsCacheEntry() noexcept = default;
     explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
@@ -154,40 +133,54 @@ public:
         SetClean();
     }
 
-    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel, bool fresh = false) noexcept
+    /**
+     * Mark an entry dirty and set its resulting freshness.
+     * Fresh entries must also be dirty.
+     */
+    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel, bool fresh) noexcept
     {
-        if (!pair.second.m_flags) {
-            Assume(!pair.second.m_prev && !pair.second.m_next);
+        if (!pair.second.IsDirty()) {
             pair.second.m_prev = sentinel.second.m_prev;
             pair.second.m_next = &sentinel;
             sentinel.second.m_prev = &pair;
             pair.second.m_prev->second.m_next = &pair;
         }
-        Assume(pair.second.m_prev && pair.second.m_next);
-        pair.second.m_flags |= DIRTY | (fresh ? FRESH : 0);
+        Assume(pair.second.IsDirty());
+        Assume(!pair.second.m_fresh || fresh);
+        pair.second.m_fresh = fresh;
     }
 
+    /** Clear the dirty state and remove the entry from the dirty-entry list. */
     void SetClean() noexcept
     {
-        if (m_flags) {
+        if (IsDirty()) {
             m_next->second.m_prev = m_prev;
             m_prev->second.m_next = m_next;
-            m_flags = 0;
+            m_fresh = false;
             m_prev = m_next = nullptr;
         }
     }
-    bool IsDirty() const noexcept { return m_flags & DIRTY; }
-    bool IsFresh() const noexcept { return m_flags & FRESH; }
+
+    /** Return whether this entry is linked into the dirty-entry list. */
+    bool IsDirty() const noexcept
+    {
+        const bool dirty{!!m_prev};
+        Assume(dirty == !!m_next && (dirty || !m_fresh));
+        return dirty;
+    }
+
+    /** Return whether this dirty entry is also fresh. */
+    bool IsFresh() const noexcept { return m_fresh; }
 
     CoinsCachePair* Next() const noexcept
     {
-        Assume(m_flags);
+        Assume(IsDirty());
         return m_next;
     }
 
     CoinsCachePair* Prev() const noexcept
     {
-        Assume(m_flags);
+        Assume(IsDirty());
         return m_prev;
     }
 
@@ -197,8 +190,7 @@ public:
         Assume(&pair.second == this);
         m_prev = &pair;
         m_next = &pair;
-        // Set sentinel to DIRTY so we can call Next on it
-        m_flags = DIRTY;
+        Assume(IsDirty());
     }
 };
 
@@ -239,22 +231,22 @@ private:
 };
 
 /**
- * Cursor for iterating over the linked list of flagged entries in CCoinsViewCache.
+ * Cursor for iterating over the linked list of dirty entries in CCoinsViewCache.
  *
  * This is a helper struct to encapsulate the diverging logic between a non-erasing
  * CCoinsViewCache::Sync and an erasing CCoinsViewCache::Flush. This allows the receiver
- * of CCoinsView::BatchWrite to iterate through the flagged entries without knowing
+ * of CCoinsView::BatchWrite to iterate through the dirty entries without knowing
  * the caller's intent.
  *
  * However, the receiver can still call CoinsViewCacheCursor::WillErase to see if the
  * caller will erase the entry after BatchWrite returns. If so, the receiver can
- * perform optimizations such as moving the coin out of the CCoinsCachEntry instead
+ * perform optimizations such as moving the coin out of the CCoinsCacheEntry instead
  * of copying it.
  */
 struct CoinsViewCacheCursor
 {
     //! If will_erase is not set, iterating through the cursor will erase spent coins from the map,
-    //! and other coins will be unflagged (removing them from the linked list).
+    //! and other coins will have their state cleared and be removed from the linked list.
     //! If will_erase is set, the underlying map and linked list will not be modified,
     //! as the caller is expected to wipe the entire map anyway.
     //! This is an optimization compared to erasing all entries as the cursor iterates them when will_erase is set.
@@ -396,7 +388,7 @@ protected:
      */
     mutable uint256 m_block_hash;
     mutable CCoinsMapMemoryResource m_cache_coins_memory_resource{};
-    /* The starting sentinel of the flagged entry circular doubly linked list. */
+    /* The starting sentinel of the dirty-entry circular doubly linked list. */
     mutable CoinsCachePair m_sentinel;
     mutable CCoinsMap cacheCoins;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -463,8 +463,9 @@ public:
      * Spend a coin. Pass moveto in order to get the deleted data.
      * If no unspent output exists for the passed outpoint, this call
      * has no effect.
+     * @return true if an unspent coin was spent.
      */
-    bool SpendCoin(const COutPoint &outpoint, Coin* moveto = nullptr);
+    [[nodiscard]] bool SpendCoin(const COutPoint &outpoint, Coin* moveto = nullptr);
 
     /**
      * Push the modifications applied to this cache to its base and wipe local state.

--- a/src/coins.h
+++ b/src/coins.h
@@ -184,7 +184,6 @@ public:
     {
         AddFlags(DIRTY | (fresh ? FRESH : 0), pair, sentinel);
     }
-    static void SetFresh(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(FRESH, pair, sentinel); } // TODO also remove from tests
 
     void SetClean() noexcept
     {
@@ -197,14 +196,12 @@ public:
     bool IsDirty() const noexcept { return m_flags & DIRTY; }
     bool IsFresh() const noexcept { return m_flags & FRESH; }
 
-    //! Only call Next when this entry is DIRTY, FRESH, or both
     CoinsCachePair* Next() const noexcept
     {
         Assume(m_flags);
         return m_next;
     }
 
-    //! Only call Prev when this entry is DIRTY, FRESH, or both
     CoinsCachePair* Prev() const noexcept
     {
         Assume(m_flags);

--- a/src/coins.h
+++ b/src/coins.h
@@ -180,8 +180,11 @@ public:
         SetClean();
     }
 
-    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(DIRTY, pair, sentinel); }
-    static void SetFresh(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(FRESH, pair, sentinel); }
+    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel, bool fresh = false) noexcept
+    {
+        AddFlags(DIRTY | (fresh ? FRESH : 0), pair, sentinel);
+    }
+    static void SetFresh(CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept { AddFlags(FRESH, pair, sentinel); } // TODO also remove from tests
 
     void SetClean() noexcept
     {

--- a/src/coins.h
+++ b/src/coins.h
@@ -121,42 +121,21 @@ struct CCoinsCacheEntry
 {
 private:
     /**
-     * These are used to create a doubly linked list of flagged entries.
-     * They are set in SetDirty, SetFresh, and unset in SetClean.
-     * A flagged entry is any entry that is either DIRTY, FRESH, or both.
+     * These are used to create a doubly linked list of dirty entries.
+     * They are set in SetDirty and unset in SetClean.
+     * A dirty entry may also be fresh.
      *
-     * DIRTY entries are tracked so that only modified entries can be passed to
+     * Dirty entries are tracked so that only modified entries can be passed to
      * the parent cache for batch writing. This is a performance optimization
      * compared to giving all entries in the cache to the parent and having the
      * parent scan for only modified entries.
      */
     CoinsCachePair* m_prev{nullptr};
     CoinsCachePair* m_next{nullptr};
-    uint8_t m_flags{0};
+    bool m_fresh{false};
 
 public:
     Coin coin; // The actual cached data.
-
-    enum Flags {
-        /**
-         * DIRTY means the CCoinsCacheEntry is potentially different from the
-         * version in the parent cache. Failure to mark a coin as DIRTY when
-         * it is potentially different from the parent cache will cause a
-         * consensus failure, since the coin's state won't get written to the
-         * parent when the cache is flushed.
-         */
-        DIRTY = (1 << 0),
-        /**
-         * FRESH means the parent cache does not have this coin or that it is a
-         * spent coin in the parent cache. If a FRESH coin in the cache is
-         * later spent, it can be deleted entirely and doesn't ever need to be
-         * flushed to the parent. This is a performance optimization. Marking a
-         * coin as FRESH when it exists unspent in the parent cache will cause a
-         * consensus failure, since it might not be deleted from the parent
-         * when this cache is flushed.
-         */
-        FRESH = (1 << 1),
-    };
 
     CCoinsCacheEntry() noexcept = default;
     explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
@@ -165,40 +144,54 @@ public:
         SetClean();
     }
 
-    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel, bool fresh = false) noexcept
+    /**
+     * Mark an entry dirty and set its resulting freshness.
+     * Fresh entries must also be dirty.
+     */
+    static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel, bool fresh) noexcept
     {
-        if (!pair.second.m_flags) {
-            Assume(!pair.second.m_prev && !pair.second.m_next);
+        if (!pair.second.IsDirty()) {
             pair.second.m_prev = sentinel.second.m_prev;
             pair.second.m_next = &sentinel;
             sentinel.second.m_prev = &pair;
             pair.second.m_prev->second.m_next = &pair;
         }
-        Assume(pair.second.m_prev && pair.second.m_next);
-        pair.second.m_flags |= DIRTY | (fresh ? FRESH : 0);
+        Assume(pair.second.IsDirty());
+        Assume(!pair.second.m_fresh || fresh);
+        pair.second.m_fresh = fresh;
     }
 
+    /** Clear the dirty state and remove the entry from the dirty-entry list. */
     void SetClean() noexcept
     {
-        if (m_flags) {
+        if (IsDirty()) {
             m_next->second.m_prev = m_prev;
             m_prev->second.m_next = m_next;
-            m_flags = 0;
+            m_fresh = false;
             m_prev = m_next = nullptr;
         }
     }
-    bool IsDirty() const noexcept { return m_flags & DIRTY; }
-    bool IsFresh() const noexcept { return m_flags & FRESH; }
+
+    /** Return whether this entry is linked into the dirty-entry list. */
+    bool IsDirty() const noexcept
+    {
+        const bool dirty{!!m_prev};
+        Assume(dirty == !!m_next && (dirty || !m_fresh));
+        return dirty;
+    }
+
+    /** Return whether this dirty entry is also fresh. */
+    bool IsFresh() const noexcept { return m_fresh; }
 
     CoinsCachePair* Next() const noexcept
     {
-        Assume(m_flags);
+        Assume(IsDirty());
         return m_next;
     }
 
     CoinsCachePair* Prev() const noexcept
     {
-        Assume(m_flags);
+        Assume(IsDirty());
         return m_prev;
     }
 
@@ -208,8 +201,7 @@ public:
         Assume(&pair.second == this);
         m_prev = &pair;
         m_next = &pair;
-        // Set sentinel to DIRTY so we can call Next on it
-        m_flags = DIRTY;
+        Assume(IsDirty());
     }
 };
 
@@ -287,22 +279,22 @@ private:
 };
 
 /**
- * Cursor for iterating over the linked list of flagged entries in CCoinsViewCache.
+ * Cursor for iterating over the linked list of dirty entries in CCoinsViewCache.
  *
  * This is a helper struct to encapsulate the diverging logic between a non-erasing
  * CCoinsViewCache::Sync and an erasing CCoinsViewCache::Flush. This allows the receiver
- * of CCoinsView::BatchWrite to iterate through the flagged entries without knowing
+ * of CCoinsView::BatchWrite to iterate through the dirty entries without knowing
  * the caller's intent.
  *
  * However, the receiver can still call CoinsViewCacheCursor::WillErase to see if the
  * caller will erase the entry after BatchWrite returns. If so, the receiver can
- * perform optimizations such as moving the coin out of the CCoinsCachEntry instead
+ * perform optimizations such as moving the coin out of the CCoinsCacheEntry instead
  * of copying it.
  */
 struct CoinsViewCacheCursor
 {
     //! If will_erase is not set, iterating through the cursor will erase spent coins from the map,
-    //! and other coins will be unflagged (removing them from the linked list).
+    //! and other coins will have their state cleared and be removed from the linked list.
     //! If will_erase is set, the underlying map and linked list will not be modified,
     //! as the caller is expected to wipe the entire map anyway.
     //! This is an optimization compared to erasing all entries as the cursor iterates them when will_erase is set.
@@ -452,7 +444,7 @@ protected:
      */
     mutable uint256 m_block_hash;
     mutable CCoinsMapMemoryResource m_cache_coins_memory_resource{};
-    /* The starting sentinel of the flagged entry circular doubly linked list. */
+    /* The starting sentinel of the dirty-entry circular doubly linked list. */
     mutable CoinsCachePair m_sentinel;
     mutable CCoinsMap cacheCoins;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -516,8 +516,9 @@ public:
      * Spend a coin. Pass moveto in order to get the deleted data.
      * If no unspent output exists for the passed outpoint, this call
      * has no effect.
+     * @return true if an unspent coin was spent.
      */
-    bool SpendCoin(const COutPoint &outpoint, Coin* moveto = nullptr);
+    [[nodiscard]] bool SpendCoin(const COutPoint &outpoint, Coin* moveto = nullptr);
 
     /**
      * Push the modifications applied to this cache to its base and wipe local state.

--- a/src/coins.h
+++ b/src/coins.h
@@ -134,21 +134,6 @@ private:
     CoinsCachePair* m_next{nullptr};
     uint8_t m_flags{0};
 
-    //! Adding a flag requires a reference to the sentinel of the flagged pair linked list.
-    static void AddFlags(uint8_t flags, CoinsCachePair& pair, CoinsCachePair& sentinel) noexcept
-    {
-        Assume(flags & (DIRTY | FRESH));
-        if (!pair.second.m_flags) {
-            Assume(!pair.second.m_prev && !pair.second.m_next);
-            pair.second.m_prev = sentinel.second.m_prev;
-            pair.second.m_next = &sentinel;
-            sentinel.second.m_prev = &pair;
-            pair.second.m_prev->second.m_next = &pair;
-        }
-        Assume(pair.second.m_prev && pair.second.m_next);
-        pair.second.m_flags |= flags;
-    }
-
 public:
     Coin coin; // The actual cached data.
 
@@ -182,16 +167,25 @@ public:
 
     static void SetDirty(CoinsCachePair& pair, CoinsCachePair& sentinel, bool fresh = false) noexcept
     {
-        AddFlags(DIRTY | (fresh ? FRESH : 0), pair, sentinel);
+        if (!pair.second.m_flags) {
+            Assume(!pair.second.m_prev && !pair.second.m_next);
+            pair.second.m_prev = sentinel.second.m_prev;
+            pair.second.m_next = &sentinel;
+            sentinel.second.m_prev = &pair;
+            pair.second.m_prev->second.m_next = &pair;
+        }
+        Assume(pair.second.m_prev && pair.second.m_next);
+        pair.second.m_flags |= DIRTY | (fresh ? FRESH : 0);
     }
 
     void SetClean() noexcept
     {
-        if (!m_flags) return;
-        m_next->second.m_prev = m_prev;
-        m_prev->second.m_next = m_next;
-        m_flags = 0;
-        m_prev = m_next = nullptr;
+        if (m_flags) {
+            m_next->second.m_prev = m_prev;
+            m_prev->second.m_next = m_next;
+            m_flags = 0;
+            m_prev = m_next = nullptr;
+        }
     }
     bool IsDirty() const noexcept { return m_flags & DIRTY; }
     bool IsFresh() const noexcept { return m_flags & FRESH; }

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -635,8 +635,7 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CoinsCachePair& sentinel, cons
     SetCoinsValue(cache_coin.value, entry.coin);
     auto [iter, inserted] = map.emplace(OUTPOINT, std::move(entry));
     assert(inserted);
-    if (cache_coin.IsDirty()) CCoinsCacheEntry::SetDirty(*iter, sentinel);
-    if (cache_coin.IsDirtyFresh()) CCoinsCacheEntry::SetFresh(*iter, sentinel);
+    if (cache_coin.IsDirty()) CCoinsCacheEntry::SetDirty(*iter, sentinel, cache_coin.IsDirtyFresh());
     return iter->second.coin.DynamicMemoryUsage();
 }
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -615,6 +615,7 @@ constexpr MaybeCoin VALUE3_DIRTY_FRESH{{VALUE3, CoinEntry::State::DIRTY_FRESH}};
 
 constexpr auto EX_OVERWRITE_UNSPENT{"Attempted to overwrite an unspent coin (when possible_overwrite is false)"};
 constexpr auto EX_FRESH_MISAPPLIED {"FRESH flag misapplied to coin that exists in parent cache"};
+constexpr auto EX_FRESH_AND_SPENT  {"A FRESH coin was not removed when it was spent"};
 
 static void SetCoinsValue(const CAmount value, Coin& coin)
 {
@@ -800,7 +801,7 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
      */
     CheckWriteCoins(MISSING,            MISSING,            MISSING            );
     CheckWriteCoins(MISSING,            SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(MISSING,            SPENT_DIRTY_FRESH,  MISSING            );
+    CheckWriteCoins(MISSING,            SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
     CheckWriteCoins(MISSING,            VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(MISSING,            VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH );
     CheckWriteCoins(SPENT_CLEAN,        MISSING,            SPENT_CLEAN        );
@@ -808,11 +809,11 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
     CheckWriteCoins(SPENT_DIRTY_FRESH,  MISSING,            SPENT_DIRTY_FRESH  );
 
     CheckWriteCoins(SPENT_CLEAN,        SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(SPENT_CLEAN,        SPENT_DIRTY_FRESH,  SPENT_DIRTY        );
+    CheckWriteCoins(SPENT_CLEAN,        SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
     CheckWriteCoins(SPENT_DIRTY,        SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(SPENT_DIRTY,        SPENT_DIRTY_FRESH,  SPENT_DIRTY        );
+    CheckWriteCoins(SPENT_DIRTY,        SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
     CheckWriteCoins(SPENT_DIRTY_FRESH,  SPENT_DIRTY,        MISSING            );
-    CheckWriteCoins(SPENT_DIRTY_FRESH,  SPENT_DIRTY_FRESH,  MISSING            );
+    CheckWriteCoins(SPENT_DIRTY_FRESH,  SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
 
     CheckWriteCoins(SPENT_CLEAN,        VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(SPENT_CLEAN,        VALUE2_DIRTY_FRESH, VALUE2_DIRTY       );
@@ -825,11 +826,11 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
     CheckWriteCoins(VALUE1_DIRTY,       MISSING,            VALUE1_DIRTY       );
     CheckWriteCoins(VALUE1_DIRTY_FRESH, MISSING,            VALUE1_DIRTY_FRESH );
     CheckWriteCoins(VALUE1_CLEAN,       SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(VALUE1_CLEAN,       SPENT_DIRTY_FRESH,  EX_FRESH_MISAPPLIED);
+    CheckWriteCoins(VALUE1_CLEAN,       SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
     CheckWriteCoins(VALUE1_DIRTY,       SPENT_DIRTY,        SPENT_DIRTY        );
-    CheckWriteCoins(VALUE1_DIRTY,       SPENT_DIRTY_FRESH,  EX_FRESH_MISAPPLIED);
+    CheckWriteCoins(VALUE1_DIRTY,       SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
     CheckWriteCoins(VALUE1_DIRTY_FRESH, SPENT_DIRTY,        MISSING            );
-    CheckWriteCoins(VALUE1_DIRTY_FRESH, SPENT_DIRTY_FRESH,  EX_FRESH_MISAPPLIED);
+    CheckWriteCoins(VALUE1_DIRTY_FRESH, SPENT_DIRTY_FRESH,  EX_FRESH_AND_SPENT );
 
     CheckWriteCoins(VALUE1_CLEAN,       VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(VALUE1_CLEAN,       VALUE2_DIRTY_FRESH, EX_FRESH_MISAPPLIED);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -576,7 +576,7 @@ constexpr CAmount VALUE2{200};
 constexpr CAmount VALUE3{300};
 
 struct CoinEntry {
-    enum class State { CLEAN, DIRTY, FRESH, DIRTY_FRESH };
+    enum class State { CLEAN, DIRTY, DIRTY_FRESH };
 
     const CAmount value;
     const State state;
@@ -588,12 +588,13 @@ struct CoinEntry {
 
     constexpr bool IsDirtyFresh() const { return state == State::DIRTY_FRESH; }
     constexpr bool IsDirty() const { return state == State::DIRTY || IsDirtyFresh(); }
-    constexpr bool IsFresh() const { return state == State::FRESH || IsDirtyFresh(); }
 
     static constexpr State ToState(const bool is_dirty, const bool is_fresh) {
-        if (is_dirty && is_fresh) return State::DIRTY_FRESH;
+        if (is_fresh) {
+            assert(is_dirty);
+            return State::DIRTY_FRESH;
+        }
         if (is_dirty) return State::DIRTY;
-        if (is_fresh) return State::FRESH;
         return State::CLEAN;
     }
 };
@@ -604,15 +605,12 @@ using CoinOrError = std::variant<MaybeCoin, std::string>;
 constexpr MaybeCoin MISSING           {std::nullopt};
 constexpr MaybeCoin SPENT_DIRTY       {{SPENT,  CoinEntry::State::DIRTY}};
 constexpr MaybeCoin SPENT_DIRTY_FRESH {{SPENT,  CoinEntry::State::DIRTY_FRESH}};
-constexpr MaybeCoin SPENT_FRESH       {{SPENT,  CoinEntry::State::FRESH}};
 constexpr MaybeCoin SPENT_CLEAN       {{SPENT,  CoinEntry::State::CLEAN}};
 constexpr MaybeCoin VALUE1_DIRTY      {{VALUE1, CoinEntry::State::DIRTY}};
 constexpr MaybeCoin VALUE1_DIRTY_FRESH{{VALUE1, CoinEntry::State::DIRTY_FRESH}};
-constexpr MaybeCoin VALUE1_FRESH      {{VALUE1, CoinEntry::State::FRESH}};
 constexpr MaybeCoin VALUE1_CLEAN      {{VALUE1, CoinEntry::State::CLEAN}};
 constexpr MaybeCoin VALUE2_DIRTY      {{VALUE2, CoinEntry::State::DIRTY}};
 constexpr MaybeCoin VALUE2_DIRTY_FRESH{{VALUE2, CoinEntry::State::DIRTY_FRESH}};
-constexpr MaybeCoin VALUE2_FRESH      {{VALUE2, CoinEntry::State::FRESH}};
 constexpr MaybeCoin VALUE2_CLEAN      {{VALUE2, CoinEntry::State::CLEAN}};
 constexpr MaybeCoin VALUE3_DIRTY      {{VALUE3, CoinEntry::State::DIRTY}};
 constexpr MaybeCoin VALUE3_DIRTY_FRESH{{VALUE3, CoinEntry::State::DIRTY_FRESH}};
@@ -639,7 +637,7 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CoinsCachePair& sentinel, cons
     auto [iter, inserted] = map.emplace(OUTPOINT, std::move(entry));
     assert(inserted);
     if (cache_coin.IsDirty()) CCoinsCacheEntry::SetDirty(*iter, sentinel);
-    if (cache_coin.IsFresh()) CCoinsCacheEntry::SetFresh(*iter, sentinel);
+    if (cache_coin.IsDirtyFresh()) CCoinsCacheEntry::SetFresh(*iter, sentinel);
     return iter->second.coin.DynamicMemoryUsage();
 }
 
@@ -703,12 +701,10 @@ BOOST_AUTO_TEST_CASE(ccoins_access)
         CheckAccessCoin(base_value, MISSING,            base_value == VALUE1 ? VALUE1_CLEAN : MISSING);
 
         CheckAccessCoin(base_value, SPENT_CLEAN,        SPENT_CLEAN       );
-        CheckAccessCoin(base_value, SPENT_FRESH,        SPENT_FRESH       );
         CheckAccessCoin(base_value, SPENT_DIRTY,        SPENT_DIRTY       );
         CheckAccessCoin(base_value, SPENT_DIRTY_FRESH,  SPENT_DIRTY_FRESH );
 
         CheckAccessCoin(base_value, VALUE2_CLEAN,       VALUE2_CLEAN      );
-        CheckAccessCoin(base_value, VALUE2_FRESH,       VALUE2_FRESH      );
         CheckAccessCoin(base_value, VALUE2_DIRTY,       VALUE2_DIRTY      );
         CheckAccessCoin(base_value, VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH);
     }
@@ -733,12 +729,10 @@ BOOST_AUTO_TEST_CASE(ccoins_spend)
         CheckSpendCoins(base_value, MISSING,            base_value == VALUE1 ? SPENT_DIRTY : MISSING);
 
         CheckSpendCoins(base_value, SPENT_CLEAN,        SPENT_DIRTY);
-        CheckSpendCoins(base_value, SPENT_FRESH,        MISSING    );
         CheckSpendCoins(base_value, SPENT_DIRTY,        SPENT_DIRTY);
         CheckSpendCoins(base_value, SPENT_DIRTY_FRESH,  MISSING    );
 
         CheckSpendCoins(base_value, VALUE2_CLEAN,       SPENT_DIRTY);
-        CheckSpendCoins(base_value, VALUE2_FRESH,       MISSING    );
         CheckSpendCoins(base_value, VALUE2_DIRTY,       SPENT_DIRTY);
         CheckSpendCoins(base_value, VALUE2_DIRTY_FRESH, MISSING    );
     }
@@ -772,8 +766,6 @@ BOOST_AUTO_TEST_CASE(ccoins_add)
 
         CheckAddCoin(base_value, SPENT_CLEAN,        VALUE3, VALUE3_DIRTY_FRESH,   false);
         CheckAddCoin(base_value, SPENT_CLEAN,        VALUE3, VALUE3_DIRTY,         true );
-        CheckAddCoin(base_value, SPENT_FRESH,        VALUE3, VALUE3_DIRTY_FRESH,   false);
-        CheckAddCoin(base_value, SPENT_FRESH,        VALUE3, VALUE3_DIRTY_FRESH,   true );
         CheckAddCoin(base_value, SPENT_DIRTY,        VALUE3, VALUE3_DIRTY,         false);
         CheckAddCoin(base_value, SPENT_DIRTY,        VALUE3, VALUE3_DIRTY,         true );
         CheckAddCoin(base_value, SPENT_DIRTY_FRESH,  VALUE3, VALUE3_DIRTY_FRESH,   false);
@@ -781,8 +773,6 @@ BOOST_AUTO_TEST_CASE(ccoins_add)
 
         CheckAddCoin(base_value, VALUE2_CLEAN,       VALUE3, EX_OVERWRITE_UNSPENT, false);
         CheckAddCoin(base_value, VALUE2_CLEAN,       VALUE3, VALUE3_DIRTY,         true );
-        CheckAddCoin(base_value, VALUE2_FRESH,       VALUE3, EX_OVERWRITE_UNSPENT, false);
-        CheckAddCoin(base_value, VALUE2_FRESH,       VALUE3, VALUE3_DIRTY_FRESH,   true );
         CheckAddCoin(base_value, VALUE2_DIRTY,       VALUE3, EX_OVERWRITE_UNSPENT, false);
         CheckAddCoin(base_value, VALUE2_DIRTY,       VALUE3, VALUE3_DIRTY,         true );
         CheckAddCoin(base_value, VALUE2_DIRTY_FRESH, VALUE3, EX_OVERWRITE_UNSPENT, false);
@@ -816,14 +806,11 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
     CheckWriteCoins(MISSING,            VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(MISSING,            VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH );
     CheckWriteCoins(SPENT_CLEAN,        MISSING,            SPENT_CLEAN        );
-    CheckWriteCoins(SPENT_FRESH,        MISSING,            SPENT_FRESH        );
     CheckWriteCoins(SPENT_DIRTY,        MISSING,            SPENT_DIRTY        );
     CheckWriteCoins(SPENT_DIRTY_FRESH,  MISSING,            SPENT_DIRTY_FRESH  );
 
     CheckWriteCoins(SPENT_CLEAN,        SPENT_DIRTY,        SPENT_DIRTY        );
     CheckWriteCoins(SPENT_CLEAN,        SPENT_DIRTY_FRESH,  SPENT_DIRTY        );
-    CheckWriteCoins(SPENT_FRESH,        SPENT_DIRTY,        MISSING            );
-    CheckWriteCoins(SPENT_FRESH,        SPENT_DIRTY_FRESH,  MISSING            );
     CheckWriteCoins(SPENT_DIRTY,        SPENT_DIRTY,        SPENT_DIRTY        );
     CheckWriteCoins(SPENT_DIRTY,        SPENT_DIRTY_FRESH,  SPENT_DIRTY        );
     CheckWriteCoins(SPENT_DIRTY_FRESH,  SPENT_DIRTY,        MISSING            );
@@ -831,21 +818,16 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
 
     CheckWriteCoins(SPENT_CLEAN,        VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(SPENT_CLEAN,        VALUE2_DIRTY_FRESH, VALUE2_DIRTY       );
-    CheckWriteCoins(SPENT_FRESH,        VALUE2_DIRTY,       VALUE2_DIRTY_FRESH );
-    CheckWriteCoins(SPENT_FRESH,        VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH );
     CheckWriteCoins(SPENT_DIRTY,        VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(SPENT_DIRTY,        VALUE2_DIRTY_FRESH, VALUE2_DIRTY       );
     CheckWriteCoins(SPENT_DIRTY_FRESH,  VALUE2_DIRTY,       VALUE2_DIRTY_FRESH );
     CheckWriteCoins(SPENT_DIRTY_FRESH,  VALUE2_DIRTY_FRESH, VALUE2_DIRTY_FRESH );
 
     CheckWriteCoins(VALUE1_CLEAN,       MISSING,            VALUE1_CLEAN       );
-    CheckWriteCoins(VALUE1_FRESH,       MISSING,            VALUE1_FRESH       );
     CheckWriteCoins(VALUE1_DIRTY,       MISSING,            VALUE1_DIRTY       );
     CheckWriteCoins(VALUE1_DIRTY_FRESH, MISSING,            VALUE1_DIRTY_FRESH );
     CheckWriteCoins(VALUE1_CLEAN,       SPENT_DIRTY,        SPENT_DIRTY        );
     CheckWriteCoins(VALUE1_CLEAN,       SPENT_DIRTY_FRESH,  EX_FRESH_MISAPPLIED);
-    CheckWriteCoins(VALUE1_FRESH,       SPENT_DIRTY,        MISSING            );
-    CheckWriteCoins(VALUE1_FRESH,       SPENT_DIRTY_FRESH,  EX_FRESH_MISAPPLIED);
     CheckWriteCoins(VALUE1_DIRTY,       SPENT_DIRTY,        SPENT_DIRTY        );
     CheckWriteCoins(VALUE1_DIRTY,       SPENT_DIRTY_FRESH,  EX_FRESH_MISAPPLIED);
     CheckWriteCoins(VALUE1_DIRTY_FRESH, SPENT_DIRTY,        MISSING            );
@@ -853,8 +835,6 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
 
     CheckWriteCoins(VALUE1_CLEAN,       VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(VALUE1_CLEAN,       VALUE2_DIRTY_FRESH, EX_FRESH_MISAPPLIED);
-    CheckWriteCoins(VALUE1_FRESH,       VALUE2_DIRTY,       VALUE2_DIRTY_FRESH );
-    CheckWriteCoins(VALUE1_FRESH,       VALUE2_DIRTY_FRESH, EX_FRESH_MISAPPLIED);
     CheckWriteCoins(VALUE1_DIRTY,       VALUE2_DIRTY,       VALUE2_DIRTY       );
     CheckWriteCoins(VALUE1_DIRTY,       VALUE2_DIRTY_FRESH, EX_FRESH_MISAPPLIED);
     CheckWriteCoins(VALUE1_DIRTY_FRESH, VALUE2_DIRTY,       VALUE2_DIRTY_FRESH );
@@ -865,11 +845,9 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
     // cases). The loop below covers these cases and makes sure the parent cache
     // is always left unchanged.
     for (const MaybeCoin& parent : {MISSING,
-                                    SPENT_CLEAN, SPENT_DIRTY, SPENT_FRESH, SPENT_DIRTY_FRESH,
-                                    VALUE1_CLEAN, VALUE1_DIRTY, VALUE1_FRESH, VALUE1_DIRTY_FRESH}) {
-        for (const MaybeCoin& child : {MISSING,
-                                       SPENT_CLEAN, SPENT_FRESH,
-                                       VALUE2_CLEAN, VALUE2_FRESH}) {
+                                    SPENT_CLEAN, SPENT_DIRTY, SPENT_DIRTY_FRESH,
+                                    VALUE1_CLEAN, VALUE1_DIRTY, VALUE1_DIRTY_FRESH}) {
+        for (const MaybeCoin& child : {MISSING, SPENT_CLEAN, VALUE2_CLEAN}) {
             auto expected{CoinOrError{parent}}; // TODO test failure cases as well
             CheckWriteCoins(parent, child, expected);
         }

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -711,7 +711,8 @@ BOOST_AUTO_TEST_CASE(ccoins_access)
 static void CheckSpendCoins(const CAmount base_value, const MaybeCoin& cache_coin, const MaybeCoin& expected)
 {
     SingleEntryCacheTest test{base_value, cache_coin};
-    test.cache.SpendCoin(OUTPOINT);
+    const bool spent{cache_coin ? cache_coin->value != SPENT : base_value == VALUE1};
+    BOOST_CHECK_EQUAL(test.cache.SpendCoin(OUTPOINT), spent);
     test.cache.SelfTest();
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(test.cache.map()), expected);
 }
@@ -726,14 +727,19 @@ BOOST_AUTO_TEST_CASE(ccoins_spend)
     for (auto base_value : {ABSENT, SPENT, VALUE1}) {
         CheckSpendCoins(base_value, MISSING,            base_value == VALUE1 ? SPENT_DIRTY : MISSING);
 
-        CheckSpendCoins(base_value, SPENT_CLEAN,        SPENT_DIRTY);
         CheckSpendCoins(base_value, SPENT_DIRTY,        SPENT_DIRTY);
-        CheckSpendCoins(base_value, SPENT_DIRTY_FRESH,  MISSING    );
 
         CheckSpendCoins(base_value, VALUE2_CLEAN,       SPENT_DIRTY);
         CheckSpendCoins(base_value, VALUE2_DIRTY,       SPENT_DIRTY);
         CheckSpendCoins(base_value, VALUE2_DIRTY_FRESH, MISSING    );
     }
+
+    SingleEntryCacheTest test{ABSENT, SPENT_DIRTY};
+    Coin moveout{CTxOut{VALUE3, CScript{}}, 1, false};
+    const Coin unchanged{moveout};
+    BOOST_CHECK(!test.cache.SpendCoin(OUTPOINT, &moveout));
+    test.cache.SelfTest();
+    BOOST_CHECK(moveout == unchanged);
 }
 
 static void CheckAddCoin(const CAmount base_value, const MaybeCoin& cache_coin, const CAmount modify_value, const CoinOrError& expected, const bool coinbase)

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -60,13 +60,11 @@ public:
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override
     {
         for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)){
-            if (it->second.IsDirty()) {
-                // Same optimization used in CCoinsViewDB is to only write dirty entries.
-                map_[it->first] = it->second.coin;
-                if (it->second.coin.IsSpent() && m_rng.randrange(3) == 0) {
-                    // Randomly delete empty entries on write.
-                    map_.erase(it->first);
-                }
+            assert(it->second.IsDirty());
+            map_[it->first] = it->second.coin;
+            if (it->second.coin.IsSpent() && m_rng.randrange(3) == 0) {
+                // Randomly delete spent entries on write.
+                map_.erase(it->first);
             }
         }
         if (!block_hash.IsNull())

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -154,16 +154,16 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n1);
 
-    // Check that setting FRESH on new node inserts it after n1
-    CCoinsCacheEntry::SetFresh(n2, sentinel);
-    BOOST_CHECK(n2.second.IsFresh() && !n2.second.IsDirty());
+    // Check that setting DIRTY and FRESH on new node inserts it after n1
+    CCoinsCacheEntry::SetDirty(n2, sentinel, /*fresh=*/true);
+    BOOST_CHECK(n2.second.IsDirty() && n2.second.IsFresh());
     BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
     BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
     BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
 
     // Check that we can set extra state, but they don't change our position
-    CCoinsCacheEntry::SetFresh(n1, sentinel);
+    CCoinsCacheEntry::SetDirty(n1, sentinel, /*fresh=*/true);
     BOOST_CHECK(n1.second.IsDirty() && n1.second.IsFresh());
     BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
     BOOST_CHECK_EQUAL(n1.second.Prev(), &sentinel);

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -19,7 +19,8 @@ std::list<CoinsCachePair> CreatePairs(CoinsCachePair& sentinel)
         nodes.emplace_back();
 
         auto node{std::prev(nodes.end())};
-        CCoinsCacheEntry::SetDirty(*node, sentinel);
+        BOOST_CHECK(!node->second.IsFresh());
+        CCoinsCacheEntry::SetDirty(*node, sentinel, /*fresh=*/false);
 
         BOOST_CHECK(node->second.IsDirty() && !node->second.IsFresh());
         BOOST_CHECK_EQUAL(node->second.Next(), &sentinel);
@@ -147,7 +148,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
     CoinsCachePair n2;
 
     // Check that setting DIRTY inserts it into linked list and sets state
-    CCoinsCacheEntry::SetDirty(n1, sentinel);
+    BOOST_CHECK(!n1.second.IsFresh());
+    CCoinsCacheEntry::SetDirty(n1, sentinel, /*fresh=*/false);
     BOOST_CHECK(n1.second.IsDirty() && !n1.second.IsFresh());
     BOOST_CHECK_EQUAL(n1.second.Next(), &sentinel);
     BOOST_CHECK_EQUAL(n1.second.Prev(), &sentinel);
@@ -187,7 +189,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
     BOOST_CHECK_EQUAL(n2.second.Prev(), &sentinel);
 
     // Adding DIRTY re-inserts it after n2
-    CCoinsCacheEntry::SetDirty(n1, sentinel);
+    BOOST_CHECK(!n1.second.IsFresh());
+    CCoinsCacheEntry::SetDirty(n1, sentinel, /*fresh=*/false);
     BOOST_CHECK(n1.second.IsDirty() && !n1.second.IsFresh());
     BOOST_CHECK_EQUAL(n2.second.Next(), &n1);
     BOOST_CHECK_EQUAL(n1.second.Prev(), &n2);

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -161,17 +161,16 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n1);
 
-    // Check that setting FRESH on new node inserts it after n1
-    CCoinsCacheEntry::SetFresh(n2, sentinel);
-    BOOST_CHECK(n2.second.IsFresh());
-    BOOST_CHECK(!n2.second.IsDirty());
+    // Check that setting DIRTY and FRESH on new node inserts it after n1
+    CCoinsCacheEntry::SetDirty(n2, sentinel, /*fresh=*/true);
+    BOOST_CHECK(n2.second.IsDirty() && n2.second.IsFresh());
     BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
     BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
     BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
 
     // Check that we can set extra state, but they don't change our position
-    CCoinsCacheEntry::SetFresh(n1, sentinel);
+    CCoinsCacheEntry::SetDirty(n1, sentinel, /*fresh=*/true);
     BOOST_CHECK(n1.second.IsDirty());
     BOOST_CHECK(n1.second.IsFresh());
     BOOST_CHECK_EQUAL(n1.second.Next(), &n2);

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -19,7 +19,8 @@ std::list<CoinsCachePair> CreatePairs(CoinsCachePair& sentinel)
         nodes.emplace_back();
 
         auto node{std::prev(nodes.end())};
-        CCoinsCacheEntry::SetDirty(*node, sentinel);
+        BOOST_CHECK(!node->second.IsFresh());
+        CCoinsCacheEntry::SetDirty(*node, sentinel, /*fresh=*/false);
 
         BOOST_CHECK(node->second.IsDirty());
         BOOST_CHECK(!node->second.IsFresh());
@@ -153,7 +154,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
     CoinsCachePair n2;
 
     // Check that setting DIRTY inserts it into linked list and sets state
-    CCoinsCacheEntry::SetDirty(n1, sentinel);
+    BOOST_CHECK(!n1.second.IsFresh());
+    CCoinsCacheEntry::SetDirty(n1, sentinel, /*fresh=*/false);
     BOOST_CHECK(n1.second.IsDirty());
     BOOST_CHECK(!n1.second.IsFresh());
     BOOST_CHECK_EQUAL(n1.second.Next(), &sentinel);
@@ -197,7 +199,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
     BOOST_CHECK_EQUAL(n2.second.Prev(), &sentinel);
 
     // Adding DIRTY re-inserts it after n2
-    CCoinsCacheEntry::SetDirty(n1, sentinel);
+    BOOST_CHECK(!n1.second.IsFresh());
+    CCoinsCacheEntry::SetDirty(n1, sentinel, /*fresh=*/false);
     BOOST_CHECK(n1.second.IsDirty());
     BOOST_CHECK(!n1.second.IsFresh());
     BOOST_CHECK_EQUAL(n2.second.Next(), &n1);

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -209,13 +209,15 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                         }
                         coins_cache_entry.coin = *opt_coin;
                     }
-                    // Avoid setting FRESH for an outpoint that already exists unspent in the parent view.
-                    bool fresh{!coins_view_cache.PeekCoin(random_out_point) && fuzzed_data_provider.ConsumeBool()};
-                    bool dirty{fresh || fuzzed_data_provider.ConsumeBool()};
-                    auto it{coins_map.emplace(random_out_point, std::move(coins_cache_entry)).first};
-                    if (dirty) CCoinsCacheEntry::SetDirty(*it, sentinel);
-                    if (fresh) CCoinsCacheEntry::SetFresh(*it, sentinel);
-                    dirty_count += dirty;
+                    bool dirty{fuzzed_data_provider.ConsumeBool()};
+                    // Avoid setting FRESH for spent coins or outpoints that already exist unspent in the parent view.
+                    bool fresh{dirty && !coins_cache_entry.coin.IsSpent() && !coins_view_cache.PeekCoin(random_out_point) && fuzzed_data_provider.ConsumeBool()};
+                    auto [it, inserted]{coins_map.emplace(random_out_point, std::move(coins_cache_entry))};
+                    if (dirty && inserted) {
+                        CCoinsCacheEntry::SetDirty(*it, sentinel);
+                        if (fresh) CCoinsCacheEntry::SetFresh(*it, sentinel);
+                        ++dirty_count;
+                    }
                 }
                 auto cursor{CoinsViewCacheCursor(dirty_count, sentinel, coins_map, /*will_erase=*/true)};
                 uint256 best_block{coins_view_cache.GetBestBlock()};

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -214,8 +214,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                     bool fresh{dirty && !coins_cache_entry.coin.IsSpent() && !coins_view_cache.PeekCoin(random_out_point) && fuzzed_data_provider.ConsumeBool()};
                     auto [it, inserted]{coins_map.emplace(random_out_point, std::move(coins_cache_entry))};
                     if (dirty && inserted) {
-                        CCoinsCacheEntry::SetDirty(*it, sentinel);
-                        if (fresh) CCoinsCacheEntry::SetFresh(*it, sentinel);
+                        CCoinsCacheEntry::SetDirty(*it, sentinel, fresh);
                         ++dirty_count;
                     }
                 }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -258,13 +258,15 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                         }
                         coins_cache_entry.coin = *opt_coin;
                     }
-                    // Avoid setting FRESH for an outpoint that already exists unspent in the parent view.
-                    bool fresh{!coins_view_cache.PeekCoin(random_out_point) && fuzzed_data_provider.ConsumeBool()};
-                    bool dirty{fresh || fuzzed_data_provider.ConsumeBool()};
-                    auto it{coins_map.emplace(random_out_point, std::move(coins_cache_entry)).first};
-                    if (dirty) CCoinsCacheEntry::SetDirty(*it, sentinel);
-                    if (fresh) CCoinsCacheEntry::SetFresh(*it, sentinel);
-                    dirty_count += dirty;
+                    bool dirty{fuzzed_data_provider.ConsumeBool()};
+                    // Avoid setting FRESH for spent coins or outpoints that already exist unspent in the parent view.
+                    bool fresh{dirty && !coins_cache_entry.coin.IsSpent() && !coins_view_cache.PeekCoin(random_out_point) && fuzzed_data_provider.ConsumeBool()};
+                    auto [it, inserted]{coins_map.emplace(random_out_point, std::move(coins_cache_entry))};
+                    if (dirty && inserted) {
+                        CCoinsCacheEntry::SetDirty(*it, sentinel);
+                        if (fresh) CCoinsCacheEntry::SetFresh(*it, sentinel);
+                        ++dirty_count;
+                    }
                 }
                 auto cursor{CoinsViewCacheCursor(dirty_count, sentinel, coins_map, /*will_erase=*/true)};
                 uint256 best_block{coins_view_cache.GetBestBlock()};

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -263,8 +263,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                     bool fresh{dirty && !coins_cache_entry.coin.IsSpent() && !coins_view_cache.PeekCoin(random_out_point) && fuzzed_data_provider.ConsumeBool()};
                     auto [it, inserted]{coins_map.emplace(random_out_point, std::move(coins_cache_entry))};
                     if (dirty && inserted) {
-                        CCoinsCacheEntry::SetDirty(*it, sentinel);
-                        if (fresh) CCoinsCacheEntry::SetFresh(*it, sentinel);
+                        CCoinsCacheEntry::SetDirty(*it, sentinel, fresh);
                         ++dirty_count;
                     }
                 }

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -156,27 +156,13 @@ public:
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256&) final
     {
         for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
-            if (it->second.IsDirty()) {
-                if (it->second.coin.IsSpent()) {
-                    m_data.erase(it->first);
-                } else {
-                    if (cursor.WillErase(*it)) {
-                        m_data[it->first] = std::move(it->second.coin);
-                    } else {
-                        m_data[it->first] = it->second.coin;
-                    }
-                }
+            assert(it->second.IsDirty());
+            if (it->second.coin.IsSpent()) {
+                m_data.erase(it->first);
+            } else if (cursor.WillErase(*it)) {
+                m_data[it->first] = std::move(it->second.coin);
             } else {
-                /* For non-dirty entries being written, compare them with what we have. */
-                auto it2 = m_data.find(it->first);
-                if (it->second.coin.IsSpent()) {
-                    assert(it2 == m_data.end());
-                } else {
-                    assert(it2 != m_data.end());
-                    assert(it->second.coin.out == it2->second.out);
-                    assert(it->second.coin.fCoinBase == it2->second.fCoinBase);
-                    assert(it->second.coin.nHeight == it2->second.nHeight);
-                }
+                m_data[it->first] = it->second.coin;
             }
         }
     }

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -319,10 +319,12 @@ FUZZ_TARGET(coinscache_sim)
 
             [&]() { // SpendCoin (moveto = nullptr)
                 uint32_t outpointidx = provider.ConsumeIntegralInRange<uint32_t>(0, NUM_OUTPOINTS - 1);
+                auto sim{lookup(outpointidx)};
                 // Invoke on real caches.
-                caches.back()->SpendCoin(data.outpoints[outpointidx], nullptr);
+                const bool real{caches.back()->SpendCoin(data.outpoints[outpointidx], nullptr)};
                 // Apply to simulation data.
                 sim_caches[caches.size()].entry[outpointidx].entrytype = EntryType::SPENT;
+                assert(real == sim.has_value());
             },
 
             [&]() { // SpendCoin (with moveto)
@@ -331,9 +333,10 @@ FUZZ_TARGET(coinscache_sim)
                 auto sim = lookup(outpointidx);
                 // Invoke on real caches.
                 Coin realcoin;
-                caches.back()->SpendCoin(data.outpoints[outpointidx], &realcoin);
+                const bool real{caches.back()->SpendCoin(data.outpoints[outpointidx], &realcoin)};
                 // Apply to simulation data.
                 sim_caches[caches.size()].entry[outpointidx].entrytype = EntryType::SPENT;
+                assert(real == sim.has_value());
                 // Compare *moveto with the value expected based on simulation data.
                 if (!sim.has_value()) {
                     assert(realcoin.IsSpent());

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -170,27 +170,13 @@ public:
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256&) final
     {
         for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
-            if (it->second.IsDirty()) {
-                if (it->second.coin.IsSpent()) {
-                    m_data.erase(it->first);
-                } else {
-                    if (cursor.WillErase(*it)) {
-                        m_data[it->first] = std::move(it->second.coin);
-                    } else {
-                        m_data[it->first] = it->second.coin;
-                    }
-                }
+            assert(it->second.IsDirty());
+            if (it->second.coin.IsSpent()) {
+                m_data.erase(it->first);
+            } else if (cursor.WillErase(*it)) {
+                m_data[it->first] = std::move(it->second.coin);
             } else {
-                /* For non-dirty entries being written, compare them with what we have. */
-                auto it2 = m_data.find(it->first);
-                if (it->second.coin.IsSpent()) {
-                    assert(it2 == m_data.end());
-                } else {
-                    assert(it2 != m_data.end());
-                    assert(it->second.coin.out == it2->second.out);
-                    assert(it->second.coin.fCoinBase == it2->second.fCoinBase);
-                    assert(it->second.coin.nHeight == it2->second.nHeight);
-                }
+                m_data[it->first] = it->second.coin;
             }
         }
     }

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -354,10 +354,12 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
 
             [&]() { // SpendCoin (moveto = nullptr)
                 uint32_t outpointidx = provider.ConsumeIntegralInRange<uint32_t>(0, NUM_OUTPOINTS - 1);
+                auto sim{lookup(outpointidx)};
                 // Invoke on real caches.
-                caches.back()->SpendCoin(data.outpoints[outpointidx], nullptr);
+                const bool real{caches.back()->SpendCoin(data.outpoints[outpointidx], nullptr)};
                 // Apply to simulation data.
                 sim_caches[caches.size()].entry[outpointidx].entrytype = EntryType::SPENT;
+                assert(real == sim.has_value());
             },
 
             [&]() { // SpendCoin (with moveto)
@@ -366,9 +368,10 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
                 auto sim = lookup(outpointidx);
                 // Invoke on real caches.
                 Coin realcoin;
-                caches.back()->SpendCoin(data.outpoints[outpointidx], &realcoin);
+                const bool real{caches.back()->SpendCoin(data.outpoints[outpointidx], &realcoin)};
                 // Apply to simulation data.
                 sim_caches[caches.size()].entry[outpointidx].entrytype = EntryType::SPENT;
+                assert(real == sim.has_value());
                 // Compare *moveto with the value expected based on simulation data.
                 if (!sim.has_value()) {
                     assert(realcoin.IsSpent());

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -122,7 +122,6 @@ std::vector<uint256> CCoinsViewDB::GetHeadBlocks() const {
 void CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash)
 {
     CDBBatch batch(*m_db);
-    size_t count = 0;
     const size_t dirty_count{cursor.GetDirtyCount()};
     assert(!block_hash.IsNull());
 
@@ -151,15 +150,13 @@ void CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block
     batch.Write(DB_HEAD_BLOCKS, Vector(block_hash, old_tip));
 
     for (auto it{cursor.Begin()}; it != cursor.End();) {
-        if (it->second.IsDirty()) {
-            CoinEntry entry(&it->first);
-            if (it->second.coin.IsSpent()) {
-                batch.Erase(entry);
-            } else {
-                batch.Write(entry, it->second.coin);
-            }
+        assert(it->second.IsDirty());
+        CoinEntry entry(&it->first);
+        if (it->second.coin.IsSpent()) {
+            batch.Erase(entry);
+        } else {
+            batch.Write(entry, it->second.coin);
         }
-        count++;
         it = cursor.NextAndMaybeErase(*it);
         if (batch.ApproximateSize() > m_options.batch_write_bytes) {
             LogDebug(BCLog::COINDB, "Writing partial batch of %.2f MiB\n", batch.ApproximateSize() / double(1_MiB));
@@ -182,7 +179,7 @@ void CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block
 
     LogDebug(BCLog::COINDB, "Writing final batch of %.2f MiB\n", batch.ApproximateSize() / double(1_MiB));
     m_db->WriteBatch(batch);
-    LogDebug(BCLog::COINDB, "Committed %u changed transaction outputs (out of %u) to coin database...", (unsigned int)dirty_count, (unsigned int)count);
+    LogDebug(BCLog::COINDB, "Committed %u changed transaction outputs to coin database...", dirty_count);
 }
 
 size_t CCoinsViewDB::EstimateSize() const

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -535,7 +535,10 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
         CAmount txfee = 0;
         assert(!tx.IsCoinBase());
         assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, txfee));
-        for (const auto& input: tx.vin) mempoolDuplicate.SpendCoin(input.prevout);
+        for (const auto& input: tx.vin) {
+            const bool spent{mempoolDuplicate.SpendCoin(input.prevout)};
+            assert(spent);
+        }
         AddCoins(mempoolDuplicate, tx, std::numeric_limits<int>::max());
     }
     for (auto it = mapNextTx.cbegin(); it != mapNextTx.cend(); it++) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -534,7 +534,10 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
         CAmount txfee = 0;
         assert(!tx.IsCoinBase());
         assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, txfee));
-        for (const auto& input: tx.vin) mempoolDuplicate.SpendCoin(input.prevout);
+        for (const auto& input: tx.vin) {
+            const bool spent{mempoolDuplicate.SpendCoin(input.prevout)};
+            assert(spent);
+        }
         AddCoins(mempoolDuplicate, tx, std::numeric_limits<int>::max());
     }
     for (auto it = mapNextTx.cbegin(); it != mapNextTx.cend(); it++) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4774,7 +4774,7 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
     for (const CTransactionRef& tx : block.vtx) {
         if (!tx->IsCoinBase()) {
             for (const CTxIn &txin : tx->vin) {
-                inputs.SpendCoin(txin.prevout);
+                (void)inputs.SpendCoin(txin.prevout);
             }
         }
         // Pass check = true as every addition may be an overwrite.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4786,7 +4786,7 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
     for (const CTransactionRef& tx : block.vtx) {
         if (!tx->IsCoinBase()) {
             for (const CTxIn &txin : tx->vin) {
-                inputs.SpendCoin(txin.prevout);
+                (void)inputs.SpendCoin(txin.prevout);
             }
         }
         // Pass check = true as every addition may be an overwrite.


### PR DESCRIPTION
**Problem:** The coins cache still exposed and tested states that production code should not create: standalone `FRESH` entries, non-dirty `BatchWrite()` cursor entries, and spent `FRESH` entries.
That makes the representation harder to reason about, because `CCoinsCacheEntry` stores a separate `DIRTY` bit even though dirty entries are already tracked in the linked list.

**Fix:** This revives and splits the relevant parts of #30673 and #33018.
The series passes freshness through `SetDirty()`, removes fresh-only test states, treats `BatchWrite()` cursor entries as dirty by construction, rejects spent `FRESH` entries, removes the bare `SetFresh()` helper, and derives dirtiness from linked-list membership.
The final commits also tighten `SpendCoin()` around the same cache-state contract: repeated spends of an entry already cached as spent now fail without changing cache accounting or caller-owned output, and callers must either check the result or explicitly discard it.
`coinscache_sim` now checks the real `SpendCoin()` result against its simulation model, and the no-op repeated-spend path no longer emits the `utxocache:spent` tracepoint because no spend occurs.