### PR TITLE
net: introduce block tracker to retry to download blocks after failure

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   addresstype.cpp
   base58.cpp
   bech32.cpp
+  block_request_tracker.cpp
   chain.cpp
   chainparams.cpp
   chainparamsbase.cpp

--- a/src/block_request_tracker.cpp
+++ b/src/block_request_tracker.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <block_request_tracker.h>
+
+template <typename T, typename V>
+static bool Contains(const T& t, const V& value) { return std::find(t.begin(), t.end(), value) != t.end(); }
+
+bool BlockRequestTracker::track(const uint256& block_hash, std::optional<NodeId> peer_id)
+{
+    LOCK(cs_block_tracker);
+    auto it = m_tracked_blocks.emplace(block_hash, BlockRequest{});
+    if (!it.second) return false; // block already tracked
+
+    if (peer_id) {
+        // Add in-flight request
+        BlockRequest& req = it.first->second;
+        if (Contains(req.in_flight, *peer_id)) {
+            return false; // Already existent request
+        }
+        req.in_flight.emplace_back(*peer_id);
+    } else {
+        // Add block to pending list
+        m_pending.emplace_back(it.first);
+    }
+    return true;
+}
+
+void BlockRequestTracker::untrack_internal(const uint256& block_hash)
+{
+    auto it = m_tracked_blocks.find(block_hash);
+    if (it == m_tracked_blocks.end()) return;
+    auto pending_it = std::remove(m_pending.begin(), m_pending.end(), it);
+    if (pending_it != m_pending.end()) m_pending.erase(pending_it);
+    m_tracked_blocks.erase(it);
+}
+
+void BlockRequestTracker::untrack(const uint256& block_hash)
+{
+    LOCK(cs_block_tracker);
+    untrack_internal(block_hash);
+}
+
+void BlockRequestTracker::untrack_request(NodeId peer_id, const uint256& block_hash)
+{
+    LOCK(cs_block_tracker);
+    // Get tracked block request
+    const auto& it = m_tracked_blocks.find(block_hash);
+    if (it == m_tracked_blocks.end()) return;
+
+    // Check if we were waiting for this peer
+    BlockRequest& request = it->second;
+    auto remove_it = std::remove(request.in_flight.begin(), request.in_flight.end(), peer_id);
+    if (remove_it == request.in_flight.end()) return;
+
+    // Clear request
+    request.in_flight.erase(remove_it);
+
+    // And add it to the pending vector if there are no other inflight request for this block
+    if (request.in_flight.empty() && !Contains(m_pending, it)) {
+        m_pending.emplace_back(it);
+    }
+}
+
+void BlockRequestTracker::for_pending(NodeId peer_id, const std::function<ForPendingStatus(const uint256&)>& check)
+{
+    LOCK(cs_block_tracker);
+
+    for (auto it = m_pending.begin(); it != m_pending.end();) {
+        const auto& pending = *it;
+        switch(check(pending->first)) {
+            case ForPendingStatus::POP: {
+                BlockRequest& request = pending->second;
+                request.in_flight.emplace_back(peer_id);
+                it = m_pending.erase(it);
+                break;
+            }
+            case ForPendingStatus::SKIP:
+                ++it;
+                break;
+            case ForPendingStatus::STOP:
+                return;
+            case ForPendingStatus::CANCEL:
+                untrack_internal(pending->first);
+                ++it;
+                break;
+        }
+    }
+}

--- a/src/block_request_tracker.h
+++ b/src/block_request_tracker.h
@@ -47,7 +47,7 @@ public:
      * Returns false when block is already tracked or when request is
      * already in-flight for 'peer_id'.
      */
