### PR TITLE
multi_index: fix compilation failure with boost >= 1.91

### DIFF
--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -91,12 +91,13 @@ class TxOrphanageImpl final : public TxOrphanage {
         }
     };
 
-    struct OrphanIndices final : boost::multi_index::indexed_by<
-        boost::multi_index::ordered_unique<boost::multi_index::tag<ByWtxid>, WtxidExtractor>,
-        boost::multi_index::ordered_unique<boost::multi_index::tag<ByPeer>, ByPeerViewExtractor>
-    >{};
-
-    using AnnouncementMap = boost::multi_index::multi_index_container<Announcement, OrphanIndices>;
+    using AnnouncementMap = boost::multi_index::multi_index_container<
+        Announcement,
+        boost::multi_index::indexed_by<
+            boost::multi_index::ordered_unique<boost::multi_index::tag<ByWtxid>, WtxidExtractor>,
+            boost::multi_index::ordered_unique<boost::multi_index::tag<ByPeer>, ByPeerViewExtractor>
+        >
+    >;
     template<typename Tag>
     using Iter = typename AnnouncementMap::index<Tag>::type::iterator;
     AnnouncementMap m_orphans;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -211,7 +211,9 @@ public:
 
     static const int ROLLING_FEE_HALFLIFE = 60 * 60 * 12; // public only for testing
 
-    struct CTxMemPoolEntry_Indices final : boost::multi_index::indexed_by<
+    using indexed_transaction_set = boost::multi_index_container<
+        CTxMemPoolEntry,
+        boost::multi_index::indexed_by<
             // sorted by txid
             boost::multi_index::hashed_unique<mempoolentry_txid, SaltedTxidHasher>,
             // sorted by wtxid
@@ -227,11 +229,7 @@ public:
                 CompareTxMemPoolEntryByEntryTime
             >
         >
-        {};
-    typedef boost::multi_index_container<
-        CTxMemPoolEntry,
-        CTxMemPoolEntry_Indices
-    > indexed_transaction_set;
+    >;
 
     /**
      * This mutex needs to be locked when accessing `mapTx` or other members

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -208,17 +208,15 @@ struct ByTimeViewExtractor
     }
 };
 
-struct Announcement_Indices final : boost::multi_index::indexed_by<
-    boost::multi_index::ordered_unique<boost::multi_index::tag<ByPeer>, ByPeerViewExtractor>,
-    boost::multi_index::ordered_non_unique<boost::multi_index::tag<ByTxHash>, ByTxHashViewExtractor>,
-    boost::multi_index::ordered_non_unique<boost::multi_index::tag<ByTime>, ByTimeViewExtractor>
->
-{};
 
 /** Data type for the main data structure (Announcement objects with ByPeer/ByTxHash/ByTime indexes). */
 using Index = boost::multi_index_container<
     Announcement,
-    Announcement_Indices
+    boost::multi_index::indexed_by<
+        boost::multi_index::ordered_unique<boost::multi_index::tag<ByPeer>, ByPeerViewExtractor>,
+        boost::multi_index::ordered_non_unique<boost::multi_index::tag<ByTxHash>, ByTxHashViewExtractor>,
+        boost::multi_index::ordered_non_unique<boost::multi_index::tag<ByTime>, ByTimeViewExtractor>
+    >
 >;
 
 /** Helper type to simplify syntax of iterator types. */


### PR DESCRIPTION
This effectively reverts a3cb309e7c31853f272bffaa65fb6ab0a7cc4083 from PR #30194.

That PR reduced the `multi_index` type signatures as recommended upstream, but this is no longer supported as of boost 1.91 because it is no longer necessary. 1.91 drops support for the pre-c++11 work-arounds that bloated the type signatures to begin with.

The upstream `BOOST_MULTI_INDEX_ENABLE_MPL_SUPPORT` define is meant to provide compatibility with removed features, but it does not work for this case. Using `indexed_by` directly when defining the `multi_index` (as opposed to inheriting from it) works with all versions, and avoids the use of the back-compat define.

This is a slight regression when building against boost < 1.91 because the bloated type signatures are reintroduced in that case, but it's not significant enough to go to the trouble of introducing version detection and ifdefs.