### PR TITLE
wallet: fix mixed-input transaction accounting in history RPCs

### DIFF
--- a/doc/release-notes-34872.md
+++ b/doc/release-notes-34872.md
@@ -1,0 +1,26 @@
+Wallet
+------
+
+- Transactions that spend a mix of wallet-owned and non-wallet inputs are now
+  reported safely by the `gettransaction`, `listtransactions`, and
+  `listsinceblock` RPCs. Previously such transactions reported a misleading fee
+  and attributed non-wallet outputs as wallet sends (see issue #14136).
+
+  When every non-wallet input has a known zero value (for example a
+  pay-to-anchor output), the wallet can still attribute the full fee and all
+  sent outputs, so these transactions continue to be reported with the usual
+  per-output `send`/`receive` entries. Otherwise the wallet cannot attribute the
+  foreign outputs or its fee share, so it reports a single unattributed
+  aggregate `send` summary carrying the negative total of wallet-owned inputs
+  spent, instead of fabricating per-recipient sends or a fee. Wallet-owned
+  outputs are still reported as `receive` entries alongside that send summary,
+  so deposit detection based on the `receive` category keeps working, and the
+  amounts of a transaction's entries sum to the wallet's net change.
+
+  Affected entries additionally expose the new `involves_mixed_inputs`,
+  `wallet_debit`, and `wallet_credit` fields, which let consumers detect the
+  conservative case without depending on the `category` value. The `vout` field
+  is now optional in the result schema: it is omitted from unattributed
+  aggregate mixed-input send summaries, which do not correspond to a single
+  output. The `fee` field is likewise omitted when the wallet cannot determine
+  the fee. (#34872)

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -201,7 +201,15 @@ WalletTxHistoryAccounting CachedTxGetHistoryAccounting(const CWallet& wallet, co
     if (input_ownership == WalletTxInputOwnership::ALL) {
         fee = debit - wtx.tx->GetValueOut();
     } else if (input_ownership == WalletTxInputOwnership::PARTIAL) {
-        CachedTxAllForeignInputsKnownZeroValue(wallet, wtx);
+        // Even when the values of all foreign inputs are known (e.g. their
+        // funding transactions are in the wallet), a nonzero foreign
+        // contribution keeps the fee unattributed: the total fee may be
+        // computable, but the wallet's share of it is not. Only when every
+        // foreign input provably contributes zero value is the entire fee
+        // attributable to the wallet.
+        if (CachedTxAllForeignInputsKnownZeroValue(wallet, wtx)) {
+            fee = debit - wtx.tx->GetValueOut();
+        }
     }
     return {input_ownership, debit, credit, fee};
 }
@@ -216,7 +224,7 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
     listReceived.clear();
     listSent.clear();
     const WalletTxHistoryAccounting accounting{CachedTxGetHistoryAccounting(wallet, wtx)};
-    const bool all_inputs_mine{accounting.input_ownership == WalletTxInputOwnership::ALL};
+    const bool can_attribute_sent_outputs{accounting.fee.has_value()};
 
     // Compute fee:
     if (accounting.fee.has_value()) {
@@ -229,9 +237,9 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
         const CTxOut& txout = wtx.tx->vout[i];
         bool ismine = wallet.IsMine(txout);
         // Only need to handle txouts if either:
-        //   1) every input is ours, so the output can be reported as sent
+        //   1) every spent input value is ours, so the output can be reported as sent
         //   2) the output is ours, so it can be reported as received
-        if (all_inputs_mine)
+        if (can_attribute_sent_outputs)
         {
             if (!include_change && OutputIsChange(wallet, txout))
                 continue;
@@ -251,8 +259,8 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
 
         COutputEntry output = {address, txout.nValue, (int)i};
 
-        // Only transactions fully funded by the wallet have attributable sent outputs.
-        if (all_inputs_mine)
+        // Only transactions whose spent value is fully funded by the wallet have attributable sent outputs.
+        if (can_attribute_sent_outputs)
             listSent.push_back(output);
 
         // If we are receiving the output, add it as a "received" entry

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -165,6 +165,18 @@ CAmount CachedTxGetChange(const CWallet& wallet, const CWalletTx& wtx)
     return wtx.nChangeCached;
 }
 
+WalletTxHistoryAccounting CachedTxGetHistoryAccounting(const CWallet& wallet, const CWalletTx& wtx)
+{
+    const CAmount debit{CachedTxGetDebit(wallet, wtx, /*avoid_reuse=*/false)};
+    const CAmount credit{CachedTxGetCredit(wallet, wtx, /*avoid_reuse=*/false)};
+    const WalletTxInputOwnership input_ownership{CachedTxGetInputOwnership(wallet, wtx)};
+    std::optional<CAmount> fee;
+    if (input_ownership == WalletTxInputOwnership::ALL) {
+        fee = debit - wtx.tx->GetValueOut();
+    }
+    return {input_ownership, debit, credit, fee};
+}
+
 void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
                   std::list<COutputEntry>& listReceived,
                   std::list<COutputEntry>& listSent, CAmount& nFee,

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -166,6 +166,7 @@ CAmount CachedTxGetChange(const CWallet& wallet, const CWalletTx& wtx)
 }
 
 WalletTxHistoryAccounting CachedTxGetHistoryAccounting(const CWallet& wallet, const CWalletTx& wtx)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     const CAmount debit{CachedTxGetDebit(wallet, wtx, /*avoid_reuse=*/false)};
     const CAmount credit{CachedTxGetCredit(wallet, wtx, /*avoid_reuse=*/false)};
@@ -181,29 +182,28 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
                   std::list<COutputEntry>& listReceived,
                   std::list<COutputEntry>& listSent, CAmount& nFee,
                   bool include_change)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     nFee = 0;
     listReceived.clear();
     listSent.clear();
+    const WalletTxHistoryAccounting accounting{CachedTxGetHistoryAccounting(wallet, wtx)};
+    const bool all_inputs_mine{accounting.input_ownership == WalletTxInputOwnership::ALL};
 
     // Compute fee:
-    CAmount nDebit = CachedTxGetDebit(wallet, wtx, /*avoid_reuse=*/false);
-    if (nDebit > 0) // debit>0 means we signed/sent this transaction
-    {
-        CAmount nValueOut = wtx.tx->GetValueOut();
-        nFee = nDebit - nValueOut;
+    if (accounting.fee.has_value()) {
+        nFee = *accounting.fee;
     }
 
-    LOCK(wallet.cs_wallet);
     // Sent/received.
     for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i)
     {
         const CTxOut& txout = wtx.tx->vout[i];
         bool ismine = wallet.IsMine(txout);
-        // Only need to handle txouts if AT LEAST one of these is true:
-        //   1) they debit from us (sent)
-        //   2) the output is to us (received)
-        if (nDebit > 0)
+        // Only need to handle txouts if either:
+        //   1) every input is ours, so the output can be reported as sent
+        //   2) the output is ours, so it can be reported as received
+        if (all_inputs_mine)
         {
             if (!include_change && OutputIsChange(wallet, txout))
                 continue;
@@ -223,8 +223,8 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
 
         COutputEntry output = {address, txout.nValue, (int)i};
 
-        // If we are debited by the transaction, add the output as a "sent" entry
-        if (nDebit > 0)
+        // Only transactions fully funded by the wallet have attributable sent outputs.
+        if (all_inputs_mine)
             listSent.push_back(output);
 
         // If we are receiving the output, add it as a "received" entry

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -58,6 +58,29 @@ WalletTxInputOwnership CachedTxGetInputOwnership(const CWallet& wallet, const CW
     return wtx.m_cached_input_ownership.value();
 }
 
+static bool AllForeignInputsKnownZeroValue(const CWallet& wallet, const CTransaction& tx)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    for (const CTxIn& txin : tx.vin) {
+        if (InputIsMine(wallet, txin)) continue;
+        const CWalletTx* prev{wallet.GetWalletTx(txin.prevout.hash)};
+        if (!prev || txin.prevout.n >= prev->tx->vout.size()) return false;
+        if (prev->tx->vout[txin.prevout.n].nValue != 0) return false;
+    }
+    return true;
+}
+
+static bool CachedTxAllForeignInputsKnownZeroValue(const CWallet& wallet, const CWalletTx& wtx)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    if (!wtx.m_cached_foreign_inputs_zero_value.has_value()) {
+        wtx.m_cached_foreign_inputs_zero_value = AllForeignInputsKnownZeroValue(wallet, *wtx.tx);
+    }
+    return wtx.m_cached_foreign_inputs_zero_value.value();
+}
+
 CAmount OutputGetCredit(const CWallet& wallet, const CTxOut& txout)
 {
     if (!MoneyRange(txout.nValue))
@@ -171,9 +194,14 @@ WalletTxHistoryAccounting CachedTxGetHistoryAccounting(const CWallet& wallet, co
     const CAmount debit{CachedTxGetDebit(wallet, wtx, /*avoid_reuse=*/false)};
     const CAmount credit{CachedTxGetCredit(wallet, wtx, /*avoid_reuse=*/false)};
     const WalletTxInputOwnership input_ownership{CachedTxGetInputOwnership(wallet, wtx)};
+
+    // Foreign input values only need to be inspected for mixed-input transactions;
+    // for fully-owned or fully-foreign transactions the fee is decided by ownership alone.
     std::optional<CAmount> fee;
     if (input_ownership == WalletTxInputOwnership::ALL) {
         fee = debit - wtx.tx->GetValueOut();
+    } else if (input_ownership == WalletTxInputOwnership::PARTIAL) {
+        CachedTxAllForeignInputsKnownZeroValue(wallet, wtx);
     }
     return {input_ownership, debit, credit, fee};
 }

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -29,6 +29,35 @@ bool AllInputsMine(const CWallet& wallet, const CTransaction& tx)
     return true;
 }
 
+static WalletTxInputOwnership GetInputOwnership(const CWallet& wallet, const CTransaction& tx)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    if (tx.vin.empty()) return WalletTxInputOwnership::NONE;
+
+    bool any_mine{false};
+    bool any_not_mine{false};
+    for (const CTxIn& txin : tx.vin) {
+        if (InputIsMine(wallet, txin)) {
+            any_mine = true;
+        } else {
+            any_not_mine = true;
+        }
+        if (any_mine && any_not_mine) return WalletTxInputOwnership::PARTIAL;
+    }
+    return any_mine ? WalletTxInputOwnership::ALL : WalletTxInputOwnership::NONE;
+}
+
+WalletTxInputOwnership CachedTxGetInputOwnership(const CWallet& wallet, const CWalletTx& wtx)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    if (!wtx.m_cached_input_ownership.has_value()) {
+        wtx.m_cached_input_ownership = GetInputOwnership(wallet, *wtx.tx);
+    }
+    return wtx.m_cached_input_ownership.value();
+}
+
 CAmount OutputGetCredit(const CWallet& wallet, const CTxOut& txout)
 {
     if (!MoneyRange(txout.nValue))

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -15,6 +15,7 @@ bool InputIsMine(const CWallet& wallet, const CTxIn& txin) EXCLUSIVE_LOCKS_REQUI
 
 /** Returns whether all of the inputs belong to the wallet*/
 bool AllInputsMine(const CWallet& wallet, const CTransaction& tx);
+WalletTxInputOwnership CachedTxGetInputOwnership(const CWallet& wallet, const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 CAmount OutputGetCredit(const CWallet& wallet, const CTxOut& txout);
 CAmount TxGetCredit(const CWallet& wallet, const CTransaction& tx);

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -50,7 +50,8 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
                         std::list<COutputEntry>& listReceived,
                         std::list<COutputEntry>& listSent,
                         CAmount& nFee,
-                        bool include_change);
+                        bool include_change)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 bool CachedTxIsFromMe(const CWallet& wallet, const CWalletTx& wtx);
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txid>& trusted_parents) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx);

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -10,6 +10,8 @@
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
+#include <optional>
+
 namespace wallet {
 bool InputIsMine(const CWallet& wallet, const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
@@ -35,6 +37,15 @@ struct COutputEntry
     CAmount amount;
     int vout;
 };
+struct WalletTxHistoryAccounting
+{
+    WalletTxInputOwnership input_ownership;
+    CAmount debit;
+    CAmount credit;
+    std::optional<CAmount> fee;
+};
+WalletTxHistoryAccounting CachedTxGetHistoryAccounting(const CWallet& wallet, const CWalletTx& wtx)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
                         std::list<COutputEntry>& listReceived,
                         std::list<COutputEntry>& listSent,

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -299,6 +299,11 @@ static bool IsMixedInput(const WalletTxHistoryAccounting& accounting)
     return accounting.input_ownership == WalletTxInputOwnership::PARTIAL;
 }
 
