### PR TITLE
fuzz: connman: strengthen assertions and extend coverage

### DIFF
--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -81,6 +81,13 @@ FUZZ_TARGET(connman, .init = initialize_connman)
     options.m_msgproc = &net_events;
     options.nMaxOutboundLimit = max_outbound_limit;
 
+    const auto local_services{ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS)};
+    options.m_local_services = local_services;
+
+    const auto use_addrman_outgoing{fuzzed_data_provider.ConsumeBool()};
+    options.m_use_addrman_outgoing = use_addrman_outgoing;
+    options.m_max_automatic_connections = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 1000);
+
     auto consume_whitelist = [&]() {
         std::vector<NetWhitelistPermissions> result(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 3));
         for (auto& entry : result) {
@@ -245,7 +252,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
     });
     (void)connman.GetAddedNodeInfo(fuzzed_data_provider.ConsumeBool());
     (void)connman.GetExtraFullOutboundCount();
-    (void)connman.GetLocalServices();
+    assert(connman.GetLocalServices() == local_services);
     assert(connman.GetMaxOutboundTarget() == max_outbound_limit);
     (void)connman.GetMaxOutboundTimeframe();
     (void)connman.GetMaxOutboundTimeLeftInCycle();
@@ -255,7 +262,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
     (void)connman.GetTotalBytesRecv();
     (void)connman.GetTotalBytesSent();
     (void)connman.GetTryNewOutboundPeer();
