### PR TITLE
musig: Require generated secnonce for partial sig

### DIFF
--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -84,12 +84,14 @@ CExtPubKey CreateMuSig2SyntheticXpub(const CPubKey& pubkey)
 
 class MuSig2SecNonceImpl
 {
+    friend std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& sighash, const CKey& our_seckey, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys);
+
 private:
     //! The actual secnonce itself
     secure_unique_ptr<secp256k1_musig_secnonce> m_nonce;
 
 public:
-    MuSig2SecNonceImpl() : m_nonce{make_secure_unique<secp256k1_musig_secnonce>()} {}
+    MuSig2SecNonceImpl() = default;
 
     // Delete copy constructors
     MuSig2SecNonceImpl(const MuSig2SecNonceImpl&) = delete;
@@ -97,7 +99,7 @@ public:
 
     secp256k1_musig_secnonce* Get() const { return m_nonce.get(); }
     void Invalidate() { m_nonce.reset(); }
-    bool IsValid() { return m_nonce != nullptr; }
+    bool IsValid() const { return m_nonce != nullptr; }
 };
 
 MuSig2SecNonce::MuSig2SecNonce() : m_impl{std::make_unique<MuSig2SecNonceImpl>()} {}
@@ -114,10 +116,10 @@ secp256k1_musig_secnonce* MuSig2SecNonce::Get() const
 
 void MuSig2SecNonce::Invalidate()
 {
-    return m_impl->Invalidate();
+    m_impl->Invalidate();
 }
 
-bool MuSig2SecNonce::IsValid()
+bool MuSig2SecNonce::IsValid() const
 {
     return m_impl->IsValid();
 }
@@ -147,8 +149,9 @@ std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& 
     GetStrongRandBytes(rand);
 
     // Generate nonce
+    secure_unique_ptr<secp256k1_musig_secnonce> generated_nonce = make_secure_unique<secp256k1_musig_secnonce>();
     secp256k1_musig_pubnonce pubnonce;
-    if (!secp256k1_musig_nonce_gen(GetSecp256k1SignContext(), secnonce.Get(), &pubnonce, rand.data(), UCharCast(our_seckey.begin()), &pubkey, sighash.data(), &keyagg_cache, nullptr)) {
+    if (!secp256k1_musig_nonce_gen(GetSecp256k1SignContext(), generated_nonce.get(), &pubnonce, rand.data(), UCharCast(our_seckey.begin()), &pubkey, sighash.data(), &keyagg_cache, nullptr)) {
         return {};
     }
 
@@ -159,11 +162,16 @@ std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& 
         return {};
     }
 
+    secnonce.m_impl->m_nonce = std::move(generated_nonce);
     return out;
 }
 
 std::optional<uint256> CreateMuSig2PartialSig(const uint256& sighash, const CKey& our_seckey, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys, const std::map<CPubKey, std::vector<uint8_t>>& pubnonces, MuSig2SecNonce& secnonce, const std::vector<std::pair<uint256, bool>>& tweaks)
 {
+    if (!secnonce.IsValid()) {
+        return std::nullopt;
+    }
+
     secp256k1_keypair keypair;
     if (!secp256k1_keypair_create(GetSecp256k1SignContext(), &keypair, UCharCast(our_seckey.begin()))) return std::nullopt;
 

--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -87,12 +87,14 @@ CExtPubKey CreateMuSig2SyntheticXpub(const CPubKey& pubkey)
 
 class MuSig2SecNonceImpl
 {
+    friend std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& sighash, const CKey& our_seckey, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys);
+
 private:
     //! The actual secnonce itself
     secure_unique_ptr<secp256k1_musig_secnonce> m_nonce;
 
 public:
-    MuSig2SecNonceImpl() : m_nonce{make_secure_unique<secp256k1_musig_secnonce>()} {}
+    MuSig2SecNonceImpl() = default;
 
     // Delete copy constructors
     MuSig2SecNonceImpl(const MuSig2SecNonceImpl&) = delete;
@@ -100,7 +102,7 @@ public:
 
     secp256k1_musig_secnonce* Get() const { return m_nonce.get(); }
     void Invalidate() { m_nonce.reset(); }
-    bool IsValid() { return m_nonce != nullptr; }
+    bool IsValid() const { return m_nonce != nullptr; }
 };
 
 MuSig2SecNonce::MuSig2SecNonce() : m_impl{std::make_unique<MuSig2SecNonceImpl>()} {}
