### PR TITLE
refactor: Properly return from ThreadSafeQuestion signal + btcsignals follow-ups

### DIFF
--- a/src/btcsignals.h
+++ b/src/btcsignals.h
@@ -30,21 +30,23 @@
 
 namespace btcsignals {
 
-/*
- * optional_last_value is the default and only supported combiner.
- * As such, its behavior is embedded into the signal functor.
- *
- * Because optional<void> is undefined, void must be special-cased.
- */
-
-template <typename T>
-class optional_last_value
+/// The default combiner, which only returns void.
+class null_value
 {
 public:
-    using result_type = std::conditional_t<std::is_void_v<T>, void, std::optional<T>>;
+    using result_type = void;
 };
 
-template <typename Signature, typename Combiner = optional_last_value<typename std::function<Signature>::result_type>>
+/// A combiner, which checks if at least one callback returned true.
+class any_of
+{
+public:
+    // This is the only supported combiner with a non-void return type. As
+    // such, its behavior is embedded into the signal functor.
+    using result_type = bool;
+};
+
+template <typename Signature, typename Combiner = null_value>
 class signal;
 
 /*
@@ -150,8 +152,6 @@ class signal
 {
     using function_type = std::function<Signature>;
 
-    static_assert(std::is_same_v<Combiner, optional_last_value<typename function_type::result_type>>, "only the optional_last_value combiner is supported");
-
     /*
      * Helper struct for maintaining a callback and its associated connection liveness
      */
@@ -184,9 +184,7 @@ public:
 
     /*
      * Execute all enabled callbacks for the signal. Rather than allowing for
-     * custom combiners, the behavior of optional_last_value is hard-coded
-     * here. Return the value of the last executed callback, or nullopt if none
-     * were executed.
+     * custom combiners, the behavior of any_of is hard-coded here.
      *
      * Callbacks which return void require special handling.
      *
@@ -208,16 +206,22 @@ public:
             connections = m_connections;
         }
         if constexpr (std::is_void_v<result_type>) {
+            static_assert(std::is_same_v<result_type, typename function_type::result_type>,
+                          "Callback result type must be equal to the combiner result type (void).");
             for (const auto& connection : connections) {
                 if (connection->connected()) {
                     connection->m_callback(args...);
                 }
             }
         } else {
-            result_type ret{std::nullopt};
+            static_assert(std::is_same_v<Combiner, any_of>,
+                          "only the any_of combiner is supported and hard-coded into this functor.");
+            static_assert(std::is_same_v<result_type, typename function_type::result_type>,
+                          "Callback result type must be equal to the combiner result type (bool).");
+            result_type ret{false};
             for (const auto& connection : connections) {
                 if (connection->connected()) {
-                    ret.emplace(connection->m_callback(args...));
+                    ret |= connection->m_callback(args...);
                 }
             }
             return ret;

--- a/src/btcsignals.h
+++ b/src/btcsignals.h
@@ -200,7 +200,7 @@ public:
      * more than one callback is enabled.
      */
     template <typename... Args>
-    result_type operator()(Args&&... args) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    [[nodiscard]] result_type operator()(Args&&... args) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
         std::vector<std::shared_ptr<connection_holder>> connections;
         {

--- a/src/btcsignals.h
+++ b/src/btcsignals.h
@@ -122,7 +122,7 @@ class scoped_connection
     connection m_conn;
 
 public:
-    scoped_connection(connection rhs) noexcept : m_conn{std::move(rhs)} {}
+    explicit scoped_connection(connection rhs) noexcept : m_conn{std::move(rhs)} {}
 
     scoped_connection(scoped_connection&&) noexcept = default;
 

--- a/src/common/interfaces.cpp
+++ b/src/common/interfaces.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <btcsignals.h>
 #include <interfaces/echo.h>
 #include <interfaces/handler.h>
+#include <util/btcsignals.h>
 
 #include <memory>
 #include <utility>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -7,13 +7,10 @@
 
 #include <init.h>
 
-#include <kernel/checks.h>
-
 #include <addrdb.h>
 #include <addrman.h>
 #include <banman.h>
 #include <blockfilter.h>
-#include <btcsignals.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <chainparamsbase.h>
@@ -42,6 +39,7 @@
 #include <kernel/blockmanager_opts.h>
 #include <kernel/caches.h>
 #include <kernel/chainstatemanager_opts.h>
+#include <kernel/checks.h>
 #include <kernel/context.h>
 #include <kernel/notifications_interface.h>
 #include <key.h>
@@ -87,6 +85,7 @@
 #include <uint256.h>
 #include <util/asmap.h>
 #include <util/batchpriority.h>
+#include <util/btcsignals.h>
 #include <util/chaintype.h>
 #include <util/check.h>
 #include <util/fs.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1573,7 +1573,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
      * be disabled when initialisation is finished.
      */
     if (args.GetBoolArg("-server", false)) {
-        uiInterface.InitMessage_connect(SetRPCWarmupStatus);
+        uiInterface.InitMessage.connect(SetRPCWarmupStatus);
         if (!AppInitServers(node))
             return InitError(_("Unable to start HTTP server. See debug log for details."));
     }
@@ -2025,7 +2025,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 #if HAVE_SYSTEM
     const std::string block_notify = args.GetArg("-blocknotify", "");
     if (!block_notify.empty()) {
-        uiInterface.NotifyBlockTip_connect([block_notify](SynchronizationState sync_state, const CBlockIndex& block, double /* verification_progress */) {
+        uiInterface.NotifyBlockTip.connect([block_notify](SynchronizationState sync_state, const CBlockIndex& block, double /* verification_progress */) {
             if (sync_state != SynchronizationState::POST_INIT) return;
             std::string command = block_notify;
             ReplaceAll(command, "%s", block.GetBlockHash().GetHex());

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -219,8 +219,7 @@ public:
     virtual std::unique_ptr<Handler> handleInitMessage(InitMessageFn fn) = 0;
 
     //! Register handler for message box messages.
-    using MessageBoxFn =
-        std::function<bool(const bilingual_str& message, unsigned int style)>;
+    using MessageBoxFn = std::function<void(const bilingual_str& message, unsigned int style)>;
     virtual std::unique_ptr<Handler> handleMessageBox(MessageBoxFn fn) = 0;
 
     //! Register handler for question messages.

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -13,7 +13,7 @@ using util::MakeUnorderedList;
 CClientUIInterface uiInterface;
 
 struct UISignals {
-    btcsignals::signal<CClientUIInterface::ThreadSafeMessageBoxSig, btcsignals::optional_last_value<bool>> ThreadSafeMessageBox;
+    btcsignals::signal<CClientUIInterface::ThreadSafeMessageBoxSig> ThreadSafeMessageBox;
     btcsignals::signal<CClientUIInterface::ThreadSafeQuestionSig, btcsignals::optional_last_value<bool>> ThreadSafeQuestion;
     btcsignals::signal<CClientUIInterface::InitMessageSig> InitMessage;
     btcsignals::signal<CClientUIInterface::InitWalletSig> InitWallet;
@@ -45,7 +45,7 @@ ADD_SIGNALS_IMPL_WRAPPER(NotifyBlockTip);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyHeaderTip);
 ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
 
-bool CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, style).value_or(false);}
+void CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, style); }
 bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, style).value_or(false);}
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::InitWallet() { return g_ui_signals.InitWallet(); }

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -4,7 +4,7 @@
 
 #include <node/interface_ui.h>
 
-#include <btcsignals.h>
+#include <util/btcsignals.h>
 #include <util/string.h>
 #include <util/translation.h>
 

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -14,7 +14,7 @@ CClientUIInterface uiInterface;
 
 struct UISignals {
     btcsignals::signal<CClientUIInterface::ThreadSafeMessageBoxSig> ThreadSafeMessageBox;
-    btcsignals::signal<CClientUIInterface::ThreadSafeQuestionSig, btcsignals::optional_last_value<bool>> ThreadSafeQuestion;
+    btcsignals::signal<CClientUIInterface::ThreadSafeQuestionSig, btcsignals::any_of> ThreadSafeQuestion;
     btcsignals::signal<CClientUIInterface::InitMessageSig> InitMessage;
     btcsignals::signal<CClientUIInterface::InitWalletSig> InitWallet;
     btcsignals::signal<CClientUIInterface::NotifyNumConnectionsChangedSig> NotifyNumConnectionsChanged;
@@ -46,7 +46,7 @@ ADD_SIGNALS_IMPL_WRAPPER(NotifyHeaderTip);
 ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
 
 void CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, style); }
-bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, style).value_or(false);}
+bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, style);}
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::InitWallet() { return g_ui_signals.InitWallet(); }
 void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -12,51 +12,6 @@ using util::MakeUnorderedList;
 
 CClientUIInterface uiInterface;
 
-struct UISignals {
-    btcsignals::signal<CClientUIInterface::ThreadSafeMessageBoxSig> ThreadSafeMessageBox;
-    btcsignals::signal<CClientUIInterface::ThreadSafeQuestionSig, btcsignals::any_of> ThreadSafeQuestion;
-    btcsignals::signal<CClientUIInterface::InitMessageSig> InitMessage;
-    btcsignals::signal<CClientUIInterface::InitWalletSig> InitWallet;
-    btcsignals::signal<CClientUIInterface::NotifyNumConnectionsChangedSig> NotifyNumConnectionsChanged;
-    btcsignals::signal<CClientUIInterface::NotifyNetworkActiveChangedSig> NotifyNetworkActiveChanged;
-    btcsignals::signal<CClientUIInterface::NotifyAlertChangedSig> NotifyAlertChanged;
-    btcsignals::signal<CClientUIInterface::ShowProgressSig> ShowProgress;
-    btcsignals::signal<CClientUIInterface::NotifyBlockTipSig> NotifyBlockTip;
-    btcsignals::signal<CClientUIInterface::NotifyHeaderTipSig> NotifyHeaderTip;
-    btcsignals::signal<CClientUIInterface::BannedListChangedSig> BannedListChanged;
-};
-static UISignals g_ui_signals;
-
-#define ADD_SIGNALS_IMPL_WRAPPER(signal_name)                                                                 \
-    btcsignals::connection CClientUIInterface::signal_name##_connect(std::function<signal_name##Sig> fn) \
-    {                                                                                                         \
-        return g_ui_signals.signal_name.connect(fn);                                                          \
-    }
-
-ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeMessageBox);
-ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeQuestion);
-ADD_SIGNALS_IMPL_WRAPPER(InitMessage);
-ADD_SIGNALS_IMPL_WRAPPER(InitWallet);
-ADD_SIGNALS_IMPL_WRAPPER(NotifyNumConnectionsChanged);
-ADD_SIGNALS_IMPL_WRAPPER(NotifyNetworkActiveChanged);
-ADD_SIGNALS_IMPL_WRAPPER(NotifyAlertChanged);
-ADD_SIGNALS_IMPL_WRAPPER(ShowProgress);
-ADD_SIGNALS_IMPL_WRAPPER(NotifyBlockTip);
-ADD_SIGNALS_IMPL_WRAPPER(NotifyHeaderTip);
-ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
-
-void CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, style); }
-bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, style);}
-void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
-void CClientUIInterface::InitWallet() { return g_ui_signals.InitWallet(); }
-void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
-void CClientUIInterface::NotifyNetworkActiveChanged(bool networkActive) { return g_ui_signals.NotifyNetworkActiveChanged(networkActive); }
-void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
-void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }
-void CClientUIInterface::NotifyBlockTip(SynchronizationState s, const CBlockIndex& block, double verification_progress) { return g_ui_signals.NotifyBlockTip(s, block, verification_progress); }
-void CClientUIInterface::NotifyHeaderTip(SynchronizationState s, int64_t height, int64_t timestamp, bool presync) { return g_ui_signals.NotifyHeaderTip(s, height, timestamp, presync); }
-void CClientUIInterface::BannedListChanged() { return g_ui_signals.BannedListChanged(); }
-
 bool InitError(const bilingual_str& str)
 {
     uiInterface.ThreadSafeMessageBox(str, CClientUIInterface::MSG_ERROR);

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_NODE_INTERFACE_UI_H
 #define BITCOIN_NODE_INTERFACE_UI_H
 
+#include <util/btcsignals.h>
+
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -14,10 +16,6 @@
 class CBlockIndex;
 enum class SynchronizationState;
 struct bilingual_str;
-
-namespace btcsignals {
-    class connection;
-} // namespace btcsignals
 
 /** Signals for UI communication. */
 class CClientUIInterface
@@ -66,48 +64,43 @@ public:
         MSG_ERROR = (ICON_ERROR | BTN_OK | MODAL)
     };
 
