### PR TITLE
blockencodings: recover from cmpctblock short-id collisions

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -91,12 +91,25 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     // Because well-formed cmpctblock messages will have a (relatively) uniform distribution
     // of short IDs, any highly-uneven distribution of elements can be safely treated as a
     // READ_STATUS_FAILED.
-    std::unordered_map<uint64_t, uint16_t> shorttxids(cmpctblock.shorttxids.size());
+    std::unordered_map<uint64_t, uint32_t> shorttxids(cmpctblock.shorttxids.size());
+    static constexpr uint32_t SHORTID_COLLISION{std::numeric_limits<uint16_t>::max() + 1U};
+    size_t shorttxids_unique_count{0};
     uint16_t index_offset = 0;
     for (size_t i = 0; i < cmpctblock.shorttxids.size(); i++) {
         while (txn_available[i + index_offset])
             index_offset++;
-        shorttxids[cmpctblock.shorttxids[i]] = i + index_offset;
+        const auto [idit, inserted] = shorttxids.emplace(cmpctblock.shorttxids[i], i + index_offset);
+        if (!inserted) {
+            // Leave all transactions sharing a short ID unavailable so they are
+            // requested explicitly with getblocktxn instead of failing the
+            // entire compact block reconstruction attempt.
+            if (idit->second != SHORTID_COLLISION) {
+                idit->second = SHORTID_COLLISION;
+                --shorttxids_unique_count;
+            }
+            continue;
+        }
+        ++shorttxids_unique_count;
         // To determine the chance that the number of entries in a bucket exceeds N,
         // we use the fact that the number of elements in a single bucket is
         // binomially distributed (with n = the number of shorttxids S, and p =
@@ -110,18 +123,14 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         if (shorttxids.bucket_size(shorttxids.bucket(cmpctblock.shorttxids[i])) > 12)
             return READ_STATUS_FAILED;
     }
