### PR TITLE
mining: add precious option to IPC block submission

### DIFF
--- a/doc/release-notes-35300.md
+++ b/doc/release-notes-35300.md
@@ -1,0 +1,20 @@
+IPC Interface
+-------------
+
+- The IPC mining interface now provides
+  `Mining.submitBlock(context, block, precious=false)`, which accepts a fully
+  assembled serialized block and returns `reason`, `debug`, and a boolean
+  `result`. With the default `precious=false`, a newly accepted and connected
+  block returns `result=true`. Duplicate blocks return `result=false` with
+  `reason="duplicate"`, valid blocks that are accepted but not connected return
+  `result=false` with `reason="inconclusive"`, and invalid blocks return their
+  BIP22 rejection reason and debug details. Unlike the `submitblock` RPC, this
+  method does not add a missing coinbase witness reserved value, so clients
+  must provide a complete block. Clients must regenerate bindings from the
+  updated `mining.capnp` schema to use this method. (#34644, #35300)
+
+- `Mining.submitBlock` and `BlockTemplate.submitSolution` now accept an optional
+  `precious` argument, which defaults to `false`. When `true`, the submitted
+  block is preferred over competing blocks with the same work, similar to the
+  `preciousblock` RPC. In this mode, a new or already-known block returns
+  `result=true` if it is connected to the active chain. (#35300)

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -60,6 +60,8 @@ public:
      * @param[in] timestamp time block header field (unix timestamp)
      * @param[in] nonce nonce block header field
      * @param[in] coinbase complete coinbase transaction (including witness)
+     * @param[in] precious prefer this block over same-work tips, similar to the
+     *                     preciousblock RPC.
      * @param[out] reason failure reason (BIP22)
      * @param[out] debug  more detailed rejection reason
      *
@@ -72,9 +74,10 @@ public:
      *       is only one byte long, so the coinbase scriptSig needs at least
      *       one additional byte of data to avoid bad-cb-length.
      *
-     * @returns true if the block was accepted as a new block
+     * @returns true if the block was accepted as a new block. With precious,
+     *          an already-known block may return true if it is connected.
      */
-    virtual bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase, std::string& reason, std::string& debug) = 0;
+    virtual bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase, bool precious, std::string& reason, std::string& debug) = 0;
 
     //! Deprecated older method preserved to return an explicit error for IPC
     //! clients using mining.capnp @7.
@@ -168,23 +171,27 @@ public:
     /**
      * Process a fully assembled block.
      *
-     * Similar to the submitblock RPC. Accepts a complete block, validates
-     * it, and if accepted as new, processes it into chainstate. Accepted
-     * blocks may then be announced to peers through normal validation signals.
+     * Similar to the submitblock RPC. Accepts a complete block, validates it,
+     * and processes accepted blocks into chainstate. Accepted blocks may then
+     * be announced to peers through normal validation signals.
      *
      * @param[in]  block  the complete block to submit
+     * @param[in]  precious prefer this block over same-work tips, similar to the
+     *                      preciousblock RPC.
      * @param[out] reason failure reason (BIP22)
      * @param[out] debug  more detailed rejection reason
-     * @returns           true if the block was accepted as a new block. Returns
+     * @returns           true if the block was accepted. By default, returns
      *                    false and sets reason if the block is a duplicate or
-     *                    the validation result is inconclusive.
+     *                    the validation result is inconclusive. With precious,
+     *                    an already-known block may return true if it is
+     *                    validated/connected.
      *
      * @note Unlike the submitblock RPC, this method does not call
      *       UpdateUncommittedBlockStructures to add a missing coinbase witness
      *       reserved value. Callers must submit a fully formed block, including
      *       the coinbase witness when a witness commitment is present.
      */
