### PR TITLE
txdb: handle malformed first coin cursor key

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -301,6 +301,25 @@ BOOST_FIXTURE_TEST_CASE(coins_cache_dbbase_simulation_test, CacheTest)
     SimulationTest(&db_base, true);
 }
 
+BOOST_AUTO_TEST_CASE(malformed_first_coin_key_cursor_invalid)
+{
+    const fs::path path{m_args.GetDataDirBase() / "malformed_first_coin_key_cursor_invalid"};
+
+    {
+        CDBWrapper dbw{{.path = path, .cache_bytes = 1_MiB, .wipe_data = true, .obfuscate = false}};
+        // Enter the DB_COIN keyspace with a key too short to deserialize as CoinEntry.
+        dbw.Write(uint8_t{'C'}, Coin{CTxOut{/*nValueIn=*/1, CScript{}}, /*nHeightIn=*/1, /*fCoinBaseIn=*/false});
+    }
+
+    CCoinsViewDB view{{.path = path, .cache_bytes = 1_MiB, .wipe_data = false, .obfuscate = false}, {}};
+    std::unique_ptr<CCoinsViewCursor> cursor{view.Cursor()};
+    BOOST_REQUIRE(cursor);
+
+    COutPoint outpoint;
+    BOOST_CHECK(!cursor->Valid());
+    BOOST_CHECK(!cursor->GetKey(outpoint));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -207,12 +207,11 @@ std::unique_ptr<CCoinsViewCursor> CCoinsViewDB::Cursor() const
        that restriction.  */
     i->pcursor->Seek(DB_COIN);
     // Cache key of first record
-    if (i->pcursor->Valid()) {
-        CoinEntry entry(&i->keyTmp.second);
-        i->pcursor->GetKey(entry);
-        i->keyTmp.first = entry.key;
-    } else {
+    CoinEntry entry(&i->keyTmp.second);
+    if (!i->pcursor->Valid() || !i->pcursor->GetKey(entry)) {
         i->keyTmp.first = 0; // Make sure Valid() and GetKey() return false
+    } else {
+        i->keyTmp.first = entry.key;
     }
     return i;
 }


### PR DESCRIPTION
Fixes #35172.

> I am still getting familiar with the codebase, so doing easy tickets for now. Thanks for bearing with me.

## What?
`CCoinsViewDB::Cursor()` caches the first coin key after seeking into the chainstate DB. If the first `DB_COIN` entry is malformed, `CDBIterator::GetKey()` returns false, but the cursor warmup path ignored that return value.

Because `CoinEntry` defaults its key marker to `DB_COIN`, a malformed key like just `C` could leave the cursor reporting `Valid() == true` and `GetKey() == true` even though the key was not decoded.

This makes the warmup path match `CCoinsViewDBCursor::Next()`: if the iterator is invalid or the key cannot be decoded, invalidate the cached key.

## Scenario

This would require an already-corrupted or manually modified local chainstate LevelDB where the first coin key is readable by LevelDB but not decodable as a `CoinEntry`. 

**_Normal node operation should not create this key shape, so this is a correctness/hardening fix rather than a common user-facing issue._**

## Testing

The regression test writes a single-byte `C` key, which enters the `DB_COIN` keyspace but is too short to decode as a `CoinEntry`. It then reopens the DB through `CCoinsViewDB` and checks that the returned cursor is invalid.


```bash
cmake --build build --target test_bitcoin -j8
build/bin/test_bitcoin --run_test=coins_tests_dbbase/malformed_first_coin_key_cursor_invalid
build/bin/test_bitcoin --run_test=coins_tests_dbbase
```
