### PR TITLE
rpc: Merge joinpsbts locktimes correctly

### DIFF
--- a/doc/release-notes-35100.md
+++ b/doc/release-notes-35100.md
@@ -1,0 +1,13 @@
+### Updated RPCs
+
+- The `joinpsbts` RPC now sets the merged transaction's `nLockTime` to the
+  maximum `nLockTime` among input PSBTs that constrain it. A PSBT constrains
+  the locktime only if it has at least one input with `nSequence` not equal
+  to `SEQUENCE_FINAL` (0xffffffff) and a non-zero `nLockTime`. PSBTs with all
+  inputs using `SEQUENCE_FINAL` or with `nLockTime` 0 no longer affect the
+  chosen locktime, since `nLockTime` is not enforced for those inputs. When no
+  input PSBT constrains the locktime, the merged transaction uses `nLockTime` 0.
+  Among constraining PSBTs, height-based and time-based locktimes cannot be
+  mixed. Attempts to join them return an error. Previously, the RPC used
+  the minimum `nLockTime` among all PSBTs, which could merge incompatible
+  locktime semantics. (#35100)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -42,6 +42,7 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <numeric>
 
@@ -1864,7 +1865,9 @@ static RPCMethod joinpsbts()
     return RPCMethod{
         "joinpsbts",
         "Joins multiple distinct version 0 PSBTs with different inputs and outputs into one version 0 PSBT with inputs and outputs from all of the PSBTs\n"
-            "No input in any of the PSBTs can be in more than one of the PSBTs.\n",
+            "No input in any of the PSBTs can be in more than one of the PSBTs.\n"
+            "The merged PSBT's transaction uses the highest nLockTime among constraining input PSBTs with the same locktime type.\n"
+            "A PSBT constrains the locktime only when it has at least one input with nSequence not equal to SEQUENCE_FINAL and a non-zero nLockTime.\n",
             {
                 {"txs", RPCArg::Type::ARR, RPCArg::Optional::NO, "The base64 strings of partially signed transactions",
                     {
@@ -1888,7 +1891,7 @@ static RPCMethod joinpsbts()
     }
 
     uint32_t best_version = 1;
-    uint32_t best_locktime = 0xffffffff;
+    std::optional<uint32_t> max_locktime = std::nullopt;
     for (unsigned int i = 0; i < txs.size(); ++i) {
         util::Result<PartiallySignedTransaction> psbt_res = DecodeBase64PSBT(txs[i].get_str());
         if (!psbt_res) {
@@ -1903,17 +1906,29 @@ static RPCMethod joinpsbts()
         if (psbtx.tx_version > best_version) {
             best_version = psbtx.tx_version;
         }
-        // Choose the lowest lock time
-        uint32_t psbt_locktime = psbtx.fallback_locktime.value_or(0);
-        if (psbt_locktime < best_locktime) {
-            best_locktime = psbt_locktime;
+        // Choose the highest nLockTime among PSBTs that constrain it. nLockTime is
+        // ignored when every input has nSequence == SEQUENCE_FINAL or nLockTime is 0.
+        const bool is_locktime_enabled = std::any_of(psbtx.inputs.begin(), psbtx.inputs.end(), [](const PSBTInput& input) {
+            return input.sequence && *input.sequence != CTxIn::SEQUENCE_FINAL;
+        });
+        const auto psbt_locktime{psbtx.fallback_locktime.value_or(0)};
+        if (is_locktime_enabled && psbt_locktime != 0) {
+            const bool is_time_locktime{psbt_locktime >= LOCKTIME_THRESHOLD};
+            if (max_locktime.has_value() && (*max_locktime >= LOCKTIME_THRESHOLD) != is_time_locktime) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot join PSBTs with mixed height-based and time-based locktimes");
+            }
+            if (!max_locktime.has_value()) {
+                max_locktime = psbt_locktime;
+            } else {
+                max_locktime = std::max(*max_locktime, psbt_locktime);
+            }
         }
     }
 
     // Create a blank psbt where everything will be added
     CMutableTransaction tx;
     tx.version = best_version;
-    tx.nLockTime = best_locktime;
+    tx.nLockTime = max_locktime.value_or(0);
     PartiallySignedTransaction merged_psbt(tx, psbtxs.at(0).GetVersion());
 
     // Merge

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -19,6 +19,7 @@ from test_framework.messages import (
     CTxIn,
     CTxOut,
     MAX_BIP125_RBF_SEQUENCE,
+    SEQUENCE_FINAL,
     WITNESS_SCALE_FACTOR,
     ser_compact_size,
 )
@@ -44,7 +45,13 @@ from test_framework.psbt import (
     PSBT_OUT_TAP_TREE,
     PSBT_OUT_SCRIPT,
 )
-from test_framework.script import CScript, OP_TRUE, SIGHASH_ALL, SIGHASH_ANYONECANPAY
+from test_framework.script import (
+    CScript,
+    LOCKTIME_THRESHOLD,
+    OP_TRUE,
+    SIGHASH_ALL,
+    SIGHASH_ANYONECANPAY,
+)
 from test_framework.script_util import MIN_STANDARD_TX_NONWITNESS_SIZE
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -574,6 +581,53 @@ class PSBTTest(BitcoinTestFramework):
             if shuffled:
                 break
         assert shuffled
+
+        def make_locktime_psbt(locktime, sequence=0):
+            tx = CTransaction()
+            tx.vin = [CTxIn(outpoint=COutPoint(hash=locktime, n=0), scriptSig=b"", nSequence=sequence)]
+            tx.vout = [CTxOut(nValue=0, scriptPubKey=b"")]
+            tx.nLockTime = locktime
+            return PSBT(
+                g=PSBTMap({PSBT_GLOBAL_UNSIGNED_TX: tx.serialize()}),
+                i=[PSBTMap()],
+                o=[PSBTMap()],
+            ).to_base64()
+
+        def assert_joined_locktime(psbts, expected_locktime):
+            for psbts_order in [psbts, list(reversed(psbts))]:
+                joined_lt = self.nodes[0].joinpsbts(psbts_order)
+                joined_lt_decoded = self.nodes[0].decodepsbt(joined_lt)
+                assert_equal(joined_lt_decoded['tx']['locktime'], expected_locktime)
+
+        psbt_0 = make_locktime_psbt(0)
+        psbt_150 = make_locktime_psbt(150)
+        psbt_200 = make_locktime_psbt(200)
+        psbt_250_seq_final = make_locktime_psbt(250, sequence=SEQUENCE_FINAL)
+        psbt_300_seq_final = make_locktime_psbt(300, sequence=SEQUENCE_FINAL)
+        psbt_time = make_locktime_psbt(LOCKTIME_THRESHOLD)
+        psbt_later_time = make_locktime_psbt(LOCKTIME_THRESHOLD + 1)
+
+        # joinpsbts uses the maximum height-based locktime
+        assert_joined_locktime([psbt_150, psbt_200], expected_locktime=200)
+
+        # joinpsbts ignores height-based locktimes from PSBTs whose inputs all use SEQUENCE_FINAL
+        assert_joined_locktime([psbt_200, psbt_250_seq_final], expected_locktime=200)
+
+        # joinpsbts uses zero locktime when no PSBT constrains the locktime
+        assert_joined_locktime([psbt_250_seq_final, psbt_300_seq_final], expected_locktime=0)
+
+        # joinpsbts uses the maximum time-based locktime
+        assert_joined_locktime([psbt_time, psbt_later_time], expected_locktime=LOCKTIME_THRESHOLD + 1)
+
+        # joinpsbts ignores zero locktime even when nSequence is non-final
+        assert_joined_locktime([psbt_0, psbt_time], expected_locktime=LOCKTIME_THRESHOLD)
+
+        # joinpsbts ignores SEQUENCE_FINAL locktimes before rejecting mixed locktime types
+        assert_joined_locktime([psbt_250_seq_final, psbt_time], expected_locktime=LOCKTIME_THRESHOLD)
+
+        # joinpsbts rejects mixed height-based and time-based locktimes
+        assert_raises_rpc_error(-8, "Cannot join PSBTs with mixed height-based and time-based locktimes", self.nodes[0].joinpsbts, [psbt_150, psbt_time])
+        assert_raises_rpc_error(-8, "Cannot join PSBTs with mixed height-based and time-based locktimes", self.nodes[0].joinpsbts, [psbt_time, psbt_150])
 
     def run_test(self):
         # Create and fund a raw tx for sending 10 BTC

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -5,9 +5,11 @@
 """Test the Partially Signed Transaction RPCs.
 """
 from decimal import Decimal
+from io import BytesIO
 from itertools import product
 from random import randbytes
 
+from test_framework.address import script_to_p2wsh
 from test_framework.blocktools import (
     MAX_STANDARD_TX_WEIGHT,
 )
@@ -17,8 +19,10 @@ from test_framework.messages import (
     COutPoint,
     CTransaction,
     CTxIn,
+    CTxInWitness,
     CTxOut,
     MAX_BIP125_RBF_SEQUENCE,
+    MAX_SEQUENCE_NONFINAL,
     SEQUENCE_FINAL,
     WITNESS_SCALE_FACTOR,
     ser_compact_size,
@@ -48,6 +52,8 @@ from test_framework.psbt import (
 from test_framework.script import (
     CScript,
     LOCKTIME_THRESHOLD,
+    OP_CHECKLOCKTIMEVERIFY,
+    OP_DROP,
     OP_TRUE,
     SIGHASH_ALL,
     SIGHASH_ANYONECANPAY,
@@ -628,6 +634,54 @@ class PSBTTest(BitcoinTestFramework):
         # joinpsbts rejects mixed height-based and time-based locktimes
         assert_raises_rpc_error(-8, "Cannot join PSBTs with mixed height-based and time-based locktimes", self.nodes[0].joinpsbts, [psbt_150, psbt_time])
         assert_raises_rpc_error(-8, "Cannot join PSBTs with mixed height-based and time-based locktimes", self.nodes[0].joinpsbts, [psbt_time, psbt_150])
+
+        # joinpsbts uses the maximum height-based locktime from CLTV-bound PSBTs
+        node = self.nodes[0]
+        amount = Decimal("1.0")
+        spend_amount = Decimal("0.999")
+        current_height = node.getblockcount()
+        locktimes = [current_height - 2, current_height - 1]
+        witness_scripts = [
+            CScript([locktime, OP_CHECKLOCKTIMEVERIFY, OP_DROP])
+            for locktime in locktimes
+        ]
+        utxos = self.create_outpoints(node, outputs=[
+            {script_to_p2wsh(witness_script): amount}
+            for witness_script in witness_scripts
+        ])
+        self.generate(node, 1)
+
+        psbts = [
+            node.createpsbt(
+                inputs=[{**utxo, "sequence": MAX_SEQUENCE_NONFINAL}],
+                outputs=[{node.getnewaddress(): spend_amount}],
+                locktime=locktime,
+                replaceable=False,
+                psbt_version=0,
+            )
+            for utxo, locktime in zip(utxos, locktimes)
+        ]
+
+        assert_joined_locktime(psbts, expected_locktime=max(locktimes))
+
+        joined = node.joinpsbts(psbts)
+        joined_psbt = PSBT.from_base64(joined)
+        tx = CTransaction()
+        tx.deserialize(BytesIO(joined_psbt.g.map[PSBT_GLOBAL_UNSIGNED_TX]))
+
+        # joinpsbts may reorder inputs, so attach each CLTV witness script by prevout.
+        scripts_by_prevout = {
+            (int(utxo["txid"], 16), utxo["vout"]): witness_script
+            for utxo, witness_script in zip(utxos, witness_scripts)
+        }
+        tx.wit.vtxinwit = [CTxInWitness() for _ in tx.vin]
+        for i, txin in enumerate(tx.vin):
+            tx.wit.vtxinwit[i].scriptWitness.stack = [
+                CScript([OP_TRUE]),
+                scripts_by_prevout[(txin.prevout.hash, txin.prevout.n)],
+            ]
+        test_accept = node.testmempoolaccept([tx.serialize().hex()], maxfeerate=0)[0]
+        assert_equal(test_accept["allowed"], True)
 
     def run_test(self):
         # Create and fund a raw tx for sending 10 BTC

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -532,6 +532,49 @@ class PSBTTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "The PSBT version can only be 2 or 0", self.nodes[0].converttopsbt, hexstring=rawtx, psbt_version=1)
         assert_raises_rpc_error(-8, "The PSBT version can only be 2 or 0", self.nodes[0].psbtbumpfee, txid=tobump, psbt_version=1)
 
+    def test_joinpsbts(self):
+        self.log.info("Test joinpsbts")
+        addr1 = self.nodes[1].getnewaddress("", "bech32m")
+        addr2 = self.nodes[1].getnewaddress("", "legacy")
+        addr3 = self.nodes[1].getnewaddress("", "p2sh-segwit")
+        utxo1, utxo2, utxo3 = self.create_outpoints(self.nodes[1], outputs=[{addr1: 11}, {addr2: 11}, {addr3: 11}])
+        self.sync_all()
+
+        # Cannot join PSBTv2s
+        psbt1 = self.nodes[1].createpsbt(inputs=[utxo1], outputs={self.nodes[0].getnewaddress(): Decimal('10.999')}, psbt_version=0)
+        psbt2 = self.nodes[1].createpsbt(inputs=[utxo1], outputs={self.nodes[0].getnewaddress(): Decimal('10.999')}, psbt_version=2)
+        assert_raises_rpc_error(-8, "joinpsbts only operates on version 0 PSBTs", self.nodes[1].joinpsbts, [psbt1, psbt2])
+
+        # Two PSBTs with a common input should not be joinable
+        psbt2 = self.nodes[1].createpsbt([utxo1], {self.nodes[0].getnewaddress(): Decimal('10.999')}, psbt_version=0)
+        assert_raises_rpc_error(-8, "exists in multiple PSBTs", self.nodes[1].joinpsbts, [psbt1, psbt2])
+
+        # Join two distinct PSBTs
+        psbt1 = self.nodes[1].createpsbt(inputs=[utxo1, utxo2, utxo3], outputs={self.nodes[0].getnewaddress(): 32.999}, psbt_version=0)
+        addr4 = self.nodes[1].getnewaddress("", "p2sh-segwit")
+        utxo4 = self.create_outpoints(self.nodes[0], outputs=[{addr4: 5}])[0]
+        self.generate(self.nodes[0], 6)
+        psbt2 = self.nodes[1].createpsbt([utxo4], {self.nodes[0].getnewaddress(): Decimal('4.999')}, psbt_version=0)
+        psbt2 = self.nodes[1].walletprocesspsbt(psbt2)['psbt']
+        psbt2_decoded = self.nodes[0].decodepsbt(psbt2)
+        assert "final_scriptwitness" in psbt2_decoded['inputs'][0] and "final_scriptSig" in psbt2_decoded['inputs'][0]
+        joined = self.nodes[0].joinpsbts([psbt1, psbt2])
+        joined_decoded = self.nodes[0].decodepsbt(joined)
+        assert_equal(len(joined_decoded['inputs']), 4)
+        assert_equal(len(joined_decoded['outputs']), 2)
+        assert "final_scriptwitness" not in joined_decoded['inputs'][3]
+        assert "final_scriptSig" not in joined_decoded['inputs'][3]
+
+        # Check that joining shuffles the inputs and outputs
+        # 10 attempts should be enough to get a shuffled join
+        shuffled = False
+        for _ in range(10):
+            shuffled_joined = self.nodes[0].joinpsbts([psbt1, psbt2])
+            shuffled |= joined != shuffled_joined
+            if shuffled:
+                break
+        assert shuffled
+
     def run_test(self):
         # Create and fund a raw tx for sending 10 BTC
         psbtx1 = self.nodes[0].walletcreatefundedpsbt([], {self.nodes[2].getnewaddress():10})['psbt']
@@ -1060,40 +1103,7 @@ class PSBTTest(BitcoinTestFramework):
         test_psbt_input_keys(decoded['inputs'][1], psbt_v2_required_keys + ['non_witness_utxo', 'bip32_derivs'])
         test_psbt_input_keys(decoded['inputs'][2], psbt_v2_required_keys + ['non_witness_utxo', 'witness_utxo', 'bip32_derivs', 'redeem_script'])
 
-        # Cannot join PSBTv2s
-        psbt1 = self.nodes[1].createpsbt(inputs=[utxo1], outputs={self.nodes[0].getnewaddress():Decimal('10.999')}, psbt_version=0)
-        psbt2 = self.nodes[1].createpsbt(inputs=[utxo1], outputs={self.nodes[0].getnewaddress():Decimal('10.999')}, psbt_version=2)
-        assert_raises_rpc_error(-8, "joinpsbts only operates on version 0 PSBTs", self.nodes[1].joinpsbts, [psbt1, psbt2])
-
-        # Two PSBTs with a common input should not be joinable
-        psbt2 = self.nodes[1].createpsbt([utxo1], {self.nodes[0].getnewaddress():Decimal('10.999')}, psbt_version=0)
-        assert_raises_rpc_error(-8, "exists in multiple PSBTs", self.nodes[1].joinpsbts, [psbt1, psbt2])
-
-        # Join two distinct PSBTs
-        psbt1 = self.nodes[1].createpsbt(inputs=[utxo1, utxo2, utxo3], outputs={self.nodes[0].getnewaddress():32.999}, psbt_version=0)
-        addr4 = self.nodes[1].getnewaddress("", "p2sh-segwit")
-        utxo4 = self.create_outpoints(self.nodes[0], outputs=[{addr4: 5}])[0]
-        self.generate(self.nodes[0], 6)
-        psbt2 = self.nodes[1].createpsbt([utxo4], {self.nodes[0].getnewaddress():Decimal('4.999')}, psbt_version=0)
-        psbt2 = self.nodes[1].walletprocesspsbt(psbt2)['psbt']
-        psbt2_decoded = self.nodes[0].decodepsbt(psbt2)
-        assert "final_scriptwitness" in psbt2_decoded['inputs'][0] and "final_scriptSig" in psbt2_decoded['inputs'][0]
-        joined = self.nodes[0].joinpsbts([psbt1, psbt2])
-        joined_decoded = self.nodes[0].decodepsbt(joined)
-        assert_equal(len(joined_decoded['inputs']), 4)
-        assert_equal(len(joined_decoded['outputs']), 2)
-        assert "final_scriptwitness" not in joined_decoded['inputs'][3]
-        assert "final_scriptSig" not in joined_decoded['inputs'][3]
-
-        # Check that joining shuffles the inputs and outputs
-        # 10 attempts should be enough to get a shuffled join
-        shuffled = False
-        for _ in range(10):
-            shuffled_joined = self.nodes[0].joinpsbts([psbt1, psbt2])
-            shuffled |= joined != shuffled_joined
-            if shuffled:
-                break
-        assert shuffled
+        self.test_joinpsbts()
 
         # Newly created PSBT needs UTXOs and updating
         addr = self.nodes[1].getnewaddress("", "p2sh-segwit")


### PR DESCRIPTION
`joinpsbts` previously took the **minimum** `nLockTime` across the PSBTs being merged, so the combined transaction could be minable earlier than the strictest party’s locktime. A merged PSBT should use the **maximum** `nLockTime` amongst the PSBTs that have at least one input with `nSequence` != `SEQUENCE_FINAL` and with `nLockTime != 0`. 

PSBTs whose inputs are all `SEQUENCE_FINAL` or with `nLockTime == 0` do not constrain the locktime.

This PR implements the fix, updates RPC documentation, adds `test_joinpsbts`, and updates the release notes.