### PR TITLE
wallet: report importdescriptors timestamp errors per item

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -26,8 +26,10 @@
 
 #include <cstdint>
 #include <fstream>
-#include <tuple>
+#include <optional>
 #include <string>
+#include <tuple>
+#include <vector>
 
 #include <univalue.h>
 
@@ -379,6 +381,8 @@ RPCMethod importdescriptors()
     int64_t lowest_timestamp = 0;
     bool rescan = false;
     UniValue response(UniValue::VARR);
+    std::vector<std::optional<int64_t>> timestamps;
+    timestamps.reserve(requests.size());
     {
         LOCK(pwallet->cs_wallet);
         EnsureWalletIsUnlocked(*pwallet);
@@ -387,12 +391,23 @@ RPCMethod importdescriptors()
 
         // Get all timestamps and extract the lowest timestamp
         for (const UniValue& request : requests.getValues()) {
-            // This throws an error if "timestamp" doesn't exist
-            const int64_t timestamp = std::max(GetImportTimestamp(request, now), minimum_timestamp);
+            int64_t timestamp{0};
+            try {
+                timestamp = std::max(GetImportTimestamp(request, now), minimum_timestamp);
+            } catch (const UniValue& e) {
+                UniValue result(UniValue::VOBJ);
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", e);
+                response.push_back(std::move(result));
+                timestamps.push_back(std::nullopt);
+                continue;
+            }
+
+            timestamps.push_back(timestamp);
             const UniValue result = ProcessDescriptorImport(*pwallet, request, timestamp);
             response.push_back(result);
 
-            if (lowest_timestamp > timestamp ) {
+            if (lowest_timestamp > timestamp) {
                 lowest_timestamp = timestamp;
             }
 
@@ -421,20 +436,26 @@ RPCMethod importdescriptors()
 
             // Compose the response
             for (unsigned int i = 0; i < requests.size(); ++i) {
-                const UniValue& request = requests.getValues().at(i);
+                const UniValue& result = results.at(i);
 
                 // If the descriptor timestamp is within the successfully scanned
                 // range, or if the import result already has an error set, let
                 // the result stand unmodified. Otherwise replace the result
                 // with an error message.
-                if (scanned_time <= GetImportTimestamp(request, now) || results.at(i).exists("error")) {
-                    response.push_back(results.at(i));
+                if (result.exists("error")) {
+                    response.push_back(result);
+                    continue;
+                }
+
+                const int64_t timestamp{*timestamps.at(i)};
+                if (scanned_time <= timestamp) {
+                    response.push_back(result);
                 } else {
                     std::string error_msg{strprintf("Rescan failed for descriptor with timestamp %d. There "
                             "was an error reading a block from time %d, which is after or within %d seconds "
                             "of key creation, and could contain transactions pertaining to the desc. As a "
                             "result, transactions and coins using this desc may not appear in the wallet.",
-                            GetImportTimestamp(request, now), scanned_time - TIMESTAMP_WINDOW - 1, TIMESTAMP_WINDOW)};
+                            timestamp, scanned_time - TIMESTAMP_WINDOW - 1, TIMESTAMP_WINDOW)};
                     if (pwallet->chain().havePruned()) {
                         error_msg += strprintf(" This error could be caused by pruning or data corruption "
                                 "(see bitcoind log for details) and could be dealt with by downloading and "

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -90,6 +90,48 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                              error_code=-8,
                              error_message='Descriptor not found.')
 
+        self.log.info("Import should return per-item timestamp errors")
+        valid_key = get_generate_key()
+        missing_timestamp_key = get_generate_key()
+        invalid_timestamp_key = get_generate_key()
+        later_valid_key = get_generate_key()
+        result = w1.importdescriptors([
+            {"desc": descsum_create(f"pkh({valid_key.pubkey})"), "timestamp": "now", "label": "valid 1"},
+            {"desc": descsum_create(f"pkh({missing_timestamp_key.pubkey})")},
+            {"desc": descsum_create(f"pkh({invalid_timestamp_key.pubkey})"), "timestamp": []},
+            {"desc": descsum_create(f"pkh({later_valid_key.pubkey})"), "timestamp": "now", "label": "valid 2"},
+        ])
+        assert_equal(len(result), 4)
+        assert_equal(result[0]["success"], True)
+        assert_equal(result[1]["success"], False)
+        assert_equal(result[1]["error"]["code"], -3)
+        assert_equal(result[1]["error"]["message"], "Missing required timestamp field for key")
+        assert_equal(result[2]["success"], False)
+        assert_equal(result[2]["error"]["code"], -3)
+        assert_equal(result[2]["error"]["message"], "Expected number or \"now\" timestamp value for key. got type array")
+        assert_equal(result[3]["success"], True)
+        test_address(w1, valid_key.p2pkh_addr, solvable=True, ismine=True, labels=["valid 1"])
+        test_address(w1, missing_timestamp_key.p2pkh_addr, ismine=False)
+        test_address(w1, invalid_timestamp_key.p2pkh_addr, ismine=False)
+        test_address(w1, later_valid_key.p2pkh_addr, solvable=True, ismine=True, labels=["valid 2"])
+
+        self.log.info("Import should return timestamp errors when every request is invalid")
+        missing_only_key = get_generate_key()
+        invalid_only_key = get_generate_key()
+        result = w1.importdescriptors([
+            {"desc": descsum_create(f"pkh({missing_only_key.pubkey})")},
+            {"desc": descsum_create(f"pkh({invalid_only_key.pubkey})"), "timestamp": {}},
+        ])
+        assert_equal(len(result), 2)
+        assert_equal(result[0]["success"], False)
+        assert_equal(result[0]["error"]["code"], -3)
+        assert_equal(result[0]["error"]["message"], "Missing required timestamp field for key")
+        assert_equal(result[1]["success"], False)
+        assert_equal(result[1]["error"]["code"], -3)
+        assert_equal(result[1]["error"]["message"], "Expected number or \"now\" timestamp value for key. got type object")
+        test_address(w1, missing_only_key.p2pkh_addr, ismine=False)
+        test_address(w1, invalid_only_key.p2pkh_addr, ismine=False)
+
         # # Test importing of a P2PKH descriptor
         key = get_generate_key()
         self.log.info("Should import a p2pkh descriptor")


### PR DESCRIPTION
Fixes #35181.

Missing or invalid `timestamp` values in `importdescriptors` now return an error in the matching result entry instead of aborting the whole RPC. Valid entries in the same batch can still be imported.

Tests:
- `ninja -C build bitcoind bitcoin-cli test_bitcoin`
- `test/functional/wallet_importdescriptors.py --configfile=$PWD/build/test/config.ini`
- `build/bin/test_bitcoin -t wallet_rpc_tests`
- `python3 -m py_compile test/functional/wallet_importdescriptors.py`
- `git diff --check`
