### PR TITLE
test: remove usages of MAX_BIP125_RBF_SEQUENCE constant from functional tests

### DIFF
--- a/doc/release-notes-34917.md
+++ b/doc/release-notes-34917.md
@@ -1,14 +1,25 @@
 Wallet RPC and Startup Option
 ------------
-The `bip125-replaceable` key in the wallet transaction RPCs such
-as `listtransactions`, `listsinceblock`, and `gettransaction` is
-marked as deprecated. Users still have the option to retrieve this
+Signalling for RBF is not necessary for replacing transactions due
+to nodes being fullrbf and the wallet doesn't need to opt into it
+by default. Therefore, RBF related RPC and startup options can be
+marked deprecated now and removed in the next release.
+
+In PR #34917, the `bip125-replaceable` key in the wallet transaction
+RPCs such as `listtransactions`, `listsinceblock`, and `gettransaction`
+is marked as deprecated. Users still have the option to retrieve this
 key by passing the `-deprecatedrpc=bip125` startup option. Also,
 the `-walletrbf` startup option has been marked as deprecated and
 will be fully removed in the next release. Using this option emits
 a warning in the logs.
 
-Moreover, the default value of -walletrbf has been changed to 0
-in PR #35405 because signalling for RBF is not necessary for
-replacing transactions due to nodes being fullrbf and the wallet
-doesn't need to opt into it by default.
+Additionally, the `replaceable` argument in several wallet RPC
+requests has been marked deprecated in PR #35433 and for now
+users have the option to use this argument via the
+`-deprecatedrpc=bip125` startup option. Affected RPCs are
+`createrawtransaction`, `fundrawtransaction`, `createpsbt`,
+`walletcreatefundedpsbt`, `send`, `sendtoaddress`, `sendmany`,
+`sendall`, `bumpfee`, and `psbtbumpfee`.
+
+Moreover, the default value of -walletrbf startup option has been
+switched to 0 in PR #35405.

--- a/doc/release-notes-34917.md
+++ b/doc/release-notes-34917.md
@@ -1,4 +1,4 @@
-RPC and Startup Option
+Wallet RPC and Startup Option
 ------------
 The `bip125-replaceable` key in the wallet transaction RPCs such
 as `listtransactions`, `listsinceblock`, and `gettransaction` is
@@ -7,3 +7,8 @@ key by passing the `-deprecatedrpc=bip125` startup option. Also,
 the `-walletrbf` startup option has been marked as deprecated and
 will be fully removed in the next release. Using this option emits
 a warning in the logs.
+
+Moreover, the default value of -walletrbf has been changed to 0
+in PR #35405 because signalling for RBF is not necessary for
+replacing transactions due to nodes being fullrbf and the wallet
+doesn't need to opt into it by default.

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -117,7 +117,7 @@ static std::vector<RPCArg> CreateTxDoc()
             },
          RPCArgOptions{.skip_type_check = true}},
         {"locktime", RPCArg::Type::NUM, RPCArg::Default{0}, "Raw locktime. Non-0 value also locktime-activates inputs"},
-        {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{true}, "Marks this transaction as BIP125-replaceable.\n"
+        {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{false}, "(DEPRECATED) Marks this transaction as BIP125-replaceable.\n"
                 "Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible."},
         {"version", RPCArg::Type::NUM, RPCArg::Default{DEFAULT_RAWTX_VERSION}, "Transaction version"},
     };
@@ -394,8 +394,10 @@ static RPCMethod createrawtransaction()
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
     std::optional<bool> rbf;
-    if (!request.params[3].isNull()) {
-        rbf = request.params[3].get_bool();
+    if (IsDeprecatedRPCEnabled("bip125")) {
+        if (!request.params[3].isNull()) {
+            rbf = request.params[3].get_bool();
+        }
     }
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf, self.Arg<uint32_t>("version"));
 
@@ -1719,8 +1721,10 @@ static RPCMethod createpsbt()
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
     std::optional<bool> rbf;
