### PR TITLE
wallet: avoid global access in external signer SPKM

### DIFF
--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparams.h>
-#include <common/args.h>
 #include <common/system.h>
 #include <external_signer.h>
 #include <node/types.h>
@@ -21,14 +19,14 @@
 using common::PSBTError;
 
 namespace wallet {
-std::unique_ptr<ExternalSignerScriptPubKeyMan> ExternalSignerScriptPubKeyMan::LoadFromStorage(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const KeyMap& keys, const CryptedKeyMap& ckeys)
+std::unique_ptr<ExternalSignerScriptPubKeyMan> ExternalSignerScriptPubKeyMan::LoadFromStorage(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const KeyMap& keys, const CryptedKeyMap& ckeys, const std::string& external_signer_command, const std::string& external_signer_chain)
 {
-    return std::unique_ptr<ExternalSignerScriptPubKeyMan>(new ExternalSignerScriptPubKeyMan(storage, descriptor, keypool_size, keys, ckeys));
+    return std::unique_ptr<ExternalSignerScriptPubKeyMan>(new ExternalSignerScriptPubKeyMan(storage, descriptor, keypool_size, keys, ckeys, external_signer_command, external_signer_chain));
 }
 
-std::unique_ptr<ExternalSignerScriptPubKeyMan> ExternalSignerScriptPubKeyMan::CreateNew(WalletStorage& storage, WalletBatch& batch, int64_t keypool_size, std::unique_ptr<Descriptor> desc)
+std::unique_ptr<ExternalSignerScriptPubKeyMan> ExternalSignerScriptPubKeyMan::CreateNew(WalletStorage& storage, WalletBatch& batch, int64_t keypool_size, std::unique_ptr<Descriptor> desc, const std::string& external_signer_command, const std::string& external_signer_chain)
 {
-    auto spkm = std::unique_ptr<ExternalSignerScriptPubKeyMan>(new ExternalSignerScriptPubKeyMan(storage, keypool_size));
+    auto spkm = std::unique_ptr<ExternalSignerScriptPubKeyMan>(new ExternalSignerScriptPubKeyMan(storage, keypool_size, external_signer_command, external_signer_chain));
 
     LOCK(spkm->cs_desc_man);
     assert(storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
@@ -52,11 +50,11 @@ std::unique_ptr<ExternalSignerScriptPubKeyMan> ExternalSignerScriptPubKeyMan::Cr
     return spkm;
 }
 
- util::Result<ExternalSigner> ExternalSignerScriptPubKeyMan::GetExternalSigner() {
-    const std::string command = gArgs.GetArg("-signer", "");
+util::Result<ExternalSigner> ExternalSignerScriptPubKeyMan::GetExternalSigner(const std::string& command, const std::string& chain)
+{
     if (command == "") return util::Error{Untranslated("restart bitcoind with -signer=<cmd>")};
     std::vector<ExternalSigner> signers;
-    ExternalSigner::Enumerate(command, signers, Params().GetChainTypeString());
+    ExternalSigner::Enumerate(command, signers, chain);
     if (signers.empty()) return util::Error{Untranslated("No external signers found")};
     // TODO: add fingerprint argument instead of failing in case of multiple signers.
     if (signers.size() > 1) return util::Error{Untranslated("More than one external signer found. Please connect only one at a time.")};
@@ -99,7 +97,7 @@ std::optional<PSBTError> ExternalSignerScriptPubKeyMan::FillPSBT(PartiallySigned
     }
     if (complete) return {};
 
-    auto signer{GetExternalSigner()};
+    auto signer{GetExternalSigner(m_external_signer_command, m_external_signer_chain)};
     if (!signer) {
         LogWarning("%s", util::ErrorString(signer).original);
         return PSBTError::EXTERNAL_SIGNER_NOT_FOUND;

--- a/src/wallet/external_signer_scriptpubkeyman.h
+++ b/src/wallet/external_signer_scriptpubkeyman.h
@@ -8,6 +8,7 @@
 #include <wallet/scriptpubkeyman.h>
 
 #include <memory>
+#include <string>
 #include <util/result.h>
 
 struct bilingual_str;
@@ -16,28 +17,36 @@ namespace wallet {
 class ExternalSignerScriptPubKeyMan : public DescriptorScriptPubKeyMan
 {
 private:
+    std::string m_external_signer_command;
+    std::string m_external_signer_chain;
+
     //! Create an ExternalSPKM from existing wallet data
-    ExternalSignerScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const KeyMap& keys, const CryptedKeyMap& ckeys)
-        : DescriptorScriptPubKeyMan(storage, descriptor, keypool_size, keys, ckeys)
+    ExternalSignerScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const KeyMap& keys, const CryptedKeyMap& ckeys, const std::string& external_signer_command, const std::string& external_signer_chain)
+        : DescriptorScriptPubKeyMan(storage, descriptor, keypool_size, keys, ckeys),
+          m_external_signer_command{external_signer_command},
+          m_external_signer_chain{external_signer_chain}
     {}
 
-    ExternalSignerScriptPubKeyMan(WalletStorage& storage, int64_t keypool_size)
-        : DescriptorScriptPubKeyMan(storage, keypool_size)
+    ExternalSignerScriptPubKeyMan(WalletStorage& storage, int64_t keypool_size, const std::string& external_signer_command, const std::string& external_signer_chain)
+        : DescriptorScriptPubKeyMan(storage, keypool_size),
+          m_external_signer_command{external_signer_command},
+          m_external_signer_chain{external_signer_chain}
     {}
 
 public:
-    static std::unique_ptr<ExternalSignerScriptPubKeyMan> LoadFromStorage(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const KeyMap& keys, const CryptedKeyMap& ckeys);
-    static std::unique_ptr<ExternalSignerScriptPubKeyMan> CreateNew(WalletStorage& storage, WalletBatch& batch, int64_t keypool_size, std::unique_ptr<Descriptor> desc);
+    static std::unique_ptr<ExternalSignerScriptPubKeyMan> LoadFromStorage(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const KeyMap& keys, const CryptedKeyMap& ckeys, const std::string& external_signer_command, const std::string& external_signer_chain);
+    static std::unique_ptr<ExternalSignerScriptPubKeyMan> CreateNew(WalletStorage& storage, WalletBatch& batch, int64_t keypool_size, std::unique_ptr<Descriptor> desc, const std::string& external_signer_command, const std::string& external_signer_chain);
 
-  static util::Result<ExternalSigner> GetExternalSigner();
+    //! Find the external signer for the given command (the -signer arg) and chain.
+    static util::Result<ExternalSigner> GetExternalSigner(const std::string& command, const std::string& chain);
 
-  /**
-  * Display address on the device and verify that the returned value matches.
-  * @returns nothing or an error message
-  */
- util::Result<void> DisplayAddress(const CTxDestination& dest, const ExternalSigner& signer) const;
+    /**
+    * Display address on the device and verify that the returned value matches.
+    * @returns nothing or an error message
+    */
+    util::Result<void> DisplayAddress(const CTxDestination& dest, const ExternalSigner& signer) const;
 
-  std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed = nullptr) const override;
+    std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed = nullptr) const override;
 };
 } // namespace wallet
 #endif // BITCOIN_WALLET_EXTERNAL_SIGNER_SCRIPTPUBKEYMAN_H

--- a/src/wallet/test/scriptpubkeyman_tests.cpp
+++ b/src/wallet/test/scriptpubkeyman_tests.cpp
@@ -2,11 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <external_signer.h>
 #include <key.h>
 #include <key_io.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <script/solver.h>
+#include <wallet/external_signer_scriptpubkeyman.h>
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/wallet.h>
 #include <wallet/test/util.h>
@@ -48,6 +50,15 @@ BOOST_AUTO_TEST_CASE(desc_spkm_topup_fail)
     BOOST_CHECK_EXCEPTION(
         CreateDescriptor(keystore, "wpkh(" + EncodeExtPubKey(extkey.Neuter()) + "/*h)", /*success=*/true),
         std::runtime_error, HasReason("Could not top up scriptPubKeys"));
+}
+
+BOOST_AUTO_TEST_CASE(external_signer_command_required)
+{
+    // With no command configured (empty -signer), GetExternalSigner reports that one is
+    // needed and returns before attempting to launch any external process.
+    const auto res = ExternalSignerScriptPubKeyMan::GetExternalSigner(/*command=*/"", /*chain=*/"regtest");
+    BOOST_CHECK(!res);
+    BOOST_CHECK_EQUAL(util::ErrorString(res).original, "restart bitcoind with -signer=<cmd>");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2723,7 +2723,7 @@ util::Result<void> CWallet::DisplayAddress(const CTxDestination& dest)
         if (signer_spk_man == nullptr) {
             continue;
         }
-        auto signer{ExternalSignerScriptPubKeyMan::GetExternalSigner()};
+        auto signer{ExternalSignerScriptPubKeyMan::GetExternalSigner(m_external_signer_command, m_external_signer_chain)};
         if (!signer) throw std::runtime_error(util::ErrorString(signer).original);
         return signer_spk_man->DisplayAddress(dest, *signer);
     }
