### PR TITLE
doc: document ZMQ notification behavior during reorgs and evictions

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -123,12 +123,20 @@ arrives. This means a transaction could be published multiple times: first when 
 mempool and then again in each block that includes it. The body part of the message is the
 serialized transaction.
 
+During a reorg, transactions from disconnected blocks are re-published via this topic.
+When assumeutxo is in use, transactions in historical blocks connected to the background
+validation chainstate are not published.
+
 #### hashtx
 
 Notifies about all transactions, both when they are added to mempool or when a new block
 arrives. This means a transaction could be published multiple times: first when it enters
 mempool and then again in each block that includes it. The body part of the message is the
 32-byte transaction hash in reversed byte order.
+
+During a reorg, transactions from disconnected blocks are re-published via this topic.
+When assumeutxo is in use, transactions in historical blocks connected to the background
+validation chainstate are not published.
 
 #### rawblock
 
@@ -150,6 +158,17 @@ The 8-byte LE uints correspond to _mempool sequence number_ and the types of bod
    - `D` : block with this hash disconnected
    - `R` : transaction with this hash removed from mempool for non-block inclusion reason
    - `A` : transaction with this hash added to mempool
+
+A transaction removal notification (`R`) is sent for all removals **except** block
+inclusion. This covers: expiry (`EXPIRY`), size limit eviction (`SIZELIMIT`),
+reorg eviction (`REORG`), conflict with an in-block transaction (`CONFLICT`), and
+replacement via RBF (`REPLACED`). Transactions removed because they were included
+in a block are not reported here; subscribers can learn about those via the
+`rawblock` or `hashblock` topics.
+
+During a reorg, the sequence of events is: the disconnected block is announced (`D`),
+then any mempool transactions evicted due to the reorg receive an `R` notification,
+then the reconnected block is announced (`C`).
 
 ### Implementing ZMQ client
 

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -123,12 +123,20 @@ arrives. This means a transaction could be published multiple times: first when 
 mempool and then again in each block that includes it. The body part of the message is the
 serialized transaction.
 
+During a reorg, transactions from disconnected blocks are re-published via this topic.
+When assumeutxo is in use, transactions in historical blocks connected to the background
+validation chainstate are not published.
+
 #### hashtx
 
 Notifies about all transactions, both when they are added to mempool or when a new block
 arrives. This means a transaction could be published multiple times: first when it enters
 mempool and then again in each block that includes it. The body part of the message is the
 32-byte transaction hash in reversed byte order.
+
+During a reorg, transactions from disconnected blocks are re-published via this topic.
+When assumeutxo is in use, transactions in historical blocks connected to the background
+validation chainstate are not published.
 
 #### rawblock
 
@@ -150,6 +158,13 @@ The 8-byte LE uints correspond to _mempool sequence number_ and the types of bod
    - `D` : block with this hash disconnected
    - `R` : transaction with this hash removed from mempool for non-block inclusion reason
    - `A` : transaction with this hash added to mempool
+
+A transaction removal notification (`R`) is sent for all removals **except** block
+inclusion. Subscribers can learn about those via the `rawblock` or `hashblock` topics.
+
+During a reorg, the disconnected block is announced (`D`) first, then any mempool
+transactions evicted as a result of the reorg (`R`), and only then the newly connected
+blocks (`C`).
 
 ### Implementing ZMQ client
 

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -6,6 +6,7 @@
 import os
 import struct
 import tempfile
