### PR TITLE
Versionbits extensions for BIP-110

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -68,8 +68,8 @@ void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& opti
 
     for (const std::string& strDeployment : args.GetArgs("-vbparams")) {
         std::vector<std::string> vDeploymentParams = SplitString(strDeployment, ':');
-        if (vDeploymentParams.size() < 3 || 6 < vDeploymentParams.size()) {
-            throw std::runtime_error("Version bits parameters malformed, expecting deployment:start:end[:min_activation_height[:max_activation_height[:active_duration]]]");
+        if (vDeploymentParams.size() < 3 || 7 < vDeploymentParams.size()) {
+            throw std::runtime_error("Version bits parameters malformed, expecting deployment:start:end[:min_activation_height[:max_activation_height[:active_duration[:threshold]]]]");
         }
         CChainParams::VersionBitsParameters vbparams{};
         const auto start_time{ToIntegral<int64_t>(vDeploymentParams[1])};
@@ -105,6 +105,13 @@ void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& opti
             }
             vbparams.active_duration = *active_duration;
         }
+        if (vDeploymentParams.size() >= 7) {
+            const auto threshold{ToIntegral<int>(vDeploymentParams[6])};
+            if (!threshold) {
+                throw std::runtime_error(strprintf("Invalid threshold (%s)", vDeploymentParams[6]));
+            }
+            vbparams.threshold = *threshold;
+        }
         // Validate that timeout and max_activation_height are mutually exclusive
         if (vbparams.timeout != Consensus::BIP9Deployment::NO_TIMEOUT && vbparams.max_activation_height < std::numeric_limits<int>::max()) {
             throw std::runtime_error(strprintf("Cannot specify both timeout (%ld) and max_activation_height (%d) for deployment %s. Use timeout for BIP9 or max_activation_height for mandatory activation deadline, not both.", vbparams.timeout, vbparams.max_activation_height, vDeploymentParams[0]));
@@ -114,8 +121,8 @@ void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& opti
             if (vDeploymentParams[0] == VersionBitsDeploymentInfo[j].name) {
                 options.version_bits_parameters[Consensus::DeploymentPos(j)] = vbparams;
                 found = true;
-                LogInfo("Setting version bits activation parameters for %s to start=%ld, timeout=%ld, min_activation_height=%d, max_activation_height=%d, active_duration=%d",
-                        vDeploymentParams[0], vbparams.start_time, vbparams.timeout, vbparams.min_activation_height, vbparams.max_activation_height, vbparams.active_duration);
+                LogInfo("Setting version bits activation parameters for %s to start=%ld, timeout=%ld, min_activation_height=%d, max_activation_height=%d, active_duration=%d, threshold=%d",
+                        vDeploymentParams[0], vbparams.start_time, vbparams.timeout, vbparams.min_activation_height, vbparams.max_activation_height, vbparams.active_duration, vbparams.threshold);
                 break;
             }
         }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -68,8 +68,8 @@ void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& opti
 
     for (const std::string& strDeployment : args.GetArgs("-vbparams")) {
         std::vector<std::string> vDeploymentParams = SplitString(strDeployment, ':');
-        if (vDeploymentParams.size() < 3 || 4 < vDeploymentParams.size()) {
-            throw std::runtime_error("Version bits parameters malformed, expecting deployment:start:end[:min_activation_height]");
+        if (vDeploymentParams.size() < 3 || 6 < vDeploymentParams.size()) {
+            throw std::runtime_error("Version bits parameters malformed, expecting deployment:start:end[:min_activation_height[:max_activation_height[:active_duration]]]");
         }
         CChainParams::VersionBitsParameters vbparams{};
         const auto start_time{ToIntegral<int64_t>(vDeploymentParams[1])};
@@ -91,13 +91,31 @@ void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& opti
         } else {
             vbparams.min_activation_height = 0;
         }
+        if (vDeploymentParams.size() >= 5) {
+            const auto max_activation_height{ToIntegral<int>(vDeploymentParams[4])};
+            if (!max_activation_height) {
+                throw std::runtime_error(strprintf("Invalid max_activation_height (%s)", vDeploymentParams[4]));
+            }
+            vbparams.max_activation_height = *max_activation_height;
+        }
+        if (vDeploymentParams.size() >= 6) {
+            const auto active_duration{ToIntegral<int>(vDeploymentParams[5])};
+            if (!active_duration) {
+                throw std::runtime_error(strprintf("Invalid active_duration (%s)", vDeploymentParams[5]));
+            }
+            vbparams.active_duration = *active_duration;
+        }
+        // Validate that timeout and max_activation_height are mutually exclusive
+        if (vbparams.timeout != Consensus::BIP9Deployment::NO_TIMEOUT && vbparams.max_activation_height < std::numeric_limits<int>::max()) {
+            throw std::runtime_error(strprintf("Cannot specify both timeout (%ld) and max_activation_height (%d) for deployment %s. Use timeout for BIP9 or max_activation_height for mandatory activation deadline, not both.", vbparams.timeout, vbparams.max_activation_height, vDeploymentParams[0]));
+        }
         bool found = false;
         for (int j=0; j < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++j) {
             if (vDeploymentParams[0] == VersionBitsDeploymentInfo[j].name) {
                 options.version_bits_parameters[Consensus::DeploymentPos(j)] = vbparams;
                 found = true;
-                LogInfo("Setting version bits activation parameters for %s to start=%ld, timeout=%ld, min_activation_height=%d",
-                        vDeploymentParams[0], vbparams.start_time, vbparams.timeout, vbparams.min_activation_height);
+                LogInfo("Setting version bits activation parameters for %s to start=%ld, timeout=%ld, min_activation_height=%d, max_activation_height=%d, active_duration=%d",
+                        vDeploymentParams[0], vbparams.start_time, vbparams.timeout, vbparams.min_activation_height, vbparams.max_activation_height, vbparams.active_duration);
                 break;
             }
         }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -65,6 +65,9 @@ struct BIP9Deployment {
      * Examples: 1916 for 95%, 1512 for testchains.
      */
     uint32_t threshold{1916};
+    /** For temporary softforks: number of blocks the deployment remains active after activation.
+     *  std::numeric_limits<int>::max() means permanent (never expires). */
+    int active_duration{std::numeric_limits<int>::max()};
 
     /** Constant for nTimeout very far in the future. */
     static constexpr int64_t NO_TIMEOUT = std::numeric_limits<int64_t>::max();

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -57,6 +57,10 @@ struct BIP9Deployment {
      *  boundary.
      */
     int min_activation_height{0};
+    /** Maximum height for activation. If less than INT_MAX, the deployment will activate
+     *  at this height regardless of signaling (similar to BIP8 flag day).
+     *  std::numeric_limits<int>::max() means no maximum (activation only via signaling). */
+    int max_activation_height{std::numeric_limits<int>::max()};
     /** Period of blocks to check signalling in (usually retarget period, ie params.DifficultyAdjustmentInterval()) */
     uint32_t period{2016};
     /**

--- a/src/deploymentstatus.h
+++ b/src/deploymentstatus.h
@@ -49,4 +49,5 @@ inline bool DeploymentEnabled(const Consensus::Params& params, Consensus::Deploy
     return params.vDeployments[dep].nStartTime != Consensus::BIP9Deployment::NEVER_ACTIVE;
 }
 
+
 #endif // BITCOIN_DEPLOYMENTSTATUS_H

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -16,6 +16,7 @@
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <tinyformat.h>
 #include <uint256.h>
 #include <util/chaintype.h>
 #include <util/log.h>
@@ -29,6 +30,7 @@
 #include <iterator>
 #include <map>
 #include <span>
+#include <stdexcept>
 #include <utility>
 
 using namespace util::hex_literals;
@@ -596,6 +598,7 @@ public:
             if (version_bits_params.active_duration != std::numeric_limits<int>::max() && version_bits_params.active_duration % consensus.vDeployments[deployment_pos].period != 0) {
                 throw std::runtime_error(strprintf("active_duration (%d) must be a multiple of period (%d)", version_bits_params.active_duration, consensus.vDeployments[deployment_pos].period));
             }
+            consensus.vDeployments[deployment_pos].threshold = version_bits_params.threshold;
         }
 
         genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 50 * COIN);

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -590,6 +590,12 @@ public:
             consensus.vDeployments[deployment_pos].nStartTime = version_bits_params.start_time;
             consensus.vDeployments[deployment_pos].nTimeout = version_bits_params.timeout;
             consensus.vDeployments[deployment_pos].min_activation_height = version_bits_params.min_activation_height;
+            consensus.vDeployments[deployment_pos].max_activation_height = version_bits_params.max_activation_height;
+            consensus.vDeployments[deployment_pos].active_duration = version_bits_params.active_duration;
+            // Validated here rather than in src/chainparams.cpp because period is not yet available at parse time
+            if (version_bits_params.active_duration != std::numeric_limits<int>::max() && version_bits_params.active_duration % consensus.vDeployments[deployment_pos].period != 0) {
+                throw std::runtime_error(strprintf("active_duration (%d) must be a multiple of period (%d)", version_bits_params.active_duration, consensus.vDeployments[deployment_pos].period));
+            }
         }
 
         genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 50 * COIN);

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -145,6 +145,7 @@ public:
         int min_activation_height;
         int max_activation_height{std::numeric_limits<int>::max()};
         int active_duration{std::numeric_limits<int>::max()};
+        int threshold{108};  // regtest default: 75% of 144
     };
 
     /**

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -142,6 +143,8 @@ public:
         int64_t start_time;
         int64_t timeout;
         int min_activation_height;
+        int max_activation_height{std::numeric_limits<int>::max()};
+        int active_duration{std::numeric_limits<int>::max()};
     };
 
     /**

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1354,6 +1354,11 @@ static void SoftForkDescPushBack(const CBlockIndex* blockindex, UniValue& softfo
     if (info.active_since.has_value()) {
         rv.pushKV("height", *info.active_since);
         is_active = (*info.active_since <= blockindex->nHeight + 1);
+        // Add height_end for temporary softforks
+        const auto& deployment = chainman.GetConsensus().vDeployments[id];
+        if (deployment.active_duration < std::numeric_limits<int>::max()) {
+            rv.pushKV("height_end", *info.active_since + deployment.active_duration - 1);
+        }
     }
     rv.pushKV("active", is_active);
     rv.pushKV("bip9", bip9);
@@ -1471,7 +1476,8 @@ RPCHelpMan getblockchaininfo()
 namespace {
 const std::vector<RPCResult> RPCHelpForDeployment{
     {RPCResult::Type::STR, "type", "one of \"buried\", \"bip9\""},
-    {RPCResult::Type::NUM, "height", /*optional=*/true, "height of the first block which the rules are or will be enforced (only for \"buried\" type, or \"bip9\" type with \"active\" status)"},
+    {RPCResult::Type::NUM, "height", /*optional=*/true, "height of the first block which enforces the rules (only for \"buried\" type, or \"bip9\" type with \"active\" status)"},
+    {RPCResult::Type::NUM, "height_end", /*optional=*/true, "height of the last block which enforces the rules (only for \"bip9\" type with \"active\" status and temporary deployments)"},
     {RPCResult::Type::BOOL, "active", "true if the rules are enforced for the mempool and the next block"},
     {RPCResult::Type::OBJ, "bip9", /*optional=*/true, "status of bip9 softforks (only for \"bip9\" type)",
     {
@@ -1479,7 +1485,7 @@ const std::vector<RPCResult> RPCHelpForDeployment{
         {RPCResult::Type::NUM_TIME, "start_time", "the minimum median time past of a block at which the bit gains its meaning"},
         {RPCResult::Type::NUM_TIME, "timeout", "the median time past of a block at which the deployment is considered failed if not yet locked in"},
         {RPCResult::Type::NUM, "min_activation_height", "minimum height of blocks for which the rules may be enforced"},
-        {RPCResult::Type::STR, "status", "status of deployment at specified block (one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\")"},
+        {RPCResult::Type::STR, "status", "status of deployment at specified block (one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\", \"expired\")"},
         {RPCResult::Type::NUM, "since", "height of the first block to which the status applies"},
         {RPCResult::Type::STR, "status_next", "status of deployment at the next block"},
         {RPCResult::Type::OBJ, "statistics", /*optional=*/true, "numeric statistics about signalling for a softfork (only for \"started\" and \"locked_in\" status)",

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1322,6 +1322,9 @@ static void SoftForkDescPushBack(const CBlockIndex* blockindex, UniValue& softfo
     bip9.pushKV("start_time", depparams.nStartTime);
     bip9.pushKV("timeout", depparams.nTimeout);
     bip9.pushKV("min_activation_height", depparams.min_activation_height);
+    if (depparams.max_activation_height < std::numeric_limits<int>::max()) {
+        bip9.pushKV("max_activation_height", depparams.max_activation_height);
+    }
 
     // BIP9 status
     bip9.pushKV("status", info.current_state);
@@ -1485,6 +1488,7 @@ const std::vector<RPCResult> RPCHelpForDeployment{
         {RPCResult::Type::NUM_TIME, "start_time", "the minimum median time past of a block at which the bit gains its meaning"},
         {RPCResult::Type::NUM_TIME, "timeout", "the median time past of a block at which the deployment is considered failed if not yet locked in"},
         {RPCResult::Type::NUM, "min_activation_height", "minimum height of blocks for which the rules may be enforced"},
+        {RPCResult::Type::NUM, "max_activation_height", /*optional=*/true, "height at which the deployment will unconditionally activate (absent for miner-vetoable deployments)"},
         {RPCResult::Type::STR, "status", "status of deployment at specified block (one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\", \"expired\")"},
         {RPCResult::Type::NUM, "since", "height of the first block to which the status applies"},
         {RPCResult::Type::STR, "status_next", "status of deployment at the next block"},

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -993,7 +993,7 @@ static RPCHelpMan getblocktemplate()
     result.pushKV("version", block.nVersion);
     result.pushKV("rules", std::move(aRules));
     result.pushKV("vbavailable", std::move(vbavailable));
-    result.pushKV("vbrequired", 0);
+    result.pushKV("vbrequired", gbtstatus.vbrequired);
 
     result.pushKV("previousblockhash", block.hashPrevBlock.GetHex());
     result.pushKV("transactions", std::move(transactions));

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -33,6 +33,7 @@ public:
         assert(dep.threshold <= dep.period);
         assert(0 <= dep.bit && dep.bit < 32 && dep.bit < VERSIONBITS_NUM_BITS);
         assert(0 <= dep.min_activation_height);
+        assert(dep.active_duration > 0);
     }
 
     ThresholdState GetStateFor(const CBlockIndex* pindexPrev) const { return AbstractThresholdConditionChecker::GetStateFor(pindexPrev, m_cache); }
@@ -148,6 +149,7 @@ FUZZ_TARGET(versionbits, .init = initialize)
             if (fuzzed_data_provider.ConsumeBool()) dep.nTimeout += interval / 2;
         }
         dep.min_activation_height = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, period * max_periods);
+        dep.active_duration = fuzzed_data_provider.ConsumeBool() ? std::numeric_limits<int>::max() : (fuzzed_data_provider.ConsumeIntegralInRange<int>(1, max_periods) * period);
         return dep;
     }()};
     TestConditionChecker checker(dep);
@@ -315,13 +317,21 @@ FUZZ_TARGET(versionbits, .init = initialize)
                 assert(exp_state == ThresholdState::FAILED);
             }
             return;
+        case ThresholdState::EXPIRED:
+            assert(!always_active_test);
+            assert(dep.active_duration < std::numeric_limits<int>::max());
+            assert(dep.min_activation_height <= current_block->nHeight + 1);
+            assert(exp_state == ThresholdState::EXPIRED || exp_state == ThresholdState::ACTIVE);
+            if (exp_state == ThresholdState::ACTIVE) {
+                assert(since == exp_since + dep.active_duration);  // EXPIRED starts exactly active_duration blocks after ACTIVE started
+            }
+            return;
         } // no default case, so the compiler can warn about missing cases
-        assert(false);
     }();
 
     if (blocks.size() >= period * max_periods) {
         // we chose the timeout (and block times) so that by the time we have this many blocks it's all over
-        assert(state == ThresholdState::ACTIVE || state == ThresholdState::FAILED);
+        assert(state == ThresholdState::ACTIVE || state == ThresholdState::FAILED || state == ThresholdState::EXPIRED);
     }
 
     if (always_active_test) {

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -481,4 +481,657 @@ BOOST_FIXTURE_TEST_CASE(versionbits_computeblockversion, BlockVersionTest)
     }
 }
 
