### PR TITLE
validation: improve block data I/O error handling in P2P paths

### DIFF
--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -37,8 +37,16 @@ FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool read_only) const
     if (pos.IsNull()) {
         return nullptr;
     }
-    fs::path path = FileName(pos);
-    fs::create_directories(path.parent_path());
+    const fs::path path = FileName(pos);
+    // Create parent path only if we are going to write.
+    if (!read_only) {
+        std::error_code ec;
+        fs::create_directories(path.parent_path(), ec);
+        if (ec) {
+            LogError("Unable to open file '%s'. Error creating parent directories: %s", fs::PathToString(path), ec.message());
+            return nullptr;
+        }
+    }
     FILE* file = fsbridge::fopen(path, read_only ? "rb": "rb+");
     if (!file && !read_only)
         file = fsbridge::fopen(path, "wb+");

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4358,7 +4358,11 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             const bool ret{m_chainman.m_blockman.ReadBlock(block, block_pos, req.blockhash)};
             // If height is above MAX_BLOCKTXN_DEPTH then this block cannot get
             // pruned after we release cs_main above, so this read should never fail.
-            assert(ret);
+            // Unless an I/O error occurs, in which case we want to shut down gracefully.
+            if (!ret) {
+                m_chainman.GetNotifications().fatalError(_("Failed to read block during GETBLOCKTXN"));
+                return;
+            }
 
             SendBlockTransactions(pfrom, peer, block, req);
             return;

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -10,6 +10,7 @@
 #include <node/kernel_notifications.h>
 #include <script/solver.h>
 #include <primitives/block.h>
+#include <undo.h>
 #include <util/chaintype.h>
 #include <validation.h>
 
@@ -322,6 +323,62 @@ BOOST_FIXTURE_TEST_CASE(prune_lock_update_and_delete, TestingSetup)
 
     // Deleting a non-existent lock returns false
     BOOST_CHECK(!blockman.DeletePruneLock("nonexistent"));
+}
+
+// Verify that block read operations return false (not throw) when the
+// blocks directory is missing (mimicking a detached volume).
+BOOST_FIXTURE_TEST_CASE(blockmanager_io_failure_consistency, TestChain100Setup)
+{
+    auto& chainman = m_node.chainman;
+    auto& blockman = m_node.chainman->m_blockman;
+    CBlockIndex& tip{*WITH_LOCK(chainman->GetMutex(), return chainman->ActiveTip())};
+    const auto blocks_dir = m_args.GetBlocksDirPath().parent_path();
+
+    SimulateFileSystemError(m_path_root, blocks_dir, [&] {
+        ASSERT_DEBUG_LOG("OpenBlockFile failed");
+        FlatFilePos tip_pos = WITH_LOCK(chainman->GetMutex(), return tip.GetBlockPos());
+        BOOST_CHECK(!blockman.ReadRawBlock(tip_pos));
+    });
+    SimulateFileSystemError(m_path_root, blocks_dir, [&] {
+        ASSERT_DEBUG_LOG("OpenBlockFile failed");
+        CBlock block;
+        BOOST_CHECK(!blockman.ReadBlock(block, tip));
+    });
+    SimulateFileSystemError(m_path_root, blocks_dir, [&] {
+        ASSERT_DEBUG_LOG("OpenUndoFile failed");
+        CBlockUndo block_undo;
+        BOOST_CHECK(!blockman.ReadBlockUndo(block_undo, tip));
+    });
+    SimulateFileSystemError(m_path_root, blocks_dir, [&] {
+        // WriteBlock should return a null position, not throw.
+        // create_directories fails so the file cannot be created.
+        ASSERT_DEBUG_LOG("Failed to write block");
+        CBlock dummy_block;
+        dummy_block.nVersion = 1;
+        LOCK(chainman->GetMutex());
+        const auto write_pos = blockman.WriteBlock(dummy_block, /*nHeight=*/999);
+        BOOST_CHECK(write_pos.IsNull());
+    });
+    SimulateFileSystemError(m_path_root, blocks_dir, [&] {
+        // WriteBlockUndo should return false, not throw.
+        // Clear BLOCK_HAVE_UNDO so it actually attempts to write.
+        ASSERT_DEBUG_LOG("Failed to write undo data");
+        LOCK(chainman->GetMutex());
+        tip.nStatus &= ~BLOCK_HAVE_UNDO;
+
+        BlockValidationState state;
+        BOOST_CHECK(!blockman.WriteBlockUndo(CBlockUndo{}, state, tip));
+        BOOST_CHECK(state.IsError());
+
+        tip.nStatus |= BLOCK_HAVE_UNDO;
+    });
+
+    // Ensure we haven't corrupted any internal state during the failure.
+    // Check we can read the block again now that there is no dir access issue going on.
+    CBlock recovered_block;
+    BOOST_CHECK(blockman.ReadBlock(recovered_block, tip));
+    CBlockUndo block_undo;
+    BOOST_CHECK(blockman.ReadBlockUndo(block_undo, tip));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -6,9 +6,12 @@
 #include <common/args.h>
 #include <flatfile.h>
 #include <streams.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+
+static constexpr uint32_t DUMMY_CHUNK_SZ{1};
 
 BOOST_FIXTURE_TEST_SUITE(flatfile_tests, BasicTestingSetup)
 
@@ -116,18 +119,88 @@ BOOST_AUTO_TEST_CASE(flatfile_allocate)
 BOOST_AUTO_TEST_CASE(flatfile_flush)
 {
     const auto data_dir = m_args.GetDataDirBase();
-    FlatFileSeq seq(data_dir, "a", 100);
+    const FlatFileSeq seq(data_dir, "a", 100);
 
     bool out_of_space;
-    seq.Allocate(FlatFilePos(0, 0), 1, out_of_space);
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 0), 1, out_of_space), 100U);
+    BOOST_CHECK(!out_of_space);
 
     // Flush without finalize should not truncate file.
