### PR TITLE
test: remove circular dependency between authproxy and util

### DIFF
--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -5,13 +5,13 @@
 """Test indices in conjunction with prune."""
 import concurrent.futures
 import os
-from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_node import TestNode
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
+    JSONRPCException,
 )
 
 from typing import List, Any

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the getblockfrompeer RPC."""
 
-from test_framework.authproxy import JSONRPCException
 from test_framework.messages import (
     CBlock,
     from_hex,
@@ -19,6 +18,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    JSONRPCException,
 )
 
 

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -11,9 +11,8 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_greater_than_or_equal,
+    JSONRPCException,
 )
-
-from test_framework.authproxy import JSONRPCException
 
 import http
 import subprocess

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -44,7 +44,7 @@ import socket
 import time
 import urllib.parse
 
-from .util import JSONRPCException
+from .util import JSONRPCException, assert_equal
 
 HTTP_TIMEOUT = 30
 USER_AGENT = "AuthServiceProxy/0.1"
@@ -139,7 +139,6 @@ class AuthServiceProxy():
             else:
                 return response['result']
         else:
-            from .util import assert_equal
             assert_equal(response['jsonrpc'], '2.0')
             if status != HTTPStatus.OK:
                 raise JSONRPCException({

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -44,17 +44,12 @@ import socket
 import time
 import urllib.parse
 
+from .util import JSONRPCException
+
 HTTP_TIMEOUT = 30
 USER_AGENT = "AuthServiceProxy/0.1"
 
 log = logging.getLogger("BitcoinRPC")
-
-class JSONRPCException(Exception):
-    def __init__(self, rpc_error, http_status=None):
-        super().__init__(f"{rpc_error} [http_status={http_status}]")
-        self.error = rpc_error
-        self.http_status = http_status
-
 
 def serialization_fallback(o):
     if isinstance(o, decimal.Decimal):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -22,7 +22,6 @@ import tempfile
 import time
 
 from .address import create_deterministic_address_bcrt1_p2tr_op_true
-from .authproxy import JSONRPCException
 from . import coverage
 from .p2p import NetworkThread
 from .test_node import TestNode
@@ -40,6 +39,7 @@ from .util import (
     p2p_port,
     wait_until_helper_internal,
     wallet_importprivkey,
+    JSONRPCException,
 )
 
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -20,7 +20,6 @@ import shlex
 import time
 import types
 
-from .authproxy import JSONRPCException
 from .descriptors import descsum_create
 from collections.abc import Callable
 from typing import Optional, Union
@@ -28,6 +27,12 @@ from typing import Optional, Union
 SATOSHI_PRECISION = Decimal('0.00000001')
 
 logger = logging.getLogger("TestFramework.utils")
+
+class JSONRPCException(Exception):
+    def __init__(self, rpc_error, http_status=None):
+        super().__init__(f"{rpc_error} [http_status={http_status}]")
+        self.error = rpc_error
+        self.http_status = http_status
 
 # Assert functions
 ##################

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -18,7 +18,6 @@ variants.
 import concurrent.futures
 import time
 
-from test_framework.authproxy import JSONRPCException
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.descriptors import descsum_create
@@ -26,6 +25,7 @@ from test_framework.script import SEQUENCE_LOCKTIME_TYPE_FLAG
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    JSONRPCException,
 )
 from test_framework.wallet_util import (
     get_generate_key,

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -12,7 +12,6 @@ import platform
 import shutil
 import stat
 
-from test_framework.authproxy import JSONRPCException
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_node import ErrorMatch
@@ -20,6 +19,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
     ensure_for,
+    JSONRPCException,
 )
 
 got_loading_error = False

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -7,7 +7,6 @@
 from decimal import Decimal, getcontext
 from itertools import product
 
-from test_framework.authproxy import JSONRPCException
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -18,6 +17,7 @@ from test_framework.util import (
     assert_greater_than_or_equal,
     assert_raises_rpc_error,
     count_bytes,
+    JSONRPCException,
 )
 from test_framework.wallet_util import (
     calculate_input_weight,

--- a/test/functional/wallet_v3_txs.py
+++ b/test/functional/wallet_v3_txs.py
@@ -6,7 +6,6 @@
 
 from decimal import Decimal, getcontext
 
-from test_framework.authproxy import JSONRPCException
 from test_framework.messages import (
     COIN,
     CTransaction,
@@ -28,6 +27,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
+    JSONRPCException,
 )
 
 from test_framework.mempool_util import (


### PR DESCRIPTION
I noticed this issue while reviewing #34773 where a lazy import 
is added in the __call__ method of the AuthServiceProxy class in 
authproxy.py

There's a circular dependency between authproxy.py and util.py
due to which the former can't use the common utility functions
and thus lazy imports are used as a workaround.

This patch set breaks the dependency so that authproxy.py can use
the utility functions from util.py in a standard fashion. Few tests that
explicitly use get_rpc_proxy and JSONRPCException needed to have
their imports updated.