### PR TITLE
wallet: feebumper, fix crash when combined bump fee is unavailable

### DIFF
--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -80,9 +80,10 @@ static feebumper::Result CheckFeeRate(const CWallet& wallet, const CMutableTrans
         reused_inputs.push_back(txin.prevout);
     }
 
-    std::optional<CAmount> combined_bump_fee = wallet.chain().calculateCombinedBumpFee(reused_inputs, newFeerate);
+    const std::optional<CAmount> combined_bump_fee = wallet.chain().calculateCombinedBumpFee(reused_inputs, newFeerate);
     if (!combined_bump_fee.has_value()) {
         errors.push_back(Untranslated(strprintf("Failed to calculate bump fees, because unconfirmed UTXOs depend on an enormous cluster of unconfirmed transactions.")));
+        return feebumper::Result::WALLET_ERROR;
     }
     CAmount new_total_fee = newFeerate.GetFee(maxTxSize) + combined_bump_fee.value();
 


### PR DESCRIPTION
When a large cluster of unconfirmed transactions exceeds the limit,
`calculateCombinedBumpFee()` returns `std::nullopt`.

Previously, we continued executing and the optional value was
accessed unconditionally, leading to a `std::bad_optional_access`
exception (https://en.cppreference.com/w/cpp/utility/optional/value.html).

Fix this by returning early when the bumped fee is null.

Note:
This is a crash for the GUI, and an uncaught exception for the RPC
`bumpfee` and `psbtbumpfee`.

