### PR TITLE
test: Allow to set height in create_block

### DIFF
--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -176,7 +176,7 @@ class ExampleTest(BitcoinTestFramework):
             # Use the blocktools functionality to manually build a block.
             # Calling the generate() rpc is easier, but this allows us to exactly
             # control the blocks and transactions.
-            block = create_block(self.tip, create_coinbase(height+1), self.block_time)
+            block = create_block(self.tip, height=height+1, ntime=self.block_time)
             block.solve()
             block_message = msg_block(block)
             # Send message is used to send a P2P message to the node over our P2PInterface

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -17,7 +17,6 @@ from collections import defaultdict
 # Use lexicographically sorted multi-line imports
 from test_framework.blocktools import (
     create_block,
-    create_coinbase,
 )
 from test_framework.messages import (
     CInv,

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -14,7 +14,6 @@ import contextlib
 from dataclasses import dataclass
 from test_framework.blocktools import (
         create_block,
-        create_coinbase
 )
 from test_framework.compressor import (
     compress_amount,

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -271,9 +271,9 @@ class AssumeutxoTest(BitcoinTestFramework):
         # the main chain headers up to the snapshot height.
         parent_block_hash = node0.getblockhash(SNAPSHOT_BASE_HEIGHT - 1)
         block_time = node0.getblock(node0.getbestblockhash())['time'] + 1
-        fork_block1 = create_block(int(parent_block_hash, 16), create_coinbase(SNAPSHOT_BASE_HEIGHT), block_time)
+        fork_block1 = create_block(int(parent_block_hash, 16), height=SNAPSHOT_BASE_HEIGHT, ntime=block_time)
         fork_block1.solve()
-        fork_block2 = create_block(fork_block1.hash_int, create_coinbase(SNAPSHOT_BASE_HEIGHT + 1), block_time + 1)
+        fork_block2 = create_block(fork_block1.hash_int, height=SNAPSHOT_BASE_HEIGHT + 1, ntime=block_time + 1)
         fork_block2.solve()
         node1.submitheader(fork_block1.serialize().hex())
         node1.submitheader(fork_block2.serialize().hex())

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -91,7 +91,7 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Create the first block with a coinbase output to our key
         height = 1
-        block = create_block(self.tip, create_coinbase(height, coinbase_pubkey), self.block_time)
+        block = create_block(self.tip, create_coinbase(height, coinbase_pubkey), ntime=self.block_time)
         self.blocks.append(block)
         self.block_time += 1
         block.solve()

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -102,7 +102,7 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Bury the block 100 deep so the coinbase output is spendable
         for _ in range(100):
-            block = create_block(self.tip, create_coinbase(height), self.block_time)
+            block = create_block(self.tip, height=height, ntime=self.block_time)
             block.solve()
             self.blocks.append(block)
             self.tip = block.hash_int
@@ -114,7 +114,7 @@ class AssumeValidTest(BitcoinTestFramework):
         tx.vin.append(CTxIn(COutPoint(self.block1.vtx[0].txid_int, 0), scriptSig=b""))
         tx.vout.append(CTxOut(49 * 100000000, CScript([OP_TRUE])))
 
-        block102 = create_block(self.tip, create_coinbase(height), self.block_time, txlist=[tx])
+        block102 = create_block(self.tip, height=height, ntime=self.block_time, txlist=[tx])
         self.block_time += 1
         block102.solve()
         self.blocks.append(block102)
@@ -124,7 +124,7 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Bury the assumed valid block 2100 deep
         for _ in range(2100):
-            block = create_block(self.tip, create_coinbase(height), self.block_time)
+            block = create_block(self.tip, height=height, ntime=self.block_time)
             block.solve()
             self.blocks.append(block)
             self.tip = block.hash_int
@@ -198,7 +198,7 @@ class AssumeValidTest(BitcoinTestFramework):
         second_chain_tip, second_chain_time, second_chain_height = int(best_hash, 16), tip_block["time"] + 1, tip_block["height"] + 1
         second_chain = []
         for _ in range(150):
-            block = create_block(second_chain_tip, create_coinbase(second_chain_height), second_chain_time)
+            block = create_block(second_chain_tip, height=second_chain_height, ntime=second_chain_time)
             block.solve()
             second_chain.append(block)
             second_chain_tip, second_chain_time, second_chain_height = block.hash_int, second_chain_time + 1, second_chain_height + 1
@@ -215,7 +215,7 @@ class AssumeValidTest(BitcoinTestFramework):
         self.log.info("Send a block not in the assumevalid header chain to node4.")
         genesis_hash = self.nodes[4].getbestblockhash()
         genesis_time = self.nodes[4].getblock(genesis_hash)['time']
-        alt1 = create_block(int(genesis_hash, 16), create_coinbase(1), genesis_time + 2)
+        alt1 = create_block(int(genesis_hash, 16), height=1, ntime=genesis_time + 2)
         alt1.solve()
         p2p4 = self.nodes[4].add_p2p_connection(BaseNode())
         p2p4.send_header_for_blocks(self.blocks[0:103])

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1374,12 +1374,12 @@ class FullBlockTest(BitcoinTestFramework):
         for additional_script in additional_output_scripts:
             coinbase.vout.append(CTxOut(0, additional_script))
         if spend is None:
-            block = create_block(base_block_hash, coinbase, block_time, version=version)
+            block = create_block(base_block_hash, coinbase, ntime=block_time, version=version)
         else:
             coinbase.vout[0].nValue += spend.vout[0].nValue - 1  # all but one satoshi to fees
             tx = self.create_tx(spend, 0, 1, output_script=script)  # spend 1 satoshi
             self.sign_tx(tx, spend)
-            block = create_block(base_block_hash, coinbase, block_time, version=version, txlist=[tx])
+            block = create_block(base_block_hash, coinbase, ntime=block_time, version=version, txlist=[tx])
         # Block is created. Find a valid nonce.
         block.solve()
         self.tip = block

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -121,7 +121,7 @@ class BIP65Test(BitcoinTestFramework):
 
         tip = self.nodes[0].getbestblockhash()
         block_time = self.nodes[0].getblockheader(tip)['mediantime'] + 1
-        block = create_block(int(tip, 16), create_coinbase(CLTV_HEIGHT - 1), block_time, version=3, txlist=invalid_cltv_txs)
+        block = create_block(int(tip, 16), height=CLTV_HEIGHT - 1, ntime=block_time, version=3, txlist=invalid_cltv_txs)
         block.solve()
 
         self.test_cltv_info(is_active=False)  # Not active as of current tip and next block does not need to obey rules
@@ -132,7 +132,7 @@ class BIP65Test(BitcoinTestFramework):
         self.log.info("Test that blocks must now be at least version 4")
         tip = block.hash_int
         block_time += 1
-        block = create_block(tip, create_coinbase(CLTV_HEIGHT), block_time, version=3)
+        block = create_block(tip, height=CLTV_HEIGHT, ntime=block_time, version=3)
         block.solve()
 
         with self.nodes[0].assert_debug_log(expected_msgs=[f'{block.hash_hex}, bad-version(0x00000003)']):

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -10,7 +10,6 @@ Test that the CHECKLOCKTIMEVERIFY soft-fork activates.
 from test_framework.blocktools import (
     TIME_GENESIS_BLOCK,
     create_block,
-    create_coinbase,
 )
 from test_framework.messages import (
     CTransaction,

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -194,7 +194,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         # Generate a block that includes previous coinbase
         tip = self.nodes[0].getbestblockhash()
         block_time = self.nodes[0].getblock(tip)['time'] + 1
-        block = create_block(int(tip, 16), cb, block_time)
+        block = create_block(int(tip, 16), cb, ntime=block_time)
         block.solve()
         self.nodes[0].submitblock(block.serialize().hex())
         self.sync_all()

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -170,7 +170,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         return test_blocks
 
     def create_test_block(self, txs):
-        block = create_block(self.tip, create_coinbase(self.tipheight + 1), self.last_block_time + 600, txlist=txs)
+        block = create_block(self.tip, height=self.tipheight + 1, ntime=self.last_block_time + 600, txlist=txs)
         block.solve()
         return block
 

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -42,7 +42,6 @@ import time
 
 from test_framework.blocktools import (
     create_block,
-    create_coinbase,
 )
 from test_framework.p2p import P2PDataStore
 from test_framework.script import (

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -9,7 +9,6 @@ Test the DERSIG soft-fork activation on regtest.
 
 from test_framework.blocktools import (
     create_block,
-    create_coinbase,
 )
 from test_framework.messages import msg_block
 from test_framework.p2p import P2PInterface

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -84,7 +84,7 @@ class BIP66Test(BitcoinTestFramework):
 
         tip = self.nodes[0].getbestblockhash()
         block_time = self.nodes[0].getblockheader(tip)['mediantime'] + 1
-        block = create_block(int(tip, 16), create_coinbase(DERSIG_HEIGHT - 1), block_time, txlist=[spendtx])
+        block = create_block(int(tip, 16), height=DERSIG_HEIGHT - 1, ntime=block_time, txlist=[spendtx])
         block.solve()
 
         assert_equal(self.nodes[0].getblockcount(), DERSIG_HEIGHT - 2)
@@ -97,7 +97,7 @@ class BIP66Test(BitcoinTestFramework):
         self.log.info("Test that blocks must now be at least version 3")
         tip = block.hash_int
         block_time += 1
-        block = create_block(tip, create_coinbase(DERSIG_HEIGHT), block_time, version=2)
+        block = create_block(tip, height=DERSIG_HEIGHT, ntime=block_time, version=2)
         block.solve()
 
         with self.nodes[0].assert_debug_log(expected_msgs=[f'{block.hash_hex}, bad-version(0x00000002)']):

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -174,7 +174,7 @@ class NotificationsTest(BitcoinTestFramework):
 
         invalid_blocks = []
         for _ in range(7):  # invalid chain must be longer than 6 blocks to trigger warning
-            block = create_block(int(tip, 16), create_coinbase(height), block_time)
+            block = create_block(int(tip, 16), height=height, ntime=block_time)
             # make block invalid by exceeding block subsidy
             block.vtx[0].vout[0].nValue += 1
             block.hashMerkleRoot = block.calc_merkle_root()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -9,7 +9,6 @@ import platform
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
 from test_framework.blocktools import (
     create_block,
-    create_coinbase,
 )
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1425,7 +1425,7 @@ class TaprootTest(BitcoinTestFramework):
         extra_output_script = CScript(bytes([OP_CHECKSIG]*((MAX_BLOCK_SIGOPS_WEIGHT - sigops_weight) // WITNESS_SCALE_FACTOR)))
 
         coinbase_tx = create_coinbase(self.lastblockheight + 1, pubkey=cb_pubkey, extra_output_script=extra_output_script, fees=fees)
-        block = create_block(self.tip, coinbase_tx, self.lastblocktime + 1, txlist=txs)
+        block = create_block(self.tip, coinbase_tx, ntime=self.lastblocktime + 1, txlist=txs)
         witness and add_witness_commitment(block)
         block.solve()
         block_response = node.submitblock(block.serialize().hex())

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -45,7 +45,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         tip = int(tip, 16)
 
         for _ in range(numblocks):
-            block = create_block(tip, create_coinbase(height + 1), block_time, version=version)
+            block = create_block(tip, height=height + 1, ntime=block_time, version=version)
             block.solve()
             peer.send_without_ping(msg_block(block))
             block_time += 1

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -10,7 +10,7 @@ soft-forks, and test that warning alerts are generated.
 import os
 import re
 
-from test_framework.blocktools import create_block, create_coinbase
+from test_framework.blocktools import create_block
 from test_framework.messages import msg_block
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -15,7 +15,6 @@ from test_framework.address import (
 from test_framework.blocktools import (
     add_witness_commitment,
     create_block,
-    create_coinbase,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import (
@@ -419,7 +418,7 @@ class ZMQTest (BitcoinTestFramework):
         bump_txid = self.nodes[0].sendrawtransaction(orig_tx['tx'].serialize().hex())
         # Mine the pre-bump tx
         txs_to_add = [orig_tx['hex']] + [tx['hex'] for tx in more_tx]
-        block = create_block(int(self.nodes[0].getbestblockhash(), 16), create_coinbase(self.nodes[0].getblockcount()+1), txlist=txs_to_add)
+        block = create_block(int(self.nodes[0].getbestblockhash(), 16), height=self.nodes[0].getblockcount() + 1, txlist=txs_to_add)
         add_witness_commitment(block)
         block.solve()
         assert_equal(self.nodes[0].submitblock(block.serialize().hex()), None)

--- a/test/functional/mining_template_verification.py
+++ b/test/functional/mining_template_verification.py
@@ -13,7 +13,6 @@ import copy
 
 from test_framework.blocktools import (
     create_block,
-    create_coinbase,
     add_witness_commitment,
 )
 
@@ -183,8 +182,8 @@ class MiningTemplateVerificationTest(BitcoinTestFramework):
 
         block_3 = create_block(
             int(block_2_hash, 16),
-            create_coinbase(block_0_height + 3),
-            block_1["mediantime"] + 1,
+            height=block_0_height + 3,
+            ntime=block_1["mediantime"] + 1,
             txlist=[tx["hex"]],
         )
         assert_equal(len(block_3.vtx), 2)
@@ -211,8 +210,8 @@ class MiningTemplateVerificationTest(BitcoinTestFramework):
         )
         block_3 = create_block(
             int(block_2_hash, 16),
-            create_coinbase(block_0_height + 3),
-            block_1["mediantime"] + 1,
+            height=block_0_height + 3,
+            ntime=block_1["mediantime"] + 1,
             txlist=[bad_tx_hex],
         )
         assert_equal(len(block_3.vtx), 2)
@@ -239,8 +238,8 @@ class MiningTemplateVerificationTest(BitcoinTestFramework):
         )
         block_3 = create_block(
             int(block_2_hash, 16),
-            create_coinbase(block_0_height + 3),
-            block_1["mediantime"] + 1,
+            height=block_0_height + 3,
+            ntime=block_1["mediantime"] + 1,
             txlist=[tx_hex, tx_2_hex],
         )
         assert_equal(len(block_3.vtx), 3)
@@ -269,8 +268,8 @@ class MiningTemplateVerificationTest(BitcoinTestFramework):
         block_1 = node.getblock(node.getbestblockhash())
         block_2 = create_block(
             int(block_1["hash"], 16),
-            create_coinbase(block_0_height + 2),
-            block_1["mediantime"] + 1,
+            height=block_0_height + 2,
+            ntime=block_1["mediantime"] + 1,
         )
 
         self.valid_block_test(node, block_2)

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -65,7 +65,7 @@ class P2PEvict(BitcoinTestFramework):
             best_block = node.getbestblockhash()
             tip = int(best_block, 16)
             best_block_time = node.getblock(best_block)['time']
-            block = create_block(tip, create_coinbase(node.getblockcount() + 1), best_block_time + 1)
+            block = create_block(tip, height=node.getblockcount() + 1, ntime=best_block_time + 1)
             block.solve()
             block_peer.send_blocks_and_test([block], node, success=True)
             protected_peers.add(current_peer)

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -16,7 +16,6 @@ import time
 
 from test_framework.blocktools import (
     create_block,
-    create_coinbase,
 )
 from test_framework.messages import (
     msg_pong,

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -10,7 +10,7 @@ the node should pretend that it does not have it to avoid fingerprinting.
 
 import time
 
-from test_framework.blocktools import (create_block, create_coinbase)
+from test_framework.blocktools import create_block
 from test_framework.messages import CInv, MSG_BLOCK
 from test_framework.p2p import (
     P2PInterface,
@@ -35,15 +35,13 @@ class P2PFingerprintTest(BitcoinTestFramework):
     def build_chain(self, nblocks, prev_hash, prev_height, prev_median_time):
         blocks = []
         for _ in range(nblocks):
-            coinbase = create_coinbase(prev_height + 1)
-            block_time = prev_median_time + 1
-            block = create_block(int(prev_hash, 16), coinbase, block_time)
+            block = create_block(int(prev_hash, 16), height=prev_height + 1, ntime=prev_median_time + 1)
             block.solve()
 
             blocks.append(block)
             prev_hash = block.hash_hex
             prev_height += 1
-            prev_median_time = block_time
+            prev_median_time += 1
         return blocks
 
     # Send a getdata request for a given block hash

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -10,7 +10,6 @@ import time
 
 from test_framework.blocktools import (
         create_block,
-        create_coinbase
 )
 from test_framework.messages import (
         MSG_BLOCK,

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -60,7 +60,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
         self.log.info("Prepare blocks without sending them to the node")
         block_dict = {}
         for _ in range(NUM_BLOCKS):
-            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks.append(create_block(tip, height=height, ntime=block_time))
             blocks[-1].solve()
             tip = blocks[-1].hash_int
             block_time += 1

--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -11,7 +11,7 @@
 from decimal import Decimal
 import time
 
-from test_framework.blocktools import create_block, create_coinbase
+from test_framework.blocktools import create_block
 from test_framework.messages import (
         CInv,
         COIN,

--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -50,7 +50,7 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
 
         self.nodes[0].setmocktime(int(time.time()))
         self.log.info("Mine one old block so we stay in IBD, then remember its coinbase wtxid")
-        block = create_block(int(self.nodes[0].getbestblockhash(), 16), create_coinbase(1), int(time.time()) - 2 * 24 * 60 * 60)
+        block = create_block(int(self.nodes[0].getbestblockhash(), 16), height=1, ntime=int(time.time()) - 2 * 24 * 60 * 60)
         block.solve()
         self.nodes[0].submitblock(block.serialize().hex())
         assert self.nodes[0].getblockchaininfo()['initialblockdownload']

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -50,7 +50,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
 
         self.log.info("Create a new block with an anyone-can-spend coinbase")
 
-        block = create_block(tip, create_coinbase(height), block_time)
+        block = create_block(tip, height=height, ntime=block_time)
         block.solve()
         # Save the coinbase for later
         block1 = block
@@ -74,7 +74,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
 
         tx1 = create_tx_with_script(block1.vtx[0], 0, script_sig=bytes([OP_TRUE]), amount=50 * COIN)
         tx2 = create_tx_with_script(tx1, 0, script_sig=bytes([OP_TRUE]), amount=50 * COIN)
-        block2 = create_block(tip, create_coinbase(height), block_time, txlist=[tx1, tx2])
+        block2 = create_block(tip, height=height, ntime=block_time, txlist=[tx1, tx2])
         block_time += 1
         block2.solve()
         orig_hash = block2.hash_int
@@ -121,7 +121,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         # Create a block that spends the output of a tx in a previous block.
         tx3 = create_tx_with_script(tx2, 0, script_sig=bytes([OP_TRUE]), amount=50 * COIN)
         tx3.vin.append(tx3.vin[0])  # Duplicates input
-        block4 = create_block(tip, create_coinbase(height), block_time, txlist=[tx3])
+        block4 = create_block(tip, height=height, ntime=block_time, txlist=[tx3])
         block4.solve()
         self.log.info("Test inflation by duplicating input")
         peer.send_blocks_and_test([block4], node, success=False,  reject_reason='bad-txns-inputs-duplicate')
@@ -130,7 +130,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         t = int(time.time())
         node.setmocktime(t)
         # Set block time +1 second past max future validity
-        block = create_block(tip, create_coinbase(height), t + MAX_FUTURE_BLOCK_TIME + 1)
+        block = create_block(tip, height=height, ntime=t + MAX_FUTURE_BLOCK_TIME + 1)
         block.solve()
         # Need force_send because the block will get rejected without a getdata otherwise
         peer.send_blocks_and_test([block], node, force_send=True, success=False, reject_reason='time-too-new')

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -99,7 +99,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
 
         self.log.info("Test very broken block.")
 
-        block3 = create_block(tip, create_coinbase(height, nValue=100), block_time)
+        block3 = create_block(tip, create_coinbase(height, nValue=100), ntime=block_time)
         block_time += 1
         block3.solve()
 

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -56,7 +56,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
 
         self.log.info("Create a new block with an anyone-can-spend coinbase.")
         height = 1
-        block = create_block(tip, create_coinbase(height), block_time)
+        block = create_block(tip, height=height, ntime=block_time)
         block.solve()
         # Save the coinbase for later
         block1 = block
@@ -171,7 +171,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
 
         tip = int(node.getbestblockhash(), 16)
         height = node.getblockcount() + 1
-        block_A = create_block(tip, create_coinbase(height))
+        block_A = create_block(tip, height=height)
         block_A.vtx.extend([tx_withhold, tx_withhold_until_block_A, tx_orphan_include_by_block_A])
         block_A.hashMerkleRoot = block_A.calc_merkle_root()
         block_A.solve()
@@ -198,7 +198,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
 
         tip = int(node.getbestblockhash(), 16)
         height = node.getblockcount() + 1
-        block_B = create_block(tip, create_coinbase(height))
+        block_B = create_block(tip, height=height)
         block_B.vtx.extend([tx_withhold_until_block_B, tx_orphan_include_by_block_B])
         block_B.hashMerkleRoot = block_B.calc_merkle_root()
         block_B.solve()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -5,7 +5,7 @@
 """Test node responses to invalid transactions.
 
 In this test we connect to one node over p2p, and test tx requests."""
-from test_framework.blocktools import create_block, create_coinbase
+from test_framework.blocktools import create_block
 from test_framework.messages import (
     COIN,
     COutPoint,

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -230,7 +230,7 @@ class SegWitTest(BitcoinTestFramework):
         tip = self.nodes[0].getbestblockhash()
         height = self.nodes[0].getblockcount() + 1
         block_time = self.nodes[0].getblockheader(tip)["mediantime"] + 1
-        block = create_block(int(tip, 16), create_coinbase(height), block_time)
+        block = create_block(int(tip, 16), height=height, ntime=block_time)
         return block
 
     def update_witness_block_with_transactions(self, block, tx_list, nonce=0):

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -10,7 +10,6 @@ from test_framework.blocktools import (
     WITNESS_COMMITMENT_HEADER,
     add_witness_commitment,
     create_block,
-    create_coinbase,
 )
 from test_framework.messages import (
     MAX_BIP125_RBF_SEQUENCE,

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -243,7 +243,7 @@ class SendHeadersTest(BitcoinTestFramework):
         test_node.check_last_headers_announcement(headers=[tip_hash])
 
         self.log.info("Verify getheaders with null locator and invalid hashstop does not return headers.")
-        block = create_block(int(tip["hash"], 16), create_coinbase(tip["height"] + 1), tip["mediantime"] + 1)
+        block = create_block(int(tip["hash"], 16), height=tip["height"] + 1, ntime=tip["mediantime"] + 1)
         block.solve()
         test_node.send_header_for_blocks([block])
         test_node.clear_block_announcements()
@@ -283,7 +283,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 height = self.nodes[0].getblockcount()
                 last_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time']
                 block_time = last_time + 1
-                new_block = create_block(tip, create_coinbase(height + 1), block_time)
+                new_block = create_block(tip, height=height + 1, ntime=block_time)
                 new_block.solve()
                 test_node.send_header_for_blocks([new_block])
                 test_node.wait_for_getdata([new_block.hash_int])
@@ -320,7 +320,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 self.log.debug("Part 2.{}.{}: starting...".format(i, j))
                 blocks = []
                 for _ in range(i + 1):
-                    blocks.append(create_block(tip, create_coinbase(height), block_time))
+                    blocks.append(create_block(tip, height=height, ntime=block_time))
                     blocks[-1].solve()
                     tip = blocks[-1].hash_int
                     block_time += 1
@@ -438,7 +438,7 @@ class SendHeadersTest(BitcoinTestFramework):
         # Create 2 blocks.  Send the blocks, then send the headers.
         blocks = []
         for _ in range(2):
-            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks.append(create_block(tip, height=height, ntime=block_time))
             blocks[-1].solve()
             tip = blocks[-1].hash_int
             block_time += 1
@@ -456,7 +456,7 @@ class SendHeadersTest(BitcoinTestFramework):
         # This time, direct fetch should work
         blocks = []
         for _ in range(3):
-            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks.append(create_block(tip, height=height, ntime=block_time))
             blocks[-1].solve()
             tip = blocks[-1].hash_int
             block_time += 1
@@ -477,7 +477,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # Create extra blocks for later
         for _ in range(20):
-            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks.append(create_block(tip, height=height, ntime=block_time))
             blocks[-1].solve()
             tip = blocks[-1].hash_int
             block_time += 1
@@ -526,7 +526,7 @@ class SendHeadersTest(BitcoinTestFramework):
             blocks = []
             # Create two more blocks.
             for _ in range(2):
-                blocks.append(create_block(tip, create_coinbase(height), block_time))
+                blocks.append(create_block(tip, height=height, ntime=block_time))
                 blocks[-1].solve()
                 tip = blocks[-1].hash_int
                 block_time += 1
@@ -545,7 +545,7 @@ class SendHeadersTest(BitcoinTestFramework):
         # Now we test that if we repeatedly don't send connecting headers, we
         # don't go into an infinite loop trying to get them to connect.
         for _ in range(NUM_HEADERS + 1):
-            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks.append(create_block(tip, height=height, ntime=block_time))
             blocks[-1].solve()
             tip = blocks[-1].hash_int
             block_time += 1

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -79,7 +79,7 @@ a. Repeat 100 times:
 b. Then send 99 more headers that don't connect.
    Expect: getheaders message each time.
 """
-from test_framework.blocktools import create_block, create_coinbase
+from test_framework.blocktools import create_block
 from test_framework.messages import CInv
 from test_framework.p2p import (
     CBlockHeader,

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -53,7 +53,7 @@ Node1 is unused in tests 3-7:
 
 import time
 
-from test_framework.blocktools import create_block, create_coinbase, create_tx_with_script
+from test_framework.blocktools import create_block, create_tx_with_script
 from test_framework.messages import CBlockHeader, CInv, MSG_BLOCK, msg_block, msg_headers, msg_inv
 from test_framework.p2p import p2p_lock, P2PInterface
 from test_framework.test_framework import BitcoinTestFramework

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -92,7 +92,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         blocks_h2 = []  # the height 2 blocks on each node's chain
         block_time = int(time.time()) + 1
         for i in range(2):
-            blocks_h2.append(create_block(tips[i], create_coinbase(2), block_time))
+            blocks_h2.append(create_block(tips[i], height=2, ntime=block_time))
             blocks_h2[i].solve()
             block_time += 1
         test_node.send_and_ping(msg_block(blocks_h2[0]))
@@ -108,7 +108,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         self.log.info("First height 2 block accepted by node0; correctly rejected by node1")
 
         # 3. Send another block that builds on genesis.
-        block_h1f = create_block(int("0x" + self.nodes[0].getblockhash(0), 0), create_coinbase(1), block_time)
+        block_h1f = create_block(int("0x" + self.nodes[0].getblockhash(0), 0), height=1, ntime=block_time)
         block_time += 1
         block_h1f.solve()
         test_node.send_and_ping(msg_block(block_h1f))
@@ -122,7 +122,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, block_h1f.hash_hex)
 
         # 4. Send another two block that build on the fork.
-        block_h2f = create_block(block_h1f.hash_int, create_coinbase(2), block_time)
+        block_h2f = create_block(block_h1f.hash_int, height=2, ntime=block_time)
         block_time += 1
         block_h2f.solve()
         test_node.send_and_ping(msg_block(block_h2f))
@@ -141,7 +141,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         self.log.info("Second height 2 block accepted, but not reorg'ed to")
 
         # 4b. Now send another block that builds on the forking chain.
-        block_h3 = create_block(block_h2f.hash_int, create_coinbase(3), block_h2f.nTime+1)
+        block_h3 = create_block(block_h2f.hash_int, height=3, ntime=block_h2f.nTime+1)
         block_h3.solve()
         test_node.send_and_ping(msg_block(block_h3))
 
@@ -164,7 +164,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         tip = block_h3
         all_blocks = []
         for i in range(288):
-            next_block = create_block(tip.hash_int, create_coinbase(i + 4), tip.nTime+1)
+            next_block = create_block(tip.hash_int, height=i + 4, ntime=tip.nTime+1)
             next_block.solve()
             all_blocks.append(next_block)
             tip = next_block
@@ -235,15 +235,15 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # 8. Create a chain which is invalid at a height longer than the
         # current chain, but which has more blocks on top of that
-        block_289f = create_block(all_blocks[284].hash_int, create_coinbase(289), all_blocks[284].nTime+1)
+        block_289f = create_block(all_blocks[284].hash_int, height=289, ntime=all_blocks[284].nTime+1)
         block_289f.solve()
-        block_290f = create_block(block_289f.hash_int, create_coinbase(290), block_289f.nTime+1)
+        block_290f = create_block(block_289f.hash_int, height=290, ntime=block_289f.nTime+1)
         block_290f.solve()
         # block_291 spends a coinbase below maturity!
         tx_to_add = create_tx_with_script(block_290f.vtx[0], 0, script_sig=b"42", amount=1)
-        block_291 = create_block(block_290f.hash_int, create_coinbase(291), block_290f.nTime+1, txlist=[tx_to_add])
+        block_291 = create_block(block_290f.hash_int, height=291, ntime=block_290f.nTime+1, txlist=[tx_to_add])
         block_291.solve()
-        block_292 = create_block(block_291.hash_int, create_coinbase(292), block_291.nTime+1)
+        block_292 = create_block(block_291.hash_int, height=292, ntime=block_291.nTime+1)
         block_292.solve()
 
         # Now send all the headers on the chain and enough blocks to trigger reorg
@@ -283,7 +283,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getblock(block_291.hash_hex)["confirmations"], -1)
 
         # Now send a new header on the invalid chain, indicating we're forked off, and expect to get disconnected
-        block_293 = create_block(block_292.hash_int, create_coinbase(293), block_292.nTime+1)
+        block_293 = create_block(block_292.hash_int, height=293, ntime=block_292.nTime+1)
         block_293.solve()
         headers_message = msg_headers()
         headers_message.headers.append(CBlockHeader(block_293))

--- a/test/functional/p2p_v2_encrypted.py
+++ b/test/functional/p2p_v2_encrypted.py
@@ -7,7 +7,6 @@ Test encrypted v2 p2p proposed in BIP 324
 """
 from test_framework.blocktools import (
     create_block,
-    create_coinbase,
 )
 from test_framework.p2p import (
     P2PDataStore,

--- a/test/functional/p2p_v2_encrypted.py
+++ b/test/functional/p2p_v2_encrypted.py
@@ -38,7 +38,7 @@ class P2PEncrypted(BitcoinTestFramework):
         last_block_time = node.getblock(last_block)['time']
         for _ in range(number):
             # Create some blocks
-            block = create_block(tip, create_coinbase(tipheight + 1), last_block_time + 1)
+            block = create_block(tip, height=tipheight + 1, ntime=last_block_time + 1)
             block.solve()
             test_blocks.append(block)
             tip = block.hash_int
@@ -47,7 +47,7 @@ class P2PEncrypted(BitcoinTestFramework):
         return test_blocks
 
     def create_test_block(self, txs):
-        block = create_block(self.tip, create_coinbase(self.tipheight + 1), self.last_block_time + 600, txlist=txs)
+        block = create_block(self.tip, height=self.tipheight + 1, ntime=self.last_block_time + 600, txlist=txs)
         block.solve()
         return block
 

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -607,7 +607,7 @@ class BlockchainTest(BitcoinTestFramework):
         fork_block = node.getblock(fork_hash)
 
         def solve_and_send_block(prevhash, height, time):
-            b = create_block(prevhash, create_coinbase(height), time)
+            b = create_block(prevhash, height=height, ntime=time)
             b.solve()
             peer.send_and_ping(msg_block(b))
             return b

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -741,7 +741,7 @@ class BlockchainTest(BitcoinTestFramework):
         self.log.info("Test getblock when only header is known")
         current_height = node.getblock(node.getbestblockhash())['height']
         block_time = node.getblock(node.getbestblockhash())['time'] + 1
-        block = create_block(int(blockhash, 16), create_coinbase(current_height + 1, nValue=100), block_time)
+        block = create_block(int(blockhash, 16), create_coinbase(current_height + 1, nValue=100), ntime=block_time)
         block.solve()
         node.submitheader(block.serialize().hex())
         assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", lambda: node.getblock(block.hash_hex))
@@ -749,7 +749,7 @@ class BlockchainTest(BitcoinTestFramework):
         self.log.info("Test getblock when block data is available but undo data isn't")
         # Submits a block building on the header-only block, so it can't be connected and has no undo data
         tx = create_tx_with_script(block.vtx[0], 0, script_sig=bytes([OP_TRUE]), amount=50 * COIN)
-        block_noundo = create_block(block.hash_int, create_coinbase(current_height + 2, nValue=100), block_time + 1, txlist=[tx])
+        block_noundo = create_block(block.hash_int, create_coinbase(current_height + 2, nValue=100), ntime=block_time + 1, txlist=[tx])
         block_noundo.solve()
         node.submitblock(block_noundo.serialize().hex())
 

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -73,7 +73,7 @@ class GetChainTipsTest (BitcoinTestFramework):
         invalid_block.solve()
 
         block_time += 1
-        block2 = create_block(invalid_block.hash_int, create_coinbase(2), block_time, version=4)
+        block2 = create_block(invalid_block.hash_int, height=2, ntime=block_time, version=4)
         block2.solve()
 
         self.log.info("Submit headers-only chain")

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -69,7 +69,7 @@ class GetChainTipsTest (BitcoinTestFramework):
         start_height = self.nodes[0].getblockcount()
         # Create invalid block (too high coinbase)
         block_time = n0.getblock(n0.getbestblockhash())['time'] + 1
-        invalid_block = create_block(tip, create_coinbase(start_height+1, nValue=100), block_time)
+        invalid_block = create_block(tip, create_coinbase(start_height + 1, nValue=100), ntime=block_time)
         invalid_block.solve()
 
         block_time += 1

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -8,7 +8,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR
 from test_framework.blocktools import (
     create_block,
-    create_coinbase,
 )
 from test_framework.util import (
     assert_equal,

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -44,7 +44,7 @@ class InvalidateTest(BitcoinTestFramework):
         # affect results since this chain will be invalidated next.
         tip = self.nodes[0].getbestblockhash()
         block_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time'] + 1
-        block = create_block(int(tip, 16), create_coinbase(self.nodes[0].getblockcount()), block_time, version=4)
+        block = create_block(int(tip, 16), height=self.nodes[0].getblockcount(), ntime=block_time, version=4)
         block.solve()
         self.nodes[0].submitheader(block.serialize().hex())
         assert_equal(self.nodes[0].getblockchaininfo()["headers"], self.nodes[0].getblockchaininfo()["blocks"] + 1)

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -129,7 +129,7 @@ def create_empty_fork(node, fork_length=FORK_LENGTH):
 
     blocks = []
     for _ in range(fork_length):
-        block = create_block(tip, create_coinbase(height + 1), block_time)
+        block = create_block(tip, height=height + 1, ntime=block_time)
         block.solve()
         blocks.append(block)
         tip = block.hash_int

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -95,7 +95,7 @@ def nbits_str(nbits):
 def target_str(target):
     return f"{target:064x}"
 
-def create_block(hashprev=None, coinbase=None, ntime=None, *, height=None, version=None, tmpl=None, txlist=None):
+def create_block(hashprev=None, coinbase=None, *, ntime=None, height=None, version=None, tmpl=None, txlist=None):
     """Create a block (with regtest difficulty)."""
     block = CBlock()
     if tmpl is None:

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -95,7 +95,7 @@ def nbits_str(nbits):
 def target_str(target):
     return f"{target:064x}"
 
-def create_block(hashprev=None, coinbase=None, ntime=None, *, version=None, tmpl=None, txlist=None):
+def create_block(hashprev=None, coinbase=None, ntime=None, *, height=None, version=None, tmpl=None, txlist=None):
     """Create a block (with regtest difficulty)."""
     block = CBlock()
     if tmpl is None:
@@ -108,7 +108,7 @@ def create_block(hashprev=None, coinbase=None, ntime=None, *, version=None, tmpl
     else:
         block.nBits = REGTEST_N_BITS
     if coinbase is None:
-        coinbase = create_coinbase(height=tmpl['height'])
+        coinbase = create_coinbase(height=height or tmpl["height"])
     block.vtx.append(coinbase)
     if txlist:
         for tx in txlist:
@@ -278,6 +278,14 @@ def send_to_witness(use_p2wsh, node, utxo, pubkey, encode_p2sh, amount, sign=Tru
     return node.sendrawtransaction(tx_to_witness)
 
 class TestFrameworkBlockTools(unittest.TestCase):
+    def test_create_block_prefers_explicit_height(self):
+        block = create_block(
+            hashprev=1,
+            tmpl={"height": 100},
+            height=200,
+        )
+        assert_equal(CScriptNum.decode(block.vtx[0].vin[0].scriptSig), 200)
+
     def test_create_coinbase(self):
         height = 20
         coinbase_tx = create_coinbase(height=height)

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 
 from test_framework.blocktools import (
     create_block,
-    create_coinbase,
 )
 from test_framework.messages import DEFAULT_MEMPOOL_EXPIRY_HOURS
 from test_framework.p2p import P2PTxInvStore

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -58,7 +58,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         # after the last time we tried to broadcast. Use mocktime and give an extra minute to be sure.
         block_time = int(time.time()) + 6 * 60
         node.setmocktime(block_time)
-        block = create_block(int(node.getbestblockhash(), 16), create_coinbase(node.getblockcount() + 1), block_time)
+        block = create_block(int(node.getbestblockhash(), 16), height=node.getblockcount() + 1, ntime=block_time)
         block.solve()
         node.submitblock(block.serialize().hex())
 
@@ -126,7 +126,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         # tx must be at least 5 minutes older than the last block to be rebroadcast
         block_time = entry_time + 6 * 60
         node.setmocktime(block_time)
-        block = create_block(int(node.getbestblockhash(), 16), create_coinbase(node.getblockcount() + 1), block_time)
+        block = create_block(int(node.getbestblockhash(), 16), height=node.getblockcount() + 1, ntime=block_time)
         block.solve()
         node.submitblock(block.serialize().hex())
         # Set correct m_best_block_time, which is used in ResubmitWalletTransactions
@@ -173,7 +173,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
 
         self.log.info("Create a block without the transaction")
         node1.bumpmocktime(6 * 60)
-        block = create_block(int(node1.getbestblockhash(), 16), create_coinbase(node1.getblockcount() + 1), node1.mocktime)
+        block = create_block(int(node1.getbestblockhash(), 16), height=node1.getblockcount() + 1, ntime=node1.mocktime)
         block.solve()
         node1.submitblock(block.serialize().hex())
         node1.syncwithvalidationinterfacequeue()


### PR DESCRIPTION
The `create_block` helper is often called with `create_coinbase`: `create_block(prev_hash, create_coinbase(new_height))`

This is fine, but a bit verbose and tedious to type each time. Also, it requires an additional import.

Improve this by allowing to set `height` in `create_block` directly, similar to other options, such as `ntime`, or `hashprev`.