### PR TITLE
coins: compact chainstate regularly

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -301,11 +301,16 @@ void CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
     }
 }
 
+std::optional<std::string> CDBWrapper::GetProperty(const std::string& property) const
+{
+    if (std::string value; DBContext().pdb->GetProperty(property, &value)) return value;
+    return std::nullopt;
+}
+
 size_t CDBWrapper::DynamicMemoryUsage() const
 {
-    std::string memory;
     std::optional<size_t> parsed;
-    if (!DBContext().pdb->GetProperty("leveldb.approximate-memory-usage", &memory) || !(parsed = ToIntegral<size_t>(memory))) {
+    if (auto memory{GetProperty("leveldb.approximate-memory-usage")}; !memory || !(parsed = ToIntegral<size_t>(*memory))) {
         LogDebug(BCLog::LEVELDB, "Failed to get approximate-memory-usage property\n");
         return 0;
     }

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -256,7 +256,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
 
     if (params.options.force_compact) {
         LogInfo("Starting database compaction of %s", fs::PathToString(params.path));
-        DBContext().pdb->CompactRange(nullptr, nullptr);
+        CompactFull();
         LogInfo("Finished database compaction of %s", fs::PathToString(params.path));
     }
 
@@ -306,6 +306,8 @@ std::optional<std::string> CDBWrapper::GetProperty(const std::string& property) 
     if (std::string value; DBContext().pdb->GetProperty(property, &value)) return value;
     return std::nullopt;
 }
+
+void CDBWrapper::CompactFull() { DBContext().pdb->CompactRange(nullptr, nullptr); }
 
 size_t CDBWrapper::DynamicMemoryUsage() const
 {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -258,6 +258,9 @@ public:
 
     void WriteBatch(CDBBatch& batch, bool fSync = false);
 
+    //! Return a LevelDB property value, if available.
+    std::optional<std::string> GetProperty(const std::string& property) const;
+
     // Get an estimate of LevelDB memory usage (in bytes).
     size_t DynamicMemoryUsage() const;
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -258,6 +258,9 @@ public:
 
     void WriteBatch(CDBBatch& batch, bool fSync = false);
 
+    //! Perform a blocking full compaction of the underlying LevelDB.
+    void CompactFull();
+
     //! Return a LevelDB property value, if available.
     std::optional<std::string> GetProperty(const std::string& property) const;
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1078,6 +1078,8 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     cache.Sync();
 
     BOOST_CHECK_EQUAL(level2_files(base), 0);
+    WITH_LOCK(::cs_main, base.CompactFull());
+    BOOST_CHECK_EQUAL(level2_files(base), 1);
 
     BOOST_CHECK(*Assert(base.GetCoin(outpoint)) == coin);
     BOOST_CHECK_EQUAL(base.GetBestBlock(), block_hash);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1078,7 +1078,7 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     cache.Sync();
 
     BOOST_CHECK_EQUAL(level2_files(base), 0);
-    WITH_LOCK(::cs_main, base.CompactFull());
+    WITH_LOCK(::cs_main, return base.CompactFull()).wait();
     BOOST_CHECK_EQUAL(level2_files(base), 1);
 
     BOOST_CHECK(*Assert(base.GetCoin(outpoint)) == coin);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -14,6 +14,7 @@
 #include <uint256.h>
 #include <undo.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <map>
@@ -1058,6 +1059,28 @@ BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
         TestFlushBehavior(view.get(), base, caches, /*do_erasing_flush=*/false);
         TestFlushBehavior(view.get(), base, caches, /*do_erasing_flush=*/true);
     }
+}
+
+BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
+{
+    auto level2_files{[](CCoinsViewDB& base) {
+        return *Assert(ToIntegral<int>(*Assert(base.GetDBProperty("leveldb.num-files-at-level2"))));
+    }};
+    const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), 0};
+    const Coin coin{MakeCoin()};
+    const uint256 block_hash{m_rng.rand256()};
+
+    CCoinsViewDB base{{.path = m_args.GetDataDirBase() / "coins_db_leveldb_layout", .cache_bytes = 1_MiB, .wipe_data = true}, {}};
+    CCoinsViewCache cache{&base};
+
+    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin});
+    cache.SetBestBlock(block_hash);
+    cache.Sync();
+
+    BOOST_CHECK_EQUAL(level2_files(base), 0);
+
+    BOOST_CHECK(*Assert(base.GetCoin(outpoint)) == coin);
+    BOOST_CHECK_EQUAL(base.GetBestBlock(), block_hash);
 }
 
 BOOST_AUTO_TEST_CASE(coins_resource_is_used)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -180,6 +180,14 @@ std::optional<std::string> CCoinsViewDB::GetDBProperty(const std::string& proper
     return m_db->GetProperty(property);
 }
 
