### PR TITLE
build: exclude mptest target from compile commands

### DIFF
--- a/cmake/libmultiprocess.cmake
+++ b/cmake/libmultiprocess.cmake
@@ -34,5 +34,5 @@ function(add_libmultiprocess subdir)
   # exclusion, tools like clang-tidy and IWYU that make use of compilation
   # database would complain that the generated c++ source files do not exist. An
   # alternate fix could build "mpexamples" by default like "mptests" above.
-  set_target_properties(mpcalculator mpprinter mpexample PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+  set_target_properties(mpcalculator mpprinter mpexample mptest PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 endfunction()


### PR DESCRIPTION
Fixes #35361

The `mptest` target includes generated `.capnp.h` files that don't exist
at CMake configure time. When IWYU reads `compile_commands.json`, it sees
these non-existent files and fails.

This PR excludes the `mptest` target from the compilation database by
setting `EXPORT_COMPILE_COMMANDS OFF`, following the same pattern already
applied to the `mpcalculator`, `mpprinter`, and `mpexample` targets in the
same file.

This change belongs in `cmake/libmultiprocess.cmake` (the integration layer).