### PR TITLE
doc: clarify libfuzzer-nosan preset uses build_fuzz_nosan dir

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -14,6 +14,8 @@ $ FUZZ=process_message build_fuzz/bin/fuzz
 ```
 
 One can use `--preset=libfuzzer-nosan` to do the same without common sanitizers enabled.
+Note that this preset uses a different build directory, so replace `build_fuzz` with
+`build_fuzz_nosan` in the build and run commands above.
 See [further](#run-without-sanitizers-for-increased-throughput) for more information.
 
 There is also a runner script to execute all fuzz targets. Refer to


### PR DESCRIPTION
Adds a clarifying note next to the first mention of the `libfuzzer-nosan` preset in the Quickstart, pointing out that it uses a different build directory (`build_fuzz_nosan`, per [`CMakePresets.json` L54](https://github.com/bitcoin/bitcoin/blob/master/CMakePresets.json#L54)).

A reader following the quickstart with `--preset=libfuzzer-nosan` and then running `cmake --build build_fuzz` as shown would otherwise operate against the wrong (or empty) directory.

Pure docs; no code changes.