### PR TITLE
doc: Fix missing cmake -B option in fuzzing quickstart guide

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -7,7 +7,7 @@ To quickly get started fuzzing Bitcoin Core using [libFuzzer](https://llvm.org/d
 ```sh
 $ git clone https://github.com/bitcoin/bitcoin
 $ cd bitcoin/
-$ cmake --preset=libfuzzer
+$ cmake --preset=libfuzzer -B build_fuzz
 $ cmake --build build_fuzz
 $ FUZZ=process_message build_fuzz/bin/fuzz
 # abort fuzzing using ctrl-c


### PR DESCRIPTION
`cmake --build` assumes our build directory is build_fuzz, but `cmake` didn't use `-B build_fuzz`, so simply copying and pasting the commands didn't work.
