### PR TITLE
Reindex: save progress to continue after interruption

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -60,6 +60,8 @@ static constexpr uint8_t DB_BLOCK_INDEX{'b'};
 static constexpr uint8_t DB_FLAG{'F'};
 static constexpr uint8_t DB_REINDEX_FLAG{'R'};
 static constexpr uint8_t DB_LAST_BLOCK{'l'};
+static constexpr uint8_t DB_REINDEX_LASTFILE{'P'}; // Last completed blk file index during reindex
+static constexpr uint8_t DB_REINDEX_ORPHAN_BLOCKS{'O'}; // Orphan block positions during reindex
 // Keys used in previous version that might still be found in the DB:
 // BlockTreeDB::DB_TXINDEX_BLOCK{'T'};
 // BlockTreeDB::DB_TXINDEX{'t'}
@@ -82,6 +84,34 @@ void BlockTreeDB::WriteReindexing(bool fReindexing)
 void BlockTreeDB::ReadReindexing(bool& fReindexing)
 {
     fReindexing = Exists(DB_REINDEX_FLAG);
+}
+
+void BlockTreeDB::WriteReindexProgress(int last_file, const std::multimap<uint256, FlatFilePos>& orphans)
+{
+    CDBBatch batch(*this);
+    batch.Write(DB_REINDEX_LASTFILE, last_file);
+    batch.Write(DB_REINDEX_ORPHAN_BLOCKS,
+        std::vector<std::pair<uint256, FlatFilePos>>(orphans.begin(), orphans.end()));
+    WriteBatch(batch);
+}
+
+bool BlockTreeDB::ReadReindexProgress(int& last_file, std::multimap<uint256, FlatFilePos>& orphans)
+{
+    if (!Read(DB_REINDEX_LASTFILE, last_file)) return false;
+    std::vector<std::pair<uint256, FlatFilePos>> entries;
+    if (Read(DB_REINDEX_ORPHAN_BLOCKS, entries)) {
+        for (auto& [hash, pos] : entries) orphans.emplace(hash, pos);
+    }
+    return true;
+}
+
+void BlockTreeDB::WriteReindexingComplete()
+{
+    CDBBatch batch(*this);
+    batch.Erase(DB_REINDEX_FLAG);
+    batch.Erase(DB_REINDEX_LASTFILE);
+    batch.Erase(DB_REINDEX_ORPHAN_BLOCKS);
+    WriteBatch(batch, /*fSync=*/true);
 }
 
 bool BlockTreeDB::ReadLastBlockFile(int& nFile)
@@ -1272,8 +1302,26 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
         // Map of disk positions for blocks with unknown parent (only used for reindex);
         // parent hash -> child disk position, multiple children can have the same parent.
         std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
+        int start_file{0};
 
-        for (int nFile{0}; nFile < total_files; ++nFile) {
+        // Restore progress from an interrupted reindex. A block in file N may reference a
+        // parent that only appears in a later file M; such blocks are held in
+        // blocks_with_unknown_parent rather than the block index. Persisting this map ensures
+        // those blocks are connected when their parent file is eventually processed.
+        {
+            int last_completed{-1};
+            const bool has_progress{WITH_LOCK(::cs_main,
+                return chainman.m_blockman.m_block_tree_db->ReadReindexProgress(
+                            last_completed, blocks_with_unknown_parent
+                        )
+            )};
+            if (has_progress) {
+                start_file = last_completed + 1;
+                LogInfo("Resuming reindex from block file blk%05u.dat...", start_file);
+            }
+        }
+
+        for (int nFile{start_file}; nFile < total_files; ++nFile) {
             FlatFilePos pos(nFile, 0);
             AutoFile file{chainman.m_blockman.OpenBlockFile(pos, /*fReadOnly=*/true)};
             if (file.IsNull()) {
@@ -1285,8 +1333,14 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
                 LogInfo("Interrupt requested. Exit reindexing.");
                 return;
             }
+            // Checkpoint progress after each fully-completed file so an interrupted reindex
+            // can resume from here rather than starting over from blk00000.dat.
+            // Only written after the interrupt check so we never record a partially-processed
+            // file as complete.
+            WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexProgress(
+                nFile, blocks_with_unknown_parent));
         }
