### PR TITLE
wallet: document importdescriptors error object fields

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -343,7 +343,8 @@ RPCHelpMan importdescriptors()
                             }},
                             {RPCResult::Type::OBJ, "error", /*optional=*/true, "",
                             {
-                                {RPCResult::Type::ELISION, "", "JSONRPC error"},
+                                {RPCResult::Type::NUM, "code", "JSONRPC error code"},
+                                {RPCResult::Type::STR, "message", "JSONRPC error message"},
                             }},
                         }},
                     }


### PR DESCRIPTION
Related to #29912 and the machine-readable OpenRPC generated from `RPCHelpMan` metadata work discussed in #34683. Split out from #34764 per review feedback that this change is conceptually separate from the broader elision work there.

The `importdescriptors` RPC help currently documents the optional `error` field using an elided `JSONRPC error` placeholder. This PR replaces that with explicit `code` and `message` fields.

`importdescriptors` already returns a structured JSON-RPC error object in practice, so this makes the documented result schema match the existing response shape more closely.

This PR changes `importdescriptors` help text, and the runtime checks on the returned json to be more strict.