### PR TITLE
tracing: add block header and compact block tracepoints

### DIFF
--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -96,6 +96,18 @@ to user-space in full. Messages longer than 32kb might be cut off. This can
 be detected in tracing scripts by comparing the message size to the length of
 the passed message.
 
+#### Tracepoint `net:block_header`
+
+Is called after a new valid block header is received from a peer. The header
+may have been announced through a `headers` message or as part of a
+`cmpctblock` message.
+
+Arguments passed:
+1. Block Height as `int32`
+2. Peer ID as `int64`
+3. Whether the header was received as part of a `cmpctblock` message as `bool`
+4. Block Header Hash as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+
 #### Tracepoint `net:inbound_connection`
 
 Is called when a new inbound connection is opened to us. Passes information about

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -108,6 +108,24 @@ Arguments passed:
 3. Whether the header was received as part of a `cmpctblock` message as `bool`
 4. Block Header Hash as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
 
+#### Tracepoint `net:compact_block_reconstructed`
+
+Is called after a compact block was successfully reconstructed. This is called
+before the reconstructed block is submitted for validation.
+
+Arguments passed:
+1. Peer ID of the peer that supplied the compact block data as `int64`
+2. Prefilled transaction count as `uint32`
+3. Transaction count from the mempool, excluding the extra transaction pool, as `uint32`
+4. Transaction count from the extra transaction pool as `uint32`
+5. Requested transaction count as `uint32`
+6. Requested transaction bytes as `uint32`
+7. Block Header Hash as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+
+The mempool and extra transaction pool counts are disjoint.
+The binary hash is passed last so the first six arguments remain scalar fields
+available to `bpftrace` users.
+
 #### Tracepoint `net:inbound_connection`
 
 Is called when a new inbound connection is opened to us. Passes information about

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -186,6 +186,19 @@ bool PartiallyDownloadedBlock::IsTxAvailable(size_t index) const
     return txn_available[index] != nullptr;
 }
 
