### PR TITLE
node: move index ownership to NodeContext

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -226,6 +226,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/database_args.cpp
   node/eviction.cpp
   node/interface_ui.cpp
+  node/indexes.cpp
   node/interfaces.cpp
   node/kernel_notifications.cpp
   node/mempool_args.cpp

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -26,11 +26,9 @@
 
 #include <cerrno>
 #include <exception>
-#include <map>
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -70,8 +68,6 @@ struct DBVal {
 };
 
 }; // namespace
-
-static std::map<BlockFilterType, BlockFilterIndex> g_filter_indexes;
 
 BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
                                    size_t n_cache_size, bool f_memory, bool f_wipe)
@@ -430,35 +426,4 @@ bool BlockFilterIndex::LookupFilterHashRange(int start_height, const CBlockIndex
         hashes_out.push_back(entry.hash);
     }
     return true;
-}
-
-BlockFilterIndex* GetBlockFilterIndex(BlockFilterType filter_type)
-{
-    auto it = g_filter_indexes.find(filter_type);
-    return it != g_filter_indexes.end() ? &it->second : nullptr;
-}
-
-void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn)
-{
-    for (auto& entry : g_filter_indexes) fn(entry.second);
-}
-
-bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
-                          size_t n_cache_size, bool f_memory, bool f_wipe)
-{
-    auto result = g_filter_indexes.emplace(std::piecewise_construct,
-                                           std::forward_as_tuple(filter_type),
-                                           std::forward_as_tuple(make_chain(), filter_type,
-                                                                 n_cache_size, f_memory, f_wipe));
-    return result.second;
-}
-
-bool DestroyBlockFilterIndex(BlockFilterType filter_type)
-{
-    return g_filter_indexes.erase(filter_type);
-}
-
-void DestroyAllBlockFilterIndexes()
-{
-    g_filter_indexes.clear();
 }

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -15,7 +15,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -96,31 +95,5 @@ public:
     bool LookupFilterHashRange(int start_height, const CBlockIndex* stop_index,
                                std::vector<uint256>& hashes_out) const;
 };
-
-/**
- * Get a block filter index by type. Returns nullptr if index has not been initialized or was
- * already destroyed.
- */
-BlockFilterIndex* GetBlockFilterIndex(BlockFilterType filter_type);
-
-/** Iterate over all running block filter indexes, invoking fn on each. */
-void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn);
-
-/**
- * Initialize a block filter index for the given type if one does not already exist. Returns true if
- * a new index is created and false if one has already been initialized.
- */
-bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
-                          size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
-
-/**
- * Destroy the block filter index with the given type. Returns false if no such index exists. This
- * just releases the allocated memory and closes the database connection, it does not delete the
- * index data.
- */
-bool DestroyBlockFilterIndex(BlockFilterType filter_type);
-
-/** Destroy all open block filter indexes. */
-void DestroyAllBlockFilterIndexes();
 
 #endif // BITCOIN_INDEX_BLOCKFILTERINDEX_H

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -84,8 +84,6 @@ struct DBVal {
 };
 }; // namespace
 
-std::unique_ptr<CoinStatsIndex> g_coin_stats_index;
-
 CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
     : BaseIndex(std::move(chain), "coinstatsindex")
 {

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -72,7 +72,4 @@ public:
     std::optional<kernel::CCoinsStats> LookUpStats(const CBlockIndex& block_index) const;
 };
 
-/// The global UTXO set hash object.
-extern std::unique_ptr<CoinStatsIndex> g_coin_stats_index;
-
 #endif // BITCOIN_INDEX_COINSTATSINDEX_H

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -30,8 +30,6 @@
 
 constexpr uint8_t DB_TXINDEX{'t'};
 
-std::unique_ptr<TxIndex> g_txindex;
-
 
 /** Access to the txindex database (indexes/txindex/) */
 class TxIndex::DB : public BaseIndex::DB

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -54,7 +54,4 @@ public:
     bool FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx) const;
 };
 
-/// The global transaction index, used in GetTransaction. May be null.
-extern std::unique_ptr<TxIndex> g_txindex;
-
 #endif // BITCOIN_INDEX_TXINDEX_H

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -39,8 +39,6 @@
 // LevelDB key prefix. We only have one key for now but it will make it easier to add others if needed.
 constexpr uint8_t DB_TXOSPENDERINDEX{'s'};
 
-std::unique_ptr<TxoSpenderIndex> g_txospenderindex;
-
 struct DBKey {
     uint64_t hash;
     CDiskTxPos pos;

--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -68,8 +68,4 @@ public:
     util::Expected<std::optional<TxoSpender>, std::string> FindSpender(const COutPoint& txo) const;
 };
 
-/// The global txo spender index. May be null.
-extern std::unique_ptr<TxoSpenderIndex> g_txospenderindex;
-
-
 #endif // BITCOIN_INDEX_TXOSPENDERINDEX_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -60,6 +60,7 @@
 #include <node/chainstatemanager_args.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
+#include <node/indexes.h>
 #include <node/kernel_notifications.h>
 #include <node/mempool_args.h>
 #include <node/mempool_persist.h>
@@ -154,8 +155,11 @@ using node::ChainstateLoadStatus;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
+using node::DestroyAllBlockFilterIndexes;
 using node::DumpMempool;
+using node::GetBlockFilterIndex;
 using node::ImportBlocks;
+using node::InitBlockFilterIndex;
 using node::KernelNotifications;
 using node::LoadChainstate;
 using node::LoadMempool;
@@ -391,7 +395,7 @@ void Shutdown(NodeContext& node)
     node.txindex.reset();
     node.txospenderindex.reset();
     node.coin_stats_index.reset();
-    DestroyAllBlockFilterIndexes();
+    DestroyAllBlockFilterIndexes(node);
 
     // Any future callbacks will be dropped. This should absolutely be safe - if
     // missing a callback results in an unrecoverable situation, unclean shutdown
@@ -1587,6 +1591,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     PeerManager::Options peerman_opts{};
     ApplyArgsManOptions(args, peerman_opts);
