### PR TITLE
wallet: make descriptor SPKM mutex non-recursive

### DIFF
--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -30,23 +30,14 @@ std::unique_ptr<ExternalSignerScriptPubKeyMan> ExternalSignerScriptPubKeyMan::Cr
 {
     auto spkm = std::unique_ptr<ExternalSignerScriptPubKeyMan>(new ExternalSignerScriptPubKeyMan(storage, keypool_size));
 
-    LOCK(spkm->cs_desc_man);
     assert(storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
     assert(storage.IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
 
     int64_t creation_time = GetTime();
 
     // Make the descriptor
-    WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
-    spkm->m_wallet_descriptor = w_desc;
-
-    // Store the descriptor
-    if (!batch.WriteDescriptor(spkm->GetID(), spkm->m_wallet_descriptor)) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
-    }
-
-    // TopUp
-    spkm->TopUpWithDB(batch);
+    WalletDescriptor w_desc(std::move(desc), creation_time, /*range_start=*/0, /*range_end=*/0, /*next_index=*/0);
+    spkm->SetupDescriptor(batch, std::move(w_desc));
 
     storage.UnsetBlankWalletFlag(batch);
     return spkm;

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -544,7 +544,6 @@ RPCMethod listdescriptors()
         if (!desc_spk_man) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Unexpected ScriptPubKey manager type.");
         }
-        LOCK(desc_spk_man->cs_desc_man);
         const auto& wallet_descriptor = desc_spk_man->GetWalletDescriptor();
         std::string descriptor;
         CHECK_NONFATAL(desc_spk_man->GetDescriptorString(descriptor, priv));

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -698,7 +698,6 @@ RPCMethod gethdkeys()
             for (auto* spkm : spkms) {
                 auto* desc_spkm{dynamic_cast<DescriptorScriptPubKeyMan*>(spkm)};
                 CHECK_NONFATAL(desc_spkm);
-                LOCK(desc_spkm->cs_desc_man);
                 WalletDescriptor w_desc = desc_spkm->GetWalletDescriptor();
 
                 // Retrieve the pubkeys from the descriptor
@@ -905,10 +904,10 @@ RPCMethod addhdkey()
 
             UniValue response(UniValue::VOBJ);
             const DescriptorScriptPubKeyMan& desc_spkm = spkm->get();
-            LOCK(desc_spkm.cs_desc_man);
             std::set<CPubKey> pubkeys;
             std::set<CExtPubKey> extpubs;
-            desc_spkm.GetWalletDescriptor().descriptor->GetPubKeys(pubkeys, extpubs);
+            const auto wallet_descriptor{desc_spkm.GetWalletDescriptor()};
+            wallet_descriptor.descriptor->GetPubKeys(pubkeys, extpubs);
             CHECK_NONFATAL(pubkeys.size() == 0);
             CHECK_NONFATAL(extpubs.size() == 1);
             response.pushKV("xpub", EncodeExtPubKey(*extpubs.begin()));

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -871,13 +871,13 @@ std::unique_ptr<DescriptorScriptPubKeyMan> DescriptorScriptPubKeyMan::GenerateNe
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const OutputType type)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return GetNewDestination_(type);
 }
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination_(const OutputType type)
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
     // Returns true if this descriptor supports getting new addresses. Conditions where we may be unable to fetch them (e.g. locked) are caught later.
     if (!m_wallet_descriptor.descriptor->IsSingleType() || !m_wallet_descriptor.descriptor->IsRange() || (!HavePrivateKeys_() && m_wallet_descriptor.next_index >= m_wallet_descriptor.range_end)) {
         return util::Error{_("No addresses available")};
@@ -915,13 +915,13 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination_(const
 
 bool DescriptorScriptPubKeyMan::IsMine(const CScript& script) const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return m_map_script_pub_keys.contains(script);
 }
 
 bool DescriptorScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     if (!m_map_keys.empty()) {
         return false;
     }
@@ -953,7 +953,7 @@ bool DescriptorScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master
 
 bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     if (!m_map_crypted_keys.empty()) {
         return false;
     }
@@ -976,7 +976,7 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetReservedDestination(const OutputType type, bool internal, int64_t& index)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     auto dest{GetNewDestination_(type)};
     if (dest) index = m_wallet_descriptor.next_index - 1;
     return dest;
@@ -984,7 +984,7 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetReservedDestination(c
 
 void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, const CTxDestination& addr)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     // Only return when the index was the most recent
     if (m_wallet_descriptor.next_index - 1 == index) {
         m_wallet_descriptor.next_index--;
@@ -995,7 +995,7 @@ void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, 
 
 std::map<CKeyID, CKey> DescriptorScriptPubKeyMan::GetKeys() const
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
     if (m_storage.HasEncryptionKeys() && !m_storage.IsLocked()) {
         KeyMap keys;
         for (const auto& key_pair : m_map_crypted_keys) {
@@ -1014,13 +1014,13 @@ std::map<CKeyID, CKey> DescriptorScriptPubKeyMan::GetKeys() const
 
 bool DescriptorScriptPubKeyMan::HasPrivKey(const CKeyID& keyid) const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return m_map_keys.contains(keyid) || m_map_crypted_keys.contains(keyid);
 }
 
 std::optional<CKey> DescriptorScriptPubKeyMan::GetKey(const CKeyID& keyid) const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     if (m_storage.HasEncryptionKeys() && !m_storage.IsLocked()) {
         const auto& it = m_map_crypted_keys.find(keyid);
         if (it == m_map_crypted_keys.end()) {
@@ -1044,13 +1044,13 @@ std::optional<CKey> DescriptorScriptPubKeyMan::GetKey(const CKeyID& keyid) const
 
 bool DescriptorScriptPubKeyMan::TopUp(unsigned int size)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return TopUp_(size);
 }
 
 bool DescriptorScriptPubKeyMan::TopUp_(unsigned int size)
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
     WalletBatch batch(m_storage.GetDatabase());
     if (!batch.TxnBegin()) return false;
     bool res = TopUpWithDB_(batch, size);
@@ -1060,13 +1060,13 @@ bool DescriptorScriptPubKeyMan::TopUp_(unsigned int size)
 
 bool DescriptorScriptPubKeyMan::TopUpWithDB(WalletBatch& batch, unsigned int size)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return TopUpWithDB_(batch, size);
 }
 
 bool DescriptorScriptPubKeyMan::TopUpWithDB_(WalletBatch& batch, unsigned int size)
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
     std::set<CScript> new_spks;
     unsigned int target_size;
     if (size > 0) {
@@ -1131,7 +1131,7 @@ bool DescriptorScriptPubKeyMan::TopUpWithDB_(WalletBatch& batch, unsigned int si
 
 std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(const CScript& script)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     std::vector<WalletDestination> result;
     auto script_it = m_map_script_pub_keys.find(script);
     if (script_it != m_map_script_pub_keys.end()) {
@@ -1160,7 +1160,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
 
 void DescriptorScriptPubKeyMan::AddDescriptorKey(const CKey& key, const CPubKey &pubkey)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     WalletBatch batch(m_storage.GetDatabase());
     if (!AddDescriptorKeyWithDB(batch, key, pubkey)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor private key failed");
@@ -1169,7 +1169,7 @@ void DescriptorScriptPubKeyMan::AddDescriptorKey(const CKey& key, const CPubKey 
 
 bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey)
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
     assert(!m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
 
     // Check if provided key already exists
@@ -1200,11 +1200,11 @@ bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const
 }
 
 // The declaration uses LOCKS_EXCLUDED for calls on newly-created SPKMs.
-// The definition uses EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man) so clang can
+// The definition uses EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex) so clang can
 // verify that this self-locking method takes the mutex only after entry.
-void DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man)
+void DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal) EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     Assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
     Assert(!m_wallet_descriptor.descriptor);
 
@@ -1229,9 +1229,9 @@ void DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, co
     m_storage.UnsetBlankWalletFlag(batch);
 }
 
-void DescriptorScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man)
+void DescriptorScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor) EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     m_wallet_descriptor = std::move(descriptor);
     if (!batch.WriteDescriptor(m_wallet_descriptor.id, m_wallet_descriptor)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
@@ -1241,7 +1241,7 @@ void DescriptorScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, WalletDescri
 
 bool DescriptorScriptPubKeyMan::IsHDEnabled() const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return m_wallet_descriptor.descriptor->IsRange();
 }
 
@@ -1249,7 +1249,7 @@ bool DescriptorScriptPubKeyMan::CanGetAddresses(bool internal) const
 {
     // We can only give out addresses from descriptors that are single type (not combo), ranged,
     // and either have cached keys or can generate more keys (ignoring encryption)
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return m_wallet_descriptor.descriptor->IsSingleType() &&
            m_wallet_descriptor.descriptor->IsRange() &&
            (HavePrivateKeys_() || m_wallet_descriptor.next_index < m_wallet_descriptor.range_end);
@@ -1257,37 +1257,37 @@ bool DescriptorScriptPubKeyMan::CanGetAddresses(bool internal) const
 
 bool DescriptorScriptPubKeyMan::HavePrivateKeys() const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return HavePrivateKeys_();
 }
 
 bool DescriptorScriptPubKeyMan::HavePrivateKeys_() const
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
     return m_map_keys.size() > 0 || m_map_crypted_keys.size() > 0;
 }
 
 bool DescriptorScriptPubKeyMan::HaveCryptedKeys() const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return !m_map_crypted_keys.empty();
 }
 
 unsigned int DescriptorScriptPubKeyMan::GetKeyPoolSize() const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return m_wallet_descriptor.range_end - m_wallet_descriptor.next_index;
 }
 
 int64_t DescriptorScriptPubKeyMan::GetTimeFirstKey() const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return m_wallet_descriptor.creation_time;
 }
 
 std::unique_ptr<FlatSigningProvider> DescriptorScriptPubKeyMan::GetSigningProvider(const CScript& script, bool include_private) const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
 
     // Find the index of the script
     auto it = m_map_script_pub_keys.find(script);
