### PR TITLE
ci, iwyu: Request IPC file generation explicitly

### DIFF
--- a/ci/test/00_setup_env_native_iwyu.sh
+++ b/ci/test/00_setup_env_native_iwyu.sh
@@ -17,7 +17,10 @@ export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=false
 export RUN_CHECK_DEPS=false
 export RUN_IWYU=true
-export GOAL="codegen"
+# Adding non-codegen targets to the build goal is a workaround
+# for https://gitlab.kitware.com/cmake/cmake/-/work_items/27862
+# and https://github.com/bitcoin-core/libmultiprocess/issues/284.
+export GOAL="codegen mp_headers mptest_headers bitcoin_ipc_headers bitcoin_ipc_test_headers bitcoin_ipc_fuzz_headers"
 export BITCOIN_CONFIG="\
  --preset dev-mode -DBUILD_GUI=OFF \
  -DCMAKE_C_COMPILER=clang-${IWYU_LLVM_V} \

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -123,7 +123,7 @@ cmake -S "$BASE_ROOT_DIR" -B "$BASE_BUILD_DIR" "${CMAKE_ARGS[@]}" || (
   false
 )
 
-if [[ "${GOAL}" != all && "${GOAL}" != codegen ]]; then
+if [[ "${GOAL}" != all && "${GOAL}" != *codegen* ]]; then
   GOAL="all ${GOAL}"
 fi
 


### PR DESCRIPTION
Fixes a part of https://github.com/bitcoin/bitcoin/issues/35361:
> ... other sporadic error output:
> 
> ```
> [1](https://github.com/bitcoin/bitcoin/actions/runs/26292243180/job/77395542650#step:11:11661)
> error: no such file or directory: '/home/admin/actions-runner/_work/_temp/build/src/ipc/capnp/common.capnp.c++'
> error: no input files
> error: unable to handle compilation, expected exactly one compiler job in ''
> error: no such file or directory: '/home/admin/actions-runner/_work/_temp/build/src/ipc/capnp/common.capnp.proxy-client.c++'
> error: no input files
> error: unable to handle compilation, expected exactly one compiler job in ''
> error: no such file or directory: '/home/admin/actions-runner/_work/_temp/build/src/ipc/capnp/common.capnp.proxy-server.c++'
> error: no input files
> error: unable to handle compilation, expected exactly one compiler job in ''
> error: no such file or directory: '/home/admin/actions-runner/_work/_temp/build/src/ipc/capnp/common.capnp.proxy-types.c++'
> error: no input files
> ```