### PR TITLE
test: NodeClockContext follow-ups

### DIFF
--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -16,6 +16,7 @@
 #include <span.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <uint256.h>
 #include <util/strencodings.h>
 #include <util/time.h>
@@ -37,9 +38,10 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
     CPubKey pubkey{"02ed26169896db86ced4cbb7b3ecef9859b5952825adbeab998fb5b307e54949c9"_hex_u8};
     CScript script = GetScriptForDestination(WitnessV0KeyHash(pubkey));
     std::vector<CMutableTransaction> noTxns;
+    NodeClockContext clock_ctx{};
     for (int i = 0; i < CHAIN_SIZE - 100; i++) {
         test_setup->CreateAndProcessBlock(noTxns, script);
-        SetMockTime(GetTime() + 1);
+        clock_ctx += 1s;
     }
     assert(WITH_LOCK(::cs_main, return test_setup->m_node.chainman->ActiveHeight() == CHAIN_SIZE));
 

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -38,10 +38,10 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
     CPubKey pubkey{"02ed26169896db86ced4cbb7b3ecef9859b5952825adbeab998fb5b307e54949c9"_hex_u8};
     CScript script = GetScriptForDestination(WitnessV0KeyHash(pubkey));
     std::vector<CMutableTransaction> noTxns;
-    NodeClockContext clock_ctx{};
+    FakeNodeClock clock{};
     for (int i = 0; i < CHAIN_SIZE - 100; i++) {
         test_setup->CreateAndProcessBlock(noTxns, script);
-        clock_ctx += 1s;
+        clock += 1s;
     }
     assert(WITH_LOCK(::cs_main, return test_setup->m_node.chainman->ActiveHeight() == CHAIN_SIZE));
 

