### PR TITLE
net: cbfilters: Don't disconnect peers for requesting unknown blocks.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3283,7 +3283,6 @@ bool PeerManagerImpl::PrepareBlockFilterRequest(CNode& node, Peer& peer,
         if (!stop_index || !BlockRequestAllowed(*stop_index)) {
             LogDebug(BCLog::NET, "peer requested invalid block hash: %s, %s",
                      stop_hash.ToString(), node.DisconnectMsg());
-            node.fDisconnect = true;
             return false;
         }
     }

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -193,6 +193,41 @@ class CompactFiltersTest(BitcoinTestFramework):
         computed_cfhash = uint256_from_str(hash256(cfilter.filter_data))
         assert_equal(computed_cfhash, stale_cfhashes[999])
 
+        self.log.info("Check that requesting unknown block hash results in no response, but doesn't result in disconnect.")
+
+        self.disconnect_nodes(0, 1)
+        unknown_block_hash = self.generate(self.nodes[1], 1, sync_fun=self.no_op)[0]
+
+        peer_0 = self.nodes[0].add_p2p_connection(P2PInterface())
+
+        requests = [
+            msg_getcfcheckpt(
+                filter_type=FILTER_TYPE_BASIC,
+                stop_hash=int(unknown_block_hash, 16),
+            ),
+            msg_getcfheaders(
+                filter_type=FILTER_TYPE_BASIC,
+                start_height=1,
+                stop_hash=int(unknown_block_hash, 16),
+            ),
+            msg_getcfilters(
+                filter_type=FILTER_TYPE_BASIC,
+                start_height=1,
+                stop_hash=int(unknown_block_hash, 16),
+            ),
+        ]
+
+        for request in requests:
+            peer_0.last_message = {}
+            peer_0.send_and_ping(request)
+
+            # No response...
+            assert all(msg not in peer_0.last_message for msg in ['cfheaders', 'cffilters', 'cfcheckpt'])
+            # ...But we're still connected!
+            assert peer_0.is_connected
+
+        self.connect_nodes(0, 1)
+
         self.log.info("Requests to node 1 without NODE_COMPACT_FILTERS results in disconnection.")
         requests = [
             msg_getcfcheckpt(
@@ -240,13 +275,6 @@ class CompactFiltersTest(BitcoinTestFramework):
                     filter_type=255,
                     stop_hash=int(main_block_hash, 16),
                 ), "requested unsupported block filter type"
-            ),
-            # Requesting unknown hash results in disconnection.
-            (
-                msg_getcfcheckpt(
-                    filter_type=FILTER_TYPE_BASIC,
-                    stop_hash=123456789,
-                ), "requested invalid block hash"
             ),
             (
                 # Request with (start block height > stop block height) results in disconnection.


### PR DESCRIPTION
Some BIP157 light clients are not complying with the following requirement:

> StopHash MUST be known to belong to a block accepted by the receiving peer. This is the case if the peer had previously sent a `headers` or `inv` message with that block or any descendents. A node that receives [`getcf(ilter|header|checkpt)s`]with an unknown StopHash SHOULD NOT respond.

https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki#getcfilters

During the recent 2-block reorg I observed on one node's logs that it disconnected BIP157 peers with the version string `/btcwire:0.5.0/neutrino:0.12.0-beta/` for asking for filters from the other side of the block race:

```
[net] peer requested invalid block hash: 95b0d0f836f18d78dfbae435fb37bf6fff2e37a4fc01c20be8495bc3ea4fbb58, disconnecting peer=8502032, [...]
```

(https://bnoc.xyz/t/raw-data-request-block-filter-peers-being-disconnected-due-to-invalid-block-requests/101)

The broken implementations should fix themselves, but disconnecting is too harsh of a punishment for this mistake, this PR keeps the log message and returns early without responding when this happens, but doesn't set `fDisconnect=true`.