### PR TITLE
depends: remove workaround for Make older than 4.2.90

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -6,22 +6,15 @@ LLD_VERSION=711
 
 OSX_SDK=$(SDK_PATH)/Xcode-$(XCODE_VERSION)-$(XCODE_BUILD_ID)-extracted-SDK-with-libcxx-headers
 
-# We can't just use $(shell command -v clang) because GNU Make handles builtins
-# in a special way and doesn't know that `command` is a POSIX-standard builtin
-# prior to 1af314465e5dfe3e8baa839a32a72e83c04f26ef, first released in v4.2.90.
-# At the time of writing, GNU Make v4.2.1 is still being used in supported
-# distro releases.
-#
-# Source: https://lists.gnu.org/archive/html/bug-make/2017-11/msg00017.html
-clang_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang")
-clangxx_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang++")
+clang_prog=$(shell command -v clang)
+clangxx_prog=$(shell command -v clang++)
 
-darwin_AR=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-ar")
-darwin_NM=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-nm")
-darwin_OBJCOPY=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-objcopy")
-darwin_OBJDUMP=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-objdump")
-darwin_RANLIB=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-ranlib")
-darwin_STRIP=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-strip")
+darwin_AR=$(shell command -v llvm-ar)
+darwin_NM=$(shell command -v llvm-nm)
+darwin_OBJCOPY=$(shell command -v llvm-objcopy)
+darwin_OBJDUMP=$(shell command -v llvm-objdump)
+darwin_RANLIB=$(shell command -v llvm-ranlib)
+darwin_STRIP=$(shell command -v llvm-strip)
 
 # Flag explanations:
 #

--- a/depends/hosts/freebsd.mk
+++ b/depends/hosts/freebsd.mk
@@ -1,22 +1,15 @@
 FREEBSD_VERSION ?= 15.0
 FREEBSD_SDK=$(SDK_PATH)/freebsd-$(host)-$(FREEBSD_VERSION)/
 
-# We can't just use $(shell command -v clang) because GNU Make handles builtins
-# in a special way and doesn't know that `command` is a POSIX-standard builtin
-# prior to 1af314465e5dfe3e8baa839a32a72e83c04f26ef, first released in v4.2.90.
-# At the time of writing, GNU Make v4.2.1 is still being used in supported
-# distro releases.
-#
-# Source: https://lists.gnu.org/archive/html/bug-make/2017-11/msg00017.html
-clang_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang")
-clangxx_prog=$(shell $(SHELL) $(.SHELLFLAGS) "command -v clang++")
+clang_prog=$(shell command -v clang)
+clangxx_prog=$(shell command -v clang++)
 
-freebsd_AR=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-ar")
-freebsd_NM=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-nm")
-freebsd_OBJCOPY=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-objcopy")
-freebsd_OBJDUMP=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-objdump")
-freebsd_RANLIB=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-ranlib")
-freebsd_STRIP=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-strip")
+freebsd_AR=$(shell command -v llvm-ar)
+freebsd_NM=$(shell command -v llvm-nm)
+freebsd_OBJCOPY=$(shell command -v llvm-objcopy)
+freebsd_OBJDUMP=$(shell command -v llvm-objdump)
+freebsd_RANLIB=$(shell command -v llvm-ranlib)
+freebsd_STRIP=$(shell command -v llvm-strip)
 
 
 freebsd_CC=$(clang_prog) --target=$(host) \

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -1,7 +1,7 @@
-ifneq ($(shell $(SHELL) $(.SHELLFLAGS) "command -v $(host)-gcc-posix"),)
+ifneq ($(shell command -v $(host)-gcc-posix),)
 mingw32_CC := $(host)-gcc-posix
 endif
-ifneq ($(shell $(SHELL) $(.SHELLFLAGS) "command -v $(host)-g++-posix"),)
+ifneq ($(shell command -v $(host)-g++-posix),)
 mingw32_CXX := $(host)-g++-posix
 endif
 


### PR DESCRIPTION
This was introduced for distros shipping older `make`, such as Ubuntu `20.04` (`4.2.1`). It's likely that any distros being used for Darwin and Windows cross compilation, are shipping a newer make at this point.