-#define ADD_SIGNALS_DECL_WRAPPER(signal_name, rtype, ...)                                  \
-    rtype signal_name(__VA_ARGS__);                                                        \
-    using signal_name##Sig = rtype(__VA_ARGS__);                                           \
-    btcsignals::connection signal_name##_connect(std::function<signal_name##Sig> fn)
-
     /** Show message box. */
-    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeMessageBox, void, const bilingual_str& message, unsigned int style);
+    btcsignals::signal<void(const bilingual_str& message, unsigned int style)> ThreadSafeMessageBox;
 
     /** If possible, ask the user a question. If not, falls back to ThreadSafeMessageBox(noninteractive_message, style) and returns false. */
-    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeQuestion, bool, const bilingual_str& message, const std::string& noninteractive_message, unsigned int style);
+    btcsignals::signal<bool(const bilingual_str& message, const std::string& noninteractive_message, unsigned int style), btcsignals::any_of> ThreadSafeQuestion;
 
     /** Progress message during initialization. */
-    ADD_SIGNALS_DECL_WRAPPER(InitMessage, void, const std::string& message);
+    btcsignals::signal<void(const std::string& message)> InitMessage;
 
     /** Wallet loader created. */
-    ADD_SIGNALS_DECL_WRAPPER(InitWallet, void, );
+    btcsignals::signal<void()> InitWallet;
 
     /** Number of network connections changed. */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyNumConnectionsChanged, void, int newNumConnections);
