### PR TITLE
net: use the proxy if overriden when doing v2->v1 reconnections

### DIFF
--- a/doc/release-notes-35319.md
+++ b/doc/release-notes-35319.md
@@ -1,0 +1,20 @@
+P2P and network changes
+-----------------------
+
+- Fix a possible leak of the originator's IP address for transactions sent with
+`sendrawtransaction` RPC when `-privatebroadcast=1`. When Bitcoin Core connects
+to a peer, if that peer has been advertised to support P2P protocol v2, then
+Bitcoin Core tries to use the v2 protocol and if that fails it retries the
+connection using the v1 protocol. When the private broadcast is about to send a
+transaction to an IPv4 or IPv6 peer it overrides the normal proxy selection and
+forces the connection through the Tor proxy (and thus through the Tor network,
+protecting the sender's IP address). However if v2 protocol is tried and it
+fails, then the v1 retry connection would be made disregarding the "override
+proxy" request, possibly making an IPv4 or IPv6 direct connection. In other
+words, for this to happen the following must be true:
+  1. An IPv4 or IPv6 address has been advertised to the sender, indicating v2
+  support.
+  2. The sender must have Tor configured.
+  3. The sender's configuration must be such that connections to IPv4 or IPv6
+  are made directly (no `-proxy=` is used for IPv4 or IPv6).
+  4. The recipient does not support v2 (the flags from 1. are bogus). (#35319)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -539,6 +539,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                                 network_id,
                                 CNodeOptions{
                                     .permission_flags = permission_flags,
+                                    .proxy_override = proxy_override,
                                     .i2p_sam_session = std::move(i2p_transient_session),
                                     .recv_flood_size = nReceiveFloodSize,
                                     .use_v2transport = use_v2transport,
@@ -1956,6 +1957,7 @@ void CConnman::DisconnectNodes()
                 // and we don't want to hold up the socket handler thread for that long.
                 if (network_active && pnode->m_transport->ShouldReconnectV1()) {
                     reconnections_to_add.push_back({
+                        .proxy_override = pnode->m_proxy_override,
                         .addr_connect = pnode->addr,
                         .grant = std::move(pnode->grantOutbound),
                         .destination = pnode->m_dest,
@@ -4028,6 +4030,7 @@ CNode::CNode(NodeId idIn,
       m_permission_flags{node_opts.permission_flags},
       m_sock{sock},
       m_connected{NodeClock::now()},
+      m_proxy_override{std::move(node_opts.proxy_override)},
       addr{addrIn},
       addrBind{addrBindIn},
       m_addr_name{addrNameIn.empty() ? addr.ToStringAddrPort() : addrNameIn},
@@ -4214,7 +4217,8 @@ void CConnman::PerformReconnections()
                               std::move(item.grant),
                               item.destination.empty() ? nullptr : item.destination.c_str(),
                               item.conn_type,
-                              item.use_v2transport);
+                              item.use_v2transport,
+                              item.proxy_override);
     }
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -488,8 +488,11 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                 LogDebug(BCLog::PROXY, "Using proxy: %s to connect to %s\n", use_proxy->ToString(), target_addr.ToStringAddrPort());
                 sock = ConnectThroughProxy(*use_proxy, target_addr.ToStringAddr(), target_addr.GetPort(), proxyConnectionFailed);
             } else {
-                // no proxy needed (none set for target network)
-                sock = ConnectDirectly(target_addr, conn_type == ConnectionType::MANUAL);
+                // No proxy needed (none set for target network). Private broadcast connections
+                // must always use a proxy, otherwise they would leak the originator's IP address.
+                if (Assume(conn_type != ConnectionType::PRIVATE_BROADCAST)) {
+                    sock = ConnectDirectly(target_addr, conn_type == ConnectionType::MANUAL);
+                }
             }
             if (!proxyConnectionFailed) {
                 // If a connection to the node was attempted, and failure (if any) is not caused by a problem connecting to

--- a/src/net.h
+++ b/src/net.h
@@ -669,6 +669,7 @@ public:
 struct CNodeOptions
 {
     NetPermissionFlags permission_flags = NetPermissionFlags::None;
+    std::optional<Proxy> proxy_override = {};
     std::unique_ptr<i2p::sam::Session> i2p_sam_session = nullptr;
     bool prefer_evict = false;
     size_t recv_flood_size{DEFAULT_MAXRECEIVEBUFFER * 1000};
@@ -711,6 +712,10 @@ public:
     std::atomic<NodeClock::time_point> m_last_recv{NodeClock::epoch};
     //! Unix epoch time at peer connection
     const NodeClock::time_point m_connected;
+
+    //! Proxy to use regardless of global proxy settings if reconnecting to this node.
+    const std::optional<Proxy> m_proxy_override;
+
     // Address of this peer
     const CAddress addr;
     // Bind address of our side of the connection
@@ -1796,6 +1801,7 @@ private:
     /** Struct for entries in m_reconnections. */
     struct ReconnectionInfo
     {
+        std::optional<Proxy> proxy_override;
         CAddress addr_connect;
         CountingSemaphoreGrant<> grant;
         std::string destination;

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -188,13 +188,19 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                     conn_type = ConnectionType::OUTBOUND_FULL_RELAY;
                 }
 
+                std::optional<Proxy> proxy_override;
+                if (conn_type == ConnectionType::PRIVATE_BROADCAST || fuzzed_data_provider.ConsumeBool()) {
+                    proxy_override.emplace(ConsumeService(fuzzed_data_provider));
+                }
+
                 connman.OpenNetworkConnection(
                     /*addrConnect=*/random_address,
                     /*fCountFailure=*/fuzzed_data_provider.ConsumeBool(),
                     /*grant_outbound=*/{},
                     /*pszDest=*/fuzzed_data_provider.ConsumeBool() ? nullptr : random_string.c_str(),
                     /*conn_type=*/conn_type,
-                    /*use_v2transport=*/fuzzed_data_provider.ConsumeBool());
+                    /*use_v2transport=*/fuzzed_data_provider.ConsumeBool(),
+                    /*proxy_override=*/proxy_override);
             },
             [&] {
                 connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());


### PR DESCRIPTION
`OpenNetworkConnection()` supports overriding the proxy to use for connecting. However when v2 connection is attempted and it fails a v1 connection is tried without that proxy.

Store the override proxy in `CNode` and pass it to `CConnman::m_reconnections` to be used for v1 retries.

This is a serious flaw I have overlooked when the override proxy is used for private broadcast connections. Reported in https://www.erisian.com.au/bitcoin-core-dev/log-2026-05-18.html#l-234