@@ -1301,7 +1301,7 @@ std::unique_ptr<FlatSigningProvider> DescriptorScriptPubKeyMan::GetSigningProvid
 
 std::unique_ptr<FlatSigningProvider> DescriptorScriptPubKeyMan::GetSigningProvider(const CPubKey& pubkey) const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
 
     // Find index of the pubkey
     auto it = m_map_pubkeys.find(pubkey);
@@ -1320,7 +1320,7 @@ std::unique_ptr<FlatSigningProvider> DescriptorScriptPubKeyMan::GetSigningProvid
 
 std::unique_ptr<FlatSigningProvider> DescriptorScriptPubKeyMan::GetSigningProvider(int32_t index, bool include_private) const
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
 
     std::unique_ptr<FlatSigningProvider> out_keys = std::make_unique<FlatSigningProvider>();
 
@@ -1494,7 +1494,7 @@ std::unique_ptr<CKeyMetadata> DescriptorScriptPubKeyMan::GetMetadata(const CTxDe
         KeyOriginInfo orig;
         CKeyID key_id = GetKeyForDestination(*provider, dest);
         if (provider->GetKeyOrigin(key_id, orig)) {
-            LOCK(cs_desc_man);
+            LOCK(m_desc_mutex);
             std::unique_ptr<CKeyMetadata> meta = std::make_unique<CKeyMetadata>();
             meta->key_origin = orig;
             meta->has_key_origin = true;
@@ -1507,13 +1507,13 @@ std::unique_ptr<CKeyMetadata> DescriptorScriptPubKeyMan::GetMetadata(const CTxDe
 
 uint256 DescriptorScriptPubKeyMan::GetID() const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return m_wallet_descriptor.id;
 }
 
 void DescriptorScriptPubKeyMan::Load()
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     std::set<CScript> new_spks;
     for (int32_t i = m_wallet_descriptor.range_start; i < m_wallet_descriptor.range_end; ++i) {
         FlatSigningProvider out_keys;
@@ -1546,19 +1546,19 @@ void DescriptorScriptPubKeyMan::Load()
 
 bool DescriptorScriptPubKeyMan::HasWalletDescriptor(const WalletDescriptor& desc) const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return HasWalletDescriptor_(desc);
 }
 
 bool DescriptorScriptPubKeyMan::HasWalletDescriptor_(const WalletDescriptor& desc) const
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
     return !m_wallet_descriptor.id.IsNull() && !desc.id.IsNull() && m_wallet_descriptor.id == desc.id;
 }
 
 void DescriptorScriptPubKeyMan::WriteDescriptor()
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     WalletBatch batch(m_storage.GetDatabase());
     if (!batch.WriteDescriptor(m_wallet_descriptor.id, m_wallet_descriptor)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
@@ -1567,7 +1567,7 @@ void DescriptorScriptPubKeyMan::WriteDescriptor()
 
 WalletDescriptor DescriptorScriptPubKeyMan::GetWalletDescriptor() const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return m_wallet_descriptor;
 }
 
@@ -1578,7 +1578,7 @@ std::unordered_set<CScript, SaltedSipHasher> DescriptorScriptPubKeyMan::GetScrip
 
 std::unordered_set<CScript, SaltedSipHasher> DescriptorScriptPubKeyMan::GetScriptPubKeys(int32_t minimum_index) const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     std::unordered_set<CScript, SaltedSipHasher> script_pub_keys;
     script_pub_keys.reserve(m_map_script_pub_keys.size());
 
@@ -1590,13 +1590,13 @@ std::unordered_set<CScript, SaltedSipHasher> DescriptorScriptPubKeyMan::GetScrip
 
 int32_t DescriptorScriptPubKeyMan::GetEndRange() const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return m_max_cached_index + 1;
 }
 
 bool DescriptorScriptPubKeyMan::GetDescriptorString(std::string& out, const bool priv) const
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
 
     FlatSigningProvider provider;
     provider.keys = GetKeys();
