### PR TITLE
BIP360 P2MR for Quantum-Resistance Migration: Validation, Policy, and Functional Tests

### DIFF
--- a/src/addresstype.cpp
+++ b/src/addresstype.cpp
@@ -87,6 +87,10 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
         addressRet = tap;
         return true;
     }
+    case TxoutType::WITNESS_V2_P2MR: {
+        addressRet = WitnessUnknown{2, vSolutions[0]};
+        return true;
+    }
     case TxoutType::ANCHOR: {
         addressRet = PayToAnchor();
         return true;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -238,6 +238,13 @@ TxValidationState ValidateInputsStandardness(const CTransaction& tx, const CCoin
             // validation.
             state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "bad-txns-nonstandard-inputs", strprintf("input %u witness program is undefined", i));
             return state;
+        } else if (whichType == TxoutType::WITNESS_V2_P2MR) {
+            // Policy-safety guard: P2MR spends must be evaluated under SCRIPT_VERIFY_P2MR rules.
+            // If the input has no witness, block it early to avoid treating v2 outputs as effectively anyone-can-spend.
+            if (tx.vin[i].scriptWitness.IsNull()) {
+                state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "bad-txns-nonstandard-inputs", strprintf("input %u p2mr witness missing", i));
+                return state;
+            }
         } else if (whichType == TxoutType::SCRIPTHASH) {
             std::vector<std::vector<unsigned char> > stack;
             ScriptError serror;
@@ -345,6 +352,28 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             } else {
                 // 0 stack elements; this is already invalid by consensus rules
                 return false;
+            }
+        }
+
+        // Check policy limits for P2MR spends:
+        // - script-path-only
+        // - No annexes
+        // - MAX_STANDARD_P2MR_STACK_ITEM_SIZE for tapscript leaf spends
+        if (witnessversion == 2 && witnessprogram.size() == WITNESS_V2_P2MR_SIZE && !p2sh) {
+            std::span stack{tx.vin[i].scriptWitness.stack};
+            if (stack.size() < 2) return false;
+            if (!stack.back().empty() && stack.back()[0] == ANNEX_TAG) {
+                // Annexes are nonstandard as long as no semantics are defined for them.
+                return false;
+            }
+            const auto& control_block = SpanPopBack(stack);
+            SpanPopBack(stack); // Ignore script
+            if (control_block.empty()) return false;
+            if ((control_block[0] & 1) != 1) return false;
+            if ((control_block[0] & TAPROOT_LEAF_MASK) == TAPROOT_LEAF_TAPSCRIPT) {
+                for (const auto& item : stack) {
+                    if (item.size() > MAX_STANDARD_P2MR_STACK_ITEM_SIZE) return false;
+                }
             }
         }
     }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -56,6 +56,8 @@ static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS{100};
 static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEM_SIZE{80};
 /** The maximum size in bytes of each witness stack item in a standard BIP 342 script (Taproot, leaf version 0xc0) */
 static constexpr unsigned int MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE{80};
+/** The maximum size in bytes of each witness stack item in a standard BIP 360 draft script (P2MR, leaf version 0xc0) */
+static constexpr unsigned int MAX_STANDARD_P2MR_STACK_ITEM_SIZE{80};
 /** The maximum size in bytes of a standard witnessScript */
 static constexpr unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE{3600};
 /** The maximum size of a standard ScriptSig */
@@ -126,6 +128,7 @@ static constexpr script_verify_flags STANDARD_SCRIPT_VERIFY_FLAGS{MANDATORY_SCRI
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM |
                                                              SCRIPT_VERIFY_WITNESS_PUBKEYTYPE |
                                                              SCRIPT_VERIFY_CONST_SCRIPTCODE |
+                                                             SCRIPT_VERIFY_P2MR |
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION |
                                                              SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS |
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE};

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -509,6 +509,7 @@ static RPCMethod decodescript()
         case TxoutType::SCRIPTHASH:
         case TxoutType::WITNESS_UNKNOWN:
         case TxoutType::WITNESS_V1_TAPROOT:
+        case TxoutType::WITNESS_V2_P2MR:
         case TxoutType::ANCHOR:
             // Should not be wrapped
             return false;
