### PR TITLE
wallet: Update tx chain state during loading during AttachChain instead of before

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -77,6 +77,7 @@
 #include <condition_variable>
 #include <exception>
 #include <optional>
+#include <ranges>
 #include <stdexcept>
 #include <thread>
 #include <tuple>
@@ -1172,11 +1173,6 @@ bool CWallet::LoadToWallet(CWalletTx&& wtx_in)
     CWalletTx& wtx = ins.first->second;
     if (!ins.second) {
         return false;
-    }
-    // If wallet doesn't have a chain (e.g when using bitcoin-wallet tool),
-    // don't bother to update txn.
-    if (HaveChain()) {
-      wtx.updateState(chain());
     }
     wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
     AddToSpends(wtx);
@@ -3243,6 +3239,18 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
     } else {
         walletInstance->SetLastBlockProcessedInMem(-1, uint256());
     }
+
+    // Update the state of every transaction now that we are connected to the chain
+    // Do this in reverse order to ensure that any abandoning will work recursively
+    for (auto& [_, wtx] : std::ranges::reverse_view(walletInstance->wtxOrdered)) {
+        wtx->updateState(chain);
+        // After updating the state of the tx, abandon if it is a coinbase that is no longer in the active chain.
+        // This could happen during an external wallet load, or if the user replaced the chain data.
+        if (wtx->IsCoinBase() && wtx->isInactive()) {
+            walletInstance->AbandonTransaction(*wtx);
+        }
+    }
+
 
     if (tip_height && *tip_height != rescan_height)
     {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1084,14 +1084,6 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
     });
     result = std::max(result, order_pos_res.m_result);
 
-    // After loading all tx records, abandon any coinbase that is no longer in the active chain.
-    // This could happen during an external wallet load, or if the user replaced the chain data.
-    for (auto& [id, wtx] : pwallet->mapWallet) {
-        if (wtx.IsCoinBase() && wtx.isInactive()) {
-            pwallet->AbandonTransaction(wtx);
-        }
-    }
-
     return result;
 }
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -136,6 +136,7 @@ BASE_SCRIPTS = [
     'p2p_dns_seeds.py',
     'wallet_groups.py',
     'p2p_blockfilters.py',
+    'wallet_chain_reprocess.py',
     'feature_assumevalid.py',
     'wallet_taproot.py',
     'feature_bip68_sequence.py',

--- a/test/functional/wallet_chain_reprocess.py
+++ b/test/functional/wallet_chain_reprocess.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    assert_greater_than,
+)
+
+class WalletChainReprocess(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def test_process_all_blocks_after_unclean(self):
+        self.log.info("Testing that all blocks are reprocessed by the wallet after an unclean shutdown")
+        self.nodes[0].createwallet("target")
+        wallet = self.nodes[0].get_wallet_rpc("target")
+
+        # Mine 1 block to the wallet, 100 to somewhere else and flush the chainstate with a restart
+        self.generatetoaddress(self.nodes[0], 1, wallet.getnewaddress(), sync_fun=self.no_op)
+        self.generate(self.nodes[0], 101, sync_fun=self.no_op)
+        self.restart_node(0)
+        self.connect_nodes(0, 1)
+        self.nodes[0].loadwallet("target")
+        wallet = self.nodes[0].get_wallet_rpc("target")
+
+        # In order to ensure that wallet transaction states match the chain, we want to mine
+        # enough blocks such that the chainstate will still be moving forward while the
+        # wallet is loading. 100 blocks should be sufficient.
+        # A transaction is included in each block that is a child of a transaction in the
+        # previous block so that every block has a wallet transaction.
+        txids = []
+        for _ in range(0, 100):
+            res = wallet.sendall([wallet.getnewaddress()])
+            assert_equal(res["complete"], True)
+            txids.append(res["txid"])
+            self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+
+        # Sync nodes, kill node 0, and restart
+        self.sync_all()
+        tip_height = self.nodes[0].getblockchaininfo()["blocks"]
+        wallet_height = wallet.getwalletinfo()["lastprocessedblock"]["height"]
+        assert_equal(tip_height, wallet_height)
+        wallet.unloadwallet()
+        self.nodes[0].kill_process()
+        self.start_node(0)
+        restart_tip_height = self.nodes[0].getblockchaininfo()["blocks"]
+        assert_greater_than(tip_height, restart_tip_height)
+        assert_greater_than(wallet_height, restart_tip_height)
+
+        self.nodes[0].loadwallet("target")
+        wallet = self.nodes[0].get_wallet_rpc("target")
+        assert_greater_than(wallet_height, wallet.getwalletinfo()["lastprocessedblock"]["height"])
+
+        # Wait for node0 to be synced
+        self.connect_nodes(0, 1)
+        self.sync_all()
+        assert_equal(wallet.getwalletinfo()["lastprocessedblock"]["height"], self.nodes[0].getblockcount())
+
+        # Check every transaction is confirmed
+        for txid in txids:
+            tx = wallet.gettransaction(txid)
+            assert_greater_than(tx["confirmations"], 0)
+
+            # None of these transactions can be abandoned either
+            assert_raises_rpc_error(-5, "Transaction not eligible for abandonment", wallet.abandontransaction, txid)
+
+
+    def run_test(self):
+        self.test_process_all_blocks_after_unclean()
+
+if __name__ == '__main__':
+    WalletChainReprocess(__file__).main()


### PR DESCRIPTION
When loading a wallet, updating the state based on the chain data prior to `AttachChain` results in some blocks being missed, which leads to inconsistent state information that can cause assertion failures. Moving the state updating inside of `AttachChain` after the chain notifications handler has been attached ensures that the state will always be up to date with the tip that the wallet is tracking.

Fixes #34599