### PR TITLE
blockstorage: keep snapshot base in normal blockfile range

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -494,6 +494,11 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
                         pindex->GetBlockHash() == *snapshot_blockhash) {
                     // Should have been set above; don't disturb it with code below.
                     Assert(pindex->m_chain_tx_count > 0);
+                    // The hardcoded m_chain_tx_count does not imply that the
+                    // background chainstate has processed the base's parents.
+                    if ((pindex->nStatus & BLOCK_HAVE_DATA) && !pindex->pprev->HaveNumChainTxs()) {
+                        m_blocks_unlinked.insert(std::make_pair(pindex->pprev, pindex));
+                    }
                 } else if (pindex->pprev->m_chain_tx_count > 0) {
                     pindex->m_chain_tx_count = pindex->pprev->m_chain_tx_count + pindex->nTx;
                 } else {
@@ -791,16 +796,23 @@ BlockfileType BlockManager::BlockfileTypeForHeight(int height)
     if (!m_snapshot_height) {
         return BlockfileType::NORMAL;
     }
-    return (height >= *m_snapshot_height) ? BlockfileType::ASSUMED : BlockfileType::NORMAL;
+    // The snapshot base block is connected by the background chainstate.
+    // Only blocks above it belong to the snapshot chainstate's blockfile range.
+    return (height > *m_snapshot_height) ? BlockfileType::ASSUMED : BlockfileType::NORMAL;
 }
 
-bool BlockManager::FlushChainstateBlockFile(int tip_height)
+bool BlockManager::FlushChainstateBlockFile(int tip_height, bool snapshot_chainstate)
 {
     AssertLockHeld(::cs_main);
-    auto& cursor = m_blockfile_cursors[BlockfileTypeForHeight(tip_height)];
-    // If the cursor does not exist, it means an assumeutxo snapshot is loaded,
-    // but no blocks past the snapshot height have been written yet, so there
-    // is no data associated with the chainstate, and it is safe not to flush.
+    BlockfileType type{BlockfileTypeForHeight(tip_height)};
+    if (snapshot_chainstate && m_snapshot_height && tip_height == *m_snapshot_height) {
+        // The base block belongs to the background chainstate's normal range,
+        // so a snapshot chainstate at the base height must not flush that cursor.
+        type = BlockfileType::ASSUMED;
+    }
+    auto& cursor = m_blockfile_cursors[type];
+    // If the cursor does not exist, there is no blockfile data associated with
+    // the chainstate, and it is safe not to flush.
     if (cursor) {
         return FlushBlockFile(cursor->file_num, /*fFinalize=*/false, /*finalize_undo=*/false);
     }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -482,6 +482,11 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
                         pindex->GetBlockHash() == *snapshot_blockhash) {
                     // Should have been set above; don't disturb it with code below.
                     Assert(pindex->m_chain_tx_count > 0);
+                    // The hardcoded m_chain_tx_count does not imply that the
+                    // background chainstate has processed the base's parents.
+                    if ((pindex->nStatus & BLOCK_HAVE_DATA) && !pindex->pprev->HaveNumChainTxs()) {
+                        m_blocks_unlinked.insert(std::make_pair(pindex->pprev, pindex));
+                    }
                 } else if (pindex->pprev->m_chain_tx_count > 0) {
                     pindex->m_chain_tx_count = pindex->pprev->m_chain_tx_count + pindex->nTx;
                 } else {
@@ -777,16 +782,23 @@ BlockfileType BlockManager::BlockfileTypeForHeight(int height)
     if (!m_snapshot_height) {
         return BlockfileType::NORMAL;
     }
-    return (height >= *m_snapshot_height) ? BlockfileType::ASSUMED : BlockfileType::NORMAL;
+    // The snapshot base block is connected by the background chainstate.
+    // Only blocks above it belong to the snapshot chainstate's blockfile range.
+    return (height > *m_snapshot_height) ? BlockfileType::ASSUMED : BlockfileType::NORMAL;
 }
 
