### PR TITLE
wallet: use `outpoint` when estimating input size

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -94,7 +94,7 @@ int CalculateMaximumSignedInputSize(const CTxOut& txout, const COutPoint outpoin
     if (!provider) return -1;
 
     if (const auto desc = InferDescriptor(txout.scriptPubKey, *provider)) {
-        if (const auto weight = MaxInputWeight(*desc, {}, coin_control, true, can_grind_r)) {
+        if (const auto weight = MaxInputWeight(*desc, CTxIn{outpoint}, coin_control, true, can_grind_r)) {
             return static_cast<int>(GetVirtualTransactionSize(*weight, 0, 0));
         }
     }

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
+#include <key.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <script/solver.h>
 #include <validation.h>
@@ -15,6 +16,22 @@
 
 namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(spend_tests, WalletTestingSetup)
+
+BOOST_AUTO_TEST_CASE(max_signed_input_size_uses_external_outpoint)
+{
+    const CKey key{GenerateRandomKey()};
+    FillableSigningProvider provider;
+    BOOST_REQUIRE(provider.AddKey(key));
+
+    const CTxOut txout{COIN, GetScriptForDestination(PKHash{key.GetPubKey()})};
+    const COutPoint outpoint{Txid{}, 0};
+    CCoinControl coin_control;
+    coin_control.Select(outpoint).SetTxOut(txout);
+
+    const int low_r{CalculateMaximumSignedInputSize(txout, COutPoint{}, &provider, /*can_grind_r=*/true, &coin_control)};
+    const int high_r{CalculateMaximumSignedInputSize(txout, outpoint, &provider, /*can_grind_r=*/true, &coin_control)};
+    BOOST_CHECK_EQUAL(high_r, low_r + 1);
+}
 
 BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
 {


### PR DESCRIPTION
### Problem
`CalculateMaximumSignedInputSize()` is passed the outpoint being sized, but a previous refactor stopped using that context when estimating the signed input size.
This could make externally selected inputs look slightly smaller than they really are.

### Fix
Pass the outpoint through again when estimating the signed input size.
Add a regression test for the external-input case.

> [!NOTE]
> the branch name still reflects the previous state of this PR, where the unused parameter was removed instead of wired back in