### PR TITLE
rpc: fix initialization-order-fiasco by lazy-init of decodepsbt_inputs

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -734,29 +734,33 @@ static CBlockUndo GetUndoChecked(BlockManager& blockman, const CBlockIndex& bloc
     return blockUndo;
 }
 
-const RPCResult getblock_vin{
-    RPCResult::Type::ARR, "vin", "",
-    {
-        {RPCResult::Type::OBJ, "", "",
+const RPCResult& GetBlockVin()
+{
+    static const RPCResult getblock_vin{
+        RPCResult::Type::ARR, "vin", "",
         {
-            {RPCResult::Type::ELISION, "", "The same output as verbosity = 2"},
-            {RPCResult::Type::OBJ, "prevout", "(Only if undo information is available)",
+            {RPCResult::Type::OBJ, "", "",
             {
-                {RPCResult::Type::BOOL, "generated", "Coinbase or not"},
-                {RPCResult::Type::NUM, "height", "The height of the prevout"},
-                {RPCResult::Type::STR_AMOUNT, "value", "The value in " + CURRENCY_UNIT},
-                {RPCResult::Type::OBJ, "scriptPubKey", "",
+                {RPCResult::Type::ELISION, "", "The same output as verbosity = 2"},
+                {RPCResult::Type::OBJ, "prevout", "(Only if undo information is available)",
                 {
-                    {RPCResult::Type::STR, "asm", "Disassembly of the output script"},
-                    {RPCResult::Type::STR, "desc", "Inferred descriptor for the output"},
-                    {RPCResult::Type::STR_HEX, "hex", "The raw output script bytes, hex-encoded"},
-                    {RPCResult::Type::STR, "address", /*optional=*/true, "The Bitcoin address (only if a well-defined address exists)"},
-                    {RPCResult::Type::STR, "type", "The type (one of: " + GetAllOutputTypes() + ")"},
+                    {RPCResult::Type::BOOL, "generated", "Coinbase or not"},
+                    {RPCResult::Type::NUM, "height", "The height of the prevout"},
+                    {RPCResult::Type::STR_AMOUNT, "value", "The value in " + CURRENCY_UNIT},
+                    {RPCResult::Type::OBJ, "scriptPubKey", "",
+                    {
+                        {RPCResult::Type::STR, "asm", "Disassembly of the output script"},
+                        {RPCResult::Type::STR, "desc", "Inferred descriptor for the output"},
+                        {RPCResult::Type::STR_HEX, "hex", "The raw output script bytes, hex-encoded"},
+                        {RPCResult::Type::STR, "address", /*optional=*/true, "The Bitcoin address (only if a well-defined address exists)"},
+                        {RPCResult::Type::STR, "type", "The type (one of: " + GetAllOutputTypes() + ")"},
+                    }},
                 }},
             }},
-        }},
-    }
-};
+        }
+    };
+    return getblock_vin;
+}
 
 static RPCMethod getblock()
 {
@@ -828,7 +832,7 @@ static RPCMethod getblock()
                     {
                         {RPCResult::Type::OBJ, "", "",
                         {
-                            getblock_vin,
+                            GetBlockVin(),
                         }},
                     }},
                 }},

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -775,240 +775,248 @@ static RPCMethod signrawtransactionwithkey()
     };
 }
 
