### PR TITLE
doc: Fix command in build-unix.md example

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -216,5 +216,5 @@ This example lists the steps necessary to setup and build a command line only di
     cmake --build build
     ctest --test-dir build
     ./build/bin/bitcoind
-    ./build/bin/bitcoin help
+    ./build/bin/bitcoin-cli help
 


### PR DESCRIPTION
Changed `./build/bin/bitcoin help` to `./build/bin/bitcoin-cli help` in the Arch Linux setup example.

The example was showing the wrong command - `bitcoin` is the multiprocess wrapper 
(used with `-m` flag), But the basic example should use `bitcoin-cli` to interact 
with the daemon, consistent with the macOS build documentation.