@@ -552,6 +553,7 @@ static RPCMethod decodescript()
             case TxoutType::WITNESS_V0_KEYHASH:
             case TxoutType::WITNESS_V0_SCRIPTHASH:
             case TxoutType::WITNESS_V1_TAPROOT:
+            case TxoutType::WITNESS_V2_P2MR:
             case TxoutType::ANCHOR:
                 // Should not be wrapped
                 return false;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1415,12 +1415,14 @@ void PrecomputedTransactionData::Init(const T& txTo, std::vector<CTxOut>&& spent
     bool uses_bip341_taproot = force;
     for (size_t inpos = 0; inpos < txTo.vin.size() && !(uses_bip143_segwit && uses_bip341_taproot); ++inpos) {
         if (!txTo.vin[inpos].scriptWitness.IsNull()) {
-            if (m_spent_outputs_ready && m_spent_outputs[inpos].scriptPubKey.size() == 2 + WITNESS_V1_TAPROOT_SIZE &&
-                m_spent_outputs[inpos].scriptPubKey[0] == OP_1) {
-                // Treat every witness-bearing spend with 34-byte scriptPubKey that starts with OP_1 as a Taproot
-                // spend. This only works if spent_outputs was provided as well, but if it wasn't, actual validation
-                // will fail anyway. Note that this branch may trigger for scriptPubKeys that aren't actually segwit
-                // but in that case validation will fail as SCRIPT_ERR_WITNESS_UNEXPECTED anyway.
+            int witver;
+            std::vector<unsigned char> witprog;
+            if (m_spent_outputs_ready && m_spent_outputs[inpos].scriptPubKey.IsWitnessProgram(witver, witprog) &&
+                witprog.size() == WITNESS_V1_TAPROOT_SIZE && (witver == 1 || witver == 2)) {
+                // Treat every witness-bearing spend with a 32-byte witness v1/v2 program as Taproot-style
+                // (BIP341/BIP342 common message extension) for sighash precomputation.
+                // This only works if spent_outputs was provided as well, but if it wasn't, actual validation
+                // will fail anyway.
                 uses_bip341_taproot = true;
             } else {
                 // Treat every spend that's not known to native witness v1 as a Witness v0 spend. This branch may
@@ -1900,6 +1902,20 @@ uint256 ComputeTaprootMerkleRoot(std::span<const unsigned char> control, const u
     return k;
 }
 
+static uint256 ComputeMerkleRootFromControlPath(std::span<const unsigned char> control, const uint256& tapleaf_hash, size_t control_base_size)
+{
+    assert(control.size() >= control_base_size);
+    assert((control.size() - control_base_size) % TAPROOT_CONTROL_NODE_SIZE == 0);
+
+    const int path_len = (control.size() - control_base_size) / TAPROOT_CONTROL_NODE_SIZE;
+    uint256 k = tapleaf_hash;
+    for (int i = 0; i < path_len; ++i) {
+        std::span node{control.subspan(control_base_size + TAPROOT_CONTROL_NODE_SIZE * i, TAPROOT_CONTROL_NODE_SIZE)};
+        k = ComputeTapbranchHash(k, node);
+    }
+    return k;
+}
+
 static bool VerifyTaprootCommitment(const std::vector<unsigned char>& control, const std::vector<unsigned char>& program, const uint256& tapleaf_hash)
 {
     assert(control.size() >= TAPROOT_CONTROL_BASE_SIZE);
@@ -1912,6 +1928,14 @@ static bool VerifyTaprootCommitment(const std::vector<unsigned char>& control, c
     const uint256 merkle_root = ComputeTaprootMerkleRoot(control, tapleaf_hash);
     // Verify that the output pubkey matches the tweaked internal pubkey, after correcting for parity.
     return q.CheckTapTweak(p, merkle_root, control[0] & 1);
+}
+
+static bool VerifyP2MRCommitment(const std::vector<unsigned char>& control, const std::vector<unsigned char>& program, const uint256& tapleaf_hash)
+{
+    assert(control.size() >= P2MR_CONTROL_BASE_SIZE);
+    assert(program.size() == uint256::size());
+    const uint256 merkle_root = ComputeMerkleRootFromControlPath(control, tapleaf_hash, P2MR_CONTROL_BASE_SIZE);
+    return std::equal(merkle_root.begin(), merkle_root.end(), program.begin());
 }
 
 static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, const std::vector<unsigned char>& program, script_verify_flags flags, const BaseSignatureChecker& checker, ScriptError* serror, bool is_p2sh)
@@ -1987,6 +2011,49 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
             }
             return set_success(serror);
         }
+    } else if (witversion == 2 && program.size() == WITNESS_V2_P2MR_SIZE && !is_p2sh) {
+        // BIP360 draft P2MR: 32-byte non-P2SH witness v2 program (which encodes a script Merkle root)
+        if (!(flags & SCRIPT_VERIFY_P2MR)) return set_success(serror);
+        if (stack.size() < 2) return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY);
+        if (!stack.back().empty() && stack.back()[0] == ANNEX_TAG) {
+            // Drop annex (this is non-standard; see IsWitnessStandard)
+            const valtype& annex = SpanPopBack(stack);
+            execdata.m_annex_hash = (HashWriter{} << annex).GetSHA256();
+            execdata.m_annex_present = true;
+        } else {
+            execdata.m_annex_present = false;
+        }
+        execdata.m_annex_init = true;
+        if (stack.size() < 2) {
+            return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY);
+        }
+
+        // Script path spending only.
+        const valtype& control = SpanPopBack(stack);
+        const valtype& script = SpanPopBack(stack);
+        if (control.size() < P2MR_CONTROL_BASE_SIZE || control.size() > P2MR_CONTROL_MAX_SIZE || ((control.size() - P2MR_CONTROL_BASE_SIZE) % TAPROOT_CONTROL_NODE_SIZE) != 0) {
+            return set_error(serror, SCRIPT_ERR_TAPROOT_WRONG_CONTROL_SIZE);
+        }
+        // Enforce the P2MR-specific control byte parity requirement.
+        if ((control[0] & 1) != 1) {
+            return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH);
+        }
+        execdata.m_tapleaf_hash = ComputeTapleafHash(control[0] & TAPROOT_LEAF_MASK, script);
+        if (!VerifyP2MRCommitment(control, program, execdata.m_tapleaf_hash)) {
+            return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH);
+        }
+        execdata.m_tapleaf_hash_init = true;
+        if ((control[0] & TAPROOT_LEAF_MASK) == TAPROOT_LEAF_TAPSCRIPT) {
+            // Tapscript (leaf version 0xc0)
+            exec_script = CScript(script.begin(), script.end());
+            execdata.m_validation_weight_left = ::GetSerializeSize(witness.stack) + VALIDATION_WEIGHT_OFFSET;
+            execdata.m_validation_weight_left_init = true;
+            return ExecuteWitnessScript(stack, exec_script, flags, SigVersion::TAPSCRIPT, checker, execdata, serror);
+        }
+        if (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION) {
+            return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION);
+        }
+        return set_success(serror);
     } else if (!is_p2sh && CScript::IsPayToAnchor(witversion, program)) {
         return true;
     } else {
@@ -2187,6 +2254,7 @@ const std::map<std::string, script_verify_flag_name>& ScriptFlagNamesToEnum()
         FLAG_NAME(WITNESS_PUBKEYTYPE),
         FLAG_NAME(CONST_SCRIPTCODE),
         FLAG_NAME(TAPROOT),
+        FLAG_NAME(P2MR),
         FLAG_NAME(DISCOURAGE_UPGRADABLE_PUBKEYTYPE),
         FLAG_NAME(DISCOURAGE_OP_SUCCESS),
         FLAG_NAME(DISCOURAGE_UPGRADABLE_TAPROOT_VERSION),

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -135,6 +135,10 @@ enum class script_verify_flag_name : uint8_t {
     //
     SCRIPT_VERIFY_TAPROOT,
 
+    // P2MR validation (BIP360 draft): witness v2, script-path-only
+    //
+    SCRIPT_VERIFY_P2MR,
+
     // Making unknown Taproot leaf versions non-standard
     //
     SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION,
@@ -237,6 +241,7 @@ struct ScriptExecutionData
 static constexpr size_t WITNESS_V0_SCRIPTHASH_SIZE = 32;
 static constexpr size_t WITNESS_V0_KEYHASH_SIZE = 20;
 static constexpr size_t WITNESS_V1_TAPROOT_SIZE = 32;
+static constexpr size_t WITNESS_V2_P2MR_SIZE = 32;
 
 static constexpr uint8_t TAPROOT_LEAF_MASK = 0xfe;
 static constexpr uint8_t TAPROOT_LEAF_TAPSCRIPT = 0xc0;
@@ -244,6 +249,8 @@ static constexpr size_t TAPROOT_CONTROL_BASE_SIZE = 33;
 static constexpr size_t TAPROOT_CONTROL_NODE_SIZE = 32;
 static constexpr size_t TAPROOT_CONTROL_MAX_NODE_COUNT = 128;
 static constexpr size_t TAPROOT_CONTROL_MAX_SIZE = TAPROOT_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT;
+static constexpr size_t P2MR_CONTROL_BASE_SIZE = 1;
+static constexpr size_t P2MR_CONTROL_MAX_SIZE = P2MR_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT;
 
 extern const HashWriter HASHER_TAPSIGHASH; //!< Hasher with tag "TapSighash" pre-fed to it.
 extern const HashWriter HASHER_TAPLEAF;    //!< Hasher with tag "TapLeaf" pre-fed to it.

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -639,6 +639,7 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
     case TxoutType::NONSTANDARD:
     case TxoutType::NULL_DATA:
     case TxoutType::WITNESS_UNKNOWN:
+    case TxoutType::WITNESS_V2_P2MR:
         return false;
     case TxoutType::PUBKEY:
         if (!CreateSig(creator, sigdata, provider, sig, CPubKey(vSolutions[0]), scriptPubKey, sigversion)) return false;
@@ -784,6 +785,9 @@ bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreato
         if (solved) {
             sigdata.scriptWitness.stack = std::move(result);
         }
+        result.clear();
+    } else if (whichType == TxoutType::WITNESS_V2_P2MR && !P2SH) {
+        sigdata.witness = true;
         result.clear();
     } else if (solved && whichType == TxoutType::WITNESS_UNKNOWN) {
         sigdata.witness = true;

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -28,6 +28,7 @@ std::string GetTxnOutputType(TxoutType t)
     case TxoutType::WITNESS_V0_KEYHASH: return "witness_v0_keyhash";
     case TxoutType::WITNESS_V0_SCRIPTHASH: return "witness_v0_scripthash";
     case TxoutType::WITNESS_V1_TAPROOT: return "witness_v1_taproot";
+    case TxoutType::WITNESS_V2_P2MR: return "witness_v2_p2mr";
     case TxoutType::WITNESS_UNKNOWN: return "witness_unknown";
     } // no default case, so the compiler can warn about missing cases
     assert(false);
@@ -165,6 +166,10 @@ TxoutType Solver(const CScript& scriptPubKey, std::vector<std::vector<unsigned c
         if (witnessversion == 1 && witnessprogram.size() == WITNESS_V1_TAPROOT_SIZE) {
             vSolutionsRet.push_back(std::move(witnessprogram));
             return TxoutType::WITNESS_V1_TAPROOT;
+        }
+        if (witnessversion == 2 && witnessprogram.size() == WITNESS_V2_P2MR_SIZE) {
+            vSolutionsRet.push_back(std::move(witnessprogram));
+            return TxoutType::WITNESS_V2_P2MR;
         }
         if (scriptPubKey.IsPayToAnchor()) {
             return TxoutType::ANCHOR;

--- a/src/script/solver.h
+++ b/src/script/solver.h
@@ -31,6 +31,7 @@ enum class TxoutType {
     WITNESS_V0_SCRIPTHASH,
     WITNESS_V0_KEYHASH,
     WITNESS_V1_TAPROOT,
+    WITNESS_V2_P2MR,
     WITNESS_UNKNOWN, //!< Only for Witness versions not already defined above
 };
 

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -131,6 +131,13 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     BOOST_CHECK(solutions[0] == std::vector<unsigned char>{16});
     BOOST_CHECK(solutions[1] == ToByteVector(uint256::ONE));
 
+    // TxoutType::WITNESS_V2_P2MR
+    s.clear();
+    s << OP_2 << ToByteVector(uint256::ONE);
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::WITNESS_V2_P2MR);
+    BOOST_CHECK_EQUAL(solutions.size(), 1U);
+    BOOST_CHECK(solutions[0] == ToByteVector(uint256::ONE));
+
     // TxoutType::ANCHOR
     s.clear();
     s << OP_1 << ANCHOR_BYTES;
@@ -298,11 +305,18 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
     WitnessUnknown unk_v1{1, ToByteVector(pubkey)};
     BOOST_CHECK(std::get<WitnessUnknown>(address) == unk_v1);
     s.clear();
-    // -> segwit versions 2+ are not specified yet
+    // -> segwit version 2 with 32-byte program (P2MR) currently maps to WitnessUnknown at destination level
+    s << OP_2 << ToByteVector(uint256::ONE);
+    BOOST_CHECK(ExtractDestination(s, address));
+    WitnessUnknown unk_v2{2, ToByteVector(uint256::ONE)};
+    BOOST_CHECK(std::get<WitnessUnknown>(address) == unk_v2);
+
+    s.clear();
+    // -> segwit version 2 with undefined program size
     s << OP_2 << ToByteVector(xpk);
     BOOST_CHECK(ExtractDestination(s, address));
-    WitnessUnknown unk_v2{2, ToByteVector(xpk)};
-    BOOST_CHECK(std::get<WitnessUnknown>(address) == unk_v2);
+    WitnessUnknown unk_v2_unknown_size{2, ToByteVector(xpk)};
+    BOOST_CHECK(std::get<WitnessUnknown>(address) == unk_v2_unknown_size);
 }
 
 BOOST_AUTO_TEST_CASE(script_standard_GetScriptFor_)

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1721,11 +1721,37 @@ BOOST_AUTO_TEST_CASE(compute_tapleaf)
     BOOST_CHECK_EQUAL(ComputeTapleafHash(0xc2, std::span(script)), tlc2);
 }
 
