### PR TITLE
policy: remove incorrect `MANDATORY_SCRIPT_VERIFY_FLAGS` comment

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -96,8 +96,7 @@ static constexpr unsigned int MAX_DUST_OUTPUTS_PER_TX{1};
 
 /**
  * Mandatory script verification flags that all new transactions must comply with for
- * them to be valid. Failing one of these tests may trigger a DoS ban;
- * see CheckInputScripts() for details.
+ * them to be valid.
  *
  * Note that this does not affect consensus validity; see GetBlockScriptFlags()
  * for that.


### PR DESCRIPTION
Since https://github.com/bitcoin/bitcoin/pull/33050 

This comment claiming that failing mandatory script checks may trigger a DoS ban/punishment is false.
`CheckInputScript` also dispute this comment.

https://github.com/bitcoin/bitcoin/blob/b0f68f0a3a361c62cb1e1cb49aacaeac171f3079/src/validation.cpp#L2113-L2118
