### PR TITLE
wallet: switch default optinrbf from true to false

### DIFF
--- a/doc/release-notes-34917.md
+++ b/doc/release-notes-34917.md
@@ -1,4 +1,4 @@
-RPC and Startup Option
+Wallet RPC and Startup Option
 ------------
 The `bip125-replaceable` key in the wallet transaction RPCs such
 as `listtransactions`, `listsinceblock`, and `gettransaction` is
@@ -7,3 +7,8 @@ key by passing the `-deprecatedrpc=bip125` startup option. Also,
 the `-walletrbf` startup option has been marked as deprecated and
 will be fully removed in the next release. Using this option emits
 a warning in the logs.
+
+Moreover, the default value of -walletrbf has been changed to 0
+in PR #35405 because signalling for RBF is not necessary for
+replacing transactions due to nodes being fullrbf and the wallet
+doesn't need to opt into it by default.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -128,7 +128,7 @@ static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS{true};
 //! -txconfirmtarget default
 static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 //! -walletrbf default
-static const bool DEFAULT_WALLET_RBF = true;
+static const bool DEFAULT_WALLET_RBF{false};
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 static const bool DEFAULT_WALLETCROSSCHAIN = false;

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -19,6 +19,7 @@ from test_framework.messages import (
     CTxIn,
     CTxOut,
     MAX_BIP125_RBF_SEQUENCE,
+    MAX_SEQUENCE_NONFINAL,
     WITNESS_SCALE_FACTOR,
     ser_compact_size,
 )
@@ -877,7 +878,7 @@ class PSBTTest(BitcoinTestFramework):
         psbtx_info = self.nodes[0].walletcreatefundedpsbt([], [{self.nodes[2].getnewaddress():unspent["amount"]+1}])
         decoded_psbt = self.nodes[0].decodepsbt(psbtx_info["psbt"])
         for psbt_in in decoded_psbt["inputs"]:
-            assert_equal(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
+            assert_equal(psbt_in["sequence"], MAX_SEQUENCE_NONFINAL)
             assert "bip32_derivs" in psbt_in
         assert_equal(decoded_psbt["fallback_locktime"], 0)
 


### PR DESCRIPTION
Partially fixes https://github.com/bitcoin/bitcoin/issues/32661.

This follows up a point raised in a review of a previous PR here: https://github.com/bitcoin/bitcoin/pull/34917#discussion_r3302602793.

With nodes running fullrbf, wallet doesn't need to opt into RBF. This patch
switches the default of wallet rbf to false. Users still have the option to
optin RBF via the individual transaction (and PSBT) creation RPCs - for now.