--- a/src/bench/util_time.cpp
+++ b/src/bench/util_time.cpp
@@ -15,7 +15,7 @@ static void BenchTimeDeprecated(benchmark::Bench& bench)
 
 static void BenchTimeMock(benchmark::Bench& bench)
 {
-    NodeClockContext clock_ctx{111s};
+    FakeNodeClock clock{111s};
     bench.run([&] {
         (void)GetTime<std::chrono::seconds>();
     });

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -33,7 +33,7 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
 
     // Set clock to genesis block, so the descriptors/keys creation time don't interfere with the blocks scanning process.
     // The reason is 'generatetoaddress', which creates a chain with deterministic timestamps in the past.
-    NodeClockContext clock_ctx{test_setup->m_node.chainman->GetParams().GenesisBlock().Time()};
+    FakeNodeClock clock{test_setup->m_node.chainman->GetParams().GenesisBlock().Time()};
     CWallet wallet{test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase()};
     {
         LOCK(wallet.cs_wallet);

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -118,7 +118,7 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
 
     // Set clock to genesis block, so the descriptors/keys creation time don't interfere with the blocks scanning process.
-    NodeClockContext clock_ctx{test_setup->m_node.chainman->GetParams().GenesisBlock().Time()};
+    FakeNodeClock clock{test_setup->m_node.chainman->GetParams().GenesisBlock().Time()};
     CWallet wallet{test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase()};
     {
         LOCK(wallet.cs_wallet);
@@ -173,7 +173,7 @@ static void AvailableCoins(benchmark::Bench& bench, const std::vector<OutputType
 {
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
     // Set clock to genesis block, so the descriptors/keys creation time don't interfere with the blocks scanning process.
-    NodeClockContext clock_ctx{test_setup->m_node.chainman->GetParams().GenesisBlock().Time()};
+    FakeNodeClock clock{test_setup->m_node.chainman->GetParams().GenesisBlock().Time()};
     CWallet wallet{test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase()};
     {
         LOCK(wallet.cs_wallet);

--- a/src/bench/wallet_encrypt.cpp
+++ b/src/bench/wallet_encrypt.cpp
@@ -8,6 +8,7 @@
 #include <random.h>
 #include <support/allocators/secure.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <util/time.h>
 #include <wallet/context.h>
 #include <wallet/test/util.h>
@@ -44,7 +45,7 @@ static void WalletEncrypt(benchmark::Bench& bench, unsigned int key_count)
 
     // Setting a mock time is necessary to force default derive iteration count during
     // wallet encryption.
-    SetMockTime(1);
+    NodeClockContext clock_ctx{1s};
 
     std::unique_ptr<WalletDatabase> database;
     std::shared_ptr<CWallet> wallet;

--- a/src/bench/wallet_encrypt.cpp
+++ b/src/bench/wallet_encrypt.cpp
@@ -45,7 +45,7 @@ static void WalletEncrypt(benchmark::Bench& bench, unsigned int key_count)
 
     // Setting a mock time is necessary to force default derive iteration count during
     // wallet encryption.
-    NodeClockContext clock_ctx{1s};
+    FakeNodeClock clock{1s};
 
     std::unique_ptr<WalletDatabase> database;
     std::shared_ptr<CWallet> wallet;

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
 
 BOOST_AUTO_TEST_CASE(addrman_terrible_many_failures)
 {
-    NodeClockContext clock_ctx{};
+    FakeNodeClock clock{};
 
     auto addrman{std::make_unique<AddrMan>(EMPTY_NETGROUPMAN, DETERMINISTIC, GetCheckRatio(m_node))};
 
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(addrman_terrible_many_failures)
     BOOST_CHECK(addrman->Add({addr}, source));
     BOOST_CHECK(addrman->Good(addr));
 
-    clock_ctx += ADDRMAN_MIN_FAIL + 24h;
+    clock += ADDRMAN_MIN_FAIL + 24h;
 
     CAddress addr_helper{CAddress(ResolveService("251.252.2.3", 8333), NODE_NONE)};
     addr_helper.nTime = Now<NodeSeconds>();
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(addrman_terrible_many_failures)
 
 BOOST_AUTO_TEST_CASE(addrman_penalty_self_announcement)
 {
-    NodeClockContext clock_ctx{};
+    FakeNodeClock clock{};
     auto addrman = std::make_unique<AddrMan>(EMPTY_NETGROUPMAN, DETERMINISTIC, GetCheckRatio(m_node));
 
     const auto base_time{Now<NodeSeconds>() - 10000s};
@@ -1030,8 +1030,8 @@ BOOST_AUTO_TEST_CASE(addrman_evictionworks)
     BOOST_CHECK_EQUAL(addrman->SelectTriedCollision().first.ToStringAddrPort(), "250.1.1.36:0");
 
     // Eviction is also successful if too much time has passed since last try
-    NodeClockContext clock_ctx{};
-    clock_ctx += 4h;
+    FakeNodeClock clock{};
+    clock += 4h;
     addrman->ResolveCollisions();
     BOOST_CHECK(addrman->SelectTriedCollision().first.ToStringAddrPort() == "[::]:0");
     //Now 19 is in tried again, and 36 back to new

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -97,8 +97,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
 
 BOOST_AUTO_TEST_CASE(addrman_terrible_many_failures)
 {
-    auto now = Now<NodeSeconds>();
-    SetMockTime(now - (ADDRMAN_MIN_FAIL + 24h));
+    NodeClockContext clock_ctx{};
 
     auto addrman{std::make_unique<AddrMan>(EMPTY_NETGROUPMAN, DETERMINISTIC, GetCheckRatio(m_node))};
 
@@ -109,7 +108,7 @@ BOOST_AUTO_TEST_CASE(addrman_terrible_many_failures)
     BOOST_CHECK(addrman->Add({addr}, source));
     BOOST_CHECK(addrman->Good(addr));
 
-    SetMockTime(now);
+    clock_ctx += ADDRMAN_MIN_FAIL + 24h;
 
     CAddress addr_helper{CAddress(ResolveService("251.252.2.3", 8333), NODE_NONE)};
     addr_helper.nTime = Now<NodeSeconds>();
@@ -132,7 +131,7 @@ BOOST_AUTO_TEST_CASE(addrman_terrible_many_failures)
 
 BOOST_AUTO_TEST_CASE(addrman_penalty_self_announcement)
 {
-    SetMockTime(Now<NodeSeconds>());
+    NodeClockContext clock_ctx{};
     auto addrman = std::make_unique<AddrMan>(EMPTY_NETGROUPMAN, DETERMINISTIC, GetCheckRatio(m_node));
 
     const auto base_time{Now<NodeSeconds>() - 10000s};

--- a/src/test/banman_tests.cpp
+++ b/src/test/banman_tests.cpp
@@ -17,7 +17,7 @@ BOOST_FIXTURE_TEST_SUITE(banman_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(file)
 {
-    NodeClockContext clock_ctx{777s};
+    FakeNodeClock clock{777s};
     const fs::path banlist_path{m_args.GetDataDirBase() / "banlist_test"};
     {
         const std::string entries_write{

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -70,6 +70,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
 
     auto& chainstate{Assert(m_node.chainman)->ActiveChainstate()};
     BlockValidationState state_dummy{};
+    NodeClockContext clock_ctx{};
 
     // Pop two blocks from the tip
     const CBlockIndex* tip{chainstate.m_chain.Tip()};
@@ -88,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     // The periodic flush interval is between 50 and 70 minutes (inclusive)
     // The next call to a PERIODIC write will flush
-    SetMockTime(GetMockTime() + DATABASE_WRITE_INTERVAL_MAX);
+    clock_ctx += DATABASE_WRITE_INTERVAL_MAX;
 
     const auto sub{std::make_shared<TestSubscriber>()};
     m_node.validation_signals->RegisterSharedValidationInterface(sub);

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -31,7 +31,7 @@ BOOST_FIXTURE_TEST_CASE(chainstate_write_interval, TestingSetup)
     m_node.validation_signals->RegisterSharedValidationInterface(sub);
     auto& chainstate{Assert(m_node.chainman)->ActiveChainstate()};
     BlockValidationState state_dummy{};
-    NodeClockContext clock_ctx{};
+    FakeNodeClock clock{};
 
     // The first periodic flush sets m_next_write and does not flush
     chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
@@ -39,12 +39,12 @@ BOOST_FIXTURE_TEST_CASE(chainstate_write_interval, TestingSetup)
     BOOST_CHECK(!sub->m_did_flush);
 
     // The periodic flush interval is between 50 and 70 minutes (inclusive)
-    clock_ctx += DATABASE_WRITE_INTERVAL_MIN - 1min;
+    clock += DATABASE_WRITE_INTERVAL_MIN - 1min;
     chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(!sub->m_did_flush);
 
-    clock_ctx += DATABASE_WRITE_INTERVAL_MAX;
+    clock += DATABASE_WRITE_INTERVAL_MAX;
     chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(sub->m_did_flush);
@@ -70,7 +70,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
 
     auto& chainstate{Assert(m_node.chainman)->ActiveChainstate()};
     BlockValidationState state_dummy{};
-    NodeClockContext clock_ctx{};
+    FakeNodeClock clock{};
 
     // Pop two blocks from the tip
     const CBlockIndex* tip{chainstate.m_chain.Tip()};
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     // The periodic flush interval is between 50 and 70 minutes (inclusive)
     // The next call to a PERIODIC write will flush
-    clock_ctx += DATABASE_WRITE_INTERVAL_MAX;
+    clock += DATABASE_WRITE_INTERVAL_MAX;
 
     const auto sub{std::make_shared<TestSubscriber>()};
     m_node.validation_signals->RegisterSharedValidationInterface(sub);

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -243,6 +243,7 @@ BOOST_FIXTURE_TEST_CASE(stale_tip_peer_management, OutboundTest)
 BOOST_FIXTURE_TEST_CASE(block_relay_only_eviction, OutboundTest)
 {
     NodeId id{0};
+    NodeClockContext clock_ctx{};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
 
@@ -274,7 +275,6 @@ BOOST_FIXTURE_TEST_CASE(block_relay_only_eviction, OutboundTest)
     }
     BOOST_CHECK(vNodes.back()->fDisconnect == false);
 
-    NodeClockContext clock_ctx{};
     clock_ctx += MINIMUM_CONNECT_TIME;
     peerLogic->CheckForStaleTipAndEvictPeers();
     for (int i = 0; i < max_outbound_block_relay; ++i) {

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -91,8 +91,8 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     }
     connman.FlushSendBuffer(dummyNode1);
 
-    NodeClockContext clock_ctx{};
-    clock_ctx += 21min;
+    FakeNodeClock clock{};
+    clock += 21min;
 
     BOOST_CHECK(peerman.SendMessages(dummyNode1)); // should result in getheaders
     {
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
         BOOST_CHECK(!to_send.empty());
     }
 
-    clock_ctx += 3min;
+    clock += 3min;
     BOOST_CHECK(peerman.SendMessages(dummyNode1)); // should result in disconnect
     BOOST_CHECK(dummyNode1.fDisconnect == true);
 
@@ -153,7 +153,7 @@ BOOST_FIXTURE_TEST_CASE(stale_tip_peer_management, OutboundTest)
     options.m_max_automatic_connections = DEFAULT_MAX_PEER_CONNECTIONS;
 
     const auto time_init{Now<NodeSeconds>()};
-    NodeClockContext clock_ctx{time_init};
+    FakeNodeClock clock{time_init};
     const auto delta{3 * std::chrono::seconds{m_node.chainman->GetConsensus().nPowTargetSpacing} + 1s};
     connman->Init(options);
     std::vector<CNode *> vNodes;
@@ -170,7 +170,7 @@ BOOST_FIXTURE_TEST_CASE(stale_tip_peer_management, OutboundTest)
         BOOST_CHECK(node->fDisconnect == false);
     }
 
-    clock_ctx += delta;
+    clock += delta;
 
     // Now tip should definitely be stale, and we should look for an extra
     // outbound peer
@@ -185,9 +185,9 @@ BOOST_FIXTURE_TEST_CASE(stale_tip_peer_management, OutboundTest)
     // If we add one more peer, something should get marked for eviction
     // on the next check (since we're mocking the time to be in the future, the
     // required time connected check should be satisfied).
-    clock_ctx.set(time_init);
+    clock.set(time_init);
     AddRandomOutboundPeer(id, vNodes, *peerLogic, *connman, ConnectionType::OUTBOUND_FULL_RELAY);
-    clock_ctx += delta;
+    clock += delta;
 
     peerLogic->CheckForStaleTipAndEvictPeers();
     for (int i = 0; i < max_outbound_full_relay; ++i) {
@@ -213,9 +213,9 @@ BOOST_FIXTURE_TEST_CASE(stale_tip_peer_management, OutboundTest)
 
     // Add an onion peer, that will be protected because it is the only one for
     // its network, so another peer gets disconnected instead.
-    clock_ctx.set(time_init);
+    clock.set(time_init);
     AddRandomOutboundPeer(id, vNodes, *peerLogic, *connman, ConnectionType::OUTBOUND_FULL_RELAY, /*onion_peer=*/true);
-    clock_ctx += delta;
+    clock += delta;
     peerLogic->CheckForStaleTipAndEvictPeers();
 
     for (int i = 0; i < max_outbound_full_relay - 2; ++i) {
@@ -226,9 +226,9 @@ BOOST_FIXTURE_TEST_CASE(stale_tip_peer_management, OutboundTest)
     BOOST_CHECK(vNodes[max_outbound_full_relay]->fDisconnect == false);
 
     // Add a second onion peer which won't be protected
-    clock_ctx.set(time_init);
+    clock.set(time_init);
     AddRandomOutboundPeer(id, vNodes, *peerLogic, *connman, ConnectionType::OUTBOUND_FULL_RELAY, /*onion_peer=*/true);
-    clock_ctx += delta;
+    clock += delta;
     peerLogic->CheckForStaleTipAndEvictPeers();
 
     BOOST_CHECK(vNodes.back()->fDisconnect == true);
@@ -243,7 +243,7 @@ BOOST_FIXTURE_TEST_CASE(stale_tip_peer_management, OutboundTest)
 BOOST_FIXTURE_TEST_CASE(block_relay_only_eviction, OutboundTest)
 {
     NodeId id{0};
-    NodeClockContext clock_ctx{};
+    FakeNodeClock clock{};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
 
@@ -275,7 +275,7 @@ BOOST_FIXTURE_TEST_CASE(block_relay_only_eviction, OutboundTest)
     }
     BOOST_CHECK(vNodes.back()->fDisconnect == false);
 
-    clock_ctx += MINIMUM_CONNECT_TIME;
+    clock += MINIMUM_CONNECT_TIME;
     peerLogic->CheckForStaleTipAndEvictPeers();
     for (int i = 0; i < max_outbound_block_relay; ++i) {
         BOOST_CHECK(vNodes[i]->fDisconnect == false);
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(), *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
 
     banman->ClearBanned();
-    const NodeClockContext clock_ctx{}; // keep mocktime constant
+    const FakeNodeClock clock{}; // keep mocktime constant
 
     CAddress addr(ip(0xa0b0c001), NODE_NONE);
     NodeId id{0};

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -117,7 +117,7 @@ FUZZ_TARGET(addrman, .init = initialize_addrman)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     NetGroupManager netgroupman{ConsumeNetGroupManager(fuzzed_data_provider)};
     auto addr_man_ptr = std::make_unique<AddrManDeterministic>(netgroupman, fuzzed_data_provider, GetCheckRatio());
     if (fuzzed_data_provider.ConsumeBool()) {
@@ -202,7 +202,7 @@ FUZZ_TARGET(addrman_serdeser, .init = initialize_addrman)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
 
     NetGroupManager netgroupman{ConsumeNetGroupManager(fuzzed_data_provider)};
     AddrManDeterministic addr_man1{netgroupman, fuzzed_data_provider, GetCheckRatio()};

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -45,7 +45,7 @@ FUZZ_TARGET(banman, .init = initialize_banman)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     fs::path banlist_file = gArgs.GetDataDirNet() / "fuzzed_banlist";
 
     const bool start_with_corrupted_banlist{fuzzed_data_provider.ConsumeBool()};
@@ -125,7 +125,7 @@ FUZZ_TARGET(banman, .init = initialize_banman)
         }
         if (!force_read_and_write_to_err) {
             ban_man.DumpBanlist();
-            clock_ctx.set(ConsumeTime(fuzzed_data_provider));
+            clock.set(ConsumeTime(fuzzed_data_provider));
             banmap_t banmap;
             ban_man.GetBanned(banmap);
             BanMan ban_man_read{banlist_file, /*client_interface=*/nullptr, /*default_ban_time=*/0};

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -42,7 +42,7 @@ void initialize_block_index_tree()
 FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     auto& chainman = static_cast<TestChainstateManager&>(*g_setup->m_node.chainman);
     auto& blockman = static_cast<TestBlockManager&>(chainman.m_blockman);
     CBlockIndex* genesis = chainman.ActiveChainstate().m_chain[0];

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -163,7 +163,7 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 
-    NodeClockContext clock_ctx{1610000000s};
+    FakeNodeClock clock{1610000000s};
 
     auto setup = g_setup;
     auto& mempool = *setup->m_node.mempool;
@@ -453,10 +453,10 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
             [&]() {
                 // Set mock time randomly or to tip's time.
                 if (fuzzed_data_provider.ConsumeBool()) {
-                    clock_ctx.set(ConsumeTime(fuzzed_data_provider));
+                    clock.set(ConsumeTime(fuzzed_data_provider));
                 } else {
                     const NodeSeconds tip_time = WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()->Time());
-                    clock_ctx.set(tip_time);
+                    clock.set(tip_time);
                 }
 
                 sent_net_msg = false;

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -41,7 +41,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     auto netgroupman{ConsumeNetGroupManager(fuzzed_data_provider)};
     auto addr_man_ptr{std::make_unique<AddrManDeterministic>(netgroupman, fuzzed_data_provider, GetCheckRatio())};
     if (fuzzed_data_provider.ConsumeBool()) {

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -60,7 +60,7 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
     CBlockHeader genesis_header{Params().GenesisBlock()};
     CBlockIndex start_index(genesis_header);
 
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast())};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast())};
 
     const uint256 genesis_hash = genesis_header.GetHash();
     start_index.phashBlock = &genesis_hash;

--- a/src/test/fuzz/i2p.cpp
+++ b/src/test/fuzz/i2p.cpp
@@ -27,7 +27,7 @@ FUZZ_TARGET(i2p, .init = initialize_i2p)
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
 
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
 
     // Mock CreateSock() to create FuzzedSock.
     auto CreateSockOrig = CreateSock;

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -29,7 +29,7 @@ void initialize_load_external_block_file()
 FUZZ_TARGET(load_external_block_file, .init = initialize_load_external_block_file)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     FuzzedFileProvider fuzzed_file_provider{fuzzed_data_provider};
     AutoFile fuzzed_block_file{fuzzed_file_provider.open()};
     if (fuzzed_block_file.IsNull()) {

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -49,7 +49,7 @@ FUZZ_TARGET(mini_miner, .init = initialize_miner)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     bilingual_str error;
     CTxMemPool pool{CTxMemPool::Options{}, error};
     Assert(error.empty());

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -32,7 +32,7 @@ void initialize_net()
 FUZZ_TARGET(net, .init = initialize_net)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     CNode node{ConsumeNode(fuzzed_data_provider)};
     node.SetCommonVersion(fuzzed_data_provider.ConsumeIntegral<int>());
     if (const auto service_opt =
@@ -81,7 +81,7 @@ FUZZ_TARGET(net, .init = initialize_net)
 FUZZ_TARGET(local_address, .init = initialize_net)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     CService service{ConsumeService(fuzzed_data_provider)};
     CNode node{ConsumeNode(fuzzed_data_provider)};
     {

--- a/src/test/fuzz/p2p_handshake.cpp
+++ b/src/test/fuzz/p2p_handshake.cpp
@@ -41,7 +41,7 @@ FUZZ_TARGET(p2p_handshake, .init = ::initialize)
     auto& node{g_setup->m_node};
     auto& connman{static_cast<ConnmanTestMsg&>(*node.connman)};
     auto& chainman{static_cast<TestChainstateManager&>(*node.chainman)};
-    NodeClockContext clock_ctx{1610000000s}; // any time to successfully reset ibd
+    FakeNodeClock clock{1610000000s}; // any time to successfully reset ibd
     chainman.ResetIbd();
 
     node.banman.reset();
@@ -80,7 +80,7 @@ FUZZ_TARGET(p2p_handshake, .init = ::initialize)
             continue;
         }
 
-        clock_ctx += std::chrono::seconds{
+        clock += std::chrono::seconds{
                     fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(
                         -std::chrono::seconds{10min}.count(), // Allow mocktime to go backwards slightly
                         std::chrono::seconds{TIMEOUT_INTERVAL}.count()),

--- a/src/test/fuzz/p2p_headers_presync.cpp
+++ b/src/test/fuzz/p2p_headers_presync.cpp
@@ -168,7 +168,7 @@ FUZZ_TARGET(p2p_headers_presync, .init = initialize)
 
     ChainstateManager& chainman = *g_testing_setup->m_node.chainman;
     CBlockHeader base{chainman.GetParams().GenesisBlock()};
-    const NodeClockContext clock_ctx{base.Time()};
+    const FakeNodeClock clock{base.Time()};
 
     LOCK(NetEventsInterface::g_msgproc_mutex);
 

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -48,7 +48,7 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
 
     auto block{ConsumeDeserializable<CBlock>(fuzzed_data_provider, TX_WITH_WITNESS)};
     if (!block || block->vtx.size() == 0 ||

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -83,7 +83,7 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     connman.Reset();
     auto& chainman{static_cast<TestChainstateManager&>(*node.chainman)};
     const auto block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
-    NodeClockContext clock_ctx{1610000000s}; // any time to successfully reset ibd
+    FakeNodeClock clock{1610000000s}; // any time to successfully reset ibd
     chainman.ResetIbd();
     chainman.DisableNextWrite();
 
@@ -116,7 +116,7 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     connman.AddTestNode(p2p_node);
     FillNode(fuzzed_data_provider, connman, p2p_node);
 
-    clock_ctx.set(ConsumeTime(fuzzed_data_provider));
+    clock.set(ConsumeTime(fuzzed_data_provider));
 
     CSerializedNetMsg net_msg;
     net_msg.m_type = random_message_type;

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -72,7 +72,7 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
     connman.Reset();
     auto& chainman{static_cast<TestChainstateManager&>(*node.chainman)};
     const auto block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
-    NodeClockContext clock_ctx{1610000000s}; // any time to successfully reset ibd
+    FakeNodeClock clock{1610000000s}; // any time to successfully reset ibd
     chainman.ResetIbd();
     chainman.DisableNextWrite();
 
@@ -110,7 +110,7 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
     {
         const std::string random_message_type{fuzzed_data_provider.ConsumeBytesAsString(CMessageHeader::MESSAGE_TYPE_SIZE).c_str()};
 
-        clock_ctx.set(ConsumeTime(fuzzed_data_provider));
+        clock.set(ConsumeTime(fuzzed_data_provider));
 
         CSerializedNetMsg net_msg;
         net_msg.m_type = random_message_type;

--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -54,7 +54,7 @@ FUZZ_TARGET(rbf, .init = initialize_rbf)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS);
     if (!mtx) {
         return;
@@ -96,7 +96,7 @@ FUZZ_TARGET(package_rbf, .init = initialize_package_rbf)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
 
     // "Real" virtual size is not important for this test since ConsumeTxMemPoolEntry generates its own virtual size values
     // so we construct small transactions for performance reasons. Child simply needs an input for later to perhaps connect to parent.

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -372,7 +372,7 @@ FUZZ_TARGET(rpc, .init = initialize_rpc)
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     bool good_data{true};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     const std::string rpc_command = fuzzed_data_provider.ConsumeRandomLengthString(64);
     if (!g_limit_to_rpc_command.empty() && rpc_command != g_limit_to_rpc_command) {
         return;

--- a/src/test/fuzz/socks5.cpp
+++ b/src/test/fuzz/socks5.cpp
@@ -31,7 +31,7 @@ void initialize_socks5()
 FUZZ_TARGET(socks5, .init = initialize_socks5)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     ProxyCredentials proxy_credentials;
     proxy_credentials.username = fuzzed_data_provider.ConsumeRandomLengthString(512);
     proxy_credentials.password = fuzzed_data_provider.ConsumeRandomLengthString(512);

--- a/src/test/fuzz/txdownloadman.cpp
+++ b/src/test/fuzz/txdownloadman.cpp
@@ -169,7 +169,7 @@ FUZZ_TARGET(txdownloadman, .init = initialize)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
 
     // Initialize txdownloadman
     bilingual_str error;
@@ -294,7 +294,7 @@ FUZZ_TARGET(txdownloadman_impl, .init = initialize)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
 
     // Initialize a TxDownloadManagerImpl
     bilingual_str error;

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -41,7 +41,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     FastRandomContext orphanage_rng{ConsumeUInt256(fuzzed_data_provider)};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
 
     auto orphanage = node::MakeTxOrphanage();
     std::vector<COutPoint> outpoints; // Duplicates are tolerated
@@ -232,7 +232,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     FastRandomContext orphanage_rng{ConsumeUInt256(fuzzed_data_provider)};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
 
     // We have num_peers peers. Some subset of them will never exceed their reserved weight or announcement count, and
     // should therefore never have any orphans evicted.

--- a/src/test/fuzz/util/check_globals.cpp
+++ b/src/test/fuzz/util/check_globals.cpp
@@ -43,7 +43,7 @@ struct CheckGlobalsImpl {
                          "The current fuzz target accessed system time.\n\n"
 
                          "This is acceptable, but requires the fuzz target to use \n"
-                         "a NodeClockContext, SteadyClockContext or call \n"
+                         "a FakeNodeClock, SteadyClockContext or call \n"
                          "SetMockTime() at the \n" "beginning of processing the \n"
                          "fuzz input.\n\n"
 

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -104,7 +104,7 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider, /*min=*/1296688602)}; // regtest genesis block timestamp
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider, /*min=*/1296688602)}; // regtest genesis block timestamp
     auto& setup{*g_setup};
     bool dirty_chainman{false}; // Reuse the global chainman, but reset it when it is dirty
     auto& chainman{*setup.m_node.chainman};

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -35,7 +35,7 @@ FUZZ_TARGET(utxo_total_supply)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider, /*min=*/1296688602)}; // regtest genesis block timestamp
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider, /*min=*/1296688602)}; // regtest genesis block timestamp
     /** The testing setup that creates a chainman only (no chainstate) */
     ChainTestingSetup test_setup{
         ChainType::REGTEST,

--- a/src/test/fuzz/validation_load_mempool.cpp
+++ b/src/test/fuzz/validation_load_mempool.cpp
@@ -41,7 +41,7 @@ FUZZ_TARGET(validation_load_mempool, .init = initialize_validation_load_mempool)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     FuzzedFileProvider fuzzed_file_provider{fuzzed_data_provider};
 
     bilingual_str error;

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -252,29 +252,29 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     TryAddToMempool(pool, entry.Fee(900LL).FromTx(tx7));
 
     std::vector<CTransactionRef> vtx;
-    NodeClockContext clock_ctx{42s};
+    FakeNodeClock clock{42s};
     constexpr std::chrono::seconds HALFLIFE{CTxMemPool::ROLLING_FEE_HALFLIFE};
-    clock_ctx += HALFLIFE;
+    clock += HALFLIFE;
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + DEFAULT_INCREMENTAL_RELAY_FEE);
     // ... we should keep the same min fee until we get a block
     pool.removeForBlock(vtx, 1);
-    clock_ctx += HALFLIFE;
+    clock += HALFLIFE;
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + DEFAULT_INCREMENTAL_RELAY_FEE)/2.0));
     // ... then feerate should drop 1/2 each halflife
 
-    clock_ctx += HALFLIFE / 2;
+    clock += HALFLIFE / 2;
     BOOST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 5 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + DEFAULT_INCREMENTAL_RELAY_FEE)/4.0));
     // ... with a 1/2 halflife when mempool is < 1/2 its target size
 
-    clock_ctx += HALFLIFE / 4;
+    clock += HALFLIFE / 4;
     BOOST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 9 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + DEFAULT_INCREMENTAL_RELAY_FEE)/8.0));
     // ... with a 1/4 halflife when mempool is < 1/4 its target size
 
-    clock_ctx += 5 * HALFLIFE;
+    clock += 5 * HALFLIFE;
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), DEFAULT_INCREMENTAL_RELAY_FEE);
     // ... but feerate should never drop below DEFAULT_INCREMENTAL_RELAY_FEE
 
-    clock_ctx += HALFLIFE;
+    clock += HALFLIFE;
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 0);
     // ... unless it has gone all the way to 0 (after getting past DEFAULT_INCREMENTAL_RELAY_FEE/2)
 }

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     FillableSigningProvider keystore;
     BOOST_CHECK(keystore.AddKey(key));
 
-    NodeClockContext clock_ctx{};
+    FakeNodeClock clock{};
 
     std::vector<CTransactionRef> orphans_added;
 

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -27,7 +27,7 @@ static CTransactionRef MakeDummyTx(uint32_t id, size_t num_witness)
 
 BOOST_AUTO_TEST_CASE(basic)
 {
-    NodeClockContext clock_ctx{};
+    FakeNodeClock clock{};
 
     PrivateBroadcast pb;
     const NodeId recipient1{1};
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
 
     // 2. Fast-forward the mock clock past the INITIAL_STALE_DURATION.
-    clock_ctx += PrivateBroadcast::INITIAL_STALE_DURATION + 1min;
+    clock += PrivateBroadcast::INITIAL_STALE_DURATION + 1min;
 
     // 3. Now that the initial duration has passed, both unconfirmed transactions should be stale.
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 2);
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_CHECK_EQUAL(stale_state.size(), 1);
     BOOST_CHECK_EQUAL(stale_state[0], tx_for_recipient2);
 
-    clock_ctx += 10h;
+    clock += 10h;
 
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 2);
 
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(basic)
 
 BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
 {
-    NodeClockContext clock_ctx{};
+    FakeNodeClock clock{};
 
     PrivateBroadcast pb;
     const auto tx{MakeDummyTx(/*id=*/42, /*num_witness=*/0)};
@@ -150,9 +150,9 @@ BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
 
     // Unpicked transactions use the longer INITIAL_STALE_DURATION.
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
-    clock_ctx += PrivateBroadcast::INITIAL_STALE_DURATION - 1min;
+    clock += PrivateBroadcast::INITIAL_STALE_DURATION - 1min;
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
-    clock_ctx += 2min;
+    clock += 2min;
     const auto stale_state{pb.GetStale()};
     BOOST_REQUIRE_EQUAL(stale_state.size(), 1);
     BOOST_CHECK_EQUAL(stale_state[0], tx);

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -5,6 +5,7 @@
 #include <primitives/transaction.h>
 #include <private_broadcast.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <util/time.h>
 
 #include <algorithm>
@@ -26,7 +27,7 @@ static CTransactionRef MakeDummyTx(uint32_t id, size_t num_witness)
 
 BOOST_AUTO_TEST_CASE(basic)
 {
-    SetMockTime(Now<NodeSeconds>());
+    NodeClockContext clock_ctx{};
 
     PrivateBroadcast pb;
     const NodeId recipient1{1};
@@ -94,7 +95,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
 
     // 2. Fast-forward the mock clock past the INITIAL_STALE_DURATION.
-    SetMockTime(Now<NodeSeconds>() + PrivateBroadcast::INITIAL_STALE_DURATION + 1min);
+    clock_ctx += PrivateBroadcast::INITIAL_STALE_DURATION + 1min;
 
     // 3. Now that the initial duration has passed, both unconfirmed transactions should be stale.
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 2);
@@ -125,7 +126,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_CHECK_EQUAL(stale_state.size(), 1);
     BOOST_CHECK_EQUAL(stale_state[0], tx_for_recipient2);
 
-    SetMockTime(Now<NodeSeconds>() + 10h);
+    clock_ctx += 10h;
 
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 2);
 
