### PR TITLE
ci: restore sockets in `i686, no IPC` job

### DIFF
--- a/ci/test/00_setup_env_i686_no_ipc.sh
+++ b/ci/test/00_setup_env_i686_no_ipc.sh
@@ -10,6 +10,7 @@ export HOST=i686-pc-linux-gnu
 export CONTAINER_NAME=ci_i686_no_multiprocess
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"
 export CI_IMAGE_PLATFORM="linux/amd64"
+export CI_CONTAINER_CAP="--security-opt seccomp=unconfined"
 export PACKAGES="llvm clang g++-multilib"
 export DEP_OPTS="DEBUG=1 NO_IPC=1"
 export GOAL="install"


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/35199.

### Problem
The `i686, no IPC` job [fails](https://github.com/bitcoin/bitcoin/actions/runs/25275669000/job/74105140405#step:11:2951) in `sock_tests` at the first [`socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)` call](https://github.com/bitcoin/bitcoin/blob/52c3381fa8f4194f9da7cf69e411602c3c7e161d/src/test/sock_tests.cpp#L33).

The failing runner [uses Docker 29.4.2](https://github.com/bitcoin/bitcoin/actions/runs/25275669000/job/74105140405#step:7:81), while a comparable passing run [used Docker 29.4.1](https://github.com/bitcoin/bitcoin/actions/runs/25249734733/job/74039837293#step:7:81).

The latest Docker [changed the default seccomp profile](https://docs.docker.com/engine/release-notes/29/#2942) to block `socketcall(2)`, and the Moby seccomp profile documents the explicit `socketcall` deny rule as returning [`ENOSYS`](https://github.com/moby/profiles/releases/tag/seccomp%2Fv0.2.2).

A previous push attempted to skip only `sock_tests` - CI failed in `util_tests/test_LockDirectory` at `socketpair(...)`, which shows the problem is not isolated to one unit test:
https://github.com/bitcoin/bitcoin/actions/runs/25281552739/job/74119501960?pr=35202

### Fix
Add Docker's documented [`--security-opt seccomp=unconfined`](https://docs.docker.com/engine/security/seccomp/#run-without-the-default-seccomp-profile) option to the `i686, no IPC` job through [CI_CONTAINER_CAP](https://github.com/bitcoin/bitcoin/blob/fab73e213dee1057e9e759133767b17ec5b1f6ab/ci/test/02_run_container.py#L137).

This is broader than a test skip, but it is limited to the affected CI job and restores socket syscall availability for the full unit and functional test run.
