### PR TITLE
iwyu: Fix warnings in `src/common` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -234,7 +234,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(((bench|crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|common/license_info|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU='/src/((bench|common|crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\.cpp'
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 
@@ -247,7 +247,8 @@ if [[ "${RUN_IWYU}" == true ]]; then
              -p "${BASE_BUILD_DIR}" "${MAKEJOBS}" \
              -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
              -Xiwyu --max_line_length=160 \
-             -Xiwyu --check_also="*/primitives/*.h" \
+             -Xiwyu --check_also='*/common/types\.h' \
+             -Xiwyu --check_also='*/primitives/transaction_identifier\.h' \
              2>&1 || true
     } | tee /tmp/iwyu_ci.out
     python3 "/include-what-you-use/fix_includes.py" --nosafe_headers < /tmp/iwyu_ci.out

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -23,8 +23,6 @@
 #endif
 
 #include <algorithm>
-#include <cassert>
-#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <map>

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -6,7 +6,6 @@
 #define BITCOIN_COMMON_ARGS_H
 
 #include <common/settings.h>
-#include <compat/compat.h>
 #include <sync.h>
 #include <util/chaintype.h>
 #include <util/fs.h>

--- a/src/common/bloom.cpp
+++ b/src/common/bloom.cpp
@@ -16,8 +16,7 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdlib>
-#include <limits>
+#include <compare>
 #include <vector>
 
 static constexpr double LN2SQUARED = 0.4804530139182014246671025263266649717305529515945455;

--- a/src/common/bloom.h
+++ b/src/common/bloom.h
@@ -6,8 +6,9 @@
 #define BITCOIN_COMMON_BLOOM_H
 
 #include <serialize.h>
-#include <span.h>
 
+#include <cstdint>
+#include <span>
 #include <vector>
 
 class COutPoint;

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -2,28 +2,25 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <common/args.h>
+#include <common/args.h> // IWYU pragma: associated
 
 #include <common/settings.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <univalue.h>
-#include <util/chaintype.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/log.h>
 #include <util/string.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <list>
 #include <map>
-#include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -2,15 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/init.h>
+
 #include <chainparams.h>
 #include <common/args.h>
-#include <common/init.h>
 #include <tinyformat.h>
 #include <util/fs.h>
 #include <util/log.h>
 #include <util/translation.h>
 
-#include <algorithm>
 #include <exception>
 #include <optional>
 

--- a/src/common/interfaces.cpp
+++ b/src/common/interfaces.cpp
@@ -2,8 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <interfaces/echo.h>
-#include <interfaces/handler.h>
+#include <interfaces/echo.h>    // IWYU pragma: associated
+#include <interfaces/handler.h> // IWYU pragma: associated
+
 #include <util/btcsignals.h>
 
 #include <memory>

--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -4,16 +4,17 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/messages.h>
+
 #include <common/types.h>
 #include <node/types.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/fees.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/translation.h>
 
-#include <cassert>
 #include <map>
 #include <string>
 #include <string_view>

--- a/src/common/messages.h
+++ b/src/common/messages.h
@@ -13,17 +13,19 @@
 
 #include <string>
 #include <string_view>
+#include <utility>
 
 struct bilingual_str;
-
 enum class FeeEstimateMode;
 enum class FeeReason;
+
 namespace node {
 enum class TransactionError;
 } // namespace node
 
 namespace common {
 enum class PSBTError;
+
 bool FeeModeFromString(std::string_view mode_string, FeeEstimateMode& fee_estimate_mode);
 std::string StringForFeeReason(FeeReason reason);
 std::string FeeModes(const std::string& delimiter);

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -6,12 +6,22 @@
 
 #include <common/netif.h>
 
+#include <compat/compat.h>
 #include <netbase.h>
 #include <util/check.h>
 #include <util/log.h>
 #include <util/sock.h>
 
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+#include <type_traits>
+
 #if defined(__linux__)
+#include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #elif defined(__FreeBSD__)
 #include <netlink/netlink.h>
@@ -26,8 +36,6 @@
 #ifdef HAVE_IFADDRS
 #include <ifaddrs.h>
 #endif
-
-#include <type_traits>
 
 namespace {
 

--- a/src/common/netif.h
+++ b/src/common/netif.h
@@ -8,6 +8,7 @@
 #include <netaddress.h>
 
 #include <optional>
+#include <vector>
 
 //! Query the OS for the default gateway for `network`. This only makes sense for NET_IPV4 and NET_IPV6.
 //! Returns std::nullopt if it cannot be found, or there is no support for this OS.

--- a/src/common/pcp.cpp
+++ b/src/common/pcp.cpp
@@ -4,19 +4,30 @@
 
 #include <common/pcp.h>
 
-#include <atomic>
-#include <common/netif.h>
+#include <compat/compat.h>
 #include <crypto/common.h>
+#include <crypto/hex_base.h>
 #include <netaddress.h>
 #include <netbase.h>
-#include <random.h>
-#include <span.h>
+#include <tinyformat.h>
 #include <util/check.h>
 #include <util/log.h>
-#include <util/readwritefile.h>
 #include <util/sock.h>
-#include <util/strencodings.h>
+#include <util/string.h>
 #include <util/threadinterrupt.h>
+#include <util/time.h>
+
+#include <algorithm>
+#include <atomic>
+#include <compare>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/src/common/pcp.h
+++ b/src/common/pcp.h
@@ -6,9 +6,15 @@
 #define BITCOIN_COMMON_PCP_H
 
 #include <netaddress.h>
-#include <util/threadinterrupt.h>
+#include <util/time.h>
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
 #include <variant>
+
+class CThreadInterrupt;
 
 // RFC6886 NAT-PMP and RFC6887 Port Control Protocol (PCP) implementation.
 // NAT-PMP and PCP use network byte order (big-endian).

--- a/src/common/run_command.cpp
+++ b/src/common/run_command.cpp
@@ -14,6 +14,10 @@
 #include <util/subprocess.h>
 #endif // ENABLE_EXTERNAL_SIGNER
 
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
 UniValue RunCommandParseJSON(const std::vector<std::string>& cmd_args, const std::string& str_std_in)
 {
 #ifdef ENABLE_EXTERNAL_SIGNER

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -2,15 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <common/settings.h>
-
 #include <bitcoin-build-config.h> // IWYU pragma: keep
+
+#include <common/settings.h>
 
 #include <tinyformat.h>
 #include <univalue.h>
 #include <util/fs.h>
 
-#include <algorithm>
 #include <fstream>
 #include <iterator>
 #include <map>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -12,7 +12,9 @@
 #include <string>
 #include <vector>
 
-class UniValue;
+// Users of this header need to explicitly #include <univalue.h>
+// IWYU pragma: no_include <univalue.h>
+class UniValue; // IWYU pragma: keep
 
 namespace common {
 

--- a/src/common/signmessage.cpp
+++ b/src/common/signmessage.cpp
@@ -4,15 +4,18 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/signmessage.h>
+
+#include <addresstype.h>
 #include <hash.h>
 #include <key.h>
 #include <key_io.h>
 #include <pubkey.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
-#include <cassert>
 #include <optional>
+#include <span>
 #include <string>
 #include <variant>
 #include <vector>

--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -12,12 +12,13 @@
 #include <util/time.h>
 
 #ifdef WIN32
-#include <cassert>
-#include <codecvt>
 #include <compat/compat.h>
+#include <util/check.h>
+#include <codecvt>
 #include <windows.h>
 #else
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 #endif
 
@@ -29,6 +30,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <locale>
 #include <optional>
 #include <stdexcept>

--- a/src/common/system.h
+++ b/src/common/system.h
@@ -7,10 +7,10 @@
 #define BITCOIN_COMMON_SYSTEM_H
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
+
 #include <util/time.h>
 
-#include <chrono>
-#include <cstdint>
+#include <cstddef>
 #include <optional>
 #include <string>
 

--- a/src/common/url.cpp
+++ b/src/common/url.cpp
@@ -5,6 +5,7 @@
 #include <common/url.h>
 
 #include <charconv>
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <system_error>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <clientversion.h>
 #include <common/signmessage.h>
+#include <compat/compat.h>
 #include <hash.h>
 #include <key.h>
 #include <script/parsing.h>


### PR DESCRIPTION
This PR [continues](https://github.com/bitcoin/bitcoin/pull/33725#issuecomment-3466897433) the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).