### PR TITLE
doc: Demonstrate running benchmarks on each commit

### DIFF
--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -37,6 +37,17 @@ The output will look similar to:
 ...
 ```
 
+In many cases, comparing benchmarks across commits is useful to see if any
+regressions occur. For example, to run benchmarks against the master branch,
+filtering on benchmarks that contain the string `MemPool`:
+
+    BASE=$(git merge-base master HEAD) && \
+    git checkout --detach --quiet "$BASE" && \
+    cmake --build build && \
+    build/bin/bench_bitcoin -filter='.*MemPool.*' && \
+    git checkout --quiet - && \
+    git rebase -i --exec "cmake --build build && build/bin/bench_bitcoin -filter='.*MemPool.*'" "$BASE"
+
 Help
 ---------------------
 


### PR DESCRIPTION
Comparing the before/after impact of a patch on the results of a benchmark or subset of benchmarks is useful information, especially to catch performance regressions or measure improvements before making a pull request. This is an adaption of the doc comment in `productivity.md` that explicitly shows how to run benches for each commit since diverging from `master`.