+void CCoinsViewDB::CompactFull()
+{
+    AssertLockHeld(::cs_main);
+    LogDebug(BCLog::COINDB, "Starting chainstate compaction of %s", fs::PathToString(m_db_params.path));
+    m_db->CompactFull();
+    LogDebug(BCLog::COINDB, "Finished chainstate compaction of %s", fs::PathToString(m_db_params.path));
+}
+
 /** Specialization of CCoinsViewCursor to iterate over a CCoinsViewDB */
 class CCoinsViewDBCursor: public CCoinsViewCursor
 {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -175,6 +175,11 @@ size_t CCoinsViewDB::EstimateSize() const
     return m_db->EstimateSize(DB_COIN, uint8_t(DB_COIN + 1));
 }
 
+std::optional<std::string> CCoinsViewDB::GetDBProperty(const std::string& property)
+{
+    return m_db->GetProperty(property);
+}
+
 /** Specialization of CCoinsViewCursor to iterate over a CCoinsViewDB */
 class CCoinsViewDBCursor: public CCoinsViewCursor
 {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -14,10 +14,14 @@
 #include <uint256.h>
 #include <util/byte_units.h>
 #include <util/log.h>
+#include <util/threadnames.h>
 #include <util/vector.h>
 
 #include <cassert>
+#include <chrono>
 #include <cstdlib>
+#include <exception>
+#include <future>
 #include <iterator>
 #include <utility>
 
@@ -56,11 +60,22 @@ CCoinsViewDB::CCoinsViewDB(DBParams db_params, CoinsViewOptions options) :
     m_options{std::move(options)},
     m_db{std::make_unique<CDBWrapper>(m_db_params)} { }
 
+CCoinsViewDB::~CCoinsViewDB()
+{
+    if (m_compaction.valid()) {
+        if (m_compaction.wait_for(std::chrono::seconds{0}) != std::future_status::ready) {
+            LogInfo("Waiting for background chainstate compaction of %s", fs::PathToString(m_db_params.path));
+        }
+        m_compaction.wait();
+    }
+}
+
 void CCoinsViewDB::ResizeCache(size_t new_cache_size)
 {
     // We can't do this operation with an in-memory DB since we'll lose all the coins upon
     // reset.
     if (!m_db_params.memory_only) {
+        LOCK(m_db_mutex);
         // Have to do a reset first to get the original `m_db` state to release its
         // filesystem lock.
         m_db.reset();
@@ -180,12 +195,23 @@ std::optional<std::string> CCoinsViewDB::GetDBProperty(const std::string& proper
     return m_db->GetProperty(property);
 }
 
-void CCoinsViewDB::CompactFull()
+std::shared_future<void> CCoinsViewDB::CompactFull()
 {
     AssertLockHeld(::cs_main);
-    LogDebug(BCLog::COINDB, "Starting chainstate compaction of %s", fs::PathToString(m_db_params.path));
-    m_db->CompactFull();
-    LogDebug(BCLog::COINDB, "Finished chainstate compaction of %s", fs::PathToString(m_db_params.path));
+    if (m_compaction.valid() && m_compaction.wait_for(std::chrono::seconds{0}) != std::future_status::ready) return m_compaction;
+    m_compaction = std::async(std::launch::async, [this] {
+        try {
+            util::ThreadRename("utxocompact");
+            LOCK(m_db_mutex);
+
+            LogDebug(BCLog::COINDB, "Starting chainstate compaction of %s", fs::PathToString(m_db_params.path));
+            m_db->CompactFull();
+            LogDebug(BCLog::COINDB, "Finished chainstate compaction of %s", fs::PathToString(m_db_params.path));
+        } catch (const std::exception& e) {
+            LogWarning("Failed chainstate compaction (%s)", e.what());
+        }
+    }).share();
+    return m_compaction;
 }
 
 /** Specialization of CCoinsViewCursor to iterate over a CCoinsViewDB */

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -56,6 +56,9 @@ public:
     //! Dynamically alter the underlying leveldb cache size.
     void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    //! Perform a blocking full compaction of the underlying LevelDB.
+    void CompactFull() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
     //! Return an underlying LevelDB property value, if available.
     std::optional<std::string> GetDBProperty(const std::string& property);
 };

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 class COutPoint;
@@ -54,6 +55,9 @@ public:
 
     //! Dynamically alter the underlying leveldb cache size.
     void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    //! Return an underlying LevelDB property value, if available.
+    std::optional<std::string> GetDBProperty(const std::string& property);
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -15,6 +15,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <optional>
 #include <string>
@@ -37,9 +38,13 @@ class CCoinsViewDB final : public CCoinsView
 protected:
     DBParams m_db_params;
     CoinsViewOptions m_options;
+    //! Prevents CompactFull() from using m_db while ResizeCache() replaces it.
+    Mutex m_db_mutex;
     std::unique_ptr<CDBWrapper> m_db;
+    std::shared_future<void> m_compaction;
 public:
     explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
+    ~CCoinsViewDB() override;
 
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
@@ -54,10 +59,10 @@ public:
     size_t EstimateSize() const override;
 
     //! Dynamically alter the underlying leveldb cache size.
-    void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
 
-    //! Perform a blocking full compaction of the underlying LevelDB.
-    void CompactFull() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    //! Perform a full compaction of the underlying LevelDB on a one-shot background thread.
+    std::shared_future<void> CompactFull() EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
 
     //! Return an underlying LevelDB property value, if available.
     std::optional<std::string> GetDBProperty(const std::string& property);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -113,6 +113,13 @@ const std::vector<std::string> CHECKLEVEL_DOC {
  * */
 static constexpr int PRUNE_LOCK_BUFFER{10};
 
+// Return whether the completed full flush should compact chainstate
+static bool ShouldCompactChainstate(bool in_ibd)
+{
+    static constexpr uint32_t flush_ratio{320}; // Roughly every 2 weeks with hourly flushes
+    return !in_ibd && FastRandomContext().randrange(flush_ratio) == 0;
+}
+
 TRACEPOINT_SEMAPHORE(validation, block_connected);
 TRACEPOINT_SEMAPHORE(utxocache, flush);
 TRACEPOINT_SEMAPHORE(mempool, replaced);
@@ -2825,9 +2832,17 @@ bool Chainstate::FlushStateToDisk(
             m_next_write = FastRandomContext().rand_uniform_delay(NodeClock::now() + DATABASE_WRITE_INTERVAL_MIN, range);
         }
     }
-    if (full_flush_completed && m_chainman.m_options.signals) {
-        // Update best block in wallet (so we can detect restored wallets).
-        m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), GetLocator(m_chain.Tip()));
+    if (full_flush_completed) {
+        if (m_chainman.m_options.signals) {
+            // Update best block in wallet (so we can detect restored wallets).
+            m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), GetLocator(m_chain.Tip()));
+        }
+
+        if (!m_chainman.m_interrupt && m_chainman.m_chainstates.size() == 1) { // Skip AssumeUTXO
+            if (ShouldCompactChainstate(m_chainman.IsInitialBlockDownload())) {
+                CoinsDB().CompactFull();
+            }
+        }
     }
     } catch (const std::runtime_error& e) {
         return FatalError(m_chainman.GetNotifications(), state, strprintf(_("System error while flushing: %s"), e.what()));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2838,9 +2838,11 @@ bool Chainstate::FlushStateToDisk(
             m_chainman.m_options.signals->ChainStateFlushed(this->GetRole(), GetLocator(m_chain.Tip()));
         }
 
-        if (!m_chainman.m_interrupt && m_chainman.m_chainstates.size() == 1) { // Skip AssumeUTXO
-            if (ShouldCompactChainstate(m_chainman.IsInitialBlockDownload())) {
+        if (!m_chainman.m_interrupt && ShouldCompactChainstate(m_chainman.IsInitialBlockDownload())) {
+            try {
                 CoinsDB().CompactFull();
+            } catch (const std::exception& e) {
+                LogWarning("Failed to start chainstate compaction (%s)", e.what());
             }
         }
     }


### PR DESCRIPTION
**Problem:** https://github.com/bitcoin-core/leveldb-subtree/pull/61 disabled read-triggered seek compactions to avoid large chainstate write amplification from random UTXO lookups.
That avoids repeated read-driven rewrites, but it also removes opportunistic cleanup that previously helped compact old chainstate data.

After IBD, normal chainstate churn can leave obsolete entries behind until ordinary LevelDB compaction naturally reaches the affected levels, keeping the chainstate database larger than necessary.

Also, chainstates created by pre-29 nodes can contain thousands of files from the old 2 MiB LevelDB table target.
After the mmap limit dropped back to 1000 and seek compaction was disabled, continuing from such a chainstate can leave many table reads on the non-mmap path until the database is compacted.

**Fix:** After each completed post-IBD full chainstate flush, give the chainstate a 1/320 chance to compact.
With roughly hourly full flushes, this averages about once every two weeks and makes a six-month stretch without compaction about a one-in-a-million event.

The randomized recurring trigger spreads compactions across nodes and keeps maintenance stateless, without storing last-compaction height or timestamp metadata in the chainstate database.
Compaction runs on a background thread (`utxocompact`) so validation only schedules the work.

Partially fixes #35298 and #35457