### PR TITLE
psbt, test: remove address type restrictions in test

### DIFF
--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -67,7 +67,7 @@ class PSBTTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.extra_args = [
-            ["-walletrbf=1", "-addresstype=bech32", "-changetype=bech32"], #TODO: Remove address type restrictions once taproot has psbt extensions
+            ["-walletrbf=1"],
             ["-walletrbf=0", "-changetype=legacy"],
             []
         ]


### PR DESCRIPTION
Because the corresponding Taproot fields were added in PSBT in #22558, 
so these restrictions are no longer necessary.