### PR TITLE
validation: fetch block input prevouts in parallel during ConnectBlock

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -49,6 +49,7 @@ threads take up 8MiB for the thread stack on a 64-bit system, and 4MiB in a
 
 - `-par=<n>` - the number of script verification threads, defaults to the number of cores in the system minus one.
 - `-rpcthreads=<n>` - the number of threads used for processing RPC requests, defaults to `16`.
+- `-prevoutfetchthreads=<n>` - the number of threads used to fetch block input prevouts, defaults to `8`.
 
 ## Linux specific
 

--- a/doc/release-notes-35295.md
+++ b/doc/release-notes-35295.md
@@ -1,0 +1,8 @@
+Performance Improvements
+------------------------
+
+- Block validation can now prefetch input prevouts from the chainstate database
+  in parallel while connecting blocks, speeding up validation when prevouts need
+  to be read from disk. A new `-prevoutfetchthreads=<n>` option controls the
+  number of prefetch worker threads. The default is 8 threads, up to a maximum
+  of 16; set it to 0 to disable parallel prefetching. (#35295)

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -368,6 +368,7 @@ void CCoinsViewCache::SanityCheck() const
 
 CCoinsViewCache::ResetGuard CoinsViewOverlay::StartFetching(const CBlock& block LIFETIMEBOUND) noexcept
 {
+    Assert(m_futures.empty());
     Assert(m_inputs.empty());
     Assert(m_input_head.load(std::memory_order_relaxed) == 0);
     Assert(m_input_tail == 0);
@@ -383,9 +384,21 @@ CCoinsViewCache::ResetGuard CoinsViewOverlay::StartFetching(const CBlock& block 
             }
             earlier_txids.emplace(tx->GetHash());
         }
-        // Only process inputs if we have something to fetch.
+        // Only submit tasks if we have something to fetch.
         if (m_inputs.size()) {
-            while (ProcessInput()) {}
+            std::vector<std::function<void()>> tasks(workers_count, [this] {
+                while (ProcessInput()) {}
+            });
+            if (auto futures{m_thread_pool->Submit(std::move(tasks))}) {
+                m_futures = std::move(*futures);
+            } else {
+                // Submit can fail if a shared owner of the thread pool outside of this class calls Stop() or
+                // Interrupt() on a different thread after we call WorkersCount() above. In that case parallel
+                // fetching will not make progress, so we clear the inputs to fall back to single threaded fetching.
+                LogWarning("Failed to submit prevout fetch tasks; falling back to single-threaded fetching for this block.");
+                m_inputs.clear();
+                StopFetching(); // Assert nothing changed if we failed to start tasks.
+            }
         }
     }
     return CreateResetGuard();

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -5,10 +5,15 @@
 #include <coins.h>
 
 #include <consensus/consensus.h>
+#include <primitives/block.h>
 #include <random.h>
 #include <uint256.h>
 #include <util/log.h>
+#include <util/threadpool.h>
 #include <util/trace.h>
+
+#include <ranges>
+#include <unordered_set>
 
 TRACEPOINT_SEMAPHORE(utxocache, add);
 TRACEPOINT_SEMAPHORE(utxocache, spent);
@@ -359,6 +364,31 @@ void CCoinsViewCache::SanityCheck() const
     }
     assert(count_dirty == count_linked && count_dirty == m_dirty_count);
     assert(recomputed_usage == cachedCoinsUsage);
+}
+
+CCoinsViewCache::ResetGuard CoinsViewOverlay::StartFetching(const CBlock& block LIFETIMEBOUND) noexcept
+{
+    Assert(m_inputs.empty());
+    Assert(m_input_head.load(std::memory_order_relaxed) == 0);
+    Assert(m_input_tail == 0);
+    if (const auto workers_count{m_thread_pool->WorkersCount()}; workers_count > 0) {
+        // Loop through the block inputs and set their prevouts in the queue.
+        // Filter inputs that spend outputs created earlier in the same block. These outputs will be created
+        // directly in the cache from the tx that creates them, so they will not be requested from a base view.
+        std::unordered_set<Txid, SaltedTxidHasher> earlier_txids;
+        earlier_txids.reserve(block.vtx.size());
+        for (const auto& tx : block.vtx | std::views::drop(1)) {
+            for (const auto& input : tx->vin) {
+                if (!earlier_txids.contains(input.prevout.hash)) m_inputs.emplace_back(input.prevout);
+            }
+            earlier_txids.emplace(tx->GetHash());
+        }
+        // Only process inputs if we have something to fetch.
+        if (m_inputs.size()) {
+            while (ProcessInput()) {}
+        }
+    }
+    return CreateResetGuard();
 }
 
 static const uint64_t MIN_TRANSACTION_OUTPUT_WEIGHT{WITNESS_SCALE_FACTOR * ::GetSerializeSize(CTxOut())};

--- a/src/coins.h
+++ b/src/coins.h
@@ -580,6 +580,8 @@ private:
 
     //! The inputs of the block which is being fetched.
     struct InputToFetch {
+        //! Workers set this after setting the coin. The main thread tests this before reading the coin.
+        std::atomic_flag ready{};
         //! The outpoint of the input to fetch.
         const COutPoint& outpoint;
         //! The coin that workers will fetch and main thread will insert into cache.
@@ -587,6 +589,14 @@ private:
         mutable std::optional<Coin> coin{std::nullopt};
 
         explicit InputToFetch(const COutPoint& o LIFETIMEBOUND) noexcept : outpoint{o} {}
+
+        //! Move ctor is required for resizing m_inputs in StartFetching. Elements will never move once parallel tasks
+        //! are started, so we can assert that coin is nullopt and ready is false.
+        InputToFetch(InputToFetch&& other) noexcept : outpoint{other.outpoint}
+        {
+            Assert(!other.coin);
+            Assert(!other.ready.test(std::memory_order_relaxed));
+        }
     };
     std::vector<InputToFetch> m_inputs{};
 
@@ -603,6 +613,9 @@ private:
 
         auto& input{m_inputs[i]};
         input.coin = base->PeekCoin(input.outpoint);
+        // Use release so writing coin above happens before the main thread acquires.
+        Assert(!input.ready.test_and_set(std::memory_order_release));
+        input.ready.notify_one();
         return true;
     }
 
@@ -621,6 +634,8 @@ private:
         if (m_input_tail < m_inputs.size() && m_inputs[m_input_tail].outpoint == outpoint) {
             // We advance the tail since the input is cached and not accessed through this method again.
             auto& input{m_inputs[m_input_tail++]};
+            // Wait until the coin is ready to be read. We need acquire so we match the worker thread's release.
+            input.ready.wait(/*old=*/false, std::memory_order_acquire);
             // We can move the coin since we won't access this input again.
             return std::move(input.coin);
         }