@@ -1613,7 +1613,7 @@ bool DescriptorScriptPubKeyMan::GetDescriptorString(std::string& out, const bool
 
 void DescriptorScriptPubKeyMan::UpgradeDescriptorCache()
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     if (m_storage.IsLocked() || m_storage.IsWalletFlagSet(WALLET_FLAG_LAST_HARDENED_XPUB_CACHED)) {
         return;
     }
@@ -1642,7 +1642,7 @@ void DescriptorScriptPubKeyMan::UpgradeDescriptorCache()
 
 util::Result<void> DescriptorScriptPubKeyMan::UpdateWalletDescriptor(WalletDescriptor& descriptor, const FlatSigningProvider& provider)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     std::string error;
     if (!CanUpdateToWalletDescriptor_(descriptor, error)) {
         return util::Error{Untranslated(std::move(error))};
@@ -1659,15 +1659,15 @@ util::Result<void> DescriptorScriptPubKeyMan::UpdateWalletDescriptor(WalletDescr
     return {};
 }
 
-void DescriptorScriptPubKeyMan::UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man)
+void DescriptorScriptPubKeyMan::UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider) EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     UpdateWithSigningProvider_(batch, signing_provider);
 }
 
 void DescriptorScriptPubKeyMan::UpdateWithSigningProvider_(WalletBatch& batch, const FlatSigningProvider& signing_provider)
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
     // Add the private keys to the descriptor
     for (const auto& entry : signing_provider.keys) {
         const CKey& key = entry.second;
@@ -1684,13 +1684,13 @@ void DescriptorScriptPubKeyMan::UpdateWithSigningProvider_(WalletBatch& batch, c
 
 bool DescriptorScriptPubKeyMan::CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error)
 {
-    LOCK(cs_desc_man);
+    LOCK(m_desc_mutex);
     return CanUpdateToWalletDescriptor_(descriptor, error);
 }
 
 bool DescriptorScriptPubKeyMan::CanUpdateToWalletDescriptor_(const WalletDescriptor& descriptor, std::string& error)
 {
-    AssertLockHeld(cs_desc_man);
+    AssertLockHeld(m_desc_mutex);
     if (!HasWalletDescriptor_(descriptor)) {
         error = "can only update matching descriptor";
         return false;

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -832,7 +832,6 @@ bool LegacyDataSPKM::DeleteRecordsWithDB(WalletBatch& batch)
 std::unique_ptr<DescriptorScriptPubKeyMan> DescriptorScriptPubKeyMan::CreateFromImport(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const FlatSigningProvider& provider)
 {
     auto spkm = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(storage, descriptor, keypool_size));
-    LOCK(spkm->cs_desc_man);
     WalletBatch batch(storage.GetDatabase());
     spkm->UpdateWithSigningProvider(batch, provider);
     return spkm;
@@ -841,7 +840,6 @@ std::unique_ptr<DescriptorScriptPubKeyMan> DescriptorScriptPubKeyMan::CreateFrom
 std::unique_ptr<DescriptorScriptPubKeyMan> DescriptorScriptPubKeyMan::CreateFromMigration(WalletStorage& storage, WalletBatch& batch, WalletDescriptor& descriptor, int64_t keypool_size, const FlatSigningProvider& provider)
 {
     auto spkm = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(storage, descriptor, keypool_size));
-    LOCK(spkm->cs_desc_man);
     spkm->UpdateWithSigningProvider(batch, provider);
     return spkm;
 }
@@ -873,41 +871,46 @@ std::unique_ptr<DescriptorScriptPubKeyMan> DescriptorScriptPubKeyMan::GenerateNe
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const OutputType type)
 {
-    // Returns true if this descriptor supports getting new addresses. Conditions where we may be unable to fetch them (e.g. locked) are caught later
-    if (!CanGetAddresses()) {
+    LOCK(cs_desc_man);
+    return GetNewDestination_(type);
+}
+
+util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination_(const OutputType type)
+{
+    AssertLockHeld(cs_desc_man);
+    // Returns true if this descriptor supports getting new addresses. Conditions where we may be unable to fetch them (e.g. locked) are caught later.
+    if (!m_wallet_descriptor.descriptor->IsSingleType() || !m_wallet_descriptor.descriptor->IsRange() || (!HavePrivateKeys_() && m_wallet_descriptor.next_index >= m_wallet_descriptor.range_end)) {
         return util::Error{_("No addresses available")};
     }
-    {
-        LOCK(cs_desc_man);
-        assert(m_wallet_descriptor.descriptor->IsSingleType()); // This is a combo descriptor which should not be an active descriptor
-        std::optional<OutputType> desc_addr_type = m_wallet_descriptor.descriptor->GetOutputType();
-        assert(desc_addr_type);
-        if (type != *desc_addr_type) {
-            throw std::runtime_error(std::string(__func__) + ": Types are inconsistent. Stored type does not match type of newly generated address");
-        }
 
-        TopUp();
-
-        // Get the scriptPubKey from the descriptor
-        FlatSigningProvider out_keys;
-        std::vector<CScript> scripts_temp;
-        if (m_wallet_descriptor.range_end <= m_max_cached_index && !TopUp(1)) {
-            // We can't generate anymore keys
-            return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
-        }
-        if (!m_wallet_descriptor.descriptor->ExpandFromCache(m_wallet_descriptor.next_index, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
-            // We can't generate anymore keys
-            return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
-        }
-
-        CTxDestination dest;
-        if (!ExtractDestination(scripts_temp[0], dest)) {
-            return util::Error{_("Error: Cannot extract destination from the generated scriptpubkey")}; // shouldn't happen
-        }
-        m_wallet_descriptor.next_index++;
-        WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
-        return dest;
+    assert(m_wallet_descriptor.descriptor->IsSingleType()); // This is a combo descriptor which should not be an active descriptor
+    std::optional<OutputType> desc_addr_type = m_wallet_descriptor.descriptor->GetOutputType();
+    assert(desc_addr_type);
+    if (type != *desc_addr_type) {
+        throw std::runtime_error(std::string(__func__) + ": Types are inconsistent. Stored type does not match type of newly generated address");
     }
+
+    TopUp_();
+
+    // Get the scriptPubKey from the descriptor
+    FlatSigningProvider out_keys;
+    std::vector<CScript> scripts_temp;
+    if (m_wallet_descriptor.range_end <= m_max_cached_index && !TopUp_(1)) {
+        // We can't generate anymore keys
+        return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
+    }
+    if (!m_wallet_descriptor.descriptor->ExpandFromCache(m_wallet_descriptor.next_index, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
+        // We can't generate anymore keys
+        return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
+    }
+
+    CTxDestination dest;
+    if (!ExtractDestination(scripts_temp[0], dest)) {
+        return util::Error{_("Error: Cannot extract destination from the generated scriptpubkey")}; // shouldn't happen
+    }
+    m_wallet_descriptor.next_index++;
+    WalletBatch(m_storage.GetDatabase()).WriteDescriptor(m_wallet_descriptor.id, m_wallet_descriptor);
+    return dest;
 }
 
 bool DescriptorScriptPubKeyMan::IsMine(const CScript& script) const
@@ -965,7 +968,7 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
             return false;
         }
         m_map_crypted_keys[pubkey.GetID()] = make_pair(pubkey, crypted_secret);
-        batch->WriteCryptedDescriptorKey(GetID(), pubkey, crypted_secret);
+        batch->WriteCryptedDescriptorKey(m_wallet_descriptor.id, pubkey, crypted_secret);
     }
     m_map_keys.clear();
     return true;
@@ -974,9 +977,9 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetReservedDestination(const OutputType type, bool internal, int64_t& index)
 {
     LOCK(cs_desc_man);
-    auto op_dest = GetNewDestination(type);
-    index = m_wallet_descriptor.next_index - 1;
-    return op_dest;
+    auto dest{GetNewDestination_(type)};
+    if (dest) index = m_wallet_descriptor.next_index - 1;
+    return dest;
 }
 
 void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, const CTxDestination& addr)
@@ -986,7 +989,7 @@ void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, 
     if (m_wallet_descriptor.next_index - 1 == index) {
         m_wallet_descriptor.next_index--;
     }
-    WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
+    WalletBatch(m_storage.GetDatabase()).WriteDescriptor(m_wallet_descriptor.id, m_wallet_descriptor);
     NotifyCanGetAddressesChanged();
 }
 
@@ -1011,13 +1014,13 @@ std::map<CKeyID, CKey> DescriptorScriptPubKeyMan::GetKeys() const
 
 bool DescriptorScriptPubKeyMan::HasPrivKey(const CKeyID& keyid) const
 {
-    AssertLockHeld(cs_desc_man);
+    LOCK(cs_desc_man);
     return m_map_keys.contains(keyid) || m_map_crypted_keys.contains(keyid);
 }
 
 std::optional<CKey> DescriptorScriptPubKeyMan::GetKey(const CKeyID& keyid) const
 {
-    AssertLockHeld(cs_desc_man);
+    LOCK(cs_desc_man);
     if (m_storage.HasEncryptionKeys() && !m_storage.IsLocked()) {
         const auto& it = m_map_crypted_keys.find(keyid);
         if (it == m_map_crypted_keys.end()) {
@@ -1041,9 +1044,16 @@ std::optional<CKey> DescriptorScriptPubKeyMan::GetKey(const CKeyID& keyid) const
 
 bool DescriptorScriptPubKeyMan::TopUp(unsigned int size)
 {
+    LOCK(cs_desc_man);
+    return TopUp_(size);
+}
+
+bool DescriptorScriptPubKeyMan::TopUp_(unsigned int size)
+{
+    AssertLockHeld(cs_desc_man);
     WalletBatch batch(m_storage.GetDatabase());
     if (!batch.TxnBegin()) return false;
-    bool res = TopUpWithDB(batch, size);
+    bool res = TopUpWithDB_(batch, size);
     if (!batch.TxnCommit()) throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot commit changes for wallet [%s]", m_storage.LogName()));
     return res;
 }
@@ -1051,6 +1061,12 @@ bool DescriptorScriptPubKeyMan::TopUp(unsigned int size)
 bool DescriptorScriptPubKeyMan::TopUpWithDB(WalletBatch& batch, unsigned int size)
 {
     LOCK(cs_desc_man);
+    return TopUpWithDB_(batch, size);
+}
+
+bool DescriptorScriptPubKeyMan::TopUpWithDB_(WalletBatch& batch, unsigned int size)
+{
+    AssertLockHeld(cs_desc_man);
     std::set<CScript> new_spks;
     unsigned int target_size;
     if (size > 0) {
@@ -1072,7 +1088,7 @@ bool DescriptorScriptPubKeyMan::TopUpWithDB(WalletBatch& batch, unsigned int siz
     FlatSigningProvider provider;
     provider.keys = GetKeys();
 
-    uint256 id = GetID();
+    uint256 id = m_wallet_descriptor.id;
     for (int32_t i = m_max_cached_index + 1; i < new_range_end; ++i) {
         FlatSigningProvider out_keys;
         std::vector<CScript> scripts_temp;
@@ -1103,7 +1119,7 @@ bool DescriptorScriptPubKeyMan::TopUpWithDB(WalletBatch& batch, unsigned int siz
         m_max_cached_index++;
     }
     m_wallet_descriptor.range_end = new_range_end;
-    batch.WriteDescriptor(GetID(), m_wallet_descriptor);
+    batch.WriteDescriptor(id, m_wallet_descriptor);
 
     // By this point, the cache size should be the size of the entire range
     assert(m_wallet_descriptor.range_end - 1 == m_max_cached_index);
@@ -1117,8 +1133,9 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
 {
     LOCK(cs_desc_man);
     std::vector<WalletDestination> result;
-    if (IsMine(script)) {
-        int32_t index = m_map_script_pub_keys[script];
+    auto script_it = m_map_script_pub_keys.find(script);
+    if (script_it != m_map_script_pub_keys.end()) {
+        int32_t index = script_it->second;
         if (index >= m_wallet_descriptor.next_index) {
             WalletLogPrintf("%s: Detected a used keypool item at index %d, mark all keypool items up to this item as used\n", __func__, index);
             auto out_keys = std::make_unique<FlatSigningProvider>();
@@ -1133,7 +1150,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
                 m_wallet_descriptor.next_index++;
             }
         }
-        if (!TopUp()) {
+        if (!TopUp_()) {
             WalletLogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);
         }
     }
@@ -1175,10 +1192,10 @@ bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const
         }
 
         m_map_crypted_keys[pubkey.GetID()] = make_pair(pubkey, crypted_secret);
-        return batch.WriteCryptedDescriptorKey(GetID(), pubkey, crypted_secret);
+        return batch.WriteCryptedDescriptorKey(m_wallet_descriptor.id, pubkey, crypted_secret);
     } else {
         m_map_keys[pubkey.GetID()] = key;
-        return batch.WriteDescriptorKey(GetID(), pubkey, key.GetPrivKey());
+        return batch.WriteDescriptorKey(m_wallet_descriptor.id, pubkey, key.GetPrivKey());
     }
 }
 
@@ -1194,7 +1211,7 @@ void DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, co
     if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
     }
-    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+    if (!batch.WriteDescriptor(m_wallet_descriptor.id, m_wallet_descriptor)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
     }
 
@@ -1204,9 +1221,19 @@ void DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, co
     }
 
     // TopUp
-    TopUpWithDB(batch);
+    TopUpWithDB_(batch);
 
     m_storage.UnsetBlankWalletFlag(batch);
+}
+
+void DescriptorScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor)
+{
+    LOCK(cs_desc_man);
+    m_wallet_descriptor = std::move(descriptor);
+    if (!batch.WriteDescriptor(m_wallet_descriptor.id, m_wallet_descriptor)) {
+        throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+    }
+    TopUpWithDB_(batch);
 }
 
 bool DescriptorScriptPubKeyMan::IsHDEnabled() const
@@ -1222,12 +1249,18 @@ bool DescriptorScriptPubKeyMan::CanGetAddresses(bool internal) const
     LOCK(cs_desc_man);
     return m_wallet_descriptor.descriptor->IsSingleType() &&
            m_wallet_descriptor.descriptor->IsRange() &&
-           (HavePrivateKeys() || m_wallet_descriptor.next_index < m_wallet_descriptor.range_end);
+           (HavePrivateKeys_() || m_wallet_descriptor.next_index < m_wallet_descriptor.range_end);
 }
 
 bool DescriptorScriptPubKeyMan::HavePrivateKeys() const
 {
     LOCK(cs_desc_man);
+    return HavePrivateKeys_();
+}
+
+bool DescriptorScriptPubKeyMan::HavePrivateKeys_() const
+{
+    AssertLockHeld(cs_desc_man);
     return m_map_keys.size() > 0 || m_map_crypted_keys.size() > 0;
 }
 
@@ -1301,7 +1334,7 @@ std::unique_ptr<FlatSigningProvider> DescriptorScriptPubKeyMan::GetSigningProvid
         m_map_signing_providers[index] = *out_keys;
     }
 
