### PR TITLE
ipc: support per-address max-connections options on -ipcbind

### DIFF
--- a/doc/release-notes-35037.md
+++ b/doc/release-notes-35037.md
@@ -1,0 +1,7 @@
+Updated settings
+----------------
+
+- IPC listeners configured with `-ipcbind` now reserve and accept
+  up to 16 client connections by default. The limit can be set per
+  listener by appending `,max-connections=<n>` to the bind address,
+  for example `-ipcbind=unix:,max-connections=8`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   deploymentinfo.cpp
   external_signer.cpp
   init/common.cpp
+  ipc/listen.cpp
   kernel/chainparams.cpp
   key.cpp
   key_io.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -757,7 +757,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-rpcworkqueue=<n>", strprintf("Set the maximum depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     if (can_listen_ipc) {
-        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Each configured listener reserves " + ToString(ipc::DEFAULT_MAX_CONNECTIONS) + " connection slots. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
+        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Append socat-style socket options like \",max-connections=<n>\" to set per-address listener options, for example \"unix:,max-connections=8\" or \"unix:/custom/path,max-connections=8\". If no max-connections option is specified, " + ToString(ipc::DEFAULT_MAX_CONNECTIONS) + " connection slots will be reserved per listener. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
     }
 
 #if HAVE_DECL_FORK
@@ -1079,18 +1079,20 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     // Reserve one listening socket per -ipcbind address plus its accepted
     // connection slots. Unlike P2P, IPC has no default listener.
