### PR TITLE
wallet: batch per-block writes in a single SQLite transaction

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1055,11 +1055,15 @@ bool CWallet::IsSpentKey(const CScript& scriptPubKey) const
     return false;
 }
 
-CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx, bool rescanning_old_block)
+CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx, bool rescanning_old_block, WalletBatch* batch_in)
 {
     LOCK(cs_wallet);
 
-    WalletBatch batch(GetDatabase());
+    // Reuse the caller-supplied batch when available so all writes performed
+    // within this call participate in the caller's SQLite transaction (single
+    // fsync at commit time). Fallback to an ephemeral batch otherwise.
+    std::optional<WalletBatch> local_batch;
+    WalletBatch& batch = batch_in ? *batch_in : local_batch.emplace(GetDatabase());
 
     Txid hash = tx->GetHash();
 
@@ -1224,7 +1228,7 @@ bool CWallet::LoadToWallet(const Txid& hash, const UpdateWalletTxFn& fill_wtx)
     return true;
 }
 
-bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxState& state, bool fUpdate, bool rescanning_old_block)
+bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxState& state, bool fUpdate, bool rescanning_old_block, WalletBatch* batch_in)
 {
     const CTransaction& tx = *ptx;
     {
@@ -1236,7 +1240,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
                         WalletLogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
-                        MarkConflicted(conf->confirmed_block_hash, conf->confirmed_block_height, range.first->second);
+                        MarkConflicted(conf->confirmed_block_hash, conf->confirmed_block_height, range.first->second, batch_in);
                     }
                     range.first++;
                 }
@@ -1269,7 +1273,14 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
                         // (e.g. it wasn't generated on this node or we're restoring from backup)
                         // add it to the address book for proper transaction accounting
                         if (!*dest.internal && !FindAddressBookEntry(dest.dest, /* allow_change= */ false)) {
-                            SetAddressBook(dest.dest, "", AddressPurpose::RECEIVE);
+                            // If a caller-supplied batch is active (currently only blockConnected),
+                            // route the address-book write through it to share the open SQLite
+                            // transaction; otherwise use the standalone SetAddressBook path.
+                            if (batch_in) {
+                                SetAddressBookWithDB(*batch_in, dest.dest, "", AddressPurpose::RECEIVE);
+                            } else {
+                                SetAddressBook(dest.dest, "", AddressPurpose::RECEIVE);
+                            }
                         }
                     }
                 }
@@ -1278,7 +1289,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             // Block disconnection override an abandoned tx as unconfirmed
             // which means user may have to call abandontransaction again
             TxState tx_state = std::visit([](auto&& s) -> TxState { return s; }, state);
-            CWalletTx* wtx = AddToWallet(MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, rescanning_old_block);
+            CWalletTx* wtx = AddToWallet(MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, rescanning_old_block, batch_in);
             if (!wtx) {
                 // Can only be nullptr if there was a db write error (missing db, read-only db or a db engine internal writing error).
                 // As we only store arriving transaction in this process, and we don't want an inconsistent state, let's throw an error.
@@ -1362,7 +1373,7 @@ bool CWallet::AbandonTransaction(CWalletTx& tx)
     return true;
 }
 
-void CWallet::MarkConflicted(const uint256& hashBlock, int conflicting_height, const Txid& hashTx)
+void CWallet::MarkConflicted(const uint256& hashBlock, int conflicting_height, const Txid& hashTx, WalletBatch* batch_in)
 {
     LOCK(cs_wallet);
 
@@ -1388,7 +1399,11 @@ void CWallet::MarkConflicted(const uint256& hashBlock, int conflicting_height, c
     };
 
     // Iterate over all its outputs, and mark transactions in the wallet that spend them conflicted too.
-    RecursiveUpdateTxState(hashTx, try_updating_state);
+    if (batch_in) {
+        RecursiveUpdateTxState(batch_in, hashTx, try_updating_state);
+    } else {
+        RecursiveUpdateTxState(hashTx, try_updating_state);
+    }
 
 }
 
@@ -1436,9 +1451,9 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
     }
 }
 
