### PR TITLE
net: use the proxy if overriden when doing v2->v1 reconnections

### DIFF
--- a/doc/release-notes-35319.md
+++ b/doc/release-notes-35319.md
@@ -1,0 +1,20 @@
+P2P and network changes
+-----------------------
+
+- Fix a possible leak of the originator's IP address for transactions sent with
+`sendrawtransaction` RPC when `-privatebroadcast=1`. When Bitcoin Core connects
+to a peer, if that peer has been advertised to support P2P protocol v2, then
+Bitcoin Core tries to use the v2 protocol and if that fails it retries the
+connection using the v1 protocol. When the private broadcast is about to send a
+transaction to an IPv4 or IPv6 peer it overrides the normal proxy selection and
+forces the connection through the Tor proxy (and thus through the Tor network,
+protecting the sender's IP address). However if v2 protocol is tried and it
+fails, then the v1 retry connection would be made disregarding the "override
+proxy" request, possibly making an IPv4 or IPv6 direct connection. In other
+words, for this to happen the following must be true:
+  1. An IPv4 or IPv6 address has been advertised to the sender, indicating v2
+  support.
+  2. The sender must have Tor configured.
+  3. The sender's configuration must be such that connections to IPv4 or IPv6
+  are made directly (no `-proxy=` is used for IPv4 or IPv6).
+  4. The recipient does not support v2 (the flags from 1. are bogus). (#35319)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1919,7 +1919,13 @@ bool CConnman::AddConnection(const std::string& address, ConnectionType conn_typ
     CountingSemaphoreGrant<> grant(*semOutbound, true);
     if (!grant) return false;
 
-    OpenNetworkConnection(CAddress(), false, std::move(grant), address.c_str(), conn_type, /*use_v2transport=*/use_v2transport);
+    OpenNetworkConnection(/*addrConnect=*/CAddress{},
+                          /*fCountFailure=*/false,
+                          /*grant_outbound=*/std::move(grant),
+                          /*pszDest=*/address.c_str(),
+                          /*conn_type=*/conn_type,
+                          /*use_v2transport=*/use_v2transport,
+                          /*proxy_override=*/std::nullopt);
     return true;
 }
 
@@ -2443,7 +2449,13 @@ void CConnman::ProcessAddrFetch()
     CAddress addr;
     CountingSemaphoreGrant<> grant(*semOutbound, /*fTry=*/true);
     if (grant) {
-        OpenNetworkConnection(addr, false, std::move(grant), strDest.c_str(), ConnectionType::ADDR_FETCH, use_v2transport);
+        OpenNetworkConnection(/*addrConnect=*/addr,
+                              /*fCountFailure=*/false,
+                              /*grant_outbound=*/std::move(grant),
+                              /*pszDest=*/strDest.c_str(),
+                              /*conn_type=*/ConnectionType::ADDR_FETCH,
+                              /*use_v2transport=*/use_v2transport,
+                              /*proxy_override=*/std::nullopt);
     }
 }
 
@@ -2571,8 +2583,13 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
         {
             for (const std::string& strAddr : connect)
             {
-                CAddress addr(CService(), NODE_NONE);
-                OpenNetworkConnection(addr, false, {}, strAddr.c_str(), ConnectionType::MANUAL, /*use_v2transport=*/use_v2transport);
+                OpenNetworkConnection(/*addrConnect=*/CAddress{CService{}, NODE_NONE},
+                                      /*fCountFailure=*/false,
+                                      /*grant_outbound=*/{},
+                                      /*pszDest=*/strAddr.c_str(),
+                                      /*conn_type=*/ConnectionType::MANUAL,
+                                      /*use_v2transport=*/use_v2transport,
+                                      /*proxy_override=*/std::nullopt);
                 for (int i = 0; i < 10 && i < nLoop; i++)
                 {
                     if (!m_interrupt_net->sleep_for(500ms)) {
@@ -2922,7 +2939,13 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
             const bool count_failures{((int)outbound_ipv46_peer_netgroups.size() + outbound_privacy_network_peers) >= std::min(m_max_automatic_connections - 1, 2)};
             // Use BIP324 transport when both us and them have NODE_V2_P2P set.
             const bool use_v2transport(addrConnect.nServices & GetLocalServices() & NODE_P2P_V2);
-            OpenNetworkConnection(addrConnect, count_failures, std::move(grant), /*pszDest=*/nullptr, conn_type, use_v2transport);
+            OpenNetworkConnection(/*addrConnect=*/addrConnect,
+                                  /*fCountFailure=*/count_failures,
+                                  /*grant_outbound=*/std::move(grant),
+                                  /*pszDest=*/nullptr,
+                                  /*conn_type=*/conn_type,
+                                  /*use_v2transport=*/use_v2transport,
+                                  /*proxy_override=*/std::nullopt);
         }
     }
 }
@@ -3021,8 +3044,13 @@ void CConnman::ThreadOpenAddedConnections()
                 break;
             }
             tried = true;