@@ -117,10 +119,10 @@ secp256k1_musig_secnonce* MuSig2SecNonce::Get() const
 
 void MuSig2SecNonce::Invalidate()
 {
-    return m_impl->Invalidate();
+    m_impl->Invalidate();
 }
 
-bool MuSig2SecNonce::IsValid()
+bool MuSig2SecNonce::IsValid() const
 {
     return m_impl->IsValid();
 }
@@ -150,8 +152,9 @@ std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& 
     GetStrongRandBytes(rand);
 
     // Generate nonce
+    secure_unique_ptr<secp256k1_musig_secnonce> generated_nonce = make_secure_unique<secp256k1_musig_secnonce>();
     secp256k1_musig_pubnonce pubnonce;
-    if (!secp256k1_musig_nonce_gen(GetSecp256k1SignContext(), secnonce.Get(), &pubnonce, rand.data(), UCharCast(our_seckey.begin()), &pubkey, sighash.data(), &keyagg_cache, nullptr)) {
+    if (!secp256k1_musig_nonce_gen(GetSecp256k1SignContext(), generated_nonce.get(), &pubnonce, rand.data(), UCharCast(our_seckey.begin()), &pubkey, sighash.data(), &keyagg_cache, nullptr)) {
         return {};
     }
 
@@ -162,11 +165,16 @@ std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& 
         return {};
     }
 