+    btcsignals::signal<void(int newNumConnections)> NotifyNumConnectionsChanged;
 
     /** Network activity state changed. */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyNetworkActiveChanged, void, bool networkActive);
+    btcsignals::signal<void(bool networkActive)> NotifyNetworkActiveChanged;
 
     /**
      * Status bar alerts changed.
      */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyAlertChanged, void, );
+    btcsignals::signal<void()> NotifyAlertChanged;
 
     /**
      * Show progress e.g. for verifychain.
      * resume_possible indicates shutting down now will result in the current progress action resuming upon restart.
      */
-    ADD_SIGNALS_DECL_WRAPPER(ShowProgress, void, const std::string& title, int nProgress, bool resume_possible);
+    btcsignals::signal<void(const std::string& title, int nProgress, bool resume_possible)> ShowProgress;
 
     /** New block has been accepted */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyBlockTip, void, SynchronizationState, const CBlockIndex& block, double verification_progress);
+    btcsignals::signal<void(SynchronizationState, const CBlockIndex& block, double verification_progress)> NotifyBlockTip;
 
     /** Best header has changed */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyHeaderTip, void, SynchronizationState, int64_t height, int64_t timestamp, bool presync);
+    btcsignals::signal<void(SynchronizationState, int64_t height, int64_t timestamp, bool presync)> NotifyHeaderTip;
 
     /** Banlist did change. */
-    ADD_SIGNALS_DECL_WRAPPER(BannedListChanged, void, void);
+    btcsignals::signal<void(void)> BannedListChanged;
 };
 
 /** Show warning message **/

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -72,7 +72,7 @@ public:
     btcsignals::connection signal_name##_connect(std::function<signal_name##Sig> fn)
 
     /** Show message box. */
-    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeMessageBox, bool, const bilingual_str& message, unsigned int style);
+    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeMessageBox, void, const bilingual_str& message, unsigned int style);
 
     /** If possible, ask the user a question. If not, falls back to ThreadSafeMessageBox(noninteractive_message, style) and returns false. */
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeQuestion, bool, const bilingual_str& message, const std::string& noninteractive_message, unsigned int style);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -386,50 +386,50 @@ public:
     }
     std::unique_ptr<Handler> handleInitMessage(InitMessageFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.InitMessage_connect(fn));
+        return MakeSignalHandler(::uiInterface.InitMessage.connect(fn));
     }
     std::unique_ptr<Handler> handleMessageBox(MessageBoxFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.ThreadSafeMessageBox_connect(fn));
+        return MakeSignalHandler(::uiInterface.ThreadSafeMessageBox.connect(fn));
     }
     std::unique_ptr<Handler> handleQuestion(QuestionFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.ThreadSafeQuestion_connect(fn));
+        return MakeSignalHandler(::uiInterface.ThreadSafeQuestion.connect(fn));
     }
     std::unique_ptr<Handler> handleShowProgress(ShowProgressFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.ShowProgress_connect(fn));
+        return MakeSignalHandler(::uiInterface.ShowProgress.connect(fn));
     }
     std::unique_ptr<Handler> handleInitWallet(InitWalletFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.InitWallet_connect(fn));
+        return MakeSignalHandler(::uiInterface.InitWallet.connect(fn));
     }
     std::unique_ptr<Handler> handleNotifyNumConnectionsChanged(NotifyNumConnectionsChangedFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.NotifyNumConnectionsChanged_connect(fn));
+        return MakeSignalHandler(::uiInterface.NotifyNumConnectionsChanged.connect(fn));
     }
     std::unique_ptr<Handler> handleNotifyNetworkActiveChanged(NotifyNetworkActiveChangedFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.NotifyNetworkActiveChanged_connect(fn));
+        return MakeSignalHandler(::uiInterface.NotifyNetworkActiveChanged.connect(fn));
     }
     std::unique_ptr<Handler> handleNotifyAlertChanged(NotifyAlertChangedFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.NotifyAlertChanged_connect(fn));
+        return MakeSignalHandler(::uiInterface.NotifyAlertChanged.connect(fn));
     }
     std::unique_ptr<Handler> handleBannedListChanged(BannedListChangedFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.BannedListChanged_connect(fn));
