### PR TITLE
wallet, test: optinrbf deprecation followups

### DIFF
--- a/doc/release-notes-34917.md
+++ b/doc/release-notes-34917.md
@@ -5,5 +5,5 @@ as `listtransactions`, `listsinceblock`, and `gettransaction` is
 marked as deprecated. Users still have the option to retrieve this
 key by passing the `-deprecatedrpc=bip125` startup option. Also,
 the `-walletrbf` startup option has been marked as deprecated and
-will be fully removed in the next release. Using this options emits
+will be fully removed in the next release. Using this option emits
 a warning in the logs.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3104,9 +3104,9 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     wallet->m_confirm_target = args.GetIntArg("-txconfirmtarget", DEFAULT_TX_CONFIRM_TARGET);
     wallet->m_spend_zero_conf_change = args.GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);
     wallet->m_signal_rbf = DEFAULT_WALLET_RBF;
-    if (args.IsArgSet("-walletrbf")) {
+    if (auto value{args.GetBoolArg("-walletrbf")}) {
         warnings.push_back(_("-walletrbf is deprecated and will be fully removed in the next release."));
-        wallet->m_signal_rbf = args.GetBoolArg("-walletrbf").value();
+        wallet->m_signal_rbf = *value;
     }
 
     wallet->m_keypool_size = std::max(args.GetIntArg("-keypool", DEFAULT_KEYPOOL_SIZE), int64_t{1});

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -71,8 +71,8 @@ class PSBTTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.extra_args = [
-            ["-walletrbf=1"],
-            ["-walletrbf=0", "-changetype=legacy"],
+            [],
+            ["-changetype=legacy"],
             []
         ]
         # whitelist peers to speed up tx relay / mempool sync
@@ -880,14 +880,6 @@ class PSBTTest(BitcoinTestFramework):
             assert_equal(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
             assert "bip32_derivs" in psbt_in
         assert_equal(decoded_psbt["fallback_locktime"], 0)
-
-        # Same construction without optional arguments, for a node with -walletrbf=0
-        unspent1 = self.nodes[1].listunspent()[0]
-        psbtx_info = self.nodes[1].walletcreatefundedpsbt([{"txid":unspent1["txid"], "vout":unspent1["vout"]}], [{self.nodes[2].getnewaddress():unspent1["amount"]+1}], block_height, {"add_inputs": True})
-        decoded_psbt = self.nodes[1].decodepsbt(psbtx_info["psbt"])
-        for psbt_in in decoded_psbt["inputs"]:
-            assert_greater_than(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
-            assert "bip32_derivs" in psbt_in
 
         # Make sure change address wallet does not have P2SH innerscript access to results in success
         # when attempting BnB coin selection

--- a/test/functional/test_framework/psbt.py
+++ b/test/functional/test_framework/psbt.py
@@ -168,6 +168,7 @@ class PSBT:
                 PSBT_GLOBAL_INPUT_COUNT: self.g.map[PSBT_GLOBAL_INPUT_COUNT],
                 PSBT_GLOBAL_OUTPUT_COUNT: self.g.map[PSBT_GLOBAL_OUTPUT_COUNT],
                 PSBT_GLOBAL_VERSION: self.g.map[PSBT_GLOBAL_VERSION],
+                PSBT_GLOBAL_FALLBACK_LOCKTIME: self.g.map[PSBT_GLOBAL_FALLBACK_LOCKTIME],
             })
 
             new_i = []

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -24,7 +24,6 @@ from test_framework.script_util import (
     script_to_p2sh_script,
 )
 
-WALLETRBF_DEPRECATION_WARNING = "Warning: -walletrbf is deprecated and will be fully removed in the next release."
 
 Key = namedtuple('Key', ['privkey',
                          'pubkey',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -151,6 +151,7 @@ BASE_SCRIPTS = [
     'wallet_listtransactions.py',
     'wallet_miniscript.py',
     # vv Tests less than 30s vv
+    'wallet_deprecated_rbf.py',
     'p2p_invalid_messages.py',
     'rpc_createmultisig.py',
     'p2p_timeouts.py --v1transport',

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -39,12 +39,12 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         self.extra_args = [
             ["-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # Pre-release: use to mine blocks. noban for immediate tx relay
             ["-nowallet", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # Pre-release: use to receive coins, swap wallets, etc
-            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v25.0
-            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v24.0.1
-            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v23.0
-            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1", f"-keypool={LAST_KEYPOOL_INDEX + 1}"], # v22.0
-            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v0.21.0
-            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v0.20.1
+            ["-nowallet", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v25.0
+            ["-nowallet", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v24.0.1
+            ["-nowallet", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v23.0
+            ["-nowallet", "-addresstype=bech32", "-whitelist=noban@127.0.0.1", f"-keypool={LAST_KEYPOOL_INDEX + 1}"], # v22.0
+            ["-nowallet", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v0.21.0
+            ["-nowallet", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v0.20.1
         ]
         self.wallet_names = [self.default_wallet_name]
 

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -28,7 +28,6 @@ from test_framework.util import (
     assert_greater_than,
     assert_raises_rpc_error,
 )
-from test_framework.wallet_util import WALLETRBF_DEPRECATION_WARNING
 
 LAST_KEYPOOL_INDEX = 9 # Index of the last derived address with the keypool size of 10
 
@@ -39,7 +38,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         # Add new version after each release:
         self.extra_args = [
             ["-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # Pre-release: use to mine blocks. noban for immediate tx relay
-            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # Pre-release: use to receive coins, swap wallets, etc
+            ["-nowallet", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # Pre-release: use to receive coins, swap wallets, etc
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v25.0
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v24.0.1
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v23.0
@@ -350,7 +349,8 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
 
             # Restore the wallet to master
             load_res = node_master.restorewallet(wallet_name, backup_path)
-            assert_equal(load_res["warnings"], [WALLETRBF_DEPRECATION_WARNING[9:]])
+            # There should be no warnings
+            assert "warnings" not in load_res
 
             wallet = node_master.get_wallet_rpc(wallet_name)
             info = wallet.getaddressinfo(address)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -510,7 +510,7 @@ class WalletTest(BitcoinTestFramework):
         # Try with walletrejectlongchains
         # Double chain limit but require combining inputs, so we pass AttemptSelection
         self.stop_node(0)
-        extra_args = ["-deprecatedrpc=bip125", "-walletrejectlongchains", "-limitclustercount=" + str(2 * chainlimit), "-limitancestorcount=" + str(2*chainlimit)]
+        extra_args = ["-walletrejectlongchains", "-limitclustercount=" + str(2 * chainlimit), "-limitancestorcount=" + str(2*chainlimit)]
         self.start_node(0, extra_args=extra_args)
 
         # wait until the wallet has submitted all transactions to the mempool
@@ -562,7 +562,7 @@ class WalletTest(BitcoinTestFramework):
                                  "amount":   baz["amount"],
                                  "category": baz["category"],
                                  "vout":     baz["vout"]}
-        expected_fields = frozenset({'amount', 'bip125-replaceable', 'confirmations', 'details', 'fee',
+        expected_fields = frozenset({'amount', 'confirmations', 'details', 'fee',
                                      'hex', 'lastprocessedblock', 'time', 'timereceived', 'trusted', 'txid', 'wtxid', 'walletconflicts', 'mempoolconflicts'})
         verbose_field = "decoded"
         expected_verbose_fields = expected_fields | {verbose_field}

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -32,7 +32,6 @@ from test_framework.util import (
     find_vout_for_address,
 )
 from test_framework.wallet import MiniWallet
-from test_framework.wallet_util import WALLETRBF_DEPRECATION_WARNING
 
 
 WALLET_PASSPHRASE = "test"
@@ -57,7 +56,6 @@ class BumpFeeTest(BitcoinTestFramework):
         # whitelist peers to speed up tx relay / mempool sync
         self.noban_tx_relay = True
         self.extra_args = [[
-            "-walletrbf={}".format(i),
             "-mintxfee=0.00002",
             "-addresstype=bech32",
         ] for i in range(self.num_nodes)]
@@ -116,8 +114,6 @@ class BumpFeeTest(BitcoinTestFramework):
         # Context independent tests
         test_feerate_checks_replaced_outputs(self, rbf_node, peer_node)
         test_bumpfee_with_feerate_ignores_walletincrementalrelayfee(self, rbf_node, peer_node)
-
-        self.restart_node(1, [], expected_stderr=WALLETRBF_DEPRECATION_WARNING)
 
     def test_invalid_parameters(self, rbf_node, peer_node, dest_address):
         self.log.info('Test invalid parameters')
@@ -463,7 +459,7 @@ def test_bumpfee_with_abandoned_descendant_succeeds(self, rbf_node, rbf_node_add
     assert bumped_result['txid'] in rbf_node.getrawmempool()
     assert parent_id not in rbf_node.getrawmempool()
     # Cleanup
-    self.restart_node(1, self.extra_args[1], expected_stderr=WALLETRBF_DEPRECATION_WARNING)
+    self.restart_node(1, self.extra_args[1])
     rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
     self.connect_nodes(1, 0)
     self.clear_mempool()
@@ -538,11 +534,11 @@ def test_maxtxfee_fails(self, rbf_node, dest_address):
     # size of bumped transaction (p2wpkh, 1 input, 2 outputs): 141 vbytes
     # expected bump fee of 141 vbytes * 0.00200000 BTC / 1000 vbytes = 0.00002820 BTC
     # which exceeds maxtxfee and is expected to raise
-    self.restart_node(1, ['-maxtxfee=0.000025'] + self.extra_args[1], expected_stderr=WALLETRBF_DEPRECATION_WARNING)
+    self.restart_node(1, ['-maxtxfee=0.000025'] + self.extra_args[1])
     rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
     rbfid = spend_one_input(rbf_node, dest_address)
     assert_raises_rpc_error(-4, "Unable to create transaction. Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)", rbf_node.bumpfee, rbfid)
-    self.restart_node(1, self.extra_args[1], expected_stderr=WALLETRBF_DEPRECATION_WARNING)
+    self.restart_node(1, self.extra_args[1])
     rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
     self.connect_nodes(1, 0)
     self.clear_mempool()

--- a/test/functional/wallet_deprecated_rbf.py
+++ b/test/functional/wallet_deprecated_rbf.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test deprecation of RPC calls."""
+from test_framework.util import assert_equal
+from test_framework.test_framework import BitcoinTestFramework
+
+'''
+This test exercises the deprecatedrpc=bip125 flag and deprecated -walletrbf options
+and should be removed when the options are removed post deprecation.
+'''
+class WalletDeprecatedRBFTest(BitcoinTestFramework):
+    def set_test_params(self):
+      self.num_nodes = 1
+      self.setup_clean_chain = True
+      self.extra_args = [[]]
+
+    def skip_test_if_missing_module(self):
+      self.skip_if_no_wallet()
+
+    def run_test(self):
+      self.log.info("Test -deprecatedrpc=bip125 and -walletrbf startup option")
+
+      self.restart_node(0, extra_args=["-walletrbf=0", "-deprecatedrpc=bip125"])
+      node = self.nodes[0]
+      node.createwallet("deprecated_optinrbf")
+      wallet = node.get_wallet_rpc("deprecated_optinrbf")
+      self.generatetoaddress(node, nblocks=101, address=wallet.getnewaddress(), sync_fun=self.no_op)
+      tx = wallet.gettransaction(wallet.sendall(recipients=[wallet.getnewaddress()])["txid"])
+      assert_equal("bip125-replaceable" in tx, True)
+      assert_equal(tx["bip125-replaceable"], "no")
+      self.stop_node(0, expected_stderr="Warning: -walletrbf is deprecated and will be fully removed in the next release.")
+
+
+if __name__ == '__main__':
+    WalletDeprecatedRBFTest(__file__).main()

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -11,10 +11,6 @@ import shutil
 
 from test_framework.blocktools import MAX_FUTURE_BLOCK_TIME
 from test_framework.descriptors import descsum_create
-from test_framework.messages import (
-    COIN,
-    tx_from_hex,
-)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_not_equal,
@@ -23,7 +19,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     find_vout_for_address,
 )
-from test_framework.wallet_util import get_generate_key, WALLETRBF_DEPRECATION_WARNING
+from test_framework.wallet_util import get_generate_key
 
 
 class ListTransactionsTest(BitcoinTestFramework):
@@ -31,7 +27,6 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.num_nodes = 3
         # whitelist peers to speed up tx relay / mempool sync
         self.noban_tx_relay = True
-        self.extra_args = [["-walletrbf=0"]] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -97,90 +92,11 @@ class ListTransactionsTest(BitcoinTestFramework):
                             {"category": "receive", "amount": Decimal("0.44")},
                             {"txid": txid})
 
-        self.run_rbf_opt_in_test()
         self.run_externally_generated_address_test()
         self.run_coinjoin_test()
         self.run_invalid_parameters_test()
         self.test_op_return()
         self.test_from_me_status_change()
-
-        for index, _ in enumerate(self.nodes):
-            self.stop_node(index, expected_stderr=WALLETRBF_DEPRECATION_WARNING)
-
-    def run_rbf_opt_in_test(self):
-        """Test the opt-in-rbf flag for sent and received transactions."""
-
-        def is_opt_in(node, txid):
-            """Check whether a transaction signals opt-in RBF itself."""
-            rawtx = node.getrawtransaction(txid, 1)
-            for x in rawtx["vin"]:
-                if x["sequence"] < 0xfffffffe:
-                    return True
-            return False
-
-        def get_unconfirmed_utxo_entry(node, txid_to_match):
-            """Find an unconfirmed output matching a certain txid."""
-            utxo = node.listunspent(0, 0)
-            for i in utxo:
-                if i["txid"] == txid_to_match:
-                    return i
-            return None
-
-        self.log.info("Test txs w/o opt-in RBF")
-        # Chain a few transactions that don't opt in.
-        txid_1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
-        assert not is_opt_in(self.nodes[0], txid_1)
-        self.sync_mempools()
-
-        # Tx2 will build off tx1, still not opting in to RBF.
-        utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[0], txid_1)
-        assert_equal(utxo_to_use["safe"], True)
-        utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[1], txid_1)
-        assert_equal(utxo_to_use["safe"], False)
-
-        # Create tx2 using createrawtransaction
-        inputs = [{"txid": utxo_to_use["txid"], "vout": utxo_to_use["vout"]}]
-        outputs = {self.nodes[0].getnewaddress(): 0.999}
-        tx2 = self.nodes[1].createrawtransaction(inputs=inputs, outputs=outputs, replaceable=False)
-        tx2_signed = self.nodes[1].signrawtransactionwithwallet(tx2)["hex"]
-        txid_2 = self.nodes[1].sendrawtransaction(tx2_signed)
-
-        # ...and check the result
-        assert not is_opt_in(self.nodes[1], txid_2)
-        self.sync_mempools()
-
-        self.log.info("Test txs with opt-in RBF")
-        # Tx3 will opt-in to RBF
-        utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[0], txid_2)
-        inputs = [{"txid": txid_2, "vout": utxo_to_use["vout"]}]
-        outputs = {self.nodes[1].getnewaddress(): 0.998}
-        tx3 = self.nodes[0].createrawtransaction(inputs, outputs)
-        tx3_modified = tx_from_hex(tx3)
-        tx3_modified.vin[0].nSequence = 0
-        tx3 = tx3_modified.serialize().hex()
-        tx3_signed = self.nodes[0].signrawtransactionwithwallet(tx3)['hex']
-        txid_3 = self.nodes[0].sendrawtransaction(tx3_signed)
-        assert is_opt_in(self.nodes[0], txid_3)
-        self.sync_mempools()
-
-        # Tx4 will chain off tx3.  Doesn't signal itself, but depends on one
-        # that does.
-        utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[1], txid_3)
-        inputs = [{"txid": txid_3, "vout": utxo_to_use["vout"]}]
-        outputs = {self.nodes[0].getnewaddress(): 0.997}
-        tx4 = self.nodes[1].createrawtransaction(inputs=inputs, outputs=outputs, replaceable=False)
-        tx4_signed = self.nodes[1].signrawtransactionwithwallet(tx4)["hex"]
-        txid_4 = self.nodes[1].sendrawtransaction(tx4_signed)
-        assert not is_opt_in(self.nodes[1], txid_4)
-
-        self.log.info("Test tx with unknown RBF state")
-        # Replace tx3, and check that tx4 becomes unknown
-        tx3_b = tx3_modified
-        tx3_b.vout[0].nValue -= int(Decimal("0.004") * COIN)  # bump the fee
-        tx3_b = tx3_b.serialize().hex()
-        tx3_b_signed = self.nodes[0].signrawtransactionwithwallet(tx3_b)['hex']
-        txid_3b = self.nodes[0].sendrawtransaction(tx3_b_signed, 0)
-        assert is_opt_in(self.nodes[0], txid_3b)
 
     def run_externally_generated_address_test(self):
         """Test behavior when receiving address is not in the address book."""

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -31,7 +31,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.num_nodes = 3
         # whitelist peers to speed up tx relay / mempool sync
         self.noban_tx_relay = True
-        self.extra_args = [["-walletrbf=0", "-deprecatedrpc=bip125"]] * self.num_nodes
+        self.extra_args = [["-walletrbf=0"]] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -126,13 +126,11 @@ class ListTransactionsTest(BitcoinTestFramework):
                     return i
             return None
 
-        self.log.info("Test txs w/o opt-in RBF (bip125-replaceable=no)")
+        self.log.info("Test txs w/o opt-in RBF")
         # Chain a few transactions that don't opt in.
         txid_1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
         assert not is_opt_in(self.nodes[0], txid_1)
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_1}, {"bip125-replaceable": "no"})
         self.sync_mempools()
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_1}, {"bip125-replaceable": "no"})
 
         # Tx2 will build off tx1, still not opting in to RBF.
         utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[0], txid_1)
@@ -149,11 +147,9 @@ class ListTransactionsTest(BitcoinTestFramework):
 
         # ...and check the result
         assert not is_opt_in(self.nodes[1], txid_2)
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_2}, {"bip125-replaceable": "no"})
         self.sync_mempools()
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_2}, {"bip125-replaceable": "no"})
 
-        self.log.info("Test txs with opt-in RBF (bip125-replaceable=yes)")
+        self.log.info("Test txs with opt-in RBF")
         # Tx3 will opt-in to RBF
         utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[0], txid_2)
         inputs = [{"txid": txid_2, "vout": utxo_to_use["vout"]}]
@@ -164,11 +160,8 @@ class ListTransactionsTest(BitcoinTestFramework):
         tx3 = tx3_modified.serialize().hex()
         tx3_signed = self.nodes[0].signrawtransactionwithwallet(tx3)['hex']
         txid_3 = self.nodes[0].sendrawtransaction(tx3_signed)
-
         assert is_opt_in(self.nodes[0], txid_3)
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_3}, {"bip125-replaceable": "yes"})
         self.sync_mempools()
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_3}, {"bip125-replaceable": "yes"})
 
         # Tx4 will chain off tx3.  Doesn't signal itself, but depends on one
         # that does.
@@ -178,13 +171,9 @@ class ListTransactionsTest(BitcoinTestFramework):
         tx4 = self.nodes[1].createrawtransaction(inputs=inputs, outputs=outputs, replaceable=False)
         tx4_signed = self.nodes[1].signrawtransactionwithwallet(tx4)["hex"]
         txid_4 = self.nodes[1].sendrawtransaction(tx4_signed)
-
         assert not is_opt_in(self.nodes[1], txid_4)
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "yes"})
-        self.sync_mempools()
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "yes"})
 
-        self.log.info("Test tx with unknown RBF state (bip125-replaceable=unknown)")
+        self.log.info("Test tx with unknown RBF state")
         # Replace tx3, and check that tx4 becomes unknown
         tx3_b = tx3_modified
         tx3_b.vout[0].nValue -= int(Decimal("0.004") * COIN)  # bump the fee
@@ -192,33 +181,6 @@ class ListTransactionsTest(BitcoinTestFramework):
         tx3_b_signed = self.nodes[0].signrawtransactionwithwallet(tx3_b)['hex']
         txid_3b = self.nodes[0].sendrawtransaction(tx3_b_signed, 0)
         assert is_opt_in(self.nodes[0], txid_3b)
-
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "unknown"})
-        self.sync_mempools()
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "unknown"})
-
-        self.log.info("Test bip125-replaceable status with gettransaction RPC")
-        for n in self.nodes[0:2]:
-            assert_equal(n.gettransaction(txid_1)["bip125-replaceable"], "no")
-            assert_equal(n.gettransaction(txid_2)["bip125-replaceable"], "no")
-            assert_equal(n.gettransaction(txid_3)["bip125-replaceable"], "yes")
-            assert_equal(n.gettransaction(txid_3b)["bip125-replaceable"], "yes")
-            assert_equal(n.gettransaction(txid_4)["bip125-replaceable"], "unknown")
-
-        self.log.info("Test bip125-replaceable status with listsinceblock")
-        for n in self.nodes[0:2]:
-            txs = {tx['txid']: tx['bip125-replaceable'] for tx in n.listsinceblock()['transactions']}
-            assert_equal(txs[txid_1], "no")
-            assert_equal(txs[txid_2], "no")
-            assert_equal(txs[txid_3], "yes")
-            assert_equal(txs[txid_3b], "yes")
-            assert_equal(txs[txid_4], "unknown")
-
-        self.log.info("Test mined transactions are no longer bip125-replaceable")
-        self.generate(self.nodes[0], 1)
-        assert txid_3b not in self.nodes[0].getrawmempool()
-        assert_equal(self.nodes[0].gettransaction(txid_3b)["bip125-replaceable"], "no")
-        assert_equal(self.nodes[0].gettransaction(txid_4)["bip125-replaceable"], "unknown")
 
     def run_externally_generated_address_test(self):
         """Test behavior when receiving address is not in the address book."""

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -44,7 +44,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 2
         self.supports_cli = False
-        self.extra_args = [["-deprecatedrpc=bip125"], ["-deprecatedrpc=create_bdb"]]
+        self.extra_args = [[], ["-deprecatedrpc=create_bdb"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -181,6 +181,15 @@ class WalletMigrationTest(BitcoinTestFramework):
         return migrate_info, wallet
 
     def test_basic(self):
+        # Remove the deprecated response fields that'd be present in the RPC responses
+        # sent by the old node(s).
+        def remove_deprecated_keys(list):
+            deprecated_keys = {"bip125-replaceable"}
+            for obj in list:
+                for key in deprecated_keys:
+                    obj.pop(key)
+            return list
+
         default = self.master_node.get_wallet_rpc(self.default_wallet_name)
 
         self.log.info("Test migration of a basic keys only wallet without balance")
@@ -236,7 +245,7 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         basic1_migrate, basic1 = self.migrate_and_get_rpc("basic1")
         assert_equal(basic1.getbalance(), bal)
-        self.assert_list_txs_equal(basic1.listtransactions(), txs)
+        self.assert_list_txs_equal(basic1.listtransactions(), remove_deprecated_keys(txs))
 
         self.log.info("Test backup file can be successfully restored")
         self.old_node.restorewallet("basic1_restored", basic1_migrate['backup_path'])
@@ -244,7 +253,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         basic1_restored_wi = basic1_restored.getwalletinfo()
         assert_equal(basic1_restored_wi['balance'], bal)
         assert_equal(basic1_restored.listaddressgroupings(), addr_gps)
-        self.assert_list_txs_equal(basic1_restored.listtransactions(), txs)
+        self.assert_list_txs_equal(remove_deprecated_keys(basic1_restored.listtransactions()), txs)
 
         # restart master node and verify that everything is still there
         self.restart_node(0)
@@ -274,7 +283,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         # Now migrate and test that we still have the same balance/transactions
         _, basic2 = self.migrate_and_get_rpc("basic2")
         assert_equal(basic2.getbalance(), basic2_balance)
-        self.assert_list_txs_equal(basic2.listtransactions(), basic2_txs)
+        self.assert_list_txs_equal(basic2.listtransactions(), remove_deprecated_keys(basic2_txs))
 
         # Now test migration on a descriptor wallet
         self.log.info("Test \"nothing to migrate\" when the user tries to migrate a loaded wallet with no legacy data")

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -31,7 +31,7 @@ class WalletSendTest(BitcoinTestFramework):
         # whitelist peers to speed up tx relay / mempool sync
         self.noban_tx_relay = True
         self.supports_cli = False
-        self.extra_args = [["-walletrbf=1", "-datacarriersize=16", "-deprecatedrpc=bip125"]] * self.num_nodes
+        self.extra_args = [["-datacarriersize=16", "-deprecatedrpc=bip125"]] * self.num_nodes
         getcontext().prec = 8 # Satoshi precision for Decimal
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -31,7 +31,7 @@ class WalletSendTest(BitcoinTestFramework):
         # whitelist peers to speed up tx relay / mempool sync
         self.noban_tx_relay = True
         self.supports_cli = False
-        self.extra_args = [["-datacarriersize=16", "-deprecatedrpc=bip125"]] * self.num_nodes
+        self.extra_args = [["-datacarriersize=16"]] * self.num_nodes
         getcontext().prec = 8 # Satoshi precision for Decimal
 
     def skip_test_if_missing_module(self):
@@ -167,7 +167,6 @@ class WalletSendTest(BitcoinTestFramework):
             # Ensure transaction exists in the wallet:
             tx = from_wallet.gettransaction(res["txid"])
             assert tx
-            assert_equal(tx["bip125-replaceable"], "yes" if replaceable else "no")
             if nonmempool:
                 assert_raises_rpc_error(-5, "No such mempool transaction", from_wallet.getrawtransaction, res["txid"])
                 assert from_wallet.getbalances()["mine"]["nonmempool"] < 0
@@ -430,14 +429,6 @@ class WalletSendTest(BitcoinTestFramework):
         # Locked coins are automatically unlocked when manually selected
         res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, inputs=[utxo1], add_to_wallet=False)
         assert res["complete"]
-
-        self.log.info("Replaceable...")
-        res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, add_to_wallet=True, replaceable=True)
-        assert res["complete"]
-        assert_equal(self.nodes[0].gettransaction(res["txid"])["bip125-replaceable"], "yes")
-        res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, add_to_wallet=True, replaceable=False)
-        assert res["complete"]
-        assert_equal(self.nodes[0].gettransaction(res["txid"])["bip125-replaceable"], "no")
 
         self.log.info("Subtract fee from output")
         self.test_send(from_wallet=w0, to_wallet=w1, amount=1, subtract_fee_from_outputs=[0])


### PR DESCRIPTION
Partially fixes https://github.com/bitcoin/bitcoin/issues/32661.

Prerequisite to #35404 and #35405.

All these changes address the points raised in the review of PR #34917
here: https://github.com/bitcoin/bitcoin/pull/34917#pullrequestreview-4362148900.

Essentially updating the existing wallet functional tests without using
the -deprecatedrpc=bip125 and -walletrbf startup options. Instead,
these two are added and tested via a singular new 
wallet_deprecated_rbf.py test that can be removed easily later when 
these startup options are completely removed from the wallet post 
deprecation.