### PR TITLE
ci: migrate linux CI jobs to namespace

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -1,7 +1,7 @@
 name: 'Configure Docker'
 description: 'Set up Docker build driver and configure build cache args'
 inputs:
-  cache-provider:
+  provider:
     description: 'gha or cirrus cache provider'
     required: true
 runs:
@@ -10,9 +10,9 @@ runs:
     - name: Check inputs
       shell: python
       run: |
-        # We expect only gha or cirrus as inputs to cache-provider
-        if "${{ inputs.cache-provider }}" not in ("gha", "cirrus"):
-          print("::warning title=Unknown input to configure docker action::Provided value was ${{ inputs.cache-provider }}")
+        # We expect only gha or cirrus as inputs to provider
+        if "${{ inputs.provider }}" not in ("gha", "cirrus"):
+          print("::warning title=Unknown input to configure docker action::Provided value was ${{ inputs.provider }}")
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
@@ -43,7 +43,7 @@ runs:
         # which are set automatically when running on GitHub infra: https://docs.docker.com/build/cache/backends/gha/#synopsis
 
         # Use cirrus cache host
-        if [[ ${{ inputs.cache-provider }} == 'cirrus' ]]; then
+        if [[ ${{ inputs.provider }} == 'cirrus' ]]; then
           url_args="url=${CIRRUS_CACHE_HOST},url_v2=${CIRRUS_CACHE_HOST}"
         else
           url_args=""
@@ -53,7 +53,7 @@ runs:
         args=(--cache-from "type=gha${url_args:+,${url_args}},scope=${CONTAINER_NAME}")
 
         # Only add --cache-to when using the Cirrus cache provider and pushing to the default branch.
