### PR TITLE
contrib: Retry signet mining after grind failure

### DIFF
--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -30,6 +30,20 @@ logging.basicConfig(
 
 PSBT_SIGNET_BLOCK = b"\xfc\x06signetb"    # proprietary PSBT global field holding the block being signed
 RE_MULTIMINER = re.compile(r"^(\d+)(-(\d+))?/(\d+)$")
+GRIND_TARGET_ERROR = "Could not satisfy difficulty target"
+
+def grind_cmd_failed_to_satisfy_target(exc):
+    if exc.returncode != 1:
+        return False
+    output = []
+    for stream in (exc.stdout, exc.stderr):
+        if stream is None:
+            continue
+        if isinstance(stream, bytes):
+            output.append(stream.decode("utf8", errors="replace"))
+        else:
+            output.append(stream)
+    return GRIND_TARGET_ERROR in "\n".join(output)
 
 def signet_txs(block, challenge):
     # assumes signet solution has not been added yet so does not need
@@ -81,7 +95,7 @@ def get_solution_from_psbt(psbt, emptyok=False):
         return None
     return ser_string(scriptSig) + scriptWitness
 
-def finish_block(block, signet_solution, grind_cmd):
+def finish_block(block, signet_solution, grind_cmd, *, capture_grind_stderr=False):
     if signet_solution is None:
         pass # Don't need to add a signet commitment if there's no signet signature needed
     else:
@@ -92,7 +106,10 @@ def finish_block(block, signet_solution, grind_cmd):
     else:
         headhex = CBlockHeader.serialize(block).hex()
         cmd = shlex.split(grind_cmd) + [headhex]
-        newheadhex = subprocess.run(cmd, stdout=subprocess.PIPE, input=b"", check=True).stdout.strip()
+        kwargs = {"stdout": subprocess.PIPE, "input": b"", "check": True}
+        if capture_grind_stderr:
+            kwargs["stderr"] = subprocess.PIPE
+        newheadhex = subprocess.run(cmd, **kwargs).stdout.strip()
         newhead = from_hex(CBlockHeader(), newheadhex.decode('utf8'))
         block.nNonce = newhead.nNonce
     return block
@@ -347,23 +364,32 @@ class Generate:
         return tmpl
 
     def mine(self, bcli, grind_cmd, tmpl, reward_spk):
-        block = new_block(tmpl, reward_spk, blocktime=self.mine_time, poolid=self.poolid)
+        while True:
+            block = new_block(tmpl, reward_spk, blocktime=self.mine_time, poolid=self.poolid)
 
-        signet_spk = tmpl["signet_challenge"]
-        if trivial_challenge(signet_spk):
-            signet_solution = None
-        else:
-            psbt = generate_psbt(block, signet_spk)
-            input_stream = os.linesep.join([psbt, "true", "ALL"]).encode('utf8')
-            psbt_signed = json.loads(bcli("-stdin", "walletprocesspsbt", input=input_stream))
-            if not psbt_signed.get("complete",False):
-               logging.debug("Generated PSBT: %s" % (psbt,))
-               sys.stderr.write("PSBT signing failed\n")
-               return None
-            psbt = decode_challenge_psbt(psbt_signed["psbt"])
-            signet_solution = get_solution_from_psbt(psbt)
+            signet_spk = tmpl["signet_challenge"]
+            if trivial_challenge(signet_spk):
+                signet_solution = None
+            else:
+                psbt = generate_psbt(block, signet_spk)
+                input_stream = os.linesep.join([psbt, "true", "ALL"]).encode('utf8')
+                psbt_signed = json.loads(bcli("-stdin", "walletprocesspsbt", input=input_stream))
+                if not psbt_signed.get("complete",False):
+                    logging.debug("Generated PSBT: %s" % (psbt,))
+                    sys.stderr.write("PSBT signing failed\n")
+                    return None
+                psbt = decode_challenge_psbt(psbt_signed["psbt"])
+                signet_solution = get_solution_from_psbt(psbt)
 
-        return finish_block(block, signet_solution, grind_cmd)
+            try:
+                return finish_block(block, signet_solution, grind_cmd, capture_grind_stderr=True)
+            except subprocess.CalledProcessError as e:
+                if not grind_cmd_failed_to_satisfy_target(e):
+                    if e.stderr:
+                        sys.stderr.buffer.write(e.stderr)
+                    raise
+                self.mine_time += 1
+                logging.debug("Grinder exhausted the nonce search space, retrying with block time %d", self.mine_time)
 
 def do_generate(args):
     if args.set_block_time is not None:

--- a/test/functional/tool_signet_miner.py
+++ b/test/functional/tool_signet_miner.py
@@ -5,7 +5,9 @@
 """Test signet miner tool"""
 
 import json
+import os
 import os.path
+from pathlib import Path
 import shlex
 import subprocess
 import sys
@@ -17,6 +19,7 @@ from test_framework.script_util import CScript, key_to_p2wpkh_script
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_not_equal,
     wallet_importprivkey,
 )
 from test_framework.wallet_util import bytes_to_wif
@@ -65,24 +68,57 @@ class SignetMinerTest(BitcoinTestFramework):
         # Nodes with different signet networks are not connected
 
     # generate block with signet miner tool
