### PR TITLE
test: remove unused `NodeClockContext` default ctor

### DIFF
--- a/src/test/util/time.h
+++ b/src/test/util/time.h
@@ -44,8 +44,6 @@ public:
     /// Initialize with the given time.
     explicit NodeClockContext(NodeSeconds init_time) { set(init_time); }
     explicit NodeClockContext(std::chrono::seconds init_time) { set(init_time); }
-    /// Initialize with current time, using the next tick to avoid going back by rounding to seconds.
-    explicit NodeClockContext() { set(++Now<NodeSeconds>().time_since_epoch()); }
 
     /// Unset mocktime.
     ~NodeClockContext() { set(0s); }


### PR DESCRIPTION
`NodeClockContext` was introduced in #34479  as a small RAII helper for tests and fuzz targets: it sets mock node time on construction and resets the global mock time on destruction. The motivation there was to make mock-time usage less error-prone and to avoid mock time leaking from one fuzz input to the next.

All current in-tree uses of NodeClockContext pass an explicit time, e.g.

```c++
NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
```

The no-argument constructor is not used anywhere.