### PR TITLE
doc: Compress doc/build-unix.md dependency package names into table

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,11 +1,10 @@
-UNIX BUILD NOTES
-====================
+# UNIX BUILD NOTES
+
 Some notes on how to build Bitcoin Core in Unix.
 
 (For BSD specific instructions, see `build-*bsd.md` in this directory.)
 
-To Build
----------------------
+## To Build
 
 ```bash
 cmake -B build
@@ -18,8 +17,7 @@ cmake --install build  # Optional
 ```
 
 See below for instructions on how to [install the dependencies on popular Linux
-distributions](#linux-distribution-specific-instructions), or the
-[dependencies](#dependencies) section for a complete overview.
+distributions](#dependencies).
 
 ## Memory Requirements
 
@@ -40,162 +38,46 @@ Finally, clang (often less resource hungry) can be used instead of gcc, which is
 
     cmake -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
 
-## Linux Distribution Specific Instructions
+## Dependencies
 
-### Ubuntu & Debian
+You can either build from self-compiled [depends](/depends/README.md) or
+install the dependencies from your distribution package manager. Dependencies
+for additional features in later columns are optional.
 
-#### Dependency Build Instructions
-
-Build requirements for the latest Debian "stable" release, or the latest Ubuntu LTS release:
-
-    sudo apt-get install build-essential cmake pkgconf python3
+| Package manager         | Required build dependencies | SQLite (wallet) | Cap'n Proto (IPC) | ZMQ | USDT | Qt and libqrencode (GUI) |
+| ----------------------- | --------------------------- | --------------- | ----------------- | --- | ---- | ------------------------ |
+| Debian / Ubuntu (`apt`) | `build-essential cmake pkgconf python3 libevent-dev libboost-dev` | `libsqlite3-dev` | `libcapnp-dev capnproto` | `libzmq3-dev` | `systemtap-sdt-dev` | `qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libgl-dev qt6-wayland libqrencode-dev` |
+| Fedora (`dnf`)          | `gcc-c++ cmake make python3 libevent-devel boost-devel` | `sqlite-devel` | `capnproto capnproto-devel` | `zeromq-devel` | `systemtap-sdt-devel` | `qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland qrencode-devel` |
+| Alpine (`apk`)          | `build-base cmake linux-headers pkgconf python3 libevent-dev boost-dev` | `sqlite-dev` | `capnproto capnproto-dev` | `zeromq-dev` | Not supported | `qt6-qtbase-dev qt6-qttools-dev libqrencode-dev` |
+| Arch (`pacman`)         | `gcc make cmake pkgconf python libevent boost` | `sqlite` | `capnproto` | `zeromq` | `systemtap` | `qt6-base qt6-tools qt6-wayland qrencode` |
 
 For Debian "oldstable", or earlier Ubuntu LTS releases, you may need to pick a
 later compiler version, according to the [dependencies](/doc/dependencies.md)
 documentation.
 
-Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
-
-    sudo apt-get install libevent-dev libboost-dev
-
-SQLite is required for the wallet:
-
-    sudo apt install libsqlite3-dev
-
 To build Bitcoin Core without the wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
+and use `-DENABLE_WALLET=OFF` to build without the wallet and skip the SQLite dependency.
 
-Cap'n Proto is needed for IPC functionality (see [multiprocess.md](multiprocess.md)):
-
-    sudo apt-get install libcapnp-dev capnproto
-
+Cap'n Proto is needed for IPC functionality (see [multiprocess.md](multiprocess.md)).
 Compile with `-DENABLE_IPC=OFF` if you do not need IPC functionality.
 
-ZMQ-enabled binaries are compiled with `-DWITH_ZMQ=ON` and require the following dependency:
+ZMQ-enabled binaries are compiled with `-DWITH_ZMQ=ON` and require libzmq.
 
-    sudo apt-get install libzmq3-dev
-
-User-Space, Statically Defined Tracing (USDT) dependencies:
-
-    sudo apt install systemtap-sdt-dev
+User-Space, Statically Defined Tracing (USDT) requires the systemtap-sdt
+development package and must be enabled via `-DWITH_USDT=ON`.
 
 GUI dependencies:
 
 Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
 the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
-    sudo apt-get install qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libgl-dev
+Additionally, install the Qt Wayland platform plugin for modern desktop environments.
 
-Additionally, to support Wayland protocol for modern desktop environments:
-
-    sudo apt install qt6-wayland
-
-The GUI will be able to encode addresses in QR codes unless this feature is explicitly disabled. To install libqrencode, run:
-
-    sudo apt-get install libqrencode-dev
-
+The GUI will be able to encode addresses in QR codes and requires libqrencode.
 Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` option to disable this feature in order to compile the GUI.
 
+### Disable-wallet mode
 
-### Fedora
-
-#### Dependency Build Instructions
-
-Build requirements:
-
-    sudo dnf install gcc-c++ cmake make python3
-
-Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
-
-    sudo dnf install libevent-devel boost-devel
-
-SQLite is required for the wallet:
-
-    sudo dnf install sqlite-devel
-
-To build Bitcoin Core without the wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
-
-ZMQ-enabled binaries are compiled with `-DWITH_ZMQ=ON` and require the following dependency:
-
-    sudo dnf install zeromq-devel
-
-User-Space, Statically Defined Tracing (USDT) dependencies:
-
-    sudo dnf install systemtap-sdt-devel
-
-Cap'n Proto is needed for IPC functionality (see [multiprocess.md](multiprocess.md)):
-
-    sudo dnf install capnproto capnproto-devel
-
-Compile with `-DENABLE_IPC=OFF` if you do not need IPC functionality.
-
-GUI dependencies:
-
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
-the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
-
-    sudo dnf install qt6-qtbase-devel qt6-qttools-devel
-
-Additionally, to support Wayland protocol for modern desktop environments:
-
-    sudo dnf install qt6-qtwayland
-
-The GUI will be able to encode addresses in QR codes unless this feature is explicitly disabled. To install libqrencode, run:
-
-    sudo dnf install qrencode-devel
-
-Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` option to disable this feature in order to compile the GUI.
-
-### Alpine
-
-#### Dependency Build Instructions
-
-Build requirements:
-
-    apk add build-base cmake linux-headers pkgconf python3
-
-Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
-
-    apk add libevent-dev boost-dev
-
-SQLite is required for the wallet:
-
-    apk add sqlite-dev
-
-To build Bitcoin Core without the wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
-
-Cap'n Proto is needed for IPC functionality (see [multiprocess.md](multiprocess.md)):
-
-    apk add capnproto capnproto-dev
-
-Compile with `-DENABLE_IPC=OFF` if you do not need IPC functionality.
-
-ZMQ dependencies (provides ZMQ API):
-
-    apk add zeromq-dev
-
-User-Space, Statically Defined Tracing (USDT) is not supported or tested on Alpine Linux at this time.
-
-GUI dependencies:
-
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
-the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
-
-    apk add qt6-qtbase-dev  qt6-qttools-dev
-
-The GUI will be able to encode addresses in QR codes unless this feature is explicitly disabled. To install libqrencode, run:
-
-    apk add libqrencode-dev
-
-Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` option to disable this feature in order to compile the GUI.
-
-## Dependencies
-
-See [dependencies.md](dependencies.md) for a complete overview, and
-[depends](/depends/README.md) on how to compile them yourself, if you wish to
-not use the packages of your Linux distribution.
-
-Disable-wallet mode
---------------------
 When the intention is to only run a P2P node, without a wallet, Bitcoin Core can
 be compiled in disable-wallet mode with:
 
@@ -204,17 +86,3 @@ be compiled in disable-wallet mode with:
 In this case there is no dependency on SQLite.
 
 Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
-
-Setup and Build Example: Arch Linux
------------------------------------
-This example lists the steps necessary to setup and build a command line only distribution of the latest changes on Arch Linux:
-
-    pacman --sync --needed capnproto cmake boost gcc git libevent make python sqlite
-    git clone https://github.com/bitcoin/bitcoin.git
-    cd bitcoin/
-    cmake -B build
-    cmake --build build
-    ctest --test-dir build
-    ./build/bin/bitcoind
-    ./build/bin/bitcoin help
-


### PR DESCRIPTION
Currently, `doc/build-unix.md` is tediously verbose, because for several Linux distros, it has exact duplicate sections with only the package names adjusted.

This is hard to maintain, and review. Also, it is hard to read, and hard to use, because a one-line copy-paste does not work to fetch the list of packages.

Fix all issues by compressing the 150+ lines into a small table and a short description.