### PR TITLE
test: restore assertion that tx contains exactly 2500 sigops

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -1089,6 +1089,7 @@ BOOST_AUTO_TEST_CASE(max_standard_legacy_sigops)
     AddCoins(coins, CTransaction(tx_create_p2pk), 0, false);
 
     // The transaction now contains exactly 2500 sigops, the check should pass.
+    BOOST_CHECK_EQUAL(p2sh_inputs_count * MAX_P2SH_SIGOPS + p2pk_inputs_count * 1, MAX_TX_LEGACY_SIGOPS);
     BOOST_CHECK(::ValidateInputsStandardness(CTransaction(tx_max_sigops), coins).IsValid());
 
     // Now, add some Segwit inputs. We add one for each defined Segwit output type. The limit


### PR DESCRIPTION
darosior wrote https://github.com/bitcoin/bitcoin/pull/29060#discussion_r3267762329:

_This is useful documentation, plus useful in making sure the comment above the check does not become stale or incorrect._

Hence reverted. 