### PR TITLE
mining: add always_add_coinbase_commitment option

### DIFF
--- a/doc/release-notes-35393.md
+++ b/doc/release-notes-35393.md
@@ -1,0 +1,12 @@
+Mining
+------
+
+- The IPC mining interface `BlockCreateOptions` now has an
+  `alwaysAddCoinbaseCommitment` option. It defaults to `false`, so empty block
+  templates and templates without SegWit spends no longer include a dummy
+  coinbase witness and SegWit OP_RETURN.
+  It's important that IPC clients DO NOT unconditionally add a witness to the
+  coinbase transaction they pass to `submitSolution()`. Clients must only do so
+  when the `witness` field of the `getCoinbaseTx()` result is set.
+  IPC clients that need the previous behavior can set this option to `true`.
+  Previous Bitcoin Core releases do not understand this option and will ignore it. (#35393)

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -44,6 +44,7 @@ struct BlockCreateOptions $Proxy.wrap("node::BlockCreateOptions") {
     useMempool @0 :Bool = true $Proxy.name("use_mempool");
     blockReservedWeight @1 :UInt64 = .defaultBlockReservedWeight $Proxy.name("block_reserved_weight");
     coinbaseOutputMaxAdditionalSigops @2 :UInt64 = .defaultCoinbaseOutputMaxAdditionalSigops $Proxy.name("coinbase_output_max_additional_sigops");
+    alwaysAddCoinbaseCommitment @3 :Bool = false $Proxy.name("always_add_coinbase_commitment");
 }
 
 struct BlockWaitOptions $Proxy.wrap("node::BlockWaitOptions") {

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -204,7 +204,12 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     coinbase_tx.lock_time = coinbaseTx.nLockTime;
 
     pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
-    m_chainstate.m_chainman.GenerateCoinbaseCommitment(*pblock, pindexPrev);
+    if (m_options.always_add_coinbase_commitment || std::any_of(
+        pblock->vtx.begin(), pblock->vtx.end(),
+        [](const CTransactionRef& tx) { return tx->HasWitness(); }
+    )) {
+        m_chainstate.m_chainman.GenerateCoinbaseCommitment(*pblock, pindexPrev);
+    }
 
     const CTransactionRef& final_coinbase{pblock->vtx[0]};
     if (final_coinbase->HasWitness()) {

--- a/src/node/mining_types.h
+++ b/src/node/mining_types.h
@@ -84,6 +84,11 @@ struct BlockCreateOptions {
      * coinbase_max_additional_weight and coinbase_output_max_additional_sigops.
      */
     CScript coinbase_output_script{CScript() << OP_TRUE};
+    /*
+     * Whether blocks without SegWit transactions (e.g. empty blocks) should
+     * have a SegWit commitment, i.e. the coinbase witness and OP_RETURN.
+     */
+    bool always_add_coinbase_commitment{false};
     /**
      * Whether to call TestBlockValidity() at the end of CreateNewBlock().
      * Should only be used for tests / benchmarks.

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -196,7 +196,10 @@ static UniValue generateBlocks(ChainstateManager& chainman, Mining& miner, const
 {
     UniValue blockHashes(UniValue::VARR);
     while (nGenerate > 0 && !chainman.m_interrupt) {
-        std::unique_ptr<BlockTemplate> block_template(miner.createNewBlock({ .coinbase_output_script = coinbase_output_script }, /*cooldown=*/false));
+        std::unique_ptr<BlockTemplate> block_template(miner.createNewBlock({
+            .coinbase_output_script = coinbase_output_script,
+            .always_add_coinbase_commitment = true
+        }, /*cooldown=*/false));
         CHECK_NONFATAL(block_template);
 
         std::shared_ptr<const CBlock> block_out;
@@ -408,7 +411,11 @@ static RPCMethod generateblock()
     {
         LOCK(chainman.GetMutex());
         {
-            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({.use_mempool = false, .coinbase_output_script = coinbase_output_script}, /*cooldown=*/false)};
+            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({
+                .use_mempool = false,
+                .coinbase_output_script = coinbase_output_script,
+                .always_add_coinbase_commitment = true
+            }, /*cooldown=*/false)};
             CHECK_NONFATAL(block_template);
 
             block = block_template->getBlock();
@@ -905,7 +912,9 @@ static RPCMethod getblocktemplate()
         // a delay to each getblocktemplate call. This differs from typical
         // long-lived IPC usage, where the overhead is paid only when creating
         // the initial template.
-        block_template = miner.createNewBlock({}, /*cooldown=*/false);
+        block_template = miner.createNewBlock({
+            .always_add_coinbase_commitment = true
+        }, /*cooldown=*/false);
         CHECK_NONFATAL(block_template);
 
 

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -58,6 +58,7 @@ FUZZ_TARGET(utxo_total_supply)
         // Use OP_FALSE to avoid BIP30 check from hitting early
         auto block = PrepareBlock(node, {
             .coinbase_output_script = CScript() << OP_FALSE,
+            .always_add_coinbase_commitment = true,
         });
         // Replace OP_FALSE with OP_TRUE
         {

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -451,6 +451,7 @@ CBlock TestChain100Setup::CreateBlock(
     auto block_template{mining->createNewBlock({
         .use_mempool = false,
         .coinbase_output_script = scriptPubKey,
+        .always_add_coinbase_commitment = true,
     }, /*cooldown=*/false)};
     Assert(block_template);
     CBlock block{block_template->getBlock()};

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -8,7 +8,7 @@ import time
 from contextlib import AsyncExitStack
 from decimal import Decimal
 from io import BytesIO
-from test_framework.blocktools import NULL_OUTPOINT, script_BIP34_coinbase_height
+from test_framework.blocktools import NULL_OUTPOINT, WITNESS_COMMITMENT_HEADER, script_BIP34_coinbase_height
 from test_framework.messages import (
     CBlockHeader,
     COIN,
@@ -67,7 +67,7 @@ class IPCMiningTest(BitcoinTestFramework):
         # as it is being called before knowing whether capnp is available).
         self.capnp_modules = load_capnp_modules(self.config)
 
-    async def build_coinbase_test(self, template, ctx, miniwallet, extra_nonce=b""):
+    async def build_coinbase_test(self, template, ctx, miniwallet, extra_nonce=b"", expect_witness=None):
         self.log.debug("Build coinbase transaction using getCoinbaseTx()")
         assert template is not None
         coinbase_res = await mining_get_coinbase_tx(template, ctx)
@@ -85,23 +85,25 @@ class IPCMiningTest(BitcoinTestFramework):
         # Typically a mining pool appends its name and an extraNonce
         coinbase_tx.vin[0].scriptSig = coinbase_res.scriptSigPrefix + extra_nonce
 
-        # We currently always provide a coinbase witness, even for empty
-        # blocks, but this may change, so always check:
         has_witness = coinbase_res.witness is not None
         if has_witness:
             coinbase_tx.wit.vtxinwit = [CTxInWitness()]
             coinbase_tx.wit.vtxinwit[0].scriptWitness.stack = [coinbase_res.witness]
+        if expect_witness is not None:
+            assert_equal(has_witness, expect_witness)
 
         # First output is our payout
         coinbase_tx.vout = [CTxOut()]
         coinbase_tx.vout[0].scriptPubKey = miniwallet.get_output_script()
         coinbase_tx.vout[0].nValue = coinbase_res.blockRewardRemaining
-        # Add SegWit OP_RETURN. This is currently always present even for
-        # empty blocks, but this may change.
+        found_witness_op_return = False
         for output_data in coinbase_res.requiredOutputs:
             output = CTxOut()
             output.deserialize(BytesIO(output_data))
             coinbase_tx.vout.append(output)
+            if len(output.scriptPubKey) >= 6 and output.scriptPubKey[2:6] == WITNESS_COMMITMENT_HEADER:
+                found_witness_op_return = True
+        assert_equal(found_witness_op_return, has_witness)
 
         coinbase_tx.nLockTime = coinbase_res.lockTime
         return coinbase_tx
@@ -238,6 +240,17 @@ class IPCMiningTest(BitcoinTestFramework):
                 assert_equal(len(txfees.result), 0)
                 txsigops = await template.getTxSigops(ctx)
                 assert_equal(len(txsigops.result), 0)
+                coinbase = await mining_get_coinbase_tx(template, ctx)
+                assert_equal(coinbase.witness, None)
+                assert_equal(coinbase.requiredOutputs, [])
+
+                self.log.debug("Check that coinbase commitment can be requested for empty templates")
+                opts = self.capnp_modules['mining'].BlockCreateOptions()
+                opts.alwaysAddCoinbaseCommitment = True
+                template_with_opts = await mining_create_block_template(mining, stack, ctx, opts)
+                coinbase_with_opts = await mining_get_coinbase_tx(template_with_opts, ctx)
+                assert_not_equal(coinbase_with_opts.witness, None)
+                assert_equal(len(coinbase_with_opts.requiredOutputs), 1)
 
                 self.log.debug("Wait for a new template")
                 waitoptions = self.capnp_modules['mining'].BlockWaitOptions()
@@ -465,10 +478,12 @@ class IPCMiningTest(BitcoinTestFramework):
             current_block_height = self.nodes[0].getchaintips()[0]["height"]
             check_opts = self.capnp_modules['mining'].BlockCheckOptions()
 
-            async with destroying((await mining.createNewBlock(ctx, self.default_block_create_options)).result, ctx) as template:
+            opts = self.capnp_modules['mining'].BlockCreateOptions()
+            opts.alwaysAddCoinbaseCommitment = True
+            async with destroying((await mining.createNewBlock(ctx, opts)).result, ctx) as template:
                 block = await mining_get_block(template, ctx)
                 balance = self.miniwallet.get_balance()
-                coinbase = await self.build_coinbase_test(template, ctx, self.miniwallet)
+                coinbase = await self.build_coinbase_test(template, ctx, self.miniwallet, expect_witness=True)
                 # Reduce payout for balance comparison simplicity
                 coinbase.vout[0].nValue = COIN
                 block.vtx[0] = coinbase


### PR DESCRIPTION
Previously the `CoinbaseTx` returned by the Mining IPC interface always included the witness field and SegWit OP_RETURN output. This is unnecessary for empty blocks, and for blocks without any SegWit spends.

This PR omits them for blocks with SegWit spends, but gives clients the option to keep them. RPC behavior is unchanged.

Strictly speaking it's a breaking change for <= v31 IPC clients, because they can't opt out of the new behavior. The interface is experimental so this is fine in general. 

_This is a breaking change for current versions of SRI_, see https://github.com/bitcoin/bitcoin/pull/35393#issuecomment-4554462636.

Two alternatives are worth considering:
1. Always omit them for IPC clients, don't expose `always_add_coinbase_commitment` (it's still needed internally for the RPC exception)
2. Keep the current behavior of always adding these fields; empty blocks don't need the space savings