+        return MakeSignalHandler(::uiInterface.BannedListChanged.connect(fn));
     }
     std::unique_ptr<Handler> handleNotifyBlockTip(NotifyBlockTipFn fn) override
     {
-        return MakeSignalHandler(::uiInterface.NotifyBlockTip_connect([fn](SynchronizationState sync_state, const CBlockIndex& block, double verification_progress) {
+        return MakeSignalHandler(::uiInterface.NotifyBlockTip.connect([fn](SynchronizationState sync_state, const CBlockIndex& block, double verification_progress) {
             fn(sync_state, BlockTip{block.nHeight, block.GetBlockTime(), block.GetBlockHash()}, verification_progress);
         }));
     }
     std::unique_ptr<Handler> handleNotifyHeaderTip(NotifyHeaderTipFn fn) override
     {
         return MakeSignalHandler(
-            ::uiInterface.NotifyHeaderTip_connect([fn](SynchronizationState sync_state, int64_t height, int64_t timestamp, bool presync) {
+            ::uiInterface.NotifyHeaderTip.connect([fn](SynchronizationState sync_state, int64_t height, int64_t timestamp, bool presync) {
                 fn(sync_state, BlockTip{(int)height, timestamp, uint256{}}, presync);
             }));
     }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -6,7 +6,6 @@
 
 #include <banman.h>
 #include <blockfilter.h>
-#include <btcsignals.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <coins.h>
@@ -60,6 +59,7 @@
 #include <txmempool.h>
 #include <uint256.h>
 #include <univalue.h>
+#include <util/btcsignals.h>
 #include <util/check.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -56,9 +56,9 @@ void noui_InitMessage(const std::string& message)
 
 void noui_connect()
 {
-    noui_ThreadSafeMessageBoxConn = uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
-    noui_ThreadSafeQuestionConn = uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
-    noui_InitMessageConn = uiInterface.InitMessage_connect(noui_InitMessage);
+    noui_ThreadSafeMessageBoxConn = uiInterface.ThreadSafeMessageBox.connect(noui_ThreadSafeMessageBox);
+    noui_ThreadSafeQuestionConn = uiInterface.ThreadSafeQuestion.connect(noui_ThreadSafeQuestion);
+    noui_InitMessageConn = uiInterface.InitMessage.connect(noui_InitMessage);
 }
 
 void noui_ThreadSafeMessageBoxRedirect(const bilingual_str& message, unsigned int style)
@@ -82,9 +82,9 @@ void noui_test_redirect()
     noui_ThreadSafeMessageBoxConn.disconnect();
     noui_ThreadSafeQuestionConn.disconnect();
     noui_InitMessageConn.disconnect();
-    noui_ThreadSafeMessageBoxConn = uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBoxRedirect);
-    noui_ThreadSafeQuestionConn = uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestionRedirect);
-    noui_InitMessageConn = uiInterface.InitMessage_connect(noui_InitMessageRedirect);
+    noui_ThreadSafeMessageBoxConn = uiInterface.ThreadSafeMessageBox.connect(noui_ThreadSafeMessageBoxRedirect);
+    noui_ThreadSafeQuestionConn = uiInterface.ThreadSafeQuestion.connect(noui_ThreadSafeQuestionRedirect);
+    noui_InitMessageConn = uiInterface.InitMessage.connect(noui_InitMessageRedirect);
 }
 
 void noui_reconnect()

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -5,8 +5,8 @@
 
 #include <noui.h>
 
-#include <btcsignals.h>
 #include <node/interface_ui.h>
+#include <util/btcsignals.h>
 #include <util/log.h>
 #include <util/translation.h>
 

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -17,7 +17,7 @@ btcsignals::connection noui_ThreadSafeMessageBoxConn;
 btcsignals::connection noui_ThreadSafeQuestionConn;
 btcsignals::connection noui_InitMessageConn;
 
-bool noui_ThreadSafeMessageBox(const bilingual_str& message, unsigned int style)
+void noui_ThreadSafeMessageBox(const bilingual_str& message, unsigned int style)
 {
     bool fSecure = style & CClientUIInterface::SECURE;
     style &= ~CClientUIInterface::SECURE;
@@ -41,12 +41,12 @@ bool noui_ThreadSafeMessageBox(const bilingual_str& message, unsigned int style)
     }
 
     tfm::format(std::cerr, "%s%s\n", strCaption, message.original);
-    return false;
 }
 
 bool noui_ThreadSafeQuestion(const bilingual_str& /* ignored interactive message */, const std::string& message, unsigned int style)
 {
-    return noui_ThreadSafeMessageBox(Untranslated(message), style);
+    noui_ThreadSafeMessageBox(Untranslated(message), style);
+    return false; // Answer the question with false in the noui context
 }
 
 void noui_InitMessage(const std::string& message)
@@ -61,10 +61,9 @@ void noui_connect()
     noui_InitMessageConn = uiInterface.InitMessage_connect(noui_InitMessage);
 }
 
-bool noui_ThreadSafeMessageBoxRedirect(const bilingual_str& message, unsigned int style)
+void noui_ThreadSafeMessageBoxRedirect(const bilingual_str& message, unsigned int style)
 {
     LogInfo("%s", message.original);
-    return false;
 }
 
 bool noui_ThreadSafeQuestionRedirect(const bilingual_str& /* ignored interactive message */, const std::string& message, unsigned int style)

