### PR TITLE
lint: Clarify rmtree/remove_all error message with preferred alternatives

### DIFF
--- a/test/lint/test_runner/src/lint_cpp.rs
+++ b/test/lint/test_runner/src/lint_cpp.rs
@@ -139,7 +139,8 @@ pub fn lint_remove_all() -> LintResult {
         .success();
     if found {
         Err(r#"
-Use of fs::remove_all or std::filesystem::remove_all is dangerous and should be avoided.
+Use of fs::remove_all or std::filesystem::remove_all is dangerous and should be avoided. If removal
+is required, prefer fs::remove.
             "#
         .trim()
         .to_string())

--- a/test/lint/test_runner/src/lint_py.rs
+++ b/test/lint/test_runner/src/lint_py.rs
@@ -89,7 +89,8 @@ pub fn lint_rmtree() -> LintResult {
         .success();
     if found {
         Err(r#"
-Use of shutil.rmtree() is dangerous and should be avoided.
+Use of shutil.rmtree() is dangerous and should be avoided. If it
+is really required for the test, use self.cleanup_folder(_).
             "#
         .trim()
         .to_string())
@@ -97,4 +98,3 @@ Use of shutil.rmtree() is dangerous and should be avoided.
         Ok(())
     }
 }
-

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -14,7 +14,8 @@ use std::fs;
 use std::process::{Command, ExitCode};
 
 use lint_cpp::{
-    lint_boost_assert, lint_includes_build_config, lint_remove_all, lint_rpc_assert, lint_std_filesystem,
+    lint_boost_assert, lint_includes_build_config, lint_remove_all, lint_rpc_assert,
+    lint_std_filesystem,
 };
 use lint_docs::{lint_doc_args, lint_doc_release_note_snippets, lint_markdown};
 use lint_py::{lint_py_lint, lint_rmtree};


### PR DESCRIPTION
An error message without a suggestion to fix will often lead developers to come up with a creative solution to side-step the grep in the linter (such as using an `auto` alias or other style-change).

Try to avoid this by mentioning a recommended solution.