### PR TITLE
wallet: apply anti-fee-sniping locktime uniformly across all funded transaction RPCs

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -670,6 +670,13 @@ CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransact
         coinControl.m_max_tx_weight = options["max_tx_weight"].getInt<int>();
     }
 
+    // If the caller explicitly provided a locktime (including 0), honour it
+    // and disable anti-fee-sniping.  Absence of the key means "use the
+    // default", which leaves anti-fee-sniping active inside CreateTransaction.
+    if (options.exists("locktime")) {
+        coinControl.m_locktime = options["locktime"].getInt<uint32_t>();
+    }
+
     if (tx.version == TRUC_VERSION) {
         if (!coinControl.m_max_tx_weight.has_value() || coinControl.m_max_tx_weight.value() > TRUC_MAX_WEIGHT) {
             coinControl.m_max_tx_weight = TRUC_MAX_WEIGHT;
@@ -1691,7 +1698,7 @@ RPCMethod walletcreatefundedpsbt()
                             "accepted as second parameter.",
                         OutputsDoc(),
                         RPCArgOptions{.skip_type_check = true}},
-                    {"locktime", RPCArg::Type::NUM, RPCArg::Default{0}, "Raw locktime. Non-0 value also locktime-activates inputs"},
+                    {"locktime", RPCArg::Type::NUM, RPCArg::DefaultHint{"locktime close to block height to prevent fee sniping"}, "Raw locktime. Non-0 value also locktime-activates inputs"},
                     {"options", RPCArg::Type::OBJ_NAMED_PARAMS, RPCArg::Optional::OMITTED, "",
                         Cat<std::vector<RPCArg>>(
                         {
@@ -1755,6 +1762,12 @@ RPCMethod walletcreatefundedpsbt()
 
     const UniValue &replaceable_arg = options["replaceable"];
     const bool rbf{replaceable_arg.isNull() ? wallet.m_signal_rbf : replaceable_arg.get_bool()};
+    // If the caller explicitly provided a locktime (including 0), honour it and
+    // disable anti-fee-sniping.  A null param means "use the default", which
+    // leaves anti-fee-sniping active inside CreateTransaction.
+    if (!request.params[2].isNull()) {
+        coin_control.m_locktime = request.params[2].getInt<uint32_t>();
+    }
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf, coin_control.m_version);
     UniValue outputs(UniValue::VOBJ);
     outputs = NormalizeOutputs(request.params[1]);

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1508,8 +1508,15 @@ util::Result<CreatedTransactionResult> FundTransaction(CWallet& wallet, const CM
     // This sets us up to remove tx completely in a future PR in favor of passing the inputs directly.
     assert(tx.vout.empty());
 
-    // Set the user desired locktime
-    coinControl.m_locktime = tx.nLockTime;
+    // Set the user desired locktime. Only propagate non-zero values; a zero
+    // value is indistinguishable from the CMutableTransaction default and
+    // should leave anti-fee-sniping active. Callers that explicitly want
+    // nLockTime=0 must set coinControl.m_locktime = 0 before calling this
+    // function (the RPC layer does this via options["locktime"] or a named
+    // locktime parameter).
+    if (tx.nLockTime != 0) {
+        coinControl.m_locktime = tx.nLockTime;
+    }
 
     // Set the user desired version
     coinControl.m_version = tx.version;

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -740,13 +740,15 @@ class PSBTTest(BitcoinTestFramework):
             assert "bip32_derivs" in psbt_in
         assert_equal(decoded_psbt["tx"]["locktime"], block_height)
 
-        # Same construction without optional arguments
+        # Same construction without optional arguments - anti-fee sniping should be applied
         psbtx_info = self.nodes[0].walletcreatefundedpsbt([], [{self.nodes[2].getnewaddress():unspent["amount"]+1}])
         decoded_psbt = self.nodes[0].decodepsbt(psbtx_info["psbt"])
         for tx_in, psbt_in in zip(decoded_psbt["tx"]["vin"], decoded_psbt["inputs"]):
             assert_equal(tx_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
             assert "bip32_derivs" in psbt_in
-        assert_equal(decoded_psbt["tx"]["locktime"], 0)
+        # Anti-fee sniping sets locktime to current block height (with 10% chance of being up to 100 blocks earlier)
+        assert_greater_than_or_equal(decoded_psbt["tx"]["locktime"], max(0, block_height - 100))
+        assert decoded_psbt["tx"]["locktime"] <= block_height
 
         # Same construction without optional arguments, for a node with -walletrbf=0
         unspent1 = self.nodes[1].listunspent()[0]

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -33,6 +33,9 @@ class CreateTxWalletTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(0)
 
         self.test_anti_fee_sniping()
+        self.test_walletcreatefundedpsbt_anti_fee_sniping()
+        self.test_fundrawtransaction_anti_fee_sniping()
+        self.test_send_anti_fee_sniping()
         self.test_tx_size_too_large()
         self.test_create_too_long_mempool_chain()
         self.test_version3()
@@ -49,6 +52,68 @@ class CreateTxWalletTest(BitcoinTestFramework):
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
         assert 0 < tx['locktime'] <= 201
+
+    def test_walletcreatefundedpsbt_anti_fee_sniping(self):
+        self.log.info('Check that walletcreatefundedpsbt applies anti-fee-sniping by default')
+        # At this point we have a recent block (from test_anti_fee_sniping), so anti-fee-sniping is active
+        block_height = self.nodes[0].getblockcount()
+        addr = self.nodes[0].getnewaddress()
+        psbt_info = self.nodes[0].walletcreatefundedpsbt([], [{addr: 1}])
+        decoded = self.nodes[0].decodepsbt(psbt_info['psbt'])
+        locktime = decoded['tx']['locktime']
+        assert locktime > 0, f"Expected anti-fee-sniping locktime > 0, got {locktime}"
+        assert locktime <= block_height, f"locktime {locktime} exceeds block_height {block_height}"
+        assert locktime >= block_height - 100, f"locktime {locktime} too far below block_height {block_height}"
+
+        self.log.info('Check that walletcreatefundedpsbt respects an explicit non-zero locktime')
+        explicit_locktime = 42
+        psbt_info = self.nodes[0].walletcreatefundedpsbt([], [{addr: 1}], explicit_locktime)
+        decoded = self.nodes[0].decodepsbt(psbt_info['psbt'])
+        assert decoded['tx']['locktime'] == explicit_locktime, \
+            f"Expected explicit locktime {explicit_locktime}, got {decoded['tx']['locktime']}"
+
+        self.log.info('Check that walletcreatefundedpsbt respects an explicit locktime=0')
+        psbt_info = self.nodes[0].walletcreatefundedpsbt([], [{addr: 1}], 0)
+        decoded = self.nodes[0].decodepsbt(psbt_info['psbt'])
+        assert decoded['tx']['locktime'] == 0, \
+            f"Expected explicit locktime 0, got {decoded['tx']['locktime']}"
+
+    def test_send_anti_fee_sniping(self):
+        self.log.info('Check that send applies anti-fee-sniping by default')
+        block_height = self.nodes[0].getblockcount()
+        addr = self.nodes[0].getnewaddress()
+        res = self.nodes[0].send(outputs=[{addr: 1}])
+        tx = self.nodes[0].gettransaction(txid=res['txid'], verbose=True)['decoded']
+        locktime = tx['locktime']
+        assert locktime > 0, f"Expected anti-fee-sniping locktime > 0, got {locktime}"
+        assert locktime <= block_height, f"locktime {locktime} exceeds block_height {block_height}"
+        assert locktime >= block_height - 100, f"locktime {locktime} too far below block_height {block_height}"
+
+        self.log.info('Check that send respects an explicit locktime=0')
+        res = self.nodes[0].send(outputs=[{addr: 1}], options={"locktime": 0})
+        tx = self.nodes[0].gettransaction(txid=res['txid'], verbose=True)['decoded']
+        assert tx['locktime'] == 0, f"Expected explicit locktime 0, got {tx['locktime']}"
+
+    def test_fundrawtransaction_anti_fee_sniping(self):
+        self.log.info('Check that fundrawtransaction applies anti-fee-sniping when raw tx has default locktime')
+        block_height = self.nodes[0].getblockcount()
+        addr = self.nodes[0].getnewaddress()
+        # createrawtransaction defaults to locktime=0
+        raw_tx = self.nodes[0].createrawtransaction([], [{addr: 1}])
+        funded = self.nodes[0].fundrawtransaction(raw_tx)
+        tx = tx_from_hex(funded['hex'])
+        locktime = tx.nLockTime
+        assert locktime > 0, f"Expected anti-fee-sniping locktime > 0, got {locktime}"
+        assert locktime <= block_height, f"locktime {locktime} exceeds block_height {block_height}"
+        assert locktime >= block_height - 100, f"locktime {locktime} too far below block_height {block_height}"
+
+        self.log.info('Check that fundrawtransaction preserves an explicit non-zero locktime in the raw tx')
+        explicit_locktime = 42
+        raw_tx = self.nodes[0].createrawtransaction([], [{addr: 1}], explicit_locktime)
+        funded = self.nodes[0].fundrawtransaction(raw_tx)
+        tx = tx_from_hex(funded['hex'])
+        assert tx.nLockTime == explicit_locktime, \
+            f"Expected explicit locktime {explicit_locktime}, got {tx.nLockTime}"
 
     def test_tx_size_too_large(self):
         # More than 10kB of outputs, so that we hit -maxtxfee with a high feerate


### PR DESCRIPTION
### Summary

Closes #34987.

Previously, `nLockTime` anti-fee-sniping (current block height ±100 blocks) was
only applied by the `send` RPC and GUI wallet flow. `walletcreatefundedpsbt` and
`fundrawtransaction` both defaulted to `nLockTime=0`, creating a wallet
fingerprinting discrepancy.

**Root cause (two issues):**

1. `wallet::FundTransaction` unconditionally set `coinControl.m_locktime = tx.nLockTime`
   even when `tx.nLockTime` was the default `0`. Since `coinControl.m_locktime` is
   `std::optional<uint32_t>`, assigning `0` makes it non-empty, which suppresses
   `DiscourageFeeSniping()` in `CreateTransaction`. Fixed by only setting `m_locktime`
   when `tx.nLockTime != 0`.

2. `walletcreatefundedpsbt` documented its `locktime` parameter default as `0` rather
   than the anti-fee-sniping default. Updated to match `send`.

**After this change:** all wallet-funded RPCs uniformly apply anti-fee-sniping unless
the caller provides an explicit locktime value.

### Behavior

| RPC | Before | After |
|-----|--------|-------|
| `send` | anti-fee-sniping ✓ | anti-fee-sniping ✓ (unchanged) |
| `walletcreatefundedpsbt` (no locktime) | `nLockTime=0` | anti-fee-sniping ✓ |
| `fundrawtransaction` (raw tx with default locktime) | `nLockTime=0` | anti-fee-sniping ✓ |
| Any RPC with explicit `locktime=N` | `nLockTime=N` | `nLockTime=N` (unchanged) |

### Test plan
- [x] `wallet_create_tx.py` — new `test_walletcreatefundedpsbt_anti_fee_sniping()` and `test_fundrawtransaction_anti_fee_sniping()`
- [x] `rpc_psbt.py` — updated existing assertion that expected `locktime=0` from `walletcreatefundedpsbt` with no arguments
- [x] `wallet_send.py`, `wallet_sendall.py`, `wallet_fundrawtransaction.py` — all pass, no regressions
