### PR TITLE
wallet: reject cyclic page references in legacy BDB parser

### DIFF
--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <optional>
 #include <stdexcept>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -632,17 +633,25 @@ void BerkeleyRODatabase::Open()
         throw std::runtime_error("BDB builtin encryption is not supported");
     }
 
-    // Do a DFS through the BTree, starting at root
+    // Do a DFS through the BTree, starting at root. Track visited pages to
+    // reject cyclic references, which would otherwise cause an infinite loop
+    // (and unbounded memory growth when following an overflow chain). Every
+    // page in a valid BDB database is referenced at most once, so a single
+    // shared set covers both the B-tree traversal and any overflow chains.
     std::vector<uint32_t> pages{inner_meta.root};
+    std::unordered_set<uint32_t> visited_pages;
     while (pages.size() > 0) {
         uint32_t curr_page = pages.back();
+        pages.pop_back();
+        if (!visited_pages.insert(curr_page).second) {
+            throw std::runtime_error("Cyclic page reference in BDB database");
+        }
         // It turns out BDB completely ignores this last_page field and doesn't actually update it to the correct
         // last page. While we should be checking this, we can't.
         // This is left commented out as a reminder to not accidentally implement this in the future.
         // if (curr_page > inner_meta.last_page) {
         //     throw std::runtime_error("Page number is greater than subdatabase last page");
         // }
-        pages.pop_back();
         SeekToPage(db_file, curr_page, page_size);
         PageHeader header(curr_page, inner_meta.other_endian);
         db_file >> header;
@@ -674,6 +683,9 @@ void BerkeleyRODatabase::Open()
                     if (orec->m_header.deleted) continue;
                     uint32_t next_page = orec->page_number;
                     while (next_page != 0) {
+                        if (!visited_pages.insert(next_page).second) {
+                            throw std::runtime_error("Cyclic page reference in BDB database");
+                        }
                         SeekToPage(db_file, next_page, page_size);
                         PageHeader opage_header(next_page, inner_meta.other_endian);
                         db_file >> opage_header;

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -15,6 +15,8 @@
 #include <wallet/walletutil.h>
 
 #include <cstddef>
+#include <cstdint>
+#include <fstream>
 #include <memory>
 #include <span>
 #include <string>
@@ -295,6 +297,200 @@ BOOST_AUTO_TEST_CASE(concurrent_txn_dont_interfere)
     BOOST_CHECK(handler->Write(key, value2, /*fOverwrite=*/true));
     BOOST_CHECK(handler2->Read(key, read_value));
     BOOST_CHECK_EQUAL(read_value, value2);
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for cyclic page references in the legacy BDB parser.
+//
+// The read-only BDB parser (src/wallet/migrate.cpp) is fed an attacker-supplied
+// file whenever a user runs `migratewallet` or `bitcoin-wallet -wallet=X dump`.
+// Its B-tree DFS and overflow-chain traversal both follow page numbers that
+// are read directly from the file. Without visited-page tracking, a crafted
+// file containing a cyclic page reference causes BerkeleyRODatabase::Open()
+// to loop forever (and, for overflow chains, grow memory without bound).
+//
+// The two tests below build minimal hand-crafted BDB files that exercise each
+// of the two cyclic code paths, and assert that MakeBerkeleyRODatabase()
+// rejects them with DatabaseStatus::FAILED_LOAD rather than hanging.
+// ---------------------------------------------------------------------------
+
+namespace {
+constexpr uint32_t kPageSize = 512;
+constexpr uint32_t kBtreeMagic = 0x00053162;
+
+class BdbFileBuilder
+{
+    std::vector<uint8_t> m_buf;
+
+public:
+    explicit BdbFileBuilder(uint32_t num_pages) : m_buf(kPageSize * num_pages, 0) {}
+
+    void W8(size_t off, uint8_t v) { m_buf.at(off) = v; }
+    void W16(size_t off, uint16_t v)
+    {
+        m_buf.at(off)     = v & 0xFF;
+        m_buf.at(off + 1) = (v >> 8) & 0xFF;
+    }
+    void W32(size_t off, uint32_t v)
+    {
+        m_buf.at(off)     = v & 0xFF;
+        m_buf.at(off + 1) = (v >> 8) & 0xFF;
+        m_buf.at(off + 2) = (v >> 16) & 0xFF;
+        m_buf.at(off + 3) = (v >> 24) & 0xFF;
+    }
+    void W32BE(size_t off, uint32_t v)
+    {
+        m_buf.at(off)     = (v >> 24) & 0xFF;
+        m_buf.at(off + 1) = (v >> 16) & 0xFF;
+        m_buf.at(off + 2) = (v >> 8) & 0xFF;
+        m_buf.at(off + 3) = v & 0xFF;
+    }
+
+    // Writes a BTree meta page (BDB page type 9) at the given page index.
+    void WriteMetaPage(uint32_t page_idx, uint32_t last_page, uint32_t root)
+    {
+        const size_t p = page_idx * kPageSize;
+        W32(p +  0, 0);              // lsn_file   = 0
+        W32(p +  4, 1);              // lsn_offset = 1 (LSNs-reset check)
+        W32(p +  8, page_idx);       // page_num
+        W32(p + 12, kBtreeMagic);    // magic
+        W32(p + 16, 9);              // version
+        W32(p + 20, kPageSize);      // pagesize
+        W8 (p + 24, 0);              // encrypt_algo
+        W8 (p + 25, 9);              // type = BTREE_META
+        W32(p + 32, last_page);      // last_page
+        W32(p + 48, 0x20);           // flags = SUBDB
+        W32(p + 76, 2);              // minkey
+        W32(p + 88, root);           // root
+    }
+
+    // Writes the outer BTREE_LEAF that names the subdatabase "main" and
+    // points at the inner meta page.
+    void WriteOuterLeaf(uint32_t page_idx, uint32_t inner_meta_page)
+    {
+        const size_t p = page_idx * kPageSize;
+        W32(p +  0, 0);              // lsn_file
+        W32(p +  4, 1);              // lsn_offset = 1
+        W32(p +  8, page_idx);       // page_num
+        W16(p + 20, 2);              // entries = 2
+        W16(p + 22, 498);            // hf_offset
+        W8 (p + 24, 1);              // level
+        W8 (p + 25, 5);              // type = BTREE_LEAF
+        W16(p + 26, 498);            // index[0] → "main"
+        W16(p + 28, 505);            // index[1] → BE(inner_meta_page)
+        // Record 0 at offset 498: key "main"
+        W16(p + 498, 4);             // RecordHeader.len
+        W8 (p + 500, 1);             // RecordHeader.type = KEYDATA
+        W8 (p + 501, 'm'); W8(p + 502, 'a'); W8(p + 503, 'i'); W8(p + 504, 'n');
+        // Record 1 at offset 505: big-endian inner meta page number
+        W16(p + 505, 4);             // RecordHeader.len
+        W8 (p + 507, 1);             // RecordHeader.type = KEYDATA
+        W32BE(p + 508, inner_meta_page);
+    }
+
+    fs::path WriteTo(const fs::path& dir, const std::string& name) const
+    {
+        fs::path path = dir / fs::PathFromString(name);
+        std::ofstream f(path.std_path(), std::ios::binary);
+        BOOST_REQUIRE(f.good());
+        f.write(reinterpret_cast<const char*>(m_buf.data()),
+                static_cast<std::streamsize>(m_buf.size()));
+        BOOST_REQUIRE(f.good());
+        return path;
+    }
+};
+} // namespace
+
+BOOST_AUTO_TEST_CASE(bdb_parser_btree_cycle_detection)
+{
+    // 4 pages: outer meta, outer leaf, inner meta, inner BTREE_INTERNAL with
+    // a self-referential InternalRecord (page_num = own page).
+    BdbFileBuilder b(/*num_pages=*/4);
+    b.WriteMetaPage(/*page_idx=*/0, /*last_page=*/3, /*root=*/1);
+    b.WriteOuterLeaf(/*page_idx=*/1, /*inner_meta_page=*/2);
+    b.WriteMetaPage(/*page_idx=*/2, /*last_page=*/3, /*root=*/3);
+
+    // Page 3: BTREE_INTERNAL with one record whose page_num points back to 3.
+    // The LSN-reset loop runs for i < outer_meta.last_page (= 3), so page 3
+    // is not subject to that check; only the DFS will touch it.
+    constexpr size_t P3 = 3 * kPageSize;
+    b.W32(P3 +  8, 3);               // page_num
+    b.W16(P3 + 20, 1);               // entries = 1
+    b.W16(P3 + 22, 499);             // hf_offset
+    b.W8 (P3 + 24, 1);               // level
+    b.W8 (P3 + 25, 3);               // type = BTREE_INTERNAL
+    b.W16(P3 + 26, 499);             // index[0] → offset 499
+    b.W16(P3 + 499, 1);              // RecordHeader.len = 1
+    b.W8 (P3 + 501, 1);              // RecordHeader.type = KEYDATA
+    b.W8 (P3 + 502, 0);              // unused
+    b.W32(P3 + 503, 3);              // InternalRecord.page_num = 3  ← CYCLE
+    b.W32(P3 + 507, 0);              // records
+    b.W8 (P3 + 511, 0);              // data[0]
+
+    const fs::path wallet_path = b.WriteTo(m_path_root, "cycle_btree.dat");
+
+    DatabaseOptions options;
+    DatabaseStatus status;
+    bilingual_str error;
+    auto db = MakeBerkeleyRODatabase(wallet_path, options, status, error);
+    BOOST_CHECK(!db);
+    BOOST_CHECK_EQUAL(status, DatabaseStatus::FAILED_LOAD);
+    BOOST_CHECK_EQUAL(error.original, "Cyclic page reference in BDB database");
+}
+
+BOOST_AUTO_TEST_CASE(bdb_parser_overflow_cycle_detection)
+{
+    // 5 pages: outer meta, outer leaf, inner meta, inner BTREE_LEAF with a
+    // key + OverflowRecord pointing at an OVERFLOW_DATA page whose next_page
+    // points back to itself.
+    BdbFileBuilder b(/*num_pages=*/5);
+    b.WriteMetaPage(/*page_idx=*/0, /*last_page=*/4, /*root=*/1);
+    b.WriteOuterLeaf(/*page_idx=*/1, /*inner_meta_page=*/2);
+    b.WriteMetaPage(/*page_idx=*/2, /*last_page=*/4, /*root=*/3);
+
+    // Page 3: BTREE_LEAF with 2 records (key + overflow value).
+    //   index[0] → offset 496: DataRecord(len=1, "k")
+    //   index[1] → offset 500: OverflowRecord(page_number = 4)
+    constexpr size_t P3 = 3 * kPageSize;
+    b.W32(P3 +  0, 0);               // lsn_file   = 0
+    b.W32(P3 +  4, 1);               // lsn_offset = 1 (LSNs-reset check covers this page)
+    b.W32(P3 +  8, 3);               // page_num
+    b.W16(P3 + 20, 2);               // entries = 2
+    b.W16(P3 + 22, 496);             // hf_offset
+    b.W8 (P3 + 24, 1);               // level
+    b.W8 (P3 + 25, 5);               // type = BTREE_LEAF
+    b.W16(P3 + 26, 496);             // index[0]
+    b.W16(P3 + 28, 500);             // index[1]
+    // Record 0 at 496: key "k"
+    b.W16(P3 + 496, 1);              // RecordHeader.len
+    b.W8 (P3 + 498, 1);              // RecordHeader.type = KEYDATA
+    b.W8 (P3 + 499, 'k');
+    // Record 1 at 500: OverflowRecord pointing to page 4
+    b.W16(P3 + 500, 0);              // RecordHeader.len (informational)
+    b.W8 (P3 + 502, 3);              // RecordHeader.type = OVERFLOW_DATA
+    b.W8 (P3 + 503, 0);              // unused2
+    b.W32(P3 + 504, 4);              // OverflowRecord.page_number = 4
+    b.W32(P3 + 508, 0);              // item_len
+
+    // Page 4: OVERFLOW_DATA page with next_page = 4  ← CYCLE.
+    // Not covered by the LSN-reset loop (runs only for i < last_page = 4).
+    constexpr size_t P4 = 4 * kPageSize;
+    b.W32(P4 +  8, 4);               // page_num
+    b.W32(P4 + 16, 4);               // next_page = 4  ← CYCLE
+    b.W16(P4 + 20, 0);               // entries (reference count; unused here)
+    b.W16(P4 + 22, 0);               // hf_offset = 0 (overflow data length)
+    b.W8 (P4 + 24, 0);               // level = 0 (required for OVERFLOW_DATA)
+    b.W8 (P4 + 25, 7);               // type = OVERFLOW_DATA
+
+    const fs::path wallet_path = b.WriteTo(m_path_root, "cycle_overflow.dat");
+
+    DatabaseOptions options;
+    DatabaseStatus status;
+    bilingual_str error;
+    auto db = MakeBerkeleyRODatabase(wallet_path, options, status, error);
+    BOOST_CHECK(!db);
+    BOOST_CHECK_EQUAL(status, DatabaseStatus::FAILED_LOAD);
+    BOOST_CHECK_EQUAL(error.original, "Cyclic page reference in BDB database");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -72,6 +72,7 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
             error.original == "Meta page number mismatch" ||
             error.original == "Data record position not in page" ||
             error.original == "Internal record position not in page" ||
+            error.original == "Cyclic page reference in BDB database" ||
             error.original == "LSNs are not reset, this database is not completely flushed. Please reopen then close the database with a version that has BDB support" ||
             error.original == "Records page has odd number of records" ||
             error.original == "Bad overflow record page type") {


### PR DESCRIPTION
The read-only BDB parser (`BerkeleyRODatabase::Open()` in migrate.cpp) walks B-tree pages and overflow chains by following page numbers read directly from the input file. Neither traversal tracked visited pages, so a crafted legacy wallet file containing a cyclic page reference causes the parser to loop forever — and, for cycles on an overflow chain, to grow memory without bound (each iteration appends `OverflowPage.data` to a `std::vector`).

## Impact

Local denial-of-service / memory exhaustion of the wallet process. Reachable whenever a user feeds an attacker-supplied `.dat` file to a BDB-reading code path:

- `migratewallet` RPC
- `bitcoin-wallet -wallet=<path> dump`

Legacy BDB wallets can no longer be created or loaded since v30.0, but the read-only parser is intentionally retained to power `migratewallet` and will remain in tree for the foreseeable future, so hardening it still matters.

Not remotely exploitable; no memory corruption.

## Fix

Add a single shared `std::unordered_set<uint32_t> visited_pages` around the B-tree DFS loop, and check it inside the overflow-chain following loop as well. In a valid BDB database every physical page is referenced at most once, so a re-visit indicates corruption or a deliberate cycle and is rejected with `"Cyclic page reference in BDB database"`.

The core change is ~11 lines in migrate.cpp.

## Testing

Two new regression tests in db_tests.cpp build minimal hand-crafted BDB files that exercise each cyclic code path:

- `bdb_parser_btree_cycle_detection` — `BTREE_INTERNAL` page whose `InternalRecord.page_num` points back to itself
- `bdb_parser_overflow_cycle_detection` — `OVERFLOW_DATA` page whose `next_page` points back to itself

Verification:

| Configuration | btree test | overflow test |
| --- | --- | --- |
| master (no fix) | hangs until SIGTERM | hangs until SIGTERM |
| this PR | passes in ~1 ms | passes in ~1 ms |

Full `db_tests` suite passes with no regressions. The existing `wallet_bdb_parser` fuzz target is updated to accept the new error string.