### PR TITLE
Update libmultiprocess subtree to fix test timeout

### DIFF
--- a/doc/versions.md
+++ b/doc/versions.md
@@ -7,33 +7,37 @@ Library versions are tracked with simple
 Versioning policy is described in the [version.h](../include/mp/version.h)
 include.
 
-## v9
+## v10
 - Current unstable version.
+
+## [v9.0](https://github.com/bitcoin-core/libmultiprocess/commits/v9.0)
+- Fixes race conditions where worker thread could be used after destruction, where getParams() could be called after request cancel, and where m_on_cancel could be called after request finishes.
+- Adds `CustomHasField` hook to map Cap'n Proto null values to C++ null values.
+- Improves `CustomBuildField` for `std::optional` to use move semantics.
+- Adds LLVM 22 compatibility fix in type-map.
+- Used in Bitcoin Core master branch, pulled in by [#34804](https://github.com/bitcoin/bitcoin/pull/34804). Also pulled into Bitcoin Core 31.x stable branch by [#34952](https://github.com/bitcoin/bitcoin/pull/34952).
 
 ## [v8.0](https://github.com/bitcoin-core/libmultiprocess/commits/v8.0)
 - Better support for non-libmultiprocess IPC clients: avoiding errors on unclean disconnects, and allowing simultaneous requests to worker threads which previously triggered "thread busy" errors.
-- Used in Bitcoin Core, pulled in by [#34422](https://github.com/bitcoin/bitcoin/pull/34422).
+- Intermediate version used in Bitcoin Core master branch between 30.x and 31.x branches, pulled in by [#34422](https://github.com/bitcoin/bitcoin/pull/34422).
 
 ## [v7.0](https://github.com/bitcoin-core/libmultiprocess/commits/v7.0)
 - Adds SpawnProcess race fix, cmake `target_capnp_sources` option, ci and documentation improvements. Adds `version.h` header declaring major and minor version numbers.
-- Used in Bitcoin Core, pulled in by [#34363](https://github.com/bitcoin/bitcoin/pull/34363).
+- Intermediate version used in Bitcoin Core master branch between 30.x and 31.x branches, pulled in by [#34363](https://github.com/bitcoin/bitcoin/pull/34363).
 
 ## [v7.0-pre2](https://github.com/bitcoin-core/libmultiprocess/commits/v7.0-pre2)
 - Fixes intermittent mptest hang and makes other minor improvements.
 - Used in Bitcoin Core 30.1 and 30.2 releases and 30.x branch, pulled in by [#33518](https://github.com/bitcoin/bitcoin/pull/33518) and [#33519](https://github.com/bitcoin/bitcoin/pull/33519).
 
 ## [v7.0-pre1](https://github.com/bitcoin-core/libmultiprocess/commits/v7.0-pre1)
-
 - Adds support for log levels to reduce logging and "thread busy" error to avoid a crash on misuse.
-- Minimum required version for Bitcoin Core 30.1 and 30.2 releases and 30.x branch, pulled in by [#33412](https://github.com/bitcoin/bitcoin/pull/33412), [#33518](https://github.com/bitcoin/bitcoin/pull/33518), and [#33519](https://github.com/bitcoin/bitcoin/pull/33519).
+- Minimum required version since Bitcoin Core 30.1, pulled in by [#33412](https://github.com/bitcoin/bitcoin/pull/33412), [#33518](https://github.com/bitcoin/bitcoin/pull/33518), and [#33519](https://github.com/bitcoin/bitcoin/pull/33519).
 
 ## [v6.0](https://github.com/bitcoin-core/libmultiprocess/commits/v6.0)
-
 - Adds CI scripts and build and test fixes.
 - Used in Bitcoin Core 30.0 release, pulled in by [#32345](https://github.com/bitcoin/bitcoin/pull/32345), [#33241](https://github.com/bitcoin/bitcoin/pull/33241), and [#33322](https://github.com/bitcoin/bitcoin/pull/33322).
 
 ## [v6.0-pre1](https://github.com/bitcoin-core/libmultiprocess/commits/v6.0-pre1)
-
 - Adds fixes for unclean shutdowns and thread sanitizer issues.
 - Drops `EventLoop::addClient` and `EventLoop::removeClient` methods,
   requiring clients to use new `EventLoopRef` class instead.

--- a/include/mp/type-context.h
+++ b/include/mp/type-context.h
@@ -189,7 +189,7 @@ auto PassField(Priority<1>, TypeList<>, ServerContext& server_context, const Fn&
             }
         })) {
             MP_LOG(loop, Log::Error) << "IPC server request #" << req << " uncaught exception (" << kj::str(*exception).cStr() << ")";
-            throw kj::mv(*exception);
+            kj::throwRecoverableException(kj::mv(*exception));
         }
         return call_context;
         // End of scope: if KJ_DEFER was reached, it runs here

--- a/include/mp/version.h
+++ b/include/mp/version.h
@@ -24,7 +24,7 @@
 //! pointing at the prior merge commit. The /doc/versions.md file should also be
 //! updated, noting any significant or incompatible changes made since the
 //! previous version.
-#define MP_MAJOR_VERSION 9
+#define MP_MAJOR_VERSION 10
 
 //! Minor version number. Should be incremented in stable branches after
 //! backporting changes. The /doc/versions.md file should also be updated to

--- a/test/mp/test/spawn_tests.cpp
+++ b/test/mp/test/spawn_tests.cpp
@@ -20,6 +20,8 @@
 
 namespace {
 
+constexpr auto FAILURE_TIMEOUT = std::chrono::seconds{30};
+
 // Poll for child process exit using waitpid(..., WNOHANG) until the child exits
 // or timeout expires. Returns true if the child exited and status_out was set.
 // Returns false on timeout or error.
@@ -94,9 +96,9 @@ KJ_TEST("SpawnProcess does not run callback in child")
     ::close(fd);
 
     int status{0};
-    // Give the child up to 1 second to exit. If it does not, terminate it and
+    // Give the child some time to exit. If it does not, terminate it and
     // reap it to avoid leaving a zombie behind.
-    const bool exited{WaitPidWithTimeout(pid, std::chrono::milliseconds{1000}, status)};
+    const bool exited{WaitPidWithTimeout(pid, FAILURE_TIMEOUT, status)};
     if (!exited) {
         ::kill(pid, SIGKILL);
         ::waitpid(pid, &status, /*options=*/0);


### PR DESCRIPTION
- https://github.com/bitcoin-core/libmultiprocess/pull/266
- https://github.com/bitcoin-core/libmultiprocess/pull/267
- https://github.com/bitcoin-core/libmultiprocess/pull/268

Branch is based on 613a548648880314e78c3045d0ded12e29a4f036 from #34804 for easy backport.

Fixes #34975.