--- a/src/coins.h
+++ b/src/coins.h
@@ -564,13 +564,62 @@ private:
 };
 
 /**
- * CCoinsViewCache overlay that avoids populating/mutating parent cache layers on cache misses.
+ * CCoinsViewCache subclass that asynchronously fetches most block input prevouts in parallel during ConnectBlock without
+ * mutating the base cache.
  *
- * This is achieved by fetching coins from the base view using PeekCoin() instead of GetCoin(),
- * so intermediate CCoinsViewCache layers are not filled.
+ * Only used in ConnectBlock to pass as an ephemeral view that can be reset if the block is invalid.
+ * It provides the same interface as CCoinsViewCache.
+ * It adds an additional StartFetching method to provide the block.
  *
- * Used during ConnectBlock() as an ephemeral, resettable top-level view that is flushed only
- * on success, so invalid blocks don't pollute the underlying cache.
+ * When a block is passed to StartFetching, the inputs of the block are flattened into a vector of InputToFetch
+ * objects. StartFetching then submits worker tasks to a ThreadPool and keeps the returned futures alive until fetching
+ * is stopped.
+ *
+ * ProcessInput() atomically fetches and increments m_input_head, so each thread can only access a single element of the
+ * m_inputs vector at a time. Workers race to claim inputs, so they may fetch elements in any order. If the fetched
+ * index is greater than or equal to the size of m_inputs, no more inputs can be fetched and false is returned.
+ *
+ * The worker claims the InputToFetch at this index, fetches the coin from the base cache and moves it into the
+ * InputToFetch object. The ready flag is then set with a release memory order. This allows the ready flag to be
+ * used as a memory fence, guaranteeing the coin being written to the object will have happened before another
+ * thread tests the flag with an acquire memory order.
+ * This assumes all base->PeekCoin() paths are safe for concurrent readers and do not mutate lower cache layers.
+ *
+ * When a coin is requested from the cache on the main thread and is not already in cacheCoins map, FetchCoinFromBase
+ * checks whether the next unconsumed entry in m_inputs has the requested outpoint. On a match, m_input_tail is advanced
+ * and the entry's ready flag is waited on with an acquire memory order until a worker has finished fetching it. The
+ * coin is then moved out and returned. Since the main thread is the only consumer of validation results, it blocks
+ * on the specific input it needs rather than racing workers for other inputs.
+ *
+ * StopFetching() is called in Flush() and in Reset() (the per-block teardown) so workers stop before the block they
+ * reference goes away. It stops fetching by moving m_input_head to the end of m_inputs (so workers quickly exit),
+ * then waits for all futures to complete and clears the per-block state (m_inputs and the head/tail counters).
+ *
+ *       Workers advance m_input_head to fetch inputs. Main thread advances m_input_tail to consume.
+ *
+ *       Before workers start:
+ *
+ *                 m_input_head
+ *                 m_input_tail
+ *                      │
+ *                      ▼
+ *                 ┌─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
+ *       m_inputs: │ waiting │ waiting │ waiting │ waiting │ waiting │ waiting │ waiting │ waiting │ waiting │
+ *                 │         │         │         │         │         │         │         │         │         │
+ *                 └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+ *
+ *       After workers start:
+ *
+ *                                       Worker 2            Worker 0  Worker 3  Worker 1  m_input_head
+ *                                          │                   │         │         │         │
+ *                                          ▼                   ▼         ▼         ▼         ▼
+ *                 ┌─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
+ *       m_inputs: │  ready  │  ready  │fetching │  ready  │fetching │fetching │fetching │ waiting │ waiting │
+ *                 │consumed │    ✓    │    ●    │    ✓    │    ●    │    ●    │    ●    │         │         │
+ *                 └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+ *                                ▲
+ *                                │
+ *                           m_input_tail
  */
 class CoinsViewOverlay : public CCoinsViewCache
 {

--- a/src/coins.h
+++ b/src/coins.h
@@ -22,7 +22,10 @@
 #include <cstdint>
 
 #include <functional>
+#include <memory>
 #include <unordered_map>
+
+class ThreadPool;
 
 /**
  * A UTXO entry.
@@ -569,8 +572,16 @@ private:
         return base->PeekCoin(outpoint);
     }
 
+    //! Non-null.
+    std::shared_ptr<ThreadPool> m_thread_pool;
+
 public:
-    using CCoinsViewCache::CCoinsViewCache;
+    explicit CoinsViewOverlay(CCoinsView* in_base, std::shared_ptr<ThreadPool> thread_pool,
+                              bool deterministic = false) noexcept
+        : CCoinsViewCache{in_base, deterministic}, m_thread_pool{std::move(thread_pool)}
+    {
+        Assert(m_thread_pool);
+    }
 };
 
 //! Utility function to add all of a transaction's outputs to a cache.

--- a/src/coins.h
+++ b/src/coins.h
@@ -11,6 +11,7 @@
 #include <core_memusage.h>
 #include <memusage.h>
 #include <primitives/transaction.h>
+#include <primitives/transaction_identifier.h>
 #include <serialize.h>
 #include <support/allocators/pool.h>
 #include <uint256.h>
@@ -21,10 +22,15 @@
 #include <cassert>
 #include <cstdint>
 
+#include <atomic>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
+class CBlock;
 class ThreadPool;
 
 /**
@@ -418,7 +424,7 @@ protected:
      * Discard all modifications made to this cache without flushing to the base view.
      * This can be used to efficiently reuse a cache instance across multiple operations.
      */
-    void Reset() noexcept;
+    virtual void Reset() noexcept;
 
     /* Fetch the coin from base. Used for cache misses in FetchCoin. */
     virtual std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const;
@@ -567,13 +573,71 @@ private:
 class CoinsViewOverlay : public CCoinsViewCache
 {
 private:
+    //! The latest input not yet being fetched. Workers atomically increment this when fetching.
+    std::atomic_uint32_t m_input_head{0};
+    //! The latest input not yet accessed by a consumer. Only the main thread increments this.
+    mutable uint32_t m_input_tail{0};
+
+    //! The inputs of the block which is being fetched.
+    struct InputToFetch {
+        //! The outpoint of the input to fetch.
+        const COutPoint& outpoint;
+        //! The coin that workers will fetch and main thread will insert into cache.
+        //! Mutable so it can be moved in FetchCoinFromBase.
+        mutable std::optional<Coin> coin{std::nullopt};
+
+        explicit InputToFetch(const COutPoint& o LIFETIMEBOUND) noexcept : outpoint{o} {}
+    };
+    std::vector<InputToFetch> m_inputs{};
+
+    /**
+     * Claim and fetch the next input in the queue.
+     *
+     * @return true if an input prevout was fetched
+     * @return false if there are no more input prevouts in the queue to fetch
+     */
+    bool ProcessInput() noexcept
+    {
+        const auto i{m_input_head.fetch_add(1, std::memory_order_relaxed)};
+        if (i >= m_inputs.size()) return false;
+
+        auto& input{m_inputs[i]};
+        input.coin = base->PeekCoin(input.outpoint);
+        return true;
+    }
+
+    //! Clear fetching data.
+    void StopFetching() noexcept
+    {
+        m_inputs.clear();
+        m_input_head.store(0, std::memory_order_relaxed);
+        m_input_tail = 0;
+    }
+
     std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const override
     {
+        // This assumes ConnectBlock accesses all inputs in the same order as
+        // they are added to m_inputs in StartFetching.
+        if (m_input_tail < m_inputs.size() && m_inputs[m_input_tail].outpoint == outpoint) {
+            // We advance the tail since the input is cached and not accessed through this method again.
+            auto& input{m_inputs[m_input_tail++]};
+            // We can move the coin since we won't access this input again.
+            return std::move(input.coin);
+        }
+
+        // We will only get here for BIP30 checks, an invalid block, or if the threadpool has not been started.
         return base->PeekCoin(outpoint);
     }
 
     //! Non-null.
     std::shared_ptr<ThreadPool> m_thread_pool;
+
+protected:
+    void Reset() noexcept override
+    {
+        StopFetching();
+        CCoinsViewCache::Reset();
+    }
 
 public:
     explicit CoinsViewOverlay(CCoinsView* in_base, std::shared_ptr<ThreadPool> thread_pool,
@@ -582,6 +646,9 @@ public:
     {
         Assert(m_thread_pool);
     }
+
+    //! Start fetching inputs from block.
+    [[nodiscard]] ResetGuard StartFetching(const CBlock& block LIFETIMEBOUND) noexcept;
 };
 
 //! Utility function to add all of a transaction's outputs to a cache.

--- a/src/coins.h
+++ b/src/coins.h
@@ -16,6 +16,7 @@
 #include <support/allocators/pool.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/overflow.h>
 #include <util/hasher.h>
 
@@ -24,6 +25,7 @@
 
 #include <atomic>
 #include <functional>
+#include <future>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -496,7 +498,7 @@ public:
      * If reallocate_cache is false, the cache will retain the same memory footprint
      * after flushing and should be destroyed to deallocate.
      */
-    void Flush(bool reallocate_cache = true);
+    virtual void Flush(bool reallocate_cache = true);
 
     /**
      * Push the modifications applied to this cache to its base while retaining
@@ -598,6 +600,7 @@ private:
             Assert(!other.ready.test(std::memory_order_relaxed));
         }
     };
+    //! Must only be mutated when m_futures is empty. Elements may be mutated when m_futures is not empty.
     std::vector<InputToFetch> m_inputs{};
 
     /**
@@ -619,9 +622,21 @@ private:
         return true;
     }
 
-    //! Clear fetching data.
+    //! Stop all worker threads and clear fetching data.
+    //! Calling this is idempotent, and may safely be called if not fetching.
     void StopFetching() noexcept
     {
+        if (m_futures.empty()) {
+            Assert(m_inputs.empty());
+            Assert(m_input_head.load(std::memory_order_relaxed) == 0);
+            Assert(m_input_tail == 0);
+            return;
+        }
+        // Skip fetching the rest of the inputs by moving the head to the end.
+        m_input_head.store(m_inputs.size(), std::memory_order_relaxed);
+        // Wait for all threads to stop.
+        for (auto& future : m_futures) future.wait();
+        m_futures.clear();
         m_inputs.clear();
         m_input_head.store(0, std::memory_order_relaxed);
         m_input_tail = 0;
@@ -644,8 +659,9 @@ private:
         return base->PeekCoin(outpoint);
     }
 
-    //! Non-null.
+    //! Non-null. May have zero workers when input fetching is disabled.
     std::shared_ptr<ThreadPool> m_thread_pool;
+    std::vector<std::future<void>> m_futures{};
 
 protected:
     void Reset() noexcept override
@@ -662,8 +678,22 @@ public:
         Assert(m_thread_pool);
     }
 
+    ~CoinsViewOverlay() noexcept override { StopFetching(); }
+
     //! Start fetching inputs from block.
     [[nodiscard]] ResetGuard StartFetching(const CBlock& block LIFETIMEBOUND) noexcept;
+
+    void Flush(bool reallocate_cache = true) override
+    {
+        if (!Assume(AllInputsConsumed())) {
+            LogWarning("Block %s input prevout prefetch queue was not fully consumed; inputs were accessed out of order, so prefetching degraded to serial lookups for this block.", GetBestBlock().ToString());
+        }
+        StopFetching();
+        CCoinsViewCache::Flush(reallocate_cache);
+    }
+
+    //! Verify that all parallel fetched input prevouts have been consumed.
+    bool AllInputsConsumed() const noexcept { return m_input_tail == m_inputs.size(); }
 };
 
 //! Utility function to add all of a transaction's outputs to a cache.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -538,6 +538,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet3: %s, testnet4: %s, signet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnet4ChainParams->GetConsensus().nMinimumChainWork.GetHex(), signetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (0 = auto, up to %d, <0 = leave that many cores free, default: %d)",
         MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-prevoutfetchthreads=<n>", strprintf("Set the number of threads used to prefetch block input prevouts from the chainstate database (0 disables, up to %d, default: %d). Negative values are rejected.", MAX_PREVOUTFETCH_THREADS, DEFAULT_PREVOUTFETCH_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempool", strprintf("Whether to save the mempool on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_MEMPOOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempoolv1",
                    strprintf("Whether a mempool.dat file created by -persistmempool or the savemempool RPC will be written in the legacy format "

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(bitcoinkernel
   ../uint256.cpp
   ../util/chaintype.cpp
   ../util/check.cpp
+  ../util/exception.cpp
   ../util/expected.cpp
   ../util/feefrac.cpp
   ../util/fs.cpp
@@ -70,6 +71,7 @@ add_library(bitcoinkernel
   ../util/rbf.cpp
   ../util/signalinterrupt.cpp
   ../util/syserror.cpp
+  ../util/thread.cpp
   ../util/threadnames.cpp
   ../util/time.cpp
   ../util/tokenpipe.cpp

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -22,6 +22,7 @@ class CChainParams;
 class ValidationSignals;
 
 static constexpr auto DEFAULT_MAX_TIP_AGE{24h};
+static constexpr int32_t DEFAULT_PREVOUTFETCH_THREADS{8};
 
 namespace kernel {
 
@@ -46,6 +47,8 @@ struct ChainstateManagerOpts {
     ValidationSignals* signals{nullptr};
     //! Number of script check worker threads. Zero means no parallel verification.
     int worker_threads_num{0};
+    //! Number of worker threads used for prefetching block input prevouts. Zero means no parallel fetching.
+    int32_t prevoutfetch_threads_num{DEFAULT_PREVOUTFETCH_THREADS};
     size_t script_execution_cache_bytes{DEFAULT_SCRIPT_EXECUTION_CACHE_BYTES};
     size_t signature_cache_bytes{DEFAULT_SIGNATURE_CACHE_BYTES};
 };

--- a/src/node/chainstatemanager_args.cpp
+++ b/src/node/chainstatemanager_args.cpp
@@ -60,6 +60,13 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& args, ChainstateManage
     // Subtract 1 because the main thread counts towards the par threads.
     opts.worker_threads_num = script_threads - 1;
 
+    if (auto value{args.GetArg<int32_t>("-prevoutfetchthreads")}) {
+        if (*value < 0) {
+            return util::Error{Untranslated(strprintf("-prevoutfetchthreads must be non-negative (got %d). Use 0 to disable parallel input fetching.", *value))};
+        }
+        opts.prevoutfetch_threads_num = std::min(*value, MAX_PREVOUTFETCH_THREADS);
+    }
+
     if (auto max_size = args.GetIntArg("-maxsigcachesize")) {
         // 1. When supplied with a max_size of 0, both the signature cache and
         //    script execution cache create the minimum possible cache (2

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <coins.h>
+#include <kernel/chainstatemanager_opts.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <primitives/transaction_identifier.h>
@@ -10,16 +11,23 @@
 #include <uint256.h>
 #include <util/byte_units.h>
 #include <util/hasher.h>
+#include <util/threadpool.h>
 
 #include <boost/test/unit_test.hpp>
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <ranges>
 
-BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests)
-
 namespace {
+
+std::shared_ptr<ThreadPool> MakeStartedThreadPool()
+{
+    auto pool{std::make_shared<ThreadPool>("fetch_test")};
+    pool->Start(DEFAULT_PREVOUTFETCH_THREADS);
+    return pool;
+}
 
 CBlock CreateBlock() noexcept
 {
@@ -78,13 +86,15 @@ void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
 
 } // namespace
 
+BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests)
+
 BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
 {
     const auto block{CreateBlock()};
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
 
     BOOST_CHECK(view.HaveCoin(outpoint));
@@ -111,7 +121,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     CheckCache(block, view);
 
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
@@ -131,7 +141,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
     CCoinsViewCache main_cache{&db};
     // Add all inputs as spent already in cache
     PopulateView(block, main_cache, /*spent=*/true);
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};
@@ -149,7 +159,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
     const auto block{CreateBlock()};
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -19,6 +19,8 @@
 #include <cstring>
 #include <memory>
 #include <ranges>
