### PR TITLE
private broadcast: disallow tor connection through exit node

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3086,23 +3086,11 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect,
     return true;
 }
 
-std::optional<Network> CConnman::PrivateBroadcast::PickNetwork(std::optional<Proxy>& proxy) const
+std::optional<Network> CConnman::PrivateBroadcast::PickNetwork() const
 {
-    prevector<4, Network> nets;
-    std::optional<Proxy> clearnet_proxy;
-    proxy.reset();
+    prevector<2, Network> nets;
     if (g_reachable_nets.Contains(NET_ONION)) {
         nets.push_back(NET_ONION);
-
-        clearnet_proxy = ProxyForIPv4or6();
-        if (clearnet_proxy.has_value()) {
-            if (g_reachable_nets.Contains(NET_IPV4)) {
-                nets.push_back(NET_IPV4);
-            }
-            if (g_reachable_nets.Contains(NET_IPV6)) {
-                nets.push_back(NET_IPV6);
-            }
-        }
     }
     if (g_reachable_nets.Contains(NET_I2P)) {
         nets.push_back(NET_I2P);
@@ -3112,11 +3100,7 @@ std::optional<Network> CConnman::PrivateBroadcast::PickNetwork(std::optional<Pro
         return std::nullopt;
     }
 
-    const Network net{nets[FastRandomContext{}.randrange(nets.size())]};
-    if (net == NET_IPV4 || net == NET_IPV6) {
-        proxy = clearnet_proxy;
-    }
-    return net;
+    return nets[FastRandomContext{}.randrange(nets.size())];
 }
 
 size_t CConnman::PrivateBroadcast::NumToOpen() const
@@ -3143,16 +3127,6 @@ size_t CConnman::PrivateBroadcast::NumToOpenSub(size_t n)
 void CConnman::PrivateBroadcast::NumToOpenWait() const
 {
     m_num_to_open.wait(0);
-}
-
-std::optional<Proxy> CConnman::PrivateBroadcast::ProxyForIPv4or6() const
-{
-    if (m_outbound_tor_ok_at_least_once.load()) {
-        if (const auto tor_proxy = GetProxy(NET_ONION)) {
-            return tor_proxy;
-        }
-    }
-    return std::nullopt;
 }
 
 Mutex NetEventsInterface::g_msgproc_mutex;
@@ -3264,8 +3238,7 @@ void CConnman::ThreadPrivateBroadcast()
             break;
         }
 
-        std::optional<Proxy> proxy;
-        const std::optional<Network> net{m_private_broadcast.PickNetwork(proxy)};
+        const std::optional<Network> net{m_private_broadcast.PickNetwork()};
         if (!net.has_value()) {
             LogWarning("Unable to open -privatebroadcast connections: neither Tor nor I2P is reachable");
             m_interrupt_net->sleep_for(5s);
@@ -3284,10 +3257,7 @@ void CConnman::ThreadPrivateBroadcast()
         }
         addrman_num_bad_addresses = 0;
 
-        auto target_str{addr.ToStringAddrPort()};
-        if (proxy.has_value()) {
-            target_str += " through the proxy at " + proxy->ToString();
-        }
+        const auto target_str{addr.ToStringAddrPort()};
 
         const bool use_v2transport(addr.nServices & GetLocalServices() & NODE_P2P_V2);
 
@@ -3296,8 +3266,7 @@ void CConnman::ThreadPrivateBroadcast()
                                   std::move(conn_max_grant),
                                   /*pszDest=*/nullptr,
                                   ConnectionType::PRIVATE_BROADCAST,
