### PR TITLE
Fix/spend div by zero

### DIFF
--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -31,7 +31,7 @@ std::string FormatMoney(const CAmount n)
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
-    for (int i = str.size()-1; (str[i] == '0' && IsDigit(str[i-2])); --i)
+    for (int i = str.size() - 1; i >= 2 && str[i] == '0' && IsDigit(str[i - 2]); --i)
         ++nTrim;
     if (nTrim)
         str.erase(str.size()-nTrim, nTrim);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2202,7 +2202,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
                            (pindex->nHeight==91812 && pindex->GetBlockHash() == uint256{"00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f"}));
 
     // undo transactions in reverse order
-    for (int i = block.vtx.size() - 1; i >= 0; i--) {
+    for (int i = static_cast<int>(block.vtx.size()) - 1; i >= 0; i--) {
         const CTransaction &tx = *(block.vtx[i]);
         Txid hash = tx.GetHash();
         bool is_coinbase = tx.IsCoinBase();

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1538,6 +1538,10 @@ RPCMethod sendall()
                 throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds for fees after creating specified outputs.");
             }
 
+
+            if (addresses_without_amount.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "No addresses without amount specified");
+            }
             const CAmount per_output_without_amount{remainder / (long)addresses_without_amount.size()};
 
             bool gave_remaining_to_first{false};


### PR DESCRIPTION
When `addresses_without_amount` is empty, the code attempts to divide 
by zero when calculating `per_output_without_amount` and when 
distributing the remainder.
This fix adds a check to ensure the vector is not empty before 
performing the division, throwing a proper RPC error instead of 
crashing.