### PR TITLE
rpc: add prev_txs param to utxoupdatepsbt

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -60,6 +60,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "mockscheduler", 0, "delta_time" },
     { "utxoupdatepsbt", 0, "psbt", ParamFormat::STRING },
     { "utxoupdatepsbt", 1, "descriptors" },
+    { "utxoupdatepsbt", 2, "prevtxs" },
     { "generatetoaddress", 0, "nblocks" },
     { "generatetoaddress", 2, "maxtries" },
     { "generatetodescriptor", 0, "num_blocks" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -219,6 +219,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "descriptorprocesspsbt", 2, "sighashtype", ParamFormat::STRING },
     { "descriptorprocesspsbt", 3, "bip32derivs" },
     { "descriptorprocesspsbt", 4, "finalize" },
+    { "descriptorprocesspsbt", 5, "prevtxs" },
     { "createpsbt", 0, "inputs" },
     { "createpsbt", 1, "outputs" },
     { "createpsbt", 2, "locktime" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -123,9 +123,29 @@ static std::vector<RPCArg> CreateTxDoc()
     };
 }
 
+// Build a txid-indexed map from an array of raw transaction hex strings.
+static std::map<Txid, CTransactionRef> ParsePrevTxs(const UniValue& prev_txs)
+{
+    std::map<Txid, CTransactionRef> result;
+    for (unsigned int i = 0; i < prev_txs.size(); ++i) {
+        CMutableTransaction mtx;
+        if (!DecodeHexTx(mtx, prev_txs[i].get_str())) {
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR,
+                               strprintf("TX decode failed for prev_tx %u", i));
+        }
+        CTransactionRef tx{MakeTransactionRef(std::move(mtx))};
+        auto [it, inserted] = result.emplace(tx->GetHash(), std::move(tx));
+        if (!inserted) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               strprintf("Duplicate prev_tx %s at index %u", it->first.ToString(), i));
+        }
+    }
+    return result;
+}
+
 // Update PSBT with information from the mempool, the UTXO set, the txindex, and the provided descriptors.
 // Optionally, sign the inputs that we can using information from the descriptors.
-PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std::any& context, const HidingSigningProvider& provider, std::optional<int> sighash_type, bool finalize)
+PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std::any& context, const HidingSigningProvider& provider, std::optional<int> sighash_type, bool finalize, const std::map<Txid, CTransactionRef>& prev_txs)
 {
     // Unserialize the transactions
     PartiallySignedTransaction psbtx;
@@ -143,7 +163,7 @@ PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std
     std::map<COutPoint, Coin> coins;
 
     // Fetch previous transactions:
-    // First, look in the txindex and the mempool
+    // First, check caller-provided transactions, then the txindex and the mempool
     for (unsigned int i = 0; i < psbtx.tx->vin.size(); ++i) {
         PSBTInput& psbt_input = psbtx.inputs.at(i);
         const CTxIn& tx_in = psbtx.tx->vin.at(i);
@@ -153,8 +173,12 @@ PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std
 
         CTransactionRef tx;
 
+        // Look in caller-provided previous transactions first
+        if (auto it = prev_txs.find(tx_in.prevout.hash); it != prev_txs.end()) {
+            tx = it->second;
+        }
         // Look in the txindex
-        if (g_txindex) {
+        if (!tx && g_txindex) {
             uint256 block_hash;
             g_txindex->FindTx(tx_in.prevout.hash, block_hash, tx);
         }
@@ -1740,7 +1764,7 @@ static RPCMethod utxoupdatepsbt()
 {
     return RPCMethod{
         "utxoupdatepsbt",
-        "Updates all segwit inputs and outputs in a PSBT with data from output descriptors, the UTXO set, txindex, or the mempool.\n",
+        "Updates all segwit inputs and outputs in a PSBT with data from output descriptors, the UTXO set, txindex, the mempool, or raw previous transactions.\n",
             {
                 {"psbt", RPCArg::Type::STR, RPCArg::Optional::NO, "A base64 string of a PSBT"},
                 {"descriptors", RPCArg::Type::ARR, RPCArg::Optional::OMITTED, "An array of either strings or objects", {
@@ -1750,12 +1774,16 @@ static RPCMethod utxoupdatepsbt()
                          {"range", RPCArg::Type::RANGE, RPCArg::Default{1000}, "Up to what index HD chains should be explored (either end or [begin,end])"},
                     }},
                 }},
+                {"prevtxs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED, "An array of raw transaction hex strings for previous transactions whose outputs are being spent in this PSBT but may not be available in the UTXO set, txindex, or the mempool", {
+                    {"rawtx", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "A raw transaction in hex"},
+                }},
             },
             RPCResult {
                     RPCResult::Type::STR, "", "The base64-encoded partially signed transaction with inputs updated"
             },
             RPCExamples {
-                HelpExampleCli("utxoupdatepsbt", "\"psbt\"")
+                HelpExampleCli("utxoupdatepsbt", "\"psbt\"") +
+                HelpExampleCli("utxoupdatepsbt", "\"psbt\" '[]' '[\"raw_parent_tx_hex\"]'")
             },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -1768,13 +1796,20 @@ static RPCMethod utxoupdatepsbt()
         }
     }
 