-        WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexing(false));
+        WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexingComplete());
         chainman.m_blockman.m_blockfiles_indexed = true;
         LogInfo("Reindexing finished");
         // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -60,6 +60,8 @@ static constexpr uint8_t DB_BLOCK_INDEX{'b'};
 static constexpr uint8_t DB_FLAG{'F'};
 static constexpr uint8_t DB_REINDEX_FLAG{'R'};
 static constexpr uint8_t DB_LAST_BLOCK{'l'};
+static constexpr uint8_t DB_REINDEX_LASTFILE{'P'}; // Last completed blk file index during reindex
+static constexpr uint8_t DB_REINDEX_ORPHAN_BLOCKS{'O'}; // Orphan block positions during reindex
 // Keys used in previous version that might still be found in the DB:
 // BlockTreeDB::DB_TXINDEX_BLOCK{'T'};
 // BlockTreeDB::DB_TXINDEX{'t'}
@@ -82,6 +84,36 @@ void BlockTreeDB::WriteReindexing(bool fReindexing)
 void BlockTreeDB::ReadReindexing(bool& fReindexing)
 {
     fReindexing = Exists(DB_REINDEX_FLAG);
+}
+
+void BlockTreeDB::WriteReindexProgress(int last_file, const std::multimap<uint256, FlatFilePos>& orphans)
+{
+    CDBBatch batch(*this);
+    batch.Write(DB_REINDEX_LASTFILE, last_file);
+    batch.Write(DB_REINDEX_ORPHAN_BLOCKS,
+        std::vector<std::pair<uint256, FlatFilePos>>(orphans.begin(), orphans.end()));
+    WriteBatch(batch);
+}
+
+bool BlockTreeDB::ReadReindexProgress(int& last_file, std::multimap<uint256, FlatFilePos>& orphans)
+{
+    if (!Read(DB_REINDEX_LASTFILE, last_file)) return false;
+    std::vector<std::pair<uint256, FlatFilePos>> entries;
+    if (Read(DB_REINDEX_ORPHAN_BLOCKS, entries)) {
+        for (auto& [hash, pos] : entries) orphans.emplace(hash, pos);
+    } else {
+        return false;
+    }
+    return true;
+}
+
+void BlockTreeDB::WriteReindexingComplete()
+{
+    CDBBatch batch(*this);
+    batch.Erase(DB_REINDEX_FLAG);
+    batch.Erase(DB_REINDEX_LASTFILE);
+    batch.Erase(DB_REINDEX_ORPHAN_BLOCKS);
+    WriteBatch(batch, /*fSync=*/true);
 }
 
 bool BlockTreeDB::ReadLastBlockFile(int& nFile)
@@ -1278,8 +1310,26 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
         // Map of disk positions for blocks with unknown parent (only used for reindex);
         // parent hash -> child disk position, multiple children can have the same parent.
         std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
+        int start_file{0};
 
-        for (int nFile{0}; nFile < total_files; ++nFile) {
+        // Restore progress from an interrupted reindex. A block in file N may reference a
+        // parent that only appears in a later file M; such blocks are held in
+        // blocks_with_unknown_parent rather than the block index. Persisting this map ensures
+        // those blocks are connected when their parent file is eventually processed.
+        {
+            int last_completed{-1};
+            const bool has_progress{WITH_LOCK(::cs_main,
+                return chainman.m_blockman.m_block_tree_db->ReadReindexProgress(
+                            last_completed, blocks_with_unknown_parent
+                        )
+            )};
+            if (has_progress && last_completed < total_files) {
+                start_file = last_completed + 1;
+                LogInfo("Resuming reindex from block file blk%05u.dat...", start_file);
+            }
+        }
+
+        for (int nFile{start_file}; nFile < total_files; ++nFile) {
             FlatFilePos pos(nFile, 0);
             AutoFile file{chainman.m_blockman.OpenBlockFile(pos, /*fReadOnly=*/true)};
             if (file.IsNull()) {
@@ -1288,11 +1338,21 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
             LogInfo("Reindexing block file blk%05u.dat (%d%% complete)...", (unsigned int)nFile, nFile * 100 / total_files);
             chainman.LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
             if (chainman.m_interrupt) {
-                LogInfo("Interrupt requested. Exit reindexing.");
+                // Save progress in case of interrupt so reindex process can resume
+                // from the last completed block file rather than starting over from blk00000.dat.
+                // Because LoadExternalBlockFile() has its own interrupt check and may return
+                // early, we set nFile - 1 as the checkpoint. This means that
+                // blocks_with_unknown_parent may contain orphans from partially-processed nFile.
+                // That's OK: the resuming reindex process will re-write them but it
+                // will not affect the result.
+                LogInfo("Interrupt requested. Saving reindexing progress...");
+                WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexProgress(
+                    nFile - 1, blocks_with_unknown_parent));
+                LogInfo("Exit reindexing.");
                 return;
             }
         }
-        WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexing(false));
+        WITH_LOCK(::cs_main, chainman.m_blockman.m_block_tree_db->WriteReindexingComplete());
         chainman.m_blockman.m_blockfiles_indexed = true;
         LogInfo("Reindexing finished");
         // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -105,6 +105,12 @@ public:
     bool ReadLastBlockFile(int& nFile);
     void WriteReindexing(bool fReindexing);
     void ReadReindexing(bool& fReindexing);
