### PR TITLE
test: Replace DEBUG_LOG_OUT with -printtoconsole=1

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -20,8 +20,6 @@
 
 using namespace std::chrono_literals;
 
-const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
-
 /**
  * Retrieves the available test setup command line arguments that may be used
  * in the benchmark. They will be used only if the benchmark utilizes a

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -28,8 +28,6 @@
 
 #include <functional>
 
-const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
-
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};
 
 const std::function<std::string()> G_TEST_GET_FULL_NAME{};

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -195,7 +195,7 @@ function(add_boost_test source_file)
   list(REMOVE_ITEM test_suite_macro "mock_process")
   foreach(test_suite_name IN LISTS test_suite_macro)
     add_test(NAME ${test_suite_name}
-      COMMAND test_bitcoin --run_test=${test_suite_name} --catch_system_error=no --log_level=test_suite -- DEBUG_LOG_OUT
+      COMMAND test_bitcoin --run_test=${test_suite_name} --catch_system_error=no --log_level=test_suite -- -printtoconsole=1
     )
     set_property(TEST ${test_suite_name} PROPERTY
       SKIP_REGULAR_EXPRESSION

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -37,8 +37,6 @@
 __AFL_FUZZ_INIT();
 #endif
 
-const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
-
 /**
  * A copy of the command line arguments that start with `--`.
  * First `LLVMFuzzerInitialize()` is called, which saves the arguments to `g_args`.

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -14,18 +14,6 @@
 #include <functional>
 #include <iostream>
 
-/** Redirect debug log to unit_test.log files */
-const std::function<void(const std::string&)> G_TEST_LOG_FUN = [](const std::string& s) {
-    static const bool should_log{std::any_of(
-        &boost::unit_test::framework::master_test_suite().argv[1],
-        &boost::unit_test::framework::master_test_suite().argv[boost::unit_test::framework::master_test_suite().argc],
-        [](const char* arg) {
-            return std::string{"DEBUG_LOG_OUT"} == arg;
-        })};
-    if (!should_log) return;
-    std::cout << s;
-};
-
 /**
  * Retrieve the command line arguments from boost.
  * Allows usage like:

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -200,7 +200,6 @@ BasicTestingSetup::BasicTestingSetup(const ChainType chainType, TestOpts opts)
     gArgs.ForceSetArg("-datadir", fs::PathToString(m_path_root));
 
     SelectParams(chainType);
-    if (G_TEST_LOG_FUN) LogInstance().PushBackCallback(G_TEST_LOG_FUN);
     InitLogging(*m_node.args);
     AppInitParameterInteraction(*m_node.args);
     LogInstance().StartLogging();

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -35,9 +35,6 @@ class FastRandomContext;
 class uint160;
 class uint256;
 
-/** This is connected to the logger. Can be used to redirect logs to any other log */
-extern const std::function<void(const std::string&)> G_TEST_LOG_FUN;
-
 /** Retrieve the command line arguments. */
 extern const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS;
 


### PR DESCRIPTION
`-printtoconsole=1` has the same functionality but works in more cases than `DEBUG_LOG_OUT`, so remove the latter (`-printtoconsole` is already used when fuzzing). This means we can drop `G_TEST_LOG_FUN`.

---
Behavior can be verified through
```shell
ctest --test-dir build --debug
```
and checking for:
```
142: Test command: /home/hodlinator/bc/2/build/bin/test_bitcoin "--run_test=coinselector_tests" "--catch_system_error=no" "--log_level=test_suite" "--" "-printtoconsole=1"
...
142: 2026-03-26T13:40:02.169392Z [test] [../src/kernel/context.cpp:20] [operator()] Using the 'sse4(1way);sse41(4way);avx2(8way)' SHA256 implementation
```

---
Inspired by: https://github.com/bitcoin/bitcoin/pull/34918#discussion_r2994780532