### PR TITLE
validation: merge `PeekCoin` into `GetCoin`

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -20,14 +20,6 @@ CoinsViewEmpty& CoinsViewEmpty::Get()
     return instance;
 }
 
-std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const
-{
-    if (auto it{cacheCoins.find(outpoint)}; it != cacheCoins.end()) {
-        return it->second.coin.IsSpent() ? std::nullopt : std::optional{it->second.coin};
-    }
-    return base->PeekCoin(outpoint);
-}
-
 CCoinsViewCache::CCoinsViewCache(CCoinsView* in_base, bool deterministic) :
     CCoinsViewBacked(in_base), m_deterministic(deterministic),
     cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
@@ -61,8 +53,15 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const 
 
 std::optional<Coin> CCoinsViewCache::GetCoin(const COutPoint& outpoint, bool peek_only) const
 {
-    if (auto it{FetchCoin(outpoint)}; it != cacheCoins.end() && !it->second.coin.IsSpent()) return it->second.coin;
-    return std::nullopt;
+    if (peek_only) {
+        if (auto it{cacheCoins.find(outpoint)}; it != cacheCoins.end()) {
+            return it->second.coin.IsSpent() ? std::nullopt : std::optional{it->second.coin};
+        }
+        return base->GetCoin(outpoint, peek_only);
+    } else {
+        if (auto it{FetchCoin(outpoint)}; it != cacheCoins.end() && !it->second.coin.IsSpent()) return it->second.coin;
+        return std::nullopt;
+    }
 }
 
 void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possible_overwrite) {
@@ -401,9 +400,4 @@ std::optional<Coin> CCoinsViewErrorCatcher::GetCoin(const COutPoint& outpoint, b
 bool CCoinsViewErrorCatcher::HaveCoin(const COutPoint& outpoint) const
 {
     return ExecuteBackedWrapper<bool>([&]() { return CCoinsViewBacked::HaveCoin(outpoint); }, m_err_callbacks);
-}
-
-std::optional<Coin> CCoinsViewErrorCatcher::PeekCoin(const COutPoint& outpoint) const
-{
-    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return CCoinsViewBacked::PeekCoin(outpoint); }, m_err_callbacks);
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -59,7 +59,7 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const 
     return ret;
 }
 
-std::optional<Coin> CCoinsViewCache::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewCache::GetCoin(const COutPoint& outpoint, bool peek_only) const
 {
     if (auto it{FetchCoin(outpoint)}; it != cacheCoins.end() && !it->second.coin.IsSpent()) return it->second.coin;
     return std::nullopt;
@@ -393,9 +393,9 @@ static ReturnType ExecuteBackedWrapper(Func func, const std::vector<std::functio
     }
 }
 
-std::optional<Coin> CCoinsViewErrorCatcher::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewErrorCatcher::GetCoin(const COutPoint& outpoint, bool peek_only) const
 {
-    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return CCoinsViewBacked::GetCoin(outpoint); }, m_err_callbacks);
+    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return CCoinsViewBacked::GetCoin(outpoint, peek_only); }, m_err_callbacks);
 }
 
 bool CCoinsViewErrorCatcher::HaveCoin(const COutPoint& outpoint) const

--- a/src/coins.h
+++ b/src/coins.h
@@ -312,7 +312,7 @@ public:
 
     //! Retrieve the Coin (unspent transaction output) for a given outpoint.
     //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
-    virtual std::optional<Coin> GetCoin(const COutPoint& outpoint) const = 0;
+    virtual std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only = false) const = 0;
 
     //! Retrieve the Coin (unspent transaction output) for a given outpoint, without caching results.
     //! Does not populate the cache. Use GetCoin() to cache the result.
@@ -354,7 +354,7 @@ public:
     CoinsViewEmpty(const CoinsViewEmpty&) = delete;
     CoinsViewEmpty& operator=(const CoinsViewEmpty&) = delete;
 
-    std::optional<Coin> GetCoin(const COutPoint&) const override { return {}; }
+    std::optional<Coin> GetCoin(const COutPoint&, bool = false) const override { return {}; }
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return GetCoin(outpoint); }
     bool HaveCoin(const COutPoint& outpoint) const override { return !!GetCoin(outpoint); }
     uint256 GetBestBlock() const override { return {}; }
@@ -378,7 +378,7 @@ public:
 
     void SetBackend(CCoinsView& in_view) { base = &in_view; }
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override { return base->GetCoin(outpoint); }
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only) const override { return base->GetCoin(outpoint, peek_only); }
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return base->PeekCoin(outpoint); }
     bool HaveCoin(const COutPoint& outpoint) const override { return base->HaveCoin(outpoint); }
     uint256 GetBestBlock() const override { return base->GetBestBlock(); }
