### PR TITLE
wallet: keep MuSig2 signing sessions by pubnonce

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -123,7 +123,7 @@ std::vector<uint8_t> MutableTransactionSignatureCreator::CreateMuSig2Nonce(const
     if (out.empty()) return {};
 
     // Store the secnonce in the SigningProvider
-    provider.SetMuSig2SecNonce(MuSig2SessionID(script_pubkey, part_pubkey, *sighash), std::move(secnonce));
+    provider.SetMuSig2SecNonce(MuSig2SessionID(script_pubkey, part_pubkey, *sighash), out, std::move(secnonce));
 
     return out;
 }
@@ -147,6 +147,8 @@ bool MutableTransactionSignatureCreator::CreateMuSig2PartialSig(const SigningPro
     auto pubnonce_it = sigdata.musig2_pubnonces.find(this_leaf_aggkey);
     if (pubnonce_it == sigdata.musig2_pubnonces.end()) return false;
     const std::map<CPubKey, std::vector<uint8_t>>& pubnonces = pubnonce_it->second;
+    const auto part_pubnonce_it = pubnonces.find(part_pubkey);
+    if (part_pubnonce_it == pubnonces.end()) return false;
 
     // Check if enough pubnonces
     if (pubnonces.size() != pubkeys.size()) return false;
@@ -157,7 +159,7 @@ bool MutableTransactionSignatureCreator::CreateMuSig2PartialSig(const SigningPro
 
     // Retrieve the secnonce
     uint256 session_id = MuSig2SessionID(script_pubkey, part_pubkey, *sighash);
-    std::optional<std::reference_wrapper<MuSig2SecNonce>> secnonce = provider.GetMuSig2SecNonce(session_id);
+    std::optional<std::reference_wrapper<MuSig2SecNonce>> secnonce = provider.GetMuSig2SecNonce(session_id, part_pubnonce_it->second);
     if (!secnonce || !secnonce->get().IsValid()) return false;
 
     // Compute the sig
@@ -167,7 +169,7 @@ bool MutableTransactionSignatureCreator::CreateMuSig2PartialSig(const SigningPro
 
     // Delete the secnonce now that we're done with it
     assert(!secnonce->get().IsValid());
-    provider.DeleteMuSig2Session(session_id);
+    provider.DeleteMuSig2Session(session_id, part_pubnonce_it->second);
 
     return true;
 }

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -9,6 +9,8 @@
 
 #include <logging.h>
 
+#include <algorithm>
+
 const SigningProvider& DUMMY_SIGNING_PROVIDER = SigningProvider();
 
 template<typename M, typename K, typename V>
@@ -63,19 +65,19 @@ std::map<CPubKey, std::vector<CPubKey>> HidingSigningProvider::GetAllMuSig2Parti
     return m_provider->GetAllMuSig2ParticipantPubkeys();
 }
 
-void HidingSigningProvider::SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const
+void HidingSigningProvider::SetMuSig2SecNonce(const uint256& id, const std::vector<uint8_t>& pubnonce, MuSig2SecNonce&& nonce) const
 {
-    m_provider->SetMuSig2SecNonce(id, std::move(nonce));
+    m_provider->SetMuSig2SecNonce(id, pubnonce, std::move(nonce));
 }
 
-std::optional<std::reference_wrapper<MuSig2SecNonce>> HidingSigningProvider::GetMuSig2SecNonce(const uint256& session_id) const
+std::optional<std::reference_wrapper<MuSig2SecNonce>> HidingSigningProvider::GetMuSig2SecNonce(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const
 {
-    return m_provider->GetMuSig2SecNonce(session_id);
+    return m_provider->GetMuSig2SecNonce(session_id, pubnonce);
 }
 
-void HidingSigningProvider::DeleteMuSig2Session(const uint256& session_id) const
+void HidingSigningProvider::DeleteMuSig2Session(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const
 {
-    m_provider->DeleteMuSig2Session(session_id);
+    m_provider->DeleteMuSig2Session(session_id, pubnonce);
 }
 
 bool FlatSigningProvider::GetCScript(const CScriptID& scriptid, CScript& script) const { return LookupHelper(scripts, scriptid, script); }
@@ -119,26 +121,30 @@ std::map<CPubKey, std::vector<CPubKey>> FlatSigningProvider::GetAllMuSig2Partici
     return aggregate_pubkeys;
 }
 
-void FlatSigningProvider::SetMuSig2SecNonce(const uint256& session_id, MuSig2SecNonce&& nonce) const
+void FlatSigningProvider::SetMuSig2SecNonce(const uint256& session_id, const std::vector<uint8_t>& pubnonce, MuSig2SecNonce&& nonce) const
 {
     if (!Assume(musig2_secnonces)) return;
-    auto [it, inserted] = musig2_secnonces->try_emplace(session_id, std::move(nonce));
-    // No secnonce should exist for this session yet.
-    Assert(inserted);
+    const auto has_session{std::any_of(musig2_secnonces->begin(), musig2_secnonces->end(), [&](const auto& entry) {
+        return entry.first.first == session_id;
+    })};
+    const bool inserted{musig2_secnonces->try_emplace(MuSig2SecNonceKey{session_id, pubnonce}, std::move(nonce)).second};
+    if (has_session && inserted) {
+        LogWarning("Starting another MuSig2 signing session for %s", session_id.ToString());
+    }
 }
 
-std::optional<std::reference_wrapper<MuSig2SecNonce>> FlatSigningProvider::GetMuSig2SecNonce(const uint256& session_id) const
+std::optional<std::reference_wrapper<MuSig2SecNonce>> FlatSigningProvider::GetMuSig2SecNonce(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const
 {
     if (!Assume(musig2_secnonces)) return std::nullopt;
-    const auto& it = musig2_secnonces->find(session_id);
+    const auto& it = musig2_secnonces->find(MuSig2SecNonceKey{session_id, pubnonce});
     if (it == musig2_secnonces->end()) return std::nullopt;
     return it->second;
 }
 
-void FlatSigningProvider::DeleteMuSig2Session(const uint256& session_id) const
+void FlatSigningProvider::DeleteMuSig2Session(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const
 {
     if (!Assume(musig2_secnonces)) return;
-    musig2_secnonces->erase(session_id);
+    musig2_secnonces->erase(MuSig2SecNonceKey{session_id, pubnonce});
 }
 
 FlatSigningProvider& FlatSigningProvider::Merge(FlatSigningProvider&& b)

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -15,6 +15,7 @@
 #include <script/script.h>
 #include <sync.h>
 
+#include <cstdint>
 #include <functional>
 #include <optional>
 
@@ -167,9 +168,9 @@ public:
     virtual bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const { return false; }
     virtual std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const { return {}; }
     virtual std::map<CPubKey, std::vector<CPubKey>> GetAllMuSig2ParticipantPubkeys() const {return {}; }
-    virtual void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const {}
-    virtual std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const { return std::nullopt; }
-    virtual void DeleteMuSig2Session(const uint256& session_id) const {}
+    virtual void SetMuSig2SecNonce(const uint256& id, const std::vector<uint8_t>& pubnonce, MuSig2SecNonce&& nonce) const {}
+    virtual std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const { return std::nullopt; }
+    virtual void DeleteMuSig2Session(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const {}
 
     bool GetKeyByXOnly(const XOnlyPubKey& pubkey, CKey& key) const
     {
@@ -215,10 +216,12 @@ public:
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
     std::map<CPubKey, std::vector<CPubKey>> GetAllMuSig2ParticipantPubkeys() const override;
-    void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const override;
-    std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const override;
-    void DeleteMuSig2Session(const uint256& session_id) const override;
+    void SetMuSig2SecNonce(const uint256& id, const std::vector<uint8_t>& pubnonce, MuSig2SecNonce&& nonce) const override;
+    std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const override;
+    void DeleteMuSig2Session(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const override;
 };
+
+using MuSig2SecNonceKey = std::pair<uint256, std::vector<uint8_t>>;
 
 struct FlatSigningProvider final : public SigningProvider
 {
@@ -228,7 +231,7 @@ struct FlatSigningProvider final : public SigningProvider
     std::map<CKeyID, CKey> keys;
     std::map<XOnlyPubKey, TaprootBuilder> tr_trees; /** Map from output key to Taproot tree (which can then make the TaprootSpendData */
     std::map<CPubKey, std::vector<CPubKey>> aggregate_pubkeys; /** MuSig2 aggregate pubkeys */
-    std::map<uint256, MuSig2SecNonce>* musig2_secnonces{nullptr};
+    std::map<MuSig2SecNonceKey, MuSig2SecNonce>* musig2_secnonces{nullptr};
 
     bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
     bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
@@ -239,9 +242,9 @@ struct FlatSigningProvider final : public SigningProvider
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
     std::map<CPubKey, std::vector<CPubKey>> GetAllMuSig2ParticipantPubkeys() const override;
-    void SetMuSig2SecNonce(const uint256& id, MuSig2SecNonce&& nonce) const override;
-    std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id) const override;
-    void DeleteMuSig2Session(const uint256& session_id) const override;
+    void SetMuSig2SecNonce(const uint256& id, const std::vector<uint8_t>& pubnonce, MuSig2SecNonce&& nonce) const override;
+    std::optional<std::reference_wrapper<MuSig2SecNonce>> GetMuSig2SecNonce(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const override;
+    void DeleteMuSig2Session(const uint256& session_id, const std::vector<uint8_t>& pubnonce) const override;
 
     FlatSigningProvider& Merge(FlatSigningProvider&& b) LIFETIMEBOUND;
 };

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -290,7 +290,7 @@ private:
     //! Number of pre-generated keys/scripts (part of the look-ahead process, used to detect payments)
     int64_t m_keypool_size GUARDED_BY(cs_desc_man){DEFAULT_KEYPOOL_SIZE};
 
-    /** Map of a session id to MuSig2 secnonce
+    /** Map of a session id and public nonce to MuSig2 secnonce
      *
      * Stores MuSig2 secnonces while the MuSig2 signing session is still ongoing.
      * Note that these secnonces must not be reused. In order to avoid being tricked into
@@ -300,8 +300,9 @@ private:
      *
      * The session id is an arbitrary value set by the signer in order for the signing logic
      * to find ongoing signing sessions. It is the SHA256 of aggregate xonly key, + participant pubkey + sighash.
+     * The public nonce is also part of the key to distinguish retries for the same transaction.
      */
-    mutable std::map<uint256, MuSig2SecNonce> m_musig2_secnonces;
+    mutable std::map<MuSig2SecNonceKey, MuSig2SecNonce> m_musig2_secnonces;
 
     bool AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 

--- a/test/functional/wallet_musig.py
+++ b/test/functional/wallet_musig.py
@@ -168,6 +168,38 @@ class WalletMuSigTest(BitcoinTestFramework):
         assert "musig2_pubnonces" in dec["inputs"][0]
         assert "musig2_partial_sigs" not in dec["inputs"][0]
 
+    def test_nonce_retry_preserves_old_session(self):
+        self.log.info("Testing nonce-less PSBT retry")
+        wallets, psbt = self.setup_musig_scenario("rawtr(musig($0/<0;1>/*,$1/<1;2>/*))")
+
+        first_nonce_psbt = wallets[0].walletprocesspsbt(psbt=psbt)["psbt"]
+        second_nonce_psbt = wallets[0].walletprocesspsbt(psbt=psbt)["psbt"]
+
+        first_dec = self.nodes[0].decodepsbt(first_nonce_psbt)
+        second_dec = self.nodes[0].decodepsbt(second_nonce_psbt)
+        first_pubnonces = first_dec["inputs"][0]["musig2_pubnonces"]
+        second_pubnonces = second_dec["inputs"][0]["musig2_pubnonces"]
+        assert_equal(len(first_pubnonces), 1)
+        assert_equal(len(second_pubnonces), 1)
+        assert first_pubnonces != second_pubnonces
+
+        other_nonce_psbt = wallets[1].walletprocesspsbt(psbt=psbt)["psbt"]
+        comb_first_nonce_psbt = self.nodes[0].combinepsbt([first_nonce_psbt, other_nonce_psbt])
+        comb_second_nonce_psbt = self.nodes[0].combinepsbt([second_nonce_psbt, other_nonce_psbt])
+
+        first_sig_psbt = wallets[0].walletprocesspsbt(psbt=comb_first_nonce_psbt)["psbt"]
+        first_sig_dec = self.nodes[0].decodepsbt(first_sig_psbt)
+        assert_equal(len(first_sig_dec["inputs"][0].get("musig2_partial_sigs", [])), 1)
+
+        second_sig_psbt = wallets[0].walletprocesspsbt(psbt=comb_second_nonce_psbt)["psbt"]
+        second_sig_dec = self.nodes[0].decodepsbt(second_sig_psbt)
+        assert_equal(len(second_sig_dec["inputs"][0].get("musig2_partial_sigs", [])), 1)
+
+        other_sig_psbt = wallets[1].walletprocesspsbt(psbt=comb_first_nonce_psbt)["psbt"]
+        comb_sig_psbt = self.nodes[0].combinepsbt([first_sig_psbt, other_sig_psbt])
+        finalized = self.nodes[0].finalizepsbt(comb_sig_psbt)
+        assert_equal(finalized["complete"], True)
+
     def test_success_case(self, comment, pattern, sighash_type=None, scriptpath=False, nosign_wallets=None, only_one_musig_wallet=False):
         self.log.info(f"Testing {comment}")
         has_internal = MULTIPATH_TWO_RE.search(pattern) is not None
@@ -342,6 +374,7 @@ class WalletMuSigTest(BitcoinTestFramework):
         self.test_failure_case_1("missing participant nonce", "tr(musig($0/<0;1>/*,$1/<1;2>/*,$2/<2;3>/*))")
         self.test_failure_case_2("insufficient partial signatures", "rawtr(musig($0/<0;1>/*,$1/<1;2>/*,$2/<2;3>/*))")
         self.test_failure_case_3("finalize without partial sigs", "rawtr(musig($0/<0;1>/*,$1/<1;2>/*))")
+        self.test_nonce_retry_preserves_old_session()
 
 if __name__ == '__main__':
     WalletMuSigTest(__file__).main()


### PR DESCRIPTION
Fixes #35250.\n\nThis keeps MuSig2 secnonces keyed by both the session id and the generated public nonce, so re-processing the same nonce-less PSBT starts another signing session instead of replacing or asserting on the existing one. Signing later looks up the secnonce matching the pubnonce present in the PSBT and deletes only that session after use.\n\nTests:\n- cmake --build build-depends -t test_bitcoin -j"$(nproc)"\n- build-depends/bin/test_bitcoin --run_test=psbt_wallet_tests --catch_system_errors=no --log_level=test_suite\n- cmake --build build-depends -t bitcoind bitcoin-cli -j"$(nproc)"\n- python3 build-depends/test/functional/test_runner.py --jobs=1 wallet_musig.py