### PR TITLE
log: add structured fields to log entries

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -373,9 +373,15 @@ std::string BCLog::Logger::GetLogPrefix(BCLog::LogFlags category, BCLog::Level l
 
 static size_t MemUsage(const util::log::Entry& log)
 {
-    return memusage::DynamicUsage(log.message) +
-           memusage::DynamicUsage(log.thread_name) +
-           memusage::MallocUsage(sizeof(memusage::list_node<util::log::Entry>));
+    size_t usage{memusage::DynamicUsage(log.message) +
+                 memusage::DynamicUsage(log.thread_name) +
+                 memusage::DynamicUsage(log.fields) +
+                 memusage::MallocUsage(sizeof(memusage::list_node<util::log::Entry>))};
+    for (const auto& field : log.fields) {
+        usage += memusage::DynamicUsage(field.key);
+        usage += memusage::DynamicUsage(field.value);
+    }
+    return usage;
 }
 
 BCLog::LogRateLimiter::LogRateLimiter(uint64_t max_bytes, std::chrono::seconds reset_window)

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -134,7 +134,14 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrint, LogSetup)
     std::vector<std::string> expected;
     for (auto& [msg, category, level, prefix, loc] : cases) {
         expected.push_back(tfm::format("[%s:%s] [%s] %s%s", util::RemovePrefix(loc.file_name(), "./"), loc.line(), loc.function_name_short(), prefix, msg));
-        LogInstance().LogPrint({.category = category, .level = level, .should_ratelimit = false, .source_loc = std::move(loc), .message = msg});
+        LogInstance().LogPrint({
+            .category = category,
+            .level = level,
+            .should_ratelimit = false,
+            .source_loc = std::move(loc),
+            .message = msg,
+            .fields = {util::log::KV("test_key", "test_value")},
+        });
     }
     std::vector<std::string> log_lines{ReadDebugLogLines()};
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -17,6 +17,8 @@
 #include <source_location>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 /// Like std::source_location, but allowing to override the function name.
 class SourceLocation
@@ -57,6 +59,16 @@ enum class Level {
     Error,
 };
 
+struct KeyValue {
+    std::string key;
+    std::string value;
+};
+
+inline KeyValue KV(std::string key, std::string value)
+{
+    return KeyValue{std::move(key), std::move(value)};
+}
+
 struct Entry {
     Category category;
     Level level;
@@ -66,6 +78,7 @@ struct Entry {
     std::string thread_name{util::ThreadGetInternalName()};
     SourceLocation source_loc;
     std::string message;
+    std::vector<KeyValue> fields;
 };
 
 /// Return whether messages with specified category should be debug logged.


### PR DESCRIPTION
## Change Description

This is a deliberately small first step for structured logging: add an optional `fields` vector to `util::log::Entry` and a small `util::log::KV()` helper for producers.

The existing text output is intentionally unchanged in this PR. The change gives future JSON/ZMQ/database log consumers a place to read structured per-message data without forcing a decision about the final wire format in the first patch.

Concretely this PR:

- adds `util::log::KeyValue` and `util::log::KV()`;
- stores `std::vector<KeyValue> fields` on `util::log::Entry`;
- accounts for field memory usage while entries are buffered before logging starts;
- extends a logging unit test to pass fields and confirm legacy formatted output remains unchanged.

This addresses the consumer-side foundation discussed in #35369.

## Testing

- `git diff --check`
- Attempted CMake configure with `cmake -B build -S . -DBUILD_GUI=OFF -DBUILD_BENCH=OFF -DBUILD_FUZZ_BINARY=OFF -DWITH_ZMQ=OFF -DWITH_USDT=OFF -DWITH_MULTIPROCESS=OFF`; configure stopped because Boost >= 1.74 is not installed in this local environment.

_The message stays human; the fields wait beneath it._
