### PR TITLE
wallet: fix importdescriptors batch abort on timestamp error

### DIFF
--- a/doc/release-notes-35185.md
+++ b/doc/release-notes-35185.md
@@ -1,0 +1,7 @@
+Wallet
+------
+
+- The `importdescriptors` RPC now reports missing or malformed `timestamp`
+  fields as errors in the corresponding result array entries, instead of
+  returning a top-level RPC error for the entire call. Other requests in the
+  same batch can still be processed and reported. (#35185)

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -379,6 +379,7 @@ RPCMethod importdescriptors()
     int64_t lowest_timestamp = 0;
     bool rescan = false;
     UniValue response(UniValue::VARR);
+    std::vector<int64_t> timestamps;
     {
         LOCK(pwallet->cs_wallet);
         EnsureWalletIsUnlocked(*pwallet);
@@ -387,10 +388,22 @@ RPCMethod importdescriptors()
 
         // Get all timestamps and extract the lowest timestamp
         for (const UniValue& request : requests.getValues()) {
-            // This throws an error if "timestamp" doesn't exist
-            const int64_t timestamp = std::max(GetImportTimestamp(request, now), minimum_timestamp);
+            int64_t parsed_timestamp = 0;
+            int64_t timestamp = 0;
+            try {
+                parsed_timestamp = GetImportTimestamp(request, now);
+                timestamp = std::max(parsed_timestamp, minimum_timestamp);
+            } catch (const UniValue& e) {
+                UniValue result(UniValue::VOBJ);
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", e);
+                response.push_back(std::move(result));
+                timestamps.push_back(0);
+                continue;
+            }
             const UniValue result = ProcessDescriptorImport(*pwallet, request, timestamp);
             response.push_back(result);
+            timestamps.push_back(parsed_timestamp);
 
             if (lowest_timestamp > timestamp ) {
                 lowest_timestamp = timestamp;
@@ -421,20 +434,18 @@ RPCMethod importdescriptors()
 
             // Compose the response
             for (unsigned int i = 0; i < requests.size(); ++i) {
-                const UniValue& request = requests.getValues().at(i);
-
-                // If the descriptor timestamp is within the successfully scanned
-                // range, or if the import result already has an error set, let
-                // the result stand unmodified. Otherwise replace the result
-                // with an error message.
-                if (scanned_time <= GetImportTimestamp(request, now) || results.at(i).exists("error")) {
+                // If the import result already has an error set, or if the
+                // descriptor timestamp is within the successfully scanned
+                // range, let the result stand unmodified. Otherwise replace
+                // the result with an error message.
+                if (results.at(i).exists("error") || scanned_time <= timestamps.at(i)) {
                     response.push_back(results.at(i));
                 } else {
                     std::string error_msg{strprintf("Rescan failed for descriptor with timestamp %d. There "
                             "was an error reading a block from time %d, which is after or within %d seconds "
                             "of key creation, and could contain transactions pertaining to the desc. As a "
                             "result, transactions and coins using this desc may not appear in the wallet.",
-                            GetImportTimestamp(request, now), scanned_time - TIMESTAMP_WINDOW - 1, TIMESTAMP_WINDOW)};
+                            timestamps.at(i), scanned_time - TIMESTAMP_WINDOW - 1, TIMESTAMP_WINDOW)};
                     if (pwallet->chain().havePruned()) {
                         error_msg += strprintf(" This error could be caused by pruning or data corruption "
                                 "(see bitcoind log for details) and could be dealt with by downloading and "

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -787,6 +787,26 @@ class ImportDescriptorsTest(BitcoinTestFramework):
             assert_equal(w_multipath.getrawchangeaddress(address_type="bech32"), w_multisplit.getrawchangeaddress(address_type="bech32"))
         assert_equal(sorted(w_multipath.listdescriptors()["descriptors"], key=lambda x: x["desc"]), sorted(w_multisplit.listdescriptors()["descriptors"], key=lambda x: x["desc"]))
 
+        self.log.info("Missing timestamp in one item should not abort the whole batch")
+        self.nodes[1].createwallet(wallet_name="wbatch", disable_private_keys=True, blank=True)
+        wbatch = self.nodes[1].get_wallet_rpc("wbatch")
+
+        key1 = get_generate_key()
+        key2 = get_generate_key()
+        key3 = get_generate_key()
+
+        res = wbatch.importdescriptors([
+            {"desc": descsum_create("wpkh(" + key1.pubkey + ")"), "timestamp": "now"},
+            {"desc": descsum_create("wpkh(" + key2.pubkey + ")")},  # missing timestamp
+            {"desc": descsum_create("wpkh(" + key3.pubkey + ")"), "timestamp": "now"},
+        ])
+        assert_equal(len(res), 3)
+        assert_equal(res[0]['success'], True)
+        assert_equal(res[1]['success'], False)
+        assert_equal(res[1]['error']['code'], -3)
+        assert_equal(res[1]['error']['message'], 'Missing required timestamp field for key')
+        assert_equal(res[2]['success'], True)
+
         self.log.info("Test older() safety")
 
         for flag in [0, SEQUENCE_LOCKTIME_TYPE_FLAG]:


### PR DESCRIPTION
Fixes #35181.

`importdescriptors` returns one result per request, but timestamp parsing
happened before the per-item result was created. A missing or invalid
timestamp could therefore throw a top-level RPC error and abort the batch
response after earlier requests may already have been applied.

Handle timestamp failures per item by adding a `{success: false, error: ...}`
result for the failing request and continuing with later requests.

Store parsed timestamps during the import loop so the rescan error path does
not need to parse failed requests again.

Tested:

```bash
python3 build/test/functional/test_runner.py wallet_importdescriptors.py --timeout-factor=3