-    bool track(const uint256& block_hash, std::optional<NodeId> peer_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+    bool track(const uint256& block_hash, std::optional<NodeId> peer_id=std::nullopt) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
 
     /** Stop tracking the block */
     void untrack(const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);

--- a/src/block_request_tracker.h
+++ b/src/block_request_tracker.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BLOCK_REQUEST_TRACKER_H
+#define BITCOIN_BLOCK_REQUEST_TRACKER_H
+
+#include <chain.h>
+#include <net.h>
+#include <serialize.h>
+#include <util/hasher.h>
+
+#include <list>
+
+/**
+ * Structure in charge of tracking single block downloads progress.
+ * Used to track on-demand block downloads (that aren't part of the automatic download process; for now).
+ */
+class BlockRequestTracker
+{
+private:
+    struct BlockRequest {
+        // The in-flight request vector (preserving insertion order).
+        // Could be empty if:
+        // 1) peer failed to provide us the block and got disconnected.
+        // 2) if there are no available peers to request the block from.
+        // And, only when this is empty, 'm_pending' will contain an entry pointing
+        // to this structure. Which can be assigned to a peer by calling 'pop_pending()'.
+        std::vector<NodeId> in_flight;
+
+        explicit BlockRequest() = default;
+    };
+
+    Mutex cs_block_tracker;
+    // The blocks we are tracking
+    using BlockTrackMap = std::unordered_map<uint256, BlockRequest, BlockHasher>;
+    BlockTrackMap m_tracked_blocks GUARDED_BY(cs_block_tracker);
+    // Block requests waiting for getdata submission
+    std::list<BlockTrackMap::iterator> m_pending;
+
+    void untrack_internal(const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(cs_block_tracker);
+
+public:
+
+    /**
+     * Add block to the tracking list.
+     * Returns false when block is already tracked or when request is
+     * already in-flight for 'peer_id'.
+     */
+    bool track(const uint256& block_hash, std::optional<NodeId> peer_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+
+    /** Stop tracking the block */
+    void untrack(const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+
+    /** Remove request made to peer_id */
+    void untrack_request(NodeId peer_id, const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+
+    /**
+     * Try to pop pending requests and assign them to a certain peer.
+     * The node must send the getdata request after acquiring the pending request.
+     */
+    enum class ForPendingStatus {
+        POP,    // Mark the current pending request as in-flight.
+        SKIP,   // Skip the current pending request.
+        STOP,   // Stop traversing the pending list.
+        CANCEL  // Untrack the request. Remove it from the tracking list.
+    };
+    void for_pending(NodeId peer_id, const std::function<ForPendingStatus(const uint256&)>& check) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+};
+
+#endif // BITCOIN_BLOCK_REQUEST_TRACKER_H

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1969,6 +1969,9 @@ util::Expected<void, std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, co
     // Ignore pre-segwit peers
     if (!CanServeWitnesses(*peer)) return util::Unexpected{"Pre-SegWit peer"};
 
+    // Ignore limited peers
+    if (IsLimitedPeer(*peer) && m_best_height - block_index.nHeight > int{NODE_NETWORK_LIMITED_MIN_BLOCKS}) return util::Unexpected{"Cannot fetch block from a limited peer"};
+
     LOCK(cs_main);
 
     // Forget about all prior requests

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1974,9 +1974,6 @@ util::Expected<void, std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, co
 
     LOCK(cs_main);
 
-    // Forget about all prior requests
-    RemoveBlockRequest(block_index.GetBlockHash(), std::nullopt);
-
     // Mark block as in-flight
     if (!BlockRequested(peer_id, block_index)) return util::Unexpected{"Already requested from this peer"};
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -534,7 +534,7 @@ public:
     /** Implement PeerManager */
     void StartScheduledTasks(CScheduler& scheduler) override;
     void CheckForStaleTipAndEvictPeers() override;
-    util::Expected<void, std::string> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index) override
+    util::Expected<void, std::string> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index, bool retry) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     std::vector<node::TxOrphanage::OrphanInfo> GetOrphanTransactions() override EXCLUSIVE_LOCKS_REQUIRED(!m_tx_download_mutex);
@@ -1996,13 +1996,14 @@ bool PeerManagerImpl::BlockRequestAllowed(const CBlockIndex& block_index)
            (GetBlockProofEquivalentTime(*m_chainman.m_best_header, block_index, *m_chainman.m_best_header, m_chainparams.GetConsensus()) < STALE_RELAY_AGE_LIMIT);
 }
 
-util::Expected<void, std::string> PeerManagerImpl::FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index)
+util::Expected<void, std::string> PeerManagerImpl::FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index, bool retry)
 {
     if (m_chainman.m_blockman.LoadingBlocks()) return util::Unexpected{"Loading blocks ..."};
 
     // If no peer id was specified, track block. The internal block sync process will
     // be in charge of downloading the block.
     if (!op_peer_id) {
+        if (!retry) return util::Unexpected("'retry' disabled, cannot perform single block request"); // future: enable one-try requests.
         if (!m_block_tracker.track(block_index.GetBlockHash())) return util::Unexpected("Already tracked block");
         LogDebug(BCLog::NET, "Block added to the tracking list, hash %s\n", block_index.GetBlockHash().ToString());
         return {};
@@ -2025,8 +2026,8 @@ util::Expected<void, std::string> PeerManagerImpl::FetchBlock(std::optional<Node
     // Mark block as in-flight
     if (!BlockRequested(peer_id, block_index)) return util::Unexpected{"Already requested from this peer"};
 
-    // Track block request
-    m_block_tracker.track(block_index.GetBlockHash(), peer_id);
+    // Track block request (only if requested)
+    if (retry) m_block_tracker.track(block_index.GetBlockHash(), peer_id);
 
     // Construct message to request the block
     const uint256& hash{block_index.GetBlockHash()};

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -534,7 +534,7 @@ public:
     /** Implement PeerManager */
     void StartScheduledTasks(CScheduler& scheduler) override;
     void CheckForStaleTipAndEvictPeers() override;
-    util::Expected<void, std::string> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) override
+    util::Expected<void, std::string> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     std::vector<node::TxOrphanage::OrphanInfo> GetOrphanTransactions() override EXCLUSIVE_LOCKS_REQUIRED(!m_tx_download_mutex);
@@ -1996,9 +1996,19 @@ bool PeerManagerImpl::BlockRequestAllowed(const CBlockIndex& block_index)
            (GetBlockProofEquivalentTime(*m_chainman.m_best_header, block_index, *m_chainman.m_best_header, m_chainparams.GetConsensus()) < STALE_RELAY_AGE_LIMIT);
 }
 
-util::Expected<void, std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, const CBlockIndex& block_index)
+util::Expected<void, std::string> PeerManagerImpl::FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index)
 {
     if (m_chainman.m_blockman.LoadingBlocks()) return util::Unexpected{"Loading blocks ..."};
+
+    // If no peer id was specified, track block. The internal block sync process will
+    // be in charge of downloading the block.
+    if (!op_peer_id) {
+        if (!m_block_tracker.track(block_index.GetBlockHash())) return util::Unexpected("Already tracked block");
+        LogDebug(BCLog::NET, "Block added to the tracking list, hash %s\n", block_index.GetBlockHash().ToString());
+        return {};
+    }
+
+    NodeId peer_id = *op_peer_id;
 
     // Ensure this peer exists and hasn't been disconnected
     PeerRef peer = GetPeerRef(peer_id);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -10,6 +10,7 @@
 #include <banman.h>
 #include <blockencodings.h>
 #include <blockfilter.h>
+#include <block_request_tracker.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <common/bloom.h>
@@ -833,6 +834,13 @@ private:
      */
     std::map<uint256, std::pair<NodeId, bool>> mapBlockSource GUARDED_BY(cs_main);
 
+    /**
+     * Follow block download progress of on-demand block requests.
+     * Enabling the "re-try download from another peer" functionality
+     * when requests fail.
+     */
+    BlockRequestTracker m_block_tracker;
+
     /** Number of peers with wtxid relay. */
     std::atomic<int> m_wtxid_relay_peers{0};
 
@@ -1403,6 +1411,33 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     // Make sure pindexBestKnownBlock is up to date, we'll need it.
     ProcessBlockAvailability(peer.m_id);
 
+    // Go through the on-demand requested blocks first
+    if (!IsLimitedPeer(peer)) {
+        m_block_tracker.for_pending(peer.m_id, [this, &state, count, &vBlocks](const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+            // Don't exceed the amount of blocks that we can request at time
+            if (vBlocks.size() >= count) return BlockRequestTracker::ForPendingStatus::CANCEL;
+
+            const CBlockIndex* index = m_chainman.m_blockman.LookupBlockIndex(block_hash);
+            if (!index) {
+                // We only request blocks we know about but, just in case, log the error and stop tracking block.
+                LogError("Pending block %s not found in block index\n", block_hash.ToString());
+                return BlockRequestTracker::ForPendingStatus::CANCEL;
+            }
+
+            // Check if this peer will be able to provide the block
+            if (state->pindexBestKnownBlock && state->pindexBestKnownBlock->nHeight >= index->nHeight) {
+                vBlocks.emplace_back(index);
+                return BlockRequestTracker::ForPendingStatus::POP;
+            }
+
+            // Continue traversing the requests pending list
+            return BlockRequestTracker::ForPendingStatus::SKIP;
+        });
+
+        // Don't exceed the amount of blocks that we can request at time
+        if (vBlocks.size() >= count) return;
+    }
+
     if (state->pindexBestKnownBlock == nullptr || state->pindexBestKnownBlock->nChainWork < m_chainman.ActiveChain().Tip()->nChainWork || state->pindexBestKnownBlock->nChainWork < m_chainman.MinimumChainWork()) {
         // This peer has nothing interesting.
         return;
@@ -1704,6 +1739,9 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
                 range.first = mapBlocksInFlight.erase(range.first);
             }
         }
