### PR TITLE
Policy: require minimal push in bare multisig output scripts

### DIFF
--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -95,6 +95,7 @@ static bool MatchMultisig(const CScript& script, int& required_sigs, std::vector
     if (!req_sigs) return false;
     required_sigs = *req_sigs;
     while (script.GetOp(it, opcode, data) && CPubKey::ValidSize(data)) {
+        if (!CheckMinimalPush(data, opcode)) return false;
         pubkeys.emplace_back(std::move(data));
     }
     auto num_keys = GetScriptNumber(opcode, data, required_sigs, MAX_PUBKEYS_PER_MULTISIG);

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -184,9 +184,7 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 BOOST_AUTO_TEST_CASE(multisig_pushdata_IsStandard)
 {
     // Non-minimal push encodings for the pubkey (OP_PUSHDATA1/2/4) are all
-    // accepted by IsStandard. MatchMultisig uses GetOp, which decodes every
-    // push form into the same raw bytes; it then calls CPubKey::ValidSize
-    // (prefix byte + length, no curve check), so the encoding is invisible.
+    // rejected by IsStandard.
 
     CKey key;
     key.MakeNewKey(true);
@@ -208,7 +206,7 @@ BOOST_AUTO_TEST_CASE(multisig_pushdata_IsStandard)
     nonminimal[2] = make_nonminimal({OP_PUSHDATA4, 0x21, 0x00, 0x00, 0x00});
 
     for (int i = 0; i < 3; i++) {
-        BOOST_CHECK(is_standard(nonminimal[i]));
+        BOOST_CHECK(!is_standard(nonminimal[i]));
     }
 }
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -37,6 +37,15 @@ sign_multisig(const CScript& scriptPubKey, const std::vector<CKey>& keys, const 
     return result;
 }
 
+static bool is_standard(const CScript& spk) {
+    TxoutType type;
+    bool res{::IsStandard(spk, type)};
+    if (res) {
+        BOOST_CHECK_EQUAL(type, TxoutType::MULTISIG);
+    }
+    return res;
+}
+
 BOOST_AUTO_TEST_CASE(multisig_verify)
 {
     script_verify_flags flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
@@ -143,15 +152,6 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
     for (int i = 0; i < 4; i++)
         key[i].MakeNewKey(true);
 
-    const auto is_standard{[](const CScript& spk) {
-        TxoutType type;
-        bool res{::IsStandard(spk, type)};
-        if (res) {
-            BOOST_CHECK_EQUAL(type, TxoutType::MULTISIG);
-        }
-        return res;
-    }};
-
     CScript a_and_b;
     a_and_b << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
     BOOST_CHECK(is_standard(a_and_b));
@@ -178,6 +178,37 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 
     for (int i = 0; i < 6; i++) {
         BOOST_CHECK(!is_standard(malformed[i]));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(multisig_pushdata_IsStandard)
+{
+    // Non-minimal push encodings for the pubkey (OP_PUSHDATA1/2/4) are all
+    // accepted by IsStandard. MatchMultisig uses GetOp, which decodes every
+    // push form into the same raw bytes; it then calls CPubKey::ValidSize
+    // (prefix byte + length, no curve check), so the encoding is invisible.
+
+    CKey key;
+    key.MakeNewKey(true);
+    auto pubkey_bytes{ToByteVector(key.GetPubKey())};
+
+    auto make_nonminimal = [&](std::vector<unsigned char> pushdata) {
+      std::vector<unsigned char> raw;
+      raw.push_back(OP_1);
+      raw.insert(raw.end(), pushdata.begin(), pushdata.end());
+      raw.insert(raw.end(), pubkey_bytes.begin(), pubkey_bytes.end());
+      raw.push_back(OP_1);
+      raw.push_back(OP_CHECKMULTISIG);
+      return CScript(raw.begin(), raw.end());
+    };
+
+    CScript nonminimal[3];
+    nonminimal[0] = make_nonminimal({OP_PUSHDATA1, 0x21});
+    nonminimal[1] = make_nonminimal({OP_PUSHDATA2, 0x21, 0x00});
+    nonminimal[2] = make_nonminimal({OP_PUSHDATA4, 0x21, 0x00, 0x00, 0x00});
+
+    for (int i = 0; i < 3; i++) {
+        BOOST_CHECK(is_standard(nonminimal[i]));
     }
 }
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -494,7 +494,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         # but is consensus-legal
         self.generateblock(node, self.wallet.get_address(), [nested_anchor_spend.serialize().hex()])
 
-        self.log.info('Non-minimal pubkey push encodings are standard bare multisig')
+        self.log.info('Non-minimal pubkey push encodings are rejected in bare multisig')
         for pushdata in [
             bytes([0x4c, 0x21]),                    # OP_PUSHDATA1 33
             bytes([0x4d, 0x21, 0x00]),              # OP_PUSHDATA2 33
@@ -502,7 +502,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         ]:
             tx = tx_from_hex(raw_tx_reference)
             tx.vout[0].scriptPubKey = CScript(bytes([OP_1]) + pushdata + pubkey + bytes([OP_1, OP_CHECKMULTISIG]))
-            assert_equal(self.nodes[1].testmempoolaccept([tx.serialize().hex()], maxfeerate=0)[0]['allowed'], True)
+            assert_equal(self.nodes[1].testmempoolaccept([tx.serialize().hex()], maxfeerate=0)[0]['allowed'], False)
 
         self.log.info('Spending a confirmed bare multisig is okay')
         address = self.wallet.get_address()

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -31,6 +31,8 @@ from test_framework.messages import (
 from test_framework.script import (
     CScript,
     OP_0,
+    OP_1,
+    OP_CHECKMULTISIG,
     OP_HASH160,
     OP_RETURN,
     OP_TRUE,
@@ -58,10 +60,11 @@ from test_framework.wallet_util import generate_keypair
 
 class MempoolAcceptanceTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 1
-        self.extra_args = [[
-            '-txindex','-permitbaremultisig=0',
-        ]] * self.num_nodes
+        self.num_nodes = 2
+        self.extra_args = [
+            ['-txindex', '-permitbaremultisig=0'],
+            ['-permitbaremultisig=1'],
+        ]
         self.supports_cli = False
 
     def check_mempool_result(self, result_expected, *args, **kwargs):
@@ -490,6 +493,16 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         )
         # but is consensus-legal
         self.generateblock(node, self.wallet.get_address(), [nested_anchor_spend.serialize().hex()])
+
+        self.log.info('Non-minimal pubkey push encodings are standard bare multisig')
+        for pushdata in [
+            bytes([0x4c, 0x21]),                    # OP_PUSHDATA1 33
+            bytes([0x4d, 0x21, 0x00]),              # OP_PUSHDATA2 33
+            bytes([0x4e, 0x21, 0x00, 0x00, 0x00]),  # OP_PUSHDATA4 33
+        ]:
+            tx = tx_from_hex(raw_tx_reference)
+            tx.vout[0].scriptPubKey = CScript(bytes([OP_1]) + pushdata + pubkey + bytes([OP_1, OP_CHECKMULTISIG]))
+            assert_equal(self.nodes[1].testmempoolaccept([tx.serialize().hex()], maxfeerate=0)[0]['allowed'], True)
 
         self.log.info('Spending a confirmed bare multisig is okay')
         address = self.wallet.get_address()


### PR DESCRIPTION
Closes #23285 by adding `CheckMinimalPush()` in `MatchMultisig()` in `solver.cpp` which is only used for policy checks (not consensus).

First commit asserts current behavior on master with unit and functional tests, second commit tightens the policy.

I noticed `CheckMinimalPush()` has an `assert(0 <= opcode && opcode <= OP_PUSHDATA4)`. That continues to be protected by `GetScriptOp()` which has guard `if (opcode <= OP_PUSHDATA4)`

To address [concern about current usage](https://github.com/bitcoin/bitcoin/issues/23285#issuecomment-966148415) I claude-generated [this script](https://gist.github.com/pinheadmz/f371e4ecc6489750e31c8dfbbb893720) which efficiently scanned all `blk*.dat` files from a fully-synced node and reported all occurrences of  PUSHDATA in a P2MS output (report below).




| Block | Date | vout | Type | Ops | Transaction |
|------:|------|:----:|------|-----|-------------|
| 244029 | 2013-06-30 | 0 | 1-of-3 | OP_PUSHDATA1 ×2 | [c49b3c445c89d832289de0fd3b0281efdcce418333dacd028061e8de9f0a6f10](https://mempool.space/tx/c49b3c445c89d832289de0fd3b0281efdcce418333dacd028061e8de9f0a6f10) |
| 244029 | 2013-06-30 | 0 | 1-of-3 | OP_PUSHDATA1 ×3 | [72590fcf0d8021bad77826c5008eaca3541f81d212d55bb7c02ec6a4bf584404](https://mempool.space/tx/72590fcf0d8021bad77826c5008eaca3541f81d212d55bb7c02ec6a4bf584404) |
| 244042 | 2013-06-30 | 0 | 1-of-3 | OP_PUSHDATA1 ×2 | [2d201879608ed2d14c362dff713a6d17d680cb42d5175dfe42e960e94736be04](https://mempool.space/tx/2d201879608ed2d14c362dff713a6d17d680cb42d5175dfe42e960e94736be04) |
| 262733 | 2013-10-10 | 3 | 1-of-2 | OP_PUSHDATA1 ×1 | [055cd2d8ff819ccd7182a08818bf85f79f22e089b81c4f6325014436e172d9b9](https://mempool.space/tx/055cd2d8ff819ccd7182a08818bf85f79f22e089b81c4f6325014436e172d9b9) |
| 263066 | 2013-10-12 | 3 | 1-of-2 | OP_PUSHDATA1 ×1 | [d8773a20a841b4105a98fb2f448f3d9bae2be06f0b9221c02a7cb4d2077f67b9](https://mempool.space/tx/d8773a20a841b4105a98fb2f448f3d9bae2be06f0b9221c02a7cb4d2077f67b9) |
| 263069 | 2013-10-12 | 2 | 1-of-2 | OP_PUSHDATA1 ×1 | [5b2169a66a937571767f278097aab307ba95a5dd5beaf9e98a64802218511a52](https://mempool.space/tx/5b2169a66a937571767f278097aab307ba95a5dd5beaf9e98a64802218511a52) |
| 263096 | 2013-10-12 | 2 | 1-of-2 | OP_PUSHDATA1 ×1 | [c6f2bf13c8742fe5136dba82ce76d1513732d5a5b2d24c8d1bc1a4b92b15cff4](https://mempool.space/tx/c6f2bf13c8742fe5136dba82ce76d1513732d5a5b2d24c8d1bc1a4b92b15cff4) |
| 263101 | 2013-10-12 | 2 | 1-of-2 | OP_PUSHDATA1 ×1 | [40af216d3207ba85a47a913a06ace72a10d433ebeb1e12a5c36713a2b11964aa](https://mempool.space/tx/40af216d3207ba85a47a913a06ace72a10d433ebeb1e12a5c36713a2b11964aa) |
| 263421 | 2013-10-13 | 2 | 1-of-3 | OP_PUSHDATA1 ×3 | [11378d2a2bb5514dc7bd5d3bf2eb94dd197e235e9337cac404cf79aa3119e53c](https://mempool.space/tx/11378d2a2bb5514dc7bd5d3bf2eb94dd197e235e9337cac404cf79aa3119e53c) |
| 263421 | 2013-10-13 | 3 | 1-of-3 | OP_PUSHDATA1 ×3 | [11378d2a2bb5514dc7bd5d3bf2eb94dd197e235e9337cac404cf79aa3119e53c](https://mempool.space/tx/11378d2a2bb5514dc7bd5d3bf2eb94dd197e235e9337cac404cf79aa3119e53c) |
| 263421 | 2013-10-13 | 4 | 1-of-1 | OP_PUSHDATA1 ×1 | [11378d2a2bb5514dc7bd5d3bf2eb94dd197e235e9337cac404cf79aa3119e53c](https://mempool.space/tx/11378d2a2bb5514dc7bd5d3bf2eb94dd197e235e9337cac404cf79aa3119e53c) |
| 264469 | 2013-10-18 | 1 | 1-of-3 | OP_PUSHDATA1 ×3 | [92a9a88b078d69de943d9d5d1d3e6b51652952200578e655e50cafaf45a17c34](https://mempool.space/tx/92a9a88b078d69de943d9d5d1d3e6b51652952200578e655e50cafaf45a17c34) |
| 264469 | 2013-10-18 | 2 | 1-of-3 | OP_PUSHDATA1 ×2 | [92a9a88b078d69de943d9d5d1d3e6b51652952200578e655e50cafaf45a17c34](https://mempool.space/tx/92a9a88b078d69de943d9d5d1d3e6b51652952200578e655e50cafaf45a17c34) |
| 264469 | 2013-10-18 | 1 | 1-of-3 | OP_PUSHDATA1 ×3 | [7c0eec816b67145a67cbfd479e3c3474df814e31c2e6ff752a48a5a6754c6c2c](https://mempool.space/tx/7c0eec816b67145a67cbfd479e3c3474df814e31c2e6ff752a48a5a6754c6c2c) |
| 264469 | 2013-10-18 | 2 | 1-of-3 | OP_PUSHDATA1 ×2 | [7c0eec816b67145a67cbfd479e3c3474df814e31c2e6ff752a48a5a6754c6c2c](https://mempool.space/tx/7c0eec816b67145a67cbfd479e3c3474df814e31c2e6ff752a48a5a6754c6c2c) |
| 268068 | 2013-11-05 | 0 | 1-of-2 | OP_PUSHDATA1 ×1 | [8e2c7cec5006949e1929f70961da8f85eebfe06a4979d611ec93ab384eaa34ed](https://mempool.space/tx/8e2c7cec5006949e1929f70961da8f85eebfe06a4979d611ec93ab384eaa34ed) |
| 268068 | 2013-11-05 | 0 | 1-of-2 | OP_PUSHDATA1 ×1 | [5e29ff050333e2d01a1995cee2ec81f7549baeaef56aa38cb912184794837e84](https://mempool.space/tx/5e29ff050333e2d01a1995cee2ec81f7549baeaef56aa38cb912184794837e84) |
| 337908 | 2015-01-07 | 2 | 1-of-1 | OP_PUSHDATA1 ×1 | [04ab6edee514a0ee2aeff48ca672d6f47d6c40923abb0d78aa33ec7e2001eb09](https://mempool.space/tx/04ab6edee514a0ee2aeff48ca672d6f47d6c40923abb0d78aa33ec7e2001eb09) |
 