+BOOST_AUTO_TEST_CASE(p2mr_witness_v2_validation)
+{
+    const std::vector<unsigned char> script_bytes{OP_TRUE};
+    const uint256 root = ComputeTapleafHash(TAPROOT_LEAF_TAPSCRIPT, std::span(script_bytes));
+    const CScript script_pubkey = CScript() << OP_2 << ToByteVector(root);
+
+    CScriptWitness witness_ok;
+    witness_ok.stack = {script_bytes, std::vector<unsigned char>{0xc1}};
+
+    ScriptError err;
+    const script_verify_flags flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT | SCRIPT_VERIFY_P2MR;
+    BOOST_CHECK(VerifyScript(CScript{}, script_pubkey, &witness_ok, flags, BaseSignatureChecker{}, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+
+    // Without P2MR verification enabled, v2 witness programs remain forward-compatible.
+    BOOST_CHECK(VerifyScript(CScript{}, script_pubkey, &witness_ok, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT, BaseSignatureChecker{}, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+
+    // P2MR control byte must have parity bit set.
+    CScriptWitness witness_bad_control;
+    witness_bad_control.stack = {script_bytes, std::vector<unsigned char>{0xc0}};
+    BOOST_CHECK(!VerifyScript(CScript{}, script_pubkey, &witness_bad_control, flags, BaseSignatureChecker{}, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH);
+}
+
 BOOST_AUTO_TEST_CASE(formatscriptflags)
 {
     // quick check that FormatScriptFlags reports any unknown/unexpected bits
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2SH), "P2SH");
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_TAPROOT), "P2SH,TAPROOT");
+    BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2MR), "P2MR");
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2SH | script_verify_flags::from_int(1u<<31)), "P2SH,0x80000000");
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_TAPROOT | script_verify_flags::from_int(1u<<27)), "TAPROOT,0x08000000");
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_TAPROOT | script_verify_flags::from_int((1u<<28) | (1ull<<58))), "TAPROOT,0x400000010000000");

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -1306,9 +1306,27 @@ BOOST_AUTO_TEST_CASE(spends_witness_prog)
     tx_spend.vin[0].scriptSig.clear();
     BOOST_CHECK(!::SpendsNonAnchorWitnessProg(CTransaction{tx_spend}, coins));
 
