### PR TITLE
net: add -outboundbind option for outgoing source address

### DIFF
--- a/doc/release-notes-35027.md
+++ b/doc/release-notes-35027.md
@@ -1,0 +1,7 @@
+P2P and network changes
+-----------------------
+
+- A new `-outboundbind=<addr>` option binds outgoing connections to the given
+  local address (one per address family). The address must be assigned to a
+  local interface. Proxied connections (Tor, I2P, SOCKS5) are not affected.
+  Existing `-bind` semantics are unchanged. (#6476)

--- a/doc/release-notes-35027.md
+++ b/doc/release-notes-35027.md
@@ -1,0 +1,7 @@
+P2P and network changes
+-----------------------
+
+- A new `-outboundbind=<addr>` option binds outgoing clearnet connections to
+  the given local address (one per address family). The address must be
+  assigned to a local interface. Connections over Tor, I2P and CJDNS are not
+  affected. Existing `-bind` semantics are unchanged. (#35027)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -569,6 +569,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                 ), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-bantime=<n>", strprintf("Default duration (in seconds) of manually configured bans (default: %u)", DEFAULT_MISBEHAVING_BANTIME), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-bind=<addr>[:<port>][=onion]", strprintf("Bind to given address and always listen on it (default: 0.0.0.0). Use [host]:port notation for IPv6. Append =onion to tag any incoming connections to that address and port as incoming Tor connections (default: 127.0.0.1:%u=onion, testnet3: 127.0.0.1:%u=onion, testnet4: 127.0.0.1:%u=onion, signet: 127.0.0.1:%u=onion, regtest: 127.0.0.1:%u=onion)", defaultChainParams->GetDefaultPort() + 1, testnetChainParams->GetDefaultPort() + 1, testnet4ChainParams->GetDefaultPort() + 1, signetChainParams->GetDefaultPort() + 1, regtestChainParams->GetDefaultPort() + 1), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-outboundbind=<addr>", "Bind outgoing connections to the given local address (one per address family). The address must be on a local interface; outgoing connections will use it as their source IP. Use [host] notation for IPv6.", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-cjdnsreachable", "If set, then this host is configured for CJDNS (connecting to fc00::/8 addresses would lead us to the CJDNS network, see doc/cjdns.md) (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-connect=<ip>", "Connect only to the specified node; -noconnect disables automatic connections (the rules for this peer are the same as for -addnode). This option can be specified multiple times to connect to multiple nodes.", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-discover", "Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
@@ -2168,6 +2169,18 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             }
         }
         return InitError(ResolveErrMsg("bind", bind_arg));
+    }
+
+    for (const std::string& bind_arg : args.GetArgs("-outboundbind")) {
+        std::optional<CService> bind_addr = Lookup(bind_arg, /*portDefault=*/0, /*fAllowLookup=*/false);
+        if (!bind_addr.has_value()) {
+            return InitError(ResolveErrMsg("outboundbind", bind_arg));
+        }
+        bilingual_str error;
+        if (!IsAddrBindable(*bind_addr, error)) {
+            return InitError(error);
+        }
+        connOptions.vOutboundBinds.push_back(bind_addr.value());
     }
 
     for (const std::string& strBind : args.GetArgs("-whitebind")) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -574,6 +574,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                 ), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-bantime=<n>", strprintf("Default duration (in seconds) of manually configured bans (default: %u)", DEFAULT_MISBEHAVING_BANTIME), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-bind=<addr>[:<port>][=onion]", strprintf("Bind to given address and always listen on it (default: 0.0.0.0). Use [host]:port notation for IPv6. Append =onion to tag any incoming connections to that address and port as incoming Tor connections (default: 127.0.0.1:%u=onion, testnet3: 127.0.0.1:%u=onion, testnet4: 127.0.0.1:%u=onion, signet: 127.0.0.1:%u=onion, regtest: 127.0.0.1:%u=onion)", defaultChainParams->GetDefaultPort() + 1, testnetChainParams->GetDefaultPort() + 1, testnet4ChainParams->GetDefaultPort() + 1, signetChainParams->GetDefaultPort() + 1, regtestChainParams->GetDefaultPort() + 1), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-outboundbind=<addr>", "Bind outgoing connections to the given local address (one per address family). The address must be assigned to a local interface and is used as the source address of outgoing clearnet connections; connections over Tor, I2P and CJDNS are unaffected. Specify a bare address without a port; set -nooutboundbind to disable a previously set address.", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-cjdnsreachable", "If set, then this host is configured for CJDNS (connecting to fc00::/8 addresses would lead us to the CJDNS network, see doc/cjdns.md) (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-connect=<ip>", "Connect only to the specified node; -noconnect disables automatic connections (the rules for this peer are the same as for -addnode). This option can be specified multiple times to connect to multiple nodes.", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-discover", "Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
@@ -2197,6 +2198,53 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             }
         }
         return InitError(ResolveErrMsg("bind", bind_arg));
