### PR TITLE
doc: remove stale shortid collision TODO

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -110,8 +110,6 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         if (shorttxids.bucket_size(shorttxids.bucket(cmpctblock.shorttxids[i])) > 12)
             return READ_STATUS_FAILED;
     }
-    // TODO: in the shortid-collision case, we should instead request both transactions
-    // which collided. Falling back to full-block-request here is overkill.
     if (shorttxids.size() != cmpctblock.shorttxids.size())
         return READ_STATUS_FAILED; // Short ID collision
 


### PR DESCRIPTION
`PartiallyDownloadedBlock::InitData()` already treats duplicate short IDs in a compact block as `READ_STATUS_FAILED`.

For an honest peer, block-level short-ID collisions are rare enough that failing the compact block early is preferable to scanning the mempool or attempting selective recovery (see https://github.com/bitcoin/bitcoin/pull/34932#issuecomment-4139177024)

This removes the old TODO suggesting that both collided transactions should be requested, since that comment no longer matches the intended handling.

No behavior change. Comment-only cleanup.