### PR TITLE
wallet: fail dump on incomplete writes

### DIFF
--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -5,7 +5,9 @@
 #include <wallet/dump.h>
 
 #include <common/args.h>
+#include <streams.h>
 #include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/translation.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
@@ -36,9 +38,8 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
         error = strprintf(_("File %s already exists. If you are sure this is what you want, move it out of the way first."), fs::PathToString(path));
         return false;
     }
-    std::ofstream dump_file;
-    dump_file.open(path.std_path());
-    if (dump_file.fail()) {
+    AutoFile dump_file{fsbridge::fopen(path, "w")};
+    if (dump_file.IsNull()) {
         error = strprintf(_("Unable to open %s for writing"), fs::PathToString(path));
         return false;
     }
@@ -57,8 +58,9 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
         throw_error(strprintf(_("Unable to write complete dump file %s."), fs::PathToString(path)));
     };
     auto write = [&](const std::string& line) {
-        dump_file.write(line.data(), line.size());
-        if (dump_file.fail()) {
+        try {
+            dump_file.write(MakeByteSpan(line));
+        } catch (const std::ios_base::failure&) {
             throw_write_error();
         }
     };
@@ -106,12 +108,13 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
         // Write the hash
         line = strprintf("checksum,%s\n", HexStr(hasher.GetHash()));
         write(line);
-        dump_file.close();
-        if (dump_file.fail()) throw_write_error();
+        if (!dump_file.Commit()) throw_write_error();
+        if (dump_file.fclose() != 0) throw_write_error();
+        DirectoryCommit(path.parent_path());
     } catch (const DumpWalletError& e) {
         error = e.message;
         // Remove the dumpfile on failure
-        dump_file.close();
+        (void)dump_file.fclose();
         fs::remove(path);
         return false;
     }

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -47,30 +47,45 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
 
     std::unique_ptr<DatabaseBatch> batch = db.MakeBatch();
 
-    bool ret = true;
-    std::unique_ptr<DatabaseCursor> cursor = batch->GetNewCursor();
-    if (!cursor) {
-        error = _("Error: Couldn't create cursor into database");
-        ret = false;
-    }
+    struct DumpWalletError {
+        bilingual_str message;
+    };
+    auto throw_error = [](bilingual_str message) {
+        throw DumpWalletError{std::move(message)};
+    };
+    auto throw_write_error = [&] {
+        throw_error(strprintf(_("Unable to write complete dump file %s."), fs::PathToString(path)));
+    };
+    auto write = [&](const std::string& line) {
+        dump_file.write(line.data(), line.size());
+        if (dump_file.fail()) {
+            throw_write_error();
+        }
+    };
+    auto write_record = [&](const std::string& line) {
+        write(line);
+        hasher << std::span{line};
+    };
 
-    // Write out a magic string with version
-    std::string line = strprintf("%s,%u\n", DUMP_MAGIC, DUMP_VERSION);
-    dump_file.write(line.data(), line.size());
-    hasher << std::span{line};
+    try {
+        std::unique_ptr<DatabaseCursor> cursor = batch->GetNewCursor();
+        if (!cursor) {
+            throw_error(_("Error: Couldn't create cursor into database"));
+        }
 
-    // Write out the file format
-    std::string format = db.Format();
-    // BDB files that are opened using BerkeleyRODatabase have its format as "bdb_ro"
-    // We want to override that format back to "bdb"
-    if (format == "bdb_ro") {
-        format = "bdb";
-    }
-    line = strprintf("%s,%s\n", "format", format);
-    dump_file.write(line.data(), line.size());
-    hasher << std::span{line};
+        // Write out a magic string with version
+        std::string line = strprintf("%s,%u\n", DUMP_MAGIC, DUMP_VERSION);
+        write_record(line);
 
-    if (ret) {
+        // Write out the file format
+        std::string format = db.Format();
+        // BDB files that are opened using BerkeleyRODatabase have its format as "bdb_ro"
+        // We want to override that format back to "bdb"
+        if (format == "bdb_ro") {
+            format = "bdb";
+        }
+        line = strprintf("%s,%s\n", "format", format);
+        write_record(line);
 
         // Read the records
         while (true) {
@@ -78,35 +93,30 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
             DataStream ss_value{};
             DatabaseCursor::Status status = cursor->Next(ss_key, ss_value);
             if (status == DatabaseCursor::Status::DONE) {
-                ret = true;
                 break;
             } else if (status == DatabaseCursor::Status::FAIL) {
-                error = _("Error reading next record from wallet database");
-                ret = false;
-                break;
+                throw_error(_("Error reading next record from wallet database"));
             }
             std::string key_str = HexStr(ss_key);
             std::string value_str = HexStr(ss_value);
             line = strprintf("%s,%s\n", key_str, value_str);
-            dump_file.write(line.data(), line.size());
-            hasher << std::span{line};
+            write_record(line);
         }
-    }
 
-    cursor.reset();
-    batch.reset();
-
-    if (ret) {
         // Write the hash
-        tfm::format(dump_file, "checksum,%s\n", HexStr(hasher.GetHash()));
+        line = strprintf("checksum,%s\n", HexStr(hasher.GetHash()));
+        write(line);
         dump_file.close();
-    } else {
+        if (dump_file.fail()) throw_write_error();
+    } catch (const DumpWalletError& e) {
+        error = e.message;
         // Remove the dumpfile on failure
         dump_file.close();
         fs::remove(path);
+        return false;
     }
 
-    return ret;
+    return true;
 }
 
 // The standard wallet deleter function blocks on the validation interface

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -29,10 +29,10 @@ class ToolWalletTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
         self.skip_if_no_wallet_tool()
 
