### PR TITLE
util/moneystr: fix potential out-of-bounds access in FormatMoney

### DIFF
--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -31,7 +31,7 @@ std::string FormatMoney(const CAmount n)
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
-    for (int i = str.size()-1; (str[i] == '0' && IsDigit(str[i-2])); --i)
+    for (int i = str.size() - 1; i >= 2 && str[i] == '0' && IsDigit(str[i - 2]); --i)
         ++nTrim;
     if (nTrim)
         str.erase(str.size()-nTrim, nTrim);


### PR DESCRIPTION
The loop in FormatMoney accesses str[i-2] without first checking that i >= 2. If str.size() < 3, this could read out of bounds.

Fix by adding explicit bounds check i >= 2 to the loop condition.