-    virtual bool submitBlock(const CBlock& block, std::string& reason, std::string& debug) = 0;
+    virtual bool submitBlock(const CBlock& block, bool precious, std::string& reason, std::string& debug) = 0;
 
     /**
      * Fetch raw transactions from the mempool by txid.

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -25,7 +25,7 @@ interface Mining $Proxy.wrap("interfaces::Mining") {
     createNewBlock @4 (context :Proxy.Context, options: BlockCreateOptions, cooldown: Bool = true) -> (result: BlockTemplate);
     checkBlock @5 (context :Proxy.Context, block: Data, options: BlockCheckOptions) -> (reason: Text, debug: Text, result: Bool);
     interrupt @6 () -> ();
-    submitBlock @7 (context :Proxy.Context, block: Data) -> (reason: Text, debug: Text, result: Bool);
+    submitBlock @7 (context :Proxy.Context, block: Data, precious: Bool = false) -> (reason: Text, debug: Text, result: Bool);
     getTransactionsByTxID @8 (context :Proxy.Context, txids: List(Data)) -> (result: List(Data));
     getTransactionsByWitnessID @9 (context :Proxy.Context, wtxids: List(Data)) -> (result: List(Data));
 }
@@ -38,7 +38,7 @@ interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {
     getTxSigops @4 (context: Proxy.Context) -> (result: List(Int64));
     getCoinbaseTx @5 (context: Proxy.Context) -> (result: CoinbaseTx);
     getCoinbaseMerklePath @6 (context: Proxy.Context) -> (result: List(Data));
-    submitSolution @10 (context: Proxy.Context, version: UInt32, timestamp: UInt32, nonce: UInt32, coinbase :Data) -> (reason: Text, debug: Text, result: Bool);
+    submitSolution @10 (context: Proxy.Context, version: UInt32, timestamp: UInt32, nonce: UInt32, coinbase :Data, precious: Bool = false) -> (reason: Text, debug: Text, result: Bool);
     waitNext @8 (context: Proxy.Context, options: BlockWaitOptions) -> (result: BlockTemplate);
     interruptWait @9() -> ();
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -917,11 +917,11 @@ public:
         return TransactionMerklePath(m_block_template->block, 0);
     }
 
-    bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase, std::string& reason, std::string& debug) override
+    bool submitSolution(uint32_t version, uint32_t timestamp, uint32_t nonce, CTransactionRef coinbase, bool precious, std::string& reason, std::string& debug) override
     {
         if (!coinbase) return false;
         AddMerkleRootAndCoinbase(m_block_template->block, std::move(coinbase), version, timestamp, nonce);
-        return SubmitBlock(chainman(), std::make_shared<const CBlock>(m_block_template->block), reason, debug);
+        return SubmitBlock(chainman(), std::make_shared<const CBlock>(m_block_template->block), precious, reason, debug);
     }
 
     std::unique_ptr<BlockTemplate> waitNext(BlockWaitOptions options) override
@@ -1022,9 +1022,9 @@ public:
         return state.IsValid();
     }
 
-    bool submitBlock(const CBlock& block_in, std::string& reason, std::string& debug) override
+    bool submitBlock(const CBlock& block_in, bool precious, std::string& reason, std::string& debug) override
     {
-        return SubmitBlock(chainman(), std::make_shared<const CBlock>(block_in), reason, debug);
+        return SubmitBlock(chainman(), std::make_shared<const CBlock>(block_in), precious, reason, debug);
     }
 
     std::vector<CTransactionRef> getTransactionsByTxID(const std::vector<Txid>& txids) override

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -376,16 +376,16 @@ protected:
     void BlockChecked(const std::shared_ptr<const CBlock>& block, const BlockValidationState& state) override
     {
         if (block->GetHash() != m_hash) return;
-        // ProcessNewBlock emits BlockChecked synchronously while holding cs_main,
-        // so SubmitBlock can read these fields after ProcessNewBlock returns
-        // without extra synchronization.
+        // ProcessNewBlock and PreciousBlock emit BlockChecked synchronously
+        // while holding cs_main, so SubmitBlock can read these fields after
+        // they return without extra synchronization.
         m_found = true;
         m_state = state;
     }
 };
 } // namespace
 
-bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock>& block, std::string& reason, std::string& debug)
+bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock>& block, bool precious, std::string& reason, std::string& debug)
 {
     reason.clear();
     debug.clear();
@@ -394,33 +394,57 @@ bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock
     // is intentionally kept separate from the RPC implementation. The RPC entry
     // point decodes hex, formats BIP22/JSONRPC results, and calls
     // UpdateUncommittedBlockStructures() for legacy witness handling. IPC
-    // callers submit already-formed blocks and need bool + reason/debug
-    // results.
+    // callers submit already-formed blocks, need bool + reason/debug results,
+    // and may optionally request preciousblock-like handling.
     auto sc = std::make_shared<SubmitBlockStateCatcher>(block->GetHash());
     CHECK_NONFATAL(chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
     bool new_block;
     bool accepted = chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/&new_block);
+
+    bool precious_connected{false};
+    if (accepted && precious && !sc->m_found) {
+        BlockValidationState state;
+        // ProcessNewBlock() returned true, so AcceptBlock() either found an
+        // existing block index entry or created one. LookupBlockIndex() must
+        // succeed and requires cs_main. PreciousBlock() serializes activation
+        // and captures whether the block was connected before releasing its
+        // chainstate lock.
+        CBlockIndex* pindex{CHECK_NONFATAL(WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(block->GetHash())))};
+        if (!chainman.ActiveChainstate().PreciousBlock(state, pindex, precious_connected) || !state.IsValid()) {
+            accepted = false;
+            reason = state.GetRejectReason();
+            debug = state.GetDebugMessage();
+            if (reason.empty()) reason = "inconclusive";
+        }
+    }
+
     // No queue drain is needed. The BlockChecked notification used above is
-    // emitted synchronously by ProcessNewBlock, unlike most validation signals.
+    // emitted synchronously by ProcessNewBlock and PreciousBlock, unlike most
+    // validation signals.
     CHECK_NONFATAL(chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);
 
-    if (!new_block && accepted) {
-        reason = "duplicate";
-    } else if (!accepted && (!sc->m_found || sc->m_state.IsValid())) {
-        // ProcessNewBlock can fail without a validation result, for example
-        // from an activation or system error. It can also fail after a valid
-        // BlockChecked result. In these cases the validation result is
-        // inconclusive.
-        reason = "inconclusive";
-    } else if (!sc->m_found) {
-        // The block was accepted but not connected, for example if it does not
-        // have more work than the current tip.
-        reason = "inconclusive";
-    } else if (!sc->m_state.IsValid()) {
-        reason = sc->m_state.GetRejectReason();
-        debug = sc->m_state.GetDebugMessage();
+    if (reason.empty()) {
+        if (sc->m_found && !sc->m_state.IsValid()) {
+            // Prefer a conclusive validation error over fallback results. In
+            // particular, PreciousBlock may fail to connect a known block
+            // after ProcessNewBlock initially classified it as a duplicate.
+            reason = sc->m_state.GetRejectReason();
+            debug = sc->m_state.GetDebugMessage();
+        } else if (!new_block && accepted && !precious_connected) {
+            reason = "duplicate";
+        } else if (!accepted && (!sc->m_found || sc->m_state.IsValid())) {
+            // ProcessNewBlock can fail without a validation result, for example
+            // from an activation or system error. It can also fail after a valid
+            // BlockChecked result. In these cases the validation result is
+            // inconclusive.
+            reason = "inconclusive";
+        } else if (!sc->m_found && !precious_connected) {
+            // The block was accepted but not connected, for example if it does
+            // not have more work than the current tip.
+            reason = "inconclusive";
+        }
     }
-    const bool result{accepted && new_block && reason.empty()};
+    const bool result{accepted && (new_block || precious_connected) && reason.empty()};
     CHECK_NONFATAL(result == reason.empty());
     return result;
 }

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -131,8 +131,9 @@ void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 void AddMerkleRootAndCoinbase(CBlock& block, CTransactionRef coinbase, uint32_t version, uint32_t timestamp, uint32_t nonce);
 
 //! Submit a block and capture the validation state via the BlockChecked callback.
-//! Returns whether the block was accepted as a new valid block.
-bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock>& block, std::string& reason, std::string& debug);
+//! Returns whether the block was accepted as a new valid block or, if precious
+//! is true, whether it was connected to the active chain.
+bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock>& block, bool precious, std::string& reason, std::string& debug);
 
 /* Interrupt a blocking call. */
 void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wait);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1709,7 +1709,8 @@ static RPCMethod preciousblock()
     }
 
     BlockValidationState state;
