### PR TITLE
test: mining: add coverage for GBT's "coinbasevalue" result field

### DIFF
--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -122,7 +122,8 @@ class MiningTest(BitcoinTestFramework):
         tx_d = self.wallet.send_self_transfer(from_node=node,
                                               fee_rate=Decimal("0.00100"))
 
-        block_template_txs = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)['transactions']
+        block_template = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
+        block_template_txs = block_template['transactions']
 
         block_template_fees = [tx['fee'] for tx in block_template_txs]
         assert_equal(block_template_fees, [
@@ -131,6 +132,10 @@ class MiningTest(BitcoinTestFramework):
             tx_b["fee"] * COIN,
             tx_c["fee"] * COIN
         ])
+        # verify that coinbasevalue field is set to claim full block reward (subsidy + fees)
+        expected_block_reward = create_coinbase(
+            height=int(block_template["height"]), fees=sum(block_template_fees)).vout[0].nValue
+        assert_equal(block_template["coinbasevalue"], expected_block_reward)
 
         block_template_sigops = [tx['sigops'] for tx in block_template_txs]
         assert_equal(block_template_sigops, [0, 4, 4, 4])


### PR DESCRIPTION
This PR adds missing coverage for the "coinbasevalue" result field of the `getblocktemplate` RPC call. Specifically, the introduced test checks that the value is set to claim the full block reward (subsidy plus fees). Can be verified with the following patch, which succeeds on master and fails on the PR branch:

```diff
diff --git a/src/rpc/mining.cpp b/src/rpc/mining.cpp
index a935810d91..ba9ac9dadb 100644
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -998,7 +998,7 @@ static RPCHelpMan getblocktemplate()
     result.pushKV("previousblockhash", block.hashPrevBlock.GetHex());
     result.pushKV("transactions", std::move(transactions));
     result.pushKV("coinbaseaux", std::move(aux));
-    result.pushKV("coinbasevalue", block.vtx[0]->vout[0].nValue);
+    result.pushKV("coinbasevalue", block.vtx[0]->vout[0].nValue - 1);
     result.pushKV("longpollid", tip.GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", GetMinimumTime(pindexPrev, consensusParams.DifficultyAdjustmentInterval()));

```

I'm not sure how relevant this field is nowadays in real-world mining scenarios (we use it for the signet miner at least), but it seems useful to have a test for it anyways. Stumbled upon this while looking at https://github.com/bitcoin-inquisition/bitcoin/pull/111.