-    (void)connman.GetUseAddrmanOutgoing();
+    assert(connman.GetUseAddrmanOutgoing() == use_addrman_outgoing);
     (void)connman.ASMapHealthCheck();
 
     connman.ClearTestNodes();

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -183,7 +183,9 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 connman.RemoveAddedNode(random_string);
             },
             [&] {
-                connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());
+                const auto set_active{fuzzed_data_provider.ConsumeBool()};
+                connman.SetNetworkActive(set_active);
+                assert(connman.GetNetworkActive() == set_active);
             },
             [&] {
                 connman.SetTryNewOutboundPeer(fuzzed_data_provider.ConsumeBool());
@@ -247,7 +249,6 @@ FUZZ_TARGET(connman, .init = initialize_connman)
     assert(connman.GetMaxOutboundTarget() == max_outbound_limit);
     (void)connman.GetMaxOutboundTimeframe();
     (void)connman.GetMaxOutboundTimeLeftInCycle();
-    (void)connman.GetNetworkActive();
     std::vector<CNodeStats> stats;
     connman.GetNodeStats(stats);
     (void)connman.GetOutboundTargetBytesLeft();

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -216,6 +216,22 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 connman.SetTryNewOutboundPeer(fuzzed_data_provider.ConsumeBool());
             },
             [&] {
+                const auto services{ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS)};
+                const auto before{connman.GetLocalServices()};
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    connman.AddLocalServices(services);
+                    assert((connman.GetLocalServices() & services) == services);
+                    // Restore by clearing only the bits that weren't already set.
+                    connman.RemoveLocalServices(ServiceFlags(services & ~before));
+                } else {
+                    connman.RemoveLocalServices(services);
+                    assert((connman.GetLocalServices() & services) == 0);
+                    // Restore by re-adding only the bits that were previously set.
+                    connman.AddLocalServices(ServiceFlags(services & before));
+                }
+                assert(connman.GetLocalServices() == before);
+            },
+            [&] {
                 ConnectionType conn_type{
                     fuzzed_data_provider.PickValueInArray(ALL_CONNECTION_TYPES)};
                 if (conn_type == ConnectionType::INBOUND) { // INBOUND is not allowed

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -101,6 +101,9 @@ FUZZ_TARGET(connman, .init = initialize_connman)
 
     connman.Init(options);
 
+    const uint64_t total_bytes_recv_initial{connman.GetTotalBytesRecv()};
+    const uint64_t total_bytes_sent_initial{connman.GetTotalBytesSent()};
+
     CNetAddr random_netaddr;
     CAddress random_address;
     CNode random_node = ConsumeNode(fuzzed_data_provider);
@@ -269,13 +272,19 @@ FUZZ_TARGET(connman, .init = initialize_connman)
     (void)connman.GetExtraFullOutboundCount();
     assert(connman.GetLocalServices() == local_services);
     assert(connman.GetMaxOutboundTarget() == max_outbound_limit);
-    (void)connman.GetMaxOutboundTimeframe();
-    (void)connman.GetMaxOutboundTimeLeftInCycle();
+    const auto time_left_in_cycle{connman.GetMaxOutboundTimeLeftInCycle()};
     std::vector<CNodeStats> stats;
     connman.GetNodeStats(stats);
-    (void)connman.GetOutboundTargetBytesLeft();
-    (void)connman.GetTotalBytesRecv();
-    (void)connman.GetTotalBytesSent();
+    const auto bytes_left{connman.GetOutboundTargetBytesLeft()};
+    assert(bytes_left <= max_outbound_limit);
+    if (max_outbound_limit == 0) {
+        assert(bytes_left == 0);
+        assert(time_left_in_cycle == std::chrono::seconds{0});
+        assert(!connman.OutboundTargetReached(/*historicalBlockServingLimit=*/false));
+        assert(!connman.OutboundTargetReached(/*historicalBlockServingLimit=*/true));
+    }
+    assert(connman.GetTotalBytesRecv() >= total_bytes_recv_initial);
+    assert(connman.GetTotalBytesSent() >= total_bytes_sent_initial);
     (void)connman.GetTryNewOutboundPeer();
     assert(connman.GetUseAddrmanOutgoing() == use_addrman_outgoing);
     (void)connman.ASMapHealthCheck();

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -107,6 +107,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
     CSubNet random_subnet;
     std::string random_string;
     std::vector<NodeId> node_ids;
+    std::vector<std::string> node_addr_names;
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100) {
         CNode& p2p_node{*ConsumeNodeAsUniquePtr(fuzzed_data_provider).release()};
@@ -114,6 +115,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
         p2p_node.fSuccessfullyConnected = true;
         connman.AddTestNode(p2p_node);
         node_ids.push_back(p2p_node.GetId());
+        node_addr_names.push_back(p2p_node.m_addr_name);
     }
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
@@ -132,7 +134,23 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 random_string = fuzzed_data_provider.ConsumeRandomLengthString(64);
             },
             [&] {
-                connman.AddNode({random_string, fuzzed_data_provider.ConsumeBool()});
+                const std::string& node_str = (!node_addr_names.empty() && fuzzed_data_provider.ConsumeBool())
+                    ? PickValue(fuzzed_data_provider, node_addr_names)
+                    : random_string;
+                const auto added_node_info{connman.GetAddedNodeInfo(/*include_connected=*/true)};
+                const auto add_node{connman.AddNode({node_str, /*use_v2transport=*/fuzzed_data_provider.ConsumeBool()})};
+                if (add_node) {
+                    assert(!connman.AddNode({node_str, /*use_v2transport=*/fuzzed_data_provider.ConsumeBool()}));
+                    assert(added_node_info.size() < connman.GetAddedNodeInfo(/*include_connected=*/true).size());
+                    const auto remove{fuzzed_data_provider.ConsumeBool()};
+                    if (remove) {
+                        assert(connman.RemoveAddedNode(node_str));
+                        assert(added_node_info.size() == connman.GetAddedNodeInfo(/*include_connected=*/true).size());
+                    }
+                }
+            },
+            [&] {
+                (void)connman.RemoveAddedNode(random_string);
             },
             [&] {
                 connman.CheckIncomingNonce(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
@@ -185,9 +203,6 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 serialized_net_msg.m_type = fuzzed_data_provider.ConsumeRandomLengthString(CMessageHeader::MESSAGE_TYPE_SIZE);
                 serialized_net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
                 connman.PushMessage(&random_node, std::move(serialized_net_msg));
-            },
-            [&] {
-                connman.RemoveAddedNode(random_string);
             },
             [&] {
                 const auto set_active{fuzzed_data_provider.ConsumeBool()};
@@ -250,7 +265,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
         (void)pnode->IsFullOutboundConn();
         (void)pnode->ConnectionTypeAsString();
     });
-    (void)connman.GetAddedNodeInfo(fuzzed_data_provider.ConsumeBool());
+    (void)connman.GetAddedNodeInfo(/*include_connected=*/false);
     (void)connman.GetExtraFullOutboundCount();
     assert(connman.GetLocalServices() == local_services);
     assert(connman.GetMaxOutboundTarget() == max_outbound_limit);


### PR DESCRIPTION
This PR improves the `connman` fuzz target by replacing some "`(void)`" calls with actual invariant checks, adding coverage for previously uncovered methods, and exercising more initialization states.

  - Set `m_local_services`, `m_use_addrman_outgoing`, and
    `m_max_automatic_connections` via fuzzed values before `Init()` to
    explore more startup configurations.

  - Add network activity and outbound-bytes invariants.

  - Add `AddNode`/`RemoveAddedNode` invariants: e.g. a successful `AddNode`
    increases `GetAddedNodeInfo()` by one; adding the same node again
    must fail; a subsequent `RemoveAddedNode` must succeed and restore
    the original count.

  - Add coverage for `AddLocalServices`/`RemoveLocalServices`.