-bool BlockManager::FlushChainstateBlockFile(int tip_height)
+bool BlockManager::FlushChainstateBlockFile(int tip_height, bool snapshot_chainstate)
 {
     AssertLockHeld(::cs_main);
-    auto& cursor = m_blockfile_cursors[BlockfileTypeForHeight(tip_height)];
-    // If the cursor does not exist, it means an assumeutxo snapshot is loaded,
-    // but no blocks past the snapshot height have been written yet, so there
-    // is no data associated with the chainstate, and it is safe not to flush.
+    BlockfileType type{BlockfileTypeForHeight(tip_height)};
+    if (snapshot_chainstate && m_snapshot_height && tip_height == *m_snapshot_height) {
+        // The base block belongs to the background chainstate's normal range,
+        // so a snapshot chainstate at the base height must not flush that cursor.
+        type = BlockfileType::ASSUMED;
+    }
+    auto& cursor = m_blockfile_cursors[type];
+    // If the cursor does not exist, there is no blockfile data associated with
+    // the chainstate, and it is safe not to flush.
     if (cursor) {
         return FlushBlockFile(cursor->file_num, /*fFinalize=*/false, /*finalize_undo=*/false);
     }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -224,7 +224,7 @@ private:
      * separator fields (STORAGE_HEADER_BYTES).
      */
     [[nodiscard]] FlatFilePos FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    [[nodiscard]] bool FlushChainstateBlockFile(int tip_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] bool FlushChainstateBlockFile(int tip_height, bool snapshot_chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     [[nodiscard]] bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     AutoFile OpenUndoFile(const FlatFilePos& pos, bool fReadOnly = false) const;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2781,7 +2781,7 @@ bool Chainstate::FlushStateToDisk(
                 // First make sure all block and undo data is flushed to disk.
                 // TODO: Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
-                if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
+                if (!m_blockman.FlushChainstateBlockFile(m_chain.Height(), /*snapshot_chainstate=*/m_from_snapshot_blockhash.has_value())) {
                     LogWarning("%s: Failed to flush block file.\n", __func__);
                 }
             }
@@ -4672,6 +4672,12 @@ VerifyDBResult CVerifyDB::VerifyDB(
         size_t curr_coins_usage = coins.DynamicMemoryUsage() + chainstate.CoinsTip().DynamicMemoryUsage();
 
         if (nCheckLevel >= 3) {
+            // A snapshot chainstate cannot disconnect its base block because
+            // the ancestor UTXO data needed by DisconnectBlock is not present
+            // in the snapshot database. Stop the disconnect walk here.
+            if (is_snapshot_cs && pindex == chainstate.SnapshotBase()) {
+                break;
+            }
             if (curr_coins_usage <= chainstate.m_coinstip_cache_size_bytes) {
                 assert(coins.GetBestBlock() == pindex->GetBlockHash());
                 DisconnectResult res = chainstate.DisconnectBlock(block, pindex, coins);
@@ -4878,13 +4884,18 @@ void Chainstate::PopulateBlockIndexCandidates()
 {
     AssertLockHeld(::cs_main);
 
+    const CBlockIndex* target_block{TargetBlock()};
     for (CBlockIndex* pindex : m_blockman.GetAllBlockIndices()) {
         // With assumeutxo, the snapshot block is a candidate for the tip, but it
         // may not have BLOCK_VALID_TRANSACTIONS (e.g. if we haven't yet downloaded
         // the block), so we special-case it here.
+        // A historical chainstate can target the snapshot base, but must still
+        // wait until the target's parents have been processed.
+        const bool target_parent_unprocessed{pindex == target_block && pindex->pprev && !pindex->pprev->HaveNumChainTxs()};
         if (pindex == SnapshotBase() ||
                 (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) &&
-                 (pindex->HaveNumChainTxs() || pindex->pprev == nullptr))) {
+                 (pindex->HaveNumChainTxs() || pindex->pprev == nullptr) &&
+                 !target_parent_unprocessed)) {
             TryAddBlockIndexCandidate(pindex);
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2792,7 +2792,7 @@ bool Chainstate::FlushStateToDisk(
                 // First make sure all block and undo data is flushed to disk.
                 // TODO: Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
-                if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
+                if (!m_blockman.FlushChainstateBlockFile(m_chain.Height(), /*snapshot_chainstate=*/m_from_snapshot_blockhash.has_value())) {
                     LogWarning("%s: Failed to flush block file.\n", __func__);
                 }
             }
@@ -4704,6 +4704,12 @@ VerifyDBResult CVerifyDB::VerifyDB(
         size_t curr_coins_usage = coins.DynamicMemoryUsage() + chainstate.CoinsTip().DynamicMemoryUsage();
 
         if (nCheckLevel >= 3) {
+            // A snapshot chainstate cannot disconnect its base block because
+            // the ancestor UTXO data needed by DisconnectBlock is not present
+            // in the snapshot database. Stop the disconnect walk here.
+            if (is_snapshot_cs && pindex == chainstate.SnapshotBase()) {
+                break;
+            }
             if (curr_coins_usage <= chainstate.m_coinstip_cache_size_bytes) {
                 assert(coins.GetBestBlock() == pindex->GetBlockHash());
                 DisconnectResult res = chainstate.DisconnectBlock(block, pindex, coins);
@@ -4910,13 +4916,18 @@ void Chainstate::PopulateBlockIndexCandidates()
 {
     AssertLockHeld(::cs_main);
 
+    const CBlockIndex* target_block{TargetBlock()};
     for (CBlockIndex* pindex : m_blockman.GetAllBlockIndices()) {
         // With assumeutxo, the snapshot block is a candidate for the tip, but it
         // may not have BLOCK_VALID_TRANSACTIONS (e.g. if we haven't yet downloaded
         // the block), so we special-case it here.
+        // A historical chainstate can target the snapshot base, but must still
+        // wait until the target's parents have been processed.
+        const bool target_parent_unprocessed{pindex == target_block && pindex->pprev && !pindex->pprev->HaveNumChainTxs()};
         if (pindex == SnapshotBase() ||
                 (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) &&
-                 (pindex->HaveNumChainTxs() || pindex->pprev == nullptr))) {
+                 (pindex->HaveNumChainTxs() || pindex->pprev == nullptr) &&
+                 !target_parent_unprocessed)) {
             TryAddBlockIndexCandidate(pindex);
         }
     }

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -62,19 +62,20 @@ class AssumeutxoTest(BitcoinTestFramework):
 
     def set_test_params(self):
         """Use the pregenerated, deterministic chain up to height 199."""
-        self.num_nodes = 4
+        self.num_nodes = 5
         self.rpc_timeout = 120
         self.extra_args = [
             [],
             ["-fastprune", "-prune=1", "-blockfilterindex=1", "-coinstatsindex=1"],
             ["-persistmempool=0","-txindex=1", "-blockfilterindex=1", "-coinstatsindex=1"],
+            [],
             []
         ]
 
     def setup_network(self):
         """Start with the nodes disconnected so that one can generate a snapshot
         including blocks the other hasn't yet seen."""
-        self.add_nodes(4)
+        self.add_nodes(self.num_nodes)
         self.start_nodes(extra_args=self.extra_args)
 
     def test_invalid_snapshot_scenarios(self, valid_snapshot_path):
@@ -218,6 +219,38 @@ class AssumeutxoTest(BitcoinTestFramework):
         node = self.nodes[0]
         msg = "Unable to load UTXO snapshot: Population failed: Work does not exceed active chainstate."
         assert_raises_rpc_error(-32603, msg, node.loadtxoutset, dump_output_path)
+
+    def test_snapshot_base_block_already_on_disk(self, dump_output_path):
+        self.log.info("Test background validation when snapshot base block is already on disk")
+        node0 = self.nodes[0]
+        node4 = self.nodes[4]
+
+        snapshot_hash = node0.getblockhash(SNAPSHOT_BASE_HEIGHT)
+        snapshot_block = node0.getblock(snapshot_hash, 0)
+
+        # Store the base block before loadtxoutset() sets BlockManager::m_snapshot_height.
+        # The block cannot be connected until its historical parents arrive.
+        submit_result = node4.submitblock(snapshot_block)
+        assert submit_result in (None, "inconclusive"), submit_result
+        assert_equal(node4.getblock(snapshot_hash)["height"], SNAPSHOT_BASE_HEIGHT)
+
+        loaded = node4.loadtxoutset(dump_output_path)
+        assert_equal(loaded['base_height'], SNAPSHOT_BASE_HEIGHT)
+
+        # Restart after loading the snapshot to check that the persisted block
+        # index state can still resume background validation.
+        self.restart_node(4, extra_args=self.extra_args[4])
+
+        # Feed only the historical blocks missing from the background chainstate.
+        # The base block itself is already on disk in the normal blockfile range.
+        # Background validation should still be able to connect it.
+        for height in range(START_HEIGHT + 1, SNAPSHOT_BASE_HEIGHT):
+            block_hash = node0.getblockhash(height)
+            submit_result = node4.submitblock(node0.getblock(block_hash, 0))
+            assert submit_result in (None, "inconclusive"), submit_result
+
+        self.wait_until(lambda: len(node4.getchainstates()['chainstates']) == 1)
+        assert_equal(node4.getblockcount(), SNAPSHOT_BASE_HEIGHT)
 
     def test_snapshot_block_invalidated(self, dump_output_path):
         self.log.info("Test snapshot is not loaded when base block is invalid.")
@@ -402,7 +435,6 @@ class AssumeutxoTest(BitcoinTestFramework):
         n0 = self.nodes[0]
         n1 = self.nodes[1]
         n2 = self.nodes[2]
-        n3 = self.nodes[3]
 
         self.mini_wallet = MiniWallet(n0)
 
@@ -411,7 +443,7 @@ class AssumeutxoTest(BitcoinTestFramework):
             n.setmocktime(n.getblockheader(n.getbestblockhash())['time'])
 
         # Generate a series of blocks that `n0` will have in the snapshot,
-        # but that n1 and n2 don't yet see.
+        # but the other nodes don't yet see.
         assert_equal(n0.getblockcount(), START_HEIGHT)
         blocks = {START_HEIGHT: Block(n0.getbestblockhash(), 1, START_HEIGHT + 1)}
         for i in range(100):
@@ -450,15 +482,14 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.test_headers_not_synced(dump_output['path'])
 
         # In order for the snapshot to activate, we have to ferry over the new
-        # headers to n1 and n2 so that they see the header of the snapshot's
-        # base block while disconnected from n0.
+        # headers to the other nodes so that they see the header of the
+        # snapshot's base block while disconnected from n0.
         for i in range(1, 300):
             block = n0.getblock(n0.getblockhash(i), 0)
-            # make n1 and n2 aware of the new header, but don't give them the
-            # block.
-            n1.submitheader(block)
-            n2.submitheader(block)
-            n3.submitheader(block)
+            # Make the other nodes aware of the new header, but don't give them
+            # the block.
+            for n in self.nodes[1:]:
+                n.submitheader(block)
 
         # Ensure everyone is seeing the same headers.
         for n in self.nodes:
@@ -473,6 +504,8 @@ class AssumeutxoTest(BitcoinTestFramework):
             assert_equal(output["nchaintx"], blocks[SNAPSHOT_BASE_HEIGHT].chain_tx)
 
         check_dump_output(dump_output)
+
+        self.test_snapshot_base_block_already_on_disk(dump_output['path'])
 
         # Mine more blocks on top of the snapshot that n1 hasn't yet seen. This
         # will allow us to test n1's sync-to-tip on top of a snapshot.

--- a/test/functional/wallet_assumeutxo.py
+++ b/test/functional/wallet_assumeutxo.py
@@ -92,16 +92,19 @@ class AssumeutxoTest(BitcoinTestFramework):
     def test_restore_wallet_pruneheight(self, n3):
         self.log.info("Ensuring wallet can't be restored from a backup that was created before the pruneheight (pruned node)")
         self.complete_background_validation(n3)
-        # After background sync, pruneheight is reset to 0, so mine 200 blocks
-        # and prune the chain again
+        # After background sync, pruneheight is reset to 0. Mine more blocks
+        # and prune again while keeping the snapshot base block available for
+        # the wallet backup created at that height.
         self.generate(n3, nblocks=200, sync_fun=self.no_op)
-        assert_equal(n3.pruneblockchain(FINAL_HEIGHT), 298)  # 298 is the height of the last block pruned (pruneheight 299)
+        last_pruned = n3.pruneblockchain(SNAPSHOT_BASE_HEIGHT - 1)
+        assert_greater_than(last_pruned, START_HEIGHT)
+        assert_greater_than(SNAPSHOT_BASE_HEIGHT, last_pruned)
         error_message = "Wallet loading failed. Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)"
-        # This backup (backup_w2.dat) was created at height 199, so it can't be restored in a node with a pruneheight of 299
+        # This backup (backup_w2.dat) was created at START_HEIGHT, which is in the pruned range.
         assert_raises_rpc_error(-4, error_message, n3.restorewallet, "w2_pruneheight", "backup_w2.dat")
 
-        self.log.info("Ensuring wallet can be restored from a backup that was created at the pruneheight (pruned node)")
-        # This backup (backup_w.dat) was created at height 299, so it can be restored in a node with a pruneheight of 299
+        self.log.info("Ensuring wallet can be restored from a backup created after the pruned range (pruned node)")
+        # This backup (backup_w.dat) was created at SNAPSHOT_BASE_HEIGHT, which remains available.
         n3.restorewallet("w_alt", "backup_w.dat")
         # Check balance of w_alt wallet
         w_alt = n3.get_wallet_rpc("w_alt")


### PR DESCRIPTION
A node that has the assumeutxo snapshot base block on disk before `loadtxoutset()` runs ends up
in a state it cannot recover from. Depending on whether it is restarted, it either aborts or
refuses to start.

Aborting, when background validation reaches the base block:

```
node/blockstorage.cpp:985 bool node::BlockManager::WriteBlockUndo(const CBlockUndo &, BlockValidationState &, CBlockIndex &): Assertion `m_blockfile_cursors[type]' failed.
```

Refusing to start, if the node is restarted after the snapshot is loaded:

```
[ReadBlockUndo] OpenUndoFile failed for FlatFilePos(nFile=-1, nPos=0) while reading block undo
[DisconnectBlock] failure reading undo data
[VerifyDB] Verification error: irrecoverable inconsistency in block data at 299
Corrupted block database detected.
Please restart with -reindex or -reindex-chainstate to recover.
```

The block database is not corrupt, so the reindex that message asks for is wasted work.

Reaching this needs the base block stored before the snapshot is loaded, which `submitblock`
does: it is accepted and written while `BlockManager::m_snapshot_height` is still unset, so it
goes to the normal blockfile cursor. `loadtxoutset()` then sets `m_snapshot_height` to that same
height, and `BlockfileTypeForHeight()` starts reporting `ASSUMED` for it.

From there the two failures follow:

- `WriteBlockUndo()` looks up the cursor for the block's height and does
  `*Assert(m_blockfile_cursors[type])`. The block is now `ASSUMED`, but nothing above the
  snapshot height has been written, so that cursor does not exist and the assertion fires when
  the background chainstate connects the base. `FindNextBlockPos()` creates the cursor lazily in
  the same situation; `WriteBlockUndo()` asserts instead.
- `VerifyDB()` skips blocks without `BLOCK_HAVE_DATA` on a snapshot chainstate
  (`validation.cpp:4674`), which is why the base is normally left alone. Here the base does have
  data, and no undo data because the snapshot chainstate never connected it, so the skip does not
  apply and `DisconnectBlock()` is attempted on it.

The base block is connected by the background chainstate, not the snapshot one, so it belongs to
the normal blockfile range. `BlockfileTypeForHeight()` now classifies only blocks *above* the
snapshot height as `ASSUMED`. A snapshot chainstate sitting at the base height must not flush the
normal cursor, so `FlushChainstateBlockFile()` takes the chainstate into account.

`VerifyDB()` stops before disconnecting the snapshot base, where the snapshot database does not
have the ancestor UTXO data the disconnect needs.

When a snapshot chainstate is loaded from disk, the base's hardcoded `m_chain_tx_count` does not
mean the background chainstate has processed its parents, so the base is kept in
`m_blocks_unlinked` until they arrive, and a historical chainstate does not add its target to the
block index candidates before then.

The functional test submits the base block, loads the snapshot, restarts, then feeds the missing
historical blocks and checks that background validation completes. Both failures above are what
it hits without this change.

Tested:

```bash
build/test/functional/test_runner.py feature_assumeutxo.py wallet_assumeutxo.py feature_pruning.py feature_reindex.py --timeout-factor=4
build/bin/test_bitcoin
```