-        if [[ ${{ inputs.cache-provider }} == 'cirrus' && ${{ github.event_name }} == "push" && ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
+        if [[ ${{ inputs.provider }} == 'cirrus' && ${{ github.event_name }} == "push" && ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
           args+=(--cache-to "type=gha${url_args:+,${url_args}},mode=max,ignore-error=true,scope=${CONTAINER_NAME}")
         fi
 

--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -1,8 +1,8 @@
 name: 'Configure Docker'
-description: 'Set up Docker build driver and configure build cache args'
+description: 'Set up Docker build driver for GitHub-hosted or Namespace runners'
 inputs:
   provider:
-    description: 'gha or cirrus cache provider'
+    description: 'Runner provider'
     required: true
 runs:
   using: 'composite'
@@ -10,54 +10,25 @@ runs:
     - name: Check inputs
       shell: python
       run: |
-        # We expect only gha or cirrus as inputs to provider
-        if "${{ inputs.provider }}" not in ("gha", "cirrus"):
+        # We expect only gha or namespace as inputs to provider
+        if "${{ inputs.provider }}" not in ("gha", "namespace"):
           print("::warning title=Unknown input to configure docker action::Provided value was ${{ inputs.provider }}")
 
+    - name: Configure Namespace Remote Docker Builder
+      if: inputs.provider == 'namespace'
+      uses: namespacelabs/nscloud-setup-buildx-action@v0
+
     - name: Set up Docker Buildx
+      if: inputs.provider == 'gha'
       uses: docker/setup-buildx-action@v4
       with:
-        # Use host network to allow access to cirrus gha cache running on the host
         driver-opts: |
           network=host
 
-    # This is required to allow buildkit to access the actions cache
-    - name: Expose actions cache variables
-      uses: actions/github-script@v8
-      with:
-        script: |
-          Object.keys(process.env).forEach(function (key) {
-            if (key.startsWith('ACTIONS_')) {
-              core.info(`Exporting ${key}`);
-              core.exportVariable(key, process.env[key]);
-            }
-          });
-
-    - name: Construct docker build cache args
+    - name: Configure docker build args
+      if: inputs.provider == 'gha'
       shell: bash
       run: |
-        # Configure docker build cache backend
-        #
-        # On forks the gha cache will work but will use Github's cache backend.
-        # Docker will check for variables $ACTIONS_CACHE_URL, $ACTIONS_RESULTS_URL and $ACTIONS_RUNTIME_TOKEN
-        # which are set automatically when running on GitHub infra: https://docs.docker.com/build/cache/backends/gha/#synopsis
-
-        # Use cirrus cache host
-        if [[ ${{ inputs.provider }} == 'cirrus' ]]; then
-          url_args="url=${CIRRUS_CACHE_HOST},url_v2=${CIRRUS_CACHE_HOST}"
-        else
-          url_args=""
-        fi
-
-        # Always optimistically --cache‑from in case a cache blob exists
-        args=(--cache-from "type=gha${url_args:+,${url_args}},scope=${CONTAINER_NAME}")
-
-        # Only add --cache-to when using the Cirrus cache provider and pushing to the default branch.
-        if [[ ${{ inputs.provider }} == 'cirrus' && ${{ github.event_name }} == "push" && ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
-          args+=(--cache-to "type=gha${url_args:+,${url_args}},mode=max,ignore-error=true,scope=${CONTAINER_NAME}")
-        fi
-
-        # Always `--load` into docker images (needed when using the `docker-container` build driver).
-        args+=(--load)
-
-        echo "DOCKER_BUILD_CACHE_ARG=${args[*]}" >> $GITHUB_ENV
+        # --load copies the built image into the local docker image store
+        # so the subsequent `docker run` can find it.
+        echo "DOCKER_BUILD_CACHE_ARG=--load" >> "$GITHUB_ENV"

--- a/.github/actions/configure-environment/action.yml
+++ b/.github/actions/configure-environment/action.yml
@@ -1,27 +1,39 @@
 name: 'Configure environment'
 description: 'Configure CI, cache and container name environment variables'
+inputs:
+  provider:
+    description: 'Runner provider'
+    required: true
 runs:
   using: 'composite'
   steps:
+    - name: Set cache hashes
+      shell: bash
+      run: |
+        echo "DEPENDS_HASH=$(git ls-tree HEAD depends "$FILE_ENV" | sha256sum | cut -d' ' -f1)" >> "$GITHUB_ENV"
+        echo "PREVIOUS_RELEASES_HASH=$(git ls-tree HEAD test/get_previous_releases.py | sha256sum | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+    - name: Get container name
+      shell: bash
+      run: |
+        source "$FILE_ENV"
+        echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+
     - name: Set CI and cache directories
       shell: bash
       run: |
         echo "BASE_ROOT_DIR=${{ runner.temp }}" >> "$GITHUB_ENV"
         echo "BASE_BUILD_DIR=${{ runner.temp }}/build" >> "$GITHUB_ENV"
-        echo "CCACHE_DIR=${{ runner.temp }}/ccache_dir" >> $GITHUB_ENV
         echo "DEPENDS_DIR=${{ runner.temp }}/depends" >> "$GITHUB_ENV"
-        echo "BASE_CACHE=${{ runner.temp }}/depends/built" >> $GITHUB_ENV
-        echo "SOURCES_PATH=${{ runner.temp }}/depends/sources" >> $GITHUB_ENV
-        echo "PREVIOUS_RELEASES_DIR=${{ runner.temp }}/previous_releases" >> $GITHUB_ENV
 
-    - name: Set cache hashes
-      shell: bash
-      run: |
-        echo "DEPENDS_HASH=$(git ls-tree HEAD depends "$FILE_ENV" | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-        echo "PREVIOUS_RELEASES_HASH=$(git ls-tree HEAD test/get_previous_releases.py | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+        cache_root="${HOME}/.cache/bitcoin-ci/${CONTAINER_NAME}"
+        mkdir -p \
+          "${cache_root}/ccache_dir" \
+          "${cache_root}/depends/built/${DEPENDS_HASH}" \
+          "${cache_root}/depends/sources/${DEPENDS_HASH}" \
+          "${cache_root}/previous_releases/${PREVIOUS_RELEASES_HASH}"
 
-    - name: Get container name
-      shell: bash
-      run: |
-        source $FILE_ENV
-        echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+        echo "CCACHE_DIR=${cache_root}/ccache_dir" >> "$GITHUB_ENV"
+        echo "BASE_CACHE=${cache_root}/depends/built/${DEPENDS_HASH}" >> "$GITHUB_ENV"
+        echo "SOURCES_PATH=${cache_root}/depends/sources/${DEPENDS_HASH}" >> "$GITHUB_ENV"
+        echo "PREVIOUS_RELEASES_DIR=${cache_root}/previous_releases/${PREVIOUS_RELEASES_HASH}" >> "$GITHUB_ENV"

--- a/.github/actions/restore-caches/action.yml
+++ b/.github/actions/restore-caches/action.yml
@@ -1,11 +1,26 @@
 name: 'Restore Caches'
 description: 'Restore ccache, depends sources, and built depends caches'
+inputs:
+  provider:
+    description: 'Runner provider'
+    required: true
 runs:
   using: 'composite'
   steps:
+    - name: Mount Namespace cache volumes
+      if: inputs.provider == 'namespace'
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        path: |
+          ${{ env.CCACHE_DIR }}
+          ${{ env.SOURCES_PATH }}
+          ${{ env.BASE_CACHE }}
+          ${{ env.PREVIOUS_RELEASES_DIR }}
+
     - name: Restore Ccache cache
+      if: inputs.provider == 'gha'
       id: ccache-cache
-      uses: cirruslabs/cache/restore@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ env.CONTAINER_NAME }}-${{ github.run_id }}
@@ -13,8 +28,9 @@ runs:
           ccache-${{ env.CONTAINER_NAME }}-
 
     - name: Restore depends sources cache
+      if: inputs.provider == 'gha'
       id: depends-sources
-      uses: cirruslabs/cache/restore@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.SOURCES_PATH }}
         key: depends-sources-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
@@ -22,8 +38,9 @@ runs:
           depends-sources-${{ env.CONTAINER_NAME }}-
 
     - name: Restore built depends cache
+      if: inputs.provider == 'gha'
       id: depends-built
-      uses: cirruslabs/cache/restore@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.BASE_CACHE }}
         key: depends-built-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
@@ -31,8 +48,9 @@ runs:
           depends-built-${{ env.CONTAINER_NAME }}-
 
     - name: Restore previous releases cache
+      if: inputs.provider == 'gha'
       id: previous-releases
-      uses: cirruslabs/cache/restore@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.PREVIOUS_RELEASES_DIR }}
         key: previous-releases-${{ env.CONTAINER_NAME }}-${{ env.PREVIOUS_RELEASES_HASH }}