-bool CWallet::SyncTransaction(const CTransactionRef& ptx, const SyncTxState& state, bool update_tx, bool rescanning_old_block)
+bool CWallet::SyncTransaction(const CTransactionRef& ptx, const SyncTxState& state, bool update_tx, bool rescanning_old_block, WalletBatch* batch_in)
 {
-    if (!AddToWalletIfInvolvingMe(ptx, state, update_tx, rescanning_old_block))
+    if (!AddToWalletIfInvolvingMe(ptx, state, update_tx, rescanning_old_block, batch_in))
         return false; // Not one of ours
 
     // If a transaction changes 'conflicted' state, that changes the balance
@@ -1576,16 +1591,33 @@ void CWallet::blockConnected(const ChainstateRole& role, const interfaces::Block
     // Uses chain max time and twice the grace period to adjust time for block time variability.
     if (block.chain_time_max < m_birth_time.load() - (TIMESTAMP_WINDOW * 2)) return;
 
-    // Scan block
+    // Open a single SQLite transaction so all per-block writes (added/updated
+    // wallet txs and the best-block locator) commit atomically with one fsync,
+    // instead of one per individual WriteKey call. This addresses the
+    // generatetoaddress / wallet sync regression introduced in v30 (issue
+    // #33618). If TxnBegin() fails for any reason we fall back to the
+    // unbatched path; correctness is unchanged.
+    WalletBatch batch(GetDatabase());
+    const bool batched = batch.TxnBegin();
+    WalletBatch* const active_batch = batched ? &batch : nullptr;
+
     bool wallet_updated = false;
     for (size_t index = 0; index < block.data->vtx.size(); index++) {
-        wallet_updated |= SyncTransaction(block.data->vtx[index], TxStateConfirmed{block.hash, block.height, static_cast<int>(index)});
+        wallet_updated |= SyncTransaction(block.data->vtx[index], TxStateConfirmed{block.hash, block.height, static_cast<int>(index)}, /*update_tx=*/true, /*rescanning_old_block=*/false, active_batch);
         transactionRemovedFromMempool(block.data->vtx[index], MemPoolRemovalReason::BLOCK);
     }
 
     // Update on disk if this block resulted in us updating a tx, or periodically every 144 blocks (~1 day)
     if (wallet_updated || block.height % 144 == 0) {
-        WriteBestBlock();
+        WriteBestBlock(active_batch);
+    }
+
+    if (batched && !batch.TxnCommit()) {
+        LogWarning("Wallet: failed to commit batched transaction in blockConnected at height %d; aborting and relying on next sync to reconcile\n", block.height);
+        batch.TxnAbort();
+        // In-memory state already reflects the new tip; the on-disk best-block
+        // locator may now lag. The periodic 144-block sync (and chainStateFlushed
+        // callback) will rewrite it on the next opportunity.
     }
 }
 
@@ -4578,7 +4610,7 @@ std::optional<CKey> CWallet::GetKey(const CKeyID& keyid) const
     return std::nullopt;
 }
 
-void CWallet::WriteBestBlock() const
+void CWallet::WriteBestBlock(WalletBatch* batch_in) const
 {
     AssertLockHeld(cs_wallet);
 
@@ -4587,8 +4619,12 @@ void CWallet::WriteBestBlock() const
         chain().findBlock(m_last_block_processed, FoundBlock().locator(loc));
 
         if (!loc.IsNull()) {
-            WalletBatch batch(GetDatabase());
-            batch.WriteBestBlock(loc);
+            if (batch_in) {
+                batch_in->WriteBestBlock(loc);
+            } else {
+                WalletBatch batch(GetDatabase());
+                batch.WriteBestBlock(loc);
+            }
         }
     }
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -357,10 +357,13 @@ private:
      * Should be called with rescanning_old_block set to true, if the transaction is
      * not discovered in real time, but during a rescan of old blocks.
      */
-    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const SyncTxState& state, bool fUpdate, bool rescanning_old_block) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const SyncTxState& state, bool fUpdate, bool rescanning_old_block, WalletBatch* batch_in = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    /** Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
-    void MarkConflicted(const uint256& hashBlock, int conflicting_height, const Txid& hashTx);
+    /** Mark a transaction (and its in-wallet descendants) as conflicting with a particular block.
+     *  If batch_in is provided, descendant updates are written through that batch so they
+     *  participate in any caller-controlled SQLite transaction (avoids re-acquiring the
+     *  database write semaphore on a connection that already holds it). */
+    void MarkConflicted(const uint256& hashBlock, int conflicting_height, const Txid& hashTx, WalletBatch* batch_in = nullptr);
 
     enum class TxUpdate { UNCHANGED, CHANGED, NOTIFY_CHANGED };
 
