### PR TITLE
btcsignals: delete broken scoped_connection move assignment

### DIFF
--- a/src/btcsignals.h
+++ b/src/btcsignals.h
@@ -120,10 +120,18 @@ class scoped_connection
     connection m_conn;
 
 public:
+    constexpr scoped_connection() noexcept = default;
     scoped_connection(connection rhs) noexcept : m_conn{std::move(rhs)} {}
 
     scoped_connection(scoped_connection&&) noexcept = default;
-    scoped_connection& operator=(scoped_connection&&) noexcept = default;
+    scoped_connection& operator=(scoped_connection&& other) noexcept
+    {
+        if (this != &other) {
+            disconnect();
+            m_conn = std::move(other.m_conn);
+        }
+        return *this;
+    }
 
     /**
      * For simplicity, disable copy assignment and construction.

--- a/src/btcsignals.h
+++ b/src/btcsignals.h
@@ -123,11 +123,11 @@ public:
     scoped_connection(connection rhs) noexcept : m_conn{std::move(rhs)} {}
 
     scoped_connection(scoped_connection&&) noexcept = default;
-    scoped_connection& operator=(scoped_connection&&) noexcept = default;
 
     /**
-     * For simplicity, disable copy assignment and construction.
+     * For simplicity, disable copy construction and copy/move assignment.
      */
+    scoped_connection& operator=(scoped_connection&&) = delete;
     scoped_connection& operator=(const scoped_connection&) = delete;
     scoped_connection(const scoped_connection&) = delete;
 

--- a/src/test/btcsignals_tests.cpp
+++ b/src/test/btcsignals_tests.cpp
@@ -97,6 +97,39 @@ BOOST_AUTO_TEST_CASE(disconnects)
     BOOST_CHECK_EQUAL(val, 6);
 }
 
+/* Move-assigning a scoped_connection should disconnect the old connection.
+ * A default-constructed scoped_connection can be move-assigned into.
+ */
+BOOST_AUTO_TEST_CASE(scoped_connection_move_assignment)
+{
+    btcsignals::signal<void(int&)> sig0;
+    int val{0};
+
+    // Default-construct, then move-assign a real connection into it.
+    btcsignals::scoped_connection sc0;
+    sc0 = btcsignals::scoped_connection{sig0.connect(IncrementCallback)};
+    sig0(val);
+    BOOST_CHECK_EQUAL(val, 1);
+
+    // Move-assign sc0 to hold a different connection.
+    // The old callback (IncrementCallback) should be disconnected.
+    btcsignals::scoped_connection sc1 = sig0.connect(SquareCallback);
+    sc0 = std::move(sc1);
+
+    val = 3;
+    sig0(val);
+    // If the old connection was properly disconnected, only SquareCallback runs.
+    BOOST_CHECK_EQUAL(val, 9);
+
+    // Self-move-assignment should be safe. Use a reference to avoid
+    // a -Wself-move warning.
+    auto& ref = sc0;
+    sc0 = std::move(ref);
+    val = 3;
+    sig0(val);
+    BOOST_CHECK_EQUAL(val, 9);
+}
+
 /* Check that move-only return types work correctly
  */
 BOOST_AUTO_TEST_CASE(moveonly_return)


### PR DESCRIPTION
The defaulted move-assignment operator for `scoped_connection` overwrites `m_conn` without first calling `disconnect()`. Since disconnection is signaled via the liveness flag (which is never cleared) the old callback remains registered in the signal and keeps firing, violating the RAII contract:

```cpp
int val{0};
btcsignals::scoped_connection sc0 = sig.connect(IncrementCallback);
btcsignals::scoped_connection sc1 = sig.connect(SquareCallback);
sc0 = std::move(sc1);
val = 3; sig(val);
// Expected: 9 (only SquareCallback)
// Actual:  16 (both callbacks fire, old connection leaked)
```

Move assignment is unused in the codebase, so following the review discussion this deletes the broken operator instead of fixing it. A correct implementation can be added if a use case arises.

Earlier versions of this PR fixed the operator and added a default constructor to enable the member-variable assignment pattern; that was dropped in favor of removing the unused operation.