+CompactBlockReconstructionStats PartiallyDownloadedBlock::GetReconstructionStats(const std::vector<CTransactionRef>& vtx_missing) const
+{
+    uint32_t requested_txn_bytes{0};
+    for (const auto& tx : vtx_missing) requested_txn_bytes += tx->ComputeTotalSize();
+    return {
+        static_cast<uint32_t>(prefilled_count),
+        static_cast<uint32_t>(mempool_count - extra_count),
+        static_cast<uint32_t>(extra_count),
+        static_cast<uint32_t>(vtx_missing.size()),
+        requested_txn_bytes,
+    };
+}
+
 ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing, bool segwit_active)
 {
     if (header.IsNull()) return READ_STATUS_INVALID;
@@ -221,9 +234,8 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
 
     if (util::log::ShouldDebugLog(BCLog::CMPCTBLOCK)) {
         const uint256 hash{block.GetHash()};
-        uint32_t tx_missing_size{0};
-        for (const auto& tx : vtx_missing) tx_missing_size += tx->ComputeTotalSize();
-        LogDebug(BCLog::CMPCTBLOCK, "Successfully reconstructed block %s with %u txn prefilled, %u txn from mempool (incl at least %u from extra pool) and %u txn (%u bytes) requested\n", hash.ToString(), prefilled_count, mempool_count, extra_count, vtx_missing.size(), tx_missing_size);
+        const auto stats{GetReconstructionStats(vtx_missing)};
+        LogDebug(BCLog::CMPCTBLOCK, "Successfully reconstructed block %s with %u txn prefilled, %u txn from mempool (incl at least %u from extra pool) and %u txn (%u bytes) requested\n", hash.ToString(), stats.prefilled_txn_count, stats.mempool_txn_count + stats.extra_pool_txn_count, stats.extra_pool_txn_count, stats.requested_txn_count, stats.requested_txn_bytes);
         if (vtx_missing.size() < 5) {
             for (const auto& tx : vtx_missing) {
                 LogDebug(BCLog::CMPCTBLOCK, "Reconstructed block %s required tx %s\n", hash.ToString(), tx->GetHash().ToString());

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -8,6 +8,7 @@
 #include <crypto/siphash.h>
 #include <primitives/block.h>
 
+#include <cstdint>
 #include <functional>
 
 class CTxMemPool;
@@ -87,6 +88,15 @@ typedef enum ReadStatus_t
     READ_STATUS_FAILED, // Failed to process object
 } ReadStatus;
 
+struct CompactBlockReconstructionStats
+{
+    uint32_t prefilled_txn_count{0};
+    uint32_t mempool_txn_count{0};
+    uint32_t extra_pool_txn_count{0};
+    uint32_t requested_txn_count{0};
+    uint32_t requested_txn_bytes{0};
+};
+
 class CBlockHeaderAndShortTxIDs {
     mutable std::optional<PresaltedSipHasher> m_hasher;
     uint64_t nonce;
@@ -147,6 +157,8 @@ public:
     // extra_txn is a list of extra transactions to look at, in <witness hash, reference> form
     ReadStatus InitData(const CBlockHeaderAndShortTxIDs& cmpctblock, const std::vector<std::pair<Wtxid, CTransactionRef>>& extra_txn);
     bool IsTxAvailable(size_t index) const;
+    // The mempool count excludes transactions found in the extra transaction pool.
+    CompactBlockReconstructionStats GetReconstructionStats(const std::vector<CTransactionRef>& vtx_missing) const;
     // segwit_active enforces witness mutation checks just before reporting a healthy status
     ReadStatus FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing, bool segwit_active);
 };

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
 #include <net_processing.h>
 
 #include <addrman.h>
@@ -90,6 +92,7 @@ using kernel::ChainstateRole;
 using namespace util::hex_literals;
 
 TRACEPOINT_SEMAPHORE(net, block_header);
+TRACEPOINT_SEMAPHORE(net, compact_block_reconstructed);
 TRACEPOINT_SEMAPHORE(net, inbound_message);
 TRACEPOINT_SEMAPHORE(net, misbehaving_connection);
 
@@ -210,6 +213,34 @@ struct QueuedBlock {
     /** Optional, used for CMPCTBLOCK downloads */
     std::unique_ptr<PartiallyDownloadedBlock> partialBlock;
 };
+
+void TraceCompactBlockReconstructed(
+    const CBlock& block,
+    const CNode& peer,
+    const PartiallyDownloadedBlock& partial_block,
+    const std::vector<CTransactionRef>& vtx_missing)
+{
+#ifdef ENABLE_TRACING
+    if (!TRACEPOINT_ACTIVE(net, compact_block_reconstructed)) return;
+
+    const uint256 hash{block.GetHash()};
+    const auto stats{partial_block.GetReconstructionStats(vtx_missing)};
+    TRACEPOINT(net, compact_block_reconstructed,
+        peer.GetId(),
+        stats.prefilled_txn_count,
+        stats.mempool_txn_count,
+        stats.extra_pool_txn_count,
+        stats.requested_txn_count,
+        stats.requested_txn_bytes,
+        hash.data()
+    );
+#else
+    (void)block;
+    (void)peer;
+    (void)partial_block;
+    (void)vtx_missing;
+#endif
+}
 
 /**
  * Data structure for an individual peer. This struct is not protected by
@@ -3505,6 +3536,7 @@ void PeerManagerImpl::ProcessCompactBlockTxns(CNode& pfrom, Peer& peer, const Bl
             }
         } else {
             // Block is okay for further processing
+            TraceCompactBlockReconstructed(*pblock, pfrom, partialBlock, block_transactions.txn);
             RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId()); // it is now an empty pointer
             fBlockRead = true;
             // mapBlockSource is used for potentially punishing peers and
@@ -4659,6 +4691,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 status = tempBlock.FillBlock(*pblock, dummy,
                                              /*segwit_active=*/DeploymentActiveAfter(prev_block, m_chainman, Consensus::DEPLOYMENT_SEGWIT));
                 if (status == READ_STATUS_OK) {
+                    TraceCompactBlockReconstructed(*pblock, pfrom, tempBlock, dummy);
                     fBlockReconstructed = true;
                 }
             }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -89,6 +89,7 @@
 using kernel::ChainstateRole;
 using namespace util::hex_literals;
 
+TRACEPOINT_SEMAPHORE(net, block_header);
 TRACEPOINT_SEMAPHORE(net, inbound_message);
 TRACEPOINT_SEMAPHORE(net, misbehaving_connection);
 