+    void WriteReindexProgress(int last_file, const std::multimap<uint256, FlatFilePos>& orphans);
+    bool ReadReindexProgress(int& last_file, std::multimap<uint256, FlatFilePos>& orphans);
+    //! Atomically clear all reindex state (reindex flag + progress checkpoint) with a sync
+    //! write, so that a power failure after this returns can never leave the node thinking
+    //! a block-file scan is still required.
+    void WriteReindexingComplete();
     void WriteFlag(const std::string& name, bool fValue);
     bool ReadFlag(const std::string& name, bool& fValue);
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, const util::SignalInterrupt& interrupt)

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -104,6 +104,12 @@ public:
     bool ReadLastBlockFile(int& nFile);
     void WriteReindexing(bool fReindexing);
     void ReadReindexing(bool& fReindexing);
+    void WriteReindexProgress(int last_file, const std::multimap<uint256, FlatFilePos>& orphans);
+    bool ReadReindexProgress(int& last_file, std::multimap<uint256, FlatFilePos>& orphans);
+    //! Atomically clear all reindex state (reindex flag + progress checkpoint) with a sync
+    //! write, so that a power failure after this returns can never leave the node thinking
+    //! a block-file scan is still required.
+    void WriteReindexingComplete();
     void WriteFlag(const std::string& name, bool fValue);
     bool ReadFlag(const std::string& name, bool& fValue);
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, const util::SignalInterrupt& interrupt)

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -8,7 +8,7 @@
 - Stop the node and restart it with -reindex. Verify that the node has reindexed up to block 3.
 - Stop the node and restart it with -reindex-chainstate. Verify that the node has reindexed up to block 3.
 - Verify that out-of-order blocks are correctly processed, see LoadExternalBlockFile()
-- Verify that an interrupted reindex does not resume from the last completed block file.
+- Verify that an interrupted reindex resumes from the last completed block file.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -103,8 +103,8 @@ class ReindexTest(BitcoinTestFramework):
             node.wait_for_rpc_connection(wait_for_import=False)
         node.stop_node()
 
-    def reindex_restart_after_interrupt(self):
-        self.log.info("Test that an interrupted reindex does not resume from the last completed block file.")
+    def reindex_resume_after_interrupt(self):
+        self.log.info("Test that an interrupted reindex resumes from the last completed block file.")
 
         self.log.info("Ensuring second node with -fastprune has multiple block files")
         node = self.nodes[1]
@@ -129,21 +129,23 @@ class ReindexTest(BitcoinTestFramework):
         with open(node.debug_log_path, "r") as dl:
             assert "Reindexing block file blk00002.dat" not in dl.read()
 
