### PR TITLE
crypto: cleanse AEAD Poly1305 key block

### DIFF
--- a/src/crypto/chacha20poly1305.cpp
+++ b/src/crypto/chacha20poly1305.cpp
@@ -46,6 +46,7 @@ void ComputeTag(ChaCha20& chacha20, std::span<const std::byte> aad, std::span<co
 
     // Use the first 32 bytes of the first keystream block as poly1305 key.
     Poly1305 poly1305{std::span{first_block}.first(Poly1305::KEYLEN)};
+    memory_cleanse(first_block, sizeof(first_block));
 
     // Compute tag:
     // - Process the padded AAD with Poly1305.


### PR DESCRIPTION
This cleanses the temporary ChaCha20 block used to derive the one-time Poly1305 key in `AEADChaCha20Poly1305::ComputeTag()`

`Poly1305` copies the first 32 bytes into its own context during construction, so the full temporary block can be wiped before processing AAD and ciphertext. This matches the existing cleanup of the `FSChaCha20Poly1305` rekey block in the same file

No behavior change is expected for callers

Tested:
- `cmake --build build --target test_bitcoin`
- `build/bin/test_bitcoin --run_test=crypto_tests`
- `ctest --test-dir build -R "^(crypto_tests|bip324_tests)$" --output-on-failure`
- `build/bin/test_bitcoin`