### PR TITLE
kernel: Add `btck_script_pubkey_is_p2tr`

### DIFF
--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -694,6 +694,11 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
     return result ? 1 : 0;
 }
 
+int btck_script_pubkey_is_p2tr(const btck_ScriptPubkey* script_pubkey)
+{
+    return btck_ScriptPubkey::get(script_pubkey).IsPayToTaproot() ? 1 : 0;
+}
+
 btck_TransactionInput* btck_transaction_input_copy(const btck_TransactionInput* input)
 {
     return btck_TransactionInput::copy(input);

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -794,6 +794,15 @@ BITCOINKERNEL_API int btck_script_pubkey_to_bytes(
     void* user_data) BITCOINKERNEL_ARG_NONNULL(1, 2);
 
 /**
+ * @brief Returns 1 if the script pubkey is a pay-to-taproot (P2TR) output, 0 otherwise.
+ *
+ * @param[in] script_pubkey Non-null.
+ * @return                  1 if P2TR, 0 otherwise.
+ */
+BITCOINKERNEL_API int btck_script_pubkey_is_p2tr(
+    const btck_ScriptPubkey* script_pubkey) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
  * Destroy the script pubkey.
  */
 BITCOINKERNEL_API void btck_script_pubkey_destroy(btck_ScriptPubkey* script_pubkey);

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -425,6 +425,11 @@ public:
     {
         return write_bytes(impl(), btck_script_pubkey_to_bytes);
     }
+
+    bool IsPayToTaproot() const
+    {
+        return btck_script_pubkey_is_p2tr(impl()) == 1;
+    }
 };
 
 class ScriptPubkeyView : public View<btck_ScriptPubkey>, public ScriptPubkeyApi<ScriptPubkeyView>

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -493,6 +493,21 @@ BOOST_AUTO_TEST_CASE(btck_script_pubkey)
     std::span<std::byte> empty_data{};
     ScriptPubkey empty_script{empty_data};
     CheckHandle(script, empty_script);
+
+    // Valid P2TR: OP_1 <32-byte key>
+    ScriptPubkey p2tr{hex_string_to_byte_vec("5120339ce7e165e67d93adb3fef88a6d4beed33f01fa876f05a225242b82a631abc0")};
+    BOOST_CHECK(p2tr.IsPayToTaproot());
+    BOOST_CHECK_EQUAL(btck_script_pubkey_is_p2tr(p2tr.get()), 1);
+
+    // P2PKH
+    ScriptPubkey p2pkh{hex_string_to_byte_vec("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac")};
+    BOOST_CHECK(!p2pkh.IsPayToTaproot());
+    BOOST_CHECK_EQUAL(btck_script_pubkey_is_p2tr(p2pkh.get()), 0);
+
+    // 34 bytes but second byte is not 0x20 (wrong push size)
+    ScriptPubkey wrong_push{hex_string_to_byte_vec("51210000000000000000000000000000000000000000000000000000000000000000")};
+    BOOST_CHECK(!wrong_push.IsPayToTaproot());
+    BOOST_CHECK_EQUAL(btck_script_pubkey_is_p2tr(wrong_push.get()), 0);
 }
 
 BOOST_AUTO_TEST_CASE(btck_transaction_output)


### PR DESCRIPTION
Currently users of the kernel must convert a script to bytes to interpret the OP codes, which can lead to errors. For instance, when scanning for silent payments, it is useful to filter transactions that do not have any P2TR outputs. Querying if a script is P2TR is non-trivial, as `OP_1 = 0x51`. This function removes the potential misinterpretation of script bytes.

There are other similar methods for script, but I have omitted them as this is the only method that has a demonstrated use-case that I am aware of.

ref: https://github.com/kernel-node/kernel-node/blob/master/crates/wallet/src/silentpayments/scanning.rs#L105