+    }
+
+    for (const std::string& bind_arg : args.GetArgs("-outboundbind")) {
+        const std::optional<CNetAddr> lookup_addr = LookupHost(bind_arg, /*fAllowLookup=*/false);
+        if (!lookup_addr.has_value()) {
+            return InitError(ResolveErrMsg("outboundbind", bind_arg));
+        }
+        // Classify fc00::/8 as CJDNS when -cjdnsreachable is set, the same
+        // way the connect path does.
+        const CNetAddr bind_addr{static_cast<CNetAddr>(MaybeFlipIPv6toCJDNS(CService{*lookup_addr, /*port=*/0}))};
+        // The unspecified (wildcard) address pins nothing, so it is not a
+        // usable source address. Any other unusable value is left to the
+        // trial bind of the effective address below.
+        if (bind_addr.IsBindAny()) {
+            return InitError(strprintf(_("-outboundbind address '%s' is not a usable source address"), bind_arg));
+        }
+        // GetArgs() returns values in descending source precedence (command line
+        // before config file), so keep the first per family: the command line
+        // wins over the config file, and repeats resolve to the first given.
+        if (bind_addr.IsIPv4()) {
+            if (!connOptions.outbound_bind_v4) connOptions.outbound_bind_v4 = bind_addr;
+        } else if (bind_addr.IsIPv6()) {
+            if (!connOptions.outbound_bind_v6) connOptions.outbound_bind_v6 = bind_addr;
+        } else if (bind_addr.IsCJDNS()) {
+            return InitError(strprintf(_("-outboundbind address '%s' is a CJDNS address (fc00::/8 while -cjdnsreachable is set), which cannot be a clearnet source"), bind_arg));
+        } else {
+            // LookupHost() also accepts Tor/I2P addresses (via SetSpecial);
+            // they cannot be a clearnet source.
+            return InitError(strprintf(_("-outboundbind address '%s' is not an IPv4 or IPv6 address"), bind_arg));
+        }
+    }
+    // Check that the addresses that will be used can be bound to. Only the
+    // effective address per family is checked, so that a command-line
+    // -outboundbind can override a config-file one that is no longer assigned
+    // to this machine.
+    for (const std::optional<CNetAddr>& bind_addr : {connOptions.outbound_bind_v4, connOptions.outbound_bind_v6}) {
+        if (!bind_addr.has_value()) continue;
+        bilingual_str error;
+        if (!IsAddrBindable(*bind_addr, error)) {
+            return InitError(error);
+        }
+    }
+    // -outboundbind only affects direct clearnet connections; a proxy configured
+    // for a family makes it inert for that family.
+    if ((connOptions.outbound_bind_v4 && GetProxy(NET_IPV4)) ||
+        (connOptions.outbound_bind_v6 && GetProxy(NET_IPV6))) {
+        InitWarning(_("Option '-outboundbind' is set but a proxy is configured; it has no effect on connections made through the proxy."));
     }
 
     for (const std::string& strBind : args.GetArgs("-whitebind")) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -491,7 +491,13 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                 // No proxy needed (none set for target network). Private broadcast connections
                 // must always use a proxy, otherwise they would leak the originator's IP address.
                 if (Assume(conn_type != ConnectionType::PRIVATE_BROADCAST)) {
-                    sock = ConnectDirectly(target_addr, conn_type == ConnectionType::MANUAL);
+                    std::optional<CNetAddr> outbound_bind;
+                    if (target_addr.IsIPv4()) {
+                        outbound_bind = m_outbound_bind_v4;
+                    } else if (target_addr.IsIPv6()) {
+                        outbound_bind = m_outbound_bind_v6;
+                    }
+                    sock = ConnectDirectly(target_addr, conn_type == ConnectionType::MANUAL, outbound_bind);
                 }
             }
             if (!proxyConnectionFailed) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -451,6 +451,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                 proxy_override.has_value() ? proxy_override : GetProxy(target_addr.GetNetwork()),
             };
             bool proxyConnectionFailed = false;
+            bool bind_failed = false;
 
             if (target_addr.IsI2P() && use_proxy) {
                 i2p::Connection conn;
@@ -492,12 +493,12 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                 // No proxy needed (none set for target network). Private broadcast connections
                 // must always use a proxy, otherwise they would leak the originator's IP address.
                 if (Assume(conn_type != ConnectionType::PRIVATE_BROADCAST)) {
-                    sock = ConnectDirectly(target_addr, conn_type == ConnectionType::MANUAL);
+                    sock = ConnectDirectly(target_addr, conn_type == ConnectionType::MANUAL, SelectOutboundBind(target_addr), &bind_failed);
                 }
             }
-            if (!proxyConnectionFailed) {
+            if (!proxyConnectionFailed && !bind_failed) {
                 // If a connection to the node was attempted, and failure (if any) is not caused by a problem connecting to
-                // the proxy, mark this as an attempt.
+                // the proxy or binding the local source address, mark this as an attempt.
                 addrman.get().Attempt(target_addr, fCountFailure);
             }
         } else if (pszDest) {

--- a/src/net.h
+++ b/src/net.h
@@ -1092,6 +1092,7 @@ public:
         std::vector<NetWhitelistPermissions> vWhitelistedRangeOutgoing;
         std::vector<NetWhitebindPermissions> vWhiteBinds;
         std::vector<CService> vBinds;
+        std::vector<CService> vOutboundBinds;
         std::vector<CService> onion_binds;
         /// True if the user did not specify -bind= or -whitebind= and thus
         /// we should bind on `0.0.0.0` (IPv4) and `::` (IPv6).
@@ -1138,6 +1139,15 @@ public:
             }
         }
         m_onion_binds = connOptions.onion_binds;
+        // Use -outboundbind addresses for outgoing connections (one per address family).
+        for (const auto& bind_addr : connOptions.vOutboundBinds) {
+            if (bind_addr.IsLocal()) continue;
+            if (bind_addr.IsIPv4() && !m_outbound_bind_v4) {
+                m_outbound_bind_v4 = static_cast<const CNetAddr&>(bind_addr);
+            } else if (bind_addr.IsIPv6() && !m_outbound_bind_v6) {
+                m_outbound_bind_v6 = static_cast<const CNetAddr&>(bind_addr);
+            }
+        }
         whitelist_forcerelay = connOptions.whitelist_forcerelay;
         whitelist_relay = connOptions.whitelist_relay;
         m_capture_messages = connOptions.m_capture_messages;
@@ -1767,6 +1777,15 @@ private:
      * an address and port that are designated for incoming Tor connections.
      */
     std::vector<CService> m_onion_binds;
+
+    /**
+     * Addresses to bind outgoing connections to, per address family.
+     * Populated from -outboundbind addresses (one per family, first
+     * non-local wins). Direct connections only; proxied (Tor, I2P, SOCKS5)
+     * are not affected.
+     */
+    std::optional<CNetAddr> m_outbound_bind_v4;
+    std::optional<CNetAddr> m_outbound_bind_v6;
 
     /**
      * flag for adding 'forcerelay' permission to whitelisted inbound

--- a/src/net.h
+++ b/src/net.h
@@ -1102,6 +1102,9 @@ public:
         std::vector<NetWhitelistPermissions> vWhitelistedRangeOutgoing;
         std::vector<NetWhitebindPermissions> vWhiteBinds;
         std::vector<CService> vBinds;
+        //! Source address for outgoing connections, one per address family.
+        std::optional<CNetAddr> outbound_bind_v4;
+        std::optional<CNetAddr> outbound_bind_v6;
         std::vector<CService> onion_binds;
         /// True if the user did not specify -bind= or -whitebind= and thus
         /// we should bind on `0.0.0.0` (IPv4) and `::` (IPv6).
@@ -1149,6 +1152,8 @@ public:
             }
         }
         m_onion_binds = connOptions.onion_binds;
+        m_outbound_bind_v4 = connOptions.outbound_bind_v4;
+        m_outbound_bind_v6 = connOptions.outbound_bind_v6;
         whitelist_forcerelay = connOptions.whitelist_forcerelay;
         whitelist_relay = connOptions.whitelist_relay;
         m_capture_messages = connOptions.m_capture_messages;
@@ -1795,6 +1800,29 @@ private:
      * an address and port that are designated for incoming Tor connections.
      */
     std::vector<CService> m_onion_binds;
