### PR TITLE
Refactor: Updated signMessage to use util::Expected and removed SigningResult::OK

### DIFF
--- a/src/common/signmessage.cpp
+++ b/src/common/signmessage.cpp
@@ -81,8 +81,6 @@ uint256 MessageHash(const std::string& message)
 std::string SigningResultString(const SigningResult res)
 {
     switch (res) {
-        case SigningResult::OK:
-            return "No error";
         case SigningResult::PRIVATE_KEY_NOT_AVAILABLE:
             return "Private key not available";
         case SigningResult::SIGNING_FAILED:

--- a/src/common/signmessage.h
+++ b/src/common/signmessage.h
@@ -41,7 +41,6 @@ enum class MessageVerificationResult {
 };
 
 enum class SigningResult {
-    OK, //!< No error
     PRIVATE_KEY_NOT_AVAILABLE,
     SIGNING_FAILED,
 };

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -14,6 +14,7 @@
 #include <pubkey.h>
 #include <script/script.h>
 #include <support/allocators/secure.h>
+#include <util/expected.h>
 #include <util/fs.h>
 #include <util/result.h>
 #include <util/ui_change_type.h>
@@ -103,7 +104,7 @@ public:
     virtual bool getPubKey(const CScript& script, const CKeyID& address, CPubKey& pub_key) = 0;
 
     //! Sign message
-    virtual SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) = 0;
+    virtual util::Expected<void, SigningResult> signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) = 0;
 
     //! Return whether wallet has private key.
     virtual bool isSpendable(const CTxDestination& dest) = 0;

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -140,22 +140,18 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
 
     const std::string& message = ui->messageIn_SM->document()->toPlainText().toStdString();
     std::string signature;
-    SigningResult res = model->wallet().signMessage(message, *pkhash, signature);
+    auto res = model->wallet().signMessage(message, *pkhash, signature);
+    if (!res) {
+        QString error;
+        switch (res.error()) {
+            case SigningResult::PRIVATE_KEY_NOT_AVAILABLE:
+                error = tr("Private key for the entered address is not available.");
+                break;
+            case SigningResult::SIGNING_FAILED:
+                error = tr("Message signing failed.");
+                break;
+        } // no default case, so the compiler can warn about missing cases
 
-    QString error;
-    switch (res) {
-        case SigningResult::OK:
-            error = tr("No error");
-            break;
-        case SigningResult::PRIVATE_KEY_NOT_AVAILABLE:
-            error = tr("Private key for the entered address is not available.");
-            break;
-        case SigningResult::SIGNING_FAILED:
-            error = tr("Message signing failed.");
-            break;
-    } // no default case, so the compiler can warn about missing cases
-
-    if (res != SigningResult::OK) {
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(QString("<nobr>") + error + QString("</nobr>"));
         return;

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -42,6 +42,6 @@ FUZZ_TARGET(message, .init = initialize_message)
         auto address = fuzzed_data_provider.ConsumeRandomLengthString(1024);
         auto signature = fuzzed_data_provider.ConsumeRandomLengthString(1024);
         (void)MessageVerify(address, signature, random_message);
-        (void)SigningResultString(fuzzed_data_provider.PickValueInArray({SigningResult::OK, SigningResult::PRIVATE_KEY_NOT_AVAILABLE, SigningResult::SIGNING_FAILED}));
+        (void)SigningResultString(fuzzed_data_provider.PickValueInArray({SigningResult::PRIVATE_KEY_NOT_AVAILABLE, SigningResult::SIGNING_FAILED}));
     }
 }

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -165,7 +165,7 @@ public:
         }
         return false;
     }
-    SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) override
+    util::Expected<void, SigningResult> signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) override
     {
         return m_wallet->SignMessage(message, pkhash, str_sig);
     }

--- a/src/wallet/rpc/signmessage.cpp
+++ b/src/wallet/rpc/signmessage.cpp
@@ -57,10 +57,12 @@ RPCMethod signmessage()
             }
 
             std::string signature;
