### PR TITLE
ipc: support per-address max-connections options on -ipcbind

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -35,6 +35,7 @@
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <ipc/exception.h>
+#include <ipc/process.h>
 #include <kernel/caches.h>
 #include <kernel/context.h>
 #include <key.h>
@@ -102,6 +103,7 @@
 #include <cstdio>
 #include <fstream>
 #include <functional>
+#include <optional>
 #include <set>
 #include <string>
 #include <thread>
@@ -179,6 +181,22 @@ static bool g_generated_pid{false};
 static fs::path GetPidFile(const ArgsManager& args)
 {
     return AbsPathForConfigVal(args, args.GetPathArg("-pid", BITCOIN_PID_FILENAME));
+}
+
+struct IpcBindOption
+{
+    std::string listen_address;
+    size_t max_connections;
+};
+
+static std::optional<IpcBindOption> ParseIpcBindOption(const std::string& configured_address, std::string& error)
+{
+    auto bind{ipc::ParseBindAddress(configured_address, error)};
+    if (!bind) return std::nullopt;
+    return IpcBindOption{
+        .listen_address = std::move(bind->address),
+        .max_connections = bind->max_connections.value_or(DEFAULT_IPC_MAX_CONNECTIONS),
+    };
 }
 
 [[nodiscard]] static bool CreatePidFile(const ArgsManager& args)
