### PR TITLE
interfaces/wallet: replace raw receive-request string APIs with typed methods

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -53,6 +54,7 @@ namespace interfaces {
 class Handler;
 struct WalletAddress;
 struct WalletBalances;
+struct WalletReceiveRequest;
 struct WalletTx;
 struct WalletTxOut;
 struct WalletTxStatus;
@@ -122,10 +124,14 @@ public:
     virtual std::vector<WalletAddress> getAddresses() = 0;
 
     //! Get receive requests.
-    virtual std::vector<std::string> getAddressReceiveRequests() = 0;
+    virtual std::vector<WalletReceiveRequest> getReceiveRequests() = 0;
 
-    //! Save or remove receive request.
-    virtual bool setAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& value) = 0;
+    //! Add a new receive request. Wallet assigns ID and timestamp.
+    //! Returns the assigned ID on success, or nullopt on failure.
+    virtual std::optional<int64_t> addReceiveRequest(const WalletReceiveRequest& request) = 0;
+
+    //! Erase a receive request.
+    virtual bool eraseReceiveRequest(const CTxDestination& dest, int64_t id) = 0;
 
     //! Display address on external signer
     virtual util::Result<void> displayAddress(const CTxDestination& dest) = 0;
@@ -361,6 +367,17 @@ struct WalletAddress
         : dest(std::move(dest)), is_mine(is_mine), purpose(std::move(purpose)), name(std::move(name))
     {
     }
+};
+
+//! Information about one wallet receive request.
+struct WalletReceiveRequest
+{
+    int64_t id{0};
+    int64_t time{0};
+    std::string address;
+    std::string label;
+    std::string message;
+    CAmount amount{0};
 };
 
 //! Collection of wallet balances.

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -9,24 +9,19 @@
 #include <qt/optionsmodel.h>
 #include <qt/walletmodel.h>
 
-#include <clientversion.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
-#include <streams.h>
-#include <util/string.h>
 
 #include <utility>
 
 #include <QLatin1Char>
 #include <QLatin1String>
 