+
+        // Untrack request
+        m_block_tracker.untrack_request(nodeid, entry.pindex->GetBlockHash());
     }
     {
         LOCK(m_tx_download_mutex);
@@ -1976,6 +2014,9 @@ util::Expected<void, std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, co
 
     // Mark block as in-flight
     if (!BlockRequested(peer_id, block_index)) return util::Unexpected{"Already requested from this peer"};
+
+    // Track block request
+    m_block_tracker.track(block_index.GetBlockHash(), peer_id);
 
     // Construct message to request the block
     const uint256& hash{block_index.GetBlockHash()};
@@ -4800,6 +4841,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // need it even when it's not a candidate for a new best tip.
             forceProcessing = IsBlockRequested(hash);
             RemoveBlockRequest(hash, pfrom.GetId());
+            m_block_tracker.untrack(hash);
             // mapBlockSource is only used for punishing peers and setting
             // which peers send us compact blocks, so the race between here and
             // cs_main in ProcessNewBlock is fine.

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -105,7 +105,7 @@ public:
      * @param[in]  op_peer_id   The peer id (std::nullopt is equivalent to "any peer")
      * @param[in]  block_index  The blockindex
      */
-    virtual util::Expected<void, std::string> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index) = 0;
+    virtual util::Expected<void, std::string> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index, bool retry) = 0;
 
     /** Begin running background tasks, should only be called once */
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -102,10 +102,10 @@ public:
     /**
      * Attempt to manually fetch block from a given peer. We must already have the header.
      *
-     * @param[in]  peer_id      The peer id
+     * @param[in]  op_peer_id   The peer id (std::nullopt is equivalent to "any peer")
      * @param[in]  block_index  The blockindex
      */