+#include <unordered_set>
+#include <vector>
 
 namespace {
 
@@ -37,10 +39,13 @@ CBlock CreateBlock() noexcept
     coinbase.vin.emplace_back();
     block.vtx.push_back(MakeTransactionRef(coinbase));
 
+    Txid prevhash{Txid::FromUint256(uint256{1})};
+
     for (const auto i : std::views::iota(1, NUM_TXS)) {
         CMutableTransaction tx;
-        Txid txid{Txid::FromUint256(uint256(i))};
+        const Txid txid{i % 20 == 0 ? prevhash : Txid::FromUint256(uint256(i))};
         tx.vin.emplace_back(txid, 0);
+        prevhash = tx.GetHash();
         block.vtx.push_back(MakeTransactionRef(tx));
     }
 
@@ -52,12 +57,16 @@ void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
     CCoinsViewCache cache{&view};
     cache.SetBestBlock(uint256::ONE);
 
+    std::unordered_set<Txid, SaltedTxidHasher> txids{};
+    txids.reserve(block.vtx.size() - 1);
     for (const auto& tx : block.vtx | std::views::drop(1)) {
         for (const auto& in : tx->vin) {
+            if (txids.contains(in.prevout.hash)) continue;
             Coin coin{};
             if (!spent) coin.out.nValue = 1;
             cache.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
         }
+        txids.emplace(tx->GetHash());
     }
 
     cache.Flush();
@@ -66,6 +75,8 @@ void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
 void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
 {
     uint32_t counter{0};
+    std::unordered_set<Txid, SaltedTxidHasher> txids{};
+    txids.reserve(block.vtx.size() - 1);
 
     for (const auto& tx : block.vtx) {
         if (tx->IsCoinBase()) {
@@ -76,9 +87,11 @@ void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
                 const auto& first{cache.AccessCoin(outpoint)};
                 const auto& second{cache.AccessCoin(outpoint)};
                 BOOST_CHECK_EQUAL(&first, &second);
-                ++counter;
-                BOOST_CHECK(cache.HaveCoinInCache(outpoint));
+                const auto have{cache.HaveCoinInCache(outpoint)};
+                BOOST_CHECK_NE(txids.contains(outpoint.hash), have);
+                counter += have;
             }
+            txids.emplace(tx->GetHash());
         }
     }
     BOOST_CHECK_EQUAL(cache.GetCacheSize(), counter);
@@ -95,6 +108,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
 
     BOOST_CHECK(view.HaveCoin(outpoint));
@@ -122,6 +136,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
     CheckCache(block, view);
 
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
@@ -142,6 +157,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
     // Add all inputs as spent already in cache
     PopulateView(block, main_cache, /*spent=*/true);
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};
@@ -160,6 +176,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};
@@ -171,5 +188,120 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
     BOOST_CHECK_EQUAL(view.GetCacheSize(), 0);
 }
 
