### PR TITLE
test: fuzz wallet_rpc target

### DIFF
--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -2,43 +2,27 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <base58.h>
-#include <key.h>
-#include <key_io.h>
-#include <primitives/block.h>
-#include <primitives/transaction.h>
-#include <psbt.h>
 #include <rpc/client.h>
 #include <rpc/request.h>
 #include <rpc/server.h>
-#include <span.h>
-#include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/rpc.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
-#include <tinyformat.h>
-#include <uint256.h>
 #include <univalue.h>
-#include <util/strencodings.h>
-#include <util/string.h>
 #include <util/time.h>
 
 #include <algorithm>
 #include <cassert>
-#include <cstdint>
 #include <cstdlib>
-#include <exception>
 #include <iostream>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 #include <vector>
 enum class ChainType;
-
-using util::Join;
-using util::ToString;
 
 namespace {
 struct RPCFuzzTestingSetup : public TestingSetup {
@@ -193,150 +177,6 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "waitfornewblock",
 };
 
-std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data)
-{
-    const size_t max_string_length = 4096;
-    const size_t max_base58_bytes_length{64};
-    std::string r;
-    CallOneOf(
-        fuzzed_data_provider,
-        [&] {
-            // string argument
-            r = fuzzed_data_provider.ConsumeRandomLengthString(max_string_length);
-        },
-        [&] {
-            // base64 argument
-            r = EncodeBase64(fuzzed_data_provider.ConsumeRandomLengthString(max_string_length));
-        },
-        [&] {
-            // hex argument
-            r = HexStr(fuzzed_data_provider.ConsumeRandomLengthString(max_string_length));
-        },
-        [&] {
-            // bool argument
-            r = fuzzed_data_provider.ConsumeBool() ? "true" : "false";
-        },
-        [&] {
-            // range argument
-            r = "[" + ToString(fuzzed_data_provider.ConsumeIntegral<int64_t>()) + "," + ToString(fuzzed_data_provider.ConsumeIntegral<int64_t>()) + "]";
-        },
-        [&] {
-            // integral argument (int64_t)
-            r = ToString(fuzzed_data_provider.ConsumeIntegral<int64_t>());
-        },
-        [&] {
-            // integral argument (uint64_t)
-            r = ToString(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-        },
-        [&] {
-            // floating point argument
-            r = strprintf("%f", fuzzed_data_provider.ConsumeFloatingPoint<double>());
-        },
-        [&] {
-            // tx destination argument
-            r = EncodeDestination(ConsumeTxDestination(fuzzed_data_provider));
-        },
-        [&] {
-            // uint160 argument
-            r = ConsumeUInt160(fuzzed_data_provider).ToString();
-        },
-        [&] {
-            // uint256 argument
-            r = ConsumeUInt256(fuzzed_data_provider).ToString();
-        },
-        [&] {
-            // base32 argument
-            r = EncodeBase32(fuzzed_data_provider.ConsumeRandomLengthString(max_string_length));
-        },
-        [&] {
-            // base58 argument
-            r = EncodeBase58(MakeUCharSpan(fuzzed_data_provider.ConsumeRandomLengthString(max_base58_bytes_length)));
-        },
-        [&] {
-            // base58 argument with checksum
-            r = EncodeBase58Check(MakeUCharSpan(fuzzed_data_provider.ConsumeRandomLengthString(max_base58_bytes_length)));
-        },
-        [&] {
-            // hex encoded block
-            std::optional<CBlock> opt_block = ConsumeDeserializable<CBlock>(fuzzed_data_provider, TX_WITH_WITNESS);
-            if (!opt_block) {
-                good_data = false;
-                return;
-            }
-            DataStream data_stream{};
-            data_stream << TX_WITH_WITNESS(*opt_block);
-            r = HexStr(data_stream);
-        },
-        [&] {
-            // hex encoded block header
-            std::optional<CBlockHeader> opt_block_header = ConsumeDeserializable<CBlockHeader>(fuzzed_data_provider);
-            if (!opt_block_header) {
-                good_data = false;
-                return;
-            }
-            DataStream data_stream{};
-            data_stream << *opt_block_header;
-            r = HexStr(data_stream);
-        },
-        [&] {
-            // hex encoded tx
-            std::optional<CMutableTransaction> opt_tx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS);
-            if (!opt_tx) {
-                good_data = false;
-                return;
-            }
-            DataStream data_stream;
-            auto allow_witness = (fuzzed_data_provider.ConsumeBool() ? TX_WITH_WITNESS : TX_NO_WITNESS);
-            data_stream << allow_witness(*opt_tx);
-            r = HexStr(data_stream);
-        },
-        [&] {
-            // base64 encoded psbt
-            std::optional<PartiallySignedTransaction> opt_psbt = ConsumeDeserializableConstructor<PartiallySignedTransaction>(fuzzed_data_provider);
-            if (!opt_psbt) {
-                good_data = false;
-                return;
-            }
-            DataStream data_stream{};
-            data_stream << *opt_psbt;
-            r = EncodeBase64(data_stream);
-        },
-        [&] {
-            // base58 encoded key
-            CKey key = ConsumePrivateKey(fuzzed_data_provider);
-            if (!key.IsValid()) {
-                good_data = false;
-                return;
-            }
-            r = EncodeSecret(key);
-        },
-        [&] {
-            // hex encoded pubkey
-            CKey key = ConsumePrivateKey(fuzzed_data_provider);
-            if (!key.IsValid()) {
-                good_data = false;
-                return;
-            }
-            r = HexStr(key.GetPubKey());
-        });
-    return r;
-}
-
-std::string ConsumeArrayRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data)
-{
-    std::vector<std::string> scalar_arguments;
-    LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 100)
-    {
-        scalar_arguments.push_back(ConsumeScalarRPCArgument(fuzzed_data_provider, good_data));
-    }
-    return "[\"" + Join(scalar_arguments, "\",\"") + "\"]";
-}
-
-std::string ConsumeRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data)
-{
-    return fuzzed_data_provider.ConsumeBool() ? ConsumeScalarRPCArgument(fuzzed_data_provider, good_data) : ConsumeArrayRPCArgument(fuzzed_data_provider, good_data);
-}
-
 RPCFuzzTestingSetup* InitializeRPCFuzzTestingSetup()
 {
     static const auto setup = MakeNoLogFileContext<RPCFuzzTestingSetup>();
@@ -348,19 +188,7 @@ RPCFuzzTestingSetup* InitializeRPCFuzzTestingSetup()
 void initialize_rpc()
 {
     rpc_testing_setup = InitializeRPCFuzzTestingSetup();
-    const std::vector<std::string> supported_rpc_commands = rpc_testing_setup->GetRPCCommands();
-    for (const std::string& rpc_command : supported_rpc_commands) {
-        const bool safe_for_fuzzing = std::find(RPC_COMMANDS_SAFE_FOR_FUZZING.begin(), RPC_COMMANDS_SAFE_FOR_FUZZING.end(), rpc_command) != RPC_COMMANDS_SAFE_FOR_FUZZING.end();
-        const bool not_safe_for_fuzzing = std::find(RPC_COMMANDS_NOT_SAFE_FOR_FUZZING.begin(), RPC_COMMANDS_NOT_SAFE_FOR_FUZZING.end(), rpc_command) != RPC_COMMANDS_NOT_SAFE_FOR_FUZZING.end();
-        if (!(safe_for_fuzzing || not_safe_for_fuzzing)) {
-            std::cerr << "Error: RPC command \"" << rpc_command << "\" not found in RPC_COMMANDS_SAFE_FOR_FUZZING or RPC_COMMANDS_NOT_SAFE_FOR_FUZZING. Please update " << __FILE__ << ".\n";
-            std::terminate();
-        }
-        if (safe_for_fuzzing && not_safe_for_fuzzing) {
-            std::cerr << "Error: RPC command \"" << rpc_command << "\" found in *both* RPC_COMMANDS_SAFE_FOR_FUZZING and RPC_COMMANDS_NOT_SAFE_FOR_FUZZING. Please update " << __FILE__ << ".\n";
-            std::terminate();
-        }
-    }
+    fuzzrpc::ValidateRpcCommands(RPC_COMMANDS_SAFE_FOR_FUZZING, RPC_COMMANDS_NOT_SAFE_FOR_FUZZING, rpc_testing_setup->GetRPCCommands(), __FILE__);
     const char* limit_to_rpc_command_env = std::getenv("LIMIT_TO_RPC_COMMAND");
     if (limit_to_rpc_command_env != nullptr) {
         g_limit_to_rpc_command = std::string{limit_to_rpc_command_env};
@@ -384,7 +212,7 @@ FUZZ_TARGET(rpc, .init = initialize_rpc)
     std::vector<std::string> arguments;
     LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 100)
     {
-        arguments.push_back(ConsumeRPCArgument(fuzzed_data_provider, good_data));
+        arguments.push_back(fuzzrpc::ConsumeRPCArgument(fuzzed_data_provider, good_data));
     }
     try {
         std::optional<test_only_CheckFailuresAreExceptionsNotAborts> maybe_mock{};

--- a/src/test/fuzz/util/CMakeLists.txt
+++ b/src/test/fuzz/util/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(test_fuzz STATIC EXCLUDE_FROM_ALL
   descriptor.cpp
   mempool.cpp
   net.cpp
+  rpc.cpp
   threadinterrupt.cpp
   ../fuzz.cpp
   ../util.cpp

--- a/src/test/fuzz/util/rpc.cpp
+++ b/src/test/fuzz/util/rpc.cpp
@@ -1,0 +1,195 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/util/rpc.h>
+
+#include <base58.h>
+#include <key.h>
+#include <key_io.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <psbt.h>
+#include <span.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/util.h>
+#include <tinyformat.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+using util::Join;
+using util::ToString;
+
+namespace fuzzrpc {
+std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data)
+{
+    const size_t max_string_length = 4096;
+    const size_t max_base58_bytes_length{64};
+    std::string r;
+    CallOneOf(
+        fuzzed_data_provider,
+        [&] {
+            // string argument
+            r = fuzzed_data_provider.ConsumeRandomLengthString(max_string_length);
+        },
+        [&] {
+            // base64 argument
+            r = EncodeBase64(fuzzed_data_provider.ConsumeRandomLengthString(max_string_length));
+        },
+        [&] {
+            // hex argument
+            r = HexStr(fuzzed_data_provider.ConsumeRandomLengthString(max_string_length));
+        },
+        [&] {
+            // bool argument
+            r = fuzzed_data_provider.ConsumeBool() ? "true" : "false";
+        },
+        [&] {
+            // range argument
+            r = "[" + ToString(fuzzed_data_provider.ConsumeIntegral<int64_t>()) + "," + ToString(fuzzed_data_provider.ConsumeIntegral<int64_t>()) + "]";
+        },
+        [&] {
+            // integral argument (int64_t)
+            r = ToString(fuzzed_data_provider.ConsumeIntegral<int64_t>());
+        },
+        [&] {
+            // integral argument (uint64_t)
+            r = ToString(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+        },
+        [&] {
+            // floating point argument
+            r = strprintf("%f", fuzzed_data_provider.ConsumeFloatingPoint<double>());
+        },
+        [&] {
+            // tx destination argument
+            r = EncodeDestination(ConsumeTxDestination(fuzzed_data_provider));
+        },
+        [&] {
+            // uint160 argument
+            r = ConsumeUInt160(fuzzed_data_provider).ToString();
+        },
+        [&] {
+            // uint256 argument
+            r = ConsumeUInt256(fuzzed_data_provider).ToString();
+        },
+        [&] {
+            // base32 argument
+            r = EncodeBase32(fuzzed_data_provider.ConsumeRandomLengthString(max_string_length));
+        },
+        [&] {
+            // base58 argument
+            r = EncodeBase58(MakeUCharSpan(fuzzed_data_provider.ConsumeRandomLengthString(max_base58_bytes_length)));
+        },
+        [&] {
+            // base58 argument with checksum
+            r = EncodeBase58Check(MakeUCharSpan(fuzzed_data_provider.ConsumeRandomLengthString(max_base58_bytes_length)));
+        },
+        [&] {
+            // hex encoded block
+            std::optional<CBlock> opt_block = ConsumeDeserializable<CBlock>(fuzzed_data_provider, TX_WITH_WITNESS);
+            if (!opt_block) {
+                good_data = false;
+                return;
+            }
+            DataStream data_stream{};
+            data_stream << TX_WITH_WITNESS(*opt_block);
+            r = HexStr(data_stream);
+        },
+        [&] {
+            // hex encoded block header
+            std::optional<CBlockHeader> opt_block_header = ConsumeDeserializable<CBlockHeader>(fuzzed_data_provider);
+            if (!opt_block_header) {
+                good_data = false;
+                return;
+            }
+            DataStream data_stream{};
+            data_stream << *opt_block_header;
+            r = HexStr(data_stream);
+        },
+        [&] {
+            // hex encoded tx
+            std::optional<CMutableTransaction> opt_tx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS);
+            if (!opt_tx) {
+                good_data = false;
+                return;
+            }
+            DataStream data_stream;
+            auto allow_witness = (fuzzed_data_provider.ConsumeBool() ? TX_WITH_WITNESS : TX_NO_WITNESS);
+            data_stream << allow_witness(*opt_tx);
+            r = HexStr(data_stream);
+        },
+        [&] {
+            // base64 encoded psbt
+            std::optional<PartiallySignedTransaction> opt_psbt = ConsumeDeserializableConstructor<PartiallySignedTransaction>(fuzzed_data_provider);
+            if (!opt_psbt) {
+                good_data = false;
+                return;
+            }
+            DataStream data_stream{};
+            data_stream << *opt_psbt;
+            r = EncodeBase64(data_stream);
+        },
+        [&] {
+            // base58 encoded key
+            CKey key = ConsumePrivateKey(fuzzed_data_provider);
+            if (!key.IsValid()) {
+                good_data = false;
+                return;
+            }
+            r = EncodeSecret(key);
+        },
+        [&] {
+            // hex encoded pubkey
+            CKey key = ConsumePrivateKey(fuzzed_data_provider);
+            if (!key.IsValid()) {
+                good_data = false;
+                return;
+            }
+            r = HexStr(key.GetPubKey());
+        });
+    return r;
+}
+
+std::string ConsumeArrayRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data)
+{
+    std::vector<std::string> scalar_arguments;
+    LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 100)
+    {
+        scalar_arguments.push_back(ConsumeScalarRPCArgument(fuzzed_data_provider, good_data));
+    }
+    return "[\"" + Join(scalar_arguments, "\",\"") + "\"]";
+}
+
+std::string ConsumeRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data)
+{
+    return fuzzed_data_provider.ConsumeBool() ? ConsumeScalarRPCArgument(fuzzed_data_provider, good_data) : ConsumeArrayRPCArgument(fuzzed_data_provider, good_data);
+}
+
+void ValidateRpcCommands(const std::vector<std::string>& rpc_commands_safe_for_fuzzing,
+                         const std::vector<std::string>& rpc_commands_not_safe_for_fuzzing,
+                         const std::vector<std::string>& supported_rpc_commands,
+                         const std::string_view source_file)
+{
+    for (const std::string& rpc_command : supported_rpc_commands) {
+        const bool safe_for_fuzzing = std::find(rpc_commands_safe_for_fuzzing.begin(), rpc_commands_safe_for_fuzzing.end(), rpc_command) != rpc_commands_safe_for_fuzzing.end();
+        const bool not_safe_for_fuzzing = std::find(rpc_commands_not_safe_for_fuzzing.begin(), rpc_commands_not_safe_for_fuzzing.end(), rpc_command) != rpc_commands_not_safe_for_fuzzing.end();
+        if (!(safe_for_fuzzing || not_safe_for_fuzzing)) {
+            std::cerr << "Error: RPC command \"" << rpc_command << "\" not found in rpc_commands_safe_for_fuzzing or rpc_commands_not_safe_for_fuzzing. Please update " << source_file << ".\n";
+            std::terminate();
+        }
+        if (safe_for_fuzzing && not_safe_for_fuzzing) {
+            std::cerr << "Error: RPC command \"" << rpc_command << "\" found in *both* rpc_commands_safe_for_fuzzing and rpc_commands_not_safe_for_fuzzing. Please update " << source_file << ".\n";
+            std::terminate();
+        }
+    }
+}
+} // namespace fuzzrpc

