### PR TITLE
kernel: validate C API inputs

### DIFF
--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -525,7 +525,9 @@ size_t btck_transaction_count_outputs(const btck_Transaction* transaction)
 const btck_TransactionOutput* btck_transaction_get_output_at(const btck_Transaction* transaction, size_t output_index)
 {
     const CTransaction& tx = *btck_Transaction::get(transaction);
-    assert(output_index < tx.vout.size());
+    if (output_index >= tx.vout.size()) {
+        return nullptr;
+    }
     return btck_TransactionOutput::ref(&tx.vout[output_index]);
 }
 
@@ -536,8 +538,11 @@ size_t btck_transaction_count_inputs(const btck_Transaction* transaction)
 
 const btck_TransactionInput* btck_transaction_get_input_at(const btck_Transaction* transaction, size_t input_index)
 {
-    assert(input_index < btck_Transaction::get(transaction)->vin.size());
-    return btck_TransactionInput::ref(&btck_Transaction::get(transaction)->vin[input_index]);
+    const CTransaction& tx = *btck_Transaction::get(transaction);
+    if (input_index >= tx.vin.size()) {
+        return nullptr;
+    }
+    return btck_TransactionInput::ref(&tx.vin[input_index]);
 }
 
 uint32_t btck_transaction_get_locktime(const btck_Transaction* transaction)
