### PR TITLE
Fix/validation int underflow

### DIFF
--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -31,7 +31,7 @@ std::string FormatMoney(const CAmount n)
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
-    for (int i = str.size()-1; (str[i] == '0' && IsDigit(str[i-2])); --i)
+    for (int i = str.size() - 1; i >= 2 && str[i] == '0' && IsDigit(str[i - 2]); --i)
         ++nTrim;
     if (nTrim)
         str.erase(str.size()-nTrim, nTrim);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2202,7 +2202,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
                            (pindex->nHeight==91812 && pindex->GetBlockHash() == uint256{"00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f"}));
 
     // undo transactions in reverse order
-    for (int i = block.vtx.size() - 1; i >= 0; i--) {
+    for (int i = static_cast<int>(block.vtx.size()) - 1; i >= 0; i--) {
         const CTransaction &tx = *(block.vtx[i]);
         Txid hash = tx.GetHash();
         bool is_coinbase = tx.IsCoinBase();


### PR DESCRIPTION
When block.vtx is empty, `block.vtx.size() - 1` causes integer underflow 
since size() returns size_t (unsigned) and subtracting 1 wraps around 
to a large number. This fix adds an explicit cast to int to prevent 
the underflow.
Fixes a potential crash when processing blocks with zero transactions.