@@ -720,8 +738,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-rpcworkqueue=<n>", strprintf("Set the maximum depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     if (can_listen_ipc) {
-        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
-        argsman.AddArg("-ipcmaxconnections=<n>", "Reserve file descriptors for up to <n> concurrent IPC socket connections (default: " + ToString(DEFAULT_IPC_MAX_CONNECTIONS) + ")", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
+        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Append \":max-connections=<n>\" to set a per-address IPC connection limit, for example \"unix::max-connections=8\" or \"unix:/custom/path:max-connections=8\". If no max-connections option is specified, " + ToString(DEFAULT_IPC_MAX_CONNECTIONS) + " accepted connections will be reserved per listener. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
     }
 
 #if HAVE_DECL_FORK
@@ -1521,11 +1538,17 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     uiInterface.InitWallet();
 
     if (interfaces::Ipc* ipc = node.init->ipc()) {
-        for (std::string address : gArgs.GetArgs("-ipcbind")) {
+        for (const std::string& configured_address : gArgs.GetArgs("-ipcbind")) {
+            std::string error;
+            auto bind{ParseIpcBindOption(configured_address, error)};
+            if (!bind) {
+                return InitError(Untranslated(strprintf("Invalid -ipcbind address '%s': %s", configured_address, error)));
+            }
+            std::string address{std::move(bind->listen_address)};
             try {
-                ipc->listenAddress(address);
+                ipc->listenAddress(address, bind->max_connections);
             } catch (const std::exception& e) {
-                return InitError(Untranslated(strprintf("Unable to bind to IPC address '%s'. %s", address, e.what())));
+                return InitError(Untranslated(strprintf("Unable to bind to IPC address '%s'. %s", configured_address, e.what())));
             }
             LogInfo("Listening for IPC requests on address %s", address);
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -164,6 +164,7 @@ static constexpr bool DEFAULT_STOPAFTERBLOCKIMPORT{false};
 #endif
 
 static constexpr int MIN_CORE_FDS = MIN_LEVELDB_FDS + NUM_FDS_MESSAGE_CAPTURE;
+static constexpr int DEFAULT_IPC_MAX_CONNECTIONS{16};
 
 /**
  * The PID file facilities.
@@ -720,6 +721,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     if (can_listen_ipc) {
         argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
+        argsman.AddArg("-ipcmaxconnections=<n>", "Reserve file descriptors for up to <n> concurrent IPC socket connections (default: " + ToString(DEFAULT_IPC_MAX_CONNECTIONS) + ")", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
     }
 
 #if HAVE_DECL_FORK
@@ -1029,16 +1031,35 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     // Number of bound interfaces (we have at least one)
     int nBind = std::max(nUserBind, size_t(1));
+
     // Maximum number of connections with other nodes, this accounts for all types of outbounds and inbounds except for manual
     int user_max_connection = args.GetIntArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
     if (user_max_connection < 0) {
         return InitError(Untranslated("-maxconnections must be greater or equal than zero"));
     }
+
+    // IPC listening socket FDs — one per -ipcbind address, no default listener
+    auto ipc_bind = args.GetArgs("-ipcbind").size();
+
+    // We only need to reserve these FDs if the user is actually binding an IPC socket
+    auto ipc_max_connections = args.GetIntArg("-ipcmaxconnections", 0);
+
+    if (ipc_max_connections < 0) {
+        return InitError(Untranslated("-ipcmaxconnections must be greater than or equal to zero"));
+    } else if (ipc_bind > 0) {
+        if (!args.IsArgSet("-ipcmaxconnections")) ipc_max_connections = DEFAULT_IPC_MAX_CONNECTIONS;
+        LogInfo("Reserving %d file descriptors for IPC (%d listening sockets, %d accepted connections)",
+                ipc_bind + ipc_max_connections, ipc_bind, ipc_max_connections);
+    } else if (ipc_max_connections > 0) {
+        LogWarning("-ipcmaxconnections is %d but -ipcbind is not enabled; option will have no effect.\n", ipc_max_connections);
+        ipc_max_connections = 0;
+    }
+
     const size_t max_private{args.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)
                              ? MAX_PRIVATE_BROADCAST_CONNECTIONS
                              : 0};
-    // Reserve enough FDs to account for the bare minimum, plus any manual connections, plus the bound interfaces
-    int min_required_fds = MIN_CORE_FDS + MAX_ADDNODE_CONNECTIONS + nBind;
+    // Reserve enough FDs to account for the bare minimum, plus any manual connections, plus the bound interfaces, plus IPC connections
+    int min_required_fds = MIN_CORE_FDS + MAX_ADDNODE_CONNECTIONS + nBind + ipc_bind + ipc_max_connections;
 
     // Try raising the FD limit to what we need (available_fds may be smaller than the requested amount if this fails)
     available_fds = RaiseFileDescriptorLimit(user_max_connection + max_private + min_required_fds);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1056,27 +1056,30 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     }
 
     // IPC listening socket FDs — one per -ipcbind address, no default listener
-    auto ipc_bind = args.GetArgs("-ipcbind").size();
+    size_t ipc_bind{0};
+    size_t ipc_max_connections{0};
+    for (const std::string& configured_address : args.GetArgs("-ipcbind")) {
+        std::string error;
+        auto bind{ParseIpcBindOption(configured_address, error)};
+        if (!bind) {
+            return InitError(Untranslated(strprintf("Invalid -ipcbind address '%s': %s", configured_address, error)));
+        }
+        ++ipc_bind;
+        ipc_max_connections += bind->max_connections;
+    }
 
-    // We only need to reserve these FDs if the user is actually binding an IPC socket
-    auto ipc_max_connections = args.GetIntArg("-ipcmaxconnections", 0);
-
-    if (ipc_max_connections < 0) {
-        return InitError(Untranslated("-ipcmaxconnections must be greater than or equal to zero"));
-    } else if (ipc_bind > 0) {
-        if (!args.IsArgSet("-ipcmaxconnections")) ipc_max_connections = DEFAULT_IPC_MAX_CONNECTIONS;
+    if (ipc_bind > 0) {
         LogInfo("Reserving %d file descriptors for IPC (%d listening sockets, %d accepted connections)",
-                ipc_bind + ipc_max_connections, ipc_bind, ipc_max_connections);
-    } else if (ipc_max_connections > 0) {
-        LogWarning("-ipcmaxconnections is %d but -ipcbind is not enabled; option will have no effect.\n", ipc_max_connections);
-        ipc_max_connections = 0;
+                static_cast<int>(ipc_bind + ipc_max_connections),
+                static_cast<int>(ipc_bind),
+                static_cast<int>(ipc_max_connections));
     }
 
     const size_t max_private{args.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)
                              ? MAX_PRIVATE_BROADCAST_CONNECTIONS
                              : 0};
     // Reserve enough FDs to account for the bare minimum, plus any manual connections, plus the bound interfaces, plus IPC connections
-    int min_required_fds = MIN_CORE_FDS + MAX_ADDNODE_CONNECTIONS + nBind + ipc_bind + ipc_max_connections;
+    int min_required_fds = MIN_CORE_FDS + MAX_ADDNODE_CONNECTIONS + nBind + static_cast<int>(ipc_bind + ipc_max_connections);
 
     // Try raising the FD limit to what we need (available_fds may be smaller than the requested amount if this fails)
     available_fds = RaiseFileDescriptorLimit(user_max_connection + max_private + min_required_fds);

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -6,7 +6,9 @@
 #define BITCOIN_INTERFACES_IPC_H
 
 #include <functional>
+#include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <typeindex>
 
@@ -69,7 +71,7 @@ public:
 
     //! Listen on a socket address exposing this process's init interface to
     //! clients. Throws an exception if there was an error.
-    virtual void listenAddress(std::string& address) = 0;
+    virtual void listenAddress(std::string& address, std::optional<size_t> max_connections = std::nullopt) = 0;
 
     //! Disconnect any incoming connections that are still connected.
     virtual void disconnectIncoming() = 0;

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -82,13 +82,13 @@ public:
         startLoop(exe_name);
         return mp::ConnectStream<messages::Init>(*m_loop, fd);
     }
-    void listen(int listen_fd, const char* exe_name, interfaces::Init& init) override
+    void listen(int listen_fd, const char* exe_name, interfaces::Init& init, std::optional<size_t> max_connections) override
     {
         startLoop(exe_name);
         if (::listen(listen_fd, /*backlog=*/5) != 0) {
             throw std::system_error(errno, std::system_category());
         }
-        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init);
+        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init, max_connections);
     }
     void serve(int fd, const char* exe_name, interfaces::Init& init, const std::function<void()>& ready_fn = {}) override
     {

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -108,10 +108,10 @@ public:
         }
         return m_protocol->connect(fd, m_exe_name);
     }
