### PR TITLE
guix: add setup.sh

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -5,72 +5,12 @@
 export LC_ALL=C
 set -e -o pipefail
 
-# Environment variables for determinism
-export TAR_OPTIONS="--no-same-owner --owner=0 --group=0 --numeric-owner --mtime='@${SOURCE_DATE_EPOCH}' --sort=name"
-export TZ=UTC
-
-# Although Guix _does_ set umask when building its own packages (in our case,
-# this is all packages in manifest.scm), it does not set it for `guix
-# shell`. It does make sense for at least `guix shell --container`
-# to set umask, so if that change gets merged upstream and we bump the
-# time-machine to a commit which includes the aforementioned change, we can
-# remove this line.
-#
-# This line should be placed before any commands which creates files.
-umask 0022
-
-if [ -n "$V" ]; then
-    # Print both unexpanded (-v) and expanded (-x) forms of commands as they are
-    # read from this file.
-    set -vx
-    # Set VERBOSE for CMake-based builds
-    export VERBOSE="$V"
-fi
-
-# Check that required environment variables are set
-cat << EOF
-Required environment variables as seen inside the container:
-    DIST_ARCHIVE_BASE: ${DIST_ARCHIVE_BASE:?not set}
-    DISTNAME: ${DISTNAME:?not set}
-    HOST: ${HOST:?not set}
-    SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH:?not set}
-    JOBS: ${JOBS:?not set}
-    DISTSRC: ${DISTSRC:?not set}
-    OUTDIR: ${OUTDIR:?not set}
-EOF
-
-ACTUAL_OUTDIR="${OUTDIR}"
-OUTDIR="${DISTSRC}/output"
-
-#####################
-# Environment Setup #
-#####################
-
-# The depends folder also serves as a base-prefix for depends packages for
-# $HOSTs after successfully building.
-BASEPREFIX="${PWD}/depends"
-
-# Given a package name and an output name, return the path of that output in our
-# current guix environment
-store_path() {
-    grep --extended-regexp "/[^-]{32}-${1}-[^-]+${2:+-${2}}" "${GUIX_ENVIRONMENT}/manifest" \
-        | head --lines=1 \
-        | sed --expression='s|\x29*$||' \
-              --expression='s|^[[:space:]]*"||' \
-              --expression='s|"[[:space:]]*$||'
-}
-
+# shellcheck source=setup.sh
+source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 
 # Set environment variables to point the NATIVE toolchain to the right
 # includes/libs
 NATIVE_GCC="$(store_path gcc-toolchain)"
-
-unset LIBRARY_PATH
-unset CPATH
-unset C_INCLUDE_PATH
-unset CPLUS_INCLUDE_PATH
-unset OBJC_INCLUDE_PATH
-unset OBJCPLUS_INCLUDE_PATH
 
 # Set native toolchain
 build_CC="${NATIVE_GCC}/bin/gcc -isystem ${NATIVE_GCC}/include"
@@ -134,15 +74,6 @@ for p in "${PATHS[@]}"; do
     fi
 done
 
-# Disable Guix ld auto-rpath behavior
-export GUIX_LD_WRAPPER_DISABLE_RPATH=yes
-
-# Make /usr/bin if it doesn't exist
-[ -e /usr/bin ] || mkdir -p /usr/bin
-
-# Symlink env to a conventional path
-[ -e /usr/bin/env ]  || ln -s --no-dereference "$(command -v env)"  /usr/bin/env
-
 # Determine the correct value for -Wl,--dynamic-linker for the current $HOST
 case "$HOST" in
     *linux*)
@@ -185,20 +116,6 @@ case "$HOST" in
         unset LIBRARY_PATH
         ;;
 esac
