### PR TITLE
wallet: importdescriptors should output the request on error

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -135,7 +135,7 @@ static int64_t GetImportTimestamp(const UniValue& data, int64_t now)
         }
         throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Expected number or \"now\" timestamp value for key. got type %s", uvTypeName(timestamp.type())));
     }
-    throw JSONRPCError(RPC_TYPE_ERROR, "Missing required timestamp field for key");
+    throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Missing required timestamp field for import request: %s", data.write()));
 }
 
 static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -92,8 +92,17 @@ class ImportDescriptorsTest(BitcoinTestFramework):
 
         # # Test importing of a P2PKH descriptor
         key = get_generate_key()
+        self.log.info("Import should fail if timestamp is missing and include request details in the error")
+        desc = descsum_create("pkh(" + key.pubkey + ")")
+        assert_raises_rpc_error(
+            -3,
+            f"Missing required timestamp field for import request: {{\"desc\":\"{desc}\"}}",
+            w1.importdescriptors,
+            [{"desc": desc}],
+        )
+
         self.log.info("Should import a p2pkh descriptor")
-        import_request = {"desc": descsum_create("pkh(" + key.pubkey + ")"),
+        import_request = {"desc": desc,
                  "timestamp": "now",
                  "label": "Descriptor import test"}
         self.test_importdesc(import_request, success=True)


### PR DESCRIPTION
*Waiting for https://github.com/bitcoin/bitcoin/pull/34861 to be merged so I can rebase on it or this can be cherry picked*

## Motivation
I was motivated by this comment https://github.com/bitcoin/bitcoin/pull/35185#issuecomment-4380232590 because when using the `importdescriptors` rpc on error we should get a more descriptive error message than `Missing required timestamp field for key`. This is because multiple descriptors could be imported, and it would be useful to know the exact request that failed.

## Solution
Instead of just printing a static error message, `Missing required timestamp field for key` also output the exact request that failed.

## Example
Request
```
[
  {
    "desc": "wpkh([abcd1234/84h/1h/0h]tpub.../0/*)#x9abc123",
    "timestamp": 1710000000,
    "active": true,
    "range": [0, 100]
  },
  {
    "desc": "wpkh([abcd1234/84h/1h/0h]tpub.../1/*)#y8def456",
    "timestamp": "now",
    "internal": true,
    "active": true,
    "range": [0, 100]
  },
  {
    "desc": "pkh(039dcc64c5c644baf0145a5f7322b16399a01a0ee2a182e3150946fe7946358247)#68u5tv65",
    "active": false
  }
]
```

Before
```
{
  "code": -3,
  "message": "Missing required timestamp field for key"
}
```

After
```
{
  "code": -3,
  "message": "Missing required timestamp field for import request: {\"desc\":\"pkh(039dcc64c5c644baf0145a5f7322b16399a01a0ee2a182e3150946fe7946358247)#68u5tv65\",\"active\":false}"
}
```

Note: after https://github.com/bitcoin/bitcoin/pull/34861 is merged, the output will be per item.