### PR TITLE
rpc: clarify wrong-network address errors

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -285,15 +285,18 @@ static RPCMethod generatetoaddress()
 {
     const int num_blocks{request.params[0].getInt<int>()};
     const uint64_t max_tries{request.params[2].isNull() ? DEFAULT_MAX_TRIES : request.params[2].getInt<int>()};
+    NodeContext& node = EnsureAnyNodeContext(request.context);
+    ChainstateManager& chainman = EnsureChainman(node);
 
     CTxDestination destination = DecodeDestination(request.params[1].get_str());
     if (!IsValidDestination(destination)) {
+        if (const auto error{GetDifferentNetworkAddressError("Address", request.params[1].get_str(), chainman.GetParams(), EnsureArgsman(node))}) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, *error);
+        }
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Error: Invalid address");
     }
 
-    NodeContext& node = EnsureAnyNodeContext(request.context);
     Mining& miner = EnsureMining(node);
-    ChainstateManager& chainman = EnsureChainman(node);
 
     CScript coinbase_output_script = GetScriptForDestination(destination);
 
@@ -331,6 +334,7 @@ static RPCMethod generateblock()
         },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
+    NodeContext& node = EnsureAnyNodeContext(request.context);
     const auto address_or_descriptor = request.params[0].get_str();
     CScript coinbase_output_script;
     std::string error;
@@ -338,13 +342,15 @@ static RPCMethod generateblock()
     if (!getScriptFromDescriptor(address_or_descriptor, coinbase_output_script, error)) {
         const auto destination = DecodeDestination(address_or_descriptor);
         if (!IsValidDestination(destination)) {
+            if (const auto different_network_error{GetDifferentNetworkAddressError("Address", address_or_descriptor, EnsureChainman(node).GetParams(), EnsureArgsman(node))}) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, *different_network_error);
+            }
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Error: Invalid address or descriptor");
         }
 
         coinbase_output_script = GetScriptForDestination(destination);
     }
 
-    NodeContext& node = EnsureAnyNodeContext(request.context);
     Mining& miner = EnsureMining(node);
     const CTxMemPool& mempool = EnsureMemPool(node);
 

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
+#include <chainparams.h>
 #include <common/args.h>
 #include <common/messages.h>
 #include <common/types.h>
@@ -213,6 +214,49 @@ std::string HelpExampleRpcNamed(const std::string& methodname, const RPCArgList&
 
     return "> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", "
            "\"method\": \"" + methodname + "\", \"params\": " + params.write() + "}' -H 'content-type: application/json' http://127.0.0.1:8332/\n";
+}
+
+namespace {
+std::string GetChainName(ChainType chain)
+{
+    switch (chain) {
+    case ChainType::MAIN:
+        return "mainnet";
+    case ChainType::TESTNET:
+        return "testnet";
+    case ChainType::TESTNET4:
+        return "testnet4";
+    case ChainType::SIGNET:
+        return "signet";
+    case ChainType::REGTEST:
+        return "regtest";
+    }
+    assert(false);
+}
+} // namespace
+
+std::optional<std::string> GetDifferentNetworkAddressError(std::string_view subject, const std::string& address, const CChainParams& current_chain_params, const ArgsManager& args)
+{
+    const auto current_chain{current_chain_params.GetChainType()};
+    std::vector<ChainType> matching_chains;
+
+    for (const auto chain : {ChainType::MAIN, ChainType::TESTNET, ChainType::TESTNET4, ChainType::SIGNET, ChainType::REGTEST}) {
+        if (chain == current_chain) continue;
+
+        if (const auto chain_params{CreateChainParams(args, chain)}; IsValidDestinationString(address, *chain_params)) {
+            matching_chains.push_back(chain);
+        }
+    }
+
+    if (matching_chains.empty()) return std::nullopt;
+
+    const std::string subject_str{subject};
+    const std::string current_chain_name{GetChainName(current_chain)};
+    if (matching_chains.size() == 1) {
+        return strprintf("%s is valid for %s, but this node is using %s", subject_str, GetChainName(matching_chains.front()), current_chain_name);
+    }
+
+    return strprintf("%s is valid for a different network, but this node is using %s", subject_str, current_chain_name);
 }
 
 // Converts a hex string to a public key if possible

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -32,6 +32,8 @@
 #include <vector>
 
 class JSONRPCRequest;
+class ArgsManager;
+class CChainParams;
 enum ServiceFlags : uint64_t;
 enum class OutputType;
 struct FlatSigningProvider;
@@ -134,6 +136,7 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 std::string HelpExampleCliNamed(const std::string& methodname, const RPCArgList& args);
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args);
 std::string HelpExampleRpcNamed(const std::string& methodname, const RPCArgList& args);
+std::optional<std::string> GetDifferentNetworkAddressError(std::string_view subject, const std::string& address, const CChainParams& current_chain_params, const ArgsManager& args);
 
 CPubKey HexToPubKey(const std::string& hex_in);
 CTxDestination AddAndGetMultisigDestination(int required, const std::vector<CPubKey>& pubkeys, OutputType type, FlatSigningProvider& keystore, CScript& script_out);

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <chainparams.h>
+#include <common/args.h>
 #include <common/messages.h>
 #include <consensus/validation.h>
 #include <core_io.h>
@@ -523,6 +525,9 @@ CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransact
                 CTxDestination dest = DecodeDestination(change_address_str);
 
                 if (!IsValidDestination(dest)) {
+                    if (const auto error{GetDifferentNetworkAddressError("Change address", change_address_str, Params(), gArgs)}) {
+                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, *error);
+                    }
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Change address must be a valid bitcoin address");
                 }
 

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -24,12 +24,20 @@ class RPCGenerateTest(BitcoinTestFramework):
         self.test_generateblock()
 
     def test_generatetoaddress(self):