@@ -375,7 +378,7 @@ private:
 
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    bool SyncTransaction(const CTransactionRef& tx, const SyncTxState& state, bool update_tx = true, bool rescanning_old_block = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool SyncTransaction(const CTransactionRef& tx, const SyncTxState& state, bool update_tx = true, bool rescanning_old_block = false, WalletBatch* batch_in = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** WalletFlags set on this wallet. */
     std::atomic<uint64_t> m_wallet_flags{0};
@@ -629,7 +632,7 @@ public:
      * Add the transaction to the wallet, wrapping it up inside a CWalletTx
      * @return the recently added wtx pointer or nullptr if there was a db write error.
      */
-    CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool rescanning_old_block = false);
+    CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool rescanning_old_block = false, WalletBatch* batch_in = nullptr);
     bool LoadToWallet(const Txid& hash, const UpdateWalletTxFn& fill_wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx) override;
     void blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) override;
@@ -997,8 +1000,11 @@ public:
     }
     /** Set last block processed height, and write to database */
     void SetLastBlockProcessed(int block_height, uint256 block_hash) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    /** Write the current best block to database */
-    void WriteBestBlock() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    /** Write the current best block to database. If batch_in is provided, the
+     *  write is performed via that batch (allowing it to participate in a
+     *  caller-controlled SQLite transaction); otherwise an ephemeral batch is
+     *  created and committed immediately. */
+    void WriteBestBlock(WalletBatch* batch_in = nullptr) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Connect the signals from ScriptPubKeyMans to the signals in CWallet
     void ConnectScriptPubKeyManNotifiers();


### PR DESCRIPTION
When a connected block updates the wallet (a transaction relevant to the wallet is observed, or the periodic 144-block sync triggers), each individual write currently runs in its own implicit SQLite autocommit transaction. That forces an fsync per WriteKey, which is the proximate cause of the v29 -> v30 regression reported in #33618: in `generatetoaddress`-style workloads where every coinbase pays the wallet, each block goes from "no on-disk write" (pre-7bacabb204) to "two or three fsynced writes" (post-7bacabb204), making the RPC ~1.5-2x slower.

Reverting 7bacabb204 is not an option: it fixes a correctness bug (#31824 — best-block locator was lagging across unclean shutdown during a reorg, leaving wallet transactions stuck as abandoned).

This change keeps the correctness fix and addresses the perf regression by wrapping the per-block writes in a single explicit SQLite transaction opened at the top of `CWallet::blockConnected` and committed once at the end. All writes performed for the block (the new/updated wallet transactions, the best-block locator, conflict descendants, and address book updates for newly-seen receiving addresses) share the same `WalletBatch`, so SQLite issues one fsync at COMMIT time instead of one per individual key write.

To make this safe, the same `WalletBatch*` is propagated through the relevant call paths:

  - SyncTransaction
  - AddToWalletIfInvolvingMe
  - AddToWallet
  - MarkConflicted (-> RecursiveUpdateTxState's batch overload)
  - WriteBestBlock
  - SetAddressBook (rerouted to SetAddressBookWithDB when a batch is active, since reusing a fresh WalletBatch on the same connection would block on m_write_semaphore that the active txn already holds)

All new parameters default to nullptr, preserving call-site behavior for every other caller (rescan, mempool path, RPC, tests, etc.). Only the blockConnected path is batched.

If TxnBegin() fails for any reason, the code transparently falls back to the previous unbatched behavior — correctness is unchanged. If TxnCommit() fails, the in-memory tip is preserved (it was already updated) and the on-disk best-block locator may briefly lag; the periodic 144-block sync and chainStateFlushed callback will reconcile on the next opportunity, mirroring how the wallet already tolerated crash-driven divergence prior to 7bacabb204.

Fixes #33618.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
