### PR TITLE
policy: use 64-bit accumulator for package total weight

### DIFF
--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -84,7 +84,7 @@ bool IsWellFormedPackage(const Package& txns, PackageValidationState& state)
         return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-too-many-transactions");
     }
 
-    const int64_t total_weight = std::accumulate(txns.cbegin(), txns.cend(), 0,
+    const int64_t total_weight = std::accumulate(txns.cbegin(), txns.cend(), int64_t{0},
                                [](int64_t sum, const auto& tx) { return sum + GetTransactionWeight(*tx); });
     // If the package only contains 1 tx, it's better to report the policy violation on individual tx weight.
     if (package_count > 1 && total_weight > MAX_PACKAGE_WEIGHT) {

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -21,6 +21,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <limits>
+
 using namespace util::hex_literals;
 
 // A fee amount that is above 1sat/vB but below 5sat/vB for most transactions created within these
@@ -199,6 +201,43 @@ BOOST_AUTO_TEST_CASE(package_sanitization_tests)
     BOOST_CHECK(IsConsistentPackage(package_with_dup_tx));
     package_with_dup_tx.emplace_back(create_placeholder_tx(1, 1));
     BOOST_CHECK(IsConsistentPackage(package_with_dup_tx));
+}
+
+// Regression test for an integer-truncation defect in IsWellFormedPackage's
+// MAX_PACKAGE_WEIGHT guard. The total-weight accumulator must be 64-bit; if the
+// std::accumulate init value is a plain `0` (int), the running sum is narrowed to
+// 32 bits each iteration, so a package whose true weight exceeds INT_MAX wraps to a
+// small/negative value and slips past the "package-too-large" check.
+//
+// We reuse a single large transaction MAX_PACKAGE_COUNT times. The weight check runs
+// before the duplicate-txid check, so the accumulator sees 25 x weight. With the bug
+// present, the wrapped total bypasses the weight guard and the package is instead
+// rejected later as "package-contains-duplicates"; with the fix, it is correctly
+// rejected as "package-too-large".
+BOOST_AUTO_TEST_CASE(package_weight_overflow_tests)
+{
+    // ~27 MB tx => weight ~109M; 25 copies => true total ~2.73e9, which exceeds
+    // INT_MAX (~2.147e9) and so overflows a 32-bit accumulator, yet stays a single
+    // ~27 MB allocation rather than 25 separate large transactions.
+    CTransactionRef big_ptx = create_placeholder_tx(/*num_inputs=*/150'000, /*num_outputs=*/150'000);
+    const int64_t tx_weight = GetTransactionWeight(*big_ptx);
+    const int64_t total_true_weight = tx_weight * MAX_PACKAGE_COUNT;
+
+    // Preconditions for this regression to be meaningful: a single tx is under
+    // INT_MAX, but MAX_PACKAGE_COUNT copies exceed it (and stay below 2^32, so a
+    // 32-bit accumulator wraps to a value <= MAX_PACKAGE_WEIGHT).
+    BOOST_REQUIRE(tx_weight <= std::numeric_limits<int32_t>::max());
+    BOOST_REQUIRE(total_true_weight > std::numeric_limits<int32_t>::max());
+    BOOST_REQUIRE(total_true_weight < (int64_t{1} << 32));
+
+    Package package_overflow(MAX_PACKAGE_COUNT, big_ptx);
+    PackageValidationState state_overflow;
+    BOOST_CHECK(!IsWellFormedPackage(package_overflow, state_overflow));
+    BOOST_CHECK_EQUAL(state_overflow.GetResult(), PackageValidationResult::PCKG_POLICY);
+    // With a correct 64-bit accumulator the weight guard fires first. If this is
+    // "package-contains-duplicates" instead, the weight guard was bypassed by the
+    // 32-bit overflow.
+    BOOST_CHECK_EQUAL(state_overflow.GetRejectReason(), "package-too-large");
 }
 
 BOOST_AUTO_TEST_CASE(package_validation_tests)


### PR DESCRIPTION
`IsWellFormedPackage()` enforces `MAX_PACKAGE_WEIGHT` by summing each transaction's weight:

```cpp
const int64_t total_weight = std::accumulate(txns.cbegin(), txns.cend(), 0,
                           [](int64_t sum, const auto& tx) { return sum + GetTransactionWeight(*tx); });
if (package_count > 1 && total_weight > MAX_PACKAGE_WEIGHT) { ... "package-too-large" }
```

`std::accumulate`'s accumulator type is the type of the init value. The init here is the literal `0`, so the accumulator is an `int`: the 64-bit lambda result is narrowed back to 32 bits on every iteration. A package whose true combined weight exceeds `INT_MAX` therefore wraps to a small or negative value, and the `total_weight > MAX_PACKAGE_WEIGHT` check is silently bypassed.

This is the only place `MAX_PACKAGE_WEIGHT` is enforced. The two sibling weight/fee accumulations in the package-acceptance path already use a 64-bit init (`int64_t{0}` / `CAmount{0}`); this call site is the inconsistent one.

### Impact

Limited and policy-only — not a consensus issue:

- Oversized transactions are still rejected individually by the per-transaction weight/standardness checks that run after `IsWellFormedPackage()`, so this does not let over-weight transactions into the mempool.
- The effect is that the package-level early rejection (`package-too-large`) fails to fire for a package whose combined weight crosses `INT_MAX`, so the node does more work before rejecting. Such a package is reachable e.g. via the `submitpackage` RPC with sufficiently large transactions.

Still, the guard should do what it says, and relying on 32-bit truncation of a weight sum is fragile.

### Fix

One line — initialise the accumulator with `int64_t{0}`.

### Test

Adds `package_weight_overflow_tests` to `txpackage_tests.cpp`. Because triggering the wrap requires a combined weight above `INT_MAX` and `MAX_PACKAGE_COUNT` is 25, each transaction must be large. To avoid allocating 25 separate large transactions, the test reuses one ~27 MB transaction 25 times — the weight check runs before the duplicate-txid check, so the accumulator still sees `25 × weight`. The test asserts the rejection reason is `package-too-large`; on the unfixed code the wrapped total bypasses the weight check and the reason is instead `package-contains-duplicates`. Happy to drop or slim the test if the maintainers prefer.

### How to reproduce the mechanism

The truncation can be observed in isolation with a minimal program that mirrors the exact `std::accumulate` expression: 25 weights of ~90,000,000 sum to 2,250,000,000 (> `INT_MAX`); the `int`-accumulator version returns `-2,044,967,296` (guard bypassed) while an `int64_t` accumulator returns the correct `2,250,000,000` (guard fires).