-    if (HavePrivateKeys() && include_private) {
+    if (HavePrivateKeys_() && include_private) {
         FlatSigningProvider master_provider;
         master_provider.keys = GetKeys();
         m_wallet_descriptor.descriptor->ExpandPrivate(index, master_provider, *out_keys);
@@ -1511,6 +1544,12 @@ void DescriptorScriptPubKeyMan::Load()
 bool DescriptorScriptPubKeyMan::HasWalletDescriptor(const WalletDescriptor& desc) const
 {
     LOCK(cs_desc_man);
+    return HasWalletDescriptor_(desc);
+}
+
+bool DescriptorScriptPubKeyMan::HasWalletDescriptor_(const WalletDescriptor& desc) const
+{
+    AssertLockHeld(cs_desc_man);
     return !m_wallet_descriptor.id.IsNull() && !desc.id.IsNull() && m_wallet_descriptor.id == desc.id;
 }
 
@@ -1518,13 +1557,14 @@ void DescriptorScriptPubKeyMan::WriteDescriptor()
 {
     LOCK(cs_desc_man);
     WalletBatch batch(m_storage.GetDatabase());
-    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+    if (!batch.WriteDescriptor(m_wallet_descriptor.id, m_wallet_descriptor)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
     }
 }
 
 WalletDescriptor DescriptorScriptPubKeyMan::GetWalletDescriptor() const
 {
+    LOCK(cs_desc_man);
     return m_wallet_descriptor;
 }
 
@@ -1547,6 +1587,7 @@ std::unordered_set<CScript, SaltedSipHasher> DescriptorScriptPubKeyMan::GetScrip
 
 int32_t DescriptorScriptPubKeyMan::GetEndRange() const
 {
+    LOCK(cs_desc_man);
     return m_max_cached_index + 1;
 }
 
@@ -1591,7 +1632,7 @@ void DescriptorScriptPubKeyMan::UpgradeDescriptorCache()
 
     // Cache the last hardened xpubs
     DescriptorCache diff = m_wallet_descriptor.cache.MergeAndDiff(temp_cache);
-    if (!WalletBatch(m_storage.GetDatabase()).WriteDescriptorCacheItems(GetID(), diff)) {
+    if (!WalletBatch(m_storage.GetDatabase()).WriteDescriptorCacheItems(m_wallet_descriptor.id, diff)) {
         throw std::runtime_error(std::string(__func__) + ": writing cache items failed");
     }
 }
@@ -1600,7 +1641,7 @@ util::Result<void> DescriptorScriptPubKeyMan::UpdateWalletDescriptor(WalletDescr
 {
     LOCK(cs_desc_man);
     std::string error;
-    if (!CanUpdateToWalletDescriptor(descriptor, error)) {
+    if (!CanUpdateToWalletDescriptor_(descriptor, error)) {
         return util::Error{Untranslated(std::move(error))};
     }
 
@@ -1610,12 +1651,18 @@ util::Result<void> DescriptorScriptPubKeyMan::UpdateWalletDescriptor(WalletDescr
     m_wallet_descriptor = descriptor;
 
     WalletBatch batch(m_storage.GetDatabase());
-    UpdateWithSigningProvider(batch, provider);
+    UpdateWithSigningProvider_(batch, provider);
     NotifyFirstKeyTimeChanged(this, m_wallet_descriptor.creation_time);
     return {};
 }
 
 void DescriptorScriptPubKeyMan::UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider)
+{
+    LOCK(cs_desc_man);
+    UpdateWithSigningProvider_(batch, signing_provider);
+}
+
+void DescriptorScriptPubKeyMan::UpdateWithSigningProvider_(WalletBatch& batch, const FlatSigningProvider& signing_provider)
 {
     AssertLockHeld(cs_desc_man);
     // Add the private keys to the descriptor
@@ -1627,7 +1674,7 @@ void DescriptorScriptPubKeyMan::UpdateWithSigningProvider(WalletBatch& batch, co
     }
 
     // Top up key pool, to generate scriptPubKeys
-    if (!TopUpWithDB(batch)) {
+    if (!TopUpWithDB_(batch)) {
         throw std::runtime_error("Could not top up scriptPubKeys");
     }
 }
@@ -1635,7 +1682,13 @@ void DescriptorScriptPubKeyMan::UpdateWithSigningProvider(WalletBatch& batch, co
 bool DescriptorScriptPubKeyMan::CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error)
 {
     LOCK(cs_desc_man);
-    if (!HasWalletDescriptor(descriptor)) {
+    return CanUpdateToWalletDescriptor_(descriptor, error);
+}
+
+bool DescriptorScriptPubKeyMan::CanUpdateToWalletDescriptor_(const WalletDescriptor& descriptor, std::string& error)
+{
+    AssertLockHeld(cs_desc_man);
+    if (!HasWalletDescriptor_(descriptor)) {
         error = "can only update matching descriptor";
         return false;
     }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1199,7 +1199,10 @@ bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const
     }
 }
 
-void DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal)
+// The declaration uses LOCKS_EXCLUDED for calls on newly-created SPKMs.
+// The definition uses EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man) so clang can
+// verify that this self-locking method takes the mutex only after entry.
+void DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man)
 {
     LOCK(cs_desc_man);
     Assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
@@ -1226,7 +1229,7 @@ void DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, co
     m_storage.UnsetBlankWalletFlag(batch);
 }
 
-void DescriptorScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor)
+void DescriptorScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man)
 {
     LOCK(cs_desc_man);
     m_wallet_descriptor = std::move(descriptor);
@@ -1656,7 +1659,7 @@ util::Result<void> DescriptorScriptPubKeyMan::UpdateWalletDescriptor(WalletDescr
     return {};
 }
 
-void DescriptorScriptPubKeyMan::UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider)
+void DescriptorScriptPubKeyMan::UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man)
 {
     LOCK(cs_desc_man);
     UpdateWithSigningProvider_(batch, signing_provider);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -15,6 +15,7 @@
 #include <script/descriptor.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
+#include <sync.h>
 #include <util/btcsignals.h>
 #include <util/hasher.h>
 #include <util/log.h>
@@ -278,6 +279,8 @@ private:
     using ScriptPubKeyMap = std::map<CScript, int32_t>; // Map of scripts to descriptor range index
     using PubKeyMap = std::map<CPubKey, int32_t>; // Map of pubkeys involved in scripts to descriptor range index
 
+    mutable Mutex cs_desc_man;
+
     ScriptPubKeyMap m_map_script_pub_keys GUARDED_BY(cs_desc_man);
     PubKeyMap m_map_pubkeys GUARDED_BY(cs_desc_man);
     int32_t m_max_cached_index = -1;
@@ -319,23 +322,29 @@ private:
     // Cached FlatSigningProviders to avoid regenerating them each time they are needed.
     mutable std::map<int32_t, FlatSigningProvider> m_map_signing_providers;
     // Fetch the SigningProvider for the given script and optionally include private keys
-    std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CScript& script, bool include_private = false) const;
+    std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CScript& script, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
     // Fetch the SigningProvider for a given index and optionally include private keys. Called by the above functions.
     std::unique_ptr<FlatSigningProvider> GetSigningProvider(int32_t index, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
-    void Load();
+    void Load() EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
     util::Result<CTxDestination> GetNewDestination_(OutputType type) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     bool TopUp_(unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     bool TopUpWithDB_(WalletBatch& batch, unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    void AddDescriptorKey(const CKey& key, const CPubKey &pubkey);
-    void UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider);
+    void AddDescriptorKey(const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    // Called immediately after constructing a new SPKM. Use LOCKS_EXCLUDED
+    // instead of EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man) because clang cannot
+    // prove at this call that the new object's mutex is not already held.
+    void UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider) LOCKS_EXCLUDED(cs_desc_man);
     void UpdateWithSigningProvider_(WalletBatch& batch, const FlatSigningProvider& signing_provider) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     bool HasWalletDescriptor_(const WalletDescriptor& desc) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     bool CanUpdateToWalletDescriptor_(const WalletDescriptor& descriptor, std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
     //! Setup descriptors based on the given CExtKey
-    void SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal);
+    // Called immediately after constructing a new SPKM.
+    void SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal) LOCKS_EXCLUDED(cs_desc_man);
+
+    WalletDescriptor m_wallet_descriptor GUARDED_BY(cs_desc_man);
 
 protected:
     //! Create a DescriptorScriptPubKeyMan from existing data (i.e. during loading)
@@ -346,12 +355,11 @@ protected:
         m_keypool_size(keypool_size)
     {}
 
-    WalletDescriptor m_wallet_descriptor GUARDED_BY(cs_desc_man);
-
     //! Same as 'TopUp' but designed for use within a batch transaction context
-    bool TopUpWithDB(WalletBatch& batch, unsigned int size = 0);
+    bool TopUpWithDB(WalletBatch& batch, unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    void SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor);
+    // Called immediately after constructing a new SPKM.
+    void SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor) LOCKS_EXCLUDED(cs_desc_man);
 
 public:
     static std::unique_ptr<DescriptorScriptPubKeyMan> LoadFromStorage(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const KeyMap& keys, const CryptedKeyMap& ckeys);
