### PR TITLE
net: deduplicate private broadcast state and snapshot types

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -536,7 +536,7 @@ public:
     bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     std::vector<node::TxOrphanage::OrphanInfo> GetOrphanTransactions() override EXCLUSIVE_LOCKS_REQUIRED(!m_tx_download_mutex);
     PeerManagerInfo GetInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
-    std::vector<PrivateBroadcast::TxBroadcastInfo> GetPrivateBroadcastInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+    PrivateBroadcast::Transactions GetPrivateBroadcastInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     std::vector<CTransactionRef> AbortPrivateBroadcast(const uint256& id) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void SendPings() override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void InitiateTxBroadcastToAll(const Txid& txid, const Wtxid& wtxid) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
@@ -1880,7 +1880,7 @@ PeerManagerInfo PeerManagerImpl::GetInfo() const
     };
 }
 
-std::vector<PrivateBroadcast::TxBroadcastInfo> PeerManagerImpl::GetPrivateBroadcastInfo() const
+PrivateBroadcast::Transactions PeerManagerImpl::GetPrivateBroadcastInfo() const
 {
     return m_tx_for_private_broadcast.GetBroadcastInfo();
 }
@@ -1891,8 +1891,7 @@ std::vector<CTransactionRef> PeerManagerImpl::AbortPrivateBroadcast(const uint25
     std::vector<CTransactionRef> removed_txs;
 
     size_t connections_cancelled{0};
-    for (const auto& tx_info : snapshot) {
-        const CTransactionRef& tx{tx_info.tx};
+    for (const auto& [tx, _] : snapshot) {
         if (tx->GetHash().ToUint256() != id && tx->GetWitnessHash().ToUint256() != id) continue;
         if (const auto peer_acks{m_tx_for_private_broadcast.Remove(tx)}) {
             removed_txs.push_back(tx);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -123,7 +123,7 @@ public:
     virtual PeerManagerInfo GetInfo() const = 0;
 
     /** Get info about transactions currently being privately broadcast. */
-    virtual std::vector<PrivateBroadcast::TxBroadcastInfo> GetPrivateBroadcastInfo() const = 0;
+    virtual PrivateBroadcast::Transactions GetPrivateBroadcastInfo() const = 0;
 
     /**
      * Abort private broadcast attempts for transactions currently being privately broadcast.

--- a/src/private_broadcast.cpp
+++ b/src/private_broadcast.cpp
@@ -114,23 +114,11 @@ std::vector<CTransactionRef> PrivateBroadcast::GetStale() const
     return stale;
 }
 
-std::vector<PrivateBroadcast::TxBroadcastInfo> PrivateBroadcast::GetBroadcastInfo() const
+PrivateBroadcast::Transactions PrivateBroadcast::GetBroadcastInfo() const
     EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
 {
     LOCK(m_mutex);
-    std::vector<TxBroadcastInfo> entries;
-    entries.reserve(m_transactions.size());
-
-    for (const auto& [tx, state] : m_transactions) {
-        std::vector<PeerSendInfo> peers;
-        peers.reserve(state.send_statuses.size());
-        for (const auto& status : state.send_statuses) {
-            peers.emplace_back(PeerSendInfo{.address = status.address, .sent = status.picked, .received = status.confirmed});
-        }
-        entries.emplace_back(TxBroadcastInfo{.tx = tx, .time_added = state.time_added, .peers = std::move(peers)});
-    }
-
-    return entries;
+    return m_transactions;
 }
 
 PrivateBroadcast::Priority PrivateBroadcast::DerivePriority(const std::vector<SendStatus>& sent_to)

--- a/src/private_broadcast.h
+++ b/src/private_broadcast.h
@@ -47,17 +47,45 @@ public:
     explicit PrivateBroadcast(size_t max_transactions = MAX_TRANSACTIONS)
         : m_max_transactions{max_transactions} {}
 
-    struct PeerSendInfo {
-        CService address;
-        NodeClock::time_point sent;
-        std::optional<NodeClock::time_point> received;
+    /// Status of a transaction sent to a given node.
+    struct SendStatus {
+        /// Node to which the transaction will be sent (or was sent).
+        const NodeId nodeid;
+        /// Address of the node.
+        const CService address;
+        /// When was the transaction picked for sending to the node.
+        const NodeClock::time_point picked;
+        /// When was the transaction reception confirmed by the node (by PONG).
+        std::optional<NodeClock::time_point> confirmed;
+
+        SendStatus(const NodeId& nodeid, const CService& address, const NodeClock::time_point& picked) : nodeid{nodeid}, address{address}, picked{picked} {}
     };
 
-    struct TxBroadcastInfo {
-        CTransactionRef tx;
-        NodeClock::time_point time_added;
-        std::vector<PeerSendInfo> peers;
+    /// Complete status of a transaction.
+    struct Status {
+        /// When was the transaction added to the queue.
+        const NodeClock::time_point time_added{NodeClock::now()};
+        /// All send attempts.
+        std::vector<SendStatus> send_statuses{};
     };
+
+    // No need for salted hasher because we are going to store just a bunch of locally originating transactions.
+
+    struct CTransactionRefHash {
+        size_t operator()(const CTransactionRef& tx) const
+        {
+            return static_cast<size_t>(tx->GetWitnessHash().ToUint256().GetUint64(0));
+        }
+    };
+
+    struct CTransactionRefComp {
+        bool operator()(const CTransactionRef& a, const CTransactionRef& b) const
+        {
+            return a->GetWitnessHash() == b->GetWitnessHash(); // If wtxid equals, then txid also equals.
+        }
+    };
+
+    using Transactions = std::unordered_map<CTransactionRef, Status, CTransactionRefHash, CTransactionRefComp>;
 
     /// Outcome of Add().
     enum class AddResult {
@@ -141,24 +169,10 @@ public:
     /**
      * Get stats about all transactions currently being privately broadcast.
      */
-    std::vector<TxBroadcastInfo> GetBroadcastInfo() const
+    Transactions GetBroadcastInfo() const
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
 private:
-    /// Status of a transaction sent to a given node.
-    struct SendStatus {
-        /// Node to which the transaction will be sent (or was sent).
-        const NodeId nodeid;
-        /// Address of the node.
-        const CService address;
-        /// When was the transaction picked for sending to the node.
-        const NodeClock::time_point picked;
-        /// When was the transaction reception confirmed by the node (by PONG).
-        std::optional<NodeClock::time_point> confirmed;
-
-        SendStatus(const NodeId& nodeid, const CService& address, const NodeClock::time_point& picked) : nodeid{nodeid}, address{address}, picked{picked} {}
-    };
-
     /// Cumulative stats from all the send attempts for a transaction. Used to prioritize transactions.
     struct Priority {
         size_t num_picked{0}; ///< Number of times the transaction was picked for sending.
@@ -182,22 +196,6 @@ private:
         SendStatus& send_status;
     };
 
-    // No need for salted hasher because we are going to store just a bunch of locally originating transactions.
-
-    struct CTransactionRefHash {
-        size_t operator()(const CTransactionRef& tx) const
-        {
-            return static_cast<size_t>(tx->GetWitnessHash().ToUint256().GetUint64(0));
-        }
-    };
-
-    struct CTransactionRefComp {
-        bool operator()(const CTransactionRef& a, const CTransactionRef& b) const
-        {
-            return a->GetWitnessHash() == b->GetWitnessHash(); // If wtxid equals, then txid also equals.
-        }
-    };
-
     /**
      * Derive the sending priority of a transaction.
      * @param[in] sent_to List of nodes that the transaction has been sent to.
@@ -211,15 +209,11 @@ private:
      */
     std::optional<TxAndSendStatusForNode> GetSendStatusByNode(const NodeId& nodeid)
         EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
-    struct TxSendStatus {
-        const NodeClock::time_point time_added{NodeClock::now()};
-        std::vector<SendStatus> send_statuses;
-    };
+
     /// Cap on the number of simultaneously tracked transactions (see Add()).
     const size_t m_max_transactions;
     mutable Mutex m_mutex;
-    std::unordered_map<CTransactionRef, TxSendStatus, CTransactionRefHash, CTransactionRefComp>
-        m_transactions GUARDED_BY(m_mutex);
+    Transactions m_transactions GUARDED_BY(m_mutex);
 };
 
 #endif // BITCOIN_PRIVATE_BROADCAST_H

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -187,19 +187,19 @@ static RPCMethod getprivatebroadcastinfo()
             const auto txs{peerman.GetPrivateBroadcastInfo()};
 
             UniValue transactions(UniValue::VARR);
-            for (const auto& tx_info : txs) {
+            for (const auto& [tx, status] : txs) {
                 UniValue o(UniValue::VOBJ);
-                o.pushKV("txid", tx_info.tx->GetHash().ToString());
-                o.pushKV("wtxid", tx_info.tx->GetWitnessHash().ToString());
-                o.pushKV("hex", EncodeHexTx(*tx_info.tx));
-                o.pushKV("time_added", TicksSinceEpoch<std::chrono::seconds>(tx_info.time_added));
+                o.pushKV("txid", tx->GetHash().ToString());
+                o.pushKV("wtxid", tx->GetWitnessHash().ToString());
+                o.pushKV("hex", EncodeHexTx(*tx));
+                o.pushKV("time_added", TicksSinceEpoch<std::chrono::seconds>(status.time_added));
                 UniValue peers(UniValue::VARR);
-                for (const auto& peer : tx_info.peers) {
+                for (const auto& ss : status.send_statuses) {
                     UniValue p(UniValue::VOBJ);
-                    p.pushKV("address", peer.address.ToStringAddrPort());
-                    p.pushKV("sent", TicksSinceEpoch<std::chrono::seconds>(peer.sent));
-                    if (peer.received.has_value()) {
-                        p.pushKV("received", TicksSinceEpoch<std::chrono::seconds>(*peer.received));
+                    p.pushKV("address", ss.address.ToStringAddrPort());
+                    p.pushKV("sent", TicksSinceEpoch<std::chrono::seconds>(ss.picked));
+                    if (ss.confirmed.has_value()) {
+                        p.pushKV("received", TicksSinceEpoch<std::chrono::seconds>(*ss.confirmed));
                     }
                     peers.push_back(std::move(p));
                 }

--- a/src/test/fuzz/private_broadcast.cpp
+++ b/src/test/fuzz/private_broadcast.cpp
@@ -195,10 +195,10 @@ FUZZ_TARGET(private_broadcast)
 
                 Assert(all_broadcast_info.size() == transactions.size());
 
-                for (const auto& info : all_broadcast_info) {
-                    const auto it{transactions.find(info.tx)};
+                for (const auto& [tx, status] : all_broadcast_info) {
+                    const auto it{transactions.find(tx)};
                     Assert(it != transactions.end());
-                    Assert(info.peers.size() == it->second); // exactly the sends we recorded
+                    Assert(status.send_statuses.size() == it->second); // exactly the sends we recorded
                 }
             },
             [&] {

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -64,16 +64,16 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_REQUIRE(tx1->GetWitnessHash() != tx2->GetWitnessHash());
 
     BOOST_CHECK_EQUAL(pb.Add(tx2), PrivateBroadcast::AddResult::Added);
-    const auto find_tx_info{[](auto& infos, const CTransactionRef& tx) -> const PrivateBroadcast::TxBroadcastInfo& {
-        const auto it{std::ranges::find(infos, tx->GetWitnessHash(), [](const auto& info) { return info.tx->GetWitnessHash(); })};
-        BOOST_REQUIRE(it != infos.end());
-        return *it;
-    }};
+    const auto time_added{NodeClock::now()};
     const auto check_peer_counts{[&](size_t tx1_peer_count, size_t tx2_peer_count) {
         const auto infos{pb.GetBroadcastInfo()};
         BOOST_CHECK_EQUAL(infos.size(), 2);
-        BOOST_CHECK_EQUAL(find_tx_info(infos, tx1).peers.size(), tx1_peer_count);
-        BOOST_CHECK_EQUAL(find_tx_info(infos, tx2).peers.size(), tx2_peer_count);
+        const auto& tx1_info{infos.at(tx1)};
+        const auto& tx2_info{infos.at(tx2)};
+        BOOST_CHECK(tx1_info.time_added == time_added);
+        BOOST_CHECK(tx2_info.time_added == time_added);
+        BOOST_CHECK_EQUAL(tx1_info.send_statuses.size(), tx1_peer_count);
+        BOOST_CHECK_EQUAL(tx2_info.send_statuses.size(), tx2_peer_count);
     }};
 
     check_peer_counts(/*tx1_peer_count=*/0, /*tx2_peer_count=*/0);
@@ -121,16 +121,16 @@ BOOST_AUTO_TEST_CASE(basic)
     const auto infos{pb.GetBroadcastInfo()};
     BOOST_CHECK_EQUAL(infos.size(), 2);
     {
-        const auto& peers{find_tx_info(infos, tx_for_recipient1).peers};
-        BOOST_CHECK_EQUAL(peers.size(), 1);
-        BOOST_CHECK_EQUAL(peers[0].address.ToStringAddrPort(), addr1.ToStringAddrPort());
-        BOOST_CHECK(peers[0].received.has_value());
+        const auto& send_statuses{infos.at(tx_for_recipient1).send_statuses};
+        BOOST_CHECK_EQUAL(send_statuses.size(), 1);
+        BOOST_CHECK_EQUAL(send_statuses[0].address.ToStringAddrPort(), addr1.ToStringAddrPort());
+        BOOST_CHECK(send_statuses[0].confirmed.has_value());
     }
     {
-        const auto& peers{find_tx_info(infos, tx_for_recipient2).peers};
-        BOOST_CHECK_EQUAL(peers.size(), 1);
-        BOOST_CHECK_EQUAL(peers[0].address.ToStringAddrPort(), addr2.ToStringAddrPort());
-        BOOST_CHECK(!peers[0].received.has_value());
+        const auto& send_statuses{infos.at(tx_for_recipient2).send_statuses};
+        BOOST_CHECK_EQUAL(send_statuses.size(), 1);
+        BOOST_CHECK_EQUAL(send_statuses[0].address.ToStringAddrPort(), addr2.ToStringAddrPort());
+        BOOST_CHECK(!send_statuses[0].confirmed.has_value());
     }
 
     const auto stale_state{pb.GetStale()};
@@ -195,8 +195,8 @@ BOOST_AUTO_TEST_CASE(rejection_at_cap)
     // Nothing was evicted: all originally-added transactions are still present.
     const auto infos{pb.GetBroadcastInfo()};
     std::set<uint256> present_wtxids;
-    for (const auto& info : infos) {
-        present_wtxids.insert(info.tx->GetWitnessHash().ToUint256());
+    for (const auto& [tx, _] : infos) {
+        present_wtxids.insert(tx->GetWitnessHash().ToUint256());
     }
     BOOST_CHECK_EQUAL(present_wtxids.size(), infos.size());
     for (size_t i{0}; i < num_cap; ++i) {


### PR DESCRIPTION
Follow-up cleanup in the private broadcast subsystem.

This PR is inspired by [#34707 (comment)](https://github.com/bitcoin/bitcoin/pull/34707#discussion_r2996756760).

This change removes duplication between the internal private broadcast state
and the snapshot used by PeerManager, RPC, and tests.

- Remove `PeerSendInfo` and `TxSendStatus`.
- Reuse `SendStatus` directly for per-peer broadcast status.
- Expose `PrivateBroadcast::Transactions` as the snapshot type.
- Keep `getprivatebroadcastinfo` JSON output unchanged.

No behavior change intended.
