### PR TITLE
validation: correct lifetime of precomputed tx data

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2508,10 +2508,9 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // in multiple threads). Preallocate the vector size so a new allocation
     // doesn't invalidate pointers into the vector, and keep txsdata in scope
     // for as long as `control`.
+    std::vector<PrecomputedTransactionData> txsdata(block.vtx.size());
     std::optional<CCheckQueueControl<CScriptCheck>> control;
     if (auto& queue = m_chainman.GetCheckQueue(); queue.HasThreads() && fScriptChecks) control.emplace(queue);
-
-    std::vector<PrecomputedTransactionData> txsdata(block.vtx.size());
 
     std::vector<int> prevheights;
     CAmount nFees = 0;


### PR DESCRIPTION
This is a cleanup that fixes the root cause of CVE-2024-52911, which was covertly fixed in #31112 (first released in 29.0).

Security advisory for CVE-2024-52911 is available [here](https://bitcoincore.org/en/2026/05/05/disclose-cve-2024-52911).