### PR TITLE
test: introduce NodeSigner, run feature_taproot.py without wallet compiled

### DIFF
--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -99,6 +99,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
 )
+from test_framework.wallet import NodeSigner
 from test_framework.wallet_util import generate_keypair
 from test_framework.key import (
     generate_privkey,
@@ -1409,9 +1410,6 @@ class TaprootTest(BitcoinTestFramework):
         parser.add_argument("--dumptests", dest="dump_tests", default=False, action="store_true",
                             help="Dump generated test cases to directory set by TEST_DUMP_DIR environment variable")
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
@@ -1468,18 +1466,16 @@ class TaprootTest(BitcoinTestFramework):
         host_spks = []
         host_pubkeys = []
         for i in range(16):
-            addr = node.getnewaddress(address_type=random.choice(["legacy", "p2sh-segwit", "bech32"]))
-            info = node.getaddressinfo(addr)
-            spk = bytes.fromhex(info['scriptPubKey'])
+            pubkey, spk, _ = self.nodesigner.getnewaddress(address_type=random.choice(["legacy", "p2sh-segwit", "bech32"]))
             host_spks.append(spk)
-            host_pubkeys.append(bytes.fromhex(info['pubkey']))
+            host_pubkeys.append(pubkey)
 
         self.init_blockinfo(node)
 
         # Create transactions spending up to 50 of the wallet's inputs, with one output for each spender, and
         # one change output at the end. The transaction is constructed on the Python side to enable
-        # having multiple outputs to the same address and outputs with no assigned address. The wallet
-        # is then asked to sign it through signrawtransactionwithwallet, and then added to a block on the
+        # having multiple outputs to the same address and outputs with no assigned address. The node
+        # is then asked to sign it through signrawtransactionwithkey, and then added to a block on the
         # Python side (to bypass standardness rules).
         self.log.info("- Creating test UTXOs...")
         random.shuffle(spenders)
@@ -1492,7 +1488,7 @@ class TaprootTest(BitcoinTestFramework):
 
             fund_tx = CTransaction()
             # Add the 50 highest-value inputs
-            unspents = node.listunspent()
+            unspents = self.nodesigner.listunspent()
             random.shuffle(unspents)
             unspents.sort(key=lambda x: int(x["amount"] * 100000000), reverse=True)
             if len(unspents) > 50:
@@ -1515,8 +1511,8 @@ class TaprootTest(BitcoinTestFramework):
                 fund_tx.vout.append(CTxOut(amount, spenders[done + i].script))
             # Add change
             fund_tx.vout.append(CTxOut(balance - 10000, random.choice(host_spks)))
-            # Ask the wallet to sign
-            fund_tx = tx_from_hex(node.signrawtransactionwithwallet(fund_tx.serialize().hex())["hex"])
+            # Ask the node to sign
+            fund_tx = tx_from_hex(self.nodesigner.signrawtransaction(fund_tx.serialize().hex(), unspents)["hex"])
             # Construct UTXOData entries
             for i in range(count_this_tx):
                 utxodata = UTXOData(outpoint=COutPoint(fund_tx.txid_int, i), output=fund_tx.vout[i], spender=spenders[done])
@@ -1668,7 +1664,7 @@ class TaprootTest(BitcoinTestFramework):
         block.solve()
         self.nodes[0].submitblock(block.serialize().hex())
         assert_equal(self.nodes[0].getblockcount(), 1)
-        self.generate(self.nodes[0], COINBASE_MATURITY)
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY, self.nodesigner.getnewaddress()[2])
 
         SEED = 317
         VALID_LEAF_VERS = list(range(0xc0, 0x100, 2)) + [0x66, 0x7e, 0x80, 0x84, 0x96, 0x98, 0xba, 0xbc, 0xbe]
@@ -1879,6 +1875,7 @@ class TaprootTest(BitcoinTestFramework):
             print(json.dumps(tests, indent=4, sort_keys=False))
 
     def run_test(self):
+        self.nodesigner = NodeSigner(self.nodes[0])
         self.gen_test_vectors()
 
         self.log.info("Post-activation tests...")

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -189,7 +189,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
     def test_mixing_uncompressed_and_compressed_keys(self, node):
         self.log.info('Mixed compressed and uncompressed multisigs are not allowed')
-        pk0, pk1, pk2 = [getnewdestination('bech32')[0].hex() for _ in range(3)]
+        pk0, pk1, pk2 = [getnewdestination('bech32')[0][1].hex() for _ in range(3)]
 
         # decompress pk2
         pk_obj = ECPubKey()

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -36,9 +36,9 @@ class ScantxoutsetTest(BitcoinTestFramework):
         assert_equal(sum(u["coinbase"] for u in self.nodes[0].scantxoutset("start", [self.wallet.get_descriptor()])["unspents"]), 49)
 
         self.log.info("Create UTXOs...")
