### PR TITLE
kernel: build: remove unused serfloat dependency

### DIFF
--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -68,7 +68,6 @@ add_library(bitcoinkernel
   ../util/hasher.cpp
   ../util/moneystr.cpp
   ../util/rbf.cpp
-  ../util/serfloat.cpp
   ../util/signalinterrupt.cpp
   ../util/syserror.cpp
   ../util/threadnames.cpp


### PR DESCRIPTION
The serfloat module (more concretely, its two functions `{Encode,Decode}Double`) is only used for [fee estimation](https://github.com/bitcoin/bitcoin/blob/7844a2f08303edb665e4292d002a826f24e62832/src/policy/fees/block_policy_estimator.cpp#L21), which is not included in the bitcoinkernel library, so the linking dependency can be removed.

(Not terribly important in practice, but: this reduces the static library size by ~1.5 KB (~2.7 KB unstripped) on my arm64 Linux machine.)