### PR TITLE
kernel: Remove NONNULL annotation from destroy method

### DIFF
--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1344,7 +1344,7 @@ BITCOINKERNEL_API btck_BlockValidationState* BITCOINKERNEL_WARN_UNUSED_RESULT bt
  * Destroy the btck_BlockValidationState.
  */
 BITCOINKERNEL_API void btck_block_validation_state_destroy(
-    btck_BlockValidationState* block_validation_state) BITCOINKERNEL_ARG_NONNULL(1);
+    btck_BlockValidationState* block_validation_state);
 
 ///@}
 


### PR DESCRIPTION
Follow-up to https://github.com/bitcoin/bitcoin/pull/33796#discussion_r2959817508

### Summary
This PR removes the `BITCOINKERNEL_ARG_NONNULL` annotation from the `btck_block_validation_state_destroy` method in the Kernel API.

### Motivation
No other *_destroy function in the Kernel API carries the NONNULL annotation. Following the convention set by free(), destroy functions should accept null pointers. 

### Usage:
Before:
```c
btck_BlockValidationState* state = NULL;
btck_block_validation_state_destroy(state); // violates nonnull contract
```

After:
```c
btck_BlockValidationState* state = NULL;
btck_block_validation_state_destroy(state); // well-defined
```
