### PR TITLE
ci: use warpbuild cache for docker buildkit cache

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -1,9 +1,22 @@
 name: 'Configure Docker'
 description: 'Set up Docker build driver and configure build cache args'
+inputs:
+  provider:
+    description: 'The cache provider to use'
+    required: false
+    default: 'gha'
 runs:
   using: 'composite'
   steps:
+    - name: Set up Docker Buildx for Warp cache
+      if: ${{ inputs.provider == 'warp' }}
+      uses: docker/setup-buildx-action@v4
+      with:
+        driver-opts: |
+          network=host
+
     - name: Set up Docker Buildx
+      if: ${{ inputs.provider != 'warp' }}
       uses: docker/setup-buildx-action@v4
 
     # This is required when using the gha cache backend with a manual docker buildx invocation.
@@ -23,13 +36,18 @@ runs:
     - name: Construct docker build cache args
       shell: bash
       run: |
+        cache_options="scope=${CONTAINER_NAME}"
+        if [[ "${{ inputs.provider }}" == "warp" ]]; then
+          cache_options="url=http://127.0.0.1:49160/,version=1,${cache_options}"
+        fi
+
         # Configure docker build cache backend
         # Always optimistically --cache‑from in case a cache blob exists
-        args=(--cache-from "type=gha,scope=${CONTAINER_NAME}")
+        args=(--cache-from "type=gha,${cache_options}")
 
         # Only add --cache-to when pushing to the default branch.
         if [[ ${{ github.event_name }} == "push" && ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
-          args+=(--cache-to "type=gha,mode=max,ignore-error=true,scope=${CONTAINER_NAME}")
+          args+=(--cache-to "type=gha,mode=max,ignore-error=true,${cache_options}")
         fi
 
         # Always `--load` into docker images (needed when using the `docker-container` build driver).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,8 @@ jobs:
 
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
+        with:
+          provider: ${{ needs.runners.outputs.provider }}
 
       - name: CI script
         run: ./ci/test_run_all.sh
@@ -557,6 +559,8 @@ jobs:
 
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
+        with:
+          provider: ${{ matrix.provider || needs.runners.outputs.provider }}
 
       - name: Clear unnecessary files
         if: ${{ needs.runners.outputs.provider == 'gha' && true || false }} # Only needed on GHA runners
@@ -600,6 +604,8 @@ jobs:
 
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
+        with:
+          provider: ${{ needs.runners.outputs.provider }}
 
       - name: CI script
         run: |


### PR DESCRIPTION
We switched to GH cache recently, but the performance is beyond terrible. We have already switched the main cache actions over to warp, and this completes the transfer with the docker buildkit cache to the Warp endpoint.

