### PR TITLE
doc: add missed advisory to 31.0 rel notes

### DIFF
--- a/doc/release-notes/release-notes-31.0.md
+++ b/doc/release-notes/release-notes-31.0.md
@@ -16,6 +16,16 @@ To receive security and update notifications, please subscribe to:
 
   <https://bitcoincore.org/en/list/announcements/join/>
 
+
+With the release of this new major version, versions `28.x` and
+older are at "End of Life" and will no longer receive updates.
+
+In accordance with the security policy, we will in two weeks disclose:
+
+* Medium and high severity vulnerabilities fixed in `29.0`. There is one of these.
+
+* Low severity vulnerabilities fixed in `31.0`. There are none of these.
+
 How to Upgrade
 ==============
 


### PR DESCRIPTION
Generally we don't post-amend release notes, but we can add the missing EOL security advisory here.
See https://github.com/bitcoin-core/bitcoincore.org/pull/1240 and https://github.com/bitcoin/bitcoin/pull/35132. 