### PR TITLE
ci: Bump toward Ubuntu 26.04

### DIFF
--- a/ci/test/00_setup_env_freebsd_cross.sh
+++ b/ci/test/00_setup_env_freebsd_cross.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_freebsd_cross
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export APT_LLVM_V="22"
 export FREEBSD_VERSION=15.0
 export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} lld"

--- a/ci/test/00_setup_env_i686_no_ipc.sh
+++ b/ci/test/00_setup_env_i686_no_ipc.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export HOST=i686-pc-linux-gnu
 export CONTAINER_NAME=ci_i686_no_multiprocess
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export CI_IMAGE_PLATFORM="linux/amd64"
 export CI_CONTAINER_CAP="--security-opt seccomp=unconfined"
 export PACKAGES="llvm clang g++-multilib"

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export CONTAINER_NAME=ci_native_fuzz
 export APT_LLVM_V="22"
 export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} libclang-rt-${APT_LLVM_V}-dev libevent-dev libboost-dev libsqlite3-dev libcapnp-dev capnproto"

--- a/ci/test/00_setup_env_native_fuzz_with_msan.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_msan.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export APT_LLVM_V="22"
 LIBCXX_DIR="/cxx_build/"
 export MSAN_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -g -O1 -fno-optimize-sibling-calls"

--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export CONTAINER_NAME=ci_native_fuzz_valgrind
 export PACKAGES="clang llvm libclang-rt-dev libevent-dev libboost-dev libsqlite3-dev valgrind libcapnp-dev capnproto"
 export NO_DEPENDS=1

--- a/ci/test/00_setup_env_native_iwyu.sh
+++ b/ci/test/00_setup_env_native_iwyu.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"  # To build codegen, CMake must be 3.31 or newer.
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"  # To build codegen, CMake must be 3.31 or newer.
 export CONTAINER_NAME=ci_native_iwyu
 export IWYU_LLVM_V="22"
 export APT_LLVM_V="${IWYU_LLVM_V}"

--- a/ci/test/00_setup_env_native_msan.sh
+++ b/ci/test/00_setup_env_native_msan.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export APT_LLVM_V="22"
 LIBCXX_DIR="/cxx_build/"
 export MSAN_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -g -O1 -fno-optimize-sibling-calls"

--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export CONTAINER_NAME=ci_native_tidy
 export TIDY_LLVM_V="22"
 export APT_LLVM_V="${TIDY_LLVM_V}"

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export CONTAINER_NAME=ci_native_valgrind
 export PACKAGES="clang llvm libclang-rt-dev valgrind python3-zmq libevent-dev libboost-dev libzmq3-dev libsqlite3-dev libcapnp-dev capnproto python3-pip"
 export PIP_PACKAGES="--break-system-packages pycapnp"

--- a/ci/test/00_setup_env_s390x.sh
+++ b/ci/test/00_setup_env_s390x.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export HOST=s390x-linux-gnu
 export PACKAGES="python3-zmq"
 export CONTAINER_NAME=ci_s390x
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export CI_IMAGE_PLATFORM="linux/s390x"
 # bind tests excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export TEST_RUNNER_EXTRA="--exclude rpc_bind --exclude feature_bind_extra"

--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -18,7 +18,6 @@
 #include <util/vector.h>
 
 #include <algorithm>
-#include <compare>
 #include <concepts>
 #include <cstdint>
 #include <cstdlib>

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -10,7 +10,6 @@
 #include <util/check.h>
 #include <util/overflow.h>
 
-#include <compare>
 #include <limits>
 #include <optional>
 #include <sstream>

--- a/test/sanitizer_suppressions/valgrind.supp
+++ b/test/sanitizer_suppressions/valgrind.supp
@@ -12,7 +12,7 @@
 #       --error-limit=no build/bin/test_bitcoin
 #
 # Note that suppressions may depend on OS and/or library versions.
-# Tested on Debian Trixie system libs,
+# Tested on Ubuntu 26.04 system libs,
 # * using clang (only x86_64, see https://bugs.kde.org/show_bug.cgi?id=485276),
 # * and GCC (only -O1, see https://bugs.kde.org/show_bug.cgi?id=472329),
 # without gui (because it only passes with a DEBUG=1 depends build).


### PR DESCRIPTION
This is for the upcoming 32.x, because I presume users and devs are more likely using a later distro. This comes with tool bumps, such as:

* GCC 14 -> 15 (https://packages.debian.org/trixie/g++ -> https://packages.ubuntu.com/resolute/g++)
* Clang 19 -> 21
* Cmake 3.31 -> 4.2
* Valgrind 3.24 -> 3.26