-using util::ToString;
-
 RecentRequestsTableModel::RecentRequestsTableModel(WalletModel *parent) :
     QAbstractTableModel(parent), walletModel(parent)
 {
     // Load entries from wallet
-    for (const std::string& request : parent->wallet().getAddressReceiveRequests()) {
+    for (const auto& request : parent->wallet().getReceiveRequests()) {
         addNewRequest(request);
     }
 
@@ -151,7 +146,7 @@ bool RecentRequestsTableModel::removeRows(int row, int count, const QModelIndex 
         for (int i = 0; i < count; ++i)
         {
             const RecentRequestEntry* rec = &list[row+i];
-            if (!walletModel->wallet().setAddressReceiveRequest(DecodeDestination(rec->recipient.address.toStdString()), ToString(rec->id), ""))
+            if (!walletModel->wallet().eraseReceiveRequest(DecodeDestination(rec->recipient.address.toStdString()), rec->id))
                 return false;
         }
 
@@ -172,34 +167,32 @@ Qt::ItemFlags RecentRequestsTableModel::flags(const QModelIndex &index) const
 // called when adding a request from the GUI
 void RecentRequestsTableModel::addNewRequest(const SendCoinsRecipient &recipient)
 {
+    interfaces::WalletReceiveRequest request;
+    request.address = recipient.address.toStdString();
+    request.label = recipient.label.toStdString();
+    request.message = recipient.message.toStdString();
+    request.amount = recipient.amount;
+
+    auto id = walletModel->wallet().addReceiveRequest(request);
+    if (!id) return;
+
     RecentRequestEntry newEntry;
-    newEntry.id = ++nReceiveRequestsMaxId;
+    newEntry.id = *id;
     newEntry.date = QDateTime::currentDateTime();
     newEntry.recipient = recipient;
-
-    DataStream ss{};
-    ss << newEntry;
-
-    if (!walletModel->wallet().setAddressReceiveRequest(DecodeDestination(recipient.address.toStdString()), ToString(newEntry.id), ss.str()))
-        return;
-
     addNewRequest(newEntry);
 }
 
 // called from ctor when loading from wallet
-void RecentRequestsTableModel::addNewRequest(const std::string &recipient)
+void RecentRequestsTableModel::addNewRequest(const interfaces::WalletReceiveRequest &request)
 {
-    SpanReader ss{MakeByteSpan(recipient)};
-
     RecentRequestEntry entry;
-    ss >> entry;
-
-    if (entry.id == 0) // should not happen
-        return;
-
-    if (entry.id > nReceiveRequestsMaxId)
-        nReceiveRequestsMaxId = entry.id;
-
+    entry.id = request.id;
+    entry.date = QDateTime::fromSecsSinceEpoch(request.time);
+    entry.recipient.address = QString::fromStdString(request.address);
+    entry.recipient.label = QString::fromStdString(request.label);
+    entry.recipient.message = QString::fromStdString(request.message);
+    entry.recipient.amount = request.amount;
     addNewRequest(entry);
 }
 

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -7,11 +7,13 @@
 
 #include <qt/sendcoinsrecipient.h>
 
-#include <string>
-
 #include <QAbstractTableModel>
 #include <QStringList>
 #include <QDateTime>
+
+namespace interfaces {
+struct WalletReceiveRequest;
+}
 
 class WalletModel;
 
@@ -20,18 +22,9 @@ class RecentRequestEntry
 public:
     RecentRequestEntry() = default;
 
-    static const int CURRENT_VERSION = 1;
-    int nVersion{RecentRequestEntry::CURRENT_VERSION};
     int64_t id{0};
     QDateTime date;
     SendCoinsRecipient recipient;
-
-    SERIALIZE_METHODS(RecentRequestEntry, obj) {
-        unsigned int date_timet;
-        SER_WRITE(obj, date_timet = obj.date.toSecsSinceEpoch());
-        READWRITE(obj.nVersion, obj.id, date_timet, obj.recipient);
-        SER_READ(obj, obj.date = QDateTime::fromSecsSinceEpoch(date_timet));
-    }
 };
 
 class RecentRequestEntryLessThan
@@ -80,7 +73,7 @@ public:
 
     const RecentRequestEntry &entry(int row) const { return list[row]; }
     void addNewRequest(const SendCoinsRecipient &recipient);
-    void addNewRequest(const std::string &recipient);
+    void addNewRequest(const interfaces::WalletReceiveRequest &request);
     void addNewRequest(RecentRequestEntry &recipient);
 
 public Q_SLOTS:
@@ -90,7 +83,6 @@ private:
     WalletModel *walletModel;
     QStringList columns;
     QList<RecentRequestEntry> list;
-    int64_t nReceiveRequestsMaxId{0};
 
     /** Updates the column title to "Amount (DisplayUnit)" and emits headerDataChanged() signal for table headers to react. */
     void updateAmountColumnTitle();

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -361,19 +361,14 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
     QCOMPARE(currentRowCount, initialRowCount+1);
 
     // Check addition to wallet
-    std::vector<std::string> requests = walletModel.wallet().getAddressReceiveRequests();
+    std::vector<interfaces::WalletReceiveRequest> requests = walletModel.wallet().getReceiveRequests();
     QCOMPARE(requests.size(), size_t{1});
-    RecentRequestEntry entry;
-    SpanReader{MakeByteSpan(requests[0])} >> entry;
-    QCOMPARE(entry.nVersion, int{1});
-    QCOMPARE(entry.id, int64_t{1});
-    QVERIFY(entry.date.isValid());
-    QCOMPARE(entry.recipient.address, address);
-    QCOMPARE(entry.recipient.label, QString{"TEST_LABEL_1"});
-    QCOMPARE(entry.recipient.amount, CAmount{1});
-    QCOMPARE(entry.recipient.message, QString{"TEST_MESSAGE_1"});
-    QCOMPARE(entry.recipient.sPaymentRequest, std::string{});
-    QCOMPARE(entry.recipient.authenticatedMerchant, QString{});
+    QCOMPARE(requests[0].id, int64_t{1});
+    QVERIFY(requests[0].time > 0);
+    QCOMPARE(QString::fromStdString(requests[0].address), address);
+    QCOMPARE(requests[0].label, std::string{"TEST_LABEL_1"});
+    QCOMPARE(requests[0].amount, CAmount{1});
+    QCOMPARE(requests[0].message, std::string{"TEST_MESSAGE_1"});
 
     // Check Remove button
     QTableView* table = receiveCoinsDialog.findChild<QTableView*>("recentRequestsView");
@@ -383,7 +378,19 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
     QCOMPARE(requestTableModel->rowCount({}), currentRowCount-1);
 
     // Check removal from wallet
-    QCOMPARE(walletModel.wallet().getAddressReceiveRequests().size(), size_t{0});
+    QCOMPARE(walletModel.wallet().getReceiveRequests().size(), size_t{0});
+
+    // Regression test: verify that a malformed receive-request blob stored in
+    // the wallet is gracefully skipped instead of crashing. Before this fix,
+    // the GUI deserialized raw blobs via SpanReader without try/catch, so a
+    // corrupt entry would throw an unhandled exception on startup.
+    {
+        const CTxDestination dest = DecodeDestination(address.toStdString());
+        LOCK(wallet->cs_wallet);
+        wallet->m_address_book[dest].receive_requests["99"] = "MALFORMED";
+    }
+    // getReceiveRequests() must not crash; the malformed entry should be skipped.
+    QCOMPARE(walletModel.wallet().getReceiveRequests().size(), size_t{0});
 }
 
 void TestGUIWatchOnly(interfaces::Node& node, TestChain100Setup& test)

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -17,6 +17,7 @@
 #include <sync.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/string.h>
 #include <util/translation.h>
 #include <util/ui_change_type.h>
 #include <wallet/coincontrol.h>
@@ -45,6 +46,7 @@ using interfaces::WalletBalances;
 using interfaces::WalletLoader;
 using interfaces::WalletMigrationResult;
 using interfaces::WalletOrderForm;
+using interfaces::WalletReceiveRequest;
 using interfaces::WalletTx;
 using interfaces::WalletTxOut;
 using interfaces::WalletTxStatus;
@@ -210,27 +212,37 @@ public:
         });
         return result;
     }