@@ -359,67 +367,65 @@ public:
     static std::unique_ptr<DescriptorScriptPubKeyMan> CreateFromMigration(WalletStorage& storage, WalletBatch& batch, WalletDescriptor& descriptor, int64_t keypool_size, const FlatSigningProvider& provider);
     static std::unique_ptr<DescriptorScriptPubKeyMan> GenerateNewSingleSig(WalletStorage& storage, WalletBatch& batch, int64_t keypool_size, const CExtKey& master_key, OutputType addr_type, bool internal);
 
-    mutable RecursiveMutex cs_desc_man;
+    util::Result<CTxDestination> GetNewDestination(OutputType type) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool IsMine(const CScript& script) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    util::Result<CTxDestination> GetNewDestination(OutputType type) override;
-    bool IsMine(const CScript& script) const override;
+    bool CheckDecryptionKey(const CKeyingMaterial& master_key) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    bool CheckDecryptionKey(const CKeyingMaterial& master_key) override;
-    bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch) override;
-
-    util::Result<CTxDestination> GetReservedDestination(OutputType type, bool internal, int64_t& index) override;
-    void ReturnDestination(int64_t index, bool internal, const CTxDestination& addr) override;
+    util::Result<CTxDestination> GetReservedDestination(OutputType type, bool internal, int64_t& index) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    void ReturnDestination(int64_t index, bool internal, const CTxDestination& addr) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
     // Tops up the descriptor cache and m_map_script_pub_keys. The cache is stored in the wallet file
     // and is used to expand the descriptor in GetNewDestination. DescriptorScriptPubKeyMan relies
     // more on ephemeral data than LegacyScriptPubKeyMan. For wallets using unhardened derivation
     // (with or without private keys), the "keypool" is a single xpub.
