### PR TITLE
test: clean up threadpool test types

### DIFF
--- a/src/test/threadpool_tests.cpp
+++ b/src/test/threadpool_tests.cpp
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(submit_tasks_complete_successfully)
 
     ThreadPool threadPool(POOL_NAME);
     threadPool.Start(NUM_WORKERS_DEFAULT);
-    std::atomic<int> counter = 0;
+    std::atomic_int counter = 0;
 
     // Store futures to ensure completion before checking counter.
     std::vector<std::future<void>> futures;
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(wait_for_task_to_finish)
 {
     ThreadPool threadPool(POOL_NAME);
     threadPool.Start(NUM_WORKERS_DEFAULT);
-    std::atomic<bool> flag = false;
+    std::atomic_bool flag = false;
     std::future<void> future = Submit(threadPool, [&flag]() {
         UninterruptibleSleep(200ms);
         flag.store(true, std::memory_order_release);
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(process_tasks_manually_when_workers_busy)
 
     // Now submit tasks and check that none of them are executed.
     int num_tasks = 20;
-    std::atomic<int> counter = 0;
+    std::atomic_int counter = 0;
     for (int i = 0; i < num_tasks; i++) {
         (void)Submit(threadPool, [&counter]() {
             counter.fetch_add(1, std::memory_order_relaxed);
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(congestion_more_workers_than_cores)
     threadPool.Start(std::max(1, GetNumCores() * 2)); // Oversubscribe by 2×
 
     int num_tasks = 200;
-    std::atomic<int> counter{0};
+    std::atomic_int counter{0};
 
     std::vector<std::future<void>> futures;
     futures.reserve(num_tasks);
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(interrupt_blocks_new_submissions)
     // 2) Interrupt() from a worker thread
     // One worker is blocked, another calls Interrupt(), and the remaining one waits for tasks.
     threadPool.Start(/*num_workers=*/3);
-    std::atomic<int> counter{0};
+    std::atomic_int counter{0};
     std::counting_semaphore<> blocker(0);
     const auto blocking_tasks = BlockWorkers(threadPool, blocker, 1);
     Submit(threadPool, [&threadPool, &counter]{
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(queued_tasks_complete_after_interrupt)
     const auto blocking_tasks = BlockWorkers(threadPool, blocker, NUM_WORKERS_DEFAULT);
 
     // Queue tasks while all workers are busy, then interrupt
-    std::atomic<int> counter{0};
+    std::atomic_int counter{0};
     const int num_tasks = 10;
     std::vector<std::future<void>> futures;
     futures.reserve(num_tasks);
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(stop_active_wait_drains_queue)
     const auto blocking_tasks = BlockWorkers(threadPool, blocker, NUM_WORKERS_DEFAULT);
 
     auto main_thread_id = std::this_thread::get_id();
-    std::atomic<int> main_thread_tasks{0};
+    std::atomic_int main_thread_tasks{0};
     const size_t num_tasks = 20;
     for (size_t i = 0; i < num_tasks; i++) {
         (void)Submit(threadPool, [&main_thread_tasks, main_thread_id]() {

--- a/src/test/threadpool_tests.cpp
+++ b/src/test/threadpool_tests.cpp
@@ -460,30 +460,30 @@ BOOST_AUTO_TEST_CASE(stop_active_wait_drains_queue)
 // Test 14, submit range of tasks in one lock acquisition
 BOOST_AUTO_TEST_CASE(submit_range_of_tasks_complete_successfully)
 {
-    constexpr int32_t num_tasks{50};
+    constexpr size_t num_tasks{50};
 
     ThreadPool threadPool{POOL_NAME};
     threadPool.Start(NUM_WORKERS_DEFAULT);
-    std::atomic_int32_t sum{0};
-    const auto square{[&sum](int32_t i) {
+    std::atomic_size_t sum{0};
+    const auto square{[&sum](size_t i) {
         sum.fetch_add(i, std::memory_order_relaxed);
         return i * i;
     }};
 
-    std::array<std::function<int32_t()>, static_cast<size_t>(num_tasks)> array_tasks;
-    std::vector<std::function<int32_t()>> vector_tasks;
-    vector_tasks.reserve(static_cast<size_t>(num_tasks));
-    for (const auto i : std::views::iota(int32_t{1}, num_tasks + 1)) {
-        array_tasks.at(static_cast<size_t>(i - 1)) = [i, square] { return square(i); };
+    std::array<std::function<size_t()>, num_tasks> array_tasks;
+    std::vector<std::function<size_t()>> vector_tasks;
+    vector_tasks.reserve(num_tasks);
+    for (const auto i : std::views::iota(size_t{1}, num_tasks + 1)) {
+        array_tasks.at(i - 1) = [i, square] { return square(i); };
         vector_tasks.emplace_back([i, square] { return square(i); });
     }
 
     auto futures{std::move(*Assert(threadPool.Submit(std::move(array_tasks))))};
-    BOOST_CHECK_EQUAL(futures.size(), static_cast<size_t>(num_tasks));
+    BOOST_CHECK_EQUAL(futures.size(), num_tasks);
     std::ranges::move(*Assert(threadPool.Submit(std::move(vector_tasks))), std::back_inserter(futures));
-    BOOST_CHECK_EQUAL(futures.size(), static_cast<size_t>(num_tasks * 2));
+    BOOST_CHECK_EQUAL(futures.size(), num_tasks * 2);
 
-    auto squares_sum{0};
+    size_t squares_sum{0};
     for (auto& future : futures) {
         squares_sum += future.get();
     }


### PR DESCRIPTION
Loosely related to the review of https://github.com/bitcoin/bitcoin/pull/31132#discussion_r3146688138.

### Problem
`threadpool_tests` currently stores a container-sized task count as `int32_t` in the range-submission test, then casts it back to `size_t` when sizing containers and checking future counts.

Some atomic declarations in the same file also use the longer `std::atomic<T>` spelling while nearby code uses the shorter standard typedefs.

### Fix
Use `size_t` for the task count, generated range, task return type, and accumulators so the test stays in the same type domain as the containers it exercises.

Also switch the remaining simple atomic declarations in `threadpool_tests` to the matching standard typedefs such as `std::atomic_int`, `std::atomic_bool`, and `std::atomic_size_t`.

