### PR TITLE
net: Disallow invalid HeadersSyncState due to lagging clock

### DIFF
--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -16,7 +16,7 @@
 // CompressedHeader (we should re-calculate parameters if we compress further).
 static_assert(sizeof(CompressedHeader) == 48);
 
-util::Expected<uint64_t, std::string> HeadersSyncState::ComputeMaxCommitments(const HeadersSyncParams& params, const CBlockIndex& chain_start)
+util::Expected<uint64_t, std::string> HeadersSyncState::ComputeMaxCommitments(const HeadersSyncParams& params, const CBlockIndex& chain_start, NodeSeconds now)
 {
     Assert(params.commitment_period > 0);
 
@@ -28,8 +28,20 @@ util::Expected<uint64_t, std::string> HeadersSyncState::ComputeMaxCommitments(co
     // exceeds this bound, because it's not possible for a consensus-valid
     // chain to be longer than this (at the current time -- in the future we
     // could try again, if necessary, to sync a longer chain).
-    const auto max_seconds_since_start{(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start.GetMedianTimePast()}}))
-                                       + MAX_FUTURE_BLOCK_TIME};
+    const int64_t max_seconds_since_start{Ticks<std::chrono::seconds>(now - NodeSeconds{std::chrono::seconds{chain_start.GetMedianTimePast()}})
+                                          + MAX_FUTURE_BLOCK_TIME};
+    if (max_seconds_since_start < 0) {
+        // Typically we would expect the chain state loading logic to
+        // already have verified that the tip of the locally stored
+        // chain is <= system clock + MAX_FUTURE_BLOCK_TIME. Getting
+        // here is really unexpected.
+        return util::Unexpected{strprintf(
+            "Failure when attempting to initiate headers sync: system clock is "
+            "more than %d minutes behind chain start MTP (%s vs %s).",
+            MAX_FUTURE_BLOCK_TIME / 60,
+            FormatISO8601DateTime(TicksSinceEpoch<std::chrono::seconds>(now)),
+            FormatISO8601DateTime(chain_start.GetMedianTimePast()))};
+    }
     return 6 * max_seconds_since_start / params.commitment_period;
 }
 

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -5,7 +5,9 @@
 #include <headerssync.h>
 
 #include <pow.h>
+#include <tinyformat.h>
 #include <util/check.h>
+#include <util/expected.h>
 #include <util/log.h>
 #include <util/time.h>
 #include <util/vector.h>
@@ -14,22 +16,10 @@
 // CompressedHeader (we should re-calculate parameters if we compress further).
 static_assert(sizeof(CompressedHeader) == 48);
 
-HeadersSyncState::HeadersSyncState(NodeId id,
-                                   const Consensus::Params& consensus_params,
-                                   const HeadersSyncParams& params,
-                                   const CBlockIndex& chain_start,
-                                   const arith_uint256& minimum_required_work)
-    : m_commit_offset((assert(params.commitment_period > 0), // HeadersSyncParams field must be initialized to non-zero.
-                       FastRandomContext().randrange(params.commitment_period))),
-      m_id(id),
-      m_consensus_params(consensus_params),
-      m_params(params),
-      m_chain_start(chain_start),
-      m_minimum_required_work(minimum_required_work),
-      m_current_chain_work(chain_start.nChainWork),
-      m_last_header_received(m_chain_start.GetBlockHeader()),
-      m_current_height(chain_start.nHeight)
+util::Expected<uint64_t, std::string> HeadersSyncState::ComputeMaxCommitments(const HeadersSyncParams& params, const CBlockIndex& chain_start)
 {
+    Assert(params.commitment_period > 0);
+
     // Estimate the number of blocks that could possibly exist on the peer's
     // chain *right now* using 6 blocks/second (fastest blockrate given the MTP
     // rule) times the number of seconds from the last allowed block until
@@ -40,8 +30,27 @@ HeadersSyncState::HeadersSyncState(NodeId id,
     // could try again, if necessary, to sync a longer chain).
     const auto max_seconds_since_start{(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start.GetMedianTimePast()}}))
                                        + MAX_FUTURE_BLOCK_TIME};
