### PR TITLE
wallet: Check only our inputs for multisig wallets

### DIFF
--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -87,9 +87,20 @@ std::optional<PSBTError> ExternalSignerScriptPubKeyMan::FillPSBT(PartiallySigned
 
     // Already complete if every input is now signed
     bool complete = true;
-    for (const auto& input : psbt.inputs) {
-        // TODO: for multisig wallets, we should only care if all _our_ inputs are signed
-        complete &= PSBTInputSigned(input);
+    size_t i = 0;
+    for (const auto& input : psbt.inputs){
+        const CScript* scriptPubKey = nullptr;
+        if (input.non_witness_utxo){
+            scriptPubKey = &input.non_witness_utxo->vout[psbt.tx->vin[i].prevout.n].scriptPubKey;
+        } else if (!input.witness_utxo.IsNull()){
+            scriptPubKey = &input.witness_utxo.scriptPubKey;
+        }
+        // Can early exit if we find one IsMine input not signed
+        if (scriptPubKey && DescriptorScriptPubKeyMan::IsMine(*scriptPubKey) && !PSBTInputSigned(input)) {
+            complete = false;
+            break;
+        }
+        ++i;
     }
     if (complete) return {};
 


### PR DESCRIPTION
When we sign PSBTs via external signers, rigth now we considere it is complete if all the inputs are signed. For multisig wallets, we should only care if the inputs owned by the wallet are signed.

This PR updates the behaviour so it only check those inputs owned by the wallet. The concrete process is:

1. Iterate through the PSBT inputs and identify the ones owned by the wallet with `DescriptorScriptPubKeyMan::IsMine`
2. If all inputs owned by the wallet are signed we consider the process complet.

This pr resolves this [TODO](https://github.com/bitcoin/bitcoin/blob/400aa68b4aa8de52c1a8bf543dd195cd1b2b1f32/src/wallet/external_signer_scriptpubkeyman.cpp#L91).