### PR TITLE
wallet: keep enumerating after duplicate signers

### DIFF
--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -53,7 +53,7 @@ bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalS
         for (const ExternalSigner& signer : signers) {
             if (signer.m_fingerprint.compare(fingerprintStr) == 0) duplicate = true;
         }
-        if (duplicate) break;
+        if (duplicate) continue;
         std::string name;
         const UniValue& model_field = signer.find_value("model");
         if (model_field.isStr() && model_field.getValStr() != "") {

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -79,6 +79,7 @@ class RPCSignerTest(BitcoinTestFramework):
         )
         assert_equal(self.nodes[1].enumeratesigners(), {"signers": [
             {"fingerprint": "00000001", "name": "trezor_t"},
+            {"fingerprint": "00000002", "name": "trezor_one"},
         ]})
         self.clear_mock_result(self.nodes[1])
 

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -72,6 +72,16 @@ class RPCSignerTest(BitcoinTestFramework):
         )
         self.clear_mock_result(self.nodes[1])
 
+        self.set_mock_result(self.nodes[1],
+            '0 [{"fingerprint": "00000001", "type": "trezor", "model": "trezor_t"}, '
+            '{"fingerprint": "00000001", "type": "trezor", "model": "trezor_t"}, '
+            '{"fingerprint": "00000002", "type": "trezor", "model": "trezor_one"}]'
+        )
+        assert_equal(self.nodes[1].enumeratesigners(), {"signers": [
+            {"fingerprint": "00000001", "name": "trezor_t"},
+        ]})
+        self.clear_mock_result(self.nodes[1])
+
         assert_equal({'fingerprint': '00000001', 'name': 'trezor_t'} in self.nodes[1].enumeratesigners()['signers'], True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Problem
`ExternalSigner::Enumerate()` says it skips duplicate signers, but the current control flow stops enumeration when it finds the first duplicate fingerprint.

This can hide later unique signer entries returned by the same `enumerate` call.

### Fix
Use `continue` instead of `break` for duplicate signer entries, so only the duplicate entry is skipped and later entries are still processed.
This does not change error handling: if an enumerate entry reports an error before it reaches the duplicate check, the RPC still reports that error.

### Test
The functional test now covers an enumerate result containing one signer, a duplicate of that signer, and a later unique signer.