### PR TITLE
Fix typo in IPC code comments

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -216,5 +216,5 @@ This example lists the steps necessary to setup and build a command line only di
     cmake --build build
     ctest --test-dir build
     ./build/bin/bitcoind
-    ./build/bin/bitcoin help
+    ./build/bin/bitcoin-cli help
 

--- a/src/ipc/libmultiprocess/include/mp/type-map.h
+++ b/src/ipc/libmultiprocess/include/mp/type-map.h
@@ -17,7 +17,7 @@ void CustomBuildField(TypeList<std::map<KeyLocalType, ValueLocalType>>,
     Value&& value,
     Output&& output)
 {
-    // FIXME dededup with vector handler above
+    // FIXME dedup with vector handler above
     auto list = output.init(value.size());
     size_t i = 0;
     for (const auto& elem : value) {

--- a/src/ipc/libmultiprocess/include/mp/type-set.h
+++ b/src/ipc/libmultiprocess/include/mp/type-set.h
@@ -16,7 +16,7 @@ void CustomBuildField(TypeList<std::set<LocalType>>,
     Value&& value,
     Output&& output)
 {
-    // FIXME dededup with vector handler above
+    // FIXME dedup with vector handler above
     auto list = output.init(value.size());
     size_t i = 0;
     for (const auto& elem : value) {


### PR DESCRIPTION
Changed "dededup" to "dedup" in FIXME comments.

Files changed:
- src/ipc/libmultiprocess/include/mp/type-set.h
- src/ipc/libmultiprocess/include/mp/type-map.h

"dedup" is the correct abbreviation of "deduplicate".