### PR TITLE
test: Add thread-safe fast-failing test macros

### DIFF
--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -45,8 +45,8 @@ BOOST_AUTO_TEST_CASE(xor_random_chunks)
         }
 
         apply_random_xor_chunks(roundtrip, obfuscation);
-        BOOST_CHECK_EQUAL_COLLECTIONS(roundtrip.begin(), roundtrip.end(), original.begin(), original.end());
-  }
+        ASSERT_EQ_COLLECTIONS(roundtrip, original);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(obfuscation_hexkey)
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(obfuscation_serialize)
     ds_out >> key_out;
 
     // Make sure saved key is the same.
-    BOOST_CHECK_EQUAL_COLLECTIONS(key_in.begin(), key_in.end(), key_out.begin(), key_out.end());
+    ASSERT_EQ_COLLECTIONS(key_in, key_out);
 }
 
 BOOST_AUTO_TEST_CASE(obfuscation_empty)
@@ -680,10 +680,7 @@ BOOST_AUTO_TEST_CASE(buffered_reader_matches_autofile_random_content)
             DataBuffer buffered_buffer{read};
             buffered_reader.read(buffered_buffer);
 
-            BOOST_CHECK_EQUAL_COLLECTIONS(
-                direct_file_buffer.begin(), direct_file_buffer.end(),
-                buffered_buffer.begin(), buffered_buffer.end()
-            );
+            ASSERT_EQ_COLLECTIONS(direct_file_buffer, buffered_buffer);
 
             total_read += read;
         }
@@ -754,10 +751,7 @@ BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
         ASSERT_EXCEPTION(verify_buffered.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
     }
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(
-        direct_result.begin(), direct_result.end(),
-        buffered_result.begin(), buffered_result.end()
-    );
+    ASSERT_EQ_COLLECTIONS(direct_result, buffered_result);
 
     fs::remove(test_direct.FileName(pos));
     fs::remove(test_buffered.FileName(pos));

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -39,9 +39,9 @@ BOOST_AUTO_TEST_CASE(xor_random_chunks)
         const auto key_bytes{m_rng.randbool() ? m_rng.randbytes<Obfuscation::KEY_SIZE>() : std::array<std::byte, Obfuscation::KEY_SIZE>{}};
         const Obfuscation obfuscation{key_bytes};
         apply_random_xor_chunks(roundtrip, obfuscation);
-        BOOST_CHECK_EQUAL(roundtrip.size(), original.size());
+        ASSERT_EQ(roundtrip.size(), original.size());
         for (size_t i{0}; i < original.size(); ++i) {
-            BOOST_CHECK_EQUAL(roundtrip[i], original[i] ^ key_bytes[i % Obfuscation::KEY_SIZE]);
+            ASSERT_EQ(roundtrip[i], original[i] ^ key_bytes[i % Obfuscation::KEY_SIZE]);
         }
 
         apply_random_xor_chunks(roundtrip, obfuscation);
@@ -54,19 +54,19 @@ BOOST_AUTO_TEST_CASE(obfuscation_hexkey)
     const auto key_bytes{m_rng.randbytes<Obfuscation::KEY_SIZE>()};
 
     const Obfuscation obfuscation{key_bytes};
