### PR TITLE
i2p: clean up SESSION CREATE error logging

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -320,7 +320,7 @@ Session::Reply Session::SendRequestAndGetReply(const Sock& sock,
 
     if (check_result_ok && reply.Get("RESULT") != "OK") {
         throw std::runtime_error(
-            strprintf("Unexpected reply to \"%s\": \"%s\"", request, reply.full));
+            strprintf("Unexpected reply to \"%s\": \"%s\"", reply.request, reply.full));
     }
 
     return reply;

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -285,7 +285,7 @@ std::string Session::Reply::Get(const std::string& key) const
     const auto& pos = keys.find(key);
     if (pos == keys.end() || !pos->second.has_value()) {
         throw std::runtime_error(
-            strprintf("Missing %s= in the reply to \"%s\": \"%s\"", key, request, full));
+            strprintf("Missing %s= in the reply to \"%s\"", key, request));
     }
     return pos->second.value();
 }
@@ -320,7 +320,7 @@ Session::Reply Session::SendRequestAndGetReply(const Sock& sock,
 
     if (check_result_ok && reply.Get("RESULT") != "OK") {
         throw std::runtime_error(
-            strprintf("Unexpected reply to \"%s\": \"%s\"", request, reply.full));
+            strprintf("Reply to \"%s\": had a RESULT not equal to OK.", reply.request));
     }
 
     return reply;

--- a/src/test/i2p_tests.cpp
+++ b/src/test/i2p_tests.cpp
@@ -172,4 +172,28 @@ BOOST_AUTO_TEST_CASE(damaged_private_key)
     }
 }
 
+
+BOOST_AUTO_TEST_CASE(session_create_reply_redacts_private_key)
+{
+    CreateSock = [](int, int, int) {
+        return std::make_unique<StaticContentsSock>("HELLO REPLY RESULT=OK VERSION=3.1\n"
+                                                    "SESSION STATUS RESULT=I2P_ERROR MESSAGE=\"oops\"\n");
+    };
+
+    const auto i2p_private_key_file = m_args.GetDataDirNet() / "test_i2p_private_key_redacted";
+    BOOST_REQUIRE(WriteBinaryFile(i2p_private_key_file, "private key marker"));
+
+    auto interrupt{std::make_shared<CThreadInterrupt>()};
+    const CService addr{in6_addr(COMPAT_IN6ADDR_LOOPBACK_INIT), /*port=*/7656};
+    const Proxy sam_proxy{addr, /*tor_stream_isolation=*/false};
+    i2p::sam::Session session(i2p_private_key_file, sam_proxy, interrupt);
+
+    DebugLogHelper log_helper{"Unexpected reply to \"SESSION CREATE ...\"", [](const std::string* line) {
+        return line == nullptr || line->find("DESTINATION=") == std::string::npos;
+    }};
+
+    i2p::Connection conn;
+    BOOST_CHECK(!session.Listen(conn));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Clean up the I2P SAM error path.

`SESSION CREATE` may contain the private key, so the generic SAM reply
error path now reports the redacted request text instead of the full
request. It also avoids echoing raw router replies in those generic
error messages.

No network behavior change intended.