### PR TITLE
ci: use pyzmq over zmq

### DIFF
--- a/ci/test/00_setup_env_mac_native.sh
+++ b/ci/test/00_setup_env_mac_native.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME="ci_mac_native"  # macos does not use a container, but the env var is needed for logging
-export PIP_PACKAGES="--break-system-packages pycapnp zmq"
+export PIP_PACKAGES="--break-system-packages pycapnp pyzmq"
 export GOAL="install deploy"
 export CMAKE_GENERATOR="Ninja"
 export CI_OS_NAME="macos"

--- a/ci/test/00_setup_env_native_msan.sh
+++ b/ci/test/00_setup_env_native_msan.sh
@@ -15,7 +15,7 @@ export MSAN_AND_LIBCXX_FLAGS="${MSAN_FLAGS} ${LIBCXX_FLAGS}"
 
 export CONTAINER_NAME="ci_native_msan"
 export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} llvm-${APT_LLVM_V}-dev libclang-${APT_LLVM_V}-dev libclang-rt-${APT_LLVM_V}-dev python3-pip"
-export PIP_PACKAGES="--break-system-packages pycapnp"
+export PIP_PACKAGES="--break-system-packages pycapnp pyzmq"
 export DEP_OPTS="DEBUG=1 NO_QT=1 CC=clang CXX=clang++ CFLAGS='${MSAN_FLAGS}' CXXFLAGS='${MSAN_AND_LIBCXX_FLAGS}'"
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1


### PR DESCRIPTION
`zmq` seems to be an alias for `pyzmq`, and the project page, https://pypi.org/project/zmq/, states "You are probably looking for pyzmq.". So switch to `pyzmq`, which is what we document, and use in all other jobs.

Also add `pyzmq` to native MSAN, so that `interface_zmq.py` is run.