### PR TITLE
net: send decoy transactions via private broadcast

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2278,14 +2278,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                     conflict->ToStringAddrPort()));
     }
 
+    const bool onion_may_become_reachable{listenonion && (!args.IsArgSet("-onlynet") || onlynet_used_with_onion)};
+    const bool onion_reachable{g_reachable_nets.Contains(NET_I2P) ||
+                               g_reachable_nets.Contains(NET_ONION) ||
+                               onion_may_become_reachable};
     if (args.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)) {
         // If -listenonion is set, then NET_ONION may not be reachable now
         // but may become reachable later, thus only error here if it is not
         // reachable and will not become reachable for sure.
-        const bool onion_may_become_reachable{listenonion && (!args.IsArgSet("-onlynet") || onlynet_used_with_onion)};
-        if (!g_reachable_nets.Contains(NET_I2P) &&
-            !g_reachable_nets.Contains(NET_ONION) &&
-            !onion_may_become_reachable) {
+        if (!onion_reachable) {
             return InitError(_("Private broadcast of own transactions requested (-privatebroadcast), "
                                "but none of Tor or I2P networks is reachable"));
         }
@@ -2303,6 +2304,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                           "-proxyrandomize=1."));
         }
     }
+
+    connOptions.m_start_private_broadcast_thread =
+        args.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST) ||
+        (onion_reachable && connOptions.m_use_addrman_outgoing);
 
     if (!node.connman->Start(scheduler, connOptions)) {
         return false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3594,7 +3594,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
             std::thread(&util::TraceThread, "i2paccept", [this] { ThreadI2PAcceptIncoming(); });
     }
 
-    if (gArgs.GetBoolArg("-privatebroadcast", DEFAULT_PRIVATE_BROADCAST)) {
+    if (connOptions.m_start_private_broadcast_thread) {
         threadPrivateBroadcast =
             std::thread(&util::TraceThread, "privbcast", [this] { ThreadPrivateBroadcast(); });
     }

--- a/src/net.h
+++ b/src/net.h
@@ -1098,6 +1098,7 @@ public:
         bool whitelist_forcerelay = DEFAULT_WHITELISTFORCERELAY;
         bool whitelist_relay = DEFAULT_WHITELISTRELAY;
         bool m_capture_messages = false;
+        bool m_start_private_broadcast_thread{false};
     };
 
     void Init(const Options& connOptions) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex, !m_total_bytes_sent_mutex)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -199,6 +199,8 @@ static constexpr size_t MAX_ADDR_PROCESSING_TOKEN_BUCKET{MAX_ADDR_TO_SEND};
 static constexpr size_t NUM_PRIVATE_BROADCAST_PER_TX{3};
 /** Private broadcast connections must complete within this time. Disconnect the peer if it takes longer. */
 static constexpr auto PRIVATE_BROADCAST_MAX_CONNECTION_LIFETIME{3min};
+/** Average interval between private broadcast decoy attempts */
+static constexpr auto PRIVATE_BROADCAST_DECOY_INTERVAL{3h};
 
 // Internal stuff
 namespace {
@@ -566,6 +568,9 @@ private:
 
     /** Rebroadcast stale private transactions (already broadcast but not received back from the network). */
     void ReattemptPrivateBroadcast(CScheduler& scheduler);
+
+    /** Periodically open one extra private broadcast connection and send the most recent tx in the mempool */
+    void InitiatePrivateBroadcastDecoy(CScheduler& scheduler);
 
     /** Get a shared pointer to the Peer object.
      *  May return an empty shared_ptr if the Peer object can't be found. */
@@ -1093,6 +1098,11 @@ private:
 
     /// The transactions to be broadcast privately.
     PrivateBroadcast m_tx_for_private_broadcast;
+
+    /// Whether the next private broadcast connection should be a decoy
+    std::atomic_bool m_trigger_private_broadcast_decoy{false};
+    /// Decoy transaction state. Only written and accessed on msghand thread, so doesn't need synchronization.
+    std::pair<NodeId, CTransactionRef> m_private_broadcast_decoy_state{-1, nullptr};
 };
 
 const CNodeState* PeerManagerImpl::State(NodeId pnode) const
@@ -1672,6 +1682,21 @@ void PeerManagerImpl::ReattemptPrivateBroadcast(CScheduler& scheduler)
     scheduler.scheduleFromNow([&] { ReattemptPrivateBroadcast(scheduler); }, delta);
 }
 