+/**
+ * Test condition checker with max_activation_height for mandatory activation deadline.
+ * When max_activation_height is set, the deployment forces LOCKED_IN one period before
+ * max_activation_height, even if threshold signaling was not met.
+ */
+class TestMaxActivationHeightConditionChecker : public AbstractThresholdConditionChecker
+{
+private:
+    mutable ThresholdConditionCache cache;
+    int m_max_activation_height;
+
+public:
+    explicit TestMaxActivationHeightConditionChecker(int max_height) : m_max_activation_height(max_height) {}
+
+    int64_t BeginTime() const override { return 0; }
+    int64_t EndTime() const override { return Consensus::BIP9Deployment::NO_TIMEOUT; }
+    int Period() const override { return 144; }
+    int Threshold() const override { return 108; }
+    int MaxActivationHeight() const override { return m_max_activation_height; }
+    bool Condition(const CBlockIndex* pindex) const override { return (pindex->nVersion & 0x100); }
+
+    ThresholdState GetStateFor(const CBlockIndex* pindexPrev) const { return AbstractThresholdConditionChecker::GetStateFor(pindexPrev, cache); }
+    int GetStateSinceHeightFor(const CBlockIndex* pindexPrev) const { return AbstractThresholdConditionChecker::GetStateSinceHeightFor(pindexPrev, cache); }
+    void ClearCache() { cache.clear(); }
+};
+
+BOOST_AUTO_TEST_CASE(versionbits_max_activation_height)
+{
+    // Test that max_activation_height forces LOCKED_IN one period before max_activation_height
+    // even without sufficient signaling.
+    //
+    // Timeline with period=144, max_activation_height=432:
+    // - Period 0 (0-143): DEFINED
+    // - Period 1 (144-287): STARTED (no signaling -> normally would stay STARTED)
+    // - Period 2 (288-431): LOCKED_IN (forced because 288 >= 432 - 144)
+    // - Period 3 (432+): ACTIVE
+
+    std::vector<CBlockIndex*> blocks;
+    auto cleanup = [&blocks]() {
+        for (auto* b : blocks) delete b;
+        blocks.clear();
+    };
+
+    // max_activation_height = 432 (period 3 start)
+    TestMaxActivationHeightConditionChecker checker(432);
+
+    // Helper to create blocks
+    auto mine_block = [&blocks](int32_t nVersion) -> CBlockIndex* {
+        CBlockIndex* pindex = new CBlockIndex();
+        pindex->nHeight = blocks.size();
+        pindex->pprev = blocks.empty() ? nullptr : blocks.back();
+        pindex->nTime = 1415926536 + 600 * pindex->nHeight;
+        pindex->nVersion = nVersion;
+        pindex->BuildSkip();
+        blocks.push_back(pindex);
+        return pindex;
+    };
+
+    // Mine through period 0 (DEFINED) - 144 blocks (0-143)
+    for (int i = 0; i < 144; i++) {
+        mine_block(0); // No signaling
+    }
+    BOOST_CHECK_EQUAL(blocks.back()->nHeight, 143);
+    // At tip 143, next block (144) would be STARTED
+    BOOST_CHECK(checker.GetStateFor(blocks.back()) == ThresholdState::STARTED);
+    BOOST_CHECK_EQUAL(checker.GetStateSinceHeightFor(blocks.back()), 144);
+
+    // Mine through period 1 (STARTED) without signaling - blocks 144-287
+    for (int i = 0; i < 144; i++) {
+        mine_block(0); // No signaling
+    }
+    BOOST_CHECK_EQUAL(blocks.back()->nHeight, 287);
+    // At tip 287, next block (288) would be LOCKED_IN due to max_activation_height
+    // 288 >= 432 - 144, so forced LOCKED_IN
+    BOOST_CHECK(checker.GetStateFor(blocks.back()) == ThresholdState::LOCKED_IN);
+    BOOST_CHECK_EQUAL(checker.GetStateSinceHeightFor(blocks.back()), 288);
+
+    // Mine through period 2 (LOCKED_IN) - blocks 288-431
+    for (int i = 0; i < 144; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK_EQUAL(blocks.back()->nHeight, 431);
+    // At tip 431, next block (432) would be ACTIVE
+    BOOST_CHECK(checker.GetStateFor(blocks.back()) == ThresholdState::ACTIVE);
+    BOOST_CHECK_EQUAL(checker.GetStateSinceHeightFor(blocks.back()), 432);
+
+    // Mine into period 3 (ACTIVE) - blocks 432+
+    for (int i = 0; i < 10; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK_EQUAL(blocks.back()->nHeight, 441);
+    BOOST_CHECK(checker.GetStateFor(blocks.back()) == ThresholdState::ACTIVE);
+    BOOST_CHECK_EQUAL(checker.GetStateSinceHeightFor(blocks.back()), 432);
+
+    cleanup();
+
+    // Test 2: Verify that signaling still works to activate earlier than max_activation_height
+    TestMaxActivationHeightConditionChecker checker2(1000); // max_activation_height far in future
+
+    // Period 0: DEFINED
+    for (int i = 0; i < 144; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK(checker2.GetStateFor(blocks.back()) == ThresholdState::STARTED);
+
+    // Period 1: Signal 108+ blocks (threshold)
+    for (int i = 0; i < 108; i++) {
+        mine_block(0x100); // Signal
+    }
+    for (int i = 0; i < 36; i++) {
+        mine_block(0); // No signal
+    }
+    BOOST_CHECK_EQUAL(blocks.back()->nHeight, 287);
+    // Should be LOCKED_IN via signaling, not via max_activation_height
+    BOOST_CHECK(checker2.GetStateFor(blocks.back()) == ThresholdState::LOCKED_IN);
+    BOOST_CHECK_EQUAL(checker2.GetStateSinceHeightFor(blocks.back()), 288);
+
+    // Period 2: LOCKED_IN -> ACTIVE
+    for (int i = 0; i < 144; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK(checker2.GetStateFor(blocks.back()) == ThresholdState::ACTIVE);
+    BOOST_CHECK_EQUAL(checker2.GetStateSinceHeightFor(blocks.back()), 432);
+
+    cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(versionbits_max_activation_height_boundary)
+{
+    // Test edge case: verify exact boundary where LOCKED_IN is forced
+    // With period=144 and max_activation_height=432:
+    // - At height 287, next block is 288, which is >= 432-144=288, so LOCKED_IN
+    // - At height 286, next block is 287, which is < 288, so would stay STARTED
+
+    std::vector<CBlockIndex*> blocks;
+    auto cleanup = [&blocks]() {
+        for (auto* b : blocks) delete b;
+        blocks.clear();
+    };
+
+    TestMaxActivationHeightConditionChecker checker(432);
+
+    auto mine_block = [&blocks](int32_t nVersion) -> CBlockIndex* {
+        CBlockIndex* pindex = new CBlockIndex();
+        pindex->nHeight = blocks.size();
+        pindex->pprev = blocks.empty() ? nullptr : blocks.back();
+        pindex->nTime = 1415926536 + 600 * pindex->nHeight;
+        pindex->nVersion = nVersion;
+        pindex->BuildSkip();
+        blocks.push_back(pindex);
+        return pindex;
+    };
+
+    // Mine to height 143 (end of period 0)
+    for (int i = 0; i < 144; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK_EQUAL(blocks.back()->nHeight, 143);
+    // State for block 144 is STARTED
+    BOOST_CHECK(checker.GetStateFor(blocks.back()) == ThresholdState::STARTED);
+
+    // Mine period 1 without signaling (blocks 144-287)
+    // But stop at block 286 first to check boundary
+    for (int i = 0; i < 143; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK_EQUAL(blocks.back()->nHeight, 286);
+    // At tip 286, next block 287 is still in STARTED period
+    // State is still STARTED
+    BOOST_CHECK(checker.GetStateFor(blocks.back()) == ThresholdState::STARTED);
+
+    // Mine block 287 (last block of period 1)
+    mine_block(0);
+    BOOST_CHECK_EQUAL(blocks.back()->nHeight, 287);
+    // At tip 287, state for next block (288) is computed
+    // 288 >= 432 - 144 = 288, so LOCKED_IN
+    BOOST_CHECK(checker.GetStateFor(blocks.back()) == ThresholdState::LOCKED_IN);
+    BOOST_CHECK_EQUAL(checker.GetStateSinceHeightFor(blocks.back()), 288);
+
+    cleanup();
+}
+
+BOOST_FIXTURE_TEST_CASE(versionbits_active_duration, BasicTestingSetup)
+{
+    // Test active_duration parameter via -vbparams
+    // Format: deployment:start:timeout:min_activation_height:max_activation_height:active_duration
+    //
+    // This tests that the parameter is parsed correctly. The actual expiry logic
+    // is tested in DeploymentActiveAt/DeploymentActiveAfter which use active_duration.
+
+    {
+        ArgsManager args;
+        // start=0, timeout=never, min_height=0, max_height=INT_MAX (disabled), active_duration=144
+        args.ForceSetArg("-vbparams", "testdummy:0:999999999999:0:2147483647:144");
+        const auto chainParams = CreateChainParams(args, ChainType::REGTEST);
+        const auto& deployment = chainParams->GetConsensus().vDeployments[Consensus::DEPLOYMENT_TESTDUMMY];
+
+        BOOST_CHECK_EQUAL(deployment.nStartTime, 0);
+        BOOST_CHECK_EQUAL(deployment.nTimeout, 999999999999);
+        BOOST_CHECK_EQUAL(deployment.min_activation_height, 0);
+        BOOST_CHECK_EQUAL(deployment.max_activation_height, std::numeric_limits<int>::max());
+        BOOST_CHECK_EQUAL(deployment.active_duration, 144);
+    }
+
+    {
+        ArgsManager args;
+        // Test with max_activation_height set
+        // start=0, timeout=NO_TIMEOUT, min_height=288, max_height=432, active_duration=1008 (144*7)
+        // NO_TIMEOUT = INT64_MAX = 9223372036854775807
+        args.ForceSetArg("-vbparams", "testdummy:0:9223372036854775807:288:432:1008");
+        const auto chainParams = CreateChainParams(args, ChainType::REGTEST);
+        const auto& deployment = chainParams->GetConsensus().vDeployments[Consensus::DEPLOYMENT_TESTDUMMY];
+
+        BOOST_CHECK_EQUAL(deployment.min_activation_height, 288);
+        BOOST_CHECK_EQUAL(deployment.max_activation_height, 432);
+        BOOST_CHECK_EQUAL(deployment.active_duration, 1008);
+    }
+
+    {
+        ArgsManager args;
+        // Test permanent deployment (active_duration = INT_MAX)
+        args.ForceSetArg("-vbparams", "testdummy:0:999999999999:0:2147483647:2147483647");
+        const auto chainParams = CreateChainParams(args, ChainType::REGTEST);
+        const auto& deployment = chainParams->GetConsensus().vDeployments[Consensus::DEPLOYMENT_TESTDUMMY];
+
+        BOOST_CHECK_EQUAL(deployment.active_duration, std::numeric_limits<int>::max());
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(versionbits_max_activation_height_parsing, BasicTestingSetup)
+{
+    // Test max_activation_height parameter via -vbparams
+
+    {
+        ArgsManager args;
+        // Test with max_activation_height=432 (mandatory activation deadline)
+        // NO_TIMEOUT = INT64_MAX = 9223372036854775807
+        args.ForceSetArg("-vbparams", "testdummy:0:9223372036854775807:0:432:2147483647");
+        const auto chainParams = CreateChainParams(args, ChainType::REGTEST);
+        const auto& deployment = chainParams->GetConsensus().vDeployments[Consensus::DEPLOYMENT_TESTDUMMY];
+
+        BOOST_CHECK_EQUAL(deployment.max_activation_height, 432);
+        // active_duration should be permanent when not specified differently
+        BOOST_CHECK_EQUAL(deployment.active_duration, std::numeric_limits<int>::max());
+    }
+
+    {
+        ArgsManager args;
+        // Test combined: max_activation_height + active_duration (RDTS)
+        // NO_TIMEOUT = INT64_MAX = 9223372036854775807
+        args.ForceSetArg("-vbparams", "testdummy:0:9223372036854775807:288:576:144");
+        const auto chainParams = CreateChainParams(args, ChainType::REGTEST);
+        const auto& deployment = chainParams->GetConsensus().vDeployments[Consensus::DEPLOYMENT_TESTDUMMY];
+
+        BOOST_CHECK_EQUAL(deployment.min_activation_height, 288);
+        BOOST_CHECK_EQUAL(deployment.max_activation_height, 576);
+        BOOST_CHECK_EQUAL(deployment.active_duration, 144);
+    }
+}
+
+/**
+ * Helper to create a BIP9Deployment for temporary deployment tests.
+ * Uses bit 8 and version mask 0x100 for signaling (same as Deployments::normal).
+ */
+static Consensus::BIP9Deployment MakeTemporaryDeployment(int active_duration, int max_activation_height = std::numeric_limits<int>::max())
+{
+    return Consensus::BIP9Deployment{
+        .bit = 8,
+        .nStartTime = 0,
+        .nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT,
+        .min_activation_height = 0,
+        .max_activation_height = max_activation_height,
+        .period = 144,
+        .threshold = 108,
+        .active_duration = active_duration,
+    };
+}
+
+BOOST_AUTO_TEST_CASE(versionbits_expired_state)
+{
+    // Test that a temporary deployment transitions from ACTIVE to EXPIRED
+    // after active_duration blocks past activation.
+    //
+    // Timeline with period=144, active_duration=288:
+    // - Period 0 (0-143): DEFINED
+    // - Period 1 (144-287): STARTED, signal enough to lock in
+    // - Period 2 (288-431): LOCKED_IN
+    // - Period 3 (432-575): ACTIVE (activation_height=432)
+    // - Period 4 (576-719): ACTIVE (blocks in this period are ACTIVE)
+    // - At pindexPrev=719: EXPIRED for block 720+ (720 >= 432 + 288)
+
+    std::vector<CBlockIndex*> blocks;
+    auto cleanup = [&blocks]() {
+        for (auto* b : blocks) delete b;
+        blocks.clear();
+    };
+
+    const auto dep = MakeTemporaryDeployment(288);
+    TestConditionChecker checker(dep);
+
+    auto mine_block = [&blocks](int32_t nVersion) -> CBlockIndex* {
+        CBlockIndex* pindex = new CBlockIndex();
+        pindex->nHeight = blocks.size();
+        pindex->pprev = blocks.empty() ? nullptr : blocks.back();
+        pindex->nTime = 1415926536 + 600 * pindex->nHeight;
+        pindex->nVersion = nVersion;
+        pindex->BuildSkip();
+        blocks.push_back(pindex);
+        return pindex;
+    };
+
+    // Period 0: DEFINED (blocks 0-143)
+    for (int i = 0; i < 144; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::STARTED);
+
+    // Period 1: STARTED, signal all blocks to lock in (blocks 144-287)
+    for (int i = 0; i < 144; i++) {
+        mine_block(VERSIONBITS_TOP_BITS | 0x100); // Signal
+    }
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::LOCKED_IN);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 288);
+
+    // Period 2: LOCKED_IN (blocks 288-431)
+    for (int i = 0; i < 144; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::ACTIVE);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 432);
+
+    // Period 3: ACTIVE (blocks 432-575), activation_height = 432
+    for (int i = 0; i < 144; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::ACTIVE);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 432);
+
+    // Period 4 (blocks 576-719): blocks in this period are ACTIVE,
+    // but at pindexPrev=719 the state for block 720+ is EXPIRED (720 >= 432 + 288)
+    for (int i = 0; i < 144; i++) {
+        mine_block(0);
+    }
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 720);
+
+    // Verify EXPIRED is terminal
+    for (int i = 0; i < 144; i++) {
+        mine_block(VERSIONBITS_TOP_BITS | 0x100); // Signal shouldn't matter
+    }
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 720);
+
+    cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(versionbits_expired_unaligned_duration_rejected)
+{
+    // Test that active_duration that is NOT a multiple of the period is rejected.
+    ArgsManager args;
+    args.ForceSetArg("-vbparams", "testdummy:0:9223372036854775807:0:432:200");
+    BOOST_CHECK_THROW(CreateChainParams(args, ChainType::REGTEST), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(versionbits_expired_minimum_duration)
+{
+    // Test active_duration = 1 period (144). Minimum useful duration.
+    // Activation at 432, so 432+144=576. At pindexPrev=575, state for 576+:
+    // 576 >= 576 -> EXPIRED. Only one period of ACTIVE.
+
+    std::vector<CBlockIndex*> blocks;
+    auto cleanup = [&blocks]() {
+        for (auto* b : blocks) delete b;
+        blocks.clear();
+    };
+
+    const auto dep = MakeTemporaryDeployment(144);
+    TestConditionChecker checker(dep);
+
+    auto mine_block = [&blocks](int32_t nVersion) -> CBlockIndex* {
+        CBlockIndex* pindex = new CBlockIndex();
+        pindex->nHeight = blocks.size();
+        pindex->pprev = blocks.empty() ? nullptr : blocks.back();
+        pindex->nTime = 1415926536 + 600 * pindex->nHeight;
+        pindex->nVersion = nVersion;
+        pindex->BuildSkip();
+        blocks.push_back(pindex);
+        return pindex;
+    };
+
+    // Period 0: DEFINED (0-143)
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::STARTED);
+
+    // Period 1: Signal (144-287)
+    for (int i = 0; i < 144; i++) mine_block(VERSIONBITS_TOP_BITS | 0x100);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::LOCKED_IN);
+
+    // Period 2: LOCKED_IN (288-431)
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::ACTIVE);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 432);
+
+    // Period 3 (432-575): ACTIVE for this period, but state for 576+:
+    // 576 >= 432 + 144 = 576 -> EXPIRED immediately at next boundary
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 576);
+
+    cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(versionbits_expired_cold_cache)
+{
+    // Test that clearing the cache and re-querying correctly recovers
+    // the EXPIRED state. This exercises the activation_height recovery
+    // path in GetStateFor where it calls GetStateSinceHeightFor to find
+    // when ACTIVE started.
+
+    std::vector<CBlockIndex*> blocks;
+    auto cleanup = [&blocks]() {
+        for (auto* b : blocks) delete b;
+        blocks.clear();
+    };
+
+    const auto dep = MakeTemporaryDeployment(288);
+    TestConditionChecker checker(dep);
+
+    auto mine_block = [&blocks](int32_t nVersion) -> CBlockIndex* {
+        CBlockIndex* pindex = new CBlockIndex();
+        pindex->nHeight = blocks.size();
+        pindex->pprev = blocks.empty() ? nullptr : blocks.back();
+        pindex->nTime = 1415926536 + 600 * pindex->nHeight;
+        pindex->nVersion = nVersion;
+        pindex->BuildSkip();
+        blocks.push_back(pindex);
+        return pindex;
+    };
+
+    // Build chain through to EXPIRED (same as basic test)
+    // Period 0: DEFINED (0-143)
+    for (int i = 0; i < 144; i++) mine_block(0);
+    // Period 1: Signal (144-287)
+    for (int i = 0; i < 144; i++) mine_block(VERSIONBITS_TOP_BITS | 0x100);
+    // Period 2: LOCKED_IN (288-431)
+    for (int i = 0; i < 144; i++) mine_block(0);
+    // Period 3: ACTIVE (432-575)
+    for (int i = 0; i < 144; i++) mine_block(0);
+    // Period 4: (576-719) -> EXPIRED at 720
+    for (int i = 0; i < 144; i++) mine_block(0);
+
+    // Verify EXPIRED with warm cache
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 720);
+
+    // Clear cache completely — simulates node restart
+    checker.clear();
+
+    // Re-query: must walk from genesis, recover activation_height, compute EXPIRED
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 720);
+
+    // Also verify intermediate states are correct after cache rebuild
+    checker.clear();
+    // Query at end of period 3 (pindexPrev=575) — should be ACTIVE
+    BOOST_CHECK(checker.StateFor(blocks[575]) == ThresholdState::ACTIVE);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks[575]), 432);
+
+    // Now query at end of period 4 with partially-populated cache
+    // (period 3 is cached as ACTIVE from the query above)
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 720);
+
+    cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(versionbits_expired_with_max_activation_height)
+{
+    // Test interaction: deployment with BOTH max_activation_height AND active_duration.
+    // max_activation_height forces LOCKED_IN, then active_duration causes EXPIRED.
+    //
+    // period=144, max_activation_height=432, active_duration=288
+    // - Period 0 (0-143): DEFINED
+    // - Period 1 (144-287): STARTED (no signaling, but forced LOCKED_IN at boundary
+    //   because 288 >= 432 - 144)
+    // - Period 2 (288-431): LOCKED_IN
+    // - Period 3 (432-575): ACTIVE (activation_height=432)
+    // - Period 4 (576-719): ACTIVE
+    // - At pindexPrev=719: EXPIRED (720 >= 432 + 288)
+
+    std::vector<CBlockIndex*> blocks;
+    auto cleanup = [&blocks]() {
+        for (auto* b : blocks) delete b;
+        blocks.clear();
+    };
+
+    const auto dep = MakeTemporaryDeployment(288, /*max_activation_height=*/432);
+    TestConditionChecker checker(dep);
+
+    auto mine_block = [&blocks](int32_t nVersion) -> CBlockIndex* {
+        CBlockIndex* pindex = new CBlockIndex();
+        pindex->nHeight = blocks.size();
+        pindex->pprev = blocks.empty() ? nullptr : blocks.back();
+        pindex->nTime = 1415926536 + 600 * pindex->nHeight;
+        pindex->nVersion = nVersion;
+        pindex->BuildSkip();
+        blocks.push_back(pindex);
+        return pindex;
+    };
+
+    // Period 0: DEFINED (0-143), no signaling
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::STARTED);
+
+    // Period 1: STARTED (144-287), no signaling — forced LOCKED_IN by max_activation_height
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::LOCKED_IN);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 288);
+
+    // Period 2: LOCKED_IN (288-431)
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::ACTIVE);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 432);
+
+    // Period 3: ACTIVE (432-575)
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::ACTIVE);
+
+    // Period 4: (576-719) -> EXPIRED at 720
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 720);
+
+    cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(versionbits_expired_zero_duration)
+{
+    // Test active_duration = 0. This means the deployment expires immediately
+    // after activation — zero blocks of enforcement.
+    // Activation at 432, so 432 + 0 = 432. At pindexPrev=431 (end of LOCKED_IN),
+    // state for 432+: LOCKED_IN transitions to ACTIVE, sets activation_height=432.
+    // But that's computed for this period boundary. The ACTIVE->EXPIRED check
+    // happens on the NEXT iteration of the walk-forward.
+    // At pindexPrev=575 (end of period 3): 576 >= 432 + 0 = 432 -> EXPIRED.
+    // So active_duration=0 gives exactly one period of ACTIVE, same as
+    // active_duration=144 with period=144 (since transitions are per-period).
+
+    std::vector<CBlockIndex*> blocks;
+    auto cleanup = [&blocks]() {
+        for (auto* b : blocks) delete b;
+        blocks.clear();
+    };
+
+    const auto dep = MakeTemporaryDeployment(0);
+    TestConditionChecker checker(dep);
+
+    auto mine_block = [&blocks](int32_t nVersion) -> CBlockIndex* {
+        CBlockIndex* pindex = new CBlockIndex();
+        pindex->nHeight = blocks.size();
+        pindex->pprev = blocks.empty() ? nullptr : blocks.back();
+        pindex->nTime = 1415926536 + 600 * pindex->nHeight;
+        pindex->nVersion = nVersion;
+        pindex->BuildSkip();
+        blocks.push_back(pindex);
+        return pindex;
+    };
+
+    // Period 0: DEFINED (0-143)
+    for (int i = 0; i < 144; i++) mine_block(0);
+    // Period 1: Signal (144-287)
+    for (int i = 0; i < 144; i++) mine_block(VERSIONBITS_TOP_BITS | 0x100);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::LOCKED_IN);
+
+    // Period 2: LOCKED_IN (288-431) -> ACTIVE at 432
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::ACTIVE);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 432);
+
+    // Period 3 (432-575): ACTIVE, but 576 >= 432+0 -> EXPIRED at next boundary
+    for (int i = 0; i < 144; i++) mine_block(0);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    BOOST_CHECK_EQUAL(checker.StateSinceHeightFor(blocks.back()), 576);
+
+    cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(versionbits_no_signaling_after_expired)
+{
+    // Test that ComputeBlockVersion does NOT set the deployment bit after EXPIRED.
+    // Uses regtest with testdummy deployment configured with active_duration.
+    //
+    // ComputeBlockVersion only signals for STARTED and LOCKED_IN states.
+    // After EXPIRED, the bit should not be set.
+
+    ArgsManager args;
+    // testdummy: start=0, timeout=never, min_height=0, max_height=INT_MAX, active_duration=144
+    args.ForceSetArg("-vbparams", "testdummy:0:9223372036854775807:0:2147483647:144");
+    const auto chainParams = CreateChainParams(args, ChainType::REGTEST);
+    const auto& params = chainParams->GetConsensus();
+
+    VersionBitsCache vbcache;
+    const auto dep = Consensus::DEPLOYMENT_TESTDUMMY;
+    TestConditionChecker checker(params.vDeployments[dep]);
+    const uint32_t bitmask = uint32_t{1} << params.vDeployments[dep].bit;
+    const int period = params.vDeployments[dep].period;
+
+    std::vector<CBlockIndex*> blocks;
+    auto cleanup = [&blocks]() {
+        for (auto* b : blocks) delete b;
+        blocks.clear();
+    };
+
+    auto mine_block = [&blocks](int32_t nVersion) -> CBlockIndex* {
+        CBlockIndex* pindex = new CBlockIndex();
+        pindex->nHeight = blocks.size();
+        pindex->pprev = blocks.empty() ? nullptr : blocks.back();
+        pindex->nTime = 1415926536 + 600 * pindex->nHeight;
+        pindex->nVersion = nVersion;
+        pindex->BuildSkip();
+        blocks.push_back(pindex);
+        return pindex;
+    };
+
+    // Period 0: DEFINED (0-143) — bit should not be set
+    for (int i = 0; i < period; i++) mine_block(VERSIONBITS_TOP_BITS);
+    BOOST_CHECK_EQUAL(vbcache.ComputeBlockVersion(blocks.back(), params) & bitmask, bitmask); // STARTED, bit set
+
+    // Period 1: STARTED — signal to lock in (144-287), bit should be set
+    for (int i = 0; i < period; i++) mine_block(VERSIONBITS_TOP_BITS | bitmask);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::LOCKED_IN);
+    BOOST_CHECK_EQUAL(vbcache.ComputeBlockVersion(blocks.back(), params) & bitmask, bitmask); // LOCKED_IN, bit set
+
+    // Period 2: LOCKED_IN (288-431), bit should be set
+    for (int i = 0; i < period; i++) mine_block(VERSIONBITS_TOP_BITS | bitmask);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::ACTIVE);
+    // ACTIVE: bit should NOT be set
+    BOOST_CHECK_EQUAL(vbcache.ComputeBlockVersion(blocks.back(), params) & bitmask, 0u);
+
+    // Period 3: ACTIVE (432-575)
+    for (int i = 0; i < period; i++) mine_block(VERSIONBITS_TOP_BITS);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    // EXPIRED: bit should NOT be set
+    BOOST_CHECK_EQUAL(vbcache.ComputeBlockVersion(blocks.back(), params) & bitmask, 0u);
+
+    // Period 4: EXPIRED (576+) — verify bit stays off
+    for (int i = 0; i < period; i++) mine_block(VERSIONBITS_TOP_BITS);
+    BOOST_CHECK(checker.StateFor(blocks.back()) == ThresholdState::EXPIRED);
+    BOOST_CHECK_EQUAL(vbcache.ComputeBlockVersion(blocks.back(), params) & bitmask, 0u);
+
+    cleanup();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -18,6 +18,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <cuckoocache.h>
+#include <deploymentinfo.h>
 #include <flatfile.h>
 #include <hash.h>
 #include <kernel/chainparams.h>
