### PR TITLE
wallet, follow-up: Refactor IsSpent to use HowSpent

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -773,28 +773,7 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
     }
 }
 
-/**
- * Outpoint is spent if any non-conflicted transaction
- * spends it:
- */
-bool CWallet::IsSpent(const COutPoint& outpoint) const
-{
-    std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
-    range = mapTxSpends.equal_range(outpoint);
-
-    for (TxSpends::const_iterator it = range.first; it != range.second; ++it) {
-        const Txid& txid = it->second;
-        const auto mit = mapWallet.find(txid);
-        if (mit != mapWallet.end()) {
-            const auto& wtx = mit->second;
-            if (!wtx.isAbandoned() && !wtx.isBlockConflicted() && !wtx.isMempoolConflicted())
-                return true; // Spent
-        }
-    }
-    return false;
-}
-
-CWallet::SpendType CWallet::HowSpent(const COutPoint& outpoint) const
+CWallet::SpendType CWallet::HowSpent(const COutPoint& outpoint, bool isSpent) const
 {
     SpendType st{SpendType::UNSPENT};
 
@@ -812,6 +791,9 @@ CWallet::SpendType CWallet::HowSpent(const COutPoint& outpoint) const
             } else if (!wtx.isAbandoned() && !wtx.isBlockConflicted() && !wtx.isMempoolConflicted()) {
                 if (st == SpendType::UNSPENT) st = SpendType::NONMEMPOOL;
             }
+            // If we are only checking for spent condition and not how the coin is spent
+            // early exit as fast as we know if it is spent.
+            if (isSpent && st != SpendType::UNSPENT) return st;
         }
     }
     return st;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -559,8 +559,10 @@ public:
         MEMPOOL,
         NONMEMPOOL,
     };
-    SpendType HowSpent(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool IsSpent(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    SpendType HowSpent(const COutPoint& outpoint, bool isSpent = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    /** Outpoint is spent if any non-conflicted transaction spends it */
+    bool IsSpent(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { return HowSpent(outpoint, /*isSpent=*/true) != SpendType::UNSPENT; }
 
     // Whether this or any known scriptPubKey with the same single key has been spent.
     bool IsSpentKey(const CScript& scriptPubKey) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
Follow-up to [#33671](https://github.com/bitcoin/bitcoin/pull/33671#discussion_r2920222467)

This PR refactors `CWallet::IsSpent` to reuse the logic already implemented in `CWallet::HowSpent`.

Instead of manually iterating over mapTxSpends and checking transaction states, IsSpent now simply returns:

`return HowSpent(outpoint) != SpendType::UNSPENT;`

Also move `CWallet::IsSpent` from wallet.cpp to wallet.h as a small inline helper, since it is a one-line wrapper around HowSpent.