### PR TITLE
depends: Boost 1.91.0-1

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version = 1.90.0
+$(package)_version = 1.91.0-1
 $(package)_download_path = https://github.com/boostorg/boost/releases/download/boost-$($(package)_version)
 $(package)_file_name = boost-$($(package)_version)-cmake.tar.gz
-$(package)_sha256_hash = 913ca43d49e93d1b158c9862009add1518a4c665e7853b349a6492d158b036d4
+$(package)_sha256_hash = 8a82bd11a720c70923806c36ee5c26dbd2d630c1eaa1d8fad9a7bd5529908a26
 $(package)_build_subdir = build
 
 define $(package)_set_vars


### PR DESCRIPTION
https://www.boost.org/releases/1.91.0/.

> MultiIndex

> Breaking change: All type lists accepted or provided by the library (indexed_by, tag, nested typedefs index_specifier_type_list, index_type_list, iterator_type_list and const_iterator_type_list) are no longer based on [Boost.MPL](https://www.boost.org/libs/mpl) but instead they are now [Boost.Mp11 lists](https://www.boost.org/libs/mp11/doc/html/mp11.html#definitions). As a result, Boost.MultiIndex doesn’t depend anymore on Boost.MPL. It is expected that most user code won’t be impacted by this change, but the previous behavior may be restored, however, by globally defining the macro BOOST_MULTI_INDEX_ENABLE_MPL_SUPPORT. Legacy support for Boost.MPL may be eventually deprecated and removed in the future.

> Breaking change: composite_key and associated class templates (composite_key_equal_to, composite_key_compare, composite_key_hash) have been made variadic (previously the maximum number of template arguments was limited by BOOST_MULTI_INDEX_LIMIT_COMPOSITE_KEY_SIZE). This change should be transparent to users, with the exception that composite_key::key_extractors returns a std::tuple instead of a boost::tuple (and similarly for the rest of affected class templates).

> Removed internal workarounds and fallbacks to support pre-C++11 compilers.