### PR TITLE
doc: recommend script_flags instead of deployments.taproot

### DIFF
--- a/doc/release-notes-26201.md
+++ b/doc/release-notes-26201.md
@@ -1,4 +1,9 @@
 RPC
 ---
 
-- 'taproot' has been removed from 'getdeploymentinfo' because its historical activation height is no longer used anywhere in the codebase. (#26201)
+- 'taproot' has been removed from 'getdeploymentinfo' because its historical
+  activation height is no longer used anywhere in the codebase.
+  Applications that rely on `deployments.taproot` to detect Taproot support
+  should either assume Taproot to be always active (since Bitcoin Core v24.0),
+  or check for `TAPROOT` in the `script_flags` array returned by
+  `getdeploymentinfo` (since Bitcoin Core v31.0). (#26201)


### PR DESCRIPTION
#26201 removed `taproot` from `getdeploymentinfo` (not yet in a release, slated for v32), which it turns out Lnd relies on: https://github.com/lightningnetwork/lnd/pull/10683

Expand the release doc note to recommend the same solution they used: check for `TAPROOT` in the `script_flags` array. This was added in v31.