### PR TITLE
doc: Improve test suite dependencies documentation

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -70,13 +70,8 @@ pkg install libzmq4 pkgconf
 ```
 
 #### Test Suite Dependencies
-There is an included test suite that is useful for testing code changes when developing.
-To run the test suite (recommended), you will need to have Python 3 installed:
 
-```bash
-pkg install python3 databases/py-sqlite3 net/py-pyzmq
-```
----
+See [`test/README.md`](/test/README.md#dependencies-and-prerequisites).
 
 ## Building Bitcoin Core
 

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -70,13 +70,8 @@ pkg install libzmq4 pkgconf
 ```
 
 #### Test Suite Dependencies
-There is an included test suite that is useful for testing code changes when developing.
-To run the test suite (recommended), you will need to have Python 3 installed:
 
-```bash
-pkg install python3 databases/py-sqlite3 net/py-pyzmq lsof
-```
----
+See [`test/README.md`](/test/README.md#dependencies-and-prerequisites).
 
 ## Building Bitcoin Core
 

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -89,12 +89,7 @@ pkgin install zeromq pkg-config
 
 #### Test Suite Dependencies
 
-There is an included test suite that is useful for testing code changes when developing.
-To run the test suite (recommended), you will need to have Python 3 installed:
-
-```bash
-pkgin install python313 py313-zmq
-```
+See [`test/README.md`](/test/README.md#dependencies-and-prerequisites).
 
 ## Building Bitcoin Core
 

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -73,19 +73,7 @@ pkgin install zeromq pkgconf
 
 #### Test Suite Dependencies
 
-There is an included test suite that is useful for testing code changes when developing.
-To run the test suite (recommended), you will need to have Python 3 installed:
-
-```bash
-pkgin install python313 py313-zmq lsof
-```
-
-When the `lsof` binary package was built for a different point release, it might be necessary to force its installation as follows:
-
-```bash
-echo "CHECK_OSABI=no" >> /etc/pkg_install.conf
-pkgin install lsof
-```
+See [`test/README.md`](/test/README.md#dependencies-and-prerequisites).
 
 ## Building Bitcoin Core
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -70,12 +70,8 @@ pkg_add zeromq
 ```
 
 #### Test Suite Dependencies
-There is an included test suite that is useful for testing code changes when developing.
-To run the test suite (recommended), you will need to have Python 3 installed:
 
-```bash
-pkg_add python py3-zmq  # Select the newest version of the python package if necessary.
-```
+See [`test/README.md`](/test/README.md#dependencies-and-prerequisites).
 
 ## Building Bitcoin Core
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -121,12 +121,7 @@ For more information on ZMQ, see: [zmq.md](zmq.md)
 
 #### Test Suite Dependencies
 
-There is an included test suite that is useful for testing code changes when developing.
-To run the test suite (recommended), you will need to have Python 3 installed:
-
-``` bash
-brew install python
-```
+See [`test/README.md`](/test/README.md#dependencies-and-prerequisites).
 
 ---
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -46,10 +46,10 @@ for additional features in later columns are optional.
 
 | Package manager         | Required build dependencies | SQLite (wallet) | Cap'n Proto (IPC) | ZMQ <sup><a href="#note1">[1]</a></sup> | USDT | Qt and libqrencode (GUI) |
 | ----------------------- | --------------------------- | --------------- | ----------------- | --- | ---- | ------------------------ |
-| Debian / Ubuntu (`apt`) | `build-essential cmake python3 libboost-dev` | `libsqlite3-dev` | `libcapnp-dev capnproto` | `libzmq3-dev pkgconf` | `systemtap-sdt-dev` | `qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libgl-dev qt6-wayland libqrencode-dev` |
-| Fedora (`dnf`)          | `gcc-c++ cmake make python3 boost-devel` | `sqlite-devel` | `capnproto capnproto-devel` | `zeromq-devel pkgconf` | `systemtap-sdt-devel` | `qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland qrencode-devel` |
-| Alpine (`apk`)          | `build-base cmake linux-headers python3 boost-dev` | `sqlite-dev` | `capnproto capnproto-dev` | `zeromq-dev` | Not supported | `qt6-qtbase-dev qt6-qttools-dev libqrencode-dev` |
-| Arch (`pacman`)         | `gcc make cmake python boost` | `sqlite` | `capnproto` | `zeromq` | `systemtap` | `qt6-base qt6-tools qt6-wayland qrencode` |
+| Debian / Ubuntu (`apt`) | `build-essential cmake libboost-dev` | `libsqlite3-dev` | `libcapnp-dev capnproto` | `libzmq3-dev pkgconf` | `systemtap-sdt-dev` | `qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libgl-dev qt6-wayland libqrencode-dev` |
+| Fedora (`dnf`)          | `gcc-c++ cmake make boost-devel` | `sqlite-devel` | `capnproto capnproto-devel` | `zeromq-devel pkgconf` | `systemtap-sdt-devel` | `qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland qrencode-devel` |
+| Alpine (`apk`)          | `build-base cmake linux-headers boost-dev` | `sqlite-dev` | `capnproto capnproto-dev` | `zeromq-dev` | Not supported | `qt6-qtbase-dev qt6-qttools-dev libqrencode-dev` |
+| Arch (`pacman`)         | `gcc make cmake boost` | `sqlite` | `capnproto` | `zeromq` | `systemtap` | `qt6-base qt6-tools qt6-wayland qrencode` |
 
 <a id="note1"></a>1. Some ZMQ packages do not vendor the CMake config files, which requires `pkgconf` or `pkg-config` to be installed.
 
@@ -88,3 +88,7 @@ be compiled in disable-wallet mode with:
 In this case there is no dependency on SQLite.
 
 Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
+
+### Test Suite Dependencies
+
+See [`test/README.md`](/test/README.md#dependencies-and-prerequisites).

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -88,3 +88,7 @@ be compiled in disable-wallet mode with:
 In this case there is no dependency on SQLite.
 
 Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
+
+### Test Suite Dependencies
+
+See [`test/README.md`](/test/README.md#dependencies-and-prerequisites).

--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -32,15 +32,9 @@ This installs:
 After installation, the commands in this guide should be executed in "Developer PowerShell for VS" or "Developer Command Prompt for VS".
 The former is assumed hereinafter.
 
-#### Python
+#### Test Suite Dependencies
 
-Python is required for running the test suite.
-
-To install Python, run:
-
-```powershell
-winget install python3
-```
+See [`test/README.md`](/test/README.md#dependencies-and-prerequisites).
 
 ### 2. Clone Bitcoin Repository
 

--- a/test/README.md
+++ b/test/README.md
@@ -51,12 +51,16 @@ venv/bin/pip3 install ./pycapnp -C force-bundled-libcapnp=True
 venv/bin/python3 build/test/functional/interface_ipc.py
 ```
 
+#### UTF-8 mode
+
 The functional tests assume Python UTF-8 Mode, which is the default on most
 systems.
-On Windows the `PYTHONUTF8` environment variable must be set to 1:
 
-```cmd
-set PYTHONUTF8=1
+On Windows, when using Python < 3.15, the `PYTHONUTF8` environment variable must be set to 1.
+For example, in PowerShell:
+
+```powershell
+$env:PYTHONUTF8 = 1
 ```
 
 ### Running the tests

--- a/test/README.md
+++ b/test/README.md
@@ -25,9 +25,9 @@ The following examples assume that the build directory is named `build`.
 
 See [/doc/fuzzing.md](/doc/fuzzing.md)
 
-### Functional tests
+## Functional tests
 
-#### Dependencies and prerequisites
+### Dependencies and prerequisites
 
 The ZMQ functional test requires a python ZMQ library. To install it:
 
@@ -59,7 +59,7 @@ On Windows the `PYTHONUTF8` environment variable must be set to 1:
 set PYTHONUTF8=1
 ```
 
-#### Running the tests
+### Running the tests
 
 Individual tests can be run by directly calling the test script, e.g.:
 
@@ -128,7 +128,7 @@ how many jobs to run, append `--jobs=n`
 The individual tests and the test_runner harness have many command-line
 options. Run `build/test/functional/test_runner.py -h` to see them all.
 
-#### Speed up test runs with a RAM disk
+### Speed up test runs with a RAM disk
 
 If you have available RAM on your system you can create a RAM disk to use as the `cache` and `tmp` directories for the functional tests in order to speed them up.
 Speed-up amount varies on each system (and according to your RAM speed and other variables), but a 2-3x speed-up is not uncommon.
@@ -179,9 +179,9 @@ To unmount:
 umount /Volumes/ramdisk
 ```
 
-#### Troubleshooting and debugging test failures
+### Troubleshooting and debugging test failures
 
-##### Resource contention
+#### Resource contention
 
 The P2P and RPC ports used by the bitcoind nodes-under-test are chosen to make
 conflicts with other processes unlikely. However, if there is another bitcoind
@@ -209,7 +209,7 @@ pkill -9 bitcoind
 ```
 
 
-##### Data directory cache
+#### Data directory cache
 
 A pre-mined blockchain with 200 blocks is generated the first time a
 functional test is run and is stored in build/test/cache. This speeds up
@@ -223,7 +223,7 @@ rm -rf build/test/cache
 killall bitcoind
 ```
 
-##### Test logging
+#### Test logging
 
 The tests contain logging at five different levels (DEBUG, INFO, WARNING, ERROR
 and CRITICAL). From within your functional tests you can log to these different
@@ -268,7 +268,7 @@ By default, the test data directory will be deleted after a successful run.
 Use `--nocleanup` to leave the test data directory intact. The test data
 directory is never deleted after a failed test.
 
-##### Attaching a debugger
+#### Attaching a debugger
 
 A python debugger can be attached to tests at any point. Just add the line:
 
@@ -318,7 +318,7 @@ Often while debugging RPC calls in functional tests, the test might time out bef
 process can return a response. Use `--timeout-factor 0` to disable all RPC timeouts for that particular
 functional test. Ex: `build/test/functional/wallet_hd.py --timeout-factor 0`.
 
-### Lint tests
+## Lint tests
 
 See the README in [test/lint](/test/lint).
 

--- a/test/README.md
+++ b/test/README.md
@@ -89,6 +89,14 @@ For example, in PowerShell:
 $env:PYTHONUTF8 = 1
 ```
 
+#### Other dependencies
+
+##### `lsof`
+
+Required for some network tests.
+
+The availability of the `lsof` command depends on your operating system.
+
 ### Running the tests
 
 Individual tests can be run by directly calling the test script, e.g.:

--- a/test/README.md
+++ b/test/README.md
@@ -29,19 +29,45 @@ See [/doc/fuzzing.md](/doc/fuzzing.md)
 
 ### Dependencies and prerequisites
 
-The ZMQ functional test requires a python ZMQ library. To install it:
+The functional tests require Python to be installed. For the minimum required Python version, refer to [Dependencies](/doc/dependencies.md#build-1).
 
-- on Unix, run `sudo apt-get install python3-zmq`
-- on mac OS, run `pip3 install pyzmq`
+#### Python optional modules
 
-The IPC functional test requires a python IPC library. `pip3 install pycapnp` may work, but if not, install it from source:
+Some tests require optional modules. The optional modules can be installed with any suitable tool,
+like the system package manager, `pip` in a virtual environment, or `uv`.
+
+If a module is not installed, the tests will be skipped rather than failed.
+
+##### `sqlite3`
+
+Required for wallet tests.
+
+Most Python installations include the [`sqlite3`](https://docs.python.org/3/library/sqlite3.html) optional module by default.
+If that is not the case, look for documentation from your OS package manager, as it might be vendored as a separate package.
+For instance, FreeBSD ships `databases/py-sqlite3`.
+
+##### `zmq`
+
+Required for ZMQ tests.
+
+The `zmq` module is generally available as the [`pyzmq`](https://pypi.org/project/pyzmq/) Python package.
+
+Mainstream Linux distributions also provide native packages. For example, it is available as `python3-zmq` on Debian/Ubuntu.
+
+##### `capnp`
+
+Required for IPC tests.
+
+The `capnp` module is generally available as the [`pycapnp`](https://pypi.org/project/pycapnp/) Python package.
+
+If installing the package via `pip` fails, install it from source:
 
 ```sh
 git clone -b v2.2.1 https://github.com/capnproto/pycapnp
 pip3 install ./pycapnp
 ```
 
-If that does not work, try adding `-C force-bundled-libcapnp=True` to the `pip` command.
+If that does not work, try adding `-C force-bundled-libcapnp=True` to the `pip3` command.
 Depending on the system, it may be necessary to install and run in a venv:
 
 ```sh

--- a/test/README.md
+++ b/test/README.md
@@ -29,27 +29,24 @@ See [/doc/fuzzing.md](/doc/fuzzing.md)
 
 ### Dependencies and prerequisites
 
-The ZMQ functional test requires a python ZMQ library. To install it:
+The functional tests require Python to be installed. For the minimum required Python version, refer to [Dependencies](/doc/dependencies.md#build-1).
 
-- on Unix, run `sudo apt-get install python3-zmq`
-- on mac OS, run `pip3 install pyzmq`
+Some tests require optional dependencies: Python modules and system utilities.
+They can be installed with any suitable tool, like the system package manager, `pip` in a virtual environment, or `uv`.
 
-The IPC functional test requires a python IPC library. `pip3 install pycapnp` may work, but if not, install it from source:
+If an optional dependency is not installed, the corresponding tests will be skipped rather than failed.
 
-```sh
-git clone -b v2.2.1 https://github.com/capnproto/pycapnp
-pip3 install ./pycapnp
-```
+| Package manager | Python | sqlite3<br>(wallet tests) | zmq<br>(ZMQ tests) | capnp<br>(IPC tests) | lsof <sup><a href="#note1">[1]</a></sup><br>(network tests) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **pip** | n/a | n/a | `pyzmq` | `pycapnp` | n/a |
+| **Debian/Ubuntu**<br>(`apt`) | `python3` | included | `python3-zmq` | n/a | n/a |
+| **macOS**<br>(`brew`) | `python3` | included | n/a | n/a | n/a |
+| **Windows**<br>(`winget`) | `python3` | included | n/a | n/a | n/a |
+| **FreeBSD**<br>(`pkg`) | `python3` | `databases/py-sqlite3` | `net/py-pyzmq` | n/a | `sysutils/lsof` |
+| **NetBSD**<br>(`pkgin`) | `python313` | included | `py313-zmq` | n/a | `lsof` |
+| **OpenBSD**<br>(`pkg_add`) | `python` | included | `py3-zmq` | n/a | n/a |
 
-If that does not work, try adding `-C force-bundled-libcapnp=True` to the `pip` command.
-Depending on the system, it may be necessary to install and run in a venv:
-
-```sh
-python -m venv venv
-git clone -b v2.2.1 https://github.com/capnproto/pycapnp
-venv/bin/pip3 install ./pycapnp -C force-bundled-libcapnp=True
-venv/bin/python3 build/test/functional/interface_ipc.py
-```
+<a id="note1"></a>1. Only used on non-Linux systems. macOS ships `lsof` in the base system. OpenBSD and Windows do not provide it, and the tests requiring it are always skipped there.
 
 #### UTF-8 mode
 


### PR DESCRIPTION
The current documentation has multiple issues:
1. OS-specific notes are missing for the `pycapnp` module.
2. `python3-zmq` is a package name in some Linux distros, rather than a Unix-wide convention.
3. Installing `pyzmq` from PyPI works in general, not only on macOS.

This PR resolves these issues. Additionally, two minor improvements have been added (see commit messages).