+static bool NeedsUnattributedAggregateSend(const WalletTxHistoryAccounting& accounting)
+{
+    return IsMixedInput(accounting) && !accounting.fee.has_value();
+}
+
 static void PushMixedInputFields(UniValue& entry, const WalletTxHistoryAccounting& accounting)
 {
     entry.pushKV("involves_mixed_inputs", true);
@@ -339,9 +344,10 @@ static void AppendWalletTxEntries(const CWallet& wallet, const CWalletTx& wtx, i
 
     const WalletTxHistoryAccounting accounting{CachedTxGetHistoryAccounting(wallet, wtx)};
     const bool is_mixed_input{IsMixedInput(accounting)};
+    const bool needs_unattributed_aggregate_send{NeedsUnattributedAggregateSend(accounting)};
     CachedTxGetAmounts(wallet, wtx, listReceived, listSent, nFee, include_change);
 
-    if (is_mixed_input && !filter_label.has_value()) {
+    if (needs_unattributed_aggregate_send && !filter_label.has_value()) {
         UniValue entry(UniValue::VOBJ);
         PushUnattributedAggregateSend(entry, accounting);
         if (fLong) {
@@ -366,6 +372,9 @@ static void AppendWalletTxEntries(const CWallet& wallet, const CWalletTx& wtx, i
             }
             entry.pushKV("vout", s.vout);
             entry.pushKV("fee", ValueFromAmount(-nFee));
+            if (is_mixed_input) {
+                PushMixedInputFields(entry, accounting);
+            }
             if (fLong)
                 WalletTxToJSON(wallet, wtx, entry);
             entry.pushKV("abandoned", wtx.isAbandoned());
@@ -466,7 +475,8 @@ RPCMethod listtransactions()
                 "For instance, a wallet transaction that pays three addresses — one wallet-owned and two external — will produce \n"
                 "four entries. The payment to the wallet-owned address appears both as a send entry and as a receive entry. \n"
                 "As a result, the RPC response will contain one entry in the receive category and three entries in the send category.\n"
-                "A transaction with both wallet-owned and non-wallet inputs cannot attribute the foreign outputs or its \n"
+                "A transaction with both wallet-owned and non-wallet inputs is reported with normal per-output send/receive entries if \n"
+                "all non-wallet inputs have known zero value. Otherwise the wallet cannot attribute the foreign outputs or its \n"
                 "fee share, so it reports a single unattributed aggregate send entry (marked with involves_mixed_inputs and \n"
                 "without address, vout, or fee) carrying the negative total of wallet-owned inputs spent. Wallet-owned outputs \n"
                 "are reported as separate receive entries, so the transaction's entries sum to the wallet's net change.\n",
@@ -602,7 +612,8 @@ RPCMethod listsinceblock()
         "Get all transactions in blocks since block [blockhash], or all transactions if omitted.\n"
                 "If \"blockhash\" is no longer a part of the main chain, transactions from the fork point onward are included.\n"
                 "Additionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the \"removed\" array.\n"
-                "A transaction with both wallet-owned and non-wallet inputs cannot attribute the foreign outputs or its \n"
+                "A transaction with both wallet-owned and non-wallet inputs is reported with normal per-output send/receive entries if \n"
+                "all non-wallet inputs have known zero value. Otherwise the wallet cannot attribute the foreign outputs or its \n"
                 "fee share, so it reports a single unattributed aggregate send entry (marked with involves_mixed_inputs and \n"
                 "without address, vout, or fee) carrying the negative total of wallet-owned inputs spent. Wallet-owned outputs \n"
                 "are reported as separate receive entries, so the transaction's entries sum to the wallet's net change.\n",
@@ -736,8 +747,7 @@ RPCMethod gettransaction()
                     RPCResult::Type::OBJ, "", "", Cat(Cat<std::vector<RPCResult>>(
                     {
                         {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT},
-                        {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for the\n"
-                                     "'send' category of transactions."},
+                        {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the wallet-attributable fee in " + CURRENCY_UNIT + ". This is negative and only available when known."},
                     },
                     TransactionDescriptionString()),
                     {
@@ -764,7 +774,7 @@ RPCMethod gettransaction()
                                 {RPCResult::Type::BOOL, "involves_mixed_inputs", /*optional=*/true, "Only present if the transaction spends both wallet-owned and non-wallet inputs."},
                                 {RPCResult::Type::STR_AMOUNT, "wallet_debit", /*optional=*/true, "Only present if involves_mixed_inputs is true. Total value of wallet-owned inputs spent by this transaction."},
                                 {RPCResult::Type::STR_AMOUNT, "wallet_credit", /*optional=*/true, "Only present if involves_mixed_inputs is true. Total value of wallet-owned outputs created by this transaction."},
-                                                 }},
+                            }},
                         }},
                         {RPCResult::Type::STR_HEX, "hex", "Raw data for transaction"},
                         {RPCResult::Type::OBJ, "decoded", /*optional=*/true, "The decoded transaction (only present when `verbose` is passed)",

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -294,6 +294,29 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
     }
 }
 
+static bool IsMixedInput(const WalletTxHistoryAccounting& accounting)
+{
+    return accounting.input_ownership == WalletTxInputOwnership::PARTIAL;
+}
+
+static void PushMixedInputFields(UniValue& entry, const WalletTxHistoryAccounting& accounting)
+{
+    entry.pushKV("involves_mixed_inputs", true);
+    entry.pushKV("wallet_debit", ValueFromAmount(accounting.debit));
+    entry.pushKV("wallet_credit", ValueFromAmount(accounting.credit));
+}
+
+// When a mixed-input transaction has unattributable outputs or fee share, the
+// wallet still knows it spent all of its own inputs into the transaction. Report
+// that gross outflow as a single aggregate send entry, while omitting address,
+// vout, and fee because none can be attributed from the transaction alone.
+static void PushUnattributedAggregateSend(UniValue& entry, const WalletTxHistoryAccounting& accounting)
+{
+    entry.pushKV("category", "send");
+    entry.pushKV("amount", ValueFromAmount(-accounting.debit));
+    PushMixedInputFields(entry, accounting);
+}
+
 /**
  * Append RPC entries for a wallet transaction based on the given criteria.
  *
@@ -314,7 +337,19 @@ static void AppendWalletTxEntries(const CWallet& wallet, const CWalletTx& wtx, i
     std::list<COutputEntry> listReceived;
     std::list<COutputEntry> listSent;
 
+    const WalletTxHistoryAccounting accounting{CachedTxGetHistoryAccounting(wallet, wtx)};
+    const bool is_mixed_input{IsMixedInput(accounting)};
     CachedTxGetAmounts(wallet, wtx, listReceived, listSent, nFee, include_change);
+
+    if (is_mixed_input && !filter_label.has_value()) {
+        UniValue entry(UniValue::VOBJ);
+        PushUnattributedAggregateSend(entry, accounting);
+        if (fLong) {
+            WalletTxToJSON(wallet, wtx, entry);
+        }
+        entry.pushKV("abandoned", wtx.isAbandoned());
+        ret.push_back(std::move(entry));
+    }
 
     // Sent
     if (!filter_label.has_value())
@@ -367,6 +402,9 @@ static void AppendWalletTxEntries(const CWallet& wallet, const CWalletTx& wtx, i
                 entry.pushKV("category", "receive");
             }
             entry.pushKV("amount", ValueFromAmount(r.amount));
+            if (is_mixed_input) {
+                PushMixedInputFields(entry, accounting);
+            }
             if (address_book_entry) {
                 entry.pushKV("label", label);
             }
@@ -412,6 +450,9 @@ static std::vector<RPCResult> TransactionDescriptionString()
            {RPCResult::Type::ARR, "parent_descs", /*optional=*/true, "Only if 'category' is 'received'. List of parent descriptors for the output script of this coin.", {
                {RPCResult::Type::STR, "desc", "The descriptor string."},
            }},
+           {RPCResult::Type::BOOL, "involves_mixed_inputs", /*optional=*/true, "Only present if the transaction spends both wallet-owned and non-wallet inputs."},
+           {RPCResult::Type::STR_AMOUNT, "wallet_debit", /*optional=*/true, "Only present if involves_mixed_inputs is true. Total value of wallet-owned inputs spent by this transaction."},
+           {RPCResult::Type::STR_AMOUNT, "wallet_credit", /*optional=*/true, "Only present if involves_mixed_inputs is true. Total value of wallet-owned outputs created by this transaction."},
            };
 }
 
