### PR TITLE
test: cover unused mempool space in coins cache limit

### DIFF
--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -18,33 +18,33 @@ BOOST_FIXTURE_TEST_SUITE(validation_flush_tests, TestingSetup)
 //! then with additional mempool head-room.
 BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 {
+    constexpr uint64_t MAX_COINS_BYTES{8_MiB};
+    constexpr uint64_t MAX_MEMPOOL_BYTES{4_MiB};
+    constexpr uint64_t MAX_ATTEMPTS{50'000};
     Chainstate& chainstate{m_node.chainman->ActiveChainstate()};
 
     LOCK(::cs_main);
+    BOOST_REQUIRE(chainstate.ResizeCoinsCaches(MAX_COINS_BYTES, /*coinsdb_size=*/1_MiB));
     CCoinsViewCache& view{chainstate.CoinsTip()};
 
     // Sanity: an empty cache should be ≲ 1 chunk (~ 256 KiB).
     BOOST_CHECK_LT(view.DynamicMemoryUsage() / (256 * 1024.0), 1.1);
 
-    constexpr size_t MAX_COINS_BYTES{8_MiB};
-    constexpr size_t MAX_MEMPOOL_BYTES{4_MiB};
-    constexpr size_t MAX_ATTEMPTS{50'000};
-
     // Run the same growth-path twice: first with 0 head-room, then with extra head-room
-    for (size_t max_mempool_size_bytes : {size_t{0}, MAX_MEMPOOL_BYTES}) {
+    for (uint64_t max_mempool_size_bytes : {uint64_t{0}, MAX_MEMPOOL_BYTES}) {
         const int64_t full_cap{int64_t(MAX_COINS_BYTES + max_mempool_size_bytes)};
         const int64_t large_cap{LargeCoinsCacheThreshold(full_cap)};
 
         // OK → LARGE
         auto state{chainstate.GetCoinsCacheSizeState(MAX_COINS_BYTES, max_mempool_size_bytes)};
-        for (size_t i{0}; i < MAX_ATTEMPTS && int64_t(view.DynamicMemoryUsage()) <= large_cap; ++i) {
+        for (uint64_t i{0}; i < MAX_ATTEMPTS && int64_t(view.DynamicMemoryUsage()) <= large_cap; ++i) {
             BOOST_CHECK_EQUAL(state, CoinsCacheSizeState::OK);
             AddTestCoin(m_rng, view);
             state = chainstate.GetCoinsCacheSizeState(MAX_COINS_BYTES, max_mempool_size_bytes);
         }
 
         // LARGE → CRITICAL
-        for (size_t i{0}; i < MAX_ATTEMPTS && int64_t(view.DynamicMemoryUsage()) <= full_cap; ++i) {
+        for (uint64_t i{0}; i < MAX_ATTEMPTS && int64_t(view.DynamicMemoryUsage()) <= full_cap; ++i) {
             BOOST_CHECK_EQUAL(state, CoinsCacheSizeState::LARGE);
             AddTestCoin(m_rng, view);
             state = chainstate.GetCoinsCacheSizeState(MAX_COINS_BYTES, max_mempool_size_bytes);
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         BOOST_CHECK_EQUAL(state, CoinsCacheSizeState::CRITICAL);
     }
 
-    // Default thresholds (no explicit limits) permit many more coins.
+    // Unused mempool space permits many more coins.
     for (int i{0}; i < 1'000; ++i) {
         AddTestCoin(m_rng, view);
         BOOST_CHECK_EQUAL(chainstate.GetCoinsCacheSizeState(), CoinsCacheSizeState::OK);
@@ -60,6 +60,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 
     // CRITICAL → OK via Flush
     BOOST_CHECK_EQUAL(chainstate.GetCoinsCacheSizeState(MAX_COINS_BYTES, /*max_mempool_size_bytes=*/0), CoinsCacheSizeState::CRITICAL);
+    BOOST_CHECK_EQUAL(chainstate.GetCoinsCacheSizeState(), CoinsCacheSizeState::OK);
     view.SetBestBlock(m_rng.rand256());
     view.Flush();
     BOOST_CHECK_EQUAL(chainstate.GetCoinsCacheSizeState(MAX_COINS_BYTES, /*max_mempool_size_bytes=*/0), CoinsCacheSizeState::OK);


### PR DESCRIPTION
This PR extends the existing unit test for `Chainstate::GetCoinsCacheSizeState()`.

`Chainstate::GetCoinsCacheSizeState()` calculates when the UTXO/coins cache is too large and should be flushed. Part of that calculation includes unused `-maxmempool` space. For example, if the mempool limit is 300 MiB but the mempool is mostly empty, some of that unused space can be counted toward the coins cache limit.

The existing `validation_flush_tests.cpp` test checks this calculation by calling:

```c++
chainstate.GetCoinsCacheSizeState(MAX_COINS_BYTES, max_mempool_size_bytes)
```

This change extends the test to also check the no-argument call:

```c++
chainstate.GetCoinsCacheSizeState()
```

That is the call used by validation code during normal operation.

The test grows the coins cache above the coins-only limit, then checks that:
- calling the explicit helper with `max_mempool_size_bytes=0` reports `CRITICAL`
- calling the normal no-argument method reports `OK`, because it includes unused mempool space

This makes sure future refactors do not accidentally drop unused mempool space from the normal cache-size calculation.