### PR TITLE
doc: Document minimum versions for Xcode CLT and MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,6 @@ if(CMAKE_VERSION VERSION_LESS 4.2 AND CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NO
   set(CMAKE_INSTALL_NAME_TOOL "${CMAKE_COMMAND} -E true")
 endif()
 enable_language(CXX)
-set(MIN_CLANG_DOCS "doc/dependencies.md#compiler")
-set(MIN_GCC_DOCS "doc/dependencies.md#compiler")
-set(MIN_MSVC_DOCS "doc/build-windows-msvc.md")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -201,11 +198,7 @@ string(APPEND CMAKE_CXX_COMPILE_OBJECT " ${APPEND_CPPFLAGS} ${APPEND_CXXFLAGS}")
 string(APPEND CMAKE_CXX_CREATE_SHARED_LIBRARY " ${APPEND_LDFLAGS}")
 string(APPEND CMAKE_CXX_LINK_EXECUTABLE " ${APPEND_LDFLAGS}")
 
-#=============================
-# C++ Feature Detection
-#=============================
-# In case the compiler is not GCC, Clang or MSVC this provides extra checks
-# which verify that some features are available in the standard library.
+# Check required C++ toolchain features early.
 include(CheckCXXFeatures)
 check_cxx_features()
 

--- a/cmake/module/CheckCXXFeatures.cmake
+++ b/cmake/module/CheckCXXFeatures.cmake
@@ -4,7 +4,7 @@
 
 include_guard(GLOBAL)
 
-#Checks for C++ features required to compile Bitcoin Core.
+# Checks for C++ features required to compile Bitcoin Core.
 
 include(CheckCXXSourceCompiles)
 
@@ -33,10 +33,8 @@ function(check_cxx_features)
       "Compiler lacks Class Template Argument Deduction (CTAD) for aggregates.\n"
       "This C++ feature is required for src/util/overloaded.h.\n"
       "You are probably using an old compiler version\n"
-      "The recommended compiler versions can be checked in:\n"
-      "  - GCC -> ${MIN_GCC_DOCS}\n"
-      "  - Clang -> ${MIN_CLANG_DOCS}\n"
-      "  - MSVC -> ${MIN_MSVC_DOCS}\n"
+      "The recommended compiler versions can be checked in\n"
+      "doc/dependencies.md#compiler.\n"
     )
   endif()
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,9 @@ macOS comes with a built-in Terminal located in:
 ### 1. Xcode Command Line Tools
 
 The Xcode Command Line Tools are a collection of build tools for macOS.
-These tools must be installed in order to build Bitcoin Core from source.
+Version 16.2 (or higher) of these tools must be
+[installed](https://developer.apple.com/documentation/xcode/installing-the-command-line-tools)
+in order to build Bitcoin Core from source.
 
 To install, run the following command from your terminal:
 

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -8,10 +8,12 @@ them using [depends](/depends/README.md).
 
 Bitcoin Core requires one of the following compilers.
 
-| Dependency | Minimum required |
+| Toolchain | Minimum required |
 | --- | --- |
 | [Clang](https://clang.llvm.org) | [17.0](https://github.com/bitcoin/bitcoin/pull/33555) |
 | [GCC](https://gcc.gnu.org) | [12.1](https://github.com/bitcoin/bitcoin/pull/33842) |
+| [Xcode CLT](/doc/build-osx.md) | [16.2](https://github.com/bitcoin/bitcoin/pull/33932) |
+| [MSVC](/doc/build-windows-msvc.md) | [18.3](https://github.com/bitcoin/bitcoin/pull/33861) |
 
 ## Required
 


### PR DESCRIPTION
The minimum required Xcode command-line tools version was not documented, which can lead to confusion.

So document it in `doc/dependencies.md` (along with adding a note one msvc there as well). This also allows to slim down the error message in the configure C++ feature check by referring to `doc/dependencies.md#compiler`.

