### PR TITLE
init: add -test=pause_load_mempool, test mempool save before loaded

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -769,6 +769,7 @@ const std::vector<std::string> TEST_OPTIONS_DOC{
     "addrman (use deterministic addrman)",
     "reindex_after_failure_noninteractive_yes (When asked for a reindex after failure interactively, simulate as-if answered with 'yes')",
     "bip94 (enforce BIP94 consensus rules)",
+    "pause_load_mempool (pause startup before loading mempool until regtest/pause_load_mempool is removed)",
 };
 
 bool HasTestOption(const ArgsManager& args, const std::string& test_option)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -745,6 +745,17 @@ static void StartupNotify(const ArgsManager& args)
 }
 #endif
 
+static void MaybeWaitForTestPause(const ArgsManager& args, const util::SignalInterrupt& interrupt, const std::string& test_option)
+{
+    if (!HasTestOption(args, test_option)) return;
+    const fs::path pause_file{args.GetDataDirNet() / fs::PathFromString(test_option)};
+
+    LogInfo("Waiting for test pause file %s to be removed\n", fs::PathToString(pause_file));
+    while (!interrupt && fs::exists(pause_file)) {
+        UninterruptibleSleep(std::chrono::milliseconds{10});
+    }
+}
+
 static bool AppInitServers(NodeContext& node)
 {
     const ArgsManager& args = *Assert(node.args);
@@ -2044,6 +2055,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
         // Load mempool from disk
         if (auto* pool{chainman.ActiveChainstate().GetMempool()}) {
+            MaybeWaitForTestPause(args, chainman.m_interrupt, "pause_load_mempool");
             LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {});
             pool->SetLoadTried(!chainman.m_interrupt);
         }

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -292,12 +292,28 @@ class InitTest(BitcoinTestFramework):
         for option in options:
             self.restart_node(1, option)
 
+    def init_pause_load_mempool_interrupt_test(self):
+        self.log.info("Test interrupting startup while pause_load_mempool is active")
+        node = self.nodes[0]
+        pause_file = node.chain_path / "pause_load_mempool"
+        pause_file.touch()
+
+        with node.busy_wait_for_debug_log([b"Waiting for test pause file"]):
+            self.start_breakable(node, extra_args=["-test=pause_load_mempool"], wait_for_import=False)
+
+        self.sigterm_node(node)
+        pause_file.unlink()
+
+        self.check_clean_start(node, [])
+        self.stop_node(0)
+
     def run_test(self):
         self.init_pid_test()
         self.init_stress_test_interrupt()
         self.init_stress_test_removals()
         self.break_wait_test()
         self.init_empty_test()
+        self.init_pause_load_mempool_interrupt_test()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -5,11 +5,7 @@
 """Tests related to node initialization."""
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-import os
-import platform
 import shutil