+
+    /**
+     * Addresses to bind outgoing connections to, per address family.
+     * Populated from -outboundbind (command line takes precedence over
+     * the config file). Applied only to outgoing clearnet (IPv4/IPv6)
+     * connections; Tor, I2P and CJDNS are unaffected.
+     */
+    std::optional<CNetAddr> m_outbound_bind_v4;
+    std::optional<CNetAddr> m_outbound_bind_v6;
+
+    /**
+     * Source address to bind for an outgoing connection to `target`: the
+     * configured address for its family, or nullopt for a non-clearnet target.
+     * CJDNS targets use this direct-connect path but are not IPv4/IPv6, so no
+     * source is bound (the tun device selects it); Tor and I2P use their own
+     * transports.
+     */
+    std::optional<CNetAddr> SelectOutboundBind(const CService& target) const
+    {
+        if (target.IsIPv4()) return m_outbound_bind_v4;
+        if (target.IsIPv6()) return m_outbound_bind_v6;
+        return std::nullopt;
+    }
 
     /**
      * flag for adding 'forcerelay' permission to whitelisted inbound

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -15,6 +15,7 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/time.h>
+#include <util/translation.h>
 
 #include <atomic>
 #include <chrono>
@@ -647,19 +648,36 @@ static bool ConnectToSocket(const Sock& sock,
     return true;
 }
 
-std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connection)
+std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connection, std::optional<CNetAddr> bind_addr)
 {
-    return ConnectDirectly(dest, manual_connection, std::chrono::milliseconds{nConnectTimeout});
+    return ConnectDirectly(dest, manual_connection, std::chrono::milliseconds{nConnectTimeout}, bind_addr);
 }
 
 std::unique_ptr<Sock> ConnectDirectly(const CService& dest,
                                       bool manual_connection,
-                                      std::chrono::milliseconds timeout)
+                                      std::chrono::milliseconds timeout,
+                                      std::optional<CNetAddr> bind_addr)
 {
     auto sock = CreateSock(dest.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
     if (!sock) {
         LogError("Cannot create a socket for connecting to %s\n", dest.ToStringAddrPort());
         return {};
+    }
+
+    // If a bind address is specified, bind to it before connecting.
+    if (bind_addr) {
+        const CService bind_service{*bind_addr, /*port=*/0};
+        struct sockaddr_storage bind_sa;
+        socklen_t bind_len = sizeof(bind_sa);
+        if (!bind_service.GetSockAddr(reinterpret_cast<struct sockaddr*>(&bind_sa), &bind_len)) {
+            LogError("Cannot get sockaddr for bind address %s\n", bind_addr->ToStringAddr());
+            return {};
+        }
+        if (sock->Bind(reinterpret_cast<struct sockaddr*>(&bind_sa), bind_len) == SOCKET_ERROR) {
+            LogError("Failed to bind outgoing connection to %s: %s\n",
+                     bind_addr->ToStringAddr(), NetworkErrorString(WSAGetLastError()));
+            return {};
+        }
     }
 
     // Create a sockaddr from the specified service.
@@ -981,4 +999,26 @@ CService GetBindAddress(const Sock& sock)
         LogWarning("getsockname failed\n");
     }
     return addr_bind;
+}
+
+bool IsAddrBindable(const CNetAddr& addr, bilingual_str& error)
+{
+    const CService service{addr, /*port=*/0};
+    struct sockaddr_storage sa;
+    socklen_t len = sizeof(sa);
+    if (!service.GetSockAddr(reinterpret_cast<struct sockaddr*>(&sa), &len)) {
+        error = strprintf(_("Address family for %s not supported"), addr.ToStringAddr());
+        return false;
+    }
+    std::unique_ptr<Sock> sock = CreateSock(service.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
+    if (!sock) {
+        error = strprintf(_("Could not create socket for %s"), addr.ToStringAddr());
+        return false;
+    }
+    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sa), len) == SOCKET_ERROR) {
+        error = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"),
+                          addr.ToStringAddr(), NetworkErrorString(WSAGetLastError()));
+        return false;
+    }
+    return true;
 }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -15,6 +15,7 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/time.h>
+#include <util/translation.h>
 
 #include <atomic>
 #include <chrono>
@@ -647,19 +648,53 @@ static bool ConnectToSocket(const Sock& sock,
     return true;
 }
 
-std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connection)
+std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connection, const std::optional<CNetAddr>& bind_addr, bool* bind_failed)
 {
-    return ConnectDirectly(dest, manual_connection, std::chrono::milliseconds{nConnectTimeout});
+    return ConnectDirectly(dest, manual_connection, std::chrono::milliseconds{nConnectTimeout}, bind_addr, bind_failed);
 }
 
 std::unique_ptr<Sock> ConnectDirectly(const CService& dest,
                                       bool manual_connection,
-                                      std::chrono::milliseconds timeout)
+                                      std::chrono::milliseconds timeout,
+                                      const std::optional<CNetAddr>& bind_addr,
+                                      bool* bind_failed)
 {
     auto sock = CreateSock(dest.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
     if (!sock) {
         LogError("Cannot create a socket for connecting to %s\n", dest.ToStringAddrPort());
         return {};
+    }
+
+    // If a bind address is specified, bind to it before connecting.
+    if (bind_addr) {
+        const CService bind_service{*bind_addr, /*port=*/0};
+        sockaddr_storage bind_sa;
+        socklen_t bind_len = sizeof(bind_sa);
+        if (!bind_service.GetSockAddr(reinterpret_cast<sockaddr*>(&bind_sa), &bind_len)) {
+            LogInfo("Cannot get sockaddr for bind address %s", bind_addr->ToStringAddr());
+            if (bind_failed) *bind_failed = true;
+            return {};
+        }
+#ifdef IP_BIND_ADDRESS_NO_PORT
+        // Defer source port selection to connect() time (Linux 4.2+), which
+        // shares local ports across distinct destinations the way an unbound
+        // connect() does; a port reserved at bind() time is exclusive. The
+        // address itself is still validated by bind() below. Best-effort.
+        const int on{1};
+        if (sock->SetSockOpt(IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT, &on, sizeof(on)) == SOCKET_ERROR) {
+            LogDebug(BCLog::NET, "Unable to set IP_BIND_ADDRESS_NO_PORT on outbound socket, continuing anyway");
+        }
+#endif
+        if (sock->Bind(reinterpret_cast<sockaddr*>(&bind_sa), bind_len) == SOCKET_ERROR) {
+            const int err{WSAGetLastError()};
+            // Logged loudly (not gated like automatic-connection failures): a
+            // source that is no longer bindable is an operator misconfiguration
+            // worth surfacing. The global log rate limiter bounds repetition.
+            LogWarning("Failed to bind to %s for outgoing connection to %s: %s",
+                       bind_addr->ToStringAddr(), dest.ToStringAddrPort(), NetworkErrorString(err));
+            if (bind_failed) *bind_failed = true;
+            return {};
+        }
     }
 
     // Create a sockaddr from the specified service.
@@ -981,4 +1016,28 @@ CService GetBindAddress(const Sock& sock)
         LogWarning("getsockname failed\n");
     }
     return addr_bind;
+}
+
+bool IsAddrBindable(const CNetAddr& addr, bilingual_str& error)
+{
+    const CService service{addr, /*port=*/0};
+    sockaddr_storage sa;
+    socklen_t len = sizeof(sa);
+    if (!service.GetSockAddr(reinterpret_cast<sockaddr*>(&sa), &len)) {
+        error = Untranslated(strprintf("Bind address family for %s not supported", addr.ToStringAddr()));
+        return false;
+    }
+    std::unique_ptr<Sock> sock = CreateSock(service.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP);
+    if (!sock) {
+        const int err{WSAGetLastError()};
+        error = Untranslated(strprintf("Couldn't open socket for %s (socket returned error %s)", addr.ToStringAddr(), NetworkErrorString(err)));
+        return false;
+    }
+    if (sock->Bind(reinterpret_cast<sockaddr*>(&sa), len) == SOCKET_ERROR) {
+        const int err{WSAGetLastError()};
+        error = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"),
+                          addr.ToStringAddr(), NetworkErrorString(err));
+        return false;
+    }
+    return true;
 }

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -21,6 +21,8 @@
 #include <unordered_set>
 #include <vector>
 
