### PR TITLE
ci: Enable ruff ambiguous-unicode-character checks

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -34,6 +34,9 @@ select = [
     "F823", # local variable name referenced before assignment
     "F841", # local variable 'foo' is assigned to but never used
     "PLE",  # Pylint errors
+    "RUF001", # ambiguous-unicode-character-string
+    "RUF002", # ambiguous-unicode-character-docstring
+    "RUF003", # ambiguous-unicode-character-comment
     "W191", # indentation contains tabs
     "W291", # trailing whitespace
     "W292", # no newline at end of file

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,44 +2,17 @@
 select = [
     "B006", # mutable-argument-default
     "B008", # function-call-in-default-argument
-    "E101", # indentation contains mixed spaces and tabs
-    "E401", # multiple imports on one line
-    "E402", # module level import not at top of file
-    "E701", # multiple statements on one line (colon)
-    "E702", # multiple statements on one line (semicolon)
-    "E703", # statement ends with a semicolon
-    "E711", # comparison to None should be 'if cond is None:'
-    "E713", # test for membership should be "not in"
-    "E714", # test for object identity should be "is not"
-    "E721", # do not compare types, use "isinstance()"
-    "E722", # do not use bare 'except'
-    "E742", # do not define classes named "l", "O", or "I"
-    "E743", # do not define functions named "l", "O", or "I"
-    "F401", # module imported but unused
-    "F402", # import module from line N shadowed by loop variable
-    "F403", # 'from foo_module import *' used; unable to detect undefined names
-    "F404", # future import(s) name after other statements
-    "F405", # foo_function may be undefined, or defined from star imports: bar_module
-    "F406", # "from module import *" only allowed at module level
-    "F407", # an undefined __future__ feature name was imported
-    "F541", # f-string without any placeholders
-    "F601", # dictionary key name repeated with different values
-    "F602", # dictionary key variable name repeated with different values
-    "F621", # too many expressions in an assignment with star-unpacking
-    "F631", # assertion test is a tuple, which are always True
-    "F632", # use ==/!= to compare str, bytes, and int literals
-    "F811", # redefinition of unused name from line N
-    "F821", # undefined name 'Foo'
-    "F822", # undefined name name in __all__
-    "F823", # local variable name referenced before assignment
-    "F841", # local variable 'foo' is assigned to but never used
+    "E", # pycodestyle errors
+    "F", # pyflakes errors
     "PLE",  # Pylint errors
     "RUF001", # ambiguous-unicode-character-string
     "RUF002", # ambiguous-unicode-character-docstring
     "RUF003", # ambiguous-unicode-character-comment
-    "W191", # indentation contains tabs
-    "W291", # trailing whitespace
-    "W292", # no newline at end of file
-    "W293", # blank line contains whitespace
-    "W605", # invalid escape sequence "x"
+    "W", # pycodestyle warnings
+]
+ignore = [
+    "E501", # line too long
+    "E712", # true-false comparison
+    "E731", # lambda assignment
+    "E741", # ambiguous-variable-name
 ]


### PR DESCRIPTION


Ambiguous unicode chars are unused and confusing. Worst, they can lead to bugs.

So enable the ruff checks to catch them. Can be tested via:

```
echo 'ZGlmZiAtLWdpdCBhL3Rlc3QvZnVuY3Rpb25hbC93YWxsZXRfZGlzYWJsZS5weSBiL3Rlc3QvZnVu
Y3Rpb25hbC93YWxsZXRfZGlzYWJsZS5weQppbmRleCBkYmNjY2Q0Li4wYjhjNDQ2IDEwMDc1NQot
LS0gYS90ZXN0L2Z1bmN0aW9uYWwvd2FsbGV0X2Rpc2FibGUucHkKKysrIGIvdGVzdC9mdW5jdGlv
bmFsL3dhbGxldF9kaXNhYmxlLnB5CkBAIC0yMSwzICsyMSw4IEBAIGNsYXNzIERpc2FibGVXYWxs
ZXRUZXN0IChCaXRjb2luVGVzdEZyYW1ld29yayk6CiAgICAgZGVmIHJ1bl90ZXN0IChzZWxmKToK
KyAgICAgICAgIiIiQSBsb3ZlbHkgZG9jc3RyaW5nICh3aXRoIGEgYFUrRkYwOWAgcGFyZW50aGVz
aXPvvIkuIiIiCiAgICAgICAgICMgTWFrZSBzdXJlIHdhbGxldCBpcyByZWFsbHkgZGlzYWJsZWQK
KyAgICAgICAgIyBu0L5xYSAgIzwtIGlzIEN5cmlsbGljIChgVSswNDNFYCkKKyAgICAgICAgcHJp
bnQoIs6XZWxsbywgd29ybGQhIikgICMgPC0gaXMgdGhlIEdyZWVrIGV0YSAoYFUrMDM5N2ApLgor
ICAgICAgICBleGFtcGxlID0gInjigI8iICogMTAwICAjICAgICLigI94IiBpcyBhc3NpZ25lZAor
ICAgICAgICBleGFtcGxlPU5vbmUjbm9xYQogICAgICAgICBhc3NlcnRfcmFpc2VzX3JwY19lcnJv
cigtMzI2MDEsICdNZXRob2Qgbm90IGZvdW5kJywgc2VsZi5ub2Rlc1swXS5nZXR3YWxsZXRpbmZv
KQo=' | base64 --decode | git apply

git diff

ruff check ./test/functional/*.py
```

It should print 4 error types.