### PR TITLE
wallet: allow anti-fee-sniping in sendall RPC while not relying on RBF default

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1498,7 +1498,7 @@ RPCMethod sendall()
                     if (output.depth == 0 && coin_control.m_version == TRUC_VERSION) {
                         coin_control.m_max_tx_weight = TRUC_CHILD_MAX_WEIGHT;
                     }
-                    CTxIn input(output.outpoint.hash, output.outpoint.n, CScript(), rbf ? MAX_BIP125_RBF_SEQUENCE : CTxIn::SEQUENCE_FINAL);
+                    CTxIn input(output.outpoint.hash, output.outpoint.n, CScript(), rbf ? MAX_BIP125_RBF_SEQUENCE : CTxIn::MAX_SEQUENCE_NONFINAL);
                     rawTx.vin.push_back(input);
                     total_input_value += output.txout.nValue;
                 }

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -59,8 +59,8 @@ class SendallTest(BitcoinTestFramework):
         return self.wallet.getbalances()["mine"]["trusted"]
 
     # Helper schema for success cases
-    def test_sendall_success(self, sendall_args, remaining_balance = 0):
-        sendall_tx_receipt = self.wallet.sendall(sendall_args)
+    def test_sendall_success(self, sendall_args, remaining_balance = 0, *, options=None):
+        sendall_tx_receipt = self.wallet.sendall(sendall_args, options=options)
         self.generate(self.nodes[0], 1)
         # wallet has remaining balance (usually empty)
         assert_equal(remaining_balance, self.wallet.getbalances()["mine"]["trusted"])
@@ -436,7 +436,7 @@ class SendallTest(BitcoinTestFramework):
     def sendall_anti_fee_sniping(self):
         self.log.info("Testing sendall does anti-fee-sniping when locktime is not specified")
         self.add_utxos([10,11])
-        tx_from_wallet = self.test_sendall_success(sendall_args = [self.remainder_target])
+        tx_from_wallet = self.test_sendall_success(sendall_args = [self.remainder_target], options={"replaceable":False})
 
         # the locktime should be within 100 blocks of the
         # block height


### PR DESCRIPTION
Partially fixes https://github.com/bitcoin/bitcoin/issues/32661.
Prerequisite to #35405.

The test change in the second commit would fail without the presence
of the first commit.