### PR TITLE
logging: make trace logging easily usable

### DIFF
--- a/doc/release-notes-35387.md
+++ b/doc/release-notes-35387.md
@@ -1,0 +1,14 @@
+Logging
+-------
+
+- The `-loglevel` option now works standalone without `-debug`. Previously,
+  `-loglevel` only set level thresholds but required `-debug` to be separately
+  specified to actually enable log categories. This made `-loglevel` harder to
+  use than necessary.
+
+  The advantage of the `-loglevel` option is that it supports finer-grained
+  control over logging, with three log levels `info`, `debug`, and `trace`
+  instead of just the default `info` level and `debug`. It is a superset of
+  other logging options, with `-loglevel=debug` being a synonym for `-debug=1`,
+  `-loglevel=<category>:debug` being a synonym for `-debug=<category>`, and
+  `-loglevel=<category>:info` being a synonym for `-debugexclude=<category>`.

--- a/doc/release-notes-35387.md
+++ b/doc/release-notes-35387.md
@@ -12,3 +12,16 @@ Logging
   other logging options, with `-loglevel=debug` being a synonym for `-debug=1`,
   `-loglevel=<category>:debug` being a synonym for `-debug=<category>`, and
   `-loglevel=<category>:info` being a synonym for `-debugexclude=<category>`.
+
+- A new `loglevel` RPC has been added, which provides a superset of
+  functionality of the `logging` RPC, and allows enabling `trace` logs as well
+  as `debug` logs. Examples:
+
+  ```sh
+   bitcoin rpc loglevel                               # See current log levels
+   bitcoin rpc loglevel trace                         # Set global log level
+   bitcoin rpc loglevel debug                         # Set global log level
+   bitcoin rpc loglevel info                          # Set global log level
+   bitcoin rpc loglevel libevent=info                 # Set per-category log level
+   bitcoin rpc loglevel trace net=debug libevent=info # Set global and category levels
+  ```

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1085,6 +1085,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // ********************************************************* Step 3: parameter-to-internal-flags
     if (auto result{init::SetLoggingCategories(args)}; !result) return InitError(util::ErrorString(result));
     if (auto result{init::SetLoggingLevel(args)}; !result) return InitError(util::ErrorString(result));
