### PR TITLE
doc: Add Nix build notes

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -48,6 +48,7 @@ The following are developer notes on how to build Bitcoin Core on your native pl
 - [FreeBSD Build Notes](build-freebsd.md)
 - [OpenBSD Build Notes](build-openbsd.md)
 - [NetBSD Build Notes](build-netbsd.md)
+- [Nix Build Notes](build-nix.md)
 
 Development
 ---------------------

--- a/doc/build-nix.md
+++ b/doc/build-nix.md
@@ -1,0 +1,73 @@
+# What is Nix
+
+[Nix](https://nix.dev/) is a declarative package manager that simplifies
+dependency management. It is used by the [NixOS](https://nixos.org/), a Linux
+distribution, but Nix itself can be installed on other Linux distributions,
+macOS, and Windows (with WSL).
+
+Several things make Nix interesting. It's a lazy functional programming
+language, which is used to write package recipes. Builds specified via package
+recipes are not performed until they are actually needed. The Nix project
+maintains a collection of package recipes called
+[Nixpkgs](https://github.com/nixos/nixpkgs).
+
+There is a centralized cache on the filesystem, called the Nix store, where
+build artifacts are located. Being a deterministic system, the same package
+recipe always results in the same build artifact (matching the same hash). So
+the store helps you save time by avoiding rebuilding the same packages and
+also optimizes storage. You can also share binary artifacts between machines.
+
+Nix also supports ad-hoc build environments. You can easily create environments
+supporting different library versions or compilers. This is very useful for
+development and is the focus of this guide.
+
+# Installation
+
+[Download](https://nixos.org/download/) the Nix package manager and follow the
+[manual](https://nix.dev/manual/nix/latest/) for how to install it. Note that
+you will likely need to restart your shell at the end of the process. If done
+correctly, `nix --version` and `nix-shell --version` should return the version
+string.
+
+# Building packages
+
+Here is a simple `shell.nix` file to help you get started, which specifies the
+mandatory dependencies:
+
+```nix
+with import <nixpkgs> {};
+
+mkShell {
+  packages = [
+    cmake
+    llvmPackages_latest.clang
+    llvmPackages_latest.lld
+    llvmPackages_latest.llvm
+    sqlite
+    capnproto
+    boost
+    pkg-config
+    libevent
+    python3
+  ];
+
+  shellHook = ''
+    export CC=clang
+    export CXX=clang++
+  '';
+}
+```
+
+The first time you run `nix-shell --pure`, the Nix expression specified in
+`shell.nix` will be evaluated and packages will be installed. Once done, you'll
+find yourself in an environment with the packages listed above and without
+access to your host packages (hence the `--pure` flag). On subsequent runs,
+`nix-shell --pure` will immediately drop you into this environment because the
+packages will be in your local Nix store.
+
+To check that you're inside the Nix shell, the environment variable
+`IN_NIX_SHELL` can be used.
+
+This should allow you to build the project using the LLVM/Clang toolchain and
+run tests with coverage, as specified in [Developer Notes](developer-notes.md).
+Please continue following instructions listed there.

--- a/doc/build-nix.md
+++ b/doc/build-nix.md
@@ -1,73 +1,14 @@
-# What is Nix
+# Getting Nix
 
-[Nix](https://nix.dev/) is a declarative package manager that simplifies
-dependency management. It is used by the [NixOS](https://nixos.org/) project, a
-Linux distribution, but Nix itself can be installed on other Linux
-distributions, macOS, and Windows (with WSL).
+[Nix](https://nix.dev) is a declarative package manager from the
+[NixOS](https://nixos.org) project. [Download Nix](https://nixos.org/download)
+and follow the [manual](https://nix.dev/manual/nix/latest) to install it.
 
-Several things make Nix interesting. It's a lazy functional programming
-language, which is used to write package recipes. Builds specified via package
-recipes are not performed until they are actually needed. The Nix project
-maintains a collection of package recipes called
-[Nixpkgs](https://github.com/nixos/nixpkgs).
+# Development environment
 
-There is a centralized cache on the filesystem, called the Nix store, where
-build artifacts are located. Being a deterministic system, the same package
-recipe always results in the same build artifact (matching the same hash). So
-the store helps you save time by avoiding rebuilding the same packages and
-also optimizes storage. You can also share binary artifacts between machines.
+Some Bitcoin Core contributors maintain
+[Bix](https://github.com/bitcoin-dev-tools/bix), which provides a Nix
+development environment. Refer to the Bix documentation on how to use it.
 
-Nix also supports ad-hoc build environments. You can easily create environments
-supporting different library versions or compilers. This is very useful for
-development and is the focus of this guide.
-
-# Installation
-
-[Download](https://nixos.org/download/) the Nix package manager and follow the
-[manual](https://nix.dev/manual/nix/latest/) for how to install it. Note that
-you will likely need to restart your shell at the end of the process. If done
-correctly, `nix --version` and `nix-shell --version` should return the version
-string.
-
-# Building packages
-
-Here is a simple `shell.nix` file to help you get started, which specifies the
-mandatory dependencies:
-
-```nix
-with import <nixpkgs> {};
-
-mkShell {
-  packages = [
-    cmake
-    llvmPackages_latest.clang
-    llvmPackages_latest.lld
-    llvmPackages_latest.llvm
-    sqlite
-    capnproto
-    boost
-    pkg-config
-    libevent
-    python3
-  ];
-
-  shellHook = ''
-    export CC=clang
-    export CXX=clang++
-  '';
-}
-```
-
-The first time you run `nix-shell --pure`, the Nix expression specified in
-`shell.nix` will be evaluated and packages will be installed. Once done, you'll
-find yourself in an environment with the packages listed above and without
-access to your host packages (hence the `--pure` flag). On subsequent runs,
-`nix-shell --pure` will immediately drop you into this environment because the
-packages will be in your local Nix store.
-
-To check that you're inside the Nix shell, the environment variable
-`IN_NIX_SHELL` can be used.
-
-This should allow you to build the project using the LLVM/Clang toolchain and
-run tests with coverage, as specified in [Developer Notes](developer-notes.md).
-Please continue following instructions listed there.
+This should allow you to build the project and run the tests, as specified in
+[Developer Notes](developer-notes.md). Please follow the instructions there.

--- a/doc/build-nix.md
+++ b/doc/build-nix.md
@@ -1,9 +1,9 @@
 # What is Nix
 
 [Nix](https://nix.dev/) is a declarative package manager that simplifies
-dependency management. It is used by the [NixOS](https://nixos.org/), a Linux
-distribution, but Nix itself can be installed on other Linux distributions,
-macOS, and Windows (with WSL).
+dependency management. It is used by the [NixOS](https://nixos.org/) project, a
+Linux distribution, but Nix itself can be installed on other Linux
+distributions, macOS, and Windows (with WSL).
 
 Several things make Nix interesting. It's a lazy functional programming
 language, which is used to write package recipes. Builds specified via package

--- a/doc/build-nix.md
+++ b/doc/build-nix.md
@@ -1,8 +1,7 @@
 # Getting Nix
 
-[Nix](https://nix.dev) is a declarative package manager from the
-[NixOS](https://nixos.org) project. [Download Nix](https://nixos.org/download)
-and follow the [manual](https://nix.dev/manual/nix/latest) to install it.
+Nix is a declarative package manager from the NixOS project. Download Nix and
+follow the manual to install it.
 
 # Development environment
 


### PR DESCRIPTION
This PR adds notes on how to create a development environment using the [Nix](https://nix.dev/) package manager, by recommending the user to use [bitcoin-dev-tools/bix](https://github.com/bitcoin-dev-tools/bix).

##### Rationale

Nix simplifies dependency management, which is especially relevant on systems without recent packages. It also allows you to install different compiler versions and libraries with ease, which is great for testing and development.

##### Why not add a package recipe at the root of the repo

Adding a configuration file for a package manager is an opinionated change. It also requires extensive testing and needs to work for a variety of users. For now, it's proposed to just link to the Bix documentation and focus on improving that project. This helps users who want to use Nix, but doesn't put burden on the main project to maintain relevant configs.