### PR TITLE
depends: fix cmake package discovery for depends-built packages

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -175,7 +175,7 @@ $(1)_config_env+=$($(1)_config_env_$(host_arch)_$(host_os)) $($(1)_config_env_$(
 $(1)_config_env+=PKG_CONFIG_LIBDIR=$($($(1)_type)_prefix)/lib/pkgconfig
 $(1)_config_env+=PKG_CONFIG_PATH=$($($(1)_type)_prefix)/share/pkgconfig
 $(1)_config_env+=PKG_CONFIG_SYSROOT_DIR=/
-$(1)_config_env+=CMAKE_MODULE_PATH=$($($(1)_type)_prefix)/lib/cmake
+$(1)_config_env+=CMAKE_PREFIX_PATH=$($($(1)_type)_prefix):$(CMAKE_PREFIX_PATH)
 $(1)_config_env+=PATH="$(build_prefix)/bin:$(PATH)"
 $(1)_build_env+=PATH="$(build_prefix)/bin:$(PATH)"
 $(1)_stage_env+=PATH="$(build_prefix)/bin:$(PATH)"


### PR DESCRIPTION
When building cmake-based depends packages (e.g. native_libmultiprocess), cmake needs to find dependencies that were previously built and installed into the depends prefix. Since 603fd6a2e70 ("depends: add MULTIPROCESS depends option"), funcs.mk has set CMAKE_MODULE_PATH in the environment to point cmake at the depends prefix. This never worked for two reasons:

1. CMake does not read CMAKE_MODULE_PATH from the environment; it only honors it when set via -D flags or set() in CMakeLists.

2. CMAKE_MODULE_PATH only affects module-mode find_package() (Find*.cmake files), but CapnProto and most modern cmake packages use config mode (NO_MODULE / *Config.cmake files), which ignores CMAKE_MODULE_PATH entirely and instead uses CMAKE_PREFIX_PATH.

CMake does read CMAKE_PREFIX_PATH from the environment, and it is the correct variable for config-mode package discovery. Replace the broken CMAKE_MODULE_PATH assignment with CMAKE_PREFIX_PATH prepended to any existing value (mirroring how PATH is handled), pointing at the type-appropriate depends prefix.

This fixes a build failure in native_libmultiprocess where cmake would find the system (nix) CapnProto 1.2.0 instead of the depends-built CapnProto 1.4.0, resulting in a compile-time version mismatch error:
  #error "Version mismatch between generated code and library headers."