+void PeerManagerImpl::InitiatePrivateBroadcastDecoy(CScheduler& scheduler)
+{
+    // Don't trigger a decoy if we aren't adding incoming txs to our mempool,
+    // since we won't have anything to send as a decoy.
+    // Also don't trigger if we are still waiting on the last decoy.
+    if (!m_opts.ignore_incoming_txs && !m_trigger_private_broadcast_decoy) {
+        m_trigger_private_broadcast_decoy = true;
+        m_connman.m_private_broadcast.NumToOpenAdd(1);
+    }
+
+    const auto delta{std::chrono::duration_cast<std::chrono::milliseconds>(
+        FastRandomContext().rand_exp_duration(PRIVATE_BROADCAST_DECOY_INTERVAL))};
+    scheduler.scheduleFromNow([&] { InitiatePrivateBroadcastDecoy(scheduler); }, delta);
+}
+
 void PeerManagerImpl::FinalizeNode(const CNode& node)
 {
     NodeId nodeid = node.GetId();
@@ -1740,11 +1765,16 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
         LOCK(m_headers_presync_mutex);
         m_headers_presync_stats.erase(nodeid);
     }
-    if (node.IsPrivateBroadcastConn() &&
-        !m_tx_for_private_broadcast.DidNodeConfirmReception(nodeid) &&
-        m_tx_for_private_broadcast.HavePendingTransactions()) {
+    if (node.IsPrivateBroadcastConn()) {
+        if (!m_tx_for_private_broadcast.DidNodeConfirmReception(nodeid) &&
+            m_tx_for_private_broadcast.HavePendingTransactions()) {
 
-        m_connman.m_private_broadcast.NumToOpenAdd(1);
+            m_connman.m_private_broadcast.NumToOpenAdd(1);
+        }
+        // If we didn't complete the handshake, we never reset the trigger. Do it here.
+        if (!node.fSuccessfullyConnected) {
+            m_trigger_private_broadcast_decoy = false;
+        }
     }
     LogDebug(BCLog::NET, "Cleared nodestate for peer=%d\n", nodeid);
 }
@@ -2036,6 +2066,9 @@ void PeerManagerImpl::StartScheduledTasks(CScheduler& scheduler)
     const auto delta = 10min + FastRandomContext().randrange<std::chrono::milliseconds>(5min);
     scheduler.scheduleFromNow([&] { ReattemptInitialBroadcast(scheduler); }, delta);
 
+    const auto decoy_delta{std::chrono::duration_cast<std::chrono::milliseconds>(
+        FastRandomContext().rand_exp_duration(PRIVATE_BROADCAST_DECOY_INTERVAL))};
+    scheduler.scheduleFromNow([&] { InitiatePrivateBroadcastDecoy(scheduler); }, decoy_delta);
     if (m_opts.private_broadcast) {
         scheduler.scheduleFromNow([&] { ReattemptPrivateBroadcast(scheduler); }, 0min);
     }
