### PR TITLE
ci: reduce ccache size on GHA runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
     env:
       DANGER_RUN_CI_ON_HOST: 1
       BASE_ROOT_DIR: ${{ github.workspace }}/repo_archive
+      CCACHE_MAXSIZE: 500M
 
     steps:
       - *ANNOTATION_PR_NUMBER
@@ -343,6 +344,7 @@ jobs:
     env:
       FILE_ENV: ${{ matrix.file-env }}
       DANGER_CI_ON_HOST_FOLDERS: 1
+      CCACHE_MAXSIZE: ${{ needs.runners.outputs.provider == 'gha' && '500M' || '2G' }}
 
     steps:
       - *ANNOTATION_PR_NUMBER
@@ -443,6 +445,7 @@ jobs:
     env:
       DANGER_CI_ON_HOST_FOLDERS: 1
       FILE_ENV: ${{ matrix.file-env }}
+      CCACHE_MAXSIZE: ${{ (matrix.provider || needs.runners.outputs.provider) == 'gha' && '500M' || '2G' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The GHA cache backend has a 10 GB per-repository limit, so jobs that save multiple 2 GB ccache entries can evict each other before slower jobs have a chance to reuse their caches. This was observed in #35024.

Set CCACHE_MAXSIZE to 500M only for jobs using GitHub-hosted runners, including matrix entries that explicitly opt into GHA. Keep the 2G limit for Cirrus runners, where the larger cache does not compete for the same constrained GHA cache quota.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