@@ -3538,10 +3539,17 @@ void PeerManagerImpl::LogBlockHeader(const CBlockIndex& index, const CNode& peer
     // don't followup with a complete and valid (compact) block.
     // Having this log by default when not in IBD ensures broad availability of
     // this data in case investigation is merited.
+    const uint256 block_hash{index.GetBlockHash()};
+    TRACEPOINT(net, block_header,
+        index.nHeight,
+        peer.GetId(),
+        via_compact_block,
+        block_hash.data()
+    );
     const auto msg = strprintf(
         "Saw new %sheader hash=%s height=%d %s",
         via_compact_block ? "cmpctblock " : "",
-        index.GetBlockHash().ToString(),
+        block_hash.ToString(),
         index.nHeight,
         peer.LogPeer()
     );

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -341,6 +341,13 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
         BOOST_CHECK( partial_block.IsTxAvailable(0));
         BOOST_CHECK(!partial_block.IsTxAvailable(1));
         BOOST_CHECK( partial_block.IsTxAvailable(2));
+        const std::vector<CTransactionRef> missing_from_mempool{block.vtx[1]};
+        const auto stats{partial_block.GetReconstructionStats(missing_from_mempool)};
+        BOOST_CHECK_EQUAL(stats.prefilled_txn_count, 1);
+        BOOST_CHECK_EQUAL(stats.mempool_txn_count, 1);
+        BOOST_CHECK_EQUAL(stats.extra_pool_txn_count, 0);
+        BOOST_CHECK_EQUAL(stats.requested_txn_count, 1);
+        BOOST_CHECK_EQUAL(stats.requested_txn_bytes, block.vtx[1]->ComputeTotalSize());
 
         // Add an unrelated tx to extra_txn:
         extra_txn[0] = {non_block_tx->GetWitnessHash(), non_block_tx};
@@ -352,6 +359,12 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
         // This transaction is now available via extra_txn:
         BOOST_CHECK(partial_block_with_extra.IsTxAvailable(1));
         BOOST_CHECK(partial_block_with_extra.IsTxAvailable(2));
+        const auto stats_with_extra{partial_block_with_extra.GetReconstructionStats({})};
+        BOOST_CHECK_EQUAL(stats_with_extra.prefilled_txn_count, 1);
+        BOOST_CHECK_EQUAL(stats_with_extra.mempool_txn_count, 1);
+        BOOST_CHECK_EQUAL(stats_with_extra.extra_pool_txn_count, 1);
+        BOOST_CHECK_EQUAL(stats_with_extra.requested_txn_count, 0);
+        BOOST_CHECK_EQUAL(stats_with_extra.requested_txn_bytes, 0);
     }
 }
 

--- a/test/functional/interface_usdt_net.py
+++ b/test/functional/interface_usdt_net.py
@@ -14,6 +14,7 @@ try:
     from bcc import BPF, USDT  # type: ignore[import]
 except ImportError:
     pass
+from test_framework.blocktools import NORMAL_GBT_REQUEST_PARAMS, create_block
 from test_framework.messages import CBlockHeader, MAX_HEADERS_RESULTS, msg_headers, msg_version
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
@@ -28,8 +29,9 @@ MAX_PEER_ADDR_LENGTH = 68
 MAX_PEER_CONN_TYPE_LENGTH = 20
 MAX_MSG_TYPE_LENGTH = 20
 MAX_MISBEHAVING_MESSAGE_LENGTH = 128
+BLOCK_HASH_LENGTH = 32
 # We won't process messages larger than 150 byte in this test. For reading
-# larger messanges see contrib/tracing/log_raw_p2p_msgs.py
+# larger messages see contrib/tracing/log_raw_p2p_msgs.py
 MAX_MSG_DATA_LENGTH = 150
 
 # from net_address.h
