### PR TITLE
doc: use repo-relative translation process link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ subsequent comment to the PR.
 ### Translation changes
 
 Note that translations should not be submitted as pull requests. Please see
-[Translation Process](/doc/translation_process.md)
+[Translation Process](doc/translation_process.md)
 for more information on helping with translations.
 
 ### Work in Progress Changes and Requests for Comments


### PR DESCRIPTION
## Summary
- replace the root-relative translation process link in CONTRIBUTING.md
- point it to the repository-local translation_process.md path so the link stays valid in the repo context

## Testing
- not run (documentation link update only)