+struct bilingual_str;
+
 extern int nConnectTimeout;
 extern bool fNameLookup;
 
@@ -301,15 +303,17 @@ extern std::function<std::unique_ptr<Sock>(int, int, int)> CreateSock;
  *
  * @param[in] dest The service to which to connect.
  * @param[in] manual_connection Whether or not the connection was manually requested (e.g. through the addnode RPC)
+ * @param[in] bind_addr If set, bind to this local address before connecting (controls source IP for outgoing connections)
  *
  * @returns the connected socket if the operation succeeded, empty unique_ptr otherwise
  */
-std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connection);
+std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connection, std::optional<CNetAddr> bind_addr = std::nullopt);
 
 /** Create a socket and try to connect to the specified service, using the provided timeout. */
 std::unique_ptr<Sock> ConnectDirectly(const CService& dest,
                                       bool manual_connection,
-                                      std::chrono::milliseconds timeout);
+                                      std::chrono::milliseconds timeout,
+                                      std::optional<CNetAddr> bind_addr = std::nullopt);
 
 /**
  * Connect to a specified destination service through a SOCKS5 proxy by first
@@ -372,5 +376,12 @@ CService MaybeFlipIPv6toCJDNS(const CService& service);
 
 /** Get the bind address for a socket as CService. */
 CService GetBindAddress(const Sock& sock);
+
+/**
+ * Check whether a local address can be bound to (assigned to a local interface).
+ * Attempts a real bind() syscall on a fresh socket; the socket is closed before
+ * return. Returns false with `error` populated on failure.
+ */
+bool IsAddrBindable(const CNetAddr& addr, bilingual_str& error);
 
 #endif // BITCOIN_NETBASE_H

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -21,6 +21,8 @@
 #include <unordered_set>
 #include <vector>
 
+struct bilingual_str;
+
 extern int nConnectTimeout;
 extern bool fNameLookup;
 
@@ -301,15 +303,23 @@ extern std::function<std::unique_ptr<Sock>(int, int, int)> CreateSock;
  *
  * @param[in] dest The service to which to connect.
  * @param[in] manual_connection Whether or not the connection was manually requested (e.g. through the addnode RPC)
+ * @param[in] bind_addr If set, bind to this local address before connecting. On
+ *            bind failure the connection is aborted; there is no fallback to a
+ *            default source address.
+ * @param[out] bind_failed If not nullptr, set to true when the connection was
+ *             aborted because the local source address could not be bound (the
+ *             destination was never contacted).
  *
  * @returns the connected socket if the operation succeeded, empty unique_ptr otherwise
  */
-std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connection);
+std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connection, const std::optional<CNetAddr>& bind_addr = std::nullopt, bool* bind_failed = nullptr);
 
 /** Create a socket and try to connect to the specified service, using the provided timeout. */
 std::unique_ptr<Sock> ConnectDirectly(const CService& dest,
                                       bool manual_connection,
-                                      std::chrono::milliseconds timeout);
+                                      std::chrono::milliseconds timeout,
+                                      const std::optional<CNetAddr>& bind_addr = std::nullopt,
+                                      bool* bind_failed = nullptr);
 
 /**
  * Connect to a specified destination service through a SOCKS5 proxy by first
@@ -372,5 +382,12 @@ CService MaybeFlipIPv6toCJDNS(const CService& service);
 
 /** Get the bind address for a socket as CService. */
 CService GetBindAddress(const Sock& sock);
+
+/**
+ * Check whether a local address can be bound to (assigned to a local interface).
+ * Attempts a real bind() syscall on a fresh socket; the socket is closed before
+ * return. Returns false with `error` populated on failure.
+ */
+bool IsAddrBindable(const CNetAddr& addr, bilingual_str& error);
 
 #endif // BITCOIN_NETBASE_H

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1590,4 +1590,51 @@ BOOST_AUTO_TEST_CASE(private_broadcast_version_does_not_update_addrman_services)
     m_node.peerman->FinalizeNode(node);
 }
 
+BOOST_AUTO_TEST_CASE(outbound_bind_address_selection)
+{
+    const uint64_t seed{0};
+    auto connman = std::make_unique<ConnmanTestMsg>(seed, seed, *m_node.addrman, *m_node.netgroupman, Params());
+
+    CConnman::Options options;
+    options.m_msgproc = m_node.peerman.get();
+
+    const CService addr1{LookupNumeric("203.0.113.1", 8333)};
+    const CService addr2{LookupNumeric("198.51.100.1", 8333)};
+    const CService addr6{LookupNumeric("2001:db8::1", 8333)};
+    const CService loopback{LookupNumeric("127.0.0.1", 8333)};
+
+    // First non-local address per family is used; second is ignored.
+    options.vOutboundBinds = {addr1, addr2};
+    connman->Init(options);
+    BOOST_REQUIRE(connman->GetOutboundBindV4());
+    BOOST_CHECK_EQUAL(connman->GetOutboundBindV4()->ToStringAddr(), "203.0.113.1");
+    BOOST_CHECK(!connman->GetOutboundBindV6());
+
+    // Loopback addresses are skipped.
+    connman = std::make_unique<ConnmanTestMsg>(seed, seed, *m_node.addrman, *m_node.netgroupman, Params());
+    options.vOutboundBinds = {loopback, addr1};
+    connman->Init(options);
+    BOOST_REQUIRE(connman->GetOutboundBindV4());
+    BOOST_CHECK_EQUAL(connman->GetOutboundBindV4()->ToStringAddr(), "203.0.113.1");
+
+    // IPv4 and IPv6 are stored independently.
+    connman = std::make_unique<ConnmanTestMsg>(seed, seed, *m_node.addrman, *m_node.netgroupman, Params());
+    options.vOutboundBinds = {addr1, addr6};
+    connman->Init(options);
+    BOOST_REQUIRE(connman->GetOutboundBindV4());
+    BOOST_REQUIRE(connman->GetOutboundBindV6());
+    BOOST_CHECK_EQUAL(connman->GetOutboundBindV4()->ToStringAddr(), "203.0.113.1");
+    BOOST_CHECK_EQUAL(connman->GetOutboundBindV6()->ToStringAddr(), "2001:db8::1");
+
+    // CJDNS addresses must not match either IsIPv4() or IsIPv6(), so the
+    // outbound bind selection in ConnectNode (which only binds for clearnet
+    // families) correctly skips them.
+    g_reachable_nets.Add(NET_CJDNS);
+    const CService cjdns_service{LookupNumeric("fc00:1:2:3:4:5:6:7", 8333)};
+    const CAddress cjdns_target{MaybeFlipIPv6toCJDNS(cjdns_service), NODE_NONE};
+    BOOST_CHECK(cjdns_target.IsCJDNS());
+    BOOST_CHECK(!cjdns_target.IsIPv4());
+    BOOST_CHECK(!cjdns_target.IsIPv6());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -24,6 +24,7 @@
 #include <test/util/validation.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <util/translation.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -1696,6 +1697,207 @@ BOOST_AUTO_TEST_CASE(addlocal_onlynet_externalip)
         g_reachable_nets.Add(net);
     }
     fDiscover = discover_orig;