@@ -2288,6 +2289,7 @@ script_verify_flags GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
     return flags;
 }
 
+static bool ContextualCheckBlockHeaderVolatile(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
@@ -2331,6 +2333,11 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // verify that the view's current state corresponds to the previous block
     uint256 hashPrevBlock = pindex->pprev == nullptr ? uint256() : pindex->pprev->GetBlockHash();
     assert(hashPrevBlock == view.GetBestBlock());
+
+    if (!ContextualCheckBlockHeaderVolatile(block, state, m_chainman, pindex->pprev)) {
+        LogError("%s: Consensus::ContextualCheckBlockHeaderVolatile: %s\n", __func__, state.ToString());
+        return false;
+    }
 
     m_chainman.num_blocks_total++;
 
@@ -4115,6 +4122,37 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
         (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CLTV))) {
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
+    }
+
+    if (!ContextualCheckBlockHeaderVolatile(block, state, chainman, pindexPrev)) return false;
+
+    return true;
+}
+
+/** Context-dependent validity checks, but rechecked in ConnectBlock().
+ *  Note that -reindex-chainstate skips the validation that happens here!
+ */
+static bool ContextualCheckBlockHeaderVolatile(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+{
+    const Consensus::Params& consensusParams = chainman.GetConsensus();
+
+    // Mandatory signaling for deployments approaching max_activation_height
+    for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; i++) {
+        const Consensus::DeploymentPos pos = static_cast<Consensus::DeploymentPos>(i);
+
+        if (chainman.m_versionbitscache.MustSignal(pindexPrev, consensusParams, pos)) {
+            const auto& deployment = consensusParams.vDeployments[pos];
+            const bool fVersionBits = (block.nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS;
+            const bool fDeploymentBit = (block.nVersion & (uint32_t{1} << deployment.bit)) != 0;
+
+            if (!(fVersionBits && fDeploymentBit)) {
+                const std::string deployment_name = VersionBitsDeploymentInfo[i].name;
+                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
+                                   "bad-version-" + deployment_name,
+                                   strprintf("Block must signal for %s approaching max_activation_height=%d",
+                                           deployment_name, deployment.max_activation_height));
+            }
+        }
     }
 
     return true;

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -19,15 +19,18 @@ std::string StateName(ThresholdState state)
     case LOCKED_IN: return "locked_in";
     case ACTIVE: return "active";
     case FAILED: return "failed";
+    case EXPIRED: return "expired";
     }
     return "invalid";
 }
 
