### PR TITLE
ci: add OpenBSD Clang cross job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,6 +469,12 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_freebsd_cross.sh'
 
+          - name: 'OpenBSD Cross'
+            warp-runner: 'warp-ubuntu-latest-x64-8x'
+            fallback-runner: 'ubuntu-latest'
+            timeout-minutes: 120
+            file-env: './ci/test/00_setup_env_openbsd_cross.sh'
+
           - name: 'No wallet'
             warp-runner: 'warp-ubuntu-latest-x64-4x'
             fallback-runner: 'ubuntu-latest'

--- a/ci/test/00_setup_env_openbsd_cross.sh
+++ b/ci/test/00_setup_env_openbsd_cross.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_openbsd_cross
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
+export APT_LLVM_V="22"
+export HOST=x86_64-unknown-openbsd
+export OPENBSD_VERSION=7.9
+export OPENBSD_SDK_BASENAME="openbsd-${HOST}-${OPENBSD_VERSION}"
+export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} lld"
+export SYSROOT="--sysroot=${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}"
+export DEP_OPTS="build_CC=clang build_CXX=clang++ \
+ CC='clang --target=${HOST} ${SYSROOT}' \
+ CXX='clang++ --target=${HOST} ${SYSROOT} -stdlib=libc++' \
+ LDFLAGS='-fuse-ld=lld' \
+ AR=llvm-ar-${APT_LLVM_V} \
+ NM=llvm-nm-${APT_LLVM_V} \
+ OBJCOPY=llvm-objcopy-${APT_LLVM_V} \
+ OBJDUMP=llvm-objdump-${APT_LLVM_V} \
+ RANLIB=llvm-ranlib-${APT_LLVM_V} \
+ STRIP=llvm-strip-${APT_LLVM_V}"
+export GOAL="install"
+export BITCOIN_CONFIG="\
+ --preset=dev-mode \
+ -DBUILD_GUI=OFF \
+ -DREDUCE_EXPORTS=ON \
+ -DWITH_USDT=OFF \
+"
+export RUN_UNIT_TESTS="false"
+export RUN_FUNCTIONAL_TESTS="false"

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -122,4 +122,23 @@ if [ -n "$FREEBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENA
   tar -C "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" -xf "$FREEBSD_SDK_PATH"
 fi
 
+if [ -n "$OPENBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}" ]; then
+  mkdir -p "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}"
+  for OPENBSD_SDK_FILENAME in base79.tgz comp79.tgz; do
+    OPENBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${OPENBSD_SDK_FILENAME}"
+    if [ ! -f "$OPENBSD_SDK_PATH" ]; then
+      ${CI_RETRY_EXE} curl --location --fail "https://cdn.openbsd.org/pub/OpenBSD/${OPENBSD_VERSION}/amd64/${OPENBSD_SDK_FILENAME}" -o "$OPENBSD_SDK_PATH"
+    fi
+    tar -C "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}" -xf "$OPENBSD_SDK_PATH"
+    (
+      # The SDK has versioned shared libs, but no unversioned libfoo.so symlink,
+      # which breaks linking the kernel with lld. Create the symlinks.
+      cd "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}/usr/lib"
+      ln -sf libc++abi.so.*.*  libc++abi.so
+      ln -sf libc++.so.*.*     libc++.so
+      ln -sf libpthread.so.*.* libpthread.so
+    )
+  done
+fi
+
 echo -n "done" > "${CFG_DONE}"

--- a/depends/hosts/openbsd.mk
+++ b/depends/hosts/openbsd.mk
@@ -1,5 +1,6 @@
 openbsd_CFLAGS=
 openbsd_CXXFLAGS=
+openbsd_LDFLAGS=
 
 openbsd_release_CFLAGS=-O2
 openbsd_release_CXXFLAGS=$(openbsd_release_CFLAGS)


### PR DESCRIPTION
This adds a Linux cross job for OpenBSD; similar to https://github.com/bitcoin/bitcoin/pull/34491 (FreeBSD).