### PR TITLE
musig: Reject partial sig without generated secnonce

### DIFF
--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -163,6 +163,10 @@ std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& 
 
 std::optional<uint256> CreateMuSig2PartialSig(const uint256& sighash, const CKey& our_seckey, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys, const std::map<CPubKey, std::vector<uint8_t>>& pubnonces, MuSig2SecNonce& secnonce, const std::vector<std::pair<uint256, bool>>& tweaks)
 {
+    if (!secnonce.HasNonce()) {
+        return std::nullopt;
+    }
+
     secp256k1_keypair keypair;
     if (!secp256k1_keypair_create(GetSecp256k1SignContext(), &keypair, UCharCast(our_seckey.begin()))) return std::nullopt;
 

--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -100,7 +100,6 @@ public:
 
     secp256k1_musig_secnonce* Get() const { return m_nonce.get(); }
     void Invalidate() { m_nonce.reset(); }
-    bool IsValid() { return m_nonce != nullptr; }
 };
 
 MuSig2SecNonce::MuSig2SecNonce() : m_impl{std::make_unique<MuSig2SecNonceImpl>()} {}
@@ -117,12 +116,8 @@ secp256k1_musig_secnonce* MuSig2SecNonce::Get() const
 
 void MuSig2SecNonce::Invalidate()
 {
-    return m_impl->Invalidate();
-}
-
-bool MuSig2SecNonce::IsValid()
-{
-    return m_impl->IsValid();
+    m_has_nonce = false;
+    m_impl->Invalidate();
 }
 
 uint256 MuSig2SessionID(const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256& sighash)
@@ -162,6 +157,7 @@ std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& 
         return {};
     }
 
+    secnonce.m_has_nonce = true;
     return out;
 }
 

--- a/src/musig.h
+++ b/src/musig.h
@@ -33,10 +33,16 @@ CExtPubKey CreateMuSig2SyntheticXpub(const CPubKey& pubkey);
  * The secret nonce must be kept a secret, otherwise the private key may be leaked.
  * As such, it needs to be treated in the same way that CKeys are treated.
  * So this class handles the secure allocation of the secp256k1_musig_secnonce object
- * that libsecp256k1 uses, and only gives out references to this object to avoid
- * any possibility of copies being made. Furthermore, objects of this class are not
- * copyable to avoid nonce reuse.
-*/
+ * that libsecp256k1 uses. Furthermore, objects of this class are not copyable to
+ * avoid nonce reuse.
+ *
+ * Use CreateMuSig2Nonce and CreateMuSig2PartialSig for signing. Get() exposes the
+ * underlying libsecp256k1 object and must not be used for signing outside those
+ * helpers.
+ *
+ * HasNonce() is true only after a successful CreateMuSig2Nonce on this object, and
+ * false after Invalidate() (e.g. following CreateMuSig2PartialSig).
+ */
 class MuSig2SecNonce
 {
     friend std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& sighash, const CKey& our_seckey, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys);

--- a/src/musig.h
+++ b/src/musig.h
@@ -39,8 +39,11 @@ CExtPubKey CreateMuSig2SyntheticXpub(const CPubKey& pubkey);
 */
 class MuSig2SecNonce
 {
+    friend std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& sighash, const CKey& our_seckey, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys);
+
 private:
     std::unique_ptr<MuSig2SecNonceImpl> m_impl;
+    bool m_has_nonce{false};
 
 public:
     MuSig2SecNonce();
@@ -54,7 +57,8 @@ public:
 
     secp256k1_musig_secnonce* Get() const;
     void Invalidate();
-    bool IsValid();
+    //! True after a successful CreateMuSig2Nonce until Invalidate().
+    bool HasNonce() const { return m_has_nonce; }
 };
 
 uint256 MuSig2SessionID(const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256& sighash);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -172,15 +172,15 @@ bool MutableTransactionSignatureCreator::CreateMuSig2PartialSig(const SigningPro
     // Retrieve the secnonce
     uint256 session_id = MuSig2SessionID(script_pubkey, part_pubkey, *sighash);
     std::optional<std::reference_wrapper<MuSig2SecNonce>> secnonce = provider.GetMuSig2SecNonce(session_id);
-    if (!secnonce || !secnonce->get().IsValid()) return false;
+    if (!secnonce || !secnonce->get().HasNonce()) return false;
 
     // Compute the sig
     std::optional<uint256> sig = ::CreateMuSig2PartialSig(*sighash, key, aggregate_pubkey, pubkeys, pubnonces, *secnonce, tweaks);
     if (!sig) return false;
     partial_sig = std::move(*sig);
 
-    // Delete the secnonce now that we're done with it
-    assert(!secnonce->get().IsValid());
+    // Delete the MuSig2 session from the provider now that the secnonce is invalidated
+    assert(!secnonce->get().HasNonce());
     provider.DeleteMuSig2Session(session_id);
 
     return true;

--- a/src/test/bip328_tests.cpp
+++ b/src/test/bip328_tests.cpp
@@ -11,6 +11,7 @@
 #include <util/strencodings.h>
 #include <crypto/hex_base.h>
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -113,6 +114,32 @@ BOOST_AUTO_TEST_CASE(invalid_key)
     // Aggregate public keys
     std::optional<CPubKey> m_aggregate_pubkey = MuSig2AggregatePubkeys(pubkeys);
     BOOST_CHECK_MESSAGE(!m_aggregate_pubkey.has_value(), "Aggregate key with an invalid public key is null");
+}
+
+BOOST_AUTO_TEST_CASE(partial_sig_requires_generated_secnonce)
+{
+    const std::vector<std::string> hex_pubkeys{
+        "03935F972DA013F80AE011890FA89B67A27B7BE6CCB24D3274D18B2D4067F261A9",
+        "02F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9",
+    };
+    std::vector<CPubKey> pubkeys;
+    for (const auto& hex_pubkey : hex_pubkeys) {
+        const std::vector<unsigned char> data{ParseHex(hex_pubkey)};
+        pubkeys.emplace_back(data.begin(), data.end());
+    }
+
+    const std::optional<CPubKey> aggregate{MuSig2AggregatePubkeys(pubkeys)};
+    BOOST_REQUIRE(aggregate.has_value());
+
+    CKey key;
+    key.MakeNewKey(true);
+
+    MuSig2SecNonce secnonce;
+    BOOST_CHECK(!secnonce.HasNonce());
+    const std::map<CPubKey, std::vector<uint8_t>> pubnonces;
+    const std::optional<uint256> partial_sig{CreateMuSig2PartialSig(
+        uint256::ZERO, key, *aggregate, pubkeys, pubnonces, secnonce, {})};
+    BOOST_CHECK(!partial_sig.has_value());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- Replace `MuSig2SecNonce::IsValid()` with `HasNonce()`, set only after a successful `CreateMuSig2Nonce` and cleared by `Invalidate()`.
- Reject `CreateMuSig2PartialSig` when the secnonce was never generated, and guard the signing provider path in `MutableTransactionSignatureCreator::CreateMuSig2PartialSig`.
- Document the intended signing API on `MuSig2SecNonce` and add a unit test.

Previously `IsValid()` only checked that secure memory was allocated, not that nonce generation succeeded. A caller could reach partial signing with an uninitialized secnonce.

## Test plan

- [ ] `build/bin/test_bitcoin --run_test=bip328_tests`
- [ ] `build/bin/test_bitcoin --run_test=psbt_tests` (unchanged behavior, sanity)
- [ ] Manual MuSig2 PSBT signing flow still works end-to-end