### PR TITLE
wallet: deprecate replaceable argument from transaction (and psbt) creation (and modification) RPCs

### DIFF
--- a/doc/release-notes-34917.md
+++ b/doc/release-notes-34917.md
@@ -1,9 +1,23 @@
-RPC and Startup Option
+Wallet
 ------------
-The `bip125-replaceable` key in the wallet transaction RPCs such
-as `listtransactions`, `listsinceblock`, and `gettransaction` is
-marked as deprecated. Users still have the option to retrieve this
+Signalling for RBF is not necessary for replacing transactions due
+to nodes being fullrbf and the wallet doesn't need to opt into it
+by default. Therefore, RBF related RPC and startup options can be
+marked deprecated now and removed in the next release.
+
+In PR #34917, the `bip125-replaceable` key in the wallet transaction
+RPCs such as `listtransactions`, `listsinceblock`, and `gettransaction`
+is marked as deprecated. Users still have the option to retrieve this
 key by passing the `-deprecatedrpc=bip125` startup option. Also,
 the `-walletrbf` startup option has been marked as deprecated and
 will be fully removed in the next release. Using this option emits
 a warning in the logs.
+
+Additionally, the `replaceable` argument in several wallet RPC
+requests has been marked deprecated in PR #35433 and for now
+users have the option to use this argument via the
+`-deprecatedrpc=bip125` startup option. Affected RPCs are
+`createrawtransaction`, `fundrawtransaction`, `createpsbt`,
+`walletcreatefundedpsbt`, `send`, `sendtoaddress`, `sendmany`,
+`sendall`, `bumpfee`, and `psbtbumpfee`.
+

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -117,7 +117,7 @@ static std::vector<RPCArg> CreateTxDoc()
             },
          RPCArgOptions{.skip_type_check = true}},
         {"locktime", RPCArg::Type::NUM, RPCArg::Default{0}, "Raw locktime. Non-0 value also locktime-activates inputs"},
-        {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{true}, "Marks this transaction as BIP125-replaceable.\n"
+        {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{true}, "(DEPRECATED) Marks this transaction as BIP125-replaceable.\n"
                 "Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible."},
         {"version", RPCArg::Type::NUM, RPCArg::Default{DEFAULT_RAWTX_VERSION}, "Transaction version"},
     };
@@ -387,6 +387,9 @@ static RPCMethod createrawtransaction()
 {
     std::optional<bool> rbf;
     if (!request.params[3].isNull()) {
+        if (!IsDeprecatedRPCEnabled("bip125")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+        }
         rbf = request.params[3].get_bool();
     }
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf, self.Arg<uint32_t>("version"));
@@ -1712,6 +1715,9 @@ static RPCMethod createpsbt()
 {
     std::optional<bool> rbf;
     if (!request.params[3].isNull()) {
+        if (!IsDeprecatedRPCEnabled("bip125")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+        }
         rbf = request.params[3].get_bool();
     }
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf, self.Arg<uint32_t>("version"));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -117,7 +117,7 @@ static std::vector<RPCArg> CreateTxDoc()
             },
          RPCArgOptions{.skip_type_check = true}},
         {"locktime", RPCArg::Type::NUM, RPCArg::Default{0}, "Raw locktime. Non-0 value also locktime-activates inputs"},
-        {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{true}, "Marks this transaction as BIP125-replaceable.\n"
+        {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{true}, "(DEPRECATED) Marks this transaction as BIP125-replaceable.\n"
                 "Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible."},
         {"version", RPCArg::Type::NUM, RPCArg::Default{DEFAULT_RAWTX_VERSION}, "Transaction version"},
     };
@@ -397,6 +397,9 @@ static RPCMethod createrawtransaction()
 {
     std::optional<bool> rbf;
     if (!request.params[3].isNull()) {
+        if (!IsDeprecatedRPCEnabled("bip125")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+        }
         rbf = request.params[3].get_bool();
     }
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf, self.Arg<uint32_t>("version"));
@@ -1722,6 +1725,9 @@ static RPCMethod createpsbt()
 {
     std::optional<bool> rbf;
     if (!request.params[3].isNull()) {
+        if (!IsDeprecatedRPCEnabled("bip125")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+        }
         rbf = request.params[3].get_bool();
     }
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf, self.Arg<uint32_t>("version"));

--- a/src/util/rbf.h
+++ b/src/util/rbf.h
@@ -9,6 +9,11 @@
 
 class CTransaction;
 