@@ -141,7 +142,7 @@ BOOST_AUTO_TEST_CASE(basic)
 
 BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
 {
-    SetMockTime(Now<NodeSeconds>());
+    NodeClockContext clock_ctx{};
 
     PrivateBroadcast pb;
     const auto tx{MakeDummyTx(/*id=*/42, /*num_witness=*/0)};
@@ -149,9 +150,9 @@ BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
 
     // Unpicked transactions use the longer INITIAL_STALE_DURATION.
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
-    SetMockTime(Now<NodeSeconds>() + PrivateBroadcast::INITIAL_STALE_DURATION - 1min);
+    clock_ctx += PrivateBroadcast::INITIAL_STALE_DURATION - 1min;
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
-    SetMockTime(Now<NodeSeconds>() + 2min);
+    clock_ctx += 2min;
     const auto stale_state{pb.GetStale()};
     BOOST_REQUIRE_EQUAL(stale_state.size(), 1);
     BOOST_CHECK_EQUAL(stale_state[0], tx);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -342,9 +342,9 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
 
     BOOST_CHECK_NO_THROW(CallRPC(std::string("clearbanned")));
 
-    NodeClockContext clock_ctx{10'000s};
+    FakeNodeClock clock{10'000s};
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 127.0.0.0/24 add 200")));
-    clock_ctx += 2s;
+    clock += 2s;
     const int64_t time_remaining_expected{198};
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
     ar = r.get_array();

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -11,6 +11,7 @@
 #include <rpc/util.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <univalue.h>
 #include <util/time.h>
 
@@ -341,10 +342,9 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
 
     BOOST_CHECK_NO_THROW(CallRPC(std::string("clearbanned")));
 
-    auto now = 10'000s;
-    SetMockTime(now);
+    NodeClockContext clock_ctx{10'000s};
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 127.0.0.0/24 add 200")));
-    SetMockTime(now += 2s);
+    clock_ctx += 2s;
     const int64_t time_remaining_expected{198};
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
     ar = r.get_array();
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     const int64_t ban_duration{o1.find_value("ban_duration").getInt<int64_t>()};
     const int64_t time_remaining{o1.find_value("time_remaining").getInt<int64_t>()};
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
-    BOOST_CHECK_EQUAL(banned_until, time_remaining_expected + now.count());
+    BOOST_CHECK_EQUAL(banned_until, time_remaining_expected + TicksSinceEpoch<std::chrono::seconds>(NodeClock::now()));
     BOOST_CHECK_EQUAL(ban_duration, banned_until - ban_created);
     BOOST_CHECK_EQUAL(time_remaining, time_remaining_expected);
 

--- a/src/test/testnet4_miner_tests.cpp
+++ b/src/test/testnet4_miner_tests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(MiningInterface)
 
     // Set node time a few minutes past the testnet4 genesis block
     const auto template_time{3min + WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip()->Time())};
-    NodeClockContext clock_ctx{template_time};
+    FakeNodeClock clock{template_time};
 
     block_template = mining->createNewBlock({}, /*cooldown=*/false);
     BOOST_REQUIRE(block_template);
@@ -57,14 +57,14 @@ BOOST_AUTO_TEST_CASE(MiningInterface)
     BOOST_REQUIRE(should_be_nullptr == nullptr);
 
     // This remains the case when exactly 20 minutes have gone by
-    clock_ctx += 17min;
+    clock += 17min;
     should_be_nullptr = block_template->waitNext(wait_options);
     BOOST_REQUIRE(should_be_nullptr == nullptr);
 
     // One second later the difficulty drops and it returns a new template
     // Note that we can't test the actual difficulty change, because the
     // difficulty is already at 1.
-    clock_ctx += 1s;
+    clock += 1s;
     block_template = block_template->waitNext(wait_options);
     BOOST_REQUIRE(block_template);
 }

--- a/src/test/util/time.h
+++ b/src/test/util/time.h
@@ -44,8 +44,8 @@ public:
     /// Initialize with the given time.
     explicit NodeClockContext(NodeSeconds init_time) { set(init_time); }
     explicit NodeClockContext(std::chrono::seconds init_time) { set(init_time); }
-    /// Initialize with current time, using the next tick to avoid going back by rounding to seconds.
-    explicit NodeClockContext() { set(++Now<NodeSeconds>().time_since_epoch()); }
+    /// Initialize with current time.
+    explicit NodeClockContext() { set(Now<NodeSeconds>()); }
 
     /// Unset mocktime.
     ~NodeClockContext() { set(0s); }

--- a/src/test/util/time.h
+++ b/src/test/util/time.h
@@ -8,10 +8,24 @@
 #include <util/check.h>
 #include <util/time.h>
 
+/// CRTP Helper to limit a class to at most one at a time.
+template <class T>
+class LimitOne
+{
+public:
+    LimitOne() { Assert(g_T_available) = false; }
+    ~LimitOne() { g_T_available = true; }
+    LimitOne(const LimitOne&) = delete;
+    LimitOne& operator=(const LimitOne&) = delete;
+
+private:
+    static inline bool g_T_available{true};
+};
+
 
 /// Helper to initialize the global MockableSteadyClock, let a duration elapse,
 /// and reset it after use in a test.
-class SteadyClockContext
+class SteadyClockContext : public LimitOne<SteadyClockContext>
 {
     MockableSteadyClock::mock_time_point::duration t{MockableSteadyClock::INITIAL_MOCK_TIME};
 
@@ -36,7 +50,7 @@ public:
 
 /// Helper to initialize the global NodeClock, let a duration elapse,
 /// and reset it after use in a test.
-class FakeNodeClock
+class FakeNodeClock : public LimitOne<FakeNodeClock>
 {
     NodeSeconds m_t{std::chrono::seconds::max()};
 

--- a/src/test/util/time.h
+++ b/src/test/util/time.h
@@ -36,22 +36,22 @@ public:
 
 /// Helper to initialize the global NodeClock, let a duration elapse,
 /// and reset it after use in a test.
-class NodeClockContext
+class FakeNodeClock
 {
     NodeSeconds m_t{std::chrono::seconds::max()};
 
 public:
     /// Initialize with the given time.
-    explicit NodeClockContext(NodeSeconds init_time) { set(init_time); }
-    explicit NodeClockContext(std::chrono::seconds init_time) { set(init_time); }
+    explicit FakeNodeClock(NodeSeconds init_time) { set(init_time); }
+    explicit FakeNodeClock(std::chrono::seconds init_time) { set(init_time); }
     /// Initialize with current time.
-    explicit NodeClockContext() { set(Now<NodeSeconds>()); }
+    explicit FakeNodeClock() { set(Now<NodeSeconds>()); }
 
     /// Unset mocktime.
-    ~NodeClockContext() { set(0s); }
+    ~FakeNodeClock() { set(0s); }
 
-    NodeClockContext(const NodeClockContext&) = delete;
-    NodeClockContext& operator=(const NodeClockContext&) = delete;
+    FakeNodeClock(const FakeNodeClock&) = delete;
+    FakeNodeClock& operator=(const FakeNodeClock&) = delete;
 
     /// Set mocktime.
     void set(NodeSeconds t) { SetMockTime(m_t = t); }

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 
 BOOST_AUTO_TEST_CASE(util_mocktime)
 {
-    NodeClockContext clock_ctx{111s};
+    FakeNodeClock clock{111s};
     // Check that mock time does not change after a sleep
     for (const auto& num_sleep : {0ms, 1ms}) {
         UninterruptibleSleep(num_sleep);

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -23,7 +23,7 @@
 using namespace std::chrono_literals;
 
 /// Version of the system clock that is mockable in the context of tests (via
-/// NodeClockContext or ::SetMockTime), otherwise the system clock.
+/// FakeNodeClock or ::SetMockTime), otherwise the system clock.
 struct NodeClock : public std::chrono::system_clock {
     using time_point = std::chrono::time_point<NodeClock>;
     /** Return current system time or mocked time, if set */

--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -63,7 +63,7 @@ FUZZ_TARGET(wallet_fees, .init = initialize_setup)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     auto& node{g_setup->m_node};
     Chainstate* chainstate = &node.chainman->ActiveChainstate();
 

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -93,7 +93,7 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     const auto& node{g_setup->m_node};
     Chainstate& chainstate{node.chainman->ActiveChainstate()};
     std::unique_ptr<CWallet> wallet_ptr{std::make_unique<CWallet>(node.chain.get(), "", CreateMockableWalletDatabase())};
@@ -218,7 +218,7 @@ FUZZ_TARGET(spkm_migration, .init = initialize_spkm_migration)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     const auto& node{g_setup->m_node};
     Chainstate& chainstate{node.chainman->ActiveChainstate()};
 

--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -34,7 +34,7 @@ FUZZ_TARGET(wallet_create_transaction, .init = initialize_setup)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     const auto& node = g_setup->m_node;
     Chainstate& chainstate{node.chainman->ActiveChainstate()};
     ArgsManager& args = *node.args;


### PR DESCRIPTION
Follow-up to #34858

Updates remaining `SetMockTime` call sites that are clean, mechanical swaps fitting the spirit of the original PR (see: https://github.com/bitcoin/bitcoin/pull/34858#pullrequestreview-4031647119 and https://github.com/bitcoin/bitcoin/pull/34858#issuecomment-4221757881). Further updates to `SetMockTime` are more complex and deserve separate, isolated PRs.

The default constructor for `NodeClockContext` increments to the next tick, which is a defensive measure to prevent time going backwards on construction. This has caused some confusion (see thread: https://github.com/bitcoin/bitcoin/pull/34858#discussion_r3057648646) and can be safely removed after updating the only test where this is load-bearing (b3c9bd7f2df230525c8e339394a315a2c500055d) (see: https://github.com/bitcoin/bitcoin/pull/34858#discussion_r3091085328). The removal also tightens the `addrman_tests/addrman_evictionworks` test to sit exactly on the `ADDRMAN_REPLACEMENT` boundary (4h), catching mutations such as:

```diff
diff --git a/src/addrman.cpp b/src/addrman.cpp
index d3dae59ae7..d0929c62cb 100644
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -920,3 +920,3 @@ void AddrManImpl::ResolveCollisions_()
                 // Has successfully connected in last X hours
-                if (current_time - info_old.m_last_success < ADDRMAN_REPLACEMENT) {
+                if (current_time - info_old.m_last_success <= ADDRMAN_REPLACEMENT) {
                     erase_collision = true;
```

The last follow-up item is updating `NodeClockContext` to `FakeNodeClock` to make it clear it is intended for testing (motivated by https://github.com/bitcoin/bitcoin/pull/34858#pullrequestreview-4082110904 and supported in https://github.com/bitcoin/bitcoin/pull/34858#issuecomment-4214352770).