+    peerman_opts.get_block_filter_index = [&node](BlockFilterType filter_type) {
+        return GetBlockFilterIndex(node, filter_type);
+    };
 
     {
         // Read asmap file if configured or embedded asmap data and initialize
@@ -1910,22 +1917,22 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 8: start indexers
 
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        node.txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex);
+        node.txindex.reset(new TxIndex(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex));
         node.indexes.emplace_back(node.txindex.get());
     }
 
     if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {
-        node.txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), index_cache_sizes.txospender_index, false, do_reindex);
+        node.txospenderindex.reset(new TxoSpenderIndex(interfaces::MakeChain(node), index_cache_sizes.txospender_index, false, do_reindex));
         node.indexes.emplace_back(node.txospenderindex.get());
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {
-        InitBlockFilterIndex([&]{ return interfaces::MakeChain(node); }, filter_type, index_cache_sizes.filter_index, false, do_reindex);
-        node.indexes.emplace_back(GetBlockFilterIndex(filter_type));
+        InitBlockFilterIndex(node, [&]{ return interfaces::MakeChain(node); }, filter_type, index_cache_sizes.filter_index, false, do_reindex);
+        node.indexes.emplace_back(GetBlockFilterIndex(node, filter_type));
     }
 
     if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
-        node.coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /*cache_size=*/0, false, do_reindex);
+        node.coin_stats_index.reset(new CoinStatsIndex(interfaces::MakeChain(node), /*n_cache_size=*/0, false, do_reindex));
         node.indexes.emplace_back(node.coin_stats_index.get());
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -387,11 +387,11 @@ void Shutdown(NodeContext& node)
 
     // Stop and delete all indexes only after flushing background callbacks.
     for (auto* index : node.indexes) index->Stop();
-    if (g_txindex) g_txindex.reset();
+    node.indexes.clear();
+    node.txindex.reset();
     if (g_txospenderindex) g_txospenderindex.reset();
     if (g_coin_stats_index) g_coin_stats_index.reset();
     DestroyAllBlockFilterIndexes();
-    node.indexes.clear(); // all instances are nullptr now
 
     // Any future callbacks will be dropped. This should absolutely be safe - if
     // missing a callback results in an unrecoverable situation, unclean shutdown
@@ -1910,8 +1910,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 8: start indexers
 
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex);
-        node.indexes.emplace_back(g_txindex.get());
+        node.txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex);
+        node.indexes.emplace_back(node.txindex.get());
     }
 
     if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -389,7 +389,7 @@ void Shutdown(NodeContext& node)
     for (auto* index : node.indexes) index->Stop();
     node.indexes.clear();
     node.txindex.reset();
-    if (g_txospenderindex) g_txospenderindex.reset();
+    node.txospenderindex.reset();
     if (g_coin_stats_index) g_coin_stats_index.reset();
     DestroyAllBlockFilterIndexes();
 
@@ -1915,8 +1915,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {
-        g_txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), index_cache_sizes.txospender_index, false, do_reindex);
-        node.indexes.emplace_back(g_txospenderindex.get());
+        node.txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), index_cache_sizes.txospender_index, false, do_reindex);
+        node.indexes.emplace_back(node.txospenderindex.get());
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -390,7 +390,7 @@ void Shutdown(NodeContext& node)
     node.indexes.clear();
     node.txindex.reset();
     node.txospenderindex.reset();
-    if (g_coin_stats_index) g_coin_stats_index.reset();
+    node.coin_stats_index.reset();
     DestroyAllBlockFilterIndexes();
 
     // Any future callbacks will be dropped. This should absolutely be safe - if
@@ -1925,8 +1925,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
-        g_coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /*cache_size=*/0, false, do_reindex);
-        node.indexes.emplace_back(g_coin_stats_index.get());
+        node.coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /*cache_size=*/0, false, do_reindex);
+        node.indexes.emplace_back(node.coin_stats_index.get());
     }
 
     // Init indexes

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3305,7 +3305,7 @@ bool PeerManagerImpl::PrepareBlockFilterRequest(CNode& node, Peer& peer,
         return false;
     }
 
-    filter_index = GetBlockFilterIndex(filter_type);
+    filter_index = m_opts.get_block_filter_index(filter_type);
     if (!filter_index) {
         LogDebug(BCLog::NET, "Filter index for supported type %s not found\n", BlockFilterTypeName(filter_type));
         return false;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -18,12 +18,15 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
 class AddrMan;
+class BlockFilterIndex;
+enum class BlockFilterType : uint8_t;
 class CTxMemPool;
 class ChainstateManager;
 class BanMan;
@@ -94,6 +97,8 @@ public:
         uint32_t max_headers_result{MAX_HEADERS_RESULTS};
         //! Whether private broadcast is used for sending transactions.
         bool private_broadcast{DEFAULT_PRIVATE_BROADCAST};
+        //! Return the running block filter index for a filter type, if enabled.
+        std::function<BlockFilterIndex*(BlockFilterType)> get_block_filter_index{[](BlockFilterType) { return nullptr; }};
     };
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -6,6 +6,7 @@
 
 #include <addrman.h>
 #include <banman.h>
+#include <index/txindex.h>
 #include <interfaces/chain.h>
 #include <interfaces/mining.h>
 #include <kernel/context.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -6,6 +6,7 @@
 
 #include <addrman.h>
 #include <banman.h>
+#include <index/coinstatsindex.h>
 #include <index/txindex.h>
 #include <index/txospenderindex.h>
 #include <interfaces/chain.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -7,6 +7,7 @@
 #include <addrman.h>
 #include <banman.h>
 #include <index/txindex.h>
+#include <index/txospenderindex.h>
 #include <interfaces/chain.h>
 #include <interfaces/mining.h>
 #include <kernel/context.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -6,9 +6,6 @@
 
 #include <addrman.h>
 #include <banman.h>