-const RPCResult decodepsbt_inputs{
-    RPCResult::Type::ARR, "inputs", "",
-    {
-        {RPCResult::Type::OBJ, "", "",
+const RPCResult& DecodePSBTInputs()
+{
+    static const RPCResult decodepsbt_inputs{
+        RPCResult::Type::ARR, "inputs", "",
         {
-            {RPCResult::Type::OBJ, "non_witness_utxo", /*optional=*/true, "Decoded network transaction for non-witness UTXOs",
-                TxDoc({.elision_description="The layout is the same as the output of decoderawtransaction."})
-            },
-            {RPCResult::Type::OBJ, "witness_utxo", /*optional=*/true, "Transaction output for witness UTXOs",
+            {RPCResult::Type::OBJ, "", "",
             {
-                {RPCResult::Type::NUM, "amount", "The value in " + CURRENCY_UNIT},
-                {RPCResult::Type::OBJ, "scriptPubKey", "",
+                {RPCResult::Type::OBJ, "non_witness_utxo", /*optional=*/true, "Decoded network transaction for non-witness UTXOs",
+                    TxDoc({.elision_description="The layout is the same as the output of decoderawtransaction."})
+                },
+                {RPCResult::Type::OBJ, "witness_utxo", /*optional=*/true, "Transaction output for witness UTXOs",
                 {
-                    {RPCResult::Type::STR, "asm", "Disassembly of the output script"},
-                    {RPCResult::Type::STR, "desc", "Inferred descriptor for the output"},
-                    {RPCResult::Type::STR_HEX, "hex", "The raw output script bytes, hex-encoded"},
+                    {RPCResult::Type::NUM, "amount", "The value in " + CURRENCY_UNIT},
+                    {RPCResult::Type::OBJ, "scriptPubKey", "",
+                    {
+                        {RPCResult::Type::STR, "asm", "Disassembly of the output script"},
+                        {RPCResult::Type::STR, "desc", "Inferred descriptor for the output"},
+                        {RPCResult::Type::STR_HEX, "hex", "The raw output script bytes, hex-encoded"},
+                        {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
+                        {RPCResult::Type::STR, "address", /*optional=*/true, "The Bitcoin address (only if a well-defined address exists)"},
+                    }},
+                }},
+                {RPCResult::Type::OBJ_DYN, "partial_signatures", /*optional=*/true, "",
+                {
+                    {RPCResult::Type::STR, "pubkey", "The public key and signature that corresponds to it."},
+                }},
+                {RPCResult::Type::STR, "sighash", /*optional=*/true, "The sighash type to be used"},
+                {RPCResult::Type::OBJ, "redeem_script", /*optional=*/true, "",
+                {
+                    {RPCResult::Type::STR, "asm", "Disassembly of the redeem script"},
+                    {RPCResult::Type::STR_HEX, "hex", "The raw redeem script bytes, hex-encoded"},
                     {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
-                    {RPCResult::Type::STR, "address", /*optional=*/true, "The Bitcoin address (only if a well-defined address exists)"},
                 }},
-            }},
-            {RPCResult::Type::OBJ_DYN, "partial_signatures", /*optional=*/true, "",
-            {
-                {RPCResult::Type::STR, "pubkey", "The public key and signature that corresponds to it."},
-            }},
-            {RPCResult::Type::STR, "sighash", /*optional=*/true, "The sighash type to be used"},
-            {RPCResult::Type::OBJ, "redeem_script", /*optional=*/true, "",
-            {
-                {RPCResult::Type::STR, "asm", "Disassembly of the redeem script"},
-                {RPCResult::Type::STR_HEX, "hex", "The raw redeem script bytes, hex-encoded"},
-                {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
-            }},
-            {RPCResult::Type::OBJ, "witness_script", /*optional=*/true, "",
-            {
-                {RPCResult::Type::STR, "asm", "Disassembly of the witness script"},
-                {RPCResult::Type::STR_HEX, "hex", "The raw witness script bytes, hex-encoded"},
-                {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
-            }},
-            {RPCResult::Type::ARR, "bip32_derivs", /*optional=*/true, "",
-            {
-                {RPCResult::Type::OBJ, "", "",
+                {RPCResult::Type::OBJ, "witness_script", /*optional=*/true, "",
                 {
-                    {RPCResult::Type::STR, "pubkey", "The public key with the derivation path as the value."},
-                    {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
-                    {RPCResult::Type::STR, "path", "The path"},
+                    {RPCResult::Type::STR, "asm", "Disassembly of the witness script"},
+                    {RPCResult::Type::STR_HEX, "hex", "The raw witness script bytes, hex-encoded"},
+                    {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
                 }},
-            }},
-            {RPCResult::Type::OBJ, "final_scriptSig", /*optional=*/true, "",
-            {
-                {RPCResult::Type::STR, "asm", "Disassembly of the final signature script"},
-                {RPCResult::Type::STR_HEX, "hex", "The raw final signature script bytes, hex-encoded"},
-            }},
-            {RPCResult::Type::ARR, "final_scriptwitness", /*optional=*/true, "",
-            {
-                {RPCResult::Type::STR_HEX, "", "hex-encoded witness data (if any)"},
-            }},
-            {RPCResult::Type::OBJ_DYN, "ripemd160_preimages", /*optional=*/ true, "",
-            {
-                {RPCResult::Type::STR, "hash", "The hash and preimage that corresponds to it."},
-            }},
-            {RPCResult::Type::OBJ_DYN, "sha256_preimages", /*optional=*/ true, "",
-            {
-                {RPCResult::Type::STR, "hash", "The hash and preimage that corresponds to it."},
-            }},
-            {RPCResult::Type::OBJ_DYN, "hash160_preimages", /*optional=*/ true, "",
-            {
-                {RPCResult::Type::STR, "hash", "The hash and preimage that corresponds to it."},
-            }},
-            {RPCResult::Type::OBJ_DYN, "hash256_preimages", /*optional=*/ true, "",
-            {
-                {RPCResult::Type::STR, "hash", "The hash and preimage that corresponds to it."},
-            }},
-            {RPCResult::Type::STR_HEX, "taproot_key_path_sig", /*optional=*/ true, "hex-encoded signature for the Taproot key path spend"},
-            {RPCResult::Type::ARR, "taproot_script_path_sigs", /*optional=*/ true, "",
-            {
-                {RPCResult::Type::OBJ, "signature", /*optional=*/ true, "The signature for the pubkey and leaf hash combination",
+                {RPCResult::Type::ARR, "bip32_derivs", /*optional=*/true, "",
                 {
-                    {RPCResult::Type::STR, "pubkey", "The x-only pubkey for this signature"},
-                    {RPCResult::Type::STR, "leaf_hash", "The leaf hash for this signature"},
-                    {RPCResult::Type::STR, "sig", "The signature itself"},
-                }},
-            }},
-            {RPCResult::Type::ARR, "taproot_scripts", /*optional=*/ true, "",
-            {
-                {RPCResult::Type::OBJ, "", "",
-                {
-                    {RPCResult::Type::STR_HEX, "script", "A leaf script"},
-                    {RPCResult::Type::NUM, "leaf_ver", "The version number for the leaf script"},
-                    {RPCResult::Type::ARR, "control_blocks", "The control blocks for this script",
+                    {RPCResult::Type::OBJ, "", "",
                     {
-                        {RPCResult::Type::STR_HEX, "control_block", "A hex-encoded control block for this script"},
+                        {RPCResult::Type::STR, "pubkey", "The public key with the derivation path as the value."},
+                        {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
+                        {RPCResult::Type::STR, "path", "The path"},
+                    }},
+                }},
+                {RPCResult::Type::OBJ, "final_scriptSig", /*optional=*/true, "",
+                {
+                    {RPCResult::Type::STR, "asm", "Disassembly of the final signature script"},
+                    {RPCResult::Type::STR_HEX, "hex", "The raw final signature script bytes, hex-encoded"},
+                }},
+                {RPCResult::Type::ARR, "final_scriptwitness", /*optional=*/true, "",
+                {
+                    {RPCResult::Type::STR_HEX, "", "hex-encoded witness data (if any)"},
+                }},
+                {RPCResult::Type::OBJ_DYN, "ripemd160_preimages", /*optional=*/ true, "",
+                {
+                    {RPCResult::Type::STR, "hash", "The hash and preimage that corresponds to it."},
+                }},
+                {RPCResult::Type::OBJ_DYN, "sha256_preimages", /*optional=*/ true, "",
+                {
+                    {RPCResult::Type::STR, "hash", "The hash and preimage that corresponds to it."},
+                }},
+                {RPCResult::Type::OBJ_DYN, "hash160_preimages", /*optional=*/ true, "",
+                {
+                    {RPCResult::Type::STR, "hash", "The hash and preimage that corresponds to it."},
+                }},
+                {RPCResult::Type::OBJ_DYN, "hash256_preimages", /*optional=*/ true, "",
+                {
+                    {RPCResult::Type::STR, "hash", "The hash and preimage that corresponds to it."},
+                }},
+                {RPCResult::Type::STR_HEX, "taproot_key_path_sig", /*optional=*/ true, "hex-encoded signature for the Taproot key path spend"},
+                {RPCResult::Type::ARR, "taproot_script_path_sigs", /*optional=*/ true, "",
+                {
+                    {RPCResult::Type::OBJ, "signature", /*optional=*/ true, "The signature for the pubkey and leaf hash combination",
+                    {
+                        {RPCResult::Type::STR, "pubkey", "The x-only pubkey for this signature"},
+                        {RPCResult::Type::STR, "leaf_hash", "The leaf hash for this signature"},
+                        {RPCResult::Type::STR, "sig", "The signature itself"},
+                    }},
+                }},
+                {RPCResult::Type::ARR, "taproot_scripts", /*optional=*/ true, "",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "script", "A leaf script"},
+                        {RPCResult::Type::NUM, "leaf_ver", "The version number for the leaf script"},
+                        {RPCResult::Type::ARR, "control_blocks", "The control blocks for this script",
+                        {
+                            {RPCResult::Type::STR_HEX, "control_block", "A hex-encoded control block for this script"},
+                        }},
+                    }},
+                }},
+                {RPCResult::Type::ARR, "taproot_bip32_derivs", /*optional=*/ true, "",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "pubkey", "The x-only public key this path corresponds to"},
+                        {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
+                        {RPCResult::Type::STR, "path", "The path"},
+                        {RPCResult::Type::ARR, "leaf_hashes", "The hashes of the leaves this pubkey appears in",
+                        {
+                            {RPCResult::Type::STR_HEX, "hash", "The hash of a leaf this pubkey appears in"},
+                        }},
+                    }},
+                }},
+                {RPCResult::Type::STR_HEX, "taproot_internal_key", /*optional=*/ true, "The hex-encoded Taproot x-only internal key"},
+                {RPCResult::Type::STR_HEX, "taproot_merkle_root", /*optional=*/ true, "The hex-encoded Taproot merkle root"},
+                {RPCResult::Type::ARR, "musig2_participant_pubkeys", /*optional=*/true, "",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "aggregate_pubkey", "The compressed aggregate public key for which the participants create."},
+                        {RPCResult::Type::ARR, "participant_pubkeys", "",
+                        {
+                            {RPCResult::Type::STR_HEX, "pubkey", "The compressed public keys that are aggregated for aggregate_pubkey."},
+                        }},
+                    }},
+                }},
+                {RPCResult::Type::ARR, "musig2_pubnonces", /*optional=*/true, "",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "participant_pubkey", "The compressed public key of the participant that created this pubnonce."},
+                        {RPCResult::Type::STR_HEX, "aggregate_pubkey", "The compressed aggregate public key for which this pubnonce is for."},
+                        {RPCResult::Type::STR_HEX, "leaf_hash", /*optional=*/true, "The hash of the leaf script that contains the aggregate pubkey being signed for. Omitted when signing for the internal key."},
+                        {RPCResult::Type::STR_HEX, "pubnonce", "The public nonce itself."},
+                    }},
+                }},
+                {RPCResult::Type::ARR, "musig2_partial_sigs", /*optional=*/true, "",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "participant_pubkey", "The compressed public key of the participant that created this partial signature."},
+                        {RPCResult::Type::STR_HEX, "aggregate_pubkey", "The compressed aggregate public key for which this partial signature is for."},
+                        {RPCResult::Type::STR_HEX, "leaf_hash", /*optional=*/true, "The hash of the leaf script that contains the aggregate pubkey being signed for. Omitted when signing for the internal key."},
+                        {RPCResult::Type::STR_HEX, "partial_sig", "The partial signature itself."},
+                    }},
+                }},
+                {RPCResult::Type::OBJ_DYN, "unknown", /*optional=*/ true, "The unknown input fields",
+                {
+                    {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
+                }},
+                {RPCResult::Type::ARR, "proprietary", /*optional=*/true, "The input proprietary map",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "identifier", "The hex string for the proprietary identifier"},
+                        {RPCResult::Type::NUM, "subtype", "The number for the subtype"},
+                        {RPCResult::Type::STR_HEX, "key", "The hex for the key"},
+                        {RPCResult::Type::STR_HEX, "value", "The hex for the value"},
                     }},
                 }},
             }},
