### PR TITLE
ci: Move --usecli --extended from i386 task to alpine task

### DIFF
--- a/ci/test/00_setup_env_i686_no_ipc.sh
+++ b/ci/test/00_setup_env_i686_no_ipc.sh
@@ -15,7 +15,6 @@ export PACKAGES="llvm clang g++-multilib"
 export DEP_OPTS="DEBUG=1 NO_IPC=1"
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1
-export TEST_RUNNER_EXTRA="--v2transport --usecli --extended"
 export BITCOIN_CONFIG="\
  --preset=dev-mode \
  -DENABLE_IPC=OFF \

--- a/ci/test/00_setup_env_native_alpine_musl.sh
+++ b/ci/test/00_setup_env_native_alpine_musl.sh
@@ -17,4 +17,5 @@ export BITCOIN_CONFIG="\
  -DREDUCE_EXPORTS=ON \
  -DCMAKE_BUILD_TYPE=Debug \
 "
+export TEST_RUNNER_EXTRA="--v2transport --usecli --extended"
 export BITCOIN_CMD="bitcoin -m" # Used in functional tests


### PR DESCRIPTION
The i386 task is getting increasingly tedious to maintain:

* It is using deprecated (disabled by default) syscalls, see commit 999e9dbfb43e7e38f72e9b38fb3743022c2b9f80
* Running it on (e.g.) aarch64 is slow, due to the additional qemu overhead

It is mostly kept to have some more 32-bit coverage for https://github.com/bitcoin/bitcoin/issues/32375. But maybe in 5 or 10 years, it can be removed .... ?

So for now, try to reduce the config it runs by moving it out to longer-term tasks.

Specifically, move `TEST_RUNNER_EXTRA="--v2transport --usecli --extended"` to the native Alpine task, which should exist long-term, runs natively, and also has a debug build enabled.