### PR TITLE
init: reserve file descriptors for IPC connections

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -164,6 +164,7 @@ static constexpr bool DEFAULT_STOPAFTERBLOCKIMPORT{false};
 #endif
 
 static constexpr int MIN_CORE_FDS = MIN_LEVELDB_FDS + NUM_FDS_MESSAGE_CAPTURE;
+static constexpr int DEFAULT_IPC_MAX_CONNECTIONS{16};
 
 /**
  * The PID file facilities.
@@ -720,6 +721,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     if (can_listen_ipc) {
         argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
+        argsman.AddArg("-ipcmaxconnections=<n>", "Reserve file descriptors for up to <n> concurrent IPC socket connections (default: " + ToString(DEFAULT_IPC_MAX_CONNECTIONS) + ")", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
     }
 
 #if HAVE_DECL_FORK
@@ -1027,18 +1029,38 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // Make sure enough file descriptors are available. We need to reserve enough FDs to account for the bare minimum,
     // plus all manual connections and all bound interfaces. Any remainder will be available for connection sockets
 
-    // Number of bound interfaces (we have at least one)
-    int nBind = std::max(nUserBind, size_t(1));
     // Maximum number of connections with other nodes, this accounts for all types of outbounds and inbounds except for manual
     int user_max_connection = args.GetIntArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
     if (user_max_connection < 0) {
         return InitError(Untranslated("-maxconnections must be greater or equal than zero"));
     }
+
+    // IPC listening socket FDs — one per -ipcbind address, no default listener
+    auto ipc_bind = args.GetArgs("-ipcbind").size();
+
+    // We only need to reserve these FDs if the user is actually binding an IPC socket
+    auto ipc_max_connections = args.GetIntArg("-ipcmaxconnections", 0);
+
+    if (ipc_max_connections < 0) {
+        return InitError(Untranslated("-ipcmaxconnections must be greater than or equal to zero"));
+    } else if (ipc_bind > 0) {
+        if (!args.IsArgSet("-ipcmaxconnections")) ipc_max_connections = DEFAULT_IPC_MAX_CONNECTIONS;
+        LogInfo("Reserving %d file descriptors for IPC (%d listening sockets, %d accepted connections)",
+                ipc_bind + ipc_max_connections, ipc_bind, ipc_max_connections);
+    } else if (ipc_max_connections > 0) {
+        LogWarning("-ipcmaxconnections is %d but -ipcbind is not enabled; option will have no effect.\n", ipc_max_connections);
+        ipc_max_connections = 0;
+    }
+
+    // Number of bound interfaces.
+    int p2p_binds = args.GetBoolArg("-listen", DEFAULT_LISTEN) ? std::max(nUserBind, size_t(1)) : 0;
+    int binds = p2p_binds + ipc_bind;
+
     const size_t max_private{args.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)
                              ? MAX_PRIVATE_BROADCAST_CONNECTIONS
                              : 0};
-    // Reserve enough FDs to account for the bare minimum, plus any manual connections, plus the bound interfaces
-    int min_required_fds = MIN_CORE_FDS + MAX_ADDNODE_CONNECTIONS + nBind;
+    // Reserve enough FDs to account for the bare minimum, plus any manual connections, plus the bound interfaces, plus IPC connections
+    int min_required_fds = MIN_CORE_FDS + MAX_ADDNODE_CONNECTIONS + binds + ipc_max_connections;
 
     // Try raising the FD limit to what we need (available_fds may be smaller than the requested amount if this fails)
     available_fds = RaiseFileDescriptorLimit(user_max_connection + max_private + min_required_fds);

--- a/test/functional/interface_ipc_init.py
+++ b/test/functional/interface_ipc_init.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test IPC initialization behavior."""
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class IPCInitTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_ipc()
+
+    def setup_nodes(self):
+        self.extra_init = [{"ipcbind": True}]
+        super().setup_nodes()
+
+    def test_ipc_startup_logging(self):
+        self.log.info("Test IPC startup logging")
+
+        with self.nodes[0].assert_debug_log(["file descriptors available"]):
+            self.restart_node(0)
+
+    def run_test(self):
+        self.test_ipc_startup_logging()
+
+
+if __name__ == '__main__':
+    IPCInitTest(__file__).main()

--- a/test/functional/interface_ipc_init.py
+++ b/test/functional/interface_ipc_init.py
@@ -5,6 +5,7 @@
 """Test IPC initialization behavior."""
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
 
 
 class IPCInitTest(BitcoinTestFramework):
@@ -19,14 +20,40 @@ class IPCInitTest(BitcoinTestFramework):
         self.extra_init = [{"ipcbind": True}]
         super().setup_nodes()
 
-    def test_ipc_startup_logging(self):
-        self.log.info("Test IPC startup logging")
+    def test_ipcmaxconnections(self):
+        self.log.info("Test -ipcmaxconnections initialization behavior")
+        node = self.nodes[0]
 
-        with self.nodes[0].assert_debug_log(["file descriptors available"]):
+        with node.assert_debug_log([
+            "file descriptors available",
+            "Reserving 17 file descriptors for IPC (1 listening sockets, 16 accepted connections)",
+        ]):
             self.restart_node(0)
+        assert_equal(node.getblockcount(), 0)
+
+        with node.assert_debug_log([
+            "Reserving 9 file descriptors for IPC (1 listening sockets, 8 accepted connections)",
+        ]):
+            self.restart_node(0, extra_args=["-ipcmaxconnections=8"])
+        assert_equal(node.getblockcount(), 0)
+
+        with node.assert_debug_log(["Reserving 1 file descriptors for IPC (1 listening sockets, 0 accepted connections)"]):
+            self.restart_node(0, extra_args=["-ipcmaxconnections=0"])
+        assert_equal(node.getblockcount(), 0)
+
+        with node.assert_debug_log(["-ipcmaxconnections is 8 but -ipcbind is not enabled; option will have no effect."]):
+            self.restart_node(0, extra_args=["-noipcbind", "-ipcmaxconnections=8"])
+        assert_equal(node.getblockcount(), 0)
+
+        self.stop_node(0)
+        node.assert_start_raises_init_error(
+            extra_args=["-ipcmaxconnections=-1"],
+            expected_msg="Error: -ipcmaxconnections must be greater than or equal to zero",
+        )
+        self.start_node(0)
 
     def run_test(self):
-        self.test_ipc_startup_logging()
+        self.test_ipcmaxconnections()
 
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -356,6 +356,7 @@ BASE_SCRIPTS = [
     'mempool_cluster.py',
     'feature_logging.py',
     'interface_ipc.py',
+    'interface_ipc_init.py',
     'interface_ipc_mining.py',
     'feature_anchors.py',
     'mempool_datacarrier.py',


### PR DESCRIPTION
When `-ipcbind` is used, the node opens one listening socket FD per bound address and accepts concurrent IPC connections. Neither was previously accounted for in `min_required_fds`, meaning IPC-heavy workloads could silently exhaust available file descriptors.

This PR adds `-ipcmaxconnections` (default: 16, mirroring `-rpcworkqueue`) so operators can control how many FDs are reserved for accepted IPC connections. It also adds `ipc_bind` to account for the listening socket FDs opened per `-ipcbind` address, which were previously unaccounted for. A warning is emitted when `-ipcmaxconnections` is set without `-ipcbind`.

This reserves file descriptors at startup. Upstream PR enforcing the connection limit https://github.com/bitcoin-core/libmultiprocess/pull/269

Note: there is also a draft alternative downstream approach in bitcoin/bitcoin#35037, using the local per-listener limit API proposed in bitcoin-core/libmultiprocess#269 to support per-address `max-connections=` options on `-ipcbind`.

So the two concrete directions under discussion are:

1. the global `-ipcmaxconnections` reservation approach in this PR
2. the per-address `-ipcbind ... max-connections=`
  approach in #35037

Suggested by Sjors in #32297 (comment).
