### PR TITLE
fuzz: remove GetDescriptorChecksum from string harness

### DIFF
--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -63,7 +63,6 @@ FUZZ_TARGET(string)
     const auto width{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 1000)};
     (void)FormatParagraph(random_string_1, width, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, width));
     (void)FormatSubVersion(random_string_1, fuzzed_data_provider.ConsumeIntegral<int>(), random_string_vector);
-    (void)GetDescriptorChecksum(random_string_1);
     (void)HelpExampleCli(random_string_1, random_string_2);
     (void)HelpExampleRpc(random_string_1, random_string_2);
     (void)HelpMessageGroup(random_string_1);


### PR DESCRIPTION
This function is already strongly fuzzed by other harness. E.g: descriptor_parse calls it several times during parsing and serialization. Also, calling GetDescriptorChecksum with a string of length 32 is not effective to exercise it.
