### PR TITLE
indexes: Don't commit ahead of the flushed chainstate

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -279,6 +279,17 @@ void BaseIndex::Commit()
     // (this could happen if init is interrupted).
     bool ok = m_best_block_index != nullptr;
     if (ok) {
+        // Don't commit if the index best block is not an ancestor of the chainstate's last flushed
+        // block. Otherwise, after an unclean shutdown, the index could be
+        // persisted ahead of a chainstate it can no longer roll back to, which
+        // would corrupt indexes with state (e.g. coinstatsindex).
+        const CBlockIndex* index_tip = m_best_block_index.load();
+        const CBlockIndex* last_flushed = WITH_LOCK(::cs_main, return m_chainstate->GetLastFlushedBlock());
+        if (!last_flushed || last_flushed->GetAncestor(index_tip->nHeight) != index_tip) {
+            LogDebug(BCLog::COINDB, "Skipping commit, index is ahead of flushed chainstate (index height %d, last flush at height %d)",
+                    index_tip->nHeight, last_flushed ? last_flushed->nHeight : -1);
+            return;
+        }
         CDBBatch batch(GetDB());
         ok = CustomCommit(batch);
         if (ok) {

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -273,7 +273,7 @@ void BaseIndex::Sync()
     }
 }
 
-bool BaseIndex::Commit()
+void BaseIndex::Commit()
 {
     // Don't commit anything if we haven't indexed any block yet
     // (this could happen if init is interrupted).
@@ -288,9 +288,7 @@ bool BaseIndex::Commit()
     }
     if (!ok) {
         LogError("Failed to commit latest %s state", GetName());
-        return false;
     }
-    return true;
 }
 
 bool BaseIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip)

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -101,7 +101,7 @@ private:
     /// from further behind on reboot. If the new state is not a successor of the previous state (due
     /// to a chain reorganization), the index must halt until Commit succeeds or else it could end up
     /// getting corrupted.
-    bool Commit();
+    void Commit();
 
     /// Loop over disconnected blocks and call CustomRemove.
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -94,13 +94,9 @@ private:
     CThreadInterrupt m_interrupt;
 
     /// Write the current index state (eg. chain block locator and subclass-specific items) to disk.
-    ///
-    /// Recommendations for error handling:
-    /// If called on a successor of the previous committed best block in the index, the index can
-    /// continue processing without risk of corruption, though the index state will need to catch up
-    /// from further behind on reboot. If the new state is not a successor of the previous state (due
-    /// to a chain reorganization), the index must halt until Commit succeeds or else it could end up
-    /// getting corrupted.
+    /// Will skip the commit if no block has been indexed yet or if the index's best block is
+    /// ahead of the chainstate's last flushed block. This avoids persisting state an unclean shutdown
+    /// could not roll back from. A later call commits when the chainstate has flushed far enough.
     void Commit();
 
     /// Loop over disconnected blocks and call CustomRemove.

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(test_bitcoin
   base32_tests.cpp
   base58_tests.cpp
   base64_tests.cpp
+  baseindex_tests.cpp
   bech32_tests.cpp
   bip32_tests.cpp
   bip324_tests.cpp

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <index/coinstatsindex.h>
+#include <interfaces/chain.h>
+#include <script/script.h>
+#include <test/util/setup_common.h>
+#include <util/byte_units.h>
+#include <util/check.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+// Tests of generic BaseIndex functionality that is independent of which
+// concrete index is being used. CoinStatsIndex is used here merely as a
+// convenient instantiation of BaseIndex.
+BOOST_AUTO_TEST_SUITE(baseindex_tests)
+
+// Test that the index does not commit ahead of the chainstate's last
+// flushed block. If it did, a subsequent unclean shutdown would corrupt
+// the index, because during reverting it would require blocks that were
+// never flushed to disk.
+BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
+{
+    Chainstate& chainstate = Assert(m_node.chainman)->ActiveChainstate();
+    auto sync_index = [&](bool do_flush, int expected_sync_height, int expected_commit_height) {
+        CoinStatsIndex index{interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB};
+        BOOST_REQUIRE(index.Init());
+        index.Sync();
+        if (do_flush) {
+            chainstate.ForceFlushStateToDisk();
+            m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
+        }
+        BOOST_CHECK_EQUAL(index.GetSummary().best_block_height, expected_sync_height);
+        index.Stop();
+        // Reload index to see which block data was actually committed.
+        BOOST_REQUIRE(index.Init());
+        BOOST_CHECK_EQUAL(index.GetSummary().best_block_height, expected_commit_height);
+        index.Stop();
+    };
+
+    // Part 1: Sync, then "crash" (stop without flushing). Models a node that
+    // started up, had its index catch up, but never flushed before going down.
+    sync_index(false, 100, 100);
+
+    // Part 2: Restart cleanly. Sync, force a chainstate flush, and drain the
+    // validation queue so the index's ChainStateFlushed callback runs.
+    sync_index(true, 100, 100);
+
+    // Part 3: Connect a new block on the chain without flushing
+    // (m_last_flushed_block stays at 100). For a real node this would happen
+    // in parallel with Sync(). Here we do it before Sync() to make the race
+    // state deterministic.
+    CreateAndProcessBlock({}, CScript() << OP_TRUE);
+    sync_index(false, 101, 101);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -42,10 +42,13 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
 
     // Part 1: Sync, then "crash" (stop without flushing). Models a node that
     // started up, had its index catch up, but never flushed before going down.
-    sync_index(false, 100, 100);
+    // The end-of-sync Commit() runs at chain tip (height 100) but
+    // m_last_flushed_block is null, so it is skipped.
+    sync_index(false, 100, 0);
 
     // Part 2: Restart cleanly. Sync, force a chainstate flush, and drain the
     // validation queue so the index's ChainStateFlushed callback runs.
+    // Now m_last_flushed_block == tip == 100 and the index can commit.
     sync_index(true, 100, 100);
 
     // Part 3: Connect a new block on the chain without flushing
@@ -53,7 +56,7 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
     // in parallel with Sync(). Here we do it before Sync() to make the race
     // state deterministic.
     CreateAndProcessBlock({}, CScript() << OP_TRUE);
-    sync_index(false, 101, 101);
+    sync_index(false, 101, 100);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -85,6 +85,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
 
     // Set m_next_write to current time
     chainstate.FlushStateToDisk(state_dummy, FlushStateMode::FORCE_FLUSH);
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), second_from_tip->pprev);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     // The periodic flush interval is between 50 and 70 minutes (inclusive)
     // The next call to a PERIODIC write will flush
