### PR TITLE
validation: Don't add pruned blocks to `m_blocks_unlinked` on startup

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -487,7 +487,9 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
                     pindex->m_chain_tx_count = pindex->pprev->m_chain_tx_count + pindex->nTx;
                 } else {
                     pindex->m_chain_tx_count = 0;
-                    m_blocks_unlinked.insert(std::make_pair(pindex->pprev, pindex));
+                    if (pindex->nStatus & BLOCK_HAVE_DATA) {
+                        m_blocks_unlinked.insert(std::make_pair(pindex->pprev, pindex));
+                    }
                 }
             } else {
                 pindex->m_chain_tx_count = pindex->nTx;

--- a/test/functional/feature_prune_stale_fork.py
+++ b/test/functional/feature_prune_stale_fork.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test node restart with a pruned stale-fork block whose parent has no transactions."""
+
+from test_framework.blocktools import create_empty_fork
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+class FeaturePruneStaleForkTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-prune=1", "-fastprune"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("Create a 2-block stale fork: parent has no transactions, child has transactions")
+        [side_parent, side_child] = create_empty_fork(node, 2)
+
+        node.submitheader(side_parent.serialize().hex())
+        node.submitblock(side_child.serialize().hex())
+        assert_equal(node.getblockheader(side_parent.hash_hex)["nTx"], 0)
+        assert_equal(node.getblockheader(side_child.hash_hex)["nTx"], 1)
+
+        self.log.info("Advance and prune so the stale-fork child's block data is removed from disk")
+        self.generate(node, 500)
+        node.pruneblockchain(node.getblockcount() - 100)
+        assert_raises_rpc_error(-1, "Block not available (pruned data)", node.getblock, side_child.hash_hex)
+
+        self.log.info("Restart and mine; node must reload cleanly after the stale-fork child was pruned")
+        self.restart_node(0)
+        self.generate(node, 1)
+
+
+if __name__ == '__main__':
+    FeaturePruneStaleForkTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -369,6 +369,7 @@ BASE_SCRIPTS = [
     'feature_blocksdir.py',
     'wallet_startup.py',
     'feature_remove_pruned_files_on_startup.py',
+    'feature_prune_stale_fork.py',
     'p2p_i2p_ports.py',
     'p2p_i2p_sessions.py',
     'feature_presegwit_node_upgrade.py',


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/35050

The `m_blocks_unlinked` map keeps track of blocks that have transactions but whose parent (or any ancestor) does not. This happens when a block is received before its parent, or during a reorg, when `FindMostWorkChain()` encounters a block whose ancestors were pruned.

The bug this PR addresses is a rare interaction of these two cases, which happens on startup when `BlockManager::LoadBlockIndex()` rebuilds `m_blocks_unlinked`. The check there only considers whether a block has transactions, and pruned blocks keep `nTx > 0` but clear `BLOCK_HAVE_DATA`. So if there's a pruned block on a stale fork whose parent has no transactions, that block is added to `m_blocks_unlinked` without having data on disk. This violates an [assertion](https://github.com/bitcoin/bitcoin/blob/ad3f73862bdbee0aac106fa9e08c4181ce78ba47/src/validation.cpp#L5352) in `CheckBlockIndex()`.

Get rid of this unintended case by gating on `BLOCK_HAVE_DATA` before adding to `m_blocks_unlinked`.