### PR TITLE
refactor: Use CBlockIndex parameters as reference

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -149,9 +149,10 @@ int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& fr
     return sign * int64_t(r.GetLow64());
 }
 
-/** Find the last common ancestor two blocks have.
- *  Both pa and pb must be non-nullptr. */
-const CBlockIndex* LastCommonAncestor(const CBlockIndex* pa, const CBlockIndex* pb) {
+/** Find the last common ancestor two blocks have. */
+const CBlockIndex& LastCommonAncestor(const CBlockIndex& a, const CBlockIndex& b) {
+    const CBlockIndex* pa{&a};
+    const CBlockIndex* pb{&b};
     // First rewind to the last common height (the forking point cannot be past one of the two).
     if (pa->nHeight > pb->nHeight) {
         pa = pa->GetAncestor(pb->nHeight);
@@ -173,5 +174,5 @@ const CBlockIndex* LastCommonAncestor(const CBlockIndex* pa, const CBlockIndex* 
         pa = pa->pprev;
         pb = pb->pprev;
     }
-    return pa;
+    return *Assert(pa);
 }

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -15,10 +15,12 @@ std::string CBlockIndex::ToString() const
 
 void CChain::SetTip(CBlockIndex& block)
 {
-    CBlockIndex* pindex = &block;
-    vChain.resize(pindex->nHeight + 1);
-    while (pindex && vChain[pindex->nHeight] != pindex) {
-        vChain[pindex->nHeight] = pindex;
+    CBlockIndex placeholder;
+    vChain.resize(block.nHeight + 1, std::ref(placeholder));
+    vChain[block.nHeight] = std::ref(block);
+    CBlockIndex* pindex = block.pprev;
+    while (pindex && &(vChain[pindex->nHeight].get()) != pindex) {
+        vChain[pindex->nHeight] = std::ref(*pindex);
         pindex = pindex->pprev;
     }
 }
@@ -60,9 +62,9 @@ const CBlockIndex* CChain::FindFork(const CBlockIndex& index) const
 CBlockIndex* CChain::FindEarliestAtLeast(int64_t nTime, int height) const
 {
     std::pair<int64_t, int> blockparams = std::make_pair(nTime, height);
-    std::vector<CBlockIndex*>::const_iterator lower = std::lower_bound(vChain.begin(), vChain.end(), blockparams,
-        [](CBlockIndex* pBlock, const std::pair<int64_t, int>& blockparams) -> bool { return pBlock->GetBlockTimeMax() < blockparams.first || pBlock->nHeight < blockparams.second; });
-    return (lower == vChain.end() ? nullptr : *lower);
+    std::vector<std::reference_wrapper<CBlockIndex>>::const_iterator lower = std::lower_bound(vChain.begin(), vChain.end(), blockparams,
+        [](std::reference_wrapper<CBlockIndex> pBlock, const std::pair<int64_t, int>& blockparams) -> bool { return pBlock.get().GetBlockTimeMax() < blockparams.first || pBlock.get().nHeight < blockparams.second; });
+    return (lower == vChain.end() ? nullptr : &(lower->get()));
 }
 
 /** Turn the lowest '1' bit in the binary representation of a number into a '0'. */

--- a/src/chain.h
+++ b/src/chain.h
@@ -382,7 +382,7 @@ public:
 class CChain
 {
 private:
-    std::vector<CBlockIndex*> vChain;  // Pointers, never nullptr
+    std::vector<std::reference_wrapper<CBlockIndex>> vChain;
 
 public:
     CChain() = default;
@@ -392,13 +392,13 @@ public:
     /** Returns the index entry for the genesis block of this chain, or nullptr if none. */
     CBlockIndex* Genesis() const
     {
-        return vChain.size() > 0 ? vChain[0] : nullptr;
+        return vChain.size() > 0 ? &(vChain[0].get()) : nullptr;
     }
 
     /** Returns the index entry for the tip of this chain, or nullptr if none. */
     CBlockIndex* Tip() const
     {
-        return vChain.size() > 0 ? vChain[vChain.size() - 1] : nullptr;
+        return vChain.size() > 0 ? &(vChain[vChain.size() - 1].get()) : nullptr;
     }
 
     /** Returns the index entry at a particular height in this chain, or nullptr if no such height exists. */
@@ -406,7 +406,7 @@ public:
     {
         if (nHeight < 0 || nHeight >= (int)vChain.size())
             return nullptr;
-        return vChain[nHeight];
+        return &(vChain[nHeight].get());
     }
 
     /** Efficiently check whether a block is present in this chain. */

--- a/src/chain.h
+++ b/src/chain.h
@@ -309,8 +309,11 @@ inline arith_uint256 GetBlockProof(const CBlockHeader& header) { return GetBitsP
 
 /** Return the time it would take to redo the work difference between from and to, assuming the current hashrate corresponds to the difficulty at tip, in seconds. */
 int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params&);
-/** Find the forking point between two chain tips. */
-const CBlockIndex* LastCommonAncestor(const CBlockIndex* pa, const CBlockIndex* pb);
+/**
+ * Find the forking point between two chain tips.
+ * The two chains must share a common ancestor (at least the same genesis).
+ */
+const CBlockIndex& LastCommonAncestor(const CBlockIndex& a, const CBlockIndex& b);
 
 
 /** Used to marshal pointers into hashes for db storage. */
@@ -379,7 +382,7 @@ public:
 class CChain
 {
 private:
-    std::vector<CBlockIndex*> vChain;
+    std::vector<CBlockIndex*> vChain;  // Pointers, never nullptr
 
 public:
     CChain() = default;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -171,15 +171,15 @@ static const CBlockIndex* NextSyncBlock(const CBlockIndex* const pindex_prev, CC
     return chain.Next(*Assert(fork));
 }
 
-bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data)
+bool BaseIndex::ProcessBlock(const CBlockIndex& index, const CBlock* block_data)
 {
-    interfaces::BlockInfo block_info = kernel::MakeBlockInfo(pindex, block_data);
+    interfaces::BlockInfo block_info = kernel::MakeBlockInfo(&index, block_data);
 
     CBlock block;
     if (!block_data) { // disk lookup if block data wasn't provided
-        if (!m_chainstate->m_blockman.ReadBlock(block, *pindex)) {
+        if (!m_chainstate->m_blockman.ReadBlock(block, index)) {
             FatalErrorf("Failed to read block %s from disk",
-                        pindex->GetBlockHash().ToString());
+                        index.GetBlockHash().ToString());
             return false;
         }
         block_info.data = &block;
@@ -187,9 +187,9 @@ bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data
 
     CBlockUndo block_undo;
     if (CustomOptions().connect_undo_data) {
-        if (pindex->nHeight > 0 && !m_chainstate->m_blockman.ReadBlockUndo(block_undo, *pindex)) {
+        if (index.nHeight > 0 && !m_chainstate->m_blockman.ReadBlockUndo(block_undo, index)) {
             FatalErrorf("Failed to read undo block data %s from disk",
-                        pindex->GetBlockHash().ToString());
+                        index.GetBlockHash().ToString());
             return false;
         }
         block_info.undo_data = &block_undo;
@@ -197,7 +197,7 @@ bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data
 
     if (!CustomAppend(block_info)) {
         FatalErrorf("Failed to write block %s to index database",
-                    pindex->GetBlockHash().ToString());
+                    index.GetBlockHash().ToString());
         return false;
     }
 
@@ -249,7 +249,7 @@ void BaseIndex::Sync()
             pindex = pindex_next;
 
 
-            if (!ProcessBlock(pindex)) return; // error logged internally
+            if (!ProcessBlock(*pindex)) return; // error logged internally
 
             auto current_time{NodeClock::now()};
             if (current_time - last_log_time >= SYNC_LOG_INTERVAL) {
@@ -374,7 +374,7 @@ void BaseIndex::BlockConnected(const ChainstateRole& role, const std::shared_ptr
     }
 
     // Dispatch block to child class; errors are logged internally and abort the node.
-    if (ProcessBlock(pindex, block.get())) {
+    if (ProcessBlock(*pindex, block.get())) {
         // Setting the best block index is intentionally the last step of this
         // function, so BlockUntilSyncedToCurrentChain callers waiting for the
         // best block index to be updated can rely on the block being fully

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -106,7 +106,7 @@ private:
     /// Loop over disconnected blocks and call CustomRemove.
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
 
-    bool ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data = nullptr);
+    bool ProcessBlock(const CBlockIndex& index, const CBlock* block_data = nullptr);
 
     virtual bool AllowPrune() const = 0;
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -297,25 +297,25 @@ bool BlockFilterIndex::CustomRemove(const interfaces::BlockInfo& block)
 }
 
 static bool LookupRange(CDBWrapper& db, const std::string& index_name, int start_height,
-                        const CBlockIndex* stop_index, std::vector<DBVal>& results)
+                        const CBlockIndex& stop_index, std::vector<DBVal>& results)
 {
     if (start_height < 0) {
         LogError("start height (%d) is negative", start_height);
         return false;
     }
-    if (start_height > stop_index->nHeight) {
+    if (start_height > stop_index.nHeight) {
         LogError("start height (%d) is greater than stop height (%d)",
-                 start_height, stop_index->nHeight);
+                 start_height, stop_index.nHeight);
         return false;
     }
 
-    size_t results_size = static_cast<size_t>(stop_index->nHeight - start_height + 1);
+    size_t results_size = static_cast<size_t>(stop_index.nHeight - start_height + 1);
     std::vector<std::pair<uint256, DBVal>> values(results_size);
 
     index_util::DBHeightKey key(start_height);
     std::unique_ptr<CDBIterator> db_it(db.NewIterator());
     db_it->Seek(index_util::DBHeightKey(start_height));
-    for (int height = start_height; height <= stop_index->nHeight; ++height) {
+    for (int height = start_height; height <= stop_index.nHeight; ++height) {
         if (!db_it->Valid() || !db_it->GetKey(key) || key.height != height) {
             return false;
         }
@@ -334,7 +334,7 @@ static bool LookupRange(CDBWrapper& db, const std::string& index_name, int start
 
     // Iterate backwards through block indexes collecting results in order to access the block hash
     // of each entry in case we need to look it up in the hash index.
-    for (const CBlockIndex* block_index = stop_index;
+    for (const CBlockIndex* block_index = &stop_index;
          block_index && block_index->nHeight >= start_height;
          block_index = block_index->pprev) {
         uint256 block_hash = block_index->GetBlockHash();
@@ -395,7 +395,7 @@ bool BlockFilterIndex::LookupFilterHeader(const CBlockIndex* block_index, uint25
     return true;
 }
 
-bool BlockFilterIndex::LookupFilterRange(int start_height, const CBlockIndex* stop_index,
+bool BlockFilterIndex::LookupFilterRange(int start_height, const CBlockIndex& stop_index,
                                          std::vector<BlockFilter>& filters_out) const
 {
     std::vector<DBVal> entries;
@@ -415,7 +415,7 @@ bool BlockFilterIndex::LookupFilterRange(int start_height, const CBlockIndex* st
     return true;
 }
 
-bool BlockFilterIndex::LookupFilterHashRange(int start_height, const CBlockIndex* stop_index,
+bool BlockFilterIndex::LookupFilterHashRange(int start_height, const CBlockIndex& stop_index,
                                              std::vector<uint256>& hashes_out) const
 
 {

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -89,11 +89,11 @@ public:
     bool LookupFilterHeader(const CBlockIndex* block_index, uint256& header_out) EXCLUSIVE_LOCKS_REQUIRED(!m_cs_headers_cache);
 
     /** Get a range of filters between two heights on a chain. */
-    bool LookupFilterRange(int start_height, const CBlockIndex* stop_index,
+    bool LookupFilterRange(int start_height, const CBlockIndex& stop_index,
                            std::vector<BlockFilter>& filters_out) const;
 
     /** Get a range of filter hashes between two heights on a chain. */
-    bool LookupFilterHashRange(int start_height, const CBlockIndex* stop_index,
+    bool LookupFilterHashRange(int start_height, const CBlockIndex& stop_index,
                                std::vector<uint256>& hashes_out) const;
 };
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -908,16 +908,21 @@ private:
 
     /** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
      *  at most count entries.
+     * vBlocks must not contain nullptr.
      */
     void FindNextBlocksToDownload(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    /** Request blocks for the background chainstate, if one is in use. */
+    /**
+     * Request blocks for the background chainstate, if one is in use.
+     * vBlocks must not contain nullptr.
+     */
     void TryDownloadingHistoricalBlocks(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, const CBlockIndex* from_tip, const CBlockIndex* target_block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
     * \brief Find next blocks to download from a peer after a starting block.
     *
     * \param vBlocks      Vector of blocks to download which will be appended to.
+    *                     Must not contain nullptr.
     * \param peer         Peer which blocks will be downloaded from.
     * \param state        Pointer to the state of the peer.
     * \param index_walk   The starting block to add to vBlocks.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -916,7 +916,7 @@ private:
      * Request blocks for the background chainstate, if one is in use.
      * vBlocks must not contain nullptr.
      */
-    void TryDownloadingHistoricalBlocks(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, const CBlockIndex* from_tip, const CBlockIndex* target_block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void TryDownloadingHistoricalBlocks(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, const CBlockIndex& from_tip, const CBlockIndex& target_block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
     * \brief Find next blocks to download from a peer after a starting block.
@@ -1446,11 +1446,8 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     FindNextBlocks(vBlocks, peer, state, index_walk, count, nWindowEnd, &m_chainman.ActiveChain(), &nodeStaller);
 }
 
-void PeerManagerImpl::TryDownloadingHistoricalBlocks(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, const CBlockIndex *from_tip, const CBlockIndex* target_block)
+void PeerManagerImpl::TryDownloadingHistoricalBlocks(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, const CBlockIndex& from_tip, const CBlockIndex& target_block)
 {
-    Assert(from_tip);
-    Assert(target_block);
-
     if (vBlocks.size() >= count) {
         return;
     }
@@ -1458,7 +1455,7 @@ void PeerManagerImpl::TryDownloadingHistoricalBlocks(const Peer& peer, unsigned 
     vBlocks.reserve(count);
     CNodeState *state = Assert(State(peer.m_id));
 
-    if (state->pindexBestKnownBlock == nullptr || state->pindexBestKnownBlock->GetAncestor(target_block->nHeight) != target_block) {
+    if (state->pindexBestKnownBlock == nullptr || state->pindexBestKnownBlock->GetAncestor(target_block.nHeight) != &target_block) {
         // This peer can't provide us the complete series of blocks leading up to the
         // assumeutxo snapshot base.
         //
@@ -1472,7 +1469,7 @@ void PeerManagerImpl::TryDownloadingHistoricalBlocks(const Peer& peer, unsigned 
         return;
     }
 
-    FindNextBlocks(vBlocks, peer, state, *from_tip, count, std::min<int>(from_tip->nHeight + BLOCK_DOWNLOAD_WINDOW, target_block->nHeight));
+    FindNextBlocks(vBlocks, peer, state, from_tip, count, std::min<int>(from_tip.nHeight + BLOCK_DOWNLOAD_WINDOW, target_block.nHeight));
 }
 
 void PeerManagerImpl::FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, const Peer& peer, CNodeState *state, const CBlockIndex& index_walk, unsigned int count, int nWindowEnd, const CChain* activeChain, NodeId* nodeStaller)
@@ -6194,7 +6191,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                 TryDownloadingHistoricalBlocks(
                     peer,
                     get_inflight_budget(),
-                    vToDownload, &from_tip, historical_blocks->second);
+                    vToDownload, from_tip, *historical_blocks->second);
             }
             for (const CBlockIndex *pindex : vToDownload) {
                 uint32_t nFetchFlags = GetFetchFlags(peer);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -920,7 +920,7 @@ private:
     * \param vBlocks      Vector of blocks to download which will be appended to.
     * \param peer         Peer which blocks will be downloaded from.
     * \param state        Pointer to the state of the peer.
-    * \param pindexWalk   Pointer to the starting block to add to vBlocks.
+    * \param index_walk   The starting block to add to vBlocks.
     * \param count        Maximum number of blocks to allow in vBlocks. No more
     *                     blocks will be added if it reaches this size.
     * \param nWindowEnd   Maximum height of blocks to allow in vBlocks. No
@@ -941,7 +941,7 @@ private:
     *                     block in the window is in flight and no other peer is
     *                     trying to download the next block).
     */
-    void FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, const Peer& peer, CNodeState *state, const CBlockIndex *pindexWalk, unsigned int count, int nWindowEnd, const CChain* activeChain=nullptr, NodeId* nodeStaller=nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, const Peer& peer, CNodeState *state, const CBlockIndex& index_walk, unsigned int count, int nWindowEnd, const CChain* activeChain=nullptr, NodeId* nodeStaller=nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /* Multimap used to preserve insertion order */
     typedef std::multimap<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator>> BlockDownloadMap;
@@ -1432,13 +1432,13 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
         return;
 
-    const CBlockIndex *pindexWalk = state->pindexLastCommonBlock;
+    const CBlockIndex& index_walk = *state->pindexLastCommonBlock;
     // Never fetch further than the best block we know the peer has, or more than BLOCK_DOWNLOAD_WINDOW + 1 beyond the last
     // linked block we have in common with this peer. The +1 is so we can detect stalling, namely if we would be able to
     // download that next block if the window were 1 larger.
     int nWindowEnd = state->pindexLastCommonBlock->nHeight + BLOCK_DOWNLOAD_WINDOW;
 
-    FindNextBlocks(vBlocks, peer, state, pindexWalk, count, nWindowEnd, &m_chainman.ActiveChain(), &nodeStaller);
+    FindNextBlocks(vBlocks, peer, state, index_walk, count, nWindowEnd, &m_chainman.ActiveChain(), &nodeStaller);
 }
 
 void PeerManagerImpl::TryDownloadingHistoricalBlocks(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, const CBlockIndex *from_tip, const CBlockIndex* target_block)
@@ -1467,15 +1467,16 @@ void PeerManagerImpl::TryDownloadingHistoricalBlocks(const Peer& peer, unsigned 
         return;
     }
 
-    FindNextBlocks(vBlocks, peer, state, from_tip, count, std::min<int>(from_tip->nHeight + BLOCK_DOWNLOAD_WINDOW, target_block->nHeight));
+    FindNextBlocks(vBlocks, peer, state, *from_tip, count, std::min<int>(from_tip->nHeight + BLOCK_DOWNLOAD_WINDOW, target_block->nHeight));
 }
 
-void PeerManagerImpl::FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, const Peer& peer, CNodeState *state, const CBlockIndex *pindexWalk, unsigned int count, int nWindowEnd, const CChain* activeChain, NodeId* nodeStaller)
+void PeerManagerImpl::FindNextBlocks(std::vector<const CBlockIndex*>& vBlocks, const Peer& peer, CNodeState *state, const CBlockIndex& index_walk, unsigned int count, int nWindowEnd, const CChain* activeChain, NodeId* nodeStaller)
 {
     std::vector<const CBlockIndex*> vToFetch;
     int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
     bool is_limited_peer = IsLimitedPeer(peer);
     NodeId waitingfor = -1;
+    const CBlockIndex* pindexWalk = &index_walk;
     while (pindexWalk->nHeight < nMaxHeight) {
         // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
         // pindexBestKnownBlock) into vToFetch. We fetch 128, because CBlockIndex::GetAncestor may be as expensive

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1036,6 +1036,7 @@ private:
      * @param[in]   stop_hash       The stop_hash for the request
      * @param[in]   max_height_diff The maximum number of items permitted to request, as specified in BIP 157
      * @param[out]  stop_index      The CBlockIndex for the stop_hash block, if the request can be serviced.
+     *                              Set to non-nullptr on success.
      * @param[out]  filter_index    The filter index, if the request can be serviced.
      * @return                      True if the request can be serviced.
      */
@@ -3335,7 +3336,7 @@ void PeerManagerImpl::ProcessGetCFilters(CNode& node, Peer& peer, DataStream& vR
     }
 
     std::vector<BlockFilter> filters;
-    if (!filter_index->LookupFilterRange(start_height, stop_index, filters)) {
+    if (!filter_index->LookupFilterRange(start_height, *stop_index, filters)) {
         LogDebug(BCLog::NET, "Failed to find block filter in index: filter_type=%s, start_height=%d, stop_hash=%s\n",
                      BlockFilterTypeName(filter_type), start_height, stop_hash.ToString());
         return;
@@ -3375,7 +3376,7 @@ void PeerManagerImpl::ProcessGetCFHeaders(CNode& node, Peer& peer, DataStream& v
     }
 
     std::vector<uint256> filter_hashes;
-    if (!filter_index->LookupFilterHashRange(start_height, stop_index, filter_hashes)) {
+    if (!filter_index->LookupFilterHashRange(start_height, *stop_index, filter_hashes)) {
         LogDebug(BCLog::NET, "Failed to find block filter hashes in index: filter_type=%s, start_height=%d, stop_hash=%s\n",
                      BlockFilterTypeName(filter_type), start_height, stop_hash.ToString());
         return;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1423,11 +1423,11 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     // pindexLastCommonBlock is required to be an ancestor of pindexBestKnownBlock, and will be used as a starting point.
     // It is being set to the fork point between the peer's best known block and the current tip, unless it is already set to
     // an ancestor with more work than the fork point.
-    auto fork_point = LastCommonAncestor(state->pindexBestKnownBlock, m_chainman.ActiveTip());
+    auto& fork_point = LastCommonAncestor(*state->pindexBestKnownBlock, *m_chainman.ActiveTip());
     if (state->pindexLastCommonBlock == nullptr ||
-        fork_point->nChainWork > state->pindexLastCommonBlock->nChainWork ||
+        fork_point.nChainWork > state->pindexLastCommonBlock->nChainWork ||
         state->pindexBestKnownBlock->GetAncestor(state->pindexLastCommonBlock->nHeight) != state->pindexLastCommonBlock) {
-        state->pindexLastCommonBlock = fork_point;
+        state->pindexLastCommonBlock = &fork_point;
     }
     if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
         return;
@@ -6184,11 +6184,11 @@ bool PeerManagerImpl::SendMessages(CNode& node)
             if (historical_blocks && !IsLimitedPeer(peer)) {
                 // If the first needed historical block is not an ancestor of the last,
                 // we need to start requesting blocks from their last common ancestor.
-                const CBlockIndex* from_tip = LastCommonAncestor(historical_blocks->first, historical_blocks->second);
+                const CBlockIndex& from_tip = LastCommonAncestor(*historical_blocks->first, *historical_blocks->second);
                 TryDownloadingHistoricalBlocks(
                     peer,
                     get_inflight_budget(),
-                    vToDownload, from_tip, historical_blocks->second);
+                    vToDownload, &from_tip, historical_blocks->second);
             }
             for (const CBlockIndex *pindex : vToDownload) {
                 uint32_t nFetchFlags = GetFetchFlags(peer);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -622,7 +622,7 @@ public:
         const CChain& active = chainman().ActiveChain();
         const CBlockIndex* block1 = chainman().m_blockman.LookupBlockIndex(block_hash1);
         const CBlockIndex* block2 = chainman().m_blockman.LookupBlockIndex(block_hash2);
-        const CBlockIndex* ancestor = block1 && block2 ? LastCommonAncestor(block1, block2) : nullptr;
+        const CBlockIndex* ancestor = block1 && block2 ? &LastCommonAncestor(*block1, *block2) : nullptr;
         // Using & instead of && below to avoid short circuiting and leaving
         // output uninitialized. Cast bool to int to avoid -Wbitwise-instead-of-logical
         // compiler warnings.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2687,8 +2687,9 @@ static RPCMethod scanblocks()
             end_range = (start_block + amount_per_chunk < stop_block->nHeight) ?
                     WITH_LOCK(::cs_main, return chainman.ActiveChain()[start_block + amount_per_chunk]) :
                     stop_block;
+            CHECK_NONFATAL(end_range);
 
-            if (index->LookupFilterRange(start_block, end_range, filters)) {
+            if (index->LookupFilterRange(start_block, *end_range, filters)) {
                 for (const BlockFilter& filter : filters) {
                     // compare the elements-set with each filter
                     if (filter.GetFilter().MatchAny(needle_set)) {

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -47,8 +47,8 @@ static bool CheckFilterLookups(BlockFilterIndex& filter_index, const CBlockIndex
 
     BOOST_CHECK(filter_index.LookupFilter(block_index, filter));
     BOOST_CHECK(filter_index.LookupFilterHeader(block_index, filter_header));
-    BOOST_CHECK(filter_index.LookupFilterRange(block_index->nHeight, block_index, filters));
-    BOOST_CHECK(filter_index.LookupFilterHashRange(block_index->nHeight, block_index,
+    BOOST_CHECK(filter_index.LookupFilterRange(block_index->nHeight, *block_index, filters));
+    BOOST_CHECK(filter_index.LookupFilterHashRange(block_index->nHeight, *block_index,
                                                    filter_hashes));
 
     BOOST_CHECK_EQUAL(filters.size(), 1U);
@@ -136,8 +136,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
              block_index = m_node.chainman->ActiveChain().Next(*block_index)) {
             BOOST_CHECK(!filter_index.LookupFilter(block_index, filter));
             BOOST_CHECK(!filter_index.LookupFilterHeader(block_index, filter_header));
-            BOOST_CHECK(!filter_index.LookupFilterRange(block_index->nHeight, block_index, filters));
-            BOOST_CHECK(!filter_index.LookupFilterHashRange(block_index->nHeight, block_index,
+            BOOST_CHECK(!filter_index.LookupFilterRange(block_index->nHeight, *block_index, filters));
+            BOOST_CHECK(!filter_index.LookupFilterHashRange(block_index->nHeight, *block_index,
                                                             filter_hashes));
         }
     }
@@ -257,8 +257,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         LOCK(cs_main);
         tip = m_node.chainman->ActiveChain().Tip();
     }
-    BOOST_CHECK(filter_index.LookupFilterRange(0, tip, filters));
-    BOOST_CHECK(filter_index.LookupFilterHashRange(0, tip, filter_hashes));
+    BOOST_CHECK(filter_index.LookupFilterRange(0, *tip, filters));
+    BOOST_CHECK(filter_index.LookupFilterHashRange(0, *tip, filter_hashes));
 
     assert(tip->nHeight >= 0);
     BOOST_CHECK_EQUAL(filters.size(), tip->nHeight + 1U);

--- a/src/test/chain_tests.cpp
+++ b/src/test/chain_tests.cpp
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(chain_test)
         for (int q = 0; q < 10000; ++q) {
             const CBlockIndex* block1 = block_index[ctx.randrange(block_index.size())].get();
             const CBlockIndex* block2 = block_index[ctx.randrange(block_index.size())].get();
-            const CBlockIndex* result = LastCommonAncestor(block1, block2);
+            const CBlockIndex* result = &LastCommonAncestor(*block1, *block2);
             BOOST_CHECK(result == NaiveLastCommonAncestor(block1, block2));
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4792,8 +4792,7 @@ bool Chainstate::ReplayBlocks()
             return false;
         }
         pindexOld = &(m_blockman.m_block_index[hashHeads[1]]);
-        pindexFork = LastCommonAncestor(pindexOld, pindexNew);
-        assert(pindexFork != nullptr);
+        pindexFork = &LastCommonAncestor(*pindexOld, *pindexNew);
     }
 
     // Rollback along the old branch.


### PR DESCRIPTION
This is a janitorial refactor, a continuation of #34440. Input method parameters of type `const CBlockIndex*` are changed to reference `const CBlockIndex&` in some places where it makes no sense to call with a nullptr.

Motivation: slight improvement in code quality, maintainability and robustness.
- more explicit representation of the non-null input invariant
- less chance of nullptr-access error with future code changes
- more explicit checks at call sites for the non-null input invariant.

The following methods are affected:
- `LastCommonAncestor()` in chain.h
- `PeerManagerImpl::FindNextBlocks()` (net_processing.cpp)
- `PeerManagerImpl::TryDownloadingHistoricalBlocks()` (net_processing.cpp)
- `BlockFilterIndex::LookupFilterRange()`, `BlockFilterIndex::LookupFilterHashRange()` (blockfilterindex.h), and `LookupRange()` in blockfilterindex.cpp
- `BaseIndex::ProcessBlock()` (base.h)

General guidelines:
- When a method has an input of type `const CBlockIndex*`, and by contract it cannot be nullptr, change it to `const CBlockIndex&`. The reference type is an implicit documentation of the nun-nullptr invariant.
- When calling a method with reference parameter, ensure that it cannot be nullptr (it is often derived from a pointer), by/because:
  - explicit prior check and error handling
  - an assert/Assert/Assume
  - itself being a non-nullptr invariant input
  - it is being an output from a method with no-nullptr output invariant
- For local variables, use reference types whenever possible, for non-nullptr references
- For technical reasons pointers are still used even in some non-nullptr cases:
  - containers/variables that can staty unitialized initially
  - containers that need `reserve()`
  - using reference type in `std::set` would result in some copy constructor calls
  - `std::optional` cannot hold a reference type
