### PR TITLE
rpc: make getprivatebroadcastinfo and abortprivatebroadcast fail if privatebroadcast is not enabled

### DIFF
--- a/doc/release-notes-35267.md
+++ b/doc/release-notes-35267.md
@@ -1,0 +1,4 @@
+RPC
+---
+
+The `getprivatebroadcastinfo` and `abortprivatebroadcast` RPCs now return an error `-32601`, "Method not found", when `-privatebroadcast` is not enabled at startup.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1852,6 +1852,7 @@ PeerManagerInfo PeerManagerImpl::GetInfo() const
     return PeerManagerInfo{
         .median_outbound_time_offset = m_outbound_time_offsets.Median(),
         .ignores_incoming_txs = m_opts.ignore_incoming_txs,
+        .private_broadcast = m_opts.private_broadcast,
     };
 }
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -71,6 +71,7 @@ struct CNodeStateStats {
 struct PeerManagerInfo {
     std::chrono::seconds median_outbound_time_offset{0s};
     bool ignores_incoming_txs{false};
+    bool private_broadcast{DEFAULT_PRIVATE_BROADCAST};
 };
 
 class PeerManager : public CValidationInterface, public NetEventsInterface

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -143,7 +143,8 @@ static RPCMethod getprivatebroadcastinfo()
 {
     return RPCMethod{
         "getprivatebroadcastinfo",
-        "Returns information about transactions that are currently being privately broadcast.\n",
+        "Returns information about transactions that are currently being privately broadcast.\n"
+        "This method is only available when running with -privatebroadcast enabled.\n",
         {},
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -176,6 +177,10 @@ static RPCMethod getprivatebroadcastinfo()
         {
             const NodeContext& node{EnsureAnyNodeContext(request.context)};
             const PeerManager& peerman{EnsurePeerman(node)};
+            if (!peerman.GetInfo().private_broadcast) {
+                throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Private broadcast is not enabled. Ensure you're running Bitcoin Core with -privatebroadcast=1.");
+            }
+
             const auto txs{peerman.GetPrivateBroadcastInfo()};
 
             UniValue transactions(UniValue::VARR);
@@ -211,7 +216,8 @@ static RPCMethod abortprivatebroadcast()
     return RPCMethod{
         "abortprivatebroadcast",
         "Abort private broadcast attempts for a transaction currently being privately broadcast.\n"
-        "The transaction will be removed from the private broadcast queue.\n",
+        "The transaction will be removed from the private broadcast queue.\n"
+        "This method is only available when running with -privatebroadcast enabled.\n",
         {
             {"id", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A transaction identifier to abort. It will be matched against both txid and wtxid for all transactions in the private broadcast queue.\n"
                                                                 "If the provided id matches a txid that corresponds to multiple transactions with different wtxids, multiple transactions will be removed and returned."},
@@ -236,10 +242,14 @@ static RPCMethod abortprivatebroadcast()
         },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
         {
-            const uint256 id{ParseHashV(self.Arg<UniValue>("id"), "id")};
 
             const NodeContext& node{EnsureAnyNodeContext(request.context)};
             PeerManager& peerman{EnsurePeerman(node)};
+            if (!peerman.GetInfo().private_broadcast) {
+                throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Private broadcast is not enabled. Ensure you're running Bitcoin Core with -privatebroadcast=1.");
+            }
+
+            const uint256 id{ParseHashV(self.Arg<UniValue>("id"), "id")};
 
             const auto removed_txs{peerman.AbortPrivateBroadcast(id)};
             if (removed_txs.empty()) {

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -223,6 +223,12 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         tx_receiver = self.nodes[1]
         far_observer = tx_receiver.add_p2p_connection(P2PInterface())
 
+        self.log.info("Test getprivatebroadcastinfo and abortprivatebroadcast fails if the node is running without -privatebroadcast set")
+        assert_raises_rpc_error(-32601, "Private broadcast is not enabled. Ensure you're running Bitcoin Core with -privatebroadcast=1.",
+            tx_receiver.getprivatebroadcastinfo)
+        assert_raises_rpc_error(-32601, "Private broadcast is not enabled. Ensure you're running Bitcoin Core with -privatebroadcast=1.",
+            tx_receiver.abortprivatebroadcast, "00" * 32)
+
         self.fill_node_addrman(node_index=0, address_types_to_add=[CAddress.NET_IPV4, CAddress.NET_IPV6, CAddress.NET_TORV3, CAddress.NET_I2P, CAddress.NET_CJDNS])
 
         wallet = MiniWallet(tx_originator)


### PR DESCRIPTION
Makes `getprivatebroadcast` and `abortprivatebroadcast` throw if `-privatebroadcast=0`.

This is motivated by: https://github.com/sparrowwallet/sparrow/issues/1989

Knowing if `privatebroadcast` is set can be useful for some external software like Sparrow to avoid call `getprivatebroadcastinfo` each time to see if broadcast was done through that.