### PR TITLE
cmake: skip missing example targets in libmultiprocess.cmake

### DIFF
--- a/cmake/libmultiprocess.cmake
+++ b/cmake/libmultiprocess.cmake
@@ -34,5 +34,9 @@ function(add_libmultiprocess subdir)
   # exclusion, tools like clang-tidy and IWYU that make use of compilation
   # database would complain that the generated c++ source files do not exist. An
   # alternate fix could build "mpexamples" by default like "mptests" above.
-  set_target_properties(mpcalculator mpprinter mpexample PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+  foreach(target mpcalculator mpprinter mpexample)
+    if(TARGET ${target})
+      set_target_properties(${target} PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+    endif()
+  endforeach()
 endfunction()


### PR DESCRIPTION
bitcoin-core/libmultiprocess#287 is removing the mpcalculator, mpprinter, and mpexample targets, which causes a configuration error when Bitcoin Core is compiled against the updated upstream libmultiprocess:

```
CMake Error at cmake/libmultiprocess.cmake:37 ... Can not find target to add properties to: mpcalculator
```

Fix this by iterating over the targets and only calling set_target_properties if the target exists. This is not needed for subtree builds (where upstream changes do not apply directly), but is useful for custom builds with an external libmultiprocess, and is needed to keep Bitcoin Core CI jobs working in the libmultiprocess repository.