@@ -429,7 +429,7 @@ public:
     CCoinsViewCache(const CCoinsViewCache &) = delete;
 
     // Standard CCoinsView methods
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only = false) const override;
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
     bool HaveCoin(const COutPoint& outpoint) const override;
     uint256 GetBestBlock() const override;
@@ -603,7 +603,7 @@ public:
         m_err_callbacks.emplace_back(std::move(f));
     }
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only) const override;
     bool HaveCoin(const COutPoint& outpoint) const override;
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -311,15 +311,11 @@ public:
     virtual ~CCoinsView() = default;
 
     //! Retrieve the Coin (unspent transaction output) for a given outpoint.
-    //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
+    //! May populate the cache unless peek_only is true.
     virtual std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only = false) const = 0;
 
-    //! Retrieve the Coin (unspent transaction output) for a given outpoint, without caching results.
-    //! Does not populate the cache. Use GetCoin() to cache the result.
-    virtual std::optional<Coin> PeekCoin(const COutPoint& outpoint) const = 0;
-
     //! Just check whether a given outpoint is unspent.
-    //! May populate the cache. Use PeekCoin() to perform a non-caching lookup.
+    //! May populate the cache. Use GetCoin(outpoint, true) to avoid caching.
     virtual bool HaveCoin(const COutPoint& outpoint) const = 0;
 
     //! Retrieve the block hash whose state this CCoinsView currently represents
@@ -355,7 +351,6 @@ public:
     CoinsViewEmpty& operator=(const CoinsViewEmpty&) = delete;
 
     std::optional<Coin> GetCoin(const COutPoint&, bool = false) const override { return {}; }
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return GetCoin(outpoint); }
     bool HaveCoin(const COutPoint& outpoint) const override { return !!GetCoin(outpoint); }
     uint256 GetBestBlock() const override { return {}; }
     std::vector<uint256> GetHeadBlocks() const override { return {}; }
@@ -379,7 +374,6 @@ public:
     void SetBackend(CCoinsView& in_view) { base = &in_view; }
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only) const override { return base->GetCoin(outpoint, peek_only); }
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return base->PeekCoin(outpoint); }
     bool HaveCoin(const COutPoint& outpoint) const override { return base->HaveCoin(outpoint); }
     uint256 GetBestBlock() const override { return base->GetBestBlock(); }
     std::vector<uint256> GetHeadBlocks() const override { return base->GetHeadBlocks(); }
@@ -430,7 +424,6 @@ public:
 
     // Standard CCoinsView methods
     std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only = false) const override;
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
     bool HaveCoin(const COutPoint& outpoint) const override;
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256& block_hash);
@@ -555,8 +548,8 @@ private:
 /**
  * CCoinsViewCache overlay that avoids populating/mutating parent cache layers on cache misses.
  *
- * This is achieved by fetching coins from the base view using PeekCoin() instead of GetCoin(),
- * so intermediate CCoinsViewCache layers are not filled.
+ * This is achieved by fetching coins from the base view using `GetCoin(outpoint, true)`
+ * instead of `GetCoin(outpoint)`, so intermediate CCoinsViewCache layers are not filled.
  *
  * Used during ConnectBlock() as an ephemeral, resettable top-level view that is flushed only
  * on success, so invalid blocks don't pollute the underlying cache.
@@ -566,7 +559,7 @@ class CoinsViewOverlay : public CCoinsViewCache
 private:
     std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const override
     {
-        return base->PeekCoin(outpoint);
+        return base->GetCoin(outpoint, /*peek_only=*/true);
     }
 
 public:
@@ -605,7 +598,6 @@ public:
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only) const override;
     bool HaveCoin(const COutPoint& outpoint) const override;
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
 
 private:
     /** A list of callbacks to execute upon leveldb read error. */

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1169,7 +1169,7 @@ BOOST_AUTO_TEST_CASE(ccoins_reset_guard)
     BOOST_CHECK_EQUAL(cache.GetDirtyCount(), 0U);
 }
 
-BOOST_AUTO_TEST_CASE(ccoins_peekcoin)
+BOOST_AUTO_TEST_CASE(ccoins_getcoin_peek_only)
 {
     CCoinsViewTest base{m_rng};
 
@@ -1182,9 +1182,10 @@ BOOST_AUTO_TEST_CASE(ccoins_peekcoin)
         cache.Flush();
     }
 
-    // Verify PeekCoin can read through the cache stack without mutating the intermediate cache.
+    // Verify GetCoin(peek_only=true) can read through the cache stack without mutating
+    // the intermediate cache.
     CCoinsViewCacheTest main_cache{&base};
