### PR TITLE
validation: fix misleading VerifyDB summary log

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4726,7 +4726,10 @@ VerifyDBResult CVerifyDB::VerifyDB(
         }
     }
 
-    LogInfo("Verification: No coin database inconsistencies in last %i blocks (%i transactions)", block_count, nGoodTransactions);
+    LogInfo("Verification: checked last %i blocks at level %i", block_count, nCheckLevel);
+    if (nCheckLevel >= 3 && !skipped_l3_checks) {
+        LogInfo("Verification: no coin database inconsistencies (%i transactions)", nGoodTransactions);
+    }
 
     if (skipped_l3_checks) {
         return VerifyDBResult::SKIPPED_L3_CHECKS;


### PR DESCRIPTION
The final `LogInfo` message about "No coin database inconsistencies" was printed unconditionally, even for check levels 0-2 where no coin DB verification runs and `nGoodTransactions` stays 0. Split into an always-on completion line and a coin-DB result line gated on `nCheckLevel >= 3 && !skipped_l3_checks`.

Before (checklevel=1):
`Verification: No coin database inconsistencies in last 6 blocks (0 transactions)`

After (checklevel=1):
`Verification: checked last 6 blocks at level 1`