### PR TITLE
refactor: pre-push-hook.sh potential regression

### DIFF
--- a/contrib/verify-commits/pre-push-hook.sh
+++ b/contrib/verify-commits/pre-push-hook.sh
@@ -8,14 +8,14 @@ if ! [[ "$2" =~ ^(git@)?(www.)?github.com(:|/)bitcoin/bitcoin(.git)?$ ]]; then
     exit 0
 fi
 
-while read LINE; do
-    set -- A "$LINE"
-    if [ "$4" != "refs/heads/master" ]; then
+# shellcheck disable=SC2034
+while read -r local_ref local_oid remote_ref remote_oid; do
+    if [ "$remote_ref" != "refs/heads/master" ]; then
         continue
     fi
-    if ! ./contrib/verify-commits/verify-commits.py "$3" > /dev/null 2>&1; then
+    if ! ./contrib/verify-commits/verify-commits.py "$local_oid" > /dev/null 2>&1; then
         echo "ERROR: A commit is not signed, can't push"
-        ./contrib/verify-commits/verify-commits.py
+        ./contrib/verify-commits/verify-commits.py "$local_oid"
         exit 1
     fi
 done < /dev/stdin


### PR DESCRIPTION
## Issue being fixed or feature implemented

With set -- A "$LINE" (quoted), the entire input line becomes $2 as a single string, leaving $3 and $4 empty. 
Since empty $4 never equals "refs/heads/master", the hook always continues, and the commit-signing verification never executes in either repo.

Using the unquoted form `set -- A $LINE` (no quotes), which relied on word-splitting to populate `$2`…`$5` correctly, trips **ShellCheck's SC2086** rule.

## What was done?

Parse the fields directly with `read:`
The fix is both ShellCheck-compliant and functionally correct.

edit: Added `# shellcheck disable=SC2034` to bypass false positive `x not being used` warning.

## How Has This Been Tested?

Not tested. I initially PR'd this to Dash, but was recommended to PR to Bitcoin too, since it's inherited.

## Breaking Changes
 
None.

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

