### PR TITLE
iwyu: Fix warnings in `src/bench` and treat them as error

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -229,7 +229,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/(((crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|bench/(block_assemble|connectblock)|common/license_info|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/(((bench|crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|common/license_info|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -11,6 +11,7 @@
 #include <hash.h>
 #include <logging/timer.h>
 #include <netaddress.h>
+#include <netgroup.h>
 #include <protocol.h>
 #include <random.h>
 #include <serialize.h>

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -7,17 +7,21 @@
 #define BITCOIN_ADDRMAN_H
 
 #include <netaddress.h>
-#include <netgroup.h>
 #include <protocol.h>
-#include <streams.h>
 #include <util/time.h>
 
+#include <cstddef>
 #include <cstdint>
+#include <ios>
 #include <memory>
 #include <optional>
+#include <string>
+#include <tuple>
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
+class NetGroupManager;
 
 /** Over how many buckets entries with tried addresses from a single group (/16 for IPv4) are spread */
 static constexpr uint32_t ADDRMAN_TRIED_BUCKETS_PER_GROUP{8};

--- a/src/base58.h
+++ b/src/base58.h
@@ -14,8 +14,7 @@
 #ifndef BITCOIN_BASE58_H
 #define BITCOIN_BASE58_H
 
-#include <span.h>
-
+#include <span>
 #include <string>
 #include <vector>
 

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -14,8 +14,10 @@
 #ifndef BITCOIN_BECH32_H
 #define BITCOIN_BECH32_H
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace bech32

--- a/src/bench/addrman.cpp
+++ b/src/bench/addrman.cpp
@@ -10,13 +10,13 @@
 #include <netgroup.h>
 #include <protocol.h>
 #include <random.h>
-#include <span.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/time.h>
 
 #include <cstring>
 #include <optional>
+#include <span>
 #include <vector>
 
 /* A "source" is a source address from which we have received a bunch of other addresses. */

--- a/src/bench/asmap.cpp
+++ b/src/bench/asmap.cpp
@@ -8,10 +8,10 @@
 #include <node/data/ip_asn.dat.h>
 #include <random.h>
 #include <util/asmap.h>
+#include <util/check.h>
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <span>
 #include <string>
 

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -4,7 +4,6 @@
 
 #include <base58.h>
 #include <bench/bench.h>
-#include <span.h>
 
 #include <array>
 #include <cstring>

--- a/src/bench/bech32.cpp
+++ b/src/bench/bech32.cpp
@@ -6,6 +6,7 @@
 #include <bench/bench.h>
 #include <util/strencodings.h>
 
+#include <array>
 #include <vector>
 
 using namespace util::hex_literals;

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -7,8 +7,8 @@
 #include <test/util/setup_common.h> // IWYU pragma: keep
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/time.h>
 
-#include <chrono>
 #include <compare>
 #include <fstream>
 #include <functional>
@@ -18,8 +18,6 @@
 #include <string_view>
 #include <utility>
 #include <vector>
-
-using namespace std::chrono_literals;
 
 /**
  * Retrieves the available test setup command line arguments that may be used

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -68,9 +69,9 @@ BenchRunner::BenchmarkMap& BenchRunner::benchmarks()
     return benchmarks_map;
 }
 
-BenchRunner::BenchRunner(std::string name, BenchFunction func)
+BenchRunner::BenchRunner(std::string_view name, BenchFunction func)
 {
-    Assert(benchmarks().try_emplace(std::move(name), std::move(func)).second);
+    Assert(benchmarks().try_emplace(std::string{name}, std::move(func)).second);
 }
 
 void BenchRunner::RunAll(const Args& args)

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -8,8 +8,8 @@
 #include <bench/nanobench.h> // IWYU pragma: export
 #include <util/fs.h>
 #include <util/macros.h>
+#include <util/time.h>
 
-#include <chrono>
 #include <functional>
 #include <map>
 #include <string>

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 /*
@@ -58,7 +59,7 @@ class BenchRunner
     static BenchmarkMap& benchmarks();
 
 public:
-    BenchRunner(std::string name, BenchFunction func);
+    BenchRunner(std::string_view name, BenchFunction func);
 
     static void RunAll(const Args& args);
 };

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -3,19 +3,19 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <common/args.h>
 #include <crypto/sha256.h>
+#include <test/util/setup_common.h>
 #include <tinyformat.h>
 #include <util/fs.h>
-#include <util/string.h>
-#include <test/util/setup_common.h>
+#include <util/time.h>
 
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
+#include <optional>
 #include <sstream>
+#include <string>
 #include <vector>
 
 static const char* DEFAULT_BENCH_FILTER = ".*";

--- a/src/bench/bip324_ecdh.cpp
+++ b/src/bench/bip324_ecdh.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <span>
 
 static void BIP324_ECDH(benchmark::Bench& bench)
 {

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -12,13 +12,12 @@
 #include <test/util/mining.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <memory>
-#include <string>
 #include <vector>
 
 using node::BlockCreateOptions;

--- a/src/bench/blockencodings.cpp
+++ b/src/bench/blockencodings.cpp
@@ -7,15 +7,23 @@
 #include <consensus/amount.h>
 #include <kernel/cs_main.h>
 #include <net_processing.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <random.h>
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
+#include <uint256.h>
 #include <util/check.h>
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
 #include <memory>
+#include <span>
+#include <utility>
 #include <vector>
 
 

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -5,14 +5,16 @@
 #include <bench/bench.h>
 #include <coins.h>
 #include <consensus/amount.h>
+#include <consensus/validation.h>
 #include <key.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
 #include <test/util/transaction_utils.h>
+#include <util/check.h>
 
-#include <cassert>
+#include <span>
 #include <vector>
 
 // Microbenchmark for simple accesses to a CCoinsViewCache database. Note from

--- a/src/bench/chacha20.cpp
+++ b/src/bench/chacha20.cpp
@@ -2,15 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-
 #include <bench/bench.h>
 #include <crypto/chacha20.h>
 #include <crypto/chacha20poly1305.h>
-#include <span.h>
-#include <util/byte_units.h>
+// IWYU incorrectly suggests removing this header.
+// See https://github.com/include-what-you-use/include-what-you-use/issues/2014.
+#include <util/byte_units.h> // IWYU pragma: keep
 
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <vector>
 
 /* Number of bytes to process per iteration */

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -5,13 +5,17 @@
 #include <bench/bench.h>
 #include <bench/data/block413567.raw.h>
 #include <consensus/validation.h>
+#include <kernel/chainparams.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <serialize.h>
 #include <streams.h>
+#include <util/check.h>
 #include <validation.h>
 
-#include <cassert>
-#include <cstddef>
+#include <memory>
+#include <span>
+#include <vector>
 
 // These are the two major time-sinks which happen after we have fully received
 // a block off the wire, but before we can relay the block on to peers using

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -12,6 +12,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <vector>
 

--- a/src/bench/cluster_linearize.cpp
+++ b/src/bench/cluster_linearize.cpp
@@ -4,13 +4,18 @@
 
 #include <bench/bench.h>
 #include <cluster_linearize.h>
+#include <serialize.h>
+#include <streams.h>
 #include <test/util/cluster_linearize.h>
+#include <tinyformat.h>
 #include <util/bitset.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
-#include <algorithm>
-#include <cassert>
 #include <cstdint>
+#include <span>
+#include <string>
+#include <tuple>
 #include <vector>
 
 using namespace cluster_linearize;

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -4,8 +4,6 @@
 
 #include <bench/bench.h>
 #include <consensus/amount.h>
-#include <interfaces/chain.h>
-#include <node/context.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
@@ -13,19 +11,21 @@
 #include <random.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/result.h>
 #include <wallet/coinselection.h>
-#include <wallet/context.h>
+#include <wallet/db.h>
 #include <wallet/spend.h>
 #include <wallet/test/util.h>
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
-#include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
-#include <set>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/bench/connectblock.cpp
+++ b/src/bench/connectblock.cpp
@@ -17,13 +17,12 @@
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <validation.h>
 
-#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <optional>
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-
 #include <bench/bench.h>
 #include <crypto/muhash.h>
 #include <crypto/ripemd160.h>
@@ -12,11 +11,12 @@
 #include <crypto/sha512.h>
 #include <crypto/siphash.h>
 #include <random.h>
-#include <span.h>
 #include <tinyformat.h>
 #include <uint256.h>
 
 #include <cstdint>
+#include <span>
+#include <string>
 #include <vector>
 
 /* Number of bytes to hash per iteration */

--- a/src/bench/descriptors.cpp
+++ b/src/bench/descriptors.cpp
@@ -7,8 +7,8 @@
 #include <script/descriptor.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
+#include <util/check.h>
 
-#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/src/bench/disconnected_transactions.cpp
+++ b/src/bench/disconnected_transactions.cpp
@@ -8,13 +8,12 @@
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
-#include <memory>
 #include <vector>
 
 constexpr size_t BLOCK_VTX_COUNT{4000};

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -16,9 +16,9 @@
 #include <sync.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <validation.h>
 
-#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/src/bench/ellswift.cpp
+++ b/src/bench/ellswift.cpp
@@ -8,9 +8,10 @@
 #include <random.h>
 #include <span.h>
 #include <uint256.h>
+#include <util/check.h>
 
 #include <algorithm>
-#include <cassert>
+#include <span>
 
 static void EllSwiftCreate(benchmark::Bench& bench)
 {

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -13,17 +13,16 @@
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <script/script.h>
-#include <span.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/strencodings.h>
-#include <util/time.h>
 #include <validation.h>
 
-#include <cassert>
 #include <memory>
+#include <span>
 #include <vector>
 
 using namespace util::hex_literals;

--- a/src/bench/load_external.cpp
+++ b/src/bench/load_external.cpp
@@ -7,7 +7,6 @@
 #include <chainparams.h>
 #include <flatfile.h>
 #include <node/blockstorage.h>
-#include <span.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
@@ -18,8 +17,8 @@
 #include <cstdio>
 #include <map>
 #include <memory>
+#include <span>
 #include <stdexcept>
-#include <vector>
 
 /**
  * The LoadExternalBlockFile() function is used during -reindex and -loadblock.

--- a/src/bench/lockedpool.cpp
+++ b/src/bench/lockedpool.cpp
@@ -4,10 +4,12 @@
 
 #include <bench/bench.h>
 #include <support/lockedpool.h>
+// IWYU incorrectly suggests removing this header.
+// See https://github.com/include-what-you-use/include-what-you-use/issues/2014.
+#include <util/byte_units.h> // IWYU pragma: keep
 
 #include <cstddef>
 #include <cstdint>
-#include <util/byte_units.h>
 #include <vector>
 
 #define ASIZE 2048

--- a/src/bench/mempool_ephemeral_spends.cpp
+++ b/src/bench/mempool_ephemeral_spends.cpp
@@ -4,9 +4,10 @@
 
 #include <bench/bench.h>
 #include <consensus/amount.h>
+#include <consensus/validation.h>
 #include <kernel/cs_main.h>
 #include <policy/ephemeral_policy.h>
-#include <policy/policy.h>
+#include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <sync.h>
@@ -15,6 +16,7 @@
 #include <txmempool.h>
 #include <util/check.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -4,7 +4,6 @@
 
 #include <bench/bench.h>
 #include <consensus/amount.h>
-#include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <random.h>
 #include <script/script.h>
@@ -17,6 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 class CCoinsViewCache;

--- a/src/bench/merkle_root.cpp
+++ b/src/bench/merkle_root.cpp
@@ -6,8 +6,10 @@
 #include <consensus/merkle.h>
 #include <random.h>
 #include <uint256.h>
+#include <util/check.h>
 
-#include <cassert>
+#include <initializer_list>
+#include <utility>
 #include <vector>
 
 static void MerkleRoot(benchmark::Bench& bench)

--- a/src/bench/nanobench.h
+++ b/src/bench/nanobench.h
@@ -41,10 +41,19 @@
 
 #include <chrono>        // high_resolution_clock
 #include <cassert>       // assert
+#include <cstdint>
 #include <cstring>       // memcpy
+// IWYU will only see this header with ANKERL_NANOBENCH_IMPLEMENT defined, which
+// makes it suggest removing forward declarations for the Input/output library.
+// IWYU pragma: begin_keep
 #include <iosfwd>        // for std::ostream* custom output target in Config
+// IWYU pragma: end_keep
+#include <limits>
+#include <ratio>
 #include <string>        // all names
+#include <type_traits>
 #include <unordered_map> // holds context information of results
+#include <utility>
 #include <vector>        // holds all results
 
 #define ANKERL_NANOBENCH(x) ANKERL_NANOBENCH_PRIVATE_##x()
@@ -126,6 +135,11 @@
 #define ANKERL_NANOBENCH_PRIVATE_NOEXCEPT_STRING_MOVE() std::is_nothrow_move_assignable<std::string>::value
 
 // declarations ///////////////////////////////////////////////////////////////////////////////////
+
+// As definitions follow these declarations within this
+// header, IWYU considers some of them redundant and
+// suggests removing them. Disable this IWYU behavior.
+// IWYU pragma: begin_keep
 
 namespace ankerl {
 namespace nanobench {
@@ -369,6 +383,8 @@ class LinuxPerformanceCounters;
 } // namespace detail
 } // namespace nanobench
 } // namespace ankerl
+
+// IWYU pragma: end_keep
 
 // definitions ////////////////////////////////////////////////////////////////////////////////////
 
@@ -1359,12 +1375,15 @@ void doNotOptimizeAway(T const& val) {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 #    include <algorithm> // sort, reverse
-#    include <atomic>    // compare_exchange_strong in loop overhead
+#    include <cmath>
+#    include <compare>
 #    include <cstdlib>   // getenv
-#    include <cstring>   // strstr, strncmp
 #    include <fstream>   // ifstream to parse proc files
+#    include <functional>
 #    include <iomanip>   // setw, setprecision
 #    include <iostream>  // cout
+#    include <iterator>
+#    include <locale>
 #    include <numeric>   // accumulate
 #    include <random>    // random_device
 #    include <sstream>   // to_s in Number
@@ -1379,17 +1398,21 @@ void doNotOptimizeAway(T const& val) {
 #        include <linux/perf_event.h>
 #        include <sys/ioctl.h>
 #        include <sys/syscall.h>
+#        include <sys/types.h>
 #    endif
 
 // declarations ///////////////////////////////////////////////////////////////////////////////////
+
+// As definitions follow these declarations within this
+// header, IWYU considers some of them redundant and
+// suggests removing them. Disable this IWYU behavior.
+// IWYU pragma: begin_keep
 
 namespace ankerl {
 namespace nanobench {
 
 // helper stuff that is only intended to be used internally
 namespace detail {
-
-struct TableInfo;
 
 // formatting utilities
 namespace fmt {
@@ -1404,6 +1427,8 @@ class MarkDownCode;
 } // namespace detail
 } // namespace nanobench
 } // namespace ankerl
+
+// IWYU pragma: end_keep
 
 // definitions ////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/bench/obfuscation.cpp
+++ b/src/bench/obfuscation.cpp
@@ -7,6 +7,7 @@
 #include <util/obfuscation.h>
 
 #include <cstddef>
+#include <span>
 #include <vector>
 
 static void ObfuscationBench(benchmark::Bench& bench)

--- a/src/bench/parse_hex.cpp
+++ b/src/bench/parse_hex.cpp
@@ -4,11 +4,12 @@
 
 #include <bench/bench.h>
 #include <random.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
-#include <cassert>
 #include <cstddef>
 #include <optional>
+#include <string>
 #include <vector>
 
 std::string generateHexString(size_t length) {

--- a/src/bench/peer_eviction.cpp
+++ b/src/bench/peer_eviction.cpp
@@ -7,8 +7,8 @@
 #include <node/eviction.h>
 #include <random.h>
 #include <test/util/net.h>
+#include <util/time.h>
 
-#include <chrono>
 #include <functional>
 #include <vector>
 

--- a/src/bench/poly1305.cpp
+++ b/src/bench/poly1305.cpp
@@ -2,14 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-
 #include <bench/bench.h>
 #include <crypto/poly1305.h>
-#include <span.h>
-#include <util/byte_units.h>
+// IWYU incorrectly suggests removing this header.
+// See https://github.com/include-what-you-use/include-what-you-use/issues/2014.
+#include <util/byte_units.h> // IWYU pragma: keep
 
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <vector>
 
 /* Number of bytes to process per iteration */

--- a/src/bench/pool.cpp
+++ b/src/bench/pool.cpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 
 template <typename Map>
 void BenchFillClearMap(benchmark::Bench& bench, Map& map)

--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -9,6 +9,7 @@
 #include <serialize.h>
 #include <streams.h>
 
+#include <span>
 #include <type_traits>
 #include <vector>
 

--- a/src/bench/readwriteblock.cpp
+++ b/src/bench/readwriteblock.cpp
@@ -9,15 +9,16 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
-#include <span.h>
 #include <streams.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/check.h>
 #include <validation.h>
 
-#include <cassert>
-#include <cstdint>
 #include <memory>
-#include <vector>
+#include <optional>
+#include <span>
 
 static CBlock CreateTestBlock()
 {

--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -2,13 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-
 #include <bench/bench.h>
 #include <common/bloom.h>
 #include <crypto/common.h>
-#include <span.h>
 
 #include <cstdint>
+#include <span>
 #include <vector>
 
 static void RollingBloom(benchmark::Bench& bench)

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -5,21 +5,22 @@
 #include <bench/bench.h>
 #include <bench/data/block413567.raw.h>
 #include <chain.h>
+#include <consensus/params.h>
 #include <core_io.h>
+#include <kernel/chainparams.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <rpc/blockchain.h>
 #include <serialize.h>
-#include <span.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <univalue.h>
 #include <validation.h>
 
-#include <cstddef>
 #include <memory>
-#include <vector>
+#include <span>
+#include <string>
 
 namespace {
 

--- a/src/bench/sign_transaction.cpp
+++ b/src/bench/sign_transaction.cpp
@@ -8,17 +8,17 @@
 #include <key.h>
 #include <primitives/transaction.h>
 #include <pubkey.h>
+#include <random.h>
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
-#include <span.h>
-#include <test/util/random.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/translation.h>
 
-#include <cassert>
 #include <map>
+#include <span>
 #include <vector>
 
 enum class InputType {

--- a/src/bench/streams_findbyte.cpp
+++ b/src/bench/streams_findbyte.cpp
@@ -5,11 +5,13 @@
 #include <bench/bench.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/fs.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <memory>
 
 static void FindByte(benchmark::Bench& bench)
 {

--- a/src/bench/strencodings.cpp
+++ b/src/bench/strencodings.cpp
@@ -6,9 +6,10 @@
 #include <consensus/consensus.h>
 #include <crypto/hex_base.h>
 #include <random.h>
-#include <span.h>
-#include <util/strencodings.h>
 
+#include <cstddef>
+#include <span>
+#include <string>
 #include <vector>
 
 static void HexStrBench(benchmark::Bench& bench)

--- a/src/bench/txgraph.cpp
+++ b/src/bench/txgraph.cpp
@@ -5,10 +5,17 @@
 #include <bench/bench.h>
 #include <random.h>
 #include <txgraph.h>
+#include <util/check.h>
 #include <util/feefrac.h>
 
-#include <cassert>
+#include <algorithm>
+#include <compare>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/src/bench/txorphanage.cpp
+++ b/src/bench/txorphanage.cpp
@@ -3,19 +3,24 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <consensus/amount.h>
+#include <consensus/consensus.h>
+#include <consensus/validation.h>
 #include <net.h>
 #include <policy/policy.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
-#include <pubkey.h>
-#include <script/sign.h>
-#include <test/util/setup_common.h>
 #include <node/txorphanage.h>
-#include <util/check.h>
+#include <random.h>
 #include <test/util/transaction_utils.h>
+#include <threadsafety.h>
+#include <util/check.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <numeric>
+#include <vector>
 
 static constexpr node::TxOrphanage::Usage TINY_TX_WEIGHT{240};
 static constexpr int64_t APPROX_WEIGHT_PER_INPUT{200};

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -11,14 +11,19 @@
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/script_error.h>
+#include <script/sign.h>
+#include <script/signingprovider.h>
+#include <script/verify_flags.h>
 #include <span.h>
 #include <test/util/transaction_utils.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/translation.h>
 
-#include <array>
-#include <cassert>
-#include <cstdint>
+#include <cstddef>
+#include <map>
+#include <span>
 #include <vector>
 
 enum class ScriptType {

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -4,6 +4,7 @@
 
 #include <bench/bench.h>
 #include <interfaces/chain.h>
+#include <interfaces/handler.h>
 #include <kernel/chainparams.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -12,14 +13,14 @@
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
-#include <util/time.h>
+#include <util/check.h>
 #include <validation.h>
+#include <wallet/db.h>
 #include <wallet/receive.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
-#include <cassert>
 #include <memory>
 #include <optional>
 #include <string>

--- a/src/bench/wallet_create.cpp
+++ b/src/bench/wallet_create.cpp
@@ -4,9 +4,9 @@
 
 #include <bench/bench.h>
 #include <random.h>
-#include <support/allocators/secure.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/translation.h>
 #include <wallet/context.h>
@@ -14,7 +14,6 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
-#include <cassert>
 #include <memory>
 #include <optional>
 #include <string>

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -9,7 +9,6 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
-#include <interfaces/chain.h>
 #include <kernel/chain.h>
 #include <kernel/types.h>
 #include <node/blockstorage.h>
@@ -22,22 +21,24 @@
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/result.h>
-#include <util/time.h>
 #include <validation.h>
 #include <versionbits.h>
 #include <wallet/coincontrol.h>
 #include <wallet/coinselection.h>
+#include <wallet/db.h>
 #include <wallet/spend.h>
 #include <wallet/test/util.h>
+#include <wallet/types.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
-#include <cassert>
 #include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/bench/wallet_encrypt.cpp
+++ b/src/bench/wallet_encrypt.cpp
@@ -3,19 +3,29 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <key.h>
 #include <key_io.h>
-#include <outputtype.h>
 #include <random.h>
+#include <script/descriptor.h>
+#include <script/signingprovider.h>
 #include <support/allocators/secure.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
-#include <util/time.h>
+#include <util/check.h>
 #include <wallet/context.h>
+#include <wallet/crypter.h>
+#include <wallet/db.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
-#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace wallet {
 static void WalletEncrypt(benchmark::Bench& bench, unsigned int key_count)

--- a/src/bench/wallet_ismine.cpp
+++ b/src/bench/wallet_ismine.cpp
@@ -11,17 +11,19 @@
 #include <script/signingprovider.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <wallet/context.h>
 #include <wallet/db.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
-#include <cassert>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace wallet {
 static void WalletIsMine(benchmark::Bench& bench, int num_combo = 0)

--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -7,8 +7,10 @@
 #include <consensus/amount.h>
 #include <outputtype.h>
 #include <primitives/transaction.h>
+#include <script/script.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
+#include <util/translation.h>
 #include <wallet/context.h>
 #include <wallet/db.h>
 #include <wallet/test/util.h>
@@ -18,6 +20,8 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/bench/wallet_migration.cpp
+++ b/src/bench/wallet_migration.cpp
@@ -2,20 +2,34 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
+#include <addresstype.h>
 #include <bench/bench.h>
-#include <interfaces/chain.h>
+#include <consensus/amount.h>
 #include <interfaces/wallet.h>
-#include <kernel/chain.h>
-#include <kernel/types.h>
-#include <node/context.h>
-#include <test/util/mining.h>
+#include <key.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
-#include <wallet/context.h>
-#include <wallet/receive.h>
+#include <tinyformat.h>
+#include <util/check.h>
+#include <util/result.h>
+#include <wallet/db.h>
+#include <wallet/scriptpubkeyman.h>
 #include <wallet/test/util.h>
+#include <wallet/transaction.h>
 #include <wallet/wallet.h>
+#include <wallet/walletdb.h>
 
+#include <algorithm>
+#include <cstddef>
+#include <memory>
 #include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace wallet{
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -7,11 +7,11 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iterator>
+#include <new>
 #include <type_traits>
 #include <utility>
 

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -9,6 +9,7 @@
 #include <clientversion.h>
 #include <hash.h>
 #include <netbase.h>
+#include <netgroup.h>
 #include <random.h>
 #include <test/data/asmap.raw.h>
 #include <test/util/setup_common.h>


### PR DESCRIPTION
This PR addresses [this](https://github.com/bitcoin/bitcoin/pull/35011#discussion_r3323359707) comment:
> I had the impression I already fixed bench in https://github.com/bitcoin/bitcoin/pull/30716 two years ago, but I guess it isn't yet enforced.
>
> Could do that as a next step?

The first two commits act as prerequisites. See the commit messages for details.

The third commit additionally ensures that our drop-in header replacements are used instead of system headers:
- `util/check.h`:https://github.com/bitcoin/bitcoin/blob/10dfdd4b9fab578e43ba211325967cbc28cb6652/src/util/check.h#L11-L13
- `util/time.h`:https://github.com/bitcoin/bitcoin/blob/10dfdd4b9fab578e43ba211325967cbc28cb6652/src/util/time.h#L9-L10