### PR TITLE
fuzz: [refactor] Remove unused g_setup pointers

### DIFF
--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -38,18 +38,13 @@
 using kernel::CBlockFileInfo;
 using node::SnapshotMetadata;
 
-namespace {
-const BasicTestingSetup* g_setup;
-} // namespace
-
 void initialize_deserialize()
 {
     static const auto testing_setup = MakeNoLogFileContext<>();
-    g_setup = testing_setup.get();
 }
 
 #define FUZZ_TARGET_DESERIALIZE(name, code)                \
-    FUZZ_TARGET(name, .init = initialize_deserialize)         \
+    FUZZ_TARGET(name, .init = initialize_deserialize)      \
     {                                                      \
         try {                                              \
             code                                           \

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -27,12 +27,10 @@
 
 namespace {
 
-const TestingSetup* g_setup;
 std::deque<COutPoint> g_available_coins;
 void initialize_miner()
 {
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
-    g_setup = testing_setup.get();
     for (uint32_t i = 0; i < uint32_t{100}; ++i) {
         g_available_coins.emplace_back(Txid::FromUint256(uint256::ZERO), i);
     }

--- a/src/wallet/test/fuzz/crypter.cpp
+++ b/src/wallet/test/fuzz/crypter.cpp
@@ -11,11 +11,9 @@
 namespace wallet {
 namespace {
 
-const TestingSetup* g_setup;
 void initialize_crypter()
 {
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
-    g_setup = testing_setup.get();
 }
 
 FUZZ_TARGET(crypter, .init = initialize_crypter)


### PR DESCRIPTION
This is unused and avoids a clang warning.

Can be tested via: `git grep --count  '\<g_setup' | grep ':2'`

Before: Prints files names.
After: No output.
