### PR TITLE
refactor: [rpc] Remove confusing and brittle integral casts (take 3)

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1167,7 +1167,7 @@ static RPCMethod exportasmap()
 
             UniValue result(UniValue::VOBJ);
             result.pushKV("path", export_path.utf8string());
-            result.pushKV("bytes_written", (uint64_t)node::data::ip_asn.size());
+            result.pushKV("bytes_written", node::data::ip_asn.size());
             result.pushKV("file_hash", HexStr(hasher.GetSHA256()));
             return result;
 #endif


### PR DESCRIPTION
This one cast is harmless, but confusing. Also, in the past they have been brittle to the extend of triggering bugs. See commit 44afed4cd970ec38560ebb673c50b4f52da830c9. So remove this one recently introduced one.