+// BIP125 defines opt-in RBF as any nSequence < maxint-1, so
+// we use the highest possible value in that range (maxint-2)
+// to avoid conflicting with other possible uses of nSequence,
+// and in the spirit of "smallest possible change from prior
+// behavior."
 static constexpr uint32_t MAX_BIP125_RBF_SEQUENCE{0xfffffffd};
 
 /** Check whether the sequence numbers on this transaction are signaling opt-in to replace-by-fee,

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -255,7 +255,7 @@ RPCMethod sendtoaddress()
                                          "transaction, just kept in your wallet."},
                     {"subtractfeefromamount", RPCArg::Type::BOOL, RPCArg::Default{false}, "The fee will be deducted from the amount being sent.\n"
                                          "The recipient will receive less bitcoins than you enter in the amount field."},
-                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "Signal that this transaction can be replaced by a transaction (BIP 125)"},
+                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "(DEPRECATED) Signal that this transaction can be replaced by a transaction (BIP 125)"},
                     {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
                     {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
                       + FeeModesDetail(std::string("economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used"))},
@@ -309,6 +309,9 @@ RPCMethod sendtoaddress()
 
     CCoinControl coin_control;
     if (!request.params[5].isNull()) {
+        if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+        }
         coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
     }
 
@@ -362,7 +365,7 @@ RPCMethod sendmany()
                             {"address", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Subtract fee from this address"},
                         },
                     },
-                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "Signal that this transaction can be replaced by a transaction (BIP 125)"},
+                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "(DEPRECATED) Signal that this transaction can be replaced by a transaction (BIP 125)"},
                     {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
                     {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
                       + FeeModesDetail(std::string("economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used"))},
@@ -415,6 +418,9 @@ RPCMethod sendmany()
 
     CCoinControl coin_control;
     if (!request.params[5].isNull()) {
+        if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+        }
         coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
     }
 

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -439,7 +439,7 @@ static std::vector<RPCArg> FundTxDoc(bool solving_data = true)
         {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
           + FeeModesDetail(std::string("economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used")), RPCArgOptions{.also_positional = true}},
         {
-            "replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "Marks this transaction as BIP125-replaceable.\n"
+            "replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "(DEPRECATED) Marks this transaction as BIP125-replaceable.\n"
             "Allows this transaction to be replaced by a transaction with higher fees"
         },
     };
@@ -1442,7 +1442,13 @@ RPCMethod sendall()
                 coin_control.m_max_tx_weight = MAX_STANDARD_TX_WEIGHT;
             }
 
-            const bool rbf{options.exists("replaceable") ? options["replaceable"].get_bool() : pwallet->m_signal_rbf};
+            bool rbf{pwallet->m_signal_rbf};
+            if (options.exists("replaceable")) {
+                if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+                    throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+                }
+                rbf = options["replaceable"].get_bool();
+            }
 
             FeeCalculation fee_calc_out;
             CFeeRate fee_rate{GetMinimumFeeRate(*pwallet, coin_control, &fee_calc_out)};

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -575,6 +575,9 @@ CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransact
             }
 
             if (options.exists("replaceable")) {
+                if (!wallet.chain().rpcEnableDeprecated("bip125")) {
+                    throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+                }
                 coinControl.m_signal_bip125_rbf = options["replaceable"].get_bool();
             }
 
@@ -1778,8 +1781,13 @@ RPCMethod walletcreatefundedpsbt()
     CCoinControl coin_control;
     coin_control.m_version = self.Arg<uint32_t>("version");
 
-    const UniValue &replaceable_arg = options["replaceable"];
-    const bool rbf{replaceable_arg.isNull() ? wallet.m_signal_rbf : replaceable_arg.get_bool()};
+    bool rbf{wallet.m_signal_rbf};
+    if (options.exists("replaceable")) {
+        if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+        }
+        rbf = options["replaceable"].get_bool();
+    }
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf, coin_control.m_version);
     UniValue outputs(UniValue::VOBJ);
     outputs = NormalizeOutputs(request.params[1]);

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -990,8 +990,8 @@ static RPCMethod bumpfee_helper(std::string method_name)
                              "\nSpecify a fee rate in " + CURRENCY_ATOM + "/vB instead of relying on the built-in fee estimator.\n"
                              "Must be at least " + incremental_fee + " higher than the current transaction fee rate.\n"
                              "WARNING: before version 0.21, fee_rate was in " + CURRENCY_UNIT + "/kvB. As of 0.21, fee_rate is in " + CURRENCY_ATOM + "/vB.\n"},
-                    {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{true},
-                             "Whether the new transaction should be\n"
+                    {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{DEFAULT_WALLET_RBF},
+                             "(DEPRECATED) Whether the new transaction should be\n"
                              "marked bip-125 replaceable. If true, the sequence numbers in the transaction will\n"
                              "be set to 0xfffffffd. If false, any input sequence numbers in the\n"
                              "transaction will be set to 0xfffffffe\n"
@@ -1076,6 +1076,9 @@ static RPCMethod bumpfee_helper(std::string method_name)
         auto conf_target = options.exists("confTarget") ? options["confTarget"] : options["conf_target"];
 
         if (options.exists("replaceable")) {
+            if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+                throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+            }
             coin_control.m_signal_bip125_rbf = options["replaceable"].get_bool();
         }
         SetFeeEstimateMode(*pwallet, coin_control, conf_target, options["estimate_mode"], options["fee_rate"], /*override_min_fee=*/false);

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1279,7 +1279,13 @@ RPCMethod send()
             PreventOutdatedOptions(options);
 
 
