### PR TITLE
Update CoinsView::NeedsUpgrade to add additional checks

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -36,7 +36,8 @@ bool CCoinsViewDB::NeedsUpgrade()
     // DB_COINS was deprecated in v0.15.0, commit
     // 1088b02f0ccd7358d2b7076bb9e122d59d502d02
     cursor->Seek(std::make_pair(DB_COINS, uint256{}));
-    return cursor->Valid();
+    std::pair<unsigned char, uint256> key;   
+    return cursor->Valid() && cursor->GetKey(key) && key.first == DB_COINS;  
 }
 
 namespace {


### PR DESCRIPTION
Additional two checks after cursor->Valid():

Seek() in LevelDB finds the first key ≥ the target. If no DB_COINS entry exists but there happens to be another key whose byte value is greater than DB_COINS, cursor->Valid() returns true — even though no legacy coins are present. 
The original code would incorrectly signal an upgrade is needed. The new code explicitly verifies the found key's prefix is DB_COINS. 