@@ -46,15 +48,19 @@ net_tracepoints_program = """
 #define MAX_MSG_TYPE_LENGTH {}
 #define MAX_MSG_DATA_LENGTH {}
 #define MAX_MISBEHAVING_MESSAGE_LENGTH {}
+#define BLOCK_HASH_LENGTH {}
 """.format(
     MAX_PEER_ADDR_LENGTH,
     MAX_PEER_CONN_TYPE_LENGTH,
     MAX_MSG_TYPE_LENGTH,
     MAX_MSG_DATA_LENGTH,
     MAX_MISBEHAVING_MESSAGE_LENGTH,
+    BLOCK_HASH_LENGTH,
 ) + """
 // A min() macro. Prefixed with _TRACEPOINT_TEST to avoid collision with other MIN macros.
 #define _TRACEPOINT_TEST_MIN(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
+
+typedef signed long long i64;
 
 struct p2p_message
 {
@@ -91,6 +97,27 @@ struct MisbehavingConnection
     u64     id;
     char    message[MAX_MISBEHAVING_MESSAGE_LENGTH];
 };
+
+struct BlockHeader
+{
+    int     height;
+    i64     peer_id;
+    bool    via_compact_block;
+    u8      hash[BLOCK_HASH_LENGTH];
+};
+
+BPF_PERF_OUTPUT(block_headers);
+int trace_block_header(struct pt_regs *ctx) {
+    struct BlockHeader header = {};
+    void *hash_pointer = NULL;
+    bpf_usdt_readarg(1, ctx, &header.height);
+    bpf_usdt_readarg(2, ctx, &header.peer_id);
+    bpf_usdt_readarg(3, ctx, &header.via_compact_block);
+    bpf_usdt_readarg(4, ctx, &hash_pointer);
+    bpf_probe_read_user(&header.hash, sizeof(header.hash), hash_pointer);
+    block_headers.perf_submit(ctx, &header, sizeof(header));
+    return 0;
+}
 
 BPF_PERF_OUTPUT(inbound_messages);
 int trace_inbound_message(struct pt_regs *ctx) {
@@ -244,6 +271,18 @@ class MisbehavingConnection(ctypes.Structure):
         return f"MisbehavingConnection(id={self.id}, message={self.message})"
 
 
+class BlockHeader(ctypes.Structure):
+    _fields_ = [
+        ("height", ctypes.c_int32),
+        ("peer_id", ctypes.c_int64),
+        ("via_compact_block", ctypes.c_bool),
+        ("hash", ctypes.c_ubyte * BLOCK_HASH_LENGTH),
+    ]
+
+    def __repr__(self):
+        return f"BlockHeader(hash={bytes(self.hash[::-1]).hex()}, height={self.height}, peer_id={self.peer_id}, via_compact_block={self.via_compact_block})"
+
+
 class NetTracepointTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -257,12 +296,71 @@ class NetTracepointTest(BitcoinTestFramework):
         self.skip_if_running_under_valgrind()
 
     def run_test(self):
+        self.block_header_tracepoint_test()
         self.p2p_message_tracepoint_test()
         self.inbound_conn_tracepoint_test()
         self.outbound_conn_tracepoint_test()
         self.evicted_inbound_conn_tracepoint_test()
         self.misbehaving_conn_tracepoint_test()
         self.closed_conn_tracepoint_test()
+
+    def block_header_tracepoint_test(self):
+        self.log.info("hook into the net:block_header tracepoint")
+        ctx = USDT(pid=self.nodes[0].process.pid)
+        ctx.enable_probe(probe="net:block_header",
+                         fn_name="trace_block_header")
+        bpf = BPF(text=net_tracepoints_program, usdt_contexts=[ctx], debug=0, cflags=bpf_cflags())
+
+        block_headers = []
+
+        def handle_block_header(_, data, __):
+            event = ctypes.cast(data, ctypes.POINTER(BlockHeader)).contents
+            self.log.info(f"handle_block_header(): {event}")
+            block_headers.append(event)
+
+        bpf["block_headers"].open_perf_buffer(handle_block_header)
+
+        self.log.info("send a new header from a P2P test node to bitcoind")
+        test_node = P2PInterface()
+        self.nodes[0].add_p2p_connection(test_node)
+        peer_id = self.nodes[0].getpeerinfo()[0]["id"]
+        expected_height = self.nodes[0].getblockcount() + 1
+        block = create_block(tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
+        block.solve()
+        test_node.send_and_ping(msg_headers([CBlockHeader(block)]))
+        bpf.perf_buffer_poll(timeout=400)
+
+        matching_headers = [event for event in block_headers if bytes(event.hash[::-1]).hex() == block.hash_hex]
+        assert_equal(1, len(matching_headers))
+        event = matching_headers[0]
+        assert_equal(expected_height, event.height)
+        assert_equal(peer_id, event.peer_id)
+        assert_equal(False, bool(event.via_compact_block))
+
+        self.log.info("send a cmpctblock with a new header to bitcoind")
+        # Build a distinct block at the same height (the previous header has no
+        # body, so the chain tip has not advanced). Bumping nTime gives it a
+        # different hash so it is treated as a new header.
+        cmpct_block = create_block(
+            tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS),
+            ntime=block.nTime + 1,
+        )
+        cmpct_block.solve()
+        compact_block = HeaderAndShortIDs()
+        compact_block.initialize_from_block(cmpct_block)
+        test_node.send_and_ping(msg_cmpctblock(compact_block.to_p2p()))
+        bpf.perf_buffer_poll(timeout=400)
+
+        matching_headers = [event for event in block_headers if bytes(event.hash[::-1]).hex() == cmpct_block.hash_hex]
+        assert_equal(1, len(matching_headers))
+        event = matching_headers[0]
+        assert_equal(expected_height, event.height)
+        assert_equal(peer_id, event.peer_id)
+        assert_equal(True, bool(event.via_compact_block))
+
+        bpf.cleanup()
+        test_node.peer_disconnect()
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0)
 
     def p2p_message_tracepoint_test(self):
         # Tests the net:inbound_message and net:outbound_message tracepoints

--- a/test/functional/interface_usdt_net.py
+++ b/test/functional/interface_usdt_net.py
@@ -8,14 +8,28 @@
 """
 
 import ctypes