+    if (auto result{init::SetLoggingExcludes(args)}; !result) return InitError(util::ErrorString(result));
 
     nConnectTimeout = args.GetIntArg("-timeout", DEFAULT_CONNECT_TIMEOUT);
     if (nConnectTimeout <= 0) {

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -27,12 +27,23 @@ namespace init {
 void AddLoggingArgs(ArgsManager& argsman)
 {
     argsman.AddArg("-debuglogfile=<file>", strprintf("Specify location of debug log file (default: %s). Relative paths will be prefixed by a net-specific datadir location. Pass -nodebuglogfile to disable writing the log to a file.", DEFAULT_DEBUGLOGFILE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-loglevel=<level>|<category>:<level>[,<category>:<level>...]",
+        strprintf("Set the global or per-category severity level for logging. "
+            "Possible values for <level> are %s (default: info). <category> can be: %s. "
+            "A global level (e.g. -loglevel=debug) enables all categories at that level; "
+            "a per-category entry (e.g. -loglevel=net:trace) enables one category. "
+            "Multiple entries can be comma-separated or given as separate -loglevel arguments "
+            "and later settings override earlier settings.",
+            LogInstance().LogLevelsString(), LogInstance().LogCategoriesString()),
+        ArgsManager::DISALLOW_ELISION, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-debug=<category>", "Output debug and trace logging (default: -nodebug, supplying <category> is optional). "
-        "If <category> is not supplied or if <category> is 1 or \"all\", output all debug logging. If <category> is 0 or \"none\", any other categories are ignored. Other valid values for <category> are: " + LogInstance().LogCategoriesString() + ". This option can be specified multiple times to output multiple categories.",
+        "If <category> is not supplied or if <category> is 1 or \"all\", output all debug logging. If <category> is 0 or \"none\", any other categories are ignored. Other valid values for <category> are: " + LogInstance().LogCategoriesString() + ". This option can be specified multiple times to output multiple categories. "
+        "Specifying -debug=1 is equivalent to specifying -loglevel=debug, and -debug=<category> is equivalent to -loglevel=<category>:debug. -loglevel takes precedence over -debug if both are used together.",
         ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
-    argsman.AddArg("-debugexclude=<category>", "Exclude debug and trace logging for a category. Can be used in conjunction with -debug=1 to output debug and trace logging for all categories except the specified category. This option can be specified multiple times to exclude multiple categories. This takes priority over \"-debug\"", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-debugexclude=<category>", "Exclude debug and trace logging for a category. Can be used in conjunction with -debug=1 to output debug and trace logging for all categories except the specified category. This option can be specified multiple times to exclude multiple categories. This takes priority over \"-debug\" and \"-loglevel\". "
+        "Specifying -debugexclude=<category> is equivalent to specifying -loglevel=category:info",
+        ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-logips", strprintf("Include IP addresses in log output (default: %u)", DEFAULT_LOGIPS), ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
-    argsman.AddArg("-loglevel=<level>|<category>:<level>", strprintf("Set the global or per-category severity level for logging categories enabled with the -debug configuration option or the logging RPC. Possible values are %s (default=%s). The following levels are always logged: error, warning, info. If <category>:<level> is supplied, the setting will override the global one and may be specified multiple times to set multiple category-specific levels. <category> can be: %s.", LogInstance().LogLevelsString(), LogInstance().LogLevelToStr(BCLog::DEFAULT_LOG_LEVEL), LogInstance().LogCategoriesString()), ArgsManager::DISALLOW_NEGATION | ArgsManager::DISALLOW_ELISION | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-logtimestamps", strprintf("Prepend debug output with timestamp (default: %u)", DEFAULT_LOGTIMESTAMPS), ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-logthreadnames", strprintf("Prepend debug output with name of the originating thread (default: %u)", DEFAULT_LOGTHREADNAMES), ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-logsourcelocations", strprintf("Prepend debug output with name of the originating source location (source file, line number and function name) (default: %u)", DEFAULT_LOGSOURCELOCATIONS), ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
@@ -59,20 +70,37 @@ void SetLoggingOptions(const ArgsManager& args)
 
 util::Result<void> SetLoggingLevel(const ArgsManager& args)
 {
-        for (const std::string& level_str : args.GetArgs("-loglevel")) {
-            if (level_str.find_first_of(':', 3) == std::string::npos) {
-                // user passed a global log level, i.e. -loglevel=<level>
-                if (!LogInstance().SetLogLevel(level_str)) {
-                    return util::Error{strprintf(_("Unsupported global logging level %s=%s. Valid values: %s."), "-loglevel", level_str, LogInstance().LogLevelsString())};
+    for (const std::string& level_arg : args.GetArgs("-loglevel")) {
+        bool seen_per_category = false;
+        for (const std::string& token : SplitString(level_arg, ',')) {
+            if (token.find(':') == std::string::npos) {
+                // Global level token — must come first in a comma-separated value
+                if (seen_per_category) {
+                    return util::Error{strprintf(_("In %s=%s, global level must be specified before any category-specific levels."), "-loglevel", level_arg)};
+                }
+                if (!LogInstance().SetLogLevel(token)) {
+                    return util::Error{strprintf(_("Unsupported global logging level %s=%s. Valid values: %s."), "-loglevel", token, LogInstance().LogLevelsString())};
+                }
+                // Global level: reset per-category overrides and flags
+                LogInstance().SetCategoryLogLevel({});
+                if (LogInstance().LogLevel() >= util::log::Level::Info) {
+                    LogInstance().DisableCategory(BCLog::ALL);
+                } else {
+                    LogInstance().EnableCategory(BCLog::ALL);
                 }
             } else {
-                // user passed a category-specific log level, i.e. -loglevel=<category>:<level>
-                const auto& toks = SplitString(level_str, ':');
+                // Category-specific level: -loglevel=net:trace (or comma token "net:trace")
+                const auto& toks = SplitString(token, ':');
                 if (!(toks.size() == 2 && LogInstance().SetCategoryLogLevel(toks[0], toks[1]))) {
-                    return util::Error{strprintf(_("Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=<category>:<loglevel>. Valid categories: %3$s. Valid loglevels: %4$s."), "-loglevel", level_str, LogInstance().LogCategoriesString(), LogInstance().LogLevelsString())};
+                    return util::Error{strprintf(_("Unsupported category-specific logging level %1$s=%2$s. Expected %1$s=<category>:<loglevel>. Valid categories: %3$s. Valid loglevels: %4$s."), "-loglevel", token, LogInstance().LogCategoriesString(), LogInstance().LogLevelsString())};
                 }
+                if (const auto flag = BCLog::Logger::GetLogCategory(toks[0])) {
+                    LogInstance().EnableCategory(*flag);
+                }
+                seen_per_category = true;
             }
         }
+    }
     return {};
 }
 
@@ -92,7 +120,11 @@ util::Result<void> SetLoggingCategories(const ArgsManager& args)
         }
     }
 
-    // Now remove the logging categories which were explicitly excluded
+    return {};
+}
+
+util::Result<void> SetLoggingExcludes(const ArgsManager& args)
+{
     for (const std::string& cat : args.GetArgs("-debugexclude")) {
         if (!LogInstance().DisableCategory(cat)) {
             return util::Error{strprintf(_("Unsupported logging category %s=%s."), "-debugexclude", cat)};

--- a/src/init/common.h
+++ b/src/init/common.h
@@ -17,6 +17,7 @@ void AddLoggingArgs(ArgsManager& args);
 void SetLoggingOptions(const ArgsManager& args);
 [[nodiscard]] util::Result<void> SetLoggingCategories(const ArgsManager& args);
 [[nodiscard]] util::Result<void> SetLoggingLevel(const ArgsManager& args);
+[[nodiscard]] util::Result<void> SetLoggingExcludes(const ArgsManager& args);
 bool StartLogging(const ArgsManager& args);
 void LogPackageVersion();
 } // namespace init

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -266,7 +266,7 @@ static std::string LogCategoryToStr(BCLog::LogFlags category)
     return it->second;
 }
 
-static std::optional<BCLog::Level> GetLogLevel(std::string_view level_str)
+std::optional<BCLog::Level> BCLog::Logger::GetLogLevel(std::string_view level_str)
 {
     if (level_str == "trace") {
         return BCLog::Level::Trace;
@@ -288,7 +288,19 @@ std::vector<LogCategory> BCLog::Logger::LogCategoriesList() const
     std::vector<LogCategory> ret;
     ret.reserve(LOG_CATEGORIES_BY_STR.size());
     for (const auto& [category, flag] : LOG_CATEGORIES_BY_STR) {
-        ret.push_back(LogCategory{.category = category, .active = WillLogCategory(flag)});
+        auto level = WillLogCategoryLevel(flag, BCLog::Level::Trace) ? BCLog::Level::Trace :
+                     WillLogCategoryLevel(flag, BCLog::Level::Debug) ? BCLog::Level::Debug : BCLog::Level::Info;
+        ret.push_back(LogCategory{.category = category, .level = level});
+    }
+    return ret;
+}
+
+std::string BCLog::Logger::LogCategoriesString()
+{
+    std::string ret;
+    for (const auto& [category, flag] : LOG_CATEGORIES_BY_STR) {
+        if (!ret.empty()) ret += ", ";
+        ret += category;
     }
     return ret;
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -57,7 +57,7 @@ struct SourceLocationHasher {
 
 struct LogCategory {
     std::string category;
-    bool active;
+    BCLog::Level level;
 };
 
 namespace BCLog {
@@ -261,16 +261,15 @@ namespace BCLog {
         bool WillLogCategoryLevel(LogFlags category, Level level) const EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
 
         /** Returns a vector of the log categories in alphabetical order. */
-        std::vector<LogCategory> LogCategoriesList() const;
+        std::vector<LogCategory> LogCategoriesList() const EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
         /** Returns a string with the log categories in alphabetical order. */
-        std::string LogCategoriesString() const
-        {
-            return util::Join(LogCategoriesList(), ", ", [&](const LogCategory& i) { return i.category; });
-        };
+        static std::string LogCategoriesString();
 
         //! Returns a string with all user-selectable log levels.
         std::string LogLevelsString() const;
 
+        //! Returns the log level corresponding to a string, or nullopt if unrecognized.
+        static std::optional<BCLog::Level> GetLogLevel(std::string_view str);
         //! Returns the string representation of a log level.
         static std::string LogLevelToStr(BCLog::Level level);
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -334,6 +334,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "psbtbumpfee", 1, "psbt_version"},
     { "logging", 0, "include" },
     { "logging", 1, "exclude" },
+    { "loglevel", 1, "categories" },
     { "disconnectnode", 1, "nodeid" },
     { "gethdkeys", 0, "active_only" },
     { "gethdkeys", 0, "options" },

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -200,22 +200,90 @@ static RPCMethod getmemoryinfo()
     };
 }
 
-static void EnableOrDisableLogCategories(UniValue cats, bool enable) {
-    cats = cats.get_array();
-    for (unsigned int i = 0; i < cats.size(); ++i) {
-        std::string cat = cats[i].get_str();
-
-        bool success;
-        if (enable) {
-            success = LogInstance().EnableCategory(cat);
+// Apply a list of (category flag, level) changes.
+static void UpdateLogCategories(std::vector<std::pair<BCLog::LogFlags, BCLog::Level>> changes)
+{
+    for (const auto& [category, level] : changes) {
+        if (category == BCLog::ALL) {
+            LogInstance().SetLogLevel(level);
+            LogInstance().SetCategoryLogLevel({});
         } else {
-            success = LogInstance().DisableCategory(cat);
+            LogInstance().AddCategoryLogLevel(category, level);
         }
-
-        if (!success) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown logging category " + cat);
+        if (level >= util::log::Level::Info) {
+            LogInstance().DisableCategory(category);
+        } else {
+            LogInstance().EnableCategory(category);
         }
     }
+}
+
+static RPCMethod loglevel()
+{
+    std::vector<RPCArg> category_args;
+    for (const auto& cat : LogInstance().LogCategoriesList()) {
+        category_args.emplace_back(cat.category, RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+            "log level for the \"" + cat.category + "\" category");
+    }
+    return RPCMethod{"loglevel",
+            "Gets and sets per-category log levels.\n"
+            "When called without arguments, returns all log categories with their current log level.\n"
+            "When called with arguments, sets the log level for specified categories,\n"
+            "then returns the updated state of all categories.\n"
+            "The valid log levels are: " + LogInstance().LogLevelsString() + "\n"
+            ,
+                {
+                    {"all", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Log level to set for all categories."},
+                    {"categories", RPCArg::Type::OBJ_NAMED_PARAMS, RPCArg::Optional::OMITTED, "Per-category log levels.", std::move(category_args)},
+                },
+                RPCResult{
+                    RPCResult::Type::OBJ_DYN, "", "keys are the logging categories, values are their current log levels",
+                    {
+                        {RPCResult::Type::STR, "category", "current log level"},
+                    }
+                },
+                RPCExamples{
+                    HelpExampleCli("loglevel", "")
+                  + HelpExampleCli("loglevel", "debug")
+                  + HelpExampleCli("-named loglevel", "info net=debug")
+                  + HelpExampleRpc("loglevel", "\"debug\"")
+                },
+        [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::vector<std::pair<BCLog::LogFlags, BCLog::Level>> changes;
+
+    // Optional named and positional "all" param.
+    if (auto level_str{self.MaybeArg<std::string_view>("all")}) {
+        const auto level = BCLog::Logger::GetLogLevel(*level_str);
+        if (!level || *level > BCLog::Level::Info) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, tfm::format("unknown log level \"%s\". Valid values: %s", *level_str, LogInstance().LogLevelsString()));
+        }
+        changes.emplace_back(BCLog::ALL, *level);
+    }
+
+    // Named "categories" params: applied in the order they appear in the request.
+    // Category names are validated by OBJ_NAMED_PARAMS, so GetLogCategory always succeeds here.
+    if (auto cats{self.MaybeArg<UniValue>("categories")}) {
+        for (const std::string& cat : cats->getKeys()) {
+            const std::string level_str = (*cats)[cat].get_str();
+            const auto level = BCLog::Logger::GetLogLevel(level_str);
+            if (!level || *level > BCLog::Level::Info) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown log level \"" + level_str + "\". Valid values: " + LogInstance().LogLevelsString());
+            }
+            changes.emplace_back(*BCLog::Logger::GetLogCategory(cat), *level);
+        }
+    }
+
+    if (!changes.empty()) UpdateLogCategories(std::move(changes));
+
+    UniValue result(UniValue::VOBJ);
+    for (const auto& logCat : LogInstance().LogCategoriesList()) {
+        result.pushKV(logCat.category, BCLog::Logger::LogLevelToStr(logCat.level));
+    }
+
+    return result;
+},
+    };
 }
 
 static RPCMethod logging()
@@ -229,6 +297,7 @@ static RPCMethod logging()
             "The valid logging categories are: " + LogInstance().LogCategoriesString() + "\n"
             "In addition, the following are available as category names with special meanings:\n"
             "  - \"all\",  \"1\" : represent all logging categories.\n"
+            "See also: the \"loglevel\" RPC, which provides a superset of functionality, allowing trace logs to be enabled in addition to debug logs.\n"
             ,
                 {
                     {"include", RPCArg::Type::ARR, RPCArg::Optional::OMITTED, "The categories to add to debug logging",
@@ -252,16 +321,22 @@ static RPCMethod logging()
                 },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (request.params[0].isArray()) {
-        EnableOrDisableLogCategories(request.params[0], true);
-    }
-    if (request.params[1].isArray()) {
-        EnableOrDisableLogCategories(request.params[1], false);
-    }
+    std::vector<std::pair<BCLog::LogFlags, BCLog::Level>> changes;
+    auto parse_categories = [&](const UniValue& cats, BCLog::Level level) {
+        for (const UniValue& cat_val : cats.get_array().getValues()) {
+            const std::string& cat = cat_val.get_str();
+            const auto flag{BCLog::Logger::GetLogCategory(cat)};
+            if (!flag) throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown logging category " + cat);
+            changes.emplace_back(*flag, level);
+        }
+    };
+    if (request.params[0].isArray()) parse_categories(request.params[0], BCLog::Level::Debug);
+    if (request.params[1].isArray()) parse_categories(request.params[1], BCLog::Level::Info);
+    UpdateLogCategories(std::move(changes));
 
     UniValue result(UniValue::VOBJ);
-    for (const auto& logCatActive : LogInstance().LogCategoriesList()) {
-        result.pushKV(logCatActive.category, logCatActive.active);
+    for (const auto& logCat : LogInstance().LogCategoriesList()) {
+        result.pushKV(logCat.category, logCat.level < BCLog::Level::Info);
     }
 
     return result;
@@ -410,6 +485,7 @@ void RegisterNodeRPCCommands(CRPCTable& t)
 {
     static const CRPCCommand commands[]{
         {"control", &getmemoryinfo},
+        {"control", &loglevel},
         {"control", &logging},
         {"util", &getindexinfo},
         {"hidden", &setmocktime},

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -163,6 +163,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "joinpsbts",
     "listbanned",
     "logging",
+    "loglevel",
     "mockscheduler",
     "ping",
     "preciousblock",

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -221,6 +221,7 @@ BOOST_FIXTURE_TEST_CASE(logging_Conf, LogSetup)
         BOOST_REQUIRE(args.ParseParameters(2, argv_test, err));
 
         auto result = init::SetLoggingLevel(args);
+        BOOST_REQUIRE(init::SetLoggingExcludes(args));
         BOOST_REQUIRE(result);
         BOOST_CHECK_EQUAL(LogInstance().LogLevel(), BCLog::Level::Debug);
     }

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -99,6 +99,40 @@ class LoggingTest(BitcoinTestFramework):
             expected_msg="Error: Unsupported category-specific logging level -loglevel=net:info:abc.",
             match=ErrorMatch.PARTIAL_REGEX,
         )
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=["-loglevel=net:trace,debug"],
+            expected_msg="global level must be specified before any category-specific levels",
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+        self.log.info("Test -loglevel enables categories without -debug")
+        # -nologlevel and -nodebug clear the test framework's -loglevel=trace and -debug for a clean baseline
+        self.restart_node(0, ['-nologlevel', '-nodebug', '-loglevel=debug'])
+        logging = self.nodes[0].logging()
+        assert logging['net']
+        assert logging['http']
+
+        self.restart_node(0, ['-nologlevel', '-nodebug', '-loglevel=net:trace'])
+        logging = self.nodes[0].logging()
+        assert logging['net']
+        assert not logging['http']
+
+        self.log.info("Test -loglevel comma-separated syntax")
+        self.restart_node(0, ['-nologlevel', '-nodebug', '-loglevel=debug,net:trace'])
+        logging = self.nodes[0].logging()
+        assert logging['net']
+        assert logging['http']  # enabled by global debug
+
+        self.log.info("Test -loglevel precedence over -debug and -debugexclude")
+        # -loglevel is processed after -debug regardless of command-line order
+        self.restart_node(0, ['-loglevel=info', '-debug=net'])
+        assert not self.nodes[0].logging()['net']
+
+        # -debugexclude is processed after -loglevel regardless of command-line order
+        self.restart_node(0, ['-debugexclude=net', '-loglevel=debug'])
+        logging = self.nodes[0].logging()
+        assert not logging['net']
+        assert logging['http']
 
         self.log.info("Test that -nodebug,-debug=0,-debug=none clear previously specified debug options")
         disable_debug_options = [
@@ -108,8 +142,10 @@ class LoggingTest(BitcoinTestFramework):
         ]
 
         for disable_debug_opt in disable_debug_options:
-            # Every category before disable_debug_opt will be ignored, including the invalid 'abc'
-            self.restart_node(0, ['-debug=http', '-debug=abc', disable_debug_opt, '-debug=rpc', '-debug=net'])
+            # Every category before disable_debug_opt will be ignored, including the invalid 'abc'.
+            # -nologlevel clears the test framework's -loglevel=trace which would otherwise
+            # enable all categories and interfere with this test.
+            self.restart_node(0, ['-nologlevel', '-debug=http', '-debug=abc', disable_debug_opt, '-debug=rpc', '-debug=net'])
             logging = self.nodes[0].logging()
             assert not logging['http']
             assert 'abc' not in logging

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -9,6 +9,7 @@ import os
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.p2p import P2PInterface
 from test_framework.test_node import ErrorMatch
+from test_framework.util import assert_raises_rpc_error
 
 
 class LoggingTest(BitcoinTestFramework):
@@ -158,6 +159,67 @@ class LoggingTest(BitcoinTestFramework):
             p2p = self.nodes[0].add_p2p_connection(P2PInterface())
             p2p.wait_for_verack()
             self.nodes[0].disconnect_p2ps()
+
+        self.log.info("Test loglevel RPC")
+        # Start with a clean baseline: all categories at info (disabled)
+        self.restart_node(0, ['-nologlevel', '-nodebug'])
+
+        # Read-only call returns all categories with level strings
+        levels = self.nodes[0].loglevel()
+        assert isinstance(levels, dict)
+        assert 'net' in levels
+        assert 'http' in levels
+        assert all(v in ('trace', 'debug', 'info') for v in levels.values())
+
+        # All categories should be at 'info' (disabled) with our clean baseline
+        assert all(v == 'info' for v in levels.values()), f"Expected all info, got: {levels}"
+
+        # Set a single category to trace
+        result = self.nodes[0].loglevel(net='trace')
+        assert result['net'] == 'trace'
+        assert result['http'] == 'info'
+        # Cross-check with logging RPC: net should be active (trace < info), http inactive
+        assert self.nodes[0].logging()['net']
+        assert not self.nodes[0].logging()['http']
+
+        # Set a single category to debug
+        result = self.nodes[0].loglevel(net='debug')
+        assert result['net'] == 'debug'
+
+        # Set a category back to info (disable it)
+        result = self.nodes[0].loglevel(net='info')
+        assert result['net'] == 'info'
+        assert not self.nodes[0].logging()['net']
+
+        # Set all categories to debug using the positional shorthand
+        result = self.nodes[0].loglevel('debug')
+        assert all(v == 'debug' for v in result.values()), f"Expected all debug, got: {result}"
+        assert self.nodes[0].logging()['net']
+        assert self.nodes[0].logging()['http']
+
+        # "all" named argument combined with per-category override
+        result = self.nodes[0].loglevel(all='info', net='trace')
+        assert result['net'] == 'trace'
+        assert result['http'] == 'info'
+
+        # Set all categories to trace, then override net back to info
+        result = self.nodes[0].loglevel(all='trace', net='info')
+        assert result['net'] == 'info'
+        assert result['http'] == 'trace'
+
+        # Invalid category raises an error
+        assert_raises_rpc_error(-8, "Unknown named parameter notacategory", self.nodes[0].loglevel, **{'notacategory': 'debug'})
+
+        # Invalid level raises an error
+        assert_raises_rpc_error(-8, "unknown log level", self.nodes[0].loglevel, net='verbose')
+
+        # loglevel and logging RPCs stay consistent
+        self.nodes[0].loglevel(all='info', rpc='debug')
+        logging_result = self.nodes[0].logging()
+        levels_result = self.nodes[0].loglevel()
+        for cat, active in logging_result.items():
+            expected_active = levels_result[cat] != 'info'
+            assert active == expected_active, f"Inconsistency for {cat}: logging={active}, loglevel={levels_result[cat]}"
 
 if __name__ == '__main__':
     LoggingTest(__file__).main()


### PR DESCRIPTION
**Problem**: Currently it is difficult to enable `trace` logging. 

The `-loglevel=trace` setting works, but does nothing by default and needs to be combined with `-debug` settings to have an effect.

Additionally, it is not possible to switch between `debug` and `trace` logging at runtime without restarting the node. These problems make `trace` logging less useful than it could be, effectively make existing `trace` logs undiscoverable, and making it not worthwhile to add new tracing.

**Solution**: Fix these issues by allowing the `-loglevel` option to work without an accompanying `-debug` option, and by adding a matching `loglevel` RPC that allows log levels to be configured at runtime.

**Usage examples**:
```bash
bitcoin rpc loglevel                               # See current log levels
bitcoin rpc loglevel trace                         # Set global level to -loglevel=trace
bitcoin rpc loglevel debug                         # Set global level to -loglevel=debug
bitcoin rpc loglevel info                          # Set global level to -loglevel=info
bitcoin rpc loglevel libevent=info                 # Set category level to -loglevel=libevent:info
bitcoin rpc loglevel trace net=debug libevent=info # Set global & category levels to -loglevel=trace,net:debug,libevent:info
```

**Compatibility:** This PR is backwards compatible and doesn't change the `-debug` and `-debugexclude` options (which become synonyms for `-loglevel=debug` and `-loglevel=info`, respectively). The `logging` RPC is also mostly unchanged, except now it validates category names before updating log levels, instead of failing with half-applied changes. Also the `logging` RPC now only toggles between `info` and `debug` levels instead of trying to remember previously assigned levels, which was needlessly confusing.