### PR TITLE
test: script: boundary at exactly 65535 bytes must use OP_PUSHDATA2

### DIFF
--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1455,6 +1455,14 @@ BOOST_AUTO_TEST_CASE(script_IsPushOnly_on_invalid_scripts)
     BOOST_CHECK(!CScript(direct, direct+sizeof(direct)).IsPushOnly());
 }
 
+BOOST_AUTO_TEST_CASE(script_CheckMinimalPush_boundary)
+{
+    // Test the boundary at exactly 65535 bytes: must use OP_PUSHDATA2, not OP_PUSHDATA4.
+    std::vector<unsigned char> data(65535, '\x42');
+    BOOST_CHECK(CheckMinimalPush(data, OP_PUSHDATA2));
+    BOOST_CHECK(!CheckMinimalPush(data, OP_PUSHDATA4));
+}
+
 BOOST_AUTO_TEST_CASE(script_GetScriptAsm)
 {
     BOOST_CHECK_EQUAL("OP_CHECKLOCKTIMEVERIFY", ScriptToAsmStr(CScript() << OP_NOP2, true));


### PR DESCRIPTION
I noticed that the following mutant is not killed by any current test (can be tested with: `cmake --build build -j $(nproc) && ./build/bin/test_bitcoin && ./build/test/functional/test_runner.py -j $(nproc) -F`):

```diff
diff --git a/src/script/script.cpp b/src/script/script.cpp
index 3f764aaf21..5cff51d2cf 100644
--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -387,7 +387,7 @@ bool CheckMinimalPush(const std::vector<unsigned char>& data, opcodetype opcode)
     } else if (data.size() <= 255) {
         // Must have used OP_PUSHDATA.
         return opcode == OP_PUSHDATA1;
-    } else if (data.size() <= 65535) {
+    } else if (data.size() < 65535) {
         // Must have used OP_PUSHDATA2.
         return opcode == OP_PUSHDATA2;
     }
```

This PR addresses it by adding a new test case to ensure that the boundary at exactly 65535 bytes must use OP_PUSHDATA2 as well. 