### PR TITLE
refactor: separate deferred script check collection from `CheckInputScripts`

### DIFF
--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -26,6 +26,11 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        ValidationCache& validation_cache,
                        std::vector<CScriptCheck>* pvChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+std::optional<uint256> PrepareScriptChecks(const CTransaction& tx,
+                                           const CCoinsViewCache& inputs, script_verify_flags flags,
+                                           bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
+                                           ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 BOOST_AUTO_TEST_SUITE(txvalidationcache_tests)
 
 BOOST_AUTO_TEST_CASE(tbv_caches_scripts_only_single_threaded)
@@ -53,15 +58,11 @@ BOOST_AUTO_TEST_CASE(tbv_caches_scripts_only_single_threaded)
         next_block_index.nHeight = next_block_index.pprev->nHeight + 1;
         next_block_index.phashBlock = &block_hash;
 
-        TxValidationState tx_state;
         PrecomputedTransactionData txdata;
-        std::vector<CScriptCheck> script_checks;
-        BOOST_REQUIRE(CheckInputScripts(CTransaction{spend_tx}, tx_state, chainstate.CoinsTip(),
-                                        GetBlockScriptFlags(next_block_index, *setup.m_node.chainman),
-                                        /*cacheSigStore=*/true, /*cacheFullScriptStore=*/true, txdata,
-                                        setup.m_node.chainman->m_validation_cache, &script_checks));
-        BOOST_REQUIRE(tx_state.IsValid());
-        BOOST_CHECK_EQUAL(script_checks.empty(), expect_cached);
+        BOOST_CHECK_EQUAL(!PrepareScriptChecks(CTransaction{spend_tx}, chainstate.CoinsTip(),
+                                               GetBlockScriptFlags(next_block_index, *setup.m_node.chainman),
+                                               /*cacheFullScriptStore=*/true, txdata,
+                                               setup.m_node.chainman->m_validation_cache), expect_cached);
     }
 }
 
@@ -188,15 +189,11 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify
         // Test the caching
         if (ret && add_to_cache) {
             // Check that we get a cache hit if the tx was valid
-            std::vector<CScriptCheck> scriptchecks;
-            BOOST_CHECK(CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
-            BOOST_CHECK(scriptchecks.empty());
+            BOOST_CHECK(!PrepareScriptChecks(tx, active_coins_tip, test_flags, add_to_cache, txdata, validation_cache));
         } else {
             // Check that we get script executions to check, if the transaction
             // was invalid, or we didn't add to cache.
-            std::vector<CScriptCheck> scriptchecks;
-            BOOST_CHECK(CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
-            BOOST_CHECK_EQUAL(scriptchecks.size(), tx.vin.size());
+            BOOST_CHECK(PrepareScriptChecks(tx, active_coins_tip, test_flags, add_to_cache, txdata, validation_cache));
         }
     }
 }
@@ -255,12 +252,10 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
 
         BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, nullptr));
 
-        // If we call again asking for scriptchecks (as happens in
-        // ConnectBlock), we should add a script check object for this -- we're
-        // not caching invalidity (if that changes, delete this test case).
-        std::vector<CScriptCheck> scriptchecks;
-        BOOST_CHECK(CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, &scriptchecks));
-        BOOST_CHECK_EQUAL(scriptchecks.size(), 1U);
+        // If we prepare script checks again (as happens in ConnectBlock), we
+        // should still need script execution for this transaction because we
+        // are not caching invalidity (if that changes, delete this test case).
+        BOOST_CHECK(PrepareScriptChecks(CTransaction(spend_tx), m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, ptd_spend_tx, m_node.chainman->m_validation_cache));
 
         // Test that CheckInputScripts returns true iff DERSIG-enforcing flags are
         // not present.  Don't add these checks to the cache, so that we can
@@ -413,12 +408,9 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         // This transaction is now invalid under segwit, because of the second input.
         BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
 
-        std::vector<CScriptCheck> scriptchecks;
         // Make sure this transaction was not cached (ie because the first
         // input was valid)
