### PR TITLE
tests: applied PYTHON_GIL to the env for every test

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -584,6 +584,11 @@ def main():
 def run_tests(*, test_list, build_dir, tmpdir, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, use_term_control, results_filepath=None):
     args = args or []
 
+    # Some optional Python dependencies (e.g. pycapnp) may emit warnings or fail under
+    # CPython free-threaded builds when the GIL is disabled. Force it on for all
+    # functional tests so every child process inherits PYTHON_GIL=1.
+    os.environ["PYTHON_GIL"] = "1"
+
     # Warn if bitcoind is already running
     try:
         # pgrep exits with code zero when one or more matching processes found


### PR DESCRIPTION
## Summay
If a user is running python3.14.0t they would see a warning log that would fail the integration test suite.

This change adds `PYTHON_GIL=1` to the env when running our functional test suite to ensure that the tests pass for users running python3.14.0t and are not manually setting `PYTHON_GIL=1`.

This resolves https://github.com/bitcoin/bitcoin/issues/33582

### Tests before and after
#### Before
```
./build/test/functional/test_runner.py interface_ipc.py
Temporary test directory at /tmp/test_runner_₿_🏃_20260319_142327
Remaining jobs: [interface_ipc.py]
1/1 - interface_ipc.py failed, Duration: 2 s

stdout:
2026-03-19T18:23:27.330123Z TestFramework (INFO): PRNG seed is: 4933091336597497631
2026-03-19T18:23:27.380917Z TestFramework (INFO): Initializing test directory /tmp/test_runner_₿_🏃_20260319_142327/interface_ipc_0
2026-03-19T18:23:28.625944Z TestFramework (INFO): Running echo test
2026-03-19T18:23:28.635856Z TestFramework (INFO): Running mining test
2026-03-19T18:23:28.648965Z TestFramework (INFO): Running deprecated mining interface test
2026-03-19T18:23:28.653589Z TestFramework (INFO): Running disconnect during BlockTemplate.waitNext
2026-03-19T18:23:28.821124Z TestFramework (INFO): Running thread busy test
2026-03-19T18:23:29.195589Z TestFramework (INFO): Stopping nodes
2026-03-19T18:23:29.299135Z TestFramework (INFO): Cleaning up /tmp/test_runner_₿_🏃_20260319_142327/interface_ipc_0 on exit
2026-03-19T18:23:29.299329Z TestFramework (INFO): Tests successful


stderr:
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'capnp.lib.capnp', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.



TEST             | STATUS    | DURATION

interface_ipc.py | ✖ Failed  | 2 s

ALL              | ✖ Failed  | 2 s (accumulated) 
Runtime: 2 s

```
#### After
```
./build/test/functional/test_runner.py interface_ipc.py
Temporary test directory at /tmp/test_runner_₿_🏃_20260319_142221
Remaining jobs: [interface_ipc.py]
1/1 - interface_ipc.py passed, Duration: 2 s

TEST             | STATUS    | DURATION

interface_ipc.py | ✓ Passed  | 2 s

ALL              | ✓ Passed  | 2 s (accumulated) 
Runtime: 2 s
```