### PR TITLE
doc: mention -DWITH_ZMQ=ON in BSD build guides

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -64,7 +64,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 #### Notifications
 ###### ZeroMQ
 
-Bitcoin Core can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
+Bitcoin Core can provide notifications via ZeroMQ. To compile ZMQ support, install the following dependency and pass `-DWITH_ZMQ=ON` when configuring.
 ```bash
 pkg install libzmq4
 ```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -82,7 +82,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 #### Notifications
 ###### ZeroMQ
 
-Bitcoin Core can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
+Bitcoin Core can provide notifications via ZeroMQ. To compile ZMQ support, install the following dependency and pass `-DWITH_ZMQ=ON` when configuring.
 ```bash
 pkgin install zeromq
 ```

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -64,7 +64,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 #### Notifications
 ###### ZeroMQ
 
-Bitcoin Core can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
+Bitcoin Core can provide notifications via ZeroMQ. To compile ZMQ support, install the following dependency and pass `-DWITH_ZMQ=ON` when configuring.
 ```bash
 pkg_add zeromq
 ```


### PR DESCRIPTION
The BSD build guides currently state:

> If the package is installed, support will be compiled in.

Since `WITH_ZMQ` defaults to `OFF`, this is inaccurate: installing the dependency alone does not enable ZMQ support. Update the wording to mention the required `-DWITH_ZMQ=ON` CMake option, matching `doc/zmq.md`.

Docs-only change; no tests run.