### PR TITLE
wallet, rpc: add include_change parameter to listtransactions

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -105,6 +105,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listtransactions", 1, "count" },
     { "listtransactions", 2, "skip" },
     { "listtransactions", 3, "include_watchonly" },
+    { "listtransactions", 4, "include_change" },
     { "walletpassphrase", 0, "passphrase", ParamFormat::STRING },
     { "walletpassphrase", 1, "timeout" },
     { "getblocktemplate", 0, "template_request" },

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -305,7 +305,7 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
 template <class Vec>
 static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nMinDepth, bool fLong,
                              Vec& ret, const std::optional<std::string>& filter_label,
-                             bool include_change = false)
+                             bool include_change)
     EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     CAmount nFee;
@@ -429,6 +429,7 @@ RPCMethod listtransactions()
                     {"count", RPCArg::Type::NUM, RPCArg::Default{10}, "The number of transactions to return"},
                     {"skip", RPCArg::Type::NUM, RPCArg::Default{0}, "The number of transactions to skip"},
                     {"include_watchonly", RPCArg::Type::BOOL, RPCArg::Default{false}, "(DEPRECATED) No longer used"},
+                    {"include_change", RPCArg::Type::BOOL, RPCArg::Default{false}, "Also add entries for change outputs.\n"},
                 },
                 RPCResult{
                     RPCResult::Type::ARR, "", "",
@@ -485,6 +486,7 @@ RPCMethod listtransactions()
     int nFrom = 0;
     if (!request.params[2].isNull())
         nFrom = request.params[2].getInt<int>();
+    bool include_change = (!request.params[4].isNull() && request.params[4].get_bool());
 
     if (nCount < 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
@@ -501,7 +503,7 @@ RPCMethod listtransactions()
         for (CWallet::TxItems::const_reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
         {
             CWalletTx *const pwtx = (*it).second;
-            ListTransactions(*pwallet, *pwtx, 0, true, ret, filter_label);
+            ListTransactions(*pwallet, *pwtx, 0, true, ret, filter_label, include_change);
             if ((int)ret.size() >= (nCount+nFrom)) break;
         }
     }
@@ -750,7 +752,7 @@ RPCMethod gettransaction()
     WalletTxToJSON(*pwallet, wtx, entry);
 
     UniValue details(UniValue::VARR);
-    ListTransactions(*pwallet, wtx, 0, false, details, /*filter_label=*/std::nullopt);
+    ListTransactions(*pwallet, wtx, 0, false, details, /*filter_label=*/std::nullopt, /*include_change=*/false);
     entry.pushKV("details", std::move(details));
 
     entry.pushKV("hex", EncodeHexTx(*wtx.tx));

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -102,6 +102,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.run_coinjoin_test()
         self.run_invalid_parameters_test()
         self.test_op_return()
+        self.test_include_change()
         self.test_from_me_status_change()
 
     def run_rbf_opt_in_test(self):
@@ -316,6 +317,32 @@ class ListTransactionsTest(BitcoinTestFramework):
         op_ret_tx = [tx for tx in self.nodes[0].listtransactions() if tx['txid'] == tx_id][0]
 
         assert 'address' not in op_ret_tx
+
+    def test_include_change(self):
+        """Test that include_change=True shows transactions to change addresses."""
+        self.log.info("Test include_change parameter")
+
+        # Send to a change address
+        change_addr = self.nodes[0].getrawchangeaddress()
+        txid = self.nodes[0].sendtoaddress(change_addr, 1)
+
+        # Without include_change, the receive entry should not appear
+        txs = self.nodes[0].listtransactions("*", 100)
+        receive_entries = [t for t in txs if t["txid"] == txid and t["category"] == "receive"]
+        assert_equal(len(receive_entries), 0)
+
+        # With include_change=True, we get both the send (to a change address)
+        # and the actual change.
+        txs = self.nodes[0].listtransactions("*", 100, 0, False, True)
+        receive_entries = [t for t in txs if t["txid"] == txid and t["category"] == "receive"]
+        assert_equal(len(receive_entries), 2)
+        assert any(e["address"] == change_addr for e in receive_entries)
+        assert all(self.nodes[0].getaddressinfo(e["address"])["ischange"] for e in receive_entries)
+
+        send_entries = [t for t in txs if t["txid"] == txid and t["category"] == "send"]
+        assert_equal(len(send_entries), 2)
+        assert any(e["address"] == change_addr for e in send_entries)
+        assert all(self.nodes[0].getaddressinfo(e["address"])["ischange"] for e in send_entries)
 
     def test_from_me_status_change(self):
         self.log.info("Test gettransaction after changing a transaction's 'from me' status")


### PR DESCRIPTION
Currently, `listtransactions` silently hides transactions whose outputs go exclusively to change addresses. This can be confusing, as reported in #34632: a user created a consolidation transaction sending funds to a change address, and the transaction disappeared from `listtransactions`, making it appear as though funds were lost.

`listsinceblock` already supports an `include_change` parameter for this purpose. The internal `ListTransactions` helper also already accepts it. This PR simply wires the parameter through the `listtransactions` RPC handler for consistency.

- Adds `include_change` (bool, default `false`) as a new argument after the existing `include_watchonly`
- No behavior change for existing callers
- Includes functional test coverage

This approach was suggested by @mossein in #34632. A more comprehensive `listrawtransactions` RPC as mentioned by @achow101 could be pursued separately.

Fixes #34632