### PR TITLE
contrib: replace deprecated --deep codesign flag, fix accidental --verify skip on ci

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -158,7 +158,7 @@ fi
 
 if [[ "$CI_OS_NAME" == "macos" && "${GOAL}" = "install deploy" ]]; then
   unzip "${BASE_BUILD_DIR}/bitcoin-macos-app.zip" -d "${BASE_BUILD_DIR}/deploy"
-  if ! ( codesign --verify "${BASE_BUILD_DIR}/deploy/Bitcoin-Qt.app" ); then
+  if ! ( codesign --verify --strict "${BASE_BUILD_DIR}/deploy/Bitcoin-Qt.app" ); then
     echo "Codesigning failed."
     false
   fi

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -123,15 +123,16 @@ cmake -S "$BASE_ROOT_DIR" -B "$BASE_BUILD_DIR" "${CMAKE_ARGS[@]}" || (
   false
 )
 
+BUILD_TARGETS="${GOAL}"
 if [[ "${GOAL}" != all && "${GOAL}" != codegen ]]; then
-  GOAL="all ${GOAL}"
+  BUILD_TARGETS="all ${GOAL}"
 fi
 
 # shellcheck disable=SC2086
-cmake --build "${BASE_BUILD_DIR}" "$MAKEJOBS" --target $GOAL || (
+cmake --build "${BASE_BUILD_DIR}" "$MAKEJOBS" --target $BUILD_TARGETS || (
   echo "Build failure. Verbose build follows."
   # shellcheck disable=SC2086
-  cmake --build "${BASE_BUILD_DIR}" -j1 --target $GOAL --verbose
+  cmake --build "${BASE_BUILD_DIR}" -j1 --target $BUILD_TARGETS --verbose
   false
 )
 

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -183,7 +183,7 @@ fi
 
 if [[ "$CI_OS_NAME" == "macos" && "${GOAL}" = "install deploy" ]]; then
   unzip "${BASE_BUILD_DIR}/bitcoin-macos-app.zip" -d "${BASE_BUILD_DIR}/deploy"
-  if ! ( codesign --verify "${BASE_BUILD_DIR}/deploy/Bitcoin-Qt.app" ); then
+  if ! ( codesign --verify --deep --strict "${BASE_BUILD_DIR}/deploy/Bitcoin-Qt.app" ); then
     echo "Codesigning failed."
     false
   fi

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -123,15 +123,16 @@ cmake -S "$BASE_ROOT_DIR" -B "$BASE_BUILD_DIR" "${CMAKE_ARGS[@]}" || (
   false
 )
 
+BUILD_TARGETS="${GOAL}"
 if [[ "${GOAL}" != all && "${GOAL}" != *codegen* ]]; then
-  GOAL="all ${GOAL}"
+  BUILD_TARGETS="all ${GOAL}"
 fi
 
 # shellcheck disable=SC2086
-cmake --build "${BASE_BUILD_DIR}" "$MAKEJOBS" --target $GOAL || (
+cmake --build "${BASE_BUILD_DIR}" "$MAKEJOBS" --target $BUILD_TARGETS || (
   echo "Build failure. Verbose build follows."
   # shellcheck disable=SC2086
-  cmake --build "${BASE_BUILD_DIR}" -j1 --target $GOAL --verbose
+  cmake --build "${BASE_BUILD_DIR}" -j1 --target $BUILD_TARGETS --verbose
   false
 )
 

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -488,7 +488,19 @@ with open(os.path.join(applicationBundle.resourcesPath, "qt.conf"), "wb") as f:
 # ------------------------------------------------
 
 if platform.system() == "Darwin":
-    subprocess.check_call(f"codesign --deep --force --sign - {target}", shell=True)
+    # The earlier strip and install_name_tool calls invalidated existing framework
+    # and plugin code signatures.
+    print("+ Signing app bundle +")
+    sign_targets = [
+        path
+        for pattern in ("Frameworks/*", "PlugIns/*/*")
+        for path in Path(target, "Contents").glob(pattern)
+        if path.is_file() or path.name.endswith(".framework")
+    ]
+    # Sign the app bundle last
+    sign_targets.append(Path(target))
+    for sign_target in sign_targets:
+        subprocess.check_call(["codesign", "--force", "--sign", "-", sign_target.as_posix()])
 
 # ------------------------------------------------
 


### PR DESCRIPTION
Replace the deprecated `codesign --deep` with explicit, and minimal, per-component signing of Frameworks, Plugins and the top-level bundle.

The CI signature check introduced in #34787 is updated to use `--strict`.

Can be tested with:

```sh
cmake -B build -DBUILD_GUI=ON
# delete artifacts before rebuilding the `deploy` target
rm -rf build/Bitcoin-Qt.app build/bitcoin-macos-app.zip
cmake --build build -t deploy
codesign --verify --deep --strict --verbose=4 build/dist/Bitcoin-Qt.app
```

Fixes #32486, supersedes #33592 (this is a condensed version)

Additionally this PR modifies `03_test_script.sh` to avoid modifying `GOAL` in place. That was causing the `codesign --verify` step to get skipped entirely.