+from decimal import Decimal
 from io import BytesIO
 # Test will be skipped if we don't have bcc installed
 try:
     from bcc import BPF, USDT  # type: ignore[import]
 except ImportError:
     pass
-from test_framework.blocktools import NORMAL_GBT_REQUEST_PARAMS, create_block
-from test_framework.messages import CBlockHeader, MAX_HEADERS_RESULTS, msg_headers, msg_version
+from test_framework.blocktools import (
+    NORMAL_GBT_REQUEST_PARAMS,
+    add_witness_commitment,
+    create_block,
+)
+from test_framework.messages import (
+    CBlockHeader,
+    HeaderAndShortIDs,
+    MAX_BIP125_RBF_SEQUENCE,
+    MAX_HEADERS_RESULTS,
+    msg_cmpctblock,
+    msg_headers,
+    msg_tx,
+    msg_version,
+)
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -23,6 +37,7 @@ from test_framework.util import (
     assert_greater_than,
     bpf_cflags,
 )
+from test_framework.wallet import MiniWallet
 
 # Tor v3 addresses are 62 chars + 6 chars for the port (':12345').
 MAX_PEER_ADDR_LENGTH = 68
@@ -106,6 +121,17 @@ struct BlockHeader
     u8      hash[BLOCK_HASH_LENGTH];
 };
 