-    if (!request.params[3].isNull()) {
-        rbf = request.params[3].get_bool();
+    if (IsDeprecatedRPCEnabled("bip125")) {
+        if (!request.params[3].isNull()) {
+            rbf = request.params[3].get_bool();
+        }
     }
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf, self.Arg<uint32_t>("version"));
 

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -46,7 +46,7 @@ void AddInputs(CMutableTransaction& rawTx, const UniValue& inputs_in, std::optio
 
         uint32_t nSequence;
 
-        if (rbf.value_or(true)) {
+        if (rbf.value_or(false)) {
             nSequence = MAX_BIP125_RBF_SEQUENCE; /* CTxIn::SEQUENCE_FINAL - 2 */
         } else if (rawTx.nLockTime) {
             nSequence = CTxIn::MAX_SEQUENCE_NONFINAL; /* CTxIn::SEQUENCE_FINAL - 1 */

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -223,8 +223,7 @@ static void SetFeeEstimateMode(const CWallet& wallet, CCoinControl& cc, const Un
         // Fee rates in sat/vB cannot represent more than 3 significant digits.
         cc.m_feerate = CFeeRate{AmountFromValue(fee_rate, /*decimals=*/3)};
         if (override_min_fee) cc.fOverrideFeeRate = true;
-        // Default RBF to true for explicit fee_rate, if unset.
-        if (!cc.m_signal_bip125_rbf) cc.m_signal_bip125_rbf = true;
+        if (!cc.m_signal_bip125_rbf) cc.m_signal_bip125_rbf = false;
         return;
     }
     if (!estimate_mode.isNull() && !FeeModeFromString(estimate_mode.get_str(), cc.m_fee_mode)) {
@@ -986,8 +985,8 @@ static RPCMethod bumpfee_helper(std::string method_name)
                              "\nSpecify a fee rate in " + CURRENCY_ATOM + "/vB instead of relying on the built-in fee estimator.\n"
                              "Must be at least " + incremental_fee + " higher than the current transaction fee rate.\n"
                              "WARNING: before version 0.21, fee_rate was in " + CURRENCY_UNIT + "/kvB. As of 0.21, fee_rate is in " + CURRENCY_ATOM + "/vB.\n"},
-                    {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{true},
-                             "Whether the new transaction should be\n"
+                    {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{false},
+                             "(DEPRECATED) Whether the new transaction should be\n"
                              "marked bip-125 replaceable. If true, the sequence numbers in the transaction will\n"
                              "be set to 0xfffffffd. If false, any input sequence numbers in the\n"
                              "transaction will be set to 0xfffffffe\n"
@@ -1043,7 +1042,7 @@ static RPCMethod bumpfee_helper(std::string method_name)
 
     CCoinControl coin_control;
     // optional parameters
-    coin_control.m_signal_bip125_rbf = true;
+    coin_control.m_signal_bip125_rbf = false;
     std::vector<CTxOut> outputs;
 
     std::optional<uint32_t> original_change_index;
@@ -1071,8 +1070,10 @@ static RPCMethod bumpfee_helper(std::string method_name)
 
         auto conf_target = options.exists("confTarget") ? options["confTarget"] : options["conf_target"];
 
-        if (options.exists("replaceable")) {
-            coin_control.m_signal_bip125_rbf = options["replaceable"].get_bool();
+        if (pwallet->chain().rpcEnableDeprecated("bip125")) {
+            if (options.exists("replaceable")) {
+                coin_control.m_signal_bip125_rbf = options["replaceable"].get_bool();
+            }
         }
         SetFeeEstimateMode(*pwallet, coin_control, conf_target, options["estimate_mode"], options["fee_rate"], /*override_min_fee=*/false);
 

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1273,7 +1273,12 @@ RPCMethod send()
             PreventOutdatedOptions(options);
 
 
-            bool rbf{options.exists("replaceable") ? options["replaceable"].get_bool() : pwallet->m_signal_rbf};
+            bool rbf{pwallet->m_signal_rbf};
+            if (pwallet->chain().rpcEnableDeprecated("bip125")) {
+                if (options.exists("replaceable")) {
+                    rbf = options["replaceable"].get_bool();
+                }
+            }
             UniValue outputs(UniValue::VOBJ);
             outputs = NormalizeOutputs(request.params[0]);
             std::vector<CRecipient> recipients = CreateRecipients(

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -569,8 +569,10 @@ CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransact
                 coinControl.fOverrideFeeRate = true;
             }
 
-            if (options.exists("replaceable")) {
-                coinControl.m_signal_bip125_rbf = options["replaceable"].get_bool();
+            if (wallet.chain().rpcEnableDeprecated("bip125")) {
+                if (options.exists("replaceable")) {
+                    coinControl.m_signal_bip125_rbf = options["replaceable"].get_bool();
+                }
             }
 
             if (options.exists("minconf")) {
@@ -1773,8 +1775,12 @@ RPCMethod walletcreatefundedpsbt()
     CCoinControl coin_control;
     coin_control.m_version = self.Arg<uint32_t>("version");
 
-    const UniValue &replaceable_arg = options["replaceable"];
-    const bool rbf{replaceable_arg.isNull() ? wallet.m_signal_rbf : replaceable_arg.get_bool()};
+    bool rbf{wallet.m_signal_rbf};
+    if (pwallet->chain().rpcEnableDeprecated("bip125")) {
+        if (options.exists("replaceable")) {
+            rbf = options["replaceable"].get_bool();
+        }
+    }
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf, coin_control.m_version);
     UniValue outputs(UniValue::VOBJ);
     outputs = NormalizeOutputs(request.params[1]);

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -250,7 +250,7 @@ RPCMethod sendtoaddress()
                                          "transaction, just kept in your wallet."},
                     {"subtractfeefromamount", RPCArg::Type::BOOL, RPCArg::Default{false}, "The fee will be deducted from the amount being sent.\n"
                                          "The recipient will receive less bitcoins than you enter in the amount field."},
-                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "Signal that this transaction can be replaced by a transaction (BIP 125)"},
+                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "(DEPRECATED) Signal that this transaction can be replaced by a transaction (BIP 125)"},
                     {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
                     {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
                       + FeeModesDetail(std::string("economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used"))},
@@ -303,8 +303,10 @@ RPCMethod sendtoaddress()
         mapValue["to"] = request.params[3].get_str();
 
     CCoinControl coin_control;
-    if (!request.params[5].isNull()) {
-        coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
+    if (pwallet->chain().rpcEnableDeprecated("bip125")) {
+        if (!request.params[5].isNull()) {
+            coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
+        }
     }
 
     coin_control.m_avoid_address_reuse = GetAvoidReuseFlag(*pwallet, request.params[8]);
@@ -357,7 +359,7 @@ RPCMethod sendmany()
                             {"address", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Subtract fee from this address"},
                         },
                     },
-                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "Signal that this transaction can be replaced by a transaction (BIP 125)"},
+                    {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "(DEPRECATED) Signal that this transaction can be replaced by a transaction (BIP 125)"},
                     {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
                     {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
                       + FeeModesDetail(std::string("economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used"))},
@@ -409,8 +411,10 @@ RPCMethod sendmany()
         mapValue["comment"] = request.params[3].get_str();
 
     CCoinControl coin_control;
-    if (!request.params[5].isNull()) {
-        coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
+    if (pwallet->chain().rpcEnableDeprecated("bip125")) {
+        if (!request.params[5].isNull()) {
+            coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
+        }
     }
 
     SetFeeEstimateMode(*pwallet, coin_control, /*conf_target=*/request.params[6], /*estimate_mode=*/request.params[7], /*fee_rate=*/request.params[8], /*override_min_fee=*/false);

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -434,7 +434,7 @@ static std::vector<RPCArg> FundTxDoc(bool solving_data = true)
         {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
           + FeeModesDetail(std::string("economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used")), RPCArgOptions{.also_positional = true}},
         {
-            "replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "Marks this transaction as BIP125-replaceable.\n"
+            "replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"wallet default"}, "(DEPRECATED) Marks this transaction as BIP125-replaceable.\n"
             "Allows this transaction to be replaced by a transaction with higher fees"
         },
     };
@@ -1438,7 +1438,12 @@ RPCMethod sendall()
                 coin_control.m_max_tx_weight = MAX_STANDARD_TX_WEIGHT;
             }
 
-            const bool rbf{options.exists("replaceable") ? options["replaceable"].get_bool() : pwallet->m_signal_rbf};
+            bool rbf{pwallet->m_signal_rbf};
+            if (pwallet->chain().rpcEnableDeprecated("bip125")) {
+                if (options.exists("replaceable")) {
+                    rbf = options["replaceable"].get_bool();
+                }
+            }
 
             FeeCalculation fee_calc_out;
             CFeeRate fee_rate{GetMinimumFeeRate(*pwallet, coin_control, &fee_calc_out)};

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1297,7 +1297,7 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     // The sequence number is set to non-maxint so that DiscourageFeeSniping
     // works.
     //
-    // BIP125 defines opt-in RBF as any nSequence < maxint-1, so
+    // (DEPRECATED) BIP125 defines opt-in RBF as any nSequence < maxint-1, so
     // we use the highest possible value in that range (maxint-2)
     // to avoid conflicting with other possible uses of nSequence,
     // and in the spirit of "smallest possible change from prior

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -128,7 +128,7 @@ static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS{true};
 //! -txconfirmtarget default
 static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 //! -walletrbf default
-static const bool DEFAULT_WALLET_RBF = true;
+static const bool DEFAULT_WALLET_RBF{false};
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 static const bool DEFAULT_WALLETCROSSCHAIN = false;

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -7,7 +7,7 @@
 from decimal import Decimal
 
 from test_framework.messages import (
-    MAX_BIP125_RBF_SEQUENCE,
+    MAX_SEQUENCE_NONFINAL,
     COIN,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -541,7 +541,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         optout_tx = self.wallet.send_self_transfer(
             from_node=self.nodes[0],
             utxo_to_spend=confirmed_utxo,
-            sequence=MAX_BIP125_RBF_SEQUENCE + 1,
+            sequence=MAX_SEQUENCE_NONFINAL,
             fee_rate=Decimal('0.01'),
         )
         assert_equal(False, self.nodes[0].getmempoolentry(optout_tx['txid'])['bip125-replaceable'])

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -15,7 +15,6 @@ from test_framework.mempool_util import (
     DEFAULT_INCREMENTAL_RELAY_FEE,
 )
 from test_framework.messages import (
-    MAX_BIP125_RBF_SEQUENCE,
     COIN,
     COutPoint,
     CTransaction,
@@ -131,7 +130,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.log.info('A transaction not in the mempool')
         fee = Decimal('0.000007')
         utxo_to_spend = self.wallet.get_utxo(txid=txid_in_block)  # use 0.3 BTC UTXO
-        tx = self.wallet.create_self_transfer(utxo_to_spend=utxo_to_spend, sequence=MAX_BIP125_RBF_SEQUENCE)['tx']
+        tx = self.wallet.create_self_transfer(utxo_to_spend=utxo_to_spend)['tx']
         tx.vout[0].nValue = int((Decimal('0.3') - fee) * COIN)
         raw_tx_0 = tx.serialize().hex()
         txid_0 = tx.txid_hex

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 from test_framework.messages import (
     COIN,
-    MAX_BIP125_RBF_SEQUENCE,
+    MAX_SEQUENCE_NONFINAL,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mempool_util import fill_mempool
@@ -54,7 +54,7 @@ class PackageRBFTest(BitcoinTestFramework):
         parent_result = self.wallet.create_self_transfer(
             fee=parent_fee,
             utxo_to_spend=parent_coin,
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
 
         num_child_outputs = 10 if heavy_child else 1
@@ -62,7 +62,7 @@ class PackageRBFTest(BitcoinTestFramework):
             utxos_to_spend=[parent_result["new_utxo"]],
             num_outputs=num_child_outputs,
             fee_per_output=int(child_fee * COIN // num_child_outputs),
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
         package_hex = [parent_result["hex"], child_result["hex"]]
         package_txns = [parent_result["tx"], child_result["tx"]]
@@ -71,7 +71,7 @@ class PackageRBFTest(BitcoinTestFramework):
     def run_test(self):
         # Counter used to count the number of times we constructed packages. Since we're constructing parent transactions with the same
         # coins (to create conflicts), and perhaps giving them the same fee, we might accidentally just create the same transaction again.
-        # To prevent this, set nSequences to MAX_BIP125_RBF_SEQUENCE - self.ctr.
+        # To prevent this, set nSequences to MAX_SEQUENCE_NONFINAL - self.ctr.
         self.ctr = 0
 
         self.log.info("Generate blocks to create UTXOs")
@@ -258,7 +258,7 @@ class PackageRBFTest(BitcoinTestFramework):
         parent_result1 = self.wallet.create_self_transfer(
             fee=DEFAULT_FEE,
             utxo_to_spend=coin,
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
 
         coin2 = self.coins.pop()
@@ -269,7 +269,7 @@ class PackageRBFTest(BitcoinTestFramework):
         parent_result2 = self.wallet.create_self_transfer(
             fee=DEFAULT_FEE,
             utxo_to_spend=coin2,
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
 
         # Child that spends both, violating cluster size rule due
@@ -278,7 +278,7 @@ class PackageRBFTest(BitcoinTestFramework):
         child_result = self.wallet.create_self_transfer_multi(
             fee_per_output=int(DEFAULT_CHILD_FEE * COIN),
             utxos_to_spend=[parent_result1["new_utxo"], parent_result2["new_utxo"]],
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
 
         package_hex2 = [parent_result1["hex"], parent_result2["hex"], child_result["hex"]]
@@ -310,7 +310,7 @@ class PackageRBFTest(BitcoinTestFramework):
         parent_result1 = self.wallet.create_self_transfer(
             fee=DEFAULT_FEE,
             utxo_to_spend=coin1,
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
 
         # Double-spends the second package
@@ -318,7 +318,7 @@ class PackageRBFTest(BitcoinTestFramework):
         parent_result2 = self.wallet.create_self_transfer(
             fee=DEFAULT_FEE,
             utxo_to_spend=coin2,
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
 
         # Child that spends both, violating cluster size rule due
@@ -327,7 +327,7 @@ class PackageRBFTest(BitcoinTestFramework):
         child_result = self.wallet.create_self_transfer_multi(
             fee_per_output=int(DEFAULT_CHILD_FEE * COIN),
             utxos_to_spend=[parent_result1["new_utxo"], parent_result2["new_utxo"]],
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
 
         package_hex3 = [parent_result1["hex"], parent_result2["hex"], child_result["hex"]]
@@ -396,7 +396,7 @@ class PackageRBFTest(BitcoinTestFramework):
         grandparent_result = self.wallet.create_self_transfer(
             fee=DEFAULT_FEE,
             utxo_to_spend=coin,
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
 
         node.sendrawtransaction(grandparent_result["hex"])
@@ -408,7 +408,7 @@ class PackageRBFTest(BitcoinTestFramework):
         parent_result = self.wallet.create_self_transfer(
             fee_rate=minrelayfeerate,
             utxo_to_spend=grandparent_result["new_utxo"],
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
         # Last tx double-spends grandparent's coin,
         # which is not inside the current package
@@ -416,7 +416,7 @@ class PackageRBFTest(BitcoinTestFramework):
         child_result = self.wallet.create_self_transfer_multi(
             fee_per_output=int(DEFAULT_CHILD_FEE * COIN),
             utxos_to_spend=[parent_result["new_utxo"], coin],
-            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            sequence=MAX_SEQUENCE_NONFINAL - self.ctr,
         )
 
         pkg_result = node.submitpackage([parent_result["hex"], child_result["hex"]])

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -24,7 +24,7 @@ from test_framework.messages import (
     CTxIn,
     CTxOut,
     CTxInWitness,
-    MAX_BIP125_RBF_SEQUENCE,
+    MAX_SEQUENCE_NONFINAL,
     MSG_WTX,
     msg_inv,
     msg_tx,
@@ -610,7 +610,7 @@ class PackageRelayTest(BitcoinTestFramework):
         # To avoid creating transactions with the same txid (can happen if we set the same feerate
         # and reuse the same input as a previous transaction that wasn't successfully submitted),
         # we give each subtest a different nSequence for its transactions.
-        self.sequence = MAX_BIP125_RBF_SEQUENCE
+        self.sequence = MAX_SEQUENCE_NONFINAL
 
         self.wallet = MiniWallet(node)
         self.wallet_nonsegwit = MiniWallet(node, mode=MiniWalletMode.RAW_P2PK)

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -12,7 +12,6 @@ from test_framework.blocktools import (
     create_block,
 )
 from test_framework.messages import (
-    MAX_BIP125_RBF_SEQUENCE,
     CBlockHeader,
     CInv,
     COutPoint,
@@ -577,7 +576,6 @@ class SegWitTest(BitcoinTestFramework):
         tx.vin = [CTxIn(COutPoint(p2sh_tx.txid_int, 0), CScript([witness_script]))]
         tx.vout = [CTxOut(p2sh_tx.vout[0].nValue - 10000, script_pubkey)]
         tx.vout.append(CTxOut(8000, script_pubkey))  # Might burn this later
-        tx.vin[0].nSequence = MAX_BIP125_RBF_SEQUENCE  # Just to have the option to bump this tx from the mempool
 
         # This is always accepted, since the mempool policy is to consider segwit as always active
         # and thus allow segwit outputs

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -12,7 +12,6 @@ from test_framework.mempool_util import (
     fill_mempool,
 )
 from test_framework.messages import (
-    MAX_BIP125_RBF_SEQUENCE,
     tx_from_hex,
 )
 from test_framework.p2p import P2PTxInvStore
@@ -296,7 +295,7 @@ class RPCPackagesTest(BitcoinTestFramework):
 
         coin = self.wallet.get_utxo()
         fee = Decimal("0.00125000")
-        replaceable_tx = self.wallet.create_self_transfer(utxo_to_spend=coin, sequence=MAX_BIP125_RBF_SEQUENCE, fee = fee)
+        replaceable_tx = self.wallet.create_self_transfer(utxo_to_spend=coin, fee = fee)
         testres_replaceable = node.testmempoolaccept([replaceable_tx["hex"]])[0]
         assert_equal(testres_replaceable["txid"], replaceable_tx["txid"])
         assert_equal(testres_replaceable["wtxid"], replaceable_tx["wtxid"])
@@ -307,7 +306,7 @@ class RPCPackagesTest(BitcoinTestFramework):
         assert_equal(testres_replaceable["fees"]["effective-includes"], [replaceable_tx["wtxid"]])
 
         # Replacement transaction is identical except has double the fee
-        replacement_tx = self.wallet.create_self_transfer(utxo_to_spend=coin, sequence=MAX_BIP125_RBF_SEQUENCE, fee = 2 * fee)
+        replacement_tx = self.wallet.create_self_transfer(utxo_to_spend=coin, fee = 2 * fee)
         testres_rbf_conflicting = node.testmempoolaccept([replaceable_tx["hex"], replacement_tx["hex"]])
         assert_equal(testres_rbf_conflicting, [
             {"txid": replaceable_tx["txid"], "wtxid": replaceable_tx["wtxid"], "package-error": "conflict-in-package"},

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -18,7 +18,6 @@ from test_framework.messages import (
     CTransaction,
     CTxIn,
     CTxOut,
-    MAX_BIP125_RBF_SEQUENCE,
     MAX_SEQUENCE_NONFINAL,
     WITNESS_SCALE_FACTOR,
     ser_compact_size,
@@ -862,15 +861,15 @@ class PSBTTest(BitcoinTestFramework):
         psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height+2, {"replaceable": False, "add_inputs": True}, False)
         decoded_psbt = self.nodes[0].decodepsbt(psbtx_info["psbt"])
         for psbt_in in decoded_psbt["inputs"]:
-            assert_greater_than(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
+            assert_equal(psbt_in["sequence"], MAX_SEQUENCE_NONFINAL)
             assert "bip32_derivs" not in psbt_in
         assert_equal(decoded_psbt["fallback_locktime"], block_height+2)
 
-        # Same construction with only locktime set and RBF explicitly enabled
+        # Same construction with only locktime set and deprecated RBF explicitly enabled
         psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height, {"replaceable": True, "add_inputs": True}, True)
         decoded_psbt = self.nodes[0].decodepsbt(psbtx_info["psbt"])
         for psbt_in in decoded_psbt["inputs"]:
-            assert_equal(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
+            assert_equal(psbt_in["sequence"], MAX_SEQUENCE_NONFINAL)
             assert "bip32_derivs" in psbt_in
         assert_equal(decoded_psbt["fallback_locktime"], block_height)
 

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -19,6 +19,7 @@ from test_framework.messages import (
     CTxIn,
     CTxOut,
     MAX_BIP125_RBF_SEQUENCE,
+    MAX_SEQUENCE_NONFINAL,
     WITNESS_SCALE_FACTOR,
     ser_compact_size,
 )
@@ -877,7 +878,7 @@ class PSBTTest(BitcoinTestFramework):
         psbtx_info = self.nodes[0].walletcreatefundedpsbt([], [{self.nodes[2].getnewaddress():unspent["amount"]+1}])
         decoded_psbt = self.nodes[0].decodepsbt(psbtx_info["psbt"])
         for psbt_in in decoded_psbt["inputs"]:
-            assert_equal(psbt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
+            assert_equal(psbt_in["sequence"], MAX_SEQUENCE_NONFINAL)
             assert "bip32_derivs" in psbt_in
         assert_equal(decoded_psbt["fallback_locktime"], 0)
 

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -17,7 +17,6 @@ from decimal import Decimal
 from itertools import product
 
 from test_framework.messages import (
-    MAX_BIP125_RBF_SEQUENCE,
     COIN,
     TX_MAX_STANDARD_VERSION,
     TX_MIN_STANDARD_VERSION,
@@ -303,10 +302,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Invalid parameter, duplicate key: data", self.nodes[0].createrawtransaction, [], multidict([("data", 'aa'), ("data", "bb")]))
         assert_raises_rpc_error(-8, "Invalid parameter, key-value pair must contain exactly one key", self.nodes[0].createrawtransaction, [], [{'a': 1, 'b': 2}])
         assert_raises_rpc_error(-8, "Invalid parameter, key-value pair not an object as expected", self.nodes[0].createrawtransaction, [], [['key-value pair1'], ['2']])
-
-        # Test `createrawtransaction` mismatch between sequence number(s) and `replaceable` option
-        assert_raises_rpc_error(-8, "Invalid parameter combination: Sequence number(s) contradict replaceable option",
-                                self.nodes[0].createrawtransaction, [{'txid': TXID, 'vout': 0, 'sequence': MAX_BIP125_RBF_SEQUENCE+1}], {}, 0, True)
 
         # Test `createrawtransaction` invalid `locktime`
         assert_raises_rpc_error(-3, "JSON value of type string is not of expected type number", self.nodes[0].createrawtransaction, [], {}, 'foo')

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -45,7 +45,6 @@ MAX_BLOOM_HASH_FUNCS = 50
 COIN = 100000000  # 1 btc in satoshis
 MAX_MONEY = 21000000 * COIN
 
-MAX_BIP125_RBF_SEQUENCE = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
 MAX_SEQUENCE_NONFINAL = 0xfffffffe  # Sequence number that is csv-opt-out (BIP 68)
 SEQUENCE_FINAL = 0xffffffff  # Sequence number that disables nLockTime if set for every input of a tx
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -72,118 +72,118 @@ class BumpFeeTest(BitcoinTestFramework):
         self.nodes[1].encryptwallet(WALLET_PASSPHRASE)
         self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
 
-        peer_node, rbf_node = self.nodes
-        rbf_node_address = rbf_node.getnewaddress()
+        peer_node, node = self.nodes
+        node_address = node.getnewaddress()
 
         # fund rbf node with 10 coins of 0.001 btc (100,000 satoshis)
         self.log.info("Mining blocks...")
         self.generate(peer_node, 110)
         for _ in range(25):
-            peer_node.sendtoaddress(rbf_node_address, 0.001)
+            peer_node.sendtoaddress(node_address, 0.001)
         self.sync_all()
         self.generate(peer_node, 1)
-        assert_equal(rbf_node.getbalance(), Decimal("0.025"))
+        assert_equal(node.getbalance(), Decimal("0.025"))
 
         self.log.info("Running tests")
         dest_address = peer_node.getnewaddress()
         for mode in ["default", "fee_rate", "new_outputs"]:
-            test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address)
-        self.test_invalid_parameters(rbf_node, peer_node, dest_address)
-        test_segwit_bumpfee_succeeds(self, rbf_node, dest_address)
+            test_simple_bumpfee_succeeds(self, mode, node, peer_node, dest_address)
+        self.test_invalid_parameters(node, peer_node, dest_address)
+        test_segwit_bumpfee_succeeds(self, node, dest_address)
         test_nonrbf_bumpfee_succeeds(self, peer_node, dest_address)
-        test_notmine_bumpfee(self, rbf_node, peer_node, dest_address)
-        test_bumpfee_with_descendant_fails(self, rbf_node, rbf_node_address, dest_address)
-        test_bumpfee_with_abandoned_descendant_succeeds(self, rbf_node, rbf_node_address, dest_address)
-        test_dust_to_fee(self, rbf_node, dest_address)
-        test_watchonly_psbt(self, peer_node, rbf_node, dest_address)
-        test_rebumping(self, rbf_node, dest_address)
-        test_rebumping_not_replaceable(self, rbf_node, dest_address)
-        test_bumpfee_already_spent(self, rbf_node, dest_address)
-        test_unconfirmed_not_spendable(self, rbf_node, rbf_node_address)
-        test_bumpfee_metadata(self, rbf_node, dest_address)
-        test_locked_wallet_fails(self, rbf_node, dest_address)
-        test_change_script_match(self, rbf_node, dest_address)
-        test_maxtxfee_fails(self, rbf_node, dest_address)
+        test_notmine_bumpfee(self, node, peer_node, dest_address)
+        test_bumpfee_with_descendant_fails(self, node, node_address, dest_address)
+        test_bumpfee_with_abandoned_descendant_succeeds(self, node, node_address, dest_address)
+        test_dust_to_fee(self, node, dest_address)
+        test_watchonly_psbt(self, peer_node, node, dest_address)
+        test_rebumping(self, node, dest_address)
+        test_rebumping_not_replaceable(self, node, dest_address)
+        test_bumpfee_already_spent(self, node, dest_address)
+        test_unconfirmed_not_spendable(self, node, node_address)
+        test_bumpfee_metadata(self, node, dest_address)
+        test_locked_wallet_fails(self, node, dest_address)
+        test_change_script_match(self, node, dest_address)
+        test_maxtxfee_fails(self, node, dest_address)
         # These tests wipe out a number of utxos that are expected in other tests
-        test_small_output_with_feerate_succeeds(self, rbf_node, dest_address)
-        test_no_more_inputs_fails(self, rbf_node, dest_address)
+        test_small_output_with_feerate_succeeds(self, node, dest_address)
+        test_no_more_inputs_fails(self, node, dest_address)
         self.test_bump_back_to_yourself()
-        self.test_provided_change_pos(rbf_node)
+        self.test_provided_change_pos(node)
         self.test_single_output()
 
         # Context independent tests
-        test_feerate_checks_replaced_outputs(self, rbf_node, peer_node)
-        test_bumpfee_with_feerate_ignores_walletincrementalrelayfee(self, rbf_node, peer_node)
+        test_feerate_checks_replaced_outputs(self, node, peer_node)
+        test_bumpfee_with_feerate_ignores_walletincrementalrelayfee(self, node, peer_node)
 
-    def test_invalid_parameters(self, rbf_node, peer_node, dest_address):
+    def test_invalid_parameters(self, node, peer_node, dest_address):
         self.log.info('Test invalid parameters')
-        rbfid = spend_one_input(rbf_node, dest_address)
-        self.sync_mempools((rbf_node, peer_node))
-        assert rbfid in rbf_node.getrawmempool() and rbfid in peer_node.getrawmempool()
+        rbfid = spend_one_input(node, dest_address)
+        self.sync_mempools((node, peer_node))
+        assert rbfid in node.getrawmempool() and rbfid in peer_node.getrawmempool()
 
         for key in ["totalFee", "feeRate"]:
-            assert_raises_rpc_error(-3, "Unexpected key {}".format(key), rbf_node.bumpfee, rbfid, {key: NORMAL})
+            assert_raises_rpc_error(-3, "Unexpected key {}".format(key), node.bumpfee, rbfid, {key: NORMAL})
 
         # Bumping to just above minrelay should fail to increase the total fee enough.
-        assert_raises_rpc_error(-8, "Insufficient total fee 0.00000141", rbf_node.bumpfee, rbfid, fee_rate=INSUFFICIENT)
+        assert_raises_rpc_error(-8, "Insufficient total fee 0.00000141", node.bumpfee, rbfid, fee_rate=INSUFFICIENT)
 
         self.log.info("Test invalid fee rate settings")
         assert_raises_rpc_error(-4, "Specified or calculated fee 0.141 is too high (cannot be higher than -maxtxfee 0.10",
-            rbf_node.bumpfee, rbfid, fee_rate=TOO_HIGH)
+            node.bumpfee, rbfid, fee_rate=TOO_HIGH)
         # Test fee_rate with zero values.
         msg = "Insufficient total fee 0.00"
         for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
-            assert_raises_rpc_error(-8, msg, rbf_node.bumpfee, rbfid, fee_rate=zero_value)
+            assert_raises_rpc_error(-8, msg, node.bumpfee, rbfid, fee_rate=zero_value)
         msg = "Invalid amount"
         # Test fee_rate values that don't pass fixed-point parsing checks.
         if not self.options.usecli:
             for invalid_value in ["", 0.000000001, 1e-09, 1.111111111, 1111111111111111, "31.999999999999999999999"]:
-                assert_raises_rpc_error(-3, msg, rbf_node.bumpfee, rbfid, fee_rate=invalid_value)
+                assert_raises_rpc_error(-3, msg, node.bumpfee, rbfid, fee_rate=invalid_value)
         # Test fee_rate values that cannot be represented in sat/vB.
         for invalid_value in [0.0001, 0.00000001, 0.00099999, 31.99999999]:
-            assert_raises_rpc_error(-3, msg, rbf_node.bumpfee, rbfid, fee_rate=invalid_value)
+            assert_raises_rpc_error(-3, msg, node.bumpfee, rbfid, fee_rate=invalid_value)
         # Test fee_rate out of range (negative number).
-        assert_raises_rpc_error(-3, "Amount out of range", rbf_node.bumpfee, rbfid, fee_rate=-1)
+        assert_raises_rpc_error(-3, "Amount out of range", node.bumpfee, rbfid, fee_rate=-1)
         # Test type error.
         for value in [{"foo": "bar"}, True]:
-            assert_raises_rpc_error(-3, "Amount is not a number or string", rbf_node.bumpfee, rbfid, fee_rate=value)
+            assert_raises_rpc_error(-3, "Amount is not a number or string", node.bumpfee, rbfid, fee_rate=value)
 
         self.log.info("Test explicit fee rate raises RPC error if both fee_rate and conf_target are passed")
         assert_raises_rpc_error(-8, "Cannot specify both conf_target and fee_rate. Please provide either a confirmation "
             "target in blocks for automatic fee estimation, or an explicit fee rate.",
-            rbf_node.bumpfee, rbfid, conf_target=NORMAL, fee_rate=NORMAL)
+            node.bumpfee, rbfid, conf_target=NORMAL, fee_rate=NORMAL)
 
         self.log.info("Test explicit fee rate raises RPC error if both fee_rate and estimate_mode are passed")
         assert_raises_rpc_error(-8, "Cannot specify both estimate_mode and fee_rate",
-            rbf_node.bumpfee, rbfid, estimate_mode="economical", fee_rate=NORMAL)
+            node.bumpfee, rbfid, estimate_mode="economical", fee_rate=NORMAL)
 
         self.log.info("Test invalid conf_target settings")
         assert_raises_rpc_error(-8, "confTarget and conf_target options should not both be set",
-            rbf_node.bumpfee, rbfid, {"confTarget": 123, "conf_target": 456})
+            node.bumpfee, rbfid, {"confTarget": 123, "conf_target": 456})
 
         self.log.info("Test invalid estimate_mode settings")
         if not self.options.usecli:
             for k, v in {"number": 42, "object": {"foo": "bar"}}.items():
                 assert_raises_rpc_error(-3, f"JSON value of type {k} for field estimate_mode is not of expected type string",
-                    rbf_node.bumpfee, rbfid, estimate_mode=v)
+                    node.bumpfee, rbfid, estimate_mode=v)
         for mode in ["foo", Decimal("3.1415"), "sat/B", "BTC/kB"]:
             assert_raises_rpc_error(-8, 'Invalid estimate_mode parameter, must be one of: "unset", "economical", "conservative"',
-                rbf_node.bumpfee, rbfid, estimate_mode=mode)
+                node.bumpfee, rbfid, estimate_mode=mode)
 
         self.log.info("Test invalid outputs values")
         assert_raises_rpc_error(-8, "Invalid parameter, output argument cannot be an empty array",
-                rbf_node.bumpfee, rbfid, {"outputs": []})
+                node.bumpfee, rbfid, {"outputs": []})
         assert_raises_rpc_error(-8, "Invalid parameter, duplicated address: " + dest_address,
-                rbf_node.bumpfee, rbfid, {"outputs": [{dest_address: 0.1}, {dest_address: 0.2}]})
+                node.bumpfee, rbfid, {"outputs": [{dest_address: 0.1}, {dest_address: 0.2}]})
         assert_raises_rpc_error(-8, "Invalid parameter, duplicate key: data",
-                rbf_node.bumpfee, rbfid, {"outputs": [{"data": "deadbeef"}, {"data": "deadbeef"}]})
+                node.bumpfee, rbfid, {"outputs": [{"data": "deadbeef"}, {"data": "deadbeef"}]})
 
         self.log.info("Test original_change_index option")
-        assert_raises_rpc_error(-1, "JSON integer out of range", rbf_node.bumpfee, rbfid, {"original_change_index": -1})
-        assert_raises_rpc_error(-8, "Change position is out of range", rbf_node.bumpfee, rbfid, {"original_change_index": 2})
+        assert_raises_rpc_error(-1, "JSON integer out of range", node.bumpfee, rbfid, {"original_change_index": -1})
+        assert_raises_rpc_error(-8, "Change position is out of range", node.bumpfee, rbfid, {"original_change_index": 2})
 
         self.log.info("Test outputs and original_change_index cannot both be provided")
-        assert_raises_rpc_error(-8, "The options 'outputs' and 'original_change_index' are incompatible. You can only either specify a new set of outputs, or designate a change output to be recycled.", rbf_node.bumpfee, rbfid, {"original_change_index": 2, "outputs": [{dest_address: 0.1}]})
+        assert_raises_rpc_error(-8, "The options 'outputs' and 'original_change_index' are incompatible. You can only either specify a new set of outputs, or designate a change output to be recycled.", node.bumpfee, rbfid, {"original_change_index": 2, "outputs": [{dest_address: 0.1}]})
 
         self.clear_mempool()
 
@@ -236,30 +236,30 @@ class BumpFeeTest(BitcoinTestFramework):
 
         node.unloadwallet("back_to_yourself")
 
-    def test_provided_change_pos(self, rbf_node):
+    def test_provided_change_pos(self, node):
         self.log.info("Test the original_change_index option")
 
-        change_addr = rbf_node.getnewaddress()
-        dest_addr = rbf_node.getnewaddress()
-        assert_equal(rbf_node.getaddressinfo(change_addr)["ischange"], False)
-        assert_equal(rbf_node.getaddressinfo(dest_addr)["ischange"], False)
+        change_addr = node.getnewaddress()
+        dest_addr = node.getnewaddress()
+        assert_equal(node.getaddressinfo(change_addr)["ischange"], False)
+        assert_equal(node.getaddressinfo(dest_addr)["ischange"], False)
 
-        send_res = rbf_node.send(outputs=[{dest_addr: 1}], options={"change_address": change_addr})
+        send_res = node.send(outputs=[{dest_addr: 1}], options={"change_address": change_addr})
         assert send_res["complete"]
         txid = send_res["txid"]
 
-        tx = rbf_node.gettransaction(txid=txid, verbose=True)
+        tx = node.gettransaction(txid=txid, verbose=True)
         assert_equal(len(tx["decoded"]["vout"]), 2)
 
-        change_pos = find_vout_for_address(rbf_node, txid, change_addr)
+        change_pos = find_vout_for_address(node, txid, change_addr)
         change_value = tx["decoded"]["vout"][change_pos]["value"]
 
-        bumped = rbf_node.bumpfee(txid, {"original_change_index": change_pos})
+        bumped = node.bumpfee(txid, {"original_change_index": change_pos})
         new_txid = bumped["txid"]
 
-        new_tx = rbf_node.gettransaction(txid=new_txid, verbose=True)
+        new_tx = node.gettransaction(txid=new_txid, verbose=True)
         assert_equal(len(new_tx["decoded"]["vout"]), 2)
-        new_change_pos = find_vout_for_address(rbf_node, new_txid, change_addr)
+        new_change_pos = find_vout_for_address(node, new_txid, change_addr)
         new_change_value = new_tx["decoded"]["vout"][new_change_pos]["value"]
 
         assert_greater_than(change_value, new_change_value)
@@ -302,22 +302,22 @@ class BumpFeeTest(BitcoinTestFramework):
 
         wallet.unloadwallet()
 
-def test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address):
+def test_simple_bumpfee_succeeds(self, mode, node, peer_node, dest_address):
     self.log.info('Test simple bumpfee: {}'.format(mode))
-    rbfid = spend_one_input(rbf_node, dest_address)
-    rbftx = rbf_node.gettransaction(rbfid)
-    self.sync_mempools((rbf_node, peer_node))
-    assert rbfid in rbf_node.getrawmempool() and rbfid in peer_node.getrawmempool()
+    rbfid = spend_one_input(node, dest_address)
+    rbftx = node.gettransaction(rbfid)
+    self.sync_mempools((node, peer_node))
+    assert rbfid in node.getrawmempool() and rbfid in peer_node.getrawmempool()
     if mode == "fee_rate":
-        bumped_psbt = rbf_node.psbtbumpfee(rbfid, fee_rate=str(NORMAL))
-        bumped_tx = rbf_node.bumpfee(rbfid, fee_rate=NORMAL)
+        bumped_psbt = node.psbtbumpfee(rbfid, fee_rate=str(NORMAL))
+        bumped_tx = node.bumpfee(rbfid, fee_rate=NORMAL)
     elif mode == "new_outputs":
         new_address = peer_node.getnewaddress()
-        bumped_psbt = rbf_node.psbtbumpfee(rbfid, outputs={new_address: 0.0003})
-        bumped_tx = rbf_node.bumpfee(rbfid, outputs={new_address: 0.0003})
+        bumped_psbt = node.psbtbumpfee(rbfid, outputs={new_address: 0.0003})
+        bumped_tx = node.bumpfee(rbfid, outputs={new_address: 0.0003})
     else:
-        bumped_psbt = rbf_node.psbtbumpfee(rbfid)
-        bumped_tx = rbf_node.bumpfee(rbfid)
+        bumped_psbt = node.psbtbumpfee(rbfid)
+        bumped_tx = node.bumpfee(rbfid)
     assert_equal(bumped_tx["errors"], [])
     assert bumped_tx["fee"] > -rbftx["fee"]
     assert_equal(bumped_tx["origfee"], -rbftx["fee"])
@@ -327,15 +327,15 @@ def test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address):
     assert_equal(bumped_psbt["origfee"], -rbftx["fee"])
     assert "psbt" in bumped_psbt
     # check that bumped_tx propagates, original tx was evicted and has a wallet conflict
-    self.sync_mempools((rbf_node, peer_node))
-    assert bumped_tx["txid"] in rbf_node.getrawmempool()
+    self.sync_mempools((node, peer_node))
+    assert bumped_tx["txid"] in node.getrawmempool()
     assert bumped_tx["txid"] in peer_node.getrawmempool()
-    assert rbfid not in rbf_node.getrawmempool()
+    assert rbfid not in node.getrawmempool()
     assert rbfid not in peer_node.getrawmempool()
-    oldwtx = rbf_node.gettransaction(rbfid)
+    oldwtx = node.gettransaction(rbfid)
     assert len(oldwtx["walletconflicts"]) > 0
     # check wallet transaction replaces and replaced_by values
-    bumpedwtx = rbf_node.gettransaction(bumped_tx["txid"])
+    bumpedwtx = node.gettransaction(bumped_tx["txid"])
     assert_equal(oldwtx["replaced_by_txid"], bumped_tx["txid"])
     assert_equal(bumpedwtx["replaces_txid"], rbfid)
     # if this is a new_outputs test, check that outputs were indeed replaced
@@ -345,27 +345,27 @@ def test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address):
     self.clear_mempool()
 
 
-def test_segwit_bumpfee_succeeds(self, rbf_node, dest_address):
+def test_segwit_bumpfee_succeeds(self, node, dest_address):
     self.log.info('Test that segwit-sourcing bumpfee works')
     # Create a transaction with segwit output, then create an RBF transaction
     # which spends it, and make sure bumpfee can be called on it.
 
-    segwit_out = rbf_node.getnewaddress(address_type='bech32')
-    segwitid = rbf_node.send({segwit_out: "0.0009"}, options={"change_position": 1})["txid"]
+    segwit_out = node.getnewaddress(address_type='bech32')
+    segwitid = node.send({segwit_out: "0.0009"}, options={"change_position": 1})["txid"]
 
-    rbfraw = rbf_node.createrawtransaction([{
+    rbfraw = node.createrawtransaction([{
         'txid': segwitid,
         'vout': 0,
         "sequence": MAX_BIP125_RBF_SEQUENCE
     }], {dest_address: Decimal("0.0005"),
-         rbf_node.getrawchangeaddress(): Decimal("0.0003")})
-    rbfsigned = rbf_node.signrawtransactionwithwallet(rbfraw)
-    rbfid = rbf_node.sendrawtransaction(rbfsigned["hex"])
-    assert rbfid in rbf_node.getrawmempool()
+         node.getrawchangeaddress(): Decimal("0.0003")})
+    rbfsigned = node.signrawtransactionwithwallet(rbfraw)
+    rbfid = node.sendrawtransaction(rbfsigned["hex"])
+    assert rbfid in node.getrawmempool()
 
-    bumped_tx = rbf_node.bumpfee(rbfid)
-    assert bumped_tx["txid"] in rbf_node.getrawmempool()
-    assert rbfid not in rbf_node.getrawmempool()
+    bumped_tx = node.bumpfee(rbfid)
+    assert bumped_tx["txid"] in node.getrawmempool()
+    assert rbfid not in node.getrawmempool()
     self.clear_mempool()
 
 
@@ -376,13 +376,13 @@ def test_nonrbf_bumpfee_succeeds(self, peer_node, dest_address):
     self.clear_mempool()
 
 
-def test_notmine_bumpfee(self, rbf_node, peer_node, dest_address):
+def test_notmine_bumpfee(self, node, peer_node, dest_address):
     self.log.info('Test that it cannot bump fee if non-owned inputs are included')
-    # here, the rbftx has a peer_node coin and then adds a rbf_node input
+    # here, the rbftx has a peer_node coin and then adds a node input
     # Note that this test depends upon the RPC code checking input ownership prior to change outputs
     # (since it can't use fundrawtransaction, it lacks a proper change output)
     fee = Decimal("0.001")
-    utxos = [node.listunspent(minimumAmount=fee)[-1] for node in (rbf_node, peer_node)]
+    utxos = [node.listunspent(minimumAmount=fee)[-1] for node in (node, peer_node)]
     inputs = [{
         "txid": utxo["txid"],
         "vout": utxo["vout"],
@@ -390,101 +390,101 @@ def test_notmine_bumpfee(self, rbf_node, peer_node, dest_address):
         "sequence": MAX_BIP125_RBF_SEQUENCE
     } for utxo in utxos]
     output_val = sum(utxo["amount"] for utxo in utxos) - fee
-    rawtx = rbf_node.createrawtransaction(inputs, {dest_address: output_val})
-    signedtx = rbf_node.signrawtransactionwithwallet(rawtx)
+    rawtx = node.createrawtransaction(inputs, {dest_address: output_val})
+    signedtx = node.signrawtransactionwithwallet(rawtx)
     signedtx = peer_node.signrawtransactionwithwallet(signedtx["hex"])
-    rbfid = rbf_node.sendrawtransaction(signedtx["hex"])
-    entry = rbf_node.getmempoolentry(rbfid)
+    rbfid = node.sendrawtransaction(signedtx["hex"])
+    entry = node.getmempoolentry(rbfid)
     old_fee = entry["fees"]["base"]
     old_feerate = int(old_fee / entry["vsize"] * Decimal(1e8))
     assert_raises_rpc_error(-4, "Transaction contains inputs that don't belong to this wallet",
-                            rbf_node.bumpfee, rbfid)
+                            node.bumpfee, rbfid)
 
     def finish_psbtbumpfee(psbt):
-        psbt = rbf_node.walletprocesspsbt(psbt)
+        psbt = node.walletprocesspsbt(psbt)
         psbt = peer_node.walletprocesspsbt(psbt["psbt"])
-        res = rbf_node.testmempoolaccept([psbt["hex"]])
+        res = node.testmempoolaccept([psbt["hex"]])
         assert res[0]["allowed"]
         assert_greater_than(res[0]["fees"]["base"], old_fee)
 
     self.log.info("Test that psbtbumpfee works for non-owned inputs")
-    psbt = rbf_node.psbtbumpfee(txid=rbfid)
+    psbt = node.psbtbumpfee(txid=rbfid)
     finish_psbtbumpfee(psbt["psbt"])
 
-    psbt = rbf_node.psbtbumpfee(txid=rbfid, fee_rate=old_feerate + 10)
+    psbt = node.psbtbumpfee(txid=rbfid, fee_rate=old_feerate + 10)
     finish_psbtbumpfee(psbt["psbt"])
 
     self.clear_mempool()
 
 
-def test_bumpfee_with_descendant_fails(self, rbf_node, rbf_node_address, dest_address):
+def test_bumpfee_with_descendant_fails(self, node, node_address, dest_address):
     self.log.info('Test that fee cannot be bumped when it has descendant')
     # parent is send-to-self, so we don't have to check which output is change when creating the child tx
-    parent_id = spend_one_input(rbf_node, rbf_node_address)
-    tx = rbf_node.createrawtransaction([{"txid": parent_id, "vout": 0}], {dest_address: 0.00020000})
-    tx = rbf_node.signrawtransactionwithwallet(tx)
-    rbf_node.sendrawtransaction(tx["hex"])
-    assert_raises_rpc_error(-8, "Transaction has descendants in the wallet", rbf_node.bumpfee, parent_id)
+    parent_id = spend_one_input(node, node_address)
+    tx = node.createrawtransaction([{"txid": parent_id, "vout": 0}], {dest_address: 0.00020000})
+    tx = node.signrawtransactionwithwallet(tx)
+    node.sendrawtransaction(tx["hex"])
+    assert_raises_rpc_error(-8, "Transaction has descendants in the wallet", node.bumpfee, parent_id)
 
     # create tx with descendant in the mempool by using MiniWallet
-    miniwallet = MiniWallet(rbf_node)
-    parent_id = spend_one_input(rbf_node, miniwallet.get_address())
-    tx = rbf_node.gettransaction(txid=parent_id, verbose=True)['decoded']
+    miniwallet = MiniWallet(node)
+    parent_id = spend_one_input(node, miniwallet.get_address())
+    tx = node.gettransaction(txid=parent_id, verbose=True)['decoded']
     miniwallet.scan_tx(tx)
-    miniwallet.send_self_transfer(from_node=rbf_node)
-    assert_raises_rpc_error(-8, "Transaction has descendants in the mempool", rbf_node.bumpfee, parent_id)
+    miniwallet.send_self_transfer(from_node=node)
+    assert_raises_rpc_error(-8, "Transaction has descendants in the mempool", node.bumpfee, parent_id)
     self.clear_mempool()
 
 
-def test_bumpfee_with_abandoned_descendant_succeeds(self, rbf_node, rbf_node_address, dest_address):
+def test_bumpfee_with_abandoned_descendant_succeeds(self, node, node_address, dest_address):
     self.log.info('Test that fee can be bumped when it has abandoned descendant')
     # parent is send-to-self, so we don't have to check which output is change when creating the child tx
-    parent_id = spend_one_input(rbf_node, rbf_node_address)
+    parent_id = spend_one_input(node, node_address)
     # Submit child transaction with low fee
-    child_id = rbf_node.send(outputs={dest_address: 0.00020000},
+    child_id = node.send(outputs={dest_address: 0.00020000},
                              options={"inputs": [{"txid": parent_id, "vout": 0}], "fee_rate": 2})["txid"]
-    assert child_id in rbf_node.getrawmempool()
+    assert child_id in node.getrawmempool()
 
     # Restart the node with higher min relay fee so the descendant tx is no longer in mempool so that we can abandon it
     self.restart_node(1, ['-minrelaytxfee=0.00005'] + self.extra_args[1])
-    rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
+    node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
     self.connect_nodes(1, 0)
-    assert parent_id in rbf_node.getrawmempool()
-    assert child_id not in rbf_node.getrawmempool()
+    assert parent_id in node.getrawmempool()
+    assert child_id not in node.getrawmempool()
     # Should still raise an error even if not in mempool
-    assert_raises_rpc_error(-8, "Transaction has descendants in the wallet", rbf_node.bumpfee, parent_id)
+    assert_raises_rpc_error(-8, "Transaction has descendants in the wallet", node.bumpfee, parent_id)
     # Now abandon the child transaction and bump the original
-    rbf_node.abandontransaction(child_id)
-    bumped_result = rbf_node.bumpfee(parent_id, {"fee_rate": HIGH})
-    assert bumped_result['txid'] in rbf_node.getrawmempool()
-    assert parent_id not in rbf_node.getrawmempool()
+    node.abandontransaction(child_id)
+    bumped_result = node.bumpfee(parent_id, {"fee_rate": HIGH})
+    assert bumped_result['txid'] in node.getrawmempool()
+    assert parent_id not in node.getrawmempool()
     # Cleanup
     self.restart_node(1, self.extra_args[1])
-    rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
+    node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
     self.connect_nodes(1, 0)
     self.clear_mempool()
 
 
-def test_small_output_with_feerate_succeeds(self, rbf_node, dest_address):
+def test_small_output_with_feerate_succeeds(self, node, dest_address):
     self.log.info('Testing small output with feerate bump succeeds')
 
     # Make sure additional inputs exist
-    self.generatetoaddress(rbf_node, COINBASE_MATURITY + 1, rbf_node.getnewaddress())
-    rbfid = spend_one_input(rbf_node, dest_address)
-    input_list = rbf_node.getrawtransaction(rbfid, 1)["vin"]
+    self.generatetoaddress(node, COINBASE_MATURITY + 1, node.getnewaddress())
+    rbfid = spend_one_input(node, dest_address)
+    input_list = node.getrawtransaction(rbfid, 1)["vin"]
     assert_equal(len(input_list), 1)
     original_txin = input_list[0]
     self.log.info('Keep bumping until transaction fee out-spends non-destination value')
     tx_fee = 0
     while True:
-        input_list = rbf_node.getrawtransaction(rbfid, 1)["vin"]
+        input_list = node.getrawtransaction(rbfid, 1)["vin"]
         new_item = list(input_list)[0]
         assert_equal(len(input_list), 1)
         assert_equal(original_txin["txid"], new_item["txid"])
         assert_equal(original_txin["vout"], new_item["vout"])
-        rbfid_new_details = rbf_node.bumpfee(rbfid)
+        rbfid_new_details = node.bumpfee(rbfid)
         rbfid_new = rbfid_new_details["txid"]
-        raw_pool = rbf_node.getrawmempool()
+        raw_pool = node.getrawmempool()
         assert rbfid not in raw_pool
         assert rbfid_new in raw_pool
         rbfid = rbfid_new
@@ -495,22 +495,22 @@ def test_small_output_with_feerate_succeeds(self, rbf_node, dest_address):
             break
 
     # input(s) have been added
-    final_input_list = rbf_node.getrawtransaction(rbfid, 1)["vin"]
+    final_input_list = node.getrawtransaction(rbfid, 1)["vin"]
     assert_greater_than(len(final_input_list), 1)
     # Original input is in final set
     assert [txin for txin in final_input_list
             if txin["txid"] == original_txin["txid"]
             and txin["vout"] == original_txin["vout"]]
 
-    self.generatetoaddress(rbf_node, 1, rbf_node.getnewaddress())
-    assert_equal(rbf_node.gettransaction(rbfid)["confirmations"], 1)
+    self.generatetoaddress(node, 1, node.getnewaddress())
+    assert_equal(node.gettransaction(rbfid)["confirmations"], 1)
     self.clear_mempool()
 
 
-def test_dust_to_fee(self, rbf_node, dest_address):
+def test_dust_to_fee(self, node, dest_address):
     self.log.info('Test that bumped output that is dust is dropped to fee')
-    rbfid = spend_one_input(rbf_node, dest_address)
-    fulltx = rbf_node.getrawtransaction(rbfid, 1)
+    rbfid = spend_one_input(node, dest_address)
+    fulltx = node.getrawtransaction(rbfid, 1)
     # The DER formatting used by Bitcoin to serialize ECDSA signatures means that signatures can have a
     # variable size of 70-72 bytes (or possibly even less), with most being 71 or 72 bytes. The signature
     # in the witness is divided by 4 for the vsize, so this variance can take the weight across a 4-byte
@@ -521,38 +521,38 @@ def test_dust_to_fee(self, rbf_node, dest_address):
     # Expected fee is 141 vbytes * fee_rate 0.00350250 BTC / 1000 vbytes = 0.00049385 BTC.
     # or occasionally 140 vbytes * fee_rate 0.00350250 BTC / 1000 vbytes = 0.00049035 BTC.
     # Dust should be dropped to the fee, so actual bump fee is 0.00050000 BTC.
-    bumped_tx = rbf_node.bumpfee(rbfid, fee_rate=350.25)
-    full_bumped_tx = rbf_node.getrawtransaction(bumped_tx["txid"], 1)
+    bumped_tx = node.bumpfee(rbfid, fee_rate=350.25)
+    full_bumped_tx = node.getrawtransaction(bumped_tx["txid"], 1)
     assert_equal(bumped_tx["fee"], Decimal("0.00050000"))
     assert_equal(len(fulltx["vout"]), 2)
     assert_equal(len(full_bumped_tx["vout"]), 1)  # change output is eliminated
     assert_equal(full_bumped_tx["vout"][0]['value'], Decimal("0.00050000"))
     self.clear_mempool()
 
-def test_maxtxfee_fails(self, rbf_node, dest_address):
+def test_maxtxfee_fails(self, node, dest_address):
     self.log.info('Test that bumpfee fails when it hits -maxtxfee')
     # size of bumped transaction (p2wpkh, 1 input, 2 outputs): 141 vbytes
     # expected bump fee of 141 vbytes * 0.00200000 BTC / 1000 vbytes = 0.00002820 BTC
     # which exceeds maxtxfee and is expected to raise
     self.restart_node(1, ['-maxtxfee=0.000025'] + self.extra_args[1])
-    rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
-    rbfid = spend_one_input(rbf_node, dest_address)
-    assert_raises_rpc_error(-4, "Unable to create transaction. Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)", rbf_node.bumpfee, rbfid)
+    node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
+    rbfid = spend_one_input(node, dest_address)
+    assert_raises_rpc_error(-4, "Unable to create transaction. Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)", node.bumpfee, rbfid)
     self.restart_node(1, self.extra_args[1])
-    rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
+    node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
     self.connect_nodes(1, 0)
     self.clear_mempool()
 
 
-def test_watchonly_psbt(self, peer_node, rbf_node, dest_address):
+def test_watchonly_psbt(self, peer_node, node, dest_address):
     self.log.info('Test that PSBT is returned for bumpfee in watchonly wallets')
     priv_rec_desc = "wpkh([00000001/84'/1'/0']tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/0/*)#rweraev0"
-    pub_rec_desc = rbf_node.getdescriptorinfo(priv_rec_desc)["descriptor"]
+    pub_rec_desc = node.getdescriptorinfo(priv_rec_desc)["descriptor"]
     priv_change_desc = "wpkh([00000001/84'/1'/0']tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/1/*)#j6uzqvuh"
-    pub_change_desc = rbf_node.getdescriptorinfo(priv_change_desc)["descriptor"]
+    pub_change_desc = node.getdescriptorinfo(priv_change_desc)["descriptor"]
     # Create a wallet with private keys that can sign PSBTs
-    rbf_node.createwallet(wallet_name="signer", disable_private_keys=False, blank=True)
-    signer = rbf_node.get_wallet_rpc("signer")
+    node.createwallet(wallet_name="signer", disable_private_keys=False, blank=True)
+    signer = node.get_wallet_rpc("signer")
     assert signer.getwalletinfo()['private_keys_enabled']
     reqs = [{
         "desc": priv_rec_desc,
@@ -572,8 +572,8 @@ def test_watchonly_psbt(self, peer_node, rbf_node, dest_address):
     assert_equal(result, [{'success': True}, {'success': True}])
 
     # Create another wallet with just the public keys, which creates PSBTs
-    rbf_node.createwallet(wallet_name="watcher", disable_private_keys=True, blank=True)
-    watcher = rbf_node.get_wallet_rpc("watcher")
+    node.createwallet(wallet_name="watcher", disable_private_keys=True, blank=True)
+    watcher = node.get_wallet_rpc("watcher")
     assert not watcher.getwalletinfo()['private_keys_enabled']
 
     reqs = [{
@@ -625,131 +625,131 @@ def test_watchonly_psbt(self, peer_node, rbf_node, dest_address):
 
     # Broadcast bumped transaction
     bumped_txid = watcher.sendrawtransaction(bumped_psbt_signed["hex"])
-    assert bumped_txid in rbf_node.getrawmempool()
-    assert original_txid not in rbf_node.getrawmempool()
+    assert bumped_txid in node.getrawmempool()
+    assert original_txid not in node.getrawmempool()
 
-    rbf_node.unloadwallet("watcher")
-    rbf_node.unloadwallet("signer")
+    node.unloadwallet("watcher")
+    node.unloadwallet("signer")
     self.clear_mempool()
 
 
-def test_rebumping(self, rbf_node, dest_address):
+def test_rebumping(self, node, dest_address):
     self.log.info('Test that re-bumping the original tx fails, but bumping successor works')
-    rbfid = spend_one_input(rbf_node, dest_address)
-    bumped = rbf_node.bumpfee(rbfid, fee_rate=ECONOMICAL)
+    rbfid = spend_one_input(node, dest_address)
+    bumped = node.bumpfee(rbfid, fee_rate=ECONOMICAL)
     assert_raises_rpc_error(-4, f"Cannot bump transaction {rbfid} which was already bumped by transaction {bumped['txid']}",
-                            rbf_node.bumpfee, rbfid, fee_rate=NORMAL)
-    rbf_node.bumpfee(bumped["txid"], fee_rate=NORMAL)
+                            node.bumpfee, rbfid, fee_rate=NORMAL)
+    node.bumpfee(bumped["txid"], fee_rate=NORMAL)
     self.clear_mempool()
 
 
-def test_rebumping_not_replaceable(self, rbf_node, dest_address):
+def test_rebumping_not_replaceable(self, node, dest_address):
     self.log.info("Test that re-bumping non-replaceable passes")
-    rbfid = spend_one_input(rbf_node, dest_address)
+    rbfid = spend_one_input(node, dest_address)
 
     def check_sequence(tx, seq_in):
-        tx = rbf_node.getrawtransaction(tx["txid"])
-        tx = rbf_node.decoderawtransaction(tx)
+        tx = node.getrawtransaction(tx["txid"])
+        tx = node.decoderawtransaction(tx)
         seq = [i["sequence"] for i in tx["vin"]]
         assert_equal(seq, [seq_in])
 
-    bumped = rbf_node.bumpfee(rbfid, fee_rate=ECONOMICAL, replaceable=False)
+    bumped = node.bumpfee(rbfid, fee_rate=ECONOMICAL, replaceable=False)
     check_sequence(bumped, MAX_SEQUENCE_NONFINAL)
-    bumped = rbf_node.bumpfee(bumped["txid"], {"fee_rate": NORMAL})
+    bumped = node.bumpfee(bumped["txid"], {"fee_rate": NORMAL})
     check_sequence(bumped, MAX_SEQUENCE_NONFINAL)
 
     self.clear_mempool()
 
 
-def test_bumpfee_already_spent(self, rbf_node, dest_address):
+def test_bumpfee_already_spent(self, node, dest_address):
     self.log.info('Test that bumping tx with already spent coin fails')
-    txid = spend_one_input(rbf_node, dest_address)
-    self.generate(rbf_node, 1)  # spend coin simply by mining block with tx
-    spent_input = rbf_node.gettransaction(txid=txid, verbose=True)['decoded']['vin'][0]
+    txid = spend_one_input(node, dest_address)
+    self.generate(node, 1)  # spend coin simply by mining block with tx
+    spent_input = node.gettransaction(txid=txid, verbose=True)['decoded']['vin'][0]
     assert_raises_rpc_error(-1, f"{spent_input['txid']}:{spent_input['vout']} is already spent",
-                            rbf_node.bumpfee, txid, fee_rate=NORMAL)
+                            node.bumpfee, txid, fee_rate=NORMAL)
 
 
-def test_unconfirmed_not_spendable(self, rbf_node, rbf_node_address):
+def test_unconfirmed_not_spendable(self, node, node_address):
     self.log.info('Test that unconfirmed outputs from bumped txns are not spendable')
-    rbfid = spend_one_input(rbf_node, rbf_node_address)
-    rbftx = rbf_node.gettransaction(rbfid)["hex"]
-    assert rbfid in rbf_node.getrawmempool()
-    bumpid = rbf_node.bumpfee(rbfid)["txid"]
-    assert bumpid in rbf_node.getrawmempool()
-    assert rbfid not in rbf_node.getrawmempool()
+    rbfid = spend_one_input(node, node_address)
+    rbftx = node.gettransaction(rbfid)["hex"]
+    assert rbfid in node.getrawmempool()
+    bumpid = node.bumpfee(rbfid)["txid"]
+    assert bumpid in node.getrawmempool()
+    assert rbfid not in node.getrawmempool()
 
     # check that outputs from the bump transaction are not spendable
     # due to the replaces_txid check in CWallet::AvailableCoins
-    assert_equal([t for t in rbf_node.listunspent(minconf=0, include_unsafe=False) if t["txid"] == bumpid], [])
+    assert_equal([t for t in node.listunspent(minconf=0, include_unsafe=False) if t["txid"] == bumpid], [])
 
     # submit a block with the rbf tx to clear the bump tx out of the mempool,
     # then invalidate the block so the rbf tx will be put back in the mempool.
     # This makes it possible to check whether the rbf tx outputs are
     # spendable before the rbf tx is confirmed.
-    block = self.generateblock(rbf_node, output="raw(51)", transactions=[rbftx])
+    block = self.generateblock(node, output="raw(51)", transactions=[rbftx])
     # Can not abandon conflicted tx
-    assert_raises_rpc_error(-5, 'Transaction not eligible for abandonment', lambda: rbf_node.abandontransaction(txid=bumpid))
-    rbf_node.invalidateblock(block["hash"])
+    assert_raises_rpc_error(-5, 'Transaction not eligible for abandonment', lambda: node.abandontransaction(txid=bumpid))
+    node.invalidateblock(block["hash"])
     # Call abandon to make sure the wallet doesn't attempt to resubmit
     # the bump tx and hope the wallet does not rebroadcast before we call.
-    rbf_node.abandontransaction(bumpid)
+    node.abandontransaction(bumpid)
 
-    tx_bump_abandoned = rbf_node.gettransaction(bumpid)
+    tx_bump_abandoned = node.gettransaction(bumpid)
     for tx in tx_bump_abandoned['details']:
         assert_equal(tx['abandoned'], True)
 
-    assert bumpid not in rbf_node.getrawmempool()
-    assert rbfid in rbf_node.getrawmempool()
+    assert bumpid not in node.getrawmempool()
+    assert rbfid in node.getrawmempool()
 
     # check that outputs from the rbf tx are not spendable before the
     # transaction is confirmed, due to the replaced_by_txid check in
     # CWallet::AvailableCoins
-    assert_equal([t for t in rbf_node.listunspent(minconf=0, include_unsafe=False) if t["txid"] == rbfid], [])
+    assert_equal([t for t in node.listunspent(minconf=0, include_unsafe=False) if t["txid"] == rbfid], [])
 
     # check that the main output from the rbf tx is spendable after confirmed
-    self.generate(rbf_node, 1, sync_fun=self.no_op)
+    self.generate(node, 1, sync_fun=self.no_op)
     assert_equal(
-        sum(1 for t in rbf_node.listunspent(minconf=0, include_unsafe=False)
-            if t["txid"] == rbfid and t["address"] == rbf_node_address and t["spendable"]), 1)
+        sum(1 for t in node.listunspent(minconf=0, include_unsafe=False)
+            if t["txid"] == rbfid and t["address"] == node_address and t["spendable"]), 1)
     self.clear_mempool()
 
 
-def test_bumpfee_metadata(self, rbf_node, dest_address):
+def test_bumpfee_metadata(self, node, dest_address):
     self.log.info('Test that bumped txn metadata persists to new txn record')
-    assert rbf_node.getbalance() < 49
-    self.generatetoaddress(rbf_node, 101, rbf_node.getnewaddress())
-    rbfid = rbf_node.sendtoaddress(dest_address, 49, "comment value", "to value")
-    bumped_tx = rbf_node.bumpfee(rbfid)
-    bumped_wtx = rbf_node.gettransaction(bumped_tx["txid"])
+    assert node.getbalance() < 49
+    self.generatetoaddress(node, 101, node.getnewaddress())
+    rbfid = node.sendtoaddress(dest_address, 49, "comment value", "to value")
+    bumped_tx = node.bumpfee(rbfid)
+    bumped_wtx = node.gettransaction(bumped_tx["txid"])
     assert_equal(bumped_wtx["comment"], "comment value")
     assert_equal(bumped_wtx["to"], "to value")
     self.clear_mempool()
 
 
-def test_locked_wallet_fails(self, rbf_node, dest_address):
+def test_locked_wallet_fails(self, node, dest_address):
     self.log.info('Test that locked wallet cannot bump txn')
-    rbfid = spend_one_input(rbf_node, dest_address)
-    rbf_node.walletlock()
+    rbfid = spend_one_input(node, dest_address)
+    node.walletlock()
     assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first.",
-                            rbf_node.bumpfee, rbfid)
-    rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
+                            node.bumpfee, rbfid)
+    node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
     self.clear_mempool()
 
 
-def test_change_script_match(self, rbf_node, dest_address):
+def test_change_script_match(self, node, dest_address):
     self.log.info('Test that the same change addresses is used for the replacement transaction when possible')
 
     # Check that there is only one change output
-    rbfid = spend_one_input(rbf_node, dest_address)
-    change_addresses = get_change_address(rbfid, rbf_node)
+    rbfid = spend_one_input(node, dest_address)
+    change_addresses = get_change_address(rbfid, node)
     assert_equal(len(change_addresses), 1)
 
     # Now find that address in each subsequent tx, and no other change
-    bumped_total_tx = rbf_node.bumpfee(rbfid, fee_rate=ECONOMICAL)
-    assert_equal(change_addresses, get_change_address(bumped_total_tx['txid'], rbf_node))
-    bumped_rate_tx = rbf_node.bumpfee(bumped_total_tx["txid"])
-    assert_equal(change_addresses, get_change_address(bumped_rate_tx['txid'], rbf_node))
+    bumped_total_tx = node.bumpfee(rbfid, fee_rate=ECONOMICAL)
+    assert_equal(change_addresses, get_change_address(bumped_total_tx['txid'], node))
+    bumped_rate_tx = node.bumpfee(bumped_total_tx["txid"])
+    assert_equal(change_addresses, get_change_address(bumped_rate_tx['txid'], node))
     self.clear_mempool()
 
 
@@ -767,65 +767,65 @@ def spend_one_input(node, dest_address, change_size=Decimal("0.00049000"), data=
     return txid
 
 
-def test_no_more_inputs_fails(self, rbf_node, dest_address):
+def test_no_more_inputs_fails(self, node, dest_address):
     self.log.info('Test that bumpfee fails when there are no available confirmed outputs')
     # feerate rbf requires confirmed outputs when change output doesn't exist or is insufficient
-    self.generatetoaddress(rbf_node, 1, dest_address)
+    self.generatetoaddress(node, 1, dest_address)
     # spend all funds, no change output
-    rbfid = rbf_node.sendall(recipients=[rbf_node.getnewaddress()])['txid']
-    assert_raises_rpc_error(-4, "Unable to create transaction. The total exceeds your balance when the 0.00001051 transaction fee is included.", rbf_node.bumpfee, rbfid)
+    rbfid = node.sendall(recipients=[node.getnewaddress()])['txid']
+    assert_raises_rpc_error(-4, "Unable to create transaction. The total exceeds your balance when the 0.00001051 transaction fee is included.", node.bumpfee, rbfid)
     self.clear_mempool()
 
 
-def test_feerate_checks_replaced_outputs(self, rbf_node, peer_node):
+def test_feerate_checks_replaced_outputs(self, node, peer_node):
     # Make sure there is enough balance
-    peer_node.sendtoaddress(rbf_node.getnewaddress(), 60)
+    peer_node.sendtoaddress(node.getnewaddress(), 60)
     self.generate(peer_node, 1)
 
     self.log.info("Test that feerate checks use replaced outputs")
     outputs = []
     for i in range(50):
-        outputs.append({rbf_node.getnewaddress(address_type="bech32"): 1})
-    tx_res = rbf_node.send(outputs=outputs, fee_rate=5)
-    tx_details = rbf_node.gettransaction(txid=tx_res["txid"], verbose=True)
+        outputs.append({node.getnewaddress(address_type="bech32"): 1})
+    tx_res = node.send(outputs=outputs, fee_rate=5)
+    tx_details = node.gettransaction(txid=tx_res["txid"], verbose=True)
 
     # Calculate the minimum feerate required for the bump to work.
     # Since the bumped tx will replace all of the outputs with a single output, we can estimate that its size will 31 * (len(outputs) - 1) bytes smaller
     tx_size = tx_details["decoded"]["vsize"]
     est_bumped_size = tx_size - (len(tx_details["decoded"]["vout"]) - 1) * 31
-    inc_fee_rate = rbf_node.getmempoolinfo()["incrementalrelayfee"]
+    inc_fee_rate = node.getmempoolinfo()["incrementalrelayfee"]
     # RPC gives us fee as negative
     min_fee = (-tx_details["fee"] + get_fee(est_bumped_size, inc_fee_rate)) * Decimal(1e8)
     min_fee_rate = (min_fee / est_bumped_size).quantize(Decimal("1.000"))
 
     # Attempt to bumpfee and replace all outputs with a single one using a feerate slightly less than the minimum
-    new_outputs = [{rbf_node.getnewaddress(address_type="bech32"): 49}]
-    assert_raises_rpc_error(-8, "Insufficient total fee", rbf_node.bumpfee, tx_res["txid"], {"fee_rate": min_fee_rate - 1, "outputs": new_outputs})
+    new_outputs = [{node.getnewaddress(address_type="bech32"): 49}]
+    assert_raises_rpc_error(-8, "Insufficient total fee", node.bumpfee, tx_res["txid"], {"fee_rate": min_fee_rate - 1, "outputs": new_outputs})
 
     # Bumpfee and replace all outputs with a single one using the minimum feerate
-    rbf_node.bumpfee(tx_res["txid"], {"fee_rate": min_fee_rate, "outputs": new_outputs})
+    node.bumpfee(tx_res["txid"], {"fee_rate": min_fee_rate, "outputs": new_outputs})
     self.clear_mempool()
 
 
-def test_bumpfee_with_feerate_ignores_walletincrementalrelayfee(self, rbf_node, peer_node):
+def test_bumpfee_with_feerate_ignores_walletincrementalrelayfee(self, node, peer_node):
     self.log.info('Test that bumpfee with fee_rate ignores walletincrementalrelayfee')
     # Make sure there is enough balance
-    peer_node.sendtoaddress(rbf_node.getnewaddress(), 2)
+    peer_node.sendtoaddress(node.getnewaddress(), 2)
     self.generate(peer_node, 1)
 
     dest_address = peer_node.getnewaddress(address_type="bech32")
-    tx = rbf_node.send(outputs=[{dest_address: 1}], fee_rate=2)
+    tx = node.send(outputs=[{dest_address: 1}], fee_rate=2)
 
     # Ensure you can not fee bump with a fee_rate below or equal to the original fee_rate
-    assert_raises_rpc_error(-8, "Insufficient total fee", rbf_node.bumpfee, tx["txid"], {"fee_rate": 1})
-    assert_raises_rpc_error(-8, "Insufficient total fee", rbf_node.bumpfee, tx["txid"], {"fee_rate": 2})
+    assert_raises_rpc_error(-8, "Insufficient total fee", node.bumpfee, tx["txid"], {"fee_rate": 1})
+    assert_raises_rpc_error(-8, "Insufficient total fee", node.bumpfee, tx["txid"], {"fee_rate": 2})
 
     # Ensure you can not fee bump if the fee_rate is more than original fee_rate but the additional fee does
     # not cover incrementalrelayfee for the size of the replacement transaction
-    assert_raises_rpc_error(-8, "Insufficient total fee", rbf_node.bumpfee, tx["txid"], {"fee_rate": 2.09})
+    assert_raises_rpc_error(-8, "Insufficient total fee", node.bumpfee, tx["txid"], {"fee_rate": 2.09})
 
     # You can fee bump as long as the new fee set from fee_rate is at least (original fee + incrementalrelayfee)
-    rbf_node.bumpfee(tx["txid"], {"fee_rate": 2.1})
+    node.bumpfee(tx["txid"], {"fee_rate": 2.1})
     self.clear_mempool()
 
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -19,7 +19,6 @@ from test_framework.blocktools import (
     COINBASE_MATURITY,
 )
 from test_framework.messages import (
-    MAX_BIP125_RBF_SEQUENCE,
     MAX_SEQUENCE_NONFINAL,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -355,8 +354,7 @@ def test_segwit_bumpfee_succeeds(self, node, dest_address):
 
     rbfraw = node.createrawtransaction([{
         'txid': segwitid,
-        'vout': 0,
-        "sequence": MAX_BIP125_RBF_SEQUENCE
+        'vout': 0
     }], {dest_address: Decimal("0.0005"),
          node.getrawchangeaddress(): Decimal("0.0003")})
     rbfsigned = node.signrawtransactionwithwallet(rbfraw)
@@ -386,8 +384,7 @@ def test_notmine_bumpfee(self, node, peer_node, dest_address):
     inputs = [{
         "txid": utxo["txid"],
         "vout": utxo["vout"],
-        "address": utxo["address"],
-        "sequence": MAX_BIP125_RBF_SEQUENCE
+        "address": utxo["address"]
     } for utxo in utxos]
     output_val = sum(utxo["amount"] for utxo in utxos) - fee
     rawtx = node.createrawtransaction(inputs, {dest_address: output_val})
@@ -754,8 +751,7 @@ def test_change_script_match(self, node, dest_address):
 
 
 def spend_one_input(node, dest_address, change_size=Decimal("0.00049000"), data=None):
-    tx_input = dict(
-        sequence=MAX_BIP125_RBF_SEQUENCE, **next(u for u in node.listunspent() if u["amount"] == Decimal("0.00100000")))
+    tx_input = dict(**next(u for u in node.listunspent() if u["amount"] == Decimal("0.00100000")))
     destinations = {dest_address: Decimal("0.00050000")}
     if change_size > 0:
         destinations[node.getrawchangeaddress()] = change_size

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -656,7 +656,7 @@ def test_rebumping_not_replaceable(self, rbf_node, dest_address):
     bumped = rbf_node.bumpfee(rbfid, fee_rate=ECONOMICAL, replaceable=False)
     check_sequence(bumped, MAX_SEQUENCE_NONFINAL)
     bumped = rbf_node.bumpfee(bumped["txid"], {"fee_rate": NORMAL})
-    check_sequence(bumped, MAX_BIP125_RBF_SEQUENCE)
+    check_sequence(bumped, MAX_SEQUENCE_NONFINAL)
 
     self.clear_mempool()
 

--- a/test/functional/wallet_deprecated_rbf.py
+++ b/test/functional/wallet_deprecated_rbf.py
@@ -2,8 +2,9 @@
 # Copyright (c) 2026-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test deprecation of RPC calls."""
-from test_framework.util import assert_equal
+"""Test deprecation of wallet RBF RPCs and startup options."""
+from test_framework.messages import MAX_BIP125_RBF_SEQUENCE
+from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error
 from test_framework.test_framework import BitcoinTestFramework
 
 '''
@@ -27,9 +28,72 @@ class WalletDeprecatedRBFTest(BitcoinTestFramework):
       node.createwallet("deprecated_optinrbf")
       wallet = node.get_wallet_rpc("deprecated_optinrbf")
       self.generatetoaddress(node, nblocks=101, address=wallet.getnewaddress(), sync_fun=self.no_op)
-      tx = wallet.gettransaction(wallet.sendall(recipients=[wallet.getnewaddress()])["txid"])
-      assert_equal("bip125-replaceable" in tx, True)
-      assert_equal(tx["bip125-replaceable"], "no")
+
+      def get_largest_unspent():
+        return max(wallet.listunspent(), key=lambda unspent: unspent["amount"])
+
+      def assert_rbf_in_tx_hex(tx_hex):
+        for input in wallet.decoderawtransaction(tx_hex)["vin"]:
+          assert_equal(input["sequence"], MAX_BIP125_RBF_SEQUENCE)
+
+      def assert_rbf_in_psbt(encoded_psbt):
+        decoded_psbt = wallet.decodepsbt(encoded_psbt)
+        for input in decoded_psbt["inputs"]:
+          assert_equal(input["sequence"], MAX_BIP125_RBF_SEQUENCE)
+
+      def assert_rbf_in_wallet_tx(tx_id):
+        wallet_mempool_tx = wallet.gettransaction(tx_id)
+        assert_equal("bip125-replaceable" in wallet_mempool_tx, True)
+        assert_equal(wallet_mempool_tx["bip125-replaceable"], "yes")
+
+      # raw transaction
+      unspent = get_largest_unspent()
+      # Test `createrawtransaction` mismatch between sequence number(s) and `replaceable` option
+      assert_raises_rpc_error(-8, "Invalid parameter combination: Sequence number(s) contradict replaceable option",
+                              self.nodes[0].createrawtransaction, [{'txid': unspent["txid"], 'vout': unspent["vout"], 'sequence': MAX_BIP125_RBF_SEQUENCE+1}], {}, 0, True)
+
+      raw_tx_hex = wallet.createrawtransaction(inputs=[unspent], outputs=[{wallet.getnewaddress(): 1}], replaceable=True)
+      assert_rbf_in_tx_hex(raw_tx_hex)
+      funded_tx_hex = wallet.fundrawtransaction(raw_tx_hex)["hex"]
+      assert_rbf_in_tx_hex(raw_tx_hex)
+      signed_tx_hex = wallet.signrawtransactionwithwallet(funded_tx_hex)["hex"]
+      sent_tx_id = wallet.sendrawtransaction(signed_tx_hex)
+      assert_rbf_in_wallet_tx(sent_tx_id)
+      bumped_tx_details = wallet.bumpfee(sent_tx_id, replaceable=True)
+      assert_greater_than(bumped_tx_details["fee"], bumped_tx_details["origfee"])
+      assert_rbf_in_wallet_tx(bumped_tx_details["txid"])
+      wallet.sendrawtransaction(wallet.gettransaction(bumped_tx_details["txid"])["hex"])
+      self.generate(node, 1, sync_fun=self.no_op)
+
+      # psbt
+      unspent = get_largest_unspent()
+      inputs = [{"txid": unspent["txid"], "vout": unspent["vout"]}]
+      outputs = [{wallet.getnewaddress(): 1}]
+      psbt_encoded = wallet.createpsbt(inputs=inputs, outputs=outputs, replaceable=True)
+      assert_rbf_in_psbt(psbt_encoded)
+      funded_psbt_encoded = wallet.walletcreatefundedpsbt(inputs=inputs, outputs=outputs, replaceable=True)["psbt"]
+      assert_rbf_in_psbt(funded_psbt_encoded)
+      signed_tx_hex = wallet.walletprocesspsbt(funded_psbt_encoded)["hex"]
+      sent_tx_id = wallet.sendrawtransaction(signed_tx_hex)
+      bumped_tx_details = wallet.psbtbumpfee(sent_tx_id, replaceable=True)
+      assert_greater_than(bumped_tx_details["fee"], bumped_tx_details["origfee"])
+      signed_bumped_tx_hex = wallet.walletprocesspsbt(bumped_tx_details["psbt"])["hex"]
+      sent_tx_id = wallet.sendrawtransaction(signed_bumped_tx_hex)
+      assert_rbf_in_wallet_tx(sent_tx_id)
+      self.generate(node, 1, sync_fun=self.no_op)
+
+      rpcs = [
+        lambda: wallet.send(outputs=[{wallet.getnewaddress(): 1}], options={"replaceable": True})["txid"],
+        lambda: wallet.sendtoaddress(address=wallet.getnewaddress(), amount=1, replaceable=True),
+        lambda: wallet.sendmany(amounts={wallet.getnewaddress():1, wallet.getnewaddress():1}, replaceable=True),
+        lambda: wallet.sendall(recipients=[wallet.getnewaddress()], replaceable=True)["txid"],
+      ]
+
+      for rpc in rpcs:
+        sent_tx_id = rpc()
+        assert_rbf_in_wallet_tx(sent_tx_id)
+        self.generate(node, 1, sync_fun=self.no_op)
+
       self.stop_node(0, expected_stderr="Warning: -walletrbf is deprecated and will be fully removed in the next release.")
 
 

--- a/test/functional/wallet_deprecated_rbf.py
+++ b/test/functional/wallet_deprecated_rbf.py
@@ -3,9 +3,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test deprecation of wallet RBF RPCs and startup options."""
-from test_framework.messages import MAX_BIP125_RBF_SEQUENCE
 from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error
 from test_framework.test_framework import BitcoinTestFramework
+
+MAX_BIP125_RBF_SEQUENCE = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
 
 '''
 This test exercises the deprecatedrpc=bip125 flag and deprecated -walletrbf options

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -8,7 +8,6 @@ from test_framework.address import key_to_p2wpkh
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.messages import MAX_BIP125_RBF_SEQUENCE
 from test_framework.util import (
     assert_array_result,
     assert_equal,
@@ -376,8 +375,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         spending_node = self.nodes[2]
         dest_address = spending_node.getnewaddress()
 
-        tx_input = dict(
-            sequence=MAX_BIP125_RBF_SEQUENCE, **next(u for u in spending_node.listunspent()))
+        tx_input = dict(**next(u for u in spending_node.listunspent()))
         rawtx = spending_node.createrawtransaction(
             [tx_input], {dest_address: tx_input["amount"] - Decimal("0.00051000"),
                          spending_node.getrawchangeaddress(): Decimal("0.00050000")})


### PR DESCRIPTION
Partially fixes https://github.com/bitcoin/bitcoin/issues/32661.

Depends on https://github.com/bitcoin/bitcoin/pull/35433 from which the
first 11 commits are added here and will be removed when this PR is
undrafted. Only the last 2 commits are specific to this PR.

This is in line with the removal and deprecation of BIP 125 RBF signalling
from the codebase.