--- a/src/test/fuzz/util/rpc.h
+++ b/src/test/fuzz/util/rpc.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_FUZZ_UTIL_RPC_H
+#define BITCOIN_TEST_FUZZ_UTIL_RPC_H
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+class FuzzedDataProvider;
+
+namespace fuzzrpc {
+
+std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data);
+std::string ConsumeArrayRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data);
+std::string ConsumeRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data);
+
+void ValidateRpcCommands(const std::vector<std::string>& rpc_commands_safe_for_fuzzing,
+                         const std::vector<std::string>& rpc_commands_not_safe_for_fuzzing,
+                         const std::vector<std::string>& supported_rpc_commands,
+                         std::string_view source_file);
+
+} // namespace fuzzrpc
+
+#endif // BITCOIN_TEST_FUZZ_UTIL_RPC_H

--- a/src/wallet/test/fuzz/CMakeLists.txt
+++ b/src/wallet/test/fuzz/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(fuzz
     coinselection.cpp
     crypter.cpp
     fees.cpp
+    rpc.cpp
     scriptpubkeyman.cpp
     spend.cpp
     wallet_bdb_parser.cpp

--- a/src/wallet/test/fuzz/rpc.cpp
+++ b/src/wallet/test/fuzz/rpc.cpp
@@ -1,0 +1,302 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <interfaces/wallet.h>
+#include <rpc/client.h>
+#include <rpc/request.h>
+#include <rpc/server.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/fuzz/util/rpc.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <test/util/time.h>
+#include <univalue.h>
+#include <script/descriptor.h>
+#include <script/signingprovider.h>
+#include <util/chaintype.h>
+#include <util/check.h>
+#include <util/fs.h>
+#include <util/string.h>
+#include <util/time.h>
+#include <wallet/context.h>
+#include <wallet/rpc/wallet.h>
+#include <wallet/wallet.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace wallet {
+namespace {
+struct WalletRPCFuzzTestingSetup : public TestingSetup {
+    fs::path m_fuzz_wallets_dir;
+    std::unique_ptr<interfaces::WalletLoader> m_wallet_loader;
+
+    WalletRPCFuzzTestingSetup(const ChainType chain_type, TestOpts opts)
+        : TestingSetup{chain_type, opts}
+    {
+        m_fuzz_wallets_dir = m_path_root / "fuzz-wallets";
+        fs::create_directories(m_fuzz_wallets_dir);
+        gArgs.ForceSetArg("-walletdir", fs::PathToString(m_fuzz_wallets_dir));
+
+        m_wallet_loader = interfaces::MakeWalletLoader(*m_node.chain, *Assert(m_node.args));
+        m_node.wallet_loader = m_wallet_loader.get();
+        m_wallet_loader->registerRpcs();
+    }
+
+    WalletContext& GetWalletContext()
+    {
+        return *Assert(m_wallet_loader->context());
+    }
+
+    void CallRPC(const std::string& rpc_method, const std::vector<std::string>& arguments, const std::optional<std::string>& wallet_name)
+    {
+        JSONRPCRequest request;
+        request.context = &m_node;
+        if (wallet_name) {
+            request.URI = "/wallet/" + *wallet_name;
+        }
+        request.strMethod = rpc_method;
+        try {
+            request.params = RPCConvertValues(rpc_method, arguments);
+        } catch (const std::runtime_error&) {
+            return;
+        }
+
+        tableRPC.execute(request);
+    }
+};
+
+WalletRPCFuzzTestingSetup* g_setup = nullptr;
+std::string g_limit_to_rpc_command;
+
+//! Keep wallet RPC fuzz inputs small to avoid oversized parameter lists.
+constexpr size_t MAX_FUZZ_RPC_ARGUMENTS{25};
+
+// RPC commands which are not appropriate for fuzzing.
+const std::vector<std::string> WALLET_RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
+    "backupwallet",          // writes to an arbitrary path supplied by fuzz input
+    "createwallet",          // wallet lifecycle is managed by the fuzz target
+    "createwalletdescriptor", // can expand the keypool for new descriptors
+    "encryptwallet",         // prohibitively slow encryption and keypool flush
+    "importdescriptors",     // can trigger a wallet rescan
+    "keypoolrefill",         // prohibitively slow keypool top-up
+    "loadwallet",            // loads an arbitrary wallet path supplied by fuzz input
+    "migratewallet",         // prohibitively slow migration
+    "rescanblockchain",      // prohibitively slow rescan
+    "restorewallet",         // reads from an arbitrary path supplied by fuzz input
+    "unloadwallet",          // interferes with the per-iteration fuzz wallets
+    "walletpassphrase",      // encryption-related and not useful for unencrypted fuzz wallets
+    "walletpassphrasechange", // encryption-related and not useful for unencrypted fuzz wallets
+};
+
+// RPC commands which are safe for fuzzing.
+const std::vector<std::string> WALLET_RPC_COMMANDS_SAFE_FOR_FUZZING{
+    "abandontransaction",
+    "abortrescan",
+    "addhdkey",
+    "bumpfee",
+    "fundrawtransaction",
+    "getaddressinfo",
+    "getaddressesbylabel",
+    "getbalance",
+    "getbalances",
+    "gethdkeys",
+    "getnewaddress",
+    "getrawchangeaddress",
+    "getreceivedbyaddress",
+    "getreceivedbylabel",
+    "gettransaction",
+    "getwalletinfo",
+    "importprunedfunds",
+    "listaddressgroupings",
+    "listdescriptors",
+    "listlabels",
+    "listlockunspent",
+    "listreceivedbyaddress",
+    "listreceivedbylabel",
+    "listsinceblock",
+    "listtransactions",
+    "listunspent",
+    "listwalletdir",
+    "listwallets",
+    "lockunspent",
+    "psbtbumpfee",
+    "removeprunedfunds",
+    "send",
+    "sendall",
+    "sendmany",
+    "sendtoaddress",
+    "setlabel",
+    "setwalletflag",
+    "signmessage",
+    "signrawtransactionwithwallet",
+    "simulaterawtransaction",
+    "walletcreatefundedpsbt",
+#ifdef ENABLE_EXTERNAL_SIGNER
+    "walletdisplayaddress",
+#endif
+    "walletlock",
+    "walletprocesspsbt",
+};
+
+const std::unordered_set<std::string> WALLET_MANAGER_RPC_COMMANDS{
+    "listwalletdir",
+    "listwallets",
+};
+
+std::vector<std::string> GetSupportedWalletRPCCommands()
+{
+    std::vector<std::string> supported_rpc_commands;
+    for (const auto& command : GetWalletRPCCommands()) {
+        supported_rpc_commands.emplace_back(command.name);
+    }
+    return supported_rpc_commands;
+}
+
+void SetupMinimalFuzzWallet(CWallet& wallet)
+{
+    LOCK(wallet.cs_wallet);
+    wallet.m_keypool_size = 1;
+
+    FlatSigningProvider keys;
+    std::string error;
+    const std::string descriptor{
+        "wpkh([5aa9973a/66h/4h/2h]tprv8ZgxMBicQKsPd1QwsGgzfu2pcPYbBosZhJknqreRHgsWx32nNEhMjGQX2cgFL8n6wz9xdDYwLcs78N4nsCo32cxEX8RBtwGsEGgybLiQJfk/0/*)"};
+    auto parsed_descs = Parse(descriptor, keys, error, /*require_checksum=*/false);
+    if (parsed_descs.empty()) return;
+
+    WalletDescriptor w_desc{std::move(parsed_descs.at(0)), /*creation_time=*/0, /*range_start=*/0, /*range_end=*/1, /*next_index=*/0};
+    const auto spk_manager = wallet.AddWalletDescriptor(w_desc, keys, /*label=*/"", /*internal=*/false);
+    if (!spk_manager) return;
+    wallet.AddActiveScriptPubKeyMan(spk_manager->get().GetID(), *Assert(w_desc.descriptor->GetOutputType()), /*internal=*/false);
+}
+
+struct FuzzWallet {
+    std::string name;
+    fs::path path;
+};
+
+class FuzzWallets {
+    WalletContext& m_context;
+
+public:
+    std::vector<FuzzWallet> wallets;
+
+    explicit FuzzWallets(WalletContext& context) : m_context{context} {}
+
+    ~FuzzWallets()
+    {
+        for (const FuzzWallet& fuzz_wallet : wallets) {
+            UnloadAndDelete(fuzz_wallet);
+        }
+    }
+
+    void Create(FuzzedDataProvider& fuzzed_data_provider)
+    {
+        static uint64_t wallet_counter{0};
+        const size_t num_wallets{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 3)};
+        wallets.reserve(num_wallets);
+
+        for (size_t i = 0; i < num_wallets; ++i) {
+            const std::string wallet_name{strprintf("fuzz-wallet-%llu-%zu", wallet_counter++, i)};
+            const fs::path wallet_path{m_fuzz_wallets_dir / fs::PathFromString(wallet_name)};
+
+            DatabaseOptions options;
+            options.require_create = true;
+            options.create_flags = WALLET_FLAG_DESCRIPTORS | WALLET_FLAG_BLANK_WALLET;
+            DatabaseStatus status;
+            bilingual_str error;
+            std::vector<bilingual_str> warnings;
+            const std::shared_ptr<CWallet> wallet = CreateWallet(m_context, wallet_name, /*load_on_start=*/std::nullopt, options, status, error, warnings);
+            if (!wallet) continue;
+
+            SetupMinimalFuzzWallet(*wallet);
+            wallets.push_back({wallet_name, wallet_path});
+        }
+    }
+
+    std::optional<std::string> PickWalletName(FuzzedDataProvider& fuzzed_data_provider) const
+    {
+        if (wallets.empty()) return std::nullopt;
+        return wallets[fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, wallets.size() - 1)].name;
+    }
+
+private:
+    const fs::path& m_fuzz_wallets_dir{g_setup->m_fuzz_wallets_dir};
+
+    void UnloadAndDelete(const FuzzWallet& fuzz_wallet)
+    {
+        std::shared_ptr<CWallet> wallet = GetWallet(m_context, fuzz_wallet.name);
+        if (wallet) {
+            std::vector<bilingual_str> warnings;
+            RemoveWallet(m_context, wallet, /*load_on_start=*/std::nullopt, warnings);
+            WaitForDeleteWallet(std::move(wallet));
+        }
+        std::error_code ec;
+        fs::remove(fuzz_wallet.path, ec);
+    }
+};
+
+void initialize_wallet_rpc()
+{
+    static const auto setup = MakeNoLogFileContext<WalletRPCFuzzTestingSetup>(ChainType::REGTEST, {.extra_args{"-keypool=1", "-unsafesqlitesync"}});
+    g_setup = setup.get();
+    SetRPCWarmupFinished();
+    fuzzrpc::ValidateRpcCommands(WALLET_RPC_COMMANDS_SAFE_FOR_FUZZING, WALLET_RPC_COMMANDS_NOT_SAFE_FOR_FUZZING, GetSupportedWalletRPCCommands(), __FILE__);
+    const char* limit_to_rpc_command_env = std::getenv("LIMIT_TO_RPC_COMMAND");
+    if (limit_to_rpc_command_env != nullptr) {
+        g_limit_to_rpc_command = std::string{limit_to_rpc_command_env};
+    }
+}
+
+} // namespace
+
+FUZZ_TARGET(wallet_rpc, .init = initialize_wallet_rpc)
+{
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider)};
+
+    FuzzWallets fuzz_wallets{g_setup->GetWalletContext()};
+    fuzz_wallets.Create(fuzzed_data_provider);
+    if (fuzz_wallets.wallets.empty()) return;
+
+    const std::string rpc_command = fuzzed_data_provider.ConsumeRandomLengthString(64);
+    if (!g_limit_to_rpc_command.empty() && rpc_command != g_limit_to_rpc_command) {
+        return;
+    }
+    const bool safe_for_fuzzing = std::find(WALLET_RPC_COMMANDS_SAFE_FOR_FUZZING.begin(), WALLET_RPC_COMMANDS_SAFE_FOR_FUZZING.end(), rpc_command) != WALLET_RPC_COMMANDS_SAFE_FOR_FUZZING.end();
+    if (!safe_for_fuzzing) {
+        return;
+    }
+
+    bool good_data{true};
+    std::vector<std::string> arguments;
+    LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), MAX_FUZZ_RPC_ARGUMENTS)
+    {
+        arguments.push_back(fuzzrpc::ConsumeRPCArgument(fuzzed_data_provider, good_data));
+    }
+
+    const std::optional<std::string> wallet_endpoint = WALLET_MANAGER_RPC_COMMANDS.contains(rpc_command) ? std::nullopt : fuzz_wallets.PickWalletName(fuzzed_data_provider);
+    try {
+        g_setup->CallRPC(rpc_command, arguments, wallet_endpoint);
+    } catch (const UniValue& json_rpc_error) {
+        const std::string error_msg{json_rpc_error.find_value("message").get_str()};
+        if (error_msg.starts_with("Internal bug detected")) {
+            // Only allow the intentional internal bug
+            assert(error_msg.find("trigger_internal_bug") != std::string::npos);
+        }
+    }
+}
+
+} // namespace wallet


### PR DESCRIPTION
### Summary
This is part of https://github.com/bitcoin/bitcoin/issues/29901 and a resurrection of https://github.com/bitcoin/bitcoin/pull/30570, which I had left up for grabs earlier.

This change adds a new fuzz target `wallet_rpc` that fuzz tests the wallet RPC

This PR also moves and modifies `ConsumeScalarRPCArgument` to be used for the `wallet_rpc` target

---

Right now, I see zero fuzz coverage for the wallet rpc, this new target will add some coverage there.
https://storage.googleapis.com/oss-fuzz-coverage/bitcoin-core/reports/20260519/linux/src/bitcoin-core/src/wallet/rpc/report.html