### PR TITLE
fuzz: remove redundant CScript method calls from script harness

### DIFF
--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -93,13 +93,6 @@ FUZZ_TARGET(script, .init = initialize_script)
     std::vector<std::vector<unsigned char>> solutions;
     (void)Solver(script, solutions);
 
-    (void)script.HasValidOps();
-    (void)script.IsPayToAnchor();
-    (void)script.IsPayToScriptHash();
-    (void)script.IsPayToWitnessScriptHash();
-    (void)script.IsPushOnly();
-    (void)script.GetSigOpCount(/* fAccurate= */ false);
-
     {
         const std::vector<uint8_t> bytes = ConsumeRandomLengthByteVector(fuzzed_data_provider);
         CompressedScript compressed_script;

--- a/src/test/fuzz/script_ops.cpp
+++ b/src/test/fuzz/script_ops.cpp
@@ -48,6 +48,7 @@ FUZZ_TARGET(script_ops)
     (void)script.GetSigOpCount(script);
     (void)script.HasValidOps();
     (void)script.IsPayToScriptHash();
+    (void)script.IsPayToAnchor();
     (void)script.IsPayToWitnessScriptHash();
     (void)script.IsPushOnly();
     (void)script.IsUnspendable();


### PR DESCRIPTION
The script harness was calling `GetSigOpCount`, `HasValidOps`, `IsPayToAnchor`, `IsPayToScriptHash`, `IsPayToWitnessScriptHash`, and `IsPushOnly` on the fuzzed CScript. All of these are already covered by the `script_ops` harness, which is the dedicated harness for CScript member methods. Also, add the missing `IsPayToAnchor` call to `script_ops` so the move preserves coverage.
