### PR TITLE
ci: don't build libunwind in msan

### DIFF
--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -62,7 +62,7 @@ if [ -n "$PIP_PACKAGES" ]; then
 fi
 
 if [[ -n "${USE_INSTRUMENTED_LIBCPP}" ]]; then
-  ${CI_RETRY_EXE} git clone --depth=1 https://github.com/llvm/llvm-project -b "llvmorg-22.1.3" /llvm-project
+  ${CI_RETRY_EXE} git clone --depth=1 https://github.com/llvm/llvm-project -b "llvmorg-22.1.7" /llvm-project
 
   cmake -G Ninja -B /cxx_build/ \
     -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -64,8 +64,11 @@ fi
 if [[ -n "${USE_INSTRUMENTED_LIBCPP}" ]]; then
   ${CI_RETRY_EXE} git clone --depth=1 https://github.com/llvm/llvm-project -b "llvmorg-22.1.7" /llvm-project
 
+# LLVM is configured with LIBCXXABI_USE_LLVM_UNWINDER=OFF,
+# because libunwind doesn't handle exceptions under MSAN.
+# https://github.com/llvm/llvm-project/issues/84348
   cmake -G Ninja -B /cxx_build/ \
-    -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+    -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
     -DCMAKE_BUILD_TYPE=Release \
     -DLLVM_USE_SANITIZER="${USE_INSTRUMENTED_LIBCPP}" \
     -DCMAKE_C_COMPILER=clang \


### PR DESCRIPTION
Also document why we use `LIBCXXABI_USE_LLVM_UNWINDER=OFF`. Upstream issue is https://github.com/llvm/llvm-project/issues/84348.