-    m_max_commitments = 6 * max_seconds_since_start / m_params.commitment_period;
+    return 6 * max_seconds_since_start / params.commitment_period;
+}
 
+HeadersSyncState::HeadersSyncState(NodeId id,
+                                   const Consensus::Params& consensus_params,
+                                   const HeadersSyncParams& params,
+                                   const CBlockIndex& chain_start,
+                                   const arith_uint256& minimum_required_work,
+                                   const uint64_t max_commitments)
+    : m_commit_offset((assert(params.commitment_period > 0), // HeadersSyncParams field must be initialized to non-zero.
+                       FastRandomContext().randrange(params.commitment_period))),
+      m_id(id),
+      m_consensus_params(consensus_params),
+      m_params(params),
+      m_chain_start(chain_start),
+      m_minimum_required_work(minimum_required_work),
+      m_current_chain_work(chain_start.nChainWork),
+      m_max_commitments(max_commitments),
+      m_last_header_received(m_chain_start.GetBlockHeader()),
+      m_current_height(chain_start.nHeight)
+{
     LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s\n", m_id, m_current_height, m_max_commitments, m_minimum_required_work.ToString());
 }
 

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -38,8 +38,16 @@ HeadersSyncState::HeadersSyncState(NodeId id,
     // exceeds this bound, because it's not possible for a consensus-valid
     // chain to be longer than this (at the current time -- in the future we
     // could try again, if necessary, to sync a longer chain).
-    const auto max_seconds_since_start{(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start.GetMedianTimePast()}}))
-                                       + MAX_FUTURE_BLOCK_TIME};
+    const auto now{NodeClock::now()};
+    const int64_t max_seconds_since_start{Ticks<std::chrono::seconds>(now - NodeSeconds{std::chrono::seconds{chain_start.GetMedianTimePast()}})
+                                          + MAX_FUTURE_BLOCK_TIME};
+    if (max_seconds_since_start < 0) {
+        throw SystemClockError{strprintf(
+            "System clock is more than %d minutes behind chain start MTP (%s vs %s).",
+            MAX_FUTURE_BLOCK_TIME / 60,
+            FormatISO8601DateTime(TicksSinceEpoch<std::chrono::seconds>(now)),
+            FormatISO8601DateTime(chain_start.GetMedianTimePast()))};
+    }
     m_max_commitments = 6 * max_seconds_since_start / m_params.commitment_period;
 
     LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s\n", m_id, m_current_height, m_max_commitments, m_minimum_required_work.ToString());

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -12,6 +12,7 @@
 #include <primitives/block.h>
 #include <uint256.h>
 #include <util/bitdeque.h>
+#include <util/expected.h>
 #include <util/hasher.h>
 
 #include <deque>
@@ -128,6 +129,8 @@ public:
     /** Return the amount of work in the chain received during the PRESYNC phase. */
     arith_uint256 GetPresyncWork() const { return m_current_chain_work; }
 
