### PR TITLE
dbwrapper: use RAII for Logv heap buffer and handle vsnprintf failure

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -63,6 +63,7 @@ public:
                 return;
             }
             char buffer[500];
+            std::unique_ptr<char[]> heap_buffer;
             for (int iter = 0; iter < 2; iter++) {
                 char* base;
                 int bufsize;
@@ -72,7 +73,8 @@ public:
                 }
                 else {
                     bufsize = 30000;
-                    base = new char[bufsize];
+                    heap_buffer = std::make_unique<char[]>(bufsize);
+                    base = heap_buffer.get();
                 }
                 char* p = base;
                 char* limit = base + bufsize;
@@ -82,8 +84,12 @@ public:
                     va_list backup_ap;
                     va_copy(backup_ap, ap);
                     // Do not use vsnprintf elsewhere in bitcoin source code, see above.
-                    p += vsnprintf(p, limit - p, format, backup_ap);
+                    const int written = vsnprintf(p, limit - p, format, backup_ap);
                     va_end(backup_ap);
+                    // vsnprintf can return a negative value on encoding error;
+                    // clamp to 0 so that the rest of this function does not
+                    // perform negative pointer arithmetic on `base`.
+                    if (written > 0) p += written;
                 }
 
                 // Truncate to available space if necessary
@@ -104,9 +110,6 @@ public:
                 assert(p <= limit);
                 base[std::min(bufsize - 1, (int)(p - base))] = '\0';
                 LogDebug(BCLog::LEVELDB, "%s\n", util::RemoveSuffixView(base, "\n"));
-                if (base != buffer) {
-                    delete[] base;
-                }
                 break;
             }
     }


### PR DESCRIPTION
## What

`CBitcoinLevelDBLogger::Logv` in `src/dbwrapper.cpp` allocates its 30 KiB fallback buffer with a raw `new char[]` and frees it with a matching `delete[]` at the bottom of the loop. This change replaces the raw `new[]`/`delete[]` pair with a `std::unique_ptr<char[]>` and clamps negative `vsnprintf` returns to zero so the rest of the function cannot perform negative pointer arithmetic on `base`.

## Why

Two small issues with the current code:

1. **Exception leak.** Any exception thrown between the `new char[30000]` and the matching `delete[] base` leaks the buffer. The `LogDebug(...)` call near the end of the loop dispatches through `tfm::format` and the logging backend, both of which can throw `std::bad_alloc`. The `if (base != buffer) delete[] base;` cleanup is unreachable in that case.

2. **`vsnprintf` negative return.** The loop adds the return value of `vsnprintf` to a `char*` (`p += vsnprintf(...)`). `vsnprintf` may return a negative value on encoding errors. When that happens, `p` ends up pointing before the beginning of `base`, after which `p[-1]` (the trailing-newline check, current line 100) is an out-of-bounds read and the subsequent `base[std::min(bufsize - 1, (int)(p - base))] = '\0'` writes through a negative index.

## What changed

- The heap buffer is now owned by `std::unique_ptr<char[]>` allocated via `std::make_unique`. The buffer is released automatically on every exit path of the loop, including exception unwinding.
- The result of `vsnprintf` is read into a local `int` and `p` is only advanced if it is positive, so subsequent `p[-1]` reads and `(int)(p - base)` arithmetic stay within `base`.
- Behaviour in the normal case (successful format, no exception) is unchanged.

## Test plan

- `cmake --build build --target bitcoin_node` succeeds with the patch applied.
- No behaviour change for callers; this is purely a local cleanup of one logger function.