### PR TITLE
ci: vcpkg-specific cleanups

### DIFF
--- a/.github/ci-windows.py
+++ b/.github/ci-windows.py
@@ -71,8 +71,8 @@ def generate(ci_type):
         "-B",
         "build",
         "-Werror=dev",
-        "--preset",
-        "vs2026",
+        "--preset=vs2026",
+        "-DVCPKG_TARGET_TRIPLET=x64-windows-release",
     ] + GENERATE_OPTIONS[ci_type]
     if run(command, check=False).returncode != 0:
         print("=== ⚠️ ===")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,15 +253,11 @@ jobs:
           py -3 --version
           bash --version
 
-      - name: Set VCPKG_ROOT
-        run: |
-          echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> "$GITHUB_ENV"
-
       - name: Restore vcpkg tools cache
         id: vcpkg-tools-cache
         uses: actions/cache/restore@v5
         with:
-          path: C:/vcpkg/downloads/tools
+          path: ~/AppData/Local/vcpkg/downloads/tools
           key: ${{ github.job }}-vcpkg-tools-${{ github.run_id }}
           restore-keys: ${{ github.job }}-vcpkg-tools-
 
@@ -288,7 +284,7 @@ jobs:
         # Only save cache from one job as they share tools. If the matrix is expanded to jobs with unique tools, this may need amending.
         if: github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && steps.vcpkg-tools-cache.outputs.cache-hit != 'true' && matrix.job-type == 'standard'
         with:
-          path: C:/vcpkg/downloads/tools
+          path: ~/AppData/Local/vcpkg/downloads/tools
           key: ${{ github.job }}-vcpkg-tools-${{ github.run_id }}
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,10 +253,6 @@ jobs:
           py -3 --version
           bash --version
 
-      - name: Using vcpkg with MSBuild
-        run: |
-          echo "set(VCPKG_BUILD_TYPE release)" >> "${VCPKG_INSTALLATION_ROOT}/triplets/x64-windows.cmake"
-
       - name: Set VCPKG_ROOT
         run: |
           echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,8 +256,6 @@ jobs:
       - name: Using vcpkg with MSBuild
         run: |
           echo "set(VCPKG_BUILD_TYPE release)" >> "${VCPKG_INSTALLATION_ROOT}/triplets/x64-windows.cmake"
-          # Workaround for libevent, which requires CMake 3.1 but is incompatible with CMake >= 4.0.
-          sed -i '1s/^/set(ENV{CMAKE_POLICY_VERSION_MINIMUM} 3.5)\n/' "${VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake"
 
       - name: Set VCPKG_ROOT
         run: |


### PR DESCRIPTION
This PR removes three vcpkg-specific workarounds. See the commit messages for more details.