@@ -627,9 +632,21 @@ btck_PrecomputedTransactionData* btck_precomputed_transaction_data_create(
 {
     try {
         const CTransaction& tx{*btck_Transaction::get(tx_to)};
+        if (spent_outputs_ != nullptr && spent_outputs_len > 0) {
+            if (spent_outputs_len != tx.vin.size()) {
+                return nullptr;
+            }
+            for (size_t i = 0; i < spent_outputs_len; i++) {
+                if (spent_outputs_[i] == nullptr) {
+                    return nullptr;
+                }
+            }
+        } else if (spent_outputs_ == nullptr && spent_outputs_len != 0) {
+            return nullptr;
+        }
+
         auto txdata{btck_PrecomputedTransactionData::create()};
         if (spent_outputs_ != nullptr && spent_outputs_len > 0) {
-            assert(spent_outputs_len == tx.vin.size());
             std::vector<CTxOut> spent_outputs;
             spent_outputs.reserve(spent_outputs_len);
             for (size_t i = 0; i < spent_outputs_len; i++) {
@@ -665,8 +682,10 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
                               const btck_ScriptVerificationFlags flags,
                               btck_ScriptVerifyStatus* status)
 {
-    // Assert that all specified flags are part of the interface before continuing
-    assert((flags & ~btck_ScriptVerificationFlags_ALL) == 0);
+    if ((flags & ~btck_ScriptVerificationFlags_ALL) != 0) {
+        if (status) *status = btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS;
+        return 0;
+    }
 
     if (!is_valid_flag_combination(script_verify_flags::from_int(flags))) {
         if (status) *status = btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION;
@@ -674,13 +693,18 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
     }
 
     const CTransaction& tx{*btck_Transaction::get(tx_to)};
-    assert(input_index < tx.vin.size());
+    if (input_index >= tx.vin.size()) {
+        if (status) *status = btck_ScriptVerifyStatus_ERROR_INPUT_INDEX_OUT_OF_RANGE;
+        return 0;
+    }
 
     const PrecomputedTransactionData& txdata{precomputed_txdata ? btck_PrecomputedTransactionData::get(precomputed_txdata) : PrecomputedTransactionData(tx)};
 
-    if (flags & btck_ScriptVerificationFlags_TAPROOT && txdata.m_spent_outputs.empty()) {
-        if (status) *status = btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED;
-        return 0;
+    if (flags & btck_ScriptVerificationFlags_TAPROOT) {
+        if (!txdata.m_spent_outputs_ready) {
+            if (status) *status = btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED;
+            return 0;
+        }
     }
 
     if (status) *status = btck_ScriptVerifyStatus_OK;
@@ -1158,8 +1182,11 @@ size_t btck_block_count_transactions(const btck_Block* block)
 
 const btck_Transaction* btck_block_get_transaction_at(const btck_Block* block, size_t index)
 {
-    assert(index < btck_Block::get(block)->vtx.size());
-    return btck_Transaction::ref(&btck_Block::get(block)->vtx[index]);
+    const auto& block_ptr{btck_Block::get(block)};
+    if (index >= block_ptr->vtx.size()) {
+        return nullptr;
+    }
+    return btck_Transaction::ref(&block_ptr->vtx[index]);
 }
 
 btck_BlockHeader* btck_block_get_header(const btck_Block* block)
@@ -1270,8 +1297,11 @@ size_t btck_block_spent_outputs_count(const btck_BlockSpentOutputs* block_spent_
 
 const btck_TransactionSpentOutputs* btck_block_spent_outputs_get_transaction_spent_outputs_at(const btck_BlockSpentOutputs* block_spent_outputs, size_t transaction_index)
 {
-    assert(transaction_index < btck_BlockSpentOutputs::get(block_spent_outputs)->vtxundo.size());
-    const auto* tx_undo{&btck_BlockSpentOutputs::get(block_spent_outputs)->vtxundo.at(transaction_index)};
+    const auto& block_undo{btck_BlockSpentOutputs::get(block_spent_outputs)};
+    if (transaction_index >= block_undo->vtxundo.size()) {
+        return nullptr;
+    }
+    const auto* tx_undo{&block_undo->vtxundo[transaction_index]};
     return btck_TransactionSpentOutputs::ref(tx_undo);
 }
 
@@ -1297,8 +1327,11 @@ void btck_transaction_spent_outputs_destroy(btck_TransactionSpentOutputs* transa
 
 const btck_Coin* btck_transaction_spent_outputs_get_coin_at(const btck_TransactionSpentOutputs* transaction_spent_outputs, size_t coin_index)
 {
-    assert(coin_index < btck_TransactionSpentOutputs::get(transaction_spent_outputs).vprevout.size());
-    const Coin* coin{&btck_TransactionSpentOutputs::get(transaction_spent_outputs).vprevout.at(coin_index)};
+    const auto& tx_undo{btck_TransactionSpentOutputs::get(transaction_spent_outputs)};
+    if (coin_index >= tx_undo.vprevout.size()) {
+        return nullptr;
+    }
+    const Coin* coin{&tx_undo.vprevout[coin_index]};
     return btck_Coin::ref(coin);
 }
 

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -504,6 +504,8 @@ typedef uint8_t btck_ScriptVerifyStatus;
 #define btck_ScriptVerifyStatus_OK ((btck_ScriptVerifyStatus)(0))
 #define btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION ((btck_ScriptVerifyStatus)(1)) //!< The flags were combined in an invalid way.
 #define btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED ((btck_ScriptVerifyStatus)(2))    //!< The taproot flag was set, so valid spent_outputs have to be provided.
+#define btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS ((btck_ScriptVerifyStatus)(3))             //!< The flags include unknown or unsupported bits.
+#define btck_ScriptVerifyStatus_ERROR_INPUT_INDEX_OUT_OF_RANGE ((btck_ScriptVerifyStatus)(4))  //!< The input index is out of range for the passed transaction.
 
 /**
  * Script verification flags that may be composed with each other.
@@ -622,7 +624,7 @@ BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_count
  *
  * @param[in] transaction  Non-null.
  * @param[in] output_index The index of the transaction output to be retrieved.
- * @return                 The transaction output
+ * @return                 The transaction output, or null if the index is out of bounds.
  */
 BITCOINKERNEL_API const btck_TransactionOutput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_get_output_at(
     const btck_Transaction* transaction, size_t output_index) BITCOINKERNEL_ARG_NONNULL(1);
@@ -634,7 +636,7 @@ BITCOINKERNEL_API const btck_TransactionOutput* BITCOINKERNEL_WARN_UNUSED_RESULT
  *
  * @param[in] transaction Non-null.
  * @param[in] input_index The index of the transaction input to be retrieved.
- * @return                 The transaction input
+ * @return                 The transaction input, or null if the index is out of bounds.
  */
 BITCOINKERNEL_API const btck_TransactionInput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_get_input_at(
     const btck_Transaction* transaction, size_t input_index) BITCOINKERNEL_ARG_NONNULL(1);
@@ -702,6 +704,10 @@ BITCOINKERNEL_API void btck_transaction_destroy(btck_Transaction* transaction);
 /**
  * @brief Create precomputed transaction data for script verification.
  *
+ * If spent_outputs is null, spent_outputs_len must be 0. If spent_outputs is
+ * non-null and spent_outputs_len is nonzero, spent_outputs_len must match the
+ * number of inputs in tx_to, and each entry must be non-null.
+ *
  * @param[in] tx_to             Non-null.
  * @param[in] spent_outputs     Nullable for non-taproot verification. Points to an array of
  *                              outputs spent by the transaction.
@@ -767,6 +773,11 @@ BITCOINKERNEL_API btck_ScriptPubkey* BITCOINKERNEL_WARN_UNUSED_RESULT btck_scrip
  * @param[in] input_index        Index of the input in tx_to spending the script_pubkey.
  * @param[in] flags              Bitfield of btck_ScriptVerificationFlags controlling validation constraints.
  * @param[out] status            Nullable, will be set to an error code if the operation fails, or OK otherwise.
+ *                               Possible errors are:
+ *                               - btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS if flags contains unknown bits.
+ *                               - btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION if flags contains an invalid combination.
+ *                               - btck_ScriptVerifyStatus_ERROR_INPUT_INDEX_OUT_OF_RANGE if input_index is out of bounds for tx_to.
+ *                               - btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED if the taproot flag is set and precomputed_txdata is missing spent outputs.
  * @return                       1 if the script is valid, 0 otherwise.
  */
 BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_script_pubkey_verify(
@@ -1409,7 +1420,7 @@ BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_count_trans
  *
  * @param[in] block             Non-null.
  * @param[in] transaction_index The index of the transaction to be retrieved.
- * @return                      The transaction.
+ * @return                      The transaction, or null if the index is out of bounds.
  */
 BITCOINKERNEL_API const btck_Transaction* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_get_transaction_at(
     const btck_Block* block, size_t transaction_index) BITCOINKERNEL_ARG_NONNULL(1);
@@ -1579,7 +1590,7 @@ BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_spent_outpu
  *
  * @param[in] block_spent_outputs             Non-null.
  * @param[in] transaction_spent_outputs_index The index of the transaction spent outputs within the block spent outputs.
- * @return                                    A transaction spent outputs pointer.
+ * @return                                    A transaction spent outputs pointer, or null if the index is out of bounds.
  */
 BITCOINKERNEL_API const btck_TransactionSpentOutputs* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_spent_outputs_get_transaction_spent_outputs_at(
     const btck_BlockSpentOutputs* block_spent_outputs,
@@ -1624,7 +1635,7 @@ BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_spent
  * @param[in] transaction_spent_outputs Non-null.
  * @param[in] coin_index                The index of the to be retrieved coin within the
  *                                      transaction spent outputs.
- * @return                              A coin pointer.
+ * @return                              A coin pointer, or null if the index is out of bounds.
  */
 BITCOINKERNEL_API const btck_Coin* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_spent_outputs_get_coin_at(
     const btck_TransactionSpentOutputs* transaction_spent_outputs,

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -99,6 +99,8 @@ enum class ScriptVerifyStatus : btck_ScriptVerifyStatus {
     OK = btck_ScriptVerifyStatus_OK,
     ERROR_INVALID_FLAGS_COMBINATION = btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION,
     ERROR_SPENT_OUTPUTS_REQUIRED = btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED,
+    ERROR_INVALID_FLAGS = btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS,
+    ERROR_INPUT_INDEX_OUT_OF_RANGE = btck_ScriptVerifyStatus_ERROR_INPUT_INDEX_OUT_OF_RANGE,
 };
 
 enum class ScriptVerificationFlags : btck_ScriptVerificationFlags {

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -414,6 +414,8 @@ BOOST_AUTO_TEST_CASE(btck_transaction_tests)
 
     BOOST_CHECK_EQUAL(tx.CountOutputs(), 2);
     BOOST_CHECK_EQUAL(tx.CountInputs(), 1);
+    BOOST_CHECK(btck_transaction_get_output_at(tx.get(), tx.CountOutputs()) == nullptr);
+    BOOST_CHECK(btck_transaction_get_input_at(tx.get(), tx.CountInputs()) == nullptr);
     BOOST_CHECK_EQUAL(tx.GetLocktime(), 510826);
     auto broken_tx_data{std::span<std::byte>{tx_data.begin(), tx_data.begin() + 10}};
     BOOST_CHECK_THROW(Transaction{broken_tx_data}, std::runtime_error);
@@ -529,6 +531,18 @@ BOOST_AUTO_TEST_CASE(btck_precomputed_txdata) {
         /*spent_outputs=*/{},
     }};
     CheckHandle(precomputed_txdata, precomputed_txdata_2);
+
+    ScriptPubkey script{hex_string_to_byte_vec("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac")};
+    TransactionOutput output{script, 1};
+    TransactionOutput output2{script, 2};
+    const btck_TransactionOutput* too_many_spent_outputs[]{output.get(), output2.get()};
+    BOOST_CHECK(btck_precomputed_transaction_data_create(
+                    tx.get(), too_many_spent_outputs, 2) == nullptr);
+    BOOST_CHECK(btck_precomputed_transaction_data_create(tx.get(), nullptr, 1) == nullptr);
+
+    const btck_TransactionOutput* null_spent_outputs[]{nullptr};
+    BOOST_CHECK(btck_precomputed_transaction_data_create(
+                    tx.get(), null_spent_outputs, 1) == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(btck_script_verify_tests)
@@ -543,6 +557,62 @@ BOOST_AUTO_TEST_CASE(btck_script_verify_tests)
         /*amount=*/0,
         /*input_index=*/0,
         /*taproot=*/false);
+
+    btck_ScriptVerifyStatus status{btck_ScriptVerifyStatus_OK};
+    BOOST_CHECK_EQUAL(btck_script_pubkey_verify(
+                          legacy_spent_script_pubkey.get(),
+                          /*amount=*/0,
+                          legacy_spending_tx.get(),
+                          /*precomputed_txdata=*/nullptr,
+                          /*input_index=*/0,
+                          btck_ScriptVerificationFlags_ALL | (1U << 31),
+                          &status),
+        0);
+    BOOST_CHECK(status == btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS);
+
+    BOOST_CHECK_EQUAL(btck_script_pubkey_verify(
+                          legacy_spent_script_pubkey.get(),
+                          /*amount=*/0,
+                          legacy_spending_tx.get(),
+                          /*precomputed_txdata=*/nullptr,
+                          /*input_index=*/0,
+                          btck_ScriptVerificationFlags_ALL | (1U << 31),
+                          /*status=*/nullptr),
+        0);
+
+    status = btck_ScriptVerifyStatus_OK;
+    BOOST_CHECK_EQUAL(btck_script_pubkey_verify(
+                          legacy_spent_script_pubkey.get(),
+                          /*amount=*/0,
+                          legacy_spending_tx.get(),
+                          /*precomputed_txdata=*/nullptr,
+                          /*input_index=*/0,
+                          btck_ScriptVerificationFlags_WITNESS,
+                          &status),
+        0);
+    BOOST_CHECK(status == btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION);
+
+    status = btck_ScriptVerifyStatus_OK;
+    BOOST_CHECK_EQUAL(btck_script_pubkey_verify(
+                          legacy_spent_script_pubkey.get(),
+                          /*amount=*/0,
+                          legacy_spending_tx.get(),
+                          /*precomputed_txdata=*/nullptr,
+                          /*input_index=*/legacy_spending_tx.CountInputs(),
+                          btck_ScriptVerificationFlags_NONE,
+                          &status),
+        0);
+    BOOST_CHECK(status == btck_ScriptVerifyStatus_ERROR_INPUT_INDEX_OUT_OF_RANGE);
+
+    BOOST_CHECK_EQUAL(btck_script_pubkey_verify(
+                          legacy_spent_script_pubkey.get(),
+                          /*amount=*/0,
+                          legacy_spending_tx.get(),
+                          /*precomputed_txdata=*/nullptr,
+                          /*input_index=*/legacy_spending_tx.CountInputs(),
+                          btck_ScriptVerificationFlags_NONE,
+                          /*status=*/nullptr),
+        0);
 
     // Legacy transaction aca326a724eda9a461c10a876534ecd5ae7b27f10f26c3862fb996f80ea2d45d with precomputed_txdata
     auto legacy_precomputed_txdata{PrecomputedTransactionData{
@@ -724,6 +794,7 @@ BOOST_AUTO_TEST_CASE(btck_block)
     CheckHandle(block, block_100);
     Block block_tx{hex_string_to_byte_vec(REGTEST_BLOCK_DATA[205])};
     CheckRange(block_tx.Transactions(), block_tx.CountTransactions());
+    BOOST_CHECK(btck_block_get_transaction_at(block_tx.get(), block_tx.CountTransactions()) == nullptr);
     auto invalid_data = hex_string_to_byte_vec("012300");
     BOOST_CHECK_THROW(Block{invalid_data}, std::runtime_error);
     auto empty_data = hex_string_to_byte_vec("");
@@ -1201,6 +1272,8 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     CheckHandle(block_spent_outputs, block_spent_outputs_prev);
     CheckRange(block_spent_outputs_prev.TxsSpentOutputs(), block_spent_outputs_prev.Count());
     BOOST_CHECK_EQUAL(block_spent_outputs.Count(), 1);
+    BOOST_CHECK(btck_block_spent_outputs_get_transaction_spent_outputs_at(
+                    block_spent_outputs.get(), block_spent_outputs.Count()) == nullptr);
 
     // Get transaction spent outputs from the last transaction in the two blocks
     TransactionSpentOutputsView transaction_spent_outputs{block_spent_outputs.GetTxSpentOutputs(block_spent_outputs.Count() - 1)};
@@ -1208,6 +1281,8 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     TransactionSpentOutputs owned_transaction_spent_outputs_prev{block_spent_outputs_prev.GetTxSpentOutputs(block_spent_outputs_prev.Count() - 1)};
     CheckHandle(owned_transaction_spent_outputs, owned_transaction_spent_outputs_prev);
     CheckRange(transaction_spent_outputs.Coins(), transaction_spent_outputs.Count());
+    BOOST_CHECK(btck_transaction_spent_outputs_get_coin_at(
+                    transaction_spent_outputs.get(), transaction_spent_outputs.Count()) == nullptr);
 
     // Get the last coin from the transaction spent outputs
     CoinView coin{transaction_spent_outputs.GetCoin(transaction_spent_outputs.Count() - 1)};


### PR DESCRIPTION
Fixes #35339.

This hardens the experimental libbitcoinkernel C API so caller-provided invalid runtime inputs fail through documented return/status channels instead of assertions. Existing script verification status numeric values are preserved, and the new values are appended.

## Summary

- Return `nullptr` for out-of-range transaction, block transaction, block spent-output, and transaction spent-output accessors.
- Add script verification statuses for unsupported flag bits and out-of-range input indexes.
- Reject malformed precomputed transaction data spent-output arrays at construction.
- Document script verification failure statuses and precomputed spent-output array requirements.
- Add focused kernel API tests for the new failure behavior, including nullable status output handling.

## Testing

- `git diff --check`
- `cmake -B build-kernel-validation -DBUILD_KERNEL_LIB=ON -DBUILD_KERNEL_TEST=ON -DBUILD_TESTS=OFF -DBUILD_DAEMON=OFF -DBUILD_CLI=OFF -DBUILD_BITCOIN_BIN=OFF -DBUILD_TX=OFF -DBUILD_UTIL=OFF -DENABLE_WALLET=OFF -DENABLE_IPC=OFF`
- `cmake --build build-kernel-validation --target test_kernel -j $(sysctl -n hw.ncpu)`
- `build-kernel-validation/bin/test_kernel`