+}
+
+BOOST_AUTO_TEST_CASE(outbound_bind_address_selection)
+{
+    const uint64_t seed{0};
+    auto connman = std::make_unique<ConnmanTestMsg>(seed, seed, *m_node.addrman, *m_node.netgroupman, Params());
+
+    CConnman::Options options;
+    options.m_msgproc = m_node.peerman.get();
+
+    const CNetAddr addr4{LookupHost("203.0.113.1", /*fAllowLookup=*/false).value()};
+    const CNetAddr addr6{LookupHost("2001:db8::1", /*fAllowLookup=*/false).value()};
+
+    // An address is stored per family; an unset family stays unset.
+    options.outbound_bind_v4 = addr4;
+    connman->Init(options);
+    BOOST_REQUIRE(connman->GetOutboundBindV4());
+    BOOST_CHECK_EQUAL(connman->GetOutboundBindV4()->ToStringAddr(), addr4.ToStringAddr());
+    BOOST_CHECK(!connman->GetOutboundBindV6());
+    // With the v6 family unset, an IPv6 target selects nothing.
+    BOOST_CHECK(!connman->SelectOutboundBindPublic(CService{LookupHost("2001:db8::3", /*fAllowLookup=*/false).value(), /*port=*/8333}));
+
+    // Setting the other family leaves the first family's stored address intact.
+    connman = std::make_unique<ConnmanTestMsg>(seed, seed, *m_node.addrman, *m_node.netgroupman, Params());
+    options.outbound_bind_v6 = addr6;
+    connman->Init(options);
+    BOOST_REQUIRE(connman->GetOutboundBindV4());
+    BOOST_REQUIRE(connman->GetOutboundBindV6());
+    BOOST_CHECK_EQUAL(connman->GetOutboundBindV6()->ToStringAddr(), addr6.ToStringAddr());
+
+    // SelectOutboundBind() picks the configured source by the target's family,
+    // and binds nothing for a non-clearnet (Tor/I2P/CJDNS) target.
+    const auto sel4{connman->SelectOutboundBindPublic(CService{LookupHost("198.51.100.1", /*fAllowLookup=*/false).value(), /*port=*/8333})};
+    BOOST_REQUIRE(sel4);
+    BOOST_CHECK_EQUAL(sel4->ToStringAddr(), addr4.ToStringAddr());
+    const auto sel6{connman->SelectOutboundBindPublic(CService{LookupHost("2001:db8::2", /*fAllowLookup=*/false).value(), /*port=*/8333})};
+    BOOST_REQUIRE(sel6);
+    BOOST_CHECK_EQUAL(sel6->ToStringAddr(), addr6.ToStringAddr());
+    const CService onion{LookupHost("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion", /*fAllowLookup=*/false).value(), /*port=*/8333};
+    BOOST_CHECK(!connman->SelectOutboundBindPublic(onion));
+    CNetAddr i2p;
+    BOOST_REQUIRE(i2p.SetSpecial("udhdrtrcetjm5sxzskjyr5ztpeszydbh4dpl3pl4utgqqw2v4jna.b32.i2p"));
+    BOOST_CHECK(!connman->SelectOutboundBindPublic(CService{i2p, /*port=*/8333}));
+    // CJDNS resembles IPv6 (fc00::/8) but IsIPv6() is false for it, so it too
+    // selects nothing; guards against a byte-based family check that would bind
+    // a clearnet source to a socket routed through the CJDNS tunnel.
+    g_reachable_nets.Add(NET_CJDNS);
+    const CService cjdns{MaybeFlipIPv6toCJDNS(CService{LookupHost("fc00:3344:5566:7788:9900:aabb:ccdd:eeff", /*fAllowLookup=*/false).value(), /*port=*/8333})};
+    BOOST_REQUIRE(cjdns.IsCJDNS());
+    BOOST_CHECK(!connman->SelectOutboundBindPublic(cjdns));
+}
+
+BOOST_AUTO_TEST_CASE(outbound_bind_connect)
+{
+    // ConnectDirectly() must bind() the socket to the given source address
+    // before connecting, and must not bind() when no address is given.
+    class BindRecordingSock : public ZeroSock
+    {
+    public:
+        explicit BindRecordingSock(std::optional<CService>& bind_dest) : m_bind_dest{bind_dest} {}
+        int Bind(const sockaddr* addr, socklen_t len) const override
+        {
+            // SetSockAddr() accepts only the exact per-family sockaddr length,
+            // so a wrong len passed to bind() leaves m_bind_dest unset.
+            CService service;
+            if (service.SetSockAddr(addr, len)) m_bind_dest = service;
+            return 0;
+        }
+        // Override ZeroSock::operator=(Sock&&) to avoid -Woverloaded-virtual; unused.
+        BindRecordingSock& operator=(Sock&&) override
+        {
+            Assert(false);
+            return *this;
+        }
+
+    private:
+        std::optional<CService>& m_bind_dest;
+    };
+
+    // A mock whose Bind() fails, to drive the fail-closed path.
+    class FailBindSock : public ZeroSock
+    {
+    public:
+        explicit FailBindSock(bool& connect_called) : m_connect_called{connect_called} {}
+        int Bind(const sockaddr*, socklen_t) const override { return SOCKET_ERROR; }
+        int Connect(const sockaddr*, socklen_t) const override
+        {
+            m_connect_called = true;
+            return 0;
+        }
+        // Override ZeroSock::operator=(Sock&&) to avoid -Woverloaded-virtual; unused.
+        FailBindSock& operator=(Sock&&) override
+        {
+            Assert(false);
+            return *this;
+        }
+
+    private:
+        bool& m_connect_called;
+    };
+
+    // Restore CreateSock on any exit path, including a throwing BOOST_REQUIRE,
+    // so a failure here does not leak the mock into later tests.
+    struct SockRestore {
+        const decltype(CreateSock) orig{CreateSock};
+        ~SockRestore() { CreateSock = orig; }
+    } sock_restore;
+
+    std::optional<CService> bound;
+    CreateSock = [&bound](int, int, int) { return std::make_unique<BindRecordingSock>(bound); };
+
+    const CService dest{LookupNumeric("198.51.100.34", 8333)};
+    const CNetAddr src{LookupHost("203.0.113.1", /*fAllowLookup=*/false).value()};
+
+    BOOST_REQUIRE(ConnectDirectly(dest, /*manual_connection=*/false, src));
+    BOOST_REQUIRE(bound.has_value());
+    BOOST_CHECK_EQUAL(bound->ToStringAddrPort(), CService(src, /*port=*/0).ToStringAddrPort());
+
+    // The same for IPv6.
+    bound.reset();
+    const CService dest6{LookupNumeric("2001:db8::1", 8333)};
+    const CNetAddr src6{LookupHost("2001:db8::2", /*fAllowLookup=*/false).value()};
+    BOOST_REQUIRE(ConnectDirectly(dest6, /*manual_connection=*/false, src6));
+    BOOST_REQUIRE(bound.has_value());
+    BOOST_CHECK_EQUAL(bound->ToStringAddrPort(), CService(src6, /*port=*/0).ToStringAddrPort());
+
+    // The bind_failed out-param stays false when no bind was requested and on
+    // a successful bind, so the caller only skips addrman accounting when the
+    // local source, not the peer, was the problem.
+    bool bind_failed{false};
+    bound.reset();
+    BOOST_REQUIRE(ConnectDirectly(dest, /*manual_connection=*/false, /*bind_addr=*/std::nullopt, &bind_failed));
+    BOOST_CHECK(!bound.has_value());
+    BOOST_CHECK(!bind_failed);
+
+    bound.reset();
+    BOOST_REQUIRE(ConnectDirectly(dest, /*manual_connection=*/false, src, &bind_failed));
+    BOOST_CHECK(!bind_failed);
+
+    // Fail-closed: a failed source bind aborts the connection and never connects,
+    // so the real source is never used as a fallback. It also reports bind_failed.
+    bool connect_called{false};
+    CreateSock = [&connect_called](int, int, int) { return std::make_unique<FailBindSock>(connect_called); };
+    BOOST_CHECK(!ConnectDirectly(dest, /*manual_connection=*/false, src, &bind_failed));
+    BOOST_CHECK(!connect_called);
+    BOOST_CHECK(bind_failed);
+
+    // A non-clearnet source has no sockaddr: ConnectDirectly() aborts before
+    // connecting (defensive; SelectOutboundBind() never yields such a source).
+    // This local failure also reports bind_failed.
+    CNetAddr onion_src;
+    BOOST_REQUIRE(onion_src.SetSpecial("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion"));
+    CreateSock = [](int, int, int) { return std::make_unique<ZeroSock>(); };
+    bind_failed = false;
+    BOOST_CHECK(!ConnectDirectly(dest, /*manual_connection=*/false, onion_src, &bind_failed));
+    BOOST_CHECK(bind_failed);
+}
+
+BOOST_AUTO_TEST_CASE(is_addr_bindable)
+{
+    // IsAddrBindable() trial-binds a fresh socket and reports the result.
+    const CNetAddr addr{LookupHost("127.0.0.1", /*fAllowLookup=*/false).value()};
+    struct SockRestore {
+        const decltype(CreateSock) orig{CreateSock};
+        ~SockRestore() { CreateSock = orig; }
+    } sock_restore;
+    bilingual_str error;
+
+    // Bind() succeeds -> bindable, error left empty.
+    CreateSock = [](int, int, int) { return std::make_unique<ZeroSock>(); };
+    BOOST_CHECK(IsAddrBindable(addr, error));
+    BOOST_CHECK(error.empty());
+
+    // Bind() fails -> not bindable, error populated.
+    class FailBind : public ZeroSock
+    {
+    public:
+        int Bind(const sockaddr*, socklen_t) const override { return SOCKET_ERROR; }
+        FailBind& operator=(Sock&&) override
+        {
+            Assert(false);
+            return *this;
+        }
+    };
+    CreateSock = [](int, int, int) { return std::make_unique<FailBind>(); };
+    error = bilingual_str{};
+    BOOST_CHECK(!IsAddrBindable(addr, error));
+    BOOST_CHECK(!error.empty());
+
+    // No socket created -> not bindable, error populated.
+    CreateSock = [](int, int, int) { return std::unique_ptr<Sock>{}; };
+    error = bilingual_str{};
+    BOOST_CHECK(!IsAddrBindable(addr, error));
+    BOOST_CHECK(!error.empty());
+
+    // A non-clearnet address has no sockaddr -> not bindable, family error.
+    CNetAddr onion;
+    BOOST_REQUIRE(onion.SetSpecial("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion"));
+    error = bilingual_str{};
+    BOOST_CHECK(!IsAddrBindable(onion, error));
+    BOOST_CHECK(!error.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -89,6 +89,9 @@ struct ConnmanTestMsg : public CConnman {
         return InitBinds(options);
     }
 
+    std::optional<CNetAddr> GetOutboundBindV4() const { return m_outbound_bind_v4; }
+    std::optional<CNetAddr> GetOutboundBindV6() const { return m_outbound_bind_v6; }
+
     void SocketHandlerPublic()
     {
         SocketHandler();

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -89,6 +89,10 @@ struct ConnmanTestMsg : public CConnman {
         return InitBinds(options);
     }
 
+    std::optional<CNetAddr> GetOutboundBindV4() const { return m_outbound_bind_v4; }
+    std::optional<CNetAddr> GetOutboundBindV6() const { return m_outbound_bind_v6; }
+    std::optional<CNetAddr> SelectOutboundBindPublic(const CService& target) const { return SelectOutboundBind(target); }
+
     void SocketHandlerPublic()
     {
         SocketHandler();

--- a/test/functional/feature_bind_outgoing.py
+++ b/test/functional/feature_bind_outgoing.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test that -outboundbind causes outgoing connections to originate from the bound address.
+
+Requires two routable addresses on the machine. To set up:
+Linux:
+  ifconfig lo:0 1.1.1.1/32 up && ifconfig lo:1 2.2.2.2/32 up
+  ifconfig lo:0 down && ifconfig lo:1 down  # to remove
+FreeBSD:
+  ifconfig lo0 1.1.1.1/32 alias && ifconfig lo0 2.2.2.2/32 alias
+  ifconfig lo0 1.1.1.1 -alias && ifconfig lo0 2.2.2.2 -alias  # to remove
+"""
+
+from test_framework.test_framework import BitcoinTestFramework, SkipTest
+from test_framework.test_node import ErrorMatch
+from test_framework.util import assert_equal, p2p_port
+
+ADDR1 = '1.1.1.1'
+ADDR2 = '2.2.2.2'
+BAD_ADDR = '192.0.2.99'  # TEST-NET-1 documentation range; guaranteed not assigned
+
+
+class BindOutgoingTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.bind_to_localhost_only = False
+        self.num_nodes = 2
+
+    def add_options(self, parser):
+        parser.add_argument(
+            "--ihave1111and2222", action='store_true', dest="ihave1111and2222",
+            help=f"Run the test, assuming {ADDR1} and {ADDR2} are configured on the machine",
+            default=False)
+
+    def skip_test_if_missing_module(self):
+        if not self.options.ihave1111and2222:
+            raise SkipTest(
+                f"To run this test make sure that {ADDR1} and {ADDR2} (routable addresses) "
+                "are assigned to interfaces on this machine and rerun with --ihave1111and2222")
+
+    def setup_network(self):
+        self.extra_args = [
+            [f'-bind={ADDR1}:{p2p_port(0)}', f'-outboundbind={ADDR1}'],
+            [f'-bind={ADDR2}:{p2p_port(1)}', f'-outboundbind={ADDR2}'],
+        ]
+        self.setup_nodes()
+
+    def run_test(self):
+        self.log.info(f"Node 0 listening on {ADDR1}, node 1 listening on {ADDR2}, both using -outboundbind for source IP")
+
+        self.log.info("Connecting node 1 -> node 0")
+        target = f"{ADDR1}:{p2p_port(0)}"
+        self.nodes[1].addnode(target, "onetry")
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1)
+
+        self.log.info("Checking that node 0 sees inbound from ADDR2")
+        peers_0 = self.nodes[0].getpeerinfo()
+        assert_equal(len(peers_0), 1)
+        assert_equal(peers_0[0]['inbound'], True)
+        source_ip = peers_0[0]['addr'].split(':')[0]
+        assert_equal(source_ip, ADDR2)
+
+        self.log.info("Checking that node 1 reports addrbind as ADDR2")
+        peers_1 = self.nodes[1].getpeerinfo()
+        assert_equal(len(peers_1), 1)
+        assert_equal(peers_1[0]['inbound'], False)
+        local_ip = peers_1[0]['addrbind'].split(':')[0]
+        assert_equal(local_ip, ADDR2)
+
+        self.log.info(f"Outbound connection correctly originated from {ADDR2}")
+
+        self.test_invalid_outboundbind_rejected()
+
+    def test_invalid_outboundbind_rejected(self):
+        self.log.info(f"Checking that -outboundbind={BAD_ADDR} (not on any interface) is rejected at startup")
+        self.stop_node(0)
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=[f'-bind={ADDR1}:{p2p_port(0)}', f'-outboundbind={BAD_ADDR}'],
+            expected_msg=f'Unable to bind to {BAD_ADDR}',
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+
+if __name__ == '__main__':
+    BindOutgoingTest(__file__).main()

--- a/test/functional/feature_bind_outgoing.py
+++ b/test/functional/feature_bind_outgoing.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test that -outboundbind sets the source address of outgoing connections.
+"""
+import re
+
+from test_framework.test_framework import BitcoinTestFramework, SkipTest
+from test_framework.test_node import (
+    ErrorMatch,
+    FailedToStartError,
+)
+from test_framework.util import append_config, assert_equal, p2p_port
+
+# We need to bind to routable addresses for this test to exercise the relevant
+# code. Both addresses are set in the CI environment, see
+# ci/test/02_run_container.py.
+#
+# To set these routable addresses on the machine, use:
+# Linux:
+# ip addr add 1.1.1.5/32 dev INTERFACE_NAME && ip addr add 1111:1111::5/128 dev INTERFACE_NAME  # to set up
+# ip addr del 1.1.1.5/32 dev INTERFACE_NAME && ip addr del 1111:1111::5/128 dev INTERFACE_NAME  # to remove it
+# FreeBSD or macOS:
+# ifconfig INTERFACE_NAME 1.1.1.5/32 alias && ifconfig INTERFACE_NAME inet6 1111:1111::5/128 alias  # to set up
+# ifconfig INTERFACE_NAME 1.1.1.5 -alias && ifconfig INTERFACE_NAME inet6 1111:1111::5 -alias  # to remove it, after the test
+ADDR4 = '1.1.1.5' # This and the address below are set in the CI environment, don't change it just here (keep them in sync).
+ADDR6 = '1111:1111::5'
+# TEST-NET-1 documentation range, not assigned to an interface, so binding to it fails.
+UNASSIGNED_ADDR = '192.0.2.99'
+# RFC3849 documentation range; parses but is not assignable in practice.
+DOC_ADDR6 = '2001:db8::1'
+
+
+class BindOutgoingTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.bind_to_localhost_only = False
+        self.num_nodes = 2
+        self.port4 = p2p_port(0)
+        # Not p2p_port(1): that is node 1's own framework-assigned listen port.
+        self.port6 = p2p_port(2)
+
+    def setup_network(self):
+        # Node 0 listens on loopback in both families; node 1 binds a routable
+        # source in each family. Because the bound source differs from the
+        # loopback destination, observing it at node 0 proves the bind took
+        # effect (the OS would otherwise select the loopback source).
+        self.extra_args = [
+            [f'-bind=127.0.0.1:{self.port4}', f'-bind=[::1]:{self.port6}'],
+            [f'-outboundbind={ADDR4}', f'-outboundbind={ADDR6}'],
+        ]
+        try:
+            self.setup_nodes()
+        except FailedToStartError as e:
+            self.cleanup_partially_started_nodes()
+            # Match only the -outboundbind trial-bind failure (bare address, no
+            # port); a listen bind failure reports "addr:port" and must not skip.
+            if (f'Unable to bind to {ADDR4} ' in str(e)
+                    or f'Unable to bind to {ADDR6} ' in str(e)):
+                raise SkipTest(
+                    f'To run this test make sure that {ADDR4} and {ADDR6} '
+                    '(routable addresses) are assigned to non-loopback '
+                    'interfaces on this machine')
+            raise
+
+    def check_source(self, target, expected_src):
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0)
+        self.nodes[1].addnode(target, 'onetry')
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1)
+
+        # The bound source differs from the (loopback) destination, so the source
+        # observed here proves -outboundbind took effect end to end.
+        peer_of_node0 = self.nodes[0].getpeerinfo()[0]
+        assert_equal(peer_of_node0['inbound'], True)
+        assert_equal(peer_of_node0['addr'].rsplit(':', 1)[0].strip('[]'), expected_src)
+
+        peer_of_node1 = self.nodes[1].getpeerinfo()[0]
+        assert_equal(peer_of_node1['inbound'], False)
+        assert_equal(peer_of_node1['addrbind'].rsplit(':', 1)[0].strip('[]'), expected_src)
+        self.nodes[1].disconnectnode(address=target)
+
+    def run_test(self):
+        self.log.info(f'Check that an IPv4 outgoing connection originates from {ADDR4}')
+        self.check_source(f'127.0.0.1:{self.port4}', ADDR4)
+
+        self.log.info(f'Check that an IPv6 outgoing connection originates from {ADDR6}')
+        self.check_source(f'[::1]:{self.port6}', ADDR6)
+
+        self.log.info(f'Check that -outboundbind={UNASSIGNED_ADDR} is rejected at startup')
+        self.stop_node(1)
+        self.nodes[1].assert_start_raises_init_error(
+            extra_args=[f'-outboundbind={UNASSIGNED_ADDR}'],
+            expected_msg=f'Error: Unable to bind to {UNASSIGNED_ADDR}',
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+        self.log.info('Check that an -outboundbind address with a port is rejected at startup')
+        self.nodes[1].assert_start_raises_init_error(
+            extra_args=[f'-outboundbind={ADDR4}:1234'],
+            expected_msg='Error: Cannot resolve -outboundbind address',
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+        self.log.info('Check that the unspecified (wildcard) address is rejected at startup')
+        for wildcard in ('0.0.0.0', '::'):
+            self.nodes[1].assert_start_raises_init_error(
+                extra_args=[f'-outboundbind={wildcard}'],
+                expected_msg=f"Error: -outboundbind address '{wildcard}' is not a usable source address",
+                match=ErrorMatch.PARTIAL_REGEX,
+            )
+
+        self.log.info(f'Check that -outboundbind={DOC_ADDR6} alone fails the trial bind at startup')
+        self.nodes[1].assert_start_raises_init_error(
+            extra_args=[f'-outboundbind={DOC_ADDR6}'],
+            expected_msg=f'Error: Unable to bind to {DOC_ADDR6}',
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+        self.log.info('Check that a non-clearnet (Tor) address is rejected at startup')
+        self.nodes[1].assert_start_raises_init_error(
+            extra_args=['-outboundbind=pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion'],
+            expected_msg='is not an IPv4 or IPv6 address',
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+        self.log.info('Check that an fc00::/8 address is rejected at startup when it '
+                      'is a CJDNS address (-cjdnsreachable)')
+        self.nodes[1].assert_start_raises_init_error(
+            extra_args=['-cjdnsreachable', '-outboundbind=fc00:db8::1'],
+            expected_msg='is a CJDNS address',
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+        self.log.info('Check that fc00::/8 stays a plain IPv6 source without -cjdnsreachable')
+        # Accepted by the parser (proven by reaching the later trial bind, which
+        # fails because the address is not assigned to this machine).
+        self.nodes[1].assert_start_raises_init_error(
+            extra_args=['-outboundbind=fc00:db8::1'],
+            expected_msg='Unable to bind to fc00:db8::1',
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+        self.log.info('Check that the proxy warning is family-specific: an IPv6 bind '
+                      'with an IPv6-only proxy warns at startup')
+        self.start_node(1, extra_args=[f'-outboundbind={ADDR6}', '-proxy=127.0.0.1:9=ipv6'])
+        self.stop_node(1, expected_stderr=re.compile(
+            r"Option '-outboundbind' is set but a proxy is configured"))
+
+        self.log.info('Check that no warning is issued when the proxy serves only '
+                      'the other family (IPv4 bind, IPv6-only proxy)')
+        self.start_node(1, extra_args=[f'-outboundbind={ADDR4}', '-proxy=127.0.0.1:9=ipv6'])
+        self.stop_node(1)  # the default asserts empty stderr: no warning
+
+        self.log.info('Check that an onion-only proxy does not trigger the warning')
+        self.start_node(1, extra_args=[f'-outboundbind={ADDR4}', '-onion=127.0.0.1:9'])
+        self.stop_node(1)
+
+        self.log.info('Check that a command-line -outboundbind overrides a config-file '
+                      'one of the same family, even when the config-file address cannot '
+                      'be bound to (only the effective address is validated)')
+        append_config(self.nodes[1].datadir_path, [f'outboundbind={UNASSIGNED_ADDR}'])
+        self.restart_node(1, [f'-outboundbind={ADDR4}'])
+        self.check_source(f'127.0.0.1:{self.port4}', ADDR4)
+
+        self.log.info('Check that a configured proxy makes -outboundbind inert, '
+                      'with a startup warning')
+        self.stop_node(1)
+        self.start_node(1, extra_args=[f'-outboundbind={ADDR4}', '-proxy=127.0.0.1:9'])
+        self.stop_node(1, expected_stderr=re.compile(
+            r"Option '-outboundbind' is set but a proxy is configured"))
+
+        # Last: this leaves a second, IPv6-family value in the config file,
+        # which later starts would have to override.
+        self.log.info('Check that a command-line -outboundbind also overrides a config-file '
+                      'v6 documentation address')
+        append_config(self.nodes[1].datadir_path, [f'outboundbind={DOC_ADDR6}'])
+        self.restart_node(1, [f'-outboundbind={ADDR4}', f'-outboundbind={ADDR6}'])
+        self.check_source(f'[::1]:{self.port6}', ADDR6)
+
+
+if __name__ == '__main__':
+    BindOutgoingTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -316,6 +316,7 @@ BASE_SCRIPTS = [
     'rpc_getblockstats.py',
     'feature_port.py',
     'feature_bind_port_externalip.py',
+    'feature_bind_outgoing.py',
     'wallet_create_tx.py',
     'wallet_send.py',
     'wallet_sendall.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -324,6 +324,7 @@ BASE_SCRIPTS = [
     'rpc_getblockstats.py',
     'feature_port.py',
     'feature_bind_port_externalip.py',
+    'feature_bind_outgoing.py',
     'wallet_create_tx.py',
     'wallet_send.py',
     'wallet_sendall.py',


### PR DESCRIPTION
Closes #6476

Adds `-outboundbind=<addr>` to set the source address of outgoing clearnet
connections, one per address family. It is separate from `-bind`; without it,
outbound follows the OS routing table as before.

- The command line wins over the config file, as for other options.
- Clearnet only: Tor and I2P use their own transport, CJDNS is direct but not
  IPv4/IPv6, and a proxy leaves the option inert for that family (with a
  startup warning).
- The effective address per family is trial-bound at startup, like `-bind` via
  `BindListenPort`; a port, the wildcard, or a non-clearnet value is rejected. A
  failed bind at connect time aborts the connection, with no fallback.

Functional and unit tests cover both families, the startup rejections, and the
bind-before-connect path.

Based on vasild's approach in
https://github.com/bitcoin/bitcoin/issues/6476#issuecomment-1666472338.