-    bool TopUp(unsigned int size = 0) override;
+    bool TopUp(unsigned int size = 0) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) override;
+    std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    bool IsHDEnabled() const override;
+    bool IsHDEnabled() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    bool HavePrivateKeys() const override;
-    bool HasPrivKey(const CKeyID& keyid) const;
+    bool HavePrivateKeys() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool HasPrivKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
     //! Retrieve the particular key if it is available. Returns nullopt if the key is not in the wallet, or if the wallet is locked.
-    std::optional<CKey> GetKey(const CKeyID& keyid) const;
-    bool HaveCryptedKeys() const override;
+    std::optional<CKey> GetKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool HaveCryptedKeys() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    unsigned int GetKeyPoolSize() const override;
+    unsigned int GetKeyPoolSize() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    int64_t GetTimeFirstKey() const override;
+    int64_t GetTimeFirstKey() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    std::unique_ptr<CKeyMetadata> GetMetadata(const CTxDestination& dest) const override;
+    std::unique_ptr<CKeyMetadata> GetMetadata(const CTxDestination& dest) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    bool CanGetAddresses(bool internal = false) const override;
+    bool CanGetAddresses(bool internal = false) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const override;
+    std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    bool CanProvide(const CScript& script, SignatureData& sigdata) override;
+    bool CanProvide(const CScript& script, SignatureData& sigdata) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
     // Fetch the SigningProvider for the given pubkey and always include private keys. This should only be called by signing code.
-    std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CPubKey& pubkey) const;
+    std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CPubKey& pubkey) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override;
-    SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
-    std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed = nullptr) const override;
+    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed = nullptr) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    uint256 GetID() const override;
+    uint256 GetID() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    bool HasWalletDescriptor(const WalletDescriptor& desc) const;
-    util::Result<void> UpdateWalletDescriptor(WalletDescriptor& descriptor, const FlatSigningProvider& provider);
-    bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error);
-    void WriteDescriptor();
+    bool HasWalletDescriptor(const WalletDescriptor& desc) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    util::Result<void> UpdateWalletDescriptor(WalletDescriptor& descriptor, const FlatSigningProvider& provider) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    void WriteDescriptor() EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    WalletDescriptor GetWalletDescriptor() const;
-    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override;
-    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys(int32_t minimum_index) const;
-    int32_t GetEndRange() const;
+    WalletDescriptor GetWalletDescriptor() const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys(int32_t minimum_index) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    int32_t GetEndRange() const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    [[nodiscard]] bool GetDescriptorString(std::string& out, bool priv) const;
+    [[nodiscard]] bool GetDescriptorString(std::string& out, bool priv) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 
-    void UpgradeDescriptorCache();
+    void UpgradeDescriptorCache() EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
 };
 
 /** struct containing information needed for migrating legacy wallets to descriptor wallets */

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -279,20 +279,20 @@ private:
     using ScriptPubKeyMap = std::map<CScript, int32_t>; // Map of scripts to descriptor range index
     using PubKeyMap = std::map<CPubKey, int32_t>; // Map of pubkeys involved in scripts to descriptor range index
 