-            bool rbf{options.exists("replaceable") ? options["replaceable"].get_bool() : pwallet->m_signal_rbf};
+            bool rbf{pwallet->m_signal_rbf};
+            if (options.exists("replaceable")) {
+                if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+                    throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+                }
+                rbf = options["replaceable"].get_bool();
+            }
             UniValue outputs(UniValue::VOBJ);
             outputs = NormalizeOutputs(request.params[0]);
             std::vector<CRecipient> recipients = CreateRecipients(

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -255,7 +255,7 @@ RPCMethod sendtoaddress()
                                          "transaction, just kept in your wallet."},
                     {"subtractfeefromamount", RPCArg::Type::BOOL, RPCArg::Default{false}, "The fee will be deducted from the amount being sent.\n"
                                          "The recipient will receive less bitcoins than you enter in the amount field."},
-                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "Signal that this transaction can be replaced by a transaction (BIP 125)"},
+                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "(DEPRECATED) Signal that this transaction can be replaced by a transaction (BIP 125)"},
                     {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
                     {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
                       + FeeModesDetail(std::string("economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used"))},
@@ -280,14 +280,14 @@ RPCMethod sendtoaddress()
                     "\nSend 0.1 BTC\n"
                     + HelpExampleCli("sendtoaddress", "\"" + EXAMPLE_ADDRESS[0] + "\" 0.1") +
                     "\nSend 0.1 BTC with a confirmation target of 6 blocks in economical fee estimate mode using positional arguments\n"
-                    + HelpExampleCli("sendtoaddress", "\"" + EXAMPLE_ADDRESS[0] + "\" 0.1 \"donation\" \"sean's outpost\" false true 6 economical") +
-                    "\nSend 0.1 BTC with a fee rate of 1.1 " + CURRENCY_ATOM + "/vB, subtract fee from amount, BIP125-replaceable, using positional arguments\n"
-                    + HelpExampleCli("sendtoaddress", "\"" + EXAMPLE_ADDRESS[0] + "\" 0.1 \"drinks\" \"room77\" true true null \"unset\" null 1.1") +
+                    + HelpExampleCli("sendtoaddress", "\"" + EXAMPLE_ADDRESS[0] + "\" 0.1 \"donation\" \"sean's outpost\" false null 6 economical") +
+                    "\nSend 0.1 BTC with a fee rate of 1.1 " + CURRENCY_ATOM + "/vB, subtract fee from amount, using positional arguments\n"
+                    + HelpExampleCli("sendtoaddress", "\"" + EXAMPLE_ADDRESS[0] + "\" 0.1 \"drinks\" \"room77\" true null null \"unset\" null 1.1") +
                     "\nSend 0.2 BTC with a confirmation target of 6 blocks in economical fee estimate mode using named arguments\n"
                     + HelpExampleCli("-named sendtoaddress", "address=\"" + EXAMPLE_ADDRESS[0] + "\" amount=0.2 conf_target=6 estimate_mode=\"economical\"") +
                     "\nSend 0.5 BTC with a fee rate of 25 " + CURRENCY_ATOM + "/vB using named arguments\n"
                     + HelpExampleCli("-named sendtoaddress", "address=\"" + EXAMPLE_ADDRESS[0] + "\" amount=0.5 fee_rate=25")
-                    + HelpExampleCli("-named sendtoaddress", "address=\"" + EXAMPLE_ADDRESS[0] + "\" amount=0.5 fee_rate=25 subtractfeefromamount=false replaceable=true avoid_reuse=true comment=\"2 pizzas\" comment_to=\"jeremy\" verbose=true")
+                    + HelpExampleCli("-named sendtoaddress", "address=\"" + EXAMPLE_ADDRESS[0] + "\" amount=0.5 fee_rate=25 subtractfeefromamount=false avoid_reuse=true comment=\"2 pizzas\" comment_to=\"jeremy\" verbose=true")
                 },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -310,6 +310,9 @@ RPCMethod sendtoaddress()
 
     CCoinControl coin_control;
     if (!request.params[5].isNull()) {
+        if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+        }
         coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
     }
 
@@ -365,7 +368,7 @@ RPCMethod sendmany()
                             {"address", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Subtract fee from this address"},
                         },
                     },
-                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "Signal that this transaction can be replaced by a transaction (BIP 125)"},
+                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "(DEPRECATED) Signal that this transaction can be replaced by a transaction (BIP 125)"},
                     {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
                     {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
                       + FeeModesDetail(std::string("economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used"))},
@@ -418,6 +421,9 @@ RPCMethod sendmany()
 
     CCoinControl coin_control;
     if (!request.params[5].isNull()) {
+        if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+        }
         coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
     }
 

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -442,7 +442,7 @@ static std::vector<RPCArg> FundTxDoc(bool solving_data = true)
         {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
           + FeeModesDetail(std::string("economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used")), RPCArgOptions{.also_positional = true}},
         {
-            "replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "Marks this transaction as BIP125-replaceable.\n"
+            "replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "(DEPRECATED) Marks this transaction as BIP125-replaceable.\n"
             "Allows this transaction to be replaced by a transaction with higher fees"
         },
     };
@@ -1440,7 +1440,13 @@ RPCMethod sendall()
                 coin_control.m_max_tx_weight = MAX_STANDARD_TX_WEIGHT;
             }
 
