### PR TITLE
dbwrapper: avoid copying unobfuscated iterator values

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -164,9 +164,14 @@ public:
 
     template<typename V> bool GetValue(V& value) {
         try {
-            DataStream ssValue{GetValueImpl()};
-            dbwrapper_private::GetObfuscation(parent)(ssValue);
-            ssValue >> value;
+            const auto& obfuscation{dbwrapper_private::GetObfuscation(parent)};
+            if (!obfuscation) {
+                SpanReader{GetValueImpl()} >> value;
+            } else {
+                DataStream ssValue{GetValueImpl()};
+                obfuscation(ssValue);
+                ssValue >> value;
+            }
         } catch (const std::exception&) {
             return false;
         }

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -10,6 +10,8 @@
 #include <util/byte_units.h>
 #include <util/string.h>
 
+#include <array>
+#include <cstddef>
 #include <memory>
 #include <ranges>
 
@@ -210,6 +212,10 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
         // A failed key decode must not consume the current iterator entry.
         uint16_t key_too_large{0};
         BOOST_CHECK(!it->GetKey(key_too_large));
+
+        // A failed value decode must not consume the current iterator entry.
+        std::array<std::byte, sizeof(uint256) + 1> value_too_large{};
+        BOOST_CHECK(!it->GetValue(value_too_large));
 
         uint8_t key_res;
         uint256 val_res;


### PR DESCRIPTION
### Motivation

`CDBIterator::GetValue()` currently copies the current LevelDB value into a
temporary `DataStream` before deserializing it. This is only needed when
database obfuscation is enabled, because deobfuscation mutates the value bytes
before they are read.

### Change

Use `SpanReader` to deserialize iterator values directly when the database has
no obfuscation key. Keep the existing `DataStream` path for obfuscated
databases.

This mirrors the existing `GetKey()` borrowed-span path while preserving the
old exception-to-`false` behavior.

### Test

```bash
cmake --build build --target test_bitcoin
build/bin/test_bitcoin --run_test=dbwrapper_tests
```