### PR TITLE
crypto: disable ASan instrumentation of SSE4 SHA256 for GCC (matching Clang)

### DIFF
--- a/src/crypto/sha256_sse4.cpp
+++ b/src/crypto/sha256_sse4.cpp
@@ -12,18 +12,23 @@
 
 namespace sha256_sse4
 {
-void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
-#if defined(__clang__)
-  /*
-  clang is unable to compile this with -O0 and -fsanitize=address.
-  See upstream bug: https://github.com/llvm/llvm-project/issues/92182.
-  This also fails to compile with -O2, -fcf-protection & -fsanitize=address.
-  See https://github.com/bitcoin/bitcoin/issues/31913.
-  */
-#if __has_feature(address_sanitizer)
+/*
+Both Clang and GCC fail with ASan on this inline assembly:
+- Clang: compile failure with -O0 or -O2 + -fcf-protection under ASan.
+  See https://github.com/llvm/llvm-project/issues/92182
+  and https://github.com/bitcoin/bitcoin/issues/31913.
+- GCC: runtime SEGV during SHA256AutoDetect()'s self-test under ASan,
+  regardless of optimization level.
+  See https://github.com/bitcoin/bitcoin/issues/34881.
+*/
+#if defined(__SANITIZE_ADDRESS__)
+  __attribute__((no_sanitize("address")))
+#elif defined(__clang__)
+#if __has_feature(address_sanitizer) // fallback can be removed once support for Clang 21 is dropped
   __attribute__((no_sanitize("address")))
 #endif
 #endif
+void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
 {
     static const uint32_t K256 alignas(16) [] = {
         0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,


### PR DESCRIPTION
Fix the runtime crash described in #34881.

Upstream already disables ASan instrumentation for `sha256_sse4::Transform()` under Clang. This extends the same workaround to GCC by adding an `#elif` branch for `__GNUC__` / `__SANITIZE_ADDRESS__` that applies the same `no_sanitize("address")` attribute.

Testing:

- reproduced the crash before the fix with GCC 13, 14, and 15 on Haswell-class machines / guests without SHA-NI (including by forcing the SSE4 implementation on GitHub CI)
- SEGV in debug builds regardless of optimization level (tested `-O0`, `-O1`, `-O2`, `-O3`)
- verified that the GCC + ASan debug configurations that previously crashed pass with this change

Issue #34881 has more details about the issue.

Note: the original Clang code placed the `__attribute__` between the function declarator and the opening brace. GCC's [Attribute Syntax](https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html) documentation notes that this position in a function definition "may, in future, be permitted," so it is not currently supported. Placing the attribute at the start of the function definition is valid form for both GCC and Clang.