### PR TITLE
contrib: Fix NameError in signet miner gbt()

### DIFF
--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -333,7 +333,7 @@ class Generate:
     def gbt(self, bcli, bestblockhash, now):
         tmpl = json.loads(bcli("getblocktemplate", '{"rules":["signet","segwit"]}'))
         if tmpl["previousblockhash"] != bestblockhash:
-            logging.warning("GBT based off unexpected block (%s not %s), retrying", tmpl["previousblockhash"], bci["bestblockhash"])
+            logging.warning("GBT based off unexpected block (%s not %s), retrying", tmpl["previousblockhash"], bestblockhash)
             time.sleep(1)
             return None
 


### PR DESCRIPTION
The logging.warning call referenced `bci["bestblockhash"]`, a variable from the calling scope `do_generate()` that is not available inside the `Generate.gbt()` method. This would crash with a NameError when getblocktemplate returned a template based on an unexpected previous block.

Use the `bestblockhash` parameter that was already being passed in and used correctly in the comparison on the line above.

The bug was introduced in 7b31332370 when the gbt logic was extracted into its own method — the if-condition was updated but the logging call was not.