-                                  use_v2transport,
-                                  proxy)) {
+                                  use_v2transport)) {
             const size_t remaining{m_private_broadcast.NumToOpenSub(1)};
             LogDebug(BCLog::PRIVBROADCAST, "Socket connected to %s; remaining connections to open: %d", target_str, remaining);
         } else {
@@ -4110,13 +4079,6 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
     if (pnode->IsPrivateBroadcastConn() && !IsOutboundMessageAllowedInPrivateBroadcast(msg.m_type)) {
         LogDebug(BCLog::PRIVBROADCAST, "Omitting send of message '%s', %s", msg.m_type, pnode->LogPeer());
         return;
-    }
-
-    if (!m_private_broadcast.m_outbound_tor_ok_at_least_once.load() && !pnode->IsInboundConn() &&
-        pnode->addr.IsTor() && msg.m_type == NetMsgType::VERACK) {
-        // If we are sending the peer VERACK that means we successfully sent
-        // and received another message to/from that peer (VERSION).
-        m_private_broadcast.m_outbound_tor_ok_at_least_once.store(true);
     }
 
     size_t nMessageSize = msg.data.size();

--- a/src/net.h
+++ b/src/net.h
@@ -1194,31 +1194,19 @@ public:
     {
     public:
         /**
-         * Remember if we ever established at least one outbound connection to a
-         * Tor peer, including sending and receiving P2P messages. If this is
-         * true then the Tor proxy indeed works and is a proxy to the Tor network,
-         * not a misconfigured ordinary SOCKS5 proxy as -proxy or -onion. If that
-         * is the case, then we assume that connecting to an IPv4 or IPv6 address
-         * via that proxy will be done through the Tor network and a Tor exit node.
-         */
-        std::atomic_bool m_outbound_tor_ok_at_least_once{false};
-
-        /**
          * Semaphore used to guard against opening too many connections.
          * Opening private broadcast connections will be paused if this is equal to 0.
          */
         std::counting_semaphore<> m_sem_conn_max{MAX_PRIVATE_BROADCAST_CONNECTIONS};
 
         /**
-         * Choose a network to open a connection to.
-         * @param[out] proxy Optional proxy to override the normal proxy selection.
-         * Will be set if !std::nullopt is returned. Could be set to `std::nullopt`
-         * if there is no need to override the proxy that would be used for connecting
-         * to the returned network.
-         * @retval std::nullopt No network could be selected.
-         * @retval !std::nullopt The network was selected and `proxy` is set (maybe to `std::nullopt`).
+         * Choose a network to open a connection to. Private broadcast is restricted
+         * to anonymous overlay networks (Tor onion, I2P) so that the recipient peer
+         * never observes the originator's real IP address.
+         * @retval std::nullopt No reachable anonymous network is configured.
+         * @retval !std::nullopt The selected network.
          */
-        std::optional<Network> PickNetwork(std::optional<Proxy>& proxy) const;
+        std::optional<Network> PickNetwork() const;
 
         /// Get the pending number of connections to open.
         size_t NumToOpen() const;
@@ -1242,13 +1230,6 @@ public:
         void NumToOpenWait() const;
 
     protected:
-        /**
-         * Check if private broadcast can be done to IPv4 or IPv6 peers and if so via which proxy.
-         * If private broadcast connections should not be opened to IPv4 or IPv6, then this will
-         * return an empty optional.
-         */
-        std::optional<Proxy> ProxyForIPv4or6() const;
-
         /// Number of `ConnectionType::PRIVATE_BROADCAST` connections to open.
         std::atomic_size_t m_num_to_open{0};
 

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -84,7 +84,6 @@ void ConnmanTestMsg::Reset()
 {
     ResetAddrCache();
     ResetMaxOutboundCycle();
-    m_private_broadcast.m_outbound_tor_ok_at_least_once.store(false);
     m_private_broadcast.m_num_to_open.store(0);
 }
 

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -51,7 +51,9 @@ NUM_PRIVATE_BROADCAST_PER_TX = 3
 
 # Fill addrman with these addresses. Must have enough Tor addresses, so that even
 # if all 10 default connections are opened to a Tor address (!?) there must be more
-# for private broadcast.
+# for private broadcast. The IPv4/IPv6/CJDNS entries are intentional negative
+# coverage: -privatebroadcast restricts PickNetwork() to onion/I2P, and the
+# selector must skip these regardless of what is sitting in addrman.
 ADDRMAN_ADDRESSES = [
     "20.0.0.1",
     "30.0.0.1",
@@ -354,6 +356,18 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         assert len(peers) >= NUM_PRIVATE_BROADCAST_PER_TX
         assert all("address" in p and "sent" in p for p in peers)
         assert_greater_than_or_equal(sum(1 for p in peers if "received" in p), broadcasts_to_expect)
+
+        # -privatebroadcast must restrict outbound destinations to hidden services
+        # (Tor onion). I2P picks go via the SAM session and never reach SOCKS5,
+        # so every private-broadcast entry observed by the SOCKS5 proxy must be a
+        # .onion address.
+        with self.destinations_lock:
+            for dest in self.destinations:
+                if dest["conn_type"] != "private-broadcast":
+                    continue
+                host = dest["requested_to"].rsplit(":", 1)[0].strip("[]")
+                assert host.endswith(".onion"), \
+                    f"private-broadcast destination must be a hidden service, got {host}"
 
     def run_test(self):
         tx_originator = self.nodes[0]


### PR DESCRIPTION
Removes the logic which allows private broadcasting to connect via tor exit relays.

This mitigates the bug noted in #35319 , simplifies the logic, and is "less surprising" to me as I thought that's how it worked before.

The proxy logic could still be fixed/removed/??? but left it in place for smallest changeset that raises assurance on what we're shipping.

Proposed alternative to #35319 , at least for backport