+// Access coins that are not block inputs
+BOOST_AUTO_TEST_CASE(access_non_input_coins)
+{
+    CBlock block;
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back();
+    block.vtx.push_back(MakeTransactionRef(coinbase));
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    Coin coin{};
+    coin.out.nValue = 1;
+    const COutPoint outpoint{Txid::FromUint256(uint256::ZERO), 0};
+    main_cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, std::move(coin));
+
+    CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
+
+    // Non-input fallback hit.
+    BOOST_CHECK(!view.AccessCoin(outpoint).IsSpent());
+
+    // Non-input fallback miss.
+    const COutPoint missing_outpoint{Txid::FromUint256(uint256::ONE), 0};
+    BOOST_CHECK(view.AccessCoin(missing_outpoint).IsSpent());
+    BOOST_CHECK(!view.HaveCoinInCache(missing_outpoint));
+}
+
+// Access a fetched input out of order (i.e. not the next one in m_inputs).
+// FetchCoinFromBase must fall back to base->PeekCoin, and the coin must still
+// be inserted into the cache.
+BOOST_AUTO_TEST_CASE(fetch_out_of_order_input_uses_normal_lookup)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    PopulateView(block, main_cache);
+
+    std::vector<COutPoint> fetched_inputs;
+    std::unordered_set<Txid, SaltedTxidHasher> txids;
+    txids.reserve(block.vtx.size() - 1);
+    for (const auto& tx : block.vtx | std::views::drop(1)) {
+        for (const auto& input : tx->vin) {
+            if (!txids.contains(input.prevout.hash)) fetched_inputs.push_back(input.prevout);
+        }
+        txids.emplace(tx->GetHash());
+    }
+    BOOST_REQUIRE_GE(fetched_inputs.size(), 2U);
+
+    CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
+    const auto reset_guard{view.StartFetching(block)};
+
+    const auto& out_of_order_input{fetched_inputs[1]};
+    BOOST_CHECK(!view.HaveCoinInCache(out_of_order_input));
+    BOOST_CHECK(!view.AccessCoin(out_of_order_input).IsSpent());
+    BOOST_CHECK(view.HaveCoinInCache(out_of_order_input));
+
+    CheckCache(block, view);
+}
+
+// The ResetGuard returned by StartFetching must clear all per-block state when
+// it goes out of scope, so the overlay can be reused for a subsequent block.
+// Flush must also clear all per-block state to be reused.
+BOOST_AUTO_TEST_CASE(fetch_state_is_reusable_after_teardown)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    PopulateView(block, main_cache);
+    CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
+
+    for (const bool use_flush : {false, true, false}) {
+        {
+            const auto reset_guard{view.StartFetching(block)};
+            CheckCache(block, view);
+            BOOST_CHECK_GT(view.GetCacheSize(), 0U);
+            if (use_flush) {
+                view.SetBestBlock(uint256::ONE);
+                view.Flush();
+            }
+        }
+        BOOST_CHECK_EQUAL(view.GetCacheSize(), 0U);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
+BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests_noworkers)
+
+// Test that disabled input fetching falls back to normal cache lookups via base->PeekCoin.
+BOOST_AUTO_TEST_CASE(fetch_unstarted_thread_pool)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    PopulateView(block, main_cache);
+    auto thread_pool{std::make_shared<ThreadPool>("fetch_none")};
+    CoinsViewOverlay view{&main_cache, thread_pool};
+    const auto reset_guard{view.StartFetching(block)};
+    CheckCache(block, view);
+}
+
+// Test that an interrupted thread pool falls back to normal cache lookups via base->PeekCoin.
+BOOST_AUTO_TEST_CASE(fetch_interrupted_thread_pool_uses_normal_lookup)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    PopulateView(block, main_cache);
+
+    auto thread_pool{std::make_shared<ThreadPool>("fetch_intr")};
+    thread_pool->Start(DEFAULT_PREVOUTFETCH_THREADS);
+    thread_pool->Interrupt();
+    CoinsViewOverlay view{&main_cache, thread_pool};
+    const auto reset_guard{view.StartFetching(block)};
+    CheckCache(block, view);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -10,6 +10,7 @@
 #include <kernel/chainstatemanager_opts.h>
 #include <kernel/cs_main.h>
 #include <policy/policy.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -92,6 +93,46 @@ public:
 std::shared_ptr<ThreadPool> g_thread_pool{std::make_shared<ThreadPool>("view_fuzz")};
 Mutex g_thread_pool_mutex;
 
