### PR TITLE
build: exclude libmultiprocess test target from compile commands

### DIFF
--- a/src/ipc/libmultiprocess/test/CMakeLists.txt
+++ b/src/ipc/libmultiprocess/test/CMakeLists.txt
@@ -37,4 +37,9 @@ if(BUILD_TESTING AND TARGET CapnProto::kj-test)
 
   add_dependencies(mptests mptest)
   add_test(NAME mptest COMMAND mptest)
+
+  # Exclude from compilation database because test includes generated .capnp.h
+  # files that don't exist at CMake configure time, causing IWYU to fail.
+  set_target_properties(mptest
+      PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 endif()


### PR DESCRIPTION
Fixes #35361

The `mptest` target includes generated `.capnp.h` files that don't exist
at CMake configure time. When IWYU reads `compile_commands.json`, it sees
these non-existent files and fails with errors like:
fatal error: 'mp/test/foo.capnp.h' file not found 
This PR excludes the `mptest` target from the compilation database by setting `EXPORT_COMPILE_COMMANDS OFF`, following the same pattern already applied to the libmultiprocess example targets in PR #31741.

**Before this change:**
- IWYU would fail on libmultiprocess test files
- CI logs show sporadic "file not found" errors

**After this change:**
- The test target is excluded from `compile_commands.json`
- IWYU no longer attempts to check these files
- Cleaner CI logs with no false positive errors