@@ -101,6 +102,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     // inside the outer loop.
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK_EQUAL(sub->m_flushed_at_block, second_from_tip);
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), second_from_tip);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2823,6 +2823,7 @@ bool Chainstate::FlushStateToDisk(
                 }
                 // Flush the chainstate (which may refer to block index entries).
                 empty_cache ? CoinsTip().Flush() : CoinsTip().Sync();
+                m_last_flushed_block = m_blockman.LookupBlockIndex(CoinsTip().GetBestBlock());
                 full_flush_completed = true;
                 TRACEPOINT(utxocache, flush,
                     int64_t{Ticks<std::chrono::microseconds>(NodeClock::now() - nNow)},
@@ -4584,6 +4585,7 @@ bool Chainstate::LoadChainTip()
     }
     m_chain.SetTip(*pindex);
     m_chainman.UpdateIBDStatus();
+    m_last_flushed_block = pindex;
     tip = m_chain.Tip();
 
     // nSequenceId is one of the keys used to sort setBlockIndexCandidates. Ensure all

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2841,8 +2841,7 @@ bool Chainstate::FlushStateToDisk(
     }
     if (full_flush_completed) {
         if (m_chainman.m_options.signals) {
-            // Update best block in wallet (so we can detect restored wallets).
-            m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), GetLocator(m_chain.Tip()));
+            m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), GetLocator(m_last_flushed_block));
         }
 
         if (!m_chainman.m_interrupt && ShouldCompactChainstate(m_chainman.IsInitialBlockDownload())) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -840,6 +840,9 @@ public:
 
     std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    //! Get the last block that was flushed to disk.
+    const CBlockIndex* GetLastFlushedBlock() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) { return m_last_flushed_block; }
+
     //! Indirection necessary to make lock annotations work with an optional mempool.
     RecursiveMutex* MempoolMutex() const LOCK_RETURNED(m_mempool->cs)
     {
@@ -890,6 +893,7 @@ protected:
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     NodeClock::time_point m_next_write{NodeClock::time_point::max()};
+    const CBlockIndex* m_last_flushed_block GUARDED_BY(::cs_main){nullptr};
 
     /**
      * In case of an invalid snapshot, rename the coins leveldb directory so


### PR DESCRIPTION
If indexes commit their data ahead of the flushed chainstate, and there is an unclean shutdown, the index will be corrupted. This is especially the case for the coinstatsindex, which has state (the muhash) which can't easily be rolled back without access to the blocks. This was only partly fixed in #33212 (for reorg scenarios) but could still happen during initial sync.

Fix this more thoroughly by having the node keep track of the last flushed block, and skipping index commits if the current block of the index is not an ancestor of the node's last flushed block (similar to the suggestion by stickies-v in https://github.com/bitcoin/bitcoin/pull/33212#pullrequestreview-31408570890. 

Fixes #33208
Fixes #34261