+void StartPoolIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
+{
+    LOCK(g_thread_pool_mutex);
+    if (!g_thread_pool->WorkersCount()) g_thread_pool->Start(DEFAULT_PREVOUTFETCH_THREADS);
+}
+
+//! Build a random block and seed a view with utxos for its inputs.
+CBlock BuildRandomBlock(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& view)
+{
+    CBlock block;
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back();
+    block.vtx.push_back(MakeTransactionRef(coinbase));
+
+    CCoinsViewCache seed_cache{&view, /*deterministic=*/true};
+    seed_cache.SetBestBlock(uint256::ONE);
+
+    Txid prevhash{Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider))};
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100)
+    {
+        CMutableTransaction tx;
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100)
+        {
+            const Txid txid{fuzzed_data_provider.ConsumeBool()
+                                ? Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider))
+                                : prevhash};
+            const COutPoint outpoint{txid, fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+            if (auto coin{ConsumeDeserializable<Coin>(fuzzed_data_provider)}; coin && !coin->IsSpent()) {
+                seed_cache.AddCoin(outpoint, std::move(*coin), /*possible_overwrite=*/true);
+            }
+            tx.vin.emplace_back(outpoint);
+        }
+        prevhash = tx.GetHash();
+        block.vtx.push_back(MakeTransactionRef(tx));
+    }
+
+    seed_cache.Flush();
+    return block;
+}
+
 } // namespace
 
 void initialize_coins_view()
@@ -102,6 +143,7 @@ void initialize_coins_view()
 void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& coins_view_cache, CCoinsView* backend_coins_view)
 {
     auto* const db{dynamic_cast<CCoinsViewDB*>(backend_coins_view)};
+    auto* const overlay{dynamic_cast<CoinsViewOverlay*>(&coins_view_cache)};
     const bool is_db{db != nullptr};
     bool good_data{true};
     auto* original_backend{backend_coins_view};
@@ -129,9 +171,11 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                 }
             },
             [&] {
+                if (overlay && !overlay->AllInputsConsumed()) return; // CoinsViewOverlay::Flush() must have all inputs consumed before being called
                 coins_view_cache.Flush(/*reallocate_cache=*/fuzzed_data_provider.ConsumeBool());
             },
             [&] {
+                if (overlay) return; // CoinsViewOverlay::Sync() is never called in production code
                 coins_view_cache.Sync();
             },
             [&] {
@@ -163,6 +207,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                 coins_view_cache.Uncache(random_out_point);
             },
             [&] {
+                if (overlay) return; // // CoinsViewOverlay::SetBackend() is never called in production code
                 const bool use_original_backend{fuzzed_data_provider.ConsumeBool()};
                 if (use_original_backend && backend_coins_view != original_backend) {
                     // FRESH flags valid against the empty backend may be invalid
@@ -346,11 +391,20 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
             assert(!exists_using_access_coin && !exists_using_have_coin_in_cache && !exists_using_have_coin);
         }
         // If HaveCoin on the backend is true, it must also be on the cache if the coin wasn't spent.
-        const bool exists_using_have_coin_in_backend = backend_coins_view->HaveCoin(random_out_point);
+        std::optional<Coin> coin_in_backend;
+        bool exists_using_have_coin_in_backend;
+        if (dynamic_cast<CoinsViewOverlay*>(&coins_view_cache)) {
+            // PeekCoin does not mutate cacheCoins, so async workers can keep running.
+            coin_in_backend = backend_coins_view->PeekCoin(random_out_point);
+            exists_using_have_coin_in_backend = coin_in_backend.has_value();
+        } else {
+            exists_using_have_coin_in_backend = backend_coins_view->HaveCoin(random_out_point);
+            coin_in_backend = backend_coins_view->GetCoin(random_out_point);
+        }
         if (!coin_using_access_coin.IsSpent() && exists_using_have_coin_in_backend) {
             assert(exists_using_have_coin);
         }
-        if (auto coin{backend_coins_view->GetCoin(random_out_point)}) {
+        if (coin_in_backend) {
             assert(exists_using_have_coin_in_backend);
             // Note we can't assert that `coin_using_get_coin == *coin` because the coin in
             // the cache may have been modified but not yet flushed.
@@ -387,8 +441,11 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
 FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 {
     SeedRandomStateForTest(SeedRand::ZEROS); // for SaltedTxidHasher
+    StartPoolIfNeeded();
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     MutationGuardCoinsViewCache backend_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
     CoinsViewOverlay coins_view_cache{&backend_cache, g_thread_pool, /*deterministic=*/true};
+    CBlock block{BuildRandomBlock(fuzzed_data_provider, backend_cache)};
+    const auto reset_guard{coins_view_cache.StartFetching(block)};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
 }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -449,3 +449,25 @@ FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view) EXCLUSIVE_LOCKS_R
     const auto reset_guard{coins_view_cache.StartFetching(block)};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
 }
+
+FUZZ_TARGET(coins_view_stacked, .init = initialize_coins_view) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
+{
+    SeedRandomStateForTest(SeedRand::ZEROS); // for SaltedTxidHasher
+    StartPoolIfNeeded();
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    auto db_params = DBParams{
+        .path = "",
+        .cache_bytes = 1_MiB,
+        .memory_only = true,
+    };
+    CCoinsViewDB backend_base_coins_view{std::move(db_params), CoinsViewOptions{}};
+    CCoinsViewCache backend_cache{&backend_base_coins_view, /*deterministic=*/true};
+    TestCoinsView(fuzzed_data_provider, backend_cache, &backend_base_coins_view);
+    CoinsViewOverlay coins_view_cache{&backend_cache, g_thread_pool, /*deterministic=*/true};
+    CBlock block{BuildRandomBlock(fuzzed_data_provider, backend_base_coins_view)};
+    {
+        const auto reset_guard{coins_view_cache.StartFetching(block)};
+        TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
+    }
+    TestCoinsView(fuzzed_data_provider, backend_cache, &backend_base_coins_view);
+}

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -7,6 +7,7 @@
 #include <consensus/tx_check.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
+#include <kernel/chainstatemanager_opts.h>
 #include <kernel/cs_main.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
@@ -17,6 +18,7 @@
 #include <test/util/setup_common.h>
 #include <txdb.h>
 #include <util/hasher.h>
+#include <util/threadpool.h>
 
 #include <cassert>
 #include <algorithm>
@@ -84,6 +86,12 @@ public:
 
     using CCoinsViewCache::CCoinsViewCache;
 };
