### PR TITLE
net: factor urgency into transaction selection priority

### DIFF
--- a/src/private_broadcast.cpp
+++ b/src/private_broadcast.cpp
@@ -126,13 +126,19 @@ PrivateBroadcast::Priority PrivateBroadcast::DerivePriority(const std::vector<Se
 {
     Priority p;
     p.num_picked = sent_to.size();
+    if (sent_to.empty()) [[unlikely]] {
+        return p;
+    }
+    NodeClock::time_point oldest_pick{sent_to.front().picked};
     for (const auto& send_status : sent_to) {
         p.last_picked = std::max(p.last_picked, send_status.picked);
+        oldest_pick = std::min(oldest_pick, send_status.picked);
         if (send_status.confirmed.has_value()) {
             ++p.num_confirmed;
             p.last_confirmed = std::max(p.last_confirmed, send_status.confirmed.value());
         }
     }
+    p.urgency = std::chrono::duration_cast<std::chrono::seconds>(NodeClock::now() - oldest_pick);
     return p;
 }
 

--- a/src/private_broadcast.h
+++ b/src/private_broadcast.h
@@ -144,14 +144,16 @@ private:
         NodeClock::time_point last_picked{}; ///< The most recent time when the transaction was picked for sending.
         size_t num_confirmed{0}; ///< Number of nodes that have confirmed reception of a transaction (by PONG).
         NodeClock::time_point last_confirmed{}; ///< The most recent time when the transaction was confirmed.
+        std::chrono::seconds urgency{0}; ///< Seconds elapsed since the first pick attempt.
 
         auto operator<=>(const Priority& other) const
         {
             // Invert `other` and `this` in the comparison because smaller num_picked, num_confirmed or
             // earlier times mean greater priority. In other words, if this.num_picked < other.num_picked
-            // then this > other.
-            return std::tie(other.num_picked, other.num_confirmed, other.last_picked, other.last_confirmed) <=>
-                   std::tie(num_picked, num_confirmed, last_picked, last_confirmed);
+            // then this > other. Urgency is placed last so it only breaks ties between transactions
+            // with equal send counts.
+            return std::tie(other.num_picked, other.num_confirmed, other.last_picked, other.last_confirmed, other.urgency) <=>
+                   std::tie(num_picked, num_confirmed, last_picked, last_confirmed, urgency);
         }
     };
 

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -157,4 +157,78 @@ BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
     BOOST_CHECK_EQUAL(stale_state[0], tx);
 }
 
+BOOST_AUTO_TEST_CASE(urgency_tie_break)
+{
+    SetMockTime(Now<NodeSeconds>());
+
+    PrivateBroadcast pb;
+    in_addr ipv4Addr;
+    ipv4Addr.s_addr = 0xa0b0c001;
+
+    const auto tx1{MakeDummyTx(/*id=*/1, /*num_witness=*/0)};
+    const auto tx2{MakeDummyTx(/*id=*/2, /*num_witness=*/0)};
+    BOOST_REQUIRE(pb.Add(tx1));
+    BOOST_REQUIRE(pb.Add(tx2));
+
+    const CService addr1{ipv4Addr, 1111};
+    const CService addr2{ipv4Addr, 2222};
+    const NodeId node1{1};
+    const NodeId node2{2};
+
+    // Both transactions have the same num_picked (0). The first pick returns tx1.
+    const auto first_pick{pb.PickTxForSend(node1, addr1)};
+    BOOST_REQUIRE(first_pick.has_value());
+    BOOST_CHECK_EQUAL(*first_pick, tx1);
+
+    // Advance time so tx1 has been waiting longer.
+    SetMockTime(Now<NodeSeconds>() + 30min);
+
+    // Second pick: tx1 has higher urgency due to time elapsed since first pick,
+    // so tx1 should still be selected over tx2.
+    const auto second_pick{pb.PickTxForSend(node2, addr2)};
+    BOOST_REQUIRE(second_pick.has_value());
+    BOOST_CHECK_EQUAL(*second_pick, tx1);
+}
+
+BOOST_AUTO_TEST_CASE(urgency_secondary_to_send_count)
+{
+    SetMockTime(Now<NodeSeconds>());
+
+    PrivateBroadcast pb;
+    in_addr ipv4Addr;
+    ipv4Addr.s_addr = 0xa0b0c001;
+
+    const auto tx1{MakeDummyTx(/*id=*/1, /*num_witness=*/0)};
+    const auto tx2{MakeDummyTx(/*id=*/2, /*num_witness=*/0)};
+    BOOST_REQUIRE(pb.Add(tx1));
+    BOOST_REQUIRE(pb.Add(tx2));
+
+    const CService addr1{ipv4Addr, 1111};
+    const CService addr2{ipv4Addr, 2222};
+    const CService addr3{ipv4Addr, 3333};
+    const NodeId node1{1};
+    const NodeId node2{2};
+    const NodeId node3{3};
+
+    // First pick: tx1 is returned (no urgency difference yet).
+    const auto first_pick{pb.PickTxForSend(node1, addr1)};
+    BOOST_REQUIRE(first_pick.has_value());
+    BOOST_CHECK_EQUAL(*first_pick, tx1);
+
+    // Advance time significantly.
+    SetMockTime(Now<NodeSeconds>() + 60min);
+
+    // Second pick: tx2 has only 0 picks, tx1 has 1 pick.
+    // Even though tx1 has higher urgency, tx2 should still win
+    // because send count takes precedence over urgency.
+    const auto second_pick{pb.PickTxForSend(node2, addr2)};
+    BOOST_REQUIRE(second_pick.has_value());
+    BOOST_CHECK_EQUAL(*second_pick, tx2);
+
+    // Third pick: only tx1 remains, so it should be returned regardless of urgency.
+    const auto third_pick{pb.PickTxForSend(node3, addr3)};
+    BOOST_REQUIRE(third_pick.has_value());
+    BOOST_CHECK_EQUAL(*third_pick, tx1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Problem

  PickTxForSend() prioritizes transactions with fewer send attempts. A
  transaction that has been waiting 1 hour with 5 attempts loses to a fresh
  transaction with 1 attempt. This can result in long-waiting transactions
  being perpetually deprioritized.

  ## Solution

  Add an urgency factor to the priority function based on elapsed time
  since the first send attempt. Urgency is placed last in the comparison
  tuple so it only breaks ties between transactions with equal send history.

  ## Changes

  - `src/private_broadcast.h`: add `urgency` field to `Priority` struct
  - `src/private_broadcast.cpp`: update `DerivePriority()` to track oldest
    pick time and calculate urgency
  - `src/test/private_broadcast_tests.cpp`: add `urgency_tie_break` and
    `urgency_secondary_to_send_count` test cases

  ## Behavior

  | Scenario | Result |
  |----------|--------|
  | TxA: 5 picks, 60min waiting vs TxB: 1 pick, 0min | TxB wins |
  | TxA: 3 picks, 30min waiting vs TxB: 3 picks, 20min | TxA wins (urgency) |
  | TxA: 0 picks, 10min waiting vs TxB: 0 picks, 0min | TxA wins (urgency) |

  No behavior change for transactions with different send attempt counts.