### PR TITLE
test: add v31.0 and basic IPC backward compatibility check

### DIFF
--- a/test/functional/interface_ipc_mining_compatibility.py
+++ b/test/functional/interface_ipc_mining_compatibility.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test IPC mining compatibility with previous releases.
+
+Previous releases are required by this test, see test/README.md.
+"""
+
+import asyncio
+from contextlib import AsyncExitStack
+from pathlib import Path
+
+from test_framework.ipc_util import (
+    load_capnp_modules,
+    make_mining_ctx,
+    mining_create_block_template,
+    mining_get_coinbase_tx,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_not_equal
+
+# Test may be skipped and not have capnp installed
+try:
+    import capnp  # type: ignore[import] # noqa: F401
+except ModuleNotFoundError:
+    pass
+
+
+class IPCMiningCompatibilityTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_ipc()
+        self.skip_if_no_py_capnp()
+        self.skip_if_no_previous_releases()
+
+    def setup_nodes(self):
+        self.extra_init = [{"ipcbind": True}]
+        self.add_nodes(self.num_nodes, versions=[310000])
+
+        # Previous-release test nodes default to running bitcoind directly, but
+        # the IPC interface is served by the multiprocess node.
+        previous_bin = Path(self.options.previous_releases_path) / "v31.0" / "bin"
+        self.nodes[0].args = [
+            str(previous_bin / "bitcoin"),
+            "-m",
+            "node",
+            *self.nodes[0].args[1:],
+        ]
+
+        self.start_nodes()
+        self.capnp_modules = load_capnp_modules(self.config)
+
+    def run_test(self):
+        self.log.info("Test current IPC mining client against a v31.0 node")
+
+        async def async_routine():
+            async with AsyncExitStack() as stack:
+                ctx, mining = await make_mining_ctx(self)
+
+                self.log.debug("Default block creation options work with v31.0")
+                opts = self.capnp_modules["mining"].BlockCreateOptions()
+                template = await mining_create_block_template(mining, stack, ctx, opts, cooldown=False)
+                coinbase = await mining_get_coinbase_tx(template, ctx)
+                assert_not_equal(coinbase.witness, None)
+                assert_equal(len(coinbase.requiredOutputs), 1)
+
+        asyncio.run(capnp.run(async_routine()))
+
+
+if __name__ == "__main__":
+    IPCMiningCompatibilityTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -358,6 +358,7 @@ BASE_SCRIPTS = [
     'feature_logging.py',
     'interface_ipc.py',
     'interface_ipc_mining.py',
+    'interface_ipc_mining_compatibility.py',
     'feature_anchors.py',
     'mempool_datacarrier.py',
     'feature_coinstatsindex.py',

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -91,6 +91,15 @@ SHA256_SUMS = {
     "866a4b703a2095301151c17dcc753e19e4dba61ec68d19709ec4f81ff4320103": {"tag": "v28.2", "archive": "bitcoin-28.2-x86_64-apple-darwin.tar.gz"},
     "98add5f220c01b387343b70edeb6273403fe081e22cd85fda132704cdcaa98aa": {"tag": "v28.2", "archive": "bitcoin-28.2-x86_64-linux-gnu.tar.gz"},
     "da0869639c323bbf6f264f1829083b9514e10179b90c34b09d8cbcab8a1897e3": {"tag": "v28.2", "archive": "bitcoin-28.2-win64.zip"},
+
+    "4de1d568dedd48604f75132421bc0abeca432639589b49a3909c81db3a813112": {"tag": "v31.0", "archive": "bitcoin-31.0-aarch64-linux-gnu.tar.gz"},
+    "8c19d007bfc73502625095ea4073af3a98ceb722d500556ab173bac5bcadd0d6": {"tag": "v31.0", "archive": "bitcoin-31.0-arm-linux-gnueabihf.tar.gz"},
+    "a2d7a13b4da53d4a3e4c517f3a0269e2429813417bb320d3b268993cfdc545d0": {"tag": "v31.0", "archive": "bitcoin-31.0-arm64-apple-darwin.tar.gz"},
+    "1d9c865aa0ccf675fc068e79d9fa57a5a70b59132fca38bb322a7d44ce2f0ff2": {"tag": "v31.0", "archive": "bitcoin-31.0-powerpc64-linux-gnu.tar.gz"},
+    "7ece4ea365bba9b2008b27f0717ef6a518598a572edaa2815e775faadc53c136": {"tag": "v31.0", "archive": "bitcoin-31.0-riscv64-linux-gnu.tar.gz"},
+    "56824dd705bc2a3b22d42e8aa02ed53498d491ff7c2c8aa96831333871887ead": {"tag": "v31.0", "archive": "bitcoin-31.0-x86_64-apple-darwin.tar.gz"},
+    "d3e4c58a35b1d0a97a457462c94f55501ad167c660c245cb1ffa565641c65074": {"tag": "v31.0", "archive": "bitcoin-31.0-x86_64-linux-gnu.tar.gz"},
+    "82fd2c504a0f20a31d4d13bd407783d6fc7bf17622d0ce85228a9b92694e03f0": {"tag": "v31.0", "archive": "bitcoin-31.0-win64.zip"},
 }
 
 


### PR DESCRIPTION
The IPC interface is still marked as experimental and breaking changes are acceptable. However they should be intentional. This PR adds a basic check.

We're only testing backwards compatibility against v31.0, not against v30.0 - v30.2. Until we mark the interface as stable, it would be fine to swap v31.0 in this test for a newer version. 

The first commit adds the v31 release hashes.

The second commit adds a simple test to requests a block template from the old node.

The test can be expanded as `mining.capnp` drifts from the v31 tag.

E.g. after #34644 it could demonstrate that `submitBlock()` is expect to fail on the older note. Similar for the new methods introduced in #34020 and #33922, although tracking new methods isn't very interesting. 

I have another PR in mind that changes the default behavior of `createNewBlock()` which builds on top of the test here.