### PR TITLE
net: factor urgency into transaction selection priority

### DIFF
--- a/src/private_broadcast.cpp
+++ b/src/private_broadcast.cpp
@@ -12,7 +12,7 @@ bool PrivateBroadcast::Add(const CTransactionRef& tx)
     EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
 {
     LOCK(m_mutex);
-    const bool inserted{m_transactions.try_emplace(tx).second};
+    const bool inserted{m_transactions.try_emplace(tx, TxBroadcastInfo{.tx = tx}).second};
     return inserted;
 }
 
@@ -110,13 +110,8 @@ std::vector<PrivateBroadcast::TxBroadcastInfo> PrivateBroadcast::GetBroadcastInf
     std::vector<TxBroadcastInfo> entries;
     entries.reserve(m_transactions.size());
 
-    for (const auto& [tx, state] : m_transactions) {
-        std::vector<PeerSendInfo> peers;
-        peers.reserve(state.send_statuses.size());
-        for (const auto& status : state.send_statuses) {
-            peers.emplace_back(PeerSendInfo{.address = status.address, .sent = status.picked, .received = status.confirmed});
-        }
-        entries.emplace_back(TxBroadcastInfo{.tx = tx, .time_added = state.time_added, .peers = std::move(peers)});
+    for (const auto& entry : m_transactions) {
+        entries.emplace_back(entry.second);
     }
 
     return entries;

--- a/src/private_broadcast.cpp
+++ b/src/private_broadcast.cpp
@@ -121,13 +121,19 @@ PrivateBroadcast::Priority PrivateBroadcast::DerivePriority(const std::vector<Se
 {
     Priority p;
     p.num_picked = sent_to.size();
+    if (sent_to.empty()) [[unlikely]] {
+        return p;
+    }
+    NodeClock::time_point oldest_pick{sent_to.front().picked};
     for (const auto& send_status : sent_to) {
         p.last_picked = std::max(p.last_picked, send_status.picked);
+        oldest_pick = std::min(oldest_pick, send_status.picked);
         if (send_status.confirmed.has_value()) {
             ++p.num_confirmed;
             p.last_confirmed = std::max(p.last_confirmed, send_status.confirmed.value());
         }
     }
+    p.urgency = std::chrono::duration_cast<std::chrono::seconds>(NodeClock::now() - oldest_pick);
     return p;
 }
 

--- a/src/private_broadcast.h
+++ b/src/private_broadcast.h
@@ -38,16 +38,24 @@ public:
     /// after it is broadcast, then we consider it stale / for rebroadcasting.
     static constexpr auto STALE_DURATION{1min};
 
-    struct PeerSendInfo {
-        CService address;
-        NodeClock::time_point sent;
-        std::optional<NodeClock::time_point> received;
+    /// Status of a transaction sent to a given node.
+    struct SendStatus {
+        /// Node to which the transaction will be sent (or was sent).
+        const NodeId nodeid;
+        /// Address of the node.
+        const CService address;
+        /// When was the transaction picked for sending to the node.
+        const NodeClock::time_point picked;
+        /// When was the transaction reception confirmed by the node (by PONG).
+        std::optional<NodeClock::time_point> confirmed;
+
+        SendStatus(const NodeId& nodeid, const CService& address, const NodeClock::time_point& picked) : nodeid{nodeid}, address{address}, picked{picked} {}
     };
 
     struct TxBroadcastInfo {
         CTransactionRef tx;
-        NodeClock::time_point time_added;
-        std::vector<PeerSendInfo> peers;
+        const NodeClock::time_point time_added{NodeClock::now()};
+        std::vector<SendStatus> send_statuses{};
     };
 
     /**
@@ -124,20 +132,6 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
 private:
-    /// Status of a transaction sent to a given node.
-    struct SendStatus {
-        /// Node to which the transaction will be sent (or was sent).
-        const NodeId nodeid;
-        /// Address of the node.
-        const CService address;
-        /// When was the transaction picked for sending to the node.
-        const NodeClock::time_point picked;
-        /// When was the transaction reception confirmed by the node (by PONG).
-        std::optional<NodeClock::time_point> confirmed;
-
-        SendStatus(const NodeId& nodeid, const CService& address, const NodeClock::time_point& picked) : nodeid{nodeid}, address{address}, picked{picked} {}
-    };
-
     /// Cumulative stats from all the send attempts for a transaction. Used to prioritize transactions.
     struct Priority {
         size_t num_picked{0}; ///< Number of times the transaction was picked for sending.
@@ -190,12 +184,9 @@ private:
      */
     std::optional<TxAndSendStatusForNode> GetSendStatusByNode(const NodeId& nodeid)
         EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
-    struct TxSendStatus {
-        const NodeClock::time_point time_added{NodeClock::now()};
-        std::vector<SendStatus> send_statuses;
-    };
+
     mutable Mutex m_mutex;
-    std::unordered_map<CTransactionRef, TxSendStatus, CTransactionRefHash, CTransactionRefComp>
+    std::unordered_map<CTransactionRef, TxBroadcastInfo, CTransactionRefHash, CTransactionRefComp>
         m_transactions GUARDED_BY(m_mutex);
 };
 

--- a/src/private_broadcast.h
+++ b/src/private_broadcast.h
@@ -138,14 +138,16 @@ private:
         NodeClock::time_point last_picked{}; ///< The most recent time when the transaction was picked for sending.
         size_t num_confirmed{0}; ///< Number of nodes that have confirmed reception of a transaction (by PONG).
         NodeClock::time_point last_confirmed{}; ///< The most recent time when the transaction was confirmed.
+        std::chrono::seconds urgency{0}; ///< Seconds elapsed since the first pick attempt.
 
         auto operator<=>(const Priority& other) const
         {
             // Invert `other` and `this` in the comparison because smaller num_picked, num_confirmed or
             // earlier times mean greater priority. In other words, if this.num_picked < other.num_picked
-            // then this > other.
-            return std::tie(other.num_picked, other.num_confirmed, other.last_picked, other.last_confirmed) <=>
-                   std::tie(num_picked, num_confirmed, last_picked, last_confirmed);
+            // then this > other. Urgency is placed last so it only breaks ties between transactions
+            // with equal send counts.
+            return std::tie(other.num_picked, other.num_confirmed, other.last_picked, other.last_confirmed, other.urgency) <=>
+                   std::tie(num_picked, num_confirmed, last_picked, last_confirmed, urgency);
         }
     };
 

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -186,12 +186,12 @@ static RPCMethod getprivatebroadcastinfo()
                 o.pushKV("hex", EncodeHexTx(*tx_info.tx));
                 o.pushKV("time_added", TicksSinceEpoch<std::chrono::seconds>(tx_info.time_added));
                 UniValue peers(UniValue::VARR);
-                for (const auto& peer : tx_info.peers) {
+                for (const auto& ss : tx_info.send_statuses) {
                     UniValue p(UniValue::VOBJ);
-                    p.pushKV("address", peer.address.ToStringAddrPort());
-                    p.pushKV("sent", TicksSinceEpoch<std::chrono::seconds>(peer.sent));
-                    if (peer.received.has_value()) {
-                        p.pushKV("received", TicksSinceEpoch<std::chrono::seconds>(*peer.received));
+                    p.pushKV("address", ss.address.ToStringAddrPort());
+                    p.pushKV("sent", TicksSinceEpoch<std::chrono::seconds>(ss.picked));
+                    if (ss.confirmed.has_value()) {
+                        p.pushKV("received", TicksSinceEpoch<std::chrono::seconds>(*ss.confirmed));
                     }
                     peers.push_back(std::move(p));
                 }

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -163,4 +163,76 @@ BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
     BOOST_CHECK_EQUAL(stale_state[0], tx);
 }
 
+BOOST_AUTO_TEST_CASE(urgency_tie_break)
+{
+    NodeClockContext clock_ctx{};
+    PrivateBroadcast pb;
+    in_addr ipv4Addr;
+    ipv4Addr.s_addr = 0xa0b0c001;
+
+    const auto tx1{MakeDummyTx(/*id=*/1, /*num_witness=*/0)};
+    const auto tx2{MakeDummyTx(/*id=*/2, /*num_witness=*/0)};
+    BOOST_REQUIRE(pb.Add(tx1));
+    BOOST_REQUIRE(pb.Add(tx2));
+
+    const CService addr1{ipv4Addr, 1111};
+    const CService addr2{ipv4Addr, 2222};
+    const NodeId node1{1};
+    const NodeId node2{2};
+
+    // Both transactions have the same num_picked (0). The first pick returns tx1.
+    const auto first_pick{pb.PickTxForSend(node1, addr1)};
+    BOOST_REQUIRE(first_pick.has_value());
+    BOOST_CHECK_EQUAL(*first_pick, tx1);
+
+    // Advance time so tx1 has been waiting longer.
+    clock_ctx += 30min;
+
+    // Second pick: tx1 has higher urgency due to time elapsed since first pick,
+    // so tx1 should still be selected over tx2.
+    const auto second_pick{pb.PickTxForSend(node2, addr2)};
+    BOOST_REQUIRE(second_pick.has_value());
+    BOOST_CHECK_EQUAL(*second_pick, tx1);
+}
+
+BOOST_AUTO_TEST_CASE(urgency_secondary_to_send_count)
+{
+    NodeClockContext clock_ctx{};
+    PrivateBroadcast pb;
+    in_addr ipv4Addr;
+    ipv4Addr.s_addr = 0xa0b0c001;
+
+    const auto tx1{MakeDummyTx(/*id=*/1, /*num_witness=*/0)};
+    const auto tx2{MakeDummyTx(/*id=*/2, /*num_witness=*/0)};
+    BOOST_REQUIRE(pb.Add(tx1));
+    BOOST_REQUIRE(pb.Add(tx2));
+
+    const CService addr1{ipv4Addr, 1111};
+    const CService addr2{ipv4Addr, 2222};
+    const CService addr3{ipv4Addr, 3333};
+    const NodeId node1{1};
+    const NodeId node2{2};
+    const NodeId node3{3};
+
+    // First pick: tx1 is returned (no urgency difference yet).
+    const auto first_pick{pb.PickTxForSend(node1, addr1)};
+    BOOST_REQUIRE(first_pick.has_value());
+    BOOST_CHECK_EQUAL(*first_pick, tx1);
+
+    // Advance time significantly.
+    clock_ctx += 60min;
+
+    // Second pick: tx2 has only 0 picks, tx1 has 1 pick.
+    // Even though tx1 has higher urgency, tx2 should still win
+    // because send count takes precedence over urgency.
+    const auto second_pick{pb.PickTxForSend(node2, addr2)};
+    BOOST_REQUIRE(second_pick.has_value());
+    BOOST_CHECK_EQUAL(*second_pick, tx2);
+
+    // Third pick: only tx1 remains, so it should be returned regardless of urgency.
+    const auto third_pick{pb.PickTxForSend(node3, addr3)};
+    BOOST_REQUIRE(third_pick.has_value());
+    BOOST_CHECK_EQUAL(*third_pick, tx1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -52,7 +52,8 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_REQUIRE(tx1->GetWitnessHash() != tx2->GetWitnessHash());
 
     BOOST_CHECK(pb.Add(tx2));
-    const auto find_tx_info{[](auto& infos, const CTransactionRef& tx) -> const PrivateBroadcast::TxBroadcastInfo& {
+    const auto time_added{NodeClock::now()};
+    const auto find_tx_info{[](const auto& infos, const CTransactionRef& tx) -> const PrivateBroadcast::TxBroadcastInfo& {
         const auto it{std::ranges::find(infos, tx->GetWitnessHash(), [](const auto& info) { return info.tx->GetWitnessHash(); })};
         BOOST_REQUIRE(it != infos.end());
         return *it;
@@ -60,8 +61,12 @@ BOOST_AUTO_TEST_CASE(basic)
     const auto check_peer_counts{[&](size_t tx1_peer_count, size_t tx2_peer_count) {
         const auto infos{pb.GetBroadcastInfo()};
         BOOST_CHECK_EQUAL(infos.size(), 2);
-        BOOST_CHECK_EQUAL(find_tx_info(infos, tx1).peers.size(), tx1_peer_count);
-        BOOST_CHECK_EQUAL(find_tx_info(infos, tx2).peers.size(), tx2_peer_count);
+        const auto& tx1_info{find_tx_info(infos, tx1)};
+        const auto& tx2_info{find_tx_info(infos, tx2)};
+        BOOST_CHECK(tx1_info.time_added == time_added);
+        BOOST_CHECK(tx2_info.time_added == time_added);
+        BOOST_CHECK_EQUAL(tx1_info.send_statuses.size(), tx1_peer_count);
+        BOOST_CHECK_EQUAL(tx2_info.send_statuses.size(), tx2_peer_count);
     }};
 
     check_peer_counts(/*tx1_peer_count=*/0, /*tx2_peer_count=*/0);
@@ -109,16 +114,16 @@ BOOST_AUTO_TEST_CASE(basic)
     const auto infos{pb.GetBroadcastInfo()};
     BOOST_CHECK_EQUAL(infos.size(), 2);
     {
-        const auto& peers{find_tx_info(infos, tx_for_recipient1).peers};
-        BOOST_CHECK_EQUAL(peers.size(), 1);
-        BOOST_CHECK_EQUAL(peers[0].address.ToStringAddrPort(), addr1.ToStringAddrPort());
-        BOOST_CHECK(peers[0].received.has_value());
+        const auto& send_statuses{find_tx_info(infos, tx_for_recipient1).send_statuses};
+        BOOST_CHECK_EQUAL(send_statuses.size(), 1);
+        BOOST_CHECK_EQUAL(send_statuses[0].address.ToStringAddrPort(), addr1.ToStringAddrPort());
+        BOOST_CHECK(send_statuses[0].confirmed.has_value());
     }
     {
-        const auto& peers{find_tx_info(infos, tx_for_recipient2).peers};
-        BOOST_CHECK_EQUAL(peers.size(), 1);
-        BOOST_CHECK_EQUAL(peers[0].address.ToStringAddrPort(), addr2.ToStringAddrPort());
-        BOOST_CHECK(!peers[0].received.has_value());
+        const auto& send_statuses{find_tx_info(infos, tx_for_recipient2).send_statuses};
+        BOOST_CHECK_EQUAL(send_statuses.size(), 1);
+        BOOST_CHECK_EQUAL(send_statuses[0].address.ToStringAddrPort(), addr2.ToStringAddrPort());
+        BOOST_CHECK(!send_statuses[0].confirmed.has_value());
     }
 
     const auto stale_state{pb.GetStale()};

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -5,6 +5,7 @@
 #include <primitives/transaction.h>
 #include <private_broadcast.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <util/time.h>
 
 #include <algorithm>
@@ -26,7 +27,7 @@ static CTransactionRef MakeDummyTx(uint32_t id, size_t num_witness)
 
 BOOST_AUTO_TEST_CASE(basic)
 {
-    SetMockTime(Now<NodeSeconds>());
+    NodeClockContext clock_ctx{};
 
     PrivateBroadcast pb;
     const NodeId recipient1{1};
@@ -99,7 +100,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
 
     // 2. Fast-forward the mock clock past the INITIAL_STALE_DURATION.
-    SetMockTime(Now<NodeSeconds>() + PrivateBroadcast::INITIAL_STALE_DURATION + 1min);
+    clock_ctx += PrivateBroadcast::INITIAL_STALE_DURATION + 1min;
 
     // 3. Now that the initial duration has passed, both unconfirmed transactions should be stale.
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 2);
@@ -130,7 +131,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_CHECK_EQUAL(stale_state.size(), 1);
     BOOST_CHECK_EQUAL(stale_state[0], tx_for_recipient2);
 
-    SetMockTime(Now<NodeSeconds>() + 10h);
+    clock_ctx += 10h;
 
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 2);
 
@@ -146,7 +147,7 @@ BOOST_AUTO_TEST_CASE(basic)
 
 BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
 {
-    SetMockTime(Now<NodeSeconds>());
+    NodeClockContext clock_ctx{};
 
     PrivateBroadcast pb;
     const auto tx{MakeDummyTx(/*id=*/42, /*num_witness=*/0)};
@@ -154,9 +155,9 @@ BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
 
     // Unpicked transactions use the longer INITIAL_STALE_DURATION.
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
-    SetMockTime(Now<NodeSeconds>() + PrivateBroadcast::INITIAL_STALE_DURATION - 1min);
+    clock_ctx += PrivateBroadcast::INITIAL_STALE_DURATION - 1min;
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
-    SetMockTime(Now<NodeSeconds>() + 2min);
+    clock_ctx += 2min;
     const auto stale_state{pb.GetStale()};
     BOOST_REQUIRE_EQUAL(stale_state.size(), 1);
     BOOST_CHECK_EQUAL(stale_state[0], tx);


### PR DESCRIPTION
## Problem

  `PickTxForSend()` prioritizes transactions with fewer send attempts. A
  transaction that has been waiting 1 hour with 5 attempts loses to a fresh
  transaction with 1 attempt. This can result in long-waiting transactions
  being perpetually deprioritized.

  ## Solution

  Add an **urgency factor** to the priority function based on elapsed time
  since the first send attempt. Urgency is placed last in the comparison
  tuple so it only breaks ties between transactions with equal send history.

  ## Changes

  - `src/private_broadcast.h`: add `urgency` field to `Priority` struct
  - `src/private_broadcast.cpp`: update `DerivePriority()` to track oldest
    pick time and calculate urgency
  - `src/test/private_broadcast_tests.cpp`: add `urgency_tie_break` and
    `urgency_secondary_to_send_count` test cases

  ## Behavior

  | Scenario | Result |
  |----------|--------|
  | TxA: 5 picks, 60min waiting vs TxB: 1 pick, 0min | TxB wins |
  | TxA: 3 picks, 30min waiting vs TxB: 3 picks, 20min | TxA wins (urgency) |
  | TxA: 0 picks, 10min waiting vs TxB: 0 picks, 0min | TxA wins (urgency) |

  No behavior change for transactions with different send attempt counts.