### PR TITLE
fuzz: several improvements to scriptpubkeyman harness

### DIFF
--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -163,10 +163,10 @@ uint32_t ConsumeSequence(FuzzedDataProvider& fuzzed_data_provider) noexcept
                fuzzed_data_provider.ConsumeIntegral<uint32_t>();
 }
 
-std::map<COutPoint, Coin> ConsumeCoins(FuzzedDataProvider& fuzzed_data_provider) noexcept
+std::map<COutPoint, Coin> ConsumeCoins(FuzzedDataProvider& fuzzed_data_provider, unsigned int num_coins) noexcept
 {
     std::map<COutPoint, Coin> coins;
-    LIMITED_WHILE (fuzzed_data_provider.ConsumeBool(), 10000) {
+    LIMITED_WHILE (fuzzed_data_provider.ConsumeBool(), num_coins) {
         const std::optional<COutPoint> outpoint{ConsumeDeserializable<COutPoint>(fuzzed_data_provider)};
         if (!outpoint) {
             break;

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -222,7 +222,7 @@ template <class Dur>
     return result;
 }
 
-[[nodiscard]] std::map<COutPoint, Coin> ConsumeCoins(FuzzedDataProvider& fuzzed_data_provider) noexcept;
+[[nodiscard]] std::map<COutPoint, Coin> ConsumeCoins(FuzzedDataProvider& fuzzed_data_provider, unsigned int num_coins = 10'000) noexcept;
 
 [[nodiscard]] CTxDestination ConsumeTxDestination(FuzzedDataProvider& fuzzed_data_provider) noexcept;
 

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -111,14 +111,12 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
     if (spk_manager == nullptr) return;
 
     if (fuzzed_data_provider.ConsumeBool()) {
-        auto wallet_desc{CreateWalletDescriptor(fuzzed_data_provider)};
-        if (!wallet_desc.has_value()) {
-            return;
-        }
-        std::string error;
-        if (spk_manager->CanUpdateToWalletDescriptor(wallet_desc->first, error)) {
-            auto new_spk_manager{CreateDescriptor(wallet_desc->first, wallet_desc->second, wallet)};
-            if (new_spk_manager != nullptr) spk_manager = new_spk_manager;
+        if (auto wallet_desc{CreateWalletDescriptor(fuzzed_data_provider)}) {
+            std::string error;
+            if (spk_manager->CanUpdateToWalletDescriptor(wallet_desc->first, error)) {
+                auto new_spk_manager{CreateDescriptor(wallet_desc->first, wallet_desc->second, wallet)};
+                if (new_spk_manager != nullptr) spk_manager = new_spk_manager;
+            }
         }
     }
 

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -127,15 +127,8 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                const CScript script{ConsumeScript(fuzzed_data_provider)};
-                if (spk_manager->IsMine(script)) {
-                    assert(spk_manager->GetScriptPubKeys().contains(script));
-                }
-            },
-            [&] {
                 auto spks{spk_manager->GetScriptPubKeys()};
                 for (const CScript& spk : spks) {
-                    assert(spk_manager->IsMine(spk));
                     CTxDestination dest;
                     bool extract_dest{ExtractDestination(spk, dest)};
                     if (extract_dest) {
@@ -151,10 +144,8 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
             },
             [&] {
                 auto spks{spk_manager->GetScriptPubKeys()};
-                if (!spks.empty()) {
-                    auto& spk{PickValue(fuzzed_data_provider, spks)};
-                    (void)spk_manager->MarkUnusedAddresses(spk);
-                }
+                auto& spk{(!spks.empty() && fuzzed_data_provider.ConsumeBool()) ? PickValue(fuzzed_data_provider, spks) : ConsumeScript(fuzzed_data_provider)};
+                (void)spk_manager->MarkUnusedAddresses(spk);
             },
             [&] {
                 LOCK(spk_manager->cs_desc_man);

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -144,6 +144,7 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
 
     if (!spks.empty() && fuzzed_data_provider.ConsumeBool()) {
         auto& spk{PickValue(fuzzed_data_provider, spks)};
+        assert(spk_manager->IsMine(spk));
         CTxDestination dest;
         bool extract_dest{ExtractDestination(spk, dest)};
         if (extract_dest) {

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -187,8 +187,11 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
         }
     }
 
-    std::string descriptor;
-    (void)spk_manager->GetDescriptorString(descriptor, /*priv=*/fuzzed_data_provider.ConsumeBool());
+    if (fuzzed_data_provider.ConsumeBool()) {
+        std::string descriptor;
+        (void)spk_manager->GetDescriptorString(descriptor, /*priv=*/fuzzed_data_provider.ConsumeBool());
+    }
+
     (void)spk_manager->GetEndRange();
     (void)spk_manager->GetKeyPoolSize();
 }

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -122,71 +122,48 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
         }
     }
 
-    bool good_data{true};
-    LIMITED_WHILE (good_data && fuzzed_data_provider.ConsumeBool(), 20) {
-        CallOneOf(
-            fuzzed_data_provider,
-            [&] {
-                auto spks{spk_manager->GetScriptPubKeys()};
-                for (const CScript& spk : spks) {
-                    CTxDestination dest;
-                    bool extract_dest{ExtractDestination(spk, dest)};
-                    if (extract_dest) {
-                        const std::string msg{fuzzed_data_provider.ConsumeRandomLengthString()};
-                        PKHash pk_hash{std::get_if<PKHash>(&dest) && fuzzed_data_provider.ConsumeBool() ?
-                                           *std::get_if<PKHash>(&dest) :
-                                           PKHash{ConsumeUInt160(fuzzed_data_provider)}};
-                        std::string str_sig;
-                        (void)spk_manager->SignMessage(msg, pk_hash, str_sig);
-                        (void)spk_manager->GetMetadata(dest);
-                    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        LOCK(spk_manager->cs_desc_man);
+        auto wallet_desc{spk_manager->GetWalletDescriptor()};
+        if (wallet_desc.descriptor->IsSingleType()) {
+            auto output_type{wallet_desc.descriptor->GetOutputType()};
+            if (output_type.has_value()) {
+                auto dest{spk_manager->GetNewDestination(*output_type)};
+                if (dest) {
+                    assert(IsValidDestination(*dest));
+                    assert(spk_manager->IsHDEnabled());
                 }
-            },
-            [&] {
-                auto spks{spk_manager->GetScriptPubKeys()};
-                auto& spk{(!spks.empty() && fuzzed_data_provider.ConsumeBool()) ? PickValue(fuzzed_data_provider, spks) : ConsumeScript(fuzzed_data_provider)};
-                (void)spk_manager->MarkUnusedAddresses(spk);
-            },
-            [&] {
-                LOCK(spk_manager->cs_desc_man);
-                auto wallet_desc{spk_manager->GetWalletDescriptor()};
-                if (wallet_desc.descriptor->IsSingleType()) {
-                    auto output_type{wallet_desc.descriptor->GetOutputType()};
-                    if (output_type.has_value()) {
-                        auto dest{spk_manager->GetNewDestination(*output_type)};
-                        if (dest) {
-                            assert(IsValidDestination(*dest));
-                            assert(spk_manager->IsHDEnabled());
-                        }
-                    }
-                }
-            },
-            [&] {
-                CMutableTransaction tx_to;
-                const std::optional<CMutableTransaction> opt_tx_to{ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS)};
-                if (!opt_tx_to) {
-                    good_data = false;
-                    return;
-                }
-                tx_to = *opt_tx_to;
+            }
+        }
+    }
 
-                std::map<COutPoint, Coin> coins{ConsumeCoins(fuzzed_data_provider, /*num_coins=*/5)};
-                const int sighash{fuzzed_data_provider.ConsumeIntegral<int>()};
-                std::map<int, bilingual_str> input_errors;
-                (void)spk_manager->SignTransaction(tx_to, coins, sighash, input_errors);
-            },
-            [&] {
-                std::optional<PartiallySignedTransaction> opt_psbt{ConsumeDeserializableConstructor<PartiallySignedTransaction>(fuzzed_data_provider)};
-                if (!opt_psbt) {
-                    good_data = false;
-                    return;
-                }
-                auto psbt{*opt_psbt};
-                std::optional<PrecomputedTransactionData> txdata_res = PrecomputePSBTData(psbt);
-                if (!txdata_res) {
-                    return;
-                }
-                const PrecomputedTransactionData& txdata = *txdata_res;
+    auto spks{spk_manager->GetScriptPubKeys()};
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        auto& spk{(!spks.empty() && fuzzed_data_provider.ConsumeBool()) ? PickValue(fuzzed_data_provider, spks) : ConsumeScript(fuzzed_data_provider)};
+        (void)spk_manager->MarkUnusedAddresses(spk);
+    }
+
+    if (!spks.empty() && fuzzed_data_provider.ConsumeBool()) {
+        auto& spk{PickValue(fuzzed_data_provider, spks)};
+        CTxDestination dest;
+        bool extract_dest{ExtractDestination(spk, dest)};
+        if (extract_dest) {
+            const std::string msg{fuzzed_data_provider.ConsumeRandomLengthString()};
+            PKHash pk_hash{std::get_if<PKHash>(&dest) && fuzzed_data_provider.ConsumeBool() ?
+                                *std::get_if<PKHash>(&dest) :
+                                PKHash{ConsumeUInt160(fuzzed_data_provider)}};
+            std::string str_sig;
+            (void)spk_manager->SignMessage(msg, pk_hash, str_sig);
+            (void)spk_manager->GetMetadata(dest);
+        }
+    }
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        if (std::optional<PartiallySignedTransaction> opt_psbt{ConsumeDeserializableConstructor<PartiallySignedTransaction>(fuzzed_data_provider)}) {
+            auto psbt{*opt_psbt};
+            if (std::optional<PrecomputedTransactionData> txdata_res{PrecomputePSBTData(psbt)}) {
+                const PrecomputedTransactionData& txdata{*txdata_res};
                 common::PSBTFillOptions options{
                     .sign = fuzzed_data_provider.ConsumeBool(),
                     .sighash_type = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 151),
@@ -196,7 +173,18 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
                 if (options.sighash_type == 151) options.sighash_type = std::nullopt;
                 (void)spk_manager->FillPSBT(psbt, txdata, options);
             }
-        );
+        }
+    }
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        if (auto opt_tx_to{ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS)}) {
+            CMutableTransaction tx_to;
+            tx_to = *opt_tx_to;
+            std::map<COutPoint, Coin> coins{ConsumeCoins(fuzzed_data_provider, /*num_coins=*/5)};
+            const int sighash{fuzzed_data_provider.ConsumeIntegral<int>()};
+            std::map<int, bilingual_str> input_errors;
+            (void)spk_manager->SignTransaction(tx_to, coins, sighash, input_errors);
+        }
     }
 
     std::string descriptor;

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -170,7 +170,7 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
                 }
                 tx_to = *opt_tx_to;
 
-                std::map<COutPoint, Coin> coins{ConsumeCoins(fuzzed_data_provider)};
+                std::map<COutPoint, Coin> coins{ConsumeCoins(fuzzed_data_provider, /*num_coins=*/5)};
                 const int sighash{fuzzed_data_provider.ConsumeIntegral<int>()};
                 std::map<int, bilingual_str> input_errors;
                 (void)spk_manager->SignTransaction(tx_to, coins, sighash, input_errors);

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -136,9 +136,14 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
     }
 
     auto spks{spk_manager->GetScriptPubKeys()};