+    secnonce.m_impl->m_nonce = std::move(generated_nonce);
     return out;
 }
 
 std::optional<uint256> CreateMuSig2PartialSig(const uint256& sighash, const CKey& our_seckey, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys, const std::map<CPubKey, std::vector<uint8_t>>& pubnonces, MuSig2SecNonce& secnonce, const std::vector<std::pair<uint256, bool>>& tweaks)
 {
+    if (!secnonce.IsValid()) {
+        return std::nullopt;
+    }
+
     secp256k1_keypair keypair;
     if (!secp256k1_keypair_create(GetSecp256k1SignContext(), &keypair, UCharCast(our_seckey.begin()))) return std::nullopt;
 

--- a/src/musig.h
+++ b/src/musig.h
@@ -35,10 +35,13 @@ CExtPubKey CreateMuSig2SyntheticXpub(const CPubKey& pubkey);
  * So this class handles the secure allocation of the secp256k1_musig_secnonce object
  * that libsecp256k1 uses, and only gives out references to this object to avoid
  * any possibility of copies being made. Furthermore, objects of this class are not
- * copyable to avoid nonce reuse.
+ * copyable to avoid nonce reuse, and the secret nonce is populated only by
+ * CreateMuSig2Nonce until Invalidate() clears it (including after CreateMuSig2PartialSig).
 */
 class MuSig2SecNonce
 {
+    friend std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256& sighash, const CKey& our_seckey, const CPubKey& aggregate_pubkey, const std::vector<CPubKey>& pubkeys);
+
 private:
     std::unique_ptr<MuSig2SecNonceImpl> m_impl;
 
@@ -54,7 +57,8 @@ public:
 
     secp256k1_musig_secnonce* Get() const;
     void Invalidate();
-    bool IsValid();
+    //! True after a successful CreateMuSig2Nonce. False after Invalidate().
+    bool IsValid() const;
 };
 
 /**

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -174,7 +174,7 @@ bool MutableTransactionSignatureCreator::CreateMuSig2PartialSig(const SigningPro
     if (part_pubnonce_it == pubnonces.end()) return false;
     uint256 session_id = MuSig2SessionID(script_pubkey, part_pubkey, *sighash, part_pubnonce_it->second);
     std::optional<std::reference_wrapper<MuSig2SecNonce>> secnonce = provider.GetMuSig2SecNonce(session_id);
-    if (!secnonce || !secnonce->get().IsValid()) return false;
+    if (!secnonce) return false;
 
     // Compute the sig
     std::optional<uint256> sig = ::CreateMuSig2PartialSig(*sighash, key, aggregate_pubkey, pubkeys, pubnonces, *secnonce, tweaks);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -175,7 +175,7 @@ bool MutableTransactionSignatureCreator::CreateMuSig2PartialSig(const SigningPro
     if (part_pubnonce_it == pubnonces.end()) return false;
     uint256 session_id = MuSig2SessionID(script_pubkey, part_pubkey, *sighash, part_pubnonce_it->second);
     std::optional<std::reference_wrapper<MuSig2SecNonce>> secnonce = provider.GetMuSig2SecNonce(session_id);
-    if (!secnonce || !secnonce->get().IsValid()) return false;
+    if (!secnonce) return false;
 
     // Compute the sig
     std::optional<uint256> sig = ::CreateMuSig2PartialSig(*sighash, key, aggregate_pubkey, pubkeys, pubnonces, *secnonce, tweaks);

--- a/src/test/bip328_tests.cpp
+++ b/src/test/bip328_tests.cpp
@@ -11,6 +11,7 @@
 #include <util/strencodings.h>
 #include <crypto/hex_base.h>
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -113,6 +114,35 @@ BOOST_AUTO_TEST_CASE(invalid_key)
     // Aggregate public keys
     std::optional<CPubKey> m_aggregate_pubkey = MuSig2AggregatePubkeys(pubkeys);
     BOOST_CHECK_MESSAGE(!m_aggregate_pubkey.has_value(), "Aggregate key with an invalid public key is null");
+}
+
+BOOST_AUTO_TEST_CASE(secnonce_lifecycle)
+{
+    CKey key1;
+    CKey key2;
+    key1.MakeNewKey(true);
+    key2.MakeNewKey(true);
+    const std::vector<CPubKey> pubkeys{key1.GetPubKey(), key2.GetPubKey()};
+    const CPubKey aggregate_pubkey = MuSig2AggregatePubkeys(pubkeys).value();
+    const uint256 sighash{uint256::ZERO};
+    MuSig2SecNonce secnonce;
+    BOOST_CHECK(!secnonce.IsValid());
+
+    const std::vector<uint8_t> pubnonce1{CreateMuSig2Nonce(secnonce, sighash, key1, aggregate_pubkey, pubkeys)};
+    BOOST_CHECK(secnonce.IsValid());
+
+    MuSig2SecNonce cosigner_secnonce;
+    const std::vector<uint8_t> pubnonce2{CreateMuSig2Nonce(cosigner_secnonce, sighash, key2, aggregate_pubkey, pubkeys)};
+    const std::map<CPubKey, std::vector<uint8_t>> pubnonces{
+        {key1.GetPubKey(), pubnonce1},
+        {key2.GetPubKey(), pubnonce2},
+    };
+
+    MuSig2SecNonce fresh_secnonce;
+    BOOST_CHECK(!CreateMuSig2PartialSig(sighash, key1, aggregate_pubkey, pubkeys, pubnonces, fresh_secnonce, {}).has_value());
+
+    BOOST_CHECK(CreateMuSig2PartialSig(sighash, key1, aggregate_pubkey, pubkeys, pubnonces, secnonce, {}).has_value());
+    BOOST_CHECK(!secnonce.IsValid());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Previously, `MuSig2SecNonce` pre-allocated secure memory in its constructor, so `IsValid()` was true before `secp256k1_musig_nonce_gen` ran. `secp256k1_musig_partial_sign` could be reached with an uninitialized `secp256k1_musig_secnonce` causing `libsecp` to crash.

This patch defers secure allocation until `CreateMuSig2Nonce` succeeds, guards `CreateMuSig2PartialSig` when no `secnonce` was generated, and adds a unit test for the lifecycle.

## Test plan

`/build/bin/test_bitcoin --run_test=bip328_tests/secnonce_lifecycle`