### PR TITLE
wallet: fix amount computed as boolean in coin selection

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -939,7 +939,7 @@ util::Result<SelectionResult> AutomaticCoinSelection(const CWallet& wallet, Coin
             if (group.m_ancestors >= max_ancestors || group.m_max_cluster_count >= max_cluster_count) total_unconf_long_chain += group.GetSelectionAmount();
         }
 
-        if (CAmount total_amount = available_coins.GetTotalAmount() - total_discarded < value_to_select) {
+        if (CAmount total_amount = available_coins.GetTotalAmount() - total_discarded; total_amount < value_to_select) {
             // Special case, too-long-mempool cluster.
             if (total_amount + total_unconf_long_chain > value_to_select) {
                 return util::Error{_("Unconfirmed UTXOs are available, but spending them creates a chain of transactions that will be rejected by the mempool")};


### PR DESCRIPTION
Stumbled upon this tiny bug. This has been working by accident.

The comparison is evaluated first, so `total_amount` ends up holding a boolean instead of the actual amount.
It can be verified by adding the value to the returned error message and running the `wallet_create_tx.py`
test.

Note:
I assume something like `-Wparentheses` in CI (or similar) should help us catching similar issues elsewhere.
