### PR TITLE
wallet: unfriend LegacyDataSPKM and DescriptorScriptPubKeyMan

### DIFF
--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -274,7 +274,6 @@ public:
 
 class DescriptorScriptPubKeyMan : public ScriptPubKeyMan
 {
-    friend class LegacyDataSPKM;
 private:
     using ScriptPubKeyMap = std::map<CScript, int32_t>; // Map of scripts to descriptor range index
     using PubKeyMap = std::map<CPubKey, int32_t>; // Map of pubkeys involved in scripts to descriptor range index


### PR DESCRIPTION
After #28333, `LegacyDataSPKM` doesn't need to use the private or protected members
of `DescriptorScriptPubKeyMan` class such as `AddDescriptorKeyWithDB` and 
`TopUpWithDB`. Moreover, these two SPKMs are siblings that inherit from the common 
`ScriptPubKeyMan` that have non intersecting use cases semantically. It seems reasonable 
to me that they are unfriended so that private members of one are not exposed to
another unnecessarily.