-import signal
-import subprocess
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_node import (
@@ -53,16 +49,6 @@ class InitTest(BitcoinTestFramework):
         self.generate(node, 200, sync_fun=self.no_op)
         self.stop_node(0)
 
-        def sigterm_node():
-            if platform.system() == 'Windows':
-                # Don't call Python's terminate() since it calls
-                # TerminateProcess(), which unlike SIGTERM doesn't allow
-                # bitcoind to perform any shutdown logic.
-                os.kill(node.process.pid, signal.CTRL_BREAK_EVENT)
-            else:
-                node.process.terminate()
-            assert_equal(0, node.process.wait())
-
         lines_to_terminate_after = [
             b'Validating signatures for all blocks',
             b'scheduler thread start',
@@ -91,14 +77,9 @@ class InitTest(BitcoinTestFramework):
         for terminate_line in lines_to_terminate_after:
             self.log.info(f"Starting node and will terminate after line {terminate_line}")
             with node.busy_wait_for_debug_log([terminate_line]):
-                if platform.system() == 'Windows':
-                    # CREATE_NEW_PROCESS_GROUP is required in order to be able
-                    # to terminate the child without terminating the test.
-                    node.start(extra_args=ALL_INDEX_ARGS, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
-                else:
-                    node.start(extra_args=ALL_INDEX_ARGS)
+                self.start_breakable(node, extra_args=ALL_INDEX_ARGS)
             self.log.debug("Terminating node after terminate line was found")
-            sigterm_node()
+            self.sigterm_node(node)
 
         # Prior to deleting/perturbing index files, start node with all indexes enabled.
         # 'check_clean_start' will ensure indexes are synchronized (i.e., data exists to modify)
@@ -279,12 +260,7 @@ class InitTest(BitcoinTestFramework):
         self.log.info("Testing waitforblockheight RPC call followed by break signal")
         node = self.nodes[0]
 
-        if platform.system() == 'Windows':
-            # CREATE_NEW_PROCESS_GROUP prevents python test from exiting
-            # with STATUS_CONTROL_C_EXIT (-1073741510) when break is sent.
-            self.start_node(node.index, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
-        else:
-            self.start_node(node.index)
+        self.start_breakable(node)
 
         current_height = node.getblock(node.getbestblockhash())['height']
 
@@ -299,15 +275,8 @@ class InitTest(BitcoinTestFramework):
             self.wait_until(lambda: any(c["method"] == "waitforblockheight" for c in node.cli.getrpcinfo()["active_commands"]))
 
             self.log.debug(f"Sending break signal to pid {node.process.pid}")
-            if platform.system() == 'Windows':
-                # Note: CTRL_C_EVENT should not be sent here because unlike
-                # CTRL_BREAK_EVENT it can not be targeted at a specific process
-                # group and may behave unpredictably.
-                node.process.send_signal(signal.CTRL_BREAK_EVENT)
-            else:
-                # Note: signal.SIGINT would work here as well
-                node.process.send_signal(signal.SIGTERM)
-            node.process.wait()
+            # Note: signal.SIGINT would work here as well
+            self.sigterm_node(node)
 
             result = fut.result()
             self.log.debug(f"waitforblockheight returned {result!r}")

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -52,7 +52,7 @@ from test_framework.wallet import MiniWallet, COIN
 class MempoolPersistTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
-        self.extra_args = [[], ["-persistmempool=0"], []]
+        self.extra_args = [["-test=pause_load_mempool"], ["-persistmempool=0"], []]
         self.uses_wallet = None
 
     def run_test(self):
@@ -114,7 +114,15 @@ class MempoolPersistTest(BitcoinTestFramework):
         # Give this node a head-start, so we can be "extra-sure" that it didn't load anything later
         # Also don't store the mempool, to keep the datadir clean
         self.start_node(1, extra_args=["-persistmempool=0"])
-        self.start_node(0)
+        # Pause this node during init, in order to check that we can't save
+        # the mempool before it's loaded.
+        pause_file = self.nodes[0].chain_path / "pause_load_mempool"
+        pause_file.touch()
+        self.start_node(0, wait_for_import=False)
+        assert_equal(self.nodes[0].getmempoolinfo()["loaded"], False)
+        assert_raises_rpc_error(-1, "The mempool was not loaded yet", self.nodes[0].savemempool)
+        pause_file.unlink()
+        self.nodes[0].wait_until(lambda: self.nodes[0].getmempoolinfo()["loaded"])
         self.start_node(2)
         assert self.nodes[0].getmempoolinfo()["loaded"]  # start_node is blocking on the mempool being loaded
         assert self.nodes[2].getmempoolinfo()["loaded"]

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -16,6 +16,7 @@ import pdb
 import random
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -495,16 +496,37 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 # adjust conf for pre 17
                 test_node_i.replace_in_config([('[regtest]', '')])
 
-    def start_node(self, i, *args, **kwargs):
+    def start_node(self, i, *args, wait_for_import=True, **kwargs):
         """Start a bitcoind"""
 
         node = self.nodes[i]
 
         node.start(*args, **kwargs)
-        node.wait_for_rpc_connection()
+        node.wait_for_rpc_connection(wait_for_import=wait_for_import)
 
         if self.options.coveragedir is not None:
             coverage.write_all_rpc_commands(self.options.coveragedir, node._rpc)
+
+    def start_breakable(self, node, extra_args=None, *, wait_for_import=True):
+        if platform.system() == 'Windows':
+            # CREATE_NEW_PROCESS_GROUP prevents python test from exiting
+            # with STATUS_CONTROL_C_EXIT (-1073741510) when break is sent.
+            self.start_node(node.index, extra_args=extra_args, wait_for_import=wait_for_import, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+        else:
+            self.start_node(node.index, extra_args=extra_args, wait_for_import=wait_for_import)
+
+    def sigterm_node(self, node):
+        if platform.system() == 'Windows':
+            # Don't call Python's terminate() since it calls
+            # TerminateProcess(), which unlike SIGTERM doesn't allow
+            # bitcoind to perform any shutdown logic.
+            # Note: CTRL_C_EVENT should not be sent here because unlike
+            # CTRL_BREAK_EVENT it can not be targeted at a specific process
+            # group and may behave unpredictably.
+            os.kill(node.process.pid, signal.CTRL_BREAK_EVENT)
+        else:
+            node.process.terminate()
+        assert_equal(0, node.process.wait())
 
     def start_nodes(self, extra_args=None, *args, **kwargs):
         """Start multiple bitcoinds"""


### PR DESCRIPTION
A new `-test=pause_load_mempool` startup argument that lets the test framework pause node initialization right before loading the mempool.

When set, the node checks for the existence of a `pause_load_mempool` file and waits until that file is removed.

This PR uses the mechanism to test that `savemempool` fails before the mempool is loaded, and that `getmempoolinfo`'s "loaded" field is false.

The main motivation for this change is to enable test coverage for an enhancement of #34020, to have the new IPC methods throw an error while the mempool is loading from disk, rather than an ambiguous empty result.

The `-test=pause_...` mechanism may be generally useful for testing other init and shutdown steps.

The first commit extracts two useful helper methods to the test framework:
- it adds `wait_for_import` to the new `start_breakable` helper right away, though it's not used until the main commit 
- it changes one `node.process.send_signal` to `self.sigterm_node(node)`, which I believe is equivalent
- it merges two different comments around `node.process.send_signal` for Windows 