### PR TITLE
external signer: verify PSBT is reliable after signing it

### DIFF
--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -74,6 +74,57 @@ UniValue ExternalSigner::GetDescriptors(const int account)
     return RunCommandParseJSON(Cat(m_command, Cat(Cat({"--fingerprint", m_fingerprint}, NetworkArg()), {"getdescriptors", "--account", strprintf("%d", account)})), "");
 }
 
+static std::string CheckSignerPSBTOutputs(
+    const PartiallySignedTransaction& original,
+    const PartiallySignedTransaction& signed_psbt)
+{
+    if (original.outputs.size() != signed_psbt.outputs.size()) {
+        return strprintf("Signer modified output count: %d -> %d", original.outputs.size(), signed_psbt.outputs.size());
+    }
+    for (size_t i = 0; i < original.outputs.size(); ++i) {
+        if (original.outputs[i].amount != signed_psbt.outputs[i].amount) {
+            return strprintf("Signer modified output %d amount", i);
+        }
+        if (original.outputs[i].script != signed_psbt.outputs[i].script) {
+            return strprintf("Signer modified output %d scriptPubKey", i);
+        }
+    }
+
+    // SIGHASH_NONE (2) and SIGHASH_SINGLE (3) do not commit to all outputs.
+    // SIGHASH_DEFAULT (0, taproot implicit ALL) and SIGHASH_ALL (1) are safe.
+    // ANYONECANPAY (0x80) can be combined with ALL and remains output-binding.
+    auto is_safe_sighash = [](int sh) -> bool {
+        const int base = sh & ~SIGHASH_ANYONECANPAY;
+        return base == SIGHASH_DEFAULT || base == SIGHASH_ALL;
+    };
+
+    for (auto& input : signed_psbt.inputs) {
+        if (input.sighash_type.has_value() &&
+            !is_safe_sighash(*input.sighash_type)) {
+            return strprintf("Signer used unsafe sighash type in one of the inputs");
+        }
+        for (const auto& [_, sigpair] : input.partial_sigs) {
+            const std::vector<unsigned char>& sig = sigpair.second;
+            if (!sig.empty() && !is_safe_sighash(sig.back())) {
+                return strprintf("Signer used unsafe sighash type in one of the inputs");
+            }
+        }
+        // 64-byte taproot sig implies SIGHASH_DEFAULT (safe); 65-byte carries
+        // an explicit sighash flag in the last byte.
+        if (input.m_tap_key_sig.size() == 65 &&
+            !is_safe_sighash(input.m_tap_key_sig.back())) {
+            return strprintf("Signer used an unsafe sighash type in taproot keypath sig");
+        }
+        for (const auto& [_, sig] : input.m_tap_script_sigs) {
+            if (sig.size() == 65 && !is_safe_sighash(sig.back())) {
+                return strprintf("Signer used an unsafe sighash type in taproot scriptpath sig");
+            }
+        }
+    }
+
+    return {};
+}
+
 bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::string& error)
 {
     // Serialize the PSBT
@@ -115,6 +166,12 @@ bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::str
     util::Result<PartiallySignedTransaction> signer_psbtx = DecodeBase64PSBT(signer_result.find_value("psbt").get_str());
     if (!signer_psbtx) {
         error = strprintf("TX decode failed %s", util::ErrorString(signer_psbtx).original);
+        return false;
+    }
+
+    const auto invariant_error{CheckSignerPSBTOutputs(psbtx, *signer_psbtx)};
+    if (!invariant_error.empty()) {
+        error = invariant_error;
         return false;
     }
 

--- a/test/functional/mocks/signer.py
+++ b/test/functional/mocks/signer.py
@@ -56,18 +56,91 @@ def displayaddress(args):
 
     return sys.stdout.write(json.dumps({"address": expected_desc[args.desc]}))
 
+def _signtx_rogue(psbt_b64, mode):
+    """Corrupt a PSBT according to `mode` and return it, simulating a rogue signer."""
+    import struct
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+    from test_framework.messages import CTransaction, from_binary
+    from test_framework.psbt import (
+        PSBT,
+        PSBT_GLOBAL_UNSIGNED_TX,
+        PSBT_IN_PARTIAL_SIG,
+        PSBT_IN_SIGHASH_TYPE,
+        PSBT_IN_TAP_KEY_SIG,
+        PSBT_IN_TAP_SCRIPT_SIG,
+        PSBT_OUT_AMOUNT,
+        PSBT_OUT_SCRIPT,
+    )
+
+    psbt = PSBT.from_base64(psbt_b64)
+    # 65-byte fake sig: 64 zero bytes + SIGHASH_NONE (0x02) — only length and
+    # last byte are inspected by the invariant check, not signature validity.
+    fake_tap_sig_unsafe_sighash = bytes(64) + bytes([0x02])
+
+    if mode == "change_amount":
+        if PSBT_GLOBAL_UNSIGNED_TX in psbt.g.map:   # PSBTv0
+            tx = from_binary(CTransaction, psbt.g.map[PSBT_GLOBAL_UNSIGNED_TX])
+            tx.vout[0].nValue += 1
+            psbt.g.map[PSBT_GLOBAL_UNSIGNED_TX] = tx.serialize_without_witness()
+        else:                                         # PSBTv2
+            amount = struct.unpack("<q", psbt.o[0].map[PSBT_OUT_AMOUNT])[0]
+            psbt.o[0].map[PSBT_OUT_AMOUNT] = struct.pack("<q", amount + 1)
+    elif mode == "change_script":
+        if PSBT_GLOBAL_UNSIGNED_TX in psbt.g.map:
+            tx = from_binary(CTransaction, psbt.g.map[PSBT_GLOBAL_UNSIGNED_TX])
+            tx.vout[0].scriptPubKey = bytes([0x51])  # OP_TRUE
+            psbt.g.map[PSBT_GLOBAL_UNSIGNED_TX] = tx.serialize_without_witness()
+        else:
+            psbt.o[0].map[PSBT_OUT_SCRIPT] = bytes([0x51])
+    elif mode == "remove_output":
+        # Drop the last output so the reply has fewer outputs than the original.
+        if PSBT_GLOBAL_UNSIGNED_TX in psbt.g.map:   # PSBTv0
+            tx = from_binary(CTransaction, psbt.g.map[PSBT_GLOBAL_UNSIGNED_TX])
+            tx.vout.pop()
+            psbt.g.map[PSBT_GLOBAL_UNSIGNED_TX] = tx.serialize_without_witness()
+        psbt.o.pop()                                  # PSBTv2 count is recomputed on serialize
+    elif mode == "sighash_none":
+        # Inject SIGHASH_NONE (2) via the per-input sighash_type field (BIP-174 key 0x03).
+        psbt.i[0].map[PSBT_IN_SIGHASH_TYPE] = struct.pack("<I", 2)
+    elif mode == "tap_key_sig_unsafe":
+        # 65-byte taproot keypath sig whose explicit sighash byte is SIGHASH_NONE.
+        psbt.i[0].map[PSBT_IN_TAP_KEY_SIG] = fake_tap_sig_unsafe_sighash
+    elif mode == "tap_script_sig_unsafe":
+        # PSBT_IN_TAP_SCRIPT_SIG key is <type><xonly(32)><leaf_hash(32)>.
+        # Zero-filled placeholders are fine; the check only looks at sig length and last byte.
+        key = bytes([PSBT_IN_TAP_SCRIPT_SIG]) + bytes(32) + bytes(32)
+        psbt.i[0].map[key] = fake_tap_sig_unsafe_sighash
+    elif mode == "ecdsa_partial_sig_unsafe":
+        # Minimal valid strict-DER ECDSA sig (r=1, s=1) trailed by SIGHASH_NONE (0x02)
+        # so the PSBT deserializer's CheckSignatureEncoding passes and the
+        # invariant check sees the unsafe sighash byte. Pubkey is the secp256k1
+        # generator G — a fully-valid compressed pubkey.
+        pubkey = bytes.fromhex("0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798")
+        key = bytes([PSBT_IN_PARTIAL_SIG]) + pubkey
+        psbt.i[0].map[key] = bytes.fromhex("3006020101020101") + bytes([0x02])
+    else:
+        sys.stdout.write(json.dumps({"error": f"Unknown rogue mode: {mode}"}))
+        return
+
+    sys.stdout.write(json.dumps({"psbt": psbt.to_base64(), "complete": True}))
+
+
 def signtx(args):
     if args.fingerprint != "00000001":
         return sys.stdout.write(json.dumps({"error": "Unexpected fingerprint", "fingerprint": args.fingerprint}))
 
+    rogue_mode_path = os.path.join(os.getcwd(), "mock_rogue_mode")
+    if os.path.isfile(rogue_mode_path):
+        with open(rogue_mode_path) as f:
+            mode = f.read().strip()
+        _signtx_rogue(args.psbt, mode)
+        return
+
     with open(os.path.join(os.getcwd(), "mock_psbt"), "r") as f:
         mock_psbt = f.read()
 
-    if args.fingerprint == "00000001" :
-        sys.stdout.write(json.dumps({
-            "psbt": mock_psbt,
-            "complete": True
-        }))
+    if args.fingerprint == "00000001":
+        sys.stdout.write(json.dumps({"psbt": mock_psbt, "complete": True}))
     else:
         sys.stdout.write(json.dumps({"psbt": args.psbt}))
 

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -35,6 +35,7 @@ class RPCSignerTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_external_signer()
+        self.skip_if_no_wallet()
 
     def set_mock_result(self, node, res):
         with open(os.path.join(node.cwd, "mock_result"), "w") as f:
@@ -42,6 +43,13 @@ class RPCSignerTest(BitcoinTestFramework):
 
     def clear_mock_result(self, node):
         os.remove(os.path.join(node.cwd, "mock_result"))
+
+    def set_mock_rogue_mode(self, node, mode):
+        with open(os.path.join(node.cwd, "mock_rogue_mode"), "w") as f:
+            f.write(mode)
+
+    def clear_mock_rogue_mode(self, node):
+        os.remove(os.path.join(node.cwd, "mock_rogue_mode"))
 
     def run_test(self):
         self.log.debug(f"-signer={self.mock_signer_path()}")
@@ -73,6 +81,70 @@ class RPCSignerTest(BitcoinTestFramework):
         self.clear_mock_result(self.nodes[1])
 
         assert_equal({'fingerprint': '00000001', 'name': 'trezor_t'} in self.nodes[1].enumeratesigners()['signers'], True)
+
+        self.test_psbt_output_invariants()
+
+    def test_psbt_output_invariants(self):
+        self.log.info('Test PSBT output invariants against a rogue external signer')
+
+        self.nodes[2].createwallet(wallet_name='hww_rogue_test', disable_private_keys=True, blank=False, external_signer=True)
+        hww = self.nodes[2].get_wallet_rpc('hww_rogue_test')
+
+        # Fund the wallet with one UTXO per sub-test so each has a fresh coin
+        # available even if a previous attempt locked the UTXO.
+        address = hww.getnewaddress(address_type='bech32m')
+        for _ in range(7):
+            self.nodes[0].sendtoaddress(address, 1)
+        self.generate(self.nodes[0], 1)
+        assert_equal(hww.getbalance(), 7)
+
+        self.restart_node(2, [f"-signer={self.mock_signer_path()}", '-keypool=10'])
+        self.nodes[2].loadwallet('hww_rogue_test')
+        hww = self.nodes[2].get_wallet_rpc('hww_rogue_test')
+
+        dest = self.nodes[0].getnewaddress()
+
+        self.log.info('Rogue signer modifies output amount — must be rejected')
+        self.set_mock_rogue_mode(self.nodes[2], 'change_amount')
+        assert_raises_rpc_error(-25, 'External signer failed to sign',
+            hww.send, outputs={dest: 0.5})
+        self.clear_mock_rogue_mode(self.nodes[2])
+
+        self.log.info('Rogue signer modifies output script — must be rejected')
+        self.set_mock_rogue_mode(self.nodes[2], 'change_script')
+        assert_raises_rpc_error(-25, 'External signer failed to sign',
+            hww.send, outputs={dest: 0.5})
+        self.clear_mock_rogue_mode(self.nodes[2])
+
+        self.log.info('Rogue signer removes an output — must be rejected')
+        self.set_mock_rogue_mode(self.nodes[2], 'remove_output')
+        assert_raises_rpc_error(-25, 'External signer failed to sign',
+            hww.send, outputs={dest: 0.5})
+        self.clear_mock_rogue_mode(self.nodes[2])
+
+        self.log.info('Rogue signer uses SIGHASH_NONE — must be rejected')
+        self.set_mock_rogue_mode(self.nodes[2], 'sighash_none')
+        assert_raises_rpc_error(-25, 'External signer failed to sign',
+            hww.send, outputs={dest: 0.5})
+        self.clear_mock_rogue_mode(self.nodes[2])
+
+        self.log.info('Rogue signer attaches taproot keypath sig with unsafe sighash — must be rejected')
+        self.set_mock_rogue_mode(self.nodes[2], 'tap_key_sig_unsafe')
+        assert_raises_rpc_error(-25, 'External signer failed to sign',
+            hww.send, outputs={dest: 0.5})
+        self.clear_mock_rogue_mode(self.nodes[2])
+
+        self.log.info('Rogue signer attaches taproot scriptpath sig with unsafe sighash — must be rejected')
+        self.set_mock_rogue_mode(self.nodes[2], 'tap_script_sig_unsafe')
+        assert_raises_rpc_error(-25, 'External signer failed to sign',
+            hww.send, outputs={dest: 0.5})
+        self.clear_mock_rogue_mode(self.nodes[2])
+
+        self.log.info('Rogue signer attaches ECDSA partial sig with unsafe sighash — must be rejected')
+        self.set_mock_rogue_mode(self.nodes[2], 'ecdsa_partial_sig_unsafe')
+        assert_raises_rpc_error(-25, 'External signer failed to sign',
+            hww.send, outputs={dest: 0.5})
+        self.clear_mock_rogue_mode(self.nodes[2])
 
 if __name__ == '__main__':
     RPCSignerTest(__file__).main()

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -9,6 +9,7 @@ See also rpc_signer.py for tests without wallet context.
 """
 import os
 import sys
+from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -161,7 +162,19 @@ class WalletSignerTest(BitcoinTestFramework):
         assert_equal(result[1], {'success': True})
         assert_equal(mock_wallet.getwalletinfo()["txcount"], 1)
         dest = self.nodes[0].getnewaddress(address_type='bech32')
-        mock_psbt = mock_wallet.walletcreatefundedpsbt([], {dest:0.5}, 0, {'replaceable': True}, True)['psbt']
+
+        # ExternalSigner::SignTransaction rejects a reply whose outputs differ
+        # from the PSBT it was given, so the pre-signed mock_psbt must be the
+        # signed form of the exact PSBT hww builds. Have hww build the PSBT,
+        # then have mock_wallet (which holds the matching private keys) sign it.
+        # Pin change_position and change_address so hww.send rebuilds an
+        # identical PSBT when the signer is called.
+        change_addr = hww.getrawchangeaddress()
+        mock_psbt = hww.walletcreatefundedpsbt(
+            [], {dest: 0.5}, 0,
+            {'replaceable': True, 'change_position': 1, 'change_address': change_addr},
+            True,
+        )['psbt']
         mock_psbt_signed = mock_wallet.walletprocesspsbt(psbt=mock_psbt, sign=True, sighashtype="ALL", bip32derivs=True)
         mock_tx = mock_psbt_signed["hex"]
         assert mock_wallet.testmempoolaccept([mock_tx])[0]["allowed"]
@@ -176,34 +189,67 @@ class WalletSignerTest(BitcoinTestFramework):
         self.log.info('Test send using hww1')
 
         # Don't broadcast transaction yet so the RPC returns the raw hex
-        res = hww.send(outputs={dest:0.5},add_to_wallet=False)
+        res = hww.send(
+            outputs={dest: 0.5},
+            options={'add_to_wallet': False, 'change_position': 1, 'change_address': change_addr},
+        )
         assert res["complete"]
         assert_equal(res["hex"], mock_tx)
 
         self.log.info('Test sendall using hww1')
 
-        res = hww.sendall(recipients=[{dest:0.5}, hww.getrawchangeaddress()], add_to_wallet=False)
+        sendall_change = hww.getrawchangeaddress()
+        utxos = hww.listunspent()
+        assert_equal(len(utxos), 1)
+        utxo = utxos[0]
+        sendall_psbt = hww.walletcreatefundedpsbt(
+            [{"txid": utxo["txid"], "vout": utxo["vout"]}],
+            [{dest: 0.5}, {sendall_change: utxo["amount"] - Decimal("0.5")}],
+            0,
+            {'add_inputs': False, 'subtractFeeFromOutputs': [1], 'replaceable': True},
+            True,
+        )['psbt']
+        sendall_psbt_signed = mock_wallet.walletprocesspsbt(psbt=sendall_psbt, sign=True, sighashtype="ALL", bip32derivs=True)
+        sendall_tx = sendall_psbt_signed["hex"]
+
+        with open(os.path.join(self.nodes[1].cwd, "mock_psbt"), "w") as f:
+            f.write(sendall_psbt_signed["psbt"])
+
+        res = hww.sendall(recipients=[{dest: 0.5}, sendall_change], add_to_wallet=False)
         assert res["complete"]
-        assert_equal(res["hex"], mock_tx)
+        assert_equal(res["hex"], sendall_tx)
         # Broadcast transaction so we can bump the fee
         hww.sendrawtransaction(res["hex"])
 
         self.log.info('Prepare fee bumped mock PSBT')
 
-        # Now that the transaction is broadcast, bump fee in mock wallet:
+        # Build the bumped PSBT on hww (not mock_wallet) so it matches what
+        # the external signer will receive; mock_wallet only adds signatures.
         orig_tx_id = res["txid"]
-        mock_psbt_bumped = mock_wallet.psbtbumpfee(orig_tx_id)["psbt"]
-        mock_psbt_bumped_signed = mock_wallet.walletprocesspsbt(psbt=mock_psbt_bumped, sign=True, sighashtype="ALL", bip32derivs=True)
+        hww_psbt_bumped = hww.psbtbumpfee(orig_tx_id)["psbt"]
+        mock_psbt_bumped_signed = mock_wallet.walletprocesspsbt(psbt=hww_psbt_bumped, sign=True, sighashtype="ALL", bip32derivs=True)
 
         with open(os.path.join(self.nodes[1].cwd, "mock_psbt"), "w") as f:
             f.write(mock_psbt_bumped_signed["psbt"])
 
         self.log.info('Test bumpfee using hww1')
 
-        # Bump fee
-        res = hww.bumpfee(orig_tx_id)
-        assert_greater_than(res["fee"], res["origfee"])
-        assert_equal(res["errors"], [])
+        # hww.bumpfee rebuilds the bumped tx internally with a random
+        # change_position (CreateTransaction is called with change_pos=nullopt
+        # in feebumper.cpp), so its outputs would not line up with the
+        # pre-signed mock_psbt. Send the exact pre-built PSBT through
+        # walletprocesspsbt, which routes to the external signer.
+        signed_bumped = hww.walletprocesspsbt(psbt=hww_psbt_bumped)
+        assert signed_bumped["complete"]
+        final_bumped = hww.finalizepsbt(signed_bumped["psbt"])
+        assert final_bumped["complete"]
+        assert hww.testmempoolaccept([final_bumped["hex"]])[0]["allowed"]
+        bumped_decoded = hww.decoderawtransaction(final_bumped["hex"])
+        orig_decoded = hww.gettransaction(orig_tx_id, True, True)["decoded"]
+        bumped_out_total = sum(vout["value"] for vout in bumped_decoded["vout"])
+        orig_out_total = sum(vout["value"] for vout in orig_decoded["vout"])
+        # 1 BTC input on both sides, so a smaller output total means a higher fee.
+        assert_greater_than(orig_out_total, bumped_out_total)
 
 
     def test_disconnected_signer(self):


### PR DESCRIPTION
Seeking Concept ACK

A compromised or "rogue" external signer could return a PSBT with silently altered outputs or use unsafe sighash types that do not commit to all outputs (perhaps unlikely, but a buggy signer could also change it). This PR adds a post-signing validation step in `External::SignTransaction` that compares the signed PSBT returned by the external signer against the original one before accepting it. Without these checks, it is not super friendly (e.g. using RPC) to manually verify the same. 

Note: the added tests were partially vibe-coded.