-    mutable Mutex cs_desc_man;
+    mutable Mutex m_desc_mutex;
 
-    ScriptPubKeyMap m_map_script_pub_keys GUARDED_BY(cs_desc_man);
-    PubKeyMap m_map_pubkeys GUARDED_BY(cs_desc_man);
+    ScriptPubKeyMap m_map_script_pub_keys GUARDED_BY(m_desc_mutex);
+    PubKeyMap m_map_pubkeys GUARDED_BY(m_desc_mutex);
     int32_t m_max_cached_index = -1;
 
-    KeyMap m_map_keys GUARDED_BY(cs_desc_man);
-    CryptedKeyMap m_map_crypted_keys GUARDED_BY(cs_desc_man);
+    KeyMap m_map_keys GUARDED_BY(m_desc_mutex);
+    CryptedKeyMap m_map_crypted_keys GUARDED_BY(m_desc_mutex);
 
     //! keeps track of whether Unlock has run a thorough check before
     bool m_decryption_thoroughly_checked = false;
 
     //! Number of pre-generated keys/scripts (part of the look-ahead process, used to detect payments)
-    int64_t m_keypool_size GUARDED_BY(cs_desc_man){DEFAULT_KEYPOOL_SIZE};
+    int64_t m_keypool_size GUARDED_BY(m_desc_mutex){DEFAULT_KEYPOOL_SIZE};
 
     /** Map of a session id to MuSig2 secnonce
      *
@@ -314,37 +314,37 @@ private:
         m_wallet_descriptor(descriptor)
     {}
 
-    bool AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
 
-    KeyMap GetKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    bool HavePrivateKeys_() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    KeyMap GetKeys() const EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
+    bool HavePrivateKeys_() const EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
 
     // Cached FlatSigningProviders to avoid regenerating them each time they are needed.
     mutable std::map<int32_t, FlatSigningProvider> m_map_signing_providers;
     // Fetch the SigningProvider for the given script and optionally include private keys
-    std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CScript& script, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CScript& script, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
     // Fetch the SigningProvider for a given index and optionally include private keys. Called by the above functions.
-    std::unique_ptr<FlatSigningProvider> GetSigningProvider(int32_t index, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    std::unique_ptr<FlatSigningProvider> GetSigningProvider(int32_t index, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
 
-    void Load() EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    void Load() EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    util::Result<CTxDestination> GetNewDestination_(OutputType type) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    bool TopUp_(unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    bool TopUpWithDB_(WalletBatch& batch, unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    void AddDescriptorKey(const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    util::Result<CTxDestination> GetNewDestination_(OutputType type) EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
+    bool TopUp_(unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
+    bool TopUpWithDB_(WalletBatch& batch, unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
+    void AddDescriptorKey(const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
     // Called immediately after constructing a new SPKM. Use LOCKS_EXCLUDED
-    // instead of EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man) because clang cannot
+    // instead of EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex) because clang cannot
     // prove at this call that the new object's mutex is not already held.
-    void UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider) LOCKS_EXCLUDED(cs_desc_man);
-    void UpdateWithSigningProvider_(WalletBatch& batch, const FlatSigningProvider& signing_provider) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    bool HasWalletDescriptor_(const WalletDescriptor& desc) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    bool CanUpdateToWalletDescriptor_(const WalletDescriptor& descriptor, std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    void UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider) LOCKS_EXCLUDED(m_desc_mutex);
+    void UpdateWithSigningProvider_(WalletBatch& batch, const FlatSigningProvider& signing_provider) EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
+    bool HasWalletDescriptor_(const WalletDescriptor& desc) const EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
+    bool CanUpdateToWalletDescriptor_(const WalletDescriptor& descriptor, std::string& error) EXCLUSIVE_LOCKS_REQUIRED(m_desc_mutex);
 
     //! Setup descriptors based on the given CExtKey
     // Called immediately after constructing a new SPKM.
-    void SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal) LOCKS_EXCLUDED(cs_desc_man);
+    void SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal) LOCKS_EXCLUDED(m_desc_mutex);
 
-    WalletDescriptor m_wallet_descriptor GUARDED_BY(cs_desc_man);
+    WalletDescriptor m_wallet_descriptor GUARDED_BY(m_desc_mutex);
 
 protected:
     //! Create a DescriptorScriptPubKeyMan from existing data (i.e. during loading)
@@ -356,10 +356,10 @@ protected:
     {}
 
     //! Same as 'TopUp' but designed for use within a batch transaction context
-    bool TopUpWithDB(WalletBatch& batch, unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool TopUpWithDB(WalletBatch& batch, unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
     // Called immediately after constructing a new SPKM.
-    void SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor) LOCKS_EXCLUDED(cs_desc_man);
+    void SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor) LOCKS_EXCLUDED(m_desc_mutex);
 
 public:
     static std::unique_ptr<DescriptorScriptPubKeyMan> LoadFromStorage(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const KeyMap& keys, const CryptedKeyMap& ckeys);
@@ -367,65 +367,65 @@ public:
     static std::unique_ptr<DescriptorScriptPubKeyMan> CreateFromMigration(WalletStorage& storage, WalletBatch& batch, WalletDescriptor& descriptor, int64_t keypool_size, const FlatSigningProvider& provider);
     static std::unique_ptr<DescriptorScriptPubKeyMan> GenerateNewSingleSig(WalletStorage& storage, WalletBatch& batch, int64_t keypool_size, const CExtKey& master_key, OutputType addr_type, bool internal);
 
-    util::Result<CTxDestination> GetNewDestination(OutputType type) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    bool IsMine(const CScript& script) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    util::Result<CTxDestination> GetNewDestination(OutputType type) override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    bool IsMine(const CScript& script) const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    bool CheckDecryptionKey(const CKeyingMaterial& master_key) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool CheckDecryptionKey(const CKeyingMaterial& master_key) override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch) override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    util::Result<CTxDestination> GetReservedDestination(OutputType type, bool internal, int64_t& index) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    void ReturnDestination(int64_t index, bool internal, const CTxDestination& addr) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    util::Result<CTxDestination> GetReservedDestination(OutputType type, bool internal, int64_t& index) override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    void ReturnDestination(int64_t index, bool internal, const CTxDestination& addr) override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
     // Tops up the descriptor cache and m_map_script_pub_keys. The cache is stored in the wallet file
     // and is used to expand the descriptor in GetNewDestination. DescriptorScriptPubKeyMan relies
     // more on ephemeral data than LegacyScriptPubKeyMan. For wallets using unhardened derivation
     // (with or without private keys), the "keypool" is a single xpub.
-    bool TopUp(unsigned int size = 0) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool TopUp(unsigned int size = 0) override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    bool IsHDEnabled() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool IsHDEnabled() const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    bool HavePrivateKeys() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    bool HasPrivKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool HavePrivateKeys() const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    bool HasPrivKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
     //! Retrieve the particular key if it is available. Returns nullopt if the key is not in the wallet, or if the wallet is locked.
-    std::optional<CKey> GetKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    bool HaveCryptedKeys() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    std::optional<CKey> GetKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    bool HaveCryptedKeys() const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    unsigned int GetKeyPoolSize() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    unsigned int GetKeyPoolSize() const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    int64_t GetTimeFirstKey() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    int64_t GetTimeFirstKey() const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    std::unique_ptr<CKeyMetadata> GetMetadata(const CTxDestination& dest) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    std::unique_ptr<CKeyMetadata> GetMetadata(const CTxDestination& dest) const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    bool CanGetAddresses(bool internal = false) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool CanGetAddresses(bool internal = false) const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    bool CanProvide(const CScript& script, SignatureData& sigdata) override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool CanProvide(const CScript& script, SignatureData& sigdata) override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
     // Fetch the SigningProvider for the given pubkey and always include private keys. This should only be called by signing code.
-    std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CPubKey& pubkey) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CPubKey& pubkey) const EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed = nullptr) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, const common::PSBTFillOptions& options, int* n_signed = nullptr) const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    uint256 GetID() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    uint256 GetID() const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    bool HasWalletDescriptor(const WalletDescriptor& desc) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    util::Result<void> UpdateWalletDescriptor(WalletDescriptor& descriptor, const FlatSigningProvider& provider) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error) EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    void WriteDescriptor() EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    bool HasWalletDescriptor(const WalletDescriptor& desc) const EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    util::Result<void> UpdateWalletDescriptor(WalletDescriptor& descriptor, const FlatSigningProvider& provider) EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error) EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    void WriteDescriptor() EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    WalletDescriptor GetWalletDescriptor() const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys(int32_t minimum_index) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
-    int32_t GetEndRange() const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    WalletDescriptor GetWalletDescriptor() const EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys(int32_t minimum_index) const EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
+    int32_t GetEndRange() const EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    [[nodiscard]] bool GetDescriptorString(std::string& out, bool priv) const EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    [[nodiscard]] bool GetDescriptorString(std::string& out, bool priv) const EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 
-    void UpgradeDescriptorCache() EXCLUSIVE_LOCKS_REQUIRED(!cs_desc_man);
+    void UpgradeDescriptorCache() EXCLUSIVE_LOCKS_REQUIRED(!m_desc_mutex);
 };
 
 /** struct containing information needed for migrating legacy wallets to descriptor wallets */

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -314,6 +314,7 @@ private:
     bool AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
     KeyMap GetKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool HavePrivateKeys_() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
     // Cached FlatSigningProviders to avoid regenerating them each time they are needed.
     mutable std::map<int32_t, FlatSigningProvider> m_map_signing_providers;