-        BOOST_CHECK(CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, &scriptchecks));
-        // Should get 2 script checks back -- caching is on a whole-transaction basis.
-        BOOST_CHECK_EQUAL(scriptchecks.size(), 2U);
+        BOOST_CHECK(PrepareScriptChecks(CTransaction(tx), m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, txdata, m_node.chainman->m_validation_cache));
     }
 }
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -23,8 +23,7 @@ struct Dersig100Setup : public TestChain100Setup {
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       ValidationCache& validation_cache,
-                       std::vector<CScriptCheck>* pvChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+                       ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 std::optional<uint256> PrepareScriptChecks(const CTransaction& tx,
                                            const CCoinsViewCache& inputs, script_verify_flags flags,
@@ -180,7 +179,7 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify
             // WITNESS requires P2SH
             test_flags |= SCRIPT_VERIFY_P2SH;
         }
-        bool ret = CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, nullptr);
+        bool ret = CheckInputScripts(tx, state, active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache);
         // CheckInputScripts should succeed iff test_flags doesn't intersect with
         // failing_flags
         bool expected_return_value = !(test_flags & failing_flags);
@@ -250,7 +249,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         TxValidationState state;
         PrecomputedTransactionData ptd_spend_tx;
 
-        BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache));
 
         // If we prepare script checks again (as happens in ConnectBlock), we
         // should still need script execution for this transaction because we
@@ -316,7 +315,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_with_cltv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
         TxValidationState state;
         PrecomputedTransactionData txdata;
-        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_cltv_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_cltv_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache));
     }
 
     // TEST CHECKSEQUENCEVERIFY
@@ -344,7 +343,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_with_csv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
         TxValidationState state;
         PrecomputedTransactionData txdata;
-        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_csv_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_csv_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache));
     }
 
     // TODO: add tests for remaining script flags
@@ -406,7 +405,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         TxValidationState state;
         PrecomputedTransactionData txdata;
         // This transaction is now invalid under segwit, because of the second input.