-            {RPCResult::Type::ARR, "taproot_bip32_derivs", /*optional=*/ true, "",
-            {
-                {RPCResult::Type::OBJ, "", "",
-                {
-                    {RPCResult::Type::STR, "pubkey", "The x-only public key this path corresponds to"},
-                    {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
-                    {RPCResult::Type::STR, "path", "The path"},
-                    {RPCResult::Type::ARR, "leaf_hashes", "The hashes of the leaves this pubkey appears in",
-                    {
-                        {RPCResult::Type::STR_HEX, "hash", "The hash of a leaf this pubkey appears in"},
-                    }},
-                }},
-            }},
-            {RPCResult::Type::STR_HEX, "taproot_internal_key", /*optional=*/ true, "The hex-encoded Taproot x-only internal key"},
-            {RPCResult::Type::STR_HEX, "taproot_merkle_root", /*optional=*/ true, "The hex-encoded Taproot merkle root"},
-            {RPCResult::Type::ARR, "musig2_participant_pubkeys", /*optional=*/true, "",
-            {
-                {RPCResult::Type::OBJ, "", "",
-                {
-                    {RPCResult::Type::STR_HEX, "aggregate_pubkey", "The compressed aggregate public key for which the participants create."},
-                    {RPCResult::Type::ARR, "participant_pubkeys", "",
-                    {
-                        {RPCResult::Type::STR_HEX, "pubkey", "The compressed public keys that are aggregated for aggregate_pubkey."},
-                    }},
-                }},
-            }},
-            {RPCResult::Type::ARR, "musig2_pubnonces", /*optional=*/true, "",
-            {
-                {RPCResult::Type::OBJ, "", "",
-                {
-                    {RPCResult::Type::STR_HEX, "participant_pubkey", "The compressed public key of the participant that created this pubnonce."},
-                    {RPCResult::Type::STR_HEX, "aggregate_pubkey", "The compressed aggregate public key for which this pubnonce is for."},
-                    {RPCResult::Type::STR_HEX, "leaf_hash", /*optional=*/true, "The hash of the leaf script that contains the aggregate pubkey being signed for. Omitted when signing for the internal key."},
-                    {RPCResult::Type::STR_HEX, "pubnonce", "The public nonce itself."},
-                }},
-            }},
-            {RPCResult::Type::ARR, "musig2_partial_sigs", /*optional=*/true, "",
-            {
-                {RPCResult::Type::OBJ, "", "",
-                {
-                    {RPCResult::Type::STR_HEX, "participant_pubkey", "The compressed public key of the participant that created this partial signature."},
-                    {RPCResult::Type::STR_HEX, "aggregate_pubkey", "The compressed aggregate public key for which this partial signature is for."},
-                    {RPCResult::Type::STR_HEX, "leaf_hash", /*optional=*/true, "The hash of the leaf script that contains the aggregate pubkey being signed for. Omitted when signing for the internal key."},
-                    {RPCResult::Type::STR_HEX, "partial_sig", "The partial signature itself."},
-                }},
-            }},
-            {RPCResult::Type::OBJ_DYN, "unknown", /*optional=*/ true, "The unknown input fields",
-            {
-                {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
-            }},
-            {RPCResult::Type::ARR, "proprietary", /*optional=*/true, "The input proprietary map",
-            {
-                {RPCResult::Type::OBJ, "", "",
-                {
-                    {RPCResult::Type::STR_HEX, "identifier", "The hex string for the proprietary identifier"},
-                    {RPCResult::Type::NUM, "subtype", "The number for the subtype"},
-                    {RPCResult::Type::STR_HEX, "key", "The hex for the key"},
-                    {RPCResult::Type::STR_HEX, "value", "The hex for the value"},
-                }},
-            }},
-        }},
-    }
-};
+        }
+    };
+    return decodepsbt_inputs;
+}
 
