### PR TITLE
doc: fix typo 'parlor' to 'parlance' in developer-notes

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -796,7 +796,7 @@ Common misconceptions are clarified in those sections:
 - Do not compare an iterator from one data structure with an iterator of
   another data structure (even if of the same type).
 
-  - *Rationale*: Behavior is undefined. In C++ parlor this means "may reformat
+  - *Rationale*: Behavior is undefined. In C++ parlance this means "may reformat
     the universe", in practice this has resulted in at least one hard-to-debug crash bug.
 
 - Watch out for out-of-bounds vector access. `&vch[vch.size()]` is illegal,


### PR DESCRIPTION
Fix a small typo in doc/developer-notes.md.

Replace "parlor" with "parlance" to use the correct term in the context of C++ terminology.