-    BOOST_CHECK_EQUAL(obfuscation.HexKey(), HexStr(key_bytes));
+    ASSERT_EQ(obfuscation.HexKey(), HexStr(key_bytes));
 }
 
 BOOST_AUTO_TEST_CASE(obfuscation_serialize)
 {
     Obfuscation obfuscation{};
-    BOOST_CHECK(!obfuscation);
+    ASSERT(!obfuscation);
 
     // Test loading a key.
     std::vector key_in{m_rng.randbytes<std::byte>(Obfuscation::KEY_SIZE)};
     DataStream ds_in;
     ds_in << key_in;
-    BOOST_CHECK_EQUAL(ds_in.size(), 1 + Obfuscation::KEY_SIZE); // serialized as a vector
+    ASSERT_EQ(ds_in.size(), 1 + Obfuscation::KEY_SIZE); // serialized as a vector
     ds_in >> obfuscation;
 
     // Test saving the key.
@@ -82,10 +82,10 @@ BOOST_AUTO_TEST_CASE(obfuscation_serialize)
 BOOST_AUTO_TEST_CASE(obfuscation_empty)
 {
     const Obfuscation null_obf{};
-    BOOST_CHECK(!null_obf);
+    ASSERT(!null_obf);
 
     const Obfuscation non_null_obf{"ff00ff00ff00ff00"_hex};
-    BOOST_CHECK(non_null_obf);
+    ASSERT(non_null_obf);
 }
 
 BOOST_AUTO_TEST_CASE(xor_file)
@@ -99,10 +99,10 @@ BOOST_AUTO_TEST_CASE(xor_file)
     {
         // Check errors for missing file
         AutoFile xor_file{raw_file("rb"), obfuscation};
-        BOOST_CHECK_EXCEPTION(xor_file << std::byte{}, std::ios_base::failure, HasReason{"AutoFile::write: file handle is nullptr"});
-        BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: file handle is nullptr"});
-        BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: file handle is nullptr"});
-        BOOST_CHECK_EXCEPTION(xor_file.size(), std::ios_base::failure, HasReason{"AutoFile::size: file handle is nullptr"});
+        ASSERT_EXCEPTION(xor_file << std::byte{}, std::ios_base::failure, HasReason{"AutoFile::write: file handle is nullptr"});
+        ASSERT_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: file handle is nullptr"});
+        ASSERT_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: file handle is nullptr"});
+        ASSERT_EXCEPTION(xor_file.size(), std::ios_base::failure, HasReason{"AutoFile::size: file handle is nullptr"});
     }
     {
 #ifdef __MINGW64__
@@ -113,28 +113,28 @@ BOOST_AUTO_TEST_CASE(xor_file)
 #endif
         AutoFile xor_file{raw_file(mode), obfuscation};
         xor_file << test1 << test2;
-        BOOST_CHECK_EQUAL(xor_file.size(), 7);
-        BOOST_REQUIRE_EQUAL(xor_file.fclose(), 0);
+        ASSERT_EQ(xor_file.size(), 7);
+        ASSERT_EQ(xor_file.fclose(), 0);
     }
     {
         // Read raw from disk
         AutoFile non_xor_file{raw_file("rb")};
         std::vector<std::byte> raw(7);
         non_xor_file >> std::span{raw};
-        BOOST_CHECK_EQUAL(HexStr(raw), "fc01fd03fd04fa");
+        ASSERT_EQ(HexStr(raw), "fc01fd03fd04fa");
         // Check that no padding exists
-        BOOST_CHECK_EXCEPTION(non_xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
-        BOOST_CHECK_EQUAL(non_xor_file.size(), 7);
+        ASSERT_EXCEPTION(non_xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
+        ASSERT_EQ(non_xor_file.size(), 7);
     }
     {
         AutoFile xor_file{raw_file("rb"), obfuscation};
         std::vector<std::byte> read1, read2;
         xor_file >> read1 >> read2;
-        BOOST_CHECK_EQUAL(HexStr(read1), HexStr(test1));
-        BOOST_CHECK_EQUAL(HexStr(read2), HexStr(test2));
+        ASSERT_EQ(HexStr(read1), HexStr(test1));
+        ASSERT_EQ(HexStr(read2), HexStr(test2));
         // Check that eof was reached
-        BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
-        BOOST_CHECK_EQUAL(xor_file.size(), 7);
+        ASSERT_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
+        ASSERT_EQ(xor_file.size(), 7);
     }
     {
         AutoFile xor_file{raw_file("rb"), obfuscation};
@@ -142,11 +142,11 @@ BOOST_AUTO_TEST_CASE(xor_file)
         // Check that ignore works
         xor_file.ignore(4);
         xor_file >> read2;
-        BOOST_CHECK_EQUAL(HexStr(read2), HexStr(test2));
+        ASSERT_EQ(HexStr(read2), HexStr(test2));
         // Check that ignore and read fail now
-        BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
-        BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
-        BOOST_CHECK_EQUAL(xor_file.size(), 7);
+        ASSERT_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
+        ASSERT_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
+        ASSERT_EQ(xor_file.size(), 7);
     }
 }
 
@@ -162,49 +162,49 @@ BOOST_AUTO_TEST_CASE(streams_vector_writer)
     // vector.
 
     VectorWriter{vch, 0, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{1, 2}}));
     VectorWriter{vch, 0, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{1, 2}}));
     vch.clear();
 
     VectorWriter{vch, 2, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
     VectorWriter{vch, 2, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
     vch.clear();
 
     vch.resize(5, 0);
     VectorWriter{vch, 2, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
     VectorWriter{vch, 2, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
     vch.clear();
 
     vch.resize(4, 0);
     VectorWriter{vch, 3, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
     VectorWriter{vch, 3, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
     vch.clear();
 
     vch.resize(4, 0);
     VectorWriter{vch, 4, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
     VectorWriter{vch, 4, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
     vch.clear();
 
     VectorWriter{vch, 0, bytes};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
+    ASSERT((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
     VectorWriter{vch, 0, bytes};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
+    ASSERT((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
     vch.clear();
 
     vch.resize(4, 8);
     VectorWriter{vch, 2, a, bytes, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
     VectorWriter{vch, 2, a, bytes, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
     vch.clear();
 }
 
@@ -218,16 +218,16 @@ BOOST_AUTO_TEST_CASE(streams_span_writer)
     // Test operator<<
     SpanWriter writer{arr};
     writer << a << b;
-    BOOST_CHECK_EQUAL(HexStr(arr), "0102000000000000");
+    ASSERT_EQ(HexStr(arr), "0102000000000000");
 
     // Use variadic constructor and write to subspan.
     SpanWriter{std::span{arr}.subspan(2), a, bytes, b};
-    BOOST_CHECK_EQUAL(HexStr(arr), "0102010304050602");
+    ASSERT_EQ(HexStr(arr), "0102010304050602");
 
     // Writing past the end throws
     std::array<std::byte, 1> small{};
-    BOOST_CHECK_THROW(SpanWriter(std::span{small}, a, b), std::ios_base::failure);
-    BOOST_CHECK_THROW(SpanWriter(std::span{small}) << a << b, std::ios_base::failure);
+    ASSERT_EXCEPTION(SpanWriter(std::span{small}, a, b), std::ios_base::failure, HasReason{""});
+    ASSERT_EXCEPTION(SpanWriter(std::span{small}) << a << b, std::ios_base::failure, HasReason{""});
 }
 
 BOOST_AUTO_TEST_CASE(streams_vector_reader)
@@ -235,44 +235,44 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader)
     std::vector<unsigned char> vch = {1, 255, 3, 4, 5, 6};
 
     SpanReader reader{vch};
-    BOOST_CHECK_EQUAL(reader.size(), 6U);
-    BOOST_CHECK(!reader.empty());
+    ASSERT_EQ(reader.size(), 6U);
+    ASSERT(!reader.empty());
 
     // Read a single byte as an unsigned char.
     unsigned char a;
     reader >> a;
-    BOOST_CHECK_EQUAL(a, 1);
-    BOOST_CHECK_EQUAL(reader.size(), 5U);
-    BOOST_CHECK(!reader.empty());
+    ASSERT_EQ(a, 1);
+    ASSERT_EQ(reader.size(), 5U);
+    ASSERT(!reader.empty());
 
     // Read a single byte as a int8_t.
     int8_t b;
     reader >> b;
-    BOOST_CHECK_EQUAL(b, -1);
-    BOOST_CHECK_EQUAL(reader.size(), 4U);
-    BOOST_CHECK(!reader.empty());
+    ASSERT_EQ(b, -1);
+    ASSERT_EQ(reader.size(), 4U);
+    ASSERT(!reader.empty());
 
     // Read a 4 bytes as an unsigned int.
     unsigned int c;
     reader >> c;
-    BOOST_CHECK_EQUAL(c, 100992003U); // 3,4,5,6 in little-endian base-256
-    BOOST_CHECK_EQUAL(reader.size(), 0U);
-    BOOST_CHECK(reader.empty());
+    ASSERT_EQ(c, 100992003U); // 3,4,5,6 in little-endian base-256
+    ASSERT_EQ(reader.size(), 0U);
+    ASSERT(reader.empty());
 
     // Reading after end of byte vector throws an error.
     signed int d;
-    BOOST_CHECK_THROW(reader >> d, std::ios_base::failure);
+    ASSERT_EXCEPTION(reader >> d, std::ios_base::failure, HasReason{""});
 
     // Read a 4 bytes as a signed int from the beginning of the buffer.
     SpanReader new_reader{vch};
     new_reader >> d;
-    BOOST_CHECK_EQUAL(d, 67370753); // 1,255,3,4 in little-endian base-256
-    BOOST_CHECK_EQUAL(new_reader.size(), 2U);
-    BOOST_CHECK(!new_reader.empty());
+    ASSERT_EQ(d, 67370753); // 1,255,3,4 in little-endian base-256
+    ASSERT_EQ(new_reader.size(), 2U);
+    ASSERT(!new_reader.empty());
 
     // Reading after end of byte vector throws an error even if the reader is
     // not totally empty.
-    BOOST_CHECK_THROW(new_reader >> d, std::ios_base::failure);
+    ASSERT_EXCEPTION(new_reader >> d, std::ios_base::failure, HasReason{""});
 }
 
 BOOST_AUTO_TEST_CASE(streams_vector_reader_rvalue)
@@ -282,8 +282,8 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader_rvalue)
     uint32_t varint = 0;
     // Deserialize into r-value
     reader >> VARINT(varint);
-    BOOST_CHECK_EQUAL(varint, 54321U);
-    BOOST_CHECK(reader.empty());
+    ASSERT_EQ(varint, 54321U);
+    ASSERT(reader.empty());
 }
 
 BOOST_AUTO_TEST_CASE(bitstream_reader_writer)
@@ -304,21 +304,21 @@ BOOST_AUTO_TEST_CASE(bitstream_reader_writer)
     DataStream data_copy{data};
     uint32_t serialized_int1;
     data >> serialized_int1;
-    BOOST_CHECK_EQUAL(serialized_int1, uint32_t{0x7700C35A}); // NOTE: Serialized as LE
+    ASSERT_EQ(serialized_int1, uint32_t{0x7700C35A}); // NOTE: Serialized as LE
     uint16_t serialized_int2;
     data >> serialized_int2;
-    BOOST_CHECK_EQUAL(serialized_int2, uint16_t{0x1072}); // NOTE: Serialized as LE
+    ASSERT_EQ(serialized_int2, uint16_t{0x1072}); // NOTE: Serialized as LE
 
     BitStreamReader bit_reader{data_copy};
-    BOOST_CHECK_EQUAL(bit_reader.Read(1), 0U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(2), 2U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(3), 6U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(4), 11U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(5), 1U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(6), 32U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(7), 7U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(16), 30497U);
-    BOOST_CHECK_THROW(bit_reader.Read(8), std::ios_base::failure);
+    ASSERT_EQ(bit_reader.Read(1), 0U);
+    ASSERT_EQ(bit_reader.Read(2), 2U);
+    ASSERT_EQ(bit_reader.Read(3), 6U);
+    ASSERT_EQ(bit_reader.Read(4), 11U);
+    ASSERT_EQ(bit_reader.Read(5), 1U);
+    ASSERT_EQ(bit_reader.Read(6), 32U);
+    ASSERT_EQ(bit_reader.Read(7), 7U);
+    ASSERT_EQ(bit_reader.Read(16), 30497U);
+    ASSERT_EXCEPTION(bit_reader.Read(8), std::ios_base::failure, HasReason{""});
 }
 
 BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
     {
         DataStream ds{};
         Obfuscation{}(ds);
-        BOOST_CHECK_EQUAL(""s, ds.str());
+        ASSERT_EQ(""s, ds.str());
     }
 
     {
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
 
         DataStream ds{"0ff0"_hex};
         obfuscation(ds);
-        BOOST_CHECK_EQUAL("\xf0\x0f"s, ds.str());
+        ASSERT_EQ("\xf0\x0f"s, ds.str());
     }
 
     {
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
 
         DataStream ds{"f00f"_hex};
         obfuscation(ds);
-        BOOST_CHECK_EQUAL("\x0f\x00"s, ds.str());
+        ASSERT_EQ("\x0f\x00"s, ds.str());
     }
 }
 
@@ -362,117 +362,117 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     // amount (third arg).
     try {
         BufferedFile bfbad{file, 25, 25};
-        BOOST_CHECK(false);
+        ASSERT(false);
     } catch (const std::exception& e) {
-        BOOST_CHECK(strstr(e.what(),
+        ASSERT(strstr(e.what(),
                         "Rewind limit must be less than buffer size") != nullptr);
     }
 
     // The buffer is 25 bytes, allow rewinding 10 bytes.
     BufferedFile bf{file, 25, 10};
-    BOOST_CHECK(!bf.eof());
+    ASSERT(!bf.eof());
 
     uint8_t i;
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 0);
+    ASSERT_EQ(i, 0);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 1);
+    ASSERT_EQ(i, 1);
 
     // After reading bytes 0 and 1, we're positioned at 2.
-    BOOST_CHECK_EQUAL(bf.GetPos(), 2U);
+    ASSERT_EQ(bf.GetPos(), 2U);
 
     // Rewind to offset 0, ok (within the 10 byte window).
-    BOOST_CHECK(bf.SetPos(0));
+    ASSERT(bf.SetPos(0));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 0);
+    ASSERT_EQ(i, 0);
 
     // We can go forward to where we've been, but beyond may fail.
-    BOOST_CHECK(bf.SetPos(2));
+    ASSERT(bf.SetPos(2));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 2);
+    ASSERT_EQ(i, 2);
 
     // If you know the maximum number of bytes that should be
     // read to deserialize the variable, you can limit the read
     // extent. The current file offset is 3, so the following
     // SetLimit() allows zero bytes to be read.
-    BOOST_CHECK(bf.SetLimit(3));
+    ASSERT(bf.SetLimit(3));
     try {
         bf >> i;
-        BOOST_CHECK(false);
+        ASSERT(false);
     } catch (const std::exception& e) {
-        BOOST_CHECK(strstr(e.what(),
+        ASSERT(strstr(e.what(),
                            "Attempt to position past buffer limit") != nullptr);
     }
     // The default argument removes the limit completely.
-    BOOST_CHECK(bf.SetLimit());
+    ASSERT(bf.SetLimit());
     // The read position should still be at 3 (no change).
-    BOOST_CHECK_EQUAL(bf.GetPos(), 3U);
+    ASSERT_EQ(bf.GetPos(), 3U);
 
     // Read from current offset, 3, forward until position 10.
     for (uint8_t j = 3; j < 10; ++j) {
         bf >> i;
-        BOOST_CHECK_EQUAL(i, j);
+        ASSERT_EQ(i, j);
     }
-    BOOST_CHECK_EQUAL(bf.GetPos(), 10U);
+    ASSERT_EQ(bf.GetPos(), 10U);
 
     // We're guaranteed (just barely) to be able to rewind to zero.
-    BOOST_CHECK(bf.SetPos(0));
-    BOOST_CHECK_EQUAL(bf.GetPos(), 0U);
+    ASSERT(bf.SetPos(0));
+    ASSERT_EQ(bf.GetPos(), 0U);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 0);
+    ASSERT_EQ(i, 0);
 
     // We can set the position forward again up to the farthest
     // into the stream we've been, but no farther. (Attempting
     // to go farther may succeed, but it's not guaranteed.)
-    BOOST_CHECK(bf.SetPos(10));
+    ASSERT(bf.SetPos(10));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 10);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 11U);
+    ASSERT_EQ(i, 10);
+    ASSERT_EQ(bf.GetPos(), 11U);
 
     // Now it's only guaranteed that we can rewind to offset 1
     // (current read position, 11, minus rewind amount, 10).
-    BOOST_CHECK(bf.SetPos(1));
-    BOOST_CHECK_EQUAL(bf.GetPos(), 1U);
+    ASSERT(bf.SetPos(1));
+    ASSERT_EQ(bf.GetPos(), 1U);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 1);
+    ASSERT_EQ(i, 1);
 
     // We can stream into large variables, even larger than
     // the buffer size.
-    BOOST_CHECK(bf.SetPos(11));
+    ASSERT(bf.SetPos(11));
     {
         uint8_t a[40 - 11];
         bf >> a;
         for (uint8_t j = 0; j < sizeof(a); ++j) {
-            BOOST_CHECK_EQUAL(a[j], 11 + j);
+            ASSERT_EQ(a[j], 11 + j);
         }
     }
-    BOOST_CHECK_EQUAL(bf.GetPos(), 40U);
+    ASSERT_EQ(bf.GetPos(), 40U);
 
     // We've read the entire file, the next read should throw.
     try {
         bf >> i;
-        BOOST_CHECK(false);
+        ASSERT(false);
     } catch (const std::exception& e) {
-        BOOST_CHECK(strstr(e.what(),
+        ASSERT(strstr(e.what(),
                         "BufferedFile::Fill: end of file") != nullptr);
     }
     // Attempting to read beyond the end sets the EOF indicator.
-    BOOST_CHECK(bf.eof());
+    ASSERT(bf.eof());
 
     // Still at offset 40, we can go back 10, to 30.
-    BOOST_CHECK_EQUAL(bf.GetPos(), 40U);
-    BOOST_CHECK(bf.SetPos(30));
+    ASSERT_EQ(bf.GetPos(), 40U);
+    ASSERT(bf.SetPos(30));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 30);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 31U);
+    ASSERT_EQ(i, 30);
+    ASSERT_EQ(bf.GetPos(), 31U);
 
     // We're too far to rewind to position zero.
-    BOOST_CHECK(!bf.SetPos(0));
+    ASSERT(!bf.SetPos(0));
     // But we should now be positioned at least as far back as allowed
     // by the rewind window (relative to our farthest read position, 40).
-    BOOST_CHECK(bf.GetPos() <= 30U);
+    ASSERT(bf.GetPos() <= 30U);
 
-    BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+    ASSERT_EQ(file.fclose(), 0);
 
     fs::remove(streams_test_filename);
 }
@@ -494,35 +494,35 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_skip)
     // This is like bf >> (7-byte-variable), in that it will cause data
     // to be read from the file into memory, but it's not copied to us.
     bf.SkipTo(7);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 7U);
