### PR TITLE
refactor: Enhance type safety in overflow operations

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -897,7 +897,7 @@ static RPCMethod getblocktemplate()
     UniValue transactions(UniValue::VARR);
     std::map<Txid, int64_t> setTxIndex;
     std::vector<CAmount> tx_fees{block_template->getTxFees()};
-    std::vector<CAmount> tx_sigops{block_template->getTxSigops()};
+    std::vector<int64_t> tx_sigops{block_template->getTxSigops()};
 
     int i = 0;
     for (const auto& it : block.vtx) {

--- a/src/util/overflow.h
+++ b/src/util/overflow.h
@@ -13,10 +13,9 @@
 #include <optional>
 #include <type_traits>
 
-template <class T>
+template <std::integral T>
 [[nodiscard]] bool AdditionOverflow(const T i, const T j) noexcept
 {
-    static_assert(std::is_integral_v<T>, "Integral required.");
     if constexpr (std::numeric_limits<T>::is_signed) {
         return (i > 0 && j > std::numeric_limits<T>::max() - i) ||
                (i < 0 && j < std::numeric_limits<T>::min() - i);
@@ -41,7 +40,7 @@ template <std::unsigned_integral T, std::unsigned_integral U>
     return true;
 }
 
-template <class T>
+template <std::integral T>
 [[nodiscard]] T SaturatingAdd(const T i, const T j) noexcept
 {
     if constexpr (std::numeric_limits<T>::is_signed) {


### PR DESCRIPTION
* Correct copy-paste error in RPC code
* Require proper integers for `SaturatingAdd()` and `AdditionOverflow()` in src/util/overflow.h

These changes increase the type safety of the code and were done while exploring increasing the type-safety of `CAmount` (currently just a `typedef` of `int64_t`).

The first commit has nothing to do with overflow but is along for the ride if reviewers agree.