@@ -2989,6 +2989,11 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
         }
         wallet->m_default_change_type = parsed.value();
     }
+
+    // Capture external signer settings here so signing code reads them from the
+    // wallet rather than from globals.
+    wallet->m_external_signer_command = args.GetArg("-signer", "");
+    wallet->m_external_signer_chain = args.GetChainTypeString();
 
     if (const auto arg{args.GetArg("-mintxfee")}) {
         std::optional<CAmount> min_tx_fee = ParseMoney(*arg);
@@ -3589,7 +3594,7 @@ void CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc, 
 {
     std::unique_ptr<DescriptorScriptPubKeyMan> spk_manager;
     if (IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
-        spk_manager = ExternalSignerScriptPubKeyMan::LoadFromStorage(*this, desc, m_keypool_size, keys, ckeys);
+        spk_manager = ExternalSignerScriptPubKeyMan::LoadFromStorage(*this, desc, m_keypool_size, keys, ckeys, m_external_signer_command, m_external_signer_chain);
     } else {
         spk_manager = DescriptorScriptPubKeyMan::LoadFromStorage(*this, desc, m_keypool_size, keys, ckeys);
     }
@@ -3646,7 +3651,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans()
             return true;
         })) throw std::runtime_error("Error: cannot process db transaction for descriptors setup");
     } else {
-        auto signer = ExternalSignerScriptPubKeyMan::GetExternalSigner();
+        auto signer = ExternalSignerScriptPubKeyMan::GetExternalSigner(m_external_signer_command, m_external_signer_chain);
         if (!signer) throw std::runtime_error(util::ErrorString(signer).original);
 
         // TODO: add account parameter
@@ -3674,7 +3679,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans()
                     continue;
                 }
                 OutputType t =  *desc->GetOutputType();