+    static util::Expected<uint64_t, std::string> ComputeMaxCommitments(const HeadersSyncParams& params, const CBlockIndex& chain_start);
+
     /** Construct a HeadersSyncState object representing a headers sync via this
      *  download-twice mechanism).
      *
@@ -138,7 +141,8 @@ public:
      */
     HeadersSyncState(NodeId id, const Consensus::Params& consensus_params,
                      const HeadersSyncParams& params, const CBlockIndex& chain_start,
-                     const arith_uint256& minimum_required_work);
+                     const arith_uint256& minimum_required_work,
+                     uint64_t max_commitments);
 
     /** Result data structure for ProcessNextHeaders. */
     struct ProcessingResult {

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -14,6 +14,7 @@
 #include <util/bitdeque.h>
 #include <util/expected.h>
 #include <util/hasher.h>
+#include <util/time.h>
 
 #include <deque>
 #include <vector>
@@ -129,7 +130,9 @@ public:
     /** Return the amount of work in the chain received during the PRESYNC phase. */
     arith_uint256 GetPresyncWork() const { return m_current_chain_work; }
 
-    static util::Expected<uint64_t, std::string> ComputeMaxCommitments(const HeadersSyncParams& params, const CBlockIndex& chain_start);
+    /** Compute the memory bound on presync commitments, or return an error if
+     *  the chain-start MTP is too far ahead of the local system time. */
+    static util::Expected<uint64_t, std::string> ComputeMaxCommitments(const HeadersSyncParams& params, const CBlockIndex& chain_start, NodeSeconds now);
 
     /** Construct a HeadersSyncState object representing a headers sync via this
      *  download-twice mechanism).

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -15,6 +15,7 @@
 #include <util/hasher.h>
 
 #include <deque>
+#include <stdexcept>
 #include <vector>
 
 // A compressed CBlockHeader, which leaves out the prevhash
@@ -99,8 +100,13 @@ struct CompressedHeader {
  * sync (temporary, per-peer storage).
  */
 
-class HeadersSyncState {
+class HeadersSyncState
+{
 public:
+    struct SystemClockError : std::runtime_error {
+        using std::runtime_error::runtime_error;
+    };
+
     ~HeadersSyncState() = default;
 
     enum class State {
@@ -135,6 +141,8 @@ public:
      * consensus_params: parameters needed for difficulty adjustment validation
      * chain_start: best known fork point that the peer's headers branch from
      * minimum_required_work: amount of chain work required to accept the chain
+     *
+     * @throws SystemClockError if system clock is too far behind chain_start MTP.
      */
     HeadersSyncState(NodeId id, const Consensus::Params& consensus_params,
                      const HeadersSyncParams& params, const CBlockIndex& chain_start,

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3030,8 +3030,19 @@ bool PeerManagerImpl::TryLowWorkHeadersSync(Peer& peer, CNode& pfrom, const CBlo
             // of headers is known, some header in this set must be new, so
             // advancing to the first unknown header would be a small effect.
             LOCK(peer.m_headers_sync_mutex);
-            peer.m_headers_sync.reset(new HeadersSyncState(peer.m_id, m_chainparams.GetConsensus(),
-                m_chainparams.HeadersSync(), chain_start_header, minimum_chain_work));
+            try {
+                peer.m_headers_sync.reset(new HeadersSyncState(peer.m_id, m_chainparams.GetConsensus(),
+                    m_chainparams.HeadersSync(), chain_start_header, minimum_chain_work));
+            } catch (const HeadersSyncState::SystemClockError& e) {
+                // Typically we would expect the chain state loading logic to
+                // already have verified that the tip of the locally stored
+                // chain is <= system clock + MAX_FUTURE_BLOCK_TIME. Getting
+                // here is really unexpected.
+                const auto msg{strprintf("Failure when attempting to initiate headers sync: %s", e.what())};
+                std::cerr << msg << std::endl;
+                LogError("%s", msg);
+                std::abort();
+            }
 
             // Now a HeadersSyncState object for tracking this synchronization
             // is created, process the headers using it as normal. Failures are

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -57,6 +57,7 @@
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/expected.h>
 #include <util/hasher.h>
 #include <util/strencodings.h>
 #include <util/time.h>
@@ -3029,9 +3030,12 @@ bool PeerManagerImpl::TryLowWorkHeadersSync(Peer& peer, CNode& pfrom, const CBlo
             // this logic in that case. So even if the first header in this set
             // of headers is known, some header in this set must be new, so
             // advancing to the first unknown header would be a small effect.
+
+            const util::Expected max_commitments{HeadersSyncState::ComputeMaxCommitments(m_chainparams.HeadersSync(), chain_start_header)};
             LOCK(peer.m_headers_sync_mutex);
             peer.m_headers_sync.reset(new HeadersSyncState(peer.m_id, m_chainparams.GetConsensus(),
-                m_chainparams.HeadersSync(), chain_start_header, minimum_chain_work));
+                m_chainparams.HeadersSync(), chain_start_header, minimum_chain_work,
+                *max_commitments));
 
             // Now a HeadersSyncState object for tracking this synchronization
             // is created, process the headers using it as normal. Failures are

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3031,7 +3031,12 @@ bool PeerManagerImpl::TryLowWorkHeadersSync(Peer& peer, CNode& pfrom, const CBlo
             // of headers is known, some header in this set must be new, so
             // advancing to the first unknown header would be a small effect.
 
-            const util::Expected max_commitments{HeadersSyncState::ComputeMaxCommitments(m_chainparams.HeadersSync(), chain_start_header)};
+            const util::Expected max_commitments{HeadersSyncState::ComputeMaxCommitments(m_chainparams.HeadersSync(), chain_start_header, Now<NodeSeconds>())};
+            if (!max_commitments) {
+                m_chainman.GetNotifications().fatalError(Untranslated(max_commitments.error()));
+                headers = {};
+                return true;
+            }
             LOCK(peer.m_headers_sync_mutex);
             peer.m_headers_sync.reset(new HeadersSyncState(peer.m_id, m_chainparams.GetConsensus(),
                 m_chainparams.HeadersSync(), chain_start_header, minimum_chain_work,

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -12,6 +12,7 @@
 #include <test/util/time.h>
 #include <uint256.h>
 #include <util/chaintype.h>
+#include <util/expected.h>
 #include <util/time.h>
 #include <validation.h>
 
@@ -45,8 +46,10 @@ class FuzzedHeadersSyncState : public HeadersSyncState
 {
 public:
     FuzzedHeadersSyncState(const HeadersSyncParams& sync_params, const size_t commit_offset,
-                           const CBlockIndex& chain_start, const arith_uint256& minimum_required_work)
-        : HeadersSyncState(/*id=*/0, Params().GetConsensus(), sync_params, chain_start, minimum_required_work)
+                           const CBlockIndex& chain_start, const arith_uint256& minimum_required_work,
+                           uint64_t max_commitments)
+        : HeadersSyncState(/*id=*/0, Params().GetConsensus(), sync_params,
+                           chain_start, minimum_required_work, max_commitments)
     {
         const_cast<size_t&>(m_commit_offset) = commit_offset;
     }
@@ -69,12 +72,14 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
         .commitment_period = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, Params().HeadersSync().commitment_period * 2),
         .redownload_buffer_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, Params().HeadersSync().redownload_buffer_size * 2),
     };
+    const util::Expected max_commitments{HeadersSyncState::ComputeMaxCommitments(params, start_index)};
     arith_uint256 min_work{UintToArith256(ConsumeUInt256(fuzzed_data_provider))};
     FuzzedHeadersSyncState headers_sync(
         params,
         /*commit_offset=*/fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, params.commitment_period - 1),
         /*chain_start=*/start_index,
-        /*minimum_required_work=*/min_work);
+        /*minimum_required_work=*/min_work,
+        /*max_commitments=*/*max_commitments);
 
     // Store headers for potential redownload phase.
     std::vector<CBlockHeader> all_headers;

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -63,7 +63,8 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
     CBlockHeader genesis_header{Params().GenesisBlock()};
     CBlockIndex start_index(genesis_header);
 
-    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast())};
+    const NodeSeconds now{ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast() - 2 * MAX_FUTURE_BLOCK_TIME)};
+    FakeNodeClock clock{now};
 
     const uint256 genesis_hash = genesis_header.GetHash();
     start_index.phashBlock = &genesis_hash;