+    ASSERT_EQ(bf.GetPos(), 7U);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 7);
+    ASSERT_EQ(i, 7);
 
     // The bytes in the buffer up to offset 7 are valid and can be read.
-    BOOST_CHECK(bf.SetPos(0));
+    ASSERT(bf.SetPos(0));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 0);
+    ASSERT_EQ(i, 0);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 1);
+    ASSERT_EQ(i, 1);
 
     bf.SkipTo(11);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 11);
+    ASSERT_EQ(i, 11);
 
     // SkipTo() honors the transfer limit; we can't position beyond the limit.
     bf.SetLimit(13);
     try {
         bf.SkipTo(14);
-        BOOST_CHECK(false);
+        ASSERT(false);
     } catch (const std::exception& e) {
-        BOOST_CHECK(strstr(e.what(), "Attempt to position past buffer limit") != nullptr);
+        ASSERT(strstr(e.what(), "Attempt to position past buffer limit") != nullptr);
     }
 
     // We can position exactly to the transfer limit.
     bf.SkipTo(13);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 13U);
+    ASSERT_EQ(bf.GetPos(), 13U);
 
-    BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+    ASSERT_EQ(file.fclose(), 0);
     fs::remove(streams_test_filename);
 }
 
@@ -550,8 +550,8 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 break;
 
             // We haven't read to the end of the file yet.
-            BOOST_CHECK(!bf.eof());
-            BOOST_CHECK_EQUAL(bf.GetPos(), currentPos);
+            ASSERT(!bf.eof());
+            ASSERT_EQ(bf.GetPos(), currentPos);
 
             // Pretend the file consists of a series of objects of varying
             // sizes; the boundaries of the objects can interact arbitrarily
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 bf.SetLimit(currentPos + 1);
                 bf >> a;
                 for (uint8_t i = 0; i < 1; ++i) {
-                    BOOST_CHECK_EQUAL(a[i], currentPos);
+                    ASSERT_EQ(a[i], currentPos);
                     currentPos++;
                 }
                 break;
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 bf.SetLimit(currentPos + 2);
                 bf >> a;
                 for (uint8_t i = 0; i < 2; ++i) {
-                    BOOST_CHECK_EQUAL(a[i], currentPos);
+                    ASSERT_EQ(a[i], currentPos);
                     currentPos++;
                 }
                 break;
@@ -589,7 +589,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 bf.SetLimit(currentPos + 5);
                 bf >> a;
                 for (uint8_t i = 0; i < 5; ++i) {
-                    BOOST_CHECK_EQUAL(a[i], currentPos);
+                    ASSERT_EQ(a[i], currentPos);
                     currentPos++;
                 }
                 break;
@@ -611,13 +611,13 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                     find = fileSize - 1;
                 bf.FindByte(std::byte(find));
                 // The value at each offset is the offset.
-                BOOST_CHECK_EQUAL(bf.GetPos(), find);
+                ASSERT_EQ(bf.GetPos(), find);
                 currentPos = find;
 
                 bf.SetLimit(currentPos + 1);
                 uint8_t i;
                 bf >> i;
-                BOOST_CHECK_EQUAL(i, currentPos);
+                ASSERT_EQ(i, currentPos);
                 currentPos++;
                 break;
             }
@@ -629,13 +629,13 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 // window, and we may not be able to move forward beyond the
                 // farthest position we've reached so far.
                 currentPos = bf.GetPos();
-                BOOST_CHECK_EQUAL(okay, currentPos == requestPos);
+                ASSERT_EQ(okay, currentPos == requestPos);
                 // Check that we can position within the rewind window.
                 if (requestPos <= maxPos &&
                     maxPos > rewindSize &&
                     requestPos >= maxPos - rewindSize) {
                     // We requested a position within the rewind window.
-                    BOOST_CHECK(okay);
+                    ASSERT(okay);
                 }
                 break;
             }
@@ -643,7 +643,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
             if (maxPos < currentPos)
                 maxPos = currentPos;
         }
-        BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+        ASSERT_EQ(file.fclose(), 0);
     }
     fs::remove(streams_test_filename);
 }
@@ -661,9 +661,9 @@ BOOST_AUTO_TEST_CASE(buffered_reader_matches_autofile_random_content)
     {
         AutoFile f{test_file.Open(pos, /*read_only=*/false), obfuscation};
         f.write(m_rng.randbytes<std::byte>(file_size));
-        BOOST_REQUIRE_EQUAL(f.fclose(), 0);
+        ASSERT_EQ(f.fclose(), 0);
     }
