### PR TITLE
ci: Match `VCPKG_HOST_TRIPLET` to `VCPKG_TARGET_TRIPLET`

### DIFF
--- a/.github/ci-windows.py
+++ b/.github/ci-windows.py
@@ -72,6 +72,11 @@ def generate(ci_type):
         "build",
         "-Werror=dev",
         "--preset=vs2026",
+        # Using x64-windows-release for both host and target triplets
+        # to ensure vcpkg builds only release packages, thereby optimizing
+        # build time.
+        # See https://github.com/microsoft/vcpkg/issues/50927.
+        "-DVCPKG_HOST_TRIPLET=x64-windows-release",
         "-DVCPKG_TARGET_TRIPLET=x64-windows-release",
     ] + GENERATE_OPTIONS[ci_type]
     if run(command, check=False).returncode != 0:


### PR DESCRIPTION
Using a non-default target triplet in https://github.com/bitcoin/bitcoin/pull/34883 introduced a [regression](https://github.com/bitcoin/bitcoin/pull/34883#issuecomment-4204744932) because packages with `"host": true` in their vcpkg configurations were still picking up the default `x64-windows` triplet, effectively building both release and debug packages.

This PR fixes this regression by setting `VCPKG_HOST_TRIPLET` explicitly.

Upstream issue: https://github.com/microsoft/vcpkg/issues/50927.