### PR TITLE
rpc: migrate generatetoaddress params to self.Arg for consistency

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -283,10 +283,10 @@ static RPCHelpMan generatetoaddress()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const int num_blocks{request.params[0].getInt<int>()};
-    const uint64_t max_tries{request.params[2].isNull() ? DEFAULT_MAX_TRIES : request.params[2].getInt<int>()};
+    const auto num_blocks{self.Arg<int>("nblocks")};
+    const auto max_tries{self.Arg<uint64_t>("maxtries")};
 
-    CTxDestination destination = DecodeDestination(request.params[1].get_str());
+    CTxDestination destination = DecodeDestination(std::string{self.Arg<std::string_view>("address")});
     if (!IsValidDestination(destination)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Error: Invalid address");
     }

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -27,6 +27,9 @@ class RPCGenerateTest(BitcoinTestFramework):
         self.generatetoaddress(self.nodes[0], 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
         assert_raises_rpc_error(-5, "Invalid address", self.generatetoaddress, self.nodes[0], 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
 
+        self.log.info("Test generatetoaddress rejects negative maxtries")
+        assert_raises_rpc_error(-1, "JSON integer out of range", self.generatetoaddress, self.nodes[0], 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ', -1)
+
     def test_generateblock(self):
         node = self.nodes[0]
         miniwallet = MiniWallet(node)


### PR DESCRIPTION
`generatetoaddress` extracts parameters using the older `request.params[]` API, while its sibling `generatetodescriptor` already uses `self.Arg<>()` (since c00000df16). This migrates all three parameter extractions in `generatetoaddress` to the `self.Arg<>` API for consistency.

As a side-effect, negative `maxtries` values (e.g. `-1`) are now correctly rejected with "JSON integer out of range" instead of silently wrapping to `UINT64_MAX` via implicit conversion.