### PR TITLE
docs: remove duplicate ///@} from bitcoinkernel.h

### DIFF
--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1610,8 +1610,6 @@ BITCOINKERNEL_API void btck_txid_destroy(btck_Txid* txid);
 
 ///@}
 
-///@}
-
 /** @name Coin
  * Functions for working with coins.
  */


### PR DESCRIPTION
### Summary

Removes a redundant **group end marker** in the kernel API docs. 

### Motivation

Cleans kernel API documentation.