+// NOLINTBEGIN(misc-no-recursion)
 ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex* pindexPrev, ThresholdConditionCache& cache) const
 {
     int nPeriod = Period();
     int nThreshold = Threshold();
     int min_activation_height = MinActivationHeight();
+    int active_duration = ActiveDuration();
     int64_t nTimeStart = BeginTime();
     int64_t nTimeTimeout = EndTime();
 
@@ -67,6 +70,23 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
     assert(cache.contains(pindexPrev));
     ThresholdState state = cache[pindexPrev];
 
+    // Everything is already cached. Return immediately.
+    if (vToCompute.empty()) {
+        return state;
+    }
+
+    // For temporary deployments, we need to know when ACTIVE started to determine the
+    // ACTIVE -> EXPIRED transition. We get this by calling GetStateSinceHeightFor, which
+    // internally calls GetStateFor on earlier periods. Those calls could recurse back here
+    // and call GetStateSinceHeightFor again, but the early return above prevents this:
+    // the walk-back above guarantees all periods before pindexPrev are already cached,
+    // and GetStateSinceHeightFor only walks backwards, so its GetStateFor calls always hit
+    // the cache, have empty vToCompute, and return immediately via the early return.
+    int activation_height = 0;
+    if (state == ThresholdState::ACTIVE && active_duration < std::numeric_limits<int>::max()) {
+        activation_height = GetStateSinceHeightFor(pindexPrev, cache);
+    }
+
     // Now walk forward and compute the state of descendants of pindexPrev
     while (!vToCompute.empty()) {
         ThresholdState stateNext = state;
@@ -101,11 +121,21 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
                 // Progresses into ACTIVE provided activation height will have been reached.
                 if (pindexPrev->nHeight + 1 >= min_activation_height) {
                     stateNext = ThresholdState::ACTIVE;
+                    if (active_duration < std::numeric_limits<int>::max()) {
+                        activation_height = pindexPrev->nHeight + 1;
+                    }
+                }
+                break;
+            }
+            case ThresholdState::ACTIVE: {
+                if (active_duration < std::numeric_limits<int>::max() &&
+                    pindexPrev->nHeight + 1 >= activation_height + active_duration) {
+                    stateNext = ThresholdState::EXPIRED;
                 }
                 break;
             }
             case ThresholdState::FAILED:
-            case ThresholdState::ACTIVE: {
+            case ThresholdState::EXPIRED: {
                 // Nothing happens, these are terminal states.
                 break;
             }
@@ -115,6 +145,7 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
 
     return state;
 }
+// NOLINTEND(misc-no-recursion)
 
 BIP9Stats AbstractThresholdConditionChecker::GetStateStatisticsFor(const CBlockIndex* pindex, std::vector<bool>* signalling_blocks) const
 {
@@ -154,6 +185,13 @@ BIP9Stats AbstractThresholdConditionChecker::GetStateStatisticsFor(const CBlockI
     return stats;
 }
 
+// WARNING: This function is called from GetStateFor and calls GetStateFor in turn.
+// The recursion is safe because this function calls GetStateFor first (which populates
+// the cache), then only walks BACKWARDS through periods that are now cached. GetStateFor
+// returns immediately for cached entries (via the early return when vToCompute is empty).
+// If the backwards walk is ever changed to query uncached periods, infinite recursion
+// will result.
+// NOLINTBEGIN(misc-no-recursion)
 int AbstractThresholdConditionChecker::GetStateSinceHeightFor(const CBlockIndex* pindexPrev, ThresholdConditionCache& cache) const
 {
     int64_t start_time = BeginTime();
@@ -188,6 +226,7 @@ int AbstractThresholdConditionChecker::GetStateSinceHeightFor(const CBlockIndex*
     // Adjust the result because right now we point to the parent block.
     return pindexPrev->nHeight + 1;
 }
+// NOLINTEND(misc-no-recursion)
 
 BIP9Info VersionBitsCache::Info(const CBlockIndex& block_index, const Consensus::Params& params, Consensus::DeploymentPos id)
 {
@@ -240,6 +279,7 @@ BIP9GBTStatus VersionBitsCache::GBTStatus(const CBlockIndex& block_index, const 
         switch (state) {
         case DEFINED:
         case FAILED:
+        case EXPIRED:
             // Not exposed to GBT
             break;
         case STARTED:

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -30,6 +30,7 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
     int nPeriod = Period();
     int nThreshold = Threshold();
     int min_activation_height = MinActivationHeight();
+    int max_activation_height = MaxActivationHeight();
     int active_duration = ActiveDuration();
     int64_t nTimeStart = BeginTime();
     int64_t nTimeTimeout = EndTime();
@@ -111,8 +112,15 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
                     pindexCount = pindexCount->pprev;
                 }
                 if (count >= nThreshold) {
+                    // Normal BIP9 activation via signaling
+                    stateNext = ThresholdState::LOCKED_IN;
+                } else if (max_activation_height < std::numeric_limits<int>::max() && pindexPrev->nHeight + 1 >= max_activation_height - nPeriod) {
+                    // Force LOCKED_IN one period before max_activation_height
+                    // This ensures activation happens AT max_activation_height (not one period later)
+                    // Overrides timeout to guarantee activation
                     stateNext = ThresholdState::LOCKED_IN;
                 } else if (pindexPrev->GetMedianTimePast() >= nTimeTimeout) {
+                    // Timeout without activation
                     stateNext = ThresholdState::FAILED;
                 }
                 break;

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -292,6 +292,16 @@ BIP9GBTStatus VersionBitsCache::GBTStatus(const CBlockIndex& block_index, const 
             break;
         case STARTED:
             result.signalling.try_emplace(vbdepinfo.name, gbtinfo);
+            {
+                const auto& dep = params.vDeployments[pos];
+                if (dep.max_activation_height < std::numeric_limits<int>::max()) {
+                    const int nHeight = block_index.nHeight + 1;
+                    if (nHeight >= dep.max_activation_height - (2 * (int)dep.period)
+                        && nHeight < dep.max_activation_height - (int)dep.period) {
+                        result.vbrequired |= checker.Mask();
+                    }
+                }
+            }
             break;
         case LOCKED_IN:
             result.locked_in.try_emplace(vbdepinfo.name, gbtinfo);
@@ -308,6 +318,18 @@ bool VersionBitsCache::IsActiveAfter(const CBlockIndex* pindexPrev, const Consen
 {
     LOCK(m_mutex);
     return ThresholdState::ACTIVE == VersionBitsConditionChecker(params, pos).GetStateFor(pindexPrev, m_caches[pos]);
+}
+
+bool VersionBitsCache::MustSignal(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos)
+{
+    LOCK(m_mutex);
+    const auto& dep = params.vDeployments[pos];
+    if (dep.max_activation_height >= std::numeric_limits<int>::max()) return false;
+    VersionBitsConditionChecker checker(params, pos);
+    if (STARTED != checker.GetStateFor(pindexPrev, m_caches[pos])) return false;
+    const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
+    return nHeight >= dep.max_activation_height - (2 * (int)dep.period)
+        && nHeight < dep.max_activation_height - (int)dep.period;
 }
 
 static int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, std::array<ThresholdConditionCache, Consensus::MAX_VERSION_BITS_DEPLOYMENTS>& caches)

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -69,6 +69,7 @@ struct BIP9GBTStatus {
         bool gbt_optional_rule;
     };
     std::map<std::string, const Info, std::less<>> signalling, locked_in, active;
+    uint32_t vbrequired{0};
 };
 
 /** BIP 9 allows multiple softforks to be deployed in parallel. We cache
@@ -85,8 +86,11 @@ public:
 
     BIP9GBTStatus GBTStatus(const CBlockIndex& block_index, const Consensus::Params& params) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Get the BIP9 state for a given deployment for the block after pindexPrev. */
+    /** Check if a deployment is active for the block after pindexPrev. */
     bool IsActiveAfter(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Check if mandatory signaling is required for a deployment at the block after pindexPrev. */
+    bool MustSignal(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Determine what nVersion a new block should use */
     int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);

--- a/src/versionbits_impl.h
+++ b/src/versionbits_impl.h
@@ -9,6 +9,8 @@
 #include <sync.h>
 #include <versionbits.h>
 
+#include <limits>
+
 /** BIP 9 defines a finite-state-machine to deploy a softfork in multiple stages.
  *  State transitions happen during retarget period if conditions are met
  *  In case of reorg, transitions can go backward. Without transition, state is
@@ -18,8 +20,9 @@ enum class ThresholdState : uint8_t {
     DEFINED,   // First state that each softfork starts out as. The genesis block is by definition in this state for each deployment.
     STARTED,   // For blocks past the starttime.
     LOCKED_IN, // For at least one retarget period after the first retarget period with STARTED blocks of which at least threshold have the associated bit set in nVersion, until min_activation_height is reached.
-    ACTIVE,    // For all blocks after the LOCKED_IN retarget period (final state)
+    ACTIVE,    // For all blocks after the LOCKED_IN retarget period (final state for permanent deployments)
     FAILED,    // For all blocks once the first retarget period after the timeout time is hit, if LOCKED_IN wasn't already reached (final state)
+    EXPIRED,   // For temporary deployments: all blocks after active_duration periods past activation (final state)
 };
 
 /** Get a string with the state name */
@@ -34,6 +37,7 @@ protected:
     virtual int64_t BeginTime() const =0;
     virtual int64_t EndTime() const =0;
     virtual int MinActivationHeight() const { return 0; }
+    virtual int ActiveDuration() const { return std::numeric_limits<int>::max(); }
     virtual int Period() const =0;
     virtual int Threshold() const =0;
 
@@ -62,6 +66,7 @@ protected:
     int64_t BeginTime() const override { return dep.nStartTime; }
     int64_t EndTime() const override { return dep.nTimeout; }
     int MinActivationHeight() const override { return dep.min_activation_height; }
+    int ActiveDuration() const override { return dep.active_duration; }
     int Period() const override { return dep.period; }
     int Threshold() const override { return dep.threshold; }
 

--- a/src/versionbits_impl.h
+++ b/src/versionbits_impl.h
@@ -37,6 +37,7 @@ protected:
     virtual int64_t BeginTime() const =0;
     virtual int64_t EndTime() const =0;
     virtual int MinActivationHeight() const { return 0; }
+    virtual int MaxActivationHeight() const { return std::numeric_limits<int>::max(); }
     virtual int ActiveDuration() const { return std::numeric_limits<int>::max(); }
     virtual int Period() const =0;
     virtual int Threshold() const =0;
@@ -66,6 +67,7 @@ protected:
     int64_t BeginTime() const override { return dep.nStartTime; }
     int64_t EndTime() const override { return dep.nTimeout; }
     int MinActivationHeight() const override { return dep.min_activation_height; }
+    int MaxActivationHeight() const override { return dep.max_activation_height; }
     int ActiveDuration() const override { return dep.active_duration; }
     int Period() const override { return dep.period; }
     int Threshold() const override { return dep.threshold; }

--- a/test/functional/feature_bip9_max_activation_height.py
+++ b/test/functional/feature_bip9_max_activation_height.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test max_activation_height for mandatory BIP9 activation.
+
+This test verifies that BIP9 deployments with max_activation_height properly
+activate at the specified height regardless of miner signaling, similar to BIP8.
+
+The test verifies four critical scenarios:
+1. Mandatory activation at max_height without signaling
+2. Normal deployment without max_height (requires signaling)
+3. Early activation via signaling before reaching max_height
+4. Max_height overrides timeout
+
+Expected behavior:
+- When max_activation_height is set and reached while in STARTED state,
+  the deployment transitions to LOCKED_IN (then ACTIVE) regardless of signaling
+- Max_activation_height overrides timeout
+- Once ACTIVE, the deployment remains ACTIVE permanently (terminal state)
+- Without max_activation_height, activation requires sufficient signaling
+"""
+
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+    add_witness_commitment,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+TESTDUMMY_BIT = 28
+TESTDUMMY_MASK = 1 << TESTDUMMY_BIT
+VERSIONBITS_TOP_BITS = 0x20000000
+
+
+class MaxActivationHeightTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 6  # 6 nodes for tests 1-6 (test 0 validation is done separately)
+        self.setup_clean_chain = True
+        # NO_TIMEOUT = std::numeric_limits<int64_t>::max() = 9223372036854775807
+        NO_TIMEOUT = '9223372036854775807'
+        # INT_MAX = std::numeric_limits<int>::max() = 2147483647
+        INT_MAX = '2147483647'
+        self.extra_args = [
+            [f'-vbparams=testdummy:0:{NO_TIMEOUT}:0:576'],      # Test 1: max_height=576 (shows full flow)
+            ['-vbparams=testdummy:0:999999999999'],              # Test 2: no max_height (uses timeout)
+            [f'-vbparams=testdummy:0:{NO_TIMEOUT}:0:576'],      # Test 3: max_height=576 (early activation)
+            [f'-vbparams=testdummy:0:{NO_TIMEOUT}:0:432'],      # Test 4: verify permanent ACTIVE
+            [f'-vbparams=testdummy:0:{NO_TIMEOUT}:0:432:144'],  # Test 5: max_height + active_duration
+            [f'-vbparams=testdummy:0:999999999999:0:{INT_MAX}:{INT_MAX}:72'],  # Test 6: custom 50% threshold (72/144)
+        ]
+
+    def setup_network(self):
+        """Keep nodes isolated - don't connect them to each other"""
+        self.add_nodes(self.num_nodes)
+        for i in range(self.num_nodes):
+            self.start_node(i, extra_args=self.extra_args[i])
+        # Nodes remain disconnected for independent blockchain testing
+
+    def mine_blocks(self, node, count, signal=False):
+        """Mine count blocks, optionally signaling for testdummy."""
+        for i in range(count):
+            tip = node.getbestblockhash()
+            height = node.getblockcount() + 1
+            tip_header = node.getblockheader(tip)
+            block_time = tip_header['time'] + 1
+            block = create_block(int(tip, 16), create_coinbase(height), ntime=block_time)
+            if signal:
+                block.nVersion = VERSIONBITS_TOP_BITS | (1 << TESTDUMMY_BIT)
+            add_witness_commitment(block)
+            block.solve()
+            node.submitblock(block.serialize().hex())
+
+            # Log every 20 blocks and at key heights for debugging
+            if height % 20 == 0 or height == 143 or height == 144:
+                mtp = node.getblockheader(node.getbestblockhash())['mediantime']
+                self.log.info(f"  Block {height}: time={block_time}, MTP={mtp}")
+
+    def get_status(self, node):
+        """Get testdummy deployment status."""
+        info = node.getdeploymentinfo()
+        td = info['deployments']['testdummy']
+        if 'bip9' in td:
+            return td['bip9']['status'], td['bip9'].get('since', 0)
+        return td.get('status', 'unknown'), 0
+
+    def run_test(self):
+        # Test 0: Verify validation rejects both timeout and max_activation_height
+        self.log.info("=== TEST 0: Validation test - reject both timeout and max_activation_height ===")
+        self.log.info("Attempting to start bitcoind with both timeout and max_activation_height...")
+
+        # Run bitcoind directly with invalid config to test validation
+        import subprocess
+
+        # Get the bitcoind binary path from the test framework
+        bitcoind_path = self.binary_paths.bitcoind
+
+        # Create a temporary datadir for this test
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                # Run bitcoind with invalid vbparams (both timeout and max_activation_height)
+                result = subprocess.run(
+                    [bitcoind_path, f'-datadir={tmpdir}', '-regtest',
+                     '-vbparams=testdummy:0:1:0:432'],  # timeout=1, max_activation_height=432
+                    capture_output=True,
+                    text=True,
+                    timeout=5
+                )
+
+                # If we get here with exit code 0, the validation failed
+                if result.returncode == 0:
+                    raise AssertionError("bitcoind should have failed to start with both timeout and max_activation_height")
+
+                # Check that the error message contains the expected validation error
+                error_output = result.stderr
+                self.log.info(f"bitcoind correctly failed with error: {error_output[:200]}")
+
+                assert "Cannot specify both timeout" in error_output and "max_activation_height" in error_output, \
+                    f"Expected validation error about both parameters, got: {error_output}"
+
+                self.log.info("SUCCESS: Validation correctly rejected invalid configuration")
+
+            except subprocess.TimeoutExpired:
+                raise AssertionError("bitcoind timed out (should have failed immediately with validation error)")
+
+        self.log.info("\n=== Test: max_activation_height=576 (full flow with non-mandatory period) ===")
+        node = self.nodes[0]
+
+        # Check deployment info to verify max_activation_height is set
+        info = node.getdeploymentinfo()
+        self.log.info(f"Deployment info: {info['deployments']['testdummy']}")
+
+        # Period 0 (0-143): DEFINED
+        self.log.info("\n--- Period 0 (blocks 0-143): DEFINED ---")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 143)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 143: Status={status}")
+        assert_equal(status, 'defined')
+
+        # Block 144: Transition to STARTED
+        self.log.info("\n--- Block 144: Transition to STARTED ---")
+        self.mine_blocks(node, 1, signal=False)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 144: Status={status}, Since={since}")
+        assert_equal(status, 'started')
+        assert_equal(since, 144)
+
+        # GBT: vbrequired should NOT have TESTDUMMY bit (before enforcement window [288, 432))
+        gbt = node.getblocktemplate({"rules": ["segwit"]})
+        assert_equal(gbt['vbrequired'] & TESTDUMMY_MASK, 0)
+
+        # Period 1 (144-287): STARTED
+        self.log.info("\n--- Period 1 (blocks 145-287): STARTED ---")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 287)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 287: Status={status}")
+        assert_equal(status, 'started')
+
+        # GBT: vbrequired SHOULD have TESTDUMMY bit (next block 288 is in enforcement window [288, 432))
+        gbt = node.getblocktemplate({"rules": ["segwit"]})
+        assert_equal(gbt['vbrequired'] & TESTDUMMY_MASK, TESTDUMMY_MASK)
+
+        # Period 2 (288-431): STARTED - forced lock-in will occur at end of this period
+        self.log.info("\n--- Period 2 (blocks 288-431): STARTED ---")
+        self.log.info("Forced lock-in will occur at block 432 (max_activation_height - nPeriod)")
+
+        # Try to mine block 288 without signaling - should be REJECTED
+        self.log.info("\nNEGATIVE TEST: Attempting to mine block 288 without signaling...")
+        tip = node.getbestblockhash()
+        height = node.getblockcount() + 1
+        tip_header = node.getblockheader(tip)
+        block_time = tip_header['time'] + 1
+        block = create_block(int(tip, 16), create_coinbase(height), ntime=block_time)
+        block.nVersion = VERSIONBITS_TOP_BITS  # No signaling bit
+        add_witness_commitment(block)
+        block.solve()
+        result = node.submitblock(block.serialize().hex())
+        self.log.info(f"Submitblock result (should be rejected): {result}")
+        # Block should be rejected - check we're still at block 287
+        assert_equal(node.getblockcount(), 287)
+        self.log.info("SUCCESS: Block without signaling was correctly REJECTED during enforcement window")
+
+        # Now mine Period 2 with proper signaling (blocks 288-430)
+        self.log.info("\nMining blocks 288-430 with proper signaling...")
+        self.mine_blocks(node, 143, signal=True)
+        assert_equal(node.getblockcount(), 430)
+
+        # GBT: vbrequired SHOULD have TESTDUMMY bit (next block 431 is in enforcement window [288, 432))
+        gbt = node.getblocktemplate({"rules": ["segwit"]})
+        assert_equal(gbt['vbrequired'] & TESTDUMMY_MASK, TESTDUMMY_MASK)
+
+        # Try to mine block 431 without signaling - should be REJECTED (last block of enforcement window)
+        self.log.info("\nNEGATIVE TEST: Attempting to mine block 431 without signaling (upper boundary)...")
+        tip = node.getbestblockhash()
+        height = node.getblockcount() + 1
+        tip_header = node.getblockheader(tip)
+        block_time = tip_header['time'] + 1
+        block = create_block(int(tip, 16), create_coinbase(height), ntime=block_time)
+        block.nVersion = VERSIONBITS_TOP_BITS  # No signaling bit
+        add_witness_commitment(block)
+        block.solve()
+        result = node.submitblock(block.serialize().hex())
+        self.log.info(f"Submitblock result (should be rejected): {result}")
+        assert_equal(node.getblockcount(), 430)
+        self.log.info("SUCCESS: Block without signaling was correctly REJECTED at upper boundary of enforcement window")
+
+        # Mine block 431 with proper signaling
+        self.mine_blocks(node, 1, signal=True)
+        assert_equal(node.getblockcount(), 431)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 431: Status={status}")
+        assert_equal(status, 'started')
+
+        # GBT: vbrequired should NOT have TESTDUMMY bit (next block 432 is outside enforcement window)
+        gbt = node.getblocktemplate({"rules": ["segwit"]})
+        assert_equal(gbt['vbrequired'] & TESTDUMMY_MASK, 0)
+
+        # status_next should be locked_in (forced lock-in at next period boundary)
+        info = node.getdeploymentinfo()
+        assert_equal(info['deployments']['testdummy']['bip9']['status_next'], 'locked_in')
+
+        # Period 3 (432-575): LOCKED_IN (forced by max_activation_height)
+        self.log.info("\n--- Period 3 (blocks 432-575): LOCKED_IN ---")
+        self.mine_blocks(node, 1, signal=False)  # Mine block 432
+        assert_equal(node.getblockcount(), 432)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 432: Status={status}, Since={since}")
+        assert_equal(status, 'locked_in')
+        assert_equal(since, 432)
+
+        # Mine through period 3 to activate at block 576
+        self.log.info("Mining blocks 433-575...")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 575)
+        status, since = self.get_status(node)
+        assert_equal(status, 'locked_in')
+
+        # status_next should be active (activation at next period boundary)
+        info = node.getdeploymentinfo()
+        assert_equal(info['deployments']['testdummy']['bip9']['status_next'], 'active')
+
+        # Period 4 (576+): ACTIVE
+        self.log.info("\n--- Period 4 (block 576+): ACTIVE ---")
+        self.mine_blocks(node, 1, signal=False)
+        assert_equal(node.getblockcount(), 576)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 576: Status={status}, Since={since}")
+        assert_equal(status, 'active')
+        assert_equal(since, 576)
+
+        # RPC field assertions: max_activation_height present, height set, no height_end (permanent)
+        info = node.getdeploymentinfo()
+        td = info['deployments']['testdummy']
+        assert_equal(td['bip9']['max_activation_height'], 576)
+        assert_equal(td['height'], 576)
+        assert 'height_end' not in td
+
+        self.log.info("\n=== TEST 1 COMPLETE ===")
+        self.log.info("Summary: max_activation_height=576 test passed")
+        self.log.info("- Deployment activated at height 576 via forced lock-in at 432")
+        self.log.info("- Mandatory signaling enforced during blocks 288-431 (BIP148-style)")
+        self.log.info("- Non-signaling blocks rejected during enforcement window")
+        self.log.info("- Non-signaling blocks accepted outside enforcement window")
+
+        # Test 2: Deployment without max_height requires signaling
+        self.log.info("\n\n=== TEST 2: Deployment without max_height requires signaling ===")
+        node = self.nodes[1]
+
+        # Period 0 (0-143): DEFINED
+        self.log.info("\n--- Period 0 (blocks 0-143): DEFINED ---")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 143)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 143: Status={status}")
+        assert_equal(status, 'defined')
+
+        # Mine period 1 (blocks 144-287) without signaling - should transition to STARTED
+        self.log.info("Mining period 1 (blocks 144-287) without signaling...")
+        self.mine_blocks(node, 144, signal=False)
+        assert_equal(node.getblockcount(), 287)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 287: Status={status}")
+        assert_equal(status, 'started')
+
+        # Mine period 2 (blocks 288-431) without signaling - should remain STARTED
+        self.log.info("Mining period 2 (blocks 288-431) without signaling...")
+        self.mine_blocks(node, 144, signal=False)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 431: Status={status}")
+        assert_equal(status, 'started')  # Should NOT lock in without signaling
+
+        # Mine period 3 (blocks 432-575) without signaling - should remain STARTED
+        self.log.info("Mining period 3 (blocks 432-575) without signaling...")
+        self.mine_blocks(node, 144, signal=False)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 575: Status={status}")
+        assert_equal(status, 'started')  # Still STARTED without signaling
+
+        # RPC field assertions: max_activation_height should be absent (no max_height)
+        info = node.getdeploymentinfo()
+        assert 'max_activation_height' not in info['deployments']['testdummy']['bip9']
+
+        self.log.info("\n=== TEST 2 COMPLETE ===")
+        self.log.info("SUCCESS: Deployment did NOT activate without signaling (no max_height)")
+
+        # Test 3: Early activation via signaling before max_height
+        self.log.info("\n\n=== TEST 3: Early activation via signaling before max_height ===")
+        node = self.nodes[2]
+
+        # Period 0 (0-143): DEFINED
+        self.log.info("\n--- Period 0 (blocks 0-143): DEFINED ---")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 143)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 143: Status={status}")
+        assert_equal(status, 'defined')
+
+        # Mine period 1 (blocks 144-287) with 100% signaling
+        self.log.info("Mining period 1 (blocks 144-287) with 100% signaling...")
+        self.mine_blocks(node, 144, signal=True)
+        assert_equal(node.getblockcount(), 287)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 287: Status={status}")
+        assert_equal(status, 'started')
+
+        # Mine period 2 (blocks 288-431) with signaling - should lock in
+        self.log.info("Mining period 2 (blocks 288-431) with signaling - should lock in...")
+        self.mine_blocks(node, 144, signal=True)
+        assert_equal(node.getblockcount(), 431)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 431: Status={status}, Since={since}")
+        assert_equal(status, 'locked_in')
+        assert_equal(since, 288)  # Locked in at start of period 2 via signaling threshold
+
+        # Mine block 432 - should activate via signaling (well before max_height 576)
+        self.log.info("Mining block 432 - should activate via signaling (before max_height 576)...")
+        self.mine_blocks(node, 1, signal=True)
+        assert_equal(node.getblockcount(), 432)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 432: Status={status}, Since={since}")
+        assert_equal(status, 'active')
+        assert_equal(since, 432)
+
+        self.log.info("\n=== TEST 3 COMPLETE ===")
+        self.log.info("SUCCESS: Deployment activated early via signaling (at 432, before max_height 576)")
+
+        # Test 4: Verify ACTIVE state is permanent
+        self.log.info("\n\n=== TEST 4: Verify ACTIVE state is permanent ===")
+        node = self.nodes[3]
+
+        # Activate via max_height (max_height=432)
+        # Mine to block 143 (period 0) without signaling
+        self.log.info("Mining period 0 (blocks 0-143) without signaling...")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 143)
+
+        # Mine through enforcement window (blocks 144-287) WITH signaling
+        # Enforcement window for max_height=432 is [144, 288)
+        self.log.info("Mining blocks 144-287 with signaling (enforcement window)...")
+        self.mine_blocks(node, 144, signal=True)
+        assert_equal(node.getblockcount(), 287)
+        status, since = self.get_status(node)
+        assert_equal(status, 'started')
+
+        # Mine period 2 (blocks 288-431) - will force lock-in at 288 (432 - 144)
+        self.log.info("Mining period 2 (blocks 288-431) - forced lock-in at end...")
+        self.mine_blocks(node, 144, signal=False)
+        assert_equal(node.getblockcount(), 431)
+        status, since = self.get_status(node)
+        assert_equal(status, 'locked_in')
+
+        # Mine block 432 - should activate
+        self.log.info("Mining block 432 - should activate via max_height...")
+        self.mine_blocks(node, 1, signal=False)
+        assert_equal(node.getblockcount(), 432)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 432: Status={status}, Since={since}")
+        assert_equal(status, 'active')
+        assert_equal(since, 432)
+
+        # Mine 300 more blocks to verify permanence
+        self.log.info("Mining 300 more blocks to verify ACTIVE state persists...")
+        self.mine_blocks(node, 300, signal=False)
+        assert_equal(node.getblockcount(), 732)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 732: Status={status}, Since={since}")
+        assert_equal(status, 'active')
+        assert_equal(since, 432)
+
+        self.log.info("\n=== TEST 4 COMPLETE ===")
+        self.log.info("SUCCESS: Deployment remains ACTIVE permanently")
+
+        # Test 5: Combined temporary deployment with max_height
+        self.log.info("\n\n=== TEST 5: Temporary deployment with max_height ===")
+        node = self.nodes[4]
+
+        # This node has max_activation_height=432 AND active_duration=144
+        # Should activate at 432 via max_height, then expire at 432+144=576
+        # Mine to block 143 (period 0) without signaling
+        self.log.info("Mining period 0 (blocks 0-143) without signaling...")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 143)
+
+        # Mine through enforcement window (blocks 144-287) WITH signaling
+        # Enforcement window for max_height=432 is [144, 288)
+        self.log.info("Mining blocks 144-287 with signaling (enforcement window)...")
+        self.mine_blocks(node, 144, signal=True)
+        assert_equal(node.getblockcount(), 287)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 287: Status={status}")
+        assert_equal(status, 'started')
+
+        # Mine period 2 (blocks 288-431) - will force lock-in at 288 (432 - 144)
+        self.log.info("Mining period 2 (blocks 288-431) - forced lock-in at end...")
+        self.mine_blocks(node, 144, signal=False)
+        assert_equal(node.getblockcount(), 431)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 431: Status={status}")
+        assert_equal(status, 'locked_in')
+
+        # Mine block 432 - should activate via max_height
+        self.log.info("Mining block 432 - should activate via max_height...")
+        self.mine_blocks(node, 1, signal=False)
+        assert_equal(node.getblockcount(), 432)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 432: Status={status}, Since={since}")
+        assert_equal(status, 'active')
+        assert_equal(since, 432)
+
+        # RPC field assertions: max_activation_height, height, and height_end for temporary deployment
+        info = node.getdeploymentinfo()
+        td = info['deployments']['testdummy']
+        assert_equal(td['bip9']['max_activation_height'], 432)
+        assert_equal(td['height'], 432)
+        assert_equal(td['height_end'], 575)  # 432 + 144 - 1
+
+        # Mine through active period to block 575 (432+144-1)
+        self.log.info("Mining through active period to block 575 (432+144-1)...")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 575)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 575: Status={status}")
+        assert_equal(status, 'active')
+
+        # status_next should be expired (expiry at next period boundary)
+        info = node.getdeploymentinfo()
+        assert_equal(info['deployments']['testdummy']['bip9']['status_next'], 'expired')
+
+        # Mine block 576 (432+144) - deployment has expired
+        # RPC status uses State(blockindex->pprev), so expired appears at tip 576
+        self.log.info("Mining block 576 (432+144) - deployment should be expired...")
+        self.mine_blocks(node, 1, signal=False)
+        assert_equal(node.getblockcount(), 576)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 576: Status={status}, Since={since}")
+        assert_equal(status, 'expired')
+        assert_equal(since, 576)
+
+        # status_next should also be expired (terminal state)
+        info = node.getdeploymentinfo()
+        assert_equal(info['deployments']['testdummy']['bip9']['status_next'], 'expired')
+
+        # Mine block 577 - verify EXPIRED is terminal
+        self.log.info("Mining block 577 - verify EXPIRED is terminal...")
+        self.mine_blocks(node, 1, signal=False)
+        assert_equal(node.getblockcount(), 577)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 577: Status={status}")
+        assert_equal(status, 'expired')
+
+        self.log.info("\n=== TEST 5 COMPLETE ===")
+        self.log.info("SUCCESS: Temporary deployment with max_height activated and expired correctly")
+
+        # Test 6: Custom per-deployment threshold
+        self.log.info("\n\n=== TEST 6: Custom per-deployment threshold (50% = 72/144 blocks) ===")
+        node = self.nodes[5]
+
+        # This node has threshold=72 (50% of 144 blocks)
+        # Default regtest threshold is 108 (75%), but this deployment should activate at 72
+
+        # Period 0 (0-143): DEFINED
+        self.log.info("Mining period 0 (blocks 0-143) without signaling...")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 143)
+        status, _ = self.get_status(node)
+        assert_equal(status, 'defined')
+
+        # Block 144: Transition to STARTED
+        self.log.info("Mining block 144 to transition to STARTED...")
+        self.mine_blocks(node, 1, signal=False)
+        assert_equal(node.getblockcount(), 144)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 144: Status={status}, Since={since}")
+        assert_equal(status, 'started')
+        assert_equal(since, 144)
+
+        # Period 1 (144-287): NEGATIVE TEST - Mine only 71 signaling blocks (one below threshold)
+        self.log.info("NEGATIVE TEST: Mining period 1 with only 71 signaling blocks (below threshold of 72)...")
+        self.mine_blocks(node, 71, signal=True)   # 71 signaling blocks
+        self.mine_blocks(node, 72, signal=False)  # 72 non-signaling blocks (+ 1 from block 144 = 73 total)
+        assert_equal(node.getblockcount(), 287)
+
+        # Block 288: Should remain STARTED (71 < 72 threshold)
+        self.mine_blocks(node, 1, signal=False)
+        assert_equal(node.getblockcount(), 288)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 288: Status={status} (should remain started, 71 < threshold 72)")
+        assert_equal(status, 'started')
+        assert_equal(since, 144)
+
+        # Period 2 (288-431): POSITIVE TEST - Mine exactly 72 signaling blocks (meets threshold)
+        self.log.info("Mining period 2 with exactly 72 signaling blocks (meets threshold of 72)...")
+        self.mine_blocks(node, 72, signal=True)   # 72 signaling blocks
+        self.mine_blocks(node, 71, signal=False)  # 71 non-signaling blocks (+ 1 from block 288 = 72 total)
+        assert_equal(node.getblockcount(), 431)
+
+        # Block 432: Should transition to LOCKED_IN (threshold met in previous period)
+        self.log.info("Mining block 432 to check lock-in...")
+        self.mine_blocks(node, 1, signal=False)
+        assert_equal(node.getblockcount(), 432)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 432: Status={status}, Since={since}")
+        assert_equal(status, 'locked_in')
+        assert_equal(since, 432)
+
+        # Mine through locked_in period to activate
+        self.log.info("Mining through locked_in period (433-575)...")
+        self.mine_blocks(node, 143, signal=False)
+        assert_equal(node.getblockcount(), 575)
+        status, since = self.get_status(node)
+        assert_equal(status, 'locked_in')
+
+        # Block 576: Should transition to ACTIVE
+        self.log.info("Mining block 576 to activate...")
+        self.mine_blocks(node, 1, signal=False)
+        assert_equal(node.getblockcount(), 576)
+        status, since = self.get_status(node)
+        self.log.info(f"Block 576: Status={status}, Since={since}")
+        assert_equal(status, 'active')
+        assert_equal(since, 576)
+
+        self.log.info("\n=== TEST 6 COMPLETE ===")
+        self.log.info("SUCCESS: Deployment activated with custom 50% threshold (72/144 blocks)")
+        self.log.info("- 71/144 signaling correctly failed to lock in (negative test)")
+        self.log.info("- 72/144 signaling correctly locked in (positive test)")
+
+
+if __name__ == '__main__':
+    MaxActivationHeightTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -145,6 +145,7 @@ BASE_SCRIPTS = [
     'rpc_bind.py --nonloopback',
     'p2p_headers_sync_with_minchainwork.py',
     'p2p_feefilter.py',
+    'feature_bip9_max_activation_height.py',
     'feature_csv_activation.py',
     'p2p_sendheaders.py',
     'feature_config_args.py',


### PR DESCRIPTION
This PR implements the [Deployment portion of BIP-110](https://github.com/bitcoin/bips/blob/master/bip-0110.mediawiki#user-content-Deployment). There is a [second PR](https://github.com/bitcoin/bitcoin/pull/34930), built on this one, that implements the BIP-110 consensus changes and deployment parameters. I have split these two features into separate PRs in order to facilitate review.

This first PR is a generic extension of the pre-existing BIP9 framework to add the BIP8-style activation and temporary deployment pieces BIP-110 needs, namely:

- **`max_activation_height`**: mandatory activation deadline - forces LOCKED_IN one period before the specified height, regardless of miner signaling (similar to BIP8's `lockinontimeout=true`)
- **`active_duration`**: number of blocks a deployment remains active after activation, after which it transitions to a new terminal **EXPIRED** state
- **Mandatory signaling enforcement**: blocks must signal for the deployment during the enforcement window (`[max_activation_height - 2*period, max_activation_height - period)`), with `vbrequired` set in `getblocktemplate` output (similar to BIP8's `MUST_SIGNAL` phase)

Regtest command-line support for `max_activation_height`, `active_duration`, and `threshold` have also been added to aid in testing.

These features may be reused as necessary for future softforks.

## Background and Motivation

See the corresponding sections on [the dependent PR](https://github.com/bitcoin/bitcoin/pull/34930).

## Features

### New `BIP9Deployment` fields
- `max_activation_height` (default: `INT_MAX` = disabled)
- `active_duration` (default: `INT_MAX` = permanent)

### State machine changes
- STARTED -> LOCKED_IN forced when `height >= max_activation_height - period`
- ACTIVE -> EXPIRED when `height >= activation_height + active_duration` (new terminal state)
- `active_duration` must be a multiple of `period`

### Mandatory signaling
- Blocks that don't signal during the mandatory signaling period (`max_activation_height - 2*period` through `max_activation_height - period - 1`) are rejected
- `getblocktemplate` sets `vbrequired` bits during this window

### RPC
- `getdeploymentinfo`: new `max_activation_height` field in `bip9` object when set
- `getdeploymentinfo`: new `height_end` field when ACTIVE with `active_duration`
- `status` field now includes `"expired"` as a possible value

### Regtest `-vbparams` support
- Extended format: `deployment:start:end[:min_activation_height[:max_activation_height[:active_duration[:threshold]]]]`
- Validates mutual exclusion of `timeout` and `max_activation_height`
- Validates `active_duration` is a multiple of `period`

## Tests

- **11 unit tests** covering forced lock-in, boundary conditions, EXPIRED transitions, cold cache recovery, parameter validation, and edge cases (zero duration, unaligned duration rejected)
- **Functional test** (`feature_bip9_max_activation_height.py`): mandatory activation, normal signaling, early activation, permanent vs temporary deployments, custom threshold, and mandatory signaling enforcement (non-signaling block rejected)
- **Fuzz test** updates for `active_duration` and EXPIRED state

Note: enforcement-level testing (consensus rules activating/deactivating via `DeploymentActiveAfter`) is in [PR 2](https://github.com/bitcoin/bitcoin/pull/34930), which provides a real deployment (REDUCED_DATA) to test against. TESTDUMMY has no consensus enforcement.

## Size

~175 lines non-test C++/H. This puts these deployment changes for BIP-110 at about half the size of [the deployment changes required for CSV (BIP-68/112/113)](https://github.com/bitcoin/bitcoin/pull/7575), which weighed in at 371 lines.
