### PR TITLE
doc: Note that generateblock does not collect transaction fees

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -305,7 +305,8 @@ static RPCHelpMan generatetoaddress()
 static RPCHelpMan generateblock()
 {
     return RPCHelpMan{"generateblock",
-        "Mine a set of ordered transactions to a specified address or descriptor and return the block hash.",
+        "Mine a set of ordered transactions to a specified address or descriptor and return the block hash.\n"
+        "Transaction fees are not collected in the block reward.",
         {
             {"output", RPCArg::Type::STR, RPCArg::Optional::NO, "The address or descriptor to send the newly generated bitcoin to."},
             {"transactions", RPCArg::Type::ARR, RPCArg::Optional::NO, "An array of hex strings which are either txids or raw transactions.\n"


### PR DESCRIPTION
## Summary

- Add a note to the `generateblock` RPC help text clarifying that transaction fees are not collected in the block reward
- This was suggested by maflcko in #31684 as a minimal doc fix

refs #31684

## Test plan

- [x] `./build/bin/test_bitcoin --run_test=rpc_tests` passes
- [x] `cmake --build build --target bitcoind` compiles cleanly
