### PR TITLE
test: Use BasicTestingSetup when sufficient

### DIFF
--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -21,16 +21,16 @@
 #include <vector>
 
 /**
- * Identical to TestingSetup but excludes lock contention logging if
+ * Identical to BasicTestingSetup but excludes lock contention logging if
  * `DEBUG_LOCKCONTENTION` is defined, as some of these tests are designed to be
  * heavily contested to trigger race conditions or other issues.
  */
-struct NoLockLoggingTestingSetup : public TestingSetup {
+struct NoLockLoggingTestingSetup : public BasicTestingSetup {
     NoLockLoggingTestingSetup()
 #ifdef DEBUG_LOCKCONTENTION
-        : TestingSetup{ChainType::MAIN, {.extra_args = { "-debugexclude=lock" } }} {}
+        : BasicTestingSetup{ChainType::MAIN, {.extra_args = { "-debugexclude=lock" } }} {}
 #else
-        : TestingSetup{ChainType::MAIN} {}
+        : BasicTestingSetup{ChainType::MAIN} {}
 #endif
 };
 

--- a/src/test/disconnected_transactions.cpp
+++ b/src/test/disconnected_transactions.cpp
@@ -7,10 +7,10 @@
 #include <kernel/disconnected_transactions.h>
 #include <test/util/setup_common.h>
 
-BOOST_FIXTURE_TEST_SUITE(disconnected_transactions, TestChain100Setup)
+BOOST_AUTO_TEST_SUITE(disconnected_transactions)
 
 //! Tests that DisconnectedBlockTransactions limits its own memory properly
-BOOST_AUTO_TEST_CASE(disconnectpool_memory_limits)
+BOOST_FIXTURE_TEST_CASE(disconnectpool_memory_limits, TestChain100Setup)
 {
     // Use the coinbase transactions from TestChain100Setup. It doesn't matter whether these
     // transactions would realistically be in a block together, they just need distinct txids and

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -14,9 +14,9 @@
 
 using interfaces::FoundBlock;
 
-BOOST_FIXTURE_TEST_SUITE(interfaces_tests, TestChain100Setup)
+BOOST_AUTO_TEST_SUITE(interfaces_tests)
 
-BOOST_AUTO_TEST_CASE(findBlock)
+BOOST_FIXTURE_TEST_CASE(findBlock, TestChain100Setup)
 {
     LOCK(Assert(m_node.chainman)->GetMutex());
     auto& chain = m_node.chain;
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(findBlock)
     BOOST_CHECK(!chain->findBlock({}, FoundBlock()));
 }
 
-BOOST_AUTO_TEST_CASE(findFirstBlockWithTimeAndHeight)
+BOOST_FIXTURE_TEST_CASE(findFirstBlockWithTimeAndHeight, TestChain100Setup)
 {
     LOCK(Assert(m_node.chainman)->GetMutex());
     auto& chain = m_node.chain;
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(findFirstBlockWithTimeAndHeight)
     BOOST_CHECK(!chain->findFirstBlockWithTimeAndHeight(/* min_time= */ active.Tip()->GetBlockTimeMax() + 1, /* min_height= */ 0));
 }
 
-BOOST_AUTO_TEST_CASE(findAncestorByHeight)
+BOOST_FIXTURE_TEST_CASE(findAncestorByHeight, TestChain100Setup)
 {
     LOCK(Assert(m_node.chainman)->GetMutex());
     auto& chain = m_node.chain;
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(findAncestorByHeight)
     BOOST_CHECK(!chain->findAncestorByHeight(active[10]->GetBlockHash(), 20));
 }
 
-BOOST_AUTO_TEST_CASE(findAncestorByHash)
+BOOST_FIXTURE_TEST_CASE(findAncestorByHash, TestChain100Setup)
 {
     LOCK(Assert(m_node.chainman)->GetMutex());
     auto& chain = m_node.chain;
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(findAncestorByHash)
     BOOST_CHECK(!chain->findAncestorByHash(active[10]->GetBlockHash(), active[20]->GetBlockHash()));
 }
 
-BOOST_AUTO_TEST_CASE(findCommonAncestor)
+BOOST_FIXTURE_TEST_CASE(findCommonAncestor, TestChain100Setup)
 {
     auto& chain = m_node.chain;
     const CChain& active{*WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return &Assert(m_node.chainman)->ActiveChain())};
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(findCommonAncestor)
     BOOST_CHECK_EQUAL(orig_hash, orig_tip->GetBlockHash());
 }
 
-BOOST_AUTO_TEST_CASE(hasBlocks)
+BOOST_FIXTURE_TEST_CASE(hasBlocks, TestChain100Setup)
 {
     LOCK(::cs_main);
     auto& chain = m_node.chain;

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(merkle_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(merkle_tests, BasicTestingSetup)
 
 static uint256 ComputeMerkleRootFromBranch(const uint256& leaf, const std::vector<uint256>& vMerkleBranch, uint32_t nIndex) {
     uint256 hash = leaf;

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(orphanage_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(orphanage_tests, BasicTestingSetup)
 
 static void MakeNewKeyWithFastRandomContext(CKey& key, FastRandomContext& rand_ctx)
 {

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -13,7 +13,7 @@
 #include <ranges>
 #include <vector>
 
-BOOST_FIXTURE_TEST_SUITE(prevector_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(prevector_tests, BasicTestingSetup)
 
 template <unsigned int N, typename T>
 class prevector_tester

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -14,7 +14,7 @@
 #include <optional>
 #include <vector>
 
-BOOST_FIXTURE_TEST_SUITE(rbf_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(rbf_tests, BasicTestingSetup)
 
 static inline CTransactionRef make_tx(const std::vector<CTransactionRef>& inputs,
                                       const std::vector<CAmount>& output_values)

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(txdownload_tests, TestingSetup)
+BOOST_AUTO_TEST_SUITE(txdownload_tests)
 
 struct Behaviors {
     bool m_txid_in_rejects;

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(validation_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(validation_tests, BasicTestingSetup)
 
 static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
 {


### PR DESCRIPTION
Improves run-times (4 warmups + 60 runs each):

| test | improvement |
|:---|---:|
| checkqueue_tests | 1.12 |
| merkle_tests | 1.14 |
| orphanage_tests | 1.48 |
| prevector_tests | 1.07 |
| rbf_tests | 1.01 |
| validation_tests | 1.60 |

---
Removed overhead is barely measurable on full test suite runtime sequential `test_bitcoin`or parallel `ctest --test-dir build`.

---
Initial version of PR also extracted a `DataDirTestingSetup` from `BasicTestingSetup`, making the latter not use the disk, but the added complexity didn't deliver sufficient speedups to clearly justify itself (at least not while running on NVMe).

---

Follow-up to https://github.com/bitcoin/bitcoin/pull/34562#discussion_r2918752158
Arguably in a similar vein as #22086.