### PR TITLE
test: Better test coverage for legacy ParseHDKeypath()

### DIFF
--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -1383,7 +1383,7 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
 std::vector<uint32_t> ParsePathBIP32(const std::string& path)
 {
     std::vector<uint32_t> out;
-    if (!ParseHDKeypath(path, out)) {
+    if (!ParseHDKeypathLegacy(path, out)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid BIP32 keypath");
     }
     return out;

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -246,102 +246,87 @@ BOOST_AUTO_TEST_CASE(bip32_max_depth) {
 
 BOOST_AUTO_TEST_CASE(parse_hd_keypath)
 {
-    std::vector<uint32_t> keypath;
+    struct TestCase {
+        bool is_valid;
+        std::string keypath;
+    };
 
-    BOOST_CHECK(ParseHDKeypath("1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1", keypath));
-    BOOST_CHECK(!ParseHDKeypath("///////////////////////////", keypath));
+    const std::vector<TestCase> tests{
+        // 28 unhardened ones, no trailing slash
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1"},
+        {false, "///////////////////////////"},
+        // 26 unhardened ones, then hardened 1, then unhardened 1
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/1"},
+        {false, "//////////////////////////'/"},
+        // 27 unhardened ones, trailing slash ignored
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/"},
+        {false, "1///////////////////////////"},
+        // 26 unhardened ones, hardened 1, trailing slash ignored
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/"},
+        {false, "1/'//////////////////////////"},
+        {true,  ""},
+        {false, " "},
+        {true,  "0"},
+        {false, "O"},
+        {true,  "0000'/0000'/0000'"},
+        {false, "0000,/0000,/0000,"},
+        {true,  "01234"},
+        {false, "0x1234"},
+        {true,  "1"},
+        {false, " 1"},
+        {true,  "42"},
+        {false, "m42"},
+        // A path element's numeric part is capped at 2^31-1; the top bit is
+        // reserved for the hardened marker (h or ').
+        {true,  "2147483647"},  // 0x7fffffff, largest normal index
+        {false, "2147483648"},  // 0x80000000, would set the hardened bit
+        {false, "4294967295"},  // 0xffffffff
+        {false, "4294967296"},  // 0xffffffff + 1
+        {true,  "m"},
+        {false, "n"},
+        {true,  "m/"},
+        {false, "n/"},
+        {true,  "m/0"},
+        {false, "n/0"},
+        {true,  "m/0'"},
+        {false, "m/0''"},
+        {true,  "m/0h"},
+        {false, "m/0hh"},
+        {false, "m/0x"},
+        {false, "m/0a"},
+        {false, "m/0G"},
+        {false, "m/h0"},
+        {true,  "m/0h/1h/2h"},
+        {true,  "m/0'/0'"},
+        {true,  "m/0h/0h"},
+        {true,  "m/0'/0h"},
+        {false, "m/'0/0'"},
+        {false, "m/h0/0'"},
+        {true,  "m/0/0"},
+        {false, "n/0/0"},
+        {true,  "m/0/0/00"},
+        {false, "m/0/0/f00"},
+        {true,  "m/0/0/000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},
+        {false, "m/1/1/111111111111111111111111111111111111111111111111111111111111111111111111111111111111"},
+        {true,  "m/0/00/0"},
+        {false, "m/0'/00/'0"},
+        {true,  "m/1/"},
+        {false, "m/1//"},
+        // The cap applies to every element, wherever it sits in the path.
+        {true,  "m/2147483647"},
+        {false, "m/2147483648"},
+        {false, "m/4294967295"},
+        {false, "m/4294967296"},
+        {true,  "m/0/2147483647"},
+        {false, "m/0/2147483648"},
+        {false, "m/0/4294967295"},
+        {false, "m/0/4294967296"},
+    };
 
-    BOOST_CHECK(ParseHDKeypath("1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/1", keypath));
-    BOOST_CHECK(!ParseHDKeypath("//////////////////////////'/", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/", keypath));
-    BOOST_CHECK(!ParseHDKeypath("1///////////////////////////", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/", keypath));
-    BOOST_CHECK(!ParseHDKeypath("1/'//////////////////////////", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("", keypath));
-    BOOST_CHECK(!ParseHDKeypath(" ", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("0", keypath));
-    BOOST_CHECK(!ParseHDKeypath("O", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("0000'/0000'/0000'", keypath));
-    BOOST_CHECK(!ParseHDKeypath("0000,/0000,/0000,", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("01234", keypath));
-    BOOST_CHECK(!ParseHDKeypath("0x1234", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("1", keypath));
-    BOOST_CHECK(!ParseHDKeypath(" 1", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("42", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m42", keypath));
-
-    // A path element's numeric part is capped at 2^31-1; the top bit is
-    // reserved for the hardened marker (h or ').
-    BOOST_CHECK(ParseHDKeypath("2147483647", keypath));  // 0x7fffffff, largest normal index
-    BOOST_CHECK(!ParseHDKeypath("2147483648", keypath)); // 0x80000000, would set the hardened bit
-    BOOST_CHECK(!ParseHDKeypath("4294967295", keypath)); // 0xffffffff
-    BOOST_CHECK(!ParseHDKeypath("4294967296", keypath)); // uint32_t max + 1
-
-    BOOST_CHECK(ParseHDKeypath("m", keypath));
-    BOOST_CHECK(!ParseHDKeypath("n", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/", keypath));
-    BOOST_CHECK(!ParseHDKeypath("n/", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0", keypath));
-    BOOST_CHECK(!ParseHDKeypath("n/0", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0'", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0''", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0h", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0hh", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0x", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0a", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0G", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/h0", keypath));
-
-    keypath.clear();
-    BOOST_REQUIRE(ParseHDKeypath("m/0h/1h/2h", keypath));
-    BOOST_REQUIRE_EQUAL(keypath.size(), 3);
-    BOOST_CHECK_EQUAL(keypath[0], BIP32_HARDENED_FLAG);
-    BOOST_CHECK_EQUAL(keypath[1], BIP32_HARDENED_FLAG | 1);
-    BOOST_CHECK_EQUAL(keypath[2], BIP32_HARDENED_FLAG | 2);
-
-    BOOST_CHECK(ParseHDKeypath("m/0'/0'", keypath));
-    BOOST_CHECK(ParseHDKeypath("m/0h/0h", keypath));
-    BOOST_CHECK(ParseHDKeypath("m/0'/0h", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/'0/0'", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/h0/0'", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/0", keypath));
-    BOOST_CHECK(!ParseHDKeypath("n/0/0", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/0/00", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0/0/f00", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/0/000000000000000000000000000000000000000000000000000000000000000000000000000000000000", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/1/1/111111111111111111111111111111111111111111111111111111111111111111111111111111111111", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/00/0", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0'/00/'0", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/1/", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/1//", keypath));
-
-    // The cap applies to every element, wherever it sits in the path.
-    BOOST_CHECK(ParseHDKeypath("m/2147483647", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/2147483648", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/4294967295", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/4294967296", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/2147483647", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0/2147483648", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0/4294967295", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0/4294967296", keypath));
+    for (const auto& [is_valid, keypath_str] : tests) {
+        std::vector<uint32_t> keypath;
+        BOOST_CHECK_EQUAL(ParseHDKeypath(keypath_str, keypath), is_valid);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -343,6 +343,22 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
             for (size_t i{0}; i < keypath_num.size(); ++i) {
                 BOOST_CHECK_EQUAL(keypath_num[i], expected[i]);
             }
+
+            // Round-trip test:
+            const std::string keypath_str2{FormatHDKeypath(keypath_num, /*apostrophe=*/true)};
+            // Note keypath_str2 may differ from keypath_str. Leading '/' is not parsed, it is removed
+            std::string keypath_str2_adjusted{keypath_str2};
+            if (keypath_str2_adjusted.starts_with('/')) {
+                keypath_str2_adjusted.erase(0, 1);
+            }
+            std::vector<uint32_t> keypath_num2;
+            BOOST_CHECK(ParseHDKeypath(keypath_str2_adjusted, keypath_num2));
+            BOOST_REQUIRE_EQUAL(keypath_num2.size(), keypath_num.size());
+            for (size_t i{0}; i < keypath_num2.size(); ++i) {
+                BOOST_CHECK_EQUAL(keypath_num2[i], keypath_num[i]);
+            }
+            const std::string keypath_str3{FormatHDKeypath(keypath_num2, /*apostrophe=*/true)};
+            BOOST_CHECK_EQUAL(keypath_str3, keypath_str2);
         }
     }
 }

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -246,86 +246,104 @@ BOOST_AUTO_TEST_CASE(bip32_max_depth) {
 
 BOOST_AUTO_TEST_CASE(parse_hd_keypath)
 {
+    static constexpr uint32_t H0{0x80000000U}; // 0'
+    static constexpr uint32_t H1{0x80000001U}; // 1'
+
     struct TestCase {
         bool is_valid;
         std::string keypath;
+        std::vector<uint32_t> expected;
     };
 
     const std::vector<TestCase> tests{
         // 28 unhardened ones, no trailing slash
-        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1"},
-        {false, "///////////////////////////"},
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1",
+                {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}},
+        {false, "///////////////////////////", {}},
         // 26 unhardened ones, then hardened 1, then unhardened 1
-        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/1"},
-        {false, "//////////////////////////'/"},
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/1",
+                {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,H1,1}},
+        {false, "//////////////////////////'/", {}},
         // 27 unhardened ones, trailing slash ignored
-        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/"},
-        {false, "1///////////////////////////"},
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/",
+                {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}},
+        {false, "1///////////////////////////", {}},
         // 26 unhardened ones, hardened 1, trailing slash ignored
-        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/"},
-        {false, "1/'//////////////////////////"},
-        {true,  ""},
-        {false, " "},
-        {true,  "0"},
-        {false, "O"},
-        {true,  "0000'/0000'/0000'"},
-        {false, "0000,/0000,/0000,"},
-        {true,  "01234"},
-        {false, "0x1234"},
-        {true,  "1"},
-        {false, " 1"},
-        {true,  "42"},
-        {false, "m42"},
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/",
+                {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,H1}},
+        {false, "1/'//////////////////////////", {}},
+        {true,  "", {}},
+        {false, " ", {}},
+        {true,  "0", {0}},
+        {false, "O", {}},
+        {true,  "0000'/0000'/0000'", {H0, H0, H0}},
+        {false, "0000,/0000,/0000,", {}},
+        {true,  "01234", {1234}},
+        {false, "0x1234", {}},
+        {true,  "1", {1}},
+        {false, " 1", {}},
+        {true,  "42", {42}},
+        {false, "m42", {}},
         // A path element's numeric part is capped at 2^31-1; the top bit is
         // reserved for the hardened marker (h or ').
-        {true,  "2147483647"},  // 0x7fffffff, largest normal index
-        {false, "2147483648"},  // 0x80000000, would set the hardened bit
-        {false, "4294967295"},  // 0xffffffff
-        {false, "4294967296"},  // 0xffffffff + 1
-        {true,  "m"},
-        {false, "n"},
-        {true,  "m/"},
-        {false, "n/"},
-        {true,  "m/0"},
-        {false, "n/0"},
-        {true,  "m/0'"},
-        {false, "m/0''"},
-        {true,  "m/0h"},
-        {false, "m/0hh"},
-        {false, "m/0x"},
-        {false, "m/0a"},
-        {false, "m/0G"},
-        {false, "m/h0"},
-        {true,  "m/0h/1h/2h"},
-        {true,  "m/0'/0'"},
-        {true,  "m/0h/0h"},
-        {true,  "m/0'/0h"},
-        {false, "m/'0/0'"},
-        {false, "m/h0/0'"},
-        {true,  "m/0/0"},
-        {false, "n/0/0"},
-        {true,  "m/0/0/00"},
-        {false, "m/0/0/f00"},
-        {true,  "m/0/0/000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},
-        {false, "m/1/1/111111111111111111111111111111111111111111111111111111111111111111111111111111111111"},
-        {true,  "m/0/00/0"},
-        {false, "m/0'/00/'0"},
-        {true,  "m/1/"},
-        {false, "m/1//"},
+        {true,  "2147483647", {0x7FFFFFFF}},  // 0x7fffffff, largest normal index
+        {false, "2147483648", {}},  // 0x80000000, would set the hardened bit
+        {false, "4294967295", {}},  // 0xffffffff
+        {false, "4294967296", {}},  // 0xffffffff + 1
+        {true,  "m", {}},
+        {false, "n", {}},
+        {true,  "m/", {}},
+        {false, "n/", {}},
+        {true,  "m/0", {0}},
+        {false, "n/0", {}},
+        {true,  "m/0'", {H0}},
+        {false, "m/0''", {}},
+
+        {true,  "m/0h", {H0}},
+        {false, "m/0hh", {}},
+        {false, "m/0x", {}},
+        {false, "m/0a", {}},
+        {false, "m/0G", {}},
+        {false, "m/h0", {}},
+        {true,  "m/0h/1h/2h", {H0, H1, 0x80000002U}},
+        {true,  "m/0'/0'", {H0, H0}},
+        {true,  "m/0h/0h", {H0, H0}},
+        {true,  "m/0'/0h", {H0, H0}},
+        {false, "m/'0/0'", {}},
+        {false, "m/h0/0'", {}},
+        {true,  "m/0/0", {0, 0}},
+        {false, "n/0/0", {}},
+        {true,  "m/0/0/00", {0, 0, 0}},
+        {false, "m/0/0/f00", {}},
+        {true,  "m/0/0/000000000000000000000000000000000000000000000000000000000000000000000000000000000000", {0, 0, 0}},
+        {false, "m/1/1/111111111111111111111111111111111111111111111111111111111111111111111111111111111111", {}},
+        {true,  "m/0/00/0", {0, 0, 0}},
+        {false, "m/0'/00/'0", {}},
+        {true,  "m/1/", {1}},
+        {false, "m/1//", {}},
         // The cap applies to every element, wherever it sits in the path.
-        {true,  "m/2147483647"},
-        {false, "m/2147483648"},
-        {false, "m/4294967295"},
-        {false, "m/4294967296"},
-        {true,  "m/0/2147483647"},
-        {false, "m/0/2147483648"},
-        {false, "m/0/4294967295"},
-        {false, "m/0/4294967296"},
+        {true,  "m/2147483647", {0x7FFFFFFF}},
+        {false, "m/2147483648", {}},
+        {false, "m/4294967295", {}},
+        {false, "m/4294967296", {}},
+        {true,  "m/0/2147483647", {0, 0x7FFFFFFF}},
+        {false, "m/0/2147483648", {}},
+        {false, "m/0/4294967295", {}},
+        {false, "m/0/4294967296", {}},
     };
 
-    for (const auto& [is_valid, keypath_str] : tests) {
-        std::vector<uint32_t> keypath;
-        BOOST_CHECK_EQUAL(ParseHDKeypath(keypath_str, keypath), is_valid);
+    for (const auto& [is_valid, keypath_str, expected] : tests) {
+        std::vector<uint32_t> keypath_num;
+        const bool res1{ParseHDKeypath(keypath_str, keypath_num)};
+        if (!is_valid) {
+            BOOST_CHECK_EQUAL(res1, false);
+        } else {
+            BOOST_CHECK_EQUAL(res1, true);
+            BOOST_REQUIRE_EQUAL(keypath_num.size(), expected.size());
+            for (size_t i{0}; i < keypath_num.size(); ++i) {
+                BOOST_CHECK_EQUAL(keypath_num[i], expected[i]);
+            }
+        }
     }
 }
 

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -339,7 +339,7 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
 
     for (const auto& [is_valid, keypath_str, expected] : tests) {
         std::vector<uint32_t> keypath_num;
-        const bool res1{ParseHDKeypath(keypath_str, keypath_num)};
+        const bool res1{ParseHDKeypathLegacy(keypath_str, keypath_num)};
         if (!is_valid) {
             BOOST_CHECK_EQUAL(res1, false);
         } else {
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
                 keypath_str2_adjusted.erase(0, 1);
             }
             std::vector<uint32_t> keypath_num2;
-            BOOST_CHECK(ParseHDKeypath(keypath_str2_adjusted, keypath_num2));
+            BOOST_CHECK(ParseHDKeypathLegacy(keypath_str2_adjusted, keypath_num2));
             BOOST_REQUIRE_EQUAL(keypath_num2.size(), keypath_num.size());
             for (size_t i{0}; i < keypath_num2.size(); ++i) {
                 BOOST_CHECK_EQUAL(keypath_num2[i], keypath_num[i]);

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -330,6 +330,11 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
         {false, "m/0/2147483648", {}},
         {false, "m/0/4294967295", {}},
         {false, "m/0/4294967296", {}},
+        {false, "1/2H/3H", {}},
+        {false, "1/2h/3h ", {}},
+        {false, "1/2h /3h", {}},
+        {true,  "1/2h/3h", {1, 0x80000002, 0x80000003}},
+        {true,  "1/2'/3h", {1, 0x80000002, 0x80000003}},
     };
 
     for (const auto& [is_valid, keypath_str, expected] : tests) {

--- a/src/test/fuzz/parse_hd_keypath.cpp
+++ b/src/test/fuzz/parse_hd_keypath.cpp
@@ -14,7 +14,7 @@ FUZZ_TARGET(parse_hd_keypath)
 {
     const std::string keypath_str(buffer.begin(), buffer.end());
     std::vector<uint32_t> keypath;
-    (void)ParseHDKeypath(keypath_str, keypath);
+    (void)ParseHDKeypathLegacy(keypath_str, keypath);
 
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const std::vector<uint32_t> random_keypath = ConsumeRandomLengthIntegralVector<uint32_t>(fuzzed_data_provider);

--- a/src/test/fuzz/parse_hd_keypath.cpp
+++ b/src/test/fuzz/parse_hd_keypath.cpp
@@ -18,6 +18,6 @@ FUZZ_TARGET(parse_hd_keypath)
 
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const std::vector<uint32_t> random_keypath = ConsumeRandomLengthIntegralVector<uint32_t>(fuzzed_data_provider);
-    (void)FormatHDKeypath(random_keypath, /*apostrophe=*/true); // WriteHDKeypath calls this with false
-    (void)WriteHDKeypath(random_keypath);
+    (void)FormatHDKeypath(random_keypath, /*apostrophe=*/fuzzed_data_provider.ConsumeBool());
+    (void)WriteHDKeypath(random_keypath, /*apostrophe=*/fuzzed_data_provider.ConsumeBool());
 }

--- a/src/test/fuzz/parse_hd_keypath.cpp
+++ b/src/test/fuzz/parse_hd_keypath.cpp
@@ -15,16 +15,16 @@ FUZZ_TARGET(parse_hd_keypath)
 {
     const std::string keypath_str(buffer.begin(), buffer.end());
     std::vector<uint32_t> keypath;
-    (void)ParseHDKeypath(keypath_str, keypath);
+    (void)ParseHDKeypathLegacy(keypath_str, keypath);
 
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const std::vector<uint32_t> random_keypath = ConsumeRandomLengthIntegralVector<uint32_t>(fuzzed_data_provider);
 
-    // Roundtrip WriteHDKeypath() and ParseHDKeypath()
+    // Roundtrip WriteHDKeypath() and ParseHDKeypathLegacy()
     for (const bool apostrophe : {false, true}) {
         std::vector<uint32_t> roundtrip;
         const std::string written{WriteHDKeypath(random_keypath, apostrophe)};
-        assert(ParseHDKeypath(written, roundtrip));
+        assert(ParseHDKeypathLegacy(written, roundtrip));
         assert(roundtrip == random_keypath);
     }
 }

--- a/src/util/bip32.cpp
+++ b/src/util/bip32.cpp
@@ -12,7 +12,7 @@
 #include <optional>
 #include <sstream>
 
-bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath)
+bool ParseHDKeypathLegacy(const std::string& keypath_str, std::vector<uint32_t>& keypath)
 {
     std::stringstream ss(keypath_str);
     std::string item;

--- a/src/util/bip32.cpp
+++ b/src/util/bip32.cpp
@@ -38,7 +38,7 @@ util::Expected<KeyPathElement, std::string> ParseKeyPathElement(std::span<const 
     return KeyPathElement{*number, is_hardened};
 }
 
-bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath)
+bool ParseHDKeypathLegacy(const std::string& keypath_str, std::vector<uint32_t>& keypath)
 {
     std::stringstream ss(keypath_str);
     std::string item;

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -10,7 +10,7 @@
 #include <vector>
 
 /** Parse an HD keypaths like "m/7/0'/2000". */
-[[nodiscard]] bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath);
+[[nodiscard]] bool ParseHDKeypathLegacy(const std::string& keypath_str, std::vector<uint32_t>& keypath);
 
 /** Write HD keypaths as strings */
 std::string WriteHDKeypath(const std::vector<uint32_t>& keypath, bool apostrophe = false);

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -30,7 +30,7 @@ struct KeyPathElement {
 util::Expected<KeyPathElement, std::string> ParseKeyPathElement(std::span<const char> elem);
 
 /** Parse an HD keypaths like "m/7/0'/2000". */
-[[nodiscard]] bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath);
+[[nodiscard]] bool ParseHDKeypathLegacy(const std::string& keypath_str, std::vector<uint32_t>& keypath);
 
 /** Write HD keypaths as strings */
 std::string WriteHDKeypath(const std::vector<uint32_t>& keypath, bool apostrophe = false);

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
 
     for (const auto& [is_valid, keypath_str, expected] : tests) {
         std::vector<uint32_t> keypath_num;
-        const bool res1{ParseHDKeypath(keypath_str, keypath_num)};
+        const bool res1{ParseHDKeypathLegacy(keypath_str, keypath_num)};
         if (!is_valid) {
             BOOST_CHECK_EQUAL(res1, false);
         } else {
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
             }
             // str2 -> num2
             std::vector<uint32_t> keypath_num2;
-            BOOST_CHECK(ParseHDKeypath(keypath_str2_adjusted, keypath_num2));
+            BOOST_CHECK(ParseHDKeypathLegacy(keypath_str2_adjusted, keypath_num2));
             BOOST_REQUIRE_EQUAL(keypath_num2.size(), keypath_num.size());
             for (size_t i{0}; i < keypath_num2.size(); ++i) {
                 BOOST_CHECK_EQUAL(keypath_num2[i], keypath_num[i]);

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -146,6 +146,9 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
         {false, "m/0/4294967296", {}},        // 0xFFFFFFFF + 1
         {true,  "m/4294967295",   {0xFFFFFFFF}},      // 0xFFFFFFFF (uint32_t max)
         {false, "m/4294967296",   {}},        // 0xFFFFFFFF + 1
+        {false, "1/2h/3h",   {}},
+        {false, "1/2'/3h",   {}},
+        {false, "1/2H/3H",   {}},
     };
 
     for (const auto& [is_valid, keypath_str, expected] : tests) {
@@ -159,6 +162,25 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
             for (size_t i{0}; i < keypath_num.size(); ++i) {
                 BOOST_CHECK_EQUAL(keypath_num[i], expected[i]);
             }
+
+            // Round-trip test:
+            // num -> str2
+            const std::string keypath_str2{FormatHDKeypath(keypath_num, /*apostrophe=*/true)};
+            // Note keypath_str2 may differ from keypath_str. Leading '/' is not parsed, it is removed
+            std::string keypath_str2_adjusted{keypath_str2};
+            if (keypath_str2_adjusted.starts_with('/')) {
+                keypath_str2_adjusted.erase(0, 1);
+            }
+            // str2 -> num2
+            std::vector<uint32_t> keypath_num2;
+            BOOST_CHECK(ParseHDKeypath(keypath_str2_adjusted, keypath_num2));
+            BOOST_REQUIRE_EQUAL(keypath_num2.size(), keypath_num.size());
+            for (size_t i{0}; i < keypath_num2.size(); ++i) {
+                BOOST_CHECK_EQUAL(keypath_num2[i], keypath_num[i]);
+            }
+            // num2 -> str3
+            const std::string keypath_str3{FormatHDKeypath(keypath_num2, /*apostrophe=*/true)};
+            BOOST_CHECK_EQUAL(keypath_str3, keypath_str2);
         }
     }
 }

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -81,63 +81,85 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
 
 BOOST_AUTO_TEST_CASE(parse_hd_keypath)
 {
+    static constexpr uint32_t H0{0x80000000U}; // 0'
+    static constexpr uint32_t H1{0x80000001U}; // 1'
+
     struct TestCase {
         bool is_valid;
         std::string keypath;
+        std::vector<uint32_t> expected;
     };
 
     const std::vector<TestCase> tests{
-        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1"},
-        {false, "///////////////////////////"},
-        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/1"},
-        {false, "//////////////////////////'/"},
-        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/"},
-        {false, "1///////////////////////////"},
-        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/"},
-        {false, "1/'//////////////////////////"},
-        {true,  ""},
-        {false, " "},
-        {true,  "0"},
-        {false, "O"},
-        {true,  "0000'/0000'/0000'"},
-        {false, "0000,/0000,/0000,"},
-        {true,  "01234"},
-        {false, "0x1234"},
-        {true,  "1"},
-        {false, " 1"},
-        {true,  "42"},
-        {false, "m42"},
-        {true,  "4294967295"},  // 0xFFFFFFFF (uint32_t max)
-        {false, "4294967296"},  // 0xFFFFFFFF + 1
-        {true,  "m"},
-        {false, "n"},
-        {true,  "m/"},
-        {false, "n/"},
-        {true,  "m/0"},
-        {false, "n/0"},
-        {true,  "m/0'"},
-        {false, "m/0''"},
-        {true,  "m/0'/0'"},
-        {false, "m/'0/0'"},
-        {true,  "m/0/0"},
-        {false, "n/0/0"},
-        {true,  "m/0/0/00"},
-        {false, "m/0/0/f00"},
-        {true,  "m/0/0/000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},
-        {false, "m/1/1/111111111111111111111111111111111111111111111111111111111111111111111111111111111111"},
-        {true,  "m/0/00/0"},
-        {false, "m/0'/00/'0"},
-        {true,  "m/1/"},
-        {false, "m/1//"},
-        {true,  "m/0/4294967295"},  // 0xFFFFFFFF (uint32_t max)
-        {false, "m/0/4294967296"},  // 0xFFFFFFFF + 1
-        {true,  "m/4294967295"},    // 0xFFFFFFFF (uint32_t max)
-        {false, "m/4294967296"},    // 0xFFFFFFFF + 1
+        // 28 unhardened ones, no trailing slash
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1",
+                {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}},
+        {false, "///////////////////////////", {}},
+        // 26 unhardened ones, then hardened 1, then unhardened 1
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/1",
+                {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,H1,1}},
+        {false, "//////////////////////////'/", {}},
+        // 27 unhardened ones, trailing slash ignored
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/",
+                {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}},
+        {false, "1///////////////////////////", {}},
+        // 26 unhardened ones, hardened 1, trailing slash ignored
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/",
+                {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,H1}},
+        {false, "1/'//////////////////////////", {}},
+        {true,  "", {}},
+        {false, " ", {}},
+        {true,  "0", {0}},
+        {false, "O", {}},
+        {true,  "0000'/0000'/0000'", {H0, H0, H0}},
+        {false, "0000,/0000,/0000,", {}},
+        {true,  "01234", {1234}},
+        {false, "0x1234", {}},
+        {true,  "1", {1}},
+        {false, " 1", {}},
+        {true,  "42", {42}},
+        {false, "m42", {}},
+        {true,  "4294967295", {0xFFFFFFFF}},  // 0xFFFFFFFF (uint32_t max)
+        {false, "4294967296", {}},    // 0xFFFFFFFF + 1
+        {true,  "m", {}},
+        {false, "n", {}},
+        {true,  "m/", {}},
+        {false, "n/", {}},
+        {true,  "m/0", {0}},
+        {false, "n/0", {}},
+        {true,  "m/0'", {H0}},
+        {false, "m/0''", {}},
+        {true,  "m/0'/0'", {H0, H0}},
+        {false, "m/'0/0'", {}},
+        {true,  "m/0/0", {0, 0}},
+        {false, "n/0/0", {}},
+        {true,  "m/0/0/00", {0, 0, 0}},
+        {false, "m/0/0/f00", {}},
+        {true,  "m/0/0/000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                {0, 0, 0}},
+        {false, "m/1/1/111111111111111111111111111111111111111111111111111111111111111111111111111111111111", {}},
+        {true,  "m/0/00/0", {0, 0, 0}},
+        {false, "m/0'/00/'0", {}},
+        {true,  "m/1/", {1}},
+        {false, "m/1//", {}},
+        {true,  "m/0/4294967295", {0, 0xFFFFFFFF}},  // 0xFFFFFFFF (uint32_t max)
+        {false, "m/0/4294967296", {}},        // 0xFFFFFFFF + 1
+        {true,  "m/4294967295",   {0xFFFFFFFF}},      // 0xFFFFFFFF (uint32_t max)
+        {false, "m/4294967296",   {}},        // 0xFFFFFFFF + 1
     };
 
-    for (const auto& [is_valid, keypath_str] : tests) {
-        std::vector<uint32_t> keypath;
-        BOOST_CHECK_EQUAL(ParseHDKeypath(keypath_str, keypath), is_valid);
+    for (const auto& [is_valid, keypath_str, expected] : tests) {
+        std::vector<uint32_t> keypath_num;
+        const bool res1{ParseHDKeypath(keypath_str, keypath_num)};
+        if (!is_valid) {
+            BOOST_CHECK_EQUAL(res1, false);
+        } else {
+            BOOST_CHECK_EQUAL(res1, true);
+            BOOST_REQUIRE_EQUAL(keypath_num.size(), expected.size());
+            for (size_t i{0}; i < keypath_num.size(); ++i) {
+                BOOST_CHECK_EQUAL(keypath_num[i], expected[i]);
+            }
+        }
     }
 }
 

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -81,76 +81,64 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
 
 BOOST_AUTO_TEST_CASE(parse_hd_keypath)
 {
-    std::vector<uint32_t> keypath;
+    struct TestCase {
+        bool is_valid;
+        std::string keypath;
+    };
 
-    BOOST_CHECK(ParseHDKeypath("1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1", keypath));
-    BOOST_CHECK(!ParseHDKeypath("///////////////////////////", keypath));
+    const std::vector<TestCase> tests{
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1"},
+        {false, "///////////////////////////"},
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/1"},
+        {false, "//////////////////////////'/"},
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/"},
+        {false, "1///////////////////////////"},
+        {true,  "1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/"},
+        {false, "1/'//////////////////////////"},
+        {true,  ""},
+        {false, " "},
+        {true,  "0"},
+        {false, "O"},
+        {true,  "0000'/0000'/0000'"},
+        {false, "0000,/0000,/0000,"},
+        {true,  "01234"},
+        {false, "0x1234"},
+        {true,  "1"},
+        {false, " 1"},
+        {true,  "42"},
+        {false, "m42"},
+        {true,  "4294967295"},  // 0xFFFFFFFF (uint32_t max)
+        {false, "4294967296"},  // 0xFFFFFFFF + 1
+        {true,  "m"},
+        {false, "n"},
+        {true,  "m/"},
+        {false, "n/"},
+        {true,  "m/0"},
+        {false, "n/0"},
+        {true,  "m/0'"},
+        {false, "m/0''"},
+        {true,  "m/0'/0'"},
+        {false, "m/'0/0'"},
+        {true,  "m/0/0"},
+        {false, "n/0/0"},
+        {true,  "m/0/0/00"},
+        {false, "m/0/0/f00"},
+        {true,  "m/0/0/000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},
+        {false, "m/1/1/111111111111111111111111111111111111111111111111111111111111111111111111111111111111"},
+        {true,  "m/0/00/0"},
+        {false, "m/0'/00/'0"},
+        {true,  "m/1/"},
+        {false, "m/1//"},
+        {true,  "m/0/4294967295"},  // 0xFFFFFFFF (uint32_t max)
+        {false, "m/0/4294967296"},  // 0xFFFFFFFF + 1
+        {true,  "m/4294967295"},    // 0xFFFFFFFF (uint32_t max)
+        {false, "m/4294967296"},    // 0xFFFFFFFF + 1
+    };
 
-    BOOST_CHECK(ParseHDKeypath("1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/1", keypath));
-    BOOST_CHECK(!ParseHDKeypath("//////////////////////////'/", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/", keypath));
-    BOOST_CHECK(!ParseHDKeypath("1///////////////////////////", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1'/", keypath));
-    BOOST_CHECK(!ParseHDKeypath("1/'//////////////////////////", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("", keypath));
-    BOOST_CHECK(!ParseHDKeypath(" ", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("0", keypath));
-    BOOST_CHECK(!ParseHDKeypath("O", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("0000'/0000'/0000'", keypath));
-    BOOST_CHECK(!ParseHDKeypath("0000,/0000,/0000,", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("01234", keypath));
-    BOOST_CHECK(!ParseHDKeypath("0x1234", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("1", keypath));
-    BOOST_CHECK(!ParseHDKeypath(" 1", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("42", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m42", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("4294967295", keypath)); // 4294967295 == 0xFFFFFFFF (uint32_t max)
-    BOOST_CHECK(!ParseHDKeypath("4294967296", keypath)); // 4294967296 == 0xFFFFFFFF (uint32_t max) + 1
-
-    BOOST_CHECK(ParseHDKeypath("m", keypath));
-    BOOST_CHECK(!ParseHDKeypath("n", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/", keypath));
-    BOOST_CHECK(!ParseHDKeypath("n/", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0", keypath));
-    BOOST_CHECK(!ParseHDKeypath("n/0", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0'", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0''", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0'/0'", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/'0/0'", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/0", keypath));
-    BOOST_CHECK(!ParseHDKeypath("n/0/0", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/0/00", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0/0/f00", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/0/000000000000000000000000000000000000000000000000000000000000000000000000000000000000", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/1/1/111111111111111111111111111111111111111111111111111111111111111111111111111111111111", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/00/0", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/0'/00/'0", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/1/", keypath));
-    BOOST_CHECK(!ParseHDKeypath("m/1//", keypath));
-
-    BOOST_CHECK(ParseHDKeypath("m/0/4294967295", keypath)); // 4294967295 == 0xFFFFFFFF (uint32_t max)
-    BOOST_CHECK(!ParseHDKeypath("m/0/4294967296", keypath)); // 4294967296 == 0xFFFFFFFF (uint32_t max) + 1
-
-    BOOST_CHECK(ParseHDKeypath("m/4294967295", keypath)); // 4294967295 == 0xFFFFFFFF (uint32_t max)
-    BOOST_CHECK(!ParseHDKeypath("m/4294967296", keypath)); // 4294967296 == 0xFFFFFFFF (uint32_t max) + 1
+    for (const auto& [is_valid, keypath_str] : tests) {
+        std::vector<uint32_t> keypath;
+        BOOST_CHECK_EQUAL(ParseHDKeypath(keypath_str, keypath), is_valid);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -608,7 +608,7 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
                     path = keyMeta.key_origin.path;
                 } else {
                     // No key origin, have to parse the string
-                    if (!ParseHDKeypath(keyMeta.hdKeypath, path)) {
+                    if (!ParseHDKeypathLegacy(keyMeta.hdKeypath, path)) {
                         strErr = "Error reading wallet database: keymeta with invalid HD keypath";
                         return DBErrors::NONCRITICAL_ERROR;
                     }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -613,7 +613,7 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
                     path = keyMeta.key_origin.path;
                 } else {
                     // No key origin, have to parse the string
-                    if (!ParseHDKeypath(keyMeta.hdKeypath, path)) {
+                    if (!ParseHDKeypathLegacy(keyMeta.hdKeypath, path)) {
                         strErr = "Error reading wallet database: keymeta with invalid HD keypath";
                         return DBErrors::NONCRITICAL_ERROR;
                     }


### PR DESCRIPTION
Background: The `ParseHDKeypath` method (`src/util/bip32.cpp`) is used only in a limited way: it is used when loading legacy wallets. Note that similar functionality is implemented independently in `src/script/descriptor.cpp` (`ParseKeyPath`, `ParseKeyPathNum`).

Deficiencies: The method has a unit test, but it checks only the bool result, and not the parsed keypath. This can be demonstrated by breaking the implementation by adding a `keypath.clear();` statement just before the final `return true;`. With this obviously broken implementation the tests pass.

Solution proposed: Extend the tests with checks (without modifying the behavior), and also rename the method.

Notes:
- Behavior is not changed. This is a legacy method expected to be removed in the future. Production code is touched only by the rename.
- Here there is no attempt to merge `ParseHDKeypath` with `ParseKeyPath`.

Potential future steps: The duplicated implementation -- `ParseHDKeypath` and `ParseKeyPath` -- could be merged, to reduce code duplication. Combining the two implementations could result in slightly better code; the former implementation looks better, while the latter has better unit test coverage.

Changes:

- Extend the unit tests with checks for the returned parsed keypath. Add the expected parsed numerical keypath as test data. Note: breaking the production code as described above now results in test failure.

- In the unit test also perform round-trip conversion: convert to string, then parse again, and convert to string again. In the last two steps the results should match the input before the round-trip (note: this is not true for the first roundtrip). Additionally, add negative tests for the unsupported 'h' hardened delimiter.

- Rename the method `ParseHDKeypath` to `ParseHDKeypathLegacy`, to make it clearer that it is used only in the legacy wallet use case, and reduce the chance of confusion with similar parsing functionality in `descriptor.cpp`.