+
+// Reuse a single global thread pool across fuzz iterations. Creating and destroying a pool every
+// iteration leaks memory, since iterations can run faster than the OS can tear down the threads.
+std::shared_ptr<ThreadPool> g_thread_pool{std::make_shared<ThreadPool>("view_fuzz")};
+Mutex g_thread_pool_mutex;
+
 } // namespace
 
 void initialize_coins_view()
@@ -376,10 +384,10 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
 // This allows us to exercise all methods on a CoinsViewOverlay, while also
 // ensuring that nothing can mutate the underlying cache until Flush or Sync is
 // called.
-FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view)
+FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     MutationGuardCoinsViewCache backend_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
-    CoinsViewOverlay coins_view_cache{&backend_cache, /*deterministic=*/true};
+    CoinsViewOverlay coins_view_cache{&backend_cache, g_thread_pool, /*deterministic=*/true};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
 }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -386,6 +386,7 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
 // called.
 FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 {
+    SeedRandomStateForTest(SeedRand::ZEROS); // for SaltedTxidHasher
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     MutationGuardCoinsViewCache backend_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
     CoinsViewOverlay coins_view_cache{&backend_cache, g_thread_pool, /*deterministic=*/true};

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -5,6 +5,7 @@
 #include <coins.h>
 #include <crypto/sha256.h>
 #include <kernel/chainstatemanager_opts.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -37,12 +38,20 @@ struct PrecomputedData
     //! Randomly generated Coin values.
     Coin coins[NUM_COINS];
 
+    //! Block with a tx containing as inputs the above outpoints.
+    CBlock block;
+
     PrecomputedData()
     {
         static const uint8_t PREFIX_O[1] = {'o'}; /** Hash prefix for outpoint hashes. */
         static const uint8_t PREFIX_S[1] = {'s'}; /** Hash prefix for coins scriptPubKeys. */
         static const uint8_t PREFIX_M[1] = {'m'}; /** Hash prefix for coins nValue/fCoinBase. */
 
+        CMutableTransaction coinbase;
+        coinbase.vin.emplace_back();
+        block.vtx.push_back(MakeTransactionRef(coinbase));
+
+        CMutableTransaction tx;
         for (uint32_t i = 0; i < NUM_OUTPOINTS; ++i) {
             uint32_t idx = (i * 1200U) >> 12; /* Map 3 or 4 entries to same txid. */
             const uint8_t ser[4] = {uint8_t(idx), uint8_t(idx >> 8), uint8_t(idx >> 16), uint8_t(idx >> 24)};
@@ -50,7 +59,9 @@ struct PrecomputedData
             CSHA256().Write(PREFIX_O, 1).Write(ser, sizeof(ser)).Finalize(txid.begin());
             outpoints[i].hash = Txid::FromUint256(txid);
             outpoints[i].n = i;
+            tx.vin.emplace_back(outpoints[i]);
         }
+        block.vtx.push_back(MakeTransactionRef(tx));
 
         for (uint32_t i = 0; i < NUM_COINS; ++i) {
             const uint8_t ser[4] = {uint8_t(i), uint8_t(i >> 8), uint8_t(i >> 16), uint8_t(i >> 24)};
@@ -185,6 +196,14 @@ public:
     }
 };
 
+// Hold a non-movable ResetGuard on the heap so StartFetching can remain active
+// for the lifetime of a CoinsViewOverlay cache level.
+struct OverlayFetchScope
+{
+    CCoinsViewCache::ResetGuard guard;
+    OverlayFetchScope(CoinsViewOverlay& view, const CBlock& block) : guard(view.StartFetching(block)) {}
+};
+
 // Reuse a single global thread pool across fuzz iterations. Creating and destroying a pool every
 // iteration leaks memory, since iterations can run faster than the OS can tear down the threads.
 std::shared_ptr<ThreadPool> g_thread_pool{std::make_shared<ThreadPool>("cache_fuzz")};
@@ -200,6 +219,7 @@ void StartPoolIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 
 FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<>()}; }) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 {
+    SeedRandomStateForTest(SeedRand::ZEROS);
     StartPoolIfNeeded();
     /** Precomputed COutPoint and CCoins values. */
     static const PrecomputedData data;
@@ -208,6 +228,8 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
     CoinsViewBottom bottom;
     /** Real CCoinsViewCache objects. */
     std::vector<std::unique_ptr<CCoinsViewCache>> caches;
+    /** Long-lived StartFetching guard (nullptr unless corresponding level is a CoinsViewOverlay). */
+    std::unique_ptr<OverlayFetchScope> overlay_fetch_scope;
     /** Simulated cache data (sim_caches[0] matches bottom, sim_caches[i+1] matches caches[i]). */
     CacheLevel sim_caches[MAX_CACHES + 1];
     /** Current height in the simulation. */
@@ -383,11 +405,17 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
 
             [&]() { // Add a cache level (if not already at the max).
                 if (caches.size() != MAX_CACHES) {
+                    if (overlay_fetch_scope) {
+                        overlay_fetch_scope.reset();
+                        sim_caches[caches.size()].Wipe();
+                    }
                     // Apply to real caches.
                     if (provider.ConsumeBool()) {
                         caches.emplace_back(new CCoinsViewCache(&*caches.back(), /*deterministic=*/true));
                     } else {
                         caches.emplace_back(new CoinsViewOverlay(&*caches.back(), g_thread_pool, /*deterministic=*/true));
+                        auto& overlay{static_cast<CoinsViewOverlay&>(*caches.back())};
+                        overlay_fetch_scope = std::make_unique<OverlayFetchScope>(overlay, data.block);
                     }
                     // Apply to simulation data.
                     sim_caches[caches.size()].Wipe();
@@ -397,10 +425,16 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
             [&]() { // Remove a cache level.
                 // Apply to real caches (this reduces caches.size(), implicitly doing the same on the simulation data).
                 caches.back()->SanityCheck();
+                overlay_fetch_scope.reset();
                 caches.pop_back();
             },
 
             [&]() { // Flush.
+                // CoinsViewOverlay::Flush() must have all inputs consumed before being called
+                if (auto* overlay{dynamic_cast<CoinsViewOverlay*>(caches.back().get())};
+                    overlay && !overlay->AllInputsConsumed()) {
+                    return;
+                }
                 // Apply to simulation data.
                 flush();
                 // Apply to real caches.
@@ -408,6 +442,7 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
             },
 
             [&]() { // Sync.
+                if (overlay_fetch_scope) return; // CoinsViewOverlay::Sync() is never called in production
                 // Apply to simulation data (note that in our simulation, syncing and flushing is the same thing).
                 flush();
                 // Apply to real caches.
@@ -416,9 +451,13 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
 
             [&]() { // Reset.
                 sim_caches[caches.size()].Wipe();
-                // Apply to real caches.
-                {
-                    const auto reset_guard{caches.back()->CreateResetGuard()};
+                // Apply to real caches. Optionally start fetching again.
+                if (overlay_fetch_scope && provider.ConsumeBool()) {
+                    overlay_fetch_scope.reset();
+                    auto& overlay{static_cast<CoinsViewOverlay&>(*caches.back())};
+                    overlay_fetch_scope = std::make_unique<OverlayFetchScope>(overlay, data.block);
+                } else {
+                    (void)caches.back()->CreateResetGuard();
                 }
             },
 
@@ -442,22 +481,21 @@ FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<
     }
 
     // Full comparison between caches and simulation data, from bottom to top,
-    // as AccessCoin on a higher cache may affect caches below it.
     for (unsigned sim_idx = 1; sim_idx <= caches.size(); ++sim_idx) {
         auto& cache = *caches[sim_idx - 1];
         size_t cache_size = 0;
 
         for (uint32_t outpointidx = 0; outpointidx < NUM_OUTPOINTS; ++outpointidx) {
             cache_size += cache.HaveCoinInCache(data.outpoints[outpointidx]);
-            const auto& real = cache.AccessCoin(data.outpoints[outpointidx]);
+            const auto real{cache.PeekCoin(data.outpoints[outpointidx])};
             auto sim = lookup(outpointidx, sim_idx);
             if (!sim.has_value()) {
-                assert(real.IsSpent());
+                assert(!real);
             } else {
-                assert(!real.IsSpent());
-                assert(real.out == data.coins[sim->first].out);
-                assert(real.fCoinBase == data.coins[sim->first].fCoinBase);
-                assert(real.nHeight == sim->second);
+                assert(!real->IsSpent());
+                assert(real->out == data.coins[sim->first].out);
+                assert(real->fCoinBase == data.coins[sim->first].fCoinBase);
+                assert(real->nHeight == sim->second);
             }
         }
 

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -4,10 +4,13 @@
 
 #include <coins.h>
 #include <crypto/sha256.h>
+#include <kernel/chainstatemanager_opts.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+#include <util/threadpool.h>
 
 #include <cassert>
 #include <cstdint>
@@ -182,10 +185,22 @@ public:
     }
 };
 
+// Reuse a single global thread pool across fuzz iterations. Creating and destroying a pool every
+// iteration leaks memory, since iterations can run faster than the OS can tear down the threads.
+std::shared_ptr<ThreadPool> g_thread_pool{std::make_shared<ThreadPool>("cache_fuzz")};
+Mutex g_thread_pool_mutex;
+
+void StartPoolIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
+{
+    LOCK(g_thread_pool_mutex);
+    if (!g_thread_pool->WorkersCount()) g_thread_pool->Start(DEFAULT_PREVOUTFETCH_THREADS);
+}
+
 } // namespace
 
-FUZZ_TARGET(coinscache_sim)
+FUZZ_TARGET(coinscache_sim, .init = [] { static auto setup{MakeNoLogFileContext<>()}; }) EXCLUSIVE_LOCKS_REQUIRED(!g_thread_pool_mutex)
 {
+    StartPoolIfNeeded();
     /** Precomputed COutPoint and CCoins values. */
     static const PrecomputedData data;
 
@@ -372,7 +387,7 @@ FUZZ_TARGET(coinscache_sim)
                     if (provider.ConsumeBool()) {
                         caches.emplace_back(new CCoinsViewCache(&*caches.back(), /*deterministic=*/true));
                     } else {
-                        caches.emplace_back(new CoinsViewOverlay(&*caches.back(), /*deterministic=*/true));
+                        caches.emplace_back(new CoinsViewOverlay(&*caches.back(), g_thread_pool, /*deterministic=*/true));
                     }
                     // Apply to simulation data.
                     sim_caches[caches.size()].Wipe();

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -991,6 +991,12 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_args, BasicTestingSetup)
 
     BOOST_CHECK(!get_opts({"-minimumchainwork=xyz"}));                                                               // invalid hex characters
     BOOST_CHECK(!get_opts({"-minimumchainwork=01234567890123456789012345678901234567890123456789012345678901234"})); // > 64 hex chars
+
+    BOOST_CHECK_EQUAL(get_valid_opts({}).prevoutfetch_threads_num, DEFAULT_PREVOUTFETCH_THREADS);
+    BOOST_CHECK_EQUAL(get_valid_opts({"-prevoutfetchthreads=0"}).prevoutfetch_threads_num, 0);
+    BOOST_CHECK_EQUAL(get_valid_opts({"-prevoutfetchthreads=3"}).prevoutfetch_threads_num, 3);
+    BOOST_CHECK_EQUAL(get_valid_opts({"-prevoutfetchthreads=100"}).prevoutfetch_threads_num, MAX_PREVOUTFETCH_THREADS);
+    BOOST_CHECK(!get_opts({"-prevoutfetchthreads=-1"}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -60,6 +60,7 @@
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <util/threadpool.h>
 #include <util/time.h>
 #include <util/trace.h>
 #include <util/translation.h>
@@ -1859,11 +1860,16 @@ CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)
     : m_dbview{std::move(db_params), std::move(options)},
       m_catcherview(&m_dbview) {}
 
-void CoinsViews::InitCache()
+void CoinsViews::InitCache(int32_t prevoutfetch_threads)
 {
     AssertLockHeld(::cs_main);
     m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
-    m_connect_block_view = std::make_unique<CoinsViewOverlay>(&*m_cacheview);
+    auto thread_pool{std::make_shared<ThreadPool>("prevout")};
+    if (prevoutfetch_threads > 0) {
+        thread_pool->Start(prevoutfetch_threads);
+        LogInfo("Block input prevout fetching uses %d additional threads", prevoutfetch_threads);
+    }
+    m_connect_block_view = std::make_unique<CoinsViewOverlay>(&*m_cacheview, std::move(thread_pool));
 }
 
 Chainstate::Chainstate(
@@ -1939,7 +1945,7 @@ void Chainstate::InitCoinsCache(size_t cache_size_bytes)
     AssertLockHeld(::cs_main);
     assert(m_coins_views != nullptr);
     m_coinstip_cache_size_bytes = cache_size_bytes;
-    m_coins_views->InitCache();
+    m_coins_views->InitCache(m_chainman.m_options.prevoutfetch_threads_num);
 }
 
 // Lock-free: depends on `m_cached_is_ibd`, which is latched by `UpdateIBDStatus()`.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3052,8 +3052,8 @@ bool Chainstate::ConnectTip(
     LogDebug(BCLog::BENCH, "  - Load block from disk: %.2fms\n",
              Ticks<MillisecondsDouble>(time_2 - time_1));
     {
-        CCoinsViewCache& view{*m_coins_views->m_connect_block_view};
-        const auto reset_guard{view.CreateResetGuard()};
+        CoinsViewOverlay& view{*m_coins_views->m_connect_block_view};
+        const auto reset_guard{view.StartFetching(*block_to_connect)};
         bool rv = ConnectBlock(*block_to_connect, state, pindexNew, view);
         if (m_chainman.m_options.signals) {
             m_chainman.m_options.signals->BlockChecked(block_to_connect, state);

--- a/src/validation.h
+++ b/src/validation.h
@@ -506,7 +506,7 @@ public:
     CoinsViews(DBParams db_params, CoinsViewOptions options);
 
     //! Initialize the CCoinsViewCache member.
-    void InitCache() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void InitCache(int32_t prevoutfetch_threads) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };
 
 enum class CoinsCacheSizeState

--- a/src/validation.h
+++ b/src/validation.h
@@ -89,6 +89,9 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES{550_MiB};
 /** Maximum number of dedicated script-checking threads allowed */
 static constexpr int MAX_SCRIPTCHECK_THREADS{15};
 
+/** Maximum number of dedicated threads allowed for prefetching block input prevouts */
+static constexpr int32_t MAX_PREVOUTFETCH_THREADS{16};
+
 /** Current sync state passed to tip changed callbacks. */
 enum class SynchronizationState {
     INIT_REINDEX,

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -92,6 +92,9 @@ class FullBlockTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.extra_args = [[
             '-testactivationheight=bip34@2',
+            # Override the functional-test default of 1 thread to exercise the multi-threaded
+            # prevout prefetching path in this block-heavy test.
+            '-prevoutfetchthreads=8',
         ]]
 
     def add_options(self, parser):

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -135,6 +135,9 @@ class ProxyTest(BitcoinTestFramework):
         if self.have_unix_sockets:
             args[5] = ['-listen', f'-proxy=unix:{socket_path}']
             args[6] = ['-listen', f'-onion=unix:{socket_path}']
+        # This test launches many nodes; disable prevout prefetching so we don't spin up a
+        # thread pool for each one.
+        args = [a + ['-prevoutfetchthreads=0'] for a in args]
         self.add_nodes(self.num_nodes, extra_args=args)
         self.start_nodes()
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -566,6 +566,8 @@ def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=
         #  nMaxConnections = available_fds - min_required_fds = 256 - 161 = 94;
         f.write("maxconnections=94\n")
         f.write("par=" + str(min(2, os.cpu_count())) + "\n")
+        # Use a single prevoutfetch worker thread to keep per-node resource usage low.
+        f.write("prevoutfetchthreads=1\n")
         f.write(extra_config)
 
 


### PR DESCRIPTION
This PR is a continuation of https://github.com/bitcoin/bitcoin/pull/31132. All outstanding issues raised there have been resolved, but the volume of stale comments can make that change difficult to review.

Currently, when connecting a block, each input prevout is looked up one at a time. For every input we first check the in-memory coins cache, and on a miss we make a synchronous round-trip to the chainstate LevelDB to read the coin from disk. Because these lookups happen serially as the block is being validated, the disk read latency stacks up and dominates the time spent in `ConnectBlock` whenever many inputs are not already in the cache.

This PR moves those disk reads onto a pool of worker threads that run in parallel with block connection. Before entering `ConnectBlock` the block is handed to a `CoinsViewOverlay`, which kicks off the workers to begin fetching all of the block's prevouts from disk and warming the cache. The main validation thread continues to do exactly the same work it does today, hitting the cache for each input in order. The only difference is that by the time it asks, the coin is much more likely to already be there. There are no validation logic or consensus behavior changes. This is purely a parallelization of an existing read pattern.

The number of fetcher threads is configurable via `-prevoutfetchthreads=<n>`, defaulting to 8 and capped at 16. Setting it to 0 disables input fetching entirely and reverts to the previous serial behavior.

We have measured large performance gains for IBD and `-reindex-chainstate`, as well as worst-case steady-state block connection at the tip. l0rinc ran many thorough benchmarking passes on the original PR across multiple machines, storage types, dbcache sizes[^1], operating systems[^2], and fetcher thread counts[^3]. Many other contributors also posted their benchmark results in the original PR. IBD speedups range from 1.18× to over 3× faster[^4]. Worst-case block connection time for network-attached storage was over 2× faster[^5]. Flamegraph comparisons before and after this change are available[^6].

On safety: `ConnectBlock` runs while holding `cs_main`, so nothing else in the node can mutate the chainstate while the fetchers are reading it.

On LevelDB: [concurrent reads are fully supported](https://github.com/bitcoin/bitcoin/blob/master/src/leveldb/include/leveldb/db.h#L44) and [documented as such](https://github.com/bitcoin/bitcoin/blob/master/src/leveldb/doc/index.md#concurrency). We already rely on this in production today against our other LevelDB-backed databases. The `txindex` DB is read by multiple simultaneous HTTP RPC worker threads via the `getrawtransaction` RPC. The `blockfilterindex` DB is called concurrently from both the P2P `cfilters` / `cfheaders` / `cfcheckpt` message handlers on the `msghand` thread, and from the `getblockfilter` RPC on the HTTP RPC worker threads. We have not yet been issuing concurrent reads against the chainstate DB, but there is no LevelDB-side reason we can't. In fact, the chainstate DB is already being touched by more than one thread on master, because LevelDB schedules its own background compaction work.

For reviewers:

The main change is `CoinsViewOverlay` gets 1 new public and 2 new private methods.

- `StartFetching`: public method called in lieu of `CreateResetGuard` before we enter `ConnectBlock`. It still returns a `ResetGuard` so the view is `Reset` before the block it is working on leaves scope. This kicks off worker threads who each just run `while (ProcessInput()) {}` and then return.
- `StopFetching`: private method called on `Reset` whenever the guard leaves scope or `Flush`. Stops all threads and clears multi threaded state.
- `ProcessInput`: private method that fetches a single input prevout. Returns `true` if an input was fetched and `false` otherwise. This is the only method on `CoinsViewOverlay` that is called concurrently by multiple threads. Every other method on the overlay is still called synchronously on the main thread.

The `CoinsViewOverlay::FetchCoinFromBase` method is also extended to lookup the coins fetched from `ProcessInput` first before falling back to `base->PeekCoin`.

Mutating methods `Reset` and `Flush` are overridden in `CoinsViewOverlay` to call `StopFetching` first.

[^1]: https://github.com/bitcoin/bitcoin/pull/31132#pullrequestreview-3515011880
[^2]: https://github.com/bitcoin/bitcoin/pull/31132#issuecomment-3767758819
[^3]: https://github.com/bitcoin/bitcoin/pull/31132#issuecomment-3617721711
[^4]: https://github.com/bitcoin/bitcoin/pull/31132#issuecomment-3678847806
[^5]: https://github.com/bitcoin/bitcoin/pull/31132#issuecomment-4071032270
[^6]: https://github.com/bitcoin/bitcoin/pull/31132#issuecomment-3617315125