-            const bool rbf{options.exists("replaceable") ? options["replaceable"].get_bool() : pwallet->m_signal_rbf};
+            bool rbf{pwallet->m_signal_rbf};
+            if (options.exists("replaceable")) {
+                if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+                    throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+                }
+                rbf = options["replaceable"].get_bool();
+            }
 
             FeeCalculation fee_calc_out;
             CFeeRate fee_rate{GetMinimumFeeRate(*pwallet, coin_control, &fee_calc_out)};

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -575,6 +575,9 @@ CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransact
         }
 
         if (options.exists("replaceable")) {
+            if (!wallet.chain().rpcEnableDeprecated("bip125")) {
+                throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+            }
             coinControl.m_signal_bip125_rbf = options["replaceable"].get_bool();
         }
 

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -988,8 +988,8 @@ static RPCMethod bumpfee_helper(std::string method_name)
                              "\nSpecify a fee rate in " + CURRENCY_ATOM + "/vB instead of relying on the built-in fee estimator.\n"
                              "Must be at least " + incremental_fee + " higher than the current transaction fee rate.\n"
                              "WARNING: before version 0.21, fee_rate was in " + CURRENCY_UNIT + "/kvB. As of 0.21, fee_rate is in " + CURRENCY_ATOM + "/vB.\n"},
-                    {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{true},
-                             "Whether the new transaction should be\n"
+                    {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{DEFAULT_WALLET_RBF},
+                             "(DEPRECATED) Whether the new transaction should be\n"
                              "marked bip-125 replaceable. If true, the sequence numbers in the transaction will\n"
                              "be set to 0xfffffffd. If false, any input sequence numbers in the\n"
                              "transaction will be set to 0xfffffffe\n"
@@ -1074,6 +1074,9 @@ static RPCMethod bumpfee_helper(std::string method_name)
         auto conf_target = options.exists("confTarget") ? options["confTarget"] : options["conf_target"];
 
         if (options.exists("replaceable")) {
+            if (!pwallet->chain().rpcEnableDeprecated("bip125")) {
+                throw JSONRPCError(RPC_METHOD_DEPRECATED, "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it.");
+            }
             coin_control.m_signal_bip125_rbf = options["replaceable"].get_bool();
         }
         SetFeeEstimateMode(*pwallet, coin_control, conf_target, options["estimate_mode"], options["fee_rate"], /*override_min_fee=*/false);

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1293,12 +1293,6 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
 
     // The sequence number is set to non-maxint so that DiscourageFeeSniping
     // works.
-    //
-    // BIP125 defines opt-in RBF as any nSequence < maxint-1, so
-    // we use the highest possible value in that range (maxint-2)
-    // to avoid conflicting with other possible uses of nSequence,
-    // and in the spirit of "smallest possible change from prior
-    // behavior."
     bool use_anti_fee_sniping = true;
     const uint32_t default_sequence{coin_control.m_signal_bip125_rbf.value_or(wallet.m_signal_rbf) ? MAX_BIP125_RBF_SEQUENCE : CTxIn::MAX_SEQUENCE_NONFINAL};
     txNew.vin.reserve(selected_coins.size());

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1292,12 +1292,6 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
 
     // The sequence number is set to non-maxint so that DiscourageFeeSniping
     // works.
-    //
-    // BIP125 defines opt-in RBF as any nSequence < maxint-1, so
-    // we use the highest possible value in that range (maxint-2)
-    // to avoid conflicting with other possible uses of nSequence,
-    // and in the spirit of "smallest possible change from prior
-    // behavior."
     bool use_anti_fee_sniping = true;
     const uint32_t default_sequence{coin_control.m_signal_bip125_rbf.value_or(wallet.m_signal_rbf) ? MAX_BIP125_RBF_SEQUENCE : CTxIn::MAX_SEQUENCE_NONFINAL};
     txNew.vin.reserve(selected_coins.size());

--- a/test/functional/data/rpc_psbt.json
+++ b/test/functional/data/rpc_psbt.json
@@ -229,7 +229,7 @@
                 }
             ],
             "version": 0,
