### PR TITLE
consensus: soft fork on testnet4 that fixes the min difficulty blocks exploit

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -115,10 +115,23 @@ struct Params {
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
     /**
-      * Enforce BIP94 timewarp attack mitigation. On testnet4 this also enforces
-      * the block storm mitigation.
+      * Enforce BIP94 timewarp attack mitigation.
       */
     bool enforce_BIP94;
+    /**
+     * Height at which the fix for the min-difficulty block exploit activates.
+     * From this height onward a block is invalid if its timestamp exceeds the
+     * previous block's timestamp by more than 2 * nPowTargetSpacing (1200
+     * seconds on testnet4). Because the min-difficulty rule only triggers when
+     * a block's timestamp is more than 2 * nPowTargetSpacing past the previous
+     * block's timestamp, capping that gap eliminates min-difficulty blocks
+     * entirely without removing the min-difficulty rule itself.
+     *
+     * This is a soft fork: previously-valid blocks at heights below this value
+     * are unaffected. A value of 0 disables the rule (default for chains where
+     * it does not apply).
+     */
+    int min_difficulty_blocks_fix_height{0};
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -128,6 +128,12 @@ struct Params {
      * block's timestamp, capping that gap eliminates min-difficulty blocks
      * entirely without removing the min-difficulty rule itself.
      *
+     * The cap does not apply to difficulty-adjustment blocks (heights divisible
+     * by DifficultyAdjustmentInterval()). On those blocks the min-difficulty
+     * rule is not consulted, so there is no exploit to close, and leaving them
+     * uncapped lets miners publish a truthful wall-clock timestamp every 2016
+     * blocks so that chain time can track real time.
+     *
      * This is a soft fork: previously-valid blocks at heights below this value
      * are unaffected. A value of 0 disables the rule (default for chains where
      * it does not apply).

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -115,7 +115,8 @@ struct Params {
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
     /**
-      * Enforce BIP94 timewarp attack mitigation.
+      * Enforce BIP94 timewarp attack mitigation. On testnet4 this also enforces
+      * the block storm mitigation.
       */
     bool enforce_BIP94;
     /**

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -321,6 +321,7 @@ public:
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
+        consensus.min_difficulty_blocks_fix_height = 151200; // epoch 75 boundary
 
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -51,7 +51,8 @@ int64_t GetMaximumTime(const CBlockIndex* pindexPrev, const Consensus::Params& c
 {
     const int height{pindexPrev->nHeight + 1};
     if (consensusParams.min_difficulty_blocks_fix_height > 0 &&
-        height >= consensusParams.min_difficulty_blocks_fix_height) {
+        height >= consensusParams.min_difficulty_blocks_fix_height &&
+        height % consensusParams.DifficultyAdjustmentInterval() != 0) {
         return pindexPrev->GetBlockTime() + consensusParams.nPowTargetSpacing * 2;
     }
     return std::numeric_limits<int64_t>::max();

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -28,6 +28,7 @@
 #include <validation.h>
 
 #include <algorithm>
+#include <limits>
 #include <utility>
 #include <numeric>
 
@@ -46,11 +47,22 @@ int64_t GetMinimumTime(const CBlockIndex* pindexPrev, const int64_t difficulty_a
     return min_time;
 }
 
+int64_t GetMaximumTime(const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams)
+{
+    const int height{pindexPrev->nHeight + 1};
+    if (consensusParams.min_difficulty_blocks_fix_height > 0 &&
+        height >= consensusParams.min_difficulty_blocks_fix_height) {
+        return pindexPrev->GetBlockTime() + consensusParams.nPowTargetSpacing * 2;
+    }
+    return std::numeric_limits<int64_t>::max();
+}
+
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime{std::max<int64_t>(GetMinimumTime(pindexPrev, consensusParams.DifficultyAdjustmentInterval()),
                                        TicksSinceEpoch<std::chrono::seconds>(NodeClock::now()))};
+    nNewTime = std::min<int64_t>(nNewTime, GetMaximumTime(pindexPrev, consensusParams));
 
     if (nOldTime < nNewTime) {
         pblock->nTime = nNewTime;
@@ -144,7 +156,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
         pblock->nVersion = gArgs.GetIntArg("-blockversion", pblock->nVersion);
     }
 
-    pblock->nTime = TicksSinceEpoch<std::chrono::seconds>(NodeClock::now());
+    pblock->nTime = std::min<int64_t>(TicksSinceEpoch<std::chrono::seconds>(NodeClock::now()),
+                                      GetMaximumTime(pindexPrev, chainparams.GetConsensus()));
     m_lock_time_cutoff = pindexPrev->GetMedianTimePast();
 
     if (m_mempool) {

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -129,6 +129,16 @@ private:
  */
 int64_t GetMinimumTime(const CBlockIndex* pindexPrev, int64_t difficulty_adjustment_interval);
 
+/**
+ * Get the maximum time a miner may use in the next block. Returns
+ * std::numeric_limits<int64_t>::max() when no consensus upper bound applies.
+ * When the min-difficulty-block exploit fix is active for the next block's
+ * height, the maximum is the previous block's timestamp plus
+ * 2 * nPowTargetSpacing, matching the consensus check in
+ * ContextualCheckBlockHeader.
+ */
+int64_t GetMaximumTime(const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams);
+
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */

--- a/src/test/testnet4_miner_tests.cpp
+++ b/src/test/testnet4_miner_tests.cpp
@@ -2,7 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <arith_uint256.h>
+#include <chain.h>
+#include <chainparams.h>
 #include <common/system.h>
+#include <util/chaintype.h>
 #include <interfaces/mining.h>
 #include <node/miner.h>
 #include <test/util/common.h>
@@ -13,10 +17,14 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <limits>
+
 using interfaces::BlockTemplate;
 using interfaces::Mining;
 using node::BlockAssembler;
 using node::BlockWaitOptions;
+using node::GetMaximumTime;
+using node::UpdateTime;
 
 namespace testnet4_miner_tests {
 
@@ -66,6 +74,119 @@ BOOST_AUTO_TEST_CASE(MiningInterface)
     clock_ctx += 1s;
     block_template = block_template->waitNext(wait_options);
     BOOST_REQUIRE(block_template);
+}
+
+BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixMaxTimeBeforeFork)
+{
+    const auto& consensus = Params().GetConsensus();
+    BOOST_REQUIRE_EQUAL(consensus.min_difficulty_blocks_fix_height, 151200);
+
+    // pindexPrev at height 151198 -> next block height 151199, still pre-fork.
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 151198;
+    pindexPrev.nTime = 1700000000;
+
+    BOOST_CHECK_EQUAL(GetMaximumTime(&pindexPrev, consensus),
+                      std::numeric_limits<int64_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixMaxTimeAtFork)
+{
+    const auto& consensus = Params().GetConsensus();
+
+    // pindexPrev at height 151199 -> next block height 151200 is the first
+    // block subject to the rule. Max allowed timestamp = prev + 2 * spacing.
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 151199;
+    pindexPrev.nTime = 1700000000;
+
+    BOOST_CHECK_EQUAL(GetMaximumTime(&pindexPrev, consensus),
+                      1700000000 + consensus.nPowTargetSpacing * 2);
+}
+
+BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixMaxTimeAfterFork)
+{
+    const auto& consensus = Params().GetConsensus();
+
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 200000;
+    pindexPrev.nTime = 1800000000;
+
+    BOOST_CHECK_EQUAL(GetMaximumTime(&pindexPrev, consensus),
+                      1800000000 + consensus.nPowTargetSpacing * 2);
+}
+
+BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixMaxTimeDisabledOnOtherChains)
+{
+    // Chains that do not set min_difficulty_blocks_fix_height (default 0)
+    // must not have any upper bound on the block timestamp.
+    const auto mainnet_params = CreateChainParams(*m_node.args, ChainType::MAIN);
+    const auto& consensus = mainnet_params->GetConsensus();
+    BOOST_REQUIRE_EQUAL(consensus.min_difficulty_blocks_fix_height, 0);
+
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 500000;
+    pindexPrev.nTime = 1700000000;
+
+    BOOST_CHECK_EQUAL(GetMaximumTime(&pindexPrev, consensus),
+                      std::numeric_limits<int64_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixUpdateTimeClampsWhenNowPastCap)
+{
+    const auto& consensus = Params().GetConsensus();
+    // Height 151201 is post-fork and not a retarget boundary, so
+    // GetNextWorkRequired does not need to walk the pprev chain.
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 151201;
+    pindexPrev.nTime = 1700000000;
+    pindexPrev.nBits = UintToArith256(consensus.powLimit).GetCompact();
+
+    // Wall-clock 3000s past pindexPrev is well above the 1200s cap.
+    NodeClockContext clock_ctx{std::chrono::seconds{1700000000 + 3000}};
+
+    CBlockHeader header;
+    header.nTime = 0;
+    UpdateTime(&header, consensus, &pindexPrev);
+
+    BOOST_CHECK_EQUAL(header.nTime, 1700000000 + consensus.nPowTargetSpacing * 2);
+}
+
+BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixUpdateTimeUsesNowWhenBelowCap)
+{
+    const auto& consensus = Params().GetConsensus();
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 151201;
+    pindexPrev.nTime = 1700000000;
+    pindexPrev.nBits = UintToArith256(consensus.powLimit).GetCompact();
+
+    // Wall-clock 500s past pindexPrev is below the 1200s cap.
+    NodeClockContext clock_ctx{std::chrono::seconds{1700000000 + 500}};
+
+    CBlockHeader header;
+    header.nTime = 0;
+    UpdateTime(&header, consensus, &pindexPrev);
+
+    BOOST_CHECK_EQUAL(header.nTime, 1700000000 + 500);
+}
+
+BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixUpdateTimeExactlyAtCap)
+{
+    const auto& consensus = Params().GetConsensus();
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 151201;
+    pindexPrev.nTime = 1700000000;
+    pindexPrev.nBits = UintToArith256(consensus.powLimit).GetCompact();
+
+    // Wall-clock exactly at the cap: must be accepted verbatim.
+    const int64_t cap_time{1700000000 + consensus.nPowTargetSpacing * 2};
+    NodeClockContext clock_ctx{std::chrono::seconds{cap_time}};
+
+    CBlockHeader header;
+    header.nTime = 0;
+    UpdateTime(&header, consensus, &pindexPrev);
+
+    BOOST_CHECK_EQUAL(header.nTime, cap_time);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/testnet4_miner_tests.cpp
+++ b/src/test/testnet4_miner_tests.cpp
@@ -94,10 +94,10 @@ BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixMaxTimeAtFork)
 {
     const auto& consensus = Params().GetConsensus();
 
-    // pindexPrev at height 151199 -> next block height 151200 is the first
-    // block subject to the rule. Max allowed timestamp = prev + 2 * spacing.
+    // pindexPrev at height 151200 -> next block height 151201 is the first
+    // non-adjustment block post-fork subject to the cap.
     CBlockIndex pindexPrev;
-    pindexPrev.nHeight = 151199;
+    pindexPrev.nHeight = 151200;
     pindexPrev.nTime = 1700000000;
 
     BOOST_CHECK_EQUAL(GetMaximumTime(&pindexPrev, consensus),
@@ -108,12 +108,41 @@ BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixMaxTimeAfterFork)
 {
     const auto& consensus = Params().GetConsensus();
 
+    // 200001 % 2016 = 417, so next block is not an adjustment block.
     CBlockIndex pindexPrev;
     pindexPrev.nHeight = 200000;
     pindexPrev.nTime = 1800000000;
 
     BOOST_CHECK_EQUAL(GetMaximumTime(&pindexPrev, consensus),
                       1800000000 + consensus.nPowTargetSpacing * 2);
+}
+
+BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixMaxTimeOnActivationAdjustmentBlock)
+{
+    const auto& consensus = Params().GetConsensus();
+
+    // The activation height 151200 = 2016 * 75 is itself a difficulty-
+    // adjustment block. The cap must not apply to it.
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 151199;
+    pindexPrev.nTime = 1700000000;
+
+    BOOST_CHECK_EQUAL(GetMaximumTime(&pindexPrev, consensus),
+                      std::numeric_limits<int64_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixMaxTimeOnLaterAdjustmentBlock)
+{
+    const auto& consensus = Params().GetConsensus();
+
+    // Next block height 153216 = 2016 * 76 is the first post-activation
+    // adjustment block after the fork epoch. Cap must not apply.
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = 153215;
+    pindexPrev.nTime = 1700000000;
+
+    BOOST_CHECK_EQUAL(GetMaximumTime(&pindexPrev, consensus),
+                      std::numeric_limits<int64_t>::max());
 }
 
 BOOST_AUTO_TEST_CASE(MinDifficultyBlocksFixMaxTimeDisabledOnOtherChains)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4093,6 +4093,20 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
         }
     }
 
