### PR TITLE
Wallet: add consistency check on wallet transactions stored on wallet database when loading the wallet.

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -723,5 +723,70 @@ BOOST_FIXTURE_TEST_CASE(RemoveTxs, TestChain100Setup)
     TestUnloadWallet(std::move(wallet));
 }
 
+BOOST_FIXTURE_TEST_CASE(test_crash_corrupt_wallet_abandon, TestChain100Setup)
+{
+    MockableData records;
+    Txid hash_cb;
+    Txid hash_hijo;
+
+    // 1. Setup: Crear una wallet, poblarla con una coinbase real y un hijo minado
+    {
+        auto database = std::make_unique<MockableDatabase>();
+        auto wallet = std::make_shared<CWallet>(m_node.chain.get(), "", std::move(database));
+        wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        AddKey(*wallet, coinbaseKey);
+
+        // Padre: Usamos la coinbase real del fixture (ya confirmada en bloque 1)
+        hash_cb = m_coinbase_txns[0]->GetHash();
+        TxState state_cb = TxStateConfirmed{m_node.chainman->ActiveChain()[1]->GetBlockHash(), 1, 0};
+        wallet->AddToWallet(m_coinbase_txns[0], state_cb);
+
+        // Hijo: Gasta la coinbase y lo minamos en el bloque 101
+        CMutableTransaction tx_hijo_mut;
+        tx_hijo_mut.vin.push_back(CTxIn(COutPoint(hash_cb, 0)));
+        tx_hijo_mut.vout.push_back(CTxOut(49 * COIN, GetScriptForRawPubKey(coinbaseKey.GetPubKey())));
+        
+        CBlock block_hijo = CreateAndProcessBlock({tx_hijo_mut}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+        hash_hijo = tx_hijo_mut.GetHash();
+        TxState state_hijo = TxStateConfirmed{block_hijo.GetHash(), 101, 1};
+        wallet->AddToWallet(MakeTransactionRef(tx_hijo_mut), state_hijo);
+        
+        records = GetMockableDatabase(*wallet).m_records;
+    }
+
+    // 2. Corrupción manual en los records: Coinbase -> Inactive
+    {
+        DataStream ssKey;
+        ssKey << std::make_pair(std::string("tx"), hash_cb);
+        SerializeData key_data{ssKey.begin(), ssKey.end()};
+        
+        auto it = records.find(key_data);
+        BOOST_CHECK(it != records.end());
+        
+        DataStream ssValue(it->second);
+        CWalletTx wtx_corrupt(MakeTransactionRef(CMutableTransaction{}), TxStateInactive{}); 
+        ssValue >> wtx_corrupt;
+        
+        wtx_corrupt.m_state = TxStateInactive{false}; 
+        
+        DataStream ssNewValue;
+        ssNewValue << wtx_corrupt;
+        records[key_data] = SerializeData{ssNewValue.begin(), ssNewValue.end()};
+    }
+
+    // 3. Reload: Al cargar sin cadena, la wallet no auto-corrige el estado y dispara el bug
+    {
+        auto database = std::make_unique<MockableDatabase>(records);
+        // Usamos nullptr en la cadena para preservar la corrupción del archivo
+        auto wallet = std::make_shared<CWallet>(nullptr, "", std::move(database));
+        
+        bilingual_str error;
+        std::vector<bilingual_str> warnings;
+        
+        // Esta llamada dispara el assert en wallet.cpp:1321
+        wallet->PopulateWalletFromDB(error, warnings);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -727,34 +727,34 @@ BOOST_FIXTURE_TEST_CASE(test_crash_corrupt_wallet_abandon, TestChain100Setup)
 {
     MockableData records;
     Txid hash_cb;
-    Txid hash_hijo;
+    Txid hash_child;
 
-    // 1. Setup: Crear una wallet, poblarla con una coinbase real y un hijo minado
+    // 1. Setup: Create a wallet, populate it with a real coinbase and a mined child
     {
         auto database = std::make_unique<MockableDatabase>();
         auto wallet = std::make_shared<CWallet>(m_node.chain.get(), "", std::move(database));
         wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
         AddKey(*wallet, coinbaseKey);
 
-        // Padre: Usamos la coinbase real del fixture (ya confirmada en bloque 1)
+        // Parent: Use the real coinbase from the fixture (already confirmed in block 1)
         hash_cb = m_coinbase_txns[0]->GetHash();
         TxState state_cb = TxStateConfirmed{m_node.chainman->ActiveChain()[1]->GetBlockHash(), 1, 0};
         wallet->AddToWallet(m_coinbase_txns[0], state_cb);
 
-        // Hijo: Gasta la coinbase y lo minamos en el bloque 101
-        CMutableTransaction tx_hijo_mut;
-        tx_hijo_mut.vin.push_back(CTxIn(COutPoint(hash_cb, 0)));
-        tx_hijo_mut.vout.push_back(CTxOut(49 * COIN, GetScriptForRawPubKey(coinbaseKey.GetPubKey())));
+        // Child: Spends the coinbase and we mine it in block 101
+        CMutableTransaction tx_child_mut;
+        tx_child_mut.vin.push_back(CTxIn(COutPoint(hash_cb, 0)));
+        tx_child_mut.vout.push_back(CTxOut(49 * COIN, GetScriptForRawPubKey(coinbaseKey.GetPubKey())));
         
-        CBlock block_hijo = CreateAndProcessBlock({tx_hijo_mut}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
-        hash_hijo = tx_hijo_mut.GetHash();
-        TxState state_hijo = TxStateConfirmed{block_hijo.GetHash(), 101, 1};
-        wallet->AddToWallet(MakeTransactionRef(tx_hijo_mut), state_hijo);
+        CBlock block_child = CreateAndProcessBlock({tx_child_mut}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+        hash_child = tx_child_mut.GetHash();
+        TxState state_child = TxStateConfirmed{block_child.GetHash(), 101, 1};
+        wallet->AddToWallet(MakeTransactionRef(tx_child_mut), state_child);
         
         records = GetMockableDatabase(*wallet).m_records;
     }
 
-    // 2. Corrupción manual en los records: Coinbase -> Inactive
+    // 2. Manual corruption in the records: Coinbase -> Inactive
     {
         DataStream ssKey;
         ssKey << std::make_pair(std::string("tx"), hash_cb);
@@ -774,17 +774,18 @@ BOOST_FIXTURE_TEST_CASE(test_crash_corrupt_wallet_abandon, TestChain100Setup)
         records[key_data] = SerializeData{ssNewValue.begin(), ssNewValue.end()};
     }
 
-    // 3. Reload: Al cargar sin cadena, la wallet no auto-corrige el estado y dispara el bug
+    // 3. Reload: When loading without a chain, the wallet doesn't auto-correct the state and triggers the bug
     {
         auto database = std::make_unique<MockableDatabase>(records);
-        // Usamos nullptr en la cadena para preservar la corrupción del archivo
+        // Use nullptr for the chain to preserve the file corruption
         auto wallet = std::make_shared<CWallet>(nullptr, "", std::move(database));
         
         bilingual_str error;
         std::vector<bilingual_str> warnings;
         
-        // Esta llamada dispara el assert en wallet.cpp:1321
-        wallet->PopulateWalletFromDB(error, warnings);
+        // This call triggers the assert in wallet.cpp:1321
+        DBErrors dbErrors = wallet->PopulateWalletFromDB(error, warnings);
+        BOOST_CHECK_EQUAL(dbErrors, DBErrors::NEED_RESCAN);
     }
 }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1039,11 +1039,34 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
     });
     result = std::max(result, order_pos_res.m_result);
 
-    // After loading all tx records, abandon any coinbase that is no longer in the active chain.
-    // This could happen during an external wallet load, or if the user replaced the chain data.
-    for (auto& [id, wtx] : pwallet->mapWallet) {
-        if (wtx.IsCoinBase() && wtx.isInactive()) {
-            pwallet->AbandonTransaction(wtx);
+    bool transactionsConsistent = true;
+    // The transactions in the wallet.db file may be inconsistent. To check internal consistency,
+    // we can check for impossible states such as parent transactions that are conflicted while child is in mempool,
+    // or child transaction in mempool and parent not confirmed/in mempool.
+    for (const auto& [id, wtx] : pwallet->mapWallet) {
+        for (const auto& txin : wtx.tx->vin) {
+            auto it = pwallet->mapWallet.find(txin.prevout.hash);
+            if (it != pwallet->mapWallet.end()) {
+                const CWalletTx& ptx = it->second;
+                if (wtx.isConfirmed() && !ptx.isConfirmed()) {
+                    result = DBErrors::NEED_RESCAN;
+                    transactionsConsistent = false;
+                } else if (wtx.InMempool() && (!ptx.isConfirmed() && !ptx.InMempool())) {
+                    result = DBErrors::NEED_RESCAN;
+                    transactionsConsistent = false;
+                }
+            }
+        }
+    }
+
+    // We can only abandon transactions if the transaction state is consistent.
+    if (transactionsConsistent) {
+        // After loading all tx records, abandon any coinbase that is no longer in the active chain.
+        // This could happen during an external wallet load, or if the user replaced the chain data.
+        for (auto& [id, wtx] : pwallet->mapWallet) {
+            if (wtx.IsCoinBase() && wtx.isInactive()) {
+                pwallet->AbandonTransaction(wtx);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes: #34599 
When loading a corrupted wallet database there exists the chance where the transaction state is inconsistent. For example, in the wallet database a parent transaction could appear to be inactive while the child transaction was confirmed (of course that makes no sense, in the blockchain both transactions are confirmed). As a result, when the wallet attempts to abandon inactive transactions, it raises an assertion error. 
To fix the problem, if when loading the wallet it encounters an inconsistent transaction state, it will return NEED_RESCAN as db errors, because, it is not usable a wallet that has inconsistent transaction state.

* Adds a new test case in wallet_tests.cpp: test_crash_corrupt_wallet_abandon
