### PR TITLE
test: Use operator<< for time_points instead of manual TickSinceEpoch

### DIFF
--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -19,7 +19,7 @@
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/blockfilter.h>
-#include <test/util/common.h> // IWYU pragma: keep
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>
 #include <uint256.h>

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -6,7 +6,7 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
-#include <node/mining_types.h> // IWYU pragma: keep
+#include <node/mining_types.h>
 #include <policy/feerate.h>
 #include <policy/packages.h>
 #include <policy/policy.h>

--- a/src/test/testnet4_miner_tests.cpp
+++ b/src/test/testnet4_miner_tests.cpp
@@ -7,6 +7,7 @@
 #include <node/mining_types.h>
 #include <primitives/block.h>
 #include <sync.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <util/time.h>
@@ -47,8 +48,7 @@ BOOST_AUTO_TEST_CASE(MiningInterface)
     BOOST_REQUIRE(block_template);
 
     // The template should use the mocked system time
-    BOOST_REQUIRE_EQUAL(TicksSinceEpoch<std::chrono::seconds>(block_template->getBlockHeader().Time()),
-                        TicksSinceEpoch<std::chrono::seconds>(template_time));
+    BOOST_REQUIRE_EQUAL(block_template->getBlockHeader().Time(), template_time);
 
     const BlockWaitOptions wait_options{.timeout = MillisecondsDouble{0}, .fee_threshold = 1};
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -15,7 +15,7 @@
 #include <random.h>
 #include <script/script.h>
 #include <sync.h>
-#include <test/util/common.h> // IWYU pragma: keep
+#include <test/util/common.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -15,8 +15,8 @@
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/chainstate.h>
-#include <test/util/common.h> // IWYU pragma: keep
 #include <test/util/coins.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>
 #include <uint256.h>


### PR DESCRIPTION
This partially reverts the changes from commit 020166080cf57e6eb869abc56d603eb1d6e5e45b to testnet4_miner_tests.cpp

Also, remove some confusing IWYU pragmas. Those were inconsistently added in 8c58f63578a44c8b4ebdda4637d1b198d8a67d08, but without any rationale why adding them is the correct approach. The correct approach should be done in a proper follow-up, with a clear rationale.