-        self.log.info("Restarting without -reindex to restart entire process")
-        # Ensure all blk files were reindexed, again
-        with node.busy_wait_for_debug_log(
+        self.log.info("Restarting without -reindex to resume reindex process")
+        # Ensure we only reindex blk files that were not already reindexed on the last run
+        with node.assert_debug_log(
             expected_msgs=[
-                b'Reindexing block file blk00000.dat',
-                b'Reindexing block file blk00001.dat',
-                b'Reindexing block file blk00002.dat',
-                b'Reindexing finished',
-                b'progress=1'
+                'Resuming reindex from block file', # most likely "blk00001.dat" unless shutdown took too long
+                'Reindexing block file blk00002.dat',
+                'Reindexing finished',
+                'progress=1',
+                f'height={expected_block_count}'
+            ],
+            unexpected_msgs=[
+                'Reindexing block file blk00000.dat'
             ],
             timeout=30
         ):
             node.start(['-fastprune'])
-            node.wait_for_rpc_connection(wait_for_import=False)
-        assert_equal(node.getblockcount(), expected_block_count)
+            node.wait_for_rpc_connection()
 
 
     def run_test(self):
@@ -154,7 +156,7 @@ class ReindexTest(BitcoinTestFramework):
 
         self.out_of_order()
         self.continue_reindex_after_shutdown()
-        self.reindex_restart_after_interrupt()
+        self.reindex_resume_after_interrupt()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -8,12 +8,14 @@
 - Stop the node and restart it with -reindex. Verify that the node has reindexed up to block 3.
 - Stop the node and restart it with -reindex-chainstate. Verify that the node has reindexed up to block 3.
 - Verify that out-of-order blocks are correctly processed, see LoadExternalBlockFile()
+- Verify that an interrupted reindex does not resume from the last completed block file.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import MAGIC_BYTES
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     util_xor,
 )
 
@@ -21,14 +23,17 @@ from test_framework.util import (
 class ReindexTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 1
+        self.num_nodes = 2
+        # self.nodes[1] will use multiple, smaller blk files
+        self.extra_args=[[], ["-fastprune"]]
 
     def reindex(self, justchainstate=False):
         self.generatetoaddress(self.nodes[0], 3, self.nodes[0].get_deterministic_priv_key().address)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
-        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"]]
+        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"], ["-fastprune"]]
         self.start_nodes(extra_args)
+        self.connect_nodes(0, 1)
         assert_equal(self.nodes[0].getblockcount(), blockcount)  # start_node is blocking on reindex
         self.log.info("Success")
 
@@ -72,8 +77,9 @@ class ReindexTest(BitcoinTestFramework):
             'LoadExternalBlockFile: Out of order block',
             'LoadExternalBlockFile: Processing out of order child',
         ]):
-            extra_args = [["-reindex"]]
+            extra_args = [["-reindex"], ["-fastprune"]]
             self.start_nodes(extra_args)
+            self.connect_nodes(0, 1)
 
         # All blocks should be accepted and processed.
         assert_equal(self.nodes[0].getblockcount(), 12)
@@ -97,6 +103,49 @@ class ReindexTest(BitcoinTestFramework):
             node.wait_for_rpc_connection(wait_for_import=False)
         node.stop_node()
 
+    def reindex_restart_after_interrupt(self):
+        self.log.info("Test that an interrupted reindex does not resume from the last completed block file.")
+
+        self.log.info("Ensuring second node with -fastprune has multiple block files")
+        node = self.nodes[1]
+        block_files = list(node.blocks_path.glob('blk[0-9][0-9][0-9][0-9][0-9].dat'))
+        # We need at least 3 block files for the test to work:
+        # blk00000 gets processed during reindex
+        # blk00001 appears in the log but (probably) does not get processed before shutdown
+        # blk00002 does not get processed, reindex is incomplete
+        assert_greater_than(len(block_files), 3)
+        expected_block_count = node.getblockcount()
+        node.stop_node()
+
+        self.log.info("Restarting with -reindex but stopping after the first block file is processed")
+        # busy_wait_for_debug_log unblocks as soon as this log line appears.
+        # The line is printed *before* blk00001.dat is loaded, so at that moment
+        # blk00000.dat is fully processed.
+        with node.busy_wait_for_debug_log([b'Reindexing block file blk00001.dat']):
+            node.start(['-fastprune', '-reindex'])
+            node.wait_for_rpc_connection(wait_for_import=False)
+        node.stop_node()
+        # Ensure at least one blk file was not reindexed
+        with open(node.debug_log_path, "r") as dl:
+            assert "Reindexing block file blk00002.dat" not in dl.read()
+
+        self.log.info("Restarting without -reindex to restart entire process")
+        # Ensure all blk files were reindexed, again
+        with node.busy_wait_for_debug_log(
+            expected_msgs=[
+                b'Reindexing block file blk00000.dat',
+                b'Reindexing block file blk00001.dat',
+                b'Reindexing block file blk00002.dat',
+                b'Reindexing finished',
+                b'progress=1'
+            ],
+            timeout=30
+        ):
+            node.start(['-fastprune'])
+            node.wait_for_rpc_connection(wait_for_import=False)
+        assert_equal(node.getblockcount(), expected_block_count)
+
+
     def run_test(self):
         self.reindex(False)
         self.reindex(True)