-            CAddress addr(CService(), NODE_NONE);
-            OpenNetworkConnection(addr, false, std::move(grant), info.m_params.m_added_node.c_str(), ConnectionType::MANUAL, info.m_params.m_use_v2transport);
+            OpenNetworkConnection(/*addrConnect=*/CAddress{CService{}, NODE_NONE},
+                                  /*fCountFailure=*/false,
+                                  /*grant_outbound=*/std::move(grant),
+                                  /*pszDest=*/info.m_params.m_added_node.c_str(),
+                                  /*conn_type=*/ConnectionType::MANUAL,
+                                  /*use_v2transport=*/info.m_params.m_use_v2transport,
+                                  /*proxy_override=*/std::nullopt);
             if (!m_interrupt_net->sleep_for(500ms)) return;
             grant = CountingSemaphoreGrant<>(*semAddnode, /*fTry=*/true);
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -539,6 +539,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                                 network_id,
                                 CNodeOptions{
                                     .permission_flags = permission_flags,
+                                    .proxy_override = proxy_override,
                                     .i2p_sam_session = std::move(i2p_transient_session),
                                     .recv_flood_size = nReceiveFloodSize,
                                     .use_v2transport = use_v2transport,
@@ -1956,6 +1957,7 @@ void CConnman::DisconnectNodes()
                 // and we don't want to hold up the socket handler thread for that long.
                 if (network_active && pnode->m_transport->ShouldReconnectV1()) {
                     reconnections_to_add.push_back({
+                        .proxy_override = pnode->m_proxy_override,
                         .addr_connect = pnode->addr,
                         .grant = std::move(pnode->grantOutbound),
                         .destination = pnode->m_dest,
@@ -4028,6 +4030,7 @@ CNode::CNode(NodeId idIn,
       m_permission_flags{node_opts.permission_flags},
       m_sock{sock},
       m_connected{NodeClock::now()},
+      m_proxy_override{std::move(node_opts.proxy_override)},
       addr{addrIn},
       addrBind{addrBindIn},
       m_addr_name{addrNameIn.empty() ? addr.ToStringAddrPort() : addrNameIn},
@@ -4214,7 +4217,8 @@ void CConnman::PerformReconnections()
                               std::move(item.grant),
                               item.destination.empty() ? nullptr : item.destination.c_str(),
                               item.conn_type,
-                              item.use_v2transport);
+                              item.use_v2transport,
+                              item.proxy_override);
     }
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -488,8 +488,11 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
                 LogDebug(BCLog::PROXY, "Using proxy: %s to connect to %s\n", use_proxy->ToString(), target_addr.ToStringAddrPort());
                 sock = ConnectThroughProxy(*use_proxy, target_addr.ToStringAddr(), target_addr.GetPort(), proxyConnectionFailed);
             } else {
-                // no proxy needed (none set for target network)
-                sock = ConnectDirectly(target_addr, conn_type == ConnectionType::MANUAL);
+                // No proxy needed (none set for target network). Private broadcast connections
+                // must always use a proxy, otherwise they would leak the originator's IP address.
+                if (Assume(conn_type != ConnectionType::PRIVATE_BROADCAST)) {
+                    sock = ConnectDirectly(target_addr, conn_type == ConnectionType::MANUAL);
+                }
             }
             if (!proxyConnectionFailed) {
                 // If a connection to the node was attempted, and failure (if any) is not caused by a problem connecting to

--- a/src/net.h
+++ b/src/net.h
@@ -1191,7 +1191,7 @@ public:
                                const char* pszDest,
                                ConnectionType conn_type,
                                bool use_v2transport,
-                               const std::optional<Proxy>& proxy_override = std::nullopt)
+                               const std::optional<Proxy>& proxy_override)
         EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex, !m_unused_i2p_sessions_mutex);
 
     /// Group of private broadcast related members.