-#include <index/coinstatsindex.h>
-#include <index/txindex.h>
-#include <index/txospenderindex.h>
 #include <interfaces/chain.h>
 #include <interfaces/mining.h>
 #include <kernel/context.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -18,6 +18,7 @@ class ArgsManager;
 class AddrMan;
 class BanMan;
 class BaseIndex;
+class BlockFilterIndex;
 class CBlockPolicyEstimator;
 class CConnman;
 class CoinStatsIndex;
@@ -49,6 +50,20 @@ namespace node {
 class KernelNotifications;
 class Warnings;
 
+// Keep NodeContext from depending on index modules while still owning indexes.
+struct BlockFilterIndexDeleter {
+    void operator()(BlockFilterIndex* index) const noexcept;
+};
+struct CoinStatsIndexDeleter {
+    void operator()(CoinStatsIndex* index) const noexcept;
+};
+struct TxIndexDeleter {
+    void operator()(TxIndex* index) const noexcept;
+};
+struct TxoSpenderIndexDeleter {
+    void operator()(TxoSpenderIndex* index) const noexcept;
+};
+
 //! NodeContext struct containing references to chain state and connection
 //! state.
 //!
@@ -79,7 +94,7 @@ struct NodeContext {
     std::unique_ptr<ChainstateManager> chainman;
     std::unique_ptr<BanMan> banman;
     ArgsManager* args{nullptr}; // Currently a raw pointer because the memory is not managed by this struct
-    std::vector<BaseIndex*> indexes; // raw pointers because memory is not managed by this struct
+    std::vector<BaseIndex*> indexes; // raw pointers because memory is managed by index owner members below or elsewhere
     std::unique_ptr<interfaces::Chain> chain;
     //! List of all chain clients (wallet processes or other client) connected to node.
     std::vector<std::unique_ptr<interfaces::ChainClient>> chain_clients;
@@ -99,9 +114,10 @@ struct NodeContext {
     //! Issues calls about blocks and transactions
     std::unique_ptr<ValidationSignals> validation_signals;
     //! Declared after validation_signals so index destructors can unregister safely.
-    std::unique_ptr<TxIndex> txindex;
-    std::unique_ptr<TxoSpenderIndex> txospenderindex;
-    std::unique_ptr<CoinStatsIndex> coin_stats_index;
+    std::vector<std::unique_ptr<BlockFilterIndex, BlockFilterIndexDeleter>> block_filter_indexes;
+    std::unique_ptr<TxIndex, TxIndexDeleter> txindex;
+    std::unique_ptr<TxoSpenderIndex, TxoSpenderIndexDeleter> txospenderindex;
+    std::unique_ptr<CoinStatsIndex, CoinStatsIndexDeleter> coin_stats_index;
     std::atomic<int> exit_status{EXIT_SUCCESS};
     //! Manages all the node warnings
     std::unique_ptr<node::Warnings> warnings;

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -20,6 +20,7 @@ class BanMan;
 class BaseIndex;
 class CBlockPolicyEstimator;
 class CConnman;
+class CoinStatsIndex;
 class ValidationSignals;
 class CScheduler;
 class CTxMemPool;
@@ -100,6 +101,7 @@ struct NodeContext {
     //! Declared after validation_signals so index destructors can unregister safely.
     std::unique_ptr<TxIndex> txindex;
     std::unique_ptr<TxoSpenderIndex> txospenderindex;
+    std::unique_ptr<CoinStatsIndex> coin_stats_index;
     std::atomic<int> exit_status{EXIT_SUCCESS};
     //! Manages all the node warnings
     std::unique_ptr<node::Warnings> warnings;

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -29,6 +29,7 @@ class NetGroupManager;
 class PeerManager;
 class TorController;
 class TxIndex;
+class TxoSpenderIndex;
 namespace interfaces {
 class Chain;
 class ChainClient;
@@ -98,6 +99,7 @@ struct NodeContext {
     std::unique_ptr<ValidationSignals> validation_signals;
     //! Declared after validation_signals so index destructors can unregister safely.
     std::unique_ptr<TxIndex> txindex;
+    std::unique_ptr<TxoSpenderIndex> txospenderindex;
     std::atomic<int> exit_status{EXIT_SUCCESS};
     //! Manages all the node warnings
     std::unique_ptr<node::Warnings> warnings;

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -28,6 +28,7 @@ class ECC_Context;
 class NetGroupManager;
 class PeerManager;
 class TorController;
+class TxIndex;
 namespace interfaces {
 class Chain;
 class ChainClient;
@@ -95,6 +96,8 @@ struct NodeContext {
     std::unique_ptr<KernelNotifications> notifications;
     //! Issues calls about blocks and transactions
     std::unique_ptr<ValidationSignals> validation_signals;
+    //! Declared after validation_signals so index destructors can unregister safely.
+    std::unique_ptr<TxIndex> txindex;
     std::atomic<int> exit_status{EXIT_SUCCESS};
     //! Manages all the node warnings
     std::unique_ptr<node::Warnings> warnings;

--- a/src/node/indexes.cpp
+++ b/src/node/indexes.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/indexes.h>
+
+#include <index/blockfilterindex.h>
+#include <index/coinstatsindex.h>
+#include <index/txindex.h>
+#include <index/txospenderindex.h>
+#include <node/context.h>
+
+namespace node {
+
+void BlockFilterIndexDeleter::operator()(BlockFilterIndex* index) const noexcept { delete index; }
+void CoinStatsIndexDeleter::operator()(CoinStatsIndex* index) const noexcept { delete index; }
+void TxIndexDeleter::operator()(TxIndex* index) const noexcept { delete index; }
+void TxoSpenderIndexDeleter::operator()(TxoSpenderIndex* index) const noexcept { delete index; }
+
+BlockFilterIndex* GetBlockFilterIndex(NodeContext& node, BlockFilterType filter_type)
+{
+    for (const auto& index : node.block_filter_indexes) {
+        if (index->GetFilterType() == filter_type) return index.get();
+    }
+    return nullptr;
+}
+
+const BlockFilterIndex* GetBlockFilterIndex(const NodeContext& node, BlockFilterType filter_type)
+{
+    for (const auto& index : node.block_filter_indexes) {
+        if (index->GetFilterType() == filter_type) return index.get();
+    }
+    return nullptr;
+}
+
+void ForEachBlockFilterIndex(NodeContext& node, std::function<void(BlockFilterIndex&)> fn)
+{
+    for (auto& index : node.block_filter_indexes) fn(*index);
+}
+
+bool InitBlockFilterIndex(NodeContext& node, std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
+                          size_t n_cache_size, bool f_memory, bool f_wipe)
+{
+    if (GetBlockFilterIndex(node, filter_type)) return false;
+    node.block_filter_indexes.emplace_back(new BlockFilterIndex(make_chain(), filter_type, n_cache_size, f_memory, f_wipe));
+    return true;
+}
+
+bool DestroyBlockFilterIndex(NodeContext& node, BlockFilterType filter_type)
+{
+    for (auto it{node.block_filter_indexes.begin()}; it != node.block_filter_indexes.end(); ++it) {
+        if ((*it)->GetFilterType() == filter_type) {
+            node.block_filter_indexes.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+void DestroyAllBlockFilterIndexes(NodeContext& node)
+{
+    node.block_filter_indexes.clear();
+}
+
+} // namespace node

--- a/src/node/indexes.h
+++ b/src/node/indexes.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_INDEXES_H
+#define BITCOIN_NODE_INDEXES_H
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+class BlockFilterIndex;
+enum class BlockFilterType : uint8_t;
+
+namespace interfaces {
+class Chain;
+}
+
+namespace node {
+struct NodeContext;
+
+/**
+ * Get a block filter index by type. Returns nullptr if index has not been initialized or was
+ * already destroyed.
+ */
+BlockFilterIndex* GetBlockFilterIndex(NodeContext& node, BlockFilterType filter_type);
+const BlockFilterIndex* GetBlockFilterIndex(const NodeContext& node, BlockFilterType filter_type);
+
+/** Iterate over all running block filter indexes, invoking fn on each. */
+void ForEachBlockFilterIndex(NodeContext& node, std::function<void(BlockFilterIndex&)> fn);
+
+/**
+ * Initialize a block filter index for the given type if one does not already exist. Returns true if
+ * a new index is created and false if one has already been initialized.
+ */
+bool InitBlockFilterIndex(NodeContext& node, std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
+                          size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+
+/**
+ * Destroy the block filter index with the given type. Returns false if no such index exists. This
+ * just releases the allocated memory and closes the database connection, it does not delete the
+ * index data.
+ */
+bool DestroyBlockFilterIndex(NodeContext& node, BlockFilterType filter_type);
+
+/** Destroy all open block filter indexes. */
+void DestroyAllBlockFilterIndexes(NodeContext& node);
+} // namespace node
+
+#endif // BITCOIN_NODE_INDEXES_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -38,6 +38,7 @@
 #include <node/coin.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
+#include <node/indexes.h>
 #include <node/kernel_notifications.h>
 #include <node/miner.h>
 #include <node/mini_miner.h>
@@ -585,11 +586,11 @@ public:
     }
     bool hasBlockFilterIndex(BlockFilterType filter_type) override
     {
-        return GetBlockFilterIndex(filter_type) != nullptr;
+        return GetBlockFilterIndex(m_node, filter_type) != nullptr;
     }
     std::optional<bool> blockFilterMatchesAny(BlockFilterType filter_type, const uint256& block_hash, const GCSFilter::ElementSet& filter_set) override
     {
-        const BlockFilterIndex* block_filter_index{GetBlockFilterIndex(filter_type)};
+        const BlockFilterIndex* block_filter_index{GetBlockFilterIndex(m_node, filter_type)};
         if (!block_filter_index) return std::nullopt;
 
         BlockFilter filter;

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -140,16 +140,16 @@ TransactionError BroadcastTransaction(NodeContext& node,
     return TransactionError::OK;
 }
 
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const Txid& hash, const BlockManager& blockman, uint256& hashBlock)
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const TxIndex* const txindex, const Txid& hash, const BlockManager& blockman, uint256& hashBlock)
 {
     if (mempool && !block_index) {
         CTransactionRef ptx = mempool->get(hash);
         if (ptx) return ptx;
     }
-    if (g_txindex) {
+    if (txindex) {
         CTransactionRef tx;
         uint256 block_hash;
-        if (g_txindex->FindTx(hash, block_hash, tx)) {
+        if (txindex->FindTx(hash, block_hash, tx)) {
             if (!block_index || block_index->GetBlockHash() == block_hash) {
                 // Don't return the transaction if the provided block hash doesn't match.
                 // The case where a transaction appears in multiple blocks (e.g. reorgs or

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -12,6 +12,7 @@
 
 class CBlockIndex;
 class CTxMemPool;
+class TxIndex;
 namespace Consensus {
 struct Params;
 }
@@ -60,17 +61,18 @@ static const CAmount DEFAULT_MAX_BURN_AMOUNT{0};
 /**
  * Return transaction with a given hash.
  * If mempool is provided and block_index is not provided, check it first for the tx.
- * If -txindex is available, check it next for the tx.
+ * If txindex is provided, check it next for the tx.
  * Finally, if block_index is provided, check for tx by reading entire block from disk.
  *
  * @param[in]  block_index     The block to read from disk, or nullptr
  * @param[in]  mempool         If provided, check mempool for tx
+ * @param[in]  txindex         If provided, check txindex for tx
  * @param[in]  hash            The txid
  * @param[in]  blockman        Used to access and read blocks from disk
  * @param[out] hashBlock       The block hash, if the tx was found via -txindex or block_index
  * @returns                    The tx if found, otherwise nullptr
  */
-CTransactionRef GetTransaction(const CBlockIndex* block_index, const CTxMemPool* mempool, const Txid& hash, const BlockManager& blockman, uint256& hashBlock);
+CTransactionRef GetTransaction(const CBlockIndex* block_index, const CTxMemPool* mempool, const TxIndex* txindex, const Txid& hash, const BlockManager& blockman, uint256& hashBlock);
 } // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -15,6 +15,7 @@
 #include <index/txindex.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
+#include <node/indexes.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <rpc/blockchain.h>
@@ -38,6 +39,7 @@
 #include <univalue.h>
 
 using node::GetTransaction;
+using node::GetBlockFilterIndex;
 using node::NodeContext;
 using util::SplitString;
 
@@ -538,7 +540,9 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
         return RESTERR(req, HTTP_BAD_REQUEST, "Unknown filtertype " + uri_parts[0]);
     }
 
-    BlockFilterIndex* index = GetBlockFilterIndex(filtertype);
+    NodeContext* node = GetNodeContext(context, req);
+    if (!node) return false;
+    BlockFilterIndex* index = GetBlockFilterIndex(*node, filtertype);
     if (!index) {
         return RESTERR(req, HTTP_BAD_REQUEST, "Index is not enabled for filtertype " + uri_parts[0]);
     }
@@ -642,7 +646,9 @@ static bool rest_block_filter(const std::any& context, HTTPRequest* req, const s
         return RESTERR(req, HTTP_BAD_REQUEST, "Unknown filtertype " + uri_parts[0]);
     }
 
-    BlockFilterIndex* index = GetBlockFilterIndex(filtertype);
+    NodeContext* node = GetNodeContext(context, req);
+    if (!node) return false;
+    BlockFilterIndex* index = GetBlockFilterIndex(*node, filtertype);
     if (!index) {
         return RESTERR(req, HTTP_BAD_REQUEST, "Index is not enabled for filtertype " + uri_parts[0]);
     }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -847,14 +847,13 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
     }
 
-    if (g_txindex) {
-        g_txindex->BlockUntilSyncedToCurrentChain();
-    }
-
     const NodeContext* const node = GetNodeContext(context, req);
     if (!node) return false;
+    if (node->txindex) {
+        node->txindex->BlockUntilSyncedToCurrentChain();
+    }
     uint256 hashBlock = uint256();
-    const CTransactionRef tx{GetTransaction(/*block_index=*/nullptr, node->mempool.get(), *hash,  node->chainman->m_blockman, hashBlock)};
+    const CTransactionRef tx{GetTransaction(/*block_index=*/nullptr, node->mempool.get(), node->txindex.get(), *hash,  node->chainman->m_blockman, hashBlock)};
     if (!tx) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -996,18 +996,19 @@ CoinStatsHashType ParseHashType(std::string_view hash_type_input)
  * @param[in] index_requested Signals if the coinstatsindex should be used (when available).
  */
 static std::optional<kernel::CCoinsStats> GetUTXOStats(CCoinsView* view, node::BlockManager& blockman,
-                                                       kernel::CoinStatsHashType hash_type,
-                                                       const std::function<void()>& interruption_point = {},
-                                                       const CBlockIndex* pindex = nullptr,
-                                                       bool index_requested = true)
+                                                        const CoinStatsIndex* coin_stats_index,
+                                                        kernel::CoinStatsHashType hash_type,
+                                                        const std::function<void()>& interruption_point = {},
+                                                        const CBlockIndex* pindex = nullptr,
+                                                        bool index_requested = true)
 {
     // Use CoinStatsIndex if it is requested and available and a hash_type of Muhash or None was requested
-    if ((hash_type == kernel::CoinStatsHashType::MUHASH || hash_type == kernel::CoinStatsHashType::NONE) && g_coin_stats_index && index_requested) {
+    if ((hash_type == kernel::CoinStatsHashType::MUHASH || hash_type == kernel::CoinStatsHashType::NONE) && coin_stats_index && index_requested) {
         if (pindex) {
-            return g_coin_stats_index->LookUpStats(*pindex);
+            return coin_stats_index->LookUpStats(*pindex);
         } else {
             CBlockIndex& block_index = *CHECK_NONFATAL(WITH_LOCK(::cs_main, return blockman.LookupBlockIndex(view->GetBestBlock())));
-            return g_coin_stats_index->LookUpStats(block_index);
+            return coin_stats_index->LookUpStats(block_index);
         }
     }
 
@@ -1096,7 +1097,7 @@ static RPCMethod gettxoutsetinfo()
 
     const CBlockIndex* pindex{nullptr};
     if (!request.params[1].isNull()) {
-        if (!g_coin_stats_index) {
+        if (!node.coin_stats_index) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Querying specific block heights requires coinstatsindex");
         }
 
@@ -1110,9 +1111,9 @@ static RPCMethod gettxoutsetinfo()
         pindex = ParseHashOrHeight(request.params[1], chainman);
     }
 
-    if (index_requested && g_coin_stats_index) {
-        if (!g_coin_stats_index->BlockUntilSyncedToCurrentChain()) {
-            const IndexSummary summary{g_coin_stats_index->GetSummary()};
+    if (index_requested && node.coin_stats_index) {
+        if (!node.coin_stats_index->BlockUntilSyncedToCurrentChain()) {
+            const IndexSummary summary{node.coin_stats_index->GetSummary()};
 
             // If a specific block was requested and the index has already synced past that height, we can return the
             // data already even though the index is not fully synced yet.
@@ -1122,7 +1123,7 @@ static RPCMethod gettxoutsetinfo()
         }
     }
 
-    const std::optional<CCoinsStats> maybe_stats = GetUTXOStats(coins_view, *blockman, hash_type, node.rpc_interruption_point, pindex, index_requested);
+    const std::optional<CCoinsStats> maybe_stats = GetUTXOStats(coins_view, *blockman, node.coin_stats_index.get(), hash_type, node.rpc_interruption_point, pindex, index_requested);
     if (maybe_stats.has_value()) {
         const CCoinsStats& stats = maybe_stats.value();
         ret.pushKV("height", stats.nHeight);
@@ -1144,7 +1145,7 @@ static RPCMethod gettxoutsetinfo()
             CCoinsStats prev_stats{};
             if (stats.nHeight > 0) {
                 const CBlockIndex& block_index = *CHECK_NONFATAL(WITH_LOCK(::cs_main, return blockman->LookupBlockIndex(stats.hashBlock)));
-                const std::optional<CCoinsStats> maybe_prev_stats = GetUTXOStats(coins_view, *blockman, hash_type, node.rpc_interruption_point, block_index.pprev, index_requested);
+                const std::optional<CCoinsStats> maybe_prev_stats = GetUTXOStats(coins_view, *blockman, node.coin_stats_index.get(), hash_type, node.rpc_interruption_point, block_index.pprev, index_requested);
                 if (!maybe_prev_stats) {
                     throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to read UTXO set");
                 }
@@ -3327,9 +3328,10 @@ UniValue CreateRolledBackUTXOSnapshot(
 
     LogInfo("Rollback complete. Computing UTXO statistics for created txoutset dump.");
     std::optional<CCoinsStats> maybe_stats = GetUTXOStats(temp_db.get(),
-                                                          chainstate.m_blockman,
-                                                          CoinStatsHashType::HASH_SERIALIZED,
-                                                          node.rpc_interruption_point);
+                                                           chainstate.m_blockman,
+                                                           /*coin_stats_index=*/nullptr,
+                                                           CoinStatsHashType::HASH_SERIALIZED,
+                                                           node.rpc_interruption_point);
 
     if (!maybe_stats) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to compute UTXO statistics");
@@ -3377,7 +3379,7 @@ PrepareUTXOSnapshot(
 
         chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
 
-        maybe_stats = GetUTXOStats(&chainstate.CoinsDB(), chainstate.m_blockman, CoinStatsHashType::HASH_SERIALIZED, interruption_point);
+        maybe_stats = GetUTXOStats(&chainstate.CoinsDB(), chainstate.m_blockman, /*coin_stats_index=*/nullptr, CoinStatsHashType::HASH_SERIALIZED, interruption_point);
         if (!maybe_stats) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to read UTXO set");
         }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -29,6 +29,7 @@
 #include <net_processing.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
+#include <node/indexes.h>
 #include <node/transaction.h>
 #include <node/utxo_snapshot.h>
 #include <node/warnings.h>
@@ -71,6 +72,7 @@ using kernel::CoinStatsHashType;
 using interfaces::BlockRef;
 using interfaces::Mining;
 using node::BlockManager;
+using node::GetBlockFilterIndex;
 using node::NodeContext;
 using node::SnapshotMetadata;
 using util::MakeUnorderedList;
@@ -2623,12 +2625,12 @@ static RPCMethod scanblocks()
         UniValue options{request.params[5].isNull() ? UniValue::VOBJ : request.params[5]};
         bool filter_false_positives{options.exists("filter_false_positives") ? options["filter_false_positives"].get_bool() : false};
 
-        BlockFilterIndex* index = GetBlockFilterIndex(filtertype);
+        NodeContext& node = EnsureAnyNodeContext(request.context);
+        BlockFilterIndex* index = GetBlockFilterIndex(node, filtertype);
         if (!index) {
             throw JSONRPCError(RPC_MISC_ERROR, tfm::format("Index is not enabled for filtertype %s", filtertype_name));
         }
 
-        NodeContext& node = EnsureAnyNodeContext(request.context);
         ChainstateManager& chainman = EnsureChainman(node);
 
         // set the start-height
@@ -2997,7 +2999,8 @@ static RPCMethod getblockfilter()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unknown filtertype");
     }
 
-    BlockFilterIndex* index = GetBlockFilterIndex(filtertype);
+    NodeContext& node = EnsureAnyNodeContext(request.context);
+    BlockFilterIndex* index = GetBlockFilterIndex(node, filtertype);
     if (!index) {
         throw JSONRPCError(RPC_MISC_ERROR, tfm::format("Index is not enabled for filtertype %s", filtertype_name));
     }
@@ -3005,7 +3008,7 @@ static RPCMethod getblockfilter()
     const CBlockIndex* block_index;
     bool block_was_connected;
     {
-        ChainstateManager& chainman = EnsureAnyChainman(request.context);
+        ChainstateManager& chainman = EnsureChainman(node);
         LOCK(cs_main);
         block_index = chainman.m_blockman.LookupBlockIndex(block_hash);
         if (!block_index) {

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -12,6 +12,7 @@
 #include <consensus/validation.h>
 #include <core_io.h>
 #include <index/txospenderindex.h>
+#include <node/context.h>
 #include <kernel/mempool_entry.h>
 #include <net_processing.h>
 #include <netbase.h>
@@ -953,7 +954,8 @@ static RPCMethod gettxspendingprevout()
                                 {"return_spending_tx", UniValueType(UniValue::VBOOL)},
                             }, /*fAllowNull=*/true, /*fStrict=*/true);
 
-            const bool mempool_only{options.exists("mempool_only") ? options["mempool_only"].get_bool() : !g_txospenderindex};
+            const NodeContext& node{EnsureAnyNodeContext(request.context)};
+            const bool mempool_only{options.exists("mempool_only") ? options["mempool_only"].get_bool() : !node.txospenderindex};
             const bool return_spending_tx{options.exists("return_spending_tx") ? options["return_spending_tx"].get_bool() : false};
 
             // Worklist of outpoints to resolve
@@ -995,7 +997,7 @@ static RPCMethod gettxspendingprevout()
 
             // Search the mempool first
             {
-                const CTxMemPool& mempool = EnsureAnyMemPool(request.context);
+                const CTxMemPool& mempool = EnsureMemPool(node);
                 LOCK(mempool.cs);
 
                 // Make the result if the spending tx appears in the mempool or this is a mempool_only request
@@ -1021,12 +1023,12 @@ static RPCMethod gettxspendingprevout()
 
             // At this point the request was not limited to the mempool and some outpoints remain
             // unresolved. We now rely on the index to determine whether they were spent or not.
-            if (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain()) {
+            if (!node.txospenderindex || !node.txospenderindex->BlockUntilSyncedToCurrentChain()) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Mempool lacks a relevant spend, and txospenderindex is unavailable.");
             }
 
             for (const auto& prevout : prevouts_to_process) {
-                const auto spender{g_txospenderindex->FindSpender(prevout.outpoint)};
+                const auto spender{node.txospenderindex->FindSpender(prevout.outpoint)};
                 if (!spender) {
                     throw JSONRPCError(RPC_MISC_ERROR, spender.error());
                 }

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -389,9 +389,10 @@ static RPCMethod getindexinfo()
 {
     UniValue result(UniValue::VOBJ);
     const std::string index_name{self.MaybeArg<std::string_view>("index_name").value_or("")};
+    const NodeContext& node{EnsureAnyNodeContext(request.context)};
 
-    if (g_txindex) {
-        result.pushKVs(SummaryToJSON(g_txindex->GetSummary(), index_name));
+    if (node.txindex) {
+        result.pushKVs(SummaryToJSON(node.txindex->GetSummary(), index_name));
     }
 
     if (g_coin_stats_index) {

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -395,8 +395,8 @@ static RPCMethod getindexinfo()
         result.pushKVs(SummaryToJSON(node.txindex->GetSummary(), index_name));
     }
 
-    if (g_coin_stats_index) {
-        result.pushKVs(SummaryToJSON(g_coin_stats_index->GetSummary(), index_name));
+    if (node.coin_stats_index) {
+        result.pushKVs(SummaryToJSON(node.coin_stats_index->GetSummary(), index_name));
     }
 
     if (node.txospenderindex) {

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -399,8 +399,8 @@ static RPCMethod getindexinfo()
         result.pushKVs(SummaryToJSON(g_coin_stats_index->GetSummary(), index_name));
     }
 
-    if (g_txospenderindex) {
-        result.pushKVs(SummaryToJSON(g_txospenderindex->GetSummary(), index_name));
+    if (node.txospenderindex) {
+        result.pushKVs(SummaryToJSON(node.txospenderindex->GetSummary(), index_name));
     }
 
     ForEachBlockFilterIndex([&result, &index_name](const BlockFilterIndex& index) {

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -7,10 +7,7 @@
 
 #include <chainparams.h>
 #include <httpserver.h>
-#include <index/blockfilterindex.h>
-#include <index/coinstatsindex.h>
-#include <index/txindex.h>
-#include <index/txospenderindex.h>
+#include <index/base.h>
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
 #include <interfaces/init.h>
@@ -391,21 +388,9 @@ static RPCMethod getindexinfo()
     const std::string index_name{self.MaybeArg<std::string_view>("index_name").value_or("")};
     const NodeContext& node{EnsureAnyNodeContext(request.context)};
 
-    if (node.txindex) {
-        result.pushKVs(SummaryToJSON(node.txindex->GetSummary(), index_name));
+    for (const auto* index : node.indexes) {
+        result.pushKVs(SummaryToJSON(index->GetSummary(), index_name));
     }
-
-    if (node.coin_stats_index) {
-        result.pushKVs(SummaryToJSON(node.coin_stats_index->GetSummary(), index_name));
-    }
-
-    if (node.txospenderindex) {
-        result.pushKVs(SummaryToJSON(node.txospenderindex->GetSummary(), index_name));
-    }
-
-    ForEachBlockFilterIndex([&result, &index_name](const BlockFilterIndex& index) {
-        result.pushKVs(SummaryToJSON(index.GetSummary(), index_name));
-    });
 
     return result;
 },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -134,8 +134,8 @@ PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std
     }
     PartiallySignedTransaction psbtx = *psbt_res;
 
-    if (g_txindex) g_txindex->BlockUntilSyncedToCurrentChain();
     const NodeContext& node = EnsureAnyNodeContext(context);
+    if (node.txindex) node.txindex->BlockUntilSyncedToCurrentChain();
 
     // If we can't find the corresponding full transaction for all of our inputs,
     // this will be used to find just the utxos for the segwit inputs for which
@@ -151,9 +151,9 @@ PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std
         CTransactionRef tx;
 
         // Look in the txindex
-        if (g_txindex) {
+        if (node.txindex) {
             uint256 block_hash;
-            g_txindex->FindTx(psbt_input.prev_txid, block_hash, tx);
+            node.txindex->FindTx(psbt_input.prev_txid, block_hash, tx);
         }
         // If we still don't have it look in the mempool
         if (!tx) {
@@ -303,12 +303,12 @@ static RPCMethod getrawtransaction()
     }
 
     bool f_txindex_ready = false;
-    if (g_txindex && !blockindex) {
-        f_txindex_ready = g_txindex->BlockUntilSyncedToCurrentChain();
+    if (node.txindex && !blockindex) {
+        f_txindex_ready = node.txindex->BlockUntilSyncedToCurrentChain();
     }
 
     uint256 hash_block;
-    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), txid, chainman.m_blockman, hash_block);
+    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), node.txindex.get(), txid, chainman.m_blockman, hash_block);
     if (!tx) {
         std::string errmsg;
         if (blockindex) {
@@ -317,7 +317,7 @@ static RPCMethod getrawtransaction()
                 throw JSONRPCError(RPC_MISC_ERROR, "Block not available");
             }
             errmsg = "No such transaction found in the provided block";
-        } else if (!g_txindex) {
+        } else if (!node.txindex) {
             errmsg = "No such mempool transaction. Use -txindex or provide a block hash to enable blockchain transaction queries";
         } else if (!f_txindex_ready) {
             errmsg = "No such mempool transaction. Blockchain transactions are still in the process of being indexed";

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -9,6 +9,7 @@
 #include <index/txindex.h>
 #include <merkleblock.h>
 #include <node/blockstorage.h>
+#include <node/context.h>
 #include <primitives/transaction.h>
 #include <rpc/blockchain.h>
 #include <rpc/server.h>
@@ -19,6 +20,7 @@
 #include <validation.h>
 
 using node::GetTransaction;
+using node::NodeContext;
 
 static RPCMethod gettxoutproof()
 {
@@ -57,7 +59,8 @@ static RPCMethod gettxoutproof()
 
             const CBlockIndex* pblockindex = nullptr;
             uint256 hashBlock;
-            ChainstateManager& chainman = EnsureAnyChainman(request.context);
+            NodeContext& node = EnsureAnyNodeContext(request.context);
+            ChainstateManager& chainman = EnsureChainman(node);
             if (!request.params[1].isNull()) {
                 LOCK(cs_main);
                 hashBlock = ParseHashV(request.params[1], "blockhash");
@@ -81,12 +84,12 @@ static RPCMethod gettxoutproof()
 
 
             // Allow txindex to catch up if we need to query it and before we acquire cs_main.
-            if (g_txindex && !pblockindex) {
-                g_txindex->BlockUntilSyncedToCurrentChain();
+            if (node.txindex && !pblockindex) {
+                node.txindex->BlockUntilSyncedToCurrentChain();
             }
 
             if (pblockindex == nullptr) {
-                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.m_blockman, hashBlock);
+                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, node.txindex.get(), *setTxids.begin(), chainman.m_blockman, hashBlock);
                 if (!tx || hashBlock.IsNull()) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
                 }

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -13,6 +13,7 @@
 #include <interfaces/mining.h>
 #include <key.h>
 #include <node/blockstorage.h>
+#include <node/indexes.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -296,36 +297,36 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
 {
     BlockFilterIndex* filter_index;
 
-    filter_index = GetBlockFilterIndex(BlockFilterType::BASIC);
+    filter_index = node::GetBlockFilterIndex(m_node, BlockFilterType::BASIC);
     BOOST_CHECK(filter_index == nullptr);
 
-    BOOST_CHECK(InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, 1_MiB, true, false));
+    BOOST_CHECK(node::InitBlockFilterIndex(m_node, [&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, 1_MiB, true, false));
 
-    filter_index = GetBlockFilterIndex(BlockFilterType::BASIC);
+    filter_index = node::GetBlockFilterIndex(m_node, BlockFilterType::BASIC);
     BOOST_CHECK(filter_index != nullptr);
     BOOST_CHECK(filter_index->GetFilterType() == BlockFilterType::BASIC);
 
     // Initialize returns false if index already exists.
-    BOOST_CHECK(!InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, 1_MiB, true, false));
+    BOOST_CHECK(!node::InitBlockFilterIndex(m_node, [&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, 1_MiB, true, false));
 
     int iter_count = 0;
-    ForEachBlockFilterIndex([&iter_count](BlockFilterIndex& _index) { iter_count++; });
+    node::ForEachBlockFilterIndex(m_node, [&iter_count](BlockFilterIndex& _index) { iter_count++; });
     BOOST_CHECK_EQUAL(iter_count, 1);
 
-    BOOST_CHECK(DestroyBlockFilterIndex(BlockFilterType::BASIC));
+    BOOST_CHECK(node::DestroyBlockFilterIndex(m_node, BlockFilterType::BASIC));
 
     // Destroy returns false because index was already destroyed.
-    BOOST_CHECK(!DestroyBlockFilterIndex(BlockFilterType::BASIC));
+    BOOST_CHECK(!node::DestroyBlockFilterIndex(m_node, BlockFilterType::BASIC));
 
-    filter_index = GetBlockFilterIndex(BlockFilterType::BASIC);
+    filter_index = node::GetBlockFilterIndex(m_node, BlockFilterType::BASIC);
     BOOST_CHECK(filter_index == nullptr);
 
     // Reinitialize index.
-    BOOST_CHECK(InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, 1_MiB, true, false));
+    BOOST_CHECK(node::InitBlockFilterIndex(m_node, [&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, 1_MiB, true, false));
 
-    DestroyAllBlockFilterIndexes();
+    node::DestroyAllBlockFilterIndexes(m_node);
 
-    filter_index = GetBlockFilterIndex(BlockFilterType::BASIC);
+    filter_index = node::GetBlockFilterIndex(m_node, BlockFilterType::BASIC);
     BOOST_CHECK(filter_index == nullptr);
 }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -16,6 +16,7 @@
 #include <crypto/hex_base.h>
 #include <dbwrapper.h>
 #include <init.h>
+#include <index/blockfilterindex.h>
 #include <interfaces/chain.h>
 #include <interfaces/mining.h>
 #include <kernel/caches.h>
@@ -29,6 +30,7 @@
 #include <node/blockstorage.h>
 #include <node/chainstate.h>
 #include <node/context.h>
+#include <node/indexes.h>
 #include <node/kernel_notifications.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
@@ -399,6 +401,9 @@ TestingSetup::TestingSetup(
     PeerManager::Options peerman_opts;
     ApplyArgsManOptions(*m_node.args, peerman_opts);
     peerman_opts.deterministic_rng = true;
+    peerman_opts.get_block_filter_index = [this](BlockFilterType filter_type) {
+        return node::GetBlockFilterIndex(m_node, filter_type);
+    };
     m_node.peerman = PeerManager::make(*m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.chainman,
                                        *m_node.mempool, *m_node.warnings,


### PR DESCRIPTION
This removes the remaining process-global index ownership and stores node-owned indexes in `NodeContext` instead.

Indexes moved:

- `g_txindex`
- `g_txospenderindex`
- `g_coin_stats_index`
- `g_filter_indexes`

`NodeContext` now owns these index instances, while `node.indexes` remains a non-owning list used for common index startup, shutdown, and `getindexinfo` handling.

Behavior should be unchanged. Indexes are still created from the same startup options, started in the same init step, stopped before destruction, and destroyed while `validation_signals` is still alive so they can unregister safely.

The block filter index registry is moved to `node/indexes.{h,cpp}` so `index/` code does not depend on `NodeContext`. `PeerManager` receives a small lookup callback instead of reaching into global state.

Review notes:
- The first four commits are small and mostly mechanical: move `txindex`, `txospenderindex`, and `coinstatsindex` ownership to `NodeContext`, then make `getindexinfo` use `node.indexes`.
- The last commit is the main one to review carefully. It moves block filter index ownership to `NodeContext`, adds `node/indexes.{h,cpp}`, and wires lookup through `PeerManager::Options` instead of global state.