### PR TITLE
test: suppress ECONNABORTED in wait_for_rpc_connection on Windows

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -378,9 +378,13 @@ class TestNode():
                     # doesn't specify errno.
                     elif isinstance(e, ConnectionResetError):
                         error_num = errno.ECONNRESET
+                    # Windows can raise this while bitcoind shuts down during startup.
+                    elif isinstance(e, ConnectionAbortedError):
+                        error_num = errno.ECONNABORTED
 
                 # Suppress similarly to the above JSONRPCException errors.
                 if error_num not in [
+                    errno.ECONNABORTED, # Treat identical to ECONNRESET
                     errno.ECONNRESET,   # This might happen when the RPC server is in warmup,
                                         # but shut down before the call to getblockcount succeeds.
                     errno.ETIMEDOUT,    # Treat identical to ECONNRESET


### PR DESCRIPTION
Since bitcoin/bitcoin#33362, `feature_bind_port_externalip.py` auto-detects whether 1.1.1.5 is available by starting a node with `-bind=1.1.1.5` and converting a bind failure into a skip. On Windows CI the address is not configured, so bitcoind exits as expected — but intermittently an RPC probe raises `ConnectionAbortedError` (WSAECONNABORTED/WinError 10053) while the process is shutting down, causing the test to fail rather than skip.

Fix by treating ECONNABORTED the same as the other transient connection errors already suppressed during startup (ECONNRESET, ETIMEDOUT, ECONNREFUSED).

Fixes #35343
