### PR TITLE
ci: Test build dir with spaces

### DIFF
--- a/.github/ci-windows.py
+++ b/.github/ci-windows.py
@@ -236,6 +236,11 @@ def main():
     parser.add_argument("step", choices=steps, help="CI step to perform.")
     args = parser.parse_args()
 
+    os.environ.setdefault(
+        "VCPKG_INSTALLED_DIR",
+        str(Path.cwd() / "vcpkg_installed_dir"),
+    )
+
     exec(f'{args.step}("{args.ci_type}")')
 
 

--- a/.github/ci-windows.py
+++ b/.github/ci-windows.py
@@ -24,6 +24,10 @@ def run(cmd, **kwargs):
         sys.exit(str(e))
 
 
+def get_build_dir() -> Path:
+    return Path.cwd() / "build_ _"
+
+
 GENERATE_OPTIONS = {
     "standard": [
         "-DBUILD_BENCH=ON",
@@ -69,7 +73,7 @@ def generate(ci_type):
     command = [
         "cmake",
         "-B",
-        "build",
+        str(get_build_dir()),
         "-Werror=dev",
         "--preset=vs2026",
         # Using x64-windows-release for both host and target triplets
@@ -91,7 +95,7 @@ def build(_ci_type):
     command = [
         "cmake",
         "--build",
-        "build",
+        str(get_build_dir()),
         "--config",
         "Release",
     ]
@@ -105,7 +109,7 @@ def check_manifests(ci_type):
         print(f"Skipping manifest validation for '{ci_type}' ci type.")
         return
 
-    release_dir = Path.cwd() / "build" / "bin" / "Release"
+    release_dir = get_build_dir() / "bin" / "Release"
     manifest_path = release_dir / "bitcoind.manifest"
     cmd_bitcoind_manifest = [
         "mt.exe",
@@ -160,7 +164,7 @@ def prepare_tests(ci_type):
 
 def run_tests(ci_type):
     workspace = Path.cwd()
-    build_dir = workspace / "build"
+    build_dir = get_build_dir()
     num_procs = str(os.process_cpu_count())
     release_bin = build_dir / "bin" / "Release"
 


### PR DESCRIPTION
In theory this is already tested by setting the scratch dir to `scratch_ ₿🧪_` in the CI:

 https://github.com/bitcoin/bitcoin/blob/b9f0040caf45355c4621e792df09fffabf23495e/ci/test/00_setup_env.sh#L26

However, this doesn't cover everything, because on Linux, the build dir will contain symlinks to the Python functional tests, which will drop the space when they are resolved. So the `subprocess.h` may not see spaces in the command.

In theory, this can be fixed by moving the CI root dir to something with spaces, but this breaks other stuff (like depends).

So, only test `subprocess.h` handling of paths with spaces on Windows, which creates copies instead of symlinks to Python scripts.

