### PR TITLE
test: Document rare failure in test_inv_block better

### DIFF
--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -116,17 +116,23 @@ class TxDownloadTest(BitcoinTestFramework):
         self.nodes[0].sendrawtransaction(tx['hex'])
 
         # Since node 1 is connected outbound to an honest peer (node 0), it
-        # should get the tx within a timeout. (Assuming that node 0
-        # announced the tx within the timeout)
+        # should get the tx within a timeout.
+        # However, node 0 sees the same connection as inbound, so it may not
+        # announce the tx within the timeout.
         # The timeout is the sum of
         # * the worst case until the tx is first requested from an inbound
         #   peer, plus
         # * the first time it is re-requested from the outbound peer, plus
         # * 2 seconds to avoid races
+        assert_equal(self.nodes[0].getpeerinfo()[0]["inbound"], True)
+        assert_equal(self.nodes[0].getpeerinfo()[0]["inv_to_send"], 1)
         assert_equal(self.nodes[1].getpeerinfo()[0]['inbound'], False)
         timeout = 2 + NONPREF_PEER_TX_DELAY + GETDATA_TX_INTERVAL
         self.log.info("Tx should be received at node 1 after {} seconds".format(timeout))
         self.nodes[0].bumpmocktime(timeout)
+        # Use an unrelated peer to ensure node 0 calls `SendMessages` at least once
+        self.nodes[0].p2ps[0].sync_with_ping()
+        assert_equal(self.nodes[0].getpeerinfo()[0]['inv_to_send'], 0)  # May fail rarely, retry the test
         self.sync_mempools()
 
         self.nodes[0].setmocktime(0)
@@ -263,7 +269,7 @@ class TxDownloadTest(BitcoinTestFramework):
         self.nodes[0].bumpmocktime(NONPREF_PEER_TX_DELAY)
         with p2p_lock:
             for peer in non_pref_peers:
-                    assert_equal(peer.tx_getdata_count, 0)
+                assert_equal(peer.tx_getdata_count, 0)
 
         # Now add another outbound (preferred) which is immediately ready for consideration
         # upon advertisement


### PR DESCRIPTION
This test may fail intermittently, see the tracking issue https://github.com/bitcoin/bitcoin/issues/19732 and https://github.com/bitcoin-core/gui/actions/runs/25819423445/job/75856716144?pr=936#step:10:5303 specifically:

```
2026-05-13T19:37:19.624321Z TestFramework (INFO): Tx should be received at node 1 after 64 seconds
2026-05-13T20:17:19.627627Z TestFramework (ERROR): Unexpected exception:
Traceback (most recent call last):
  File "/home/runner/work/_temp/test/functional/test_framework/test_framework.py", line 143, in main
    self.run_test()
  File "/home/runner/work/_temp/build/test/functional/p2p_tx_download.py", line 413, in run_test
    test()
  File "/home/runner/work/_temp/build/test/functional/p2p_tx_download.py", line 130, in test_inv_block
    self.sync_mempools()
  File "/home/runner/work/_temp/test/functional/test_framework/test_framework.py", line 721, in sync_mempools
    raise AssertionError("Mempool sync timed out after {}s:{}".format(
AssertionError: Mempool sync timed out after 2400s:
  {'2db3a22f9370eb32f110597882acebef1c76cf319837bac69b829917730d2349'}
  set()
```

The test assumes that node1 gets the tx from its honest outbound peer (node0). However, the same connection is inbound from the view of node0, so node0 will use an exponentially distributed delay, which may be more than the expected timeout.

Document this clearer, so that the this specific failure can simply be re-run without having to spend a long time thinking and debugging it every time it happens.