-    def bitcoin_wallet_process(self, *args):
+    def bitcoin_wallet_process(self, *args, **kwargs):
         default_args = ['-datadir={}'.format(self.nodes[0].datadir_path), '-chain=%s' % self.chain]
 
-        return subprocess.Popen(self.get_binaries().wallet_argv() + default_args + list(args), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        return subprocess.Popen(self.get_binaries().wallet_argv() + default_args + list(args), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, **kwargs)
 
     def assert_raises_tool_error(self, error, *args):
         p = self.bitcoin_wallet_process(*args)
@@ -268,6 +268,23 @@ class ToolWalletTest(BitcoinTestFramework):
 
         self.log.info('Checking that a dumpfile cannot be overwritten')
         self.assert_raises_tool_error('File {} already exists. If you are sure this is what you want, move it out of the way first.'.format(wallet_dump),  '-wallet=todump2', '-dumpfile={}'.format(wallet_dump), 'dump')
+
+        if os.name == 'posix':
+            self.log.info('Checking that incomplete dumps fail and are removed')
+
+            def limit_dump_size():
+                import resource
+                import signal
+                signal.signal(signal.SIGXFSZ, signal.SIG_IGN)
+                resource.setrlimit(resource.RLIMIT_FSIZE, (512, 512))
+
+            limited_dump = self.nodes[0].datadir_path / "wallet-limited.dump"
+            p = self.bitcoin_wallet_process('-wallet=todump', '-dumpfile={}'.format(limited_dump), 'dump', preexec_fn=limit_dump_size)
+            stdout, stderr = p.communicate()
+            assert_equal(stdout, '')
+            assert_equal(p.poll(), 1)
+            assert "Unable to write complete dump file {}.".format(limited_dump) in stderr.strip()
+            assert not limited_dump.exists()
 
         self.log.info('Checking createfromdump arguments')
         self.assert_raises_tool_error('No dump file provided. To use createfromdump, -dumpfile=<filename> must be provided.', '-wallet=todump', 'createfromdump')


### PR DESCRIPTION
<!--
Pull requests without a rationale and clear improvement may be closed immediately.
-->

This makes `bitcoin-wallet dump` fail if writing the dump file does not complete successfully.

Previously, `DumpWallet()` only checked whether the dump file could be opened. If later writes or close failed, the tool could still return success and print the private-key warning, leaving a truncated dump file behind.

The change adds write/close checks while dumping wallet records. If writing fails, the partial dump file is removed and `bitcoin-wallet` returns an error.

The functional test now covers a forced incomplete dump on POSIX systems by limiting the dump process file size. It checks that:

- stdout stays empty;
- the command exits with failure;
- the write error is reported;
- the partial dump file is removed.

Tested with:

```bash
cmake -S /tmp/bitcoin-core-wallet-dump-pr -B /tmp/bitcoin-core-wallet-dump-pr-build -DBUILD_TESTS=OFF -DBUILD_BENCH=OFF -DBUILD_GUI=OFF -DENABLE_WALLET=ON -DBUILD_WALLET_TOOL=ON -DENABLE_IPC=OFF -DWITH_ZMQ=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build /tmp/bitcoin-core-wallet-dump-pr-build --target bitcoind bitcoin-wallet -j"$(sysctl -n hw.ncpu)"
python3 test/functional/tool_wallet.py --configfile=/tmp/bitcoin-core-wallet-dump-pr-build/test/config.ini
```
