### PR TITLE
test: fix `P2SH` script in coins cache fuzz target

### DIFF
--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -70,7 +70,7 @@ struct PrecomputedData
                 coins[i].out.scriptPubKey[0] = OP_HASH160;
                 coins[i].out.scriptPubKey[1] = 20;
                 std::copy(hash.begin(), hash.begin() + 20, coins[i].out.scriptPubKey.begin() + 2);
-                coins[i].out.scriptPubKey[12] = OP_EQUAL;
+                coins[i].out.scriptPubKey[22] = OP_EQUAL;
                 break;
             case 2: /* P2WPKH */
                 coins[i].out.scriptPubKey.resize(22);
@@ -446,7 +446,7 @@ FUZZ_TARGET(coinscache_sim)
             }
         }
 
-        // HaveCoinInCache ignores spent coins, so GetCacheSize() may exceed it. */
+        // HaveCoinInCache ignores spent coins, so GetCacheSize() may exceed it.
         assert(cache.GetCacheSize() >= cache_size);
     }
 


### PR DESCRIPTION
### Problem
`coinscache_sim` manually constructs a 23-byte P2SH `scriptPubKey`, but placed `OP_EQUAL` at byte index 12.
That index is inside the 20-byte script hash payload, so the constructed script did not match the standard P2SH layout:
https://github.com/bitcoin/bitcoin/blob/fa2670bd4b5b199c417011942228ba87d1613030/src/script/script.cpp#L223-L230

### Fix
Place `OP_EQUAL` after `OP_HASH160`, the 20-byte push opcode, and the 20-byte script hash.
Also remove a stray trailing comment terminator in the same fuzz target.