@@ -105,6 +154,7 @@ class ReindexTest(BitcoinTestFramework):
 
         self.out_of_order()
         self.continue_reindex_after_shutdown()
+        self.reindex_restart_after_interrupt()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -8,7 +8,7 @@
 - Stop the node and restart it with -reindex. Verify that the node has reindexed up to block 3.
 - Stop the node and restart it with -reindex-chainstate. Verify that the node has reindexed up to block 3.
 - Verify that out-of-order blocks are correctly processed, see LoadExternalBlockFile()
-- Verify that an interrupted reindex does not resume from the last completed block file.
+- Verify that an interrupted reindex resumes from the last completed block file.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -103,8 +103,8 @@ class ReindexTest(BitcoinTestFramework):
             node.wait_for_rpc_connection(wait_for_import=False)
         node.stop_node()
 
-    def reindex_restart_after_interrupt(self):
-        self.log.info("Test that an interrupted reindex does not resume from the last completed block file.")
+    def reindex_resume_after_interrupt(self):
+        self.log.info("Test that an interrupted reindex resumes from the last completed block file.")
 
         self.log.info("Ensuring second node with -fastprune has multiple block files")
         node = self.nodes[1]
@@ -133,15 +133,17 @@ class ReindexTest(BitcoinTestFramework):
         with open(node.debug_log_path, "r") as dl:
             assert f"Reindexing block file {last_filename}" not in dl.read()
 
-        self.log.info("Restarting without -reindex to restart entire process")
-        # Ensure all blk files were reindexed, again
-        with node.busy_wait_for_debug_log(
+        self.log.info("Restarting without -reindex to resume reindex process")
+        # Ensure we only reindex blk files that were not already reindexed on the last run
+        with node.assert_debug_log(
             expected_msgs=[
-                b'Reindexing block file blk00000.dat',
-                b'Reindexing block file blk00001.dat',
-                b'Reindexing block file ' + last_filename.encode(),
-                b'Reindexing finished',
-                b'progress=1'
+                'Resuming reindex from block file', # most likely "blk00001.dat" unless shutdown took too long
+                'Reindexing block file ' + last_filename,
+                'Reindexing finished',
+                'progress=1'
+            ],
+            unexpected_msgs=[
+                'Reindexing block file blk00000.dat'
             ],
             timeout=30
         ):
@@ -158,7 +160,7 @@ class ReindexTest(BitcoinTestFramework):
 
         self.out_of_order()
         self.continue_reindex_after_shutdown()
-        self.reindex_restart_after_interrupt()
+        self.reindex_resume_after_interrupt()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -8,12 +8,14 @@
 - Stop the node and restart it with -reindex. Verify that the node has reindexed up to block 3.
 - Stop the node and restart it with -reindex-chainstate. Verify that the node has reindexed up to block 3.
 - Verify that out-of-order blocks are correctly processed, see LoadExternalBlockFile()
+- Verify that an interrupted reindex does not resume from the last completed block file.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import MAGIC_BYTES
 from test_framework.util import (
     assert_equal,
+    assert_greater_than_or_equal,
     util_xor,
 )
 
@@ -21,14 +23,17 @@ from test_framework.util import (
 class ReindexTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 1
+        self.num_nodes = 2
+        # self.nodes[1] will use multiple, smaller blk files
+        self.extra_args=[[], ["-fastprune"]]
 
     def reindex(self, justchainstate=False):
         self.generatetoaddress(self.nodes[0], 3, self.nodes[0].get_deterministic_priv_key().address)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
-        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"]]
+        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"], ["-fastprune"]]
         self.start_nodes(extra_args)
+        self.connect_nodes(0, 1)
         assert_equal(self.nodes[0].getblockcount(), blockcount)  # start_node is blocking on reindex
         self.log.info("Success")
 
@@ -72,8 +77,9 @@ class ReindexTest(BitcoinTestFramework):
             'LoadExternalBlockFile: Out of order block',
             'LoadExternalBlockFile: Processing out of order child',
         ]):
