### PR TITLE
doc: update release process to mention security advisories pre-announcements

### DIFF
--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -20,6 +20,15 @@ To receive security and update notifications, please subscribe to:
 
   <https://bitcoincore.org/en/list/announcements/join/>
 
+With the release of this new major version, versions *version minus 3* and
+older are at "End of Life" and will no longer receive updates.
+
+In accordance with the security policy, we will in two weeks disclose:
+
+* Medium and high severity vulnerabilities fixed in *version minus 2*. There are N of these.
+
+* Low severity vulnerabilities fixed in *version*. There are M of these.
+
 How to Upgrade
 ==============
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -25,6 +25,7 @@ Release Process
   - set `CLIENT_VERSION_MINOR` to `0`
   - set `CLIENT_VERSION_BUILD` to `0`
   - set `CLIENT_VERSION_IS_RELEASE` to `true`
+* Check with the security team whether there is any security advisory to pre-announce.
 
 #### Before branch-off
 
@@ -296,7 +297,7 @@ cat "$VERSION"/*/all.SHA256SUMS.asc > SHA256SUMS.asc
 
   - Create a [new GitHub release](https://github.com/bitcoin/bitcoin/releases/new) with a link to the archived release notes
 
-- Announce the release:
+- Announce the release, along with any security advisory pre-announcements:
 
   - bitcoin-dev and bitcoin-core-dev mailing list
 


### PR DESCRIPTION
We missed a pre-announcement with the release of 31.0. This updates the release process docs to make sure we check those before publishing a major release.