### PR TITLE
[RFC] rpc: expose locked-memory arena_count from getmemoryinfo

### DIFF
--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -120,6 +120,7 @@ static UniValue RPCLockedMemoryInfo()
     obj.pushKV("locked", stats.locked);
     obj.pushKV("chunks_used", stats.chunks_used);
     obj.pushKV("chunks_free", stats.chunks_free);
+    obj.pushKV("arena_count", stats.arena_count);
     return obj;
 }
 
@@ -166,6 +167,7 @@ static RPCMethod getmemoryinfo()
                                 {RPCResult::Type::NUM, "locked", "Amount of bytes that succeeded locking. If this number is smaller than total, locking pages failed at some point and key data could be swapped to disk."},
                                 {RPCResult::Type::NUM, "chunks_used", "Number allocated chunks"},
                                 {RPCResult::Type::NUM, "chunks_free", "Number unused chunks"},
+                                {RPCResult::Type::NUM, "arena_count", "Number allocated arenas"},
                             }},
                         }
                     },

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -320,7 +320,7 @@ void LockedPool::free(void *ptr)
 LockedPool::Stats LockedPool::stats() const
 {
     std::lock_guard<std::mutex> lock(mutex);
-    LockedPool::Stats r{0, 0, 0, cumulative_bytes_locked, 0, 0};
+    LockedPool::Stats r{0, 0, 0, cumulative_bytes_locked, 0, 0, arenas.size()};
     for (const auto &arena: arenas) {
         Arena::Stats i = arena.stats();
         r.used += i.used;

--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -150,6 +150,7 @@ public:
         size_t locked;
         size_t chunks_used;
         size_t chunks_free;
+        size_t arena_count;
     };
 
     /** Create a new LockedPool. This takes ownership of the MemoryPageLocker,

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -171,6 +171,7 @@ BOOST_AUTO_TEST_CASE(lockedpool_tests_mock)
     LockedPool pool(std::move(x));
     BOOST_CHECK(pool.stats().total == 0);
     BOOST_CHECK(pool.stats().locked == 0);
+    BOOST_CHECK_EQUAL(pool.stats().arena_count, 0U);
 
     // Ensure unreasonable requests are refused without allocating anything
     void *invalid_toosmall = pool.alloc(0);
@@ -185,6 +186,7 @@ BOOST_AUTO_TEST_CASE(lockedpool_tests_mock)
     void *a0 = pool.alloc(LockedPool::ARENA_SIZE / 2);
     BOOST_CHECK(a0);
     BOOST_CHECK(pool.stats().locked == LockedPool::ARENA_SIZE);
+    BOOST_CHECK_EQUAL(pool.stats().arena_count, 1U);
     void *a1 = pool.alloc(LockedPool::ARENA_SIZE / 2);
     BOOST_CHECK(a1);
     void *a2 = pool.alloc(LockedPool::ARENA_SIZE / 2);
@@ -208,6 +210,7 @@ BOOST_AUTO_TEST_CASE(lockedpool_tests_mock)
     BOOST_CHECK(pool.stats().total == 3*LockedPool::ARENA_SIZE);
     BOOST_CHECK(pool.stats().locked == LockedPool::ARENA_SIZE);
     BOOST_CHECK(pool.stats().used == 0);
+    BOOST_CHECK_EQUAL(pool.stats().arena_count, 3U);
 }
 
 // These tests used the live LockedPoolManager object, this is also used

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -60,6 +60,7 @@ class RpcMiscTest(BitcoinTestFramework):
         assert_greater_than_or_equal(memory['locked'], 0)
         assert_greater_than(memory['chunks_used'], 0)
         assert_greater_than(memory['chunks_free'], 0)
+        assert_greater_than(memory['arena_count'], 0)
         assert_equal(memory['used'] + memory['free'], memory['total'])
 
         self.log.info("test mallocinfo")


### PR DESCRIPTION
First of all, this is caused by the TODO comment below, just put this PR here to ask some questions about this TODO since I'm not very familiar with all the use pattern of lockedpool:
From AI analysis, the `arena.size()` is related with the number of wallets, and 10000 wallets causes about 10 arenas, is this a real production scenario in practice? Do we really has to keep this TODO there?

```
    // TODO we can do better than this linear search by keeping a map
    // of arena extents to arena, and looking up the address.

```

Mirror the existing chunks_used / chunks_free fields by adding a sibling arena_count field that exposes LockedPool's arenas.size() directly. All three are internal implementation details of the secure-memory pool surfaced to operators and diagnostic tooling.

Beyond observability, arena_count is also performance-relevant. As the existing TODO in LockedPool::free() points out:

    // TODO we can do better than this linear search by keeping a map
    // of arena extents to arena, and looking up the address.

LockedPool::free() walks the arena list linearly on every secure deallocation. While this is fine for the common case of a single arena, the cost scales with arena count. Exposing arena_count gives operators and developers a way to see when the pool has grown past that hot path's sweet spot, without having to estimate it from total / ARENA_SIZE (which is wrong when the first arena is capped by RLIMIT_MEMLOCK and misleading when memory is fragmented).

Includes unit-test coverage in allocator_tests (mock pool, before and after multi-arena allocation) and a functional-test assertion in rpc_misc.py.

