### PR TITLE
rpc: stop accepting HTTP RPC before shutdown

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -267,6 +267,7 @@ static void ShutdownNotify(const ArgsManager& args)
 
 void Interrupt(NodeContext& node)
 {
+    InterruptRPC();
 #if HAVE_SYSTEM
     ShutdownNotify(*node.args);
 #endif
@@ -274,7 +275,6 @@ void Interrupt(NodeContext& node)
     if (node.notifications) WITH_LOCK(node.notifications->m_tip_block_mutex, node.notifications->m_tip_block_cv.notify_all());
     InterruptHTTPServer();
     InterruptHTTPRPC();
-    InterruptRPC();
     InterruptREST();
     if (node.tor_controller) {
         node.tor_controller->Interrupt();

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -346,16 +346,15 @@ bool IsDeprecatedRPCEnabled(const std::string& method)
 UniValue JSONRPCExec(const JSONRPCRequest& jreq, bool catch_errors)
 {
     UniValue result;
-    if (catch_errors) {
-        try {
-            result = tableRPC.execute(jreq);
-        } catch (UniValue& e) {
-            return JSONRPCReplyObj(NullUniValue, std::move(e), jreq.id, jreq.m_json_version);
-        } catch (const std::exception& e) {
-            return JSONRPCReplyObj(NullUniValue, JSONRPCError(RPC_MISC_ERROR, e.what()), jreq.id, jreq.m_json_version);
-        }
-    } else {
+    try {
+        RpcInterruptionPoint();
         result = tableRPC.execute(jreq);
+    } catch (UniValue& e) {
+        if (!catch_errors) throw;
+        return JSONRPCReplyObj(NullUniValue, std::move(e), jreq.id, jreq.m_json_version);
+    } catch (const std::exception& e) {
+        if (!catch_errors) throw;
+        return JSONRPCReplyObj(NullUniValue, JSONRPCError(RPC_MISC_ERROR, e.what()), jreq.id, jreq.m_json_version);
     }
 
     return JSONRPCReplyObj(std::move(result), NullUniValue, jreq.id, jreq.m_json_version);

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -20,14 +20,33 @@ class LongpollThread(threading.Thread):
         self.longpollid = template['longpollid']
         # create a new connection to the node, we can't use the same
         # connection from two threads
-        self.node = get_rpc_proxy(node.url, 1, timeout=600, coveragedir=node.coverage_dir)
+        self.node = get_rpc_proxy(node.url, node.index, timeout=600, coveragedir=node.coverage_dir)
+        self.exception = None
 
     def run(self):
-        self.node.getblocktemplate({'longpollid': self.longpollid, 'rules': ['segwit']})
+        try:
+            self.node.getblocktemplate({'longpollid': self.longpollid, 'rules': ['segwit']})
+        except Exception as e:
+            self.exception = e
+
+
+class GetBlockTemplateThread(threading.Thread):
+    def __init__(self, node):
+        threading.Thread.__init__(self)
+        self.node = get_rpc_proxy(node.url, node.index, timeout=600, coveragedir=node.coverage_dir)
+        self.exception = None
+
+    def run(self):
+        try:
+            self.node.getblocktemplate({'rules': ['segwit']})
+        except Exception as e:
+            self.exception = e
+
 
 class GetBlockTemplateLPTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
+        self.extra_args = [["-rpcthreads=2"], []]
         self.supports_cli = False
 
     def run_test(self):
@@ -53,6 +72,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         # check that thread will exit now that new transaction entered mempool
         thr.join(5)  # wait 5 seconds or until thread exits
         assert not thr.is_alive()
+        assert_equal(thr.exception, None)
 
         self.log.info("Test that longpoll will terminate if we generate a block ourselves")
         thr = LongpollThread(self.nodes[0])
@@ -61,6 +81,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)  # generate a block on own node
         thr.join(5)  # wait 5 seconds or until thread exits
         assert not thr.is_alive()
+        assert_equal(thr.exception, None)
 
         self.log.info("Test that introducing a new transaction into the mempool will terminate the longpoll")
         thr = LongpollThread(self.nodes[0])
@@ -71,6 +92,27 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         # after one minute, every 10 seconds the mempool is probed, so in 80 seconds it should have returned
         thr.join(60 + 20)
         assert not thr.is_alive()
+        assert_equal(thr.exception, None)
+
+        self.log.info("Test that shutdown does not process queued getblocktemplate requests")
+        longpoll_threads = [LongpollThread(self.nodes[0]) for _ in range(2)]
+        for thr in longpoll_threads:
+            thr.start()
+        for thr in longpoll_threads:
+            thr.join(5)
+            assert thr.is_alive()
+
+        queued_gbt_thread = GetBlockTemplateThread(self.nodes[0])
+        queued_gbt_thread.start()
+        queued_gbt_thread.join(1)
+        assert queued_gbt_thread.is_alive()
+
+        self.nodes[0].process.terminate()
+        self.nodes[0].wait_until_stopped()
+        for thr in [*longpoll_threads, queued_gbt_thread]:
+            thr.join(5)
+            assert not thr.is_alive()
+        assert_equal(queued_gbt_thread.exception.error['code'], -9)
 
 if __name__ == '__main__':
     GetBlockTemplateLPTest(__file__).main()


### PR DESCRIPTION
Refs #34262

`getblocktemplate` asks Bitcoin Core to build a candidate block for mining.

The problem is that an RPC request can be accepted before shutdown starts, but sit in the HTTP RPC queue and only begin running after shutdown has already started.

During shutdown, Bitcoin Core wakes up mining code that is waiting. So if the queued request is `getblocktemplate`, it can continue into block template creation after RPC shutdown has started. That can hit the existing `CHECK_NONFATAL(block_template)` check and return a less helpful internal RPC error instead of the normal shutdown RPC error.

This PR handles that queued-shutdown path by checking for RPC interruption once, early in `JSONRPCExec()`, before command execution starts. It also interrupts RPC earlier in shutdown, before waking mining waiters.

This keeps the existing `CHECK_NONFATAL` in `getblocktemplate`. The check still catches unexpected internal bugs, while this shutdown case should be handled before the command starts running.

To test this, the new regression test fills both RPC worker threads with longpolling `getblocktemplate` calls, then queues one more `getblocktemplate` request behind them. It then shuts down the node and checks that the queued request returns the normal shutdown RPC error.

---

Testing:

- `cmake --build build --target test_bitcoin -j 8`
- `build/bin/test_bitcoin -t rpc_tests`
- `test/functional/mining_getblocktemplate_longpoll.py --configfile build/test/config.ini`