-    chainman.ActiveChainstate().PreciousBlock(state, pblockindex);
+    bool connected{false};
+    chainman.ActiveChainstate().PreciousBlock(state, pblockindex, connected);
 
     if (!state.IsValid()) {
         throw JSONRPCError(RPC_DATABASE_ERROR, state.ToString());

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -5,8 +5,8 @@
 #include <blockencodings.h>
 #include <chainparams.h>
 #include <consensus/merkle.h>
-#include <pow.h>
 #include <streams.h>
+#include <test/util/mining.h>
 #include <test/util/random.h>
 #include <test/util/txmempool.h>
 
@@ -52,7 +52,7 @@ static CBlock BuildBlockTestCase(FastRandomContext& ctx) {
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    GrindBlock(block, Params().GetConsensus());
     return block;
 }
 
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    GrindBlock(block, Params().GetConsensus());
 
     // Test simple header round-trip with only coinbase
     {
@@ -331,7 +331,7 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
     mtx.vin[0].prevout.hash = Txid::FromUint256(rand_ctx.rand256());
     block.vtx.push_back(MakeTransactionRef(std::move(mtx)));
     block.hashMerkleRoot = BlockMerkleRoot(block);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    GrindBlock(block, Params().GetConsensus());
 
     std::vector<std::pair<Wtxid, CTransactionRef>> extra_txn;
     extra_txn.resize(10);

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -13,13 +13,13 @@
 #include <interfaces/mining.h>
 #include <key.h>
 #include <node/blockstorage.h>
-#include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/blockfilter.h>
 #include <test/util/common.h>
+#include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <tinyformat.h>
@@ -111,7 +111,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
         block.hashMerkleRoot = BlockMerkleRoot(block);
     }
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, m_node.chainman->GetConsensus())) ++block.nNonce;
+    GrindBlock(block, m_node.chainman->GetConsensus());
 
     return block;
 }

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -13,13 +13,13 @@
 #include <consensus/consensus.h>
 #include <key.h>
 #include <merkleblock.h>
-#include <pow.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/mining.h>
 #include <uint256.h>
 #include <validation.h>
 
@@ -366,9 +366,7 @@ void ReadFromStream(FuzzedDataProvider& fuzzed_data_provider, Stream& stream) no
 
 inline void FinalizeHeader(CBlockHeader& header, const ChainstateManager& chainman)
 {
-    while (!CheckProofOfWork(header.GetHash(), header.nBits, chainman.GetParams().GetConsensus())) {
-        ++(header.nNonce);
-    }
+    GrindBlock(header, chainman.GetParams().GetConsensus());
 }
 
 #endif // BITCOIN_TEST_FUZZ_UTIL_H

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -7,8 +7,8 @@
 #include <consensus/params.h>
 #include <headerssync.h>
 #include <net_processing.h>
-#include <pow.h>
 #include <test/util/common.h>
+#include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 
@@ -92,8 +92,6 @@ struct HeadersGeneratorSetup : public RegTestingSetup {
     }
 
 private:
-    /** Search for a nonce to meet (regtest) proof of work */
-    void FindProofOfWork(CBlockHeader& starting_header);
     /**
      * Generate headers in a chain that build off a given starting hash, using
      * the given nVersion, advancing time by 1 second from the starting
@@ -103,13 +101,6 @@ private:
             uint256 prev_hash, int32_t nVersion, uint32_t prev_time,
             const uint256& merkle_root, uint32_t nBits);
 };
-
-void HeadersGeneratorSetup::FindProofOfWork(CBlockHeader& starting_header)
-{
-    while (!CheckProofOfWork(starting_header.GetHash(), starting_header.nBits, Params().GetConsensus())) {
-        ++starting_header.nNonce;
-    }
-}
 
 std::vector<CBlockHeader> HeadersGeneratorSetup::GenerateHeaders(
         const size_t count, uint256 prev_hash, const int32_t nVersion,
@@ -123,7 +114,7 @@ std::vector<CBlockHeader> HeadersGeneratorSetup::GenerateHeaders(
         next_header.nTime = ++prev_time;
         next_header.nBits = nBits;
 
-        FindProofOfWork(next_header);
+        GrindBlock(next_header, Params().GetConsensus());
         prev_hash = next_header.GetHash();
     }
     return headers;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -25,6 +25,7 @@
 #include <serialize.h>
 #include <sync.h>
 #include <test/util/common.h>
+#include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
 #include <test/util/time.h>
@@ -139,14 +140,6 @@ static void MutateCoinbase(CBlock& block, int extra_nonce)
     block.vtx.at(0) = MakeTransactionRef(std::move(coinbase));
     block.hashMerkleRoot = BlockMerkleRoot(block);
     block.nNonce = 0;
-}
-
-static void GrindBlock(CBlock& block, const Consensus::Params& consensus)
-{
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, consensus)) {
-        ++block.nNonce;
-        BOOST_REQUIRE(block.nNonce != 0);
-    }
 }
 
 static BlockCreateOptions BlockOptions()
@@ -970,7 +963,6 @@ BOOST_AUTO_TEST_SUITE_END()
 namespace miner_tests_precious {
 using miner_tests::ActiveTipHash;
 using miner_tests::BlockOptions;
-using miner_tests::GrindBlock;
 using miner_tests::MakeMining;
 using miner_tests::MutateCoinbase;
 } // namespace miner_tests_precious

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -57,6 +57,11 @@ using node::BlockAssembler;
 using node::BlockCreateOptions;
 
 namespace miner_tests {
+static std::unique_ptr<Mining> MakeMining(const node::NodeContext& node)
+{
+    return interfaces::MakeMining(node, /*wait_loaded=*/false);
+}
+
 struct MinerTestingSetup : public TestingSetup {
     void TestPackageSelection(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void TestBasicMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst, int baseheight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
@@ -83,10 +88,6 @@ struct MinerTestingSetup : public TestingSetup {
         m_node.mempool = std::make_unique<CTxMemPool>(opts, error);
         Assert(error.empty());
         return *m_node.mempool;
-    }
-    std::unique_ptr<Mining> MakeMining()
-    {
-        return interfaces::MakeMining(m_node, /*wait_loaded=*/false);
     }
 };
 } // namespace miner_tests