@@ -3556,7 +3589,19 @@ void PeerManagerImpl::PushPrivateBroadcastTx(CNode& node)
 {
     Assume(node.IsPrivateBroadcastConn());
 
-    const auto opt_tx{m_tx_for_private_broadcast.PickTxForSend(node.GetId(), CService{node.addr})};
+    std::optional<CTransactionRef> opt_tx{};
+    if (m_trigger_private_broadcast_decoy.exchange(false)) {
+        LOCK(m_mempool.cs);
+        const auto& entry_time_index{m_mempool.mapTx.get<entry_time>()};
+        const auto last_entry_inserted{entry_time_index.rbegin()};
+        if (last_entry_inserted != entry_time_index.rend()) {
+            opt_tx = last_entry_inserted->GetSharedTx();
+            m_private_broadcast_decoy_state = std::make_pair(node.GetId(), *opt_tx);
+        }
+    }
+    if (!opt_tx) {
+        opt_tx = m_tx_for_private_broadcast.PickTxForSend(node.GetId(), CService{node.addr});
+    }
     if (!opt_tx) {
         LogDebug(BCLog::PRIVBROADCAST, "Disconnecting: no more transactions for private broadcast (connected in vain), %s", node.LogPeer());
         node.fDisconnect = true;
@@ -4143,7 +4188,10 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         if (pfrom.IsPrivateBroadcastConn()) {
-            const auto pushed_tx_opt{m_tx_for_private_broadcast.GetTxForNode(pfrom.GetId())};
+            auto pushed_tx_opt{m_tx_for_private_broadcast.GetTxForNode(pfrom.GetId())};
+            if (!pushed_tx_opt && m_private_broadcast_decoy_state.first == pfrom.GetId()) {
+                pushed_tx_opt = m_private_broadcast_decoy_state.second;
+            }
             if (!pushed_tx_opt) {
                 LogDebug(BCLog::PRIVBROADCAST, "Disconnecting: got GETDATA without sending an INV, %s",
                          pfrom.LogPeer());

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -324,6 +324,10 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             self.log.debug(f"{label}: outbound connection i={i} to {dest['requested_to']} must be a private broadcast, checking it")
             peer.wait_for_disconnect()
             # Now it is (C).
+            tx_msg = peer.last_message.get("tx")
+            if tx_msg.tx.txid_hex != tx["txid"]:
+                self.log.debug(f"{label}: outbound connection i={i} did not broadcast txid={tx['txid']} (likely a decoy), ignoring")
+                continue
             assert_equal(peer.message_count, {
                 "version": 1,
                 "verack": 1,

--- a/test/functional/p2p_private_broadcast_decoy.py
+++ b/test/functional/p2p_private_broadcast_decoy.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test that a private-broadcast decoy connection is opened on a schedule and
+announces the most recent mempool transaction.
+"""
+
+import time
+
+from test_framework.socks5 import (
+    Socks5Configuration,
+    Socks5Server,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    p2p_port,
+    tor_port,
+)
+from test_framework.wallet import MiniWallet
+
+DUMMY_ONION_ADDR = "testonlyad777777777777777777777777777777777777777775b6qd.onion"
+DUMMY_ONION_PORT = 8333
+
+
+class P2PPrivateBroadcastDecoyTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.disable_autoconnect = False
+
+    def setup_network(self):
+        socks5_config = Socks5Configuration()
+        socks5_config.addr = ("127.0.0.1", p2p_port(self.num_nodes))
+        socks5_config.unauth = True
+
+        def factory(_addr, _port):
+            return {"actual_to_addr": "127.0.0.1", "actual_to_port": tor_port(1)}
+
+        self.socks5_server = Socks5Server(socks5_config)
+        self.socks5_server.conf.destinations_factory = factory
+        self.socks5_server.start()
+
+        self.extra_args = [
+            [
+                f"-onion=127.0.0.1:{socks5_config.addr[1]}",
+                # We can't use connect=0 for private broadcast
+                "-maxconnections=0",
+                "-test=addrman",
+                "-v2transport=0",
+            ],
+            [
+                "-connect=0",
+                f"-bind=127.0.0.1:{tor_port(1)}=onion",
+            ],
+        ]
+        self.setup_nodes()
+
+    def run_test(self):
+        sender, receiver = self.nodes
+
+        sender.addpeeraddress(
+            address=DUMMY_ONION_ADDR, port=DUMMY_ONION_PORT, tried=False
+        )
+
+        wallet = MiniWallet(sender)
+        tx = wallet.create_self_transfer()
+        sender.sendrawtransaction(hexstring=tx["hex"])
+        assert tx["txid"] in sender.getrawmempool()
+        assert tx["txid"] not in receiver.getrawmempool()
+
+        # No connections in either direction yet.
+        assert_equal(sender.getpeerinfo(), [])
+        assert_equal(receiver.getpeerinfo(), [])
+
+        # The decoy schedule is exponential with a 3h mean, so the next
+        # decoy is virtually certain (~1 in 9 million) to fire within 48h.
+        self.log.info("Advancing nodes[0]'s scheduler 48h to fire the decoy")
+        for _ in range(48):
+            sender.mockscheduler(60 * 60)
+
+        self.log.info("Waiting for nodes[1] to receive the decoy-broadcast tx")
+        self.wait_until(lambda: tx["txid"] in receiver.getrawmempool())
+
+        self.log.info(
+            "Advancing nodes[0]'s clock 4min to timeout any decoy connections"
+        )
+        sender.setmocktime(int(time.time()) + 4 * 60)
+
+        self.log.info("Verifying nodes[0] and nodes[1] are not connected")
+        self.wait_until(lambda: sender.getpeerinfo() == [])
+        self.wait_until(lambda: receiver.getpeerinfo() == [])
+
+
+if __name__ == "__main__":
+    P2PPrivateBroadcastDecoyTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -312,6 +312,7 @@ BASE_SCRIPTS = [
     'feature_minchainwork.py',
     'rpc_estimatefee.py',
     'p2p_private_broadcast.py',
+    'p2p_private_broadcast_decoy.py',
     'rpc_getblockstats.py',
     'feature_port.py',
     'feature_bind_port_externalip.py',


### PR DESCRIPTION
The private broadcast feature removes the link between a transaction and its originating node IP or onion address. However, a passive observer with a large number of sybil nodes can still fingerprint transactions that are broadcast via private broadcast. Any recipient of a transaction via a private broadcast connection can be certain that it was deliberately sent via private broadcast.

This PR introduces private broadcast decoy connections. Randomly on average once every 3 hours, any node with Tor or I2P reachable opens an extra private broadcast connection. Instead of one of the node's own pending transactions, the connection announces the most recent transaction in the mempool. Because of normal transaction relay latency, the recipient may not have seen that transaction yet, and from its point of view the connection is indistinguishable from a user-submitted private broadcast. If the recipient already has the transaction, the private broadcast will timeout after 3 minutes. In this case there is still plausible deniability since this mimics user-submitted transactions. We open 3 connections for each submitted transaction. After the first successful connection the other connections may connect to nodes that have already received the transaction from the first recipient.

`-blocksonly` nodes are excluded. If the mempool is empty, no decoy is sent that round.

Every user-submitted private broadcast now has plausible deniability of being a decoy.

This makes it more difficult for a network-level observer to distinguish the traffic pattern of a user-submitted broadcast from a decoy.

Log lines such as

```
New private-broadcast peer connected: transport: v2, version: 70016, peer=xxx
```

still appear, but they no longer distinguish user-submitted transactions from decoys.