### PR TITLE
qa: use NORMAL_GBT_REQUEST_PARAMS consistently in functional tests

### DIFF
--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -11,6 +11,7 @@ from test_framework.address import (
     script_to_p2wsh,
 )
 from test_framework.blocktools import (
+    NORMAL_GBT_REQUEST_PARAMS,
     send_to_witness,
     witness_script,
 )
@@ -109,7 +110,7 @@ class SegWitTest(BitcoinTestFramework):
 
         self.log.info("Verify sigops are counted in GBT with pre-BIP141 rules before the fork")
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
-        tmpl = self.nodes[0].getblocktemplate({'rules': ['segwit']})
+        tmpl = self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
         assert_equal(tmpl['sizelimit'], 1000000)
         assert 'weightlimit' not in tmpl
         assert_equal(tmpl['sigoplimit'], 20000)
@@ -221,7 +222,7 @@ class SegWitTest(BitcoinTestFramework):
         self.log.info("Verify sigops are counted in GBT with BIP141 rules after the fork")
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         raw_tx = self.nodes[0].getrawtransaction(txid, True)
-        tmpl = self.nodes[0].getblocktemplate({'rules': ['segwit']})
+        tmpl = self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
         assert_greater_than_or_equal(tmpl['sizelimit'], 3999577)  # actual maximum size is lower due to minimum mandatory non-witness data
         assert_equal(tmpl['weightlimit'], 4000000)
         assert_equal(tmpl['sigoplimit'], 80000)
@@ -275,7 +276,7 @@ class SegWitTest(BitcoinTestFramework):
         assert txid3 in self.nodes[0].getrawmempool()
 
         # Check that getblocktemplate includes all transactions.
-        template = self.nodes[0].getblocktemplate({"rules": ["segwit"]})
+        template = self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
         template_txids = [t['txid'] for t in template['transactions']]
         assert txid1 in template_txids
         assert txid2 in template_txids

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -235,7 +235,7 @@ class MiningTest(BitcoinTestFramework):
         assert_equal(node.getblocktemplate(template_request={
             'data': block.serialize().hex(),
             'mode': 'proposal',
-            'rules': ['segwit'],
+            **NORMAL_GBT_REQUEST_PARAMS,
         }), None)
 
         bad_block = copy.deepcopy(block)

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -7,6 +7,7 @@
 import random
 import threading
 
+from test_framework.blocktools import NORMAL_GBT_REQUEST_PARAMS
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, get_rpc_proxy
 from test_framework.wallet import MiniWallet
@@ -16,14 +17,14 @@ class LongpollThread(threading.Thread):
     def __init__(self, node):
         threading.Thread.__init__(self)
         # query current longpollid
-        template = node.getblocktemplate({'rules': ['segwit']})
+        template = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
         self.longpollid = template['longpollid']
         # create a new connection to the node, we can't use the same
         # connection from two threads
         self.node = get_rpc_proxy(node.url, 1, timeout=600, coveragedir=node.coverage_dir)
 
     def run(self):
-        self.node.getblocktemplate({'longpollid': self.longpollid, 'rules': ['segwit']})
+        self.node.getblocktemplate({'longpollid': self.longpollid, **NORMAL_GBT_REQUEST_PARAMS})
 
 class GetBlockTemplateLPTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -34,9 +35,9 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         self.log.info("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.log.info("Test that longpollid doesn't change between successive getblocktemplate() invocations if nothing else happens")
         self.generate(self.nodes[0], 10)
-        template = self.nodes[0].getblocktemplate({'rules': ['segwit']})
+        template = self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
         longpollid = template['longpollid']
-        template2 = self.nodes[0].getblocktemplate({'rules': ['segwit']})
+        template2 = self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
         assert_equal(template2['longpollid'], longpollid)
 
         self.log.info("Test that longpoll waits if we do nothing")

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -7,6 +7,7 @@
 from decimal import Decimal
 import time
 
+from test_framework.blocktools import NORMAL_GBT_REQUEST_PARAMS
 from test_framework.messages import (
     COIN,
     MAX_BLOCK_WEIGHT,
@@ -352,14 +353,14 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # getblocktemplate to (eventually) return a new block.
         mock_time = int(time.time())
         self.nodes[0].setmocktime(mock_time)
-        template = self.nodes[0].getblocktemplate({'rules': ['segwit']})
+        template = self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
         self.nodes[0].prioritisetransaction(txid=tx_id, fee_delta=-int(self.relayfee*COIN))
 
         # Calling prioritisetransaction with the inverse amount should delete its prioritisation entry
         assert tx_id not in self.nodes[0].getprioritisedtransactions()
 
         self.nodes[0].setmocktime(mock_time+10)
-        new_template = self.nodes[0].getblocktemplate({'rules': ['segwit']})
+        new_template = self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
 
         assert_not_equal(template, new_template)
 

--- a/test/functional/mining_template_verification.py
+++ b/test/functional/mining_template_verification.py
@@ -14,6 +14,7 @@ import copy
 from test_framework.blocktools import (
     create_block,
     add_witness_commitment,
+    NORMAL_GBT_REQUEST_PARAMS,
 )
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -38,7 +39,7 @@ def assert_template(node, block, expect, *, rehash=True, submit=True, solve=True
     rsp = node.getblocktemplate(template_request={
         'data': block.serialize().hex(),
         'mode': 'proposal',
-        'rules': ['segwit'],
+        **NORMAL_GBT_REQUEST_PARAMS,
     })
     assert_equal(rsp, expect)
     # Only attempt to submit invalid templates
@@ -81,7 +82,7 @@ class MiningTemplateVerificationTest(BitcoinTestFramework):
             template_request={
                 "data": block.serialize()[:-1].hex(),
                 "mode": "proposal",
-                "rules": ["segwit"],
+                **NORMAL_GBT_REQUEST_PARAMS,
             }
         )
 
@@ -114,7 +115,7 @@ class MiningTemplateVerificationTest(BitcoinTestFramework):
         assert_raises_rpc_error(-22, "Block decode failed", node.getblocktemplate, {
             'data': bad_block_sn.hex(),
             'mode': 'proposal',
-            'rules': ['segwit'],
+            **NORMAL_GBT_REQUEST_PARAMS,
         })
 
     def nbits_test(self, node, block):


### PR DESCRIPTION
Functional tests have a constant that defines normal parameters to `getblocktemplate` but some tests were still hardcoding its value. This PR updates those tests to use the constant instead, so that if normal parameters to `getblocktemplate` need to be changed, it is only necessary to change them in a single place.

This is preparatory work for the implementation of BIP 54, which introduces a new GBT "forced" rule.