### PR TITLE
net: cleanup SOCKS5 auth logging

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -432,7 +432,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             vAuth.push_back(auth->password.size());
             vAuth.insert(vAuth.end(), auth->password.begin(), auth->password.end());
             sock.SendComplete(vAuth, g_socks5_recv_timeout, g_socks5_interrupt);
-            LogDebug(BCLog::PROXY, "SOCKS5 sending proxy authentication %s:%s\n", auth->username, auth->password);
+            LogDebug(BCLog::PROXY, "SOCKS5 sending username/password authentication\n");
             uint8_t pchRetA[2];
             if (InterruptibleRecv(pchRetA, 2, g_socks5_recv_timeout, sock) != IntrRecvError::OK) {
                 LogError("Error reading proxy authentication response\n");

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -431,8 +431,8 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             vAuth.insert(vAuth.end(), auth->username.begin(), auth->username.end());
             vAuth.push_back(auth->password.size());
             vAuth.insert(vAuth.end(), auth->password.begin(), auth->password.end());
-            sock.SendComplete(vAuth, g_socks5_recv_timeout, g_socks5_interrupt);
             LogDebug(BCLog::PROXY, "SOCKS5 sending username/password authentication\n");
+            sock.SendComplete(vAuth, g_socks5_recv_timeout, g_socks5_interrupt);
             uint8_t pchRetA[2];
             if (InterruptibleRecv(pchRetA, 2, g_socks5_recv_timeout, sock) != IntrRecvError::OK) {
                 LogError("Error reading proxy authentication response\n");


### PR DESCRIPTION
`Socks5()` logs the supplied `username` and `password` in `BCLog::PROXY`
when the server selects `USER_PASS`.

Keep the log entry for the auth path, but omit the credentials.
Log the message before sending the authentication data.

No functional behavior change intended.