### PR TITLE
ci: run ipc functional tests in arm job

### DIFF
--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -8,7 +8,8 @@ export LC_ALL=C.UTF-8
 
 export HOST=arm-linux-gnueabihf
 export DPKG_ADD_ARCH="armhf"
-export PACKAGES="python3-zmq g++-arm-linux-gnueabihf libc6:armhf libstdc++6:armhf libfontconfig1:armhf libxcb1:armhf"
+export PACKAGES="python3-pip python3-zmq g++-arm-linux-gnueabihf libc6:armhf libstdc++6:armhf libfontconfig1:armhf libxcb1:armhf"
+export PIP_PACKAGES="--break-system-packages pycapnp"
 export CONTAINER_NAME=ci_arm_linux
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/debian:trixie"  # Check that https://packages.debian.org/trixie/g++-arm-linux-gnueabihf (version 14.x, similar to guix) can cross-compile
 export CI_IMAGE_PLATFORM="linux/arm64"


### PR DESCRIPTION
These are currently skipped, because `pycapnp` isn't installed (https://github.com/bitcoin/bitcoin/actions/runs/26943765833/job/79499532298#step:10:4286):
```bash
interface_ipc.py                                                                 | ○ Skipped | 0 s
interface_ipc_mining.py                                                          | ○ Skipped | 0 s
```
They seem to work fine locally. Not sure if this was missed, or on purpose.