### PR TITLE
test: remove unnecessary rpc calls from feature_dbcrash

### DIFF
--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -196,12 +196,12 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
                 # Sanity check -- if we chose inputs that are too small, skip
                 continue
 
-            self.wallet.send_self_transfer_multi(
-                from_node=node,
+            tx = self.wallet.create_self_transfer_multi(
                 utxos_to_spend=utxos_to_spend,
                 num_outputs=3,
                 fee_per_output=FEE // 3,
             )
+            node.sendrawtransaction(hexstring=tx["hex"], maxfeerate=0)
             num_transactions += 1
 
     def run_test(self):


### PR DESCRIPTION
On my machine dbcrash takes 17 minutes to run (wihtout `--usecli`), and is making on the order of 200,000 RPC calls. The bulk of these come from miniwallet's `send_self_transfer_multi` which calls miniwallets `sendrawtransaction`, which does:

```python
    def sendrawtransaction(self, *, from_node, tx_hex, maxfeerate=0, **kwargs):
        txid = from_node.sendrawtransaction(hexstring=tx_hex, maxfeerate=maxfeerate, **kwargs)
        self.scan_tx(from_node.decoderawtransaction(tx_hex))
        return txid
```

The second `decoderawtransaction` here doubles the number of RPC calls per send, and feature_dbcrash doesn't use the miniwallet utxo list outside of setup and rescans, it already tracks it's own `utxo_list`, so this is wasted work.

By creating the transaction and sending using a direct node RPC to send, we can halve the number of rpc calls in this section.

This change reduces the runtime to 9 minutes for me.