### PR TITLE
handle InitData() failures in optimistic compact block reconstruction

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4642,8 +4642,10 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 // able to without any round trips.
                 PartiallyDownloadedBlock tempBlock(&m_mempool);
                 ReadStatus status = tempBlock.InitData(cmpctblock, vExtraTxnForCompact);
-                if (status != READ_STATUS_OK) {
-                    // TODO: don't ignore failures
+                if (status == READ_STATUS_INVALID) {
+                    Misbehaving(peer, "invalid compact block");
+                    return;
+                } else if (status != READ_STATUS_OK) {
                     return;
                 }
                 std::vector<CTransactionRef> dummy;


### PR DESCRIPTION
Summary:
In the optimistic compact block reconstruction path (entered when the block
is already in-flight from a different peer, or this peer has too many blocks
outstanding), `InitData()` failures were silently ignored behind a`// TODO: don't ignore failures\` comment.

This commit resolves the TODO by distinguishing between the two failure
modes, consistent with the handling in the non-optimistic path above
(~L4594) and in `ProcessCompactBlockTxns` (~L3487):

- `READ_STATUS_INVALID`: the compact block is malformed. For example an invalid header or data the peer constructed intentionally). Call `Misbehaving()`
  on the peer. No `RemoveBlockRequest` is needed here because
  `BlockRequested` was never called for this peer in the optimistic path.
- `READ_STATUS_FAILED`: likely a short-id hash collision — not the peer's
  fault. Return silently as before.