-        pubk1, spk_P2SH_SEGWIT, addr_P2SH_SEGWIT = getnewdestination("p2sh-segwit")
-        pubk2, spk_LEGACY, addr_LEGACY = getnewdestination("legacy")
-        pubk3, spk_BECH32, addr_BECH32 = getnewdestination("bech32")
+        (_, pubk1), spk_P2SH_SEGWIT, addr_P2SH_SEGWIT = getnewdestination("p2sh-segwit")
+        (_, pubk2), spk_LEGACY, addr_LEGACY = getnewdestination("legacy")
+        (_, pubk3), spk_BECH32, addr_BECH32 = getnewdestination("bech32")
         self.sendtodestination(spk_P2SH_SEGWIT, 0.001)
         self.sendtodestination(spk_LEGACY, 0.002)
         self.sendtodestination(spk_BECH32, 0.004)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -421,7 +421,7 @@ class MiniWallet:
 
 def getnewdestination(address_type='bech32m'):
     """Generate a random destination of the specified type and return the
-       corresponding public key, scriptPubKey and address. Supported types are
+       corresponding key pair, scriptPubKey and address. Supported types are
        'legacy', 'p2sh-segwit', 'bech32' and 'bech32m'. Can be used when a random
        destination is needed, but no compiled wallet is available (e.g. as
        replacement to the getnewaddress/getaddressinfo RPCs)."""
@@ -442,4 +442,4 @@ def getnewdestination(address_type='bech32m'):
         address = output_key_to_p2tr(pubkey)
     else:
         assert False
-    return pubkey, scriptpubkey, address
+    return (key, pubkey), scriptpubkey, address

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -54,7 +54,10 @@ from test_framework.util import (
     assert_greater_than_or_equal,
     get_fee,
 )
-from test_framework.wallet_util import generate_keypair
+from test_framework.wallet_util import (
+    bytes_to_wif,
+    generate_keypair,
+)
 
 DEFAULT_FEE = Decimal("0.0001")
 
@@ -417,6 +420,41 @@ class MiniWallet:
         for t in chain:
             self.sendrawtransaction(from_node=from_node, tx_hex=t["hex"])
         return chain
+
+
+class NodeSigner:
+    """Simple wallet replacement that delegates signing of existing raw transactions to a node by
+       using the `signrawtransactionwithkey` RPC. This can be used for spending from widespread
+       output types (P2PKH, P2WPKH, P2SH-P2WPKH, P2TR) without having the wallet compiled in."""
+    def __init__(self, node):
+        self._node = node
+        self._key_entries = []
+
+    def getnewaddress(self, address_type='legacy'):
+        (seckey, pubkey), spk, address = getnewdestination(address_type)
+        redeem_script = key_to_p2wpkh_script(pubkey) if address_type == 'p2sh-segwit' else None
+        self._key_entries.append({"seckey_wif": bytes_to_wif(seckey.get_bytes()), "output_script": spk, "redeem_script": redeem_script})
+        return pubkey, spk, address
+
+    def listunspent(self):
+        needles = [descsum_create(f'raw({key_entry["output_script"].hex()})') for key_entry in self._key_entries]
+        scan_res = self._node.scantxoutset(action="start", scanobjects=needles)
+        spend_height = scan_res['height'] + 1  # coins would be spent in the next block
+        unspents = []
+        for u in scan_res['unspents']:
+            if u["coinbase"] and (spend_height - u["height"]) < COINBASE_MATURITY:  # skip immature coins
+                continue
+            unspent = { "txid": u["txid"], "vout": u["vout"], "scriptPubKey": u["scriptPubKey"], "amount": u["amount"] }
+            key_entry = [ke for ke in self._key_entries if ke["output_script"] == bytes.fromhex(u["scriptPubKey"])][0]
+            if key_entry["redeem_script"] is not None:
+                unspent["redeemScript"] = key_entry["redeem_script"].hex()
+            unspents.append(unspent)
+        return unspents
+
+    def signrawtransaction(self, tx_hex, inputs):
+        output_scripts_to_sign = {i["scriptPubKey"] for i in inputs}
+        seckeys_wif = [ke["seckey_wif"] for ke in self._key_entries if ke["output_script"].hex() in output_scripts_to_sign]
+        return self._node.signrawtransactionwithkey(tx_hex, seckeys_wif, inputs)
 
 
 def getnewdestination(address_type='bech32m'):


### PR DESCRIPTION
This PR introduces a simple `NodeSigner` wallet replacement class that delegates signing to a specified node via the `signrawtransactionwithkey` RPC. Note that this is fundamentally different to `MiniWallet`, as it allows spending standard output types (P2PKH, P2WPKH, P2SH-P2WPKH, P2TR) and operates on already existing raw transactions, rather than allowing to create them from scratch (though support for that could still be added later).

A `NodeSigner` instance is plugged into the taproot functional test (`feature_taproot.py`) in order to allow running without having the Bitcoin Core wallet compiled. This was done with the intention to change the nature of this functional test as little as possible, as it seems that the variety of additional (pre-taproot) output script types and a rather sophisticated scheme for deriving amounts (including change) is desired -- if this is not considered relevant, a more invasive replacement using MiniWallet might also be a possible alternative.