@@ -72,7 +73,11 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
         .commitment_period = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, Params().HeadersSync().commitment_period * 2),
         .redownload_buffer_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, Params().HeadersSync().redownload_buffer_size * 2),
     };
-    const util::Expected max_commitments{HeadersSyncState::ComputeMaxCommitments(params, start_index)};
+    const util::Expected max_commitments{HeadersSyncState::ComputeMaxCommitments(params, start_index, now)};
+    if (!max_commitments) {
+        assert(now < NodeSeconds{std::chrono::seconds{start_index.GetMedianTimePast() - MAX_FUTURE_BLOCK_TIME}});
+        return;
+    }
     arith_uint256 min_work{UintToArith256(ConsumeUInt256(fuzzed_data_provider))};
     FuzzedHeadersSyncState headers_sync(
         params,

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -10,6 +10,7 @@
 #include <pow.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <validation.h>
 
 #include <cstddef>
@@ -250,6 +251,18 @@ BOOST_AUTO_TEST_CASE(too_little_work)
         /*exp_request_more=*/false,
         /*exp_headers_size=*/0, /*exp_pow_validated_prev=*/std::nullopt,
         /*exp_locator_hash=*/std::nullopt);
+}
+
+BOOST_AUTO_TEST_CASE(system_clock_lagging_behind_chain_start)
+{
+    FakeNodeClock clock{(genesis.GetBlockTime() - MAX_FUTURE_BLOCK_TIME - 1) * 1s};
+    HeadersSyncState hss{CreateState()};
+
+    CHECK_RESULT(hss.ProcessNextHeaders({{FirstChain().front()}}, /*full_headers_message=*/true),
+        hss, /*exp_state=*/State::PRESYNC,
+        /*exp_success=*/true, /*exp_request_more=*/true,
+        /*exp_headers_size=*/0, /*exp_pow_validated_prev=*/std::nullopt,
+        /*exp_locator_hash=*/FirstChain().front().GetHash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -10,8 +10,8 @@
 #include <pow.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
-#include <test/util/time.h>
 #include <util/expected.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <cstddef>
@@ -81,13 +81,14 @@ struct HeadersGeneratorSetup : public RegTestingSetup {
         return second_chain;
     }
 
-    HeadersSyncState CreateState()
+    util::Expected<HeadersSyncState, std::string> CreateState(NodeSeconds now = Now<NodeSeconds>())
     {
         const HeadersSyncParams params{
             .commitment_period = COMMITMENT_PERIOD,
             .redownload_buffer_size = REDOWNLOAD_BUFFER_SIZE,
         };
-        util::Expected max_commitments{HeadersSyncState::ComputeMaxCommitments(params, chain_start)};
+        util::Expected max_commitments{HeadersSyncState::ComputeMaxCommitments(params, chain_start, now)};
+        if (!max_commitments) return util::Unexpected{std::move(max_commitments.error())};
 
         return HeadersSyncState{/*id=*/0,
                                 Params().GetConsensus(),
@@ -154,7 +155,7 @@ BOOST_AUTO_TEST_CASE(sneaky_redownload)
 
     // Feed the first chain to HeadersSyncState, by delivering 1 header
     // initially and then the rest.
-    HeadersSyncState hss{CreateState()};
+    HeadersSyncState hss{*CreateState()};
 
     // Just feed one header and check state.
     // Pretend the message is still "full", so we don't abort.
@@ -193,7 +194,7 @@ BOOST_AUTO_TEST_CASE(happy_path)
     // Headers message that moves us to the next state doesn't need to be full.
     for (const bool full_headers_message : {false, true}) {
         // This time we feed the first chain twice.
-        HeadersSyncState hss{CreateState()};
+        HeadersSyncState hss{*CreateState()};
 
         // Sufficient work transitions us from PRESYNC to REDOWNLOAD:
         const auto genesis_hash{genesis.GetHash()};
@@ -235,7 +236,7 @@ BOOST_AUTO_TEST_CASE(too_little_work)
 
     // Verify that just trying to process the second chain would not succeed
     // (too little work).
-    HeadersSyncState hss{CreateState()};
+    HeadersSyncState hss{*CreateState()};
     BOOST_REQUIRE_EQUAL(hss.GetState(), State::PRESYNC);
 
     // Pretend just the first message is "full", so we don't abort.
@@ -260,14 +261,9 @@ BOOST_AUTO_TEST_CASE(too_little_work)
 
 BOOST_AUTO_TEST_CASE(system_clock_lagging_behind_chain_start)
 {
-    FakeNodeClock clock{(genesis.GetBlockTime() - MAX_FUTURE_BLOCK_TIME - 1) * 1s};
-    HeadersSyncState hss{CreateState()};
-
-    CHECK_RESULT(hss.ProcessNextHeaders({{FirstChain().front()}}, /*full_headers_message=*/true),
-        hss, /*exp_state=*/State::PRESYNC,
-        /*exp_success=*/true, /*exp_request_more=*/true,
-        /*exp_headers_size=*/0, /*exp_pow_validated_prev=*/std::nullopt,
-        /*exp_locator_hash=*/FirstChain().front().GetHash());
+    const NodeSeconds boundary{(genesis.GetBlockTime() - MAX_FUTURE_BLOCK_TIME) * 1s};
+    BOOST_CHECK(CreateState(boundary));
+    BOOST_CHECK(!CreateState(boundary - 1s));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -11,6 +11,7 @@
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/expected.h>
 #include <validation.h>
 
 #include <cstddef>
@@ -82,14 +83,18 @@ struct HeadersGeneratorSetup : public RegTestingSetup {
 
     HeadersSyncState CreateState()
     {
-        return {/*id=*/0,
-                Params().GetConsensus(),
-                HeadersSyncParams{
-                    .commitment_period = COMMITMENT_PERIOD,
-                    .redownload_buffer_size = REDOWNLOAD_BUFFER_SIZE,
-                },
-                chain_start,
-                /*minimum_required_work=*/CHAIN_WORK};
+        const HeadersSyncParams params{
+            .commitment_period = COMMITMENT_PERIOD,
+            .redownload_buffer_size = REDOWNLOAD_BUFFER_SIZE,
+        };
+        util::Expected max_commitments{HeadersSyncState::ComputeMaxCommitments(params, chain_start)};
+
+        return HeadersSyncState{/*id=*/0,
+                                Params().GetConsensus(),
+                                params,
+                                chain_start,
+                                /*minimum_required_work=*/CHAIN_WORK,
+                                /*max_commitments=*/*max_commitments};
     }
 
 private:

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -259,10 +259,7 @@ BOOST_AUTO_TEST_CASE(system_clock_lagging_behind_chain_start)
     BOOST_CHECK_NO_THROW(CreateState());
 
     clock -= 1s;
-    // TODO: Fix - Being more than MAX_FUTURE_BLOCK_TIME behind the starting
-    // block leads HeadersSyncState() to compute a negative max_seconds_since_start
-    // which leads to very high HeadersSyncState::m_max_commitments.
-    BOOST_CHECK_NO_THROW(CreateState());
+    BOOST_CHECK_THROW(CreateState(), HeadersSyncState::SystemClockError);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -10,6 +10,7 @@
 #include <pow.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <validation.h>
 
 #include <cstddef>
@@ -250,6 +251,18 @@ BOOST_AUTO_TEST_CASE(too_little_work)
         /*exp_request_more=*/false,
         /*exp_headers_size=*/0, /*exp_pow_validated_prev=*/std::nullopt,
         /*exp_locator_hash=*/std::nullopt);
+}
+
+BOOST_AUTO_TEST_CASE(system_clock_lagging_behind_chain_start)
+{
+    FakeNodeClock clock{(chain_start.GetBlockTime() - MAX_FUTURE_BLOCK_TIME) * 1s};
+    BOOST_CHECK_NO_THROW(CreateState());
+
+    clock -= 1s;
+    // TODO: Fix - Being more than MAX_FUTURE_BLOCK_TIME behind the starting
+    // block leads HeadersSyncState() to compute a negative max_seconds_since_start
+    // which leads to very high HeadersSyncState::m_max_commitments.
+    BOOST_CHECK_NO_THROW(CreateState());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -22,6 +22,7 @@ from test_framework.blocktools import (
 
 from test_framework.util import assert_equal
 
+import re
 import time
 
 NODE1_BLOCKS_REQUIRED = 15
@@ -150,7 +151,10 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         node.setmocktime(node.getblockheader(node.getblockhash(0))['mediantime'] - MAX_FUTURE_BLOCK_TIME - 1)
         p2p = node.add_p2p_connection(P2PInterface())
         p2p.send_without_ping(headers_message)
-        p2p.wait_for_getheaders(timeout=30, block_hash=hashPrevBlock)  # TODO: A negative elapsed interval should trigger fatal shutdown.
+        node.wait_until_stopped(expect_error=True, expected_ret_code=[-6,          # Unix
+                                                                      3,           # Windows native
+                                                                      0xC0000409], # Windows cross builds
+                                expected_stderr=re.compile("Failure when attempting to initiate headers sync: System clock"))
 
     def test_large_reorgs_can_succeed(self):
         self.log.info("Test that a 2000+ block reorg, starting from a point that is more than 2000 blocks before a locator entry, can succeed")

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -15,6 +15,7 @@ from test_framework.messages import (
 )
 
 from test_framework.blocktools import (
+    MAX_FUTURE_BLOCK_TIME,
     NORMAL_GBT_REQUEST_PARAMS,
     create_block,
 )
@@ -143,6 +144,13 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
 
         # getpeerinfo should show a sync in progress
         assert_equal(node.getpeerinfo()[0]['presynced_headers'], 2000)
+
+        self.log.info("Test whether a lagging clock aborts low-work headers sync")
+        node.disconnect_p2ps()
+        node.setmocktime(node.getblockheader(node.getblockhash(0))['mediantime'] - MAX_FUTURE_BLOCK_TIME - 1)
+        p2p = node.add_p2p_connection(P2PInterface())
+        p2p.send_without_ping(headers_message)
+        p2p.wait_for_getheaders(timeout=30, block_hash=hashPrevBlock)  # TODO: A negative elapsed interval should trigger fatal shutdown.
 
     def test_large_reorgs_can_succeed(self):
         self.log.info("Test that a 2000+ block reorg, starting from a point that is more than 2000 blocks before a locator entry, can succeed")


### PR DESCRIPTION
### Problem

Headers presync computes `m_max_commitments` from the elapsed time since the chain-start MTP plus `MAX_FUTURE_BLOCK_TIME`. When the local system clock is more than `MAX_FUTURE_BLOCK_TIME` behind the chain-start MTP, that elapsed value is negative, but it is used in arithmetic assigned to the unsigned commitment cap. This can turn the intended zero bound into a large cap, letting low-work headers presync continue instead of aborting when a reasonable commitment cap would have been exceeded.

### Fix

Instead of allowing an invalid `HeadersSyncState` object to be created, emit an error and **abort the node process**.

*Post-merge edit: ~Typically, the node will detect that the system clock is set too far in the past when comparing it to the chain tip during chain state loading and shut down before we start syncing headers. So in practice this is very unlikely to make a difference (might be possible if the system clock jumps backwards after we loaded the chain state).~ If there is a pre-existing chain state in the datadir when the node starts up the chain state loading logic will detect that the system clock is set too far in the past and abort before reaching the logic added in this PR. For a fresh datadir however, we will abort due to this headers sync logic. See #36134.* 

#### Commits

* Add functional and unit characterization tests [pinning the current behavior](https://github.com/bitcoin/bitcoin/pull/35260).
* The fix, along with corresponding test changes.

---

Replaces #35208 which was clamping `m_max_commitments` to zero and then letting the `HeadersSyncState` consume headers until the block height either reached the the next `commitment_period` point and aborted, or reached the minimum work threshold and succeeded (possible when having been offline for >144 blocks).