@@ -424,7 +465,11 @@ RPCMethod listtransactions()
                 "transactions specified in the 'skip' argument. A transaction can have multiple entries in this RPC response. \n"
                 "For instance, a wallet transaction that pays three addresses — one wallet-owned and two external — will produce \n"
                 "four entries. The payment to the wallet-owned address appears both as a send entry and as a receive entry. \n"
-                "As a result, the RPC response will contain one entry in the receive category and three entries in the send category.\n",
+                "As a result, the RPC response will contain one entry in the receive category and three entries in the send category.\n"
+                "A transaction with both wallet-owned and non-wallet inputs cannot attribute the foreign outputs or its \n"
+                "fee share, so it reports a single unattributed aggregate send entry (marked with involves_mixed_inputs and \n"
+                "without address, vout, or fee) carrying the negative total of wallet-owned inputs spent. Wallet-owned outputs \n"
+                "are reported as separate receive entries, so the transaction's entries sum to the wallet's net change.\n",
                 {
                     {"label", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "If set, should be a valid label name to return only incoming transactions\n"
                           "with the specified label, or \"*\" to disable filtering and return all transactions."},
@@ -439,17 +484,17 @@ RPCMethod listtransactions()
                         {
                             {RPCResult::Type::STR, "address",  /*optional=*/true, "The bitcoin address of the transaction (not returned if the output does not have an address, e.g. OP_RETURN null data)."},
                             {RPCResult::Type::STR, "category", "The transaction category.\n"
-                                "\"send\"                  Transactions sent.\n"
+                                "\"send\"                  Transactions sent. For mixed-input transactions whose outputs or fee share cannot be attributed, a single unattributed aggregate send entry carries the negative total of wallet-owned inputs spent.\n"
                                 "\"receive\"               Non-coinbase transactions received.\n"
                                 "\"generate\"              Coinbase transactions received with more than 100 confirmations.\n"
                                 "\"immature\"              Coinbase transactions received with 100 or fewer confirmations.\n"
                                 "\"orphan\"                Orphaned coinbase transactions received."},
-                            {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT + ". This is negative for the 'send' category, and is positive\n"
-                                "for all other categories"},
+                            {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT + ". This is negative for the 'send' category and positive for\n"
+                                "receive categories. For an unattributed aggregate mixed-input send, this is the negative total of wallet-owned inputs spent."},
                             {RPCResult::Type::STR, "label", /*optional=*/true, "A comment for the address/transaction, if any"},
-                            {RPCResult::Type::NUM, "vout", "the vout value"},
-                            {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for the\n"
-                                 "'send' category of transactions."},
+                            {RPCResult::Type::NUM, "vout", /*optional=*/true, "the vout value"},
+                            {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for\n"
+                                 "'send' category transactions whose fee is known to the wallet (omitted for unattributed aggregate mixed-input sends)."},
                         },
                         TransactionDescriptionString()),
                         {
@@ -529,16 +574,16 @@ static std::vector<RPCResult> ListSinceBlockTxFields()
         {
             {RPCResult::Type::STR, "address", /*optional=*/true, "The bitcoin address of the transaction (not returned if the output does not have an address, e.g. OP_RETURN null data)."},
             {RPCResult::Type::STR, "category", "The transaction category.\n"
-                "\"send\"                  Transactions sent.\n"
+                "\"send\"                  Transactions sent. For mixed-input transactions whose outputs or fee share cannot be attributed, a single unattributed aggregate send entry carries the negative total of wallet-owned inputs spent.\n"
                 "\"receive\"               Non-coinbase transactions received.\n"
                 "\"generate\"              Coinbase transactions received with more than 100 confirmations.\n"
                 "\"immature\"              Coinbase transactions received with 100 or fewer confirmations.\n"
                 "\"orphan\"                Orphaned coinbase transactions received."},
-            {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT + ". This is negative for the 'send' category, and is positive\n"
-                "for all other categories"},
-            {RPCResult::Type::NUM, "vout", "the vout value"},
+            {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT + ". This is negative for the 'send' category and positive for\n"
+                "receive categories. For an unattributed aggregate mixed-input send, this is the negative total of wallet-owned inputs spent."},
+            {RPCResult::Type::NUM, "vout", /*optional=*/true, "the vout value"},
             {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for the\n"
-                 "'send' category of transactions."},
+                 "'send' category transactions whose fee is known to the wallet (omitted for unattributed aggregate mixed-input sends)."},
         },
         Cat(
             TransactionDescriptionString(),
@@ -556,7 +601,11 @@ RPCMethod listsinceblock()
         "listsinceblock",
         "Get all transactions in blocks since block [blockhash], or all transactions if omitted.\n"
                 "If \"blockhash\" is no longer a part of the main chain, transactions from the fork point onward are included.\n"
-                "Additionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the \"removed\" array.\n",
+                "Additionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the \"removed\" array.\n"
+                "A transaction with both wallet-owned and non-wallet inputs cannot attribute the foreign outputs or its \n"
+                "fee share, so it reports a single unattributed aggregate send entry (marked with involves_mixed_inputs and \n"
+                "without address, vout, or fee) carrying the negative total of wallet-owned inputs spent. Wallet-owned outputs \n"
+                "are reported as separate receive entries, so the transaction's entries sum to the wallet's net change.\n",
                 {
                     {"blockhash", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "If set, the block hash to list transactions since, otherwise list all transactions."},
                     {"target_confirmations", RPCArg::Type::NUM, RPCArg::Default{1}, "Return the nth block hash from the main chain. e.g. 1 would mean the best block hash. Note: this is not used as a filter, but only affects [lastblock] in the return value"},
@@ -698,21 +747,24 @@ RPCMethod gettransaction()
                             {
                                 {RPCResult::Type::STR, "address", /*optional=*/true, "The bitcoin address involved in the transaction."},
                                 {RPCResult::Type::STR, "category", "The transaction category.\n"
-                                    "\"send\"                  Transactions sent.\n"
+                                    "\"send\"                  Transactions sent. For mixed-input transactions whose outputs or fee share cannot be attributed, a single unattributed aggregate send entry carries the negative total of wallet-owned inputs spent.\n"
                                     "\"receive\"               Non-coinbase transactions received.\n"
                                     "\"generate\"              Coinbase transactions received with more than 100 confirmations.\n"
                                     "\"immature\"              Coinbase transactions received with 100 or fewer confirmations.\n"
                                     "\"orphan\"                Orphaned coinbase transactions received."},
                                 {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT},
                                 {RPCResult::Type::STR, "label", /*optional=*/true, "A comment for the address/transaction, if any"},
-                                {RPCResult::Type::NUM, "vout", "the vout value"},
-                                {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for the \n"
-                                    "'send' category of transactions."},
+                                {RPCResult::Type::NUM, "vout", /*optional=*/true, "the vout value"},
+                                {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for\n"
+                                    "'send' category transactions whose fee is known to the wallet (omitted for unattributed aggregate mixed-input sends)."},
                                 {RPCResult::Type::BOOL, "abandoned", "'true' if the transaction has been abandoned (inputs are respendable)."},
                                 {RPCResult::Type::ARR, "parent_descs", /*optional=*/true, "Only if 'category' is 'received'. List of parent descriptors for the output script of this coin.", {
                                     {RPCResult::Type::STR, "desc", "The descriptor string."},
                                 }},
-                            }},
+                                {RPCResult::Type::BOOL, "involves_mixed_inputs", /*optional=*/true, "Only present if the transaction spends both wallet-owned and non-wallet inputs."},
+                                {RPCResult::Type::STR_AMOUNT, "wallet_debit", /*optional=*/true, "Only present if involves_mixed_inputs is true. Total value of wallet-owned inputs spent by this transaction."},
+                                {RPCResult::Type::STR_AMOUNT, "wallet_credit", /*optional=*/true, "Only present if involves_mixed_inputs is true. Total value of wallet-owned outputs created by this transaction."},
+                                                 }},
                         }},
                         {RPCResult::Type::STR_HEX, "hex", "Raw data for transaction"},
                         {RPCResult::Type::OBJ, "decoded", /*optional=*/true, "The decoded transaction (only present when `verbose` is passed)",
@@ -750,14 +802,15 @@ RPCMethod gettransaction()
     }
     const CWalletTx& wtx = it->second;
 
-    CAmount nCredit = CachedTxGetCredit(*pwallet, wtx, /*avoid_reuse=*/false);
-    CAmount nDebit = CachedTxGetDebit(*pwallet, wtx, /*avoid_reuse=*/false);
-    CAmount nNet = nCredit - nDebit;
-    CAmount nFee = (CachedTxIsFromMe(*pwallet, wtx) ? wtx.tx->GetValueOut() - nDebit : 0);
+    const WalletTxHistoryAccounting accounting{CachedTxGetHistoryAccounting(*pwallet, wtx)};
 
-    entry.pushKV("amount", ValueFromAmount(nNet - nFee));
-    if (CachedTxIsFromMe(*pwallet, wtx))
-        entry.pushKV("fee", ValueFromAmount(nFee));
+    entry.pushKV("amount", ValueFromAmount(accounting.credit - accounting.debit + accounting.fee.value_or(0)));
+    if (accounting.fee.has_value()) {
+        entry.pushKV("fee", ValueFromAmount(-*accounting.fee));
+    }
+    if (IsMixedInput(accounting)) {
+        PushMixedInputFields(entry, accounting);
+    }
 
     WalletTxToJSON(*pwallet, wtx, entry);
 

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -295,7 +295,7 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
 }
 
 /**
- * List transactions based on the given criteria.
+ * Append RPC entries for a wallet transaction based on the given criteria.
  *
  * @param  wallet         The wallet.
  * @param  wtx            The wallet transaction.
@@ -305,9 +305,9 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
  * @param  filter_label   Optional label string to filter incoming transactions.
  */
 template <class Vec>
-static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nMinDepth, bool fLong,
-                             Vec& ret, const std::optional<std::string>& filter_label,
-                             bool include_change = false)
+static void AppendWalletTxEntries(const CWallet& wallet, const CWalletTx& wtx, int nMinDepth, bool fLong,
+                                  Vec& ret, const std::optional<std::string>& filter_label,
+                                  bool include_change = false)
     EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     CAmount nFee;
@@ -503,7 +503,7 @@ RPCMethod listtransactions()
         for (CWallet::TxItems::const_reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
         {
             CWalletTx *const pwtx = (*it).second;
-            ListTransactions(*pwallet, *pwtx, 0, true, ret, filter_label);
+            AppendWalletTxEntries(*pwallet, *pwtx, 0, true, ret, filter_label);
             if ((int)ret.size() >= (nCount+nFrom)) break;
         }
     }