@@ -126,13 +127,42 @@ static std::unique_ptr<CBlockIndex> CreateBlockIndex(int nHeight, CBlockIndex* a
     return index;
 }
 
+static uint256 ActiveTipHash(const node::NodeContext& node)
+{
+    return WITH_LOCK(::cs_main, return Assert(node.chainman)->ActiveChain().Tip()->GetBlockHash());
+}
+
+static void MutateCoinbase(CBlock& block, int extra_nonce)
+{
+    CMutableTransaction coinbase{*block.vtx.at(0)};
+    coinbase.vin.at(0).scriptSig << extra_nonce;
+    block.vtx.at(0) = MakeTransactionRef(std::move(coinbase));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    block.nNonce = 0;
+}
+
+static void GrindBlock(CBlock& block, const Consensus::Params& consensus)
+{
+    while (!CheckProofOfWork(block.GetHash(), block.nBits, consensus)) {
+        ++block.nNonce;
+        BOOST_REQUIRE(block.nNonce != 0);
+    }
+}
+
+static BlockCreateOptions BlockOptions()
+{
+    BlockCreateOptions options;
+    options.coinbase_output_script = CScript() << OP_TRUE;
+    return options;
+}
+
 // Test suite for ancestor feerate transaction selection.
 // Implemented as an additional function, rather than a separate test case,
 // to allow reusing the blockchain created in CreateNewBlock_validity.
 void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst)
 {
     CTxMemPool& tx_mempool{MakeMempool()};
-    auto mining{MakeMining()};
+    auto mining{MakeMining(m_node)};
     BlockCreateOptions options{
         .coinbase_output_script = scriptPubKey,
     };
@@ -377,7 +407,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
     const CAmount HIGHFEE = COIN;
     const CAmount HIGHERFEE = 4 * COIN;
 
-    auto mining{MakeMining()};
+    auto mining{MakeMining(m_node)};
     BOOST_REQUIRE(mining);
 
     BlockCreateOptions options{
@@ -704,7 +734,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
 
 void MinerTestingSetup::TestPrioritisedMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst)
 {
-    auto mining{MakeMining()};
+    auto mining{MakeMining(m_node)};
     BOOST_REQUIRE(mining);
 
     BlockCreateOptions options{
@@ -792,7 +822,7 @@ void MinerTestingSetup::TestPrioritisedMining(const CScript& scriptPubKey, const
 // NOTE: These tests rely on CreateNewBlock doing its own self-validation!
 BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 {
-    auto mining{MakeMining()};
+    auto mining{MakeMining(m_node)};
     BOOST_REQUIRE(mining);
 
     // Note that by default, these tests run with size accounting enabled.
@@ -933,6 +963,225 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     m_node.chainman->ActiveChain().Tip()->nHeight--;
 
     TestPrioritisedMining(scriptPubKey, txFirst);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+namespace miner_tests_precious {
+using miner_tests::ActiveTipHash;
+using miner_tests::BlockOptions;
+using miner_tests::GrindBlock;
+using miner_tests::MakeMining;
+using miner_tests::MutateCoinbase;
+} // namespace miner_tests_precious
+
+BOOST_FIXTURE_TEST_SUITE(miner_tests_precious, RegTestingSetup)
+
+BOOST_AUTO_TEST_CASE(SubmitBlock_precious)
+{
+    auto mining{MakeMining(m_node)};
+    BOOST_REQUIRE(mining);
+
+    auto block_template{mining->createNewBlock(BlockOptions(), /*cooldown=*/false)};
+    BOOST_REQUIRE(block_template);
+
+    const auto& consensus{Assert(m_node.chainman)->GetParams().GetConsensus()};
+    CBlock active_block{block_template->getBlock()};
+    MutateCoinbase(active_block, /*extra_nonce=*/1);
+    GrindBlock(active_block, consensus);
+
+    CBlock side_block{block_template->getBlock()};
+    MutateCoinbase(side_block, /*extra_nonce=*/2);
+    GrindBlock(side_block, consensus);
+
+    BOOST_REQUIRE(active_block.GetHash() != side_block.GetHash());
+    BOOST_REQUIRE_EQUAL(active_block.hashPrevBlock, side_block.hashPrevBlock);
+
+    std::string reason{"stale reason"};
+    std::string debug{"stale debug"};
+    BOOST_REQUIRE(mining->submitBlock(active_block, /*precious=*/false, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), active_block.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(!mining->submitBlock(active_block, /*precious=*/false, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "duplicate");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), active_block.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(!mining->submitBlock(side_block, /*precious=*/false, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "inconclusive");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), active_block.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(mining->submitBlock(side_block, /*precious=*/true, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), side_block.GetHash());
+
+    // Re-submitting the active tip with precious=true is a no-op reorg, but
+    // the block is validated/connected so submitBlock should report success.
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(mining->submitBlock(side_block, /*precious=*/true, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), side_block.GetHash());
+
+    // Submitting a brand-new same-work block with precious=true on the first
+    // try (no prior precious=false store) should still reorg to it. This
+    // exercises the path where AcceptBlock stores a fresh block and
+    // PreciousBlock immediately promotes it.
+    auto next_template{mining->createNewBlock(BlockOptions(), /*cooldown=*/false)};
+    BOOST_REQUIRE(next_template);
+
+    CBlock next_active{next_template->getBlock()};
+    MutateCoinbase(next_active, /*extra_nonce=*/1);
+    GrindBlock(next_active, consensus);
+
+    CBlock next_side{next_template->getBlock()};
+    MutateCoinbase(next_side, /*extra_nonce=*/2);
+    GrindBlock(next_side, consensus);
+
+    BOOST_REQUIRE(next_active.GetHash() != next_side.GetHash());
+    BOOST_REQUIRE_EQUAL(next_active.hashPrevBlock, side_block.GetHash());
+    BOOST_REQUIRE_EQUAL(next_side.hashPrevBlock, side_block.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(mining->submitBlock(next_active, /*precious=*/false, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), next_active.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(mining->submitBlock(next_side, /*precious=*/true, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), next_side.GetHash());
+
+    // Lower-work blocks cannot trigger a reorg, but PreciousBlock still reports
+    // whether they are already connected to the active chain.
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(mining->submitBlock(side_block, /*precious=*/true, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), next_side.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(!mining->submitBlock(active_block, /*precious=*/true, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "duplicate");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), next_side.GetHash());
+
+    // A same-work block can pass initial block checks and be stored without
+    // being connected. If making that known block precious later exposes a
+    // ConnectBlock failure, return its validation error instead of "duplicate".
+    auto connect_template{mining->createNewBlock(BlockOptions(), /*cooldown=*/false)};
+    BOOST_REQUIRE(connect_template);
+
+    CBlock connect_active{connect_template->getBlock()};
+    MutateCoinbase(connect_active, /*extra_nonce=*/1);
+    GrindBlock(connect_active, consensus);
+
+    CBlock connect_invalid{connect_template->getBlock()};
+    MutateCoinbase(connect_invalid, /*extra_nonce=*/2);
+    CMutableTransaction invalid_coinbase{*connect_invalid.vtx.at(0)};
+    ++invalid_coinbase.vout.at(0).nValue;
+    connect_invalid.vtx.at(0) = MakeTransactionRef(std::move(invalid_coinbase));
+    connect_invalid.hashMerkleRoot = BlockMerkleRoot(connect_invalid);
+    connect_invalid.nNonce = 0;
+    GrindBlock(connect_invalid, consensus);
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(mining->submitBlock(connect_active, /*precious=*/false, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), connect_active.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(!mining->submitBlock(connect_invalid, /*precious=*/false, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "inconclusive");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), connect_active.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(!mining->submitBlock(connect_invalid, /*precious=*/true, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "bad-cb-amount");
+    BOOST_REQUIRE(!debug.empty());
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), connect_active.GetHash());
+
+    // An invalid block submitted with precious=true must be rejected by
+    // ProcessNewBlock; PreciousBlock must not run when accepted=false. The
+    // validation reason should surface and the active tip should not move.
+    auto invalid_template{mining->createNewBlock(BlockOptions(), /*cooldown=*/false)};
+    BOOST_REQUIRE(invalid_template);
+    CBlock invalid_block{invalid_template->getBlock()};
+    invalid_block.hashMerkleRoot = uint256::ONE;
+    invalid_block.nNonce = 0;
+    GrindBlock(invalid_block, consensus);
+
+    const uint256 tip_before_invalid{ActiveTipHash(m_node)};
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(!mining->submitBlock(invalid_block, /*precious=*/true, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "bad-txnmrklroot");
+    BOOST_REQUIRE_EQUAL(debug, "hashMerkleRoot mismatch");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), tip_before_invalid);
+}
+
+BOOST_AUTO_TEST_CASE(SubmitSolution_precious)
+{
+    auto mining{MakeMining(m_node)};
+    BOOST_REQUIRE(mining);
+
+    auto side_template{mining->createNewBlock(BlockOptions(), /*cooldown=*/false)};
+    BOOST_REQUIRE(side_template);
+
+    const auto& consensus{Assert(m_node.chainman)->GetParams().GetConsensus()};
+    CBlock active_block{side_template->getBlock()};
+    MutateCoinbase(active_block, /*extra_nonce=*/1);
+    GrindBlock(active_block, consensus);
+
+    CBlock side_block{side_template->getBlock()};
+    MutateCoinbase(side_block, /*extra_nonce=*/2);
+    GrindBlock(side_block, consensus);
+
+    BOOST_REQUIRE(active_block.GetHash() != side_block.GetHash());
+    BOOST_REQUIRE_EQUAL(active_block.hashPrevBlock, side_block.hashPrevBlock);
+
+    std::string reason{"stale reason"};
+    std::string debug{"stale debug"};
+    BOOST_REQUIRE(mining->submitBlock(active_block, /*precious=*/false, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), active_block.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(!side_template->submitSolution(side_block.nVersion, side_block.nTime, side_block.nNonce, side_block.vtx.at(0), /*precious=*/false, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "inconclusive");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), active_block.GetHash());
+
+    reason = "stale reason";
+    debug = "stale debug";
+    BOOST_REQUIRE(side_template->submitSolution(side_block.nVersion, side_block.nTime, side_block.nNonce, side_block.vtx.at(0), /*precious=*/true, reason, debug));
+    BOOST_REQUIRE_EQUAL(reason, "");
+    BOOST_REQUIRE_EQUAL(debug, "");
+    BOOST_REQUIRE_EQUAL(ActiveTipHash(m_node), side_block.GetHash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -887,19 +887,19 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         std::string reason{"stale reason"};
         std::string debug{"stale debug"};
         if (current_height % 2 == 0) {
-            BOOST_REQUIRE(mining->submitBlock(block, reason, debug));
+            BOOST_REQUIRE(mining->submitBlock(block, /*precious=*/false, reason, debug));
             BOOST_REQUIRE_EQUAL(reason, "");
             BOOST_REQUIRE_EQUAL(debug, "");
 
             reason = "stale reason";
             debug = "stale debug";
-            BOOST_REQUIRE(!mining->submitBlock(block, reason, debug));
+            BOOST_REQUIRE(!mining->submitBlock(block, /*precious=*/false, reason, debug));
             BOOST_REQUIRE_EQUAL(reason, "duplicate");
             BOOST_REQUIRE_EQUAL(debug, "");
         } else {
             reason = "stale reason";
             debug = "stale debug";
-            BOOST_REQUIRE(block_template->submitSolution(block.nVersion, block.nTime, block.nNonce, MakeTransactionRef(txCoinbase), reason, debug));
+            BOOST_REQUIRE(block_template->submitSolution(block.nVersion, block.nTime, block.nNonce, MakeTransactionRef(txCoinbase), /*precious=*/false, reason, debug));
             BOOST_REQUIRE_EQUAL(reason, "");
             BOOST_REQUIRE_EQUAL(debug, "");
             BOOST_CHECK_THROW(block_template->submitSolutionOld7(block.nVersion, block.nTime, block.nNonce,

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -7,10 +7,10 @@
 #include <consensus/params.h>
 #include <interfaces/mining.h>
 #include <net_processing.h>
-#include <pow.h>
 #include <primitives/block.h>
 #include <protocol.h>
 #include <sync.h>
+#include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <util/check.h>
@@ -35,7 +35,7 @@ static void mineBlock(node::NodeContext& node, FakeNodeClock& clock, std::chrono
     auto block_template{mining->createNewBlock({}, /*cooldown=*/false)};
     BOOST_REQUIRE(block_template);
     CBlock block{block_template->getBlock()};
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
+    GrindBlock(block, node.chainman->GetConsensus());
     block.fChecked = true; // little speedup
     clock.set(curr_time); // process block at current time
     Assert(node.chainman->ProcessNewBlock(std::make_shared<const CBlock>(block), /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -31,6 +31,14 @@
 
 using node::NodeContext;
 
+void GrindBlock(CBlockHeader& block, const Consensus::Params& consensus)
+{
+    while (!CheckProofOfWork(block.GetHash(), block.nBits, consensus)) {
+        ++block.nNonce;
+        assert(block.nNonce != 0);
+    }
+}
+
 COutPoint generatetoaddress(const NodeContext& node, const std::string& address)
 {
     const auto dest = DecodeDestination(address);
@@ -67,10 +75,7 @@ std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const
         block.nBits = params.GenesisBlock().nBits;
         block.nNonce = 0;
 
-        while (!CheckProofOfWork(block.GetHash(), block.nBits, params.GetConsensus())) {
-            ++block.nNonce;
-            assert(block.nNonce);
-        }
+        GrindBlock(block, params.GetConsensus());
     }
     return ret;
 }
@@ -101,10 +106,7 @@ protected:
 
 COutPoint MineBlock(const NodeContext& node, std::shared_ptr<CBlock>& block)
 {
-    while (!CheckProofOfWork(block->GetHash(), block->nBits, Params().GetConsensus())) {
-        ++block->nNonce;
-        assert(block->nNonce);
-    }
+    GrindBlock(*block, Params().GetConsensus());
 
     return ProcessBlock(node, block);
 }

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -11,12 +11,19 @@
 #include <vector>
 
 class CBlock;
+class CBlockHeader;
 class CChainParams;
 class COutPoint;
+namespace Consensus {
+struct Params;
+} // namespace Consensus
 namespace node {
 struct BlockCreateOptions;
 struct NodeContext;
 } // namespace node
+
+/** Increment the nonce until the block header satisfies proof of work. */
+void GrindBlock(CBlockHeader& block, const Consensus::Params& consensus);
 
 /** Create a blockchain, starting from genesis */
 std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const CChainParams& params);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -38,7 +38,6 @@
 #include <noui.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
-#include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <random.h>
@@ -54,6 +53,7 @@
 #include <streams.h>
 #include <sync.h>
 #include <test/util/coverage.h>
+#include <test/util/mining.h>
 #include <test/util/net.h>
 #include <test/util/random.h>
 #include <test/util/txmempool.h>
@@ -461,7 +461,7 @@ CBlock TestChain100Setup::CreateBlock(
     }
     RegenerateCommitments(block, *Assert(m_node.chainman));
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, m_node.chainman->GetConsensus())) ++block.nNonce;
+    GrindBlock(block, m_node.chainman->GetConsensus());
 
     return block;
 }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -9,13 +9,13 @@
 #include <consensus/validation.h>
 #include <interfaces/mining.h>
 #include <node/blockstorage.h>
-#include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <random.h>
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/common.h>
+#include <test/util/mining.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
@@ -114,9 +114,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::FinalizeBlock(std::shared_ptr<CBlock>
 
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
 
-    while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
-        ++(pblock->nNonce);
-    }
+    GrindBlock(*pblock, Params().GetConsensus());
 
     // submit block header, so that miner can get the block height from the
     // global state and the node has the topology of the chain

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3510,14 +3510,16 @@ bool Chainstate::ActivateBestChain_(BlockValidationState& state, std::shared_ptr
     return true;
 }
 
-bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
+bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex, bool& connected)
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(::cs_main);
+    LOCK(m_chainstate_mutex);
     {
         LOCK(cs_main);
         if (pindex->nChainWork < m_chain.Tip()->nChainWork) {
             // Nothing to do, this block is not at the tip.
+            connected = m_chain.Contains(*pindex);
             return true;
         }
         if (m_chain.Tip()->nChainWork > m_chainman.nLastPreciousChainwork) {
@@ -3538,7 +3540,9 @@ bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
         }
     }
 
-    return ActivateBestChain(state, std::shared_ptr<const CBlock>());
+    const bool activated{ActivateBestChain_(state, std::shared_ptr<const CBlock>())};
+    connected = WITH_LOCK(::cs_main, return m_chain.Contains(*pindex));
+    return activated;
 }
 
 bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const pindex)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3339,11 +3339,6 @@ static void LimitValidationInterfaceQueue(ValidationSignals& signals) LOCKS_EXCL
 bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<const CBlock> pblock)
 {
     AssertLockNotHeld(m_chainstate_mutex);
-
-    // Note that while we're often called here from ProcessNewBlock, this is
-    // far from a guarantee. Things in the P2P/RPC will often end up calling
-    // us in the middle of ProcessNewBlock - do not assume pblock is set
-    // sanely for performance or correctness!
     AssertLockNotHeld(::cs_main);
 
     // ABC maintains a fair degree of expensive-to-calculate internal state
@@ -3351,6 +3346,18 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
     // during large connects - and to allow for e.g. the callback queue to drain
     // we use m_chainstate_mutex to enforce mutual exclusion so that only one caller may execute this function at a time
     LOCK(m_chainstate_mutex);
+    return ActivateBestChain_(state, std::move(pblock));
+}
+
+bool Chainstate::ActivateBestChain_(BlockValidationState& state, std::shared_ptr<const CBlock> pblock)
+{
+    AssertLockHeld(m_chainstate_mutex);
+
+    // Note that while we're often called here from ProcessNewBlock, this is
+    // far from a guarantee. Things in the P2P/RPC will often end up calling
+    // us in the middle of ProcessNewBlock - do not assume pblock is set
+    // sanely for performance or correctness!
+    AssertLockNotHeld(::cs_main);
 
     // Belt-and-suspenders check that we aren't attempting to advance the
     // chainstate past the target block.

--- a/src/validation.h
+++ b/src/validation.h
@@ -555,8 +555,8 @@ class Chainstate
 protected:
     /**
      * The ChainState Mutex
-     * A lock that must be held when modifying this ChainState - held in ActivateBestChain() and
-     * InvalidateBlock()
+     * A lock that must be held when modifying this ChainState - held in
+     * ActivateBestChain(), PreciousBlock(), and InvalidateBlock()
      */
     Mutex m_chainstate_mutex;
 
@@ -797,9 +797,13 @@ public:
     // Manual block validity manipulation:
     /** Mark a block as precious and reorganize.
      *
+     * @param[out] connected Whether the block is in the active chain when the
+     *                       operation completes, captured before releasing
+     *                       m_chainstate_mutex.
+     *
      * May not be called in a validationinterface callback.
      */
-    bool PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
+    bool PreciousBlock(BlockValidationState& state, CBlockIndex* pindex, bool& connected)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(::cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -575,6 +575,13 @@ protected:
 
     std::optional<const char*> m_last_script_check_reason_logged GUARDED_BY(::cs_main){};
 
+    //! Internal helper for callers that already hold m_chainstate_mutex.
+    bool ActivateBestChain_(
+        BlockValidationState& state,
+        std::shared_ptr<const CBlock> pblock)
+        EXCLUSIVE_LOCKS_REQUIRED(m_chainstate_mutex)
+        LOCKS_EXCLUDED(::cs_main);
+
 public:
     //! Reference to a BlockManager instance which itself is shared across all
     //! Chainstate instances.

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -28,6 +28,10 @@ from test_framework.messages import (
     msg_headers,
     ser_uint256,
 )
+from test_framework.script import (
+    CScript,
+    CScriptNum,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -126,8 +130,29 @@ class IPCMiningTest(BitcoinTestFramework):
         block.hashMerkleRoot = block.calc_merkle_root()
         return block
 
-    async def assert_submit_block(self, mining, ctx, block, *, result, reason="", debug=""):
-        submit = await mining.submitBlock(ctx, block.serialize())
+    def make_block_variant(self, block, coinbase, extra_nonce):
+        """Make a solved same-template block with a distinct coinbase scriptSig."""
+        block = deepcopy(block)
+        coinbase = deepcopy(coinbase)
+        coinbase.vin[0].scriptSig = CScript(bytes(coinbase.vin[0].scriptSig) + bytes(CScript([CScriptNum(extra_nonce)])))
+        block.vtx[0] = coinbase
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        return block, coinbase
+
+    def assert_chain_tip(self, node, block_hash, *, active):
+        matching_tips = [tip for tip in node.getchaintips() if tip["hash"] == block_hash]
+        assert_equal(len(matching_tips), 1)
+        if active:
+            assert_equal(matching_tips[0]["status"], "active")
+        else:
+            assert_not_equal(matching_tips[0]["status"], "active")
+
+    async def assert_submit_block(self, mining, ctx, block, *, result, reason="", debug="", precious=None):
+        if precious is None:
+            submit = await mining.submitBlock(ctx, block.serialize())
+        else:
+            submit = await mining.submitBlock(ctx, block.serialize(), precious)
         assert_equal(submit.result, result)
         assert_equal(submit.reason, reason)
         assert_equal(submit.debug, debug)
@@ -805,6 +830,124 @@ class IPCMiningTest(BitcoinTestFramework):
 
         asyncio.run(capnp.run(async_routine()))
 
+    def run_precious_submission_test(self):
+        """Test precious submitBlock and submitSolution IPC arguments."""
+        self.log.info("Running precious block submission test")
+
+        async def async_routine():
+            node = self.nodes[0]
+            ctx, mining = await make_mining_ctx(self)
+
+            async with AsyncExitStack() as stack:
+                self.log.debug("Build same-height blocks from one template")
+                template = await mining_create_block_template(mining, stack, ctx, self.default_block_create_options)
+                block = await self.build_candidate_block(template, ctx)
+                coinbase = block.vtx[0]
+                active_block, _ = self.make_block_variant(block, coinbase, extra_nonce=1)
+                side_block, _ = self.make_block_variant(block, coinbase, extra_nonce=2)
+
+                assert_not_equal(active_block.hash_hex, side_block.hash_hex)
+                assert_equal(active_block.hashPrevBlock, side_block.hashPrevBlock)
+
+                self.log.debug("submitBlock with precious=false stores but does not connect a same-work side block")
+                await self.assert_submit_block(mining, ctx, active_block, result=True)
+                assert_equal(node.getbestblockhash(), active_block.hash_hex)
+                await self.assert_submit_block(mining, ctx, side_block, result=False, reason="inconclusive", precious=False)
+                assert_equal(node.getbestblockhash(), active_block.hash_hex)
+                self.assert_chain_tip(node, side_block.hash_hex, active=False)
+
+                self.log.debug("submitBlock with precious=true prefers the stored side block")
+                await self.assert_submit_block(mining, ctx, side_block, result=True, precious=True)
+                assert_equal(node.getbestblockhash(), side_block.hash_hex)
+                self.assert_chain_tip(node, side_block.hash_hex, active=True)
+
+                self.log.debug("submitBlock with precious=true on the active tip should still report success")
+                await self.assert_submit_block(mining, ctx, side_block, result=True, precious=True)
+                assert_equal(node.getbestblockhash(), side_block.hash_hex)
+
+                self.log.debug("submitBlock with precious=true on a brand-new same-work block reorgs on the first try")
+                fresh_template = await mining_create_block_template(mining, stack, ctx, self.default_block_create_options)
+                fresh_block = await self.build_candidate_block(fresh_template, ctx)
+                fresh_coinbase = fresh_block.vtx[0]
+                fresh_active, _ = self.make_block_variant(fresh_block, fresh_coinbase, extra_nonce=10)
+                fresh_side, _ = self.make_block_variant(fresh_block, fresh_coinbase, extra_nonce=11)
+                assert_not_equal(fresh_active.hash_hex, fresh_side.hash_hex)
+                assert_equal(fresh_active.hashPrevBlock, fresh_side.hashPrevBlock)
+
+                await self.assert_submit_block(mining, ctx, fresh_active, result=True)
+                assert_equal(node.getbestblockhash(), fresh_active.hash_hex)
+                # fresh_side has never been submitted, so this exercises the
+                # AcceptBlock-then-PreciousBlock path on a single call.
+                await self.assert_submit_block(mining, ctx, fresh_side, result=True, precious=True)
+                assert_equal(node.getbestblockhash(), fresh_side.hash_hex)
+                self.assert_chain_tip(node, fresh_side.hash_hex, active=True)
+
+                self.log.debug("submitBlock with precious=true on an invalid block surfaces the validation error and does not change the tip")
+                invalid_template = await mining_create_block_template(mining, stack, ctx, self.default_block_create_options)
+                invalid_block = await mining_get_block(invalid_template, ctx)
+                invalid_block.hashMerkleRoot = 1
+                invalid_block.nNonce = 0
+                invalid_block.solve()
+                tip_before_invalid = node.getbestblockhash()
+                await self.assert_submit_block(
+                    mining, ctx, invalid_block,
+                    result=False,
+                    reason="bad-txnmrklroot",
+                    debug="hashMerkleRoot mismatch",
+                    precious=True,
+                )
+                assert_equal(node.getbestblockhash(), tip_before_invalid)
+
+                self.log.debug("Build another same-height pair for submitSolution")
+                stale_template = await mining_create_block_template(mining, stack, ctx, self.default_block_create_options)
+                stale_block = await self.build_candidate_block(stale_template, ctx)
+                stale_coinbase = stale_block.vtx[0]
+                active_solution_block, _ = self.make_block_variant(stale_block, stale_coinbase, extra_nonce=3)
+                side_solution_block, side_solution_coinbase = self.make_block_variant(stale_block, stale_coinbase, extra_nonce=4)
+
+                assert_not_equal(active_solution_block.hash_hex, side_solution_block.hash_hex)
+                assert_equal(active_solution_block.hashPrevBlock, side_solution_block.hashPrevBlock)
+
+                self.log.debug("Make the template stale by connecting a sibling block")
+                await self.assert_submit_block(mining, ctx, active_solution_block, result=True)
+                assert_equal(node.getbestblockhash(), active_solution_block.hash_hex)
+
+                self.log.debug("submitSolution with precious=false does not connect the stale same-work solution")
+                result = await stale_template.submitSolution(
+                    ctx,
+                    side_solution_block.nVersion,
+                    side_solution_block.nTime,
+                    side_solution_block.nNonce,
+                    side_solution_coinbase.serialize(),
+                    False,
+                )
+                assert_equal(result.result, False)
+                assert_equal(result.reason, "inconclusive")
+                assert_equal(result.debug, "")
+                assert_equal(node.getbestblockhash(), active_solution_block.hash_hex)
+                self.assert_chain_tip(node, side_solution_block.hash_hex, active=False)
+
+                self.log.debug("submitSolution with precious=true prefers the stale same-work solution")
+                result = await stale_template.submitSolution(
+                    ctx,
+                    side_solution_block.nVersion,
+                    side_solution_block.nTime,
+                    side_solution_block.nNonce,
+                    side_solution_coinbase.serialize(),
+                    True,
+                )
+                assert_equal(result.result, True)
+                assert_equal(result.reason, "")
+                assert_equal(result.debug, "")
+                assert_equal(node.getbestblockhash(), side_solution_block.hash_hex)
+                self.assert_chain_tip(node, side_solution_block.hash_hex, active=True)
+
+            # Move to a strictly better chain so peers converge before later tests.
+            self.connect_nodes(0, 1)
+            self.generate(node, 1)
+
+        asyncio.run(capnp.run(async_routine()))
+
     def run_test(self):
         self.miniwallet = MiniWallet(self.nodes[0])
         # Amount of time in milliseconds the test is allowed to wait or be idle before it should fail.
@@ -819,6 +962,7 @@ class IPCMiningTest(BitcoinTestFramework):
         self.run_coinbase_and_submission_test()
         self.run_waitnext_mining_policy_test()
         self.run_block_max_weight_test()
+        self.run_precious_submission_test()
         self.run_ipc_option_override_test()
         self.run_transaction_lookup_test()
 


### PR DESCRIPTION
This PR adds a `precious` flag to the IPC Mining submitBlock and submitSolution methods, as suggested in https://github.com/bitcoin/bitcoin/pull/34644#discussion_r3247072448. Built on top https://github.com/bitcoin/bitcoin/pull/34644.

With this change, IPC mining clients can submit and prefer a block in one IPC call, instead of submitting it over IPC and then using the `preciousblock` RPC separately.

By default, same-work side blocks keep the existing behavior: `submitBlock` reports duplicate/inconclusive cases as failure with a reason, while `submitSolution` continues to return true when `ProcessNewBlock` accepts or already knows the block.

Includes unit and IPC functional coverage for default behavior, precious reorgs, active-tip no-op submissions, and invalid-block rejection.