-    std::vector<std::string> getAddressReceiveRequests() override {
+    std::vector<WalletReceiveRequest> getReceiveRequests() override
+    {
         LOCK(m_wallet->cs_wallet);
-        return m_wallet->GetAddressReceiveRequests();
+        std::vector<WalletReceiveRequest> result;
+        for (const auto& req : GetReceiveRequests(*m_wallet)) {
+            result.push_back({
+                .id = req.id,
+                .time = req.time,
+                .address = req.address,
+                .label = req.label,
+                .message = req.message,
+                .amount = req.amount,
+            });
+        }
+        return result;
     }
-    bool setAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& value) override {
-        // Note: The setAddressReceiveRequest interface used by the GUI to store
-        // receive requests is a little awkward and could be improved in the
-        // future:
-        //
-        // - The same method is used to save requests and erase them, but
-        //   having separate methods could be clearer and prevent bugs.
-        //
-        // - Request ids are passed as strings even though they are generated as
-        //   integers.
-        //
-        // - Multiple requests can be stored for the same address, but it might
-        //   be better to only allow one request or only keep the current one.
+    std::optional<int64_t> addReceiveRequest(const WalletReceiveRequest& request) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        ReceiveRequest req;
+        req.address = request.address;
+        req.label = request.label;
+        req.message = request.message;
+        req.amount = request.amount;
+        return AddReceiveRequest(*m_wallet, req);
+    }
+    bool eraseReceiveRequest(const CTxDestination& dest, int64_t id) override
+    {
         LOCK(m_wallet->cs_wallet);
         WalletBatch batch{m_wallet->GetDatabase()};
-        return value.empty() ? m_wallet->EraseAddressReceiveRequest(batch, dest, id)
-                             : m_wallet->SetAddressReceiveRequest(batch, dest, id, value);
+        return m_wallet->EraseAddressReceiveRequest(batch, dest, util::ToString(id));
     }
     util::Result<void> displayAddress(const CTxDestination& dest) override
     {

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -4,10 +4,18 @@
 
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
+#include <key_io.h>
+#include <logging.h>
+#include <serialize.h>
+#include <streams.h>
 #include <util/check.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+#include <util/time.h>
 #include <wallet/receive.h>
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
+#include <wallet/walletdb.h>
 
 namespace wallet {
 bool InputIsMine(const CWallet& wallet, const CTxIn& txin)
@@ -392,5 +400,107 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
     }
 
     return ret;
+}
+
+namespace {
+//! Serialization-compatible mirror of SendCoinsRecipient (defined in Qt code)
+//! without Qt dependencies. Field order and types must match exactly to
+//! produce byte-identical serialized output for DB compatibility.
+struct RecipientData
+{
+    int nVersion{1};
+    std::string address;
+    std::string label;
+    CAmount amount{0};
+    std::string message;
+    std::string sPaymentRequest;
+    std::string authenticatedMerchant;
+
+    SERIALIZE_METHODS(RecipientData, obj)
+    {
+        READWRITE(obj.nVersion, obj.address, obj.label, obj.amount,
+                  obj.message, obj.sPaymentRequest, obj.authenticatedMerchant);
+    }
+};
+
+//! Serialization-compatible mirror of RecentRequestEntry (defined in Qt code)
+//! without Qt dependencies. Used to read and write receive request blobs
+//! stored in the wallet database.
+struct RequestEntryData
+{
+    int nVersion{1};
+    int64_t id{0};
+    unsigned int date_timet{0};
+    RecipientData recipient;
+
+    SERIALIZE_METHODS(RequestEntryData, obj)
+    {
+        READWRITE(obj.nVersion, obj.id, obj.date_timet, obj.recipient);
+    }
+};
+} // namespace
+
+std::vector<ReceiveRequest> GetReceiveRequests(const CWallet& wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    std::vector<ReceiveRequest> result;
+    for (const auto& [dest, entry] : wallet.m_address_book) {
+        const std::string address = EncodeDestination(dest);
+        for (const auto& [id_str, data] : entry.receive_requests) {
+            try {
+                RequestEntryData parsed;
+                SpanReader{MakeByteSpan(data)} >> parsed;
+                if (parsed.id == 0) continue;
+                ReceiveRequest req;
+                req.id = parsed.id;
+                req.time = parsed.date_timet;
+                req.address = address;
+                req.label = std::move(parsed.recipient.label);
+                req.message = std::move(parsed.recipient.message);
+                req.amount = parsed.recipient.amount;
+                result.emplace_back(std::move(req));
+            } catch (const std::exception& e) {
+                LogWarning("Could not deserialize receive request %s for %s: %s",
+                           id_str, address, e.what());
+            }
+        }
+    }
+    return result;
+}
+
+std::optional<int64_t> AddReceiveRequest(CWallet& wallet, const ReceiveRequest& request)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    const CTxDestination dest = DecodeDestination(request.address);
+    if (!IsValidDestination(dest)) return std::nullopt;
+
+    // Determine the next ID by scanning existing request keys across all
+    // addresses. Keys are string forms of integer IDs.
+    int64_t max_id{0};
+    for (const auto& [_, addr_entry] : wallet.m_address_book) {
+        for (const auto& [id_str, _v] : addr_entry.receive_requests) {
+            if (auto id = ToIntegral<int64_t>(id_str)) {
+                if (*id > max_id) max_id = *id;
+            }
+        }
+    }
+    const int64_t new_id = max_id + 1;
+
+    RequestEntryData entry;
+    entry.id = new_id;
+    entry.date_timet = static_cast<unsigned int>(GetTime());
+    entry.recipient.address = request.address;
+    entry.recipient.label = request.label;
+    entry.recipient.message = request.message;
+    entry.recipient.amount = request.amount;
+
+    DataStream ss{};
+    ss << entry;
+
+    WalletBatch batch{wallet.GetDatabase()};
+    if (!wallet.SetAddressReceiveRequest(batch, dest, util::ToString(new_id), ss.str())) {
+        return std::nullopt;
+    }
+    return new_id;
 }
 } // namespace wallet

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -10,6 +10,10 @@
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
+#include <optional>
+#include <string>
+#include <vector>
+
 namespace wallet {
 bool InputIsMine(const CWallet& wallet, const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
@@ -52,6 +56,24 @@ Balance GetBalance(const CWallet& wallet, int min_depth = 0, bool avoid_reuse = 
 
 std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet);
 std::set<std::set<CTxDestination>> GetAddressGroupings(const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+
+//! Wallet-level receive request data, independent of interface/GUI types.
+struct ReceiveRequest {
+    int64_t id{0};
+    int64_t time{0};
+    std::string address;
+    std::string label;
+    std::string message;
+    CAmount amount{0};
+};
+
+//! Read all receive requests stored in the wallet. Malformed entries are
+//! logged and skipped rather than causing a crash.
+std::vector<ReceiveRequest> GetReceiveRequests(const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+
+//! Add a new receive request. Wallet assigns ID and timestamp.
+//! Returns the assigned ID on success, or nullopt on failure.
+std::optional<int64_t> AddReceiveRequest(CWallet& wallet, const ReceiveRequest& request) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_RECEIVE_H


### PR DESCRIPTION
Replace getAddressReceiveRequests() and setAddressReceiveRequest() with three typed methods on interfaces::Wallet:

- getReceiveRequests()  -> vector<WalletReceiveRequest>
- addReceiveRequest()   -> optional<int64_t> (assigned ID)
- eraseReceiveRequest() -> bool

The previous interface passed serialized blobs between the wallet and GUI, forcing GUI code to handle serialization/deserialization of RecentRequestEntry objects directly. This created tight coupling to the wallet storage format and caused the GUI to crash on startup if it encountered a malformed entry.

The wallet layer now owns:
- ID assignment (scans existing keys for max ID, assigns max+1)
- Timestamp generation (calls GetTime() internally)
- Serialization via Qt-independent mirror structs (RecipientData, RequestEntryData) that are byte-compatible with the existing DB format
- Graceful error recovery: malformed entries are logged via LogWarning and skipped instead of crashing

The GUI (RecentRequestsTableModel) no longer contains any serialization logic. The SERIALIZE_METHODS macro, nVersion field, and nReceiveRequestsMaxId tracker are removed from RecentRequestEntry and the table model.

A regression test is added that writes a malformed blob directly into the wallet address book and verifies getReceiveRequests() returns successfully without crashing.