@@ -634,7 +634,7 @@ RPCMethod listsinceblock()
     for (const auto& [_, tx] : wallet.mapWallet) {
 
         if (depth == -1 || abs(wallet.GetTxDepthInMainChain(tx)) < depth) {
-            ListTransactions(wallet, tx, 0, true, transactions, filter_label, include_change);
+            AppendWalletTxEntries(wallet, tx, 0, true, transactions, filter_label, include_change);
         }
     }
 
@@ -651,7 +651,7 @@ RPCMethod listsinceblock()
             if (it != wallet.mapWallet.end()) {
                 // We want all transactions regardless of confirmation count to appear here,
                 // even negative confirmation ones, hence the big negative.
-                ListTransactions(wallet, it->second, -100000000, true, removed, filter_label, include_change);
+                AppendWalletTxEntries(wallet, it->second, -100000000, true, removed, filter_label, include_change);
             }
         }
         blockId = block.hashPrevBlock;
@@ -762,7 +762,7 @@ RPCMethod gettransaction()
     WalletTxToJSON(*pwallet, wtx, entry);
 
     UniValue details(UniValue::VARR);
-    ListTransactions(*pwallet, wtx, 0, false, details, /*filter_label=*/std::nullopt);
+    AppendWalletTxEntries(*pwallet, wtx, /*nMinDepth=*/0, /*fLong=*/false, details, /*filter_label=*/std::nullopt);
     entry.pushKV("details", std::move(details));
 
     entry.pushKV("hex", EncodeHexTx(*wtx.tx));

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -511,6 +511,17 @@ BOOST_FIXTURE_TEST_CASE(CachedInputOwnershipTest, ListCoinsTestingSetup)
     partial_wtx.MarkDirty();
     BOOST_CHECK(!partial_wtx.m_cached_input_ownership.has_value());
     BOOST_CHECK(CachedTxGetInputOwnership(*wallet, partial_wtx) == WalletTxInputOwnership::PARTIAL);
+
+    // The known-zero-value-foreign-inputs classification is computed for mixed
+    // (PARTIAL) transactions by CachedTxGetHistoryAccounting and is likewise
+    // cached and invalidated by MarkDirty(). The foreign input is not a wallet
+    // transaction, so its value is unknown and the classification is false.
+    BOOST_CHECK(!partial_wtx.m_cached_foreign_inputs_zero_value.has_value());
+    CachedTxGetHistoryAccounting(*wallet, partial_wtx);
+    BOOST_CHECK(partial_wtx.m_cached_foreign_inputs_zero_value.has_value());
+    BOOST_CHECK_EQUAL(partial_wtx.m_cached_foreign_inputs_zero_value.value(), false);
+    partial_wtx.MarkDirty();
+    BOOST_CHECK(!partial_wtx.m_cached_foreign_inputs_zero_value.has_value());
 }
 
 void TestCoinsResult(ListCoinsTest& context, OutputType out_type, CAmount amount,

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -479,6 +479,40 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 2U);
 }
 
+BOOST_FIXTURE_TEST_CASE(CachedInputOwnershipTest, ListCoinsTestingSetup)
+{
+    LOCK(wallet->cs_wallet);
+
+    const COutPoint mine_outpoint{m_coinbase_txns[0]->GetHash(), 0};
+    const COutPoint foreign_outpoint{Txid::FromUint256(uint256::ONE), 0};
+    BOOST_CHECK(InputIsMine(*wallet, CTxIn{mine_outpoint}));
+
+    const auto make_wtx = [](const std::vector<COutPoint>& prevouts) {
+        CMutableTransaction tx;
+        for (const COutPoint& prevout : prevouts) tx.vin.emplace_back(prevout);
+        tx.vout.emplace_back(1 * COIN, CScript() << OP_TRUE);
+        return CWalletTx(MakeTransactionRef(std::move(tx)), TxStateInactive{});
+    };
+
+    CWalletTx none_wtx{make_wtx({foreign_outpoint})};
+    BOOST_CHECK(CachedTxGetInputOwnership(*wallet, none_wtx) == WalletTxInputOwnership::NONE);
+
+    CWalletTx all_wtx{make_wtx({mine_outpoint})};
+    BOOST_CHECK(CachedTxGetInputOwnership(*wallet, all_wtx) == WalletTxInputOwnership::ALL);
+
+    CWalletTx partial_wtx{make_wtx({mine_outpoint, foreign_outpoint})};
+    BOOST_CHECK(CachedTxGetInputOwnership(*wallet, partial_wtx) == WalletTxInputOwnership::PARTIAL);
+
+    CWalletTx empty_wtx{make_wtx({})};
+    BOOST_CHECK(CachedTxGetInputOwnership(*wallet, empty_wtx) == WalletTxInputOwnership::NONE);
+
+    // The classification is cached and invalidated by MarkDirty().
+    BOOST_CHECK(partial_wtx.m_cached_input_ownership.has_value());
+    partial_wtx.MarkDirty();
+    BOOST_CHECK(!partial_wtx.m_cached_input_ownership.has_value());
+    BOOST_CHECK(CachedTxGetInputOwnership(*wallet, partial_wtx) == WalletTxInputOwnership::PARTIAL);
+}
+
 void TestCoinsResult(ListCoinsTest& context, OutputType out_type, CAmount amount,
                      std::map<OutputType, size_t>& expected_coins_sizes)
 {

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -242,6 +242,8 @@ public:
     mutable std::optional<bool> m_cached_from_me{std::nullopt};
     // Cached value for whether none, some, or all inputs belong to the wallet
     mutable std::optional<WalletTxInputOwnership> m_cached_input_ownership{std::nullopt};
+    // Cached value for whether every non-wallet input is known to spend a zero-value output
+    mutable std::optional<bool> m_cached_foreign_inputs_zero_value{std::nullopt};
     int64_t nOrderPos; //!< position in ordered transaction list
     std::multimap<int64_t, CWalletTx*>::const_iterator m_it_wtxOrdered;
 
@@ -351,6 +353,7 @@ public:
         m_is_cache_empty = true;
         m_cached_from_me = std::nullopt;
         m_cached_input_ownership = std::nullopt;
+        m_cached_foreign_inputs_zero_value = std::nullopt;
     }
 
     /** True if only scriptSigs are different */

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -19,6 +19,7 @@
 #include <bitset>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -163,6 +164,11 @@ struct CachableAmount
     }
 };
 
+enum class WalletTxInputOwnership {
+    NONE,
+    PARTIAL,
+    ALL,
+};
 
 typedef std::map<std::string, std::string> mapValue_t;
 
@@ -234,6 +240,8 @@ public:
     unsigned int nTimeSmart;
     // Cached value for whether the transaction spends any inputs known to the wallet
     mutable std::optional<bool> m_cached_from_me{std::nullopt};
+    // Cached value for whether none, some, or all inputs belong to the wallet
+    mutable std::optional<WalletTxInputOwnership> m_cached_input_ownership{std::nullopt};
     int64_t nOrderPos; //!< position in ordered transaction list
     std::multimap<int64_t, CWalletTx*>::const_iterator m_it_wtxOrdered;
 
@@ -342,6 +350,7 @@ public:
         fChangeCached = false;
         m_is_cache_empty = true;
         m_cached_from_me = std::nullopt;
+        m_cached_input_ownership = std::nullopt;
     }
 
     /** True if only scriptSigs are different */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1133,6 +1133,9 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
 
     // Cache the outputs that belong to the wallet
     RefreshTXOsFromTx(wtx);
+    if (fInsertedNew) {
+        MarkOutputsDirty(wtx.tx);
+    }
 
     // Notify UI of new or updated transaction
     NotifyTransactionChanged(hash, fInsertedNew ? CT_NEW : CT_UPDATED);
@@ -1199,6 +1202,9 @@ bool CWallet::LoadToWallet(const Txid& hash, const UpdateWalletTxFn& fill_wtx)
 
     // Make sure the tx outputs are known by the wallet
     RefreshTXOsFromTx(wtx);
+    if (ins.second) {
+        MarkOutputsDirty(wtx.tx);
+    }
     return true;
 }
 
