### PR TITLE
depends: Drop trailing slash from `CMAKE_INSTALL_LIBDIR`

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -222,7 +222,7 @@ $(1)_cmake=env CC="$$($(1)_cc)" \
                -DCMAKE_AR=`which $$($(1)_ar)` \
                -DCMAKE_NM=`which $$($(1)_nm)` \
                -DCMAKE_RANLIB=`which $$($(1)_ranlib)` \
-               -DCMAKE_INSTALL_LIBDIR=lib/ \
+               -DCMAKE_INSTALL_LIBDIR=lib \
                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                -DCMAKE_VERBOSE_MAKEFILE:BOOL=$(V) \
                -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY:BOOL=TRUE \


### PR DESCRIPTION
1. The trailing slash is [redundant](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html).
2. It causes [CMP0177](https://cmake.org/cmake/help/latest/policy/CMP0177.html)-specifc warnings when using CMake >=3.31.

On the master branch:
```
$ gmake -C depends freetype_configured
gmake: Entering directory '/home/hebasto/dev/bitcoin/depends'
Extracting freetype...
/home/hebasto/dev/bitcoin/depends/sources/freetype-2.11.1.tar.gz: OK
Preprocessing freetype...
patching file CMakeLists.txt
Configuring freetype...
-- The C compiler identification is GNU 15.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Looking for fcntl.h
-- Looking for fcntl.h - found
CMake Warning (dev) at CMakeLists.txt:577 (install):
  Policy CMP0177 is not set: install() DESTINATION paths are normalized.  Run
  "cmake --help-policy CMP0177" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:596 (install):
  Policy CMP0177 is not set: install() DESTINATION paths are normalized.  Run
  "cmake --help-policy CMP0177" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:601 (install):
  Policy CMP0177 is not set: install() DESTINATION paths are normalized.  Run
  "cmake --help-policy CMP0177" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Configuring done (0.2s)
-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_EXPORT_NO_PACKAGE_REGISTRY


-- Build files have been written to: /home/hebasto/dev/bitcoin/depends/work/build/x86_64-pc-linux-gnu/freetype/2.11.1-0539b8d2229/build
gmake: Leaving directory '/home/hebasto/dev/bitcoin/depends'
```

With this PR:
```
$ gmake -C depends freetype_configured
gmake: Entering directory '/home/hebasto/dev/bitcoin/depends'
Extracting freetype...
/home/hebasto/dev/bitcoin/depends/sources/freetype-2.11.1.tar.gz: OK
Preprocessing freetype...
patching file CMakeLists.txt
Configuring freetype...
-- The C compiler identification is GNU 15.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Looking for fcntl.h
-- Looking for fcntl.h - found
-- Configuring done (0.2s)
-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_EXPORT_NO_PACKAGE_REGISTRY


-- Build files have been written to: /home/hebasto/dev/bitcoin/depends/work/build/x86_64-pc-linux-gnu/freetype/2.11.1-c25288632f9/build
gmake: Leaving directory '/home/hebasto/dev/bitcoin/depends'
```