+    for (const CScript& spk : spks) {
+        assert(spk_manager->IsMine(spk));
+    }
 
     if (fuzzed_data_provider.ConsumeBool()) {
         auto& spk{(!spks.empty() && fuzzed_data_provider.ConsumeBool()) ? PickValue(fuzzed_data_provider, spks) : ConsumeScript(fuzzed_data_provider)};
+        // Assert before MarkUnusedAddresses(), as it may TopUp() and add scripts not in `spks`.
+        if (spk_manager->IsMine(spk)) assert(spks.contains(spk));
         (void)spk_manager->MarkUnusedAddresses(spk);
     }
 


### PR DESCRIPTION
The scriptpubkeyman harness is slow - I'm getting under 40 exec/s on my personal server. This PR solves the following issues that may be affecting the performance:

- There are redundant `IsMine` calls
- `ConsumeCoins` always create up to 10'000 coins which may cause slowness.
- There are some expensive ops in a loop - e.g. One of the slow units I got on my server is about a repeated sequence of `GetNewDestination` calls (see flamegraph below).
- We're always calling `GetDescriptorString` unconditionally. It looks like an inofensive function but this is extremely costly due to calls to `ToNormalizedString`/`ToPrivateString` functions that touch key operations.
- Not related to slowness, but there is a bug on harness because we are aborting the execution when we cannot update the wallet descriptor, we can just skip and continue. 

![spkm-updated](https://github.com/user-attachments/assets/8220b0f6-b430-43b2-8594-2a7825080c0a)