+from decimal import Decimal
 from io import BytesIO
 
 from test_framework.address import (
@@ -125,6 +126,7 @@ class ZMQTest (BitcoinTestFramework):
             else:
                 self.log.info("Skipping ipc test, because UNIX sockets are not supported.")
             self.test_sequence()
+            self.test_reorg_eviction_ordering()
             self.test_mempool_sync()
             self.test_reorg()
             self.test_multiple_interfaces()
@@ -453,6 +455,63 @@ class ZMQTest (BitcoinTestFramework):
         mempool_seq += 1
         self.generatetoaddress(self.nodes[0], 1, ADDRESS_BCRT1_UNSPENDABLE)
         self.sync_all()  # want to make sure we didn't break "consensus" for other tests
+
+    def test_reorg_eviction_ordering(self):
+        """
+        Check the order in which a reorg that evicts a mempool transaction is
+        published on the 'sequence' topic: the disconnected block ('D'), then
+        the eviction ('R'), then the connected blocks ('C').
+
+        BlockDisconnected is emitted inline by DisconnectTip, the reorg
+        eviction by MaybeUpdateMempoolForReorg at the end of
+        ActivateBestChainStep, and the BlockConnected signals are batched and
+        only emitted by ActivateBestChain once the step has returned. All three
+        go through the same serial task runner, so subscribers observe them in
+        that order.
+        """
+        self.log.info("Testing 'sequence' ordering for a reorg that evicts a transaction")
+        [seq] = self.setup_zmq_test([("sequence", f"tcp://127.0.0.1:{self.zmq_port_base}")])
+        self.disconnect_nodes(0, 1)
+
+        # Two conflicting spends of the same utxo. `parent` gets confirmed on
+        # nodes[0]'s chain, `conflict` on the chain nodes[0] will reorg to.
+        utxo = self.wallet.get_utxo()
+        parent = self.wallet.create_self_transfer(utxo_to_spend=utxo)
+        conflict = self.wallet.create_self_transfer(utxo_to_spend=utxo, fee_rate=Decimal("0.006"))
+
+        # nodes[0]: confirm `parent`, then leave a child of it in the mempool.
+        self.nodes[0].sendrawtransaction(parent["hex"])
+        dc_block = self.generatetoaddress(self.nodes[0], 1, ADDRESS_BCRT1_UNSPENDABLE, sync_fun=self.no_op)[0]
+        child_txid = self.wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=parent["new_utxo"])["txid"]
+
+        # nodes[1]: build a longer chain confirming `conflict` instead. After the
+        # reorg `parent` can no longer re-enter nodes[0]'s mempool, so its
+        # in-mempool child is evicted with MemPoolRemovalReason::REORG.
+        self.nodes[1].sendrawtransaction(conflict["hex"])
+        connect_blocks = self.generatetoaddress(self.nodes[1], 2, ADDRESS_BCRT1_P2WSH_OP_TRUE, sync_fun=self.no_op)
+
+        self.connect_nodes(0, 1)
+        self.sync_blocks()
+        assert child_txid not in self.nodes[0].getrawmempool()
+
+        # Skip the notifications published before the reorg, then record it.
+        (hash_str, label, _) = seq.receive_sequence()
+        while (hash_str, label) != (dc_block, "D"):
+            (hash_str, label, _) = seq.receive_sequence()
+        observed = [(dc_block, "D")]
+        while len(observed) < 4:
+            (hash_str, label, _) = seq.receive_sequence()
+            observed.append((hash_str, label))
+
+        assert_equal(observed, [
+            (dc_block, "D"),
+            (child_txid, "R"),
+            (connect_blocks[0], "C"),
+            (connect_blocks[1], "C"),
+        ])
+
+        # `parent` and its child are gone for good; resync the wallet's utxo set.
+        self.wallet.rescan_utxos()
 
     def test_mempool_sync(self):
         """


### PR DESCRIPTION
Partially addresses #14278.

Expands `doc/zmq.md` to document notification behavior that is implemented
in the source but not described anywhere in the docs:

**`rawtx` / `hashtx`**
- These topics re-publish transactions from disconnected blocks during a reorg
- They are suppressed for historical blocks connected to the assumeutxo
  background validation chainstate (consistent with `rawblock`/`hashblock`)

**`sequence` (`R` removals)**
- Clarify that `R` covers *all* mempool removal reasons except block inclusion:
  `EXPIRY`, `SIZELIMIT`, `REORG`, `CONFLICT`, `REPLACED` (RBF)
- Explicitly note that block-inclusion removals are not reported via `R`;
  subscribers should use `rawblock`/`hashblock` for those

**Reorg ordering**
- Document the sequence of events during a reorg:
  `D` (block disconnected) → `R` (evicted mempool txs) → `C` (block connected)

All behavior described here is derived directly from
`src/zmq/zmqnotificationinterface.cpp` and `src/txmempool.cpp`.