### PR TITLE
wallet: fix abandon crash on inconsistent state

### DIFF
--- a/doc/release-notes-34599.md
+++ b/doc/release-notes-34599.md
@@ -1,0 +1,8 @@
+Wallet
+------
+
+- Fixed an assertion failure in `abandontransaction` that could abort the node
+  when a wallet descendant of the abandoned transaction was concurrently
+  confirmed in a block or in the mempool (e.g. during a chain reorganisation
+  or when RBF candidates share inputs). Such descendants are now left untouched
+  and the abandonment proceeds without crashing. (#34599)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -723,5 +723,50 @@ BOOST_FIXTURE_TEST_CASE(RemoveTxs, TestChain100Setup)
     TestUnloadWallet(std::move(wallet));
 }
 
+// Regression test for https://github.com/bitcoin/bitcoin/issues/34599:
+// AbandonTransaction must not abort if a wallet descendant of the abandoned
+// transaction is in TxStateConfirmed (or TxStateInMempool) while the parent
+// itself is not. The wallet's per-tx state can transiently diverge from the
+// chain, and the lambda inside AbandonTransaction used to assert against that.
+BOOST_FIXTURE_TEST_CASE(abandon_with_confirmed_descendant, WalletTestingSetup)
+{
+    // Parent: a transaction with one spendable output.
+    CMutableTransaction parent_mtx;
+    parent_mtx.vout.emplace_back(1 * COIN, CScript{});
+    const auto parent_ref = MakeTransactionRef(parent_mtx);
+    const Txid parent_hash = parent_ref->GetHash();
+
+    BOOST_REQUIRE(m_wallet.AddToWallet(parent_ref, TxStateInactive{}) != nullptr);
+
+    // Child: spends parent's vout 0. Synthesise a TxStateConfirmed for it -
+    // mirrors the inconsistency the wallet can momentarily reach during
+    // reorgs / RBF candidate tracking.
+    CMutableTransaction child_mtx;
+    child_mtx.vin.emplace_back(parent_hash, /*n=*/0);
+    const auto child_ref = MakeTransactionRef(child_mtx);
+    const Txid child_hash = child_ref->GetHash();
+
+    uint256 fake_block_hash;
+    {
+        LOCK(cs_main);
+        auto inserted = m_node.chainman->BlockIndex().emplace(
+            std::piecewise_construct, std::make_tuple(GetRandHash()), std::make_tuple());
+        BOOST_REQUIRE(inserted.second);
+        fake_block_hash = inserted.first->first;
+        inserted.first->second.phashBlock = &inserted.first->first;
+    }
+    TxStateConfirmed conf{fake_block_hash, /*height=*/0, /*index=*/0};
+    BOOST_REQUIRE(m_wallet.AddToWallet(child_ref, conf) != nullptr);
+
+    // Pre-fix: assert(!wtx.isConfirmed()) inside AbandonTransaction's lambda
+    // would abort the process when the recursive descent reached the child.
+    // Post-fix: AbandonTransaction returns true and leaves the child alone.
+    BOOST_CHECK(m_wallet.AbandonTransaction(parent_hash));
+
+    LOCK(m_wallet.cs_wallet);
+    BOOST_CHECK(m_wallet.mapWallet.at(parent_hash).isAbandoned());
+    BOOST_CHECK(m_wallet.mapWallet.at(child_hash).isConfirmed());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1317,9 +1317,15 @@ bool CWallet::AbandonTransaction(CWalletTx& tx)
     }
 
     auto try_updating_state = [](CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
-        // If the orig tx was not in block/mempool, none of its spends can be.
-        assert(!wtx.isConfirmed());
-        assert(!wtx.InMempool());
+        // A descendant in mapTxSpends may be confirmed or in mempool even when
+        // the parent we are abandoning is not -- e.g. transient state during
+        // reorgs, or RBF candidates that share inputs. Don't abandon those;
+        // halting descent here is safe because we cannot know whether the
+        // descendant's recorded children belong to the same chain that
+        // confirmed it. See issue #34599.
+        if (wtx.isConfirmed() || wtx.InMempool()) {
+            return TxUpdate::UNCHANGED;
+        }
         // If already conflicted or abandoned, no need to set abandoned
         if (!wtx.isBlockConflicted() && !wtx.isAbandoned()) {
             wtx.m_state = TxStateInactive{/*abandoned=*/true};


### PR DESCRIPTION
Fixes #34599.

`CWallet::AbandonTransaction` walks the abandoned tx's descendants
via `mapTxSpends` and asserts that none of them is confirmed or in
the mempool. That holds at the consensus level — if the parent isn't
in the chain, no child can be — but the assertion runs against the
wallet's in-memory per-tx state, which can transiently diverge:

- during reorgs, where per-tx state transitions are processed
  individually and intermediate states are observable;
- around RBF candidates, where multiple wallet wtxs share an input
  outpoint via `mapTxSpends` and so end up linked to the same parent
  output even though only one of them is the "real" descendant.

When the divergence is hit, the node aborts. The fix replaces the
two `assert` calls with a `TxUpdate::UNCHANGED` early-return so the
recursion safely halts at the inconsistent descendant instead of
crashing — preserving the original intent ("don't abandon something
that's confirmed or in mempool") and matching the no-assert pattern
already used by the sibling lambdas in `MarkConflicted`,
`transactionAddedToMempool` and `transactionRemovedFromMempool`.

A new `wallet_tests/abandon_with_confirmed_descendant` unit test
synthesises the inconsistency (parent `TxStateInactive`, child
`TxStateConfirmed` linked via `mapTxSpends`) and exercises the
assertion site directly: pre-fix it aborts, post-fix
`AbandonTransaction` returns `true`, marks the parent abandoned and
leaves the child untouched.

Precedent: PR #31757 / commit 9ef429b6ae fixed an analogous wallet
assertion crash on double block disconnection by handling the
inconsistent-state case rather than relying on the assertion.