### PR TITLE
util: Clarify the assertion message in assertion failures (Assert, Assume, etc.)

### DIFF
--- a/src/test/util_check_tests.cpp
+++ b/src/test/util_check_tests.cpp
@@ -9,6 +9,13 @@
 
 BOOST_AUTO_TEST_SUITE(util_check_tests)
 
+namespace {
+void TriggerNonFatalUnreachable()
+{
+    NONFATAL_UNREACHABLE();
+}
+} // namespace
+
 BOOST_AUTO_TEST_CASE(check_pass)
 {
     Assume(true);
@@ -22,12 +29,21 @@ BOOST_AUTO_TEST_CASE(check_fail)
     test_only_CheckFailuresAreExceptionsNotAborts mock_checks{};
 
     if constexpr (G_ABORT_ON_FAILED_ASSUME) {
-        BOOST_CHECK_EXCEPTION(Assume(false), NonFatalCheckError, HasReason{"Internal bug detected: false"});
+        BOOST_CHECK_EXCEPTION(Assume(false), NonFatalCheckError, HasReason{"Internal bug detected: 'false' check failed"});
     } else {
         BOOST_CHECK_NO_THROW(Assume(false));
     }
-    BOOST_CHECK_EXCEPTION(Assert(false), NonFatalCheckError, HasReason{"Internal bug detected: false"});
-    BOOST_CHECK_EXCEPTION(CHECK_NONFATAL(false), NonFatalCheckError, HasReason{"Internal bug detected: false"});
+    BOOST_CHECK_EXCEPTION(Assert(false), NonFatalCheckError, HasReason{"Internal bug detected: 'false' check failed"});
+    BOOST_CHECK_EXCEPTION(CHECK_NONFATAL(false), NonFatalCheckError, HasReason{"Internal bug detected: 'false' check failed"});
+
+    // Repeat with a more realistic assert condition
+    void* this_should_be_nonnull{nullptr};
+    BOOST_CHECK_EXCEPTION(Assert(this_should_be_nonnull != nullptr), NonFatalCheckError, HasReason{"Internal bug detected: 'this_should_be_nonnull != nullptr' check failed"});
+}
+
+BOOST_AUTO_TEST_CASE(unreachable_diagnostics)
+{
+    BOOST_CHECK_EXCEPTION(TriggerNonFatalUnreachable(), NonFatalCheckError, HasReason{"Internal bug detected: Unreachable code reached (non-fatal)"});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_check_tests.cpp
+++ b/src/test/util_check_tests.cpp
@@ -9,6 +9,13 @@
 
 BOOST_AUTO_TEST_SUITE(util_check_tests)
 
+namespace {
+void TriggerNonFatalUnreachable()
+{
+    NONFATAL_UNREACHABLE();
+}
+} // namespace
+
 BOOST_AUTO_TEST_CASE(check_pass)
 {
     Assume(true);
@@ -22,12 +29,18 @@ BOOST_AUTO_TEST_CASE(check_fail)
     test_only_CheckFailuresAreExceptionsNotAborts mock_checks{};
 
     if constexpr (G_ABORT_ON_FAILED_ASSUME) {
-        BOOST_CHECK_EXCEPTION(Assume(false), NonFatalCheckError, HasReason{"Internal bug detected: false"});
+        BOOST_CHECK_EXCEPTION(Assume(false), NonFatalCheckError, HasReason{"Internal bug detected: `false` check failed"});
     } else {
         BOOST_CHECK_NO_THROW(Assume(false));
     }
-    BOOST_CHECK_EXCEPTION(Assert(false), NonFatalCheckError, HasReason{"Internal bug detected: false"});
-    BOOST_CHECK_EXCEPTION(CHECK_NONFATAL(false), NonFatalCheckError, HasReason{"Internal bug detected: false"});
+    BOOST_CHECK_EXCEPTION(CHECK_NONFATAL(false), NonFatalCheckError, HasReason{"Internal bug detected: `false` check failed"});
+    void* this_should_be_nonnull{nullptr};
+    BOOST_CHECK_EXCEPTION(Assert(this_should_be_nonnull != nullptr), NonFatalCheckError, HasReason{"Internal bug detected: `this_should_be_nonnull != nullptr` check failed"});
+}
+
+BOOST_AUTO_TEST_CASE(unreachable_diagnostics)
+{
+    BOOST_CHECK_EXCEPTION(TriggerNonFatalUnreachable(), NonFatalCheckError, HasReason{"Internal bug detected: Unreachable code reached (non-fatal)"});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_check_tests.cpp
+++ b/src/test/util_check_tests.cpp
@@ -40,7 +40,10 @@ BOOST_AUTO_TEST_CASE(check_fail)
 
 BOOST_AUTO_TEST_CASE(unreachable_diagnostics)
 {
-    BOOST_CHECK_EXCEPTION(TriggerNonFatalUnreachable(), NonFatalCheckError, HasReason{"Internal bug detected: Unreachable code reached (non-fatal)"});
+    // Disable aborts for easier testing here
+    test_only_CheckFailuresAreExceptionsNotAborts mock_checks{};
+
+    BOOST_CHECK_EXCEPTION(TriggerNonFatalUnreachable(), NonFatalCheckError, HasReason{"Internal bug detected: unreachable"});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -24,6 +24,11 @@ std::string StrFormatInternalBug(std::string_view msg, const std::source_locatio
                      CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
 }
 
+std::string StrFormatFailedCheck(std::string_view assertion)
+{
+    return strprintf("'%s' check failed", assertion);
+}
+
 NonFatalCheckError::NonFatalCheckError(std::string_view msg, const std::source_location& loc)
     : std::runtime_error{StrFormatInternalBug(msg, loc)}
 {
@@ -34,9 +39,9 @@ bool g_detail_test_only_CheckFailuresAreExceptionsNotAborts{false};
 void assertion_fail(const std::source_location& loc, std::string_view assertion)
 {
     if (g_detail_test_only_CheckFailuresAreExceptionsNotAborts) {
-        throw NonFatalCheckError{assertion, loc};
+        throw NonFatalCheckError{StrFormatFailedCheck(assertion), loc};
     }
-    auto str = strprintf("%s:%s %s: Assertion `%s' failed.\n", loc.file_name(), loc.line(), loc.function_name(), assertion);
+    auto str = strprintf("%s:%s %s: Assertion failed: %s.\n", loc.file_name(), loc.line(), loc.function_name(), StrFormatFailedCheck(assertion));
     fwrite(str.data(), 1, str.size(), stderr);
     std::abort();
 }

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -46,4 +46,12 @@ void internal_abort_helper(const std::source_location& loc, std::string_view err
     std::abort();
 }
 
+void check_non_fatal_fail(const std::source_location& loc, std::string_view error_msg)
+{
+    if constexpr (G_ABORT_ON_FAILED_ASSUME) {
+        internal_abort_helper(loc, error_msg);
+    }
+    throw NonFatalCheckError{error_msg, loc};
+}
+
 std::atomic<bool> g_enable_dynamic_fuzz_determinism{false};

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -36,12 +36,12 @@ NonFatalCheckError::NonFatalCheckError(std::string_view msg, const std::source_l
 
 bool g_detail_test_only_CheckFailuresAreExceptionsNotAborts{false};
 
-void assertion_fail(const std::source_location& loc, std::string_view assertion)
+void internal_abort_helper(const std::source_location& loc, std::string_view error_msg)
 {
     if (g_detail_test_only_CheckFailuresAreExceptionsNotAborts) {
-        throw NonFatalCheckError{assertion, loc};
+        throw NonFatalCheckError{error_msg, loc};
     }
-    auto str = strprintf("%s:%s %s: Assertion: %s.\n", loc.file_name(), loc.line(), loc.function_name(), assertion);
+    auto str = strprintf("%s:%s %s: Assertion: %s.\n", loc.file_name(), loc.line(), loc.function_name(), error_msg);
     fwrite(str.data(), 1, str.size(), stderr);
     std::abort();
 }

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -24,6 +24,11 @@ std::string StrFormatInternalBug(std::string_view msg, const std::source_locatio
                      CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
 }
 
+std::string StrFormatFailedCheck(std::string_view assertion)
+{
+    return strprintf("`%s` check failed", assertion);
+}
+
 NonFatalCheckError::NonFatalCheckError(std::string_view msg, const std::source_location& loc)
     : std::runtime_error{StrFormatInternalBug(msg, loc)}
 {
@@ -36,7 +41,7 @@ void assertion_fail(const std::source_location& loc, std::string_view assertion)
     if (g_detail_test_only_CheckFailuresAreExceptionsNotAborts) {
         throw NonFatalCheckError{assertion, loc};
     }
-    auto str = strprintf("%s:%s %s: Assertion `%s' failed.\n", loc.file_name(), loc.line(), loc.function_name(), assertion);
+    auto str = strprintf("%s:%s %s: Assertion: %s.\n", loc.file_name(), loc.line(), loc.function_name(), assertion);
     fwrite(str.data(), 1, str.size(), stderr);
     std::abort();
 }

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -57,6 +57,7 @@ struct test_only_CheckFailuresAreExceptionsNotAborts {
 };
 
 std::string StrFormatInternalBug(std::string_view msg, const std::source_location& loc);
+std::string StrFormatFailedCheck(std::string_view assertion);
 
 class NonFatalCheckError : public std::runtime_error
 {
@@ -75,7 +76,7 @@ T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const std::source_location& lo
         if constexpr (G_ABORT_ON_FAILED_ASSUME) {
             assertion_fail(loc, assertion);
         }
-        throw NonFatalCheckError{assertion, loc};
+        throw NonFatalCheckError{StrFormatFailedCheck(assertion), loc};
     }
     return std::forward<T>(val);
 }

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -68,15 +68,15 @@ public:
 /// Internal helper. The noreturn enables optimizers to discard invalid paths.
 [[noreturn]] void internal_abort_helper(const std::source_location& loc, std::string_view error_msg);
 
+/** Helper for CHECK_NONFATAL() and NONFATAL_UNREACHABLE() */
+[[noreturn]] void check_non_fatal_fail(const std::source_location& loc, std::string_view error_msg);
+
 /** Helper for CHECK_NONFATAL() */
 template <typename T>
 T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const std::source_location& loc, std::string_view assertion)
 {
     if (!val) {
-        if constexpr (G_ABORT_ON_FAILED_ASSUME) {
-            internal_abort_helper(loc, StrFormatFailedCheck(assertion));
-        }
-        throw NonFatalCheckError{StrFormatFailedCheck(assertion), loc};
+        check_non_fatal_fail(loc, StrFormatFailedCheck(assertion));
     }
     return std::forward<T>(val);
 }
@@ -109,6 +109,9 @@ constexpr T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] con
  * For example in RPC code, where it is undesirable to crash the whole program, this can be generally used to replace
  * asserts or recoverable logic errors. A NonFatalCheckError in RPC code is caught and passed as a string to the RPC
  * caller, which can then report the issue to the developers.
+ *
+ * Note: in certain test environments an abort is triggered instead
+ * (in fuzz tests, when ABORT_ON_FAILED_ASSUME is set, etc.; see G_ABORT_ON_FAILED_ASSUME).
  */
 #define CHECK_NONFATAL(condition) \
     inline_check_non_fatal(condition, std::source_location::current(), #condition)
@@ -130,9 +133,13 @@ constexpr T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] con
 
 /**
  * NONFATAL_UNREACHABLE() is a macro that is used to mark unreachable code. It throws a NonFatalCheckError.
+ * Control flow will not continue past this macro.
+ *
+ * Note: in certain test environments an abort is triggered instead
+ * (in fuzz tests, when ABORT_ON_FAILED_ASSUME is set, etc.; see G_ABORT_ON_FAILED_ASSUME).
  */
 #define NONFATAL_UNREACHABLE() \
-    throw NonFatalCheckError { "Unreachable code reached (non-fatal)", std::source_location::current() }
+    check_non_fatal_fail(std::source_location::current(), "unreachable")
 
 #if defined(__has_feature)
 #    if __has_feature(address_sanitizer)

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -66,7 +66,7 @@ public:
 };
 
 /// Internal helper. The noreturn enables optimizers to discard invalid paths.
-[[noreturn]] void assertion_fail(const std::source_location& loc, std::string_view assertion);
+[[noreturn]] void internal_abort_helper(const std::source_location& loc, std::string_view error_msg);
 
 /** Helper for CHECK_NONFATAL() */
 template <typename T>
@@ -74,7 +74,7 @@ T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const std::source_location& lo
 {
     if (!val) {
         if constexpr (G_ABORT_ON_FAILED_ASSUME) {
-            assertion_fail(loc, StrFormatFailedCheck(assertion));
+            internal_abort_helper(loc, StrFormatFailedCheck(assertion));
         }
         throw NonFatalCheckError{StrFormatFailedCheck(assertion), loc};
     }
@@ -91,7 +91,7 @@ constexpr T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] con
 {
     if (IS_ASSERT || std::is_constant_evaluated() || G_ABORT_ON_FAILED_ASSUME) {
         if (!val) {
-            assertion_fail(loc, StrFormatFailedCheck(assertion));
+            internal_abort_helper(loc, StrFormatFailedCheck(assertion));
         }
     }
     return std::forward<T>(val);

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -57,6 +57,7 @@ struct test_only_CheckFailuresAreExceptionsNotAborts {
 };
 
 std::string StrFormatInternalBug(std::string_view msg, const std::source_location& loc);
+std::string StrFormatFailedCheck(std::string_view assertion);
 
 class NonFatalCheckError : public std::runtime_error
 {
@@ -73,9 +74,9 @@ T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const std::source_location& lo
 {
     if (!val) {
         if constexpr (G_ABORT_ON_FAILED_ASSUME) {
-            assertion_fail(loc, assertion);
+            assertion_fail(loc, StrFormatFailedCheck(assertion));
         }
-        throw NonFatalCheckError{assertion, loc};
+        throw NonFatalCheckError{StrFormatFailedCheck(assertion), loc};
     }
     return std::forward<T>(val);
 }
@@ -90,7 +91,7 @@ constexpr T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] con
 {
     if (IS_ASSERT || std::is_constant_evaluated() || G_ABORT_ON_FAILED_ASSUME) {
         if (!val) {
-            assertion_fail(loc, assertion);
+            assertion_fail(loc, StrFormatFailedCheck(assertion));
         }
     }
     return std::forward<T>(val);

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -27,6 +27,7 @@ class RpcMiscTest(BitcoinTestFramework):
 
         self.log.info("test CHECK_NONFATAL")
         msg_internal_bug = 'request.params[9].get_str() != "trigger_internal_bug"'
+        msg_failed_check = f"'{msg_internal_bug}' check failed"
         self.restart_node(0)  # Required to flush the chainstate
         try:
             node.echo(arg9="trigger_internal_bug")
@@ -41,7 +42,7 @@ class RpcMiscTest(BitcoinTestFramework):
             self.start_node(0)
         except JSONRPCException as e:
             assert_equal(e.error["code"], -1)
-            assert f"Internal bug detected: {msg_internal_bug}" in e.error["message"]
+            assert f"Internal bug detected: {msg_failed_check}" in e.error["message"]
 
         self.log.info("test max arg size")
         ARG_SZ_COMMON = 131071  # Common limit, used previously in the test framework, serves as a regression test

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -27,6 +27,7 @@ class RpcMiscTest(BitcoinTestFramework):
 
         self.log.info("test CHECK_NONFATAL")
         msg_internal_bug = 'request.params[9].get_str() != "trigger_internal_bug"'
+        msg_failed_check = f"`{msg_internal_bug}` check failed"
         self.restart_node(0)  # Required to flush the chainstate
         try:
             node.echo(arg9="trigger_internal_bug")
@@ -41,7 +42,7 @@ class RpcMiscTest(BitcoinTestFramework):
             self.start_node(0)
         except JSONRPCException as e:
             assert_equal(e.error["code"], -1)
-            assert f"Internal bug detected: {msg_internal_bug}" in e.error["message"]
+            assert f"Internal bug detected: {msg_failed_check}" in e.error["message"]
 
         self.log.info("test max arg size")
         ARG_SZ_COMMON = 131071  # Common limit, used previously in the test framework, serves as a regression test


### PR DESCRIPTION
Clarify the message in case of assertion failures. Additionally unify the behavior of `NONFATAL_UNREACHABLE` w.r.t. abort handling.

Motivation: This was discussed in https://github.com/bitcoin/bitcoin/pull/34844#discussion_r3303436384

The error message generated by `Assert`, `Assume`, and `CHECK_NONFATAL` contains the failing assertion condition text, but it's unclear whether that's the failed expectation or the actual case. 

For example,
`"Internal bug detected: pindex != nullptr"`
in fact means that what happened was `pindex == nullptr`.

Clarify the situation, by inserting "\`%s\` check failed".

The above example is now:
``"Internal bug detected: `pindex != nullptr` check failed"``
which is more unambiguous. Note: the message for non-assert type errors, such as unreachable from `NONFATAL_UNREACHABLE`, are not affected.

Additionally, change `NONFATAL_UNREACHABLE` to behave like `CHECK_NONFATAL`, and honor the special abort setting (`G_ABORT_ON_FAILED_ASSUME`).