### PR TITLE
db: warn about legacy chainstate table format

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -36,6 +36,20 @@
 
 static auto CharCast(const std::byte* data) { return reinterpret_cast<const char*>(data); }
 
+static int32_t CountSmallLevelDBFiles(const fs::path& path)
+{
+    try {
+        int32_t small_files{0};
+        for (auto& entry : fs::directory_iterator{path}) {
+            // A few non-table files may match; the threshold tolerates them.
+            small_files += entry.is_regular_file() && entry.file_size() < 3_MiB;
+        }
+        return small_files;
+    } catch (const fs::filesystem_error&) {
+        return -1;
+    }
+}
+
 bool DestroyDB(const std::string& path_str)
 {
     return leveldb::DestroyDB(path_str, {}).ok();
@@ -218,7 +232,9 @@ struct LevelDBContext {
 };
 
 CDBWrapper::CDBWrapper(const DBParams& params)
-    : m_db_context{std::make_unique<LevelDBContext>()}, m_name{fs::PathToString(params.path.stem())}
+    : m_db_context{std::make_unique<LevelDBContext>()},
+      m_name{fs::PathToString(params.path.stem())},
+      m_path{params.path}
 {
     DBContext().penv = nullptr;
     DBContext().readoptions.verify_checksums = true;
@@ -310,6 +326,15 @@ size_t CDBWrapper::DynamicMemoryUsage() const
         return 0;
     }
     return parsed.value();
+}
+
+void CDBWrapper::WarnIfNeedsCompaction() const
+{
+    if (auto small_files{CountSmallLevelDBFiles(m_path)}; small_files > 100) {
+        LogWarning("LevelDB database %s contains %d small files. This may indicate a legacy table format. "
+                   "-forcecompactdb can migrate it to a more efficient format when run once.",
+                   m_name, small_files);
+    }
 }
 
 std::optional<std::string> CDBWrapper::ReadImpl(std::span<const std::byte> key) const

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -193,6 +193,9 @@ private:
     //! the name of this database
     std::string m_name;
 
+    //! filesystem path to this database
+    fs::path m_path;
+
     //! optional XOR-obfuscation of the database
     Obfuscation m_obfuscation;
 
@@ -260,6 +263,8 @@ public:
 
     // Get an estimate of LevelDB memory usage (in bytes).
     size_t DynamicMemoryUsage() const;
+
+    void WarnIfNeedsCompaction() const;
 
     CDBIterator* NewIterator();
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -54,7 +54,12 @@ struct CoinEntry {
 CCoinsViewDB::CCoinsViewDB(DBParams db_params, CoinsViewOptions options) :
     m_db_params{std::move(db_params)},
     m_options{std::move(options)},
-    m_db{std::make_unique<CDBWrapper>(m_db_params)} { }
+    m_db{std::make_unique<CDBWrapper>(m_db_params)}
+{
+    if (!m_db_params.memory_only && !m_db_params.options.force_compact) {
+        m_db->WarnIfNeedsCompaction();
+    }
+}
 
 void CCoinsViewDB::ResizeCache(size_t new_cache_size)
 {

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -323,12 +323,28 @@ class InitTest(BitcoinTestFramework):
         for option in options:
             self.restart_node(1, option)
 
+    def chainstate_warning_test(self):
+        self.log.info("Test warning when the chainstate contains many small files")
+        node = self.nodes[1]
+        warning = "This may indicate a legacy table format"
+
+        with node.assert_debug_log(expected_msgs=[], unexpected_msgs=[warning]):
+            self.restart_node(1)
+        self.stop_node(1)
+
+        for i in range(101):
+            (node.chain_path / "chainstate" / f"small_file_{i}").touch()
+        with node.assert_debug_log(expected_msgs=[warning]):
+            self.start_node(1)
+        self.stop_node(1)
+
     def run_test(self):
         self.init_pid_test()
         self.init_stress_test_interrupt()
         self.init_stress_test_removals()
         self.break_wait_test()
         self.init_empty_test()
+        self.chainstate_warning_test()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Problem:** Chainstates created by pre-29 nodes can contain thousands of files from the old 2 MiB LevelDB table target.
Now that the mmap limit dropped back to 1000 and seek compaction was disabled, continuing IBD from such a chainstate can leave many reads on the non-mmap path until the database is compacted.
A current 32 MiB-layout chainstate had 6 matching small files, while pre-29 chainstates can have more than 6000, so a coarse threshold gives users a warning without flagging normal current layouts.

**Fix:** Warn at startup when the chainstate database has more than 100 small files and point users to `-forcecompactdb`.

Partially fixes #35457 together with #35465. Draft until the latter's scope is clarified.