-    void listenAddress(std::string& address) override
+    void listenAddress(std::string& address, std::optional<size_t> max_connections) override
     {
         int fd = m_process->bind(gArgs.GetDataDirNet(), m_exe_name, address);
-        m_protocol->listen(fd, m_exe_name, m_init);
+        m_protocol->listen(fd, m_exe_name, m_init, max_connections);
     }
     void disconnectIncoming() override
     {

--- a/src/ipc/libmultiprocess/include/mp/proxy-io.h
+++ b/src/ipc/libmultiprocess/include/mp/proxy-io.h
@@ -820,8 +820,8 @@ std::unique_ptr<ProxyClient<InitInterface>> ConnectStream(EventLoop& loop, int f
 //! handles requests from the stream by calling the init object. Embed the
 //! ProxyServer in a Connection object that is stored and erased if
 //! disconnected. This should be called from the event loop thread.
-template <typename InitInterface, typename InitImpl>
-void _Serve(EventLoop& loop, kj::Own<kj::AsyncIoStream>&& stream, InitImpl& init)
+template <typename InitInterface, typename InitImpl, typename OnDisconnect>
+void _Serve(EventLoop& loop, kj::Own<kj::AsyncIoStream>&& stream, InitImpl& init, OnDisconnect&& on_disconnect)
 {
     loop.m_incoming_connections.emplace_front(loop, kj::mv(stream), [&](Connection& connection) {
         // Disable deleter so proxy server object doesn't attempt to delete the
@@ -831,23 +831,49 @@ void _Serve(EventLoop& loop, kj::Own<kj::AsyncIoStream>&& stream, InitImpl& init
     });
     auto it = loop.m_incoming_connections.begin();
     MP_LOG(loop, Log::Info) << "IPC server: socket connected.";
-    it->onDisconnect([&loop, it] {
+    it->onDisconnect([&loop, it, on_disconnect = std::forward<OnDisconnect>(on_disconnect)]() mutable {
         MP_LOG(loop, Log::Info) << "IPC server: socket disconnected.";
         loop.m_incoming_connections.erase(it);
+        on_disconnect();
     });
 }
 
 //! Given connection receiver and an init object, handle incoming connections by
 //! calling _Serve, to create ProxyServer objects and forward requests to the
 //! init object.
-template <typename InitInterface, typename InitImpl>
-void _Listen(EventLoop& loop, kj::Own<kj::ConnectionReceiver>&& listener, InitImpl& init)
+struct ListenState
 {
-    auto* ptr = listener.get();
+    explicit ListenState(kj::Own<kj::ConnectionReceiver>&& listener_, std::optional<size_t> max_connections_)
+        : listener(kj::mv(listener_)), max_connections(max_connections_) {}
+
+    kj::Own<kj::ConnectionReceiver> listener;
+    std::optional<size_t> max_connections;
+    size_t active_connections{0};
+    //! Tracks whether accept() has already been posted. This is needed because
+    //! active_connections only counts accepted connections, so without a
+    //! separate flag, nested _Listen() calls could queue multiple pending
+    //! accepts before active_connections increases.
+    bool accept_pending{false};
+};
+
+template <typename InitInterface, typename InitImpl>
+void _Listen(EventLoop& loop, InitImpl& init, const std::shared_ptr<ListenState>& state)
+{
+    if (state->accept_pending) return;
+    if (state->max_connections && state->active_connections >= *state->max_connections) return;
+
+    state->accept_pending = true;
+    auto* ptr = state->listener.get();
     loop.m_task_set->add(ptr->accept().then(
-        [&loop, &init, listener = kj::mv(listener)](kj::Own<kj::AsyncIoStream>&& stream) mutable {
-            _Serve<InitInterface>(loop, kj::mv(stream), init);
-            _Listen<InitInterface>(loop, kj::mv(listener), init);
+        [&loop, &init, state](kj::Own<kj::AsyncIoStream>&& stream) mutable {
+            state->accept_pending = false;
+            ++state->active_connections;
+            _Serve<InitInterface>(loop, kj::mv(stream), init, [&loop, &init, state] {
+                assert(state->active_connections > 0);
+                --state->active_connections;
+                _Listen<InitInterface>(loop, init, state);
+            });
+            _Listen<InitInterface>(loop, init, state);
         }));
 }
 
@@ -857,18 +883,21 @@ template <typename InitInterface, typename InitImpl>
 void ServeStream(EventLoop& loop, int fd, InitImpl& init)
 {
     _Serve<InitInterface>(
-        loop, loop.m_io_context.lowLevelProvider->wrapSocketFd(fd, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP), init);
+        loop,
+        loop.m_io_context.lowLevelProvider->wrapSocketFd(fd, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP),
+        init,
+        [] {});
 }
 
 //! Given listening socket file descriptor and an init object, handle incoming
 //! connections and requests by calling methods on the Init object.
 template <typename InitInterface, typename InitImpl>
-void ListenConnections(EventLoop& loop, int fd, InitImpl& init)
+void ListenConnections(EventLoop& loop, int fd, InitImpl& init, std::optional<size_t> max_connections = std::nullopt)
 {
     loop.sync([&]() {
-        _Listen<InitInterface>(loop,
+        _Listen<InitInterface>(loop, init, std::make_shared<ListenState>(
             loop.m_io_context.lowLevelProvider->wrapListenSocketFd(fd, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP),
-            init);
+            max_connections));
     });
 }
 

--- a/src/ipc/process.h
+++ b/src/ipc/process.h
@@ -7,11 +7,58 @@
 
 #include <util/fs.h>
 
+#include <charconv>
+#include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <system_error>
 
 namespace ipc {
 class Protocol;
+
+struct BindAddress
+{
+    std::string address;
+    std::optional<size_t> max_connections;
+};
+
+inline std::optional<BindAddress> ParseBindAddress(std::string address, std::string& error)
+{
+    constexpr std::string_view MAX_CONNECTIONS_ARG{":max-connections="};
+    constexpr std::string_view MAX_CONNECTIONS_VALUE{"max-connections="};
+
+    if (!address.starts_with("unix:")) {
+        return BindAddress{std::move(address), std::nullopt};
+    }
+
+    if (std::string_view{address}.substr(5).starts_with(MAX_CONNECTIONS_VALUE)) {
+        error = "Missing unix socket path before max-connections option; use unix::max-connections=<n> for the default path";
+        return std::nullopt;
+    }
+
+    const auto option_pos = address.rfind(MAX_CONNECTIONS_ARG);
+    if (option_pos == std::string::npos || option_pos < 5) {
+        return BindAddress{std::move(address), std::nullopt};
+    }
+
+    const std::string value{address.substr(option_pos + MAX_CONNECTIONS_ARG.size())};
+    if (value.empty()) {
+        error = "Missing value for max-connections option";
+        return std::nullopt;
+    }
+
+    int64_t parsed_limit{-1};
+    const auto [last, ec] = std::from_chars(value.data(), value.data() + value.size(), parsed_limit);
+    if (ec != std::errc{} || last != value.data() + value.size() || parsed_limit < 0) {
+        error = "Invalid max-connections value '" + value + "'";
+        return std::nullopt;
+    }
+
+    address.erase(option_pos);
+    return BindAddress{std::move(address), static_cast<size_t>(parsed_limit)};
+}
 
 //! IPC process interface for spawning bitcoin processes and serving requests
 //! in processes that have been spawned.

--- a/src/ipc/protocol.h
+++ b/src/ipc/protocol.h
@@ -7,8 +7,10 @@
 
 #include <interfaces/init.h>
 
+#include <cstddef>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <typeindex>
 
 namespace ipc {
@@ -37,7 +39,7 @@ public:
     //! Listen for connections on provided socket descriptor, accept them, and
     //! handle requests on accepted connections. This method doesn't block, and
     //! performs I/O on a background thread.
-    virtual void listen(int listen_fd, const char* exe_name, interfaces::Init& init) = 0;
+    virtual void listen(int listen_fd, const char* exe_name, interfaces::Init& init, std::optional<size_t> max_connections = std::nullopt) = 0;
 
     //! Handle requests on provided socket descriptor, forwarding them to the
     //! provided Init interface. Socket communication is handled on the

--- a/src/ipc/test/ipc_test.cpp
+++ b/src/ipc/test/ipc_test.cpp
@@ -183,3 +183,41 @@ void IpcSocketTest(const fs::path& datadir)
         connect_and_test(addresses[i]);
     }
 }
+
+//! Test ipc::Protocol listen() local connection limiting over a unix socket.
+void IpcSocketMaxConnectionsTest(const fs::path& datadir)
+{
+    std::unique_ptr<interfaces::Init> init{std::make_unique<TestInit>()};
+    std::unique_ptr<ipc::Protocol> protocol{ipc::capnp::MakeCapnpProtocol()};
+    std::unique_ptr<ipc::Process> process{ipc::MakeProcess()};
+
+    std::string address{strprintf("unix:%s", TempPath("bitcoin_sock_limit_XXXXXX"))};
+    int serve_fd = process->bind(datadir, "test_bitcoin", address);
+    BOOST_CHECK_GE(serve_fd, 0);
+    protocol->listen(serve_fd, "test-serve", *init, /*max_connections=*/1);
+
+    auto connect_echo{[&](const std::string& connect_address) {
+        std::string addr{connect_address};
+        int connect_fd{process->connect(datadir, "test_bitcoin", addr)};
+        BOOST_CHECK_EQUAL(addr, connect_address);
+        std::unique_ptr<interfaces::Init> remote_init{protocol->connect(connect_fd, "test-connect")};
+        std::unique_ptr<interfaces::Echo> remote_echo{remote_init->makeEcho()};
+        return std::make_pair(std::move(remote_init), std::move(remote_echo));
+    }};
+
+    auto [remote_init1, remote_echo1] = connect_echo(address);
+    BOOST_CHECK_EQUAL(remote_echo1->echo("echo test 1"), "echo test 1");
+
+    auto second_call = std::async(std::launch::async, [&] {
+        auto [remote_init2, remote_echo2] = connect_echo(address);
+        return remote_echo2->echo("echo test 2");
+    });
+
+    BOOST_CHECK(second_call.wait_for(std::chrono::milliseconds{100}) == std::future_status::timeout);
+
+    remote_echo1.reset();
+    remote_init1.reset();
+
+    BOOST_REQUIRE(second_call.wait_for(std::chrono::seconds{5}) == std::future_status::ready);
+    BOOST_CHECK_EQUAL(second_call.get(), "echo test 2");
+}

--- a/src/ipc/test/ipc_test.h
+++ b/src/ipc/test/ipc_test.h
@@ -26,5 +26,6 @@ public:
 void IpcPipeTest();
 void IpcSocketPairTest();
 void IpcSocketTest(const fs::path& datadir);
+void IpcSocketMaxConnectionsTest(const fs::path& datadir);
 
 #endif // BITCOIN_IPC_TEST_IPC_TEST_H

--- a/src/ipc/test/ipc_tests.cpp
+++ b/src/ipc/test/ipc_tests.cpp
@@ -15,6 +15,7 @@ BOOST_AUTO_TEST_CASE(ipc_tests)
     IpcPipeTest();
     IpcSocketPairTest();
     IpcSocketTest(m_args.GetDataDirNet());
+    IpcSocketMaxConnectionsTest(m_args.GetDataDirNet());
 }
 
 // Test address parsing.

--- a/src/ipc/test/ipc_tests.cpp
+++ b/src/ipc/test/ipc_tests.cpp
@@ -38,6 +38,29 @@ BOOST_AUTO_TEST_CASE(parse_address_test)
                   "unix:/var/empty/notexist/0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.sock",
                   "Unix address path \"/var/empty/notexist/0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.sock\" exceeded maximum socket path length");
     check_address("invalid", "invalid", "Unrecognized address 'invalid'");
+
+    auto check_bind{[](const std::string& configured_address, const std::string& expected_address, std::optional<size_t> expected_max_connections, const std::string& expected_error) {
+        std::string error;
+        auto bind{ipc::ParseBindAddress(configured_address, error)};
+        if (!expected_error.empty()) {
+            BOOST_CHECK(!bind);
+            BOOST_CHECK_EQUAL(error, expected_error);
+            return;
+        }
+        BOOST_REQUIRE(bind);
+        BOOST_CHECK_EQUAL(bind->address, expected_address);
+        BOOST_CHECK_EQUAL(bind->max_connections.has_value(), expected_max_connections.has_value());
+        if (bind->max_connections && expected_max_connections) {
+            BOOST_CHECK_EQUAL(*bind->max_connections, *expected_max_connections);
+        }
+    }};
+    check_bind("unix", "unix", std::nullopt, "");
+    check_bind("unix:", "unix:", std::nullopt, "");
+    check_bind("unix::max-connections=8", "unix:", 8, "");
+    check_bind("unix:path.sock:max-connections=8", "unix:path.sock", 8, "");
+    check_bind("unix:max-connections=8", "", std::nullopt, "Missing unix socket path before max-connections option; use unix::max-connections=<n> for the default path");
+    check_bind("unix::max-connections=-1", "", std::nullopt, "Invalid max-connections value '-1'");
+    check_bind("unix::max-connections=", "", std::nullopt, "Missing value for max-connections option");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/interface_ipc_init.py
+++ b/test/functional/interface_ipc_init.py
@@ -19,35 +19,36 @@ class IPCInitTest(BitcoinTestFramework):
     def setup_nodes(self):
         self.extra_init = [{"ipcbind": True}]
         super().setup_nodes()
+        self.nodes[0].args = [arg for arg in self.nodes[0].args if not arg.startswith("-ipcbind=")]
 
-    def test_ipcmaxconnections(self):
-        self.log.info("Test -ipcmaxconnections initialization behavior")
+    def test_ipcbind_max_connections(self):
+        self.log.info("Test -ipcbind max-connections initialization behavior")
         node = self.nodes[0]
 
         with node.assert_debug_log([
             "file descriptors available",
             "Reserving 9 file descriptors for IPC (1 listening sockets, 8 accepted connections)",
         ]):
-            self.restart_node(0, extra_args=["-ipcmaxconnections=8"])
+            self.restart_node(0, extra_args=["-ipcbind=unix::max-connections=8"])
         assert_equal(node.getblockcount(), 0)
 
         with node.assert_debug_log(["Reserving 1 file descriptors for IPC (1 listening sockets, 0 accepted connections)"]):
-            self.restart_node(0, extra_args=["-ipcmaxconnections=0"])
-        assert_equal(node.getblockcount(), 0)
-
-        with node.assert_debug_log(["-ipcmaxconnections is 8 but -ipcbind is not enabled; option will have no effect."]):
-            self.restart_node(0, extra_args=["-noipcbind", "-ipcmaxconnections=8"])
+            self.restart_node(0, extra_args=["-ipcbind=unix::max-connections=0"])
         assert_equal(node.getblockcount(), 0)
 
         self.stop_node(0)
         node.assert_start_raises_init_error(
-            extra_args=["-ipcmaxconnections=-1"],
-            expected_msg="Error: -ipcmaxconnections must be greater than or equal to zero",
+            extra_args=["-ipcbind=unix::max-connections=-1"],
+            expected_msg="Error: Invalid -ipcbind address 'unix::max-connections=-1': Invalid max-connections value '-1'",
+        )
+        node.assert_start_raises_init_error(
+            extra_args=["-ipcbind=unix::max-connections="],
+            expected_msg="Error: Invalid -ipcbind address 'unix::max-connections=': Missing value for max-connections option",
         )
         self.start_node(0)
 
     def run_test(self):
-        self.test_ipcmaxconnections()
+        self.test_ipcbind_max_connections()
 
 
 if __name__ == '__main__':

--- a/test/functional/interface_ipc_init.py
+++ b/test/functional/interface_ipc_init.py
@@ -5,6 +5,7 @@
 """Test IPC initialization behavior."""
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
 
 
 class IPCInitTest(BitcoinTestFramework):
@@ -19,14 +20,34 @@ class IPCInitTest(BitcoinTestFramework):
         self.extra_init = [{"ipcbind": True}]
         super().setup_nodes()
 
-    def test_ipc_startup_logging(self):
-        self.log.info("Test IPC startup logging")
+    def test_ipcmaxconnections(self):
+        self.log.info("Test -ipcmaxconnections initialization behavior")
+        node = self.nodes[0]
 
-        with self.nodes[0].assert_debug_log(["file descriptors available"]):
-            self.restart_node(0)
+        with node.assert_debug_log([
+            "file descriptors available",
+            "Reserving 9 file descriptors for IPC (1 listening sockets, 8 accepted connections)",
+        ]):
+            self.restart_node(0, extra_args=["-ipcmaxconnections=8"])
+        assert_equal(node.getblockcount(), 0)
+
+        with node.assert_debug_log(["Reserving 1 file descriptors for IPC (1 listening sockets, 0 accepted connections)"]):
+            self.restart_node(0, extra_args=["-ipcmaxconnections=0"])
+        assert_equal(node.getblockcount(), 0)
+
+        with node.assert_debug_log(["-ipcmaxconnections is 8 but -ipcbind is not enabled; option will have no effect."]):
+            self.restart_node(0, extra_args=["-noipcbind", "-ipcmaxconnections=8"])
+        assert_equal(node.getblockcount(), 0)
+
+        self.stop_node(0)
+        node.assert_start_raises_init_error(
+            extra_args=["-ipcmaxconnections=-1"],
+            expected_msg="Error: -ipcmaxconnections must be greater than or equal to zero",
+        )
+        self.start_node(0)
 
     def run_test(self):
-        self.test_ipc_startup_logging()
+        self.test_ipcmaxconnections()
 
 
 if __name__ == '__main__':

--- a/test/functional/interface_ipc_init.py
+++ b/test/functional/interface_ipc_init.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test IPC initialization behavior."""
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class IPCInitTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_ipc()
+
+    def setup_nodes(self):
+        self.extra_init = [{"ipcbind": True}]
+        super().setup_nodes()
+
+    def test_ipc_startup_logging(self):
+        self.log.info("Test IPC startup logging")
+
+        with self.nodes[0].assert_debug_log(["file descriptors available"]):
+            self.restart_node(0)
+
+    def run_test(self):
+        self.test_ipc_startup_logging()
+
+
+if __name__ == '__main__':
+    IPCInitTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -356,6 +356,7 @@ BASE_SCRIPTS = [
     'mempool_cluster.py',
     'feature_logging.py',
     'interface_ipc.py',
+    'interface_ipc_init.py',
     'interface_ipc_mining.py',
     'feature_anchors.py',
     'mempool_datacarrier.py',


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
This is a draft follow-up to #34978 to make the per-address IPC connection-limit approach concrete.

The branch extends `-ipcbind` to accept `:max-connections=<n>` options, for example `-ipcbind=unix::max-connections=8` or `-ipcbind=unix:/custom/path:max-connections=8`, instead of introducing a separate global `-ipcmaxconnections` option.

It also vendors the local listener limit support needed in `libmultiprocess` and threads the parsed per-address limit through to `ListenConnections()` so each listener can stop accepting new IPC connections after reaching its local cap and resume accepting after a disconnect.

The draft includes:
- parser coverage for `-ipcbind` max-connections and invalid inputs
- functional init coverage for FD reservation logging and init errors
- an IPC behavior test verifying that with `max_connections=1`, a second client only becomes usable after the first disconnects

This is intended to help evaluate the per-address approach downstream against the global-limit direction in #34978.