### PR TITLE
Fix compilation errors on macOS 15 by adding explicit constructors

### DIFF
--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -956,6 +956,8 @@ static RPCMethod gettxspendingprevout()
             struct Entry {
                 COutPoint outpoint;
                 const UniValue* raw;
+                Entry(COutPoint _outpoint, const UniValue* _raw)
+                    : outpoint(std::move(_outpoint)), raw(_raw) {}
             };
             std::vector<Entry> prevouts_to_process;
             prevouts_to_process.reserve(output_params.size());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2990,6 +2990,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
 struct ConnectedBlock {
     const CBlockIndex* pindex;
     std::shared_ptr<const CBlock> pblock;
+    ConnectedBlock(const CBlockIndex* _pindex, std::shared_ptr<const CBlock> _pblock)
+        : pindex(_pindex), pblock(std::move(_pblock)) {}
 };
 
 /**


### PR DESCRIPTION
On macOS 15, with clang version 15.0.0, compilation was failing at mempool.cpp and validation.cpp. Adding explicit constructors to the `ConnectedBlock` and `Entry` structs appears to have remedied that.
