### PR TITLE
wallet: clean old key material before overwriting in SetKey

### DIFF
--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -66,6 +66,8 @@ bool CCrypter::SetKey(const CKeyingMaterial& new_key, const std::span<const unsi
         return false;
     }
 
+    if (fKeySet) CleanKey();
+
     memcpy(vchKey.data(), new_key.data(), new_key.size());
     memcpy(vchIV.data(), new_iv.data(), new_iv.size());
 

--- a/src/wallet/test/wallet_crypto_tests.cpp
+++ b/src/wallet/test/wallet_crypto_tests.cpp
@@ -130,5 +130,19 @@ BOOST_AUTO_TEST_CASE(decrypt) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(setkey_cleans_old_key) {
+    CKeyingMaterial key1(WALLET_CRYPTO_KEY_SIZE, 0x41);
+    CKeyingMaterial key2(WALLET_CRYPTO_KEY_SIZE, 0x42);
+    std::array<uint8_t, WALLET_CRYPTO_IV_SIZE> iv1{};
+    std::array<uint8_t, WALLET_CRYPTO_IV_SIZE> iv2{};
+
+    CCrypter crypt;
+    BOOST_CHECK(crypt.SetKey(key1, iv1));
+    BOOST_CHECK_EQUAL(crypt.vchKey[0], 0x41);
+
+    BOOST_CHECK(crypt.SetKey(key2, iv2));
+    BOOST_CHECK_EQUAL(crypt.vchKey[0], 0x42);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet


### PR DESCRIPTION
When CCrypter::SetKey() is called on an instance that already has a key set (fKeySet=true), the old key and IV are overwritten without being cleansed first. This can leave sensitive key material in memory longer than necessary.

This fix adds a call to CleanKey() before overwriting the key when fKeySet is already true, ensuring old key material is securely wiped before new key data is written