+    // Parse caller-provided previous transactions, if any.
+    std::map<Txid, CTransactionRef> prev_txs;
+    if (!request.params[2].isNull()) {
+        prev_txs = ParsePrevTxs(request.params[2].get_array());
+    }
+
     // We don't actually need private keys further on; hide them as a precaution.
     const PartiallySignedTransaction& psbtx = ProcessPSBT(
         request.params[0].get_str(),
         request.context,
         HidingSigningProvider(&provider, /*hide_secret=*/true, /*hide_origin=*/false),
         /*sighash_type=*/std::nullopt,
-        /*finalize=*/false);
+        /*finalize=*/false,
+        prev_txs);
 
     DataStream ssTx{};
     ssTx << psbtx;
@@ -2052,7 +2087,8 @@ RPCMethod descriptorprocesspsbt()
         request.context,
         HidingSigningProvider(&provider, /*hide_secret=*/false, !bip32derivs),
         sighash_type,
-        finalize);
+        finalize,
+        /*prev_txs=*/{});
 
     // Check whether or not all of the inputs are now signed
     bool complete = true;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -2034,7 +2034,7 @@ RPCMethod descriptorprocesspsbt()
 {
     return RPCMethod{
         "descriptorprocesspsbt",
-        "Update all segwit inputs in a PSBT with information from output descriptors, the UTXO set or the mempool. \n"
+        "Update all segwit inputs in a PSBT with information from output descriptors, the UTXO set, the mempool, or raw previous transactions. \n"
                 "Then, sign the inputs we are able to with information from the output descriptors. ",
                 {
                     {"psbt", RPCArg::Type::STR, RPCArg::Optional::NO, "The transaction base64 string"},
@@ -2055,6 +2055,9 @@ RPCMethod descriptorprocesspsbt()
             "       \"SINGLE|ANYONECANPAY\""},
                     {"bip32derivs", RPCArg::Type::BOOL, RPCArg::Default{true}, "Include BIP 32 derivation paths for public keys if we know them"},
                     {"finalize", RPCArg::Type::BOOL, RPCArg::Default{true}, "Also finalize inputs if possible"},
+                    {"prevtxs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED, "An array of raw transaction hex strings for previous transactions whose outputs are being spent in this PSBT but may not be available in the UTXO set, txindex, or the mempool", {
+                        {"rawtx", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "A raw transaction in hex"},
+                    }},
                 },
                 RPCResult{
                     RPCResult::Type::OBJ, "", "",
@@ -2082,13 +2085,19 @@ RPCMethod descriptorprocesspsbt()
     bool bip32derivs = request.params[3].isNull() ? true : request.params[3].get_bool();
     bool finalize = request.params[4].isNull() ? true : request.params[4].get_bool();
 
+    // Parse caller-provided previous transactions, if any.
+    std::map<Txid, CTransactionRef> prev_txs;
+    if (!request.params[5].isNull()) {
+        prev_txs = ParsePrevTxs(request.params[5].get_array());
+    }
+
     const PartiallySignedTransaction& psbtx = ProcessPSBT(
         request.params[0].get_str(),
         request.context,
         HidingSigningProvider(&provider, /*hide_secret=*/false, !bip32derivs),
         sighash_type,
         finalize,
-        /*prev_txs=*/{});
+        prev_txs);
 
     // Check whether or not all of the inputs are now signed
     bool complete = true;

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -406,6 +406,54 @@ class PSBTTest(BitcoinTestFramework):
 
         self.log.info("PSBT parameter handling test completed successfully")
 
