### PR TITLE
wallet: reject input_weights for outpoints not in transaction

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -648,6 +648,19 @@ CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransact
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout cannot be negative");
             }
 
+            COutPoint outpoint(txid, vout);
+            bool found = false;
+            for (const CTxIn& txin : tx.vin) {
+                if (txin.prevout == outpoint) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                    strprintf("Input weight specified for %s:%d but this outpoint is not in the transaction inputs", txid.GetHex(), vout));
+            }
+
             const UniValue& weight_v = input.find_value("weight");
             if (!weight_v.isNum()) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing weight key");
@@ -662,7 +675,7 @@ CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransact
                 throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid parameter, weight cannot be greater than the maximum standard tx weight of %d", MAX_STANDARD_TX_WEIGHT));
             }
 
-            coinControl.SetInputWeight(COutPoint(txid, vout), weight);
+            coinControl.SetInputWeight(outpoint, weight);
         }
     }
 

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -1062,6 +1062,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Invalid parameter, weight cannot be less than 165", wallet.fundrawtransaction, raw_tx, input_weights=[{"txid": ext_utxo["txid"], "vout": ext_utxo["vout"], "weight": -1}])
         assert_raises_rpc_error(-8, "Invalid parameter, weight cannot be greater than", wallet.fundrawtransaction, raw_tx, input_weights=[{"txid": ext_utxo["txid"], "vout": ext_utxo["vout"], "weight": 400001}])
 
+        # input_weights for an outpoint not in the transaction must be rejected
+        wallet_utxo = wallet.listunspent()[0]
+        assert_raises_rpc_error(-8, "not in the transaction inputs", wallet.fundrawtransaction, raw_tx, input_weights=[
+            {"txid": ext_utxo["txid"], "vout": ext_utxo["vout"], "weight": 165},
+            {"txid": wallet_utxo["txid"], "vout": wallet_utxo["vout"], "weight": 165},
+        ])
+
         # But funding should work when the solving data is provided
         funded_tx = wallet.fundrawtransaction(raw_tx, solving_data={"pubkeys": [addr_info['pubkey']], "scripts": [addr_info["embedded"]["scriptPubKey"]]})
         signed_tx = wallet.signrawtransactionwithwallet(funded_tx['hex'])


### PR DESCRIPTION
fundrawtransaction, send, and walletcreatefundedpsbt accept an input_weights parameter that sets the weight for transaction inputs. SetInputWeight uses map::operator[] which silently creates entries in the coin control selection set for outpoints not in the transaction, causing unintended UTXOs to be spent.

Validate that each input_weights entry corresponds to an actual input in the transaction before setting the weight.