-    BOOST_CHECK_EQUAL(fs::file_size(test_file.FileName(pos)), file_size);
+    ASSERT_EQ(fs::file_size(test_file.FileName(pos)), file_size);
 
     {
         AutoFile direct_file{test_file.Open(pos, /*read_only=*/true), obfuscation};
@@ -690,12 +690,12 @@ BOOST_AUTO_TEST_CASE(buffered_reader_matches_autofile_random_content)
 
         {
             DataBuffer excess_byte{1};
-            BOOST_CHECK_EXCEPTION(direct_file.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+            ASSERT_EXCEPTION(direct_file.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
         }
 
         {
             DataBuffer excess_byte{1};
-            BOOST_CHECK_EXCEPTION(buffered_reader.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+            ASSERT_EXCEPTION(buffered_reader.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
         }
     }
 
@@ -731,8 +731,8 @@ BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
                 total_written += write_size;
             }
         }
-        BOOST_REQUIRE_EQUAL(buffered_file.fclose(), 0);
-        BOOST_REQUIRE_EQUAL(direct_file.fclose(), 0);
+        ASSERT_EQ(buffered_file.fclose(), 0);
+        ASSERT_EQ(direct_file.fclose(), 0);
     }
 
     // Compare the resulting files
@@ -742,7 +742,7 @@ BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
         verify_direct.read(direct_result);
 
         DataBuffer excess_byte{1};
-        BOOST_CHECK_EXCEPTION(verify_direct.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+        ASSERT_EXCEPTION(verify_direct.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
     }
 
     DataBuffer buffered_result{file_size};
@@ -751,7 +751,7 @@ BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
         verify_buffered.read(buffered_result);
 
         DataBuffer excess_byte{1};
-        BOOST_CHECK_EXCEPTION(verify_buffered.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+        ASSERT_EXCEPTION(verify_buffered.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
     }
 
     BOOST_CHECK_EQUAL_COLLECTIONS(
@@ -775,7 +775,7 @@ BOOST_AUTO_TEST_CASE(buffered_writer_reader)
         f << v1 << v2;
         f.write(std::as_bytes(std::span{&v3, 1}));
     }
-    BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+    ASSERT_EQ(file.fclose(), 0);
 
     // Read back and verify using BufferedReader
     {
@@ -784,12 +784,12 @@ BOOST_AUTO_TEST_CASE(buffered_writer_reader)
         BufferedReader f(std::move(file), sizeof(v1) + sizeof(v2) + sizeof(v3));
         f >> _v1 >> _v2;
         f.read(std::as_writable_bytes(std::span{&_v3, 1}));
-        BOOST_CHECK_EQUAL(_v1, v1);
-        BOOST_CHECK_EQUAL(_v2, v2);
-        BOOST_CHECK_EQUAL(_v3, v3);
+        ASSERT_EQ(_v1, v1);
+        ASSERT_EQ(_v2, v2);
+        ASSERT_EQ(_v3, v3);
 
         DataBuffer excess_byte{1};
-        BOOST_CHECK_EXCEPTION(f.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+        ASSERT_EXCEPTION(f.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
     }
 
     fs::remove(test_file);
@@ -805,8 +805,8 @@ BOOST_AUTO_TEST_CASE(streams_hashed)
     HashVerifier hash_verifier{stream};
     std::string result;
     hash_verifier >> result;
-    BOOST_CHECK_EQUAL(data, result);
-    BOOST_CHECK_EQUAL(hash_writer.GetHash(), hash_verifier.GetHash());
+    ASSERT_EQ(data, result);
+    ASSERT_EQ(hash_writer.GetHash(), hash_verifier.GetHash());
 }
 
 BOOST_AUTO_TEST_CASE(size_preserves_position)
@@ -824,7 +824,7 @@ BOOST_AUTO_TEST_CASE(size_preserves_position)
     (void)f.size();
     uint8_t first{};
     f >> first;
-    BOOST_CHECK_EQUAL(first, 0);
+    ASSERT_EQ(first, 0);
 
     // Case: Pos at middle of the file
     f.seek(0, SEEK_SET);
@@ -834,15 +834,15 @@ BOOST_AUTO_TEST_CASE(size_preserves_position)
     uint8_t middle{};
     f >> middle;
     // Pos still at 4
-    BOOST_CHECK_EQUAL(middle, 4);
+    ASSERT_EQ(middle, 4);
 
     // Case: Pos at EOF
     f.seek(0, SEEK_END);
     (void)f.size();
     uint8_t end{};
-    BOOST_CHECK_EXCEPTION(f >> end, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
+    ASSERT_EXCEPTION(f >> end, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
 
-    BOOST_REQUIRE_EQUAL(f.fclose(), 0);
+    ASSERT_EQ(f.fclose(), 0);
     fs::remove(path);
 }
 

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -39,9 +39,9 @@ BOOST_AUTO_TEST_CASE(xor_random_chunks)
         const auto key_bytes{m_rng.randbool() ? m_rng.randbytes<Obfuscation::KEY_SIZE>() : std::array<std::byte, Obfuscation::KEY_SIZE>{}};
         const Obfuscation obfuscation{key_bytes};
         apply_random_xor_chunks(roundtrip, obfuscation);
-        BOOST_CHECK_EQUAL(roundtrip.size(), original.size());
+        ASSERT_EQ(roundtrip.size(), original.size());
         for (size_t i{0}; i < original.size(); ++i) {
-            BOOST_CHECK_EQUAL(roundtrip[i], original[i] ^ key_bytes[i % Obfuscation::KEY_SIZE]);
+            ASSERT_EQ(roundtrip[i], original[i] ^ key_bytes[i % Obfuscation::KEY_SIZE]);
         }
 
         apply_random_xor_chunks(roundtrip, obfuscation);
@@ -54,19 +54,19 @@ BOOST_AUTO_TEST_CASE(obfuscation_hexkey)
     const auto key_bytes{m_rng.randbytes<Obfuscation::KEY_SIZE>()};
 
     const Obfuscation obfuscation{key_bytes};
-    BOOST_CHECK_EQUAL(obfuscation.HexKey(), HexStr(key_bytes));
+    ASSERT_EQ(obfuscation.HexKey(), HexStr(key_bytes));
 }
 
 BOOST_AUTO_TEST_CASE(obfuscation_serialize)
 {
     Obfuscation obfuscation{};
-    BOOST_CHECK(!obfuscation);
+    ASSERT(!obfuscation);
 
     // Test loading a key.
     std::vector key_in{m_rng.randbytes<std::byte>(Obfuscation::KEY_SIZE)};
     DataStream ds_in;
     ds_in << key_in;
-    BOOST_CHECK_EQUAL(ds_in.size(), 1 + Obfuscation::KEY_SIZE); // serialized as a vector
+    ASSERT_EQ(ds_in.size(), 1 + Obfuscation::KEY_SIZE); // serialized as a vector
     ds_in >> obfuscation;
 
     // Test saving the key.
@@ -82,10 +82,10 @@ BOOST_AUTO_TEST_CASE(obfuscation_serialize)
 BOOST_AUTO_TEST_CASE(obfuscation_empty)
 {
     const Obfuscation null_obf{};
-    BOOST_CHECK(!null_obf);
+    ASSERT(!null_obf);
 
     const Obfuscation non_null_obf{"ff00ff00ff00ff00"_hex};
-    BOOST_CHECK(non_null_obf);
+    ASSERT(non_null_obf);
 }
 
 BOOST_AUTO_TEST_CASE(streams_scoped_data_stream_usage)
@@ -96,14 +96,14 @@ BOOST_AUTO_TEST_CASE(streams_scoped_data_stream_usage)
         stream << uint8_t{42};
         BOOST_CHECK_GT(stream.size(), 0U);
     }
-    BOOST_CHECK(stream.empty());
+    ASSERT(stream.empty());
 
     {
         ScopedDataStreamUsage usage{stream};
         stream << uint16_t{42};
         BOOST_CHECK_GT(stream.size(), 0U);
     }
-    BOOST_CHECK(stream.empty());
+    ASSERT(stream.empty());
 }
 
 BOOST_AUTO_TEST_CASE(xor_file)
@@ -117,10 +117,10 @@ BOOST_AUTO_TEST_CASE(xor_file)
     {
         // Check errors for missing file
         AutoFile xor_file{raw_file("rb"), obfuscation};
-        BOOST_CHECK_EXCEPTION(xor_file << std::byte{}, std::ios_base::failure, HasReason{"AutoFile::write: file handle is nullptr"});
-        BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: file handle is nullptr"});
-        BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: file handle is nullptr"});
-        BOOST_CHECK_EXCEPTION(xor_file.size(), std::ios_base::failure, HasReason{"AutoFile::size: file handle is nullptr"});
+        ASSERT_EXCEPTION(xor_file << std::byte{}, std::ios_base::failure, HasReason{"AutoFile::write: file handle is nullptr"});
+        ASSERT_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: file handle is nullptr"});
+        ASSERT_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: file handle is nullptr"});
+        ASSERT_EXCEPTION(xor_file.size(), std::ios_base::failure, HasReason{"AutoFile::size: file handle is nullptr"});
     }
     {
 #ifdef __MINGW64__
@@ -131,28 +131,28 @@ BOOST_AUTO_TEST_CASE(xor_file)
 #endif
         AutoFile xor_file{raw_file(mode), obfuscation};
         xor_file << test1 << test2;
-        BOOST_CHECK_EQUAL(xor_file.size(), 7);
-        BOOST_REQUIRE_EQUAL(xor_file.fclose(), 0);
+        ASSERT_EQ(xor_file.size(), 7);
+        ASSERT_EQ(xor_file.fclose(), 0);
     }
     {
         // Read raw from disk
         AutoFile non_xor_file{raw_file("rb")};
         std::vector<std::byte> raw(7);
         non_xor_file >> std::span{raw};
-        BOOST_CHECK_EQUAL(HexStr(raw), "fc01fd03fd04fa");
+        ASSERT_EQ(HexStr(raw), "fc01fd03fd04fa");
         // Check that no padding exists
-        BOOST_CHECK_EXCEPTION(non_xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
-        BOOST_CHECK_EQUAL(non_xor_file.size(), 7);
+        ASSERT_EXCEPTION(non_xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
+        ASSERT_EQ(non_xor_file.size(), 7);
     }
     {
         AutoFile xor_file{raw_file("rb"), obfuscation};
         std::vector<std::byte> read1, read2;
         xor_file >> read1 >> read2;
-        BOOST_CHECK_EQUAL(HexStr(read1), HexStr(test1));
-        BOOST_CHECK_EQUAL(HexStr(read2), HexStr(test2));
+        ASSERT_EQ(HexStr(read1), HexStr(test1));
+        ASSERT_EQ(HexStr(read2), HexStr(test2));
         // Check that eof was reached
-        BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
-        BOOST_CHECK_EQUAL(xor_file.size(), 7);
+        ASSERT_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
+        ASSERT_EQ(xor_file.size(), 7);
     }
     {
         AutoFile xor_file{raw_file("rb"), obfuscation};
@@ -160,11 +160,11 @@ BOOST_AUTO_TEST_CASE(xor_file)
         // Check that ignore works
         xor_file.ignore(4);
         xor_file >> read2;
-        BOOST_CHECK_EQUAL(HexStr(read2), HexStr(test2));
+        ASSERT_EQ(HexStr(read2), HexStr(test2));
         // Check that ignore and read fail now
-        BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
-        BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
-        BOOST_CHECK_EQUAL(xor_file.size(), 7);
+        ASSERT_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
+        ASSERT_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
+        ASSERT_EQ(xor_file.size(), 7);
     }
 }
 
@@ -180,49 +180,49 @@ BOOST_AUTO_TEST_CASE(streams_vector_writer)
     // vector.
 
     VectorWriter{vch, 0, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{1, 2}}));
     VectorWriter{vch, 0, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{1, 2}}));
     vch.clear();
 
     VectorWriter{vch, 2, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
     VectorWriter{vch, 2, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
     vch.clear();
 
     vch.resize(5, 0);
     VectorWriter{vch, 2, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
     VectorWriter{vch, 2, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
     vch.clear();
 
     vch.resize(4, 0);
     VectorWriter{vch, 3, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
     VectorWriter{vch, 3, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
     vch.clear();
 
     vch.resize(4, 0);
     VectorWriter{vch, 4, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
     VectorWriter{vch, 4, a, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
     vch.clear();
 
     VectorWriter{vch, 0, bytes};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
+    ASSERT((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
     VectorWriter{vch, 0, bytes};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
+    ASSERT((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
     vch.clear();
 
     vch.resize(4, 8);
     VectorWriter{vch, 2, a, bytes, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
     VectorWriter{vch, 2, a, bytes, b};
-    BOOST_CHECK((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
+    ASSERT((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
     vch.clear();
 }
 
@@ -236,16 +236,16 @@ BOOST_AUTO_TEST_CASE(streams_span_writer)
     // Test operator<<
     SpanWriter writer{arr};
     writer << a << b;
-    BOOST_CHECK_EQUAL(HexStr(arr), "0102000000000000");
+    ASSERT_EQ(HexStr(arr), "0102000000000000");
 
     // Use variadic constructor and write to subspan.
     SpanWriter{std::span{arr}.subspan(2), a, bytes, b};
-    BOOST_CHECK_EQUAL(HexStr(arr), "0102010304050602");
+    ASSERT_EQ(HexStr(arr), "0102010304050602");
 
     // Writing past the end throws
     std::array<std::byte, 1> small{};
-    BOOST_CHECK_THROW(SpanWriter(std::span{small}, a, b), std::ios_base::failure);
-    BOOST_CHECK_THROW(SpanWriter(std::span{small}) << a << b, std::ios_base::failure);
+    ASSERT_EXCEPTION(SpanWriter(std::span{small}, a, b), std::ios_base::failure, HasReason{""});
+    ASSERT_EXCEPTION(SpanWriter(std::span{small}) << a << b, std::ios_base::failure, HasReason{""});
 }
 
 BOOST_AUTO_TEST_CASE(streams_vector_reader)
@@ -253,44 +253,44 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader)
     std::vector<unsigned char> vch = {1, 255, 3, 4, 5, 6};
 
     SpanReader reader{vch};
-    BOOST_CHECK_EQUAL(reader.size(), 6U);
-    BOOST_CHECK(!reader.empty());
+    ASSERT_EQ(reader.size(), 6U);
+    ASSERT(!reader.empty());
 
     // Read a single byte as an unsigned char.
     unsigned char a;
     reader >> a;
-    BOOST_CHECK_EQUAL(a, 1);
-    BOOST_CHECK_EQUAL(reader.size(), 5U);
-    BOOST_CHECK(!reader.empty());
+    ASSERT_EQ(a, 1);
+    ASSERT_EQ(reader.size(), 5U);
+    ASSERT(!reader.empty());
 
     // Read a single byte as a int8_t.
     int8_t b;
     reader >> b;
-    BOOST_CHECK_EQUAL(b, -1);
-    BOOST_CHECK_EQUAL(reader.size(), 4U);
-    BOOST_CHECK(!reader.empty());
+    ASSERT_EQ(b, -1);
+    ASSERT_EQ(reader.size(), 4U);
+    ASSERT(!reader.empty());
 
     // Read a 4 bytes as an unsigned int.
     unsigned int c;
     reader >> c;
-    BOOST_CHECK_EQUAL(c, 100992003U); // 3,4,5,6 in little-endian base-256
-    BOOST_CHECK_EQUAL(reader.size(), 0U);
-    BOOST_CHECK(reader.empty());
+    ASSERT_EQ(c, 100992003U); // 3,4,5,6 in little-endian base-256
+    ASSERT_EQ(reader.size(), 0U);
+    ASSERT(reader.empty());
 
     // Reading after end of byte vector throws an error.
     signed int d;
-    BOOST_CHECK_THROW(reader >> d, std::ios_base::failure);
+    ASSERT_EXCEPTION(reader >> d, std::ios_base::failure, HasReason{""});
 
     // Read a 4 bytes as a signed int from the beginning of the buffer.
     SpanReader new_reader{vch};
     new_reader >> d;
-    BOOST_CHECK_EQUAL(d, 67370753); // 1,255,3,4 in little-endian base-256
-    BOOST_CHECK_EQUAL(new_reader.size(), 2U);
-    BOOST_CHECK(!new_reader.empty());
+    ASSERT_EQ(d, 67370753); // 1,255,3,4 in little-endian base-256
+    ASSERT_EQ(new_reader.size(), 2U);
+    ASSERT(!new_reader.empty());
 
     // Reading after end of byte vector throws an error even if the reader is
     // not totally empty.
-    BOOST_CHECK_THROW(new_reader >> d, std::ios_base::failure);
+    ASSERT_EXCEPTION(new_reader >> d, std::ios_base::failure, HasReason{""});
 }
 
 BOOST_AUTO_TEST_CASE(streams_vector_reader_rvalue)
@@ -300,8 +300,8 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader_rvalue)
     uint32_t varint = 0;
     // Deserialize into r-value
     reader >> VARINT(varint);
-    BOOST_CHECK_EQUAL(varint, 54321U);
-    BOOST_CHECK(reader.empty());
+    ASSERT_EQ(varint, 54321U);
+    ASSERT(reader.empty());
 }
 
 BOOST_AUTO_TEST_CASE(bitstream_reader_writer)
@@ -322,21 +322,21 @@ BOOST_AUTO_TEST_CASE(bitstream_reader_writer)
     DataStream data_copy{data};
     uint32_t serialized_int1;
     data >> serialized_int1;
-    BOOST_CHECK_EQUAL(serialized_int1, uint32_t{0x7700C35A}); // NOTE: Serialized as LE
+    ASSERT_EQ(serialized_int1, uint32_t{0x7700C35A}); // NOTE: Serialized as LE
     uint16_t serialized_int2;
     data >> serialized_int2;
-    BOOST_CHECK_EQUAL(serialized_int2, uint16_t{0x1072}); // NOTE: Serialized as LE
+    ASSERT_EQ(serialized_int2, uint16_t{0x1072}); // NOTE: Serialized as LE
 
     BitStreamReader bit_reader{data_copy};
-    BOOST_CHECK_EQUAL(bit_reader.Read(1), 0U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(2), 2U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(3), 6U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(4), 11U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(5), 1U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(6), 32U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(7), 7U);
-    BOOST_CHECK_EQUAL(bit_reader.Read(16), 30497U);
-    BOOST_CHECK_THROW(bit_reader.Read(8), std::ios_base::failure);
+    ASSERT_EQ(bit_reader.Read(1), 0U);
+    ASSERT_EQ(bit_reader.Read(2), 2U);
+    ASSERT_EQ(bit_reader.Read(3), 6U);
+    ASSERT_EQ(bit_reader.Read(4), 11U);
+    ASSERT_EQ(bit_reader.Read(5), 1U);
+    ASSERT_EQ(bit_reader.Read(6), 32U);
+    ASSERT_EQ(bit_reader.Read(7), 7U);
+    ASSERT_EQ(bit_reader.Read(16), 30497U);
+    ASSERT_EXCEPTION(bit_reader.Read(8), std::ios_base::failure, HasReason{""});
 }
 
 BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
     {
         DataStream ds{};
         Obfuscation{}(ds);
-        BOOST_CHECK_EQUAL(""s, ds.str());
+        ASSERT_EQ(""s, ds.str());
     }
 
     {
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
 
         DataStream ds{"0ff0"_hex};
         obfuscation(ds);
-        BOOST_CHECK_EQUAL("\xf0\x0f"s, ds.str());
+        ASSERT_EQ("\xf0\x0f"s, ds.str());
     }
 
     {
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
 
         DataStream ds{"f00f"_hex};
         obfuscation(ds);
-        BOOST_CHECK_EQUAL("\x0f\x00"s, ds.str());
+        ASSERT_EQ("\x0f\x00"s, ds.str());
     }
 }
 
@@ -377,101 +377,101 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     file.seek(0, SEEK_SET);
 
     // The buffer size must be greater than the rewind amount.
-    BOOST_CHECK_EXCEPTION((BufferedFile{file, /*nBufSize=*/25, /*nRewindIn=*/25}), std::ios_base::failure, HasReason{"Rewind limit must be less than buffer size"});
+    ASSERT_EXCEPTION((BufferedFile{file, /*nBufSize=*/25, /*nRewindIn=*/25}), std::ios_base::failure, HasReason{"Rewind limit must be less than buffer size"});
 
     // The buffer is 25 bytes, allow rewinding 10 bytes.
     BufferedFile bf{file, 25, 10};
-    BOOST_CHECK(!bf.eof());
+    ASSERT(!bf.eof());
 
     uint8_t i;
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 0);
+    ASSERT_EQ(i, 0);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 1);
+    ASSERT_EQ(i, 1);
 
     // After reading bytes 0 and 1, we're positioned at 2.
-    BOOST_CHECK_EQUAL(bf.GetPos(), 2U);
+    ASSERT_EQ(bf.GetPos(), 2U);
 
     // Rewind to offset 0, ok (within the 10 byte window).
-    BOOST_CHECK(bf.SetPos(0));
+    ASSERT(bf.SetPos(0));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 0);
+    ASSERT_EQ(i, 0);
 
     // We can go forward to where we've been, but beyond may fail.
-    BOOST_CHECK(bf.SetPos(2));
+    ASSERT(bf.SetPos(2));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 2);
+    ASSERT_EQ(i, 2);
 
     // If you know the maximum number of bytes that should be
     // read to deserialize the variable, you can limit the read
     // extent. The current file offset is 3, so the following
     // SetLimit() allows zero bytes to be read.
-    BOOST_CHECK(bf.SetLimit(3));
-    BOOST_CHECK_EXCEPTION(bf >> i, std::ios_base::failure, HasReason{"Attempt to position past buffer limit"});
+    ASSERT(bf.SetLimit(3));
+    ASSERT_EXCEPTION(bf >> i, std::ios_base::failure, HasReason{"Attempt to position past buffer limit"});
     // The default argument removes the limit completely.
-    BOOST_CHECK(bf.SetLimit());
+    ASSERT(bf.SetLimit());
     // The read position should still be at 3 (no change).
-    BOOST_CHECK_EQUAL(bf.GetPos(), 3U);
+    ASSERT_EQ(bf.GetPos(), 3U);
 
     // Read from current offset, 3, forward until position 10.
     for (uint8_t j = 3; j < 10; ++j) {
         bf >> i;
-        BOOST_CHECK_EQUAL(i, j);
+        ASSERT_EQ(i, j);
     }
-    BOOST_CHECK_EQUAL(bf.GetPos(), 10U);
+    ASSERT_EQ(bf.GetPos(), 10U);
 
     // We're guaranteed (just barely) to be able to rewind to zero.
-    BOOST_CHECK(bf.SetPos(0));
-    BOOST_CHECK_EQUAL(bf.GetPos(), 0U);
+    ASSERT(bf.SetPos(0));
+    ASSERT_EQ(bf.GetPos(), 0U);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 0);
+    ASSERT_EQ(i, 0);
 
     // We can set the position forward again up to the farthest
     // into the stream we've been, but no farther. (Attempting
     // to go farther may succeed, but it's not guaranteed.)
-    BOOST_CHECK(bf.SetPos(10));
+    ASSERT(bf.SetPos(10));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 10);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 11U);
+    ASSERT_EQ(i, 10);
+    ASSERT_EQ(bf.GetPos(), 11U);
 
     // Now it's only guaranteed that we can rewind to offset 1
     // (current read position, 11, minus rewind amount, 10).
-    BOOST_CHECK(bf.SetPos(1));
-    BOOST_CHECK_EQUAL(bf.GetPos(), 1U);
+    ASSERT(bf.SetPos(1));
+    ASSERT_EQ(bf.GetPos(), 1U);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 1);
+    ASSERT_EQ(i, 1);
 
     // We can stream into large variables, even larger than
     // the buffer size.
-    BOOST_CHECK(bf.SetPos(11));
+    ASSERT(bf.SetPos(11));
     {
         uint8_t a[40 - 11];
         bf >> a;
         for (uint8_t j = 0; j < sizeof(a); ++j) {
-            BOOST_CHECK_EQUAL(a[j], 11 + j);
+            ASSERT_EQ(a[j], 11 + j);
         }
     }
-    BOOST_CHECK_EQUAL(bf.GetPos(), 40U);
+    ASSERT_EQ(bf.GetPos(), 40U);
 
     // We've read the entire file, the next read should throw.
-    BOOST_CHECK_EXCEPTION(bf >> i, std::ios_base::failure, HasReason{"BufferedFile::Fill: end of file"});
+    ASSERT_EXCEPTION(bf >> i, std::ios_base::failure, HasReason{"BufferedFile::Fill: end of file"});
     // Attempting to read beyond the end sets the EOF indicator.
-    BOOST_CHECK(bf.eof());
+    ASSERT(bf.eof());
 
     // Still at offset 40, we can go back 10, to 30.
-    BOOST_CHECK_EQUAL(bf.GetPos(), 40U);
-    BOOST_CHECK(bf.SetPos(30));
+    ASSERT_EQ(bf.GetPos(), 40U);
+    ASSERT(bf.SetPos(30));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 30);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 31U);
+    ASSERT_EQ(i, 30);
+    ASSERT_EQ(bf.GetPos(), 31U);
 
     // We're too far to rewind to position zero.
