### PR TITLE
test: fix feature_index_prune.py bug when using --usecli

### DIFF
--- a/ci/test/00_setup_env_i686_no_ipc.sh
+++ b/ci/test/00_setup_env_i686_no_ipc.sh
@@ -14,7 +14,7 @@ export PACKAGES="llvm clang g++-multilib"
 export DEP_OPTS="DEBUG=1 NO_IPC=1"
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1
-export TEST_RUNNER_EXTRA="--v2transport --usecli"
+export TEST_RUNNER_EXTRA="--v2transport --usecli --extended"
 export BITCOIN_CONFIG="\
  --preset=dev-mode \
  -DENABLE_IPC=OFF \

--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -18,11 +18,11 @@ from typing import List, Any
 
 def send_batch_request(node: TestNode, method: str, params: List[Any]) -> List[Any]:
     """Send batch request and parse all results"""
-    data = [{"method": method, "params": p} for p in params]
+    data = [getattr(node, method).get_request(*p) for p in params]
     response = node.batch(data)
     result = []
     for item in response:
-        assert item["error"] is None, item["error"]
+        assert "error" not in item, item["error"]
         result.append(item["result"])
 
     return result


### PR DESCRIPTION
**First commit**

This commit fixes an error that made feature_index_prune.py fail if --usecli was used.

The test was failing because `node.batch(data)` was called with `data` being a dict. This worked in the normal scenario because `AuthServiceProxy.batch()` expects a list of petitions in the form of a dict. But  `TestNodeCLI.batch()` expects callables and not a dict. When `--usecli` is used the test fails with an error `TypeError: 'dict' object is not callable`.

This is fixed by using `get_request()` which returns a lambda function if `--usecli` is used and returns a dict if not.
The `assert` is also changed because before this PR, the requests, constructed by hand were not specifiying the json-rpc version. By default if no version is specified we use version 1.0 which always returns `error: none` if there is no error. However, in version 2.0, it does not include an error key if there is no error. By using `get_request()` the requests are done in version 2.0 so there's no key error.

**Second commit**

The current CI doesn't cover the case of running all tests with --extended if using --usecli.
This led to a test failing (feature_index_prune.py) if run with --usecli and the CI not catching it.
See https://github.com/bitcoin/bitcoin/pull/34991 for context.

This commit improves the CI test coverage by also running now all functional tests (--extended) with the flag --usecli.



<details>
<summary>First "wrong" approach</summary>
Fixes two bugs that make `feature_index_prune.py` fail if `--usecli` is used.

1. Makes `TestNodeCLI.batch()` response equivalent to what a JSON-RPC response would look like by adding `error=None` in the response. The lack of `error` in the response was giving a `KeyError` message.
2. Makes `send_batch_request()` compatible with --usecli. Before the PR it was passing dicts to `node.batch()`, but `TestNodeCLI.batch()` expects callables, not dicts.
</details>