### PR TITLE
p2p: UTXO set sharing

### DIFF
--- a/contrib/utxo-tools/utxo_snapshot_merkle.py
+++ b/contrib/utxo-tools/utxo_snapshot_merkle.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Compute the chunk Merkle root of a dumptxoutset snapshot file.
+
+The file is split into chunks of 3.9 MiB. Each chunk is hashed
+with SHA256d to produce a leaf hash. At each level, if the count
+is odd, the last element is duplicated before pairing.
+
+Usage:
+  python3 utxo_snapshot_merkle.py <snapshot_file>
+"""
+import argparse
+import hashlib
+import os
+import sys
+
+UTXO_SET_CHUNK_SIZE = 3_900_000
+
+
+def sha256d(data: bytes) -> bytes:
+    """Double SHA-256"""
+    return hashlib.sha256(hashlib.sha256(data).digest()).digest()
+
+
+def compute_merkle_root(leaf_hashes: list[bytes]) -> bytes:
+    """Compute the Merkle root"""
+    if not leaf_hashes:
+        return b'\x00' * 32
+    hashes = list(leaf_hashes)
+    while len(hashes) > 1:
+        if len(hashes) % 2 == 1:
+            hashes.append(hashes[-1])
+        next_level = []
+        for i in range(0, len(hashes), 2):
+            next_level.append(sha256d(hashes[i] + hashes[i + 1]))
+        hashes = next_level
+    return hashes[0]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute the chunk Merkle root of a dumptxoutset snapshot file.")
+    parser.add_argument("snapshot", help="Path to the dumptxoutset snapshot file")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.snapshot):
+        print(f"Error: file not found: {args.snapshot}", file=sys.stderr)
+        sys.exit(1)
+
+    file_size = os.path.getsize(args.snapshot)
+    total_chunks = (file_size + UTXO_SET_CHUNK_SIZE - 1) // UTXO_SET_CHUNK_SIZE
+
+    print(f"File: {args.snapshot}")
+    print(f"Size: {file_size} bytes")
+    print(f"Chunks: {total_chunks} (chunk size: {UTXO_SET_CHUNK_SIZE})")
+
+    leaf_hashes = []
+    with open(args.snapshot, "rb") as f:
+        remaining = file_size
+        while remaining > 0:
+            chunk_size = min(remaining, UTXO_SET_CHUNK_SIZE)
+            chunk = f.read(chunk_size)
+            leaf_hashes.append(sha256d(chunk))
+            remaining -= chunk_size
+
+    root = compute_merkle_root(leaf_hashes)
+    root_hex = root[::-1].hex()
+    print(f"Merkle root: {root_hex}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -235,6 +235,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/txdownloadman_impl.cpp
   node/txorphanage.cpp
   node/txreconciliation.cpp
+  node/utxo_set_share.cpp
   node/utxo_snapshot.cpp
   node/warnings.cpp
   noui.cpp

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -163,7 +163,7 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint32_t leaf_
     }
 }
 
-static std::vector<uint256> ComputeMerklePath(const std::vector<uint256>& leaves, uint32_t position) {
+std::vector<uint256> ComputeMerklePath(const std::vector<uint256>& leaves, uint32_t position) {
     std::vector<uint256> ret;
     MerkleComputation(leaves, position, ret);
     return ret;

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -24,6 +24,11 @@ uint256 BlockMerkleRoot(const CBlock& block, bool* mutated = nullptr);
 uint256 BlockWitnessMerkleRoot(const CBlock& block);
 
 /**
+ * Compute the merkle path for a given leaf position in a set of leaf hashes.
+ */
+std::vector<uint256> ComputeMerklePath(const std::vector<uint256>& leaves, uint32_t position);
+
+/**
  * Compute merkle path to the specified transaction
  *
  * @param[in] block the block

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1912,6 +1912,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
     }
 
+    // Create UTXO set download manager
+    node.utxo_set_download_manager = std::make_unique<node::UTXOSetDownloadManager>();
+    peerman_opts.utxo_set_download_manager = node.utxo_set_download_manager.get();
+
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman,
                                      node.banman.get(), chainman,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -59,6 +59,7 @@
 #include <node/mempool_persist_args.h>
 #include <node/miner.h>
 #include <node/peerman_args.h>
+#include <node/utxo_set_share.h>
 #include <policy/feerate.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <policy/fees/block_policy_estimator_args.h>
@@ -1895,6 +1896,21 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     ChainstateManager& chainman = *Assert(node.chainman);
     auto& kernel_notifications{*Assert(node.notifications)};
+
+    // Initialize UTXO set sharing if share dir contains any valid snapshots
+    {
+        fs::path share_dir{args.GetDataDirNet() / "share"};
+        std::error_code error;
+        if (fs::is_directory(share_dir, error)) {
+            node.utxo_set_share_provider = std::make_unique<node::UTXOSetShareProvider>();
+            size_t num_snapshots{node.utxo_set_share_provider->Initialize(share_dir, chainman.GetParams())};
+            if (num_snapshots > 0) {
+                g_local_services = ServiceFlags(g_local_services | NODE_UTXO_SET);
+                LogInfo("UTXO set sharing enabled: %d snapshot(s) available", num_snapshots);
+            }
+            peerman_opts.utxo_set_share_provider = node.utxo_set_share_provider.get();
+        }
+    }
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman,

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -182,7 +182,7 @@ public:
                 .hash_serialized = AssumeutxoHash{uint256{"e4b90ef9eae834f56c4b64d2d50143cee10ad87994c614d7d04125e2a6025050"}},
                 .m_chain_tx_count = 1305397408,
                 .blockhash = uint256{"0000000000000000000147034958af1652b2b91bba607beacc5e72a56f0fb5ee"},
-                .chunk_merkle_root = uint256{},  // TODO: compute from mainnet snapshot
+                .chunk_merkle_root = uint256{"f2b7098f7f3946b7dcbbe061136d9782b44176159ed6c381fe17e9a7c0f0ef54"},
             }
         };
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -161,24 +161,28 @@ public:
                 .hash_serialized = AssumeutxoHash{uint256{"a2a5521b1b5ab65f67818e5e8eccabb7171a517f9e2382208f77687310768f96"}},
                 .m_chain_tx_count = 991032194,
                 .blockhash = uint256{"0000000000000000000320283a032748cef8227873ff4872689bf23f1cda83a5"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from mainnet snapshot
             },
             {
                 .height = 880'000,
                 .hash_serialized = AssumeutxoHash{uint256{"dbd190983eaf433ef7c15f78a278ae42c00ef52e0fd2a54953782175fbadcea9"}},
                 .m_chain_tx_count = 1145604538,
                 .blockhash = uint256{"000000000000000000010b17283c3c400507969a9c2afd1dcf2082ec5cca2880"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from mainnet snapshot
             },
             {
                 .height = 910'000,
                 .hash_serialized = AssumeutxoHash{uint256{"4daf8a17b4902498c5787966a2b51c613acdab5df5db73f196fa59a4da2f1568"}},
                 .m_chain_tx_count = 1226586151,
                 .blockhash = uint256{"0000000000000000000108970acb9522ffd516eae17acddcb1bd16469194a821"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from mainnet snapshot
             },
             {
                 .height = 935'000,
                 .hash_serialized = AssumeutxoHash{uint256{"e4b90ef9eae834f56c4b64d2d50143cee10ad87994c614d7d04125e2a6025050"}},
                 .m_chain_tx_count = 1305397408,
                 .blockhash = uint256{"0000000000000000000147034958af1652b2b91bba607beacc5e72a56f0fb5ee"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from mainnet snapshot
             }
         };
 
@@ -274,12 +278,14 @@ public:
                 .hash_serialized = AssumeutxoHash{uint256{"f841584909f68e47897952345234e37fcd9128cd818f41ee6c3ca68db8071be7"}},
                 .m_chain_tx_count = 66484552,
                 .blockhash = uint256{"0000000000000093bcb68c03a9a168ae252572d348a2eaeba2cdf9231d73206f"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from testnet3 snapshot
             },
             {
                 .height = 4'840'000,
                 .hash_serialized = AssumeutxoHash{uint256{"ce6bb677bb2ee9789c4a1c9d73e6683c53fc20e8fdbedbdaaf468982a0c8db2a"}},
                 .m_chain_tx_count = 536078574,
                 .blockhash = uint256{"00000000000000f4971a7fb37fbdff89315b69a2e1920c467654a382f0d64786"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from testnet3 snapshot
             }
         };
 
@@ -379,12 +385,14 @@ public:
                 .hash_serialized = AssumeutxoHash{uint256{"784fb5e98241de66fdd429f4392155c9e7db5c017148e66e8fdbc95746f8b9b5"}},
                 .m_chain_tx_count = 11347043,
                 .blockhash = uint256{"0000000002ebe8bcda020e0dd6ccfbdfac531d2f6a81457191b99fc2df2dbe3b"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from testnet4 snapshot
             },
             {
                 .height = 120'000,
                 .hash_serialized = AssumeutxoHash{uint256{"10b05d05ad468d0971162e1b222a4aa66caca89da2bb2a93f8f37fb29c4794b0"}},
                 .m_chain_tx_count = 14141057,
                 .blockhash = uint256{"000000000bd2317e51b3c5794981c35ba894ce27d3e772d5c39ecd9cbce01dc8"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from testnet4 snapshot
             }
         };
 
@@ -492,12 +500,14 @@ public:
                 .hash_serialized = AssumeutxoHash{uint256{"fe0a44309b74d6b5883d246cb419c6221bcccf0b308c9b59b7d70783dbdf928a"}},
                 .m_chain_tx_count = 2289496,
                 .blockhash = uint256{"0000003ca3c99aff040f2563c2ad8f8ec88bd0fd6b8f0895cfaf1ef90353a62c"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from signet snapshot
             },
             {
                 .height = 290'000,
                 .hash_serialized = AssumeutxoHash{uint256{"97267e000b4b876800167e71b9123f1529d13b14308abec2888bbd2160d14545"}},
                 .m_chain_tx_count = 28547497,
                 .blockhash = uint256{"0000000577f2741bb30cd9d39d6d71b023afbeb9764f6260786a97969d5c9ac0"},
+                .chunk_merkle_root = uint256{},  // TODO: compute from signet snapshot
             }
         };
 
@@ -610,6 +620,7 @@ public:
                 .hash_serialized = AssumeutxoHash{uint256{"b952555c8ab81fec46f3d4253b7af256d766ceb39fb7752b9d18cdf4a0141327"}},
                 .m_chain_tx_count = 111,
                 .blockhash = uint256{"6affe030b7965ab538f820a56ef56c8149b7dc1d1c144af57113be080db7c397"},
+                .chunk_merkle_root = uint256{},
             },
             {
                 // For use by fuzz target src/test/fuzz/utxo_snapshot.cpp
@@ -617,6 +628,7 @@ public:
                 .hash_serialized = AssumeutxoHash{uint256{"17dcc016d188d16068907cdeb38b75691a118d43053b8cd6a25969419381d13a"}},
                 .m_chain_tx_count = 201,
                 .blockhash = uint256{"385901ccbd69dff6bbd00065d01fb8a9e464dede7cfe0372443884f9b1dcf6b9"},
+                .chunk_merkle_root = uint256{},
             },
             {
                 // For use by test/functional/feature_assumeutxo.py and test/functional/tool_bitcoin_chainstate.py
@@ -624,6 +636,7 @@ public:
                 .hash_serialized = AssumeutxoHash{uint256{"d2b051ff5e8eef46520350776f4100dd710a63447a8e01d917e92e79751a63e2"}},
                 .m_chain_tx_count = 334,
                 .blockhash = uint256{"7cc695046fec709f8c9394b6f928f81e81fd3ac20977bb68760fa1faa7916ea2"},
+                .chunk_merkle_root = uint256{"b42f449642695bfe79e6f3158d588e45265ee728e4d11dc341596a33f0f466b5"},
             },
         };
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -46,6 +46,12 @@ struct AssumeutxoData {
     //! The hash of the base block for this snapshot. Used to refer to assumeutxo data
     //! prior to having a loaded blockindex.
     uint256 blockhash;
+
+    //! The expected Merkle root of the snapshot file chunked into
+    //! UTXO_SET_CHUNK_SIZE-byte pieces and hashed with SHA256d. Used to verify
+    //! integrity of peer-advertised chunk trees during P2P UTXO set downloads.
+    //! A null value means the root is unknown and validation is skipped.
+    uint256 chunk_merkle_root;
 };
 
 /**

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -205,6 +205,7 @@ static const std::map<std::string, BCLog::LogFlags, std::less<>> LOG_CATEGORIES_
     {"txpackages", BCLog::TXPACKAGES},
     {"kernel", BCLog::KERNEL},
     {"privatebroadcast", BCLog::PRIVBROADCAST},
+    {"utxosetshare", BCLog::UTXOSETSHARE},
 };
 
 static const std::unordered_map<BCLog::LogFlags, std::string> LOG_CATEGORIES_BY_FLAG{

--- a/src/logging/categories.h
+++ b/src/logging/categories.h
@@ -46,6 +46,7 @@ enum LogFlags : CategoryMask {
     TXPACKAGES = (CategoryMask{1} << 28),
     KERNEL = (CategoryMask{1} << 29),
     PRIVBROADCAST = (CategoryMask{1} << 30),
+    UTXOSETSHARE = (CategoryMask{1} << 31),
     ALL = ~NONE,
 };
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -38,6 +38,7 @@
 #include <node/txorphanage.h>
 #include <node/txreconciliation.h>
 #include <node/utxo_set_share.h>
+#include <node/utxo_snapshot.h>
 #include <node/warnings.h>
 #include <policy/feerate.h>
 #include <policy/fees/block_policy_estimator.h>
@@ -129,6 +130,8 @@ static const unsigned int MAX_INV_SZ = 50000;
 static const unsigned int MAX_GETDATA_SZ = 1000;
 /** Number of blocks that can be requested at any given time from a single peer. */
 static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
+/** Maximum number of UTXO set chunk requests in flight per peer */
+static constexpr int MAX_UTXO_CHUNKS_IN_FLIGHT_PER_PEER{5};
 /** Default time during which a peer must stall block download progress before being disconnected.
  * the actual timeout is increased temporarily if peers are disconnected for hitting the timeout */
 static constexpr auto BLOCK_STALLING_TIMEOUT_DEFAULT{2s};
@@ -415,6 +418,9 @@ struct Peer {
     /** Time offset computed during the version handshake based on the
      * timestamp the peer sent in the version message. */
     std::atomic<std::chrono::seconds> m_time_offset{0s};
+
+    /** Whether we have registered this peer for UTXO set interaction */
+    bool m_sent_getutxostinf GUARDED_BY(NetEventsInterface::g_msgproc_mutex){false};
 
     explicit Peer(NodeId id, ServiceFlags our_services, bool is_inbound)
         : m_id{id}
@@ -758,6 +764,7 @@ private:
     FeeFilterRounder m_fee_filter_rounder GUARDED_BY(NetEventsInterface::g_msgproc_mutex);
 
     const CChainParams& m_chainparams;
+    CScheduler* m_scheduler{nullptr};
     CConnman& m_connman;
     AddrMan& m_addrman;
     /** Pointer to this node's banman. May be nullptr - check existence before dereferencing. */
@@ -1081,6 +1088,9 @@ private:
 
     /** Handle a getutxoset request. Responds with a single chunk and its Merkle proof. */
     void ProcessGetUTXOSet(CNode& node, Peer& peer, DataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(g_msgproc_mutex);
+
+    /** Activate a completed UTXO set download. Runs on the scheduler thread. */
+    void MaybeActivateDownloadedSnapshot();
 
     /** Checks if address relay is permitted with peer. If needed, initializes
      * the m_addr_known bloom filter and sets m_addr_relay_enabled to true.
@@ -1717,6 +1727,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
         m_txdownloadman.DisconnectedPeer(nodeid);
     }
     if (m_txreconciliation) m_txreconciliation->ForgetPeer(nodeid);
+    if (m_opts.utxo_set_download_manager) m_opts.utxo_set_download_manager->RequeueChunksForPeer(nodeid);
     m_num_preferred_download_peers -= state->fPreferredDownload;
     m_peers_downloading_from -= (!state->vBlocksInFlight.empty());
     assert(m_peers_downloading_from >= 0);
@@ -2032,6 +2043,8 @@ PeerManagerImpl::PeerManagerImpl(CConnman& connman, AddrMan& addrman,
 
 void PeerManagerImpl::StartScheduledTasks(CScheduler& scheduler)
 {
+    m_scheduler = &scheduler;
+
     // Stale tip checking and peer eviction are on two different timers, but we
     // don't want them to get out of sync due to drift in the scheduler, so we
     // combine them in one function and schedule at the quicker (peer-eviction)
@@ -2045,6 +2058,13 @@ void PeerManagerImpl::StartScheduledTasks(CScheduler& scheduler)
 
     if (m_opts.private_broadcast) {
         scheduler.scheduleFromNow([&] { ReattemptPrivateBroadcast(scheduler); }, 0min);
+    }
+
+    if (m_opts.utxo_set_download_manager) {
+        scheduler.scheduleEvery([this] {
+            m_opts.utxo_set_download_manager->HandleTimeouts(
+                std::chrono::time_point_cast<std::chrono::seconds>(SteadyClock::now()));
+        }, 10s);
     }
 }
 
@@ -3440,7 +3460,6 @@ void PeerManagerImpl::ProcessGetUTXOSetInfo(CNode& node, Peer& peer)
 void PeerManagerImpl::ProcessGetUTXOSet(CNode& node, Peer& peer, DataStream& vRecv)
 {
     if (!(peer.m_our_services & NODE_UTXO_SET)) return;
-
     node::MsgGetUTXOSet request;
     vRecv >> request;
 
@@ -3462,6 +3481,38 @@ void PeerManagerImpl::ProcessGetUTXOSet(CNode& node, Peer& peer, DataStream& vRe
     response.data = std::move(data);
 
     MakeAndPushMessage(node, NetMsgType::UTXOSET, response);
+}
+
+void PeerManagerImpl::MaybeActivateDownloadedSnapshot()
+{
+    if (!m_opts.utxo_set_download_manager) return;
+    if (m_opts.utxo_set_download_manager->GetState() != node::UTXOSetDownloadManager::State::COMPLETE) return;
+
+    const fs::path path{m_opts.utxo_set_download_manager->GetOutputPath()};
+    AutoFile afile{fsbridge::fopen(path, "rb")};
+    if (afile.IsNull()) {
+        LogWarning("Failed to open downloaded UTXO set: %s", fs::PathToString(path));
+        return;
+    }
+
+    node::SnapshotMetadata metadata{m_chainparams.MessageStart()};
+    try {
+        afile >> metadata;
+    } catch (const std::ios_base::failure& e) {
+        LogWarning("Failed to parse downloaded UTXO set metadata: %s", e.what());
+        return;
+    }
+
+    auto activation_result{m_chainman.ActivateSnapshot(afile, metadata, /*in_memory=*/false)};
+    if (!activation_result) {
+        LogWarning("Failed to activate downloaded UTXO set: %s", util::ErrorString(activation_result).original);
+        return;
+    }
+
+    m_connman.RemoveLocalServices(NODE_NETWORK);
+    m_connman.AddLocalServices(NODE_NETWORK_LIMITED);
+
+    LogInfo("Downloaded UTXO set activated at height %d", (*activation_result)->nHeight);
 }
 
 void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked)
@@ -5108,7 +5159,11 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     }
 
     if (msg_type == NetMsgType::UTXOSETINFO) {
-        // Client-side handling (implemented later)
+        if (!m_opts.utxo_set_download_manager) return;
+        if (!peer.m_sent_getutxostinf) return;
+        std::vector<node::UTXOSetInfoEntry> entries;
+        vRecv >> entries;
+        m_opts.utxo_set_download_manager->ProcessUTXOSetInfo(pfrom.GetId(), entries);
         return;
     }
 
@@ -5118,7 +5173,21 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     }
 
     if (msg_type == NetMsgType::UTXOSET) {
-        // Client-side handling (implemented later)
+        if (!m_opts.utxo_set_download_manager) return;
+        if (m_opts.utxo_set_download_manager->GetState() != node::UTXOSetDownloadManager::State::DOWNLOADING) return;
+        if (!m_opts.utxo_set_download_manager->PeerHasInflightChunks(pfrom.GetId())) return;
+        node::MsgUTXOSet msg;
+        vRecv >> msg;
+        if (!m_opts.utxo_set_download_manager->ProcessUTXOSetChunk(pfrom.GetId(), msg)) {
+            LogDebug(BCLog::UTXOSETSHARE, "Invalid UTXO set chunk from peer=%d, disconnecting", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+
+        // When download completes, activate on the scheduler thread
+        if (m_opts.utxo_set_download_manager->GetState() == node::UTXOSetDownloadManager::State::COMPLETE) {
+            m_scheduler->scheduleFromNow([this] { MaybeActivateDownloadedSnapshot(); }, 0s);
+        }
         return;
     }
 
@@ -6278,5 +6347,28 @@ bool PeerManagerImpl::SendMessages(CNode& node)
             MakeAndPushMessage(node, NetMsgType::GETDATA, vGetData);
     } // release cs_main
     MaybeSendFeefilter(node, peer, current_time);
+
+    // Drive UTXO set download: request chunks from peers with NODE_UTXO_SET
+    if (m_opts.utxo_set_download_manager && (peer.m_their_services & NODE_UTXO_SET)) {
+        auto* dm{m_opts.utxo_set_download_manager};
+        auto state{dm->GetState()};
+
+        if (!peer.m_sent_getutxostinf) {
+            if (state == node::UTXOSetDownloadManager::State::DISCOVERING) {
+                MakeAndPushMessage(node, NetMsgType::GETUTXOSETINFO);
+                peer.m_sent_getutxostinf = true;
+            }
+        }
+
+        if (state == node::UTXOSetDownloadManager::State::DOWNLOADING) {
+            int in_flight{dm->CountInFlightForPeer(node.GetId())};
+            for (int i{in_flight}; i < MAX_UTXO_CHUNKS_IN_FLIGHT_PER_PEER; ++i) {
+                auto req{dm->GetNextChunkRequest(node.GetId())};
+                if (!req) break;
+                MakeAndPushMessage(node, NetMsgType::GETUTXOSET, *req);
+            }
+        }
+    }
+
     return true;
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -37,6 +37,7 @@
 #include <node/txdownloadman.h>
 #include <node/txorphanage.h>
 #include <node/txreconciliation.h>
+#include <node/utxo_set_share.h>
 #include <node/warnings.h>
 #include <policy/feerate.h>
 #include <policy/fees/block_policy_estimator.h>
@@ -1074,6 +1075,12 @@ private:
      * @param[in]   vRecv           The raw message received
      */
     void ProcessGetCFCheckPt(CNode& node, Peer& peer, DataStream& vRecv);
+
+    /** Handle a getutxostinf request. Responds with utxosetinfo listing available snapshots. */
+    void ProcessGetUTXOSetInfo(CNode& node, Peer& peer);
+
+    /** Handle a getutxoset request. Responds with a single chunk and its Merkle proof. */
+    void ProcessGetUTXOSet(CNode& node, Peer& peer, DataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(g_msgproc_mutex);
 
     /** Checks if address relay is permitted with peer. If needed, initializes
      * the m_addr_known bloom filter and sets m_addr_relay_enabled to true.
@@ -3422,6 +3429,41 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& node, Peer& peer, DataStream& v
               headers);
 }
 
+void PeerManagerImpl::ProcessGetUTXOSetInfo(CNode& node, Peer& peer)
+{
+    if (!(peer.m_our_services & NODE_UTXO_SET)) return;
+
+    auto entries{m_opts.utxo_set_share_provider->GetInfoEntries()};
+    MakeAndPushMessage(node, NetMsgType::UTXOSETINFO, entries);
+}
+
+void PeerManagerImpl::ProcessGetUTXOSet(CNode& node, Peer& peer, DataStream& vRecv)
+{
+    if (!(peer.m_our_services & NODE_UTXO_SET)) return;
+
+    node::MsgGetUTXOSet request;
+    vRecv >> request;
+
+    auto result{m_opts.utxo_set_share_provider->GetChunk(request.height, request.block_hash, request.chunk_index)};
+    if (!result) {
+        LogDebug(BCLog::UTXOSETSHARE, "Invalid getutxoset request: chunk %d for height=%d from peer=%d, disconnecting",
+                 request.chunk_index, request.height, node.GetId());
+        node.fDisconnect = true;
+        return;
+    }
+
+    auto& [data, proof] = *result;
+
+    node::MsgUTXOSet response;
+    response.height = request.height;
+    response.block_hash = request.block_hash;
+    response.chunk_index = request.chunk_index;
+    response.proof_hashes = std::move(proof);
+    response.data = std::move(data);
+
+    MakeAndPushMessage(node, NetMsgType::UTXOSET, response);
+}
+
 void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked)
 {
     bool new_block{false};
@@ -5057,6 +5099,26 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
     if (msg_type == NetMsgType::GETCFCHECKPT) {
         ProcessGetCFCheckPt(pfrom, peer, vRecv);
+        return;
+    }
+
+    if (msg_type == NetMsgType::GETUTXOSETINFO) {
+        ProcessGetUTXOSetInfo(pfrom, peer);
+        return;
+    }
+
+    if (msg_type == NetMsgType::UTXOSETINFO) {
+        // Client-side handling (implemented later)
+        return;
+    }
+
+    if (msg_type == NetMsgType::GETUTXOSET) {
+        ProcessGetUTXOSet(pfrom, peer, vRecv);
+        return;
+    }
+
+    if (msg_type == NetMsgType::UTXOSET) {
+        // Client-side handling (implemented later)
         return;
     }
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -33,6 +33,7 @@ class DataStream;
 class uint256;
 
 namespace node {
+class UTXOSetShareProvider;
 class Warnings;
 } // namespace node
 
@@ -92,6 +93,8 @@ public:
         uint32_t max_headers_result{MAX_HEADERS_RESULTS};
         //! Whether private broadcast is used for sending transactions.
         bool private_broadcast{DEFAULT_PRIVATE_BROADCAST};
+        //! UTXO set share provider (nullptr if not serving)
+        node::UTXOSetShareProvider* utxo_set_share_provider{nullptr};
     };
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -33,6 +33,7 @@ class DataStream;
 class uint256;
 
 namespace node {
+class UTXOSetDownloadManager;
 class UTXOSetShareProvider;
 class Warnings;
 } // namespace node
@@ -95,6 +96,8 @@ public:
         bool private_broadcast{DEFAULT_PRIVATE_BROADCAST};
         //! UTXO set share provider (nullptr if not serving)
         node::UTXOSetShareProvider* utxo_set_share_provider{nullptr};
+        //! UTXO set download manager
+        node::UTXOSetDownloadManager* utxo_set_download_manager{nullptr};
     };
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -14,6 +14,7 @@
 #include <net_processing.h>
 #include <netgroup.h>
 #include <node/kernel_notifications.h>
+#include <node/utxo_set_share.h>
 #include <node/warnings.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <scheduler.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -42,6 +42,7 @@ class SignalInterrupt;
 
 namespace node {
 class KernelNotifications;
+class UTXOSetShareProvider;
 class Warnings;
 
 //! NodeContext struct containing references to chain state and connection
@@ -91,6 +92,8 @@ struct NodeContext {
     std::atomic<int> exit_status{EXIT_SUCCESS};
     //! Manages all the node warnings
     std::unique_ptr<node::Warnings> warnings;
+    //! Serves UTXO set chunks to peers
+    std::unique_ptr<UTXOSetShareProvider> utxo_set_share_provider;
     std::thread background_init_thread;
 
     //! Declare default constructor and destructor that are not inline, so code

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -42,6 +42,7 @@ class SignalInterrupt;
 
 namespace node {
 class KernelNotifications;
+class UTXOSetDownloadManager;
 class UTXOSetShareProvider;
 class Warnings;
 
@@ -94,6 +95,8 @@ struct NodeContext {
     std::unique_ptr<node::Warnings> warnings;
     //! Serves UTXO set chunks to peers
     std::unique_ptr<UTXOSetShareProvider> utxo_set_share_provider;
+    //! Manages downloading a UTXO set snapshot from peers
+    std::unique_ptr<UTXOSetDownloadManager> utxo_set_download_manager;
     std::thread background_init_thread;
 
     //! Declare default constructor and destructor that are not inline, so code

--- a/src/node/utxo_set_share.cpp
+++ b/src/node/utxo_set_share.cpp
@@ -233,6 +233,7 @@ bool UTXOSetDownloadManager::StartDownload(const uint256& target_blockhash,
     if (m_state != State::IDLE) return false;
 
     m_target_blockhash = target_blockhash;
+    m_expected_chunk_merkle_root = au_data.chunk_merkle_root;
     m_target_height = au_data.height;
     m_output_path = output_path;
     m_state = State::DISCOVERING;
@@ -250,6 +251,14 @@ void UTXOSetDownloadManager::ProcessUTXOSetInfo(int64_t peer_id,
     for (const auto& entry : entries) {
         if (entry.block_hash != m_target_blockhash) continue;
         if (entry.data_length <= 1) continue;
+        if (!m_expected_chunk_merkle_root.IsNull() &&
+            entry.merkle_root != m_expected_chunk_merkle_root) {
+            LogDebug(BCLog::UTXOSETSHARE,
+                     "Rejecting utxosetinfo from peer=%d: merkle_root %s does not match expected %s",
+                     peer_id, entry.merkle_root.ToString(),
+                     m_expected_chunk_merkle_root.ToString());
+            continue;
+        }
 
         m_data_length = entry.data_length;
         m_merkle_root = entry.merkle_root;

--- a/src/node/utxo_set_share.cpp
+++ b/src/node/utxo_set_share.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/utxo_set_share.h>
+
+#include <hash.h>
+#include <uint256.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace node {
+
+bool VerifyChunkMerkleProof(const uint256& leaf_hash,
+                            const std::vector<uint256>& proof,
+                            uint32_t chunk_index,
+                            uint32_t total_chunks,
+                            const uint256& merkle_root)
+{
+    if (total_chunks == 0) return false;
+
+    // Verify proof depth matches the expected tree height
+    uint32_t expected_depth{0};
+    for (uint32_t n{total_chunks - 1}; n > 0; n >>= 1) ++expected_depth;
+    if (proof.size() != expected_depth) return false;
+
+    uint256 computed{leaf_hash};
+    uint32_t index{chunk_index};
+
+    for (const uint256& sibling : proof) {
+        bool is_right_child{(index % 2) != 0};
+        if (is_right_child) {
+            computed = Hash(sibling, computed);
+        } else {
+            computed = Hash(computed, sibling);
+        }
+        index /= 2;
+    }
+
+    return computed == merkle_root;
+}
+
+} // namespace node

--- a/src/node/utxo_set_share.cpp
+++ b/src/node/utxo_set_share.cpp
@@ -4,8 +4,14 @@
 
 #include <node/utxo_set_share.h>
 
+#include <consensus/merkle.h>
 #include <hash.h>
+#include <kernel/chainparams.h>
+#include <logging.h>
+#include <node/utxo_snapshot.h>
+#include <streams.h>
 #include <uint256.h>
+#include <util/fs.h>
 
 #include <cstdint>
 #include <vector>
@@ -39,6 +45,184 @@ bool VerifyChunkMerkleProof(const uint256& leaf_hash,
     }
 
     return computed == merkle_root;
+}
+
+/** Compute leaf hashes by from snapshot file */
+static std::vector<uint256> ComputeLeafHashes(const fs::path& path, uint64_t file_size)
+{
+    AutoFile file{fsbridge::fopen(path, "rb")};
+    if (file.IsNull()) return {};
+
+    std::vector<uint256> leaf_hashes;
+    uint64_t remaining{file_size};
+
+    while (remaining > 0) {
+        uint64_t chunk_size{std::min(remaining, UTXO_SET_CHUNK_SIZE)};
+        std::vector<unsigned char> buffer(chunk_size);
+        file.read(MakeWritableByteSpan(buffer));
+        leaf_hashes.push_back(Hash(buffer));
+        remaining -= chunk_size;
+    }
+
+    return leaf_hashes;
+}
+
+/** Try to load a sidecar file. Returns nullopt if not found. */
+static std::optional<ChunkMerkleCache> LoadSidecar(const fs::path& sidecar_path, uint64_t expected_size)
+{
+    AutoFile file{fsbridge::fopen(sidecar_path, "rb")};
+    if (file.IsNull()) return std::nullopt;
+
+    try {
+        ChunkMerkleCache cache;
+        file >> cache;
+        if (cache.snapshot_file_size != expected_size) return std::nullopt;
+        // Validate leaf count matches expected number of chunks (ceiling division)
+        if (cache.leaf_hashes.size() != (expected_size - 1) / UTXO_SET_CHUNK_SIZE + 1) return std::nullopt;
+        return cache;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+/** Write a sidecar file */
+static bool WriteSidecar(const fs::path& sidecar_path, const ChunkMerkleCache& cache)
+{
+    AutoFile file{fsbridge::fopen(sidecar_path, "wb")};
+    if (file.IsNull()) return false;
+
+    try {
+        file << cache;
+        if (!file.Commit()) return false;
+        if (file.fclose() != 0) return false;
+        return true;
+    } catch (const std::exception&) {
+        return false;
+    }
+}
+
+size_t UTXOSetShareProvider::Initialize(const fs::path& share_dir, const CChainParams& params)
+{
+    m_snapshots.clear();
+
+    std::error_code error;
+    if (!fs::is_directory(share_dir, error)) return 0;
+
+    for (const auto& entry : fs::directory_iterator(share_dir, error)) {
+        if (!entry.is_regular_file(error)) continue;
+        if (entry.path().extension() == ".merkle") continue;
+
+        // Try to read snapshot metadata
+        AutoFile file{fsbridge::fopen(entry.path(), "rb")};
+        if (file.IsNull()) continue;
+
+        SnapshotMetadata metadata(params.MessageStart());
+        try {
+            file >> metadata;
+        } catch (const std::exception& e) {
+            LogDebug(BCLog::UTXOSETSHARE, "Unable to read %s: %s", fs::PathToString(entry.path()), e.what());
+            continue;
+        }
+
+        // Check with assumeutxo params
+        auto au_data{params.AssumeutxoForBlockhash(metadata.m_base_blockhash)};
+        if (!au_data) {
+            LogDebug(BCLog::UTXOSETSHARE, "Skipping %s: no assumeutxo params for block %s",
+                     fs::PathToString(entry.path()), metadata.m_base_blockhash.ToString());
+            continue;
+        }
+
+        uint64_t file_size{fs::file_size(entry.path(), error)};
+        if (error) continue;
+
+        // Try loading the sidecar file or compute it
+        fs::path sidecar_path{entry.path()};
+        sidecar_path += ".merkle";
+
+        std::vector<uint256> leaf_hashes;
+        uint256 merkle_root;
+
+        auto cached{LoadSidecar(sidecar_path, file_size)};
+        if (cached) {
+            leaf_hashes = std::move(cached->leaf_hashes);
+            merkle_root = cached->merkle_root;
+            LogDebug(BCLog::UTXOSETSHARE, "Loaded sidecar for %s", fs::PathToString(entry.path()));
+        } else {
+            LogInfo("Computing chunk hashes for %s", fs::PathToString(entry.path()));
+            leaf_hashes = ComputeLeafHashes(entry.path(), file_size);
+            if (leaf_hashes.empty()) continue;
+
+            merkle_root = ComputeMerkleRoot(leaf_hashes);
+
+            ChunkMerkleCache cache;
+            cache.snapshot_file_size = file_size;
+            cache.leaf_hashes = leaf_hashes;
+            cache.merkle_root = merkle_root;
+
+            if (WriteSidecar(sidecar_path, cache)) {
+                LogDebug(BCLog::UTXOSETSHARE, "Wrote sidecar for %s", fs::PathToString(entry.path()));
+            } else {
+                LogWarning("Failed to write sidecar for %s", fs::PathToString(entry.path()));
+            }
+        }
+
+        SnapshotData sd;
+        sd.path = entry.path();
+        sd.info.height = au_data->height;
+        sd.info.block_hash = au_data->blockhash;
+        sd.info.serialized_hash = uint256{std::span<const unsigned char>{au_data->hash_serialized.data(), 32}};
+        sd.info.data_length = file_size;
+        sd.info.merkle_root = merkle_root;
+        sd.leaf_hashes = std::move(leaf_hashes);
+
+        LogInfo("Serving UTXO set at height %d", sd.info.height);
+        m_snapshots.push_back(std::move(sd));
+    }
+
+    return m_snapshots.size();
+}
+
+std::vector<UTXOSetInfoEntry> UTXOSetShareProvider::GetInfoEntries() const
+{
+    std::vector<UTXOSetInfoEntry> entries;
+    entries.reserve(m_snapshots.size());
+    for (const auto& sd : m_snapshots) {
+        entries.push_back(sd.info);
+    }
+    return entries;
+}
+
+std::optional<std::pair<std::vector<unsigned char>, std::vector<uint256>>> UTXOSetShareProvider::GetChunk(uint32_t height, const uint256& block_hash, uint32_t chunk_index) const
+{
+    const SnapshotData* snapshot{nullptr};
+    for (const auto& sd : m_snapshots) {
+        if (sd.info.height == height && sd.info.block_hash == block_hash) {
+            snapshot = &sd;
+            break;
+        }
+    }
+    if (!snapshot) return std::nullopt;
+
+    std::vector<uint256> leaf_hashes = snapshot->leaf_hashes;
+    uint32_t total_chunks = leaf_hashes.size();
+    if (chunk_index >= total_chunks) return std::nullopt;
+
+    AutoFile file{fsbridge::fopen(snapshot->path, "rb")};
+    if (file.IsNull()) return std::nullopt;
+
+    uint64_t offset{chunk_index * UTXO_SET_CHUNK_SIZE};
+    file.seek(offset, SEEK_SET);
+    uint64_t chunk_size{UTXO_SET_CHUNK_SIZE};
+    if (chunk_index == total_chunks - 1) {
+        chunk_size = snapshot->info.data_length - offset;
+    }
+
+    std::vector<unsigned char> data(chunk_size);
+    file.read(MakeWritableByteSpan(data));
+
+    std::vector<uint256> proof{ComputeMerklePath(leaf_hashes, chunk_index)};
+
+    return std::make_pair(std::move(data), std::move(proof));
 }
 
 } // namespace node

--- a/src/node/utxo_set_share.cpp
+++ b/src/node/utxo_set_share.cpp
@@ -225,4 +225,201 @@ std::optional<std::pair<std::vector<unsigned char>, std::vector<uint256>>> UTXOS
     return std::make_pair(std::move(data), std::move(proof));
 }
 
+bool UTXOSetDownloadManager::StartDownload(const uint256& target_blockhash,
+                                           const AssumeutxoData& au_data,
+                                           const fs::path& output_path)
+{
+    LOCK(m_mutex);
+    if (m_state != State::IDLE) return false;
+
+    m_target_blockhash = target_blockhash;
+    m_target_height = au_data.height;
+    m_output_path = output_path;
+    m_state = State::DISCOVERING;
+
+    LogInfo("UTXO set download started for height %d, blockhash=%s", m_target_height, m_target_blockhash.ToString());
+    return true;
+}
+
+void UTXOSetDownloadManager::ProcessUTXOSetInfo(int64_t peer_id,
+                                                const std::vector<UTXOSetInfoEntry>& entries)
+{
+    LOCK(m_mutex);
+    if (m_state != State::DISCOVERING) return;
+
+    for (const auto& entry : entries) {
+        if (entry.block_hash != m_target_blockhash) continue;
+        if (entry.data_length <= 1) continue;
+
+        m_data_length = entry.data_length;
+        m_merkle_root = entry.merkle_root;
+        m_total_chunks = static_cast<uint32_t>((m_data_length - 1) / UTXO_SET_CHUNK_SIZE + 1);
+        m_chunks.assign(m_total_chunks, ChunkInfo{});
+        m_chunks_done = 0;
+        m_state = State::DOWNLOADING;
+
+        AutoFile file{fsbridge::fopen(m_output_path, "wb")};
+        if (file.IsNull()) {
+            LogWarning("Failed to create output file %s", fs::PathToString(m_output_path));
+            m_state = State::FAILED;
+            return;
+        }
+
+        LogInfo("UTXO set download: %d chunks to download (%d bytes), merkle_root=%s, from peer=%d",
+                m_total_chunks, m_data_length, m_merkle_root.ToString(), peer_id);
+        return;
+    }
+
+    LogDebug(BCLog::UTXOSETSHARE, "No matching UTXO set info from peer=%d", peer_id);
+}
+
+bool UTXOSetDownloadManager::ProcessUTXOSetChunk(int64_t peer_id, const MsgUTXOSet& chunk)
+{
+    fs::path output_path;
+    uint64_t offset;
+
+    {
+        LOCK(m_mutex);
+        if (m_state != State::DOWNLOADING) return true;
+
+        if (chunk.height != m_target_height ||
+            chunk.block_hash != m_target_blockhash ||
+            chunk.chunk_index >= m_total_chunks) {
+            return false;
+        }
+
+        // Validate chunk data size against what data_length implies
+        uint64_t expected_size{UTXO_SET_CHUNK_SIZE};
+        if (chunk.chunk_index == m_total_chunks - 1) {
+            expected_size = m_data_length - (m_total_chunks - 1) * UTXO_SET_CHUNK_SIZE;
+        }
+        if (chunk.data.size() != expected_size) {
+            LogDebug(BCLog::UTXOSETSHARE, "Unexpected chunk size %zu (expected %zu) for chunk %d from peer=%d", chunk.data.size(), expected_size, chunk.chunk_index, peer_id);
+            return false;
+        }
+
+        auto& ci = m_chunks[chunk.chunk_index];
+        if (ci.state == ChunkState::DONE) return true; // duplicate, ignore
+
+        // Verify Merkle proof
+        uint256 leaf_hash{Hash(chunk.data)};
+        if (!VerifyChunkMerkleProof(leaf_hash, chunk.proof_hashes, chunk.chunk_index, m_total_chunks, m_merkle_root)) {
+            LogDebug(BCLog::UTXOSETSHARE, "Invalid Merkle proof for chunk %d from peer=%d", chunk.chunk_index, peer_id);
+            return false;
+        }
+
+        ci.state = ChunkState::DONE;
+        ci.assigned_peer = -1;
+        ++m_chunks_done;
+
+        LogDebug(BCLog::UTXOSETSHARE, "Chunk %d/%d verified (peer=%d)", m_chunks_done, m_total_chunks, peer_id);
+
+        output_path = m_output_path;
+        offset = chunk.chunk_index * UTXO_SET_CHUNK_SIZE;
+    }
+
+    // Write chunk data to file outside the lock
+    AutoFile file{fsbridge::fopen(output_path, "rb+")};
+    if (file.IsNull()) {
+        LOCK(m_mutex);
+        m_state = State::FAILED;
+        return true;
+    }
+    file.seek(offset, SEEK_SET);
+    file.write(MakeByteSpan(chunk.data));
+    if (!file.Commit() || file.fclose() != 0) {
+        LOCK(m_mutex);
+        m_state = State::FAILED;
+        return true;
+    }
+
+    // Re-lock to check if all chunks are now written
+    LOCK(m_mutex);
+    if (m_state != State::DOWNLOADING) return true;
+    if (m_chunks_done == m_total_chunks) {
+        m_state = State::COMPLETE;
+        LogInfo("UTXO set download complete: %s", fs::PathToString(m_output_path));
+    }
+
+    return true;
+}
+
+std::optional<MsgGetUTXOSet> UTXOSetDownloadManager::GetNextChunkRequest(int64_t peer_id)
+{
+    LOCK(m_mutex);
+    if (m_state != State::DOWNLOADING) return std::nullopt;
+
+    for (uint32_t i = 0; i < m_total_chunks; ++i) {
+        if (m_chunks[i].state == ChunkState::NEEDED) {
+            m_chunks[i].state = ChunkState::IN_FLIGHT;
+            m_chunks[i].assigned_peer = peer_id;
+            m_chunks[i].request_time = std::chrono::time_point_cast<std::chrono::seconds>(SteadyClock::now());
+
+            MsgGetUTXOSet req;
+            req.height = m_target_height;
+            req.block_hash = m_target_blockhash;
+            req.chunk_index = i;
+            return req;
+        }
+    }
+    return std::nullopt;
+}
+
+void UTXOSetDownloadManager::RequeueChunksForPeer(int64_t peer_id)
+{
+    LOCK(m_mutex);
+    for (auto& ci : m_chunks) {
+        if (ci.state == ChunkState::IN_FLIGHT && ci.assigned_peer == peer_id) {
+            ci.state = ChunkState::NEEDED;
+            ci.assigned_peer = -1;
+        }
+    }
+}
+
+void UTXOSetDownloadManager::HandleTimeouts(SteadySeconds now)
+{
+    LOCK(m_mutex);
+    if (m_state != State::DOWNLOADING) return;
+
+    for (auto& ci : m_chunks) {
+        if (ci.state == ChunkState::IN_FLIGHT && (now - ci.request_time) > CHUNK_TIMEOUT) {
+            LogDebug(BCLog::UTXOSETSHARE, "Chunk timed out from peer=%d, re-queuing", ci.assigned_peer);
+            ci.state = ChunkState::NEEDED;
+            ci.assigned_peer = -1;
+        }
+    }
+}
+
+bool UTXOSetDownloadManager::PeerHasInflightChunks(int64_t peer_id) const
+{
+    LOCK(m_mutex);
+    if (m_state != State::DOWNLOADING) return false;
+    for (const auto& ci : m_chunks) {
+        if (ci.state == ChunkState::IN_FLIGHT && ci.assigned_peer == peer_id) return true;
+    }
+    return false;
+}
+
+int UTXOSetDownloadManager::CountInFlightForPeer(int64_t peer_id) const
+{
+    LOCK(m_mutex);
+    int count{0};
+    for (const auto& ci : m_chunks) {
+        if (ci.state == ChunkState::IN_FLIGHT && ci.assigned_peer == peer_id) ++count;
+    }
+    return count;
+}
+
+UTXOSetDownloadManager::State UTXOSetDownloadManager::GetState() const
+{
+    LOCK(m_mutex);
+    return m_state;
+}
+
+fs::path UTXOSetDownloadManager::GetOutputPath() const
+{
+    LOCK(m_mutex);
+    return m_output_path;
+}
+
 } // namespace node

--- a/src/node/utxo_set_share.h
+++ b/src/node/utxo_set_share.h
@@ -177,6 +177,7 @@ private:
 
     // Target snapshot info
     uint256 m_target_blockhash GUARDED_BY(m_mutex);
+    uint256 m_expected_chunk_merkle_root GUARDED_BY(m_mutex);
     uint32_t m_target_height GUARDED_BY(m_mutex){0};
     uint64_t m_data_length GUARDED_BY(m_mutex){0};
     uint256 m_merkle_root GUARDED_BY(m_mutex);

--- a/src/node/utxo_set_share.h
+++ b/src/node/utxo_set_share.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <vector>
 
+#include <serialize.h>
 #include <uint256.h>
 
 namespace node {
@@ -21,6 +22,56 @@ bool VerifyChunkMerkleProof(const uint256& leaf_hash,
                             uint32_t chunk_index,
                             uint32_t total_chunks,
                             const uint256& merkle_root);
+
+/** Entry in a utxosetinfo message, describing an available UTXO set. */
+struct UTXOSetInfoEntry {
+    uint32_t height{0};
+    uint256 block_hash;
+    uint256 serialized_hash;
+    uint64_t data_length{0};
+    uint256 merkle_root;
+
+    SERIALIZE_METHODS(UTXOSetInfoEntry, obj)
+    {
+        READWRITE(obj.height);
+        READWRITE(obj.block_hash);
+        READWRITE(obj.serialized_hash);
+        READWRITE(obj.data_length);
+        READWRITE(obj.merkle_root);
+    }
+};
+
+/** getutxoset message: request a chunk of UTXO set data. */
+struct MsgGetUTXOSet {
+    uint32_t height{0};
+    uint256 block_hash;
+    uint32_t chunk_index{0};
+
+    SERIALIZE_METHODS(MsgGetUTXOSet, obj)
+    {
+        READWRITE(obj.height);
+        READWRITE(obj.block_hash);
+        READWRITE(obj.chunk_index);
+    }
+};
+
+/** utxoset message: one chunk of UTXO set data with the Merkle proof. */
+struct MsgUTXOSet {
+    uint32_t height{0};
+    uint256 block_hash;
+    uint32_t chunk_index{0};
+    std::vector<uint256> proof_hashes;
+    std::vector<unsigned char> data;
+
+    SERIALIZE_METHODS(MsgUTXOSet, obj)
+    {
+        READWRITE(obj.height);
+        READWRITE(obj.block_hash);
+        READWRITE(obj.chunk_index);
+        READWRITE(obj.proof_hashes);
+        READWRITE(obj.data);
+    }
+};
 
 } // namespace node
 

--- a/src/node/utxo_set_share.h
+++ b/src/node/utxo_set_share.h
@@ -1,0 +1,27 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_UTXO_SET_SHARE_H
+#define BITCOIN_NODE_UTXO_SET_SHARE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <uint256.h>
+
+namespace node {
+
+static constexpr uint64_t UTXO_SET_CHUNK_SIZE = 3'900'000;
+
+/** Verify a Merkle proof for a chunk against a known root */
+bool VerifyChunkMerkleProof(const uint256& leaf_hash,
+                            const std::vector<uint256>& proof,
+                            uint32_t chunk_index,
+                            uint32_t total_chunks,
+                            const uint256& merkle_root);
+
+} // namespace node
+
+#endif // BITCOIN_NODE_UTXO_SET_SHARE_H

--- a/src/node/utxo_set_share.h
+++ b/src/node/utxo_set_share.h
@@ -7,15 +7,19 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <chrono>
 #include <optional>
 #include <utility>
 #include <vector>
 
 #include <serialize.h>
+#include <sync.h>
 #include <uint256.h>
 #include <util/fs.h>
+#include <util/time.h>
 
 class CChainParams;
+struct AssumeutxoData;
 
 namespace node {
 
@@ -115,6 +119,72 @@ private:
     };
 
     std::vector<SnapshotData> m_snapshots;
+};
+
+/** Manages downloading a UTXO set snapshot from peers */
+class UTXOSetDownloadManager
+{
+public:
+    enum class State { IDLE, DISCOVERING, DOWNLOADING, COMPLETE, FAILED };
+
+    /** Begin a download targeting the given assumeutxo snapshot.
+     *  Output is written to output_path. */
+    bool StartDownload(const uint256& target_blockhash,
+                       const AssumeutxoData& au_data,
+                       const fs::path& output_path) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Process a utxosetinfo response from a peer. Selects the matching
+     *  entry and transitions to DOWNLOADING if valid. */
+    void ProcessUTXOSetInfo(int64_t peer_id,
+                            const std::vector<UTXOSetInfoEntry>& entries) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Process a received chunk. Verifies the Merkle proof and writes to
+     *  the output file. Returns false if the proof is invalid. */
+    bool ProcessUTXOSetChunk(int64_t peer_id, const MsgUTXOSet& chunk) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Get the next chunk request to send to a peer, or nullopt if none
+     *  available. Marks the chunk as in-flight for this peer. */
+    std::optional<MsgGetUTXOSet> GetNextChunkRequest(int64_t peer_id) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Re-queue any in-flight chunks assigned to this peer */
+    void RequeueChunksForPeer(int64_t peer_id) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Re-assign chunks that have been in-flight for too long */
+    void HandleTimeouts(SteadySeconds now) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Whether peer has any chunks currently assigned to it */
+    bool PeerHasInflightChunks(int64_t peer_id) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Count chunks currently in-flight for a given peer */
+    int CountInFlightForPeer(int64_t peer_id) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    State GetState() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    fs::path GetOutputPath() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+private:
+    enum class ChunkState { NEEDED, IN_FLIGHT, DONE };
+
+    struct ChunkInfo {
+        ChunkState state{ChunkState::NEEDED};
+        int64_t assigned_peer{-1};
+        SteadySeconds request_time{};
+    };
+
+    mutable Mutex m_mutex;
+
+    State m_state GUARDED_BY(m_mutex){State::IDLE};
+    fs::path m_output_path GUARDED_BY(m_mutex);
+
+    // Target snapshot info
+    uint256 m_target_blockhash GUARDED_BY(m_mutex);
+    uint32_t m_target_height GUARDED_BY(m_mutex){0};
+    uint64_t m_data_length GUARDED_BY(m_mutex){0};
+    uint256 m_merkle_root GUARDED_BY(m_mutex);
+    uint32_t m_total_chunks GUARDED_BY(m_mutex){0};
+
+    std::vector<ChunkInfo> m_chunks GUARDED_BY(m_mutex);
+    uint32_t m_chunks_done GUARDED_BY(m_mutex){0};
+    static constexpr std::chrono::seconds CHUNK_TIMEOUT{60};
 };
 
 } // namespace node

--- a/src/node/utxo_set_share.h
+++ b/src/node/utxo_set_share.h
@@ -7,10 +7,15 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
+#include <utility>
 #include <vector>
 
 #include <serialize.h>
 #include <uint256.h>
+#include <util/fs.h>
+
+class CChainParams;
 
 namespace node {
 
@@ -71,6 +76,45 @@ struct MsgUTXOSet {
         READWRITE(obj.proof_hashes);
         READWRITE(obj.data);
     }
+};
+
+/** Sidecar file with leaf hashes and Merkle root */
+struct ChunkMerkleCache {
+    uint64_t snapshot_file_size{0};
+    std::vector<uint256> leaf_hashes;
+    uint256 merkle_root;
+
+    SERIALIZE_METHODS(ChunkMerkleCache, obj)
+    {
+        READWRITE(obj.snapshot_file_size);
+        READWRITE(obj.leaf_hashes);
+        READWRITE(obj.merkle_root);
+    }
+};
+
+/** Serves UTXO set chunks and Merkle proofs for snapshot files in the share dir */
+class UTXOSetShareProvider
+{
+public:
+    /** Scan share dir for valid snapshot files, load or compute sidecar
+     *  caches. Returns the number of snapshots ready to serve. */
+    size_t Initialize(const fs::path& share_dir, const CChainParams& params);
+
+    /** Get info entries for all available snapshots */
+    std::vector<UTXOSetInfoEntry> GetInfoEntries() const;
+
+    /** Read a chunk from the snapshot identified by (height, block_hash).
+     *  Returns {chunk_data, merkle_proof}, or nullopt if not found. */
+    std::optional<std::pair<std::vector<unsigned char>, std::vector<uint256>>> GetChunk(uint32_t height, const uint256& block_hash, uint32_t chunk_index) const;
+
+private:
+    struct SnapshotData {
+        fs::path path;
+        UTXOSetInfoEntry info;
+        std::vector<uint256> leaf_hashes;
+    };
+
+    std::vector<SnapshotData> m_snapshots;
 };
 
 } // namespace node

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -99,6 +99,7 @@ static std::string serviceFlagToStr(size_t bit)
     case NODE_COMPACT_FILTERS: return "COMPACT_FILTERS";
     case NODE_NETWORK_LIMITED: return "NETWORK_LIMITED";
     case NODE_P2P_V2:          return "P2P_V2";
+    case NODE_UTXO_SET:        return "UTXO_SET";
     // Not using default, so we get warned when a case is missing
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -264,6 +264,26 @@ inline constexpr const char* WTXIDRELAY{"wtxidrelay"};
  * txreconciliation, as described by BIP 330.
  */
 inline constexpr const char* SENDTXRCNCL{"sendtxrcncl"};
+/**
+ * getutxostinf requests a list of available UTXO set snapshots from a peer.
+ * Only available with service bit NODE_UTXO_SET.
+ */
+inline constexpr const char* GETUTXOSETINFO{"getutxostinf"};
+/**
+ * utxosetinfo is a response to a getutxostinf request containing a list of
+ * available UTXO set snapshots that the peer can serve.
+ */
+inline constexpr const char* UTXOSETINFO{"utxosetinfo"};
+/**
+ * getutxoset requests a single chunk of UTXO set data from a peer.
+ * Only available with service bit NODE_UTXO_SET.
+ */
+inline constexpr const char* GETUTXOSET{"getutxoset"};
+/**
+ * utxoset is a response to a getutxoset request containing one chunk of
+ * UTXO set data with its Merkle proof.
+ */
+inline constexpr const char* UTXOSET{"utxoset"};
 }; // namespace NetMsgType
 
 /** All known message types (see above). Keep this in the same order as the list of messages above. */
@@ -303,6 +323,10 @@ inline const std::array ALL_NET_MESSAGE_TYPES{std::to_array<std::string>({
     NetMsgType::CFCHECKPT,
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
+    NetMsgType::GETUTXOSETINFO,
+    NetMsgType::UTXOSETINFO,
+    NetMsgType::GETUTXOSET,
+    NetMsgType::UTXOSET,
 })};
 
 /** nServices flags */
@@ -328,6 +352,10 @@ enum ServiceFlags : uint64_t {
 
     // NODE_P2P_V2 means the node supports BIP324 transport
     NODE_P2P_V2 = (1 << 11),
+
+    // NODE_UTXO_SET means the node can serve a complete UTXO set for at
+    // least one assumeutxo height.
+    NODE_UTXO_SET = (1 << 12),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -30,6 +30,7 @@
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/transaction.h>
+#include <node/utxo_set_share.h>
 #include <node/utxo_snapshot.h>
 #include <node/warnings.h>
 #include <primitives/transaction.h>
@@ -3450,6 +3451,74 @@ static RPCMethod loadtxoutset()
     };
 }
 
+static RPCMethod downloadutxoset()
+{
+    return RPCMethod{
+        "downloadutxoset",
+        "Download a UTXO set snapshot from peers through P2P network.\n"
+        "The download happens asynchronously in the background. Once complete, the snapshot is automatically activated. "
+        "The snapshot is saved to the share directory inside the data dir, so the node can re-serve it to other peers.",
+        {
+            {"height", RPCArg::Type::NUM, RPCArg::Optional::NO, "The block height of the UTXO set to download."},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+                {
+                    {RPCResult::Type::NUM, "height", "the target snapshot height"},
+                    {RPCResult::Type::STR_HEX, "blockhash", "the target block hash"},
+                    {RPCResult::Type::STR, "path", "the output file path"},
+                }
+        },
+        RPCExamples{
+            HelpExampleCli("downloadutxoset", "840000")
+        },
+        [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
+{
+    NodeContext& node{EnsureAnyNodeContext(request.context)};
+    ChainstateManager& chainman{EnsureChainman(node)};
+
+    const int height{self.Arg<int>("height")};
+    auto au_data{chainman.GetParams().AssumeutxoForHeight(height)};
+    if (!au_data) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("No assumeutxo data for height %d", height));
+    }
+
+    {
+        LOCK(::cs_main);
+        if (chainman.ActiveChainstate().m_from_snapshot_blockhash) {
+            throw JSONRPCError(RPC_MISC_ERROR, "A snapshot-based chainstate is already active");
+        }
+        const CBlockIndex* snapshot_block{chainman.m_blockman.LookupBlockIndex(au_data->blockhash)};
+        if (!snapshot_block) {
+            throw JSONRPCError(RPC_MISC_ERROR, strprintf("The base block header (%s) must appear in the headers chain. Make sure all headers are syncing, and call downloadutxoset again",
+                au_data->blockhash.ToString()));
+        }
+        if (!chainman.m_best_header || chainman.m_best_header->GetAncestor(snapshot_block->nHeight) != snapshot_block) {
+            throw JSONRPCError(RPC_MISC_ERROR, "The base block header is not in the best headers chain. Make sure all headers are syncing, and call downloadutxoset again");
+        }
+    }
+
+    if (!node.utxo_set_download_manager) {
+        throw JSONRPCError(RPC_MISC_ERROR, "UTXO set download is not available");
+    }
+
+    const fs::path share_dir{EnsureArgsman(node).GetDataDirNet() / "share"};
+    fs::create_directories(share_dir);
+    const fs::path output_path{share_dir / fs::u8path(strprintf("utxo-%d.dat", height))};
+
+    if (!node.utxo_set_download_manager->StartDownload(au_data->blockhash, *au_data, output_path)) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Failed to start download. A download may already be in progress.");
+    }
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("height", height);
+    result.pushKV("blockhash", au_data->blockhash.ToString());
+    result.pushKV("path", fs::PathToString(output_path));
+    return result;
+},
+    };
+}
+
 const std::vector<RPCResult> RPCHelpForChainstate{
     {RPCResult::Type::NUM, "blocks", "number of blocks in this chainstate"},
     {RPCResult::Type::STR_HEX, "bestblockhash", "blockhash of the tip"},
@@ -3549,6 +3618,7 @@ void RegisterBlockchainRPCCommands(CRPCTable& t)
         {"blockchain", &getblockfilter},
         {"blockchain", &dumptxoutset},
         {"blockchain", &loadtxoutset},
+        {"blockchain", &downloadutxoset},
         {"blockchain", &getchainstates},
         {"hidden", &invalidateblock},
         {"hidden", &reconsiderblock},

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -381,6 +381,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "encryptwallet", 0, "passphrase", ParamFormat::STRING },
     { "getaddressesbylabel", 0, "label", ParamFormat::STRING },
     { "loadtxoutset", 0, "path", ParamFormat::STRING },
+    { "downloadutxoset", 0, "height" },
     { "migratewallet", 0, "wallet_name", ParamFormat::STRING },
     { "migratewallet", 1, "passphrase", ParamFormat::STRING },
     { "setlabel", 1, "label", ParamFormat::STRING },

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(test_bitcoin
   txvalidation_tests.cpp
   txvalidationcache_tests.cpp
   uint256_tests.cpp
+  utxo_set_share_tests.cpp
   util_check_tests.cpp
   util_expected_tests.cpp
   util_string_tests.cpp

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -106,6 +106,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "deriveaddresses",
     "descriptorprocesspsbt",
     "disconnectnode",
+    "downloadutxoset",
     "echo",
     "echojson",
     "estimaterawfee",

--- a/src/test/utxo_set_share_tests.cpp
+++ b/src/test/utxo_set_share_tests.cpp
@@ -4,10 +4,14 @@
 
 #include <consensus/merkle.h>
 #include <hash.h>
+#include <kernel/chainparams.h>
 #include <node/utxo_set_share.h>
+#include <node/utxo_snapshot.h>
+#include <streams.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/fs.h>
 
 #include <cstdint>
 #include <vector>
@@ -105,6 +109,76 @@ BOOST_AUTO_TEST_CASE(merkle_proof_zero_chunks)
     uint256 root{m_rng.rand256()};
     std::vector<uint256> proof;
     BOOST_CHECK(!node::VerifyChunkMerkleProof(leaf, proof, 0, 0, root));
+}
+
+BOOST_AUTO_TEST_CASE(provider_init_and_serve)
+{
+    // Create a share directory with a synthetic snapshot file that matches
+    // regtest assumeutxo params at height 110.
+    auto regtest_params{CChainParams::RegTest({})};
+    auto au_data{regtest_params->AssumeutxoForHeight(110)};
+    BOOST_REQUIRE(au_data.has_value());
+
+    fs::path share_dir{m_path_root / "share"};
+    fs::create_directories(share_dir);
+
+    // Write a fake snapshot
+    fs::path snapshot_path{share_dir / "utxo-snapshot-110.dat"};
+    {
+        AutoFile file{fsbridge::fopen(snapshot_path, "wb")};
+        BOOST_REQUIRE(!file.IsNull());
+
+        node::SnapshotMetadata metadata(regtest_params->MessageStart(), au_data->blockhash, /*coins_count=*/42);
+        file << metadata;
+
+        // Write some random body data
+        std::vector<unsigned char> body{m_rng.randbytes(node::UTXO_SET_CHUNK_SIZE * 2 + 500)};
+        file.write(MakeByteSpan(body));
+        BOOST_REQUIRE(file.fclose() == 0);
+    }
+
+    // Initialize the provider
+    node::UTXOSetShareProvider provider;
+    size_t count{provider.Initialize(share_dir, *regtest_params)};
+    BOOST_CHECK_EQUAL(count, 1U);
+
+    // Check info entries
+    auto entries{provider.GetInfoEntries()};
+    BOOST_CHECK_EQUAL(entries.size(), 1U);
+    BOOST_CHECK_EQUAL(entries[0].height, static_cast<uint32_t>(au_data->height));
+    BOOST_CHECK_EQUAL(entries[0].block_hash.ToString(), au_data->blockhash.ToString());
+
+    // Check chunks
+    uint64_t file_size{entries[0].data_length};
+    uint32_t total_chunks{static_cast<uint32_t>((file_size + node::UTXO_SET_CHUNK_SIZE - 1) / node::UTXO_SET_CHUNK_SIZE)};
+    BOOST_CHECK_EQUAL(total_chunks, 3U);
+
+    // Retrieve each chunk and verify it's Merkle proof
+    for (uint32_t i = 0; i < total_chunks; ++i) {
+        auto result{provider.GetChunk(entries[0].height, entries[0].block_hash, i)};
+        BOOST_REQUIRE(result.has_value());
+
+        auto& [data, proof] = *result;
+        BOOST_CHECK(!data.empty());
+
+        uint256 leaf_hash{Hash(data)};
+        BOOST_CHECK(node::VerifyChunkMerkleProof(leaf_hash, proof, i, total_chunks, entries[0].merkle_root));
+    }
+
+    // Out-of-range chunk should fail
+    auto bad{provider.GetChunk(entries[0].height, entries[0].block_hash, total_chunks)};
+    BOOST_CHECK(!bad.has_value());
+
+    // Verify sidecar file
+    fs::path sidecar_path{snapshot_path};
+    sidecar_path += ".merkle";
+    BOOST_CHECK(fs::exists(sidecar_path));
+
+    // Re-init should load from sidecar
+    node::UTXOSetShareProvider provider2;
+    BOOST_CHECK_EQUAL(provider2.Initialize(share_dir, *regtest_params), 1U);
+    auto entries2{provider2.GetInfoEntries()};
+    BOOST_CHECK_EQUAL(entries2[0].merkle_root.ToString(), entries[0].merkle_root.ToString());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/utxo_set_share_tests.cpp
+++ b/src/test/utxo_set_share_tests.cpp
@@ -181,4 +181,116 @@ BOOST_AUTO_TEST_CASE(provider_init_and_serve)
     BOOST_CHECK_EQUAL(entries2[0].merkle_root.ToString(), entries[0].merkle_root.ToString());
 }
 
+BOOST_AUTO_TEST_CASE(download_manager_lifecycle)
+{
+    // Use a provider-served snapshot as the source, then download it
+    // through the download manager to verify the full lifecycle.
+    auto regtest_params{CChainParams::RegTest({})};
+    auto au_data{regtest_params->AssumeutxoForHeight(110)};
+    BOOST_REQUIRE(au_data.has_value());
+
+    fs::path share_dir{m_path_root / "share_test"};
+    fs::create_directories(share_dir);
+
+    // Make a small snapshot
+    fs::path src_path{share_dir / "source.dat"};
+    {
+        AutoFile file{fsbridge::fopen(src_path, "wb")};
+        BOOST_REQUIRE(!file.IsNull());
+        node::SnapshotMetadata metadata(regtest_params->MessageStart(), au_data->blockhash, /*coins_count=*/1);
+        file << metadata;
+        std::vector<unsigned char> body{m_rng.randbytes(node::UTXO_SET_CHUNK_SIZE * 2 + 100)};
+        file.write(MakeByteSpan(body));
+        BOOST_REQUIRE(file.fclose() == 0);
+    }
+
+    node::UTXOSetShareProvider provider;
+    BOOST_REQUIRE_EQUAL(provider.Initialize(share_dir, *regtest_params), 1U);
+    auto info_entries{provider.GetInfoEntries()};
+    BOOST_REQUIRE_EQUAL(info_entries.size(), 1U);
+
+    fs::path output_path{m_path_root / "downloaded.dat"};
+    node::UTXOSetDownloadManager dm;
+    BOOST_CHECK(dm.StartDownload(au_data->blockhash, *au_data, output_path));
+    BOOST_CHECK(dm.GetState() == node::UTXOSetDownloadManager::State::DISCOVERING);
+
+    // No requests yet
+    BOOST_CHECK(!dm.GetNextChunkRequest(1).has_value());
+
+    // Serve info to peer
+    dm.ProcessUTXOSetInfo(1, info_entries);
+    BOOST_CHECK(dm.GetState() == node::UTXOSetDownloadManager::State::DOWNLOADING);
+
+    // Download the chunks
+    uint32_t total_chunks{static_cast<uint32_t>((info_entries[0].data_length + node::UTXO_SET_CHUNK_SIZE - 1) / node::UTXO_SET_CHUNK_SIZE)};
+    for (uint32_t i = 0; i < total_chunks; ++i) {
+        auto req{dm.GetNextChunkRequest(1)};
+        BOOST_REQUIRE(req.has_value());
+        BOOST_CHECK_EQUAL(req->chunk_index, i);
+
+        auto chunk_result{provider.GetChunk(req->height, req->block_hash, req->chunk_index)};
+        BOOST_REQUIRE(chunk_result.has_value());
+
+        node::MsgUTXOSet msg;
+        msg.height = req->height;
+        msg.block_hash = req->block_hash;
+        msg.chunk_index = req->chunk_index;
+        msg.proof_hashes = std::move(chunk_result->second);
+        msg.data = std::move(chunk_result->first);
+
+        BOOST_CHECK(dm.ProcessUTXOSetChunk(1, msg));
+    }
+
+    BOOST_CHECK(!dm.GetNextChunkRequest(1).has_value());
+    BOOST_CHECK(dm.GetState() == node::UTXOSetDownloadManager::State::COMPLETE);
+    BOOST_CHECK(fs::exists(output_path));
+}
+
+BOOST_AUTO_TEST_CASE(download_manager_invalid_proof)
+{
+    auto regtest_params{CChainParams::RegTest({})};
+    auto au_data{regtest_params->AssumeutxoForHeight(110)};
+    BOOST_REQUIRE(au_data.has_value());
+
+    fs::path share_dir{m_path_root / "share_test2"};
+    fs::create_directories(share_dir);
+
+    fs::path src_path{share_dir / "source2.dat"};
+    {
+        AutoFile file{fsbridge::fopen(src_path, "wb")};
+        BOOST_REQUIRE(!file.IsNull());
+        node::SnapshotMetadata metadata(regtest_params->MessageStart(), au_data->blockhash, /*coins_count=*/1);
+        file << metadata;
+        std::vector<unsigned char> body{m_rng.randbytes(1000)};
+        file.write(MakeByteSpan(body));
+        BOOST_REQUIRE(file.fclose() == 0);
+    }
+
+    node::UTXOSetShareProvider provider;
+    BOOST_REQUIRE_EQUAL(provider.Initialize(share_dir, *regtest_params), 1U);
+    auto info_entries{provider.GetInfoEntries()};
+
+    fs::path output_path{m_path_root / "downloaded2.dat"};
+    node::UTXOSetDownloadManager dm;
+    dm.StartDownload(au_data->blockhash, *au_data, output_path);
+    dm.ProcessUTXOSetInfo(1, info_entries);
+
+    auto req{dm.GetNextChunkRequest(1)};
+    BOOST_REQUIRE(req.has_value());
+
+    auto chunk_result{provider.GetChunk(req->height, req->block_hash, req->chunk_index)};
+    BOOST_REQUIRE(chunk_result.has_value());
+
+    node::MsgUTXOSet msg;
+    msg.height = req->height;
+    msg.block_hash = req->block_hash;
+    msg.chunk_index = req->chunk_index;
+    msg.proof_hashes = std::move(chunk_result->second);
+    msg.data = std::move(chunk_result->first);
+    // Tamper with the data
+    msg.data[0] ^= 0xff;
+
+    BOOST_CHECK(!dm.ProcessUTXOSetChunk(1, msg));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/utxo_set_share_tests.cpp
+++ b/src/test/utxo_set_share_tests.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/merkle.h>
+#include <hash.h>
+#include <node/utxo_set_share.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(utxo_set_share_tests, BasicTestingSetup)
+
+std::vector<uint256> MakeLeaves(FastRandomContext& rng, size_t count)
+{
+    std::vector<uint256> leaves;
+    leaves.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        leaves.push_back(rng.rand256());
+    }
+    return leaves;
+}
+
+BOOST_AUTO_TEST_CASE(merkle_root_single_leaf)
+{
+    std::vector<uint256> leaves{MakeLeaves(m_rng, 1)};
+    uint256 root{ComputeMerkleRoot(leaves)};
+    // Root is the leaf itself
+    BOOST_CHECK_EQUAL(root.ToString(), leaves[0].ToString());
+}
+
+BOOST_AUTO_TEST_CASE(merkle_root_two_leaves)
+{
+    std::vector<uint256> leaves{MakeLeaves(m_rng, 2)};
+    uint256 root{ComputeMerkleRoot(leaves)};
+    BOOST_CHECK_EQUAL(root.ToString(), Hash(leaves[0], leaves[1]).ToString());
+}
+
+BOOST_AUTO_TEST_CASE(merkle_root_three_leaves)
+{
+    std::vector<uint256> leaves{MakeLeaves(m_rng, 3)};
+    uint256 root{ComputeMerkleRoot(leaves)};
+
+    uint256 h01{Hash(leaves[0], leaves[1])};
+    // Last leaf is duplicated to make up for the uneven count
+    uint256 h22{Hash(leaves[2], leaves[2])};
+    BOOST_CHECK_EQUAL(root.ToString(), Hash(h01, h22).ToString());
+}
+
+BOOST_AUTO_TEST_CASE(merkle_proof_roundtrip)
+{
+    for (uint32_t num_leaves : {1, 2, 3, 4, 5, 7, 8, 16}) {
+        std::vector<uint256> leaves{MakeLeaves(m_rng, num_leaves)};
+        uint256 root{ComputeMerkleRoot(leaves)};
+
+        for (uint32_t pos = 0; pos < num_leaves; ++pos) {
+            std::vector<uint256> proof{ComputeMerklePath(leaves, pos)};
+            BOOST_CHECK(node::VerifyChunkMerkleProof(leaves[pos], proof, pos, num_leaves, root));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(merkle_proof_invalid_leaf)
+{
+    std::vector<uint256> leaves{MakeLeaves(m_rng, 4)};
+    uint256 root{ComputeMerkleRoot(leaves)};
+    std::vector<uint256> proof{ComputeMerklePath(leaves, 0)};
+
+    uint256 wrong_leaf{m_rng.rand256()};
+    BOOST_CHECK(!node::VerifyChunkMerkleProof(wrong_leaf, proof, 0, 4, root));
+}
+
+BOOST_AUTO_TEST_CASE(merkle_proof_invalid_root)
+{
+    std::vector<uint256> leaves{MakeLeaves(m_rng, 4)};
+    uint256 root{ComputeMerkleRoot(leaves)};
+    std::vector<uint256> proof{ComputeMerklePath(leaves, 0)};
+
+    BOOST_CHECK(node::VerifyChunkMerkleProof(leaves[0], proof, 0, 4, root));
+
+    uint256 wrong_root{m_rng.rand256()};
+    BOOST_CHECK(!node::VerifyChunkMerkleProof(leaves[0], proof, 0, 4, wrong_root));
+}
+
+BOOST_AUTO_TEST_CASE(merkle_proof_invalid_proof)
+{
+    std::vector<uint256> leaves{MakeLeaves(m_rng, 8)};
+    uint256 root{ComputeMerkleRoot(leaves)};
+
+    std::vector<uint256> proof{ComputeMerklePath(leaves, 3)};
+
+    // Corrupt one proof hash
+    proof[0] = m_rng.rand256();
+    BOOST_CHECK(!node::VerifyChunkMerkleProof(leaves[3], proof, 3, 8, root));
+}
+
+BOOST_AUTO_TEST_CASE(merkle_proof_zero_chunks)
+{
+    uint256 leaf{m_rng.rand256()};
+    uint256 root{m_rng.rand256()};
+    std::vector<uint256> proof;
+    BOOST_CHECK(!node::VerifyChunkMerkleProof(leaf, proof, 0, 0, root));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/utxo_set_share_tests.cpp
+++ b/src/test/utxo_set_share_tests.cpp
@@ -293,4 +293,85 @@ BOOST_AUTO_TEST_CASE(download_manager_invalid_proof)
     BOOST_CHECK(!dm.ProcessUTXOSetChunk(1, msg));
 }
 
+BOOST_AUTO_TEST_CASE(download_manager_rejects_bad_merkle_root)
+{
+    auto regtest_params{CChainParams::RegTest({})};
+    auto au_data{regtest_params->AssumeutxoForHeight(110)};
+    BOOST_REQUIRE(au_data.has_value());
+
+    fs::path share_dir{m_path_root / "share_test3"};
+    fs::create_directories(share_dir);
+
+    fs::path src_path{share_dir / "source3.dat"};
+    {
+        AutoFile file{fsbridge::fopen(src_path, "wb")};
+        BOOST_REQUIRE(!file.IsNull());
+        node::SnapshotMetadata metadata(regtest_params->MessageStart(), au_data->blockhash, /*coins_count=*/1);
+        file << metadata;
+        std::vector<unsigned char> body{m_rng.randbytes(1000)};
+        file.write(MakeByteSpan(body));
+        BOOST_REQUIRE(file.fclose() == 0);
+    }
+
+    node::UTXOSetShareProvider provider;
+    BOOST_REQUIRE_EQUAL(provider.Initialize(share_dir, *regtest_params), 1U);
+    auto info_entries{provider.GetInfoEntries()};
+    BOOST_REQUIRE_EQUAL(info_entries.size(), 1U);
+
+    // Create au_data with a specific non-null chunk_merkle_root that differs
+    // from what the provider computed
+    AssumeutxoData custom_au_data{*au_data};
+    custom_au_data.chunk_merkle_root = uint256{"0000000000000000000000000000000000000000000000000000000000000001"};
+
+    fs::path output_path{m_path_root / "downloaded3.dat"};
+    node::UTXOSetDownloadManager dm;
+    BOOST_CHECK(dm.StartDownload(au_data->blockhash, custom_au_data, output_path));
+
+    // Feed info with the provider's actual merkle root — should be rejected
+    // because it doesn't match the expected chunk_merkle_root.
+    dm.ProcessUTXOSetInfo(1, info_entries);
+    BOOST_CHECK(dm.GetState() == node::UTXOSetDownloadManager::State::DISCOVERING);
+
+    // Now feed info with the correct merkle root
+    auto fixed_entries{info_entries};
+    fixed_entries[0].merkle_root = custom_au_data.chunk_merkle_root;
+    dm.ProcessUTXOSetInfo(1, fixed_entries);
+    BOOST_CHECK(dm.GetState() == node::UTXOSetDownloadManager::State::DOWNLOADING);
+}
+
+BOOST_AUTO_TEST_CASE(download_manager_skips_validation_when_null)
+{
+    // When chunk_merkle_root is null any merkle_root from
+    // the peer is be accepted.
+    auto regtest_params{CChainParams::RegTest({})};
+    auto au_data{regtest_params->AssumeutxoForHeight(110)};
+    BOOST_REQUIRE(au_data.has_value());
+    BOOST_CHECK(au_data->chunk_merkle_root.IsNull());
+
+    fs::path share_dir{m_path_root / "share_test4"};
+    fs::create_directories(share_dir);
+
+    fs::path src_path{share_dir / "source4.dat"};
+    {
+        AutoFile file{fsbridge::fopen(src_path, "wb")};
+        BOOST_REQUIRE(!file.IsNull());
+        node::SnapshotMetadata metadata(regtest_params->MessageStart(), au_data->blockhash, /*coins_count=*/1);
+        file << metadata;
+        std::vector<unsigned char> body{m_rng.randbytes(1000)};
+        file.write(MakeByteSpan(body));
+        BOOST_REQUIRE(file.fclose() == 0);
+    }
+
+    node::UTXOSetShareProvider provider;
+    BOOST_REQUIRE_EQUAL(provider.Initialize(share_dir, *regtest_params), 1U);
+    auto info_entries{provider.GetInfoEntries()};
+
+    fs::path output_path{m_path_root / "downloaded4.dat"};
+    node::UTXOSetDownloadManager dm;
+    BOOST_CHECK(dm.StartDownload(au_data->blockhash, *au_data, output_path));
+
+    dm.ProcessUTXOSetInfo(1, info_entries);
+    BOOST_CHECK(dm.GetState() == node::UTXOSetDownloadManager::State::DOWNLOADING);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5891,6 +5891,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
 
     std::optional<CCoinsStats> maybe_stats;
 
+    LogInfo("[snapshot] computing UTXO set hash to verify against assumeutxo value");
     try {
         maybe_stats = ComputeUTXOStats(
             CoinStatsHashType::HASH_SERIALIZED, snapshot_coinsdb, m_blockman, [&interrupt = m_interrupt] { SnapshotUTXOHashBreakpoint(interrupt); });

--- a/test/functional/p2p_utxo_set_share.py
+++ b/test/functional/p2p_utxo_set_share.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test P2P UTXO set sharing."""
+
+import hashlib
+import os
+import shutil
+
+from test_framework.messages import (
+    hash256,
+    msg_getutxoset,
+    msg_getutxostinf,
+    ser_uint256,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import MiniWallet
+
+# Using height 299 because it has a valid assumeutxo param
+START_HEIGHT = 199
+SNAPSHOT_HEIGHT = 299
+CHUNK_SIZE = 3_900_000
+
+
+def verify_merkle_proof(leaf_hash, proof, chunk_index, total_chunks, merkle_root):
+    computed = leaf_hash
+    index = chunk_index
+    for sibling in proof:
+        if index & 1:
+            computed = hash256(ser_uint256(sibling) + ser_uint256(computed))
+        else:
+            computed = hash256(ser_uint256(computed) + ser_uint256(sibling))
+        computed = int.from_bytes(computed, 'little')
+        index >>= 1
+    return computed == merkle_root
+
+
+class UTXOSetShareTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [[], []]
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+        self.start_nodes(extra_args=self.extra_args)
+
+    def run_test(self):
+        n0 = self.nodes[0]
+        n1 = self.nodes[1]
+        wallet = MiniWallet(n0)
+
+        # Generate blocks to SNAPSHOT_HEIGHT so blockhash matches the hardcoded
+        # assumeutxo parameters for height 299.
+        for n in self.nodes:
+            n.setmocktime(n.getblockheader(n.getbestblockhash())['time'])
+
+        assert_equal(n0.getblockcount(), START_HEIGHT)
+        for i in range(100):
+            if i % 3 == 0:
+                wallet.send_self_transfer(from_node=n0)
+            self.generate(n0, nblocks=1, sync_fun=self.no_op)
+            if i == 4:
+                temp_invalid = n0.getbestblockhash()
+                n0.invalidateblock(temp_invalid)
+                self.generateblock(n0, output="raw(aaaa)", transactions=[], sync_fun=self.no_op)
+                stale_hash = n0.getbestblockhash()
+                n0.invalidateblock(stale_hash)
+                n0.reconsiderblock(temp_invalid)
+        assert_equal(n0.getblockcount(), SNAPSHOT_HEIGHT)
+
+        # Create UTXO snapshot and place in share directory
+        dump_output = n0.dumptxoutset("utxos.dat", "latest")
+        snapshot_path = dump_output['path']
+
+        share_dir = os.path.join(n0.datadir_path, "regtest", "share")
+        os.makedirs(share_dir, exist_ok=True)
+        shutil.copy(snapshot_path, os.path.join(share_dir, "utxos.dat"))
+
+        # Restart serving node to pick up the snapshot. We also start the
+        # node in prune mode to have it signal NODE_NETWORK_LIMITED. This
+        # means the downloading node won't sync any blocks from the sharing
+        # nodes after activating the downloaded snapshot. This avoids a
+        # potential race between downloading and validating the (very short
+        # chain) and activating the downloaded snapshot.
+        self.restart_node(0, extra_args=["-prune=1"])
+        n0.setmocktime(n0.getblockheader(n0.getbestblockhash())['time'])
+
+        self.log.info("Test NODE_UTXO_SET service bit is advertised")
+        services = n0.getnetworkinfo()['localservicesnames']
+        assert 'UTXO_SET' in services
+
+        # Connect peer and request utxosetinfo
+        peer = n0.add_p2p_connection(P2PInterface())
+        peer.send_and_ping(msg_getutxostinf())
+
+        self.log.info("Test utxosetinfo response is valid")
+        assert 'utxosetinfo' in peer.last_message
+        info_msg = peer.last_message['utxosetinfo']
+        assert_greater_than(len(info_msg.entries), 0)
+
+        entry = info_msg.entries[0]
+        assert_equal(entry.height, SNAPSHOT_HEIGHT)
+        assert_greater_than(entry.data_length, 0)
+
+        self.log.info("Test requesting all chunks and verifying Merkle proofs")
+        total_chunks = (entry.data_length + CHUNK_SIZE - 1) // CHUNK_SIZE
+        reassembled = b""
+
+        for i in range(total_chunks):
+            req = msg_getutxoset(height=entry.height, block_hash=entry.block_hash, chunk_index=i)
+            peer.send_and_ping(req)
+            assert 'utxoset' in peer.last_message
+            chunk_msg = peer.last_message['utxoset']
+
+            assert_equal(chunk_msg.height, entry.height)
+            assert_equal(chunk_msg.block_hash, entry.block_hash)
+            assert_equal(chunk_msg.chunk_index, i)
+            assert_greater_than(len(chunk_msg.data), 0)
+
+            if i < total_chunks - 1:
+                assert_equal(len(chunk_msg.data), CHUNK_SIZE)
+
+            leaf_hash = int.from_bytes(hash256(chunk_msg.data), 'little')
+            assert verify_merkle_proof(leaf_hash, chunk_msg.proof_hashes, i, total_chunks, entry.merkle_root)
+
+            reassembled += chunk_msg.data
+
+        self.log.info("Test reassembled data matches original snapshot")
+        with open(snapshot_path, 'rb') as f:
+            original = f.read()
+        assert_equal(len(reassembled), len(original))
+        assert_equal(hashlib.sha256(reassembled).hexdigest(), hashlib.sha256(original).hexdigest())
+
+        self.log.info("Test invalid chunk index causes disconnect")
+        peer2 = n0.add_p2p_connection(P2PInterface())
+        bad_req = msg_getutxoset(height=entry.height, block_hash=entry.block_hash, chunk_index=total_chunks)
+        peer2.send_without_ping(bad_req)
+        peer2.wait_for_disconnect()
+
+        self.log.info("Test wrong block hash causes disconnect")
+        peer3 = n0.add_p2p_connection(P2PInterface())
+        bad_req = msg_getutxoset(height=entry.height, block_hash=0xdeadbeef, chunk_index=0)
+        peer3.send_without_ping(bad_req)
+        peer3.wait_for_disconnect()
+
+        self.log.info("Test wrong height causes disconnect")
+        peer4 = n0.add_p2p_connection(P2PInterface())
+        bad_req = msg_getutxoset(height=entry.height + 1, block_hash=entry.block_hash, chunk_index=0)
+        peer4.send_without_ping(bad_req)
+        peer4.wait_for_disconnect()
+
+        self.log.info("Test node without snapshot does not advertise NODE_UTXO_SET")
+        n1_services = n1.getnetworkinfo()['localservicesnames']
+        assert 'UTXO_SET' not in n1_services
+
+        self.log.info("Test getutxostinf to non-serving node gets no response")
+        peer5 = n1.add_p2p_connection(P2PInterface())
+        peer5.send_and_ping(msg_getutxostinf())
+        assert 'utxosetinfo' not in peer5.last_message
+
+        self.log.info("Test downloadutxoset with invalid height")
+        assert_raises_rpc_error(-8, "No assumeutxo data for height", n1.downloadutxoset, 12345)
+
+        # Transfer headers to downloading node so it can activate snapshot
+        for i in range(1, SNAPSHOT_HEIGHT + 1):
+            block = n0.getblock(n0.getblockhash(i), 0)
+            n1.submitheader(block)
+        assert_equal(n1.getblockchaininfo()["headers"], SNAPSHOT_HEIGHT)
+
+        self.log.info("Test full P2P download via downloadutxoset RPC")
+        result = n1.downloadutxoset(SNAPSHOT_HEIGHT)
+        assert_equal(result['height'], SNAPSHOT_HEIGHT)
+
+        self.log.info("Test duplicate downloadutxoset is rejected")
+        assert_raises_rpc_error(-1, "Failed to start download. A download may already be in progress.", n1.downloadutxoset, SNAPSHOT_HEIGHT)
+
+        # Connect nodes so download can proceed
+        self.connect_nodes(0, 1)
+        self.wait_until(lambda: len(n1.getchainstates()['chainstates']) == 2, timeout=30)
+
+
+if __name__ == '__main__':
+    UTXOSetShareTest(__file__).main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -59,6 +59,7 @@ NODE_WITNESS = (1 << 3)
 NODE_COMPACT_FILTERS = (1 << 6)
 NODE_NETWORK_LIMITED = (1 << 10)
 NODE_P2P_V2 = (1 << 11)
+NODE_UTXO_SET = (1 << 12)
 
 MSG_TX = 1
 MSG_BLOCK = 2
@@ -1382,6 +1383,127 @@ class msg_block:
 
     def __repr__(self):
         return "msg_block(block=%s)" % (repr(self.block))
+
+
+class UTXOSetInfoEntry:
+    __slots__ = ("height", "block_hash", "serialized_hash", "data_length", "merkle_root")
+
+    def __init__(self, height=0, block_hash=0, serialized_hash=0, data_length=0, merkle_root=0):
+        self.height = height
+        self.block_hash = block_hash
+        self.serialized_hash = serialized_hash
+        self.data_length = data_length
+        self.merkle_root = merkle_root
+
+    def deserialize(self, f):
+        self.height = int.from_bytes(f.read(4), "little")
+        self.block_hash = deser_uint256(f)
+        self.serialized_hash = deser_uint256(f)
+        self.data_length = int.from_bytes(f.read(8), "little")
+        self.merkle_root = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += self.height.to_bytes(4, "little")
+        r += ser_uint256(self.block_hash)
+        r += ser_uint256(self.serialized_hash)
+        r += self.data_length.to_bytes(8, "little")
+        r += ser_uint256(self.merkle_root)
+        return r
+
+    def __repr__(self):
+        return "UTXOSetInfoEntry(height=%d)" % self.height
+
+
+class msg_getutxostinf:
+    __slots__ = ()
+    msgtype = b"getutxostinf"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_getutxostinf()"
+
+
+class msg_utxosetinfo:
+    __slots__ = ("entries",)
+    msgtype = b"utxosetinfo"
+
+    def __init__(self):
+        self.entries = []
+
+    def deserialize(self, f):
+        self.entries = deser_vector(f, UTXOSetInfoEntry)
+
+    def serialize(self):
+        return ser_vector(self.entries)
+
+    def __repr__(self):
+        return "msg_utxosetinfo(entries=%d)" % len(self.entries)
+
+
+class msg_getutxoset:
+    __slots__ = ("height", "block_hash", "chunk_index")
+    msgtype = b"getutxoset"
+
+    def __init__(self, height=0, block_hash=0, chunk_index=0):
+        self.height = height
+        self.block_hash = block_hash
+        self.chunk_index = chunk_index
+
+    def deserialize(self, f):
+        self.height = int.from_bytes(f.read(4), "little")
+        self.block_hash = deser_uint256(f)
+        self.chunk_index = int.from_bytes(f.read(4), "little")
+
+    def serialize(self):
+        r = b""
+        r += self.height.to_bytes(4, "little")
+        r += ser_uint256(self.block_hash)
+        r += self.chunk_index.to_bytes(4, "little")
+        return r
+
+    def __repr__(self):
+        return "msg_getutxoset(height=%d, chunk_index=%d)" % (self.height, self.chunk_index)
+
+
+class msg_utxoset:
+    __slots__ = ("height", "block_hash", "chunk_index", "proof_hashes", "data")
+    msgtype = b"utxoset"
+
+    def __init__(self, height=0, block_hash=0, chunk_index=0, proof_hashes=None, data=b""):
+        self.height = height
+        self.block_hash = block_hash
+        self.chunk_index = chunk_index
+        self.proof_hashes = proof_hashes or []
+        self.data = data
+
+    def deserialize(self, f):
+        self.height = int.from_bytes(f.read(4), "little")
+        self.block_hash = deser_uint256(f)
+        self.chunk_index = int.from_bytes(f.read(4), "little")
+        self.proof_hashes = deser_uint256_vector(f)
+        self.data = deser_string(f)
+
+    def serialize(self):
+        r = b""
+        r += self.height.to_bytes(4, "little")
+        r += ser_uint256(self.block_hash)
+        r += self.chunk_index.to_bytes(4, "little")
+        r += ser_uint256_vector(self.proof_hashes)
+        r += ser_string(self.data)
+        return r
+
+    def __repr__(self):
+        return "msg_utxoset(height=%d, chunk_index=%d, data_len=%d)" % (
+            self.height, self.chunk_index, len(self.data))
 
 
 # Generic type to control the raw bytes sent over the wire.

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -68,6 +68,8 @@ from test_framework.messages import (
     msg_sendtxrcncl,
     msg_tx,
     MSG_TX,
+    msg_utxoset,
+    msg_utxosetinfo,
     MSG_TYPE_MASK,
     msg_verack,
     msg_version,
@@ -148,6 +150,8 @@ MESSAGEMAP = {
     b"sendheaders": msg_sendheaders,
     b"sendtxrcncl": msg_sendtxrcncl,
     b"tx": msg_tx,
+    b"utxoset": msg_utxoset,
+    b"utxosetinfo": msg_utxosetinfo,
     b"verack": msg_verack,
     b"version": msg_version,
     b"wtxidrelay": msg_wtxidrelay,
@@ -562,6 +566,8 @@ class P2PInterface(P2PConnection):
     def on_sendheaders(self, message): pass
     def on_sendtxrcncl(self, message): pass
     def on_tx(self, message): pass
+    def on_utxoset(self, message): pass
+    def on_utxosetinfo(self, message): pass
     def on_wtxidrelay(self, message): pass
 
     def on_inv(self, message):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -346,6 +346,7 @@ BASE_SCRIPTS = [
     'rpc_deriveaddresses.py',
     'rpc_deriveaddresses.py --usecli',
     'p2p_ping.py',
+    'p2p_utxo_set_share.py',
     'p2p_tx_privacy.py',
     'rpc_getdescriptoractivity.py',
     'rpc_scanblocks.py',


### PR DESCRIPTION
This implements a [draft BIP](https://github.com/bitcoin/bips/pull/2137) for a protocol to share a UTXO set over P2P. Ideally, please review the BIP draft along side this PR if you already want to look at the code.

### Motivation

The motivation is to make it possible to use the assumeutxo feature without having to acquire a snapshot from a third party.

### UX

The UX for the user is very similar to how `loadtxoutset` works today:

- The user starts their new node and has to wait until the headers have synced
- The user then invokes the RPC `downloadutxoset` with their selected height
- The utxo set download finishes in the background
- Upon completion the snapshot is compared to assumeutxo params and if those match, it is activated

### Design choices

- Capability to serve UTXO sets is signaled with a service bit
- The UTXO set is shared in chunks of 3.9 MB
- A merkle root of these chunks serves as integrity check to prevent sending useless data as a trivial DoS vector
- UTXO set snapshots for sharing are placed in a `share` folder in the datadir, they are atomically loaded on startup and then shared
- A node that downloaded a snapshot will share it themselves until the snapshot has been deleted from their share folder
- The merkle root is introduced to the assumeutxo data in the chainparams to ensure peers can not lie to us about it

### Status

This is certainly still rough around the edges and the merkle roots in the chain params have not all been filled in yet. I am primarily looking for concept and approach feedback as well as potentially overlooked DoS vectors to start.

If you find a DoS vector on the serving side feel free to crash the live demo node below for bragging rights. Just please give me a heads up afterwards :)

### Live demo

The feature can be tried out on mainnet:

1. Build this branch (duh)
2. Start with a fresh node (datadir) and `-connect=178.104.141.103:8333 -debug=utxosetshare`. You can also use `addnode` but this will make it harder to watch the logs since historical blocks are still synced at the same time. Note that since the demo node is pruned, your node will need to be restarted to sync blocks after snapshot validation if you are using `-connect`.
4. Wait until the headers have synced, then use `bitcoin-cli downloadutxoset 935000`
5. Watch the logs to see the the chunks come in and then see the completed snapshot getting activated