+    // Min-difficulty block exploit fix: once active, a block's timestamp must
+    // not exceed the previous block's timestamp by more than 2 * nPowTargetSpacing
+    // (1200 seconds on testnet4). This kills the min-difficulty block exploit
+    // on testnet4 (BIP 94): since the min-difficulty rule only triggers when
+    // the gap is greater than 2 * nPowTargetSpacing, capping the gap at that
+    // boundary makes min-difficulty blocks impossible. Soft fork: only blocks
+    // at or above the activation height are affected.
+    if (consensusParams.min_difficulty_blocks_fix_height > 0 &&
+        nHeight >= consensusParams.min_difficulty_blocks_fix_height) {
+        if (block.GetBlockTime() > pindexPrev->GetBlockTime() + consensusParams.nPowTargetSpacing * 2) {
+            return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-too-far-ahead", "block's timestamp too far ahead of previous block");
+        }
+    }
+
     // Check timestamp
     if (block.Time() > NodeClock::now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4100,8 +4100,16 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     // the gap is greater than 2 * nPowTargetSpacing, capping the gap at that
     // boundary makes min-difficulty blocks impossible. Soft fork: only blocks
     // at or above the activation height are affected.
+    //
+    // The cap is skipped on difficulty-adjustment blocks (heights divisible
+    // by DifficultyAdjustmentInterval()). On those blocks the min-difficulty
+    // rule does not apply (see GetNextWorkRequired in pow.cpp), so no exploit
+    // exists to close there. Leaving adjustment blocks uncapped lets miners
+    // publish a truthful wall-clock timestamp every 2016 blocks, allowing
+    // chain time to track real time.
     if (consensusParams.min_difficulty_blocks_fix_height > 0 &&
-        nHeight >= consensusParams.min_difficulty_blocks_fix_height) {
+        nHeight >= consensusParams.min_difficulty_blocks_fix_height &&
+        nHeight % consensusParams.DifficultyAdjustmentInterval() != 0) {
         if (block.GetBlockTime() > pindexPrev->GetBlockTime() + consensusParams.nPowTargetSpacing * 2) {
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-too-far-ahead", "block's timestamp too far ahead of previous block");
         }


### PR DESCRIPTION
## Summary

Invalidate any non-difficulty-adjustment block whose timestamp is more than 20 minutes than its previous block's timestamp, after block height 151,200 (epoch 75 boundary).

## Motivation

Testnet4's min-difficulty rule (allowing difficulty-1 blocks after 20 minutes) is being exploited, causing ~85-90% of blocks to be CPU-mined min-difficulty blocks. This results in a race of CPU miners broadcasting blocks at exactly the second that it's acceptable. This race is so intense that CPU miners have figured out sending empty blocks, as they propagate faster than those that contain transactions, resulting in a network where transactions are confirmed at only the remaining ASIC blocks, that have ~1 hour average block times.

After the fork, min difficulty blocks will no longer be allowed, as blocks that have a timestamp longer than 20 minutes than their previous blocks become invalid, except difficulty-adjusting blocks (epoch boundary blocks).

Previously, PR https://github.com/bitcoin/bitcoin/pull/34420 addressed the same issue, but the change was a hard fork. The current soft fork proposal fixes the problem for non-upgraded nodes as long as majority of the hashrate is mining on upgraded clients, and therefore fixes the problem with the least network disruption.

## Changes

- Add `min_difficulty_blocks_fix_height` consensus parameter (default `0` = disabled).
- Set fork height to 151,200 for testnet4 (epoch 75 boundary).
- In `ContextualCheckBlockHeader()`, reject any block whose timestamp exceeds the previous block's timestamp by more than `2 * nPowTargetSpacing` (1200 seconds on testnet4) once the activation height is reached. Because the min-difficulty rule only kicks in when the inter-block gap is strictly greater than `2 * nPowTargetSpacing`, capping the gap at exactly that boundary makes min-difficulty blocks impossible -- without touching the min-difficulty rule itself. Difficulty-adjustment blocks (heights divisible by `DifficultyAdjustmentInterval()`) are exempt from the cap: `GetNextWorkRequired()` already bypasses the min-difficulty rule on those blocks and requires the retargeted difficulty regardless of timestamp, so there is no exploit to close there. Leaving adjustment blocks uncapped lets miners publish a truthful wall-clock timestamp every 2016 blocks, so that chain time can track real time instead of drifting indefinitely behind it under the per-block cap.
- Add `GetMaximumTime()` in `node/miner` mirroring `GetMinimumTime()`, and clamp candidate block timestamps (both in `BlockAssembler::CreateNewBlock()` and `UpdateTime()`) so that `getblocktemplate` never returns a `curtime` that would produce a block rejected by the new rule. The same adjustment-block exemption applies: `GetMaximumTime()` returns `std::numeric_limits<int64_t>::max()` when the next block is a difficulty-adjustment block, so the template is not clamped there and ASIC miners are free to stamp it with wall-clock time.
- Add unit tests covering boundary behavior of `GetMaximumTime` (pre-fork, first post-fork non-adjustment block, activation block at height 151,200 which is itself an adjustment block, a later adjustment block at height 153,216, and disabled on other chains) and clamping behavior of `UpdateTime` (wall-clock past the cap, below the cap, and exactly at the cap).

## Soft fork properties

This is a strict tightening of consensus rules:
- Any block valid under the new rule is also valid under the old rules.
- Blocks at heights below 151,200 are completely unaffected.
- Non-upgraded nodes continue to accept blocks mined by upgraded miners (they satisfy the old ruleset). Propagation to non-upgraded nodes happens naturally through normal chain gossip, so no coordinated upgrade is required beyond sufficient hashrate majority adopting the rule by the activation height.

## Test Plan

- `./build/bin/test_bitcoin --run_test=testnet4_miner_tests` -- all boundary and clamping tests pass.
- Regression: `./build/bin/test_bitcoin --run_test=miner_tests,pow_tests,validation_tests,validation_block_tests` -- no regressions.
- Manual: pre-activation behavior on live testnet4 matches expectations (`getblocktemplate` returns a `curtime` below the prospective cap).

## Discussion

[bitcoin-dev mailing list thread #1](https://groups.google.com/g/bitcoindev/c/iVLHJ1HWhoU)
[bitcoin-dev mailing list thread #2](https://groups.google.com/g/bitcoindev/c/Jsv1VYpewuU)
[Bitcointalk thread](https://bitcointalk.org/index.php?topic=5569103.0)
Supersedes hard fork proposal #34420