-const RPCResult decodepsbt_outputs{
-    RPCResult::Type::ARR, "outputs", "",
-    {
-        {RPCResult::Type::OBJ, "", "",
+const RPCResult& DecodePSBTOutputs()
+{
+    static const RPCResult decodepsbt_outputs{
+        RPCResult::Type::ARR, "outputs", "",
         {
-            {RPCResult::Type::OBJ, "redeem_script", /*optional=*/true, "",
+            {RPCResult::Type::OBJ, "", "",
             {
-                {RPCResult::Type::STR, "asm", "Disassembly of the redeem script"},
-                {RPCResult::Type::STR_HEX, "hex", "The raw redeem script bytes, hex-encoded"},
-                {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
-            }},
-            {RPCResult::Type::OBJ, "witness_script", /*optional=*/true, "",
-            {
-                {RPCResult::Type::STR, "asm", "Disassembly of the witness script"},
-                {RPCResult::Type::STR_HEX, "hex", "The raw witness script bytes, hex-encoded"},
-                {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
-            }},
-            {RPCResult::Type::ARR, "bip32_derivs", /*optional=*/true, "",
-            {
-                {RPCResult::Type::OBJ, "", "",
+                {RPCResult::Type::OBJ, "redeem_script", /*optional=*/true, "",
                 {
-                    {RPCResult::Type::STR, "pubkey", "The public key this path corresponds to"},
-                    {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
-                    {RPCResult::Type::STR, "path", "The path"},
+                    {RPCResult::Type::STR, "asm", "Disassembly of the redeem script"},
+                    {RPCResult::Type::STR_HEX, "hex", "The raw redeem script bytes, hex-encoded"},
+                    {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
                 }},
-            }},
-            {RPCResult::Type::STR_HEX, "taproot_internal_key", /*optional=*/ true, "The hex-encoded Taproot x-only internal key"},
-            {RPCResult::Type::ARR, "taproot_tree", /*optional=*/ true, "The tuples that make up the Taproot tree, in depth first search order",
-            {
-                {RPCResult::Type::OBJ, "tuple", /*optional=*/ true, "A single leaf script in the taproot tree",
+                {RPCResult::Type::OBJ, "witness_script", /*optional=*/true, "",
                 {
-                    {RPCResult::Type::NUM, "depth", "The depth of this element in the tree"},
-                    {RPCResult::Type::NUM, "leaf_ver", "The version of this leaf"},
-                    {RPCResult::Type::STR, "script", "The hex-encoded script itself"},
+                    {RPCResult::Type::STR, "asm", "Disassembly of the witness script"},
+                    {RPCResult::Type::STR_HEX, "hex", "The raw witness script bytes, hex-encoded"},
+                    {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
                 }},
-            }},
-            {RPCResult::Type::ARR, "taproot_bip32_derivs", /*optional=*/ true, "",
-            {
-                {RPCResult::Type::OBJ, "", "",
+                {RPCResult::Type::ARR, "bip32_derivs", /*optional=*/true, "",
                 {
-                    {RPCResult::Type::STR, "pubkey", "The x-only public key this path corresponds to"},
-                    {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
-                    {RPCResult::Type::STR, "path", "The path"},
-                    {RPCResult::Type::ARR, "leaf_hashes", "The hashes of the leaves this pubkey appears in",
+                    {RPCResult::Type::OBJ, "", "",
                     {
-                        {RPCResult::Type::STR_HEX, "hash", "The hash of a leaf this pubkey appears in"},
+                        {RPCResult::Type::STR, "pubkey", "The public key this path corresponds to"},
+                        {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
+                        {RPCResult::Type::STR, "path", "The path"},
+                    }},
+                }},
+                {RPCResult::Type::STR_HEX, "taproot_internal_key", /*optional=*/ true, "The hex-encoded Taproot x-only internal key"},
+                {RPCResult::Type::ARR, "taproot_tree", /*optional=*/ true, "The tuples that make up the Taproot tree, in depth first search order",
+                {
+                    {RPCResult::Type::OBJ, "tuple", /*optional=*/ true, "A single leaf script in the taproot tree",
+                    {
+                        {RPCResult::Type::NUM, "depth", "The depth of this element in the tree"},
+                        {RPCResult::Type::NUM, "leaf_ver", "The version of this leaf"},
+                        {RPCResult::Type::STR, "script", "The hex-encoded script itself"},
+                    }},
+                }},
+                {RPCResult::Type::ARR, "taproot_bip32_derivs", /*optional=*/ true, "",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "pubkey", "The x-only public key this path corresponds to"},
+                        {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
+                        {RPCResult::Type::STR, "path", "The path"},
+                        {RPCResult::Type::ARR, "leaf_hashes", "The hashes of the leaves this pubkey appears in",
+                        {
+                            {RPCResult::Type::STR_HEX, "hash", "The hash of a leaf this pubkey appears in"},
+                        }},
+                    }},
+                }},
+                {RPCResult::Type::ARR, "musig2_participant_pubkeys", /*optional=*/true, "",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "aggregate_pubkey", "The compressed aggregate public key for which the participants create."},
+                        {RPCResult::Type::ARR, "participant_pubkeys", "",
+                        {
+                            {RPCResult::Type::STR_HEX, "pubkey", "The compressed public keys that are aggregated for aggregate_pubkey."},
+                        }},
+                    }},
+                }},
+                {RPCResult::Type::OBJ_DYN, "unknown", /*optional=*/true, "The unknown output fields",
+                {
+                    {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
+                }},
+                {RPCResult::Type::ARR, "proprietary", /*optional=*/true, "The output proprietary map",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "identifier", "The hex string for the proprietary identifier"},
+                        {RPCResult::Type::NUM, "subtype", "The number for the subtype"},
+                        {RPCResult::Type::STR_HEX, "key", "The hex for the key"},
+                        {RPCResult::Type::STR_HEX, "value", "The hex for the value"},
                     }},
                 }},
             }},
-            {RPCResult::Type::ARR, "musig2_participant_pubkeys", /*optional=*/true, "",
-            {
-                {RPCResult::Type::OBJ, "", "",
-                {
-                    {RPCResult::Type::STR_HEX, "aggregate_pubkey", "The compressed aggregate public key for which the participants create."},
-                    {RPCResult::Type::ARR, "participant_pubkeys", "",
-                    {
-                        {RPCResult::Type::STR_HEX, "pubkey", "The compressed public keys that are aggregated for aggregate_pubkey."},
-                    }},
-                }},
-            }},
-            {RPCResult::Type::OBJ_DYN, "unknown", /*optional=*/true, "The unknown output fields",
-            {
-                {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
-            }},
-            {RPCResult::Type::ARR, "proprietary", /*optional=*/true, "The output proprietary map",
-            {
-                {RPCResult::Type::OBJ, "", "",
-                {
-                    {RPCResult::Type::STR_HEX, "identifier", "The hex string for the proprietary identifier"},
-                    {RPCResult::Type::NUM, "subtype", "The number for the subtype"},
-                    {RPCResult::Type::STR_HEX, "key", "The hex for the key"},
-                    {RPCResult::Type::STR_HEX, "value", "The hex for the value"},
-                }},
-            }},
-        }},
-    }
-};
+        }
+    };
+    return decodepsbt_outputs;
+}
 
 static RPCMethod decodepsbt()
 {
@@ -1048,8 +1056,8 @@ static RPCMethod decodepsbt()
                         {
                              {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
                         }},
-                        decodepsbt_inputs,
-                        decodepsbt_outputs,
+                        DecodePSBTInputs(),
+                        DecodePSBTOutputs(),
                         {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The transaction fee paid if all UTXOs slots in the PSBT have been filled."},
                     }
                 },


### PR DESCRIPTION
Prior to this commit, `decodepsbt_inputs` would call `TxDoc` during initialization which lives in another TLU. `TxDoc` relies on `CURRENCY_UNIT` to be initialized when it may not have been (note this is different from the TLU containing `decodepsbt_inputs` which also has a `CURRENCY_UNIT`). Fix this by lazy initializing `decodepsbt_inputs`. Also prevent the issue in the future by doing the same for `decodepsbt_outputs` and `getblock_vin`.

Curious why the CI missed this, it broke fuzzamoto. It was introduced in fadf901fd4b4d95bd0dd046b8d44a1154c5ea9a8. I was able to trigger this with clang-21 and `ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"`:

```
=================================================================
==926804==ERROR: AddressSanitizer: initialization-order-fiasco on address 0x5631e5784288 at pc 0x5631e3309f9c bp 0x7ffdb6abc7b0 sp 0x7ffdb6abc7a8
READ of size 8 at 0x5631e5784288 thread T0
    #0 0x5631e3309f9b in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::size() const /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/basic_string.h:1064:16
    #1 0x5631e3309f9b in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> std::operator+<char, std::char_traits<char>, std::allocator<char>>(char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/basic_string.tcc:618:35
    #2 0x5631e4238948 in TxDoc(TxDocOptions const&) /root/bitcoin/src/rpc/rawtransaction_util.cpp:382:76
    #3 0x5631e316945e in __cxx_global_var_init.9 /root/bitcoin/src/rpc/rawtransaction.cpp:784:17
    #4 0x5631e3186355 in _GLOBAL__sub_I_rawtransaction.cpp /root/bitcoin/src/rpc/rawtransaction.cpp
    #5 0x7fa6ca046375 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x27375) (BuildId: 79005c16293efa45b441fed45f4f29b138557e9e)
    #6 0x5631e31cf160 in _start (/root/bitcoin/build/bin/bitcoind+0x25b160)

0x5631e5784288 is located 56 bytes before global variable 'CURRENCY_ATOM[abi:cxx11]' defined in '/root/bitcoin/src/policy/feerate.h:20' (0x5631e57842c0) of size 32
  registered at:
    #0 0x5631e31e5738 in __asan_register_globals /root/llvm-project/compiler-rt/lib/asan/asan_globals.cpp:431:3
    #1 0x5631e31e68a9 in __asan_register_elf_globals /root/llvm-project/compiler-rt/lib/asan/asan_globals.cpp:414:3

0x5631e5784288 is located 8 bytes inside of global variable 'CURRENCY_UNIT[abi:cxx11]' defined in '/root/bitcoin/src/policy/feerate.h:19' (0x5631e5784280) of size 32
  registered at:
    #0 0x5631e31e5738 in __asan_register_globals /root/llvm-project/compiler-rt/lib/asan/asan_globals.cpp:431:3
    #1 0x5631e31e68a9 in __asan_register_elf_globals /root/llvm-project/compiler-rt/lib/asan/asan_globals.cpp:414:3

SUMMARY: AddressSanitizer: initialization-order-fiasco /root/bitcoin/src/rpc/rawtransaction_util.cpp:382:76 in TxDoc(TxDocOptions const&)
Shadow bytes around the buggy address:
  0x5631e5784000: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x5631e5784080: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x5631e5784100: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x5631e5784180: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x5631e5784200: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
=>0x5631e5784280: f6[f6]f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x5631e5784300: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x5631e5784380: f6 f6 f6 f6 01 f9 f9 f9 f6 f6 f6 f6 f6 f6 f6 f6
  0x5631e5784400: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x5631e5784480: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x5631e5784500: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==926804==ABORTING

```

Can be reviewed with `git diff HEAD~1 -w` since it's mostly indentation.