### PR TITLE
ci, iwyu: Fix warnings in `src/compat/` & `src/support/` and treat them as error

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -209,7 +209,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(((compat|crypto|index|kernel|primitives|univalue/(lib|test)|util|zmq)/.*|common/license_info|node/blockstorage|node/utxo_snapshot|clientversion|core_io|signet)\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/(((compat|crypto|index|kernel|primitives|support|univalue/(lib|test)|util|zmq)/.*|common/license_info|node/blockstorage|node/utxo_snapshot|clientversion|core_io|signet)\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 
@@ -223,6 +223,7 @@ if [[ "${RUN_IWYU}" == true ]]; then
              -Xiwyu --max_line_length=160 \
              -Xiwyu --check_also="*/primitives/*.h" \
              -Xiwyu --check_also="*/compat/*.h" \
+             -Xiwyu --check_also="*/support/*.h" \
              2>&1 | tee /tmp/iwyu_ci.out
     python3 "/include-what-you-use/fix_includes.py" --nosafe_headers < /tmp/iwyu_ci.out
     git diff -U1 | ./contrib/devtools/clang-format-diff.py -binary="clang-format-${IWYU_LLVM_V}" -p1 -i -v

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -209,7 +209,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(((crypto|index|kernel|primitives|univalue/(lib|test)|util|zmq)/.*|common/license_info|node/blockstorage|node/utxo_snapshot|clientversion|core_io|signet)\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/(((compat|crypto|index|kernel|primitives|univalue/(lib|test)|util|zmq)/.*|common/license_info|node/blockstorage|node/utxo_snapshot|clientversion|core_io|signet)\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 
@@ -222,6 +222,7 @@ if [[ "${RUN_IWYU}" == true ]]; then
              -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
              -Xiwyu --max_line_length=160 \
              -Xiwyu --check_also="*/primitives/*.h" \
+             -Xiwyu --check_also="*/compat/*.h" \
              2>&1 | tee /tmp/iwyu_ci.out
     python3 "/include-what-you-use/fix_includes.py" --nosafe_headers < /tmp/iwyu_ci.out
     git diff -U1 | ./contrib/devtools/clang-format-diff.py -binary="clang-format-${IWYU_LLVM_V}" -p1 -i -v

--- a/src/support/allocators/pool.h
+++ b/src/support/allocators/pool.h
@@ -5,17 +5,17 @@
 #ifndef BITCOIN_SUPPORT_ALLOCATORS_POOL_H
 #define BITCOIN_SUPPORT_ALLOCATORS_POOL_H
 
+#include <util/check.h>
+#include <util/overflow.h>
+
+#include <algorithm>
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <list>
 #include <memory>
 #include <new>
 #include <type_traits>
 #include <utility>
-
-#include <util/check.h>
-#include <util/overflow.h>
 
 /**
  * A memory resource similar to std::pmr::unsynchronized_pool_resource, but

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -9,8 +9,11 @@
 #include <support/lockedpool.h>
 #include <support/cleanse.h>
 
+#include <cstddef>
 #include <memory>
+#include <new>
 #include <string>
+#include <utility>
 
 //
 // Allocator that locks its contents from being paged

--- a/src/support/allocators/zeroafterfree.h
+++ b/src/support/allocators/zeroafterfree.h
@@ -8,7 +8,7 @@
 
 #include <support/cleanse.h>
 
-#include <memory>
+#include <cstddef>
 #include <vector>
 
 template <typename T>


### PR DESCRIPTION
This PR [continues](https://github.com/bitcoin/bitcoin/pull/33725#issuecomment-3466897433) the ongoing effort to enforce IWYU warnings.(see https://github.com/bitcoin/bitcoin/pull/35011#issuecomment-4214396321)

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).