-    // TODO: in the shortid-collision case, we should instead request both transactions
-    // which collided. Falling back to full-block-request here is overkill.
-    if (shorttxids.size() != cmpctblock.shorttxids.size())
-        return READ_STATUS_FAILED; // Short ID collision
 
     std::vector<bool> have_txn(txn_available.size());
     {
     LOCK(pool->cs);
     for (const auto& [wtxid, txit] : pool->txns_randomized) {
         uint64_t shortid = cmpctblock.GetShortID(wtxid);
-        std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(shortid);
-        if (idit != shorttxids.end()) {
+        std::unordered_map<uint64_t, uint32_t>::iterator idit = shorttxids.find(shortid);
+        if (idit != shorttxids.end() && idit->second != SHORTID_COLLISION) {
             if (!have_txn[idit->second]) {
                 txn_available[idit->second] = txit->GetSharedTx();
                 have_txn[idit->second]  = true;
@@ -139,15 +148,15 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
         // the performance win of an early exit here is too good to pass up and worth
         // the extra risk.
-        if (mempool_count == shorttxids.size())
+        if (mempool_count == shorttxids_unique_count)
             break;
     }
     }
 
     for (size_t i = 0; i < extra_txn.size(); i++) {
         uint64_t shortid = cmpctblock.GetShortID(extra_txn[i].first);
-        std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(shortid);
-        if (idit != shorttxids.end()) {
+        std::unordered_map<uint64_t, uint32_t>::iterator idit = shorttxids.find(shortid);
+        if (idit != shorttxids.end() && idit->second != SHORTID_COLLISION) {
             if (!have_txn[idit->second]) {
                 txn_available[idit->second] = extra_txn[i].second;
                 have_txn[idit->second]  = true;
@@ -171,7 +180,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
         // the performance win of an early exit here is too good to pass up and worth
         // the extra risk.
-        if (mempool_count == shorttxids.size())
+        if (mempool_count == shorttxids_unique_count)
             break;
     }
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -355,6 +355,36 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(ShortIDCollisionRecoveryTest)
+{
+    CTxMemPool& pool = *Assert(m_node.mempool);
+    auto rand_ctx(FastRandomContext(uint256{42}));
+    const CBlock block(BuildBlockTestCase(rand_ctx));
+
+    TestHeaderAndShortIDs shortIDs(block, rand_ctx);
+    BOOST_REQUIRE_EQUAL(shortIDs.shorttxids.size(), 2U);
+    shortIDs.shorttxids[1] = shortIDs.shorttxids[0];
+
+    DataStream stream{};
+    stream << shortIDs;
+
+    CBlockHeaderAndShortTxIDs shortIDs2;
+    stream >> shortIDs2;
+
+    PartiallyDownloadedBlock partialBlock(&pool);
+    BOOST_CHECK(partialBlock.InitData(shortIDs2, empty_extra_txn) == READ_STATUS_OK);
+    BOOST_CHECK(partialBlock.IsTxAvailable(0));
+    BOOST_CHECK(!partialBlock.IsTxAvailable(1));
+    BOOST_CHECK(!partialBlock.IsTxAvailable(2));
+
+    CBlock reconstructed;
+    BOOST_CHECK(partialBlock.FillBlock(reconstructed, {block.vtx[1], block.vtx[2]}, /*segwit_active=*/true) == READ_STATUS_OK);
+    bool mutated;
+    BOOST_CHECK_EQUAL(block.GetHash().ToString(), reconstructed.GetHash().ToString());
+    BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(reconstructed, &mutated).ToString());
+    BOOST_CHECK(!mutated);
+}
+
 BOOST_AUTO_TEST_CASE(TransactionsRequestSerializationTest) {
     BlockTransactionsRequest req1;
     req1.blockhash = m_rng.rand256();

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -424,6 +424,23 @@ class CompactBlocksTest(BitcoinTestFramework):
         block.solve()
         return block
 
+    # Build a block with independent spends so individual transactions can be
+    # selectively preloaded into the mempool.
+    def build_block_with_independent_transactions(self, node, utxos):
+        block = self.build_block_on_tip(node)
+        next_utxos = []
+
+        for utxo in utxos:
+            tx = CTransaction()
+            tx.vin.append(CTxIn(COutPoint(utxo[0], utxo[1]), b''))
+            tx.vout.append(CTxOut(utxo[2] - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
+            next_utxos.append([tx.txid_int, 0, tx.vout[0].nValue])
+            block.vtx.append(tx)
+
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        return block, next_utxos
+
     # Test that we only receive getblocktxn requests for transactions that the
     # node needs, and that responding to them causes the block to be
     # reconstructed.
@@ -506,6 +523,46 @@ class CompactBlocksTest(BitcoinTestFramework):
         with p2p_lock:
             # Shouldn't have gotten a request for any transaction
             assert "getblocktxn" not in test_node.last_message
+
+    def test_shortid_collision_recovery(self, test_node):
+        node = self.nodes[0]
+        utxos = [self.utxos.pop(0) for _ in range(5)]
+        block, next_utxos = self.build_block_with_independent_transactions(node, utxos)
+
+        # Preload every non-colliding transaction so only the collided entries
+        # need to be requested.
+        for tx in [block.vtx[1], block.vtx[3], block.vtx[5]]:
+            test_node.send_without_ping(msg_tx(tx))
+        test_node.sync_with_ping()
+
+        mempool = node.getrawmempool()
+        for tx in [block.vtx[1], block.vtx[3], block.vtx[5]]:
+            assert tx.txid_hex in mempool
+
+        comp_block = HeaderAndShortIDs()
+        comp_block.initialize_from_block(block, prefill_list=[0], use_witness=True)
+        # With only the coinbase prefilled, shortids[1] and shortids[3]
+        # correspond to transactions at absolute indexes 2 and 4.
+        comp_block.shortids[3] = comp_block.shortids[1]
+
+        with p2p_lock:
+            test_node.last_message.pop("getblocktxn", None)
+            test_node.last_message.pop("getdata", None)
+
+        test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+
+        with p2p_lock:
+            assert "getdata" not in test_node.last_message
+            assert "getblocktxn" in test_node.last_message
+            absolute_indexes = test_node.last_message["getblocktxn"].block_txn_request.to_absolute()
+        assert_equal(absolute_indexes, [2, 4])
+
+        msg = msg_blocktxn()
+        msg.block_transactions = BlockTransactions(block.hash_int, [block.vtx[2], block.vtx[4]])
+        test_node.send_and_ping(msg)
+        assert_equal(node.getbestblockhash(), block.hash_hex)
+
+        self.utxos.extend(next_utxos)
 
     # Incorrectly responding to a getblocktxn shouldn't cause the block to be
     # permanently failed.
@@ -979,6 +1036,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         self.log.info("Testing getblocktxn requests (segwit node)...")
         self.test_getblocktxn_requests(self.segwit_node)
+
+        self.log.info("Testing compact block short-id collision recovery...")
+        self.test_shortid_collision_recovery(self.segwit_node)
 
         self.log.info("Testing getblocktxn handler (segwit node should return witnesses)...")
         self.test_getblocktxn_handler(self.segwit_node)


### PR DESCRIPTION
When two transactions in a compact block share the same 6-byte short ID, `InitData()` currently returns `READ_STATUS_FAILED`, abandoning reconstruction entirely and falling back to a full block download. 

This is unnecessarily broad. A collision only means those specific positions are ambiguous - the rest of the compact block is still usable.

This PR marks collided short IDs with a sentinel value instead of failing. Ambiguous entries are skipped during mempool/extra_txn matching and left as unavailable in `txn_available`, so they flow naturally into the existing `getblocktxn` request path. Only the collided transactions are fetched; the compact block fast path is preserved for everything else.                                         
                                                                                                    
Safety is unchanged: ambiguous positions are never guessed, and reconstructed blocks are still validated for merkle mutation before acceptance.