### PR TITLE
net: Warn when Tor onion service lacks a dedicated onion bind

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2187,6 +2187,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     if (listenonion) {
+        if (connOptions.onion_binds.empty() && (!connOptions.vBinds.empty() || connOptions.bind_on_any)) {
+            InitWarning(_("The Tor onion service is being directed to a -bind address without a "
+                          "dedicated onion socket (-bind=<addr>=onion). Incoming Tor connections "
+                          "will not be identified as onion connections."));
+        }
         if (connOptions.onion_binds.size() > 1) {
             InitWarning(strprintf(_("More than one onion bind address is provided. Using %s "
                                     "for the automatically created Tor onion service."),

--- a/test/functional/feature_bind_extra.py
+++ b/test/functional/feature_bind_extra.py
@@ -21,6 +21,7 @@ from test_framework.util import (
     assert_equal,
     p2p_port,
     rpc_port,
+    tor_port,
 )
 
 class BindExtraTest(BitcoinTestFramework):
@@ -93,6 +94,19 @@ class BindExtraTest(BitcoinTestFramework):
             binds = set(filter(lambda e: e[1] != rpc_port(i), binds))
             assert_equal(binds, set(expected_services))
 
+        self.stop_node(0)
+
+        warn_msg = ("Warning: The Tor onion service is being directed to a -bind address without a "
+                    "dedicated onion socket (-bind=<addr>=onion). Incoming Tor connections will not "
+                    "be identified as onion connections.")
+
+        self.log.info("Test -bind without dedicated onion bind warns when -listenonion=1")
+        bind_port = p2p_port(self.num_nodes)
+        self.start_node(0, extra_args=[f"-bind=127.0.0.1:{bind_port}", "-listenonion=1"])
+        self.stop_node(0, expected_stderr=warn_msg)
+
+        self.log.info("Test -bind with dedicated onion bind does not warn when -listenonion=1")
+        self.start_node(0, extra_args=[f"-bind=127.0.0.1:{bind_port}", f"-bind=127.0.0.1:{tor_port(0)}=onion", "-listenonion=1"])
         self.stop_node(0)
 
         addr = "127.0.0.1:11012"

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -46,7 +46,10 @@ import tempfile
 
 from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    tor_port,
+)
 from test_framework.netutil import test_ipv6_local, test_unix_socket
 
 # Networks returned by RPC getpeerinfo.
@@ -435,7 +438,7 @@ class ProxyTest(BitcoinTestFramework):
         self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
         self.log.info("Test passing -onlynet=onion without -proxy or -onion but with -listenonion=1 is ok")
-        self.start_node(1, extra_args=["-onlynet=onion", "-listenonion=1"])
+        self.start_node(1, extra_args=["-onlynet=onion", "-listenonion=1", f"-bind=127.0.0.1:{tor_port(1)}=onion"])
         self.stop_node(1)
 
         self.log.info("Test passing unknown network to -onlynet raises expected init error")

--- a/test/functional/feature_torcontrol.py
+++ b/test/functional/feature_torcontrol.py
@@ -11,6 +11,7 @@ from test_framework.util import (
     assert_equal,
     ensure_for,
     p2p_port,
+    tor_port,
 )
 
 
@@ -118,6 +119,7 @@ class TorControlTest(BitcoinTestFramework):
             f"-torcontrol=127.0.0.1:{mock_tor.port}",
             "-listenonion=1",
             "-debug=tor",
+            f"-bind=127.0.0.1:{tor_port(0)}=onion",
         ])
 
         # Wait for connection and PROTOCOLINFO command

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -530,9 +530,12 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             # the RPC should throw.
             "-torcontrol=127.0.0.1:1",
             "-listenonion",
+            f"-bind=127.0.0.1:{tor_port(0)}=onion",
         ])
         assert_raises_rpc_error(-1, "none of the Tor or I2P networks is reachable",
                                 tx_originator.sendrawtransaction, hexstring=txs[0]["hex"], maxfeerate=0.1)
+
+        self.restart_node(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

When `-bind` is specified without a dedicated onion socket (`-bind=<addr>=onion`) but `-listenonion` is enabled, the auto-created Tor hidden service routes incoming connections to the regular bind address. This makes it impossible to distinguish incoming Tor connections from regular IPv4 connections, causing `-netinfo` to report 0 onion connections even when they exist.

This adds a startup warning to alert users so they can add `-bind=127.0.0.1:8334=onion` for accurate connection tracking.

Fixes #33458

## Test plan

Start bitcoind with `-bind` but without a dedicated onion bind:
```
./build/bin/bitcoind -bind=0.0.0.0:8333 -listenonion=1
```

**Before this change:** No warning is emitted. Users have no indication that incoming Tor connections will be misidentified.

**After this change:** A warning is printed at startup:
```
Warning: The Tor onion service is being directed to a -bind address without a dedicated onion socket (-bind=<addr>=onion). Incoming Tor connections will not be identified as onion connections.
```

The warning does not appear when a dedicated onion bind is provided:
```
./build/bin/bitcoind -bind=0.0.0.0:8333 -bind=127.0.0.1:8334=onion -listenonion=1
```

Functional test `feature_proxy.py` updated to expect the new warning.