-    virtual util::Expected<void, std::string> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) = 0;
+    virtual util::Expected<void, std::string> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index) = 0;
 
     /** Begin running background tasks, should only be called once */
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -536,6 +536,8 @@ static RPCMethod getblockfrompeer()
             {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash to try to fetch"},
             {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "The peer to fetch it from (see getpeerinfo for peer IDs). "
                         "If omitted, the node will fetch the block from any available peer."},
+            {"retry", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Whether to automatically retry to download the block from different peers if the initial request fails or not. "
+                        "If omitted, the node will continuously attempt to download the block from various peers until it succeeds."},
         },
         RPCResult{RPCResult::Type::OBJ, "", /*optional=*/false, "", {}},
         RPCExamples{
@@ -550,6 +552,8 @@ static RPCMethod getblockfrompeer()
 
     const uint256& block_hash{ParseHashV(request.params[0], "blockhash")};
     const std::optional<NodeId> peer_id = request.params[1].isNull() ? std::nullopt : std::make_optional(request.params[1].getInt<int64_t>());
+    const bool retry = !request.params[2].isNull() ? request.params[2].get_bool() : true; // default true
+    if (!retry && !peer_id) throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot disable the 'retry' process without specifying a peer from which the block will be downloaded ('peer_id')");
 
     const CBlockIndex* const index = WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(block_hash););
 
@@ -568,7 +572,7 @@ static RPCMethod getblockfrompeer()
         throw JSONRPCError(RPC_MISC_ERROR, "Block already downloaded");
     }
 