+    def test_utxoupdatepsbt_prevtxs(self):
+        """Test that utxoupdatepsbt can populate inputs from caller-provided raw transactions."""
+        self.log.info("Test utxoupdatepsbt with prevtxs parameter")
+        node = self.nodes[0]
+
+        # Create a parent transaction but do not broadcast it
+        addr_parent = node.getnewaddress(address_type="bech32")
+        parent_hex = node.createrawtransaction(
+            [node.listunspent()[0]],
+            [{addr_parent: 49.999}]
+        )
+        parent_hex = node.signrawtransactionwithwallet(parent_hex)["hex"]
+        parent_txid = node.decoderawtransaction(parent_hex)["txid"]
+
+        # Build a child PSBT that spends the (unbroadcast) parent output
+        child_addr = node.getnewaddress(address_type="bech32")
+        child_psbt = node.createpsbt(
+            [{"txid": parent_txid, "vout": 0}],
+            [{child_addr: 49.998}]
+        )
+
+        # Without prevtxs, the input cannot be populated because the parent
+        # is not in the mempool, UTXO set, or txindex
+        updated_without = node.utxoupdatepsbt(child_psbt)
+        decoded = node.decodepsbt(updated_without)
+        assert "non_witness_utxo" not in decoded["inputs"][0], \
+            "Input should not be populated without prevtxs"
+
+        # With prevtxs, the parent transaction is found and the input is populated
+        updated_with = node.utxoupdatepsbt(child_psbt, [], [parent_hex])
+        decoded = node.decodepsbt(updated_with)
+        assert "non_witness_utxo" in decoded["inputs"][0], \
+            "Input should be populated via prevtxs"
+        assert_equal(decoded["inputs"][0]["non_witness_utxo"]["txid"], parent_txid)
+
+        # Test error handling: invalid hex in prevtxs
+        assert_raises_rpc_error(-22, "TX decode failed",
+                                node.utxoupdatepsbt, child_psbt, [], ["not_valid_hex"])
+
+        # Test error handling: duplicate prevtxs
+        assert_raises_rpc_error(-8, "Duplicate prev_tx",
+                                node.utxoupdatepsbt, child_psbt, [], [parent_hex, parent_hex])
+
+        self.log.info("Test utxoupdatepsbt prevtxs with named parameters")
+        updated_named = node.utxoupdatepsbt(psbt=child_psbt, prevtxs=[parent_hex])
+        decoded = node.decodepsbt(updated_named)
+        assert "non_witness_utxo" in decoded["inputs"][0]
+
     def run_test(self):
         # Create and fund a raw tx for sending 10 BTC
         psbtx1 = self.nodes[0].walletcreatefundedpsbt([], {self.nodes[2].getnewaddress():10})['psbt']
@@ -859,6 +907,7 @@ class PSBTTest(BitcoinTestFramework):
 
         self.test_utxo_conversion()
         self.test_psbt_incomplete_after_invalid_modification()
+        self.test_utxoupdatepsbt_prevtxs()
 
         self.test_input_confs_control()
 

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -454,6 +454,12 @@ class PSBTTest(BitcoinTestFramework):
         decoded = node.decodepsbt(updated_named)
         assert "non_witness_utxo" in decoded["inputs"][0]
 
+        self.log.info("Test descriptorprocesspsbt with prevtxs parameter")
+        desc = node.getaddressinfo(addr_parent)["desc"]
+        result = node.descriptorprocesspsbt(child_psbt, [desc], "DEFAULT", True, True, [parent_hex])
+        decoded = node.decodepsbt(result["psbt"])
+        assert "non_witness_utxo" in decoded["inputs"][0]
+
     def run_test(self):
         # Create and fund a raw tx for sending 10 BTC
         psbtx1 = self.nodes[0].walletcreatefundedpsbt([], {self.nodes[2].getnewaddress():10})['psbt']


### PR DESCRIPTION
## Summary

Add an optional `prev_txs` parameter to `utxoupdatepsbt`, allowing callers
to provide raw parent transactions whose outputs are not yet in the UTXO set,
txindex, or mempool.

## Motivation

When constructing presigned transaction chains (e.g. a Lightning commitment
transaction at zero fee paired with an anchor spend), the child PSBT cannot
be populated because the parent has not been broadcast yet. The existing
`signrawtransactionwithwallet` supports this via its `prevtxs` parameter,
but no equivalent exists in the PSBT workflow. Users are forced to either
fall back to legacy raw transaction signing or manually edit the PSBT binary
with external tools.

This closes the gap so that `utxoupdatepsbt` can handle the same use case
natively, which is increasingly relevant with `submitpackage` and TRUC/anchor
adoption.

## Changes

- Add `ParsePrevTxs()` helper to decode an array of raw transaction hex
  into a txid-indexed map
- Extend `ProcessPSBT()` to accept caller-provided transactions and check
  them before falling through to txindex/mempool/UTXO set lookup
- Register the new `prev_txs` array parameter on `utxoupdatepsbt`
- Add functional test covering the happy path, named parameter form, and
  invalid hex error handling

refs #30873

## Test plan

- [x] `test/functional/rpc_psbt.py` passes, including new
  `test_utxoupdatepsbt_prev_txs` covering:
  - Input NOT populated when parent is unavailable
  - Input populated correctly via `prev_txs`
  - Correct txid in the resulting `non_witness_utxo`
  - Error on invalid hex
  - Named parameter form works
