### PR TITLE
net: disconnect evicted inbound peers immediately

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1732,6 +1732,15 @@ bool CConnman::AttemptToEvictConnection()
                 pnode->ConnectedThroughNetwork(),
                 TicksSinceEpoch<std::chrono::seconds>(pnode->m_connected));
             pnode->fDisconnect = true;
+            // Remove accepted inbound eviction candidates immediately instead
+            // of waiting for the socket handler thread. Otherwise, accept loops
+            // outside the socket handler can temporarily exceed maxconnections.
+            if (Assume(pnode->IsInboundConn())) {
+                m_nodes.erase(remove(m_nodes.begin(), m_nodes.end(), pnode), m_nodes.end());
+                pnode->CloseSocketDisconnect();
+                pnode->Release();
+                m_nodes_disconnected.push_back(pnode);
+            }
             return true;
         }
     }
@@ -1981,12 +1990,16 @@ void CConnman::DisconnectNodes()
     }
     {
         // Delete disconnected nodes
-        std::list<CNode*> nodes_disconnected_copy = m_nodes_disconnected;
+        std::list<CNode*> nodes_disconnected_copy;
+        {
+            LOCK(m_nodes_mutex);
+            nodes_disconnected_copy = m_nodes_disconnected;
+        }
         for (CNode* pnode : nodes_disconnected_copy)
         {
             // Destroy the object only after other threads have stopped using it.
             if (pnode->GetRefCount() <= 0) {
-                m_nodes_disconnected.remove(pnode);
+                WITH_LOCK(m_nodes_mutex, m_nodes_disconnected.remove(pnode));
                 DeleteNode(pnode);
             }
         }
@@ -3701,10 +3714,11 @@ void CConnman::StopNodes()
         DeleteNode(pnode);
     }
 
-    for (CNode* pnode : m_nodes_disconnected) {
+    std::list<CNode*> disconnected_nodes;
+    WITH_LOCK(m_nodes_mutex, disconnected_nodes.swap(m_nodes_disconnected));
+    for (CNode* pnode : disconnected_nodes) {
         DeleteNode(pnode);
     }
-    m_nodes_disconnected.clear();
     WITH_LOCK(m_reconnections_mutex, m_reconnections.clear());
     vhListenSocket.clear();
     semOutbound.reset();

--- a/src/net.h
+++ b/src/net.h
@@ -1622,7 +1622,7 @@ private:
 
     mutable Mutex m_added_nodes_mutex;
     std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);
-    std::list<CNode*> m_nodes_disconnected;
+    std::list<CNode*> m_nodes_disconnected GUARDED_BY(m_nodes_mutex);
     mutable Mutex m_nodes_mutex;
     std::atomic<NodeId> nLastNodeId{0};
     unsigned int nPrevNodeCount{0};

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -163,4 +163,45 @@ BOOST_FIXTURE_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection, 
     connman->ClearTestNodes();
 }
 
+BOOST_FIXTURE_TEST_CASE(inbound_eviction_removes_node_immediately, LogIPsTestingSetup)
+{
+    auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
+    auto peerman = PeerManager::make(*connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
+
+    constexpr int max_inbound{29};
+    CConnman::Options options;
+    options.m_msgproc = peerman.get();
+    options.m_max_automatic_connections = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS +
+                                           MAX_BLOCK_RELAY_ONLY_CONNECTIONS +
+                                           MAX_FEELER_CONNECTIONS + max_inbound;
+    connman->Init(options);
+
+    const auto bind_addr{CAddress{ip(0x0100007f), NODE_NONE}};
+
+    for (int i{0}; i < max_inbound; ++i) {
+        connman->CreateNodeFromAcceptedSocketPublic(std::make_unique<ZeroSock>(), NetPermissionFlags::None,
+                                                    bind_addr, CAddress{ip(0x01010101 + i), NODE_NONE});
+    }
+    const std::vector<CNode*> original_nodes{connman->TestNodes()};
+    BOOST_REQUIRE_EQUAL(original_nodes.size(), static_cast<size_t>(max_inbound));
+
+    connman->CreateNodeFromAcceptedSocketPublic(std::make_unique<ZeroSock>(), NetPermissionFlags::None,
+                                                bind_addr, CAddress{ip(0x02020202), NODE_NONE});
+    const std::vector<CNode*> nodes{connman->TestNodes()};
+
+    size_t disconnected_original_nodes{0};
+    for (const CNode* node : original_nodes) {
+        if (node->fDisconnect) ++disconnected_original_nodes;
+    }
+    size_t replacement_nodes{0};
+    for (const CNode* node : nodes) {
+        if (std::ranges::find(original_nodes, node) == original_nodes.end()) ++replacement_nodes;
+    }
+    BOOST_CHECK_EQUAL(nodes.size(), static_cast<size_t>(max_inbound));
+    BOOST_CHECK_EQUAL(disconnected_original_nodes, 1U);
+    BOOST_CHECK_EQUAL(replacement_nodes, 1U);
+
+    connman->StopNodes();
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Summary

`CreateNodeFromAcceptedSocket()` enforces the inbound connection limit by calling `AttemptToEvictConnection()` before accepting a replacement peer. Previously, the selected peer was only marked with `fDisconnect` and remained in `m_nodes` until the socket handler later ran `DisconnectNodes()`.

That is enough for inbound TCP accepts, which run in the socket handler thread, but not for accept loops outside the socket handler. In particular, `ThreadI2PAcceptIncoming()` can continue accepting replacement peers before the socket handler drains the evicted peers, temporarily exceeding `-maxconnections`.

This removes an evicted inbound peer from `m_nodes` immediately, closes/releases it into `m_nodes_disconnected`, and guards `m_nodes_disconnected` with `m_nodes_mutex` because it can now be updated from the eviction path as well as the socket handler path.

The regression test fills the inbound slots, accepts one more socket, and checks that the live node set remains capped while one original node is marked disconnected and replaced. As a regression check, transplanting the new test onto unpatched `origin/master` fails with:

```text
nodes.size() == static_cast<size_t>(max_inbound) has failed [30 != 29]
```

### Local I2P Repro

As supporting evidence, I also reproduced the behavior with a local `i2pd` SAM router using `-maxconnections=40` and 120 SAM `STREAM CONNECT` attempts:

```text
origin/master d406cffafdd1: 120/120 streams succeeded, peak connections_in=35
patched branch (same patch): 120/120 streams succeeded, peak connections_in=29
```

### Test

```bash
cmake --build build --target test_bitcoin
build/bin/test_bitcoin --run_test=net_peer_connection_tests
```

Fixes https://github.com/bitcoin/bitcoin/issues/27843.