### PR TITLE
depends: Fix cross-compiling on macOS for Windows

### DIFF
--- a/depends/packages/native_qt.mk
+++ b/depends/packages/native_qt.mk
@@ -97,9 +97,9 @@ ifneq ($(V),)
 $(package)_cmake_opts += --log-level=STATUS
 endif
 
-ifeq ($(host_os),darwin)
-$(package)_cmake_opts += -DQT_INTERNAL_XCODE_VERSION=$(XCODE_VERSION)
+ifeq ($(build_os),darwin)
 $(package)_cmake_opts += -DQT_NO_APPLE_SDK_MAX_VERSION_CHECK=ON
+$(package)_cmake_opts += -DQT_NO_XCODE_MIN_VERSION_CHECK=ON
 endif
 endef
 


### PR DESCRIPTION
1. Use `build_os` instead of `host_os` for native packages.

2. `XCODE_VERSION` is available only for `darwin` hosts. Therefore, simply disable the Xcode version check for `native_qt`.

Fixes https://github.com/bitcoin/bitcoin/issues/34874.