### PR TITLE
ci: add NetBSD Clang cross job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,12 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_mac_cross_intel.sh'
 
+          - name: 'NetBSD Cross'
+            warp-runner: 'warp-ubuntu-latest-x64-8x'
+            fallback-runner: 'ubuntu-latest'
+            timeout-minutes: 120
+            file-env: './ci/test/00_setup_env_netbsd_cross.sh'
+
           - name: 'FreeBSD Cross'
             warp-runner: 'warp-ubuntu-latest-x64-8x'
             fallback-runner: 'ubuntu-latest'

--- a/ci/test/00_setup_env_netbsd_cross.sh
+++ b/ci/test/00_setup_env_netbsd_cross.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_netbsd_cross
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
+export APT_LLVM_V="22"
+export HOST=x86_64-unknown-netbsd
+export NETBSD_VERSION=11.0_RC6
+export NETBSD_SDK_BASENAME="netbsd-${HOST}-${NETBSD_VERSION}"
+export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} lld-${APT_LLVM_V}"
+export SYSROOT="--sysroot=${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}"
+export DEP_OPTS="build_CC=clang build_CXX=clang++ \
+ CC='clang --target=${HOST} ${SYSROOT}' \
+ CXX='clang++ --target=${HOST} ${SYSROOT} -stdlib=libstdc++' \
+ LDFLAGS='-fuse-ld=lld -lgcc_s' \
+ AR=llvm-ar-${APT_LLVM_V} \
+ NM=llvm-nm-${APT_LLVM_V} \
+ OBJCOPY=llvm-objcopy-${APT_LLVM_V} \
+ OBJDUMP=llvm-objdump-${APT_LLVM_V} \
+ RANLIB=llvm-ranlib-${APT_LLVM_V} \
+ STRIP=llvm-strip-${APT_LLVM_V}"
+export GOAL="install"
+export BITCOIN_CONFIG="\
+ --preset=dev-mode \
+ -DBUILD_GUI=OFF \
+ -DREDUCE_EXPORTS=ON \
+ -DWITH_USDT=OFF \
+"
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -118,6 +118,17 @@ if [ -n "$XCODE_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${OSX_SDK_BASENAME}" ]
   tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
 fi
 
+if [ -n "$NETBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}" ]; then
+  mkdir -p "${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}"
+  for NETBSD_SDK_FILENAME in base.tar.xz comp.tar.xz; do
+    NETBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${NETBSD_SDK_FILENAME}"
+    if [ ! -f "$NETBSD_SDK_PATH" ]; then
+      ${CI_RETRY_EXE} curl --location --fail "https://cdn.netbsd.org/pub/NetBSD/NetBSD-${NETBSD_VERSION}/amd64/binary/sets/${NETBSD_SDK_FILENAME}" -o "$NETBSD_SDK_PATH"
+    fi
+    tar -C "${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}" -xf "$NETBSD_SDK_PATH"
+  done
+fi
+
 if [ -n "$FREEBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" ]; then
   FREEBSD_SDK_FILENAME="base-${FREEBSD_VERSION}.txz"
   FREEBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${FREEBSD_SDK_FILENAME}"

--- a/depends/hosts/netbsd.mk
+++ b/depends/hosts/netbsd.mk
@@ -1,5 +1,6 @@
 netbsd_CFLAGS=
 netbsd_CXXFLAGS=
+netbsd_LDFLAGS=
 
 ifneq ($(LTO),)
 netbsd_AR = $(host_toolchain)gcc-ar


### PR DESCRIPTION
This adds a Linux cross job for NetBSD; similar to https://github.com/bitcoin/bitcoin/pull/34491 (FreeBSD).

This uses the upcoming NetBSD 11.0 release (rc5).