### PR TITLE
sync: guard semaphore grant self-move

### DIFF
--- a/src/semaphore_grant.h
+++ b/src/semaphore_grant.h
@@ -58,11 +58,13 @@ public:
 
     CountingSemaphoreGrant& operator=(CountingSemaphoreGrant&& other) noexcept
     {
-        Release();
-        sem = other.sem;
-        fHaveGrant = other.fHaveGrant;
-        other.fHaveGrant = false;
-        other.sem = nullptr;
+        if (this != &other) {
+            Release();
+            sem = other.sem;
+            fHaveGrant = other.fHaveGrant;
+            other.fHaveGrant = false;
+            other.sem = nullptr;
+        }
         return *this;
     }
 

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -2,13 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <semaphore_grant.h>
 #include <sync.h>
 #include <test/util/common.h>
 
 #include <boost/test/unit_test.hpp>
 
 #include <mutex>
+#include <semaphore>
 #include <stdexcept>
+#include <utility>
 
 namespace {
 template <typename MutexType>
@@ -77,6 +80,20 @@ void TestInconsistentLockOrderDetected(MutexType& mutex1, MutexType& mutex2)
 } // namespace
 
 BOOST_AUTO_TEST_SUITE(sync_tests)
+
+BOOST_AUTO_TEST_CASE(semaphore_grant_self_move)
+{
+    std::counting_semaphore<1> sem{1};
+    BinarySemaphoreGrant grant{sem};
+    BOOST_CHECK(grant);
+
+    // Use a reference to avoid -Wself-move warnings.
+    auto& self{grant};
+    grant = std::move(self);
+
+    BOOST_CHECK(grant);
+    BOOST_CHECK(!sem.try_acquire());
+}
 
 BOOST_AUTO_TEST_CASE(potential_deadlock_detected)
 {


### PR DESCRIPTION
### Problem

`CountingSemaphoreGrant::operator=(CountingSemaphoreGrant&&)` releases the
currently held semaphore grant before taking ownership from the source grant.

On self-move assignment, the source and destination are the same object, so this
releases the held grant and leaves the object empty.

### Fix

Guard move assignment against self-move, making it a no-op when source and
destination alias.

Add a regression test that verifies a self-moved grant remains held.

### Test

```bash
git diff --check
cmake --build build --target test_bitcoin -j 8
build/bin/test_bitcoin --run_test=sync_tests
```
