### PR TITLE
iwyu: Fix warnings in `src/script` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -229,7 +229,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(((crypto|index|kernel|primitives|univalue/(lib|test)|util|zmq)/.*|bench/(block_assemble|connectblock)|common/license_info|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/(((crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|bench/(block_assemble|connectblock)|common/license_info|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -4,6 +4,7 @@
 
 #include <addresstype.h>
 #include <bench/bench.h>
+#include <coins.h>
 #include <key.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>

--- a/src/core_io.cpp
+++ b/src/core_io.cpp
@@ -11,6 +11,7 @@
 #include <consensus/validation.h>
 #include <crypto/hex_base.h>
 #include <key_io.h>
+#include <prevector.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/descriptor.h>

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -24,6 +24,7 @@
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/verify_flags.h>
 #include <serialize.h>
 #include <streams.h>
 #include <sync.h>

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -16,6 +16,7 @@
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/verify_flags.h>
 #include <uint256.h>
 #include <util/chaintype.h>
 #include <util/log.h>

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -6,6 +6,7 @@
 #define BITCOIN_PSBT_H
 
 #include <common/types.h>
+#include <musig.h>
 #include <node/transaction.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -4,29 +4,45 @@
 
 #include <script/descriptor.h>
 
+#include <addresstype.h>
+#include <attributes.h>
+#include <consensus/consensus.h>
+#include <crypto/hex_base.h>
+#include <crypto/sha256.h>
 #include <hash.h>
+#include <key.h>
 #include <key_io.h>
-#include <pubkey.h>
 #include <musig.h>
+#include <primitives/transaction.h>
+#include <pubkey.h>
+#include <script/interpreter.h>
+#include <script/keyorigin.h>
 #include <script/miniscript.h>
 #include <script/parsing.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
 #include <script/solver.h>
+#include <serialize.h>
+#include <tinyformat.h>
 #include <uint256.h>
-
-#include <common/args.h>
-#include <span.h>
 #include <util/bip32.h>
 #include <util/check.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/vector.h>
 
 #include <algorithm>
+#include <iterator>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <span>
+#include <stdexcept>
 #include <string>
+#include <tuple>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 using util::Split;

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -6,12 +6,22 @@
 #define BITCOIN_SCRIPT_DESCRIPTOR_H
 
 #include <outputtype.h>
-#include <script/script.h>
-#include <script/sign.h>
-#include <script/signingprovider.h>
+#include <pubkey.h>
+#include <uint256.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
+
+class CScript;
+class SigningProvider;
+struct FlatSigningProvider;
 
 using ExtPubKeyMap = std::unordered_map<uint32_t, CExtPubKey>;
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -8,10 +8,20 @@
 #include <crypto/ripemd160.h>
 #include <crypto/sha1.h>
 #include <crypto/sha256.h>
+#include <prevector.h>
 #include <pubkey.h>
 #include <script/script.h>
+#include <serialize.h>
+#include <span.h>
 #include <tinyformat.h>
 #include <uint256.h>
+
+#include <algorithm>
+#include <cassert>
+#include <compare>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
 
 typedef std::vector<unsigned char> valtype;
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -9,21 +9,22 @@
 #include <consensus/amount.h>
 #include <hash.h>
 #include <primitives/transaction.h>
-#include <script/script_error.h> // IWYU pragma: export
-#include <script/verify_flags.h> // IWYU pragma: export
-#include <span.h>
+#include <script/script.h>
+#include <script/script_error.h>
+#include <script/verify_flags.h>
 #include <uint256.h>
 
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <optional>
+#include <span>
+#include <string>
+#include <utility>
 #include <vector>
 
 class CPubKey;
-class CScript;
-class CScriptNum;
 class XOnlyPubKey;
-struct CScriptWitness;
 
 /** Signature hash types/flags */
 enum

--- a/src/script/miniscript.cpp
+++ b/src/script/miniscript.cpp
@@ -2,16 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <limits>
-#include <vector>
+#include <script/miniscript.h>
 
 #include <primitives/transaction.h>
-#include <script/miniscript.h>
 #include <script/script.h>
 #include <script/solver.h>
-#include <span.h>
 #include <util/check.h>
 #include <util/vector.h>
+
+#include <limits>
+#include <vector>
 
 namespace miniscript {
 namespace internal {

--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -5,32 +5,35 @@
 #ifndef BITCOIN_SCRIPT_MINISCRIPT_H
 #define BITCOIN_SCRIPT_MINISCRIPT_H
 
+#include <consensus/consensus.h>
+#include <crypto/hex_base.h>
+#include <policy/policy.h>
+#include <script/interpreter.h>
+#include <script/parsing.h>
+#include <script/script.h>
+#include <serialize.h>
+#include <util/check.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+#include <util/vector.h>
+
 #include <algorithm>
 #include <compare>
 #include <concepts>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
-#include <iterator>
 #include <memory>
 #include <optional>
 #include <set>
+#include <span>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
-
-#include <consensus/consensus.h>
-#include <policy/policy.h>
-#include <script/interpreter.h>
-#include <script/parsing.h>
-#include <script/script.h>
-#include <serialize.h>
-#include <span.h>
-#include <util/check.h>
-#include <util/strencodings.h>
-#include <util/string.h>
-#include <util/vector.h>
 
 namespace miniscript {
 

--- a/src/script/parsing.cpp
+++ b/src/script/parsing.cpp
@@ -4,8 +4,6 @@
 
 #include <script/parsing.h>
 
-#include <span.h>
-
 #include <algorithm>
 #include <cstddef>
 #include <string>

--- a/src/script/parsing.h
+++ b/src/script/parsing.h
@@ -5,8 +5,7 @@
 #ifndef BITCOIN_SCRIPT_PARSING_H
 #define BITCOIN_SCRIPT_PARSING_H
 
-#include <span.h>
-
+#include <span>
 #include <string>
 
 namespace script {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -11,6 +11,7 @@
 #include <uint256.h>
 #include <util/hash_type.h>
 
+#include <compare>
 #include <string>
 
 CScriptID::CScriptID(const CScript& in) : BaseHash(Hash160(in)) {}

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -8,14 +8,15 @@
 
 #include <attributes.h>
 #include <crypto/common.h>
-#include <prevector.h> // IWYU pragma: export
+#include <prevector.h>
 #include <serialize.h>
 #include <uint256.h>
 #include <util/hash_type.h>
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
-#include <cstring>
+#include <iterator>
 #include <limits>
 #include <span>
 #include <stdexcept>

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -9,12 +9,12 @@
 #include <pubkey.h>
 #include <random.h>
 #include <script/interpreter.h>
-#include <span.h>
 #include <uint256.h>
 #include <util/log.h>
 
 #include <mutex>
 #include <shared_mutex>
+#include <utility>
 #include <vector>
 
 SignatureCache::SignatureCache(const size_t max_size_bytes)

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -10,13 +10,15 @@
 #include <crypto/sha256.h>
 #include <cuckoocache.h>
 #include <script/interpreter.h>
-#include <span.h>
 #include <uint256.h>
-#include <util/byte_units.h>
+// IWYU incorrectly suggests removing this header.
+// See https://github.com/include-what-you-use/include-what-you-use/issues/2014.
+#include <util/byte_units.h> // IWYU pragma: keep
 #include <util/hasher.h>
 
 #include <cstddef>
 #include <shared_mutex>
+#include <span>
 #include <vector>
 
 class CPubKey;

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -5,20 +5,34 @@
 
 #include <script/sign.h>
 
+#include <addresstype.h>
+#include <coins.h>
 #include <consensus/amount.h>
+#include <hash.h>
 #include <key.h>
 #include <musig.h>
 #include <policy/policy.h>
+#include <prevector.h>
 #include <primitives/transaction.h>
-#include <random.h>
 #include <script/keyorigin.h>
 #include <script/miniscript.h>
 #include <script/script.h>
+#include <script/script_error.h>
 #include <script/signingprovider.h>
 #include <script/solver.h>
+#include <script/verify_flags.h>
+#include <serialize.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/translation.h>
 #include <util/vector.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <span>
+#include <string>
 
 typedef std::vector<unsigned char> valtype;
 

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -7,19 +7,25 @@
 #define BITCOIN_SCRIPT_SIGN_H
 
 #include <attributes.h>
-#include <coins.h>
-#include <hash.h>
+#include <consensus/amount.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/keyorigin.h>
+#include <script/script.h>
 #include <script/signingprovider.h>
 #include <uint256.h>
 
-class CKey;
-class CKeyID;
-class CScript;
-class CTransaction;
-class SigningProvider;
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <set>
+#include <utility>
+#include <vector>
+
+class COutPoint;
+class CTxIn;
+class CTxOut;
+class Coin;
 
 struct bilingual_str;
 struct CMutableTransaction;

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -3,11 +3,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <script/keyorigin.h>
-#include <script/interpreter.h>
 #include <script/signingprovider.h>
 
+#include <musig.h>
+#include <script/interpreter.h>
+#include <script/keyorigin.h>
+#include <util/check.h>
 #include <util/log.h>
+
+#include <algorithm>
+#include <cstddef>
 
 const SigningProvider& DUMMY_SIGNING_PROVIDER = SigningProvider();
 

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -9,14 +9,26 @@
 #include <addresstype.h>
 #include <attributes.h>
 #include <key.h>
-#include <musig.h>
 #include <pubkey.h>
 #include <script/keyorigin.h>
 #include <script/script.h>
 #include <sync.h>
+#include <uint256.h>
 
+#include <compare>
+#include <cstdint>
 #include <functional>
+#include <map>
+#include <memory>
 #include <optional>
+#include <set>
+#include <span>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+
+class MuSig2SecNonce;
 
 struct ShortestVectorFirstComparator
 {

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -3,13 +3,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <script/solver.h>
+
+#include <prevector.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/script.h>
-#include <script/solver.h>
-#include <span.h>
 
-#include <algorithm>
 #include <cassert>
 #include <string>
 

--- a/src/script/solver.h
+++ b/src/script/solver.h
@@ -10,10 +10,10 @@
 
 #include <attributes.h>
 #include <script/script.h>
-#include <span.h>
 
-#include <string>
 #include <optional>
+#include <span>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -11,6 +11,7 @@
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/verify_flags.h>
 #include <streams.h>
 #include <uint256.h>
 #include <util/log.h>

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -2,10 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/data/script_tests.json.h>
-#include <test/data/bip341_wallet_vectors.json.h>
-
 #include <common/system.h>
+#include <compressor.h>
 #include <core_io.h>
 #include <key.h>
 #include <rpc/util.h>
@@ -16,24 +14,25 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/solver.h>
+#include <secp256k1.h>
 #include <streams.h>
+#include <test/data/bip341_wallet_vectors.json.h>
+#include <test/data/script_tests.json.h>
+#include <test/util/common.h>
 #include <test/util/json.h>
 #include <test/util/random.h>
-#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
+#include <univalue.h>
 #include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
+#include <boost/test/unit_test.hpp>
+
 #include <cstdint>
 #include <string>
 #include <vector>
-
-#include <boost/test/unit_test.hpp>
-
-#include <secp256k1.h>
-#include <univalue.h>
 
 // Uncomment if you want to output updated JSON tests.
 // #define UPDATE_JSON_TESTS

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -2,6 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <wallet/feebumper.h>
+
+#include <coins.h>
 #include <common/system.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
@@ -11,7 +14,6 @@
 #include <util/rbf.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
-#include <wallet/feebumper.h>
 #include <wallet/fees.h>
 #include <wallet/receive.h>
 #include <wallet/spend.h>

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -5,6 +5,9 @@
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
+#include <wallet/rpc/wallet.h>
+
+#include <coins.h>
 #include <core_io.h>
 #include <key_io.h>
 #include <rpc/server.h>
@@ -14,7 +17,6 @@
 #include <wallet/context.h>
 #include <wallet/receive.h>
 #include <wallet/rpc/util.h>
-#include <wallet/rpc/wallet.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2,6 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <wallet/scriptpubkeyman.h>
+
+#include <coins.h>
 #include <hash.h>
 #include <key_io.h>
 #include <node/types.h>
@@ -17,7 +20,6 @@
 #include <util/string.h>
 #include <util/time.h>
 #include <util/translation.h>
-#include <wallet/scriptpubkeyman.h>
 
 #include <optional>
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -16,6 +16,7 @@
 #include <script/descriptor.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
+#include <util/hasher.h>
 #include <util/log.h>
 #include <util/result.h>
 #include <util/time.h>
@@ -27,6 +28,7 @@
 #include <functional>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 
 enum class OutputType;
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 class CScript;


### PR DESCRIPTION
This PR [continues](https://github.com/bitcoin/bitcoin/pull/33725#issuecomment-3466897433) the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).