-    const size_t ipc_addresses{args.GetArgs("-ipcbind").size()};
-
-    if (ipc_addresses > MAX_IPC_FDS) {
-        return InitError(Untranslated("Too many IPC file descriptors requested"));
-    }
-
-    // Maximum number of IPC connections. The multiplication cannot overflow
-    // because ipc_addresses was capped above.
-    const size_t ipc_max_connections{ipc_addresses * ipc::DEFAULT_MAX_CONNECTIONS};
-
-    if (ipc_max_connections > MAX_IPC_FDS - ipc_addresses) {
-        return InitError(Untranslated("Too many IPC file descriptors requested"));
+    size_t ipc_addresses{0};
+    size_t ipc_max_connections{0};
+    for (const std::string& configured_address : args.GetArgs("-ipcbind")) {
+        auto listen_address{interfaces::Ipc::parseListenAddress(configured_address)};
+        if (!listen_address) {
+            return InitError(Untranslated(strprintf("Invalid -ipcbind address '%s': %s", configured_address, util::ErrorString(listen_address).original)));
+        }
+        // Check the aggregate after adding this listener so multiple
+        // individually valid -ipcbind values cannot exceed the IPC FD cap.
+        ipc_addresses += 1;
+        ipc_max_connections += listen_address->max_connections;
+        if (ipc_addresses + ipc_max_connections > MAX_IPC_FDS) {
+            return InitError(Untranslated("Too many IPC file descriptors requested"));
+        }
     }
 
     if (ipc_addresses > 0) {
@@ -1563,16 +1565,17 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     uiInterface.InitWallet();
 
     if (interfaces::Ipc* ipc = node.init->ipc()) {
-        for (const std::string& address : gArgs.GetArgs("-ipcbind")) {
-            try {
-                const ipc::ListenAddress listen_address{
-                    .address = address,
-                };
-                ipc->listenAddress(listen_address);
-            } catch (const std::exception& e) {
-                return InitError(Untranslated(strprintf("Unable to bind to IPC address '%s'. %s", address, e.what())));
+        for (const std::string& configured_address : gArgs.GetArgs("-ipcbind")) {
+            auto listen_address{interfaces::Ipc::parseListenAddress(configured_address)};
+            if (!listen_address) {
+                return InitError(Untranslated(strprintf("Invalid -ipcbind address '%s': %s", configured_address, util::ErrorString(listen_address).original)));
             }
-            LogInfo("Listening for IPC requests on address %s", address);
+            try {
+                ipc->listenAddress(*listen_address);
+            } catch (const std::exception& e) {
+                return InitError(Untranslated(strprintf("Unable to bind to IPC address '%s'. %s", configured_address, e.what())));
+            }
+            LogInfo("Listening for IPC requests on address %s", listen_address->address);
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -36,6 +36,7 @@
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <ipc/exception.h>
+#include <ipc/types.h>
 #include <kernel/blockmanager_opts.h>
 #include <kernel/caches.h>
 #include <kernel/chainstatemanager_opts.h>
@@ -756,7 +757,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-rpcworkqueue=<n>", strprintf("Set the maximum depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     if (can_listen_ipc) {
-        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
+        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Each configured listener reserves " + ToString(ipc::DEFAULT_MAX_CONNECTIONS) + " connection slots. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
     }
 
 #if HAVE_DECL_FORK
@@ -1064,6 +1065,10 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // Make sure enough file descriptors are available. We need to reserve enough FDs to account for the bare minimum,
     // plus all manual connections and all bound interfaces. Any remainder will be available for connection sockets
 
+    // Keep IPC reservations far below int max so adding core and P2P
+    // reservations to the int-based min_required_fds cannot overflow.
+    constexpr size_t MAX_IPC_FDS{ipc::MAX_CONNECTIONS + 1};
+
     // Number of bound interfaces (we have at least one)
     int nBind = std::max(nUserBind, size_t(1));
     // Maximum number of connections with other nodes, this accounts for all types of outbounds and inbounds except for manual
@@ -1071,11 +1076,37 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     if (user_max_connection < 0) {
         return InitError(Untranslated("-maxconnections must be greater or equal than zero"));
     }
+
+    // Reserve one listening socket per -ipcbind address plus its accepted
+    // connection slots. Unlike P2P, IPC has no default listener.
+    const size_t ipc_addresses{args.GetArgs("-ipcbind").size()};
+
+    if (ipc_addresses > MAX_IPC_FDS) {
+        return InitError(Untranslated("Too many IPC file descriptors requested"));
+    }
+
+    // Maximum number of IPC connections. The multiplication cannot overflow
+    // because ipc_addresses was capped above.
+    const size_t ipc_max_connections{ipc_addresses * ipc::DEFAULT_MAX_CONNECTIONS};
+
+    if (ipc_max_connections > MAX_IPC_FDS - ipc_addresses) {
+        return InitError(Untranslated("Too many IPC file descriptors requested"));
+    }
+
+    if (ipc_addresses > 0) {
+        LogInfo("Reserving %d file descriptors for IPC (%d listening sockets, %d connection slots)",
+                static_cast<int>(ipc_addresses + ipc_max_connections),
+                static_cast<int>(ipc_addresses),
+                static_cast<int>(ipc_max_connections));
+    }
+
     const size_t max_private{args.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)
                              ? MAX_PRIVATE_BROADCAST_CONNECTIONS
                              : 0};
-    // Reserve enough FDs to account for the bare minimum, plus any manual connections, plus the bound interfaces
-    int min_required_fds = MIN_CORE_FDS + MAX_ADDNODE_CONNECTIONS + nBind;
+
+    // Reserve enough FDs to account for the bare minimum, plus any manual connections, plus bound P2P interfaces,
+    // plus IPC listeners and their accepted connection slots.
+    int min_required_fds = MIN_CORE_FDS + MAX_ADDNODE_CONNECTIONS + nBind + static_cast<int>(ipc_addresses + ipc_max_connections);
 
     // Try raising the FD limit to what we need (available_fds may be smaller than the requested amount if this fails)
     available_fds = RaiseFileDescriptorLimit(user_max_connection + max_private + min_required_fds);
@@ -1532,9 +1563,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     uiInterface.InitWallet();
 
     if (interfaces::Ipc* ipc = node.init->ipc()) {
-        for (std::string address : gArgs.GetArgs("-ipcbind")) {
+        for (const std::string& address : gArgs.GetArgs("-ipcbind")) {
             try {
-                ipc->listenAddress(address);
+                const ipc::ListenAddress listen_address{
+                    .address = address,
+                };
+                ipc->listenAddress(listen_address);
             } catch (const std::exception& e) {
                 return InitError(Untranslated(strprintf("Unable to bind to IPC address '%s'. %s", address, e.what())));
             }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -36,6 +36,7 @@
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <ipc/exception.h>
+#include <ipc/types.h>
 #include <kernel/blockmanager_opts.h>
 #include <kernel/caches.h>
 #include <kernel/chainstatemanager_opts.h>
@@ -756,7 +757,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-rpcworkqueue=<n>", strprintf("Set the maximum depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     if (can_listen_ipc) {
-        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
+        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Each configured listener reserves " + ToString(ipc::DEFAULT_MAX_CONNECTIONS) + " connection slots. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
     }
 
 #if HAVE_DECL_FORK
@@ -1064,6 +1065,9 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // Make sure enough file descriptors are available. We need to reserve enough FDs to account for the bare minimum,
     // plus all manual connections and all bound interfaces. Any remainder will be available for connection sockets
 
+    // Keep IPC reservations low enough to leave room for core and P2P file descriptor reservations.
+    constexpr size_t MAX_IPC_FDS{ipc::MAX_CONNECTIONS + 1};
+
     // Number of bound interfaces (we have at least one)
     int num_p2p_bind = std::max(num_user_p2p_bind, size_t(1));
     // Maximum number of connections with other nodes, this accounts for all types of outbounds and inbounds except for manual
@@ -1071,10 +1075,35 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     if (user_p2p_max_connections < 0) {
         return InitError(Untranslated("-maxconnections must be greater or equal than zero"));
     }
+
+    // Reserve one listening socket per -ipcbind address plus its accepted
+    // connection slots. Unlike P2P, IPC has no default listener.
+    const size_t ipc_addresses{args.GetArgs("-ipcbind").size()};
+
+    if (ipc_addresses > MAX_IPC_FDS) {
+        return InitError(Untranslated("Too many IPC file descriptors requested"));
+    }
+
+    // Maximum number of IPC connections. The multiplication cannot overflow
+    // because ipc_addresses was capped above.
+    const size_t ipc_max_connections{ipc_addresses * ipc::DEFAULT_MAX_CONNECTIONS};
+    // Actual number of IPC file descriptors to be reserved.
+    const size_t ipc_fds{ipc_max_connections + ipc_addresses};
+
+    if (ipc_fds > MAX_IPC_FDS) {
+        return InitError(Untranslated("Too many IPC file descriptors requested"));
+    }
+
+    if (ipc_addresses > 0) {
+        LogInfo("Reserving %d file descriptors for IPC (%d listening sockets, %d connection slots)",
+                static_cast<int>(ipc_fds),
+                static_cast<int>(ipc_addresses),
+                static_cast<int>(ipc_max_connections));
+    }
+
     const size_t max_private{args.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)
                              ? MAX_PRIVATE_BROADCAST_CONNECTIONS
                              : 0};
-
     // HTTP server listen sockets: by default two (IPv4 and IPv6 loopback), or one per -rpcbind entry
     int num_rpc_bind = std::max(args.GetArgs("-rpcbind").size(), size_t(2));
     // HTTP server connected client sockets
@@ -1096,11 +1125,12 @@ bool AppInitParameterInteraction(const ArgsManager& args)
                               num_rpc_bind +
                               user_rpc_max_connections +
                               user_p2p_max_connections +
+                              static_cast<int64_t>(ipc_fds) +
                               static_cast<int64_t>(max_private);
     if (total_fds > std::numeric_limits<int>::max()) {
         return InitError(Untranslated("Too many file descriptors requested. Try lower values for -rpcmaxconnections "
                                       "or -maxconnections, or fewer settings of "
-                                      "-rpcbind, -bind and -whitebind"));
+                                      "-rpcbind, -bind, -whitebind and -ipcbind"));
     }
 
     // Subset of total_fds must also be a safe int
@@ -1108,7 +1138,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
                            MAX_ADDNODE_CONNECTIONS +
                            num_p2p_bind +
                            num_rpc_bind +
-                           user_rpc_max_connections;
+                           user_rpc_max_connections +
+                           static_cast<int>(ipc_fds);
 
     // Try raising the FD limit to what the user wants (available_fds may be smaller than the requested amount if this fails)
     available_fds = RaiseFileDescriptorLimit(static_cast<int>(total_fds));
@@ -1576,13 +1607,16 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     uiInterface.InitWallet();
 
     if (interfaces::Ipc* ipc = node.init->ipc()) {
-        for (std::string address : gArgs.GetArgs("-ipcbind")) {
+        for (const std::string& address : gArgs.GetArgs("-ipcbind")) {
+            ipc::ListenAddress listen_address{
+                .address = address,
+            };
             try {
-                ipc->listenAddress(address);
+                ipc->listenAddress(listen_address);
             } catch (const std::exception& e) {
-                return InitError(Untranslated(strprintf("Unable to bind to IPC address '%s'. %s", address, e.what())));
+                return InitError(Untranslated(strprintf("Unable to bind to IPC address '%s'. %s", listen_address.address, e.what())));
             }
-            LogInfo("Listening for IPC requests on address %s", address);
+            LogInfo("Listening for IPC requests on address %s", listen_address.address);
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -757,7 +757,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-rpcworkqueue=<n>", strprintf("Set the maximum depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     if (can_listen_ipc) {
-        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Each configured listener reserves " + ToString(ipc::DEFAULT_MAX_CONNECTIONS) + " connection slots. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
+        argsman.AddArg("-ipcbind=<address>", "Bind to Unix socket address and listen for incoming connections. Valid address values are \"unix\" to listen on the default path, <datadir>/node.sock, or \"unix:/custom/path\" to specify a custom path. Append socat-style socket options like \",max-connections=<n>\" to set per-address listener options, for example \"unix:,max-connections=8\" or \"unix:/custom/path,max-connections=8\". If no max-connections option is specified, " + ToString(ipc::DEFAULT_MAX_CONNECTIONS) + " connection slots will be reserved per listener. Can be specified multiple times to listen on multiple paths. Default behavior is not to listen on any path. If relative paths are specified, they are interpreted relative to the network data directory. If paths include any parent directory components and the parent directories do not exist, they will be created. Enabling this gives local processes that can access the socket unauthenticated RPC access, so it's important to choose a path with secure permissions if customizing this.", ArgsManager::ALLOW_ANY, OptionsCategory::IPC);
     }
 
 #if HAVE_DECL_FORK
@@ -1078,20 +1078,23 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     // Reserve one listening socket per -ipcbind address plus its accepted
     // connection slots. Unlike P2P, IPC has no default listener.
-    const size_t ipc_addresses{args.GetArgs("-ipcbind").size()};
-
-    if (ipc_addresses > MAX_IPC_FDS) {
-        return InitError(Untranslated("Too many IPC file descriptors requested"));
+    size_t ipc_addresses{0};
+    size_t ipc_max_connections{0};
+    for (const std::string& configured_address : args.GetArgs("-ipcbind")) {
+        auto listen_address{interfaces::Ipc::parseListenAddress(configured_address)};
+        if (!listen_address) {
+            return InitError(Untranslated(strprintf("Invalid -ipcbind address '%s': %s", configured_address, util::ErrorString(listen_address).original)));
+        }
+        // Check the aggregate after adding this listener so multiple
+        // individually valid -ipcbind values cannot exceed the IPC FD cap.
+        ipc_addresses += 1;
+        ipc_max_connections += listen_address->max_connections;
     }
-
-    // Maximum number of IPC connections. The multiplication cannot overflow
-    // because ipc_addresses was capped above.
-    const size_t ipc_max_connections{ipc_addresses * ipc::DEFAULT_MAX_CONNECTIONS};
     // Actual number of IPC file descriptors to be reserved.
     const size_t ipc_fds{ipc_max_connections + ipc_addresses};
 
     if (ipc_fds > MAX_IPC_FDS) {
-        return InitError(Untranslated("Too many IPC file descriptors requested"));
+        return InitError(Untranslated(strprintf("Too many IPC file descriptors requested: %d -ipcbind listeners and connection slots exceed the limit of %d. Reduce the number of -ipcbind addresses or their max-connections values", static_cast<int>(ipc_fds), static_cast<int>(MAX_IPC_FDS))));
     }
 
     if (ipc_addresses > 0) {
@@ -1607,16 +1610,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     uiInterface.InitWallet();
 
     if (interfaces::Ipc* ipc = node.init->ipc()) {
-        for (const std::string& address : gArgs.GetArgs("-ipcbind")) {
-            ipc::ListenAddress listen_address{
-                .address = address,
-            };
+        for (const std::string& configured_address : gArgs.GetArgs("-ipcbind")) {
+            auto listen_address{interfaces::Ipc::parseListenAddress(configured_address)};
+            Assert(listen_address); // Already validated in AppInitParameterInteraction.
             try {
-                ipc->listenAddress(listen_address);
+                ipc->listenAddress(*listen_address);
             } catch (const std::exception& e) {
-                return InitError(Untranslated(strprintf("Unable to bind to IPC address '%s'. %s", listen_address.address, e.what())));
+                return InitError(Untranslated(strprintf("Unable to bind to IPC address '%s'. %s", listen_address->address, e.what())));
             }
-            LogInfo("Listening for IPC requests on address %s", listen_address.address);
+            LogInfo("Listening for IPC requests on address %s", listen_address->address);
         }
     }
 

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -6,6 +6,7 @@
 #define BITCOIN_INTERFACES_IPC_H
 
 #include <ipc/types.h>
+#include <util/result.h>
 
 #include <functional>
 #include <memory>
@@ -68,6 +69,9 @@ public:
     //! refused but not required ("auto"), and throws an exception if there was
     //! an unexpected error.
     virtual std::unique_ptr<Init> connectAddress(std::string& address) = 0;
+
+    //! Parse an IPC listening address and its per-listener options.
+    static util::Result<ipc::ListenAddress> parseListenAddress(std::string address);
 
     //! Listen on a configured socket address exposing this process's init
     //! interface and accepting at most listen_address.max_connections simultaneous

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_INTERFACES_IPC_H
 #define BITCOIN_INTERFACES_IPC_H
 
+#include <ipc/types.h>
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -67,9 +69,10 @@ public:
     //! an unexpected error.
     virtual std::unique_ptr<Init> connectAddress(std::string& address) = 0;
 
-    //! Listen on a socket address exposing this process's init interface to
-    //! clients. Throws an exception if there was an error.
-    virtual void listenAddress(std::string& address) = 0;
+    //! Listen on a configured socket address exposing this process's init
+    //! interface and accepting at most listen_address.max_connections simultaneous
+    //! client connections. Throws an exception if there was an error.
+    virtual void listenAddress(const ipc::ListenAddress& listen_address) = 0;
 
     //! Disconnect any incoming connections that are still connected.
     virtual void disconnectIncoming() = 0;

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_INTERFACES_IPC_H
 #define BITCOIN_INTERFACES_IPC_H
 
+#include <ipc/types.h>
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -67,9 +69,11 @@ public:
     //! an unexpected error.
     virtual std::unique_ptr<Init> connectAddress(std::string& address) = 0;
 
-    //! Listen on a socket address exposing this process's init interface to
-    //! clients. Throws an exception if there was an error.
-    virtual void listenAddress(std::string& address) = 0;
+    //! Listen on a configured socket address exposing this process's init
+    //! interface and accepting at most listen_address.max_connections simultaneous
+    //! client connections. Updates listen_address.address with the resolved socket
+    //! address. Throws an exception if there was an error.
+    virtual void listenAddress(ipc::ListenAddress& listen_address) = 0;
 
     //! Disconnect any incoming connections that are still connected.
     virtual void disconnectIncoming() = 0;

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -83,13 +83,13 @@ public:
         startLoop();
         return mp::ConnectStream<messages::Init>(*m_loop, std::move(stream));
     }
-    void listen(mp::SocketId listen_fd, interfaces::Init& init) override
+    void listen(mp::SocketId listen_fd, interfaces::Init& init, std::optional<size_t> max_connections) override
     {
         startLoop();
         if (::listen(listen_fd, /*backlog=*/5) != 0) {
             throw std::system_error(errno, std::system_category());
         }
-        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init);
+        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init, max_connections);
     }
     void serve(interfaces::Init& init, const std::function<mp::Stream()>& make_stream) override
     {

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "ipc/util.h"
 #include <interfaces/init.h>
 #include <ipc/capnp/context.h>
 #include <ipc/capnp/init.capnp.h>

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "ipc/util.h"
 #include <interfaces/init.h>
 #include <ipc/capnp/context.h>
 #include <ipc/capnp/init.capnp.h>
@@ -83,13 +84,13 @@ public:
         startLoop();
         return mp::ConnectStream<messages::Init>(*m_loop, std::move(stream));
     }
-    void listen(mp::SocketId listen_fd, interfaces::Init& init) override
+    void listen(mp::SocketId listen_fd, interfaces::Init& init, std::optional<size_t> max_connections) override
     {
         startLoop();
         if (::listen(listen_fd, /*backlog=*/5) != 0) {
             throw std::system_error(errno, std::system_category());
         }
-        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init);
+        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init, max_connections);
     }
     void serve(interfaces::Init& init, const std::function<mp::Stream()>& make_stream) override
     {

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -9,6 +9,7 @@
 #include <ipc/capnp/protocol.h>
 #include <ipc/process.h>
 #include <ipc/protocol.h>
+#include <ipc/types.h>
 #include <tinyformat.h>
 #include <util/fs.h>
 #include <util/log.h>
@@ -110,10 +111,11 @@ public:
         }
         return m_protocol->connect(m_protocol->makeStream(fd));
     }
-    void listenAddress(std::string& address) override
+    void listenAddress(const ListenAddress& listen_address) override
     {
+        std::string address{listen_address.address};
         mp::SocketId fd = m_process->bind(gArgs.GetDataDirNet(), m_exe_name, address);
-        m_protocol->listen(fd, m_init);
+        m_protocol->listen(fd, m_init, listen_address.max_connections);
     }
     void disconnectIncoming() override
     {

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -9,6 +9,7 @@
 #include <ipc/capnp/protocol.h>
 #include <ipc/process.h>
 #include <ipc/protocol.h>
+#include <ipc/types.h>
 #include <tinyformat.h>
 #include <util/fs.h>
 #include <util/log.h>
@@ -110,10 +111,10 @@ public:
         }
         return m_protocol->connect(m_protocol->makeStream(fd));
     }
-    void listenAddress(std::string& address) override
+    void listenAddress(ListenAddress& listen_address) override
     {
-        mp::SocketId fd = m_process->bind(gArgs.GetDataDirNet(), m_exe_name, address);
-        m_protocol->listen(fd, m_init);
+        mp::SocketId fd = m_process->bind(gArgs.GetDataDirNet(), m_exe_name, listen_address.address);
+        m_protocol->listen(fd, m_init, listen_address.max_connections);
     }
     void disconnectIncoming() override
     {

--- a/src/ipc/listen.cpp
+++ b/src/ipc/listen.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/url.h>
+#include <interfaces/ipc.h>
+#include <util/string.h>
+#include <util/translation.h>
+
+#include <charconv>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+namespace interfaces {
+util::Result<ipc::ListenAddress> Ipc::parseListenAddress(std::string address)
+{
+    constexpr std::string_view UNIX_PREFIX{"unix:"};
+
+    // Only Unix socket -ipcbind values support inline socket options. Leave
+    // other address families untouched so ipc::Process can report address
+    // scheme errors consistently with -ipcconnect.
+    if (!address.starts_with(UNIX_PREFIX)) {
+        return ipc::ListenAddress{.address = std::move(address)};
+    }
+
+    // Socket options follow the first comma:
+    //   unix:,max-connections=8
+    //   unix:/custom/path,max-connections=8
+    // Commas in socket paths must be URL-encoded as %2C.
+    //
+    // Subsequent commas separate individual options.
+    const size_t option_pos{address.find(',')};
+    if (option_pos == std::string::npos) {
+        return ipc::ListenAddress{.address = UrlDecode(address)};
+    }
+
+    const std::string_view address_view{address};
+    const std::string_view options_view{
+        address_view.substr(option_pos + 1)};
+
+    ipc::ListenAddress listen_address{
+        .address = UrlDecode(address_view.substr(0, option_pos)),
+    };
+
+    size_t next{0};
+    while (next <= options_view.size()) {
+        const size_t end{options_view.find(',', next)};
+        const std::string_view option{
+            options_view.substr(next, end - next)};
+
+        if (option.empty()) {
+            return util::Error{Untranslated("Empty socket option")};
+        }
+
+        const size_t equals{option.find('=')};
+        const std::string_view name{option.substr(0, equals)};
+        const std::string_view value{
+            equals == std::string_view::npos ? std::string_view{} : option.substr(equals + 1)};
+
+        if (name != "max-connections") {
+            return util::Error{Untranslated(strprintf("Unknown socket option '%s'", name))};
+        }
+        if (value.empty()) {
+            return util::Error{Untranslated("Missing value for max-connections option")};
+        }
+
+        int64_t parsed_value{-1};
+        const auto [last, ec]{std::from_chars(value.data(), value.data() + value.size(), parsed_value)};
+
+        if (ec != std::errc{} || last != value.data() + value.size()) {
+            return util::Error{Untranslated("Invalid max-connections value '" + std::string{value} + "'")};
+        }
+        if (parsed_value < 1) {
+            return util::Error{Untranslated("max-connections must be at least 1")};
+        }
+        if (parsed_value > static_cast<int64_t>(ipc::MAX_CONNECTIONS)) {
+            return util::Error{Untranslated("max-connections must be at most " + util::ToString(ipc::MAX_CONNECTIONS))};
+        }
+
+        listen_address.max_connections = static_cast<size_t>(parsed_value);
+
+        if (end == std::string_view::npos) break;
+        next = end + 1;
+    }
+
+    return listen_address;
+}
+} // namespace interfaces

--- a/src/ipc/listen.cpp
+++ b/src/ipc/listen.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <interfaces/ipc.h>
+#include <util/string.h>
+#include <util/translation.h>
+
+#include <charconv>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+namespace interfaces {
+util::Result<ipc::ListenAddress> Ipc::parseListenAddress(std::string address)
+{
+    constexpr std::string_view UNIX_PREFIX{"unix:"};
+
+    // Only Unix socket -ipcbind values support inline socket options. Leave
+    // other address families untouched so ipc::Process can report address
+    // scheme errors consistently with -ipcconnect.
+    if (!address.starts_with(UNIX_PREFIX)) {
+        return ipc::ListenAddress{.address = std::move(address)};
+    }
+
+    // Socket options follow the first comma:
+    //   unix:,max-connections=8
+    //   unix:/custom/path,max-connections=8
+    //
+    // Subsequent commas separate individual options.
+    constexpr std::string_view MAX_CONNECTIONS_OPTION{",max-connections="};
+    const size_t option_pos{address.find(MAX_CONNECTIONS_OPTION)};
+    if (option_pos == std::string::npos) {
+        return ipc::ListenAddress{.address = std::move(address)};
+    }
+
+    const std::string_view address_view{address};
+    const std::string_view options_view{
+        address_view.substr(option_pos + 1)};
+
+    ipc::ListenAddress listen_address{
+        .address = address.substr(0, option_pos),
+    };
+
+    size_t next{0};
+    while (next <= options_view.size()) {
+        const size_t end{options_view.find(',', next)};
+        const std::string_view option{
+            options_view.substr(next, end - next)};
+
+        if (option.empty()) {
+            return util::Error{Untranslated("Empty socket option")};
+        }
+
+        const size_t equals{option.find('=')};
+        const std::string_view name{option.substr(0, equals)};
+        const std::string_view value{
+            equals == std::string_view::npos ? std::string_view{} : option.substr(equals + 1)};
+
+        if (name == "max-connections") {
+            if (value.empty()) {
+                return util::Error{Untranslated("Missing value for max-connections option")};
+            }
+
+            int64_t parsed_limit{-1};
+            const auto [last, ec]{std::from_chars(value.data(), value.data() + value.size(), parsed_limit)};
+
+            if (ec != std::errc{} ||
+                last != value.data() + value.size()) {
+                return util::Error{Untranslated("Invalid max-connections value '" + std::string{value} + "'")};
+            }
+            if (parsed_limit < 1) {
+                return util::Error{Untranslated("max-connections must be at least 1")};
+            }
+            if (parsed_limit > static_cast<int64_t>(ipc::MAX_CONNECTIONS)) {
+                return util::Error{Untranslated("max-connections must be at most " + util::ToString(ipc::MAX_CONNECTIONS))};
+            }
+
+            listen_address.max_connections = static_cast<size_t>(parsed_limit);
+        } else {
+            return util::Error{Untranslated("Unknown socket option '" + std::string{name} + "'")};
+        }
+
+        if (end == std::string_view::npos) break;
+        next = end + 1;
+    }
+
+    return listen_address;
+}
+} // namespace interfaces

--- a/src/ipc/protocol.h
+++ b/src/ipc/protocol.h
@@ -8,8 +8,10 @@
 #include <interfaces/init.h>
 #include <ipc/util.h>
 
+#include <cstddef>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <typeindex>
 
 namespace ipc {
@@ -38,7 +40,7 @@ public:
     //! Listen for connections on provided socket id, accept them, and handle
     //! requests on accepted connections. This method doesn't block, and
     //! performs I/O on a background thread.
-    virtual void listen(mp::SocketId listen_fd, interfaces::Init& init) = 0;
+    virtual void listen(mp::SocketId listen_fd, interfaces::Init& init, std::optional<size_t> max_connections = std::nullopt) = 0;
 
     //! Handle requests from a stream provided by the make_stream callback,
     //! forwarding them to the provided Init interface. Socket communication is

--- a/src/ipc/test/ipc_tests.cpp
+++ b/src/ipc/test/ipc_tests.cpp
@@ -5,12 +5,15 @@
 #include <interfaces/init.h>
 #include <ipc/capnp/mining.capnp.h>
 #include <ipc/capnp/protocol.h>
+#include <interfaces/ipc.h>
 #include <ipc/process.h>
 #include <ipc/protocol.h>
 #include <ipc/test/ipc_test.capnp.h>
 #include <ipc/test/ipc_test.capnp.proxy.h>
 #include <ipc/test/ipc_test.h>
 #include <mp/proxy-types.h>
+#include <ipc/types.h>
+
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>
@@ -198,12 +201,56 @@ void IpcSocketTest(const fs::path& datadir)
     }
 }
 
+//! Test ipc::Protocol listen() local connection limiting over a unix socket.
+void IpcSocketMaxConnectionsTest(const fs::path& datadir)
+{
+    std::unique_ptr<interfaces::Init> init{std::make_unique<TestInit>()};
+    std::unique_ptr<ipc::Protocol> protocol{ipc::capnp::MakeCapnpProtocol("IpcSocketMaxConnectionsTest")};
+    std::unique_ptr<ipc::Process> process{ipc::MakeProcess()};
+
+    std::string address{strprintf("unix:%s", TempPath("bitcoin_sock_limit_XXXXXX"))};
+    mp::SocketId serve_fd = process->bind(datadir, "test_bitcoin", address);
+    BOOST_CHECK_NE(serve_fd, mp::SocketError);
+    protocol->listen(serve_fd, *init, /*max_connections=*/1);
+
+    auto connect_fd{[&](const std::string& connect_address) {
+        std::string addr{connect_address};
+        mp::SocketId fd{process->connect(datadir, "test_bitcoin", addr)};
+        return std::make_pair(fd, addr);
+    }};
+
+    auto [fd1, addr1] = connect_fd(address);
+    BOOST_CHECK_EQUAL(addr1, address);
+    std::unique_ptr<interfaces::Init> remote_init1{protocol->connect(protocol->makeStream(fd1))};
+    std::unique_ptr<interfaces::Echo> remote_echo1{remote_init1->makeEcho()};
+    BOOST_CHECK_EQUAL(remote_echo1->echo("echo test 1"), "echo test 1");
+
+    auto second_call = std::async(std::launch::async, [&] {
+        std::string addr{address};
+        mp::SocketId fd{process->connect(datadir, "test_bitcoin", addr)};
+        std::unique_ptr<interfaces::Init> remote_init{protocol->connect(protocol->makeStream(fd))};
+        std::unique_ptr<interfaces::Echo> remote_echo{remote_init->makeEcho()};
+        return std::make_pair(remote_echo->echo("echo test 2"), addr);
+    });
+
+    BOOST_CHECK(second_call.wait_for(std::chrono::milliseconds{100}) == std::future_status::timeout);
+
+    remote_echo1.reset();
+    remote_init1.reset();
+
+    BOOST_REQUIRE(second_call.wait_for(std::chrono::seconds{5}) == std::future_status::ready);
+    auto [echo2, addr2] = second_call.get();
+    BOOST_CHECK_EQUAL(addr2, address);
+    BOOST_CHECK_EQUAL(echo2, "echo test 2");
+}
+
 BOOST_FIXTURE_TEST_SUITE(ipc_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(ipc_tests)
 {
     IpcPipeTest();
     IpcSocketPairTest();
     IpcSocketTest(m_args.GetDataDirNet());
+    IpcSocketMaxConnectionsTest(m_args.GetDataDirNet());
 }
 
 // Test address parsing.
@@ -228,6 +275,34 @@ BOOST_AUTO_TEST_CASE(parse_address_test)
                   "unix:" + prefix + "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.sock",
                   "Unix address path \"" + prefix + "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.sock\" exceeded maximum socket path length");
     check_address("invalid", "invalid", "Unrecognized address 'invalid'");
+
+    auto check_listen_address{[](const std::string& configured_address, const std::string& expected_address, size_t expected_max_connections, const std::string& expected_error) {
+        auto listen_address{interfaces::Ipc::parseListenAddress(configured_address)};
+        if (!expected_error.empty()) {
+            BOOST_CHECK(!listen_address);
+            BOOST_CHECK_EQUAL(util::ErrorString(listen_address).original, expected_error);
+            return;
+        }
+        BOOST_REQUIRE(listen_address);
+        BOOST_CHECK_EQUAL(listen_address->address, expected_address);
+        BOOST_CHECK_EQUAL(listen_address->max_connections, expected_max_connections);
+    }};
+    check_listen_address("unix", "unix", ipc::DEFAULT_MAX_CONNECTIONS, "");
+    check_listen_address("unix:", "unix:", ipc::DEFAULT_MAX_CONNECTIONS, "");
+    check_listen_address("unix:,max-connections=8", "unix:", 8, "");
+    check_listen_address("unix:path.sock,max-connections=8", "unix:path.sock", 8, "");
+    check_listen_address("unix:,max-connections=1", "unix:", 1, "");
+    check_listen_address("unix:,max-connections=1048576", "unix:", ipc::MAX_CONNECTIONS, "");
+    check_listen_address("unix:path.sock,max-connections=8,unknown=1", "", 0, "Unknown socket option 'unknown'");
+    check_listen_address("unix:,max-connections=8,", "", 0, "Empty socket option");
+    check_listen_address("unix:,max-connections=0", "", 0, "max-connections must be at least 1");
+    check_listen_address("unix:,max-connections=-1", "", 0, "max-connections must be at least 1");
+    check_listen_address("unix:,max-connections=-9223372036854775808", "", 0, "max-connections must be at least 1");
+    check_listen_address("unix:,max-connections=1048577", "", 0, "max-connections must be at most 1048576");
+    check_listen_address("unix:,max-connections=9223372036854775808", "", 0, "Invalid max-connections value '9223372036854775808'");
+    check_listen_address("unix:,max-connections=", "", 0, "Missing value for max-connections option");
+    check_listen_address("unix:path,backup.sock", "unix:path,backup.sock", ipc::DEFAULT_MAX_CONNECTIONS, "");
+    check_listen_address("unix:path,backup.sock,max-connections=8", "unix:path,backup.sock", 8, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/ipc/types.h
+++ b/src/ipc/types.h
@@ -1,0 +1,40 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+//! @file ipc/types.h is a home for public enum and struct type definitions
+//! that are used internally by ipc code, but also used externally by wallet,
+//! mining or GUI code.
+//!
+//! This file is intended to define only simple types that do not have external
+//! dependencies. More complicated types should be defined in dedicated header
+//! files.
+
+#ifndef BITCOIN_IPC_TYPES_H
+#define BITCOIN_IPC_TYPES_H
+
+#include <cstddef>
+#include <string>
+
+namespace ipc {
+
+//! Default accepted client connection limit for each IPC listening socket.
+inline constexpr size_t DEFAULT_MAX_CONNECTIONS{16};
+
+//! Maximum accepted client connection limit for an IPC listening socket.
+//! This conservative bound leaves ample room for other file descriptor
+//! reservations in int-based initialization accounting.
+inline constexpr size_t MAX_CONNECTIONS{size_t{1} << 20};
+
+struct ListenAddress {
+    //! Socket address passed to ipc::Process::bind(), with any -ipcbind socket
+    //! options stripped.
+    std::string address;
+
+    //! Maximum simultaneous client connections accepted by this listener.
+    size_t max_connections{DEFAULT_MAX_CONNECTIONS};
+};
+
+} // namespace ipc
+
+#endif // BITCOIN_IPC_TYPES_H

--- a/src/ipc/types.h
+++ b/src/ipc/types.h
@@ -1,0 +1,40 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+//! @file ipc/types.h is a home for public enum and struct type definitions
+//! that are used internally by ipc code, but also used externally by wallet,
+//! mining or GUI code.
+//!
+//! This file is intended to define only simple types that do not have external
+//! dependencies. More complicated types should be defined in dedicated header
+//! files.
+
+#ifndef BITCOIN_IPC_TYPES_H
+#define BITCOIN_IPC_TYPES_H
+
+#include <cstddef>
+#include <string>
+
+namespace ipc {
+
+//! Default accepted client connection limit for each IPC listening socket.
+inline constexpr size_t DEFAULT_MAX_CONNECTIONS{16};
+
+//! Maximum accepted client connection limit for an IPC listening socket.
+//! This conservative bound leaves ample room for other file descriptor
+//! reservations.
+inline constexpr size_t MAX_CONNECTIONS{256};
+
+struct ListenAddress {
+    //! Socket address passed to ipc::Process::bind(), with any -ipcbind socket
+    //! options stripped.
+    std::string address;
+
+    //! Maximum simultaneous client connections accepted by this listener.
+    size_t max_connections{DEFAULT_MAX_CONNECTIONS};
+};
+
+} // namespace ipc
+
+#endif // BITCOIN_IPC_TYPES_H

--- a/test/functional/interface_ipc_init.py
+++ b/test/functional/interface_ipc_init.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test IPC initialization behavior."""
+
+import socket
+import tempfile
+import time
+from pathlib import Path
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+MAX_IPC_CONNECTIONS = 1 << 20
+
+
+class IPCInitTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_ipc()
+
+    def setup_nodes(self):
+        self.extra_init = [{"ipcbind": True}]
+        super().setup_nodes()
+        self.nodes[0].args = [arg for arg in self.nodes[0].args if not arg.startswith("-ipcbind=")]
+        self.ipc_tmpdir = tempfile.TemporaryDirectory(prefix="btc-ipc-init-")
+        self.ipcbind_path = Path(self.ipc_tmpdir.name) / "ipcinit.sock"
+        self.ipcbind_path2 = Path(self.ipc_tmpdir.name) / "ipcinit2.sock"
+
+    def test_ipcbind_max_connections(self):
+        self.log.info("Test -ipcbind max-connections initialization behavior")
+        node = self.nodes[0]
+
+        # Test default value (16)
+        with node.assert_debug_log([
+            "Reserving 17 file descriptors for IPC (1 listening sockets, 16 connection slots)",
+        ]):
+            self.restart_node(0, extra_args=[f"-ipcbind=unix:{self.ipcbind_path}"])
+
+        ipcbind_arg = f"-ipcbind=unix:{self.ipcbind_path},max-connections={{}}"
+
+        with node.assert_debug_log([
+            "Reserving 9 file descriptors for IPC (1 listening sockets, 8 connection slots)",
+        ]):
+            self.restart_node(0, extra_args=[ipcbind_arg.format(8)])
+        assert_equal(node.getblockcount(), 0)
+
+        self.stop_node(0)
+        node.assert_start_raises_init_error(
+            extra_args=[ipcbind_arg.format(0)],
+            expected_msg=f"Error: Invalid -ipcbind address 'unix:{self.ipcbind_path},max-connections=0': max-connections must be at least 1",
+        )
+        node.assert_start_raises_init_error(
+            extra_args=[ipcbind_arg.format(MAX_IPC_CONNECTIONS + 1)],
+            expected_msg=f"Error: Invalid -ipcbind address 'unix:{self.ipcbind_path},max-connections={MAX_IPC_CONNECTIONS + 1}': max-connections must be at most {MAX_IPC_CONNECTIONS}",
+        )
+
+        # Individually valid limits must not exceed the aggregate IPC FD cap.
+        half_max = MAX_IPC_CONNECTIONS // 2
+        node.assert_start_raises_init_error(
+            extra_args=[
+                ipcbind_arg.format(half_max),
+                f"-ipcbind=unix:{self.ipcbind_path2},max-connections={half_max}",
+            ],
+            expected_msg="Error: Too many IPC file descriptors requested",
+        )
+
+    def test_ipcbind_connection_limiting(self):
+        self.log.info("Test per-address -ipcbind connection limiting")
+        node = self.nodes[0]
+        self.restart_node(0, extra_args=[
+            f"-ipcbind=unix:{self.ipcbind_path},max-connections=1",
+            f"-ipcbind=unix:{self.ipcbind_path2},max-connections=1",
+            "-debug=ipc",
+        ])
+
+        def ipc_client(path):
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.connect(str(path))
+            return client
+
+        # Each listener independently accepts its first client.
+        with node.assert_debug_log(["IPC server: socket connected."], timeout=5):
+            first1 = ipc_client(self.ipcbind_path)
+        with node.assert_debug_log(["IPC server: socket connected."], timeout=5):
+            first2 = ipc_client(self.ipcbind_path2)
+
+        # Further clients can connect to the socket backlog but must not be
+        # accepted while their listener's only slot is occupied.
+        with node.assert_debug_log([], unexpected_msgs=["IPC server: socket connected."]):
+            second1 = ipc_client(self.ipcbind_path)
+            second2 = ipc_client(self.ipcbind_path2)
+            time.sleep(0.5)
+
+        # Freeing a slot on either listener immediately admits its waiting client.
+        with node.assert_debug_log([
+            "IPC server: socket disconnected.",
+            "IPC server: socket connected.",
+        ], timeout=5):
+            first1.close()
+        with node.assert_debug_log([
+            "IPC server: socket disconnected.",
+            "IPC server: socket connected.",
+        ], timeout=5):
+            first2.close()
+
+        with node.assert_debug_log(["IPC server: socket disconnected."], timeout=5):
+            second1.close()
+        with node.assert_debug_log(["IPC server: socket disconnected."], timeout=5):
+            second2.close()
+
+    def run_test(self):
+        self.test_ipcbind_max_connections()
+        self.test_ipcbind_connection_limiting()
+
+
+if __name__ == '__main__':
+    IPCInitTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -391,6 +391,7 @@ BASE_SCRIPTS = [
     'p2p_handshake.py',
     'p2p_handshake.py --v2transport',
     'interface_ipc_cli.py',
+    'interface_ipc_init.py',
     'feature_dirsymlinks.py',
     'feature_help.py',
     'feature_framework_startup_failures.py',


### PR DESCRIPTION
The branch extends `-ipcbind` to accept `,max-connections=<n>` options, for example `-ipcbind=unix:,max-connections=8` or `-ipcbind=unix:/custom/path,max-connections=8`, instead of introducing a separate global `-ipcmaxconnections` option.

This keeps the connection limit attached to each IPC listener instead of introducing a global `-ipcmaxconnections` option (https://github.com/bitcoin/bitcoin/pull/34978). A global option would not allow different limits for different `-ipcbind` addresses, and the inline option format can be extended in the future with additional options.