### PR TITLE
wallet: stop materializing skipped descriptor addresses after high-index detection

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1068,20 +1068,16 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
     LOCK(cs_desc_man);
     std::vector<WalletDestination> result;
     if (IsMine(script)) {
-        int32_t index = m_map_script_pub_keys[script];
+        const int32_t index = m_map_script_pub_keys[script];
+        CTxDestination observed_dest;
+        // Return only the observed destination. Other skipped addresses can be
+        // recorded lazily if they are later seen in transactions.
+        if (ExtractDestination(script, observed_dest)) {
+            result.push_back({observed_dest, std::nullopt});
+        }
         if (index >= m_wallet_descriptor.next_index) {
-            WalletLogPrintf("%s: Detected a used keypool item at index %d, mark all keypool items up to this item as used\n", __func__, index);
-            auto out_keys = std::make_unique<FlatSigningProvider>();
-            std::vector<CScript> scripts_temp;
-            while (index >= m_wallet_descriptor.next_index) {
-                if (!m_wallet_descriptor.descriptor->ExpandFromCache(m_wallet_descriptor.next_index, m_wallet_descriptor.cache, scripts_temp, *out_keys)) {
-                    throw std::runtime_error(std::string(__func__) + ": Unable to expand descriptor from cache");
-                }
-                CTxDestination dest;
-                ExtractDestination(scripts_temp[0], dest);
-                result.push_back({dest, std::nullopt});
-                m_wallet_descriptor.next_index++;
-            }
+            WalletLogPrintf("%s: Detected a used keypool item at index %d, advance descriptor state past this item\n", __func__, index);
+            m_wallet_descriptor.next_index = index + 1;
         }
         if (!TopUp()) {
             WalletLogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -17,6 +17,7 @@ variants.
 
 import concurrent.futures
 import time
+from decimal import Decimal
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.blocktools import COINBASE_MATURITY
@@ -64,6 +65,85 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         if error_code is not None:
             assert_equal(result[0]['error']['code'], error_code)
             assert_equal(result[0]['error']['message'], error_message)
+
+    def test_high_index_descriptor_import_gap_regression(self, funding_wallet):
+        self.log.info("Test high-index descriptor import does not materialize a gap-sized receive address set")
+
+        wallet_name = "w_high_index_gap"
+        self.nodes[1].createwallet(wallet_name=wallet_name)
+        gap_wallet = self.nodes[1].get_wallet_rpc(wallet_name)
+
+        high_index = 1000
+        legacy_desc = next(
+            desc["desc"]
+            for desc in gap_wallet.listdescriptors(True)["descriptors"]
+            if desc["active"] and not desc["internal"] and desc["desc"].startswith("pkh(")
+        )
+        high_addr = gap_wallet.deriveaddresses(legacy_desc, [high_index, high_index])[0]
+        next_addr = gap_wallet.deriveaddresses(legacy_desc, [high_index + 1, high_index + 1])[0]
+        next_after_reload_addr = gap_wallet.deriveaddresses(legacy_desc, [high_index + 2, high_index + 2])[0]
+        mid_addr = gap_wallet.deriveaddresses(legacy_desc, [high_index - 1, high_index - 1])[0]
+
+        txid = funding_wallet.sendtoaddress(high_addr, 1)
+        self.sync_mempools()
+        assert_equal(gap_wallet.listreceivedbyaddress(minconf=0, include_empty=True), [])
+
+        self.test_importdesc(
+            {
+                "desc": legacy_desc,
+                "active": True,
+                "range": [0, high_index],
+                "next_index": 0,
+                "timestamp": "now",
+            },
+            success=True,
+            wallet=gap_wallet,
+        )
+
+        assert_equal(gap_wallet.getbalances()["mine"]["untrusted_pending"], Decimal("1"))
+        received = gap_wallet.listreceivedbyaddress(minconf=0, include_empty=True)
+        assert_equal(len(received), 1)
+        assert_equal(received[0]["address"], high_addr)
+        assert_equal(received[0]["amount"], Decimal("1"))
+        assert_equal(received[0]["confirmations"], 0)
+        assert_equal(received[0]["txids"], [txid])
+
+        self.generatetoaddress(self.nodes[0], 1, funding_wallet.getnewaddress())
+        self.sync_all()
+
+        assert_equal(gap_wallet.getbalance(), Decimal("1"))
+        filtered = gap_wallet.listreceivedbyaddress(minconf=0, include_empty=True, address_filter=high_addr)
+        assert_equal(len(filtered), 1)
+        assert_equal(filtered[0]["address"], high_addr)
+        assert_equal(filtered[0]["amount"], Decimal("1"))
+
+        issued_addr = gap_wallet.getnewaddress("", "legacy")
+        assert_equal(issued_addr, next_addr)
+        assert issued_addr != high_addr
+
+        change_addr = gap_wallet.getrawchangeaddress(address_type="legacy")
+        assert gap_wallet.getaddressinfo(change_addr)["ischange"]
+
+        funding_wallet.sendtoaddress(mid_addr, 1)
+        self.generatetoaddress(self.nodes[0], 1, funding_wallet.getnewaddress())
+        self.sync_all()
+
+        received_addrs = {entry["address"] for entry in gap_wallet.listreceivedbyaddress(minconf=0, include_empty=True)}
+        assert_equal(received_addrs, {high_addr, issued_addr, mid_addr})
+        assert_equal(gap_wallet.getbalance(), Decimal("2"))
+
+        gap_wallet.unloadwallet()
+        self.nodes[1].loadwallet(wallet_name)
+        gap_wallet = self.nodes[1].get_wallet_rpc(wallet_name)
+
+        received_addrs = {entry["address"] for entry in gap_wallet.listreceivedbyaddress(minconf=0, include_empty=True)}
+        assert_equal(received_addrs, {high_addr, issued_addr, mid_addr})
+        assert_equal(gap_wallet.getbalance(), Decimal("2"))
+
+        issued_after_reload = gap_wallet.getnewaddress("", "legacy")
+        assert_equal(issued_after_reload, next_after_reload_addr)
+        assert issued_after_reload not in {high_addr, issued_addr, mid_addr}
+        assert gap_wallet.getaddressinfo(gap_wallet.getrawchangeaddress(address_type="legacy"))["ischange"]
 
     def run_test(self):
         self.log.info('Setting up wallets')
@@ -820,6 +900,8 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                 success=True,
                 warnings=[expected_warning],
             )
+
+        self.test_high_index_descriptor_import_gap_regression(w0)
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -26,6 +26,7 @@ from test_framework.descriptors import descsum_create
 from test_framework.script import SEQUENCE_LOCKTIME_TYPE_FLAG
 from test_framework.util import (
     assert_equal,
+    assert_not_equal,
     assert_raises_rpc_error,
 )
 from test_framework.wallet_util import (
@@ -119,7 +120,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
 
         issued_addr = gap_wallet.getnewaddress("", "legacy")
         assert_equal(issued_addr, next_addr)
-        assert issued_addr != high_addr
+        assert_not_equal(issued_addr, high_addr)
 
         change_addr = gap_wallet.getrawchangeaddress(address_type="legacy")
         assert gap_wallet.getaddressinfo(change_addr)["ischange"]


### PR DESCRIPTION
This fixes the high-index ranged descriptor update path reported in #25895.

When a descriptor wallet detects use of a ranged item at a high index, `MarkUnusedAddresses()` currently expands every skipped item up to that index and records each destination in the address book. For large gaps, that turns a single high-index hit into gap-sized work and can make the import/update path appear hung.

Instead, advance `next_index` directly past the observed item and return only the observed destination. Skipped destinations are no longer materialized eagerly, but they can still be recorded later if they are actually seen in wallet transactions.

This intentionally changes `listreceivedbyaddress(..., include_empty=True)` behavior for this case: a high-index hit no longer creates a gap-sized receive address set. `getnewaddress()` progression, change derivation, lazy recording of later-used skipped addresses, and reload persistence are covered by the functional test added here.

Tests:
- `wallet_importdescriptors.py`
- `wallet_listreceivedby.py`
- `wallet_descriptor.py`
- `test_bitcoin --run_test=scriptpubkeyman_tests,wallet_tests,walletdb_tests,walletload_tests`