### PR TITLE
cmake: Set `CTEST_NIGHTLY_START_TIME` for CDash Nightly pipelines

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,1 +1,2 @@
 set(CTEST_SUBMIT_URL "https://my.cdash.org/submit.php?project=bitcoin-core")
+set(CTEST_NIGHTLY_START_TIME "00:00:00 UTC")


### PR DESCRIPTION
This PR follows up on https://github.com/bitcoin/bitcoin/pull/35222.

According to the [CMake documentation](https://cmake.org/cmake/help/latest/variable/CTEST_NIGHTLY_START_TIME.html) for `CTEST_NIGHTLY_START_TIME`:
> ... this variable must always be set for a nightly build in a dashboard script.

Examples of nightly build reports utilizing this configuration can be found on the [Bitcoin Core CDash board](https://my.cdash.org/index.php?project=bitcoin-core), based on [this commit](https://github.com/hebasto/bitcoin-core-nightly/commit/98aad4f72f4ba4952bd04b93360645f4037028e3).