### PR TITLE
cmake: add CTestConfig.cmake

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,1 @@
+set(CTEST_SUBMIT_URL "https://my.cdash.org/submit.php?project=bitcoin-core")


### PR DESCRIPTION
Add a `CTestConfig.cmake` file with the CDash submission URL for Bitcoin Core at the project root.

This lets developers use CTest’s built-in dashboard support to upload local configure, build, and test results to CDash. With this a developer can use their own CTest dashboard script or manual `ctest` workflow and upload results to a collection point.

This is useful for sharing reproducible build/test results from local machines, CI experiments, and platform-specific debugging. CDash keeps the configure output, build warnings/errors, and test results grouped under a single dashboard submission, making it easier to inspect failures and compare behavior across environments.

The file only defines the CDash upload location. It does not change the default build or test behavior.

**WARNING** uploaded test results may also include (potentially) identifiable information, such as hostnames, usernames, especially if you attach notes which are located within you rhome directory, as the full file path is printed.