-
-###########################
-# Source Tarball Building #
-###########################
-
-GIT_ARCHIVE="${DIST_ARCHIVE_BASE}/${DISTNAME}.tar.gz"
-
-# Create the source tarball if not already there
-if [ ! -e "$GIT_ARCHIVE" ]; then
-    mkdir -p "$(dirname "$GIT_ARCHIVE")"
-    git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
-fi
-
-mkdir -p "$OUTDIR"
 
 ###########################
 # Binary Tarball Building #

--- a/contrib/guix/libexec/setup.sh
+++ b/contrib/guix/libexec/setup.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+export LC_ALL=C
+set -e -o pipefail
+
+# Environment variables for determinism
+export TAR_OPTIONS="--no-same-owner --owner=0 --group=0 --numeric-owner --mtime='@${SOURCE_DATE_EPOCH}' --sort=name"
+export TZ=UTC
+
+# Although Guix _does_ set umask when building its own packages (in our case,
+# this is all packages in manifest.scm), it does not set it for `guix
+# shell`. It does make sense for at least `guix shell --container`
+# to set umask, so if that change gets merged upstream and we bump the
+# time-machine to a commit which includes the aforementioned change, we can
+# remove this line.
+#
+# This line should be placed before any commands which creates files.
+umask 0022
+
+if [ -n "$V" ]; then
+    # Print both unexpanded (-v) and expanded (-x) forms of commands as they are
+    # read from this file.
+    set -vx
+    # Set VERBOSE for CMake-based builds
+    export VERBOSE="$V"
+fi
+
+# Check that required environment variables are set
+cat << EOF
+Required environment variables as seen inside the container:
+    DIST_ARCHIVE_BASE: ${DIST_ARCHIVE_BASE:?not set}
+    DISTNAME: ${DISTNAME:?not set}
+    HOST: ${HOST:?not set}
+    SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH:?not set}
+    JOBS: ${JOBS:?not set}
+    DISTSRC: ${DISTSRC:?not set}
+    OUTDIR: ${OUTDIR:?not set}
+EOF
+
+export ACTUAL_OUTDIR="${OUTDIR}"
+export OUTDIR="${DISTSRC}/output"
+
+#####################
+# Environment Setup #
+#####################
+
+# The depends folder also serves as a base-prefix for depends packages for
+# $HOSTs after successfully building.
+export BASEPREFIX="${PWD}/depends"
+
+# Given a package name and an output name, return the path of that output in our
+# current guix environment
+store_path() {
+    grep --extended-regexp "/[^-]{32}-${1}-[^-]+${2:+-${2}}" "${GUIX_ENVIRONMENT}/manifest" \
+        | head --lines=1 \
+        | sed --expression='s|\x29*$||' \
+              --expression='s|^[[:space:]]*"||' \
+              --expression='s|"[[:space:]]*$||'
+}
+
+# Disable Guix ld auto-rpath behavior
+export GUIX_LD_WRAPPER_DISABLE_RPATH=yes
+
+# Make /usr/bin if it doesn't exist
+[ -e /usr/bin ] || mkdir -p /usr/bin
+
+# Symlink env to a conventional path
+[ -e /usr/bin/env ]  || ln -s --no-dereference "$(command -v env)"  /usr/bin/env
+
+###########################
+# Source Tarball Building #
+###########################
+
+GIT_ARCHIVE="${DIST_ARCHIVE_BASE}/${DISTNAME}.tar.gz"
+
+# Create the source tarball if not already there
+if [ ! -e "$GIT_ARCHIVE" ]; then
+    mkdir -p "$(dirname "$GIT_ARCHIVE")"
+    git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
+fi
+
+mkdir -p "$OUTDIR"
+
+unset LIBRARY_PATH
+unset CPATH
+unset C_INCLUDE_PATH
+unset CPLUS_INCLUDE_PATH
+unset OBJC_INCLUDE_PATH
+unset OBJCPLUS_INCLUDE_PATH


### PR DESCRIPTION
This is the first change in #25573, which splits out the setup & tarball generation code from `build.sh`, so that it can be re-used, from multiple (future) build scripts.