### PR TITLE
fuzz: fix dead HD keypaths (de)serialization round-trip

### DIFF
--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -67,7 +67,7 @@ FUZZ_TARGET(script_sign, .init = initialize_script_sign)
         }
         std::map<CPubKey, KeyOriginInfo> deserialized_hd_keypaths;
         try {
-            DeserializeHDKeypaths(serialized, key, hd_keypaths);
+            DeserializeHDKeypaths(serialized, key, deserialized_hd_keypaths);
         } catch (const std::ios_base::failure&) {
         }
         assert(hd_keypaths.size() >= deserialized_hd_keypaths.size());


### PR DESCRIPTION
`DeserializeHDKeypaths()` was writing into the original `hd_keypaths` map instead of `deserialized_hd_keypaths`. As a result the latter was always empty and the round-trip assertion following was trivially true, so the serialize/deserialize round-trip wasn't actually being exercised.

That bug was introduced with the commit introducing the fuzz target (commit f898ef65c947776750e49d050633f830546bbdc6, #18994).