### PR TITLE
doc: fix typos and minor formatting issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ about Git.
 ### Creating the Pull Request
 
 The title of the pull request should be prefixed by the component or area that
-the pull request affects. Valid areas as:
+the pull request affects. Valid areas are:
 
   - `consensus` for changes to consensus critical code
   - `doc` for changes to the documentation

--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -65,7 +65,7 @@ Almost all options can be negated by being specified with a `no` prefix. For exa
 
 In general, negating an option is like setting it to `0` if it is a boolean or integer option, and setting it to an empty string or path or list if it is a string or path or list option.
 
-However, there are exceptions to this general rule. For example, it is an error to negate some options (e.g. `-nodatadir` is disallowed), and some negated strings are treated like `"0"` instead of `""` (e.g. `-noproxy` is treated like `-proxy=0`), and some negating some lists can have side effects in addition to clearing the lists (e.g. `-noconnect` disables automatic connections in addition to dropping any manual connections specified previously with `-connect=<host>`). When there are exceptions to the rule, they should either be obvious from context, or should be mentioned in usage documentation. Nonobvious, undocumented exceptions should be reported as bugs.
+However, there are exceptions to this general rule. For example, it is an error to negate some options (e.g. `-nodatadir` is disallowed), and some negated strings are treated like `"0"` instead of `""` (e.g. `-noproxy` is treated like `-proxy=0`), and some negating lists can have side effects in addition to clearing the lists (e.g. `-noconnect` disables automatic connections in addition to dropping any manual connections specified previously with `-connect=<host>`). When there are exceptions to the rule, they should either be obvious from context, or should be mentioned in usage documentation. Nonobvious, undocumented exceptions should be reported as bugs.
 
 ## Configuration File Path
 

--- a/doc/files.md
+++ b/doc/files.md
@@ -165,5 +165,5 @@ This table describes the files installed by Bitcoin Core across different platfo
 
 ## Filesystem recommendations
 
-When choosing a filesystem for the data directory (`datadir`) or blocks directory (`blocksdir`) on **macOS**,the `exFAT` filesystem should be avoided.
+When choosing a filesystem for the data directory (`datadir`) or blocks directory (`blocksdir`) on **macOS**, the `exFAT` filesystem should be avoided.
 There have been multiple reports of database corruption and data loss when using this filesystem with Bitcoin Core, see [Issue #31454](https://github.com/bitcoin/bitcoin/issues/31454) for more details.

--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -86,7 +86,7 @@ address is used for making outbound connections and accepting inbound
 connections.
 
 In the I2P network, the receiver of an inbound connection sees the address of
-the initiator.  This is unlike the Tor network, where the recipient does not
+the initiator. This is unlike the Tor network, where the recipient does not
 know who is connecting to it.
 
 If your node is configured by setting `-i2pacceptincoming=0` to not accept


### PR DESCRIPTION
Fix four small documentation issues found in actively maintained files:

- `CONTRIBUTING.md`: "Valid areas as:" → "Valid areas are:" (grammar)
- `doc/i2p.md`: remove double space after period
- `doc/bitcoin-conf.md`: "some negating some lists" → "some negating lists" (duplicate word)
- `doc/files.md`: missing space after comma in `**macOS**,the`