-            "result" : "cHNidP8BAJoCAAAAAljoeiG1ba8MI76OcHBFbDNvfLqlyHV5JPVFiHuyq911AAAAAAD/////g40EJ9DsZQpoqka7CwmK6kQiwHGyyng1Kgd5WdB86h0BAAAAAP////8CcKrwCAAAAAAWABTYXCtx0AYLCcmIauuBXlCZHdoSTQDh9QUAAAAAFgAUAK6pouXw+HaliN9VRuh0LR2HAI8AAAAAAAAAAAA="
+            "result" : "cHNidP8BAJoCAAAAAljoeiG1ba8MI76OcHBFbDNvfLqlyHV5JPVFiHuyq911AAAAAAD9////g40EJ9DsZQpoqka7CwmK6kQiwHGyyng1Kgd5WdB86h0BAAAAAP3///8CcKrwCAAAAAAWABTYXCtx0AYLCcmIauuBXlCZHdoSTQDh9QUAAAAAFgAUAK6pouXw+HaliN9VRuh0LR2HAI8AAAAAAAAAAAA="
         }
     ],
     "signer" : [

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -133,7 +133,7 @@ class NotificationsTest(BitcoinTestFramework):
 
             # Generate transaction on node 0, sync mempools, and check for
             # notification on node 1.
-            tx1 = self.nodes[0].sendtoaddress(address=ADDRESS_BCRT1_UNSPENDABLE, amount=1, replaceable=True)
+            tx1 = self.nodes[0].sendtoaddress(address=ADDRESS_BCRT1_UNSPENDABLE, amount=1)
             assert_equal(tx1 in self.nodes[0].getrawmempool(), True)
             self.sync_mempools()
             self.expect_wallet_notify([(tx1, -1, UNCONFIRMED_HASH_STRING)])
@@ -156,7 +156,7 @@ class NotificationsTest(BitcoinTestFramework):
             assert_equal(self.nodes[1].gettransaction(bump1)["confirmations"], 1)
 
             # Generate a second transaction to be bumped.
-            tx2 = self.nodes[0].sendtoaddress(address=ADDRESS_BCRT1_UNSPENDABLE, amount=1, replaceable=True)
+            tx2 = self.nodes[0].sendtoaddress(address=ADDRESS_BCRT1_UNSPENDABLE, amount=1)
             assert_equal(tx2 in self.nodes[0].getrawmempool(), True)
             self.sync_mempools()
             self.expect_wallet_notify([(tx2, -1, UNCONFIRMED_HASH_STRING)])

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -858,15 +858,15 @@ class PSBTTest(BitcoinTestFramework):
         # replaceable arg
         block_height = self.nodes[0].getblockcount()
         unspent = self.nodes[0].listunspent()[0]
-        psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height+2, {"replaceable": False, "add_inputs": True}, False)
+        psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height+2, {"add_inputs": True}, False)
         decoded_psbt = self.nodes[0].decodepsbt(psbtx_info["psbt"])
         for psbt_in in decoded_psbt["inputs"]:
-            assert_greater_than(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
+            assert_equal(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
             assert "bip32_derivs" not in psbt_in
         assert_equal(decoded_psbt["fallback_locktime"], block_height+2)
 
-        # Same construction with only locktime set and RBF explicitly enabled
-        psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height, {"replaceable": True, "add_inputs": True}, True)
+        # Same construction with only locktime set and deprecated RBF explicitly enabled
+        psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height, {"add_inputs": True}, True)
         decoded_psbt = self.nodes[0].decodepsbt(psbtx_info["psbt"])
         for psbt_in in decoded_psbt["inputs"]:
             assert_equal(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -968,7 +968,7 @@ class PSBTTest(BitcoinTestFramework):
 
         # Creator Tests
         for creator in creators:
-            created_tx = self.nodes[0].createpsbt(inputs=creator['inputs'], outputs=creator['outputs'], replaceable=False, psbt_version=creator['version'])
+            created_tx = self.nodes[0].createpsbt(inputs=creator['inputs'], outputs=creator['outputs'], psbt_version=creator['version'])
             assert_equal(created_tx, creator['result'])
 
         # Signer tests

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -1011,7 +1011,7 @@ class PSBTTest(BitcoinTestFramework):
 
         # Creator Tests
         for creator in creators:
-            created_tx = self.nodes[0].createpsbt(inputs=creator['inputs'], outputs=creator['outputs'], replaceable=False, psbt_version=creator['version'])
+            created_tx = self.nodes[0].createpsbt(inputs=creator['inputs'], outputs=creator['outputs'], psbt_version=creator['version'])
             assert_equal(created_tx, creator['result'])
 
         # Signer tests

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -901,15 +901,15 @@ class PSBTTest(BitcoinTestFramework):
         # replaceable arg
         block_height = self.nodes[0].getblockcount()
         unspent = self.nodes[0].listunspent()[0]
-        psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height+2, {"replaceable": False, "add_inputs": True}, False)
+        psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height+2, {"add_inputs": True}, False)
         decoded_psbt = self.nodes[0].decodepsbt(psbtx_info["psbt"])
         for psbt_in in decoded_psbt["inputs"]:
-            assert_greater_than(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
+            assert_equal(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
             assert "bip32_derivs" not in psbt_in
         assert_equal(decoded_psbt["fallback_locktime"], block_height+2)
 
-        # Same construction with only locktime set and RBF explicitly enabled
-        psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height, {"replaceable": True, "add_inputs": True}, True)
+        # Same construction with only locktime set and deprecated RBF explicitly enabled
+        psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height, {"add_inputs": True}, True)
         decoded_psbt = self.nodes[0].decodepsbt(psbtx_info["psbt"])
         for psbt_in in decoded_psbt["inputs"]:
             assert_equal(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -17,7 +17,6 @@ from decimal import Decimal
 from itertools import product
 
 from test_framework.messages import (
-    MAX_BIP125_RBF_SEQUENCE,
     COIN,
     TX_MAX_STANDARD_VERSION,
     TX_MIN_STANDARD_VERSION,
@@ -259,8 +258,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-1, "createrawtransaction", self.nodes[0].createrawtransaction, [], {}, 0, False, 2, 3, 'foo')
 
         # Test `createrawtransaction` invalid version parameters
-        assert_raises_rpc_error(-8, f"Invalid parameter, version out of range({TX_MIN_STANDARD_VERSION}~{TX_MAX_STANDARD_VERSION})", self.nodes[0].createrawtransaction, [], {}, 0, False, TX_MIN_STANDARD_VERSION - 1)
-        assert_raises_rpc_error(-8, f"Invalid parameter, version out of range({TX_MIN_STANDARD_VERSION}~{TX_MAX_STANDARD_VERSION})", self.nodes[0].createrawtransaction, [], {}, 0, False, TX_MAX_STANDARD_VERSION + 1)
+        assert_raises_rpc_error(-8, f"Invalid parameter, version out of range({TX_MIN_STANDARD_VERSION}~{TX_MAX_STANDARD_VERSION})", self.nodes[0].createrawtransaction, [], {}, 0, None, TX_MIN_STANDARD_VERSION - 1)
+        assert_raises_rpc_error(-8, f"Invalid parameter, version out of range({TX_MIN_STANDARD_VERSION}~{TX_MAX_STANDARD_VERSION})", self.nodes[0].createrawtransaction, [], {}, 0, None, TX_MAX_STANDARD_VERSION + 1)
 
         # Test `createrawtransaction` invalid `inputs`
         assert_raises_rpc_error(-3, "JSON value of type string is not of expected type array", self.nodes[0].createrawtransaction, 'foo', {})
@@ -303,10 +302,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Invalid parameter, duplicate key: data", self.nodes[0].createrawtransaction, [], multidict([("data", 'aa'), ("data", "bb")]))
         assert_raises_rpc_error(-8, "Invalid parameter, key-value pair must contain exactly one key", self.nodes[0].createrawtransaction, [], [{'a': 1, 'b': 2}])
         assert_raises_rpc_error(-8, "Invalid parameter, key-value pair not an object as expected", self.nodes[0].createrawtransaction, [], [['key-value pair1'], ['2']])
-
-        # Test `createrawtransaction` mismatch between sequence number(s) and `replaceable` option
-        assert_raises_rpc_error(-8, "Invalid parameter combination: Sequence number(s) contradict replaceable option",
-                                self.nodes[0].createrawtransaction, [{'txid': TXID, 'vout': 0, 'sequence': MAX_BIP125_RBF_SEQUENCE+1}], {}, 0, True)
 
         # Test `createrawtransaction` invalid `locktime`
         assert_raises_rpc_error(-3, "JSON value of type string is not of expected type number", self.nodes[0].createrawtransaction, [], {}, 'foo')

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -41,7 +41,7 @@ def create_transactions(node, address, amt, fees):
         # prevent 0 change output
         if ins_total > amt + fee:
             outputs[node.getrawchangeaddress()] = ins_total - amt - fee
-        raw_tx = node.createrawtransaction(inputs, outputs, 0, True)
+        raw_tx = node.createrawtransaction(inputs, outputs, 0)
         raw_tx = node.signrawtransactionwithwallet(raw_tx)
         assert_equal(raw_tx['complete'], True)
         txs.append(raw_tx)

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -22,7 +22,6 @@ from test_framework.descriptors import descsum_create
 from test_framework.extendedkey import ExtendedPrivateKey
 from test_framework.messages import (
     MAX_BIP125_RBF_SEQUENCE,
-    MAX_SEQUENCE_NONFINAL,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -99,7 +98,6 @@ class BumpFeeTest(BitcoinTestFramework):
         test_dust_to_fee(self, rbf_node, dest_address)
         test_watchonly_psbt(self, peer_node, rbf_node, dest_address)
         test_rebumping(self, rbf_node, dest_address)
-        test_rebumping_not_replaceable(self, rbf_node, dest_address)
         test_bumpfee_already_spent(self, rbf_node, dest_address)
         test_unconfirmed_not_spendable(self, rbf_node, rbf_node_address)
         test_bumpfee_metadata(self, rbf_node, dest_address)
@@ -643,25 +641,6 @@ def test_rebumping(self, rbf_node, dest_address):
                             rbf_node.bumpfee, rbfid, fee_rate=NORMAL)
     rbf_node.bumpfee(bumped["txid"], fee_rate=NORMAL)
     self.clear_mempool()
-
-
-def test_rebumping_not_replaceable(self, rbf_node, dest_address):
-    self.log.info("Test that re-bumping non-replaceable passes")
-    rbfid = spend_one_input(rbf_node, dest_address)
-
-    def check_sequence(tx, seq_in):
-        tx = rbf_node.getrawtransaction(tx["txid"])
-        tx = rbf_node.decoderawtransaction(tx)
-        seq = [i["sequence"] for i in tx["vin"]]
-        assert_equal(seq, [seq_in])
-
-    bumped = rbf_node.bumpfee(rbfid, fee_rate=ECONOMICAL, replaceable=False)
-    check_sequence(bumped, MAX_SEQUENCE_NONFINAL)
-    bumped = rbf_node.bumpfee(bumped["txid"], {"fee_rate": NORMAL})
-    check_sequence(bumped, MAX_BIP125_RBF_SEQUENCE)
-
-    self.clear_mempool()
-
 
 def test_bumpfee_already_spent(self, rbf_node, dest_address):
     self.log.info('Test that bumping tx with already spent coin fails')

--- a/test/functional/wallet_deprecated_rbf.py
+++ b/test/functional/wallet_deprecated_rbf.py
@@ -2,9 +2,12 @@
 # Copyright (c) 2026-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test deprecation of RPC calls."""
-from test_framework.util import assert_equal
+"""Test deprecation of wallet RBF RPCs and startup options."""
+from test_framework.messages import MAX_BIP125_RBF_SEQUENCE
+from test_framework.util import assert_equal, assert_not_equal, assert_greater_than, assert_raises_rpc_error, JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
+
+DEPRECATED_RPC_MESSAGE = "Deprecated \"replaceable\" argument passed. Run with -deprecatedrpc=bip125 startup option to use it."
 
 '''
 This test exercises the deprecatedrpc=bip125 flag and deprecated -walletrbf options
@@ -20,16 +23,95 @@ class WalletDeprecatedRBFTest(BitcoinTestFramework):
       self.skip_if_no_wallet()
 
     def run_test(self):
-      self.log.info("Test -deprecatedrpc=bip125 and -walletrbf startup option")
-
-      self.restart_node(0, extra_args=["-walletrbf=0", "-deprecatedrpc=bip125"])
+      self.log.info("Test without and with -deprecatedrpc=bip125 and -walletrbf startup options")
       node = self.nodes[0]
       node.createwallet("deprecated_optinrbf")
       wallet = node.get_wallet_rpc("deprecated_optinrbf")
       self.generatetoaddress(node, nblocks=101, address=wallet.getnewaddress(), sync_fun=self.no_op)
-      tx = wallet.gettransaction(wallet.sendall(recipients=[wallet.getnewaddress()])["txid"])
-      assert_equal("bip125-replaceable" in tx, True)
-      assert_equal(tx["bip125-replaceable"], "no")
+
+      # helper functions
+      def get_largest_unspent():
+        return max(wallet.listunspent(), key=lambda unspent: unspent["amount"])
+
+      def check_rbf_signalling(inputs, rbf_signalling=True):
+        for input in inputs:
+          if rbf_signalling:
+            assert_equal(input["sequence"], MAX_BIP125_RBF_SEQUENCE)
+          else:
+            assert_not_equal(input["sequence"], MAX_BIP125_RBF_SEQUENCE)
+
+      def assert_rbf_signalling_in_wallet_tx(tx_id):
+        wallet_mempool_tx = wallet.gettransaction(tx_id)
+        assert_equal("bip125-replaceable" in wallet_mempool_tx, True)
+        assert_equal(wallet_mempool_tx["bip125-replaceable"], "yes")
+
+      send_rpcs = [
+        lambda: wallet.send(outputs=[{wallet.getnewaddress(): 1}], options={"replaceable": True})["txid"],
+        lambda: wallet.sendtoaddress(address=wallet.getnewaddress(), amount=1, replaceable=True),
+        lambda: wallet.sendmany(amounts={wallet.getnewaddress():1, wallet.getnewaddress():1}, replaceable=True),
+        lambda: wallet.sendall(recipients=[wallet.getnewaddress()], replaceable=True)["txid"],
+      ]
+
+      # check for errors regarding usage of deprecated arguments without -deprecatedrpc startup option
+      unspent = get_largest_unspent()
+      assert_raises_rpc_error(-32, DEPRECATED_RPC_MESSAGE, wallet.createrawtransaction, inputs=[unspent], outputs=[{wallet.getnewaddress(): 1}], replaceable=True)
+      assert_raises_rpc_error(-32, DEPRECATED_RPC_MESSAGE, wallet.createpsbt, inputs=[unspent], outputs=[{wallet.getnewaddress(): 1}], replaceable=True)
+      for rpc in send_rpcs:
+        try:
+          rpc()
+        except JSONRPCException as e:
+          assert_equal(e.error["code"], -32)
+          assert_equal(e.error["message"], DEPRECATED_RPC_MESSAGE)
+        except Exception as e:
+          raise AssertionError("Unexpected exception raised: " + type(e).__name__)
+
+      # restart the node with deprecated startup options
+      self.restart_node(0, extra_args=["-walletrbf=0", "-deprecatedrpc=bip125"])
+      node.loadwallet("deprecated_optinrbf")
+      wallet = node.get_wallet_rpc("deprecated_optinrbf")
+
+      # Test `createrawtransaction` mismatch between sequence number(s) and `replaceable` option
+      assert_raises_rpc_error(-8, "Invalid parameter combination: Sequence number(s) contradict replaceable option",
+                              self.nodes[0].createrawtransaction, [{'txid': unspent["txid"], 'vout': unspent["vout"], 'sequence': MAX_BIP125_RBF_SEQUENCE+1}], {}, 0, True)
+
+      # test raw transaction RPCs
+      raw_tx_hex = wallet.createrawtransaction(inputs=[unspent], outputs=[{wallet.getnewaddress(): 1}], replaceable=False)
+      check_rbf_signalling(wallet.decoderawtransaction(raw_tx_hex)["vin"], rbf_signalling=False)
+      raw_tx_hex = wallet.createrawtransaction(inputs=[unspent], outputs=[{wallet.getnewaddress(): 1}], replaceable=True)
+      check_rbf_signalling(wallet.decoderawtransaction(raw_tx_hex)["vin"])
+      funded_tx_hex = wallet.fundrawtransaction(raw_tx_hex)["hex"]
+      check_rbf_signalling(wallet.decoderawtransaction(funded_tx_hex)["vin"])
+      signed_tx_hex = wallet.signrawtransactionwithwallet(funded_tx_hex)["hex"]
+      sent_tx_id = wallet.sendrawtransaction(signed_tx_hex)
+      assert_rbf_signalling_in_wallet_tx(sent_tx_id)
+      bumped_tx_details = wallet.bumpfee(sent_tx_id, replaceable=True)
+      assert_greater_than(bumped_tx_details["fee"], bumped_tx_details["origfee"])
+      assert_rbf_signalling_in_wallet_tx(bumped_tx_details["txid"])
+      wallet.sendrawtransaction(wallet.gettransaction(bumped_tx_details["txid"])["hex"])
+      self.generate(node, 1, sync_fun=self.no_op)
+
+      # test psbt RPCs (along with testing bumping non-replaceable passes)
+      unspent = get_largest_unspent()
+      inputs = [{"txid": unspent["txid"], "vout": unspent["vout"]}]
+      outputs = [{wallet.getnewaddress(): 1}]
+      psbt_encoded = wallet.createpsbt(inputs=inputs, outputs=outputs, replaceable=False)
+      check_rbf_signalling(wallet.decodepsbt(psbt_encoded)["inputs"], rbf_signalling=False)
+      funded_psbt_encoded = wallet.walletcreatefundedpsbt(inputs=inputs, outputs=outputs, replaceable=False)["psbt"]
+      check_rbf_signalling(wallet.decodepsbt(funded_psbt_encoded)["inputs"], rbf_signalling=False)
+      signed_tx_hex = wallet.walletprocesspsbt(funded_psbt_encoded)["hex"]
+      sent_tx_id = wallet.sendrawtransaction(signed_tx_hex)
+      bumped_tx_details = wallet.psbtbumpfee(sent_tx_id, replaceable=True)
+      assert_greater_than(bumped_tx_details["fee"], bumped_tx_details["origfee"])
+      signed_bumped_tx_hex = wallet.walletprocesspsbt(bumped_tx_details["psbt"])["hex"]
+      sent_tx_id = wallet.sendrawtransaction(signed_bumped_tx_hex)
+      assert_rbf_signalling_in_wallet_tx(sent_tx_id)
+      self.generate(node, 1, sync_fun=self.no_op)
+
+      for rpc in send_rpcs:
+        sent_tx_id = rpc()
+        assert_rbf_signalling_in_wallet_tx(sent_tx_id)
+        self.generate(node, 1, sync_fun=self.no_op)
+
       self.stop_node(0, expected_stderr="Warning: -walletrbf is deprecated and will be fully removed in the next release.")
 
 

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -1474,7 +1474,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         self.log.info("Crafting TX using an unconfirmed input")
         target_address = self.nodes[2].getnewaddress()
-        raw_tx1 = wallet.createrawtransaction([], {target_address: 0.1}, 0, True)
+        raw_tx1 = wallet.createrawtransaction([], {target_address: 0.1}, 0)
         funded_tx1 = wallet.fundrawtransaction(raw_tx1, {'fee_rate': 1, 'maxconf': 0})['hex']
 
         # Make sure we only had the one input

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -435,7 +435,7 @@ class SendallTest(BitcoinTestFramework):
     def sendall_anti_fee_sniping(self):
         self.log.info("Testing sendall does anti-fee-sniping when locktime is not specified")
         self.add_utxos([10,11])
-        tx_from_wallet = self.test_sendall_success(sendall_args = [self.remainder_target], options={"replaceable":False})
+        tx_from_wallet = self.test_sendall_success(sendall_args = [self.remainder_target])
 
         # the locktime should be within 100 blocks of the
         # block height

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -176,7 +176,7 @@ class WalletSignerTest(BitcoinTestFramework):
         assert_equal(result[1], {'success': True})
         assert_equal(mock_wallet.getwalletinfo()["txcount"], 1)
         dest = self.nodes[0].getnewaddress(address_type='bech32')
-        mock_psbt = mock_wallet.walletcreatefundedpsbt([], {dest:0.5}, 0, {'replaceable': True}, True)['psbt']
+        mock_psbt = mock_wallet.walletcreatefundedpsbt([], {dest:0.5}, 0, {}, True)['psbt']
         mock_psbt_signed = mock_wallet.walletprocesspsbt(psbt=mock_psbt, sign=True, sighashtype="ALL", bip32derivs=True)
         mock_tx = mock_psbt_signed["hex"]
         assert mock_wallet.testmempoolaccept([mock_tx])[0]["allowed"]


### PR DESCRIPTION
Fixes #32661.

The `replaceable` argument in several wallet RPC requests
has been marked deprecated and for now users have the
option to use this argument via the `-deprecatedrpc=bip125`
startup option. Affected RPCs are `createrawtransaction`,
`fundrawtransaction`, `createpsbt`, `walletcreatefundedpsbt`,
`send`, `sendtoaddress`, `sendmany`, `sendall`, `bumpfee`,
and `psbtbumpfee`.

This builds upon the existing issue of removing the option for
users to signal replaceability because fullrbf is the default policy
and prevalent in the network (since bitcoin core v28 was released
in late 2024) that makes every transaction replaceable by default,
making this user option unnecessary.