--- a/src/net.h
+++ b/src/net.h
@@ -669,6 +669,7 @@ public:
 struct CNodeOptions
 {
     NetPermissionFlags permission_flags = NetPermissionFlags::None;
+    std::optional<Proxy> proxy_override = {};
     std::unique_ptr<i2p::sam::Session> i2p_sam_session = nullptr;
     bool prefer_evict = false;
     size_t recv_flood_size{DEFAULT_MAXRECEIVEBUFFER * 1000};
@@ -711,6 +712,10 @@ public:
     std::atomic<NodeClock::time_point> m_last_recv{NodeClock::epoch};
     //! Unix epoch time at peer connection
     const NodeClock::time_point m_connected;
+
+    //! Proxy to use regardless of global proxy settings if reconnecting to this node.
+    const std::optional<Proxy> m_proxy_override;
+
     // Address of this peer
     const CAddress addr;
     // Bind address of our side of the connection
@@ -1796,6 +1801,7 @@ private:
     /** Struct for entries in m_reconnections. */
     struct ReconnectionInfo
     {
+        std::optional<Proxy> proxy_override;
         CAddress addr_connect;
         CountingSemaphoreGrant<> grant;
         std::string destination;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -358,7 +358,13 @@ static RPCMethod addnode()
     if (command == "onetry")
     {
         CAddress addr;
-        connman.OpenNetworkConnection(addr, /*fCountFailure=*/false, /*grant_outbound=*/{}, std::string{node_arg}.c_str(), ConnectionType::MANUAL, use_v2transport);
+        connman.OpenNetworkConnection(/*addrConnect=*/addr,
+                                      /*fCountFailure=*/false,
+                                      /*grant_outbound=*/{},
+                                      /*pszDest=*/std::string{node_arg}.c_str(),
+                                      /*conn_type=*/ConnectionType::MANUAL,
+                                      /*use_v2transport=*/use_v2transport,
+                                      /*proxy_override=*/std::nullopt);
         return UniValue::VNULL;
     }
 

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -188,13 +188,19 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                     conn_type = ConnectionType::OUTBOUND_FULL_RELAY;
                 }
 
+                std::optional<Proxy> proxy_override;
+                if (conn_type == ConnectionType::PRIVATE_BROADCAST || fuzzed_data_provider.ConsumeBool()) {
+                    proxy_override.emplace(ConsumeService(fuzzed_data_provider));
+                }
+
                 connman.OpenNetworkConnection(
                     /*addrConnect=*/random_address,
                     /*fCountFailure=*/fuzzed_data_provider.ConsumeBool(),
                     /*grant_outbound=*/{},
                     /*pszDest=*/fuzzed_data_provider.ConsumeBool() ? nullptr : random_string.c_str(),
                     /*conn_type=*/conn_type,
-                    /*use_v2transport=*/fuzzed_data_provider.ConsumeBool());
+                    /*use_v2transport=*/fuzzed_data_provider.ConsumeBool(),
+                    /*proxy_override=*/proxy_override);
             },
             [&] {
                 connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -15,6 +15,7 @@ from test_framework.p2p import (
     P2PInterface,
     P2P_SERVICES,
     P2P_VERSION,
+    start_p2p_listener,
 )
 from test_framework.messages import (
     CAddress,
@@ -221,22 +222,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
                     listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
                     listener.peer_connect_send_version(services=P2P_SERVICES)
 
-                    def on_listen_done(addr, port):
-                        nonlocal actual_to_addr
-                        nonlocal actual_to_port
-                        actual_to_addr = addr
-                        actual_to_port = port
-
-                    # Use port=0 to let the OS assign an available port. This
-                    # avoids "address already in use" errors when tests run
-                    # concurrently or ports are still in TIME_WAIT state.
-                    self.network_thread.listen(
-                        addr="127.0.0.1",
-                        port=0,
-                        p2p=listener,
-                        callback=on_listen_done)
-                    # Wait until the callback has been called.
-                    self.wait_until(lambda: actual_to_port != 0)
+                    actual_to_addr, actual_to_port = start_p2p_listener(self.network_thread, listener)
 
                 self.log.debug(f"Instructing the SOCKS5 proxy to redirect connection i={i} ({conn_type}) for "
                                f"{format_addr_port(requested_to_addr, requested_to_port)} to "

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -29,8 +29,7 @@ from test_framework.netutil import (
 )
 from test_framework.script_util import build_malleated_tx_package
 from test_framework.socks5 import (
-    Socks5Configuration,
-    Socks5Server,
+    start_socks5_server,
 )
 from test_framework.test_framework import (
     BitcoinTestFramework,
@@ -40,7 +39,6 @@ from test_framework.util import (
     assert_greater_than_or_equal,
     assert_not_equal,
     assert_raises_rpc_error,
-    p2p_port,
     tor_port,
 )
 from test_framework.wallet import (
@@ -166,18 +164,6 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         self.num_nodes = 2
 
     def setup_nodes(self):
-        # Start a SOCKS5 proxy server.
-        socks5_server_config = Socks5Configuration()
-        # self.nodes[0] listens on p2p_port(0),
-        # self.nodes[1] listens on p2p_port(1),
-        # thus we tell the SOCKS5 server to listen on p2p_port(self.num_nodes) (self.num_nodes is 2)
-        socks5_server_config.addr = ("127.0.0.1", p2p_port(self.num_nodes))
-        socks5_server_config.unauth = True
-        socks5_server_config.auth = True
-
-        self.socks5_server = Socks5Server(socks5_server_config)
-        self.socks5_server.start()
-
         self.destinations = []
 
         self.destinations_lock = threading.Lock()
@@ -268,7 +254,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
                     "actual_to_port": actual_to_port,
                 }
 
-        self.socks5_server.conf.destinations_factory = destinations_factory
+        self.socks5_server = start_socks5_server(destinations_factory)
 
         self.extra_args = [
             [
@@ -279,7 +265,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
                 "-v2transport=0",
                 "-test=addrman",
                 "-privatebroadcast",
-                f"-proxy={socks5_server_config.addr[0]}:{socks5_server_config.addr[1]}",
+                f"-proxy={self.socks5_server.conf.addr[0]}:{self.socks5_server.conf.addr[1]}",
                 # To increase coverage, make it think that the I2P network is reachable so that it
                 # selects such addresses as well. Pick a proxy address where nobody is listening
                 # and connection attempts fail quickly.

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -48,116 +48,6 @@ from test_framework.wallet import (
 
 NUM_PRIVATE_BROADCAST_PER_TX = 3
 
-# Fill addrman with these addresses. Must have enough Tor addresses, so that even
-# if all 10 default connections are opened to a Tor address (!?) there must be more
-# for private broadcast.
-ADDRMAN_ADDRESSES = [
-    "20.0.0.1",
-    "30.0.0.1",
-    "40.0.0.1",
-    "50.0.0.1",
-    "60.0.0.1",
-    "70.0.0.1",
-    "80.0.0.1",
-    "90.0.0.1",
-    "100.0.0.1",
-    "110.0.0.1",
-    "120.0.0.1",
-    "130.0.0.1",
-    "140.0.0.1",
-    "150.0.0.1",
-    "160.0.0.1",
-    "170.0.0.1",
-    "180.0.0.1",
-    "190.0.0.1",
-    "200.0.0.1",
-    "210.0.0.1",
-
-    "[20::1]",
-    "[30::1]",
-    "[40::1]",
-    "[50::1]",
-    "[60::1]",
-    "[70::1]",
-    "[80::1]",
-    "[90::1]",
-    "[100::1]",
-    "[110::1]",
-    "[120::1]",
-    "[130::1]",
-    "[140::1]",
-    "[150::1]",
-    "[160::1]",
-    "[170::1]",
-    "[180::1]",
-    "[190::1]",
-    "[200::1]",
-    "[210::1]",
-
-    "testonlyad777777777777777777777777777777777777777775b6qd.onion",
-    "testonlyah77777777777777777777777777777777777777777z7ayd.onion",
-    "testonlyal77777777777777777777777777777777777777777vp6qd.onion",
-    "testonlyap77777777777777777777777777777777777777777r5qad.onion",
-    "testonlyat77777777777777777777777777777777777777777udsid.onion",
-    "testonlyax77777777777777777777777777777777777777777yciid.onion",
-    "testonlya777777777777777777777777777777777777777777rhgyd.onion",
-    "testonlybd77777777777777777777777777777777777777777rs4ad.onion",
-    "testonlybp77777777777777777777777777777777777777777zs2ad.onion",
-    "testonlybt777777777777777777777777777777777777777777x6id.onion",
-    "testonlybx777777777777777777777777777777777777777775styd.onion",
-    "testonlyb3777777777777777777777777777777777777777774ckid.onion",
-    "testonlycd77777777777777777777777777777777777777777733id.onion",
-    "testonlych77777777777777777777777777777777777777777t6kid.onion",
-    "testonlycl77777777777777777777777777777777777777777tt3ad.onion",
-    "testonlyct77777777777777777777777777777777777777777wvhyd.onion",
-    "testonlycx7777777777777777777777777777777777777777774bad.onion",
-    "testonlyc377777777777777777777777777777777777777777u6aid.onion",
-    "testonlydd777777777777777777777777777777777777777777u5ad.onion",
-    "testonlydh77777777777777777777777777777777777777777wgnyd.onion",
-
-    "testonlyad77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlyah77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlyap77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlyat77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlyax77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlya377777777777777777777777777777777777777777q.b32.i2p",
-    "testonlya777777777777777777777777777777777777777777q.b32.i2p",
-    "testonlybd77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlybh77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlybl77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlybp77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlybt77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlybx77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlyb777777777777777777777777777777777777777777q.b32.i2p",
-    "testonlych77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlycp77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlyct77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlycx77777777777777777777777777777777777777777q.b32.i2p",
-    "testonlyc377777777777777777777777777777777777777777q.b32.i2p",
-    "testonlyc777777777777777777777777777777777777777777q.b32.i2p",
-
-    "[fc00::1]",
-    "[fc00::2]",
-    "[fc00::3]",
-    "[fc00::5]",
-    "[fc00::6]",
-    "[fc00::7]",
-    "[fc00::8]",
-    "[fc00::9]",
-    "[fc00::10]",
-    "[fc00::11]",
-    "[fc00::12]",
-    "[fc00::13]",
-    "[fc00::15]",
-    "[fc00::16]",
-    "[fc00::17]",
-    "[fc00::18]",
-    "[fc00::19]",
-    "[fc00::20]",
-    "[fc00::22]",
-    "[fc00::23]",
-]
-
 
 class P2PPrivateBroadcast(BitcoinTestFramework):
     def set_test_params(self):
@@ -333,13 +223,9 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
         tx_receiver = self.nodes[1]
         far_observer = tx_receiver.add_p2p_connection(P2PInterface())
 
-        wallet = MiniWallet(tx_originator)
+        self.fill_node_addrman(node_index=0, address_types_to_add=[CAddress.NET_IPV4, CAddress.NET_IPV6, CAddress.NET_TORV3, CAddress.NET_I2P, CAddress.NET_CJDNS])
 
-        # Fill tx_originator's addrman.
-        for addr in ADDRMAN_ADDRESSES:
-            res = tx_originator.addpeeraddress(address=addr, port=0 if addr.endswith(".i2p") else 8333, tried=False)
-            if not res["success"]:
-                self.log.debug(f"Could not add {addr} to tx_originator's addrman (collision?)")
+        wallet = MiniWallet(tx_originator)
 
         txs = wallet.create_self_transfer_chain(chain_length=3)
         self.log.info(f"Created txid={txs[0]['txid']}: for basic test")

--- a/test/functional/p2p_private_broadcast_retry_v1.py
+++ b/test/functional/p2p_private_broadcast_retry_v1.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Ensure that when v2 private broadcast connection to IPv4 fails the v1 retry
+will also be made through the Tor proxy.
+
+The test does:
+* Add a bunch of IPv4 addresses to the node's addrman (they will be added without P2P_V2 flag).
+* Get them to report P2P_V2 in their service flags and connect to each one, so that the flags
+  in addrman are updated to contain P2P_V2.
+* Get one successful connection to a Tor peer (.onion) so that bitcoind assumes the configured
+  Tor proxy works and is indeed a proxy to the Tor network. This will make it open private
+  broadcast connections also to IPv4 addresses via that proxy.
+* Start some private broadcast connections.
+* Remember the destination IPv4 address of the first connection and get it to fail the v2
+  transport.
+* Wait for a subsequent connection also through the Tor proxy to the same IPv4 and expect
+  it to be v1, i.e. the v2->v1 downgrade retry.
+"""
+
+from test_framework.netutil import (
+    format_addr_port
+)
+from test_framework.p2p import (
+    P2PConnection,
+    P2PInterface,
+    P2P_SERVICES,
+    start_p2p_listener,
+)
+from test_framework.messages import (
+    CAddress,
+    NODE_P2P_V2,
+)
+from test_framework.socks5 import (
+    start_socks5_server,
+)
+from test_framework.test_framework import (
+    BitcoinTestFramework,
+)
+from test_framework.v2_p2p import (
+    EncryptedP2PState,
+)
+from test_framework.wallet import (
+    MiniWallet,
+)
+
+class P2PDetermineV2or1AndClose(P2PConnection):
+    def __init__(self, on_v2or1_determined):
+        super().__init__()
+        self.on_v2or1_determined = on_v2or1_determined
+
+    # https://docs.python.org/3/library/asyncio-protocol.html#asyncio.Protocol.data_received
+    def data_received(self, data):
+        self.recvbuf += data
+        if len(self.recvbuf) >= 4:
+            self.on_v2or1_determined(1 if self.recvbuf[0:4] == self.magic_bytes else 2)
+            self.peer_disconnect()
+
+    def on_open(self):
+        pass
+
+    def on_close(self):
+        pass
+
+class P2PPrivateBroadcastRetryV1(BitcoinTestFramework):
+    def set_test_params(self):
+        self.disable_autoconnect = False
+        self.num_nodes = 1
+
+    def ipv4_via_tor_proxy_conn_versions_append(self, v2or1):
+        """
+        Add to the transport versions (v2 or v1) tried towards the first IPv4 which
+        nodes[0] tries to connect to via the Tor proxy.
+        """
+        self.ipv4_via_tor_proxy_conn_versions.append(v2or1)
+
+    def setup_nodes(self):
+        def destinations_factory_all_proxy(requested_to_addr, requested_to_port):
+            """
+            Instruct the SOCKS5 proxy to redirect all connections to newly created P2PInterface
+            objects that claim support for P2P_V2.
+            """
+            listener = P2PInterface()
+            listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
+            listener.peer_connect_send_version(services=P2P_SERVICES | NODE_P2P_V2)
+
+            actual_to_addr, actual_to_port = start_p2p_listener(self.network_thread, listener)
+
+            self.log.debug("Instructing the common proxy to redirect connection for "
+                           f"{format_addr_port(requested_to_addr, requested_to_port)} to "
+                           f"{format_addr_port(actual_to_addr, actual_to_port)} (Python {type(listener).__name__})")
+
+            return {
+                "actual_to_addr": actual_to_addr,
+                "actual_to_port": actual_to_port,
+            }
+
+        self.all_proxy = start_socks5_server(destinations_factory_all_proxy)
+
+        self.ipv4_via_tor_proxy_addr_port = None # Remember the first IPv4 address connected to via the Tor proxy.
+        self.ipv4_via_tor_proxy_conn_versions = [] # Transport versions tried on that address.
+
+        def destinations_factory_tor_proxy(requested_to_addr, requested_to_port):
+            """
+            Instruct the SOCKS5 proxy to redirect all connections to newly created P2PInterface,
+            except the first connection to an IPv4 address and all subsequent connections to that
+            address which are redirected to P2PDetermineV2or1AndClose.
+            """
+            requested_to = format_addr_port(requested_to_addr, requested_to_port)
+
+            if not requested_to_addr.endswith(".onion") and self.ipv4_via_tor_proxy_addr_port is None: # First IPv4
+                self.ipv4_via_tor_proxy_addr_port = requested_to
+
+            if self.ipv4_via_tor_proxy_addr_port == requested_to:
+                # This is either the first (v2) or the second (the expected v1 retry) connection to requested_to.
+                listener = P2PDetermineV2or1AndClose(self.ipv4_via_tor_proxy_conn_versions_append)
+                listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
+            else:
+                listener = P2PInterface()
+                listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
+                listener.peer_connect_send_version(services=P2P_SERVICES | NODE_P2P_V2)
+                if not requested_to_addr.endswith(".onion"):
+                    listener.v2_state = EncryptedP2PState(initiating=False, net=self.chain)
+
+            actual_to_addr, actual_to_port = start_p2p_listener(self.network_thread, listener)
+
+            self.log.debug(f"Instructing the Tor proxy to redirect connection for {requested_to} to "
+                           f"{format_addr_port(actual_to_addr, actual_to_port)} (Python {type(listener).__name__})")
+
+            return {
+                "actual_to_addr": actual_to_addr,
+                "actual_to_port": actual_to_port,
+            }
+
+        self.tor_proxy = start_socks5_server(destinations_factory_tor_proxy)
+
+        self.extra_args = [
+            [
+                "-privatebroadcast=1",
+                f"-proxy={self.all_proxy.conf.addr[0]}:{self.all_proxy.conf.addr[1]}",
+                f"-onion={self.tor_proxy.conf.addr[0]}:{self.tor_proxy.conf.addr[1]}",
+                "-test=addrman",
+                "-v2transport=0",
+            ],
+        ]
+
+        super().setup_nodes()
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        node0 = self.nodes[0]
+
+        self.log.info("Filling node0's addrman with addresses")
+        self.fill_node_addrman(node_index=0, address_types_to_add=[CAddress.NET_IPV4])
+
+        self.log.info("Opening manual connections to all IPv4 addresses to add P2P_V2 flag to addrman entries")
+        for a in node0.getnodeaddresses(count=0, network="ipv4"):
+            node0.addnode(node=format_addr_port(a["address"], a["port"]), command="onetry", v2transport=False)
+
+        self.log.info("Waiting for all IPv4 addresses to get P2P_V2 as a result of peers advertising support")
+        self.wait_until(lambda: all(a["services"] & NODE_P2P_V2 != 0 for a in node0.getnodeaddresses(count=0, network="ipv4")))
+
+        # The destinations behind the -proxy= don't actually support v2. When bitcoind runs with -v2transport=1
+        # and tries v2 on them they would print benign "magic byte mismatch" warnings.
+        # Disable those since none of them are needed anymore.
+        self.all_proxy.conf.destinations_factory = None
+
+        self.restart_node(0, extra_args=self.extra_args[0] + ["-v2transport=1"])
+
+        self.log.info("Opening a connection to a Tor addresses, so bitcoind considers -onion= is a real Tor proxy")
+        node0.addnode(node="testonlyad777777777777777777777777777777777777777775b6qd.onion:1234", command="onetry", v2transport=False)
+
+        self.log.info("Waiting for at least one Tor connection")
+        self.wait_until(lambda: any(p["network"] == "onion" for p in node0.getpeerinfo()))
+
+        self.log.info("Starting private broadcast connections")
+        wallet = MiniWallet(node0)
+        tx = wallet.create_self_transfer()
+        node0.sendrawtransaction(hexstring=tx["hex"])
+
+        self.log.info("Tor proxy: waiting for connection to an IPv4 address")
+        self.wait_until(lambda: self.ipv4_via_tor_proxy_addr_port is not None)
+        self.log.info(f"Tor proxy: got {self.ipv4_via_tor_proxy_addr_port}, waiting for v2")
+        self.wait_until(lambda: 2 in self.ipv4_via_tor_proxy_conn_versions)
+        self.log.info(f"Tor proxy: got {self.ipv4_via_tor_proxy_addr_port} v2, waiting for v1")
+        self.wait_until(lambda: 1 in self.ipv4_via_tor_proxy_conn_versions)
+        self.log.info(f"Tor proxy: got {self.ipv4_via_tor_proxy_addr_port} v2, v1")
+
+        self.stop_node(0)
+        self.all_proxy.stop()
+        self.tor_proxy.stop()
+
+
+if __name__ == "__main__":
+    P2PPrivateBroadcastRetryV1(__file__).main()

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -973,3 +973,27 @@ class P2PTxInvStore(P2PInterface):
         self.wait_until(lambda: set(self.tx_invs_received.keys()) == set([int(tx, 16) for tx in txns]), timeout=timeout)
         # Flush messages and wait for the getdatas to be processed
         self.sync_with_ping()
+
+def start_p2p_listener(network_thread, listener):
+    listen_addr = ""
+    listen_port = 0
+
+    def on_listen_done(addr, port):
+        nonlocal listen_addr
+        nonlocal listen_port
+        listen_addr = addr
+        listen_port = port
+
+    # Use port=0 to let the OS assign an available port. This
+    # avoids "address already in use" errors when tests run
+    # concurrently or ports are still in TIME_WAIT state.
+    network_thread.listen(
+        addr="127.0.0.1",
+        port=0,
+        p2p=listener,
+        callback=on_listen_done)
+
+    # Wait until the callback has been called.
+    wait_until_helper_internal(lambda: listen_port != 0)
+
+    return listen_addr, listen_port

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -327,3 +327,15 @@ class Socks5Server():
                     logger.debug(f"Stop(): Handler {i} thread joined")
                 else:
                     logger.warning(f"Stop(): Handler thread {i} didn't finish after force close")
+
+def start_socks5_server(destinations_factory):
+    config = Socks5Configuration()
+    config.addr = ("127.0.0.1", 0) # Use port=0 to let the OS pick one. The actual port is later in server.conf.addr[1].
+    config.unauth = True
+    config.auth = True
+    config.destinations_factory = destinations_factory
+
+    server = Socks5Server(config)
+    server.start()
+
+    return server

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -24,6 +24,7 @@ import time
 from .address import create_deterministic_address_bcrt1_p2tr_op_true
 from .authproxy import JSONRPCException
 from . import coverage
+from .messages import CAddress
 from .p2p import NetworkThread
 from .test_node import TestNode
 from .util import (
@@ -729,6 +730,125 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
     def wait_until(self, test_function, timeout=60, check_interval=0.05):
         return wait_until_helper_internal(test_function, timeout=timeout, timeout_factor=self.options.timeout_factor, check_interval=check_interval)
+
+    def fill_node_addrman(self, *, node_index, address_types_to_add):
+        ADDRESSES = {
+            CAddress.NET_IPV4: [
+                "20.0.0.1",
+                "30.0.0.1",
+                "40.0.0.1",
+                "50.0.0.1",
+                "60.0.0.1",
+                "70.0.0.1",
+                "80.0.0.1",
+                "90.0.0.1",
+                "100.0.0.1",
+                "110.0.0.1",
+                "120.0.0.1",
+                "130.0.0.1",
+                "140.0.0.1",
+                "150.0.0.1",
+                "160.0.0.1",
+                "170.0.0.1",
+                "180.0.0.1",
+                "190.0.0.1",
+                "200.0.0.1",
+                "210.0.0.1",
+            ],
+            CAddress.NET_IPV6: [
+                "[20::1]",
+                "[30::1]",
+                "[40::1]",
+                "[50::1]",
+                "[60::1]",
+                "[70::1]",
+                "[80::1]",
+                "[90::1]",
+                "[100::1]",
+                "[110::1]",
+                "[120::1]",
+                "[130::1]",
+                "[140::1]",
+                "[150::1]",
+                "[160::1]",
+                "[170::1]",
+                "[180::1]",
+                "[190::1]",
+                "[200::1]",
+                "[210::1]",
+            ],
+            CAddress.NET_TORV3: [
+                "testonlyad777777777777777777777777777777777777777775b6qd.onion",
+                "testonlyah77777777777777777777777777777777777777777z7ayd.onion",
+                "testonlyal77777777777777777777777777777777777777777vp6qd.onion",
+                "testonlyap77777777777777777777777777777777777777777r5qad.onion",
+                "testonlyat77777777777777777777777777777777777777777udsid.onion",
+                "testonlyax77777777777777777777777777777777777777777yciid.onion",
+                "testonlya777777777777777777777777777777777777777777rhgyd.onion",
+                "testonlybd77777777777777777777777777777777777777777rs4ad.onion",
+                "testonlybp77777777777777777777777777777777777777777zs2ad.onion",
+                "testonlybt777777777777777777777777777777777777777777x6id.onion",
+                "testonlybx777777777777777777777777777777777777777775styd.onion",
+                "testonlyb3777777777777777777777777777777777777777774ckid.onion",
+                "testonlycd77777777777777777777777777777777777777777733id.onion",
+                "testonlych77777777777777777777777777777777777777777t6kid.onion",
+                "testonlycl77777777777777777777777777777777777777777tt3ad.onion",
+                "testonlyct77777777777777777777777777777777777777777wvhyd.onion",
+                "testonlycx7777777777777777777777777777777777777777774bad.onion",
+                "testonlyc377777777777777777777777777777777777777777u6aid.onion",
+                "testonlydd777777777777777777777777777777777777777777u5ad.onion",
+                "testonlydh77777777777777777777777777777777777777777wgnyd.onion",
+            ],
+            CAddress.NET_I2P: [
+                "testonlyad77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlyah77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlyap77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlyat77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlyax77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlya377777777777777777777777777777777777777777q.b32.i2p",
+                "testonlya777777777777777777777777777777777777777777q.b32.i2p",
+                "testonlybd77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlybh77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlybl77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlybp77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlybt77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlybx77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlyb777777777777777777777777777777777777777777q.b32.i2p",
+                "testonlych77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlycp77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlyct77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlycx77777777777777777777777777777777777777777q.b32.i2p",
+                "testonlyc377777777777777777777777777777777777777777q.b32.i2p",
+                "testonlyc777777777777777777777777777777777777777777q.b32.i2p",
+            ],
+            CAddress.NET_CJDNS: [
+                "[fc00::1]",
+                "[fc00::2]",
+                "[fc00::3]",
+                "[fc00::5]",
+                "[fc00::6]",
+                "[fc00::7]",
+                "[fc00::8]",
+                "[fc00::9]",
+                "[fc00::10]",
+                "[fc00::11]",
+                "[fc00::12]",
+                "[fc00::13]",
+                "[fc00::15]",
+                "[fc00::16]",
+                "[fc00::17]",
+                "[fc00::18]",
+                "[fc00::19]",
+                "[fc00::20]",
+                "[fc00::22]",
+                "[fc00::23]",
+            ],
+        }
+        for addr_type in address_types_to_add:
+            for addr in ADDRESSES[addr_type]:
+                res = self.nodes[node_index].addpeeraddress(address=addr, port=0 if addr.endswith(".i2p") else 8333, tried=False)
+                if not res["success"]:
+                    self.log.debug(f"Could not add {addr} to nodes[{node_index}]'s addrman (collision?)")
 
     # Private helper methods. These should not be accessed by the subclass test scripts.
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -368,6 +368,7 @@ BASE_SCRIPTS = [
     'p2p_permissions.py',
     'feature_blocksdir.py',
     'wallet_startup.py',
+    'p2p_private_broadcast_retry_v1.py',
     'feature_remove_pruned_files_on_startup.py',
     'p2p_i2p_ports.py',
     'p2p_i2p_sessions.py',


### PR DESCRIPTION
This PR includes https://github.com/bitcoin/bitcoin/pull/35319 and on top of that adds a regression functional test.

The functional test exercises the relevant code paths without modifying non-test code. To do that it does:

* Add a bunch of IPv4 addresses to the node's addrman (they will be added without P2P_V2 flag).
* Get them to report P2P_V2 in their service flags and connect to each one, so that the flags
  in addrman are updated to contain P2P_V2.
* Get one successful connection to a Tor peer (.onion) so that bitcoind assumes the configured
  Tor proxy works and is indeed a proxy to the Tor network. This will make it open private
  broadcast connections also to IPv4 addresses via that proxy.
* Start some private broadcast connections.
* Remember the destination IPv4 address of the first connection and get it to fail the v2
  transport.
* Wait for a subsequent connection also through the Tor proxy to the same IPv4 and expect
  it to be v1, i.e. the v2->v1 downgrade retry.

The test fails without the fix - the v1 retry never arrives to the Tor proxy. And passes with the fix. The fix is in the first commit here and in https://github.com/bitcoin/bitcoin/pull/35319, can remove it by `git show fd230f942d | git apply -R`.