-    if (const auto res{peerman.FetchBlock(peer_id, *index)}; !res) {
+    if (const auto res{peerman.FetchBlock(peer_id, *index, retry)}; !res) {
         throw JSONRPCError(RPC_MISC_ERROR, res.error());
     }
     return UniValue::VOBJ;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -534,7 +534,8 @@ static RPCMethod getblockfrompeer()
         "Returns an empty JSON object if the request was successfully scheduled.",
         {
             {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash to try to fetch"},
-            {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::NO, "The peer to fetch it from (see getpeerinfo for peer IDs)"},
+            {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "The peer to fetch it from (see getpeerinfo for peer IDs). "
+                        "If omitted, the node will fetch the block from any available peer."},
         },
         RPCResult{RPCResult::Type::OBJ, "", /*optional=*/false, "", {}},
         RPCExamples{
@@ -548,7 +549,7 @@ static RPCMethod getblockfrompeer()
     PeerManager& peerman = EnsurePeerman(node);
 
     const uint256& block_hash{ParseHashV(request.params[0], "blockhash")};
-    const NodeId peer_id{request.params[1].getInt<int64_t>()};
+    const std::optional<NodeId> peer_id = request.params[1].isNull() ? std::nullopt : std::make_optional(request.params[1].getInt<int64_t>());
 
     const CBlockIndex* const index = WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(block_hash););
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -96,6 +96,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getbalance", 2, "include_watchonly" },
     { "getbalance", 3, "avoid_reuse" },
     { "getblockfrompeer", 1, "peer_id" },
+    { "getblockfrompeer", 2, "retry" },
     { "getblockhash", 0, "height" },
     { "waitforblockheight", 0, "height" },
     { "waitforblockheight", 1, "timeout" },

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -205,5 +205,23 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         # Now verify that the block was requested and received from another peer after the initial failure
         self.wait_until(lambda: self.check_for_block(node=2, hash=pruned_block_15), timeout=3)
 
+        #######################################
+        # Test fetching block from "any" peer #
+        #######################################
+
+        self.log.info("Fetch block from \"any\" peer")
+        # Disconnect only connection that can provide the block
+        self.disconnect_nodes(0, 2)
+        self.disconnect_nodes(1, 2)
+
+        # Try to fetch the block from "any" peer. When there is no available peer
+        result = pruned_node.getblockfrompeer(pruned_block_10)
+        assert_equal(result, {})
+
+        # Now connect the full node. The node should automatically request the missing block
+        self.connect_nodes(0, 2)
+        self.wait_until(lambda: self.check_for_block(node=2, hash=pruned_block_10), timeout=5)
+
+
 if __name__ == '__main__':
     GetBlockFromPeerTest(__file__).main()

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -10,6 +10,7 @@ from test_framework.messages import (
     from_hex,
     msg_headers,
     NODE_WITNESS,
+    NODE_NETWORK_LIMITED,
 )
 from test_framework.p2p import (
     P2P_SERVICES,
@@ -154,6 +155,17 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         pruneheight += 250
         assert_equal(pruned_node.pruneblockchain(1000), pruneheight)
         assert_raises_rpc_error(-1, "Block not available (pruned data)", pruned_node.getblock, pruned_block)
+
+        ######################################################
+        # Test reject fetching old block from a limited peer #
+        ######################################################
+
+        self.log.info("Test reject fetching old block from limited peer")
+        pruned_node.add_p2p_connection(P2PInterface(), services=NODE_NETWORK_LIMITED | NODE_WITNESS)
+        limited_peer_id = pruned_node.getpeerinfo()[-1]["id"]  # last connection
+
+        pruned_block_10 = self.nodes[0].getblockhash(10)
+        assert_raises_rpc_error(-1, "Cannot fetch block from a limited peer", pruned_node.getblockfrompeer, pruned_block_10, limited_peer_id)
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -21,6 +21,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
+import time
 
 
 class GetBlockFromPeerTest(BitcoinTestFramework):
@@ -167,6 +168,42 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         pruned_block_10 = self.nodes[0].getblockhash(10)
         assert_raises_rpc_error(-1, "Cannot fetch block from a limited peer", pruned_node.getblockfrompeer, pruned_block_10, limited_peer_id)
 
+        ##############################################################################################
+        # Verify node managing to fetch block from another peer after first peer fails to deliver it #
+        ##############################################################################################
+
+        self.log.info("Try to fetch block from a peer, fail and verify that the node can fetch it from somewhere else")
+
+        # Disconnect only "good" peer that can serve blocks
+        self.disconnect_nodes(0, 2)
+
+        # Set mock time and connect two "bad" peers
+        current_time = int(time.time())
+        for node in self.nodes:
+            node.setmocktime(current_time)
+
+        # Connect a limited peer
+        pruned_node.add_p2p_connection(P2PInterface(), services=NODE_NETWORK_LIMITED | NODE_WITNESS)
+        # Connect second peer that can serve blocks but will not answer to the getdata requests
+        pruned_node.add_p2p_connection(P2PInterface())
+        not_responding_peer_id = pruned_node.getpeerinfo()[-1]["id"]  # last connection
+
+        # Try to fetch block
+        pruned_block_15 = self.nodes[0].getblockhash(15)
+        result = pruned_node.getblockfrompeer(pruned_block_15, not_responding_peer_id)
+        assert_equal(result, {})
+
+        # Connect other full-nodes nodes
+        self.connect_nodes(2, 0)
+        self.connect_nodes(1, 2)
+
+        # Move clock above the block request timeout and assert the initial block fetching failed
+        with pruned_node.assert_debug_log([f"Timeout downloading block {pruned_block_15}, disconnecting peer={not_responding_peer_id}"], timeout=5):
+            for node in self.nodes:
+                node.setmocktime(current_time + 610)
+
+        # Now verify that the block was requested and received from another peer after the initial failure
+        self.wait_until(lambda: self.check_for_block(node=2, hash=pruned_block_15), timeout=3)
 
 if __name__ == '__main__':
     GetBlockFromPeerTest(__file__).main()

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -198,9 +198,10 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         self.connect_nodes(1, 2)
 
         # Move clock above the block request timeout and assert the initial block fetching failed
+        current_time = current_time + 610
         with pruned_node.assert_debug_log([f"Timeout downloading block {pruned_block_15}, disconnecting peer={not_responding_peer_id}"], timeout=5):
             for node in self.nodes:
-                node.setmocktime(current_time + 610)
+                node.setmocktime(current_time)
 
         # Now verify that the block was requested and received from another peer after the initial failure
         self.wait_until(lambda: self.check_for_block(node=2, hash=pruned_block_15), timeout=3)
@@ -210,7 +211,7 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         #######################################
 
         self.log.info("Fetch block from \"any\" peer")
-        # Disconnect only connection that can provide the block
+        # Disconnect only connections that can provide the block
         self.disconnect_nodes(0, 2)
         self.disconnect_nodes(1, 2)
 
@@ -221,6 +222,37 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         # Now connect the full node. The node should automatically request the missing block
         self.connect_nodes(0, 2)
         self.wait_until(lambda: self.check_for_block(node=2, hash=pruned_block_10), timeout=5)
+
+        ##############################################################################
+        # Try to fetch block from certain peer only once, no automatic retry process #
+        ##############################################################################
+
+        self.log.info("Try to fetch block from certain peer only once")
+
+        # Advance peers time so every peer stay responsive
+        current_time = current_time + 60
+        for node in self.nodes:
+            node.setmocktime(current_time)
+
+        # Connect peer that can serve blocks but will not answer to the getdata requests
+        pruned_node.add_p2p_connection(P2PInterface())
+        not_responding_peer_id = pruned_node.getpeerinfo()[-1]["id"]  # last connection
+        # Also connect full node that can serve the block
+        self.connect_nodes(1, 2)
+
+        # Request block with 'retry=false'
+        pruned_block_9 = self.nodes[0].getblockhash(9)
+        result = pruned_node.getblockfrompeer(pruned_block_9, not_responding_peer_id, retry=False)
+        assert_equal(result, {})
+
+        # Move clock above the block request timeout and assert the initial block fetching failed
+        with pruned_node.assert_debug_log([f"Timeout downloading block {pruned_block_9}, disconnecting peer={not_responding_peer_id}"], timeout=5):
+            for node in self.nodes:
+                node.setmocktime(current_time + 610)
+
+        # Sleep for a bit and verify that the block was not requested to any other peer
+        time.sleep(3)
+        self.wait_until(lambda: not self.check_for_block(node=2, hash=pruned_block_9), timeout=3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Revival of closed/stale #27837 . The change is taken (as of b18c72cfcd6f27070928bc0ba16db6897960f211) and rebased to current master. Original description follows.

Coming from #27652, part of #29183.

The general idea is to keep track of the user requested blocks so, in
case of a bad behaving peer or a network disconnection, they can be
fetched from another one automatically without any further user interaction.

This was requested by users because the `getblockfrompeer` RPC command
lacks the functionality to notify them about block request failures or peer
disconnections (which is expected due to the asynchronous nature of the block
requests).

Currently, this new functionality is limited to blocks requested by the
user via the 'getblockfrompeer' RPC command.

In the future, this class could expand its scope and be utilized in the
regular chain synchronization process. Or, even could be employed in
special procedures like a prune node rescan that uses BIP158 block filters,
or even into BIP157 itself.