-            extra_args = [["-reindex"]]
+            extra_args = [["-reindex"], ["-fastprune"]]
             self.start_nodes(extra_args)
+            self.connect_nodes(0, 1)
 
         # All blocks should be accepted and processed.
         assert_equal(self.nodes[0].getblockcount(), 12)
@@ -97,6 +103,53 @@ class ReindexTest(BitcoinTestFramework):
             node.wait_for_rpc_connection(wait_for_import=False)
         node.stop_node()
 
+    def reindex_restart_after_interrupt(self):
+        self.log.info("Test that an interrupted reindex does not resume from the last completed block file.")
+
+        self.log.info("Ensuring second node with -fastprune has multiple block files")
+        node = self.nodes[1]
+        block_files = list(node.blocks_path.glob('blk[0-9][0-9][0-9][0-9][0-9].dat'))
+        # We need at least 3 block files for the test to work:
+        # blk00000 gets processed during reindex
+        # blk00001 appears in the log but (probably) does not get processed before shutdown
+        # blk00002 does not get processed, reindex is incomplete
+        assert_greater_than_or_equal(len(block_files), 3)
+        expected_block_count = node.getblockcount()
+        node.stop_node()
+
+        # Get the name of the last file
+        last_file = max(block_files, key=lambda p: int(p.stem[3:]))
+        last_filename = last_file.name
+
+        self.log.info("Restarting with -reindex but stopping after the first block file is processed")
+        # busy_wait_for_debug_log unblocks as soon as this log line appears.
+        # The line is printed *before* blk00001.dat is loaded, so at that moment
+        # blk00000.dat is fully processed.
+        with node.busy_wait_for_debug_log([b'Reindexing block file blk00001.dat']):
+            node.start(['-fastprune', '-reindex'])
+            node.wait_for_rpc_connection(wait_for_import=False)
+        node.stop_node()
+        # Ensure at least one blk file was not reindexed
+        with open(node.debug_log_path, "r") as dl:
+            assert f"Reindexing block file {last_filename}" not in dl.read()
+
+        self.log.info("Restarting without -reindex to restart entire process")
+        # Ensure all blk files were reindexed, again
+        with node.busy_wait_for_debug_log(
+            expected_msgs=[
+                b'Reindexing block file blk00000.dat',
+                b'Reindexing block file blk00001.dat',
+                b'Reindexing block file ' + last_filename.encode(),
+                b'Reindexing finished',
+                b'progress=1'
+            ],
+            timeout=30
+        ):
+            node.start(['-fastprune'])
+            node.wait_for_rpc_connection()
+        assert_equal(node.getblockcount(), expected_block_count)
+
+
     def run_test(self):
         self.reindex(False)
         self.reindex(True)
@@ -105,6 +158,7 @@ class ReindexTest(BitcoinTestFramework):
 
         self.out_of_order()
         self.continue_reindex_after_shutdown()
+        self.reindex_restart_after_interrupt()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, if the reindex process is interrupted it will start over on next run at `blk00000.dat`. Even after reindexing is finished when the node is in `ActivateBestChain()` an interruption may STILL require a full reindex process because `DB_REINDEX_FLAG` is written `false`, but not flushed.

Mentioned in https://github.com/bitcoin/bitcoin/issues/30424 but I couldn't find any specific follow-up:
> There is no reindex progess (it should pick up the previous work and try to make progess)

The solution in this PR is simply to write a new field `DB_REINDEX_LASTFILE` when reindex is interrupted and flush the `DB_REINDEX_FLAG` setting when the process is complete. The complication is that blocks may be out of order on disk and so as we reindex we store orphan blocks temporarily in memory until they are reconnected with their parent in later files. To ensure that data is recovered, the orphan map is serialized and also saved to the database as `DB_REINDEX_ORPHAN_BLOCKS`.
