### PR TITLE
kernel: Block validation without a complete UTXO set

### DIFF
--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -751,6 +751,11 @@ void btck_witness_stack_destroy(btck_WitnessStack* witness_stack)
     delete witness_stack;
 }
 
+btck_TransactionOutPoint* btck_transaction_out_point_create(const btck_Txid* txid, uint32_t index)
+{
+    return btck_TransactionOutPoint::create(COutPoint{btck_Txid::get(txid), index});
+}
+
 btck_TransactionOutPoint* btck_transaction_out_point_copy(const btck_TransactionOutPoint* out_point)
 {
     return btck_TransactionOutPoint::copy(out_point);

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -551,6 +551,11 @@ const btck_Txid* btck_transaction_get_txid(const btck_Transaction* transaction)
     return btck_Txid::ref(&btck_Transaction::get(transaction)->GetHash());
 }
 
+int btck_transaction_is_coinbase(const btck_Transaction* transaction)
+{
+    return btck_Transaction::get(transaction)->IsCoinBase() ? 1 : 0;
+}
+
 btck_Transaction* btck_transaction_copy(const btck_Transaction* transaction)
 {
     return btck_Transaction::copy(transaction);

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1349,6 +1349,12 @@ const btck_Coin* btck_transaction_spent_outputs_get_coin_at(const btck_Transacti
     return btck_Coin::ref(coin);
 }
 
+btck_Coin* btck_coin_create(const btck_TransactionOutput* output, uint32_t height, int is_coinbase)
+{
+    if (height >> 31 != 0) return nullptr;
+    return btck_Coin::create(btck_TransactionOutput::get(output), height, is_coinbase == 1);
+}
+
 btck_Coin* btck_coin_copy(const btck_Coin* coin)
 {
     return btck_Coin::copy(coin);

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -28,10 +28,12 @@
 #include <serialize.h>
 #include <streams.h>
 #include <sync.h>
+#include <tinyformat.h>
 #include <uint256.h>
 #include <undo.h>
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/hasher.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/task_runner.h>
@@ -50,6 +52,7 @@
 #include <stdexcept>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -506,6 +509,37 @@ struct btck_Txid: Handle<btck_Txid, Txid> {};
 struct btck_PrecomputedTransactionData : Handle<btck_PrecomputedTransactionData, PrecomputedTransactionData> {};
 struct btck_BlockHeader: Handle<btck_BlockHeader, CBlockHeader> {};
 struct btck_ConsensusParams: Handle<btck_ConsensusParams, Consensus::Params> {};
+
+class CoinsViewBlock : public CCoinsViewCache
+{
+private:
+    btck_FetchCoin m_coin_fetcher;
+    void* m_user_data;
+    // Omit any queries for the self-spends as done by the BIP30 checks - we don't have enough information for them anyway.
+    std::unordered_set<Txid, SaltedTxidHasher> m_block_txids;
+
+    std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const override
+    {
+        if (m_block_txids.contains(outpoint.hash)) return std::nullopt;
+        btck_Coin* coin{m_coin_fetcher(m_user_data, btck_TransactionOutPoint::ref(&outpoint))};
+        if (!coin) return std::nullopt;
+        std::optional<Coin> result{std::move(btck_Coin::get(coin))};
+        delete coin;
+        return result;
+    }
+
+public:
+    CoinsViewBlock(const CBlock& block, btck_FetchCoin coin_fetcher, void* user_data)
+        : CCoinsViewCache(&CoinsViewEmpty::Get()),
+          m_coin_fetcher{coin_fetcher},
+          m_user_data{user_data}
+    {
+        SetBestBlock(block.hashPrevBlock);
+
+        m_block_txids.reserve(block.vtx.size());
+        for (const auto& tx : block.vtx) m_block_txids.insert(tx->GetHash());
+    }
+};
 
 btck_Transaction* btck_transaction_create(const void* raw_transaction, size_t raw_transaction_len)
 {
@@ -1418,6 +1452,27 @@ btck_BlockValidationState* btck_chainstate_manager_process_block_header(
         LogError("Failed to process block header: %s", e.what());
         return nullptr;
     }
+}
+
+int btck_chainstate_manager_validate_block(
+    btck_ChainstateManager* chainstate_manager,
+    const btck_Block* _block,
+    const btck_BlockTreeEntry* entry,
+    btck_FetchCoin coin_fetcher,
+    void* user_data,
+    btck_BlockValidationState* state)
+{
+    const CBlock& block{*btck_Block::get(_block)};
+
+    try {
+        CoinsViewBlock coins{block, coin_fetcher, user_data};
+        auto& chainman{*btck_ChainstateManager::get(chainstate_manager).m_chainman};
+        btck_BlockValidationState::get(state) = chainman.ValidateBlock(block, btck_BlockTreeEntry::get(entry), coins);
+    } catch (const std::exception& e) {
+        LogError("Failed to validate block: %s", e.what());
+        btck_BlockValidationState::get(state).Error(strprintf("Exception in ValidateBlock: %s", e.what()));
+    }
+    return btck_BlockValidationState::get(state).IsValid() ? 0 : -1;
 }
 
 const btck_Chain* btck_chainstate_manager_get_active_chain(const btck_ChainstateManager* chainman)

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -771,6 +771,11 @@ const btck_Txid* btck_transaction_out_point_get_txid(const btck_TransactionOutPo
     return btck_Txid::ref(&btck_TransactionOutPoint::get(out_point).hash);
 }
 
+int btck_transaction_out_point_equals(const btck_TransactionOutPoint* out_point1, const btck_TransactionOutPoint* out_point2)
+{
+    return btck_TransactionOutPoint::get(out_point1) == btck_TransactionOutPoint::get(out_point2) ? 1 : 0;
+}
+
 void btck_transaction_out_point_destroy(btck_TransactionOutPoint* out_point)
 {
     delete out_point;

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1791,6 +1791,17 @@ BITCOINKERNEL_API void btck_witness_stack_destroy(btck_WitnessStack* witness_sta
 ///@{
 
 /**
+ * @brief Create a transaction out point from a txid and an output index.
+ *
+ * @param[in] txid  Non-null.
+ * @param[in] index The output index.
+ * @return          The allocated transaction out point. Must be freed with
+ *                  btck_transaction_out_point_destroy.
+ */
+BITCOINKERNEL_API btck_TransactionOutPoint* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_out_point_create(
+    const btck_Txid* txid, uint32_t index) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
  * @brief Copy a transaction out point.
  *
  * @param[in] transaction_out_point Non-null.

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -703,6 +703,15 @@ BITCOINKERNEL_API int btck_transaction_check(
     btck_TxValidationState* validation_state) BITCOINKERNEL_ARG_NONNULL(1, 2);
 
 /**
+ * @brief Check if this is a coinbase transaction.
+ *
+ * @param[in] transaction Non-null.
+ * @return                1 if it is coinbase, 0 if it is not.
+ */
+BITCOINKERNEL_API int btck_transaction_is_coinbase(
+    const btck_Transaction* transaction) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
  * Destroy the transaction.
  */
 BITCOINKERNEL_API void btck_transaction_destroy(btck_Transaction* transaction);

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1830,6 +1830,17 @@ BITCOINKERNEL_API const btck_Txid* btck_transaction_out_point_get_txid(
     const btck_TransactionOutPoint* transaction_out_point) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
+ * @brief Check if two transaction out points are equal.
+ *
+ * @param[in] transaction_out_point1 Non-null.
+ * @param[in] transaction_out_point2 Non-null.
+ * @return                           0 if the transaction out points are not equal.
+ */
+BITCOINKERNEL_API int btck_transaction_out_point_equals(
+    const btck_TransactionOutPoint* transaction_out_point1,
+    const btck_TransactionOutPoint* transaction_out_point2) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
  * Destroy the transaction out point.
  */
 BITCOINKERNEL_API void btck_transaction_out_point_destroy(btck_TransactionOutPoint* transaction_out_point);

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1871,6 +1871,17 @@ BITCOINKERNEL_API void btck_txid_destroy(btck_Txid* txid);
 ///@{
 
 /**
+ * @brief Create a coin.
+ *
+ * @param[in] output              Non-null.
+ * @param[in] confirmation_height The block height the coin was confirmed in. Heights are stored as 31-bit values, so it must fit in 31 bits.
+ * @param[in] is_coinbase         Set to 1 if the coin is from a coinbase output, set to 0 otherwise.
+ * @return                        The coin, or null if the height does not fit in a 31 bit value.
+ */
+BITCOINKERNEL_API btck_Coin* BITCOINKERNEL_WARN_UNUSED_RESULT btck_coin_create(
+    const btck_TransactionOutput* output, uint32_t confirmation_height, int is_coinbase) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
  * @brief Copy a coin.
  *
  * @param[in] coin Non-null.

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -388,6 +388,14 @@ typedef void (*btck_ValidationInterfaceBlockDisconnected)(void* user_data, btck_
  */
 typedef int (*btck_WriteBytes)(const void* bytes, size_t size, void* userdata);
 
+/** Function signature for retrieving a coin.
+ *
+ * The returned coin's ownership passes to the caller invoking this callback.
+ *
+ * Return nullptr if the coin cannot be retrieved.
+ */
+typedef btck_Coin* (*btck_FetchCoin)(void* user_data, const btck_TransactionOutPoint* outpoint);
+
 /**
  * Whether a validated data structure is valid, invalid, or an error was
  * encountered during processing.
@@ -1284,6 +1292,31 @@ BITCOINKERNEL_API const btck_BlockTreeEntry* btck_chainstate_manager_get_best_en
 BITCOINKERNEL_API btck_BlockValidationState* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_process_block_header(
     btck_ChainstateManager* chainstate_manager,
     const btck_BlockHeader* header) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Validate the passed in block.
+ *
+ * This validates the block against the caller's supplied spent coins without
+ * requiring a full UTXO set or mutating the chainstate. Coins created and
+ * consumed within the same block are ignored. BIP-30 violating transactions
+ * cannot be detected through this function.
+ *
+ * @param[in] chainstate_manager      Non-null.
+ * @param[in] block                   Non-null.
+ * @param[in] block_tree_entry        Non-null. The entry must be associated with the block.
+ * @param[in] coin_fetcher            Non-null. Callback for getting the coins spent by this block.
+ * @param[in] user_data               Nullable. Holds a user-defined opaque structure that will be
+ *                                    passed back through the coin_fetcher callback.
+ * @param[out] block_validation_state The result of the block validation.
+ * @return                            0 if the block is valid.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_validate_block(
+    btck_ChainstateManager* chainstate_manager,
+    const btck_Block* block,
+    const btck_BlockTreeEntry* block_tree_entry,
+    btck_FetchCoin coin_fetcher,
+    void* user_data,
+    btck_BlockValidationState* block_validation_state) BITCOINKERNEL_ARG_NONNULL(1, 2, 3, 4, 6);
 
 /**
  * @brief Triggers the start of a reindex if the wipe options were previously

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -562,6 +562,11 @@ class OutPoint : public Handle<btck_TransactionOutPoint, btck_transaction_out_po
 public:
     OutPoint(const OutPointView& view)
         : Handle(view) {}
+
+    OutPoint(const TxidView& txid, uint32_t index)
+        : Handle{btck_transaction_out_point_create(txid.get(), index)}
+    {
+    }
 };
 
 template <typename Derived>

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -669,6 +669,11 @@ public:
         return btck_transaction_count_outputs(impl());
     }
 
+    bool IsCoinbase() const
+    {
+        return btck_transaction_is_coinbase(impl()) != 0;
+    }
+
     size_t CountInputs() const
     {
         return btck_transaction_count_inputs(impl());

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -1364,6 +1364,14 @@ public:
     MAKE_RANGE_METHOD(TxsSpentOutputs, BlockSpentOutputs, &BlockSpentOutputs::Count, &BlockSpentOutputs::GetTxSpentOutputs, *this)
 };
 
+class CoinFetcher
+{
+public:
+    virtual ~CoinFetcher() = default;
+
+    virtual std::optional<Coin> FetchCoin(OutPointView out_point) = 0;
+};
+
 class ChainMan : UniqueHandle<btck_ChainstateManager, btck_chainstate_manager_destroy>
 {
 public:
@@ -1398,6 +1406,21 @@ public:
     {
         auto state = btck_chainstate_manager_process_block_header(get(), header.get());
         return BlockValidationState{state};
+    }
+
+    bool ValidateBlock(const Block& block,
+                       const BlockTreeEntry& entry,
+                       CoinFetcher& fetcher,
+                       BlockValidationState& state)
+    {
+        return btck_chainstate_manager_validate_block(
+                   get(), block.get(), entry.get(),
+                   +[](void* user_data, const btck_TransactionOutPoint* out_point) -> btck_Coin* {
+                       auto coin{static_cast<CoinFetcher*>(user_data)->FetchCoin(OutPointView{out_point})};
+                       if (!coin) return nullptr;
+                       return btck_coin_copy(coin->get());
+                   },
+                   &fetcher, state.get()) == 0;
     }
 
     ChainView GetChain() const

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -549,6 +549,12 @@ public:
     {
         return TxidView{btck_transaction_out_point_get_txid(impl())};
     }
+
+    template <typename Other>
+    bool operator==(const OutPointApi<Other>& other) const
+    {
+        return btck_transaction_out_point_equals(impl(), static_cast<const Other&>(other).get()) != 0;
+    }
 };
 
 class OutPointView : public View<btck_TransactionOutPoint>, public OutPointApi<OutPointView>

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -1283,6 +1283,9 @@ public:
 class Coin : public Handle<btck_Coin, btck_coin_copy, btck_coin_destroy>, public CoinApi<Coin>
 {
 public:
+    Coin(const TransactionOutput& output, uint32_t confirmation_height, bool is_coinbase)
+        : Handle{btck_coin_create(output.get(), confirmation_height, is_coinbase)} {}
+
     Coin(btck_Coin* coin) : Handle{coin} {}
 
     Coin(const CoinView& view) : Handle{view} {}

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -397,6 +397,9 @@ BOOST_AUTO_TEST_CASE(btck_transaction_tests)
     auto tx2{Transaction{tx_data_2}};
     CheckHandle(tx, tx2);
 
+    BOOST_CHECK(!tx.IsCoinbase());
+    BOOST_CHECK(!tx2.IsCoinbase());
+
     auto invalid_data = hex_string_to_byte_vec("012300");
     BOOST_CHECK_THROW(Transaction{invalid_data}, std::runtime_error);
     auto empty_data = hex_string_to_byte_vec("");
@@ -1171,6 +1174,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     check_equal(read_block_2.ToBytes(), hex_string_to_byte_vec(REGTEST_BLOCK_DATA[REGTEST_BLOCK_DATA.size() - 2]));
 
     Txid txid = read_block.Transactions()[0].Txid();
+    BOOST_CHECK(read_block.Transactions()[0].IsCoinbase());
     Txid txid_2 = read_block_2.Transactions()[0].Txid();
     BOOST_CHECK(txid != txid_2);
     BOOST_CHECK(txid == txid);

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -523,6 +523,10 @@ BOOST_AUTO_TEST_CASE(btck_transaction_input)
     OutPoint point_0 = input_0.OutPoint();
     OutPoint point_1 = input_1.OutPoint();
     CheckHandle(point_0, point_1);
+    OutPoint max_index_point{point_0.Txid(), std::numeric_limits<uint32_t>::max()};
+    BOOST_CHECK_EQUAL(max_index_point.index(), std::numeric_limits<uint32_t>::max());
+    OutPoint point{point_0.Txid(), point_0.index()};
+    BOOST_CHECK_EQUAL(byte_span_to_hex_string_reversed(point.Txid().ToBytes()), byte_span_to_hex_string_reversed(point_0.Txid().ToBytes()));
 
     WitnessStackView ws_0 = input_0.GetWitnessStack();
     BOOST_CHECK_EQUAL(ws_0.CountItems(), 0);

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -523,10 +523,12 @@ BOOST_AUTO_TEST_CASE(btck_transaction_input)
     OutPoint point_0 = input_0.OutPoint();
     OutPoint point_1 = input_1.OutPoint();
     CheckHandle(point_0, point_1);
+    BOOST_CHECK(point_0 != point_1);
     OutPoint max_index_point{point_0.Txid(), std::numeric_limits<uint32_t>::max()};
     BOOST_CHECK_EQUAL(max_index_point.index(), std::numeric_limits<uint32_t>::max());
     OutPoint point{point_0.Txid(), point_0.index()};
     BOOST_CHECK_EQUAL(byte_span_to_hex_string_reversed(point.Txid().ToBytes()), byte_span_to_hex_string_reversed(point_0.Txid().ToBytes()));
+    BOOST_CHECK(point == point_0);
 
     WitnessStackView ws_0 = input_0.GetWitnessStack();
     BOOST_CHECK_EQUAL(ws_0.CountItems(), 0);

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -15,7 +15,6 @@
 #include <charconv>
 #include <cstdint>
 #include <cstdlib>
-#include <exception>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -1134,6 +1133,38 @@ BOOST_AUTO_TEST_CASE(btck_chainman_in_memory_tests)
     BOOST_CHECK(context.interrupt());
 }
 
+class BlockSpentCoinFetcher : public CoinFetcher
+{
+private:
+    std::vector<std::pair<OutPoint, Coin>> m_coins;
+
+public:
+    BlockSpentCoinFetcher() = default;
+
+    BlockSpentCoinFetcher(const Block& block, const BlockSpentOutputs& block_spent_outputs)
+    {
+        size_t undo_index{0};
+        for (const auto transaction : block.Transactions()) {
+            if (transaction.IsCoinbase()) continue;
+            TransactionSpentOutputsView tx_undo{block_spent_outputs.GetTxSpentOutputs(undo_index)};
+            ++undo_index;
+            size_t input_index{0};
+            for (const auto input : transaction.Inputs()) {
+                m_coins.emplace_back(input.OutPoint(), Coin{tx_undo.GetCoin(input_index)});
+                ++input_index;
+            }
+        }
+    }
+
+    std::optional<Coin> FetchCoin(OutPointView out_point) override
+    {
+        for (const auto& [stored, coin] : m_coins) {
+            if (stored == out_point) return coin;
+        }
+        return std::nullopt;
+    }
+};
+
 BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
 {
     auto test_directory{TestDirectory{"regtest_test_bitcoin_kernel"}};
@@ -1216,8 +1247,12 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
         return std::nullopt;
     };
 
+    std::vector<std::pair<Block, BlockSpentOutputs>> blocks;
+
     for (const auto block_tree_entry : chain.Entries()) {
+        if (block_tree_entry.GetHeight() == 0) continue;
         auto block{chainman->ReadBlock(block_tree_entry)};
+
         for (const auto transaction : block->Transactions()) {
             std::vector<TransactionInput> inputs;
             std::vector<TransactionOutput> spent_outputs;
@@ -1239,6 +1274,63 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
             for (size_t i{0}; i < inputs.size(); ++i) {
                 BOOST_CHECK(spent_outputs[i].GetScriptPubkey().Verify(spent_outputs[i].Amount(), transaction, &precomputed_txdata, i, ScriptVerificationFlags::ALL, status));
             }
+        }
+
+        BlockSpentOutputs block_spent_outputs{chainman->ReadBlockSpentOutputs(block_tree_entry)};
+        BlockSpentCoinFetcher coin_fetcher{*block, block_spent_outputs};
+
+        BlockValidationState state{};
+        BOOST_CHECK(chainman->ValidateBlock(*block, block_tree_entry, coin_fetcher, state));
+        BOOST_CHECK_EQUAL(state.GetValidationMode(), ValidationMode::VALID);
+        BOOST_CHECK_EQUAL(state.GetBlockValidationResult(), BlockValidationResult::UNSET);
+
+        blocks.emplace_back(std::move(*block), std::move(block_spent_outputs));
+    }
+
+    BOOST_REQUIRE_EQUAL(blocks.size(), REGTEST_BLOCK_DATA.size());
+
+    // Validate every block with a fresh chainman by first processing its
+    // header, then validating without the UTXO set.
+    {
+        auto test_directory2{TestDirectory{"regtest_test_bitcoin_kernel_fresh"}};
+        auto notifications2{std::make_shared<TestKernelNotifications>()};
+        auto context2{create_context(notifications2, ChainType::REGTEST)};
+        auto chainman2{create_chainman(
+            test_directory2, /*reindex=*/false, /*wipe_chainstate=*/false,
+            /*block_tree_db_in_memory=*/false, /*chainstate_db_in_memory=*/false, context2)};
+
+        for (const auto& [block, block_spent_outputs] : blocks) {
+            BlockValidationState header_state{chainman2->ProcessBlockHeader(block.GetHeader())};
+            BOOST_CHECK_EQUAL(header_state.GetValidationMode(), ValidationMode::VALID);
+            BlockTreeEntry entry{*chainman2->GetBlockTreeEntry(block.GetHash())};
+
+            BlockSpentCoinFetcher coin_fetcher{block, block_spent_outputs};
+            BlockValidationState state;
+            BOOST_CHECK(chainman2->ValidateBlock(block, entry, coin_fetcher, state));
+            BOOST_CHECK_EQUAL(state.GetValidationMode(), ValidationMode::VALID);
+            // Validate again to ensure there is no lingering state
+            BOOST_CHECK(chainman2->ValidateBlock(block, entry, coin_fetcher, state));
+            BOOST_CHECK_EQUAL(state.GetValidationMode(), ValidationMode::VALID);
+        }
+
+        {
+            // Validate with no coins
+            BlockValidationState state;
+            BlockTreeEntry entry{*chainman2->GetBlockTreeEntry(blocks[205].first.GetHash())};
+            BlockSpentCoinFetcher empty_fetcher{};
+            BOOST_CHECK(!chainman2->ValidateBlock(blocks[205].first, entry, empty_fetcher, state));
+            BOOST_CHECK_EQUAL(state.GetValidationMode(), ValidationMode::INVALID);
+            BOOST_CHECK_EQUAL(state.GetBlockValidationResult(), BlockValidationResult::CONSENSUS);
+        }
+
+        {
+            // Validate with an incorrect set of coins
+            BlockSpentCoinFetcher wrong_fetcher{blocks[205].first, blocks[205].second};
+            BlockValidationState state;
+            BlockTreeEntry entry{*chainman2->GetBlockTreeEntry(blocks[204].first.GetHash())};
+            BOOST_CHECK(!chainman2->ValidateBlock(blocks[204].first, entry, wrong_fetcher, state));
+            BOOST_CHECK_EQUAL(state.GetValidationMode(), ValidationMode::INVALID);
+            BOOST_CHECK_EQUAL(state.GetBlockValidationResult(), BlockValidationResult::CONSENSUS);
         }
     }
 

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -15,6 +15,7 @@
 #include <charconv>
 #include <cstdint>
 #include <cstdlib>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -494,6 +495,22 @@ BOOST_AUTO_TEST_CASE(btck_transaction_output)
     TransactionOutput output{script, 1};
     TransactionOutput output2{script, 2};
     CheckHandle(output, output2);
+}
+
+BOOST_AUTO_TEST_CASE(btck_coin)
+{
+    ScriptPubkey script{hex_string_to_byte_vec("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac")};
+    TransactionOutput output{script, 1};
+
+    BOOST_CHECK_EXCEPTION((Coin{output, std::numeric_limits<uint32_t>::max(), false}), std::runtime_error, HasReason{"failed to instantiate btck object"});
+    Coin coin{output, 0, false};
+    Coin coin2{output, 1, true};
+    CheckHandle(coin, coin2);
+
+    BOOST_CHECK(!coin.IsCoinbase());
+    BOOST_CHECK_EQUAL(coin.GetConfirmationHeight(), 0);
+    BOOST_CHECK(coin2.IsCoinbase());
+    BOOST_CHECK_EQUAL(coin2.GetConfirmationHeight(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(btck_transaction_input)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4482,6 +4482,40 @@ MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef&
     return result;
 }
 
+BlockValidationState ChainstateManager::ValidateBlock(
+    const CBlock& block,
+    const CBlockIndex& index,
+    CCoinsViewCache& coins)
+{
+    LOCK(cs_main);
+    assert(index.GetBlockHash() == block.GetHash());
+    BlockValidationState state;
+    if (!index.IsValid(BLOCK_VALID_TREE)) {
+        auto msg{strprintf("Block %s is marked invalid", index.GetBlockHash().ToString())};
+        LogDebug(BCLog::VALIDATION, "%s", msg);
+        state.Invalid(BlockValidationResult::BLOCK_CACHED_INVALID, "duplicate-invalid", msg);
+        return state;
+    }
+
+    if (!CheckBlock(block, state, GetConsensus(), /*fCheckPOW=*/true, /*fCheckMerkleRoot=*/true)) {
+        if (state.IsValid()) NONFATAL_UNREACHABLE();
+        return state;
+    }
+
+    if (!ContextualCheckBlock(block, state, *this, index.pprev)) {
+        if (state.IsValid()) NONFATAL_UNREACHABLE();
+        return state;
+    }
+
+    // Needs to be mutable for ConnectBlock, but is not actually mutated with fJustCheck
+    CBlockIndex* index_mut{const_cast<CBlockIndex*>(&index)};
+    if (!ActiveChainstate().ConnectBlock(block, state, index_mut, coins, /*fJustCheck=*/true)) {
+        if (state.IsValid()) NONFATAL_UNREACHABLE();
+        return state;
+    }
+
+    return state;
+}
 
 BlockValidationState TestBlockValidity(
     Chainstate& chainstate,

--- a/src/validation.h
+++ b/src/validation.h
@@ -1024,6 +1024,21 @@ public:
     void CheckBlockIndex() const;
 
     /**
+     * Validate a block against the passed in coins without using the
+     * chainstate manager's coins.
+     * Similarly to TestBlockValidity it does not mutate state.
+     *
+     * @param[in] block       The block to validate.
+     * @param[in] block_index The block index entry corresponding to the block.
+     * @param[in] coins       Contains the coins spent by the block. Its best block
+     *                        hash must be set tot he block's previous hash.
+     */
+    BlockValidationState ValidateBlock(
+        const CBlock& block,
+        const CBlockIndex& block_index,
+        CCoinsViewCache& coins);
+
+    /**
      * Alias for ::cs_main.
      * Should be used in new code to make it easier to make ::cs_main a member
      * of this class.


### PR DESCRIPTION
This adds a kernel C header API endpoint for validating a block without having access to the full UTXO set. The introduced block validation function is intended to be called after having instantiated a chainstate manager and processing the block's header. Following this contract, the block is internally validated by the `CheckBlock`, `ContextualCheckBlockHeader`, `ContextualCheckBlock`, and finally `ConnectBlock` functions.

The `CoinsViewBlock` class is introduced to validate user-provided coins passed through a callback. It inherits from `CCoinsViewCache` and is eventually passed to `ConnectBlock`. This allows validating the block's scripts and spends against user-provided UTXOs instead of using the chainstate's own internal UTXO set.

This also includes some more API endpoints to populate the coins and OutPoints and retrieve relevant data.