-    // Various undefined version >1 32-byte witness programs.
+    // Version 2 32-byte witness program (P2MR).
     const auto program{ToByteVector(XOnlyPubKey{pubkey})};
-    for (int i{2}; i <= 16; ++i) {
+    tx_create.vout[0].scriptPubKey = GetScriptForDestination(WitnessUnknown{2, program});
+    BOOST_CHECK_EQUAL(Solver(tx_create.vout[0].scriptPubKey, sol_dummy), TxoutType::WITNESS_V2_P2MR);
+    tx_spend.vin[0].prevout.hash = tx_create.GetHash();
+    AddCoins(coins, CTransaction{tx_create}, 0, false);
+    BOOST_CHECK(::SpendsNonAnchorWitnessProg(CTransaction{tx_spend}, coins));
+
+    // It's also detected within P2SH.
+    redeem_script = tx_create.vout[0].scriptPubKey;
+    tx_create.vout[0].scriptPubKey = GetScriptForDestination(ScriptHash(redeem_script));
+    BOOST_CHECK_EQUAL(Solver(tx_create.vout[0].scriptPubKey, sol_dummy), TxoutType::SCRIPTHASH);
+    tx_spend.vin[0].prevout.hash = tx_create.GetHash();
+    tx_spend.vin[0].scriptSig = CScript{} << ToByteVector(redeem_script);
+    AddCoins(coins, CTransaction{tx_create}, 0, false);
+    BOOST_CHECK(::SpendsNonAnchorWitnessProg(CTransaction{tx_spend}, coins));
+    tx_spend.vin[0].scriptSig.clear();
+    BOOST_CHECK(!::SpendsNonAnchorWitnessProg(CTransaction{tx_spend}, coins));
+
+    // Various undefined version >1 32-byte witness programs.
+    for (int i{3}; i <= 16; ++i) {
         tx_create.vout[0].scriptPubKey = GetScriptForDestination(WitnessUnknown{i, program});
         BOOST_CHECK_EQUAL(Solver(tx_create.vout[0].scriptPubKey, sol_dummy), TxoutType::WITNESS_UNKNOWN);
         tx_spend.vin[0].prevout.hash = tx_create.GetHash();

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -94,6 +94,7 @@ IsMineResult LegacyWalletIsMineInnerDONOTUSE(const LegacyDataSPKM& keystore, con
     case TxoutType::NULL_DATA:
     case TxoutType::WITNESS_UNKNOWN:
     case TxoutType::WITNESS_V1_TAPROOT:
+    case TxoutType::WITNESS_V2_P2MR:
     case TxoutType::ANCHOR:
         break;
     case TxoutType::PUBKEY:

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -251,6 +251,7 @@ static OutputType GetOutputType(TxoutType type, bool is_from_p2sh)
 {
     switch (type) {
         case TxoutType::WITNESS_V1_TAPROOT:
+        case TxoutType::WITNESS_V2_P2MR:
             return OutputType::BECH32M;
         case TxoutType::WITNESS_V0_KEYHASH:
         case TxoutType::WITNESS_V0_SCRIPTHASH:

--- a/test/functional/feature_p2mr.py
+++ b/test/functional/feature_p2mr.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test BIP360 draft P2MR mempool policy and script validation."""
+
+from typing import Optional
+
+from test_framework.key import TaggedHash
+from test_framework.messages import (
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    ser_string,
+)
+from test_framework.script import (
+    CScript,
+    LEAF_VERSION_TAPSCRIPT,
+    OP_2,
+    OP_TRUE,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+
+
+class P2MRTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    @staticmethod
+    def p2mr_script_pubkey(script: bytes) -> CScript:
+        # BIP360 draft: witness v2 program commits directly to TapLeaf/TapBranch root.
+        root = TaggedHash("TapLeaf", bytes([LEAF_VERSION_TAPSCRIPT]) + ser_string(script))
+        return CScript([OP_2, root])
+
+    def build_spend(self, *, prev_txid: str, prev_vout: int, prev_value: int, witness_stack: Optional[list[bytes]]) -> CTransaction:
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(prev_txid, 16), prev_vout), nSequence=0xFFFFFFFD)]
+        tx.vout = [CTxOut(prev_value - 1000, self.wallet.get_output_script())]
+        tx.version = 2
+        tx.nLockTime = 0
+        if witness_stack is not None:
+            tx.wit.vtxinwit = [CTxInWitness()]
+            tx.wit.vtxinwit[0].scriptWitness.stack = witness_stack
+        return tx
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+
+        leaf_script = bytes(CScript([OP_TRUE]))
+        p2mr_spk = self.p2mr_script_pubkey(leaf_script)
+
+        self.log.info("Funding a witness-v2 P2MR output")
+        funding = self.wallet.send_to(from_node=node, scriptPubKey=p2mr_spk, amount=50_000, fee=500)
+
+        self.log.info("Missing witness must fail standardness for P2MR")
+        no_witness_tx = self.build_spend(
+            prev_txid=funding["txid"],
+            prev_vout=funding["sent_vout"],
+            prev_value=50_000,
+            witness_stack=None,
+        )
+        res = node.testmempoolaccept([no_witness_tx.serialize().hex()])[0]
+        assert_equal(res["allowed"], False)
+        assert "bad-txns-nonstandard-inputs" in res["reject-reason"]
+
+        self.log.info("Wrong control-byte parity must fail script verification")
+        bad_control_tx = self.build_spend(
+            prev_txid=funding["txid"],
+            prev_vout=funding["sent_vout"],
+            prev_value=50_000,
+            witness_stack=[leaf_script, bytes([LEAF_VERSION_TAPSCRIPT])],  # 0xc0, parity bit unset
+        )
+        res = node.testmempoolaccept([bad_control_tx.serialize().hex()])[0]
+        assert_equal(res["allowed"], False)
+        self.log.info(f"Bad control reject reason: {res['reject-reason']}")
+        assert (
+            "bad-witness-nonstandard" in res["reject-reason"]
+            or "bad-txns-nonstandard-inputs" in res["reject-reason"]
+            or (
+                "mempool-script-verify-flag-failed" in res["reject-reason"]
+                and "Witness program hash mismatch" in res["reject-reason"]
+            )
+            or "witness program is undefined" in res["reject-reason"]
+        )
+
+        self.log.info("Valid P2MR witness must be accepted")
+        good_control = bytes([LEAF_VERSION_TAPSCRIPT | 1])  # 0xc1, parity bit set
+        good_tx = self.build_spend(
+            prev_txid=funding["txid"],
+            prev_vout=funding["sent_vout"],
+            prev_value=50_000,
+            witness_stack=[leaf_script, good_control],
+        )
+        res = node.testmempoolaccept([good_tx.serialize().hex()])[0]
+        assert_equal(res["allowed"], True)
+
+        self.log.info("Submitting valid P2MR spend")
+        txid = node.sendrawtransaction(good_tx.serialize().hex())
+        assert_equal(txid, good_tx.txid_hex)
+
+        self.log.info("Mining block including P2MR spend")
+        self.generate(node, 1)
+
+
+if __name__ == '__main__':
+    P2MRTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -103,6 +103,7 @@ BASE_SCRIPTS = [
     # vv Tests less than 5m vv
     'feature_fee_estimation.py',
     'feature_taproot.py',
+    'feature_p2mr.py',
     'feature_block.py',
     'mempool_ephemeral_dust.py',
     'wallet_conflicts.py',


### PR DESCRIPTION
## Summary
- add BIP360 P2MR script/type/policy plumbing
- add witness-v2 P2MR functional coverage
- fix P2MR control-path merkle parsing in the interpreter

## Key Changes
- script/interpreter: P2MR commitment verification path for witness v2
- policy: standardness and mempool input checks for P2MR spends
- solver/sign/rpc/wallet wiring for the new script type
- tests: unit updates plus `feature_p2mr.py` registered in functional test runner

## Validation
- `ctest --output-on-failure -j6` (pass)
- focused functional tests (pass):
  - `feature_p2mr.py`
  - `feature_taproot.py`
  - `mempool_accept.py`
  - `mempool_packages.py`
  - `mempool_package_limits.py`
- `test_runner.py --extended --jobs=6` (pass; environment-dependent skips only)
- previously skipped actionable tests now enabled and passed:
  - `tool_bench_sanity_check.py`
  - `tool_bitcoin_chainstate.py`
  - `wallet_backwards_compatibility.py`
  - `wallet_migration.py`
  - `mempool_compatibility.py`
  - `feature_coinstatsindex_compatibility.py`
  - `feature_unsupported_utxo_db.py`
