### PR TITLE
doc: add an AI contribution policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -10,6 +10,7 @@ body:
         * General bitcoin questions and/or support requests should use Bitcoin StackExchange at https://bitcoin.stackexchange.com.
         * For reporting security issues, please read instructions at https://bitcoincore.org/en/contact/.
         * If the node is "stuck" during sync or giving "block checksum mismatch" errors, please ensure your hardware is stable by running `memtest` and observe CPU temperature with a load-test tool such as `linpack` before creating an issue.
+        * If you use AI tools when opening this issue, please read the [AI policy](https://github.com/bitcoin/bitcoin/blob/master/doc/AI_POLICY.md).
 
         ----
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,11 @@ name: Feature Request
 description: Suggest an idea for this project.
 labels: [Feature]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        If you use AI tools when opening this issue, please read the [AI policy](https://github.com/bitcoin/bitcoin/blob/master/doc/AI_POLICY.md).
+
   - type: textarea
     id: feature
     attributes:

--- a/.github/ISSUE_TEMPLATE/gui_issue.yml
+++ b/.github/ISSUE_TEMPLATE/gui_issue.yml
@@ -2,6 +2,11 @@ name: Issue or feature request related to the GUI
 description: Any report, issue or feature request related to the GUI
 labels: [GUI]
 body:
+- type: markdown
+  attributes:
+    value: |
+      If you use AI tools when opening this issue, please read the [AI policy](https://github.com/bitcoin/bitcoin/blob/master/doc/AI_POLICY.md).
+
 - type: checkboxes
   id: acknowledgement
   attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,13 @@
 <!--
 *** Please remove the following help text before submitting: ***
 
-Pull requests without a rationale and clear improvement may be closed
-immediately.
+Pull requests may be closed immediately if they:
+- do not have a rationale and clear improvement
+- do not adhere to doc/AI_POLICY.md
 
 GUI-related pull requests should be opened against
-https://github.com/bitcoin-core/gui
-first. See CONTRIBUTING.md
+https://github.com/bitcoin-core/gui first.
+See CONTRIBUTING.md
 -->
 
 <!--

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,10 @@ Getting Started
 
 New contributors are very welcome and needed.
 
+If you use AI tools while contributing, please read and follow the [AI
+policy](/doc/AI_POLICY.md). Contributors are responsible for understanding and
+explaining their own work in their own words.
+
 In-depth reviewing and testing are the bottleneck of the project, and are the
 most effective way anyone can start to contribute. It will teach you much more
 about the code and process than opening pull requests, and may help you uncover

--- a/doc/AI_POLICY.md
+++ b/doc/AI_POLICY.md
@@ -1,0 +1,37 @@
+# AI Policy
+
+Using AI (i.e. LLMs) as tools for coding is welcome, provided that such use adheres to the following policy, adds value, and does not waste the community's time.
+
+A high bar is held for all contributions to this project.
+
+**AI should not be used to generate comments when communicating with maintainers and other contributors**.
+Comments are expected to be written by humans.
+Comments that are believed to be written by AI may be moderated.
+
+If you are opening an issue, you should be able to describe the problem in your own words.
+
+You should only open a pull request if you:
+
+- know the language the code is written in
+- could have written the code yourself
+- understand the existing surrounding code and the effect of the suggested changes
+
+You must also be able to explain the pull request changes in your own words.
+This includes the pull request body and responses to questions.
+**Do not copy responses from the AI when replying to questions from reviewers.**
+
+This project requires a human author in the loop who understands the work produced by AI.
+**Pull requests should not be opened or driven by autonomous agents**.
+A human author must choose the work, understand the change, and be responsible for the contribution.
+Pull requests that appear in violation of this can be closed without notice.
+
+If you wish to include context from an interaction with AI in your comments, it must be disclosed as such.
+It must be accompanied by human commentary explaining the relevance and implications of the context.
+
+Questions or proposed changes to this policy can be discussed in [bitcoin-core/meta].
+
+This policy was adapted from [ripgrep's AI policy], which was adapted from [uv's AI policy].
+
+[bitcoin-core/meta]: https://github.com/bitcoin-core/meta
+[ripgrep's ai policy]: https://github.com/BurntSushi/ripgrep/blob/f0cec341ab95c25c691ad3d5754d4bd9eedde21f/AI_POLICY.md
+[uv's ai policy]: https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md


### PR DESCRIPTION
This policy, adapted from ripgrep, https://github.com/BurntSushi/ripgrep/blob/f0cec341ab95c25c691ad3d5754d4bd9eedde21f/AI_POLICY.md who in turn adapted it from uv https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md, works as a reasonable and pragmatic AI contribution policy at this point in time.

It codifies roughly how the project is currently operating, it's expectations when Ai is being used, and what we don't wish to see.

Link to the document directly from the new PR and issue helptext.