-    BOOST_CHECK(!bf.SetPos(0));
+    ASSERT(!bf.SetPos(0));
     // But we should now be positioned at least as far back as allowed
     // by the rewind window (relative to our farthest read position, 40).
-    BOOST_CHECK(bf.GetPos() <= 30U);
+    ASSERT(bf.GetPos() <= 30U);
 
-    BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+    ASSERT_EQ(file.fclose(), 0);
 
     fs::remove(streams_test_filename);
 }
@@ -493,30 +493,30 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_skip)
     // This is like bf >> (7-byte-variable), in that it will cause data
     // to be read from the file into memory, but it's not copied to us.
     bf.SkipTo(7);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 7U);
+    ASSERT_EQ(bf.GetPos(), 7U);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 7);
+    ASSERT_EQ(i, 7);
 
     // The bytes in the buffer up to offset 7 are valid and can be read.
-    BOOST_CHECK(bf.SetPos(0));
+    ASSERT(bf.SetPos(0));
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 0);
+    ASSERT_EQ(i, 0);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 1);
+    ASSERT_EQ(i, 1);
 
     bf.SkipTo(11);
     bf >> i;
-    BOOST_CHECK_EQUAL(i, 11);
+    ASSERT_EQ(i, 11);
 
     // SkipTo() honors the transfer limit; we can't position beyond the limit.
     bf.SetLimit(13);
