### PR TITLE
ci: isolate container test networks

### DIFF
--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -211,6 +211,9 @@ def main():
         print("Stop and remove CI container by ID")
         run(["docker", "container", "kill", container_id])
 
+        print("Remove CI container networks")
+        run(["docker", "network", "rm", network_name], check=False)
+
 
 if __name__ == "__main__":
     main()

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -4,6 +4,8 @@
 # file COPYING or https://opensource.org/license/mit/.
 
 from pathlib import Path
+import hashlib
+import ipaddress
 import os
 import shlex
 import subprocess
@@ -20,6 +22,20 @@ def run(cmd, **kwargs):
         sys.exit(str(e))
 
 
+def get_container_network_config(container_name):
+    host_id = int.from_bytes(hashlib.sha256(container_name.encode()).digest()[:4], "big") % ((1 << 20) - 1) + 1
+
+    ip4_base = int(ipaddress.IPv4Address("11.0.0.0")) + (host_id << 4)
+    ip4_addr = ipaddress.IPv4Address(ip4_base + 5)
+    ip4_subnet = ipaddress.IPv4Network((ip4_base, 28))
+
+    ip6_base = int(ipaddress.IPv6Address("1111:2222::")) + (host_id << 16)
+    ip6_addr = ipaddress.IPv6Address(ip6_base + 5)
+    ip6_subnet = ipaddress.IPv6Network((ip6_base, 112))
+
+    return ip4_subnet, ip4_addr, ip6_subnet, ip6_addr
+
+
 def main():
     print("Export only allowed settings:")
     settings = run(
@@ -33,7 +49,14 @@ def main():
     settings.update([
         "BASE_BUILD_DIR",
         "CI_FAILFAST_TEST_LEAVE_DANGLING",
+        "BIND_TEST_ROUTABLE_IPV4",
+        "BIND_TEST_ROUTABLE_IPV6",
     ])
+
+    if not os.getenv("DANGER_RUN_CI_ON_HOST"):
+        ip4_subnet, ip4_addr, ip6_subnet, ip6_addr = get_container_network_config(os.environ["CONTAINER_NAME"])
+        os.environ["BIND_TEST_ROUTABLE_IPV4"] = str(ip4_addr)
+        os.environ["BIND_TEST_ROUTABLE_IPV6"] = str(ip6_addr)
 
     # Append $USER to /tmp/env to support multi-user systems and $CONTAINER_NAME
     # to allow support starting multiple runs simultaneously by the same user.
@@ -114,8 +137,8 @@ def main():
                 sys.exit(1)
             CI_CCACHE_MOUNT = f"type=bind,src={os.environ['CCACHE_DIR']},dst={os.environ['CCACHE_DIR']}"
 
-        run(["docker", "network", "create", "--ipv6", "--subnet", "1111:1111::/112", "ci-ip6net"], check=False)
-        run(["docker", "network", "create", "--subnet", "1.1.1.0/24", "ci-ip4net"], check=False)
+        network_name = f"{os.environ['CONTAINER_NAME']}-net"
+        run(["docker", "network", "create", "--ipv6", "--subnet", str(ip4_subnet), "--subnet", str(ip6_subnet), network_name], check=False)
 
         if os.getenv("RESTART_CI_DOCKER_BEFORE_RUN"):
             print("Restart docker before run to stop and clear all containers started with --rm")
@@ -144,8 +167,7 @@ def main():
             *CI_BUILD_MOUNT,
             f"--env-file={env_file}",
             f"--name={os.environ['CONTAINER_NAME']}",
-            "--network=ci-ip6net",
-            "--ip6=1111:1111::5", # Used by some of the tests, don't change it just here (keep them in sync).
+            "--network=none",
             f"--platform={os.environ['CI_IMAGE_PLATFORM']}",
             os.environ["CONTAINER_NAME"],
         ]
@@ -156,7 +178,7 @@ def main():
             text=True,
         ).stdout.strip()
 
-        run(["docker", "network", "connect", "--ip=1.1.1.5", "ci-ip4net", container_id]) # The IP address is used by some of the tests, don't change it just here (keep them in sync).
+        run(["docker", "network", "connect", f"--ip={os.environ['BIND_TEST_ROUTABLE_IPV4']}", f"--ip6={os.environ['BIND_TEST_ROUTABLE_IPV6']}", network_name, container_id])
 
     def ci_exec(cmd_inner, **kwargs):
         if os.getenv("DANGER_RUN_CI_ON_HOST"):

--- a/test/functional/feature_bind_port_discover.py
+++ b/test/functional/feature_bind_port_discover.py
@@ -6,6 +6,8 @@
 Test that -discover does not add all interfaces' addresses if we listen on only some of them
 """
 
+import os
+
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
 from test_framework.test_node import (
     FailedToStartError,
@@ -29,8 +31,8 @@ from test_framework.util import (
 # FreeBSD and MacOS:
 # ifconfig INTERFACE_NAME 1.1.1.5/32 alias && ifconfig INTERFACE_NAME inet6 1111:1111::5/128 alias  # to set up
 # ifconfig INTERFACE_NAME 1.1.1.5 -alias && ifconfig INTERFACE_NAME inet6 1111:1111::5 -alias       # to remove it, after the test
-ADDR1 = '1.1.1.5' # This and the address below are set in the CI environment, don't change it just here (keep them in sync).
-ADDR2 = '1111:1111::5'
+ADDR1 = os.getenv('BIND_TEST_ROUTABLE_IPV4', '1.1.1.5') # This and the address below are set in the CI environment, don't change it just here (keep them in sync).
+ADDR2 = os.getenv('BIND_TEST_ROUTABLE_IPV6', '1111:1111::5')
 
 class BindPortDiscoverTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/feature_bind_port_externalip.py
+++ b/test/functional/feature_bind_port_externalip.py
@@ -6,6 +6,8 @@
 Test that the proper port is used for -externalip=
 """
 
+import os
+
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
 from test_framework.test_node import (
     FailedToStartError,
@@ -24,7 +26,7 @@ from test_framework.util import assert_equal, p2p_port
 # FreeBSD and MacOS:
 # ifconfig INTERFACE_NAME 1.1.1.5/32 alias  # to set up
 # ifconfig INTERFACE_NAME 1.1.1.5 -alias  # to remove it, after the test
-ADDR = '1.1.1.5' # This is set in the CI environment, don't change it just here (keep them in sync).
+ADDR = os.getenv('BIND_TEST_ROUTABLE_IPV4', '1.1.1.5') # This is set in the CI environment, don't change it just here (keep them in sync).
 
 # array of tuples [arguments, expected port in localaddresses]
 EXPECTED = [


### PR DESCRIPTION
Fixes #35416

Local CI jobs currently share Docker networks while requesting fixed
routable addresses. That prevents two jobs from running at the same time
because the second container cannot claim the same static IPs. See
33362.

Name the networks "{container_name}-ipv[4|6]", using a subnet based on
the hash of their name, so each CI job gets a separate network while the
tests continue to see the addresses they expect.

Increment them to 11.x.x.x and 1111:2222:x to avoid hitting (existing) dangling networks on machines.

On successful runs, the networks are cleaned up. On failed runs they will remain (as they are being used by the failing container).