-        BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache));
 
         // Make sure this transaction was not cached (ie because the first
         // input was valid)

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -16,8 +16,8 @@
 #include <boost/test/unit_test.hpp>
 
 struct Dersig100Setup : public TestChain100Setup {
-    Dersig100Setup()
-        : TestChain100Setup{ChainType::REGTEST, {.extra_args = {"-testactivationheight=dersig@102"}}} {}
+    Dersig100Setup(std::optional<int> worker_threads_num = {})
+        : TestChain100Setup{ChainType::REGTEST, {.extra_args = {"-testactivationheight=dersig@102"}, .worker_threads_num = worker_threads_num}} {}
 };
 
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
@@ -27,6 +27,43 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        std::vector<CScriptCheck>* pvChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 BOOST_AUTO_TEST_SUITE(txvalidationcache_tests)
+
+BOOST_AUTO_TEST_CASE(tbv_caches_scripts_only_single_threaded)
+{
+    std::vector<std::pair<int, bool>> pairs{
+        {/*worker_threads_num=*/0, /*expect_cached=*/true},
+        {/*worker_threads_num=*/1, /*expect_cached=*/false}};
+    for (const auto& [worker_threads_num, expect_cached] : pairs) {
+        Dersig100Setup setup{worker_threads_num};
+        LOCK(cs_main);
+
+        auto& chainstate = setup.m_node.chainman->ActiveChainstate();
+        const CScript script_pub_key{CScript() << ToByteVector(setup.coinbaseKey.GetPubKey()) << OP_CHECKSIG};
+        const CMutableTransaction spend_tx{setup.CreateValidMempoolTransaction(
+            setup.m_coinbase_txns[0], /*input_vout=*/0, /*input_height=*/0,
+            setup.coinbaseKey, script_pub_key, 11 * CENT, /*submit=*/false)};
+        const CBlock block{setup.CreateBlock({spend_tx}, script_pub_key, chainstate)};
+
+        const BlockValidationState state{TestBlockValidity(chainstate, block, /*check_pow=*/false, /*check_merkle_root=*/false)};
+        BOOST_REQUIRE(state.IsValid());
+
+        CBlockIndex next_block_index{block};
+        const uint256 block_hash{block.GetHash()};
+        next_block_index.pprev = chainstate.m_chain.Tip();
+        next_block_index.nHeight = next_block_index.pprev->nHeight + 1;
+        next_block_index.phashBlock = &block_hash;
+
+        TxValidationState tx_state;
+        PrecomputedTransactionData txdata;
+        std::vector<CScriptCheck> script_checks;
+        BOOST_REQUIRE(CheckInputScripts(CTransaction{spend_tx}, tx_state, chainstate.CoinsTip(),
+                                        GetBlockScriptFlags(next_block_index, *setup.m_node.chainman),
+                                        /*cacheSigStore=*/true, /*cacheFullScriptStore=*/true, txdata,
+                                        setup.m_node.chainman->m_validation_cache, &script_checks));
+        BOOST_REQUIRE(tx_state.IsValid());
+        BOOST_CHECK_EQUAL(script_checks.empty(), expect_cached);
+    }
+}
 
 BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
 {

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -277,7 +277,7 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
             .notifications = *m_node.notifications,
             .signals = m_node.validation_signals.get(),
             // Use no worker threads while fuzzing to avoid non-determinism
-            .worker_threads_num = EnableFuzzDeterminism() ? 0 : 2,
+            .worker_threads_num = opts.worker_threads_num.value_or(EnableFuzzDeterminism() ? 0 : 2),
         };
         if (opts.min_validation_cache) {
             chainman_opts.script_execution_cache_bytes = 0;

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -56,6 +56,7 @@ struct TestOpts {
     bool setup_net{true};
     bool setup_validation_interface{true};
     bool min_validation_cache{false}; // Equivalent of -maxsigcachebytes=0
+    std::optional<int> worker_threads_num{};
 };
 
 /** Basic testing setup.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2039,6 +2039,18 @@ ValidationCache::ValidationCache(const size_t script_execution_cache_bytes, cons
               approx_size_bytes >> 20, script_execution_cache_bytes >> 20, num_elems);
 }
 
+bool ValidationCache::IsScriptValidated(const uint256& entry, bool erase)
+{
+    AssertLockHeld(cs_main); //TODO: Remove this requirement by making CuckooCache not require external locks
+    return m_script_execution_cache.contains(entry, erase);
+}
+
+void ValidationCache::CacheScriptValidation(const uint256& entry)
+{
+    AssertLockHeld(cs_main); //TODO: Remove this requirement by making CuckooCache not require external locks
+    m_script_execution_cache.insert(entry);
+}
+
 /**
  * Check whether all of this transaction's input scripts succeed.
  *
@@ -2078,8 +2090,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     uint256 hashCacheEntry;
     CSHA256 hasher = validation_cache.ScriptExecutionCacheHasher();
     hasher.Write(UCharCast(tx.GetWitnessHash().begin()), 32).Write((unsigned char*)&flags, sizeof(flags)).Finalize(hashCacheEntry.begin());
-    AssertLockHeld(cs_main); //TODO: Remove this requirement by making CuckooCache not require external locks
-    if (validation_cache.m_script_execution_cache.contains(hashCacheEntry, !cacheFullScriptStore)) {
+    if (validation_cache.IsScriptValidated(hashCacheEntry, !cacheFullScriptStore)) {
         return true;
     }
 
@@ -2127,7 +2138,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     if (cacheFullScriptStore && !pvChecks) {
         // We executed all of the provided scripts, and were told to
         // cache the result. Do so now.
-        validation_cache.m_script_execution_cache.insert(hashCacheEntry);
+        validation_cache.CacheScriptValidation(hashCacheEntry);
     }
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2051,6 +2051,18 @@ void ValidationCache::CacheScriptValidation(const uint256& entry)
     m_script_execution_cache.insert(entry);
 }
 
+static std::vector<CTxOut> GetSpentOutputs(const CTransaction& tx, const CCoinsViewCache& inputs)
+{
+    std::vector<CTxOut> spent_outputs;
+    spent_outputs.reserve(tx.vin.size());
+    for (const auto& txin : tx.vin) {
+        const Coin& coin = inputs.AccessCoin(txin.prevout);
+        assert(!coin.IsSpent());
+        spent_outputs.emplace_back(coin.out);
+    }
+    return spent_outputs;
+}
+
 /**
  * Check whether all of this transaction's input scripts succeed.
  *
@@ -2094,18 +2106,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         return true;
     }
 
-    if (!txdata.m_spent_outputs_ready) {
-        std::vector<CTxOut> spent_outputs;
-        spent_outputs.reserve(tx.vin.size());
-
-        for (const auto& txin : tx.vin) {
-            const COutPoint& prevout = txin.prevout;
-            const Coin& coin = inputs.AccessCoin(prevout);
-            assert(!coin.IsSpent());
-            spent_outputs.emplace_back(coin.out);
-        }
-        txdata.Init(tx, std::move(spent_outputs));
-    }
+    if (!txdata.m_spent_outputs_ready) txdata.Init(tx, GetSpentOutputs(tx, inputs));
     assert(txdata.m_spent_outputs.size() == tx.vin.size());
 
     for (unsigned int i = 0; i < tx.vin.size(); i++) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -151,8 +151,7 @@ static void CollectScriptChecks(const CTransaction& tx,
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       ValidationCache& validation_cache,
-                       std::vector<CScriptCheck>* pvChecks = nullptr)
+                       ValidationCache& validation_cache)
                        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool CheckFinalTxAtTip(const CBlockIndex& active_chain_tip, const CTransaction& tx)
@@ -2126,10 +2125,6 @@ static void CollectScriptChecks(const CTransaction& tx,
  * This involves ECDSA signature checks so can be computationally intensive. This function should
  * only be called after the cheap sanity checks in CheckTxInputs passed.
  *
- * If pvChecks is not nullptr, script checks are pushed onto it instead of being performed inline. Any
- * script checks which are not necessary (eg due to script execution cache hits) are, obviously,
- * not pushed onto pvChecks/run.
- *
  * Setting cacheSigStore/cacheFullScriptStore to false will remove elements from the corresponding cache
  * which are matched. This is useful for checking blocks where we will likely never need the cache
  * entry again.
@@ -2142,15 +2137,10 @@ static void CollectScriptChecks(const CTransaction& tx,
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       ValidationCache& validation_cache,
-                       std::vector<CScriptCheck>* pvChecks)
+                       ValidationCache& validation_cache)
 {
     const auto hash_cache_entry{PrepareScriptChecks(tx, inputs, flags, cacheFullScriptStore, txdata, validation_cache)};
     if (!hash_cache_entry) return true;
-
-    if (pvChecks) {
-        pvChecks->reserve(tx.vin.size());
-    }
 
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
 
@@ -2162,9 +2152,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
 
         // Verify signature
         CScriptCheck check(txdata.m_spent_outputs[i], tx, validation_cache.m_signature_cache, i, flags, cacheSigStore, &txdata);
-        if (pvChecks) {
-            pvChecks->emplace_back(std::move(check));
-        } else if (auto result = check(); result.has_value()) {
+        if (auto result = check(); result.has_value()) {
             // Tx failures never trigger disconnections/bans.
             // This is so that network splits aren't triggered
             // either due to non-consensus relay policies (such as
@@ -2179,7 +2167,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         }
     }
 
-    if (cacheFullScriptStore && !pvChecks) {
+    if (cacheFullScriptStore) {
         // We executed all of the provided scripts, and were told to
         // cache the result. Do so now.
         validation_cache.CacheScriptValidation(*hash_cache_entry);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -142,6 +142,12 @@ std::optional<uint256> PrepareScriptChecks(const CTransaction& tx,
                                            bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
                                            ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+static void CollectScriptChecks(const CTransaction& tx,
+                                const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
+                                bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
+                                ValidationCache& validation_cache,
+                                std::vector<CScriptCheck>& checks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
@@ -2100,6 +2106,20 @@ std::optional<uint256> PrepareScriptChecks(const CTransaction& tx,
     return hash_cache_entry;
 }
 
+static void CollectScriptChecks(const CTransaction& tx,
+                                const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
+                                bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
+                                ValidationCache& validation_cache,
+                                std::vector<CScriptCheck>& checks) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    if (PrepareScriptChecks(tx, inputs, flags, cacheFullScriptStore, txdata, validation_cache)) {
+        checks.reserve(tx.vin.size());
+        for (unsigned int i = 0; i < tx.vin.size(); ++i) {
+            checks.emplace_back(txdata.m_spent_outputs[i], tx, validation_cache.m_signature_cache, i, flags, cacheSigStore, &txdata);
+        }
+    }
+}
+
 /**
  * Check whether all of this transaction's input scripts succeed.
  *
@@ -2609,18 +2629,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         if (!tx.IsCoinBase() && fScriptChecks)
         {
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
-            bool tx_ok;
             TxValidationState tx_state;
-            // If CheckInputScripts is called with a pointer to a checks vector, the resulting checks are appended to it. In that case
-            // they need to be added to control which runs them asynchronously. Otherwise, CheckInputScripts runs the checks before returning.
             if (control) {
                 std::vector<CScriptCheck> vChecks;
-                tx_ok = CheckInputScripts(tx, tx_state, view, flags, fCacheResults, fCacheResults, txsdata[i], m_chainman.m_validation_cache, &vChecks);
-                if (tx_ok) control->Add(std::move(vChecks));
-            } else {
-                tx_ok = CheckInputScripts(tx, tx_state, view, flags, fCacheResults, fCacheResults, txsdata[i], m_chainman.m_validation_cache);
-            }
-            if (!tx_ok) {
+                CollectScriptChecks(tx, view, flags, fCacheResults, fCacheResults, txsdata[i], m_chainman.m_validation_cache, vChecks);
+                control->Add(std::move(vChecks));
+            } else if (!CheckInputScripts(tx, tx_state, view, flags, fCacheResults, fCacheResults, txsdata[i], m_chainman.m_validation_cache)) {
                 // Any transaction validation failure in ConnectBlock is a block consensus failure
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
                               tx_state.GetRejectReason(), tx_state.GetDebugMessage());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -137,6 +137,11 @@ const CBlockIndex* Chainstate::FindForkInGlobalIndex(const CBlockLocator& locato
     return m_chain.Genesis();
 }
 
+std::optional<uint256> PrepareScriptChecks(const CTransaction& tx,
+                                           const CCoinsViewCache& inputs, script_verify_flags flags,
+                                           bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
+                                           ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
@@ -2064,6 +2069,38 @@ static std::vector<CTxOut> GetSpentOutputs(const CTransaction& tx, const CCoinsV
 }
 
 /**
+ * Perform pre-checks for script validation: skip coinbase, check the script
+ * execution cache, and initialize txdata. Returns nullopt if the caller can
+ * skip script validation, or the cache entry hash needed to store results.
+ *
+ * Non-static (and redeclared) in src/test/txvalidationcache_tests.cpp
+ */
+std::optional<uint256> PrepareScriptChecks(const CTransaction& tx,
+                                           const CCoinsViewCache& inputs, script_verify_flags flags,
+                                           bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
+                                           ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    if (tx.IsCoinBase()) return std::nullopt;
+
+    // First check if script executions have been cached with the same
+    // flags. Note that this assumes that the inputs provided are
+    // correct (ie that the transaction hash which is in tx's prevouts
+    // properly commits to the scriptPubKey in the inputs view of that
+    // transaction).
+    uint256 hash_cache_entry;
+    CSHA256 hasher = validation_cache.ScriptExecutionCacheHasher();
+    hasher.Write(UCharCast(tx.GetWitnessHash().begin()), 32).Write((unsigned char*)&flags, sizeof(flags)).Finalize(hash_cache_entry.begin());
+    if (validation_cache.IsScriptValidated(hash_cache_entry, !cacheFullScriptStore)) {
+        return std::nullopt;
+    }
+
+    if (!txdata.m_spent_outputs_ready) txdata.Init(tx, GetSpentOutputs(tx, inputs));
+    assert(txdata.m_spent_outputs.size() == tx.vin.size());
+
+    return hash_cache_entry;
+}
+
+/**
  * Check whether all of this transaction's input scripts succeed.
  *
  * This involves ECDSA signature checks so can be computationally intensive. This function should
@@ -2088,26 +2125,12 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        ValidationCache& validation_cache,
                        std::vector<CScriptCheck>* pvChecks)
 {
-    if (tx.IsCoinBase()) return true;
+    const auto hash_cache_entry{PrepareScriptChecks(tx, inputs, flags, cacheFullScriptStore, txdata, validation_cache)};
+    if (!hash_cache_entry) return true;
 
     if (pvChecks) {
         pvChecks->reserve(tx.vin.size());
     }
-
-    // First check if script executions have been cached with the same
-    // flags. Note that this assumes that the inputs provided are
-    // correct (ie that the transaction hash which is in tx's prevouts
-    // properly commits to the scriptPubKey in the inputs view of that
-    // transaction).
-    uint256 hashCacheEntry;
-    CSHA256 hasher = validation_cache.ScriptExecutionCacheHasher();
-    hasher.Write(UCharCast(tx.GetWitnessHash().begin()), 32).Write((unsigned char*)&flags, sizeof(flags)).Finalize(hashCacheEntry.begin());
-    if (validation_cache.IsScriptValidated(hashCacheEntry, !cacheFullScriptStore)) {
-        return true;
-    }
-
-    if (!txdata.m_spent_outputs_ready) txdata.Init(tx, GetSpentOutputs(tx, inputs));
-    assert(txdata.m_spent_outputs.size() == tx.vin.size());
 
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
 
@@ -2139,7 +2162,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     if (cacheFullScriptStore && !pvChecks) {
         // We executed all of the provided scripts, and were told to
         // cache the result. Do so now.
-        validation_cache.CacheScriptValidation(hashCacheEntry);
+        validation_cache.CacheScriptValidation(*hash_cache_entry);
     }
 
     return true;

--- a/src/validation.h
+++ b/src/validation.h
@@ -373,8 +373,10 @@ private:
     //! Pre-initialized hasher to avoid having to recreate it for every hash calculation.
     CSHA256 m_script_execution_cache_hasher;
 
-public:
+    //! Cache for script verification results to avoid re-validation.
     CuckooCache::cache<uint256, SignatureCacheHasher> m_script_execution_cache;
+
+public:
     SignatureCache m_signature_cache;
 
     ValidationCache(size_t script_execution_cache_bytes, size_t signature_cache_bytes);
@@ -384,6 +386,9 @@ public:
 
     //! Return a copy of the pre-initialized hasher.
     CSHA256 ScriptExecutionCacheHasher() const { return m_script_execution_cache_hasher; }
+
+    bool IsScriptValidated(const uint256& entry, bool erase) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void CacheScriptValidation(const uint256& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
 /** Functions for validating blocks and updating the block tree */

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -16,12 +16,14 @@ from test_framework.util import (
 
 class RPCGenerateTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 1
+        self.num_nodes = 2
+        self.extra_args = [["-par=1"], ["-par=2"]]
 
     def run_test(self):
         self.test_generatetoaddress()
         self.test_generate()
         self.test_generateblock()
+        self.test_generateblock_thread_modes()
 
     def test_generatetoaddress(self):
         self.generatetoaddress(self.nodes[0], 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
@@ -133,6 +135,21 @@ class RPCGenerateTest(BitcoinTestFramework):
 
         self.log.info("Test rpc generate is a hidden command not discoverable in general help")
         assert message not in self.nodes[0].help()
+
+    def test_generateblock_thread_modes(self):
+        for node, mode in zip(self.nodes, ("single-threaded", "multi-threaded")):
+            miniwallet = MiniWallet(node)
+            address = miniwallet.get_address()
+
+            self.log.info(f"Generate and submit a block with a scripted tx on the {mode} path")
+            generated_block = self.generateblock(node, output=address, transactions=[miniwallet.create_self_transfer()["hex"]], submit=False)
+            assert_equal(node.submitblock(hexdata=generated_block["hex"]), None)
+            assert_equal(generated_block["hash"], node.getbestblockhash())
+
+            self.log.info(f"Fail to generate an out-of-order block on the {mode} path")
+            txid1 = miniwallet.send_self_transfer(from_node=node)["txid"]
+            rawtx2 = miniwallet.create_self_transfer(utxo_to_spend=miniwallet.get_utxo(txid=txid1))["hex"]
+            assert_raises_rpc_error(-25, "TestBlockValidity failed: bad-txns-inputs-missingorspent", self.generateblock, node, address, [rawtx2, txid1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Problem:** `CheckInputScripts()` currently serves two different purposes:
* In the single-threaded path it executes script checks inline and may cache successful results.
* In the multithreaded block validation path it instead prepares deferred `CScriptChecks` for the `checkqueue`.

That makes the function name misleading and the control flow harder to follow in a consensus-sensitive area.
The main issue is that these two uses are intertwined in one function.

**Fix:** This PR separates those responsibilities without changing behavior, making it a pure refactor with test coverage of the affected functionality.

It first cleans up the shared pieces around script checking by encapsulating script execution cache access in `ValidationCache`, extracting spent output collection into `GetSpentOutputs()`, and extracting the common pre-check logic into `PrepareScriptChecks()`.

It then splits deferred script-check collection out of `CheckInputScripts()` into a separate `CollectScriptChecks()` helper.
`ConnectBlock()` uses `CollectScriptChecks()` only in the existing multithreaded path when worker threads are available.
The single-threaded path still calls `CheckInputScripts()` directly, as before.

With that split in place, `CheckInputScripts()` no longer needs the `pvChecks` parameter and can go back to only doing inline script validation.
The tests are updated to cover both thread modes directly and to test the cache pre-check logic through `PrepareScriptChecks()`.

**Notes:** This is a narrower alternative to https://github.com/bitcoin/bitcoin/pull/32575, keeping the original author and content in each commit where possible.
The original PR eventually went further than a refactor and unified the single-threaded and multithreaded cases by always going through the `checkqueue`.

This PR keeps the current thread-mode behavior intact and only separates the two uses into different functions so the code is easier to read, review, and reason about.
If there is still interest in unifying the paths later, that can be discussed separately.