### PR TITLE
doc: fix typos in benchmarking.md, tracing.md, and assumeutxo.md

### DIFF
--- a/doc/assumeutxo.md
+++ b/doc/assumeutxo.md
@@ -72,7 +72,7 @@ Example usage:
 $ bitcoin-cli -rpcclienttimeout=0 dumptxoutset /path/to/output rollback
 ```
 
-For most of the duration of `dumptxoutset` running the node is in a temporary
+For most of the duration that `dumptxoutset` is running, the node is in a temporary
 state that does not actually reflect reality, i.e. blocks are marked invalid
 although we know they are not invalid. Because of this it is discouraged to
 interact with the node in any other way during this time to avoid inconsistent

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -2,7 +2,7 @@ Benchmarking
 ============
 
 Bitcoin Core has an internal benchmarking framework, with benchmarks
-for cryptographic algorithms (e.g. SHA1, SHA256, SHA512, RIPEMD160, Poly1305, ChaCha20), rolling bloom filter, coins selection,
+for cryptographic algorithms (e.g. SHA1, SHA256, SHA512, RIPEMD160, Poly1305, ChaCha20), rolling bloom filter, coin selection,
 thread queue, wallet balance.
 
 Running

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -266,7 +266,7 @@ Is called when the second `CreateTransactionInternal` with Avoid Partial Spends 
 Arguments passed:
 1. Wallet name as `pointer to C-style string`
 2. Whether the Avoid Partial Spends solution will be used as `bool`
-3. Whether `CreateTransactionInternal` succeeded as` bool`
+3. Whether `CreateTransactionInternal` succeeded as `bool`
 4. The expected transaction fee as an `int64`
 5. The position of the change output as an `int32`
 


### PR DESCRIPTION
Fix three small but clear errors in documentation:

- `benchmarking.md`: `"coins selection"` → `"coin selection"` (wrong plural)
- `tracing.md`: `"succeeded as` bool`"` → `"succeeded as `bool`"` (missing space breaks backtick formatting)
- `assumeutxo.md`: `"For most of the duration of dumptxoutset running"` → `"For most of the duration that dumptxoutset is running,"` (awkward phrasing, missing comma)