### PR TITLE
test: cover feebumper enormous-cluster failure

### DIFF
--- a/src/wallet/test/feebumper_tests.cpp
+++ b/src/wallet/test/feebumper_tests.cpp
@@ -2,16 +2,26 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
+#include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
+#include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
+#include <txgraph.h>
+#include <txmempool.h>
+#include <util/rbf.h>
 #include <util/strencodings.h>
+#include <validation.h>
+#include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>
 #include <wallet/test/util.h>
 #include <wallet/test/wallet_test_fixture.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <algorithm>
 
 namespace wallet {
 namespace feebumper {
@@ -49,6 +59,101 @@ BOOST_AUTO_TEST_CASE(external_max_weight_test)
     CheckMaxWeightComputation("", {"3042021f0f8906f0394979d5b737134773e5b88bf036c7d63542301d600ab677ba5a59021f0e9fe07e62c113045fa1c1532e2914720e8854d189c4f5b8c88f57956b704401", "0359edba11ed1a0568094a6296a16c4d5ee4c8cfe2f5e2e6826871b5ecf8188f79"}, "00149961a78658030cc824af4c54fbf5294bec0cabdd", 272);
     // P2WSH HTLC
     CheckMaxWeightComputation("", {"3042021f5c4c29e6b686aae5b6d0751e90208592ea96d26bc81d78b0d3871a94a21fa8021f74dc2f971e438ccece8699c8fd15704c41df219ab37b63264f2147d15c34d801", "01", "6321024cf55e52ec8af7866617dc4e7ff8433758e98799906d80e066c6f32033f685f967029000b275210214827893e2dcbe4ad6c20bd743288edad21100404eb7f52ccd6062fd0e7808f268ac"}, "002089e84892873c679b1129edea246e484fd914c2601f776d4f2f4a001eb8059703", 318);
+}
+
+static CTransactionRef MakeMempoolTx(const std::vector<COutPoint>& inputs, const CScript& script_pub_key)
+{
+    CMutableTransaction tx;
+    tx.vin.reserve(inputs.size());
+    for (const auto& input : inputs) {
+        tx.vin.emplace_back(input);
+    }
+    tx.vout.emplace_back(COIN, script_pub_key);
+    return MakeTransactionRef(tx);
+}
+
+// CTxMemPool::GatherClusters() bails out and returns an empty vector once
+// `ret.size() > 500`. Hardcoded in src/txmempool.cpp:988 — there is no
+// exported constant. Kept in sync manually; if you change one, update the
+// other.
+static constexpr unsigned kGatherClustersDoSLimit{500};
+
+static constexpr unsigned kClusterChainLength{MAX_CLUSTER_COUNT_LIMIT};
+
+// Smallest number of full disjoint clusters whose aggregate size strictly
+// exceeds the GatherClusters DoS limit.
+static constexpr unsigned kNumClusters{(kGatherClustersDoSLimit / kClusterChainLength) + 1};
+
+static_assert(kNumClusters * kClusterChainLength > kGatherClustersDoSLimit,
+              "test setup must produce a mempool that trips GatherClusters' DoS limit");
+static_assert(kNumClusters <= COINBASE_MATURITY,
+              "TestChain100Setup provides COINBASE_MATURITY coinbases; "
+              "increase the fixture if more are needed");
+
+// Builds the cluster topology that forces GatherClusters to walk an
+// aggregate ancestor set above its DoS limit, leaving MiniMiner unable
+// to compute combined bump fees. Returns the txid of the wallet tx that
+// will be fed to bumpfee.
+static Txid BuildEnormousClusterAndWalletTx(CTxMemPool& pool, CWallet& wallet, const std::vector<CTransactionRef>& coinbase_txns, const CScript& script_pub_key)
+{
+    std::vector<CTransactionRef> tip_txs;
+    tip_txs.reserve(kNumClusters);
+    TestMemPoolEntryHelper entry;
+    for (unsigned c = 0; c < kNumClusters; ++c) {
+        CTransactionRef last_tx = coinbase_txns.at(c);
+        for (unsigned i = 0; i < kClusterChainLength; ++i) {
+            const auto tx = MakeMempoolTx({COutPoint{last_tx->GetHash(), 0}}, script_pub_key);
+            TryAddToMempool(pool, entry.Fee(CENT).FromTx(tx));
+            last_tx = tx;
+        }
+        tip_txs.push_back(last_tx);
+    }
+
+    CMutableTransaction original_tx;
+    original_tx.vin.reserve(tip_txs.size());
+    for (const auto& tip_tx : tip_txs) {
+        original_tx.vin.emplace_back(COutPoint{tip_tx->GetHash(), 0}, CScript{}, MAX_BIP125_RBF_SEQUENCE);
+    }
+    original_tx.vout.emplace_back((kNumClusters * COIN) / 2, script_pub_key);
+    const auto original_tx_ref = MakeTransactionRef(original_tx);
+    const Txid original_txid = original_tx_ref->GetHash();
+
+    LOCK(wallet.cs_wallet);
+    for (const auto& tip_tx : tip_txs) {
+        wallet.AddToWallet(tip_tx, TxStateInactive{});
+    }
+    wallet.AddToWallet(original_tx_ref, TxStateInactive{});
+    return original_txid;
+}
+
+// When the unconfirmed inputs of a wallet tx form an aggregate ancestor set
+// that exceeds the DoS limit in CTxMemPool::GatherClusters() (see
+// src/txmempool.cpp `if (ret.size() > 500)`), MiniMiner cannot compute
+// combined bump fees and bumpfee must surface a clear error to the caller
+// instead of crashing or silently returning garbage.
+BOOST_FIXTURE_TEST_CASE(bumpfee_fails_when_unconfirmed_inputs_form_enormous_cluster, TestChain100Setup)
+{
+    auto wallet = CreateSyncedWallet(*m_node.chain, WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()), coinbaseKey);
+    CTxMemPool& pool = *Assert(m_node.mempool);
+    const CScript script_pub_key = GetScriptForRawPubKey(coinbaseKey.GetPubKey());
+
+    const Txid original_txid = BuildEnormousClusterAndWalletTx(pool, *wallet, m_coinbase_txns, script_pub_key);
+    BOOST_REQUIRE_EQUAL(pool.size(), kNumClusters * kClusterChainLength);
+
+    CCoinControl coin_control;
+    coin_control.m_feerate = CFeeRate(2'000); // any valid feerate; value is not assertion-relevant
+    std::vector<bilingual_str> errors;
+    CAmount old_fee{0};
+    CAmount new_fee{0};
+    CMutableTransaction bumped_tx;
+    const Result result = CreateRateBumpTransaction(*wallet, original_txid, coin_control, errors, old_fee, new_fee, bumped_tx, /*require_mine=*/true, /*outputs=*/{}, /*original_change_index=*/std::nullopt);
+
+    BOOST_CHECK(result == Result::WALLET_ERROR);
+    // Match a stable, structurally-meaningful substring rather than the full
+    // literal — survives any future cosmetic rewording in feebumper.cpp.
+    BOOST_CHECK(std::any_of(errors.begin(), errors.end(), [](const auto& e) {
+        return e.original.find("cluster of unconfirmed") != std::string::npos;
+    }));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

When a wallet transaction's unconfirmed inputs reference an aggregate mempool ancestor set whose size exceeds the `GatherClusters()` DoS limit (currently 500), `MiniMiner` cannot compute combined bump fees and `CreateRateBumpTransaction()` must surface a clear error to the caller instead of crashing or silently returning garbage.

This adds a unit test that constructs the offending topology, eight disjoint mempool chains, each at the cluster-count cap, totalling 512 transactions, and exercises `CreateRateBumpTransaction` through a wallet tx whose inputs are the chain tips. The test asserts the expected `Result::WALLET_ERROR` and that the surfaced error mentions the cluster-of-unconfirmed-transactions condition.

The construction is parameterised on `MAX_CLUSTER_COUNT_LIMIT` and the local `kGatherClustersDoSLimit`, so it survives changes to either; a `static_assert` pins the relationship at compile time. A second `static_assert` ensures the cluster count fits in the coinbases provided by `TestChain100Setup`.

## Test plan

- [x] `cmake --build build --target test_bitcoin --config Release -j`
- [x] `build/bin/Release/test_bitcoin.exe --run_test=feebumper_tests --log_level=message` passes
- [x] Mutation check: temporarily change `if (ret.size() > 500)` in `src/txmempool.cpp:988` to `> 1000`, rebuild, confirm the test now **fails** with both assertions, then revert

## Related

Closes #34902.
