### PR TITLE
net: cap future-MTP headers commitments

### DIFF
--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -38,9 +38,9 @@ HeadersSyncState::HeadersSyncState(NodeId id,
     // exceeds this bound, because it's not possible for a consensus-valid
     // chain to be longer than this (at the current time -- in the future we
     // could try again, if necessary, to sync a longer chain).
-    const auto max_seconds_since_start{(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start.GetMedianTimePast()}}))
-                                       + MAX_FUTURE_BLOCK_TIME};
-    m_max_commitments = 6 * max_seconds_since_start / m_params.commitment_period;
+    const int64_t max_seconds_since_start{(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start.GetMedianTimePast()}}))
+                                   + MAX_FUTURE_BLOCK_TIME};
+    m_max_commitments = max_seconds_since_start > 0 ? 6 * max_seconds_since_start / m_params.commitment_period : 0;
 
     LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s\n", m_id, m_current_height, m_max_commitments, m_minimum_required_work.ToString());
 }

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -60,7 +60,7 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
     CBlockHeader genesis_header{Params().GenesisBlock()};
     CBlockIndex start_index(genesis_header);
 
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast())};
+    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast() - 2 * MAX_FUTURE_BLOCK_TIME)};
 
     const uint256 genesis_hash = genesis_header.GetHash();
     start_index.phashBlock = &genesis_hash;

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -148,10 +148,10 @@ BOOST_AUTO_TEST_CASE(future_chain_start_mtp_bounds_commitments)
     HeadersSyncState hss{CreateState(/*commitment_period=*/1)};
 
     CHECK_RESULT(hss.ProcessNextHeaders({{FirstChain().front()}}, /*full_headers_message=*/true),
-        hss, /*exp_state=*/State::PRESYNC,
-        /*exp_success=*/true, /*exp_request_more=*/true,
+        hss, /*exp_state=*/State::FINAL,
+        /*exp_success=*/false, /*exp_request_more=*/false,
         /*exp_headers_size=*/0, /*exp_pow_validated_prev=*/std::nullopt,
-        /*exp_locator_hash=*/FirstChain().front().GetHash());
+        /*exp_locator_hash=*/std::nullopt);
 }
 
 BOOST_AUTO_TEST_CASE(sneaky_redownload)

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -10,6 +10,7 @@
 #include <pow.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <validation.h>
 
 #include <cstddef>
@@ -79,12 +80,12 @@ struct HeadersGeneratorSetup : public RegTestingSetup {
         return second_chain;
     }
 
-    HeadersSyncState CreateState()
+    HeadersSyncState CreateState(size_t commitment_period = COMMITMENT_PERIOD)
     {
         return {/*id=*/0,
                 Params().GetConsensus(),
                 HeadersSyncParams{
-                    .commitment_period = COMMITMENT_PERIOD,
+                    .commitment_period = commitment_period,
                     .redownload_buffer_size = REDOWNLOAD_BUFFER_SIZE,
                 },
                 chain_start,
@@ -140,6 +141,18 @@ std::vector<CBlockHeader> HeadersGeneratorSetup::GenerateHeaders(
 // 3. Repeat the second set of headers in both phases to demonstrate behavior
 //    when the chain a peer provides has too little work.
 BOOST_FIXTURE_TEST_SUITE(headers_sync_chainwork_tests, HeadersGeneratorSetup)
+
+BOOST_AUTO_TEST_CASE(future_chain_start_mtp_bounds_commitments)
+{
+    const NodeClockContext clock_ctx{std::chrono::seconds{genesis.GetBlockTime() - MAX_FUTURE_BLOCK_TIME - 1}};
+    HeadersSyncState hss{CreateState(/*commitment_period=*/1)};
+
+    CHECK_RESULT(hss.ProcessNextHeaders({{FirstChain().front()}}, /*full_headers_message=*/true),
+        hss, /*exp_state=*/State::PRESYNC,
+        /*exp_success=*/true, /*exp_request_more=*/true,
+        /*exp_headers_size=*/0, /*exp_pow_validated_prev=*/std::nullopt,
+        /*exp_locator_hash=*/FirstChain().front().GetHash());
+}
 
 BOOST_AUTO_TEST_CASE(sneaky_redownload)
 {


### PR DESCRIPTION
Follow-up is in #35351


### Problem
Headers presync computes `m_max_commitments` from the elapsed time since the chain-start MTP plus `MAX_FUTURE_BLOCK_TIME`.
When the local clock is more than `MAX_FUTURE_BLOCK_TIME` behind the chain-start MTP, that elapsed value is negative, but it is used in arithmetic assigned to the unsigned commitment cap.
This can turn the intended zero bound into a large cap, letting low-work headers presync continue instead of aborting when the commitment cap is reached.

### Fix
Assign an explicit zero commitment cap when the chain-start MTP is still too far in the future for a locally acceptable extension to exist.

The branch is split into two bisect-friendly commits: a regression test [pinning the current behavior](https://github.com/bitcoin/bitcoin/pull/35260), and the minimal fix, which flips those test assertions.

The `headers_sync_state` fuzz target also now allows the same clock-skew case instead of always choosing a time at or after the chain-start MTP.