+struct CompactBlockReconstructed
+{
+    i64     peer_id;
+    u32     prefilled_txn_count;
+    u32     mempool_txn_count;
+    u32     extra_pool_txn_count;
+    u32     requested_txn_count;
+    u32     requested_txn_bytes;
+    u8      hash[BLOCK_HASH_LENGTH];
+};
+
 BPF_PERF_OUTPUT(block_headers);
 int trace_block_header(struct pt_regs *ctx) {
     struct BlockHeader header = {};
@@ -116,6 +142,22 @@ int trace_block_header(struct pt_regs *ctx) {
     bpf_usdt_readarg(4, ctx, &hash_pointer);
     bpf_probe_read_user(&header.hash, sizeof(header.hash), hash_pointer);
     block_headers.perf_submit(ctx, &header, sizeof(header));
+    return 0;
+}
+
+BPF_PERF_OUTPUT(compact_block_reconstructed);
+int trace_compact_block_reconstructed(struct pt_regs *ctx) {
+    struct CompactBlockReconstructed reconstructed = {};
+    void *hash_pointer = NULL;
+    bpf_usdt_readarg(1, ctx, &reconstructed.peer_id);
+    bpf_usdt_readarg(2, ctx, &reconstructed.prefilled_txn_count);
+    bpf_usdt_readarg(3, ctx, &reconstructed.mempool_txn_count);
+    bpf_usdt_readarg(4, ctx, &reconstructed.extra_pool_txn_count);
+    bpf_usdt_readarg(5, ctx, &reconstructed.requested_txn_count);
+    bpf_usdt_readarg(6, ctx, &reconstructed.requested_txn_bytes);
+    bpf_usdt_readarg(7, ctx, &hash_pointer);
+    bpf_probe_read_user(&reconstructed.hash, sizeof(reconstructed.hash), hash_pointer);
+    compact_block_reconstructed.perf_submit(ctx, &reconstructed, sizeof(reconstructed));
     return 0;
 }
 
@@ -283,6 +325,21 @@ class BlockHeader(ctypes.Structure):
         return f"BlockHeader(hash={bytes(self.hash[::-1]).hex()}, height={self.height}, peer_id={self.peer_id}, via_compact_block={self.via_compact_block})"
 
 
+class CompactBlockReconstructed(ctypes.Structure):
+    _fields_ = [
+        ("peer_id", ctypes.c_int64),
+        ("prefilled_txn_count", ctypes.c_uint32),
+        ("mempool_txn_count", ctypes.c_uint32),
+        ("extra_pool_txn_count", ctypes.c_uint32),
+        ("requested_txn_count", ctypes.c_uint32),
+        ("requested_txn_bytes", ctypes.c_uint32),
+        ("hash", ctypes.c_ubyte * BLOCK_HASH_LENGTH),
+    ]
+
+    def __repr__(self):
+        return f"CompactBlockReconstructed(hash={bytes(self.hash[::-1]).hex()}, peer_id={self.peer_id}, prefilled_txn_count={self.prefilled_txn_count}, mempool_txn_count={self.mempool_txn_count}, extra_pool_txn_count={self.extra_pool_txn_count}, requested_txn_count={self.requested_txn_count}, requested_txn_bytes={self.requested_txn_bytes})"
+
+
 class NetTracepointTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -297,6 +354,7 @@ class NetTracepointTest(BitcoinTestFramework):
 
     def run_test(self):
         self.block_header_tracepoint_test()
+        self.compact_block_reconstructed_tracepoint_test()
         self.p2p_message_tracepoint_test()
         self.inbound_conn_tracepoint_test()
         self.outbound_conn_tracepoint_test()
@@ -357,6 +415,105 @@ class NetTracepointTest(BitcoinTestFramework):
         assert_equal(expected_height, event.height)
         assert_equal(peer_id, event.peer_id)
         assert_equal(True, bool(event.via_compact_block))
+
+        bpf.cleanup()
+        test_node.peer_disconnect()
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0)
+
+    def compact_block_reconstructed_tracepoint_test(self):
+        self.log.info("hook into the net:compact_block_reconstructed tracepoint")
+        ctx = USDT(pid=self.nodes[0].process.pid)
+        ctx.enable_probe(probe="net:compact_block_reconstructed",
+                         fn_name="trace_compact_block_reconstructed")
+        bpf = BPF(text=net_tracepoints_program, usdt_contexts=[ctx], debug=0, cflags=bpf_cflags())
+
+        reconstructed_blocks = []
+
+        def handle_compact_block_reconstructed(_, data, __):
+            event = ctypes.cast(data, ctypes.POINTER(CompactBlockReconstructed)).contents
+            self.log.info(f"handle_compact_block_reconstructed(): {event}")
+            reconstructed_blocks.append(event)
+
+        bpf["compact_block_reconstructed"].open_perf_buffer(handle_compact_block_reconstructed)
+
+        def send_compact_block(block, *, use_witness=False):
+            compact_block = HeaderAndShortIDs()
+            compact_block.initialize_from_block(block, use_witness=use_witness)
+            test_node.send_and_ping(msg_cmpctblock(compact_block.to_p2p()))
+            assert_equal(block.hash_hex, self.nodes[0].getbestblockhash())
+
+        def assert_compact_block_reconstructed(
+            block_hash,
+            *,
+            peer_id,
+            prefilled_txn_count,
+            mempool_txn_count,
+            extra_pool_txn_count,
+            requested_txn_count,
+            requested_txn_bytes,
+        ):
+            bpf.perf_buffer_poll(timeout=400)
+            matching_blocks = [event for event in reconstructed_blocks if bytes(event.hash[::-1]).hex() == block_hash]
+            assert_equal(1, len(matching_blocks))
+            event = matching_blocks[0]
+            assert_equal(peer_id, event.peer_id)
+            assert_equal(prefilled_txn_count, event.prefilled_txn_count)
+            assert_equal(mempool_txn_count, event.mempool_txn_count)
+            assert_equal(extra_pool_txn_count, event.extra_pool_txn_count)
+            assert_equal(requested_txn_count, event.requested_txn_count)
+            assert_equal(requested_txn_bytes, event.requested_txn_bytes)
+
+        self.log.info("send a compact block with only a prefilled coinbase transaction to bitcoind")
+        test_node = P2PInterface()
+        self.nodes[0].add_p2p_connection(test_node)
+        peer_id = self.nodes[0].getpeerinfo()[0]["id"]
+        block = create_block(tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
+        block.solve()
+        send_compact_block(block)
+        assert_compact_block_reconstructed(
+            block.hash_hex,
+            peer_id=peer_id,
+            prefilled_txn_count=1,
+            mempool_txn_count=0,
+            extra_pool_txn_count=0,
+            requested_txn_count=0,
+            requested_txn_bytes=0,
+        )
+
+        self.log.info("send a compact block reconstructed using a replaced transaction from the extra transaction pool")
+        wallet = MiniWallet(self.nodes[0])
+        utxo_to_spend = wallet.get_utxo()
+        tx_to_replace = wallet.create_self_transfer(
+            fee_rate=Decimal("0.0001"),
+            sequence=MAX_BIP125_RBF_SEQUENCE,
+            utxo_to_spend=utxo_to_spend,
+        )
+        tx_replacement = wallet.create_self_transfer(
+            fee_rate=Decimal("0.005"),
+            sequence=MAX_BIP125_RBF_SEQUENCE,
+            utxo_to_spend=utxo_to_spend,
+        )
+        test_node.send_and_ping(msg_tx(tx_to_replace["tx"]))
+        assert_equal([tx_to_replace["txid"]], self.nodes[0].getrawmempool())
+        test_node.send_and_ping(msg_tx(tx_replacement["tx"]))
+        assert_equal([tx_replacement["txid"]], self.nodes[0].getrawmempool())
+
+        block = create_block(
+            tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS),
+            txlist=[tx_to_replace["tx"]],
+        )
+        add_witness_commitment(block)
+        block.solve()
+        send_compact_block(block, use_witness=True)
+        assert_compact_block_reconstructed(
+            block.hash_hex,
+            peer_id=peer_id,
+            prefilled_txn_count=1,
+            mempool_txn_count=0,
+            extra_pool_txn_count=1,
+            requested_txn_count=0,
+            requested_txn_bytes=0,
+        )
 
         bpf.cleanup()
         test_node.peer_disconnect()