-    BOOST_CHECK_EXCEPTION(bf.SkipTo(14), std::ios_base::failure, HasReason{"Attempt to position past buffer limit"});
+    ASSERT_EXCEPTION(bf.SkipTo(14), std::ios_base::failure, HasReason{"Attempt to position past buffer limit"});
 
     // We can position exactly to the transfer limit.
     bf.SkipTo(13);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 13U);
+    ASSERT_EQ(bf.GetPos(), 13U);
 
-    BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+    ASSERT_EQ(file.fclose(), 0);
     fs::remove(streams_test_filename);
 }
 
@@ -544,8 +544,8 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 break;
 
             // We haven't read to the end of the file yet.
-            BOOST_CHECK(!bf.eof());
-            BOOST_CHECK_EQUAL(bf.GetPos(), currentPos);
+            ASSERT(!bf.eof());
+            ASSERT_EQ(bf.GetPos(), currentPos);
 
             // Pretend the file consists of a series of objects of varying
             // sizes; the boundaries of the objects can interact arbitrarily
@@ -559,7 +559,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 bf.SetLimit(currentPos + 1);
                 bf >> a;
                 for (uint8_t i = 0; i < 1; ++i) {
-                    BOOST_CHECK_EQUAL(a[i], currentPos);
+                    ASSERT_EQ(a[i], currentPos);
                     currentPos++;
                 }
                 break;
@@ -571,7 +571,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 bf.SetLimit(currentPos + 2);
                 bf >> a;
                 for (uint8_t i = 0; i < 2; ++i) {
-                    BOOST_CHECK_EQUAL(a[i], currentPos);
+                    ASSERT_EQ(a[i], currentPos);
                     currentPos++;
                 }
                 break;
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 bf.SetLimit(currentPos + 5);
                 bf >> a;
                 for (uint8_t i = 0; i < 5; ++i) {
-                    BOOST_CHECK_EQUAL(a[i], currentPos);
+                    ASSERT_EQ(a[i], currentPos);
                     currentPos++;
                 }
                 break;
@@ -605,13 +605,13 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                     find = fileSize - 1;
                 bf.FindByte(std::byte(find));
                 // The value at each offset is the offset.
-                BOOST_CHECK_EQUAL(bf.GetPos(), find);
+                ASSERT_EQ(bf.GetPos(), find);
                 currentPos = find;
 
                 bf.SetLimit(currentPos + 1);
                 uint8_t i;
                 bf >> i;
-                BOOST_CHECK_EQUAL(i, currentPos);
+                ASSERT_EQ(i, currentPos);
                 currentPos++;
                 break;
             }
