### PR TITLE
contrib: Add zsh completion scripts

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -45,7 +45,7 @@ Command Line Tools
 ---------------------
 
 ### [Completions](/contrib/completions) ###
-Shell completions for bash and fish.
+Shell completions for bash, zsh and fish.
 
 UTXO Set Tools
 --------------

--- a/contrib/completions/zsh/_bitcoin-cli
+++ b/contrib/completions/zsh/_bitcoin-cli
@@ -1,0 +1,141 @@
+#compdef bitcoin-cli
+
+# zsh completion for bitcoin-cli(1)
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# call bitcoin-cli for RPC, forwarding relevant connection args
+_bitcoin_rpc() {
+    local rpcargs=()
+    local i
+    for i in $words; do
+        case "$i" in
+            -conf=*|-datadir=*|-regtest|-rpc*|-testnet|-testnet4)
+                rpcargs+=("$i")
+                ;;
+        esac
+    done
+    $bitcoin_cli "${rpcargs[@]}" "$@"
+}
+
+_bitcoin-cli() {
+    local cur="$words[CURRENT]"
+    local bitcoin_cli="$words[1]"
+
+    # Context-sensitive completions based on argument position.
+    # bash uses 0-indexed cword/words; zsh uses 1-indexed CURRENT/words.
+    # bash words[cword-N] becomes zsh words[CURRENT-N] (offsets cancel out),
+    # and bash (cword > N) becomes zsh (CURRENT > N+1).
+
+    if (( CURRENT > 6 )); then
+        case ${words[CURRENT-5]} in
+            sendtoaddress)
+                compadd -- true false
+                return 0
+                ;;
+        esac
+    fi
+
+    if (( CURRENT > 5 )); then
+        case ${words[CURRENT-4]} in
+            listtransactions|setban)
+                compadd -- true false
+                return 0
+                ;;
+            signrawtransactionwithkey|signrawtransactionwithwallet)
+                compadd -- ALL NONE SINGLE 'ALL|ANYONECANPAY' 'NONE|ANYONECANPAY' 'SINGLE|ANYONECANPAY'
+                return 0
+                ;;
+        esac
+    fi
+
+    if (( CURRENT > 4 )); then
+        case ${words[CURRENT-3]} in
+            getbalance|gettxout|listreceivedbyaddress|listsinceblock)
+                compadd -- true false
+                return 0
+                ;;
+        esac
+    fi
+
+    if (( CURRENT > 3 )); then
+        case ${words[CURRENT-2]} in
+            addnode)
+                compadd -- add remove onetry
+                return 0
+                ;;
+            setban)
+                compadd -- add remove
+                return 0
+                ;;
+            fundrawtransaction|getblock|getblockheader|getmempoolancestors|getmempooldescendants|getrawtransaction|gettransaction|listreceivedbyaddress|sendrawtransaction)
+                compadd -- true false
+                return 0
+                ;;
+        esac
+    fi
+
+    case "$words[CURRENT-1]" in
+        backupwallet)
+            _files
+            return 0
+            ;;
+        getaddednodeinfo|getrawmempool|lockunspent)
+            compadd -- true false
+            return 0
+            ;;
+        getbalance|getnewaddress|listtransactions|sendmany)
+            return 0
+            ;;
+    esac
+
+    case "$cur" in
+        -conf=*)
+            compset -P '*='
+            _files
+            return 0
+            ;;
+        -datadir=*)
+            compset -P '*='
+            _files -/
+            return 0
+            ;;
+        -*=*)
+            # prevent nonsense completions
+            return 0
+            ;;
+        *)
+            local -a opts
+
+            # only parse -help if sensible
+            if [[ -z "$cur" || "$cur" == -* ]]; then
+                local helpopts
+                helpopts=$($bitcoin_cli -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }')
+                opts+=(${(f)helpopts})
+            fi
+
+            # only parse help if sensible
+            if [[ -z "$cur" || "$cur" == [a-z]* ]]; then
+                local commands
+                commands=$(_bitcoin_rpc help 2>/dev/null | awk '$1 ~ /^[a-z]/ { print $1 }')
+                opts+=(${(f)commands})
+            fi
+
+            # suppress trailing space for options that expect a value
+            compadd -S '' -- ${(M)opts:#*=}
+            compadd -- ${opts:#*=}
+            return 0
+            ;;
+    esac
+}
+
+_bitcoin-cli "$@"
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=zsh

--- a/contrib/completions/zsh/_bitcoin-tx
+++ b/contrib/completions/zsh/_bitcoin-tx
@@ -1,0 +1,67 @@
+#compdef bitcoin-tx
+
+# zsh completion for bitcoin-tx(1)
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+_bitcoin-tx() {
+    local cur="$words[CURRENT]"
+    local bitcoin_tx="$words[1]"
+
+    case "$cur" in
+        load=*:*)
+            compset -P 'load=*:'
+            _files
+            return 0
+            ;;
+        *=*)
+            # prevent attempts to complete other arguments
+            return 0
+            ;;
+    esac
+
+    # nothing to complete after terminal flags
+    if [[ "$words[CURRENT-1]" == "-help" || "$words[CURRENT-1]" == "-help-debug" || "$words[CURRENT-1]" == "-version" ]]; then
+        return 0
+    fi
+
+    # check if -create was given in any previous argument
+    local has_create=false
+    local w
+    for w in "${(@)words[2,CURRENT-1]}"; do
+        [[ "$w" == "-create" ]] && has_create=true
+    done
+
+    # parse options from -help
+    local helpopts
+    helpopts=$($bitcoin_tx -help | awk '/^  -/ { sub(/=.*/, "="); print $1 }')
+    local -a opts
+    opts=(${(f)helpopts})
+
+    if $has_create; then
+        # -create enables transaction building, show both options and commands
+        local helpcmds
+        helpcmds=$($bitcoin_tx -help | awk '/^Commands:/{found=1; next} found && /^  [a-z]/ { sub(/=.*/, "="); print $1 }')
+        local -a cmds
+        cmds=(${(f)helpcmds})
+        compadd -S '' -- ${(M)opts:#*=} ${(M)cmds:#*=}
+        compadd -- ${opts:#*=} ${cmds:#*=}
+    elif (( CURRENT == 2 )); then
+        # first argument: show options only
+        compadd -S '' -- ${(M)opts:#*=}
+        compadd -- ${opts:#*=}
+    fi
+
+    return 0
+}
+
+_bitcoin-tx "$@"
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=zsh

--- a/contrib/completions/zsh/_bitcoin-util
+++ b/contrib/completions/zsh/_bitcoin-util
@@ -1,0 +1,45 @@
+#compdef bitcoin-util
+
+# zsh completion for bitcoin-util(1)
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+_bitcoin-util() {
+    local cur="$words[CURRENT]"
+    local bitcoin_util="$words[1]"
+
+    case "$cur" in
+        -*=*)
+            return 0
+            ;;
+    esac
+
+    if (( CURRENT == 2 )) || [[ "$words[CURRENT-1]" == -* && "$words[CURRENT-1]" != "-help" && "$words[CURRENT-1]" != "-help-debug" ]]; then
+        # options and commands
+        local helpopts
+        helpopts=$($bitcoin_util -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }')
+        local -a opts
+        opts=(${(f)helpopts})
+        compadd -S '' -- ${(M)opts:#*=}
+        compadd -- ${opts:#*=}
+
+        local helpcmds
+        helpcmds=$($bitcoin_util -help | awk '/^Commands:/{found=1; next} found && /^  [a-z]/ { print $1 }')
+        local -a cmds
+        cmds=(${(f)helpcmds})
+        compadd -- "${cmds[@]}"
+    fi
+
+    return 0
+}
+
+_bitcoin-util "$@"
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=zsh

--- a/contrib/completions/zsh/_bitcoin-wallet
+++ b/contrib/completions/zsh/_bitcoin-wallet
@@ -1,0 +1,56 @@
+#compdef bitcoin-wallet
+
+# zsh completion for bitcoin-wallet(1)
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+_bitcoin-wallet() {
+    local cur="$words[CURRENT]"
+    local bitcoin_wallet="$words[1]"
+
+    case "$cur" in
+        -dumpfile=*|-wallet=*)
+            compset -P '*='
+            _files
+            return 0
+            ;;
+        -datadir=*)
+            compset -P '*='
+            _files -/
+            return 0
+            ;;
+        -*=*)
+            return 0
+            ;;
+    esac
+
+    if (( CURRENT == 2 )) || [[ "$words[CURRENT-1]" == -* && "$words[CURRENT-1]" != "-help" && "$words[CURRENT-1]" != "-help-debug" ]]; then
+        # options and commands
+        local helpopts
+        helpopts=$($bitcoin_wallet -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }')
+        local -a opts
+        opts=(${(f)helpopts})
+        compadd -S '' -- ${(M)opts:#*=}
+        compadd -- ${opts:#*=}
+
+        # also show commands when no subcommand given yet
+        local helpcmds
+        helpcmds=$($bitcoin_wallet -help | awk '/^Commands:/{found=1; next} found && /^  [a-z]/ { print $1 }')
+        local -a cmds
+        cmds=(${(f)helpcmds})
+        compadd -- "${cmds[@]}"
+    fi
+
+    return 0
+}
+
+_bitcoin-wallet "$@"
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=zsh

--- a/contrib/completions/zsh/_bitcoind
+++ b/contrib/completions/zsh/_bitcoind
@@ -1,0 +1,51 @@
+#compdef bitcoind bitcoin-qt
+
+# zsh completion for bitcoind(1) and bitcoin-qt(1)
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+_bitcoind() {
+    local cur="$words[CURRENT]"
+    local bitcoind="$words[1]"
+
+    case "$cur" in
+        -conf=*|-pid=*|-loadblock=*|-rpccookiefile=*|-wallet=*)
+            compset -P '*='
+            _files
+            return 0
+            ;;
+        -datadir=*)
+            compset -P '*='
+            _files -/
+            return 0
+            ;;
+        -*=*)
+            # prevent nonsense completions
+            return 0
+            ;;
+        *)
+            # only parse -help if sensible
+            if [[ -z "$cur" || "$cur" == -* ]]; then
+                local helpopts
+                helpopts=$($bitcoind -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }')
+                local -a opts
+                opts=(${(f)helpopts})
+                # suppress trailing space for options that expect a value
+                compadd -S '' -- ${(M)opts:#*=}
+                compadd -- ${opts:#*=}
+            fi
+            return 0
+            ;;
+    esac
+}
+
+_bitcoind "$@"
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=zsh


### PR DESCRIPTION
Add zsh completion scripts for `bitcoind`, `bitcoin-cli`, and `bitcoin-tx` using zsh's native `compdef` system.

Bash and fish completions already exist, but zsh has no equivalent. Since zsh is the default shell on macOS and widely used on Linux, this fills the gap.

Closes #33404. Continues the work started in #33402.

The scripts are under `contrib/completions/zsh/` and match the existing bash completions in functionality:

- `_bitcoind` - option completion with file/directory path handling
- `_bitcoin-cli` - RPC command and option completion with context-sensitive arguments (booleans, sighash types, subcommands)
- `_bitcoin-tx` - option and command completion with file path handling

All completions dynamically parse `-help` output rather than hardcoding option lists.

### How to test

Copy the scripts to a directory in your zsh `fpath` and start a new shell:

    mkdir -p ~/.zsh/completions
    cp contrib/completions/zsh/_bitcoin* ~/.zsh/completions/
    # add to .zshrc: fpath=(~/.zsh/completions $fpath) && autoload -Uz compinit && compinit

Then verify tab completion works:

    bitcoind -<TAB>                        # shows options from -help
    bitcoind -datadir=<TAB>                # completes directories
    bitcoin-cli <TAB>                      # shows options and RPC commands
    bitcoin-cli getblock <hash> <TAB>      # suggests true/false
    bitcoin-tx -create <TAB>               # shows transaction commands