--- a/src/noui.h
+++ b/src/noui.h
@@ -10,7 +10,7 @@
 struct bilingual_str;
 
 /** Non-GUI handler, which logs and prints messages. */
-bool noui_ThreadSafeMessageBox(const bilingual_str& message, unsigned int style);
+void noui_ThreadSafeMessageBox(const bilingual_str& message, unsigned int style);
 /** Non-GUI handler, which logs and prints questions. */
 bool noui_ThreadSafeQuestion(const bilingual_str& /* ignored interactive message */, const std::string& message, unsigned int style);
 /** Non-GUI handler, which only logs a message. */

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -485,9 +485,9 @@ int GuiMain(int argc, char* argv[])
     util::ThreadSetInternalName("main");
 
     // Subscribe to global signals from core
-    btcsignals::scoped_connection handler_message_box = ::uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
-    btcsignals::scoped_connection handler_question = ::uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
-    btcsignals::scoped_connection handler_init_message = ::uiInterface.InitMessage_connect(noui_InitMessage);
+    btcsignals::scoped_connection handler_message_box{::uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox)};
+    btcsignals::scoped_connection handler_question{::uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion)};
+    btcsignals::scoped_connection handler_init_message{::uiInterface.InitMessage_connect(noui_InitMessage)};
 
     // Do not refer to data directory yet, this can be overridden by Intro::pickDataDirectory
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -485,9 +485,9 @@ int GuiMain(int argc, char* argv[])
     util::ThreadSetInternalName("main");
 
     // Subscribe to global signals from core
-    btcsignals::scoped_connection handler_message_box{::uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox)};
-    btcsignals::scoped_connection handler_question{::uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion)};
-    btcsignals::scoped_connection handler_init_message{::uiInterface.InitMessage_connect(noui_InitMessage)};
+    btcsignals::scoped_connection handler_message_box{::uiInterface.ThreadSafeMessageBox.connect(noui_ThreadSafeMessageBox)};
+    btcsignals::scoped_connection handler_question{::uiInterface.ThreadSafeQuestion.connect(noui_ThreadSafeQuestion)};
+    btcsignals::scoped_connection handler_init_message{::uiInterface.InitMessage.connect(noui_InitMessage)};
 
     // Do not refer to data directory yet, this can be overridden by Intro::pickDataDirectory
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -6,7 +6,6 @@
 
 #include <qt/bitcoin.h>
 
-#include <btcsignals.h>
 #include <chainparams.h>
 #include <common/args.h>
 #include <common/init.h>
@@ -31,6 +30,7 @@
 #include <qt/utilitydialog.h>
 #include <qt/winshutdownmonitor.h>
 #include <uint256.h>
+#include <util/btcsignals.h>
 #include <util/exception.h>
 #include <util/log.h>
 #include <util/string.h>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1589,7 +1589,7 @@ void BitcoinGUI::showModalOverlay()
         modalOverlay->toggleVisibility();
 }
 
