### PR TITLE
musig: Reject empty pubkey list in GetMuSig2KeyAggCache

### DIFF
--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -18,6 +18,10 @@ constexpr uint256 MUSIG_CHAINCODE{
 
 static bool GetMuSig2KeyAggCache(const std::vector<CPubKey>& pubkeys, secp256k1_musig_keyagg_cache& keyagg_cache)
 {
+    if (pubkeys.empty()) {
+        return false;
+    }
+
     // Parse the pubkeys
     std::vector<secp256k1_pubkey> secp_pubkeys;
     std::vector<const secp256k1_pubkey*> pubkey_ptrs;

--- a/src/test/bip328_tests.cpp
+++ b/src/test/bip328_tests.cpp
@@ -89,6 +89,12 @@ BOOST_AUTO_TEST_CASE(valid_keys)
     }
 }
 
+BOOST_AUTO_TEST_CASE(empty_pubkey_list)
+{
+    const std::optional<CPubKey> aggregate_pubkey{MuSig2AggregatePubkeys({})};
+    BOOST_CHECK(!aggregate_pubkey.has_value());
+}
+
 BOOST_AUTO_TEST_CASE(invalid_key)
 {
     std::vector<std::string> test_vectors = {


### PR DESCRIPTION
Per [BIP327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki?plain=1#L300), MuSig2 key aggregation is defined for `u` public keys where `0 < u < 2^32`.

Previously, the code did not handle `u == 0`.

This patch updates the code to reject an empty pubkey list and adds a regression test.