@@ -623,13 +623,13 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 // window, and we may not be able to move forward beyond the
                 // farthest position we've reached so far.
                 currentPos = bf.GetPos();
-                BOOST_CHECK_EQUAL(okay, currentPos == requestPos);
+                ASSERT_EQ(okay, currentPos == requestPos);
                 // Check that we can position within the rewind window.
                 if (requestPos <= maxPos &&
                     maxPos > rewindSize &&
                     requestPos >= maxPos - rewindSize) {
                     // We requested a position within the rewind window.
-                    BOOST_CHECK(okay);
+                    ASSERT(okay);
                 }
                 break;
             }
@@ -637,7 +637,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
             if (maxPos < currentPos)
                 maxPos = currentPos;
         }
-        BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+        ASSERT_EQ(file.fclose(), 0);
     }
     fs::remove(streams_test_filename);
 }
@@ -655,9 +655,9 @@ BOOST_AUTO_TEST_CASE(buffered_reader_matches_autofile_random_content)
     {
         AutoFile f{test_file.Open(pos, /*read_only=*/false), obfuscation};
         f.write(m_rng.randbytes<std::byte>(file_size));
-        BOOST_REQUIRE_EQUAL(f.fclose(), 0);
+        ASSERT_EQ(f.fclose(), 0);
     }
