### PR TITLE
net: calculate compact filters on the fly for an already advertised block

### DIFF
--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -14,15 +14,18 @@
 #include <index/db_key.h>
 #include <interfaces/chain.h>
 #include <interfaces/types.h>
+#include <primitives/block.h>
 #include <serialize.h>
 #include <streams.h>
 #include <sync.h>
 #include <uint256.h>
+#include <undo.h>
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/hasher.h>
 #include <util/log.h>
 #include <util/syserror.h>
+#include <validation.h>
 
 #include <cerrno>
 #include <exception>
@@ -58,6 +61,12 @@ constexpr unsigned int FLTR_FILE_CHUNK_SIZE{1_MiB};
  *  is big enough for a 2,000,000 length block chain, which
  *  we should be enough until ~2047. */
 constexpr size_t CF_HEADERS_CACHE_MAX_SZ{2000};
+/** Maximum distance below the active chain tip at which a missing filter may be
+ *  computed on the fly to mask the race between block connection and CustomAppend
+ *  writing the filter. Bounds the CPU work a peer can extract from a range
+ *  request that hits an unindexed block. Older missing entries signal a real
+ *  DB/indexing problem rather than a race and are not filled. */
+constexpr int ONTHEFLY_TIP_WINDOW{10};
 
 namespace {
 
@@ -249,10 +258,21 @@ std::optional<uint256> BlockFilterIndex::ReadFilterHeader(int height, const uint
 
 bool BlockFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
+    LOCK(m_cs_write);
+
+    // LookupFilter may have already computed and written this filter on the fly
+    // (during the window between block connection and this callback running).
+    // If so, adopt the stored header and skip re-writing.
+    DBVal existing;
+    if (index_util::LookUpOne(*m_db, {block.hash, block.height}, existing)) {
+        m_last_header = existing.header;
+        return true;
+    }
+
     BlockFilter filter(m_filter_type, *Assert(block.data), *Assert(block.undo_data));
-    const uint256& header = filter.ComputeHeader(m_last_header);
+    const uint256 header = filter.ComputeHeader(m_last_header);
     bool res = Write(filter, block.height, header);
-    if (res) m_last_header = header; // update last header
+    if (res) m_last_header = header;
     return res;
 }
 
@@ -355,24 +375,81 @@ static bool LookupRange(CDBWrapper& db, const std::string& index_name, int start
     return true;
 }
 
-bool BlockFilterIndex::LookupFilter(const CBlockIndex* block_index, BlockFilter& filter_out) const
+bool BlockFilterIndex::ComputeAndPersistFilter(const CBlockIndex* block_index, BlockFilter& filter_out)
 {
-    DBVal entry;
-    if (!index_util::LookUpOne(*m_db, {block_index->GetBlockHash(), block_index->nHeight}, entry)) {
-        return false;
+    // m_chainstate is null until Init() has been called; without it we cannot
+    // read block data from disk.
+    if (!m_chainstate) return false;
+
+    {
+        LOCK(cs_main);
+        bool have_data = (block_index->nStatus & BLOCK_HAVE_DATA) != 0;
+        bool have_undo = (block_index->nStatus & BLOCK_HAVE_UNDO) != 0;
+        if (!have_data || (block_index->nHeight > 0 && !have_undo)) return false;
     }
 
+    CBlock block;
+    if (!m_chainstate->m_blockman.ReadBlock(block, *block_index)) return false;
+
+    CBlockUndo block_undo;
+    if (block_index->nHeight > 0 &&
+        !m_chainstate->m_blockman.ReadBlockUndo(block_undo, *block_index)) return false;
+
+    BlockFilter filter(m_filter_type, block, block_undo);
+
+    // Opportunistically persist to DB so future lookups hit the fast path.
+    // Requires the previous filter header to form a complete chain entry; if it
+    // isn't available yet, skip the write — CustomAppend will persist correctly
+    // once the predecessor is indexed.
+    {
+        LOCK(m_cs_write);
+        DBVal existing;
+        // Double-check under the lock: a concurrent call (or CustomAppend) may have
+        // written it while we read from disk.
+        if (!index_util::LookUpOne(*m_db, {block_index->GetBlockHash(), block_index->nHeight}, existing)) {
+            uint256 prev_header;
+            bool have_prev = (block_index->nHeight == 0);
+            if (!have_prev) {
+                auto opt = ReadFilterHeader(block_index->nHeight - 1, block_index->pprev->GetBlockHash());
+                if (opt) {
+                    prev_header = *opt;
+                    have_prev = true;
+                }
+            }
+            if (have_prev) {
+                if (!Write(filter, block_index->nHeight, filter.ComputeHeader(prev_header))) {
+                    LogWarning("Failed to persist on-the-fly filter for block %s; "
+                               "filter will be recomputed on next request",
+                               block_index->GetBlockHash().ToString());
+                }
+            }
+        }
+    }
+
+    filter_out = std::move(filter);
+    return true;
+}
+
+bool BlockFilterIndex::LookupFilter(const CBlockIndex* block_index, BlockFilter& filter_out)
+{
+    DBVal entry;
+    if (index_util::LookUpOne(*m_db, {block_index->GetBlockHash(), block_index->nHeight}, entry)) {
+        return ReadFilterFromDisk(entry.pos, entry.hash, filter_out);
+    }
+    // Miss: fall back through EnsureRangeIndexed so any racing tip-window predecessors get
+    // filled and the chain of filter headers stays continuous.
+    if (!EnsureRangeIndexed(block_index->nHeight, block_index)) return false;
+    if (!index_util::LookUpOne(*m_db, {block_index->GetBlockHash(), block_index->nHeight}, entry)) return false;
     return ReadFilterFromDisk(entry.pos, entry.hash, filter_out);
 }
 
 bool BlockFilterIndex::LookupFilterHeader(const CBlockIndex* block_index, uint256& header_out)
 {
-    LOCK(m_cs_headers_cache);
-
-    bool is_checkpoint{block_index->nHeight % CFCHECKPT_INTERVAL == 0};
+    const bool is_checkpoint{block_index->nHeight % CFCHECKPT_INTERVAL == 0};
 
     if (is_checkpoint) {
         // Try to find the block in the headers cache if this is a checkpoint height.
+        LOCK(m_cs_headers_cache);
         auto header = m_headers_cache.find(block_index->GetBlockHash());
         if (header != m_headers_cache.end()) {
             header_out = header->second;
@@ -382,25 +459,80 @@ bool BlockFilterIndex::LookupFilterHeader(const CBlockIndex* block_index, uint25
 
     DBVal entry;
     if (!index_util::LookUpOne(*m_db, {block_index->GetBlockHash(), block_index->nHeight}, entry)) {
-        return false;
+        // Race-window fallback: fill any missing tip-subrange entries (including those
+        // ahead of this block on the chain) so the filter header for `block_index` ends
+        // up persisted, then re-read.
+        if (!EnsureRangeIndexed(block_index->nHeight, block_index)) return false;
+        if (!index_util::LookUpOne(*m_db, {block_index->GetBlockHash(), block_index->nHeight}, entry)) return false;
     }
 
-    if (is_checkpoint &&
-        m_headers_cache.size() < CF_HEADERS_CACHE_MAX_SZ) {
+    if (is_checkpoint) {
         // Add to the headers cache if this is a checkpoint height.
-        m_headers_cache.emplace(block_index->GetBlockHash(), entry.header);
+        LOCK(m_cs_headers_cache);
+        if (m_headers_cache.size() < CF_HEADERS_CACHE_MAX_SZ) {
+            m_headers_cache.try_emplace(block_index->GetBlockHash(), entry.header);
+        }
     }
 
     header_out = entry.header;
     return true;
 }
 
+bool BlockFilterIndex::EnsureRangeIndexed(int start_height, const CBlockIndex* stop_index)
+{
+    // Split [start_height, stop_index->nHeight] at the tip window. The stable subrange below
+    // the window must already be in the DB — we will not compute old filters on demand. The
+    // tip subrange may have race-induced holes which we fill from raw block data.
+    if (!m_chainstate) return false;
+    int tip_height;
+    {
+        LOCK(cs_main);
+        const CBlockIndex* tip = m_chainstate->m_chain.Tip();
+        if (!tip) return false;
+        tip_height = tip->nHeight;
+    }
+
+    const int cutoff = tip_height - ONTHEFLY_TIP_WINDOW; // inclusive upper bound of stable part
+    const int stop_height = stop_index->nHeight;
+
+    if (start_height <= cutoff) {
+        const int stable_end = std::min(stop_height, cutoff);
+        const CBlockIndex* stable_stop = (stable_end == stop_height) ? stop_index
+                                                                     : stop_index->GetAncestor(stable_end);
+        if (!stable_stop) return false;
+        std::vector<DBVal> stable_entries;
+        if (!LookupRange(*m_db, m_name, start_height, stable_stop, stable_entries)) return false;
+    }
+
+    if (stop_height <= cutoff) return true; // entire request was in the stable subrange
+
+    // Tip subrange: collect block indexes from stop_index back to cutoff+1 via pprev so we can
+    // fill missing entries in ascending height order. Walking back to cutoff+1 (rather than the
+    // caller's start_height) ensures that the first block we compute has its predecessor's
+    // filter header either in the stable subrange (already on disk) or just written by an
+    // earlier iteration — required by ComputeAndPersistFilter to chain the filter header.
+    const int fill_start = cutoff + 1;
+    std::vector<const CBlockIndex*> tip_chain;
+    for (const CBlockIndex* bi = stop_index; bi && bi->nHeight >= fill_start; bi = bi->pprev) {
+        tip_chain.push_back(bi);
+    }
+    for (auto it = tip_chain.rbegin(); it != tip_chain.rend(); ++it) {
+        DBVal existing;
+        if (index_util::LookUpOne(*m_db, {(*it)->GetBlockHash(), (*it)->nHeight}, existing)) continue;
+        BlockFilter tmp;
+        if (!ComputeAndPersistFilter(*it, tmp)) return false;
+    }
+    return true;
+}
+
 bool BlockFilterIndex::LookupFilterRange(int start_height, const CBlockIndex* stop_index,
-                                         std::vector<BlockFilter>& filters_out) const
+                                         std::vector<BlockFilter>& filters_out)
 {
     std::vector<DBVal> entries;
     if (!LookupRange(*m_db, m_name, start_height, stop_index, entries)) {
-        return false;
+        if (!EnsureRangeIndexed(start_height, stop_index)) return false;
+        entries.clear();
+        if (!LookupRange(*m_db, m_name, start_height, stop_index, entries)) return false;
     }
 
     filters_out.resize(entries.size());
@@ -411,17 +543,17 @@ bool BlockFilterIndex::LookupFilterRange(int start_height, const CBlockIndex* st
         }
         ++filter_pos_it;
     }
-
     return true;
 }
 
 bool BlockFilterIndex::LookupFilterHashRange(int start_height, const CBlockIndex* stop_index,
-                                             std::vector<uint256>& hashes_out) const
-
+                                             std::vector<uint256>& hashes_out)
 {
     std::vector<DBVal> entries;
     if (!LookupRange(*m_db, m_name, start_height, stop_index, entries)) {
-        return false;
+        if (!EnsureRangeIndexed(start_height, stop_index)) return false;
+        entries.clear();
+        if (!LookupRange(*m_db, m_name, start_height, stop_index, entries)) return false;
     }
 
     hashes_out.clear();

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -53,6 +53,9 @@ private:
     /** cache of block hash to filter header, to avoid disk access when responding to getcfcheckpt. */
     std::unordered_map<uint256, uint256, BlockHasher> m_headers_cache GUARDED_BY(m_cs_headers_cache);
 
+    /** Protects on-the-fly writes in LookupFilter from racing with CustomAppend. */
+    Mutex m_cs_write;
+
     // Last computed header to avoid disk reads on every new block.
     uint256 m_last_header{};
 
@@ -61,6 +64,18 @@ private:
     bool Write(const BlockFilter& filter, uint32_t block_height, const uint256& filter_header);
 
     std::optional<uint256> ReadFilterHeader(int height, const uint256& expected_block_hash);
+
+    /** Compute a filter for block_index from raw block/undo data and best-effort persist it.
+     *  Used to mask the race between block connection and CustomAppend writing the filter.
+     *  Returns true if filter_out is populated; persistence is best-effort and not required
+     *  for success. */
+    bool ComputeAndPersistFilter(const CBlockIndex* block_index, BlockFilter& filter_out);
+
+    /** Ensure every block in [start_height, stop_index] has a filter entry in the DB,
+     *  computing missing entries on the fly when within a small window of the chain tip.
+     *  Returns false if any missing entry lies more than ONTHEFLY_TIP_WINDOW blocks
+     *  below the tip — bounds DoS for callers serving peer requests. */
+    bool EnsureRangeIndexed(int start_height, const CBlockIndex* stop_index);
 
 protected:
     bool CustomInit(const std::optional<interfaces::BlockRef>& block) override;
@@ -82,19 +97,27 @@ public:
 
     BlockFilterType GetFilterType() const { return m_filter_type; }
 
-    /** Get a single filter by block. */
-    bool LookupFilter(const CBlockIndex* block_index, BlockFilter& filter_out) const;
+    /** Get a single filter by block.
+     *  If the filter is not yet indexed, computes it from raw block data (when available)
+     *  and writes it to the database so subsequent requests succeed immediately. */
+    bool LookupFilter(const CBlockIndex* block_index, BlockFilter& filter_out);
 
     /** Get a single filter header by block. */
     bool LookupFilterHeader(const CBlockIndex* block_index, uint256& header_out) EXCLUSIVE_LOCKS_REQUIRED(!m_cs_headers_cache);
 
-    /** Get a range of filters between two heights on a chain. */
+    /** Get a range of filters between two heights on a chain.
+     *  If any filter in the range is not yet indexed but the block is within a small window of
+     *  the active chain tip, computes it from raw block data and persists it. Returns false if
+     *  any missing entry is outside that window (DoS protection against unindexed-block fetches). */
     bool LookupFilterRange(int start_height, const CBlockIndex* stop_index,
-                           std::vector<BlockFilter>& filters_out) const;
+                           std::vector<BlockFilter>& filters_out);
 
-    /** Get a range of filter hashes between two heights on a chain. */
+    /** Get a range of filter hashes between two heights on a chain.
+     *  If any hash in the range is not yet indexed but the block is within a small window of
+     *  the active chain tip, computes the filter from raw block data and persists it. Returns
+     *  false if any missing entry is outside that window (DoS protection). */
     bool LookupFilterHashRange(int start_height, const CBlockIndex* stop_index,
-                               std::vector<uint256>& hashes_out) const;
+                               std::vector<uint256>& hashes_out);
 };
 
 /**

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -578,7 +578,7 @@ public:
     }
     std::optional<bool> blockFilterMatchesAny(BlockFilterType filter_type, const uint256& block_hash, const GCSFilter::ElementSet& filter_set) override
     {
-        const BlockFilterIndex* block_filter_index{GetBlockFilterIndex(filter_type)};
+        BlockFilterIndex* block_filter_index{GetBlockFilterIndex(filter_type)};
         if (!block_filter_index) return std::nullopt;
 
         BlockFilter filter;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(test_bitcoin
   blockencodings_tests.cpp
   blockfilter_index_tests.cpp
   blockfilter_tests.cpp
+  cfilter_race_tests.cpp
   blockmanager_tests.cpp
   bloom_tests.cpp
   bswap_tests.cpp

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -118,11 +118,10 @@ bool BuildChainTestingSetup::BuildChain(const CBlockIndex* pindex,
 BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
 {
     BlockFilterIndex filter_index(interfaces::MakeChain(m_node), BlockFilterType::BASIC, 1_MiB, true);
-    BOOST_REQUIRE(filter_index.Init());
 
     uint256 last_header;
 
-    // Filter should not be found in the index before it is started.
+    // Before Init(), m_chainstate is null so no filter can be computed or found.
     {
         LOCK(cs_main);
 
@@ -142,7 +141,9 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         }
     }
 
-    // BlockUntilSyncedToCurrentChain should return false before index is started.
+    BOOST_REQUIRE(filter_index.Init());
+
+    // BlockUntilSyncedToCurrentChain should return false before Sync() is called.
     BOOST_CHECK(!filter_index.BlockUntilSyncedToCurrentChain());
 
     filter_index.Sync();

--- a/src/test/cfilter_race_tests.cpp
+++ b/src/test/cfilter_race_tests.cpp
@@ -1,0 +1,251 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addresstype.h>
+#include <blockfilter.h>
+#include <chain.h>
+#include <index/blockfilterindex.h>
+#include <interfaces/chain.h>
+#include <kernel/types.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <util/byte_units.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <atomic>
+#include <future>
+#include <memory>
+
+namespace {
+
+// A CValidationInterface that, when armed, stalls the validation-signals
+// scheduler thread inside BlockConnected until Release() is called. Register
+// this before the BlockFilterIndex so our callback fires first — at that point
+// the filter index's CustomAppend has not yet run and the filter is not yet
+// written.
+class PreFilterBlocker : public CValidationInterface
+{
+public:
+    void Arm() { m_armed = true; }
+    void WaitForEntry() { m_entered.get_future().wait(); }
+    void Release()
+    {
+        if (!m_released.exchange(true)) m_release.set_value();
+    }
+
+protected:
+    void BlockConnected(const kernel::ChainstateRole& role,
+                        const std::shared_ptr<const CBlock>&,
+                        const CBlockIndex*) override
+    {
+        if (!role.validated) return;
+        if (m_armed.exchange(false)) {
+            m_entered.set_value();
+            m_release_fut.wait();
+        }
+    }
+
+private:
+    std::atomic_bool m_armed{false};
+    std::atomic_bool m_released{false};
+    std::promise<void> m_entered;
+    std::promise<void> m_release;
+    std::shared_future<void> m_release_fut{m_release.get_future()};
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(cfilter_race_tests, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(cfilter_available_during_append_window)
+{
+    // Register the blocker BEFORE the filter index so our BlockConnected fires
+    // first on the scheduler thread.
+    auto blocker = std::make_shared<PreFilterBlocker>();
+    m_node.validation_signals->RegisterSharedValidationInterface(blocker);
+
+    BlockFilterIndex filter_index(interfaces::MakeChain(m_node),
+                                  BlockFilterType::BASIC,
+                                  /*n_cache_size=*/1_MiB,
+                                  /*f_memory=*/true);
+    BOOST_REQUIRE(filter_index.Init());
+    filter_index.Sync(); // backfills filters for the pre-mined 100 blocks
+
+    // Sanity: filter for the existing tip is present.
+    const CBlockIndex* old_tip;
+    {
+        LOCK(cs_main);
+        old_tip = m_node.chainman->ActiveChain().Tip();
+    }
+    BlockFilter dummy;
+    BOOST_REQUIRE(filter_index.LookupFilter(old_tip, dummy));
+
+    // Arm the gate: the next BlockConnected callback will park the scheduler
+    // thread inside PreFilterBlocker::BlockConnected before the filter index
+    // gets a chance to run CustomAppend.
+    blocker->Arm();
+
+    // Mine one block. ProcessNewBlock advances the chain synchronously and
+    // enqueues BlockConnected onto the validation-signals scheduler thread.
+    const CScript coinbase_script = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
+    const CBlock new_block = CreateAndProcessBlock({}, coinbase_script);
+
+    // Block until the scheduler thread has reached our gate. At this point:
+    //  - the new block is in m_blockman (chain has advanced),
+    //  - BLOCK_HAVE_DATA is set on the new tip,
+    //  - the filter index's BlockConnected has NOT yet run (CustomAppend not called).
+    // This is the exact window a peer's getcfilters could land in.
+    blocker->WaitForEntry();
+
+    const CBlockIndex* new_tip;
+    {
+        LOCK(cs_main);
+        new_tip = m_node.chainman->m_blockman.LookupBlockIndex(new_block.GetHash());
+    }
+    BOOST_REQUIRE(new_tip);
+    BOOST_REQUIRE_EQUAL(new_tip->nHeight, old_tip->nHeight + 1);
+    BOOST_REQUIRE(new_tip->nStatus & BLOCK_HAVE_DATA);
+
+    // EXPECTED TO FAIL TODAY:
+    // ProcessGetCFilters ultimately calls LookupFilter / LookupFilterRange,
+    // which only read from the on-disk filter file. During the append window
+    // the filter is not yet written, so the lookup returns false and a peer
+    // would get no reply. After the planned fix (compute on the fly for a
+    // known block with data when no on-disk filter exists), this should pass.
+    BlockFilter filter;
+    BOOST_CHECK_MESSAGE(
+        filter_index.LookupFilter(new_tip, filter),
+        "filter for connected tip should be retrievable in the window between "
+        "block connection and filter write");
+
+    // Release the scheduler thread and let the filter index write the filter.
+    blocker->Release();
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+
+    // After CustomAppend has run, the filter is on disk regardless of fix state.
+    BlockFilter from_disk;
+    BOOST_CHECK(filter_index.LookupFilter(new_tip, from_disk));
+
+    m_node.validation_signals->UnregisterSharedValidationInterface(blocker);
+    filter_index.Interrupt();
+    filter_index.Stop();
+}
+
+BOOST_AUTO_TEST_CASE(cfilter_range_available_during_append_window)
+{
+    // Same setup as the single-lookup case, but exercises LookupFilterRange,
+    // which is the path actually used by ProcessGetCFilters.
+    auto blocker = std::make_shared<PreFilterBlocker>();
+    m_node.validation_signals->RegisterSharedValidationInterface(blocker);
+
+    BlockFilterIndex filter_index(interfaces::MakeChain(m_node),
+                                  BlockFilterType::BASIC,
+                                  /*n_cache_size=*/1_MiB,
+                                  /*f_memory=*/true);
+    BOOST_REQUIRE(filter_index.Init());
+    filter_index.Sync();
+
+    const CBlockIndex* old_tip;
+    {
+        LOCK(cs_main);
+        old_tip = m_node.chainman->ActiveChain().Tip();
+    }
+
+    // Baseline: range over fully-indexed history works.
+    std::vector<BlockFilter> baseline;
+    BOOST_REQUIRE(filter_index.LookupFilterRange(old_tip->nHeight - 2, old_tip, baseline));
+    BOOST_REQUIRE_EQUAL(baseline.size(), 3U);
+
+    blocker->Arm();
+    const CScript coinbase_script = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
+    const CBlock new_block = CreateAndProcessBlock({}, coinbase_script);
+    blocker->WaitForEntry();
+
+    const CBlockIndex* new_tip;
+    {
+        LOCK(cs_main);
+        new_tip = m_node.chainman->m_blockman.LookupBlockIndex(new_block.GetHash());
+    }
+    BOOST_REQUIRE(new_tip);
+    BOOST_REQUIRE_EQUAL(new_tip->nHeight, old_tip->nHeight + 1);
+
+    // Range covers indexed history plus the not-yet-written new tip. With the
+    // on-the-fly fill, this must return one filter per block in the range.
+    std::vector<BlockFilter> filters;
+    const int range_start = new_tip->nHeight - 3;
+    BOOST_CHECK_MESSAGE(
+        filter_index.LookupFilterRange(range_start, new_tip, filters),
+        "LookupFilterRange should fill the race-window tip from raw block data");
+    BOOST_CHECK_EQUAL(filters.size(), 4U);
+
+    // The last filter must match what we get by reading the new tip directly
+    // (computed-and-persisted by the range call above).
+    if (filters.size() == 4U) {
+        BlockFilter direct;
+        BOOST_CHECK(filter_index.LookupFilter(new_tip, direct));
+        BOOST_CHECK(filters.back().GetHash() == direct.GetHash());
+    }
+
+    blocker->Release();
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+
+    m_node.validation_signals->UnregisterSharedValidationInterface(blocker);
+    filter_index.Interrupt();
+    filter_index.Stop();
+}
+
+BOOST_AUTO_TEST_CASE(cfilter_header_available_during_append_window)
+{
+    // Exercises LookupFilterHeader during the race window. This is the path
+    // ProcessGetCFHeaders uses to fetch prev_filter_header at start-1 of a
+    // requested range; for a getcfheaders [tip, tip] request, prev is at
+    // tip-1, which can itself be inside the race window.
+    auto blocker = std::make_shared<PreFilterBlocker>();
+    m_node.validation_signals->RegisterSharedValidationInterface(blocker);
+
+    BlockFilterIndex filter_index(interfaces::MakeChain(m_node),
+                                  BlockFilterType::BASIC,
+                                  /*n_cache_size=*/1_MiB,
+                                  /*f_memory=*/true);
+    BOOST_REQUIRE(filter_index.Init());
+    filter_index.Sync();
+
+    blocker->Arm();
+    const CScript coinbase_script = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
+    const CBlock new_block = CreateAndProcessBlock({}, coinbase_script);
+    blocker->WaitForEntry();
+
+    const CBlockIndex* new_tip;
+    {
+        LOCK(cs_main);
+        new_tip = m_node.chainman->m_blockman.LookupBlockIndex(new_block.GetHash());
+    }
+    BOOST_REQUIRE(new_tip);
+
+    // Filter header for the racing tip must be reachable; on-the-fly compute
+    // fills the chain and persists the entry so the header is available.
+    uint256 header;
+    BOOST_CHECK_MESSAGE(
+        filter_index.LookupFilterHeader(new_tip, header),
+        "filter header for connected tip should be retrievable during the append window");
+    BOOST_CHECK(header != uint256{});
+
+    blocker->Release();
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+
+    // After CustomAppend has run, the header is on disk and consistent.
+    uint256 from_disk;
+    BOOST_CHECK(filter_index.LookupFilterHeader(new_tip, from_disk));
+    BOOST_CHECK(from_disk == header);
+
+    m_node.validation_signals->UnregisterSharedValidationInterface(blocker);
+    filter_index.Interrupt();
+    filter_index.Stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
A compact block filter request might arrive when a block has already been processed (and advertised) but its filter has not yet been constructed. In that window the node fails to respond, which the requesting peer treats as misbehaviour and may disconnect/ban.

Fixes: https://github.com/bitcoin/bitcoin/issues/29655, https://github.com/bitcoin/bitcoin/issues/27085
Related discussion: [1](https://bnoc.xyz/t/request-block-filter-peers-being-disconnected-due-to-invalid-block-requests/101/2), [2](https://github.com/lightninglabs/neutrino/issues/338)

**The problem:**
Bitcoin Core receives a new block and processes it, then advertises it; however, by that moment the compact filter might not yet have been constructed. If a peer asks for a filter in that window, Bitcoin Core simply does not respond. From the peer's perspective this is a misbehaviour (we advertised a block and don't provide filters for it), which results in disconnects or bans. While it does not critically affect core nodes, it breaks the network topology for BIP 157 clients.

More precisely, [BIP157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki#getcfilters) specifies that for `getcfilters` requestor:

```
StopHash MUST be known to belong to a block accepted by the receiving peer. This is the case if the peer had previously sent a headers or inv message with that block or any descendents. A node that receives getcfilters with an unknown StopHash SHOULD NOT respond.
```

Current behaviour clearly contradicts the above specification.

I (re-)discovered it while testing "light" compact block filter nodes [kyoto](https://github.com/2140-dev/kyoto) and its addition to [ldk-node](https://github.com/lightningdevkit/ldk-node), it was also discussed in context of [neutrino](https://github.com/lightninglabs/neutrino).

**Proposed solution:** compute filters on the fly when they are requested for blocks we already have. Unlike filter headers, individual filters do not commit to their predecessors, so we can compute them independently for a set of blocks. Moreover we compute each filter at most once and persist it, so subsequent requests proceed as usual by reading the already-computed filter from disk.

Changes:
- `LookupFilter`
- `LookupFilterHeader`
- `LookupFilterRange`
- `LookupFilterHashRange`

Schematically `LookupFilter` now works as follows:
1. On filter request, check if we know the requested block. If not, abort.
2. Check if the filter is already computed and stored. If so, respond with it.
3. Otherwise compute the filter, persist it, respond with it.

`LookupFilterRange` (and `LookupFilterHashRange`) now work as follows:
1. We are asked for a filter range, say `[tip-N, tip]` (BIP 157 caps `N` at 1000).
2. Check if filters for the full range `[tip-N, tip]` are already on disk. If so, respond with them.
3. Otherwise check if filters for the stable subrange `[tip-N, tip-10]` are all on disk. If any are missing, fail — those are too far behind the tip to be a race-window miss and we refuse to recompute them on demand.
4. For each block in `[tip-9, tip]` that is missing from the index, compute its filter on the fly. Then respond with the complete range.

`LookupFilterHeader` is used by `ProcessGetCFHeaders` to fetch `prev_filter_header` at `start - 1` of a requested range. For a `getcfheaders [tip, tip]` request, that predecessor is at `tip - 1`, which can itself be inside the race window. Without on-the-fly fallback on this path, the response would fail even though the filter hashes are recoverable. All four lookup paths now share the same chain-aware fallback.

This change exposes the possibility that an external peer can force our node to compute filters on the fly and thus burn CPU. However this is not a concern, because:

- It can only happen once per filter — subsequent requests read from disk.
- There is a hard limit on the depth of on-the-fly computation: only the 10 blocks below the active chain tip (`ONTHEFLY_TIP_WINDOW`).
- The whole window is tiny (single-digit milliseconds on testnet4, tens of milliseconds on mainnet — see numbers below).

The value 10 for constant `ONTHEFLY_TIP_WINDOW` is somewhat arbitrary and perhaps can be lowered. Myself I observed a window of maximum depth 2, on regtest.

**Benchmarks**

I benchmarked the four scenarios below on testnet4 (heights 134703–134802). The benchmark files are not included in this PR because they require a synced node and real block data, but I can include them in an additional commit on request.

- 1a. Request 100 filters, all already computed and stored.
- 1b. Request 100 filters, 90 already stored, 10 computed on the fly (the worst case for a 100-block request).
- 2a. Request 10 filters, all already stored.
- 2b. Request 10 filters, none stored — all computed on the fly (the worst case for a 10-block request).

Results on testnet4:

| Scenario | Per-request total | Per-block on-the-fly cost | Overhead vs all-indexed |
|---|---|---|---|
| 1a (100 indexed)            | 0.97 ms | — | baseline |
| 1b (100, 10 on the fly)     | 1.25 ms | ~28 µs | +0.28 ms |
| 2a (10 indexed)             | 0.099 ms | — | baseline |
| 2b (10 all on the fly)      | 0.50 ms | ~40 µs | +0.40 ms |

Mainnet figures extrapolation (compute scales roughly with block size and script count; estimated from the per-block compute cost of ~3.4 ms measured against a real mainnet datadir):

| Scenario | Per-request total | Overhead vs all-indexed |
|---|---|---|
| 1a (100 indexed) | ~2.5 ms | baseline |
| 1b (100, 10 on the fly) | ~36 ms | +~34 ms |
| 2a (10 indexed) | ~0.25 ms | baseline |
| 2b (10 all on the fly) | ~34 ms | +~34 ms |

In other words, the worst-case extra cost a hostile peer can extract is ~34 ms per request, bounded to the 10 tip blocks, paid at most once per block per node lifetime due to the write-back.

In theory, on-the-fly entries interact correctly with reorgs: the standard hash-vs-height fallback in `LookUpOne` ensures `CustomAppend` overwrites them with the new chain's filter, and `CustomRemove` preserves them via the hash index just like any other filter. I haven't tested it with block reorganizations.

This PR does not affect block propagation, as the very root of this bug is the independence of block processing and filter construction in `CustomAppend`. Nor does it affect the initial block download, since during IBD a node does not respond to compact filter messages.

I've used Claude Code for this PR.

