### PR TITLE
doc: improve clarity in reduce-traffic.md and REST-interface.md

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -58,7 +58,7 @@ Responds with 404 if the block or the byte range doesn't exist.
 Given a block hash: returns <COUNT> amount of blockheaders in upward direction.
 Returns empty if the block doesn't exist or it isn't in the active chain.
 
-*Deprecated (but not removed) since 24.0:*
+*Deprecated (but not removed) since 24.0, use the query parameter form above instead:*
 `GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
 
 #### Blockfilter Headers
@@ -68,7 +68,7 @@ Given a block hash: returns <COUNT> amount of blockfilter headers in upward
 direction for the filter type <FILTERTYPE>.
 Returns empty if the block doesn't exist or it isn't in the active chain.
 
-*Deprecated (but not removed) since 24.0:*
+*Deprecated (but not removed) since 24.0, use the query parameter form above instead:*
 `GET /rest/blockfilterheaders/<FILTERTYPE>/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
 
 #### Blockfilters

--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -43,7 +43,7 @@ connected to a handful of nodes.
 Forwarding transactions to peers increases the P2P traffic. To only sync blocks
 with other peers, you can disable transaction relay.
 
-Be reminded of the effects of this setting.
+Note the following effects of this setting:
 
 - Fee estimation will no longer work.
 - It sets the flag "-walletbroadcast" to be "0", only if it is currently unset.


### PR DESCRIPTION
Two small clarity improvements in documentation:

**reduce-traffic.md**
- Replace `"Be reminded of the effects of this setting."` with `"Note the following effects of this setting:"` — the original phrasing is awkward and reads as if the user has already been told something they haven't.

**REST-interface.md**
- Add migration guidance to both deprecated endpoint notices (`/rest/headers` and `/rest/blockfilterheaders`) so users know to switch to the query parameter form documented directly above each one.