### PR TITLE
doc: fix stale autotools reference and SQLite typo

### DIFF
--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -15,7 +15,7 @@ The example commands below use `pkgin`.
 pkgin install git cmake pkg-config boost libevent
 ```
 
-NetBSD currently ships with an older version of `gcc` than is needed to build. You should upgrade your `gcc` and then pass this new version to the configure script.
+NetBSD currently ships with an older version of `gcc` than is needed to build. You should upgrade your `gcc` and then pass this new version to the CMake configuration.
 
 For example, grab `gcc12`:
 ```

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -139,7 +139,7 @@ It is required that you have `python` and `zip` installed.
 
 There are many ways to configure Bitcoin Core, here are a few common examples:
 
-##### Wallet (only SQlite) and GUI Support:
+##### Wallet and GUI:
 
 This enables the GUI.
 If `sqlite` or `qt` are not installed, this will throw an error.


### PR DESCRIPTION
Two small documentation fixes:

- `doc/build-netbsd.md`: Replace "configure script" with "CMake configuration". The build system was migrated from autotools to CMake, but this sentence still referred to the old `./configure` workflow while the code example right below it already uses `cmake -B build`.

- `doc/build-osx.md`: Fix capitalization of `SQlite` → `SQLite` in a section heading.