-    BOOST_CHECK_EQUAL(fs::file_size(test_file.FileName(pos)), file_size);
+    ASSERT_EQ(fs::file_size(test_file.FileName(pos)), file_size);
 
     {
         AutoFile direct_file{test_file.Open(pos, /*read_only=*/true), obfuscation};
@@ -684,12 +684,12 @@ BOOST_AUTO_TEST_CASE(buffered_reader_matches_autofile_random_content)
 
         {
             DataBuffer excess_byte{1};
-            BOOST_CHECK_EXCEPTION(direct_file.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+            ASSERT_EXCEPTION(direct_file.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
         }
 
         {
             DataBuffer excess_byte{1};
-            BOOST_CHECK_EXCEPTION(buffered_reader.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+            ASSERT_EXCEPTION(buffered_reader.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
         }
     }
 
@@ -725,8 +725,8 @@ BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
                 total_written += write_size;
             }
         }
-        BOOST_REQUIRE_EQUAL(buffered_file.fclose(), 0);
-        BOOST_REQUIRE_EQUAL(direct_file.fclose(), 0);
+        ASSERT_EQ(buffered_file.fclose(), 0);
+        ASSERT_EQ(direct_file.fclose(), 0);
     }
 
     // Compare the resulting files
@@ -736,7 +736,7 @@ BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
         verify_direct.read(direct_result);
 
         DataBuffer excess_byte{1};
-        BOOST_CHECK_EXCEPTION(verify_direct.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+        ASSERT_EXCEPTION(verify_direct.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
     }
 
     DataBuffer buffered_result{file_size};
@@ -745,7 +745,7 @@ BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
         verify_buffered.read(buffered_result);
 
         DataBuffer excess_byte{1};
-        BOOST_CHECK_EXCEPTION(verify_buffered.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+        ASSERT_EXCEPTION(verify_buffered.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
     }
 
     BOOST_CHECK_EQUAL_COLLECTIONS(
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE(buffered_writer_reader)
         f << v1 << v2;
         f.write(std::as_bytes(std::span{&v3, 1}));
     }
-    BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+    ASSERT_EQ(file.fclose(), 0);
 
     // Read back and verify using BufferedReader
     {
@@ -778,12 +778,12 @@ BOOST_AUTO_TEST_CASE(buffered_writer_reader)
         BufferedReader f(std::move(file), sizeof(v1) + sizeof(v2) + sizeof(v3));
         f >> _v1 >> _v2;
         f.read(std::as_writable_bytes(std::span{&_v3, 1}));
-        BOOST_CHECK_EQUAL(_v1, v1);
-        BOOST_CHECK_EQUAL(_v2, v2);
-        BOOST_CHECK_EQUAL(_v3, v3);
+        ASSERT_EQ(_v1, v1);
+        ASSERT_EQ(_v2, v2);
+        ASSERT_EQ(_v3, v3);
 
         DataBuffer excess_byte{1};
-        BOOST_CHECK_EXCEPTION(f.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
+        ASSERT_EXCEPTION(f.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
     }
 
     fs::remove(test_file);
@@ -799,8 +799,8 @@ BOOST_AUTO_TEST_CASE(streams_hashed)
     HashVerifier hash_verifier{stream};
     std::string result;
     hash_verifier >> result;
-    BOOST_CHECK_EQUAL(data, result);
-    BOOST_CHECK_EQUAL(hash_writer.GetHash(), hash_verifier.GetHash());
+    ASSERT_EQ(data, result);
+    ASSERT_EQ(hash_writer.GetHash(), hash_verifier.GetHash());
 }
 
 BOOST_AUTO_TEST_CASE(size_preserves_position)
@@ -818,7 +818,7 @@ BOOST_AUTO_TEST_CASE(size_preserves_position)
     (void)f.size();
     uint8_t first{};
     f >> first;
-    BOOST_CHECK_EQUAL(first, 0);
+    ASSERT_EQ(first, 0);
 
     // Case: Pos at middle of the file
     f.seek(0, SEEK_SET);
@@ -828,15 +828,15 @@ BOOST_AUTO_TEST_CASE(size_preserves_position)
     uint8_t middle{};
     f >> middle;
     // Pos still at 4
-    BOOST_CHECK_EQUAL(middle, 4);
+    ASSERT_EQ(middle, 4);
 
     // Case: Pos at EOF
     f.seek(0, SEEK_END);
     (void)f.size();
     uint8_t end{};
-    BOOST_CHECK_EXCEPTION(f >> end, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
+    ASSERT_EXCEPTION(f >> end, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
 
-    BOOST_REQUIRE_EQUAL(f.fclose(), 0);
+    ASSERT_EQ(f.fclose(), 0);
     fs::remove(path);
 }
 

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -45,8 +45,8 @@ BOOST_AUTO_TEST_CASE(xor_random_chunks)
         }
 
         apply_random_xor_chunks(roundtrip, obfuscation);
-        BOOST_CHECK_EQUAL_COLLECTIONS(roundtrip.begin(), roundtrip.end(), original.begin(), original.end());
-  }
+        ASSERT_EQ_COLLECTIONS(roundtrip, original);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(obfuscation_hexkey)
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(obfuscation_serialize)
     ds_out >> key_out;
 
     // Make sure saved key is the same.
-    BOOST_CHECK_EQUAL_COLLECTIONS(key_in.begin(), key_in.end(), key_out.begin(), key_out.end());
+    ASSERT_EQ_COLLECTIONS(key_in, key_out);
 }
 
 BOOST_AUTO_TEST_CASE(obfuscation_empty)
@@ -674,10 +674,7 @@ BOOST_AUTO_TEST_CASE(buffered_reader_matches_autofile_random_content)
             DataBuffer buffered_buffer{read};
             buffered_reader.read(buffered_buffer);
 
-            BOOST_CHECK_EQUAL_COLLECTIONS(
-                direct_file_buffer.begin(), direct_file_buffer.end(),
-                buffered_buffer.begin(), buffered_buffer.end()
-            );
+            ASSERT_EQ_COLLECTIONS(direct_file_buffer, buffered_buffer);
 
             total_read += read;
         }
@@ -748,10 +745,7 @@ BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
         ASSERT_EXCEPTION(verify_buffered.read(excess_byte), std::ios_base::failure, HasReason{"end of file"});
     }
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(
-        direct_result.begin(), direct_result.end(),
-        buffered_result.begin(), buffered_result.end()
-    );
+    ASSERT_EQ_COLLECTIONS(direct_result, buffered_result);
 
     fs::remove(test_direct.FileName(pos));
     fs::remove(test_buffered.FileName(pos));

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_library(test_util STATIC EXCLUDE_FROM_ALL
   blockfilter.cpp
   coins.cpp
+  common.cpp
   coverage.cpp
   json.cpp
   logging.cpp

--- a/src/test/util/common.cpp
+++ b/src/test/util/common.cpp
@@ -1,0 +1,5 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <test/util/common.h>

--- a/src/test/util/common.h
+++ b/src/test/util/common.h
@@ -5,10 +5,24 @@
 #ifndef BITCOIN_TEST_UTIL_COMMON_H
 #define BITCOIN_TEST_UTIL_COMMON_H
 
+#include <tinyformat.h>
+
+#include <algorithm>
 #include <chrono>
+#include <concepts>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <iterator>
 #include <optional>
-#include <ostream>
+#include <ranges>
+#include <source_location>
+#include <sstream>
 #include <string>
+#include <string_view>
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
 
 /**
  * BOOST_CHECK_EXCEPTION predicates to check the specific validation error.
@@ -58,5 +72,166 @@ inline std::ostream& operator<<(std::ostream& os, const T& obj)
 }
 
 // @}
+
+namespace detail {
+
+/// Returns a printable Python-style b"" byte string with \x escapes.
+inline std::string make_printable(std::string_view v)
+{
+    std::string out = "b\"";
+    out.reserve(v.size() * 2); // Include a bit of overhead
+    for (unsigned char c : v) {
+        if (32 <= c && c <= 126 && c != '\\' && c != '\"') {
+            // Any ascii_is_printing char other than quote and backslash is fine.
+            out += static_cast<char>(c);
+        } else {
+            // The others are escaped.
+            out += tfm::format("\\x%02X", c);
+        }
+    }
+    out += '\"';
+    return out;
+}
+
+/// Make a value nicely readable after a test failure.
+template <typename T>
+std::string format_value(const T& value)
+{
+    if constexpr (std::same_as<T, bool>) {
+        // Use boolalpha formatting
+        return value ? "true" : "false";
+    } else if constexpr (std::is_integral_v<T> && sizeof(T) == 1) {
+        // May represent a char, but avoid printing terminal escape codes
+        // Like std::ascii_is_printing from C++26
+        if (32 <= value && value <= 126) {
+            return tfm::format("%s ('%c')", int{value}, static_cast<char>(value));
+        } else {
+            return tfm::format("%s (0x%02X)", int{value}, static_cast<unsigned char>(value));
+        }
+    } else if constexpr (std::is_pointer_v<T> || std::is_array_v<T>) {
+        // Passing an array as a value is often wrong, because the check
+        // may have meant to run on the elements of the array. Even for
+        // string equality checks, char* pointers and char[N] arrays may be
+        // unsafe, because they may lack a null terminator.
+        //
+        // Tolerate only const char* (not char*) and const char[N] to
+        // compare strings. The dev should generally prefer std::string and
+        // std::string_view.
+        if constexpr (std::is_bounded_array_v<T> && std::same_as<std::remove_all_extents_t<T>, char>) {
+            return tfm::format("%s from char array (%p)", make_printable(value), value);
+        } else if constexpr (std::same_as<T, const char*>) {
+            if (value != nullptr) {
+                return tfm::format("%s from pointer (%p)", make_printable(value), value);
+            }
+        }
+        return tfm::format("pointer (%p)", value);
+    } else if constexpr (std::same_as<T, std::string> || std::same_as<T, std::string_view>) {
+        return make_printable(value);
+    } else {
+        static_assert(requires(std::ostream& os) { os << value; }, "Please provide an operator<<(std::ostream&, const T&) for formatting.");
+        std::ostringstream out;
+        out << value;
+        return out.str();
+    }
+}
+
+[[noreturn]] inline void fail_report(std::string_view expr, std::string_view explanation, const std::source_location& loc)
+{
+    std::cerr << tfm::format("%s(%s): Error: Check '%s' failed in \"%s\"! %s\n", loc.file_name(), loc.line(), expr, loc.function_name(), explanation)
+              << std::endl;
+    std::abort();
+}
+
+// The fail-fast behavior of the check_* unit test helpers is intentional.
+// Also, they are marked noexcept, because the handling itself must not throw.
+
+inline void check_bool(bool result, std::string_view expr, std::source_location loc = std::source_location::current()) noexcept
+{
+    if (!result) fail_report(expr, "", loc);
+}
+
+template <typename L, typename R, typename OpFunc>
+void check_op(const L& lhs, const R& rhs, std::string_view expr, const char* inv_op, const OpFunc& op,
+              std::source_location loc = std::source_location::current()) noexcept
+{
+    if constexpr (std::is_integral_v<L> && std::is_integral_v<R>) {
+        // Reject mixed signs for integrals after integral promotion.
+        if constexpr (std::is_signed_v<decltype(std::declval<L>() + 0)> != std::is_signed_v<decltype(std::declval<R>() + 0)>) {
+            static_assert(std::is_signed_v<L> == std::is_signed_v<R>,
+                          "ERROR: Mixed signed/unsigned comparison! Ensure both sides have the same type of signedness.");
+        }
+    }
+    if (!op(lhs, rhs)) {
+        std::string explanation{"[" + format_value(lhs) + " " + inv_op + " " + format_value(rhs) + "]"};
+        fail_report(expr, explanation, loc);
+    }
+}
+
+template <std::ranges::forward_range L, std::ranges::forward_range R>
+void check_eq_collections(const L& lhs, const R& rhs, std::string_view expr, std::source_location loc = std::source_location::current())
+{
+    auto [it1, it2] = std::ranges::mismatch(lhs, rhs);
+    auto end1 = std::ranges::end(lhs);
+    auto end2 = std::ranges::end(rhs);
+
+    // If both reached end, they are identical
+    if (it1 == end1 && it2 == end2) return;
+
+    auto format_it = [](auto it, auto end) -> std::string {
+        if (it == end) return "end";
+        return format_value(*it);
+    };
+
+    auto index = std::ranges::distance(std::ranges::begin(lhs), it1);
+
+    std::string explanation = tfm::format("Mismatch at index %d: [%s != %s]", index, format_it(it1, end1), format_it(it2, end2));
+
+    fail_report(expr, explanation, loc);
+}
+
+template <typename ExType, typename Func, typename Predicate>
+void check_exception(std::string_view expr, std::string_view type, std::string_view pred_expr, const Func& code, const Predicate& pred,
+                     std::source_location loc = std::source_location::current()) noexcept
+{
+    try {
+        code();
+        std::string m{tfm::format("Nothing was thrown while expecting %s to be thrown.", type)};
+        fail_report(expr, m, loc);
+    } catch (const ExType& ex) {
+        if (!pred(ex)) {
+            std::string m{tfm::format("The correct exception type was caught, but the predicate [%s] failed.", pred_expr)};
+            if constexpr (requires { ex.what(); }) {
+                m += " Exception message: ";
+                m += ex.what();
+            }
+            fail_report(expr, m, loc);
+        }
+        return;
+    } catch (...) {
+        std::exception_ptr ex{std::current_exception()};
+        std::string detail{"Non-standard exception object"};
+        try {
+            if (ex) std::rethrow_exception(ex);
+        } catch (const std::exception& e) {
+            // name might be mangled, but this should be fine and still understandable and useful
+            detail = tfm::format("[%s] with message: %s", typeid(e).name(), e.what());
+        } catch (...) {
+        }
+        std::string m{tfm::format("Expected [%s] but caught different exception: %s", type, detail)};
+        fail_report(expr, m, loc);
+    }
+}
+
+} // namespace detail
+
+#define ASSERT(expr) detail::check_bool(static_cast<bool>(expr), #expr)
+#define ASSERT_EQ(l, r) detail::check_op(l, r, #l " == " #r, "!=", std::equal_to<>{})
+#define ASSERT_NE(l, r) detail::check_op(l, r, #l " != " #r, "==", std::not_equal_to<>{})
+#define ASSERT_LT(l, r) detail::check_op(l, r, #l " < " #r, ">=", std::less<>{})
+#define ASSERT_GT(l, r) detail::check_op(l, r, #l " > " #r, "<=", std::greater<>{})
+#define ASSERT_LE(l, r) detail::check_op(l, r, #l " <= " #r, ">", std::less_equal<>{})
+#define ASSERT_GE(l, r) detail::check_op(l, r, #l " >= " #r, "<", std::greater_equal<>{})
+#define ASSERT_EQ_COLLECTIONS(l, r) detail::check_eq_collections(l, r, "range equality of " #l ", " #r)
+#define ASSERT_EXCEPTION(expr, exp_type, pred) detail::check_exception<exp_type>(#expr, #exp_type, #pred, [&]() { (void)(expr); }, pred)
 
 #endif // BITCOIN_TEST_UTIL_COMMON_H


### PR DESCRIPTION
Currently, the unit tests use different boost check macros. However, this is problematic:

* The check macros are tied to the boost test framework and can not be used in other tests, such as the fuzz tests.
* The check macros are not overflow-safe. For example `BOOST_CHECK_GT(-10, 10U);` compiles and passes fine, even though it is obviously wrong.
* The check macros are not thread-safe. Using them in a thread will compile fine, but then fail tsan later on. Usually it is trivial to replace them by a plain `assert`, but it would be better if the macros just worked under tsan.
* The check macros are not fast-failing. This is confusing, as the test continues to run and will print more logs, making it harder to spot the first failure. Also, it is contrary to the internal check macros `assert` and `Assert`, and even `CHECK_NONFATAL` under debug mode, which all lead to an immediate abort.

Fix all issues by adding new check macros: `ASSERT`, `ASSERT_EQ` (and friends), `ASSERT_EQ_COLLECTIONS` (C++20 range-based), as well as `ASSERT_EXCEPTION`. They can be used as a drop-in replacement for the corresponding boost macro.

The implementation for all macros is only ~150 LOC, so it should be preferable to any external dependency addressing the above issues (which I couldn't find anyway).

(Tracking issue: https://github.com/bitcoin/bitcoin/issues/34666)

### Note on naming (why `ASSERT`?)

The test macros follow the naming and semantics of the internal Bitcoin Core macros (`assert`, and `Assert`). While it may confusing to have three unary `assert` macros that do *roughly* the same, it should be harmless and any macro that compiles is fine to use. (There is a special edge case to `Assert`, which allows to be turned into an exception as part of `g_detail_test_only_CheckFailuresAreExceptionsNotAborts`, but this shouldn't matter much).

In theory, if devs didn't care about nice diagnostic messages on a failure (printing the left and right side), the macros could even be a direct alias of `assert` or `Assert`, reducing the LOC even more. Though, I think it is fine and preferable to have slightly better failure messages in tests.

Also, the naming and semantics follow the Bitcoin Core functional test macros, which also start with `assert_`.

### Later optimizations

The macros are currently sitting in the header, but once they are applied to the whole codebase, the pretty-printing implementation can move to a cpp file, which reduces the weight of the header and makes it possible to change or add pretty-printing features without a whole re-compilation of all tests.