-    seq.Flush(FlatFilePos(0, 1));
+    BOOST_CHECK(seq.Flush(FlatFilePos(0, 1)));
     BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 100U);
 
     // Flush with finalize should truncate file.
-    seq.Flush(FlatFilePos(0, 1), true);
+    BOOST_CHECK(seq.Flush(FlatFilePos(0, 1), true));
     BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 1U);
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_open_readonly_missing_dir)
+{
+    // Open file with read_only=true on a directory that does not exist.
+    // File should be null instead of throwing an exception.
+    const auto data_dir = m_args.GetDataDirBase() / "nonexistent";
+    const FlatFileSeq seq(data_dir, "a", DUMMY_CHUNK_SZ);
+
+    const AutoFile file{seq.Open(FlatFilePos(0, 0), /*read_only=*/true)};
+    BOOST_CHECK(file.IsNull());
+    // A read-only open must not create the missing directory either.
+    BOOST_CHECK(!fs::exists(data_dir));
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_open_write_creates_dir)
+{
+    // Open with read_only=false on a directory that does not yet exist
+    // should create it and succeed.
+    const auto data_dir = m_args.GetDataDirBase() / "new_write_dir";
+    const FlatFileSeq seq(data_dir, "a", DUMMY_CHUNK_SZ);
+
+    const AutoFile file{seq.Open(FlatFilePos(0, 0), /*read_only=*/false)};
+    BOOST_CHECK(!file.IsNull());
+    BOOST_CHECK(fs::exists(data_dir));
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_open_write_missing_unwritable_parent)
+{
+    // Open with read_only=false when the parent directory cannot be created
+    const auto data_dir = m_args.GetDataDirBase();
+    const auto dir = data_dir / "parent_dir";
+    fs::create_directories(dir);
+
+    // Make it read-only so creating subdirectories fails.
+    SimulateFileSystemError(m_path_root, dir, [&dir]() {
+        const FlatFileSeq seq(dir / "blocks", "a", DUMMY_CHUNK_SZ);
+        const AutoFile file{seq.Open(FlatFilePos(0, 0), /*read_only=*/false)};
+        BOOST_CHECK(file.IsNull());
+    });
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_flush_unwritable_dir)
+{
+    // Flush returns false when the file cannot be opened for writing.
+    const auto data_dir = m_args.GetDataDirBase() / "flush_dir";
+    fs::create_directories(data_dir);
+    const FlatFileSeq seq(data_dir, "a", DUMMY_CHUNK_SZ);
+
+    SimulateFileSystemError(m_path_root, data_dir, [&seq]() {
+        BOOST_CHECK(!seq.Flush(FlatFilePos(0, 1)));
+    });
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_allocate_unwritable_dir)
+{
+    // Allocate should return 0 when the file cannot be opened for writing.
+    // Note that out_of_space stays false. Callers that only check
+    // out_of_space will miss this failure.
+    const auto data_dir = m_args.GetDataDirBase() / "alloc_dir";
+    fs::create_directories(data_dir);
+    const FlatFileSeq seq(data_dir, "a", DUMMY_CHUNK_SZ);
+
+    SimulateFileSystemError(m_path_root, data_dir, [&seq]() {
+        bool out_of_space;
+        // Note: this throws due to 'CheckDiskSpace'. In the future, this shouldn't throw either.
+        BOOST_CHECK_THROW(seq.Allocate(FlatFilePos(0, 0), 1, out_of_space), fs::filesystem_error);
+        BOOST_CHECK(!out_of_space);
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_library(test_util STATIC EXCLUDE_FROM_ALL
   blockfilter.cpp
   coins.cpp
+  common.cpp
   coverage.cpp
   json.cpp
   logging.cpp

--- a/src/test/util/common.cpp
+++ b/src/test/util/common.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <test/util/common.h>
+
+void SimulateFileSystemError(const fs::path& test_root_dir, const fs::path& path, const std::function<void()>& fn)
+{
+#ifdef WIN32
+    // On Windows, any open file (such as the db) prevents directory renaming,
+    // so we can't simulate a filesystem error in this platform. Skip it.
+    return;
+#else
+    // This check relies on filesystem permission manipulation to simulate I/O
+    // failures. Running as root bypasses permission checks, so the OS will
+    // allow directory creation and file writes even when perms are set to
+    // none, making it impossible to simulate the expected failures.
+    if (getuid() == 0) return;
+ #endif
+
+    const fs::path root = fs::weakly_canonical(test_root_dir);
+    const fs::path target = fs::weakly_canonical(path);
+
+    // Simple sanity check: ensure target is inside the test directory.
+    if (!fs::PathToString(target).starts_with(fs::PathToString(root))) {
+        throw std::runtime_error("Path escapes test root directory");
+    }
+
+    if (!fs::exists(target)) {
+        throw std::runtime_error("Path does not exist");
+    }
+
+    const fs::path parent = target.parent_path();
+    const fs::path backup = parent / fs::PathFromString(target.filename().string() + "_bak");
+    const auto old_perms = fs::status(parent).permissions();
+
+    // Make the target disappear (file or directory)
+    fs::rename(target, backup);
+
+    // Helper to restore state (permissions + original path)
+    auto restore = [&]() {
+        fs::permissions(parent, old_perms, fs::perm_options::replace);
+        fs::rename(backup, target);
+    };
+
+    // Block any access and dir recreation under the parent directory
+    fs::permissions(parent, fs::perms::none, fs::perm_options::replace);
+
+    try {
+        fn(); // run test under simulated failure
+    } catch (...) {
+        restore();
+        throw;
+    }
+
+    restore();
+}

--- a/src/test/util/common.h
+++ b/src/test/util/common.h
@@ -5,10 +5,16 @@
 #ifndef BITCOIN_TEST_UTIL_COMMON_H
 #define BITCOIN_TEST_UTIL_COMMON_H
 
+#include <util/fs.h>
+
 #include <chrono>
 #include <optional>
 #include <ostream>
 #include <string>
+
+#ifndef WIN32
+#include <unistd.h>
+#endif
 
 /**
  * BOOST_CHECK_EXCEPTION predicates to check the specific validation error.
@@ -58,5 +64,14 @@ inline std::ostream& operator<<(std::ostream& os, const T& obj)
 }
 
 // @}
+
+/**
+ * Simulate a filesystem access failure for `path` by temporarily making it
+ * unavailable. The target is removed and its parent made inaccessible while
+ * `fn()` executes, then everything is restored.
+ *
+ * Note: Returns early if the environment does not allow simulating a fs error.
+ */
+void SimulateFileSystemError(const fs::path& test_root_dir, const fs::path& path, const std::function<void()>& fn);
 
 #endif // BITCOIN_TEST_UTIL_COMMON_H

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -17,6 +17,7 @@
 #include <test/util/chainstate.h>
 #include <test/util/coins.h>
 #include <test/util/common.h>
+#include <test/util/logging.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>
 #include <uint256.h>
@@ -171,6 +172,109 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
     // validation chain.
     BOOST_CHECK(block_added);
     BOOST_CHECK_EQUAL(curr_tip, get_notify_tip());
+}
+
+static void check_activate_best_chain_fatal_error(const std::string& expected_log, node::NodeContext& node, Chainstate& chainstate)
+{
+    Assert(node.notifications)->m_shutdown_on_fatal_error = false;
+    node.exit_status = EXIT_SUCCESS;
+
+    ASSERT_DEBUG_LOG(expected_log);
+    BlockValidationState state;
+    BOOST_REQUIRE(!chainstate.ActivateBestChain(state));
+    BOOST_CHECK(state.IsError());
+    BOOST_CHECK_EQUAL(node.exit_status, EXIT_FAILURE); // Ensure fatal error
+}
+// Verify ActivateBestChain triggers a fatal error when a block read fails
+// during block connection (ConnectTip path).
+BOOST_FIXTURE_TEST_CASE(activate_best_chain_connect_io_failure, TestChain100Setup)
+{
+    auto& chainstate = m_node.chainman->ActiveChainstate();
+    const auto blocks_dir = m_args.GetBlocksDirPath();
+
+    const auto paths = {
+        blocks_dir / "blk00000.dat", // Inaccessible block file
+        fs::path{blocks_dir.parent_path()}, // Inaccessible blocks directory
+    };
+    for (const auto& path : paths) {
+        // Disconnect block without changing validity so ActivateBestChain has a block to reconnect.
+        BlockValidationState state;
+        BOOST_REQUIRE([&] {
+            LOCK2(m_node.chainman->GetMutex(), chainstate.MempoolMutex());
+            return chainstate.DisconnectTip(state, /*disconnectpool=*/nullptr);
+        }());
+        BOOST_CHECK(state.IsValid());
+
+        SimulateFileSystemError(m_path_root, path, [&] {
+            check_activate_best_chain_fatal_error("Failed to read block", m_node, chainstate);
+        });
+
+        // Sanity: the block reconnects once the filesystem is restored.
+        BOOST_REQUIRE(chainstate.ActivateBestChain(state));
+        BOOST_CHECK(state.IsValid());
+    }
+}
+
+// Verify ActivateBestChain triggers a fatal error when a block read fails
+// during a reorg (DisconnectTip path).
+BOOST_FIXTURE_TEST_CASE(activate_best_chain_disconnect_io_failure, TestChain100Setup)
+{
+    auto& chainman = m_node.chainman;
+    auto& chainstate = chainman->ActiveChainstate();
+    const auto blocks_dir = m_args.GetBlocksDirPath();
+
+    // Set up a scenario where ActivateBestChain must reorg:
+    //
+    //   Original chain: ... -> 100 -> 101 -> 102 -> 103   (more work)
+    //   Fork:           ... -> 100 -> F101 -> F102        (currently active)
+    //
+    // The fork is active but has less work than the original chain, so
+    // ActivateBestChain will disconnect the fork blocks via DisconnectTip
+    // before reconnecting the original chain.
+
+    // Extend the chain by 3 blocks (heights 101–103).
+    for (int i = 0; i < 3; i++) CreateAndProcessBlock({}, CScript() << OP_1);
+
+    // Invalidate at height 101 to create room for a shorter fork.
+    CBlockIndex* b101_index = WITH_LOCK(chainman->GetMutex(), return chainman->ActiveChain()[101]);
+    BlockValidationState state;
+    chainstate.InvalidateBlock(state, b101_index);
+    BOOST_CHECK(state.IsValid());
+    BOOST_REQUIRE_EQUAL(100, WITH_LOCK(chainman->GetMutex(), return chainman->ActiveHeight()));
+
+    // Build a 2-block fork from height 100. The original chain is invalid,
+    // so these become the active tip.
+    for (int i = 0; i < 2; i++) CreateAndProcessBlock({}, CScript() << OP_2);
+    BOOST_REQUIRE_EQUAL(102, WITH_LOCK(chainman->GetMutex(), return chainman->ActiveHeight()));
+
+    // Now restore the original chain's validity. It has more work (103 > 102) but ActivateBestChain
+    // hasn't been called yet, so we're still on the fork. Similar to ReconsiderBlock but without the ABC call.
+    {
+        LOCK(chainman->GetMutex());
+        chainstate.ResetBlockFailureFlags(b101_index);
+        chainman->RecalculateBestHeader();
+    }
+
+    const auto paths = {
+        blocks_dir / "blk00000.dat",     // Inaccessible block file
+        blocks_dir / "rev00000.dat",     // Inaccessible undo file
+        fs::path{blocks_dir.parent_path()}  // Inaccessible blocks directory
+    };
+
+    for (const auto& path : paths) {
+        BOOST_REQUIRE_EQUAL(102, WITH_LOCK(chainman->GetMutex(), return chainman->ActiveHeight()));
+        SimulateFileSystemError(m_path_root, path, [&] {
+            check_activate_best_chain_fatal_error("Failed to disconnect block", m_node, chainstate);
+        });
+        BOOST_CHECK_EQUAL(102, WITH_LOCK(chainman->GetMutex(), return chainman->ActiveHeight()));
+    }
+
+
+    // Sanity check: the reorg completes once the filesystem is restored.
+    state = BlockValidationState();
+    BOOST_CHECK(chainstate.ActivateBestChain(state));
+    BOOST_CHECK(state.IsValid());
+    BOOST_CHECK_EQUAL(103, WITH_LOCK(chainman->GetMutex(), return chainman->ActiveHeight()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/p2p_handle_io_errors.py
+++ b/test/functional/p2p_handle_io_errors.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that inaccessible block files are properly handled through P2P paths."""
+
+import contextlib
+import os
+import platform
+import re
+import stat
+
+from test_framework.blocktools import (
+    create_block,
+    create_empty_fork,
+)
+from test_framework.messages import (
+    BlockTransactionsRequest,
+    CInv,
+    MSG_BLOCK,
+    MSG_WITNESS_FLAG,
+    msg_block,
+    msg_getblocktxn,
+    msg_getcfilters,
+    msg_getdata,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import (
+    BitcoinTestFramework,
+    SkipTest
+)
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import MiniWallet
+
+
+@contextlib.contextmanager
+def simulate_io_error(target_path):
+    # Make files under target_path inaccessible.
+    # Simulating a detached volume or permission change.
+    backup = target_path.with_name(target_path.name + "_bak")
+    parent_dir = target_path.parent
+    old_mode = stat.S_IMODE(os.stat(parent_dir).st_mode)
+
+    os.rename(target_path, backup)
+    os.chmod(parent_dir, 0o500)  # Prevent dir re-creation
+    try:
+        yield
+    finally:
+        os.chmod(parent_dir, old_mode)
+        os.rename(backup, target_path)
+
+class P2PBlockIOErrorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [['-fastprune']]
+
+    def test_block_accept_on_broken_fs(self):
+        self.log.info("Test block accept on inaccessible filesystem")
+        node = self.nodes[0]
+        peer = node.add_p2p_connection(P2PInterface())
+        block = create_block(tmpl=node.getblocktemplate({"rules": ["segwit"]}))
+        block.solve()
+
+        with simulate_io_error(node.blocks_path):
+            with node.assert_debug_log(expected_msgs=["AcceptBlock FAILED (System error while saving block to disk"]):
+                peer.send_without_ping(msg_block(block))
+                peer.wait_for_disconnect()
+
+        node.wait_until_stopped(
+            expect_error=True,
+            expected_stderr=re.compile(r"fatal internal error"),
+        )
+
+        # Restart node for next test
+        self.start_node(0)
+
+    def test_block_connect_on_broken_fs(self):
+        self.log.info("Test block connect on inaccessible filesystem")
+        node = self.nodes[0]
+        peer = node.add_p2p_connection(P2PInterface())
+        blocks = create_empty_fork(node, fork_length=2)
+        large_block_hash = self.generatetodescriptor(node, 1, f"raw({'55'*70_000})")[0]
+        peer.send_and_ping(msg_block(blocks[0]))
+        # Remove access to the fork block only.
+        (node.blocks_path / 'blk00002.dat').unlink()
+        assert_raises_rpc_error(-1, 'Block not found on disk', node.getblock, blocks[0].hash_hex)
+        assert_equal(node.getblock(large_block_hash)["hash"], large_block_hash) # can still access the tip
+
+        with node.assert_debug_log(expected_msgs=["ActivateBestChain failed (Failed to read block.)"]):
+            peer.send_without_ping(msg_block(blocks[1]))
+            peer.wait_for_disconnect()
+
+        node.wait_until_stopped(
+            expect_error=True,
+            expected_stderr=re.compile(r"fatal internal error"),
+        )
+
+        # Restart node for next test. Only the fork block file was deleted,
+        # so reindexing the remaining block files must restore the old tip.
+        self.start_node(0, extra_args=['-reindex'])
+        self.wait_until(lambda: node.getbestblockhash() == large_block_hash)
+
+    def test_getdata_on_broken_fs(self):
+        """GETDATA handler must discard the failed request and disconnect during block I/O issues"""
+        self.log.info("Test GETDATA on inaccessible filesystem")
+        node = self.nodes[0]
+        self.generate(node, 6)
+
+        peer = node.add_p2p_connection(P2PInterface())
+        block_hash = node.getblockhash(3)  # Not in recent cache
+        with simulate_io_error(node.blocks_path):
+            # Bug: we currently swallow the GETDATA request, never reply to the other party, and log issue under debug-NET
+            with node.assert_debug_log(expected_msgs=["[ProcessMessages] [net] ProcessMessages(getdata, 37 bytes): Exception 'filesystem error"],
+                                       timeout=30):
+                peer.send_without_ping(msg_getdata([CInv(MSG_BLOCK | MSG_WITNESS_FLAG, int(block_hash, 16))]))
+
+            # And the node keeps running
+            node.getblockcount()
+
+    def test_getblocktxn_fatal_on_block_io_error(self):
+        """GETBLOCKTXN block read failures must trigger a fatal shutdown, not an assertion or silent catch.
+
+        Unlike GETDATA, this path operates on recent blocks that must be
+        available for normal operation (reorgs). A failure here is
+        unrecoverable and must not be swallowed by the P2P message handling
+        general try-catch.
+        """
+        self.log.info("Test GETBLOCKTXN triggers fatal error on inaccessible filesystem")
+        node = self.nodes[0]
+
+        # Generate block so that current tip is evicted from the cache.
+        self.generate(node, 1)
+        block_hash = node.getblockhash(node.getblockcount() - 1)
+
+        peer = node.add_p2p_connection(P2PInterface())
+        with simulate_io_error(node.blocks_path):
+            gbtn = msg_getblocktxn()
+            gbtn.block_txn_request = BlockTransactionsRequest(blockhash=int(block_hash, 16), indexes=[0])
+
+            # Bug: we currently swallow the GETBLOCKTXN request, never reply to the other party, and log issue under debug-NET
+            with node.assert_debug_log(expected_msgs=["[ProcessMessages] [net] ProcessMessages(getblocktxn, 34 bytes): Exception 'filesystem error"],
+                                       timeout=10):
+                peer.send_without_ping(gbtn)
+
+            # And the node keeps running
+            node.getblockcount()
+
+    def test_getcfilters_on_broken_fs(self):
+        """GETCFILTERS must log the filter-index read failure and keep running."""
+        self.log.info("Test GETCFILTERS on inaccessible filter index filesystem")
+        node = self.nodes[0]
+        self.restart_node(0, extra_args=['-blockfilterindex=1', '-peerblockfilters=1'])
+        self.generate(node, 5)
+        self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
+
+        filter_dir = node.blocks_path.parent / "indexes" / "blockfilter" / "basic"
+        stop_hash = node.getbestblockhash()
+
+        height = node.getblockcount()
+        peer = node.add_p2p_connection(P2PInterface())
+        with simulate_io_error(filter_dir):
+            # Bug: we currently swallow the GETCFILTERS request, never reply to the other party, and log issue under debug-NET
+            with node.assert_debug_log(expected_msgs=["[ProcessMessages] [net] ProcessMessages(getcfilters, 37 bytes): Exception 'filesystem error"],
+                                       timeout=30):
+                peer.send_without_ping(msg_getcfilters(filter_type=0, start_height=0, stop_hash=int(stop_hash, 16)))
+            # And the node keeps running
+            assert_equal(node.getblockcount(), height)
+
+    def test_index_read_on_broken_fs(self):
+        """txindex and txospenderindex block file reads should handle filesystem errors properly."""
+        self.log.info("Test index reads on inaccessible filesystem")
+        node = self.nodes[0]
+        self.restart_node(0, extra_args=['-txindex=1', '-txospenderindex=1'])
+
+        # Confirm a spend so both indexes have info to retrieve
+        wallet = MiniWallet(node)
+        self.generate(wallet, 1)
+        self.generate(node, 100)  # mature the coinbase
+        spent = wallet.get_utxo()
+        spend = wallet.send_self_transfer(from_node=node, utxo_to_spend=spent)
+        self.generate(node, 1)    # confirm the spend
+        self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
+
+        height = node.getblockcount()
+        with simulate_io_error(node.blocks_path):
+            # Bug: leaks out the exception instead of properly handling the filesystem error
+            assert_raises_rpc_error(-1, "filesystem error", node.getrawtransaction, spend["txid"])
+            assert_raises_rpc_error(-1, "filesystem error", node.gettxspendingprevout, [{"txid": spent["txid"], "vout": spent["vout"]}])
+            # And the node keeps running
+            assert_equal(node.getblockcount(), height)
+
+    def run_test(self):
+        # On Windows, open files (like the DB) are locked and prevent renaming
+        # their parent directory, so we can't trigger the expected filesystem error.
+        # Also, when running as root, permission changes don't restrict access, so the
+        # test condition can't be enforced either.
+        if platform.system() == 'Windows' or os.geteuid() == 0:
+            raise SkipTest("Unable to enforce dir permissions")
+
+        self.test_block_accept_on_broken_fs()
+        self.test_block_connect_on_broken_fs()
+        self.test_getdata_on_broken_fs()
+        self.test_getblocktxn_fatal_on_block_io_error()
+        self.test_getcfilters_on_broken_fs()
+        self.test_index_read_on_broken_fs()
+
+
+if __name__ == '__main__':
+    P2PBlockIOErrorTest(__file__).main()

--- a/test/functional/p2p_handle_io_errors.py
+++ b/test/functional/p2p_handle_io_errors.py
@@ -66,7 +66,7 @@ class P2PBlockIOErrorTest(BitcoinTestFramework):
         block.solve()
 
         with simulate_io_error(node.blocks_path):
-            with node.assert_debug_log(expected_msgs=["AcceptBlock FAILED (System error while saving block to disk"]):
+            with node.assert_debug_log(expected_msgs=["AcceptBlock FAILED (AcceptBlock: Failed to find position to write new block to disk)"]):
                 peer.send_without_ping(msg_block(block))
                 peer.wait_for_disconnect()
 
@@ -113,12 +113,12 @@ class P2PBlockIOErrorTest(BitcoinTestFramework):
         peer = node.add_p2p_connection(P2PInterface())
         block_hash = node.getblockhash(3)  # Not in recent cache
         with simulate_io_error(node.blocks_path):
-            # Bug: we currently swallow the GETDATA request, never reply to the other party, and log issue under debug-NET
-            with node.assert_debug_log(expected_msgs=["[ProcessMessages] [net] ProcessMessages(getdata, 37 bytes): Exception 'filesystem error"],
-                                       timeout=30):
+            # Request block and expect disconnection.
+            with node.assert_debug_log(expected_msgs=["Cannot load block from disk"]):
                 peer.send_without_ping(msg_getdata([CInv(MSG_BLOCK | MSG_WITNESS_FLAG, int(block_hash, 16))]))
+                peer.wait_for_disconnect()
 
-            # And the node keeps running
+            # Currently, the node keeps running
             node.getblockcount()
 
     def test_getblocktxn_fatal_on_block_io_error(self):
@@ -141,13 +141,19 @@ class P2PBlockIOErrorTest(BitcoinTestFramework):
             gbtn = msg_getblocktxn()
             gbtn.block_txn_request = BlockTransactionsRequest(blockhash=int(block_hash, 16), indexes=[0])
 
-            # Bug: we currently swallow the GETBLOCKTXN request, never reply to the other party, and log issue under debug-NET
-            with node.assert_debug_log(expected_msgs=["[ProcessMessages] [net] ProcessMessages(getblocktxn, 34 bytes): Exception 'filesystem error"],
-                                       timeout=10):
+            # Request block and expect crash+disconnect.
+            with node.assert_debug_log(expected_msgs=["Unable to open file"]):
                 peer.send_without_ping(gbtn)
+                peer.wait_for_disconnect()
 
-            # And the node keeps running
-            node.getblockcount()
+            node.wait_until_stopped(
+                expected_ret_code=-6,
+                expect_error=True,
+                expected_stderr=re.compile("Assertion"), # assertion crash
+            )
+
+        # Restart node for next test
+        self.start_node(0)
 
     def test_getcfilters_on_broken_fs(self):
         """GETCFILTERS must log the filter-index read failure and keep running."""
@@ -163,10 +169,10 @@ class P2PBlockIOErrorTest(BitcoinTestFramework):
         height = node.getblockcount()
         peer = node.add_p2p_connection(P2PInterface())
         with simulate_io_error(filter_dir):
-            # Bug: we currently swallow the GETCFILTERS request, never reply to the other party, and log issue under debug-NET
-            with node.assert_debug_log(expected_msgs=["[ProcessMessages] [net] ProcessMessages(getcfilters, 37 bytes): Exception 'filesystem error"],
-                                       timeout=30):
-                peer.send_without_ping(msg_getcfilters(filter_type=0, start_height=0, stop_hash=int(stop_hash, 16)))
+            with node.assert_debug_log(expected_msgs=["Failed to find block filter in index"]):
+                peer.send_and_ping(msg_getcfilters(filter_type=0, start_height=0, stop_hash=int(stop_hash, 16)))
+            # Request dropped (no cfilter reply), peer stays connected, node keeps running.
+            assert "cfilter" not in peer.last_message
             # And the node keeps running
             assert_equal(node.getblockcount(), height)
 
@@ -187,9 +193,12 @@ class P2PBlockIOErrorTest(BitcoinTestFramework):
 
         height = node.getblockcount()
         with simulate_io_error(node.blocks_path):
-            # Bug: leaks out the exception instead of properly handling the filesystem error
-            assert_raises_rpc_error(-1, "filesystem error", node.getrawtransaction, spend["txid"])
-            assert_raises_rpc_error(-1, "filesystem error", node.gettxspendingprevout, [{"txid": spent["txid"], "vout": spent["vout"]}])
+            with node.assert_debug_log(expected_msgs=["OpenBlockFile failed"]):
+                assert_raises_rpc_error(-5, "No such mempool or blockchain transaction", node.getrawtransaction, spend["txid"])
+
+            with node.assert_debug_log(expected_msgs=["Deserialize or I/O error - cannot open block"]):
+                assert_raises_rpc_error(-1, "IO error finding spending tx for outpoint", node.gettxspendingprevout, [{"txid": spent["txid"], "vout": spent["vout"]}])
+
             # And the node keeps running
             assert_equal(node.getblockcount(), height)
 

--- a/test/functional/p2p_handle_io_errors.py
+++ b/test/functional/p2p_handle_io_errors.py
@@ -141,15 +141,14 @@ class P2PBlockIOErrorTest(BitcoinTestFramework):
             gbtn = msg_getblocktxn()
             gbtn.block_txn_request = BlockTransactionsRequest(blockhash=int(block_hash, 16), indexes=[0])
 
-            # Request block and expect crash+disconnect.
+            # Request block and expect fatal error + disconnect.
             with node.assert_debug_log(expected_msgs=["Unable to open file"]):
                 peer.send_without_ping(gbtn)
                 peer.wait_for_disconnect()
 
             node.wait_until_stopped(
-                expected_ret_code=-6,
                 expect_error=True,
-                expected_stderr=re.compile("Assertion"), # assertion crash
+                expected_stderr=re.compile(r"Failed to read block during GETBLOCKTXN"),
             )
 
         # Restart node for next test

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -106,6 +106,7 @@ BASE_SCRIPTS = [
     'feature_block.py',
     'mempool_ephemeral_dust.py',
     'wallet_conflicts.py',
+    'p2p_handle_io_errors.py',
     'p2p_opportunistic_1p1c.py',
     'p2p_node_network_limited.py --v1transport',
     'p2p_node_network_limited.py --v2transport',


### PR DESCRIPTION
Early note: the majority of this PR consists of test coverage. The changes per se are quite small, just the issue shows up in multiple paths in slightly different forms.

The goal of the PR is to ensure I/O errors are not silently ignored during validation or P2P message handling. In some cases, such as `GETDATA` or `GETBLOCKTXN` requests, errors can be swallowed, leaving the node unresponsive to the request without any action. In a harder to reach but more severe case, a swallowed error can leave the node alive but stuck, unable to process new blocks and advance the chain. Also, silently ignoring errors obviously makes problems harder to diagnose. So this PR seeks to improve all of that.

Currently, the same root cause, inability to access the blocks directory, can produce different behaviors depending on where it occurs: 
1. If it happens during block connection, inside `AcceptBlock()`, the error gets caught and triggers a fatal error graceful shutdown. This is the correct behavior.

2. If it happens during block connection (due to the unguarded `FlatFileSeq::Open` -> `fs::create_directories` call), after `AcceptBlock()`, inside `ActivateBestChain()`, the error gets thrown and swallowed by the P2P general try-catch, leaving the node in a living but stuck state. Where `ActivateBestChain()` will always silently fail on any posterior block processing, retrying to active the failing block.

3. If it happens during `GETDATA` request, the file system error gets swallowed by the message handling general try-catch, only logging a net-debug-level message. The remote peer is not disconnected, nor the node aborts. It just silently ignores the request. This is different to a missing block data, which currently logs the error + disconnects the peer.

4. If it happens during `GETBLOCKTXN` request, the file system error either gets swallowed by the message handling general try-catch or crashes the system via an assertion, depending on if the problem is at the blocks directory level or at the block data level, which is inconsistent.

5. If it happens during `GETCFILTERS` request, the file system error gets swallowed by the message handling general try-catch.

6. If this happens in any of the index functions, the node crashes.


So, this PR makes failure handling consistent and ensures the node never enters a stuck state due to a block I/O error. Changes:

1. `GETDATA` now treats the issue in the same way as other I/O errors: it logs the error + disconnect the remote peer.
2. `GETBLOCKTXN` now triggers a fatal error and graceful shutdown. The error here is stricter than in `GETDATA` because it can only access the last 10 blocks, which must be available for reorgs.
3. `ActivateBestChain()` now triggers a fatal error and graceful shutdown when it happens. Fixing the silent stuck node state scenario.
4. `GETCFILTERS` now logs the error through the expected path: "Failed to find block filter in index". A more descriptive error message can be added in a follow-up PR.
5. The index-related functions now ignore the error instead of crashing the node. This matches how the code was written, as these paths were not expecting `OpenFile` to throw. Better error handling can be added in a follow-up PR.


Testing Note
Can reproduce the different behaviors that cause the stuck node scenario by running the second commit’s unit test 28af683b5dfdce88892e367b308857b94ec630fe or by manually introducing an exception in `ConnectTip()` (which occurs inside `ActivateBestChain()`). Previously, the thrown exception would have being caught by the general P2P try-catch and logged only at net-debug level, which most users do not have enabled, leaving the node alive but stuck, as subsequent block connections repeatedly attempt to process the failing block, throw the exception again, and get silently swallowed. Adding a functional test for this scenario is not possible due to the requirement of failing inside `ActivateBestChain()`, which always occurs after `AcceptBlock()`, which correctly captures the error.


Separate Note
There is another assertion scenario that we can move to graceful shutdown (fatal error) in the compact block relay that I haven't done here.

Extra Note
If want to see a similar error producing a crash, but in the wallet, go to #34176.