### PR TITLE
guix: Remove `make-lld-wrapper`

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -419,7 +419,6 @@ inspecting signatures in Mach-O binaries.")
           ((string-contains target "darwin")
            (list clang-toolchain-19
                  lld-19
-                 (make-lld-wrapper lld-19 #:lld-as-ld? #t)
                  python-signapple
                  zip))
           (else '())))))


### PR DESCRIPTION
The [LLD wrapper](https://codeberg.org/guix/guix/src/commit/c5eee3336cc1d10a3cc1c97fde2809c3451624d3/gnu/packages/llvm.scm#L1794-L1824) aims to add any missing `-rpath` flags. However, this is only required for native binaries, and is already handled by the native toolchain (currently `gcc-toolchain-14`).

Based on my testing, it wasn't necessary in the original https://github.com/bitcoin/bitcoin/pull/21778.

My Guix build for macOS targets (on both `x86_64` and `aarch64` platforms):
```
ebb020db55591ed1b85b5d64145a658032879b8641cde43c259cae3e6abc19db  guix-build-b849d6c51815/output/arm64-apple-darwin/SHA256SUMS.part
798596beec8e473519d8b512cd6d178d1bce9e9a9e89d955844df0c89853be41  guix-build-b849d6c51815/output/arm64-apple-darwin/bitcoin-b849d6c51815-arm64-apple-darwin-codesigning.tar.gz
efe3cc64e3d5ca76fa96d1faa39d7411989feb7fb285eed212675bd7e9309552  guix-build-b849d6c51815/output/arm64-apple-darwin/bitcoin-b849d6c51815-arm64-apple-darwin-unsigned.tar.gz
9f468c9c005d0a13a2a3b876a5f9a92770d08a63b8e19e1d76f123947773fd77  guix-build-b849d6c51815/output/arm64-apple-darwin/bitcoin-b849d6c51815-arm64-apple-darwin-unsigned.zip
e81d27c3e74ea43ce812f392af50400bd6988b8fc6cee4c5e61d225724cc0552  guix-build-b849d6c51815/output/dist-archive/bitcoin-b849d6c51815.tar.gz
8b20cd54087c9a0651e938ffb61d60e18cd90219928e168e7f96c1c3756bb751  guix-build-b849d6c51815/output/x86_64-apple-darwin/SHA256SUMS.part
0ae6cd4889f5c2922caa792cc0db13c5ba41c0fe0dc1c3de1624840ce9cd732e  guix-build-b849d6c51815/output/x86_64-apple-darwin/bitcoin-b849d6c51815-x86_64-apple-darwin-codesigning.tar.gz
2c5a6fdf7a57ff2fb1a5ed0a58db24f9862b4a6c030118352555f6a4fc32d936  guix-build-b849d6c51815/output/x86_64-apple-darwin/bitcoin-b849d6c51815-x86_64-apple-darwin-unsigned.tar.gz
9039796aaf9228c20215831e95c4fe8024a50bfee809608e9185c0ba4d18ac21  guix-build-b849d6c51815/output/x86_64-apple-darwin/bitcoin-b849d6c51815-x86_64-apple-darwin-unsigned.zip
```

Split from https://github.com/bitcoin/bitcoin/pull/32764.