### PR DESCRIPTION
This PR adds two USDT tracepoints for compact block relay:
  
- `net:block_header`: fires when a new valid header is received from a peer (via `headers` or `cmpctblock`).
- `net:compact_block_reconstructed`: fires when a compact block is successfully reconstructed, just before validation.

The motivation is to expose structured, low-overhead observability for compact block relay behavior. 

Compact block relay is performance-sensitive: whether a node reconstructs a block without round trips depends on mempool overlap, extra transaction pool usefulness, and peer behavior. 

Today this information is mostly available only through debug logs, which are string-based, less precise for tooling, and not ideal for continuous measurement.

What they enable measuring:
- Which peers announce new headers first, and whether headers arrived via compact block announcements.
- Per-peer compact block reconstruction success.
- Where each transaction came from — prefilled, mempool, extra pool, or a `getblocktxn` round trip.
- How often compact blocks reconstruct with no round trip, and the bandwidth cost when they don't.
- Whether high-bandwidth compact block peers actually improve relay, and how mempool divergence affects reconstruction quality.

Design notes.
- All data is already available at the reconstruction point; nothing new is computed in the hot path. USDT tracepoints stay inactive unless a tracing tool is attached.
- Mempool and extra-pool counts are reported as disjoint fields, so consumers can aggregate without double-counting. The reconstruction tracepoint includes the peer ID, making metrics attributable to the peer that supplied the compact block data.