@@ -324,8 +325,14 @@ private:
 
     void Load();
 
+    util::Result<CTxDestination> GetNewDestination_(OutputType type) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool TopUp_(unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool TopUpWithDB_(WalletBatch& batch, unsigned int size = 0) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     void AddDescriptorKey(const CKey& key, const CPubKey &pubkey);
-    void UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    void UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider);
+    void UpdateWithSigningProvider_(WalletBatch& batch, const FlatSigningProvider& signing_provider) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool HasWalletDescriptor_(const WalletDescriptor& desc) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool CanUpdateToWalletDescriptor_(const WalletDescriptor& descriptor, std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
     //! Setup descriptors based on the given CExtKey
     void SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal);
@@ -343,6 +350,8 @@ protected:
 
     //! Same as 'TopUp' but designed for use within a batch transaction context
     bool TopUpWithDB(WalletBatch& batch, unsigned int size = 0);
+
+    void SetupDescriptor(WalletBatch& batch, WalletDescriptor descriptor);
 
 public:
     static std::unique_ptr<DescriptorScriptPubKeyMan> LoadFromStorage(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size, const KeyMap& keys, const CryptedKeyMap& ckeys);
@@ -372,9 +381,9 @@ public:
     bool IsHDEnabled() const override;
 
     bool HavePrivateKeys() const override;
-    bool HasPrivKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool HasPrivKey(const CKeyID& keyid) const;
     //! Retrieve the particular key if it is available. Returns nullopt if the key is not in the wallet, or if the wallet is locked.
-    std::optional<CKey> GetKey(const CKeyID& keyid) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    std::optional<CKey> GetKey(const CKeyID& keyid) const;
     bool HaveCryptedKeys() const override;
 
     unsigned int GetKeyPoolSize() const override;
@@ -403,7 +412,7 @@ public:
     bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error);
     void WriteDescriptor();
 
-    WalletDescriptor GetWalletDescriptor() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    WalletDescriptor GetWalletDescriptor() const;
     std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override;
     std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys(int32_t minimum_index) const;
     int32_t GetEndRange() const;

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -157,7 +157,6 @@ FUZZ_TARGET(scriptpubkeyman, .init = initialize_spkm)
                 }
             },
             [&] {
-                LOCK(spk_manager->cs_desc_man);
                 auto wallet_desc{spk_manager->GetWalletDescriptor()};
                 if (wallet_desc.descriptor->IsSingleType()) {
                     auto output_type{wallet_desc.descriptor->GetOutputType()};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3503,7 +3503,6 @@ std::vector<WalletDescriptor> CWallet::GetWalletDescriptors(const CScript& scrip
     std::vector<WalletDescriptor> descs;
     for (const auto spk_man: GetScriptPubKeyMans(script)) {
         if (const auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
-            LOCK(desc_spk_man->cs_desc_man);
             descs.push_back(desc_spk_man->GetWalletDescriptor());
         }
     }
@@ -3775,7 +3774,6 @@ std::optional<bool> CWallet::IsInternalScriptPubKeyMan(ScriptPubKeyMan* spk_man)
         throw std::runtime_error(std::string(__func__) + ": unexpected ScriptPubKeyMan type.");
     }
 
-    LOCK(desc_spk_man->cs_desc_man);
     const auto& type = desc_spk_man->GetWalletDescriptor().descriptor->GetOutputType();
     assert(type.has_value());
 
@@ -4524,7 +4522,6 @@ std::set<CExtPubKey> CWallet::GetActiveHDPubKeys() const
     for (const auto& spkm : GetActiveScriptPubKeyMans()) {
         const DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
         assert(desc_spkm);
-        LOCK(desc_spkm->cs_desc_man);
         WalletDescriptor w_desc = desc_spkm->GetWalletDescriptor();
 
         std::set<CPubKey> desc_pubkeys;
@@ -4542,7 +4539,6 @@ std::optional<CKey> CWallet::GetKey(const CKeyID& keyid) const
     for (const auto& spkm : GetAllScriptPubKeyMans()) {
         const DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
         assert(desc_spkm);
-        LOCK(desc_spkm->cs_desc_man);
         if (std::optional<CKey> key = desc_spkm->GetKey(keyid)) {
             return key;
         }


### PR DESCRIPTION
Part of https://github.com/bitcoin/bitcoin/issues/19303

This PR makes `DescriptorScriptPubKeyMan` use a non-recursive private mutex by moving locking responsibility into its public methods and using lock-held internal helpers for shared logic.

The change removes external locking of `DescriptorScriptPubKeyMan::cs_desc_man`, splits recursive internal call paths such as keypool top-up and descriptor updates, and then renames the mutex to `m_desc_mutex`.

No wallet database format, RPC behavior, keypool semantics, or external signer behavior is intended to change.