### PR TITLE
argsman: Prevent duplicate option registration across categories

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -668,6 +668,11 @@ void ArgsManager::AddArg(const std::string& name, const std::string& help, unsig
     std::string arg_name = name.substr(0, eq_index);
 
     LOCK(cs_args);
+
+    for (const auto& arg_map : m_available_args) {
+        Assert(!arg_map.second.contains(arg_name));
+    }
+
     std::map<std::string, Arg>& arg_map = m_available_args[cat];
     auto ret = arg_map.emplace(arg_name, Arg{name.substr(eq_index, name.size() - eq_index), help, flags});
     assert(ret.second); // Make sure an insertion actually happened


### PR DESCRIPTION
Follow-up to #28802

This PR enforces the invariant that option names are unique across categories.

-<ins>_**Rationale**_</ins>:
- While adapting the `argsman_tests.cpp` cases introduced in #28802 for the GNU-style parsing changes proposed in #33540, I noticed that the same option name can currently be registered in multiple categories.

- At present in `master`, this ambiguity is largely masked by the existing command-line parsing behaviour. However, it relies on assumptions about how options are interpreted based on their position. Future changes to option parsing, such as the GNU-style parsing proposed in #33540, may expose this ambiguity and lead to unexpected option resolution.

- To avoid ambiguous option resolution and make the distinction between global and command-specific options explicit, this PR adds validation in `AddArg()` preventing the same option name from being registered across different categories.