-            SigningResult err = pwallet->SignMessage(strMessage, *pkhash, signature);
-            if (err == SigningResult::SIGNING_FAILED) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, SigningResultString(err));
-            } else if (err != SigningResult::OK) {
+            auto res = pwallet->SignMessage(strMessage, *pkhash, signature);
+            if (!res) {
+                const SigningResult err{res.error()};
+                if (err == SigningResult::SIGNING_FAILED) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, SigningResultString(err));
+                }
                 throw JSONRPCError(RPC_WALLET_ERROR, SigningResultString(err));
             }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1329,22 +1329,22 @@ bool DescriptorScriptPubKeyMan::SignTransaction(CMutableTransaction& tx, const s
     return ::SignTransaction(tx, keys.get(), coins, {.sighash_type = sighash}, input_errors);
 }
 
-SigningResult DescriptorScriptPubKeyMan::SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const
+util::Expected<void, SigningResult> DescriptorScriptPubKeyMan::SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const
 {
     std::unique_ptr<FlatSigningProvider> keys = GetSigningProvider(GetScriptForDestination(pkhash), true);
     if (!keys) {
-        return SigningResult::PRIVATE_KEY_NOT_AVAILABLE;
+        return util::Unexpected{SigningResult::PRIVATE_KEY_NOT_AVAILABLE};
     }
 
     CKey key;
     if (!keys->GetKey(ToKeyID(pkhash), key)) {
-        return SigningResult::PRIVATE_KEY_NOT_AVAILABLE;
+        return util::Unexpected{SigningResult::PRIVATE_KEY_NOT_AVAILABLE};
     }
 
     if (!MessageSign(key, message, str_sig)) {
-        return SigningResult::SIGNING_FAILED;
+        return util::Unexpected{SigningResult::SIGNING_FAILED};
     }
-    return SigningResult::OK;
+    return {};
 }
 
 std::optional<PSBTError> DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction& psbtx, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed) const

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -18,6 +18,7 @@
 #include <script/signingprovider.h>
 #include <util/hasher.h>
 #include <util/log.h>
+#include <util/expected.h>
 #include <util/result.h>
 #include <util/time.h>
 #include <wallet/crypter.h>
@@ -137,7 +138,7 @@ public:
     /** Creates new signatures and adds them to the transaction. Returns whether all inputs were signed */
     virtual bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const { return false; }
     /** Sign a message with the given script */
-    virtual SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const { return SigningResult::SIGNING_FAILED; };
+    virtual util::Expected<void, SigningResult> SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const { return util::Unexpected{SigningResult::SIGNING_FAILED}; };
     /** Adds script and derivation path information to a PSBT, and optionally signs it. */
     virtual std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed = nullptr) const { return common::PSBTError::UNSUPPORTED; }
 
@@ -394,7 +395,7 @@ public:
     std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CPubKey& pubkey) const;
 
     bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override;
-    SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
+    util::Expected<void, SigningResult> SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
     std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed = nullptr) const override;
 
     uint256 GetID() const override;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2251,7 +2251,7 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, co
     return {};
 }
 
-SigningResult CWallet::SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const
+util::Expected<void, SigningResult> CWallet::SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const
 {
     SignatureData sigdata;
     CScript script_pub_key = GetScriptForDestination(pkhash);
@@ -2261,7 +2261,7 @@ SigningResult CWallet::SignMessage(const std::string& message, const PKHash& pkh
             return spk_man_pair.second->SignMessage(message, pkhash, str_sig);
         }
     }
-    return SigningResult::PRIVATE_KEY_NOT_AVAILABLE;
+    return util::Unexpected{SigningResult::PRIVATE_KEY_NOT_AVAILABLE};
 }
 
 OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& change_type, const std::vector<CRecipient>& vecSend) const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -24,6 +24,7 @@
 #include <tinyformat.h>
 #include <uint256.h>
 #include <util/fs.h>
+#include <util/expected.h>
 #include <util/hasher.h>
 #include <util/log.h>
 #include <util/result.h>
@@ -665,7 +666,7 @@ public:
     bool SignTransaction(CMutableTransaction& tx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     /** Sign the tx given the input coins and sighash. */
     bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const;
-    SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const;
+    util::Expected<void, SigningResult> SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const;
 
     /**
      * Fills out a PSBT with information from the wallet. Fills in UTXOs if we have


### PR DESCRIPTION
## Summary
Similar to https://github.com/bitcoin/bitcoin/pull/32958 and https://github.com/bitcoin/bitcoin/pull/35105.

We now are using `util::Expected` and removed `SigningResult::OK`

This makes the enum less confusing because now it no longer includes `OK` and is now a pure error enum.