### PR TITLE
wallet, refactor: rename file from migrate to legacybdb

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -14,8 +14,8 @@ add_library(bitcoin_wallet STATIC EXCLUDE_FROM_ALL
   feebumper.cpp
   fees.cpp
   interfaces.cpp
+  legacybdb.cpp
   load.cpp
-  migrate.cpp
   receive.cpp
   rpc/addresses.cpp
   rpc/backup.cpp

--- a/src/wallet/legacybdb.cpp
+++ b/src/wallet/legacybdb.cpp
@@ -7,7 +7,7 @@
 #include <streams.h>
 #include <util/log.h>
 #include <util/translation.h>
-#include <wallet/migrate.h>
+#include <wallet/legacybdb.h>
 
 #include <array>
 #include <cstddef>

--- a/src/wallet/legacybdb.h
+++ b/src/wallet/legacybdb.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WALLET_MIGRATE_H
-#define BITCOIN_WALLET_MIGRATE_H
+#ifndef BITCOIN_WALLET_LEGACYBDB_H
+#define BITCOIN_WALLET_LEGACYBDB_H
 
 #include <wallet/db.h>
 
@@ -107,4 +107,4 @@ public:
 std::unique_ptr<BerkeleyRODatabase> MakeBerkeleyRODatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
 } // namespace wallet
 
-#endif // BITCOIN_WALLET_MIGRATE_H
+#endif // BITCOIN_WALLET_LEGACYBDB_H

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -9,8 +9,8 @@
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/translation.h>
+#include <wallet/legacybdb.h>
 #include <wallet/sqlite.h>
-#include <wallet/migrate.h>
 #include <wallet/test/util.h>
 #include <wallet/walletutil.h>
 

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -11,7 +11,7 @@
 #include <util/translation.h>
 #include <wallet/db.h>
 #include <wallet/dump.h>
-#include <wallet/migrate.h>
+#include <wallet/legacybdb.h>
 
 #include <fstream>
 #include <iostream>

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -19,7 +19,7 @@
 #include <util/fs.h>
 #include <util/time.h>
 #include <util/translation.h>
-#include <wallet/migrate.h>
+#include <wallet/legacybdb.h>
 #include <wallet/sqlite.h>
 #include <wallet/wallet.h>
 


### PR DESCRIPTION
The wallet/migrate.h|cpp file contain all the code related to the
Berkeley DB that was used in the legacy wallets. Although it's true
that this code is used only within the context of wallet migration
but the name of the file is not exact.

This patch renames the file to legacybdb so that the intent is clearer in the
call sites. I felt this rename might be necessary so that the name
doesn't conflict with the upcoming wallet/migration.h|cpp files in #34909.
