### PR TITLE
fuzz: Fix timeout in `txorphan`

### DIFF
--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -197,9 +197,13 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                 [&] {
                     // Make a block out of txs and then EraseForBlock
                     CBlock block;
+                    int64_t block_weight{0};
                     int num_txs = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 1000);
                     for (int i{0}; i < num_txs; ++i) {
                         auto& tx_to_remove = PickValue(fuzzed_data_provider, tx_history);
+                        const auto tx_weight = GetTransactionWeight(*tx_to_remove);
+                        if (block_weight + tx_weight > MAX_BLOCK_WEIGHT) break;
+                        block_weight += tx_weight;
                         block.vtx.push_back(tx_to_remove);
                     }
                     orphanage->EraseForBlock(block);


### PR DESCRIPTION
The `EraseForBlock` branch in the `txorphan` harness could produce a block with 1000 transactions in it, each with potentially up to 200,000 inputs, resulting in way too many [map lookups](https://github.com/bitcoin/bitcoin/blob/3cab711d69572431af78b0071fb721496f0241d7/src/node/txorphanage.cpp#L625). This was producing inputs that were taking 2 seconds or longer per iteration, which is too long.

Fix by only adding transactions to the block up to the block weight limit. This matches production behavior, as `EraseForBlock` is only called on a newly [connected block](https://github.com/bitcoin/bitcoin/blob/3cab711d69572431af78b0071fb721496f0241d7/src/net_processing.cpp#L2090).