### PR TITLE
scripted-diff: Rename UNIQUE_NAME to BITCOIN_UNIQUE_NAME

### DIFF
--- a/src/logging/timer.h
+++ b/src/logging/timer.h
@@ -99,13 +99,13 @@ private:
 
 
 #define LOG_TIME_MICROS_WITH_CATEGORY(end_msg, log_category) \
-    BCLog::Timer<std::chrono::microseconds> UNIQUE_NAME(logging_timer)(__func__, end_msg, log_category)
+    BCLog::Timer<std::chrono::microseconds> BITCOIN_UNIQUE_NAME(logging_timer)(__func__, end_msg, log_category)
 #define LOG_TIME_MILLIS_WITH_CATEGORY(end_msg, log_category) \
-    BCLog::Timer<std::chrono::milliseconds> UNIQUE_NAME(logging_timer)(__func__, end_msg, log_category)
+    BCLog::Timer<std::chrono::milliseconds> BITCOIN_UNIQUE_NAME(logging_timer)(__func__, end_msg, log_category)
 #define LOG_TIME_MILLIS_WITH_CATEGORY_MSG_ONCE(end_msg, log_category) \
-    BCLog::Timer<std::chrono::milliseconds> UNIQUE_NAME(logging_timer)(__func__, end_msg, log_category, /* msg_on_completion=*/false)
+    BCLog::Timer<std::chrono::milliseconds> BITCOIN_UNIQUE_NAME(logging_timer)(__func__, end_msg, log_category, /* msg_on_completion=*/false)
 #define LOG_TIME_SECONDS(end_msg) \
-    BCLog::Timer<std::chrono::seconds> UNIQUE_NAME(logging_timer)(__func__, end_msg)
+    BCLog::Timer<std::chrono::seconds> BITCOIN_UNIQUE_NAME(logging_timer)(__func__, end_msg)
 
 
 #endif // BITCOIN_LOGGING_TIMER_H

--- a/src/sync.h
+++ b/src/sync.h
@@ -251,7 +251,7 @@ public:
 // it is not possible to use the lock's copy of the mutex for that purpose.
 // Instead, the original mutex needs to be passed back to the reverse_lock for
 // the sake of thread-safety analysis, but it is not actually used otherwise.
-#define REVERSE_LOCK(g, cs) typename std::decay<decltype(g)>::type::reverse_lock UNIQUE_NAME(revlock)(g, cs, #cs, __FILE__, __LINE__)
+#define REVERSE_LOCK(g, cs) typename std::decay<decltype(g)>::type::reverse_lock BITCOIN_UNIQUE_NAME(revlock)(g, cs, #cs, __FILE__, __LINE__)
 
 // When locking a Mutex, require negative capability to ensure the lock
 // is not already held
@@ -265,7 +265,7 @@ inline MutexType& MaybeCheckNotHeld(MutexType& m) LOCKS_EXCLUDED(m) LOCK_RETURNE
 template <typename MutexType>
 inline MutexType* MaybeCheckNotHeld(MutexType* m) LOCKS_EXCLUDED(m) LOCK_RETURNED(m) { return m; }
 
-#define LOCK(cs) UniqueLock UNIQUE_NAME(criticalblock)(MaybeCheckNotHeld(cs), #cs, __FILE__, __LINE__)
+#define LOCK(cs) UniqueLock BITCOIN_UNIQUE_NAME(criticalblock)(MaybeCheckNotHeld(cs), #cs, __FILE__, __LINE__)
 #define LOCK2(cs1, cs2)                                               \
     UniqueLock criticalblock1(MaybeCheckNotHeld(cs1), #cs1, __FILE__, __LINE__); \
     UniqueLock criticalblock2(MaybeCheckNotHeld(cs2), #cs2, __FILE__, __LINE__)

--- a/src/test/util/logging.h
+++ b/src/test/util/logging.h
@@ -39,6 +39,6 @@ private:
     MatchFn m_match;
 };
 
-#define ASSERT_DEBUG_LOG(message) DebugLogHelper UNIQUE_NAME(debugloghelper)(message)
+#define ASSERT_DEBUG_LOG(message) DebugLogHelper BITCOIN_UNIQUE_NAME(debugloghelper)(message)
 
 #endif // BITCOIN_TEST_UTIL_LOGGING_H

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -8,7 +8,7 @@
 #define PASTE(x, y) x ## y
 #define PASTE2(x, y) PASTE(x, y)
 
-#define UNIQUE_NAME(name) PASTE2(name, __COUNTER__)
+#define BITCOIN_UNIQUE_NAME(name) PASTE2(name, __COUNTER__)
 
 /**
  * Converts the parameter X to a string after macro replacement on X has been performed.

--- a/src/util/stdmutex.h
+++ b/src/util/stdmutex.h
@@ -38,6 +38,6 @@ public:
 };
 
 // Provide STDLOCK(..) wrapper around StdMutex::Guard that checks the lock is not already held
-#define STDLOCK(cs) StdMutex::Guard UNIQUE_NAME(criticalblock){StdMutex::CheckNotHeld(cs)}
+#define STDLOCK(cs) StdMutex::Guard BITCOIN_UNIQUE_NAME(criticalblock){StdMutex::CheckNotHeld(cs)}
 
 #endif // BITCOIN_UTIL_STDMUTEX_H


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/34454#issuecomment-3822800049:
> ... it is annoying that we keep running into the same bug over and over again (IIRC it happened in the past at least once for Bitcoin Core). Surely this is going to happen again in the future.

And here we go again.

---

The `nb30.h` Windows header [defines](https://github.com/mingw-w64/mingw-w64/blob/b536c4fdb038a9c59a7e5fb36e7d1293c4dc61d6/mingw-w64-headers/include/nb30.h#L78) `UNIQUE_NAME` as a macro.

This introduces a fragile dependency on header inclusion order: if Windows headers happen to be included before `UNIQUE_NAME` is used, the preprocessor expands it into a numeric literal, causing syntax errors.

Rename the macro to `BITCOIN_UNIQUE_NAME` to remove this fragility and avoid the collision entirely.

---

Noticed while doing a Guix build of the [QML repo](https://github.com/bitcoin-core/gui-qml) for Windows.

Recent similar PRs: https://github.com/bitcoin/bitcoin/pull/34454 and https://github.com/bitcoin/bitcoin/pull/34868.