-    def mine_block(self, node):
+    def mine_block(self, node, *, grind_cmd=None):
         n_blocks = node.getblockcount()
         base_dir = self.config["environment"]["SRCDIR"]
         signet_miner_path = os.path.join(base_dir, "contrib", "signet", "miner")
         rpc_argv = node.binaries.rpc_argv() + [f"-datadir={node.cli.datadir}"]
         util_argv = node.binaries.util_argv() + ["grind"]
+        if grind_cmd is None:
+            grind_cmd = shlex.join(util_argv)
         subprocess.run([
                 sys.executable,
                 signet_miner_path,
                 f'--cli={shlex.join(rpc_argv)}',
                 'generate',
                 f'--address={node.getnewaddress()}',
-                f'--grind-cmd={shlex.join(util_argv)}',
+                f'--grind-cmd={grind_cmd}',
                 f'--nbits={DIFF_1_N_BITS:08x}',
                 f'--set-block-time={int(time.time())}',
                 '--poolnum=99',
             ], check=True, stderr=subprocess.STDOUT)
         assert_equal(node.getblockcount(), n_blocks + 1)
+
+    def fail_first_grind_cmd(self, util_argv):
+        attempts_path = Path(self.options.tmpdir) / "grind_attempts"
+        headers_path = Path(self.options.tmpdir) / "grind_headers"
+        wrapper_path = Path(self.options.tmpdir) / "grind_fails_once.py"
+        wrapper_path.write_text("""#!/usr/bin/env python3
+import subprocess
+import sys
+from pathlib import Path
+
+attempts_path = Path(sys.argv[1])
+headers_path = Path(sys.argv[2])
+real_cmd = sys.argv[3:-1]
+headhex = sys.argv[-1]
+attempts = int(attempts_path.read_text(encoding="utf8")) if attempts_path.exists() else 0
+attempts_path.write_text(str(attempts + 1), encoding="utf8")
+with headers_path.open("a", encoding="utf8") as headers:
+    headers.write(headhex + "\\n")
+if attempts == 0:
+    sys.stderr.write("Could not satisfy difficulty target\\n")
+    sys.exit(1)
+sys.exit(subprocess.run(real_cmd + [headhex]).returncode)
+""", encoding="utf8")
+        os.chmod(wrapper_path, 0o755)
+        grind_cmd = shlex.join([
+            sys.executable,
+            str(wrapper_path),
+            str(attempts_path),
+            str(headers_path),
+        ] + util_argv)
+        return grind_cmd, attempts_path, headers_path
 
     # generate block using the signet miner tool genpsbt and solvepsbt commands
     def mine_block_manual(self, node, *, sign):
@@ -124,6 +160,20 @@ class SignetMinerTest(BitcoinTestFramework):
         self.mine_block(node)
         # MUST include signet commitment
         assert get_signet_commitment(get_segwit_commitment(node))
+
+        self.log.info("Retry mining a signed block when the grinder exhausts the nonce search space")
+        util_argv = node.binaries.util_argv() + ["grind"]
+        grind_cmd, attempts_path, headers_path = self.fail_first_grind_cmd(util_argv)
+        self.mine_block(node, grind_cmd=grind_cmd)
+        assert get_signet_commitment(get_segwit_commitment(node))
+        assert_equal(attempts_path.read_text(encoding="utf8"), "2")
+        headers = headers_path.read_text(encoding="utf8").splitlines()
+        assert_equal(len(headers), 2)
+        assert_not_equal(
+            headers[0],
+            headers[1],
+            error_message="miner should rebuild the block after grinder exhaustion",
+        )
 
         self.log.info("Mine manually using genpsbt and solvepsbt")
         self.mine_block_manual(node, sign=True)


### PR DESCRIPTION
Fixes #30102.

## Motivation

`bitcoin-util grind` can exhaust the nonce search space for a candidate signet block header on higher difficulty chains. When this happens, `contrib/signet/miner` currently exits instead of trying another candidate block.

## Changes

Retry mining when the grinder fails with `Could not satisfy difficulty target`. The retry rebuilds the block with an incremented block time, giving the grinder a fresh header to search.

Other grinder failures still raise the original subprocess error.

## Test

The functional test wraps `bitcoin-util grind` so the first attempt reports target exhaustion and the second attempt delegates to the real grinder. The test uses a signed signet block and records both candidate headers to verify that the retry rebuilds the block before grinding again.

Tested locally with:

```
python3 -m py_compile contrib/signet/miner test/functional/tool_signet_miner.py
git diff --check origin/master..HEAD
conda-build-env/bin/ninja -C build-clang22-clean bitcoind bitcoin-cli bitcoin-util
PATH=$PWD/conda-build-env/bin:$PATH DYLD_LIBRARY_PATH=$PWD/conda-build-env/lib HOME=$PWD/.conda-home CONDA_NUMBER_CHANNEL_NOTICES=0 CONDA_NO_PLUGINS=true CONDA_PKGS_DIRS=$PWD/.conda-pkgs XDG_CACHE_HOME=$PWD/.cache conda-build-env/bin/python build-clang22-clean/test/functional/test_runner.py --jobs=1 tool_signet_miner.py
```