### PR TITLE
iwyu: map std::hash to <functional>

### DIFF
--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -5,4 +5,10 @@
   { "include": [ "<mmintrin.h>", "private", "<immintrin.h>", "public" ] },
   { "include": [ "<smmintrin.h>", "private", "<immintrin.h>", "public" ] },
   { "include": [ "<tmmintrin.h>", "private", "<immintrin.h>", "public" ] },
+
+  # IWYU's std_symbol_map.inc maps std::hash<T> specializations to their
+  # correct headers, but with libstdc++ IWYU still suggests a wrong
+  # header for the bare std::hash symbol. Map it to <functional> where
+  # the primary template is defined.
+  { "symbol": ["std::hash", "private", "<functional>", "public"] },
 ]


### PR DESCRIPTION
IWYU incorrectly suggests `<variant>` for `std::hash`, as observed in #33922. 

On Ubuntu with include-what-you-use 0.26 based clang version 22.1.1,
it incorrectly suggested `<string_view>`.

On macOS with IWYU 0.26 based on clang version 22.1.2, it correctly suggests `<functional>`.

Fix this by adding the mapping.

Tracked upstream: https://github.com/include-what-you-use/include-what-you-use/issues/2007