@@ -1297,6 +1303,19 @@ void CWallet::MarkInputsDirty(const CTransactionRef& tx)
         auto it = mapWallet.find(txin.prevout.hash);
         if (it != mapWallet.end()) {
             it->second.MarkDirty();
+        }
+    }
+}
+
+void CWallet::MarkOutputsDirty(const CTransactionRef& tx)
+{
+    const Txid& txid{tx->GetHash()};
+    for (uint32_t i{0}; i < tx->vout.size(); ++i) {
+        const auto range{mapTxSpends.equal_range(COutPoint{txid, i})};
+        for (auto it{range.first}; it != range.second; ++it) {
+            if (auto wit{mapWallet.find(it->second)}; wit != mapWallet.end()) {
+                wit->second.MarkDirty();
+            }
         }
     }
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -372,6 +372,10 @@ private:
     /** Mark a transaction's inputs dirty, thus forcing the outputs to be recomputed */
     void MarkInputsDirty(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    /** Mark transactions spending a transaction's outputs dirty, thus forcing
+     * their inputs to be recomputed. */
+    void MarkOutputsDirty(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool SyncTransaction(const CTransactionRef& tx, const SyncTxState& state, bool rescanning_old_block = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -388,6 +388,7 @@ BASE_SCRIPTS = [
     'interface_ipc_cli.py',
     'feature_dirsymlinks.py',
     'feature_help.py',
+    'wallet_gettransaction_mixed_inputs.py',
     'feature_framework_startup_failures.py',
     'feature_shutdown.py',
     'wallet_migration.py',

--- a/test/functional/wallet_gettransaction_mixed_inputs.py
+++ b/test/functional/wallet_gettransaction_mixed_inputs.py
@@ -398,7 +398,87 @@ class WalletGetTransactionMixedInputsTest(BitcoinTestFramework):
         self.test_zero_value_foreign_anchor_input(node, alice, funder)
         self.test_late_zero_value_foreign_parent_import(node, funder, alice)
         self.test_known_nonzero_foreign_input(node, funder, alice, bob)
+        self.test_zero_value_wallet_input(node, funder, alice, bob)
         self.test_wallet_change_output(node, funder, alice, bob)
+
+    def test_zero_value_wallet_input(self, node, funder, alice, bob):
+        self.log.info("Test a mixed-input transaction whose only wallet-owned input has zero value")
+        # Give bob a utxo whose funding transaction is unknown to alice.
+        bob_funding_txid = funder.sendtoaddress(bob.getnewaddress(), Decimal("0.4"))
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+
+        # Create a zero-value output to alice. It is below the dust threshold,
+        # so mine it directly instead of submitting it to the mempool.
+        zero_address = alice.getnewaddress()
+        funder_input = funder.listunspent()[0]
+        funder_change_sat = int(funder_input["amount"] * COIN) - 10000
+
+        parent_tx = CTransaction()
+        parent_tx.vin.append(CTxIn(COutPoint(int(funder_input["txid"], 16), funder_input["vout"]), b"", SEQUENCE_FINAL))
+        parent_tx.vout.append(CTxOut(0, self.script_for_address(alice, zero_address)))
+        parent_tx.vout.append(CTxOut(funder_change_sat, self.script_for_address(funder, funder.getnewaddress())))
+        parent_signed = funder.signrawtransactionwithwallet(parent_tx.serialize().hex())
+        assert_equal(parent_signed["complete"], True)
+        parent_hex = parent_signed["hex"]
+        parent_txid = tx_from_hex(parent_hex).txid_hex
+        self.generateblock(node, output=funder.getnewaddress(), transactions=[parent_hex])
+        before_blockhash = node.getbestblockhash()
+
+        # Premise: bob's input value is unknown to alice's wallet.
+        assert_raises_rpc_error(-5, "Invalid or non-wallet transaction id", alice.gettransaction, bob_funding_txid)
+
+        fee = Decimal("0.00002000")
+        alice_credit = Decimal("0.1")
+        bob_input = next(u for u in bob.listunspent() if u["txid"] == bob_funding_txid)
+        bob_credit = bob_input["amount"] - alice_credit - fee
+
+        label = "alice_zero_value_input"
+        alice_output = alice.getnewaddress(label)
+
+        raw_tx = node.createrawtransaction(
+            inputs=[
+                {"txid": parent_txid, "vout": 0},
+                {"txid": bob_input["txid"], "vout": bob_input["vout"]},
+            ],
+            outputs={
+                alice_output: alice_credit,
+                bob.getnewaddress(): bob_credit,
+            },
+        )
+        raw_tx = alice.signrawtransactionwithwallet(raw_tx)["hex"]
+        raw_tx = bob.signrawtransactionwithwallet(raw_tx)["hex"]
+
+        txid = node.sendrawtransaction(raw_tx)
+        node.syncwithvalidationinterfacequeue()
+
+        # Alice spends nothing of value, so the aggregate send summary reports a
+        # zero wallet debit (a zero-amount send) while the received output is
+        # still attributed.
+        alice_vout = find_vout_for_address(node, txid, alice_output)
+        self.assert_wallet_view(
+            wallet_name="alice",
+            wallet=alice,
+            txid=txid,
+            label=label,
+            address=alice_output,
+            vout=alice_vout,
+            wallet_debit=Decimal("0"),
+            wallet_credit=alice_credit,
+            before_blockhash=before_blockhash,
+        )
+
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+        self.assert_wallet_view(
+            wallet_name="alice",
+            wallet=alice,
+            txid=txid,
+            label=label,
+            address=alice_output,
+            vout=alice_vout,
+            wallet_debit=Decimal("0"),
+            wallet_credit=alice_credit,
+            before_blockhash=before_blockhash,
+        )
 
     def test_known_nonzero_foreign_input(self, node, funder, alice, bob):
         self.log.info("Test known nonzero foreign input values keep accounting conservative")

--- a/test/functional/wallet_gettransaction_mixed_inputs.py
+++ b/test/functional/wallet_gettransaction_mixed_inputs.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+"""Test wallet history RPC accounting for mixed-input transactions."""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, find_vout_for_address
+
+
+class WalletGetTransactionMixedInputsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def assert_mixed_fields(self, entry, wallet_debit, wallet_credit):
+        assert_equal(entry["involves_mixed_inputs"], True)
+        assert_equal(entry["wallet_debit"], wallet_debit)
+        assert_equal(entry["wallet_credit"], wallet_credit)
+        assert "fee" not in entry
+
+    def assert_unattributed_aggregate_send(self, entry, txid, expected_amount, wallet_debit, wallet_credit, include_txid):
+        if include_txid:
+            assert_equal(entry["txid"], txid)
+        # The conservative fallback is a single aggregate "send" entry: the wallet
+        # provably spent all of its own inputs but cannot attribute the foreign
+        # outputs or its fee share, so it has no address, vout, or fee.
+        assert_equal(entry["category"], "send")
+        assert_equal(entry["amount"], expected_amount)
+        assert "address" not in entry
+        assert "vout" not in entry
+        assert "fee" not in entry
+        self.assert_mixed_fields(entry, wallet_debit, wallet_credit)
+
+    def assert_receive_entry(self, entry, txid, address, vout, amount, wallet_debit, wallet_credit, include_txid):
+        if include_txid:
+            assert_equal(entry["txid"], txid)
+        assert_equal(entry["category"], "receive")
+        assert_equal(entry["address"], address)
+        assert_equal(entry["vout"], vout)
+        assert_equal(entry["amount"], amount)
+        self.assert_mixed_fields(entry, wallet_debit, wallet_credit)
+
+    def assert_mixed_history_entries(self, entries, txid, expected_net, address, vout, wallet_debit, wallet_credit, include_txid=True):
+        """Check that a conservative mixed-input transaction is reported as a single
+        unattributed aggregate send carrying the negative wallet debit plus a receive
+        entry for the wallet-owned output (and nothing else), with entry amounts
+        summing to the wallet net change."""
+        assert_equal(len(entries), 2)
+        assert_equal(sum(entry["amount"] for entry in entries), expected_net)
+
+        send_entries = [entry for entry in entries if entry["category"] == "send"]
+        assert_equal(len(send_entries), 1)
+        self.assert_unattributed_aggregate_send(send_entries[0], txid, -wallet_debit, wallet_debit, wallet_credit, include_txid=include_txid)
+
+        receive_entries = [entry for entry in entries if entry["category"] == "receive"]
+        assert_equal(len(receive_entries), 1)
+        self.assert_receive_entry(receive_entries[0], txid, address, vout, wallet_credit, wallet_debit, wallet_credit, include_txid=include_txid)
+
+    def assert_wallet_view(self, wallet_name, wallet, txid, label, address, vout, wallet_debit, wallet_credit, before_blockhash):
+        expected_amount = wallet_credit - wallet_debit
+
+        tx_info = wallet.gettransaction(txid)
+        assert_equal(tx_info["amount"], expected_amount)
+        self.assert_mixed_fields(tx_info, wallet_debit, wallet_credit)
+        self.assert_mixed_history_entries(tx_info["details"], txid, expected_amount, address, vout, wallet_debit, wallet_credit, include_txid=False)
+
+        history = [entry for entry in wallet.listtransactions("*", 100) if entry["txid"] == txid]
+        self.assert_mixed_history_entries(history, txid, expected_amount, address, vout, wallet_debit, wallet_credit)
+
+        labeled_history = [entry for entry in wallet.listtransactions(label, 100) if entry["txid"] == txid]
+        assert_equal(len(labeled_history), 1)
+        self.assert_receive_entry(labeled_history[0], txid, address, vout, wallet_credit, wallet_debit, wallet_credit, include_txid=True)
+
+        since = [entry for entry in wallet.listsinceblock(before_blockhash)["transactions"] if entry["txid"] == txid]
+        self.assert_mixed_history_entries(since, txid, expected_amount, address, vout, wallet_debit, wallet_credit)
+
+        self.log.debug("%s mixed-input wallet net amount: %s", wallet_name, expected_amount)
+
+    def test_basic_mixed_input_transaction(self, node, funder, alice, bob):
+        self.log.info("Test basic mixed-input transaction accounting")
+        funder.sendtoaddress(alice.getnewaddress(), Decimal("1.0"))
+        funder.sendtoaddress(bob.getnewaddress(), Decimal("1.0"))
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+        before_mixed_input_blockhash = node.getbestblockhash()
+
+        alice_input = alice.listunspent()[0]
+        bob_input = bob.listunspent()[0]
+        alice_credit = Decimal("1.50000000")
+        bob_credit = Decimal("0.49998000")
+        alice_label = "alice_mixed"
+        bob_label = "bob_mixed"
+        alice_output = alice.getnewaddress(alice_label)
+        bob_output = bob.getnewaddress(bob_label)
+
+        raw_tx = node.createrawtransaction(
+            inputs=[
+                {"txid": alice_input["txid"], "vout": alice_input["vout"]},
+                {"txid": bob_input["txid"], "vout": bob_input["vout"]},
+            ],
+            outputs={
+                alice_output: alice_credit,
+                bob_output: bob_credit,
+            },
+        )
+        raw_tx = alice.signrawtransactionwithwallet(raw_tx)["hex"]
+        raw_tx = bob.signrawtransactionwithwallet(raw_tx)["hex"]
+
+        txid = node.sendrawtransaction(raw_tx)
+        node.syncwithvalidationinterfacequeue()
+        assert_equal(node.getmempoolentry(txid)["fees"]["base"], Decimal("0.00002000"))
+
+        wallet_views = [
+            {
+                "wallet_name": "alice",
+                "wallet": alice,
+                "label": alice_label,
+                "address": alice_output,
+                "vout": find_vout_for_address(node, txid, alice_output),
+                "wallet_debit": alice_input["amount"],
+                "wallet_credit": alice_credit,
+            },
+            {
+                "wallet_name": "bob",
+                "wallet": bob,
+                "label": bob_label,
+                "address": bob_output,
+                "vout": find_vout_for_address(node, txid, bob_output),
+                "wallet_debit": bob_input["amount"],
+                "wallet_credit": bob_credit,
+            },
+        ]
+
+        for view in wallet_views:
+            self.assert_wallet_view(txid=txid, before_blockhash=before_mixed_input_blockhash, **view)
+
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+
+        for view in wallet_views:
+            self.assert_wallet_view(txid=txid, before_blockhash=before_mixed_input_blockhash, **view)
+
+        return {"txid": txid, "wallet_views": wallet_views}
+
+    def test_reorged_mixed_input_removed_entries(self, node, funder, mixed_tx):
+        self.log.info("Test reorged mixed-input transactions appear in listsinceblock removed entries")
+        reorged_blockhash = node.getbestblockhash()
+        node.invalidateblock(reorged_blockhash)
+        self.generatetoaddress(node, 2, funder.getnewaddress())
+
+        txid = mixed_tx["txid"]
+        for view in mixed_tx["wallet_views"]:
+            wallet = view["wallet"]
+            address = view["address"]
+            vout = view["vout"]
+            wallet_debit = view["wallet_debit"]
+            wallet_credit = view["wallet_credit"]
+            expected_net = wallet_credit - wallet_debit
+            since = wallet.listsinceblock(reorged_blockhash)
+            removed = [entry for entry in since["removed"] if entry["txid"] == txid]
+            self.assert_mixed_history_entries(removed, txid, expected_net, address, vout, wallet_debit, wallet_credit)
+            reincluded = [entry for entry in since["transactions"] if entry["txid"] == txid]
+            self.assert_mixed_history_entries(reincluded, txid, expected_net, address, vout, wallet_debit, wallet_credit)
+
+    def run_test(self):
+        node = self.nodes[0]
+        funder = node.get_wallet_rpc(self.default_wallet_name)
+
+        node.createwallet("alice")
+        node.createwallet("bob")
+        alice = node.get_wallet_rpc("alice")
+        bob = node.get_wallet_rpc("bob")
+
+        self.generatetoaddress(node, 101, funder.getnewaddress())
+
+        mixed_tx = self.test_basic_mixed_input_transaction(node, funder, alice, bob)
+
+        self.test_reorged_mixed_input_removed_entries(
+            node=node,
+            funder=funder,
+            mixed_tx=mixed_tx,
+        )
+
+        self.test_wallet_change_output(node, funder, alice, bob)
+
+    def test_wallet_change_output(self, node, funder, alice, bob):
+        self.log.info("Test a wallet-owned change output in a conservative mixed-input transaction is reported as a receive entry")
+        # Fund alice and bob with positive-value inputs. The foreign (bob) input
+        # has positive value, so the transaction is always reported conservatively
+        # (the absent fee on the entries below confirms the conservative view).
+        alice_funding_txid = funder.sendtoaddress(alice.getnewaddress(), Decimal("1.0"))
+        bob_funding_txid = funder.sendtoaddress(bob.getnewaddress(), Decimal("1.0"))
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+        before_blockhash = node.getbestblockhash()
+
+        alice_input = next(u for u in alice.listunspent() if u["txid"] == alice_funding_txid)
+        bob_input = next(u for u in bob.listunspent() if u["txid"] == bob_funding_txid)
+
+        fee = Decimal("0.00002000")
+        # Alice keeps part of her input as change to a raw change address, so the
+        # wallet classifies the output as change (not a labeled receive); the
+        # remainder funds bob's output.
+        alice_change_amount = Decimal("0.4")
+        alice_change_address = alice.getrawchangeaddress()
+        bob_credit = alice_input["amount"] + bob_input["amount"] - alice_change_amount - fee
+
+        raw_tx = node.createrawtransaction(
+            inputs=[
+                {"txid": alice_input["txid"], "vout": alice_input["vout"]},
+                {"txid": bob_input["txid"], "vout": bob_input["vout"]},
+            ],
+            outputs={
+                alice_change_address: alice_change_amount,
+                bob.getnewaddress(): bob_credit,
+            },
+        )
+        raw_tx = alice.signrawtransactionwithwallet(raw_tx)["hex"]
+        raw_tx = bob.signrawtransactionwithwallet(raw_tx)["hex"]
+        txid = node.sendrawtransaction(raw_tx)
+        node.syncwithvalidationinterfacequeue()
+
+        # Premise: the wallet-owned output is genuinely change, not a labeled receive.
+        assert_equal(alice.getaddressinfo(alice_change_address)["ischange"], True)
+
+        alice_debit = alice_input["amount"]
+        alice_credit = alice_change_amount
+        expected_net = alice_credit - alice_debit
+        change_vout = find_vout_for_address(node, txid, alice_change_address)
+
+        # The conservative aggregate send view does not skip change: the change
+        # output is reported as a receive entry alongside the aggregate send, so
+        # the entry amounts still sum to alice's net change.
+        tx_info = alice.gettransaction(txid)
+        assert_equal(tx_info["amount"], expected_net)
+        self.assert_mixed_fields(tx_info, alice_debit, alice_credit)
+        self.assert_mixed_history_entries(tx_info["details"], txid, expected_net, alice_change_address, change_vout, alice_debit, alice_credit, include_txid=False)
+
+        history = [entry for entry in alice.listtransactions("*", 100) if entry["txid"] == txid]
+        self.assert_mixed_history_entries(history, txid, expected_net, alice_change_address, change_vout, alice_debit, alice_credit)
+
+        since = [entry for entry in alice.listsinceblock(before_blockhash)["transactions"] if entry["txid"] == txid]
+        self.assert_mixed_history_entries(since, txid, expected_net, alice_change_address, change_vout, alice_debit, alice_credit)
+
+        # The same conservative shape holds after confirmation.
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+        confirmed = [entry for entry in alice.listtransactions("*", 100) if entry["txid"] == txid]
+        self.assert_mixed_history_entries(confirmed, txid, expected_net, alice_change_address, change_vout, alice_debit, alice_credit)
+
+
+if __name__ == '__main__':
+    WalletGetTransactionMixedInputsTest(__file__).main()

--- a/test/functional/wallet_gettransaction_mixed_inputs.py
+++ b/test/functional/wallet_gettransaction_mixed_inputs.py
@@ -6,6 +6,17 @@
 
 from decimal import Decimal
 
+from test_framework.messages import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    SEQUENCE_FINAL,
+    tx_from_hex,
+)
+from test_framework.script import CScript, OP_RETURN
+from test_framework.script_util import PAY_TO_ANCHOR
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, find_vout_for_address
 
@@ -18,11 +29,12 @@ class WalletGetTransactionMixedInputsTest(BitcoinTestFramework):
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
-    def assert_mixed_fields(self, entry, wallet_debit, wallet_credit):
+    def assert_mixed_fields(self, entry, wallet_debit, wallet_credit, expect_fee=False):
         assert_equal(entry["involves_mixed_inputs"], True)
         assert_equal(entry["wallet_debit"], wallet_debit)
         assert_equal(entry["wallet_credit"], wallet_credit)
-        assert "fee" not in entry
+        if not expect_fee:
+            assert "fee" not in entry
 
     def assert_unattributed_aggregate_send(self, entry, txid, expected_amount, wallet_debit, wallet_credit, include_txid):
         if include_txid:
@@ -81,6 +93,87 @@ class WalletGetTransactionMixedInputsTest(BitcoinTestFramework):
         self.assert_mixed_history_entries(since, txid, expected_amount, address, vout, wallet_debit, wallet_credit)
 
         self.log.debug("%s mixed-input wallet net amount: %s", wallet_name, expected_amount)
+
+    def script_for_address(self, wallet, address):
+        return CScript(bytes.fromhex(wallet.getaddressinfo(address)["scriptPubKey"]))
+
+    def assert_wallet_funded_mixed_input_view(self, wallet, txid, external_address, wallet_debit, external_amount, burn_amount, fee):
+        wallet_credit = Decimal("0.00000000")
+        expected_amount = -(external_amount + burn_amount)
+
+        tx_info = wallet.gettransaction(txid)
+        assert_equal(tx_info["amount"], expected_amount)
+        assert_equal(tx_info["fee"], -fee)
+        self.assert_mixed_fields(tx_info, wallet_debit, wallet_credit, expect_fee=True)
+        # Fully attributable: every send entry is a real per-output send with a
+        # vout and fee, so there is no unattributed aggregate fallback entry.
+        assert_equal(any(detail["category"] == "send" and ("vout" not in detail or "fee" not in detail) for detail in tx_info["details"]), False)
+
+        send_details = [entry for entry in tx_info["details"] if entry["category"] == "send"]
+        assert_equal(len(send_details), 2)
+        external_details = [entry for entry in send_details if entry.get("address") == external_address]
+        burn_details = [entry for entry in send_details if "address" not in entry]
+        assert_equal(len(external_details), 1)
+        assert_equal(len(burn_details), 1)
+
+        for entry, amount in [(external_details[0], external_amount), (burn_details[0], burn_amount)]:
+            assert_equal(entry["amount"], -amount)
+            assert_equal(entry["fee"], -fee)
+            self.assert_mixed_fields(entry, wallet_debit, wallet_credit, expect_fee=True)
+
+        history = [entry for entry in wallet.listtransactions("*", 100) if entry["txid"] == txid]
+        assert_equal(len(history), 2)
+        assert_equal(any(entry["category"] == "send" and ("vout" not in entry or "fee" not in entry) for entry in history), False)
+        assert_equal(sum(entry["amount"] for entry in history), expected_amount)
+
+    def test_zero_value_foreign_anchor_input(self, node, wallet, external_wallet):
+        self.log.info("Test zero-value foreign anchor inputs keep wallet fee/send accounting attributable")
+        wallet_input = next(utxo for utxo in wallet.listunspent() if utxo["amount"] >= Decimal("1.00000000"))
+        wallet_debit = wallet_input["amount"]
+        wallet_debit_sat = int(wallet_debit * COIN)
+        fee_sat = 1000
+        burn_sat = 1
+        fee = Decimal(fee_sat) / COIN
+        burn_amount = Decimal(burn_sat) / COIN
+        external_amount = Decimal(wallet_debit_sat - fee_sat - burn_sat) / COIN
+
+        parent_address = wallet.getrawchangeaddress()
+        parent_script = self.script_for_address(wallet, parent_address)
+
+        parent_tx = CTransaction()
+        parent_tx.version = 3
+        parent_tx.vin.append(CTxIn(COutPoint(int(wallet_input["txid"], 16), wallet_input["vout"]), b"", SEQUENCE_FINAL))
+        parent_tx.vout.append(CTxOut(wallet_debit_sat, parent_script))
+        parent_tx.vout.append(CTxOut(0, PAY_TO_ANCHOR))
+        parent_signed = wallet.signrawtransactionwithwallet(parent_tx.serialize().hex())
+        assert_equal(parent_signed["complete"], True)
+        parent_hex = parent_signed["hex"]
+        parent_tx = tx_from_hex(parent_hex)
+        parent_txid = parent_tx.txid_hex
+
+        external_address = external_wallet.getnewaddress()
+        external_script = self.script_for_address(external_wallet, external_address)
+        child_tx = CTransaction()
+        child_tx.version = 3
+        child_tx.vin.append(CTxIn(COutPoint(int(parent_txid, 16), 0), b"", SEQUENCE_FINAL))
+        child_tx.vin.append(CTxIn(COutPoint(int(parent_txid, 16), 1), b"", SEQUENCE_FINAL))
+        child_tx.vout.append(CTxOut(wallet_debit_sat - fee_sat - burn_sat, external_script))
+        child_tx.vout.append(CTxOut(burn_sat, CScript([OP_RETURN])))
+        child_signed = wallet.signrawtransactionwithwallet(child_tx.serialize().hex(), [
+            {"txid": parent_txid, "vout": 0, "scriptPubKey": parent_script.hex(), "amount": wallet_debit},
+            {"txid": parent_txid, "vout": 1, "scriptPubKey": PAY_TO_ANCHOR.hex(), "amount": Decimal("0.00000000")},
+        ])
+        assert_equal(child_signed["complete"], True)
+        child_hex = child_signed["hex"]
+        child_tx = tx_from_hex(child_hex)
+
+        submit_res = node.submitpackage([parent_hex, child_hex], maxburnamount=burn_amount)
+        assert_equal(submit_res["package_msg"], "success")
+        node.syncwithvalidationinterfacequeue()
+
+        self.assert_wallet_funded_mixed_input_view(wallet, child_tx.txid_hex, external_address, wallet_debit, external_amount, burn_amount, fee)
+        self.generatetoaddress(node, 1, external_wallet.getnewaddress())
+        self.assert_wallet_funded_mixed_input_view(wallet, child_tx.txid_hex, external_address, wallet_debit, external_amount, burn_amount, fee)
 
     def test_basic_mixed_input_transaction(self, node, funder, alice, bob):
         self.log.info("Test basic mixed-input transaction accounting")
@@ -185,6 +278,7 @@ class WalletGetTransactionMixedInputsTest(BitcoinTestFramework):
             mixed_tx=mixed_tx,
         )
 
+        self.test_zero_value_foreign_anchor_input(node, alice, funder)
         self.test_wallet_change_output(node, funder, alice, bob)
 
     def test_wallet_change_output(self, node, funder, alice, bob):

--- a/test/functional/wallet_gettransaction_mixed_inputs.py
+++ b/test/functional/wallet_gettransaction_mixed_inputs.py
@@ -18,7 +18,11 @@ from test_framework.messages import (
 from test_framework.script import CScript, OP_RETURN
 from test_framework.script_util import PAY_TO_ANCHOR
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, find_vout_for_address
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    find_vout_for_address,
+)
 
 
 class WalletGetTransactionMixedInputsTest(BitcoinTestFramework):
@@ -125,6 +129,119 @@ class WalletGetTransactionMixedInputsTest(BitcoinTestFramework):
         assert_equal(len(history), 2)
         assert_equal(any(entry["category"] == "send" and ("vout" not in entry or "fee" not in entry) for entry in history), False)
         assert_equal(sum(entry["amount"] for entry in history), expected_amount)
+
+    def import_addr_descriptor(self, node, wallet, address, label, timestamp="now"):
+        result = wallet.importdescriptors([{
+            "desc": node.getdescriptorinfo(f"addr({address})")["descriptor"],
+            "timestamp": timestamp,
+            "label": label,
+        }])
+        assert_equal(result[0]["success"], True)
+
+    def test_late_zero_value_foreign_parent_import(self, node, funder, alice):
+        self.log.info("Test late parent import invalidates mixed-input accounting caches")
+        wallet_input_address = alice.getnewaddress()
+        wallet_receive_address = alice.getnewaddress()
+        parent_import_address = alice.getnewaddress()
+        external_address = funder.getnewaddress()
+
+        funding_txid = funder.sendtoaddress(wallet_input_address, Decimal("1.0"))
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+        funding_blockhash = node.getbestblockhash()
+        funding_tx_hex = funder.gettransaction(funding_txid)["hex"]
+        funding_txoutproof = node.gettxoutproof([funding_txid], funding_blockhash)
+
+        wallet_input = next(u for u in alice.listunspent() if u["txid"] == funding_txid)
+        wallet_debit = wallet_input["amount"]
+
+        parent_input = funder.listunspent()[0]
+        parent_import_amount_sat = 10_000_000
+        parent_fee_sat = 1_000
+        parent_change_sat = int(parent_input["amount"] * COIN) - parent_import_amount_sat - parent_fee_sat
+
+        parent_tx = CTransaction()
+        parent_tx.version = 3
+        parent_tx.vin.append(CTxIn(COutPoint(int(parent_input["txid"], 16), parent_input["vout"]), b"", SEQUENCE_FINAL))
+        parent_tx.vout.append(CTxOut(parent_change_sat, self.script_for_address(funder, funder.getrawchangeaddress())))
+        parent_tx.vout.append(CTxOut(0, PAY_TO_ANCHOR))
+        parent_tx.vout.append(CTxOut(parent_import_amount_sat, self.script_for_address(alice, parent_import_address)))
+        parent_signed = funder.signrawtransactionwithwallet(parent_tx.serialize().hex())
+        assert_equal(parent_signed["complete"], True)
+        parent_hex = parent_signed["hex"]
+        parent_tx = tx_from_hex(parent_hex)
+        parent_txid = parent_tx.txid_hex
+
+        wallet_credit = Decimal("0.80000000")
+        fee = Decimal("0.00001000")
+        external_amount = wallet_debit - wallet_credit - fee
+        child_tx = CTransaction()
+        child_tx.version = 3
+        child_tx.vin.append(CTxIn(COutPoint(int(funding_txid, 16), wallet_input["vout"]), b"", SEQUENCE_FINAL))
+        child_tx.vin.append(CTxIn(COutPoint(int(parent_txid, 16), 1), b"", SEQUENCE_FINAL))
+        child_tx.vout.append(CTxOut(int(wallet_credit * COIN), self.script_for_address(alice, wallet_receive_address)))
+        child_tx.vout.append(CTxOut(int(external_amount * COIN), self.script_for_address(funder, external_address)))
+        child_signed = alice.signrawtransactionwithwallet(child_tx.serialize().hex(), [
+            {"txid": funding_txid, "vout": wallet_input["vout"], "scriptPubKey": self.script_for_address(alice, wallet_input_address).hex(), "amount": wallet_debit},
+            {"txid": parent_txid, "vout": 1, "scriptPubKey": PAY_TO_ANCHOR.hex(), "amount": Decimal("0.00000000")},
+        ])
+        assert_equal(child_signed["complete"], True)
+        child_hex = child_signed["hex"]
+        child_tx = tx_from_hex(child_hex)
+        child_txid = child_tx.txid_hex
+
+        self.generateblock(node, output=funder.getnewaddress(), transactions=[parent_hex, child_hex])
+        child_blockhash = node.getbestblockhash()
+        parent_txoutproof = node.gettxoutproof([parent_txid], child_blockhash)
+        child_txoutproof = node.gettxoutproof([child_txid], child_blockhash)
+        import_timestamp = node.getblock(child_blockhash)["time"] + 3 * 60 * 60
+        node.setmocktime(import_timestamp + 60)
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+        node.setmocktime(0)
+
+        node.createwallet(wallet_name="late_parent_import", disable_private_keys=True, blank=True)
+        late_wallet = node.get_wallet_rpc("late_parent_import")
+        self.import_addr_descriptor(node, late_wallet, wallet_input_address, "late_input", import_timestamp)
+        self.import_addr_descriptor(node, late_wallet, wallet_receive_address, "late_receive", import_timestamp)
+        self.import_addr_descriptor(node, late_wallet, parent_import_address, "late_parent", import_timestamp)
+
+        late_wallet.importprunedfunds(funding_tx_hex, funding_txoutproof)
+        late_wallet.importprunedfunds(child_hex, child_txoutproof)
+        assert_raises_rpc_error(-5, "Invalid or non-wallet transaction id", late_wallet.gettransaction, parent_txid)
+
+        child_vout = 0
+        self.assert_wallet_view(
+            wallet_name="late_parent_import_before_parent",
+            wallet=late_wallet,
+            txid=child_txid,
+            label="late_receive",
+            address=wallet_receive_address,
+            vout=child_vout,
+            wallet_debit=wallet_debit,
+            wallet_credit=wallet_credit,
+            before_blockhash=funding_blockhash,
+        )
+
+        late_wallet.importprunedfunds(parent_hex, parent_txoutproof)
+
+        tx_info = late_wallet.gettransaction(child_txid)
+        assert_equal(tx_info["amount"], -external_amount)
+        assert_equal(tx_info["fee"], -fee)
+        self.assert_mixed_fields(tx_info, wallet_debit, wallet_credit, expect_fee=True)
+
+        send_details = [entry for entry in tx_info["details"] if entry["category"] == "send"]
+        receive_details = [entry for entry in tx_info["details"] if entry["category"] == "receive"]
+        assert_equal(len(send_details), 2)
+        assert_equal(len(receive_details), 1)
+        assert_equal(any("vout" not in entry or "fee" not in entry for entry in send_details), False)
+        for entry in send_details:
+            self.assert_mixed_fields(entry, wallet_debit, wallet_credit, expect_fee=True)
+            assert_equal(entry["fee"], -fee)
+        assert_equal(sum(entry["amount"] for entry in send_details), -wallet_debit + fee)
+        self.assert_receive_entry(receive_details[0], child_txid, wallet_receive_address, child_vout, wallet_credit, wallet_debit, wallet_credit, include_txid=False)
+
+        history = [entry for entry in late_wallet.listtransactions("*", 100) if entry["txid"] == child_txid]
+        assert_equal(len(history), 3)
+        assert_equal(any(entry["category"] == "send" and ("vout" not in entry or "fee" not in entry) for entry in history), False)
 
     def test_zero_value_foreign_anchor_input(self, node, wallet, external_wallet):
         self.log.info("Test zero-value foreign anchor inputs keep wallet fee/send accounting attributable")
@@ -279,6 +396,7 @@ class WalletGetTransactionMixedInputsTest(BitcoinTestFramework):
         )
 
         self.test_zero_value_foreign_anchor_input(node, alice, funder)
+        self.test_late_zero_value_foreign_parent_import(node, funder, alice)
         self.test_wallet_change_output(node, funder, alice, bob)
 
     def test_wallet_change_output(self, node, funder, alice, bob):

--- a/test/functional/wallet_gettransaction_mixed_inputs.py
+++ b/test/functional/wallet_gettransaction_mixed_inputs.py
@@ -397,7 +397,77 @@ class WalletGetTransactionMixedInputsTest(BitcoinTestFramework):
 
         self.test_zero_value_foreign_anchor_input(node, alice, funder)
         self.test_late_zero_value_foreign_parent_import(node, funder, alice)
+        self.test_known_nonzero_foreign_input(node, funder, alice, bob)
         self.test_wallet_change_output(node, funder, alice, bob)
+
+    def test_known_nonzero_foreign_input(self, node, funder, alice, bob):
+        self.log.info("Test known nonzero foreign input values keep accounting conservative")
+        # Refill alice, then have alice fund bob so that the funding transaction
+        # of bob's input is in alice's wallet and its value is known to alice.
+        funder.sendtoaddress(alice.getnewaddress(), Decimal("1.0"))
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+        bob_funding_txid = alice.sendtoaddress(bob.getnewaddress(), Decimal("0.3"))
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+        before_blockhash = node.getbestblockhash()
+
+        # Premise: alice's wallet contains the transaction funding bob's input
+        assert_equal(alice.gettransaction(bob_funding_txid)["txid"], bob_funding_txid)
+
+        alice_credit = Decimal("0.2")
+        fee = Decimal("0.00002000")
+        alice_input = next(u for u in alice.listunspent() if u["amount"] >= alice_credit)
+        bob_input = next(u for u in bob.listunspent() if u["txid"] == bob_funding_txid)
+        bob_credit = alice_input["amount"] + bob_input["amount"] - alice_credit - fee
+
+        label = "alice_known_foreign"
+        alice_output = alice.getnewaddress(label)
+        bob_output = bob.getnewaddress()
+
+        raw_tx = node.createrawtransaction(
+            inputs=[
+                {"txid": alice_input["txid"], "vout": alice_input["vout"]},
+                {"txid": bob_input["txid"], "vout": bob_input["vout"]},
+            ],
+            outputs={
+                alice_output: alice_credit,
+                bob_output: bob_credit,
+            },
+        )
+        raw_tx = alice.signrawtransactionwithwallet(raw_tx)["hex"]
+        raw_tx = bob.signrawtransactionwithwallet(raw_tx)["hex"]
+
+        txid = node.sendrawtransaction(raw_tx)
+        node.syncwithvalidationinterfacequeue()
+        assert_equal(node.getmempoolentry(txid)["fees"]["base"], fee)
+
+        # Although alice's wallet can compute the total fee (it knows every
+        # input value), the wallet's fee share is still unattributable, so
+        # the transaction must be reported with the conservative aggregate send view.
+        alice_vout = find_vout_for_address(node, txid, alice_output)
+        self.assert_wallet_view(
+            wallet_name="alice",
+            wallet=alice,
+            txid=txid,
+            label=label,
+            address=alice_output,
+            vout=alice_vout,
+            wallet_debit=alice_input["amount"],
+            wallet_credit=alice_credit,
+            before_blockhash=before_blockhash,
+        )
+
+        self.generatetoaddress(node, 1, funder.getnewaddress())
+        self.assert_wallet_view(
+            wallet_name="alice",
+            wallet=alice,
+            txid=txid,
+            label=label,
+            address=alice_output,
+            vout=alice_vout,
+            wallet_debit=alice_input["amount"],
+            wallet_credit=alice_credit,
+            before_blockhash=before_blockhash,
+        )
 
     def test_wallet_change_output(self, node, funder, alice, bob):
         self.log.info("Test a wallet-owned change output in a conservative mixed-input transaction is reported as a receive entry")

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -13,7 +13,6 @@ from test_framework.blocktools import MAX_FUTURE_BLOCK_TIME
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    assert_not_equal,
     assert_array_result,
     assert_equal,
     assert_raises_rpc_error,
@@ -156,6 +155,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.log.info('Check "coin-join" transaction')
         input_0 = next(i for i in self.nodes[0].listunspent(query_options={"minimumAmount": 0.2}, include_unsafe=False))
         input_1 = next(i for i in self.nodes[1].listunspent(query_options={"minimumAmount": 0.2}, include_unsafe=False))
+        output_0 = self.nodes[0].getnewaddress()
         raw_hex = self.nodes[0].createrawtransaction(
             inputs=[
                 {
@@ -168,17 +168,62 @@ class ListTransactionsTest(BitcoinTestFramework):
                 },
             ],
             outputs={
-                self.nodes[0].getnewaddress(): 0.123,
+                output_0: 0.123,
                 self.nodes[1].getnewaddress(): 0.123,
             },
         )
         raw_hex = self.nodes[0].signrawtransactionwithwallet(raw_hex)["hex"]
         raw_hex = self.nodes[1].signrawtransactionwithwallet(raw_hex)["hex"]
         txid_join = self.nodes[0].sendrawtransaction(hexstring=raw_hex, maxfeerate=0)
-        fee_join = self.nodes[0].getmempoolentry(txid_join)["fees"]["base"]
-        # Fee should be correct: assert_equal(fee_join, self.nodes[0].gettransaction(txid_join)['fee'])
-        # But it is not, see for example https://github.com/bitcoin/bitcoin/issues/14136:
-        assert_not_equal(fee_join, self.nodes[0].gettransaction(txid_join)["fee"])
+        expected_credit = Decimal("0.123")
+        expected_amount = expected_credit - input_0["amount"]
+        tx_info = self.nodes[0].gettransaction(txid_join)
+
+        assert_equal(tx_info["amount"], expected_amount)
+        assert "fee" not in tx_info
+        assert_equal(tx_info["involves_mixed_inputs"], True)
+        assert_equal(tx_info["wallet_debit"], input_0["amount"])
+        assert_equal(tx_info["wallet_credit"], expected_credit)
+        send_details = [detail for detail in tx_info["details"] if detail["category"] == "send"]
+        assert_equal(len(send_details), 1)
+        assert_equal(sum(detail["amount"] for detail in tx_info["details"]), expected_amount)
+        assert_array_result(tx_info["details"], {"category": "send"}, {
+            "amount": -input_0["amount"],
+            "wallet_debit": input_0["amount"],
+            "wallet_credit": expected_credit,
+            "involves_mixed_inputs": True,
+        })
+        assert "address" not in send_details[0]
+        assert "vout" not in send_details[0]
+        assert "fee" not in send_details[0]
+        assert_array_result(tx_info["details"], {"category": "receive"}, {
+            "address": output_0,
+            "amount": expected_credit,
+            "involves_mixed_inputs": True,
+        })
+
+        # The unfiltered history reports a single unattributed aggregate send
+        # plus a receive entry for the wallet-owned output.
+        history = [entry for entry in self.nodes[0].listtransactions("*", 100) if entry["txid"] == txid_join]
+        assert_equal(len(history), 2)
+        history_send = [entry for entry in history if entry["category"] == "send"]
+        assert_equal(len(history_send), 1)
+        assert_equal(sum(entry["amount"] for entry in history), expected_amount)
+        assert_array_result(history, {"category": "send"}, {
+            "amount": -input_0["amount"],
+            "wallet_debit": input_0["amount"],
+            "wallet_credit": expected_credit,
+            "involves_mixed_inputs": True,
+        })
+        assert_array_result(history, {"category": "receive"}, {
+            "address": output_0,
+            "amount": expected_credit,
+            "involves_mixed_inputs": True,
+        })
+        for entry in history:
+            assert "fee" not in entry
+        assert "address" not in history_send[0]
+        assert "vout" not in history_send[0]
 
     def run_invalid_parameters_test(self):
         self.log.info("Test listtransactions RPC parameter validity")
@@ -204,7 +249,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         default_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
         wallet = self.nodes[0].get_wallet_rpc("fromme")
 
-        # The 'fee' field of gettransaction is only added when the transaction is 'from me'
+        # The 'fee' field of gettransaction is only added when the wallet-attributable fee is known.
         # Run twice, once for a transaction in the mempool, again when it confirms
         for confirm in [False, True]:
             key = get_generate_key()
@@ -235,12 +280,24 @@ class ListTransactionsTest(BitcoinTestFramework):
 
             import_res = wallet.importdescriptors([{"desc": descriptor, "timestamp": "now"}])
             assert_equal(import_res[0]["success"], True)
-            # TODO: We should check that the fee matches, but since the transaction spends inputs
-            # not known to the wallet, it is incorrectly calculating the fee.
-            # assert_equal(wallet.gettransaction(txid)["fee"], fee)
             tx_info = wallet.gettransaction(txid)
-            assert "fee" in tx_info
-            assert_equal(any(detail["category"] == "send" for detail in tx_info["details"]), True)
+            assert_equal(tx_info["amount"], Decimal("0.5"))
+            assert "fee" not in tx_info
+            assert_equal(tx_info["involves_mixed_inputs"], True)
+            assert_equal(tx_info["wallet_debit"], Decimal("1"))
+            assert_equal(tx_info["wallet_credit"], Decimal("1.5"))
+            send_details = [detail for detail in tx_info["details"] if detail["category"] == "send"]
+            assert_equal(len(send_details), 1)
+            assert_equal(sum(detail["amount"] for detail in tx_info["details"]), Decimal("0.5"))
+            assert_array_result(tx_info["details"], {"category": "send"}, {
+                "amount": Decimal("-1"),
+                "wallet_debit": Decimal("1"),
+                "wallet_credit": Decimal("1.5"),
+                "involves_mixed_inputs": True,
+            })
+            assert "address" not in send_details[0]
+            assert "vout" not in send_details[0]
+            assert "fee" not in send_details[0]
 
 if __name__ == '__main__':
     ListTransactionsTest(__file__).main()


### PR DESCRIPTION
When a wallet owns only some inputs of a transaction, such as in CoinJoins, payjoins, or other collaborative transactions, wallet history RPCs currently apply normal send accounting.

That works when all inputs are wallet-owned, but breaks for mixed-input transactions.

Example:

Inputs:
```
1.00 BTC wallet-owned
2.00 BTC foreign
```

Outputs:
```
0.80 BTC wallet-owned
2.19 BTC non-wallet
```

The wallet can safely know:

```
wallet_debit  = 1.00
wallet_credit = 0.80
wallet_net    = -0.20
```


But it cannot reliably know, from wallet history alone, the foreign input value, the total fee, the wallet's fee share, or which non-wallet output should be attributed as the user's payment. This is especially important after restore, rescan, or descriptor import, where any local transaction-intent metadata may be missing.

This PR adds a conservative fallback for that no-metadata case:

- classify wallet transactions as having no wallet inputs, partial wallet inputs, or all wallet inputs
- keep existing send/fee accounting when all inputs are wallet-owned
- also keep normal per-output send/fee accounting for mixed-input transactions when every non-wallet input has a known zero value
- otherwise report a single unattributed aggregate `send` entry with no address, no `vout`, and no fee, carrying the negative total of wallet-owned inputs spent
- report wallet-owned outputs as `receive` entries, so the transaction's entries sum to the wallet's net change
- expose `involves_mixed_inputs`, `wallet_debit`, and `wallet_credit`
- document that `vout` and `fee` are optional when attribution is unavailable

This does not try to fully solve collaborative transaction attribution. A richer layer with foreign-output / fee-share / intent metadata would still be useful for wallet-created transactions. This PR only makes the fallback honest when that metadata is unavailable.
  
Addresses #14136