### PR TITLE
contrib: override system locale in gen-manpages.py

### DIFF
--- a/contrib/devtools/gen-manpages.py
+++ b/contrib/devtools/gen-manpages.py
@@ -50,8 +50,13 @@ mandir = os.getenv('MANDIR', os.path.join(topdir, 'doc/man'))
 versions = []
 for relpath in BINARIES:
     abspath = os.path.join(builddir, relpath)
+    # Prevent QT from emitting a localized version string for --version and --help
+    is_qt = relpath == "bin/bitcoin-qt"
     try:
-        r = subprocess.run([abspath, "--version"], stdout=subprocess.PIPE, check=True, text=True)
+        cmd_args = ["--version"]
+        if is_qt:
+            cmd_args.append("--lang=en")
+        r = subprocess.run([abspath, *cmd_args], stdout=subprocess.PIPE, check=True, text=True)
     except IOError:
         if(args.skip_missing_binaries):
             print(f'{abspath} not found or not an executable. Skipping...', file=sys.stderr)
@@ -69,13 +74,13 @@ for relpath in BINARIES:
     copyright = r.stdout.split('\n')[1:]
     assert copyright[0].startswith('Copyright (C)')
 
-    versions.append((abspath, verstr, copyright))
+    versions.append((abspath, verstr, copyright, is_qt))
 
 if not versions:
     print(f'No binaries found in {builddir}. Please ensure the binaries are present in {builddir}, or set another build path using the BUILDDIR env variable.')
     sys.exit(1)
 
-if any(verstr.endswith('-dirty') for (_, verstr, _) in versions):
+if any(verstr.endswith('-dirty') for (_, verstr, _, _) in versions):
     print("WARNING: Binaries were built from a dirty tree.")
     print('man pages generated from dirty binaries should NOT be committed.')
     print('To properly generate man pages, please commit your changes (or discard them), rebuild, then run this script again.')
@@ -93,7 +98,16 @@ with tempfile.NamedTemporaryFile('w', suffix='.h2m') as footer:
     footer.flush()
 
     # Call the binaries through help2man to produce a manual page for each of them.
-    for (abspath, verstr, _) in versions:
+    for (abspath, verstr, _, is_qt) in versions:
         outname = os.path.join(mandir, os.path.basename(abspath) + '.1')
+        help_option = '--help-option=--help' + (' --lang=en' if is_qt else '')
         print(f'Generating {outname}…')
-        subprocess.run([help2man, '-N', '--version-string=' + verstr, '--include=' + footer.name, '-o', outname, abspath], check=True)
+        subprocess.run([
+            help2man,
+            '-N',
+            '--version-string=' + verstr,
+            '--include=' + footer.name,
+            '-o', outname,
+            help_option,
+            abspath,
+        ], check=True)


### PR DESCRIPTION
`bitcoin-qt --help` emits a translation of "version", which creates a diff when updating or verifying man pages.

The script aborts earlier however, because `bitcoin-qt --version` also emits a localized output, which triggers the `Copyright (C)` assertion on a translated term like "Auteursrecht".

Fix this by passing `--lang=en` to both `bitcoin-qt` invocations.

None of the actual command options are translated, so this commit does not affect the actual manual page.

Noticed while verifying the manual updates in #34800 on macOS with Dutch system locale.

See also https://github.com/bitcoin/bitcoin/blob/master/test/lint/lint-locale-dependence.py notes about localization (though the issue here is translation).