+        invalid_address = 'foobar'
+        unique_wrong_network_address = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'
+        ambiguous_wrong_network_address = 'tb1qcrh3yqn4nlleplcez2yndq2ry8h9ncg3qh7n54'
+
         self.generatetoaddress(self.nodes[0], 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
-        assert_raises_rpc_error(-5, "Invalid address", self.generatetoaddress, self.nodes[0], 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
+        assert_raises_rpc_error(-5, "Invalid address", self.generatetoaddress, self.nodes[0], 1, invalid_address)
+        assert_raises_rpc_error(-5, "valid for mainnet, but this node is using regtest", self.generatetoaddress, self.nodes[0], 1, unique_wrong_network_address)
+        assert_raises_rpc_error(-5, "valid for a different network, but this node is using regtest", self.generatetoaddress, self.nodes[0], 1, ambiguous_wrong_network_address)
 
     def test_generateblock(self):
         node = self.nodes[0]
         miniwallet = MiniWallet(node)
+        unique_wrong_network_address = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'
+        ambiguous_wrong_network_address = 'tb1qcrh3yqn4nlleplcez2yndq2ry8h9ncg3qh7n54'
 
         self.log.info('Mine an empty block to address and return the hex')
         address = miniwallet.get_address()
@@ -108,6 +116,8 @@ class RPCGenerateTest(BitcoinTestFramework):
 
         self.log.info('Fail to generate block with invalid address/descriptor')
         assert_raises_rpc_error(-5, 'Invalid address or descriptor', self.generateblock, node, '1234', [])
+        assert_raises_rpc_error(-5, 'valid for mainnet, but this node is using regtest', self.generateblock, node, unique_wrong_network_address, [])
+        assert_raises_rpc_error(-5, 'valid for a different network, but this node is using regtest', self.generateblock, node, ambiguous_wrong_network_address, [])
 
         self.log.info('Fail to generate block with a ranged descriptor')
         ranged_descriptor = 'pkh(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0/*)'

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -767,6 +767,10 @@ class PSBTTest(BitcoinTestFramework):
         psbtx_legacy = self.nodes[1].walletcreatefundedpsbt([], [small_output])
         self.assert_change_type(psbtx_legacy, "pubkeyhash")
 
+        assert_raises_rpc_error(-5, "Change address must be a valid bitcoin address", self.nodes[0].walletcreatefundedpsbt, [], [small_output], 0, {"changeAddress": "foobar"})
+        assert_raises_rpc_error(-5, "valid for mainnet, but this node is using regtest", self.nodes[0].walletcreatefundedpsbt, [], [small_output], 0, {"changeAddress": "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"})
+        assert_raises_rpc_error(-5, "valid for a different network, but this node is using regtest", self.nodes[0].walletcreatefundedpsbt, [], [small_output], 0, {"change_address": "tb1qcrh3yqn4nlleplcez2yndq2ry8h9ncg3qh7n54"})
+
         # Make sure the change type of the wallet can also be overwritten
         psbtx_np2wkh = self.nodes[1].walletcreatefundedpsbt([], [small_output], 0, {"change_type":"p2sh-segwit"})
         self.assert_change_type(psbtx_np2wkh, "scripthash")

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -767,9 +767,9 @@ class PSBTTest(BitcoinTestFramework):
         psbtx_legacy = self.nodes[1].walletcreatefundedpsbt([], [small_output])
         self.assert_change_type(psbtx_legacy, "pubkeyhash")
 
-        assert_raises_rpc_error(-5, "Change address must be a valid bitcoin address", self.nodes[0].walletcreatefundedpsbt, [], [small_output], 0, {"changeAddress": "foobar"})
-        assert_raises_rpc_error(-5, "valid for mainnet, but this node is using regtest", self.nodes[0].walletcreatefundedpsbt, [], [small_output], 0, {"changeAddress": "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"})
-        assert_raises_rpc_error(-5, "valid for a different network, but this node is using regtest", self.nodes[0].walletcreatefundedpsbt, [], [small_output], 0, {"change_address": "tb1qcrh3yqn4nlleplcez2yndq2ry8h9ncg3qh7n54"})
+        assert_raises_rpc_error(-5, "Change address must be a valid bitcoin address", self.nodes[0].walletcreatefundedpsbt, [], [small_output], locktime=0, options={"changeAddress": "foobar"})
+        assert_raises_rpc_error(-5, "valid for mainnet, but this node is using regtest", self.nodes[0].walletcreatefundedpsbt, [], [small_output], locktime=0, options={"changeAddress": "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"})
+        assert_raises_rpc_error(-5, "valid for a different network, but this node is using regtest", self.nodes[0].walletcreatefundedpsbt, [], [small_output], locktime=0, options={"change_address": "tb1qcrh3yqn4nlleplcez2yndq2ry8h9ncg3qh7n54"})
 
         # Make sure the change type of the wallet can also be overwritten
         psbtx_np2wkh = self.nodes[1].walletcreatefundedpsbt([], [small_output], 0, {"change_type":"p2sh-segwit"})


### PR DESCRIPTION
Fixes #26290.

This updates RPC address validation to return a more specific error when an
address is valid for a different network than the one the node is running on.

Changes:
- add a shared helper to detect different-network addresses
- use it in `generatetoaddress`
- use it in the raw-address fallback path of `generateblock`
- use it for `changeAddress` / `change_address` in `walletcreatefundedpsbt`
- keep existing generic errors for malformed addresses

Tests:
- `test/functional/rpc_generate.py`
- `test/functional/rpc_psbt.py`