### PR TITLE
wallet: Enforce BDB btree levels and overflow item sizes

### DIFF
--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -626,6 +626,7 @@ void BerkeleyRODatabase::Open()
     if (inner_meta.last_page > outer_meta.last_page) {
         throw std::runtime_error("Subdatabase last page is greater than database last page");
     }
+    uint64_t max_data_size = static_cast<uint64_t>(outer_meta.last_page) * page_size;
 
     // Make sure encryption is disabled
     if (inner_meta.encrypt_algo != 0) {
@@ -673,6 +674,9 @@ void BerkeleyRODatabase::Open()
                 } else if (const OverflowRecord* orec = std::get_if<OverflowRecord>(&rec)) {
                     if (orec->m_header.deleted) continue;
                     uint32_t next_page = orec->page_number;
+                    if (orec->item_len > max_data_size) {
+                        throw std::runtime_error("Overflow record has an impossible length");
+                    }
                     while (next_page != 0) {
                         SeekToPage(db_file, next_page, page_size);
                         PageHeader opage_header(next_page, inner_meta.other_endian);
@@ -683,6 +687,9 @@ void BerkeleyRODatabase::Open()
                         OverflowPage opage(opage_header);
                         db_file >> opage;
                         data.insert(data.end(), opage.data.begin(), opage.data.end());
+                        if (data.size() > orec->item_len) {
+                            throw std::runtime_error("Overflow record data is larger than stated size");
+                        }
                         next_page = opage_header.next_page;
                     }
                 }

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -633,10 +633,17 @@ void BerkeleyRODatabase::Open()
         throw std::runtime_error("BDB builtin encryption is not supported");
     }
 
+    // Read the root's level from its header
+    // Note that we will read the root page twice in order to process it.
+    SeekToPage(db_file, inner_meta.root, page_size);
+    PageHeader root_header(inner_meta.root, inner_meta.other_endian);
+    db_file >> root_header;
+
     // Do a DFS through the BTree, starting at root
-    std::vector<uint32_t> pages{inner_meta.root};
+    // We track the expected level of each page in order to avoid loops
+    std::vector<std::pair<uint32_t, uint32_t>> pages{{inner_meta.root, root_header.level}};
     while (pages.size() > 0) {
-        uint32_t curr_page = pages.back();
+        auto [curr_page, expected_level] = pages.back();
         // It turns out BDB completely ignores this last_page field and doesn't actually update it to the correct
         // last page. While we should be checking this, we can't.
         // This is left commented out as a reminder to not accidentally implement this in the future.
@@ -647,17 +654,23 @@ void BerkeleyRODatabase::Open()
         SeekToPage(db_file, curr_page, page_size);
         PageHeader header(curr_page, inner_meta.other_endian);
         db_file >> header;
+        if (header.level != expected_level) {
+            throw std::runtime_error("BTree page has an unexpected level");
+        }
         switch (header.type) {
         case PageType::BTREE_INTERNAL: {
             InternalPage int_page(header);
             db_file >> int_page;
             for (const InternalRecord& rec : int_page.records) {
                 if (rec.m_header.deleted) continue;
-                pages.push_back(rec.page_num);
+                pages.emplace_back(rec.page_num, header.level - 1);
             }
             break;
         }
         case PageType::BTREE_LEAF: {
+            if (header.level != 1) {
+                throw std::runtime_error("BTree Leaf page is not at level 1");
+            }
             RecordsPage rec_page(header);
             db_file >> rec_page;
             if (rec_page.records.size() % 2 != 0) {

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -74,14 +74,15 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
             error.original == "Internal record position not in page" ||
             error.original == "LSNs are not reset, this database is not completely flushed. Please reopen then close the database with a version that has BDB support" ||
             error.original == "Records page has odd number of records" ||
-            error.original == "Bad overflow record page type") {
-            // Do nothing
-        } else if (error.original == "Subdatabase last page is greater than database last page" ||
-                   error.original == "Page number is greater than database last page" ||
-                   error.original == "Last page number could not fit in file" ||
-                   error.original == "Subdatabase has an unexpected name" ||
-                   error.original == "Unsupported BDB data file version number" ||
-                   error.original == "BDB builtin encryption is not supported") {
+            error.original == "Bad overflow record page type" ||
+            error.original == "BTree page has an unexpected level" ||
+            error.original == "BTree Leaf page is not at level 1" ||
+            error.original == "Subdatabase last page is greater than database last page" ||
+            error.original == "Page number is greater than database last page" ||
+            error.original == "Last page number could not fit in file" ||
+            error.original == "Subdatabase has an unexpected name" ||
+            error.original == "Unsupported BDB data file version number" ||
+            error.original == "BDB builtin encryption is not supported") {
         } else {
             throw std::runtime_error(error.original);
         }


### PR DESCRIPTION
Alternative to #34946

BDB's overflow records include the total length of the data to be read from the overflow pages. If this length is impossible (larger than max page * page size), or if the data that we are reading exceeds the stated length, then throw an exception as this is an invalid BDB file. This prevents infinite looping if an overflow page makes a circular reference.

BDB BTrees also include the level in the tree that the page is supposed to be at. Leaf pages are always at level 1. Starting from the root page, we can validate that each child has a level one less than the parent, until we reach a leaf page with a level of 1. This also ensures that we cannot have circular internal page references.