### PR TITLE
refactor: disable default std::hash for CTransactionRef

### DIFF
--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -86,7 +86,10 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   ${CI_RETRY_EXE} git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_"${IWYU_LLVM_V}" /include-what-you-use
-  (cd /include-what-you-use && patch -p1 < /ci_container_base/ci/test/01_iwyu.patch)
+  pushd /include-what-you-use
+  patch -p1 < /ci_container_base/ci/test/01_iwyu.patch
+  patch -p1 < /ci_container_base/ci/test/02_iwyu_hash.patch
+  popd
   cmake -B /iwyu-build/ -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-"${IWYU_LLVM_V}" -S /include-what-you-use
   make -C /iwyu-build/ install "$MAKEJOBS"
 fi

--- a/ci/test/02_iwyu_hash.patch
+++ b/ci/test/02_iwyu_hash.patch
@@ -1,0 +1,44 @@
+Map std::hash to its providing standard headers.
+Backport of https://github.com/include-what-you-use/include-what-you-use/pull/2013
+(commit 52f85e1f4d990f55fc6556d543eb051d79364a16) to the clang_22 release
+branch. Drop once the upstream fix lands in the IWYU branch tracked by
+ci/test/00_setup_env_native_iwyu.sh.
+
+--- a/std_symbol_map.inc
++++ b/std_symbol_map.inc
+@@ -1054,12 +1054,27 @@
+ { "std::has_unique_object_representations_v", kPrivate, "<type_traits>", kPublic },
+ { "std::has_virtual_destructor", kPrivate, "<type_traits>", kPublic },
+ { "std::has_virtual_destructor_v", kPrivate, "<type_traits>", kPublic },
++{ "std::hash", kPrivate, "<functional>", kPublic },
++{ "std::hash", kPrivate, "<bitset>", kPublic },
++{ "std::hash", kPrivate, "<coroutine>", kPublic },
++{ "std::hash", kPrivate, "<filesystem>", kPublic },
++{ "std::hash", kPrivate, "<memory>", kPublic },
++{ "std::hash", kPrivate, "<optional>", kPublic },
++{ "std::hash", kPrivate, "<stacktrace>", kPublic },
++{ "std::hash", kPrivate, "<string>", kPublic },
++{ "std::hash", kPrivate, "<string_view>", kPublic },
++{ "std::hash", kPrivate, "<system_error>", kPublic },
++{ "std::hash", kPrivate, "<thread>", kPublic },
++{ "std::hash", kPrivate, "<typeindex>", kPublic },
++{ "std::hash", kPrivate, "<variant>", kPublic },
++{ "std::hash", kPrivate, "<vector>", kPublic },
+ { "std::hash<std::basic_stacktrace<:0>>", kPrivate, "<stacktrace>", kPublic },
+ { "std::hash<std::basic_string<char, std::char_traits<char>, :0>>", kPrivate, "<string>", kPublic },
+ { "std::hash<std::basic_string<char16_t, std::char_traits<char16_t>, :0>>", kPrivate, "<string>", kPublic },
+ { "std::hash<std::basic_string<char32_t, std::char_traits<char32_t>, :0>>", kPrivate, "<string>", kPublic },
+ { "std::hash<std::basic_string<char8_t, std::char_traits<char8_t>, :0>>", kPrivate, "<string>", kPublic },
+ { "std::hash<std::basic_string<wchar_t, std::char_traits<wchar_t>, :0>>", kPrivate, "<string>", kPublic },
++{ "std::hash<std::bitset<:0>>", kPrivate, "<bitset>", kPublic },
+ { "std::hash<std::coroutine_handle<:0>>", kPrivate, "<coroutine>", kPublic },
+ { "std::hash<std::error_code>", kPrivate, "<system_error>", kPublic },
+ { "std::hash<std::error_condition>", kPrivate, "<system_error>", kPublic },
+@@ -1069,6 +1084,7 @@
+ { "std::hash<std::shared_ptr<:0>>", kPrivate, "<memory>", kPublic },
+ { "std::hash<std::stacktrace_entry>", kPrivate, "<stacktrace>", kPublic },
+ { "std::hash<std::string_view>", kPrivate, "<string_view>", kPublic },
++{ "std::hash<std::thread::id>", kPrivate, "<thread>", kPublic },
+ { "std::hash<std::type_index>", kPrivate, "<typeindex>", kPublic },
+ { "std::hash<std::u16string_view>", kPrivate, "<string_view>", kPublic },
+ { "std::hash<std::u32string_view>", kPrivate, "<string_view>", kPublic },

--- a/ci/test_imagefile
+++ b/ci/test_imagefile
@@ -16,7 +16,8 @@ ENV BASE_ROOT_DIR=${BASE_ROOT_DIR}
 
 # Make retry available in PATH, needed for CI_RETRY_EXE
 COPY ./ci/retry/retry /usr/bin/retry
-COPY ./ci/test/00_setup_env.sh ./${FILE_ENV} ./ci/test/01_base_install.sh ./ci/test/01_iwyu.patch /ci_container_base/ci/test/
+COPY ./ci/test/00_setup_env.sh ./${FILE_ENV} ./ci/test/01_base_install.sh /ci_container_base/ci/test/
+COPY ./ci/test/*.patch /ci_container_base/ci/test/
 
 # Bash is required, so install it when missing
 RUN sh -c "bash -c 'true' || ( apk update && apk add --no-cache bash )"

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -403,4 +403,16 @@ struct CMutableTransaction
 typedef std::shared_ptr<const CTransaction> CTransactionRef;
 template <typename Tx> static inline CTransactionRef MakeTransactionRef(Tx&& txIn) { return std::make_shared<const CTransaction>(std::forward<Tx>(txIn)); }
 
+namespace std {
+/** Disable default std::hash for CTransactionRef to prevent accidentally
+ *  comparing by pointer. Use CTransactionRefHash or provide a custom
+ *  hasher. */
+template <>
+struct hash<CTransactionRef> {
+    hash() = delete;
+    // Belt-and-suspenders, already implied by the above.
+    size_t operator()(const CTransactionRef&) const = delete;
+};
+} // namespace std
+
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H


### PR DESCRIPTION
While working on #33922 I initially forgot to add `CTransactionRefComp` to the `std::unordered_map<CTransactionRef` defined there. This PR turns that into a compiler error. See https://github.com/bitcoin/bitcoin/pull/33922#discussion_r2894597519

This change triggers a false positive IWYU error, and an inconsistent one at that: our CI wants `<variant>`, while a manual build on Ubuntu (version 0.26 with clang version 22.1.1) wants `<string_view>`.

Various workarounds were discussed in:
- https://github.com/include-what-you-use/include-what-you-use/issues/2007
- https://github.com/bitcoin/bitcoin/pull/35073
- https://github.com/bitcoin/bitcoin/pull/33922#discussion_r3100806462

Addressed by back-porting:
- https://github.com/include-what-you-use/include-what-you-use/pull/2013