### PR TITLE
cli: Return more correct error on -norpccookiefile without -rpcpassword

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -901,15 +901,12 @@ static UniValue CallRPC(BaseRequestHandler* rh, const std::string& strMethod, co
     evhttp_request_set_error_cb(req.get(), http_error_cb);
 
     // Get credentials
-    std::string strRPCUserColonPass;
-    bool failedToGetAuthCookie = false;
+    std::optional<std::string> rpc_credentials;
     if (gArgs.GetArg("-rpcpassword", "") == "") {
         // Try fall back to cookie-based authentication if no password is provided
-        if (!GetAuthCookie(&strRPCUserColonPass)) {
-            failedToGetAuthCookie = true;
-        }
+        rpc_credentials = GetAuthCookie();
     } else {
-        strRPCUserColonPass = username + ":" + gArgs.GetArg("-rpcpassword", "");
+        rpc_credentials = username + ":" + gArgs.GetArg("-rpcpassword", "");
     }
 
     struct evkeyvalq* output_headers = evhttp_request_get_output_headers(req.get());
@@ -917,7 +914,7 @@ static UniValue CallRPC(BaseRequestHandler* rh, const std::string& strMethod, co
     evhttp_add_header(output_headers, "Host", host.c_str());
     evhttp_add_header(output_headers, "Connection", "close");
     evhttp_add_header(output_headers, "Content-Type", "application/json");
-    evhttp_add_header(output_headers, "Authorization", (std::string("Basic ") + EncodeBase64(strRPCUserColonPass)).c_str());
+    evhttp_add_header(output_headers, "Authorization", (std::string("Basic ") + EncodeBase64(rpc_credentials.value_or(""))).c_str());
 
     // Attach request data
     std::string strRequest = rh->PrepareRequest(strMethod, args).write() + "\n";
@@ -942,7 +939,7 @@ static UniValue CallRPC(BaseRequestHandler* rh, const std::string& strMethod, co
                     "Use \"bitcoin-cli -help\" for more info.",
                     host, port, responseErrorMessage));
     } else if (response.status == HTTP_UNAUTHORIZED) {
-        if (failedToGetAuthCookie) {
+        if (!rpc_credentials.has_value()) {
             throw std::runtime_error(strprintf(
                 "Could not locate RPC credentials. No authentication cookie could be found, and RPC password is not set.  See -rpcpassword and -stdinrpcpass.  Configuration file: (%s)",
                 fs::PathToString(gArgs.GetConfigFilePath())));

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -151,7 +151,7 @@ bool GetAuthCookie(std::string *cookie_out)
     std::string cookie;
     fs::path filepath = GetAuthCookieFile();
     if (filepath.empty()) {
-        return true; // -norpccookiefile
+        return false; // -norpccookiefile
     }
     file.open(filepath.std_path());
     if (!file.is_open())

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -145,23 +145,21 @@ GenerateAuthCookieResult GenerateAuthCookie(const std::optional<fs::perms>& cook
     return GenerateAuthCookieResult::OK;
 }
 
-bool GetAuthCookie(std::string *cookie_out)
+std::optional<std::string> GetAuthCookie()
 {
     std::ifstream file;
     std::string cookie;
     fs::path filepath = GetAuthCookieFile();
     if (filepath.empty()) {
-        return false; // -norpccookiefile
+        return std::nullopt; // -norpccookiefile
     }
     file.open(filepath.std_path());
-    if (!file.is_open())
-        return false;
+    if (!file.is_open()) {
+        return std::nullopt;
+    }
     std::getline(file, cookie);
     file.close();
-
-    if (cookie_out)
-        *cookie_out = cookie;
-    return true;
+    return cookie;
 }
 
 void DeleteAuthCookie()

--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -43,7 +43,7 @@ GenerateAuthCookieResult GenerateAuthCookie(const std::optional<fs::perms>& cook
                                             std::string& pass);
 
 /** Read the RPC authentication cookie from disk */
-bool GetAuthCookie(std::string *cookie_out);
+std::optional<std::string> GetAuthCookie();
 /** Delete RPC authentication cookie from disk */
 void DeleteAuthCookie();
 /** Parse JSON-RPC batch reply into a vector */

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -195,8 +195,13 @@ class TestBitcoinCli(BitcoinTestFramework):
         # Re-enable rpcport in conf if present
         self.nodes[0].replace_in_config([("#" + conf_rpcport, conf_rpcport)])
 
+        msg_missing_cred = "Could not locate RPC credentials. No authentication cookie could be found, and RPC password is not set."
         self.log.info("Test connecting with non-existing RPC cookie file")
-        assert_raises_process_error(1, "Could not locate RPC credentials", self.nodes[0].cli('-rpccookiefile=does-not-exist', '-rpcpassword=').echo)
+        assert_raises_process_error(1, msg_missing_cred, self.nodes[0].cli('-rpccookiefile=does-not-exist', '-rpcpassword=').echo)
+
+        self.log.info("Test connecting with neither cookie file, nor password")
+        assert_raises_process_error(1, msg_missing_cred, self.nodes[0].cli("-norpccookiefile").echo)
+        assert_raises_process_error(1, msg_missing_cred, self.nodes[0].cli("-norpccookiefile", "-rpcpassword=").echo)
 
         self.log.info("Test connecting without RPC cookie file and with password arg")
         assert_equal(BLOCKS, self.nodes[0].cli('-norpccookiefile', f'-rpcuser={user}', f'-rpcpassword={password}').getblockcount())


### PR DESCRIPTION
This clarifies an error message to be more precise. When neither a cookie file, nor password are provided, the `bitcoin-cli` error message would be:

> Incorrect rpcuser or rpcpassword.

Implying that the user can only fix the error by setting an rpcpassword.
However, the user can also set -rpccookiesfile to fix the error. So the
new error message makes more sense:

> Could not locate RPC credentials. No authentication cookie could be found, and RPC password is not set.

Also, refactor to `std::optional`, which makes the code clearer.