-                auto spk_manager = ExternalSignerScriptPubKeyMan::CreateNew(*this, batch, m_keypool_size, std::move(desc));
+                auto spk_manager = ExternalSignerScriptPubKeyMan::CreateNew(*this, batch, m_keypool_size, std::move(desc), m_external_signer_command, m_external_signer_chain);
                 uint256 id = spk_manager->GetID();
                 AddScriptPubKeyMan(id, std::move(spk_manager));
                 AddActiveScriptPubKeyManWithDb(batch, id, t, internal);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -739,6 +739,11 @@ public:
     /** Absolute maximum transaction fee (in satoshis) used by default for the wallet */
     CAmount m_default_max_tx_fee{DEFAULT_TRANSACTION_MAXFEE};
 
+    /** Command used to invoke an external signer (the -signer arg), or empty if none configured. */
+    std::string m_external_signer_command;
+    /** Chain argument passed to an external signer. */
+    std::string m_external_signer_chain;
+
     /** Number of pre-generated keys/scripts by each spkm (part of the look-ahead process, used to detect payments) */
     int64_t m_keypool_size{DEFAULT_KEYPOOL_SIZE};
 


### PR DESCRIPTION
This PR removes direct access to process-wide state from `ExternalSignerScriptPubKeyMan`.

Instead of reading `gArgs`/`Params()` from the `SPKM`, the wallet load/setup path now reads the external signer command and chain once, stores them on `CWallet`, and passes the narrow values into the external signer SPKM.

This keeps argument and chain selection at the wallet boundary and makes the SPKM less coupled to global state.