@@ -40,6 +58,7 @@ runs:
           previous-releases-${{ env.CONTAINER_NAME }}-
 
     - name: export cache hits
+      if: inputs.provider == 'gha'
       shell: bash
       run: |
         echo "depends-sources-cache-hit=${{ steps.depends-sources.outputs.cache-hit }}" >> $GITHUB_ENV

--- a/.github/actions/save-caches/action.yml
+++ b/.github/actions/save-caches/action.yml
@@ -1,9 +1,14 @@
 name: 'Save Caches'
 description: 'Save ccache, depends sources, and built depends caches'
+inputs:
+  provider:
+    description: 'Runner provider'
+    required: true
 runs:
   using: 'composite'
   steps:
     - name: debug cache hit inputs
+      if: inputs.provider == 'gha'
       shell: bash
       run: |
         echo "depends sources direct cache hit to primary key: ${{ env.depends-sources-cache-hit }}"
@@ -11,29 +16,29 @@ runs:
         echo "previous releases direct cache hit to primary key: ${{ env.previous-releases-cache-hit }}"
 
     - name: Save Ccache cache
-      uses: cirruslabs/cache/save@v5
-      if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) }}
+      if: ${{ inputs.provider == 'gha' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
+      uses: actions/cache/save@v5
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ env.CONTAINER_NAME }}-${{ github.run_id }}
 
     - name: Save depends sources cache
-      uses: cirruslabs/cache/save@v5
-      if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.depends-sources-cache-hit != 'true') }}
+      if: ${{ inputs.provider == 'gha' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && env.depends-sources-cache-hit != 'true' }}
+      uses: actions/cache/save@v5
       with:
         path: ${{ env.SOURCES_PATH }}
         key: depends-sources-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
 
     - name: Save built depends cache
-      uses: cirruslabs/cache/save@v5
-      if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.depends-built-cache-hit != 'true' )}}
+      if: ${{ inputs.provider == 'gha' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && env.depends-built-cache-hit != 'true' }}
+      uses: actions/cache/save@v5
       with:
         path: ${{ env.BASE_CACHE }}
         key: depends-built-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
 
     - name: Save previous releases cache
