### PR TITLE
log: Avoid rounding headers sync progress to 100%

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4252,8 +4252,8 @@ bool ChainstateManager::ProcessNewBlockHeaders(std::span<const CBlockHeader> hea
             const CBlockIndex& last_accepted{**ppindex};
             int64_t blocks_left{(NodeClock::now() - last_accepted.Time()) / GetConsensus().PowTargetSpacing()};
             blocks_left = std::max<int64_t>(0, blocks_left);
-            const double progress{100.0 * last_accepted.nHeight / (last_accepted.nHeight + blocks_left)};
-            LogInfo("Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
+            const int progress{last_accepted.nHeight ? static_cast<int>(10000LL * last_accepted.nHeight / (last_accepted.nHeight + blocks_left)) : 0};
+            LogInfo("Synchronizing blockheaders, height: %d (~%d.%02d%%)\n", last_accepted.nHeight, progress / 100, progress % 100);
         }
     }
     return true;
@@ -4279,8 +4279,8 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
     if (initial_download) {
         int64_t blocks_left{(NodeClock::now() - NodeSeconds{std::chrono::seconds{timestamp}}) / GetConsensus().PowTargetSpacing()};
         blocks_left = std::max<int64_t>(0, blocks_left);
-        const double progress{100.0 * height / (height + blocks_left)};
-        LogInfo("Pre-synchronizing blockheaders, height: %d (~%.2f%%)\n", height, progress);
+        const int progress{height ? static_cast<int>(10000LL * height / (height + blocks_left)) : 0};
+        LogInfo("Pre-synchronizing blockheaders, height: %d (~%d.%02d%%)\n", height, progress / 100, progress % 100);
     }
 }
 


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->
This applies the same progress formatting behavior as bitcoin-core/gui#935 to the node headers sync logs.                                                                                                                                       During headers synchronization, the estimated progress was formatted with `%.2f%%`, which rounds to two decimal         places. This could display `100.00%` even when the estimate still had headers left to process.                                                                                                                                                  This patch formats the progress using fixed-point integer arithmetic, truncating to two decimal places instead of       rounding. As a result, the log only displays `100.00%` when the estimated number of blocks left is zero.                                                                                                                                        The same truncation is applied to both headers sync and headers presync progress logs for consistency. 

During a correct sync this is pointless, as the time were this error would happen is minimal, however in some special cases this can create confussion, please read  https://github.com/bitcoin-core/gui/issues/65#issuecomment-4143720788 to get more context.



<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