-    const auto fetched{main_cache.PeekCoin(outpoint)};
+    const auto fetched{main_cache.GetCoin(outpoint, /*peek_only=*/true)};
     BOOST_CHECK(fetched.has_value());
     BOOST_CHECK(*fetched == coin);
     BOOST_CHECK(!main_cache.HaveCoinInCache(outpoint));

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -47,7 +47,7 @@ class CCoinsViewTest : public CoinsViewEmpty
 public:
     explicit CCoinsViewTest(FastRandomContext& rng) : m_rng{rng} {}
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, bool) const override
     {
         if (auto it{map_.find(outpoint)}; it != map_.end() && !it->second.IsSpent()) return it->second;
         return std::nullopt;

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
     view.SetBestBlock(uint256::ONE);
     BOOST_CHECK(view.SpendCoin(outpoint));
     view.Flush();
-    BOOST_CHECK(!main_cache.PeekCoin(outpoint).has_value());
+    BOOST_CHECK(!main_cache.GetCoin(outpoint).has_value());
 }
 
 BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
     view.SetBestBlock(uint256::ONE);
     BOOST_CHECK(view.SpendCoin(outpoint));
     view.Flush();
-    BOOST_CHECK(!main_cache.PeekCoin(outpoint).has_value());
+    BOOST_CHECK(!main_cache.GetCoin(outpoint).has_value());
 }
 
 // Test for the case where a block spends coins that are spent in the cache, but
@@ -162,4 +162,3 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -112,7 +112,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                 Coin coin{random_coin};
                 if (fuzzed_data_provider.ConsumeBool()) {
                     // We can only skip the check if no unspent coin exists for this outpoint.
-                    const bool possible_overwrite{coins_view_cache.PeekCoin(outpoint) || fuzzed_data_provider.ConsumeBool()};
+                    const bool possible_overwrite{coins_view_cache.GetCoin(outpoint, /*peek_only=*/fuzzed_data_provider.ConsumeBool()) || fuzzed_data_provider.ConsumeBool()};
                     coins_view_cache.AddCoin(outpoint, std::move(coin), possible_overwrite);
                 } else {
                     coins_view_cache.EmplaceCoinInternalDANGER(std::move(outpoint), std::move(coin));
@@ -205,7 +205,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                         coins_cache_entry.coin = *opt_coin;
                     }
                     // Avoid setting FRESH for an outpoint that already exists unspent in the parent view.
-                    bool fresh{!coins_view_cache.PeekCoin(random_out_point) && fuzzed_data_provider.ConsumeBool()};
+                    bool fresh{!coins_view_cache.GetCoin(random_out_point, /*peek_only=*/true) && fuzzed_data_provider.ConsumeBool()};
                     bool dirty{fresh || fuzzed_data_provider.ConsumeBool()};
                     auto it{coins_map.emplace(random_out_point, std::move(coins_cache_entry)).first};
                     if (dirty) CCoinsCacheEntry::SetDirty(*it, sentinel);
@@ -265,7 +265,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                 const int height{int(fuzzed_data_provider.ConsumeIntegral<uint32_t>() >> 1)};
                 const bool check_for_overwrite{transaction.IsCoinBase() || [&] {
                     for (uint32_t i{0}; i < transaction.vout.size(); ++i) {
-                        if (coins_view_cache.PeekCoin(COutPoint{transaction.GetHash(), i})) return true;
+                        if (coins_view_cache.GetCoin(COutPoint{transaction.GetHash(), i}, /*peek_only=*/fuzzed_data_provider.ConsumeBool())) return true;
                     }
                     return fuzzed_data_provider.ConsumeBool();
                 }()}; // We can only skip the check if the current txid has no unspent outputs

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -247,14 +247,12 @@ FUZZ_TARGET(coinscache_sim)
         CallOneOf(
             provider,
 
-            [&]() { // PeekCoin/GetCoin
+            [&]() { // GetCoin
                 uint32_t outpointidx = provider.ConsumeIntegralInRange<uint32_t>(0, NUM_OUTPOINTS - 1);
                 // Look up in simulation data.
                 auto sim = lookup(outpointidx);
                 // Look up in real caches.
-                auto realcoin = provider.ConsumeBool() ?
-                    caches.back()->PeekCoin(data.outpoints[outpointidx]) :
-                    caches.back()->GetCoin(data.outpoints[outpointidx]);
+                auto realcoin = caches.back()->GetCoin(data.outpoints[outpointidx], /*peek_only=*/provider.ConsumeBool());
                 // Compare results.
                 if (!sim.has_value()) {
                     assert(!realcoin);

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -144,7 +144,7 @@ class CoinsViewBottom final : public CoinsViewEmpty
     std::map<COutPoint, Coin> m_data;
 
 public:
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const final
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, bool = false) const final
     {
         if (auto it{m_data.find(outpoint)}; it != m_data.end()) {
             assert(!it->second.IsSpent());

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -69,7 +69,7 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
     }
 }
 
-std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint, bool = false) const
 {
     if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
         Assert(!coin.IsSpent()); // The UTXO database should never contain spent coins

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -69,18 +69,13 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
     }
 }
 
-std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint, bool = false) const
+std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint, bool) const
 {
     if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
         Assert(!coin.IsSpent()); // The UTXO database should never contain spent coins
         return coin;
     }
     return std::nullopt;