-      uses: cirruslabs/cache/save@v5
-      if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.previous-releases-cache-hit != 'true' )}}
+      if: ${{ inputs.provider == 'gha' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && env.previous-releases-cache-hit != 'true' }}
+      uses: actions/cache/save@v5
       with:
         path: ${{ env.PREVIOUS_RELEASES_DIR }}
         key: previous-releases-${{ env.CONTAINER_NAME }}-${{ env.PREVIOUS_RELEASES_HASH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          cache-provider: ${{ needs.runners.outputs.provider }}
+          provider: ${{ needs.runners.outputs.provider }}
 
       - name: CI script
         run: ./ci/test_run_all.sh
@@ -554,7 +554,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          cache-provider: ${{ matrix.provider || needs.runners.outputs.provider }}
+          provider: ${{ matrix.provider || needs.runners.outputs.provider }}
 
       - name: Clear unnecessary files
         if: ${{ needs.runners.outputs.provider == 'gha' && true || false }} # Only needed on GHA runners
@@ -597,7 +597,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          cache-provider: ${{ needs.runners.outputs.provider }}
+          provider: ${{ needs.runners.outputs.provider }}
 
       - name: CI script
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
   windows-cross:
     name: 'Windows-cross to x86_64, ${{ matrix.crt }}'
     needs: [runners, record-frozen-commit]
-    runs-on: ${{ needs.runners.outputs.provider == 'namespace' && 'namespace-profile-x64-linux-small' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.runners.outputs.provider == 'namespace' && format('namespace-profile-x64-linux-small;overrides.cache-tag={0}', matrix.cache-tag) || 'ubuntu-24.04' }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
 
     strategy:
@@ -333,15 +333,19 @@ jobs:
         crt: [msvcrt, ucrt]
         include:
           - crt: msvcrt
+            # cache-tags are needed at GHA template time to restore the correct cache mount for the job (in the runs-on field), so can't be read from $FILE_ENV or any other file.
+            cache-tag: 'bitcoin-ci-windows-cross-msvcrt'
             file-env: './ci/test/00_setup_env_win64_msvcrt.sh'
             artifact-name: 'x86_64-w64-mingw32-executables'
           - crt: ucrt
+            cache-tag: 'bitcoin-ci-windows-cross-ucrt'
             file-env: './ci/test/00_setup_env_win64.sh'
             artifact-name: 'x86_64-w64-mingw32ucrt-executables'
 
     env:
       FILE_ENV: ${{ matrix.file-env }}
       DANGER_CI_ON_HOST_FOLDERS: 1
+      RUNNER_PROVIDER: ${{ needs.runners.outputs.provider }}
 
     steps:
       - *ANNOTATION_PR_NUMBER
@@ -357,19 +361,22 @@ jobs:
           provider: ${{ needs.runners.outputs.provider }}
 
       - name: Restore caches
-        id: restore-cache
         uses: ./.github/actions/restore-caches
+        with:
+          provider: ${{ env.RUNNER_PROVIDER }}
 
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          provider: ${{ needs.runners.outputs.provider }}
+          provider: ${{ env.RUNNER_PROVIDER }}
 
       - name: CI script
         run: ./ci/test_run_all.sh
 
       - name: Save caches
         uses: ./.github/actions/save-caches
+        with:
+          provider: ${{ env.RUNNER_PROVIDER }}
 
       - name: Upload built executables
         uses: actions/upload-artifact@v7
@@ -437,103 +444,119 @@ jobs:
   ci-matrix:
     name: ${{ matrix.name }}
     needs: runners
-    runs-on: ${{ matrix.namespace-runner && needs.runners.outputs.provider == 'namespace' && matrix.namespace-runner || matrix.fallback-runner }}
+    runs-on: ${{ matrix.namespace-runner && needs.runners.outputs.provider == 'namespace' && format('{0};overrides.cache-tag={1}', matrix.namespace-runner, matrix.cache-tag) || matrix.fallback-runner }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
 
     env:
       DANGER_CI_ON_HOST_FOLDERS: 1
       FILE_ENV: ${{ matrix.file-env }}
+      RUNNER_PROVIDER: ${{ matrix.provider || needs.runners.outputs.provider }}
 
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: 'iwyu'
+            cache-tag: 'bitcoin-ci-iwyu'
             namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_iwyu.sh'
 
           - name: '32 bit ARM'
+            cache-tag: 'bitcoin-ci-32bit-arm'
             namespace-runner: 'namespace-profile-apple-arm64-linux-medium;container.privileged=true;container.host-pid-namespace=true' # Required for qemu/binfmt registration to affect the runner host.
             fallback-runner: 'ubuntu-24.04-arm'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_arm.sh'
 
           - name: 'ASan + LSan + UBSan + integer'
+            cache-tag: 'bitcoin-ci-asan'
             namespace-runner: 'namespace-profile-x64-linux-medium;container.privileged=true;container.host-pid-namespace=true;container.mount-host-sys=sys' # This is needed to mount namespace resources (/sys) into the container.
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_asan.sh'
 
           - name: 'macOS-cross to arm64'
+            cache-tag: 'bitcoin-ci-macos-cross-arm64'
             namespace-runner: 'namespace-profile-x64-linux-small'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_mac_cross.sh'
 
           - name: 'macOS-cross to x86_64'
+            cache-tag: 'bitcoin-ci-macos-cross-x86-64'
             namespace-runner: 'namespace-profile-x64-linux-small'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_mac_cross_intel.sh'
 
           - name: 'FreeBSD Cross'
+            cache-tag: 'bitcoin-ci-freebsd-cross'
             namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_freebsd_cross.sh'
 
           - name: 'No wallet'
+            cache-tag: 'bitcoin-ci-no-wallet'
             namespace-runner: 'namespace-profile-x64-linux-small'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_nowallet.sh'
 
           - name: 'i686, no IPC'
+            cache-tag: 'bitcoin-ci-i686-no-ipc'
             namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_i686_no_ipc.sh'
 
           - name: 'fuzzer,address,undefined,integer'
+            cache-tag: 'bitcoin-ci-fuzz-asan-ubsan-integer'
             namespace-runner: 'namespace-profile-x64-linux-large'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 240
             file-env: './ci/test/00_setup_env_native_fuzz.sh'
 
           - name: 'previous releases'
+            cache-tag: 'bitcoin-ci-previous-releases'
             namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_previous_releases.sh'
 
           - name: 'Alpine (musl)'
+            cache-tag: 'bitcoin-ci-alpine-musl'
             namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_alpine_musl.sh'
 
           - name: 'tidy'
+            cache-tag: 'bitcoin-ci-tidy'
             namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_tidy.sh'
 
           - name: 'TSan'
+            cache-tag: 'bitcoin-ci-tsan'
             namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_tsan.sh'
 
           - name: 'MSan, fuzz'
+            cache-tag: 'bitcoin-ci-msan-fuzz'
             namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 150
             file-env: './ci/test/00_setup_env_native_fuzz_with_msan.sh'
 
           - name: 'MSan'
+            cache-tag: 'bitcoin-ci-msan'
             namespace-runner: 'namespace-profile-x64-linux-large'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
@@ -552,6 +575,8 @@ jobs:
       - name: Restore caches
         id: restore-cache
         uses: ./.github/actions/restore-caches
+        with:
+          provider: ${{ env.RUNNER_PROVIDER }}
 
       - name: Set up QEMU for 32 bit ARM tests
         if: ${{ env.CONTAINER_NAME == 'ci_arm_linux' && env.RUNNER_PROVIDER == 'namespace' }}
@@ -562,7 +587,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          provider: ${{ matrix.provider || needs.runners.outputs.provider }}
+          provider: ${{ env.RUNNER_PROVIDER }}
 
       - name: Clear unnecessary files
         if: ${{ needs.runners.outputs.provider == 'gha' && true || false }} # Only needed on GHA runners
@@ -584,11 +609,13 @@ jobs:
 
       - name: Save caches
         uses: ./.github/actions/save-caches
+        with:
+          provider: ${{ env.RUNNER_PROVIDER }}
 
   lint:
     name: 'lint'
     needs: runners
-    runs-on: ${{ needs.runners.outputs.provider == 'namespace' && 'namespace-profile-x64-linux-tiny' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.runners.outputs.provider == 'namespace' && 'namespace-profile-x64-linux-tiny;overrides.cache-tag=bitcoin-ci-linter' || 'ubuntu-24.04' }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
     timeout-minutes: 20
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ concurrency:
 
 env:
   CI_FAILFAST_TEST_LEAVE_DANGLING: 1  # GHA does not care about dangling processes and setting this variable avoids killing the CI script itself on error
-  CIRRUS_CACHE_HOST: http://127.0.0.1:12321/ # When using Cirrus Runners this host can be used by the docker `gha` build cache type.
-  REPO_USE_CIRRUS_RUNNERS: 'bitcoin/bitcoin' # Use cirrus runners and cache for this repo, instead of falling back to the slow GHA runners
+  REPO_USE_NAMESPACE_RUNNERS: 'bitcoin/bitcoin' # Use Namespace runners for this repo; other forks fall back to the free GHA runners.
 
 defaults:
   run:
@@ -47,9 +46,9 @@ jobs:
           fi
       - id: runners
         run: |
-          if [[ "${REPO_USE_CIRRUS_RUNNERS}" == "${{ github.repository }}" ]]; then
-            echo "provider=cirrus" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Runner Selection::Using Cirrus Runners"
+          if [[ "${REPO_USE_NAMESPACE_RUNNERS}" == "${{ github.repository }}" ]]; then
+            echo "provider=namespace" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Runner Selection::Using Namespace runners"
           else
             echo "provider=gha" >> "$GITHUB_OUTPUT"
             echo "::notice title=Runner Selection::Using GitHub-hosted runners"
@@ -58,7 +57,7 @@ jobs:
   test-each-commit:
     name: 'test ancestor commits'
     needs: runners
-    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.runners.outputs.provider == 'namespace' && 'namespace-profile-x64-linux-medium' || 'ubuntu-24.04' }}
     env:
       TEST_RUNNER_PORT_MIN: "14000"  # Use a larger port, to avoid colliding with CIRRUS_CACHE_HOST port 12321.
     if: github.event_name == 'pull_request' && github.event.pull_request.commits != 1
@@ -325,7 +324,7 @@ jobs:
   windows-cross:
     name: 'Windows-cross to x86_64, ${{ matrix.crt }}'
     needs: [runners, record-frozen-commit]
-    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.runners.outputs.provider == 'namespace' && 'namespace-profile-x64-linux-small' || 'ubuntu-24.04' }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
 
     strategy:
@@ -436,7 +435,7 @@ jobs:
   ci-matrix:
     name: ${{ matrix.name }}
     needs: runners
-    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && matrix.cirrus-runner || matrix.fallback-runner }}
+    runs-on: ${{ matrix.namespace-runner && needs.runners.outputs.provider == 'namespace' && matrix.namespace-runner || matrix.fallback-runner }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
 
@@ -449,92 +448,91 @@ jobs:
       matrix:
         include:
           - name: 'iwyu'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+            namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_iwyu.sh'
 
           - name: '32 bit ARM'
-            cirrus-runner: 'ubuntu-24.04-arm' # Cirrus' Arm runners are Apple (with virtual Linux aarch64), which doesn't support 32-bit mode
+            namespace-runner: 'namespace-profile-apple-arm64-linux-medium;container.privileged=true;container.host-pid-namespace=true' # Required for qemu/binfmt registration to affect the runner host.
             fallback-runner: 'ubuntu-24.04-arm'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_arm.sh'
-            provider: 'gha'
 
           - name: 'ASan + LSan + UBSan + integer'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' # has to match container in ci/test/00_setup_env_native_asan.sh for tracing tools
+            namespace-runner: 'namespace-profile-x64-linux-medium;container.privileged=true;container.host-pid-namespace=true;container.mount-host-sys=sys' # This is needed to mount namespace resources (/sys) into the container.
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_asan.sh'
 
           - name: 'macOS-cross to arm64'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
+            namespace-runner: 'namespace-profile-x64-linux-small'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_mac_cross.sh'
 
           - name: 'macOS-cross to x86_64'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
+            namespace-runner: 'namespace-profile-x64-linux-small'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_mac_cross_intel.sh'
 
           - name: 'FreeBSD Cross'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+            namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_freebsd_cross.sh'
 
           - name: 'No wallet'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
+            namespace-runner: 'namespace-profile-x64-linux-small'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_nowallet.sh'
 
           - name: 'i686, no IPC'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+            namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_i686_no_ipc.sh'
 
           - name: 'fuzzer,address,undefined,integer'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
+            namespace-runner: 'namespace-profile-x64-linux-large'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 240
             file-env: './ci/test/00_setup_env_native_fuzz.sh'
 
           - name: 'previous releases'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+            namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_previous_releases.sh'
 
           - name: 'Alpine (musl)'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+            namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_alpine_musl.sh'
 
           - name: 'tidy'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+            namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_tidy.sh'
 
           - name: 'TSan'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+            namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_tsan.sh'
 
           - name: 'MSan, fuzz'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
+            namespace-runner: 'namespace-profile-x64-linux-medium'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 150
             file-env: './ci/test/00_setup_env_native_fuzz_with_msan.sh'
 
           - name: 'MSan'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
+            namespace-runner: 'namespace-profile-x64-linux-large'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_msan.sh'
@@ -580,7 +578,7 @@ jobs:
   lint:
     name: 'lint'
     needs: runners
-    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xs' || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.runners.outputs.provider == 'namespace' && 'namespace-profile-x64-linux-tiny' || 'ubuntu-24.04' }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
     timeout-minutes: 20
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,6 +549,12 @@ jobs:
         id: restore-cache
         uses: ./.github/actions/restore-caches
 
+      - name: Set up QEMU for 32 bit ARM tests
+        if: ${{ env.CONTAINER_NAME == 'ci_arm_linux' && env.RUNNER_PROVIDER == 'namespace' }}
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm
+
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,8 @@ jobs:
 
       - name: Configure environment
         uses: ./.github/actions/configure-environment
+        with:
+          provider: ${{ needs.runners.outputs.provider }}
 
       - name: Restore caches
         id: restore-cache
@@ -544,6 +546,8 @@ jobs:
 
       - name: Configure environment
         uses: ./.github/actions/configure-environment
+        with:
+          provider: ${{ matrix.namespace-runner && needs.runners.outputs.provider == 'namespace' && 'namespace' || 'gha' }}
 
       - name: Restore caches
         id: restore-cache

--- a/ci/README.md
+++ b/ci/README.md
@@ -80,20 +80,27 @@ trigger cache-invalidation and rebuilds as necessary.
 
 To configure the primary repository, follow these steps:
 
-1. Register with [Cirrus Runners](https://cirrus-runners.app/) and purchase runners.
-2. Install the Cirrus Runners GitHub app against the GitHub organization.
+1. Install the Namespace GitHub app against the GitHub organization and create the required runner profiles.
+2. Create the Linux runner profiles referenced by the workflow:
+   1. `x64-linux-tiny`
+   1. `x64-linux-small`
+   1. `x64-linux-medium`
+   1. `x64-linux-large`
+   1. `apple-arm64-linux-medium`
 3. Enable organisation-level runners to be used in public repositories:
    1. `Org settings -> Actions -> Runner Groups -> Default -> Allow public repos`
-4. Permit the following actions to run:
-   1. cirruslabs/cache/restore@\*
-   1. cirruslabs/cache/save@\*
+4. Enable caching on the Namespace runner profiles used by CI.
+6. Permit the following actions to run:
+   1. actions/cache/restore@\*
+   1. actions/cache/save@\*
    1. docker/setup-buildx-action@\*
-   1. actions/github-script@\*
+   1. namespacelabs/nscloud-cache-action@\*
+   1. namespacelabs/nscloud-setup-buildx-action@\*
 
 ### Forked repositories
 
 When used in a fork the CI will run on GitHub's free hosted runners by default.
-In this case, due to GitHub's 10GB-per-repo cache size limitations caches will be frequently evicted and missed, but the workflows will run (slowly).
+In this case, due to GitHub's 10GB-per-repo cache size limitations caches will be frequently evicted and missed, but the workflows will run.
 
-It is also possible to use your own Cirrus Runners in your own fork with an appropriate patch to the `REPO_USE_CIRRUS_RUNNERS` variable in ../.github/workflows/ci.yml
-NB that Cirrus Runners only work at an organisation level, therefore in order to use your own Cirrus Runners, *the fork must be within your own organisation*.
+It is also possible to use your own Namespace runners in your own fork with an appropriate patch to the `REPO_USE_NAMESPACE_RUNNERS` variable in ../.github/workflows/ci.yml.
+The macOS native jobs and the 32-bit ARM cross job still run on GitHub-hosted runners because there are no matching Namespace profiles configured here.

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -10,8 +10,9 @@ export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
 
 # Only install BCC tracing packages in CI. Container has to match the host for BCC to work.
 if [[ "${INSTALL_BCC_TRACING_TOOLS}" == "true" ]]; then
-  # Required for USDT functional tests to run
-  BPFCC_PACKAGE="bpfcc-tools linux-headers-$(uname --kernel-release)"
+  # Required for USDT functional tests to run. BCC can use in-kernel headers
+  # from /sys/kernel/kheaders.tar.xz when they are exposed by the host kernel.
+  BPFCC_PACKAGE="bpfcc-tools"
   export CI_CONTAINER_CAP="--privileged -v /sys/kernel:/sys/kernel:rw"
 else
   BPFCC_PACKAGE=""

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -62,7 +62,8 @@ def main():
         CI_IMAGE_LABEL = "bitcoin-ci-test"
 
         # Use buildx unconditionally
-        # Using buildx is required to properly load the correct driver, for use with registry caching. Neither build, nor BUILDKIT=1 currently do this properly
+        # Namespace jobs configure buildx in the workflow, while GitHub-hosted
+        # jobs pass explicit Actions cache flags via DOCKER_BUILD_CACHE_ARG.
         cmd_build = ["docker", "buildx", "build"]
         cmd_build += [
             f"--file={os.environ['BASE_READ_ONLY_DIR']}/ci/test_imagefile",
@@ -95,16 +96,16 @@ def main():
             # ensure the directories exist
             for create_dir in [
                     os.environ["CCACHE_DIR"],
-                    f"{os.environ['DEPENDS_DIR']}/built",
-                    f"{os.environ['DEPENDS_DIR']}/sources",
+                    os.environ["BASE_CACHE"],
+                    os.environ["SOURCES_PATH"],
                     os.environ["PREVIOUS_RELEASES_DIR"],
                     os.environ["BASE_BUILD_DIR"],  # Unset by default, must be defined externally
             ]:
                 Path(create_dir).mkdir(parents=True, exist_ok=True)
 
             CI_CCACHE_MOUNT = f"type=bind,src={os.environ['CCACHE_DIR']},dst={os.environ['CCACHE_DIR']}"
-            CI_DEPENDS_MOUNT = f"type=bind,src={os.environ['DEPENDS_DIR']}/built,dst={os.environ['DEPENDS_DIR']}/built"
-            CI_DEPENDS_SOURCES_MOUNT = f"type=bind,src={os.environ['DEPENDS_DIR']}/sources,dst={os.environ['DEPENDS_DIR']}/sources"
+            CI_DEPENDS_MOUNT = f"type=bind,src={os.environ['BASE_CACHE']},dst={os.environ['DEPENDS_DIR']}/built"
+            CI_DEPENDS_SOURCES_MOUNT = f"type=bind,src={os.environ['SOURCES_PATH']},dst={os.environ['DEPENDS_DIR']}/sources"
             CI_PREVIOUS_RELEASES_MOUNT = f"type=bind,src={os.environ['PREVIOUS_RELEASES_DIR']},dst={os.environ['PREVIOUS_RELEASES_DIR']}"
             CI_BUILD_MOUNT = [f"--mount=type=bind,src={os.environ['BASE_BUILD_DIR']},dst={os.environ['BASE_BUILD_DIR']}"]
 

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -32,12 +32,18 @@ fi
 echo "Free disk space:"
 df -h
 
-# We force an install of linux-headers again here via $PACKAGES to fix any
-# kernel mismatch between a cached docker image and the underlying host.
-# This can happen occasionally on hosted runners if the runner image is updated.
+# We need kernel headers for the USDT tests in the asan job.
+# Reinstall packages at runtime to fix any mismatch between a cached docker image and the underlying host.
+# If the host does not expose in-kernel headers, install matching linux-headers for BCC as well.
+# This is needed to permit jobs on namespace (in-kernel headers) and github actions.
 if [[ "$CONTAINER_NAME" == "ci_native_asan" ]]; then
+  runtime_packages="$PACKAGES"
+  if [[ ! -r /sys/kernel/kheaders.tar.xz ]]; then
+    runtime_packages="$runtime_packages linux-headers-$(uname --kernel-release)"
+  fi
   $CI_RETRY_EXE apt-get update
-  ${CI_RETRY_EXE} bash -c "apt-get install --no-install-recommends --no-upgrade -y $PACKAGES"
+  # shellcheck disable=SC2086
+  ${CI_RETRY_EXE} apt-get install --no-install-recommends --no-upgrade -y $runtime_packages
 fi
 
 # What host to compile for. See also ./depends/README.md


### PR DESCRIPTION
- Migrate linux CI jobs over to [namespace.so](https://namespace.so/)
- Configure docker to use namespace's [remote docker builders](https://namespace.so/docs/solutions/docker-builders) (and implicit shared docker buildkit cache)
- Configure caches to use the namespace [cache volumes](https://namespace.so/docs/architecture/storage/cache-volumes)
- Fixup the kernel headers needed is the ASAN job for the USDT tests.
  - The namespace hypervisor/host is using a newer kernel which does not have headers in the Ubuntu version in the container, but they do provide in-kernel headers, which we can mount into the container.
- Ensure CI still works on GHA for forks