### PR TITLE
rest: use empty() instead of size()/length() comparisons

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -162,7 +162,7 @@ static std::string AvailableDataFormatsString()
         }
     }
 
-    if (formats.length() > 0)
+    if (!formats.empty())
         return formats.substr(0, formats.length() - 2);
 
     return formats;
@@ -910,7 +910,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
 
     // throw exception in case of an empty request
     std::string strRequestMutable = req->ReadBody();
-    if (strRequestMutable.length() == 0 && uriParts.size() == 0)
+    if (strRequestMutable.empty() && uriParts.empty())
         return RESTERR(req, HTTP_BAD_REQUEST, "Error: empty request");
 
     bool fInputParsed = false;
@@ -920,7 +920,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
     // parse/deserialize input
     // input-format = output-format, rest/getutxos/bin requires binary input, gives binary output, ...
 
-    if (uriParts.size() > 0)
+    if (!uriParts.empty())
     {
         //inputs is sent over URI scheme (/rest/getutxos/checkmempool/txid1-n/txid2-n/...)
         if (uriParts[0] == "checkmempool") fCheckMemPool = true;
@@ -941,7 +941,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
             vOutPoints.emplace_back(*txid, *output);
         }
 
-        if (vOutPoints.size() > 0)
+        if (!vOutPoints.empty())
             fInputParsed = true;
         else
             return RESTERR(req, HTTP_BAD_REQUEST, "Error: empty request");
@@ -958,7 +958,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
     case RESTResponseFormat::BINARY: {
         try {
             //deserialize only if user sent a request
-            if (strRequestMutable.size() > 0)
+            if (!strRequestMutable.empty())
             {
                 if (fInputParsed) //don't allow sending input over URI and HTTP RAW DATA
                     return RESTERR(req, HTTP_BAD_REQUEST, "Combination of URI scheme inputs and raw post data is not allowed");


### PR DESCRIPTION
Replace several `.size() == 0`, `.size() > 0`, `.length() == 0` and `.length() > 0` emptiness checks in src/rest.cpp with the more idiomatic and self-documenting `empty()` / `!empty()`.

This is a behaviour-preserving cleanup.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