-}
-
-std::optional<Coin> CCoinsViewDB::PeekCoin(const COutPoint& outpoint) const
-{
-    return GetCoin(outpoint);
 }
 
 bool CCoinsViewDB::HaveCoin(const COutPoint& outpoint) const

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -40,7 +40,7 @@ protected:
 public:
     explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, bool) const override;
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
     bool HaveCoin(const COutPoint& outpoint) const override;
     uint256 GetBestBlock() const override;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -41,7 +41,6 @@ public:
     explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint, bool) const override;
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
     bool HaveCoin(const COutPoint& outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -739,7 +739,7 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 
 CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
 
-std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint, bool peek_only) const
 {
     // Check to see if the inputs are made available by another tx in the package.
     // These Coins would not be available in the underlying CoinsView.
@@ -759,7 +759,7 @@ std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
         }
         return std::nullopt;
     }
-    return base->GetCoin(outpoint);
+    return base->GetCoin(outpoint, peek_only);
 }
 
 void CCoinsViewMemPool::PackageAddTransaction(const CTransactionRef& tx)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -768,7 +768,8 @@ protected:
 public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
     /** GetCoin, returning whether it exists and is not spent. Also updates m_non_base_coins if the
-     * coin is not fetched from base. May populate the base view on cache misses. */
+     * coin is not fetched from base. May populate the base view on cache misses unless
+     * peek_only is true. */
     std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only = false) const override;
     /** Add the coins created by this transaction. These coins are only temporarily stored in
      * m_temp_added and cannot be flushed to the back end. Only used for package validation. */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -769,7 +769,7 @@ public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
     /** GetCoin, returning whether it exists and is not spent. Also updates m_non_base_coins if the
      * coin is not fetched from base. May populate the base view on cache misses. */
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, bool peek_only = false) const override;
     /** Add the coins created by this transaction. These coins are only temporarily stored in
      * m_temp_added and cannot be flushed to the back end. Only used for package validation. */
     void PackageAddTransaction(const CTransactionRef& tx);


### PR DESCRIPTION
### Problem
Review on https://github.com/bitcoin/bitcoin/pull/34124 made it clear that the new `PeekCoin` method is hard to distinguish from the existing `GetCoin` at call sites where caching does not matter.

### Fix
Merge `PeekCoin` into `GetCoin` by adding a `peek_only` flag to the `CCoinsView` interface and removing the separate virtual method.
This preserves the non-caching lookup behavior in `CCoinsViewCache` and `CoinsViewOverlay`, while allowing backends without caches to ignore the flag.

### Details
Tests and fuzz scaffolding now call `GetCoin(..., true)` only where side-effect-free reads matter, and `CCoinsViewCache` now shares the common result handling between peeking and caching lookups.
The post-`Flush()` overlay assertions use plain `GetCoin()` because they only check the flushed spentness and do not need to preserve parent cache state.

### Context
The unclear boundary between `PeekCoin` and `GetCoin` was flagged during review by:
* **Russ Yanofsky** in https://github.com/bitcoin/bitcoin/pull/34165#discussion_r2789324653, whose original suggestion (prototyped in https://github.com/bitcoin/bitcoin/commit/642fa06f0af7321d35959f599e2edf74e72c6bd9) was a different approach - making `GetCoin`, `PeekCoin`, and `HaveCoin` non-virtual public methods implemented on top of two simpler virtual hooks (`LookupCoin` and `MutableLookupCoin`), so subclasses couldn't accidentally violate the caching contract. Russ noted that a fuller solution would enforce the distinction at compile time with `const`, which would in turn require splitting the coin lookup interface from the coin writing interface (dropping `BatchWrite` from the "view" side into a separate "store" interface).
* **Anthony Towns** in https://github.com/bitcoin/bitcoin/pull/34124#issuecomment-4037752227, who sketched out the single-method `GetCoin(outpoint, peek_only)` shape this PR takes (see https://github.com/ajtowns/bitcoin/commit/bff58741b76ef4ca5f4a26da29e9582a49f71d2c).
This change is forward-compatible with https://github.com/bitcoin/bitcoin/pull/31132 as well.