### PR TITLE
txdb: handle malformed first coin cursor key

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -5,6 +5,7 @@
 #include <addresstype.h>
 #include <clientversion.h>
 #include <coins.h>
+#include <dbwrapper.h>
 #include <streams.h>
 #include <test/util/common.h>
 #include <test/util/poolresourcetester.h>
@@ -299,6 +300,22 @@ BOOST_FIXTURE_TEST_CASE(coins_cache_dbbase_simulation_test, CacheTest)
 {
     CCoinsViewDB db_base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
     SimulationTest(&db_base, true);
+}
+
+BOOST_AUTO_TEST_CASE(coins_cursor_malformed_first_key)
+{
+    const fs::path path{m_args.GetDataDirBase() / "coins_cursor_malformed_first_key"};
+    {
+        CDBWrapper db{{.path = path, .cache_bytes = 1_MiB, .wipe_data = true}};
+        // The coin DB prefix is intentionally not followed by a serialized COutPoint.
+        db.Write(uint8_t{'C'}, uint8_t{0});
+    }
+
+    CCoinsViewDB db{{.path = path, .cache_bytes = 1_MiB}, {}};
+    std::unique_ptr<CCoinsViewCursor> cursor{db.Cursor()};
+    COutPoint key;
+    BOOST_CHECK(!cursor->Valid());
+    BOOST_CHECK(!cursor->GetKey(key));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -207,12 +207,11 @@ std::unique_ptr<CCoinsViewCursor> CCoinsViewDB::Cursor() const
        that restriction.  */
     i->pcursor->Seek(DB_COIN);
     // Cache key of first record
-    if (i->pcursor->Valid()) {
-        CoinEntry entry(&i->keyTmp.second);
-        i->pcursor->GetKey(entry);
-        i->keyTmp.first = entry.key;
-    } else {
+    CoinEntry entry(&i->keyTmp.second);
+    if (!i->pcursor->Valid() || !i->pcursor->GetKey(entry)) {
         i->keyTmp.first = 0; // Make sure Valid() and GetKey() return false
+    } else {
+        i->keyTmp.first = entry.key;
     }
     return i;
 }


### PR DESCRIPTION
### Motivation

`CCoinsViewDB::Cursor()` caches the first coin key after seeking to the coin
prefix. It checked that the underlying LevelDB iterator was valid, but ignored
whether deserializing the first key succeeded.

`CCoinsViewDBCursor::Next()` already treats a failed key decode as an invalid
cursor. The initial cursor setup should do the same.

### Change

Make `CCoinsViewDB::Cursor()` mark the cursor invalid if the first key cannot
be decoded.

Add a regression test covering a malformed first coin key.

### Test

```bash
cmake --build build --target test_bitcoin
build/bin/test_bitcoin --run_test=coins_tests_dbbase
```