### PR TITLE
ci: add --usecli when using --extended

### DIFF
--- a/ci/test/00_setup_env_i686_no_ipc.sh
+++ b/ci/test/00_setup_env_i686_no_ipc.sh
@@ -14,7 +14,7 @@ export PACKAGES="llvm clang g++-multilib"
 export DEP_OPTS="DEBUG=1 NO_IPC=1"
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1
-export TEST_RUNNER_EXTRA="--v2transport --usecli"
+export TEST_RUNNER_EXTRA="--v2transport"
 export BITCOIN_CONFIG="\
  --preset=dev-mode \
  -DENABLE_IPC=OFF \

--- a/ci/test/00_setup_env_native_previous_releases.sh
+++ b/ci/test/00_setup_env_native_previous_releases.sh
@@ -11,7 +11,7 @@ export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:22.04"
 # Use minimum supported python3.10 and gcc-12, see doc/dependencies.md
 export PACKAGES="gcc-12 g++-12 python3-zmq"
 export DEP_OPTS="CC=gcc-12 CXX=g++-12"
-export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
+export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --usecli --exclude feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1
 export DOWNLOAD_PREVIOUS_RELEASES="true"


### PR DESCRIPTION
The current CI doesn't cover the case of running all tests with `--extended` if using `--usecli`.
This led to a test failing (`feature_index_prune.py`) if run with `--usecli` and the CI not catching it.
See #34991 for context.

This PR improves the CI test coverage by also running now all functional tests (`--extended`) with the flag `--usecli`.
The CI obviously will fail in this PR until #34991 is merged into master.

~I don't know if this is the best approach; I just looked for a ci using `--usecli` and added the `--extended` flag to cover these scenarios.~
I'm open to changing the approach.