### PR TITLE
cmake: Remove NetBSD-specific workaround from `add_boost_if_needed`

### DIFF
--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -31,17 +31,6 @@ function(add_boost_if_needed)
 
   find_package(Boost 1.74.0 REQUIRED CONFIG)
   mark_as_advanced(Boost_INCLUDE_DIR boost_headers_DIR)
-  # Workaround for a bug in NetBSD pkgsrc.
-  # See https://gnats.netbsd.org/59856.
-  if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
-    get_filename_component(_boost_include_dir "${boost_headers_DIR}/../../../include/" ABSOLUTE)
-    if(_boost_include_dir MATCHES "^/usr/pkg/")
-      set_target_properties(Boost::headers PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES ${_boost_include_dir}
-      )
-    endif()
-    unset(_boost_include_dir)
-  endif()
   set_target_properties(Boost::headers PROPERTIES IMPORTED_GLOBAL TRUE)
   target_compile_definitions(Boost::headers INTERFACE
     # We don't use multi_index serialization.


### PR DESCRIPTION
The patched package [`boost-1.90.0`](https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/meta-pkgs/boost/index.html) is available as of the [`pkgsrc-2026Q1`](https://mail-index.netbsd.org/netbsd-announce/2026/03/27/msg000392.html) release.