-static bool ThreadSafeMessageBox(BitcoinGUI* gui, const bilingual_str& message, unsigned int style)
+[[nodiscard]] static bool ThreadSafeMessageBox(BitcoinGUI* gui, const bilingual_str& message, unsigned int style)
 {
     bool modal = (style & CClientUIInterface::MODAL);
     // The SECURE flag has no effect in the Qt GUI.
@@ -1621,7 +1621,7 @@ void BitcoinGUI::subscribeToCoreSignals()
 {
     // Connect signals to client
     m_handler_message_box = m_node.handleMessageBox([this](const bilingual_str& message, unsigned int style) {
-        return ThreadSafeMessageBox(this, message, style);
+        (void)ThreadSafeMessageBox(this, message, style);
     });
     m_handler_question = m_node.handleQuestion([this](const bilingual_str& message, const std::string& /*non_interactive_message*/, unsigned int style) {
         return ThreadSafeMessageBox(this, message, style);

--- a/src/test/btcsignals_tests.cpp
+++ b/src/test/btcsignals_tests.cpp
@@ -12,22 +12,6 @@
 namespace {
 
 
-struct MoveOnlyData {
-    MoveOnlyData(int data) : m_data(data) {}
-    MoveOnlyData(MoveOnlyData&&) = default;
-
-    MoveOnlyData& operator=(MoveOnlyData&&) = delete;
-    MoveOnlyData(const MoveOnlyData&) = delete;
-    MoveOnlyData& operator=(const MoveOnlyData&) = delete;
-
-    int m_data;
-};
-
-MoveOnlyData MoveOnlyReturnCallback(int val)
-{
-    return {val};
-}
-
 void IncrementCallback(int& val)
 {
     val++;
@@ -97,44 +81,30 @@ BOOST_AUTO_TEST_CASE(disconnects)
     BOOST_CHECK_EQUAL(val, 6);
 }
 
-/* Check that move-only return types work correctly
- */
-BOOST_AUTO_TEST_CASE(moveonly_return)
+BOOST_AUTO_TEST_CASE(any_of_combiner)
 {
-    btcsignals::signal<MoveOnlyData(int)> sig0;
-    sig0.connect(MoveOnlyReturnCallback);
-    int data{3};
-    auto ret = sig0(data);
-    BOOST_CHECK_EQUAL(ret->m_data, 3);
-}
-
-/* The result of the signal invocation should always be the result of the last
- * enabled callback.
- */
-BOOST_AUTO_TEST_CASE(return_value)
-{
-    btcsignals::signal<bool()> sig0;
+    btcsignals::signal<bool(), btcsignals::any_of> sig0;
     decltype(sig0)::result_type ret;
     ret = sig0();
-    BOOST_CHECK(!ret);
+    BOOST_CHECK_EQUAL(ret, false);
     {
-        btcsignals::scoped_connection conn0 = sig0.connect(ReturnTrue);
+        btcsignals::scoped_connection conn0{sig0.connect(ReturnTrue)};
         ret = sig0();
-        BOOST_CHECK(ret && *ret == true);
+        BOOST_CHECK_EQUAL(ret, true);
     }
     ret = sig0();
-    BOOST_CHECK(!ret);
+    BOOST_CHECK_EQUAL(ret, false);
     {
-        btcsignals::scoped_connection conn1 = sig0.connect(ReturnTrue);
-        btcsignals::scoped_connection conn0 = sig0.connect(ReturnFalse);
+        btcsignals::scoped_connection conn0{sig0.connect(ReturnTrue)};
+        btcsignals::scoped_connection conn1{sig0.connect(ReturnFalse)};
         ret = sig0();
-        BOOST_CHECK(ret && *ret == false);
+        BOOST_CHECK_EQUAL(ret, true);
         conn0.disconnect();
         ret = sig0();
-        BOOST_CHECK(ret && *ret == true);
+        BOOST_CHECK_EQUAL(ret, false);
     }
     ret = sig0();
-    BOOST_CHECK(!ret);
+    BOOST_CHECK_EQUAL(ret, false);
 }
 
 /* Test the thread-safety of connect/disconnect/empty/connected/callbacks.

--- a/src/test/btcsignals_tests.cpp
+++ b/src/test/btcsignals_tests.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <btcsignals.h>
 #include <test/util/setup_common.h>
+#include <util/btcsignals.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/btcsignals_tests.cpp
+++ b/src/test/btcsignals_tests.cpp
@@ -111,17 +111,18 @@ BOOST_AUTO_TEST_CASE(any_of_combiner)
  * Connect sig0 to an incrementor function and loop in a thread.
  * Meanwhile, in another thread, inject and call new increment callbacks.
  * Both threads are constantly calling empty/connected.
- * Though the end-result is undefined due to a non-deterministic number of
- * total callbacks executed, this should all be completely threadsafe.
+ * The end-result must be deterministic for the atomic modified by conn0.
+ * Though, the end-result for the atomic modified by the extra connections is
+ * undefined due to a non-deterministic number of total callbacks executed.
+ * In any case, this should all be completely threadsafe.
  * Sanitizers should pick up any buggy data race behavior (if present).
  */
 BOOST_AUTO_TEST_CASE(thread_safety)
 {
     btcsignals::signal<void()> sig0;
-    std::atomic<uint32_t> val{0};
-    auto conn0 = sig0.connect([&val] {
-        val++;
-    });
+    std::atomic<uint32_t> val_det{0};
+    std::atomic<uint32_t> val_non_det{0};
+    auto conn0 = sig0.connect([&val_det] { val_det++; });
 
     std::thread incrementor([&conn0, &sig0] {
         for (int i = 0; i < 1000; i++) {
@@ -134,16 +135,17 @@ BOOST_AUTO_TEST_CASE(thread_safety)
         assert(conn0.connected());
     });
 
-    std::thread extra_increment_injector([&conn0, &sig0, &val] {
+    std::thread extra_increment_injector([&conn0, &sig0, &val_non_det] {
         static constexpr size_t num_extra_conns{1000};
         std::vector<btcsignals::scoped_connection> extra_conns;
         extra_conns.reserve(num_extra_conns);
         for (size_t i = 0; i < num_extra_conns; i++) {
             BOOST_CHECK(!sig0.empty());
             BOOST_CHECK(conn0.connected());
-            extra_conns.emplace_back(sig0.connect([&val] {
-                val++;
-            }));
+            btcsignals::scoped_connection extra{sig0.connect([&val_non_det] { val_non_det++; })};
+            if (i % 2 == 0) {
+                extra_conns.emplace_back(std::move(extra));
+            }
             sig0();
         }
     });
@@ -152,10 +154,16 @@ BOOST_AUTO_TEST_CASE(thread_safety)
     conn0.disconnect();
     BOOST_CHECK(sig0.empty());
 
-    // sig will have been called 2000 times, and at least 1000 of those will
-    // have been executing multiple incrementing callbacks. So while val is
-    // probably MUCH bigger, it's guaranteed to be at least 3000.
-    BOOST_CHECK_GE(val.load(), 3000);
+    // sig0 will have been called 2000 times, and only the first connection did
+    // increment val_det, so it must be 2000.
+    BOOST_CHECK_EQUAL(val_det.load(), 2000);
+    // The number of connections that increment val_non_det is growing from 1
+    // to 500, where 500 are disconnected immediately again after the step.
+    // Before the end of each step the connections are called at least once.
+    // However, it is unknown how often the connections have been called
+    // exactly. The 500th Triangular Number gives a lower estimate.
+    // T_n=n(n+1)/2
+    BOOST_CHECK_GE(val_non_det.load(), 500 * 501 / 2);
 }
 
 /* Test that connection and disconnection works from within signal

--- a/src/util/btcsignals.h
+++ b/src/util/btcsignals.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_BTCSIGNALS_H
-#define BITCOIN_BTCSIGNALS_H
+#ifndef BITCOIN_UTIL_BTCSIGNALS_H
+#define BITCOIN_UTIL_BTCSIGNALS_H
 
 #include <sync.h>
 
@@ -258,4 +258,4 @@ public:
 
 } // namespace btcsignals
 
-#endif // BITCOIN_BTCSIGNALS_H
+#endif // BITCOIN_UTIL_BTCSIGNALS_H

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -6,7 +6,6 @@
 #define BITCOIN_WALLET_SCRIPTPUBKEYMAN_H
 
 #include <addresstype.h>
-#include <btcsignals.h>
 #include <common/messages.h>
 #include <common/signmessage.h>
 #include <common/types.h>
@@ -16,6 +15,7 @@
 #include <script/descriptor.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
+#include <util/btcsignals.h>
 #include <util/hasher.h>
 #include <util/log.h>
 #include <util/result.h>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -7,7 +7,6 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include <addresstype.h>
-#include <btcsignals.h>
 #include <consensus/amount.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
@@ -23,6 +22,7 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <uint256.h>
+#include <util/btcsignals.h>
 #include <util/fs.h>
 #include <util/hasher.h>
 #include <util/log.h>


### PR DESCRIPTION
Previously, the ThreadSafeQuestion signal was using `btcsignals::optional_last_value<bool>`.
However, this only worked by accident:

* Calling `CClientUIInterface::ThreadSafeQuestion` did not return an
  `std::optional<bool>`, but `value_or(false)`. This makes it hard for
  callers to differentiate between `nullopt` and `false`.
* The return value was further influenced by the order in which the
  connections were done. The noui callbacks would always overwrite the
  return value with false. This makes the code overall brittle, and
  confusing.

For example, the following patch that changes the order of connections
would break the only and single place where the return value actually
matters:

```diff
diff --git a/src/qt/bitcoin.cpp b/src/qt/bitcoin.cpp
index https://github.com/bitcoin/bitcoin/commit/0b89c605b9ce69abcce88ac5a88699c353418078..976549470e 100644
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -488,3 +488,2 @@ int GuiMain(int argc, char* argv[])
     btcsignals::scoped_connection handler_message_box = ::uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
-    btcsignals::scoped_connection handler_question = ::uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
     btcsignals::scoped_connection handler_init_message = ::uiInterface.InitMessage_connect(noui_InitMessage);
@@ -663,2 +662,3 @@ int GuiMain(int argc, char* argv[])
         app.createWindow(networkStyle.data());
+    btcsignals::scoped_connection handler_question = ::uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
         // Perform base initialization before spinning up initialization/shutdown thread
```

This can be tested by applying the patch and then calling:

(May have to be started twice to trigger the question)

```
bitcoin-qt -regtest -datadir=/tmp -mocktime=123456789
```

Before the changes in this commit (on current master), pressing `OK`
would not have any effect and would abort the program.

After the changes in this commit, pressing `OK` will correctly trigger a
-reindex and leave the program running.

So fix that by properly returning from the signal.

Also, remove the then-unused `btcsignals::optional_last_value<T>` combiner.

Also, other follow-ups from https://github.com/bitcoin/bitcoin/pull/34495#issuecomment-4212629857