### PR TITLE
guix: disable LTO in GCC

### DIFF
--- a/contrib/guix/manifest_build.scm
+++ b/contrib/guix/manifest_build.scm
@@ -167,11 +167,13 @@ chain for " target " development."))
         ((#:configure-flags flags)
           #~(append #$flags
             ;; https://gcc.gnu.org/install/configure.html
-            (list "--enable-threads=posix"
-                  "--enable-default-ssp=yes"
+            (list "--enable-default-ssp=yes"
+                  "--enable-gprofng=no"
                   "--enable-host-bind-now=yes"
+                  "--enable-threads=posix"
                   "--disable-gcov"
                   "--disable-libgomp"
+                  "--disable-libsanitizer"
                   "--disable-lto"
                   "--disable-nls"
                   #$building-on)))))))
@@ -184,13 +186,13 @@ chain for " target " development."))
         ((#:configure-flags flags)
            #~(append #$flags
             ;; https://gcc.gnu.org/install/configure.html
-            (list "--enable-initfini-array=yes"
+            (list "--enable-cet=yes"
                   "--enable-default-ssp=yes"
                   "--enable-default-pie=yes"
-                  "--enable-host-bind-now=yes"
-                  "--enable-standard-branch-protection=yes"
-                  "--enable-cet=yes"
                   "--enable-gprofng=no"
+                  "--enable-host-bind-now=yes"
+                  "--enable-initfini-array=yes"
+                  "--enable-standard-branch-protection=yes"
                   "--disable-gcov"
                   "--disable-libgomp"
                   "--disable-libquadmath"

--- a/contrib/guix/manifest_build.scm
+++ b/contrib/guix/manifest_build.scm
@@ -173,6 +173,7 @@ chain for " target " development."))
                   "--disable-gcov"
                   "--disable-libgomp"
                   "--disable-lto"
+                  "--disable-nls"
                   #$building-on)))))))
 
 (define-public linux-base-gcc
@@ -195,6 +196,7 @@ chain for " target " development."))
                   "--disable-libquadmath"
                   "--disable-libsanitizer"
                   "--disable-lto"
+                  "--disable-nls"
                   #$building-on)))
         ((#:phases phases)
           #~(modify-phases #$phases

--- a/contrib/guix/manifest_build.scm
+++ b/contrib/guix/manifest_build.scm
@@ -172,6 +172,7 @@ chain for " target " development."))
                   "--enable-host-bind-now=yes"
                   "--disable-gcov"
                   "--disable-libgomp"
+                  "--disable-lto"
                   #$building-on)))))))
 
 (define-public linux-base-gcc
@@ -193,6 +194,7 @@ chain for " target " development."))
                   "--disable-libgomp"
                   "--disable-libquadmath"
                   "--disable-libsanitizer"
+                  "--disable-lto"
                   #$building-on)))
         ((#:phases phases)
           #~(modify-phases #$phases

--- a/contrib/guix/manifest_build.scm
+++ b/contrib/guix/manifest_build.scm
@@ -199,6 +199,7 @@ chain for " target " development."))
                   "--disable-libsanitizer"
                   "--disable-lto"
                   "--disable-nls"
+                  "--disable-tm-clone-registry"
                   #$building-on)))
         ((#:phases phases)
           #~(modify-phases #$phases

--- a/contrib/guix/manifest_build.scm
+++ b/contrib/guix/manifest_build.scm
@@ -165,14 +165,14 @@ chain for " target " development."))
     (arguments
       (substitute-keyword-arguments (package-arguments base-gcc)
         ((#:configure-flags flags)
-          `(append ,flags
+          #~(append #$flags
             ;; https://gcc.gnu.org/install/configure.html
-            (list "--enable-threads=posix",
-                  "--enable-default-ssp=yes",
-                  "--enable-host-bind-now=yes",
-                  "--disable-gcov",
-                  "--disable-libgomp",
-                  building-on)))))))
+            (list "--enable-threads=posix"
+                  "--enable-default-ssp=yes"
+                  "--enable-host-bind-now=yes"
+                  "--disable-gcov"
+                  "--disable-libgomp"
+                  #$building-on)))))))
 
 (define-public linux-base-gcc
   (package
@@ -180,22 +180,22 @@ chain for " target " development."))
     (arguments
       (substitute-keyword-arguments (package-arguments base-gcc)
         ((#:configure-flags flags)
-          `(append ,flags
+           #~(append #$flags
             ;; https://gcc.gnu.org/install/configure.html
-            (list "--enable-initfini-array=yes",
-                  "--enable-default-ssp=yes",
-                  "--enable-default-pie=yes",
-                  "--enable-host-bind-now=yes",
-                  "--enable-standard-branch-protection=yes",
-                  "--enable-cet=yes",
-                  "--enable-gprofng=no",
-                  "--disable-gcov",
-                  "--disable-libgomp",
-                  "--disable-libquadmath",
-                  "--disable-libsanitizer",
-                  building-on)))
+            (list "--enable-initfini-array=yes"
+                  "--enable-default-ssp=yes"
+                  "--enable-default-pie=yes"
+                  "--enable-host-bind-now=yes"
+                  "--enable-standard-branch-protection=yes"
+                  "--enable-cet=yes"
+                  "--enable-gprofng=no"
+                  "--disable-gcov"
+                  "--disable-libgomp"
+                  "--disable-libquadmath"
+                  "--disable-libsanitizer"
+                  #$building-on)))
         ((#:phases phases)
-          `(modify-phases ,phases
+          #~(modify-phases #$phases
             ;; Given a XGCC package, return a modified package that replace each instance of
             ;; -rpath in the default system spec that's inserted by Guix with -rpath-link
             (add-after 'pre-configure 'replace-rpath-with-rpath-link


### PR DESCRIPTION
We don't use LTO in release builds, and neither do any of our dependencies, so disable support in GCC (`--disable-lto`):
> Enable support for link-time optimization (LTO). This is enabled by default, and may be disabled using --disable-lto.

This reduces what needs to be compiled when building the Guix toolchain. It would also make it clear if something started using it.

Also disable Native Language Support (`--disable-nls`):
> The --enable-nls option enables Native Language Support (NLS), which lets GCC output diagnostics in languages other than American English. Native Language Support is enabled by default if not doing a canadian cross build.

Also disable support for transactional memory (`--disable-tm-clone-registry`):
> Disable TM clone registry in libgcc. It is enabled in libgcc by default. This option helps to reduce code size for embedded targets which do not use transactional memory. 

See https://gcc.gnu.org/install/configure.html.