### PR TITLE
test: FakeNodeClock follow-ups in unit tests

### DIFF
--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -38,10 +38,9 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
     CPubKey pubkey{"02ed26169896db86ced4cbb7b3ecef9859b5952825adbeab998fb5b307e54949c9"_hex_u8};
     CScript script = GetScriptForDestination(WitnessV0KeyHash(pubkey));
     std::vector<CMutableTransaction> noTxns;
-    FakeNodeClock clock{};
     for (int i = 0; i < CHAIN_SIZE - 100; i++) {
         test_setup->CreateAndProcessBlock(noTxns, script);
-        clock += 1s;
+        test_setup->m_clock += 1s;
     }
     assert(WITH_LOCK(::cs_main, return test_setup->m_node.chainman->ActiveHeight() == CHAIN_SIZE));
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -21,11 +21,11 @@
 #include <test/util/blockfilter.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <tinyformat.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/fs.h>
-#include <util/time.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -332,14 +332,15 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
 class IndexReorgCrash : public BaseIndex
 {
 private:
+    FakeNodeClock& m_clock;
     std::unique_ptr<BaseIndex::DB> m_db;
     std::shared_future<void> m_blocker;
     int m_blocking_height;
 
 public:
     explicit IndexReorgCrash(std::unique_ptr<interfaces::Chain> chain, std::shared_future<void> blocker,
-                             int blocking_height) : BaseIndex(std::move(chain), "test index"), m_blocker(blocker),
-                                                    m_blocking_height(blocking_height)
+                             int blocking_height, FakeNodeClock& clock)
+        : BaseIndex(std::move(chain), "test index"), m_clock(clock), m_blocker(blocker), m_blocking_height(blocking_height)
     {
         const fs::path path = gArgs.GetDataDirNet() / "index";
         fs::create_directories(path);
@@ -356,7 +357,7 @@ public:
 
         // Move mock time forward so the best index gets updated only when we are not at the blocking height
         if (block.height == m_blocking_height - 1 || block.height > m_blocking_height) {
-            SetMockTime(GetTime<std::chrono::seconds>() + 31s);
+            m_clock += 31s;
         }
 
         return true;
@@ -365,14 +366,11 @@ public:
 
 BOOST_FIXTURE_TEST_CASE(index_reorg_crash, BuildChainTestingSetup)
 {
-    // Enable mock time
-    SetMockTime(GetTime<std::chrono::minutes>());
-
     std::promise<void> promise;
     std::shared_future<void> blocker(promise.get_future());
     int blocking_height = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip()->nHeight);
 
-    IndexReorgCrash index(interfaces::MakeChain(m_node), blocker, blocking_height);
+    IndexReorgCrash index{interfaces::MakeChain(m_node), blocker, blocking_height, m_clock};
     BOOST_REQUIRE(index.Init());
     BOOST_REQUIRE(index.StartBackgroundSync());
 

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -70,7 +70,6 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
 
     auto& chainstate{Assert(m_node.chainman)->ActiveChainstate()};
     BlockValidationState state_dummy{};
-    FakeNodeClock clock{};
 
     // Pop two blocks from the tip
     const CBlockIndex* tip{chainstate.m_chain.Tip()};
@@ -89,7 +88,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     // The periodic flush interval is between 50 and 70 minutes (inclusive)
     // The next call to a PERIODIC write will flush
-    clock += DATABASE_WRITE_INTERVAL_MAX;
+    m_clock += DATABASE_WRITE_INTERVAL_MAX;
 
     const auto sub{std::make_shared<TestSubscriber>()};
     m_node.validation_signals->RegisterSharedValidationInterface(sub);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -26,13 +26,13 @@
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
+#include <test/util/time.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/feefrac.h>
 #include <util/strencodings.h>
-#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <versionbits.h>
@@ -342,6 +342,8 @@ std::vector<CTransactionRef> CreateBigSigOpsCluster(const CTransactionRef& first
 
 void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst, int baseheight)
 {
+    FakeNodeClock clock{};
+
     Txid hash;
     CMutableTransaction tx;
     TestMemPoolEntryHelper entry;
@@ -565,7 +567,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
     LOCK(tx_mempool.cs);
 
     // non-final txs in mempool
-    SetMockTime(m_node.chainman->ActiveChain().Tip()->GetMedianTimePast() + 1);
+    clock.set(std::chrono::seconds{m_node.chainman->ActiveChain().Tip()->GetMedianTimePast() + 1});
     const int flags{LOCKTIME_VERIFY_SEQUENCE};
     // height map
     std::vector<int> prevheights;
@@ -670,7 +672,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
         ancestor->nTime += SEQUENCE_LOCK_TIME; // Trick the MedianTimePast
     }
     m_node.chainman->ActiveChain().Tip()->nHeight++;
-    SetMockTime(m_node.chainman->ActiveChain().Tip()->GetMedianTimePast() + 1);
+    clock.set(std::chrono::seconds{m_node.chainman->ActiveChain().Tip()->GetMedianTimePast() + 1});
 
     block_template = mining->createNewBlock(options, /*cooldown=*/false);
     BOOST_REQUIRE(block_template);
@@ -896,12 +898,10 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     TestBasicMining(scriptPubKey, txFirst, baseheight);
 
     m_node.chainman->ActiveChain().Tip()->nHeight--;
-    SetMockTime(0);
 
     TestPackageSelection(scriptPubKey, txFirst);
 
     m_node.chainman->ActiveChain().Tip()->nHeight--;
-    SetMockTime(0);
 
     TestPrioritisedMining(scriptPubKey, txFirst);
 }

--- a/src/test/pcp_tests.cpp
+++ b/src/test/pcp_tests.cpp
@@ -92,7 +92,6 @@ public:
           m_local_ip(local_ip),
           m_gateway_ip(gateway_ip)
     {
-        ElapseTime(std::chrono::seconds(0)); // start mocking steady time
         PrepareOp();
     }
 
@@ -193,10 +192,10 @@ public:
     {
         // Only handles receive events.
         if (AtEndOfScript() || requested != Sock::RECV) {
-            ElapseTime(timeout);
+            m_clock += timeout;
         } else {
             std::chrono::milliseconds delay = std::min(m_time_left, timeout);
-            ElapseTime(delay);
+            m_clock += delay;
             m_time_left -= delay;
             if (CurOp().op == TestOp::RECV && m_time_left == 0s && occurred != nullptr) {
                 *occurred = Sock::RECV;
@@ -223,17 +222,11 @@ private:
     const std::vector<TestOp> m_script;
     mutable size_t m_script_ptr = 0;
     mutable std::chrono::milliseconds m_time_left;
-    mutable std::chrono::milliseconds m_time{MockableSteadyClock::INITIAL_MOCK_TIME};
+    mutable SteadyClockContext m_clock{};
     mutable bool m_connected{false};
     mutable CService m_bound;
     mutable CNetAddr m_local_ip;
     mutable CNetAddr m_gateway_ip;
-
-    void ElapseTime(std::chrono::milliseconds duration) const
-    {
-        m_time += duration;
-        MockableSteadyClock::SetMockTime(m_time);
-    }
 
     bool AtEndOfScript() const { return m_script_ptr == m_script.size(); }
     const TestOp &CurOp() const {

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -12,8 +12,8 @@
 #include <protocol.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <util/check.h>
-#include <util/time.h>
 #include <validation.h>
 #include <validationinterface.h>
 
@@ -27,17 +27,17 @@ BOOST_FIXTURE_TEST_SUITE(peerman_tests, RegTestingSetup)
 /** Window, in blocks, for connecting to NODE_NETWORK_LIMITED peers */
 static constexpr int64_t NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS = 144;
 
-static void mineBlock(node::NodeContext& node, std::chrono::seconds block_time)
+static void mineBlock(node::NodeContext& node, FakeNodeClock& clock, std::chrono::seconds block_time)
 {
     auto curr_time = GetTime<std::chrono::seconds>();
-    SetMockTime(block_time); // update time so the block is created with it
+    clock.set(block_time); // update time so the block is created with it
     auto mining{interfaces::MakeMining(node)};
     auto block_template{mining->createNewBlock({}, /*cooldown=*/false)};
     BOOST_REQUIRE(block_template);
     CBlock block{block_template->getBlock()};
     while (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
     block.fChecked = true; // little speedup
-    SetMockTime(curr_time); // process block at current time
+    clock.set(curr_time); // process block at current time
     Assert(node.chainman->ProcessNewBlock(std::make_shared<const CBlock>(block), /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
     node.validation_signals->SyncWithValidationInterfaceQueue(); // drain events queue
 }
@@ -45,6 +45,7 @@ static void mineBlock(node::NodeContext& node, std::chrono::seconds block_time)
 // Verifying when network-limited peer connections are desirable based on the node's proximity to the tip
 BOOST_AUTO_TEST_CASE(connections_desirable_service_flags)
 {
+    FakeNodeClock clock{};
     std::unique_ptr<PeerManager> peerman = PeerManager::make(*m_node.connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
     auto consensus = m_node.chainman->GetParams().GetConsensus();
 
@@ -58,15 +59,15 @@ BOOST_AUTO_TEST_CASE(connections_desirable_service_flags)
     int tip_block_height = tip->nHeight;
     peerman->SetBestBlock(tip_block_height, std::chrono::seconds{tip_block_time});
 
-    SetMockTime(tip_block_time + 1); // Set node time to tip time
+    clock.set(std::chrono::seconds{tip_block_time + 1}); // Set node time to tip time
     BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK_LIMITED | NODE_WITNESS));
 
     // Check we don't disallow limited peers connections when we are behind but still recoverable (below the connection safety window)
-    SetMockTime(GetTime<std::chrono::seconds>() + std::chrono::seconds{consensus.nPowTargetSpacing * (NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS - 1)});
+    clock += std::chrono::seconds{consensus.nPowTargetSpacing * (NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS - 1)};
     BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK_LIMITED | NODE_WITNESS));
 
     // Check we disallow limited peers connections when we are further than the limited peers safety window
-    SetMockTime(GetTime<std::chrono::seconds>() + std::chrono::seconds{consensus.nPowTargetSpacing * 2});
+    clock += std::chrono::seconds{consensus.nPowTargetSpacing * 2};
     BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK | NODE_WITNESS));
 
     // By now, we tested that the connections desirable services flags change based on the node's time proximity to the tip.
@@ -75,15 +76,15 @@ BOOST_AUTO_TEST_CASE(connections_desirable_service_flags)
 
     // First, verify a block in the past doesn't enable limited peers connections
     // At this point, our time is (NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS + 1) * 10 minutes ahead the tip's time.
-    mineBlock(m_node, /*block_time=*/std::chrono::seconds{tip_block_time + 1});
+    mineBlock(m_node, clock, /*block_time=*/std::chrono::seconds{tip_block_time + 1});
     BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK | NODE_WITNESS));
 
     // Verify a block close to the tip enables limited peers connections
-    mineBlock(m_node, /*block_time=*/GetTime<std::chrono::seconds>());
+    mineBlock(m_node, clock, /*block_time=*/GetTime<std::chrono::seconds>());
     BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK_LIMITED | NODE_WITNESS));
 
     // Lastly, verify the stale tip checks can disallow limited peers connections after not receiving blocks for a prolonged period.
-    SetMockTime(GetTime<std::chrono::seconds>() + std::chrono::seconds{consensus.nPowTargetSpacing * NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS + 1});
+    clock += std::chrono::seconds{consensus.nPowTargetSpacing * NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS + 1};
     BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK | NODE_WITNESS));
 }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -416,7 +416,6 @@ TestChain100Setup::TestChain100Setup(
     TestOpts opts)
     : TestingSetup{ChainType::REGTEST, opts}
 {
-    SetMockTime(1598887952);
     constexpr std::array<unsigned char, 32> vchKey = {
         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}};
     coinbaseKey.Set(vchKey.begin(), vchKey.end(), true);
@@ -438,7 +437,7 @@ void TestChain100Setup::mineBlocks(int num_blocks)
     for (int i = 0; i < num_blocks; i++) {
         std::vector<CMutableTransaction> noTxns;
         CBlock b = CreateAndProcessBlock(noTxns, scriptPubKey);
-        SetMockTime(GetTime() + 1);
+        m_clock += 1s;
         m_coinbase_txns.push_back(b.vtx[0]);
     }
 }

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -14,6 +14,7 @@
 #include <primitives/transaction.h>
 #include <random.h>
 #include <test/util/random.h>
+#include <test/util/time.h>
 #include <util/chaintype.h> // IWYU pragma: export
 #include <util/fs.h>
 #include <util/signalinterrupt.h>
@@ -226,6 +227,7 @@ struct TestChain100Setup : public TestingSetup {
      */
     std::vector<CTransactionRef> PopulateMempool(FastRandomContext& det_rand, size_t num_transactions, bool submit);
 
+    FakeNodeClock m_clock{std::chrono::seconds{1598887952}};
     std::vector<CTransactionRef> m_coinbase_txns; // For convenience, coinbase transactions
     CKey coinbaseKey; // private/public key needed to spend coinbase transactions
 };

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -246,12 +246,12 @@ BOOST_FIXTURE_TEST_CASE(write_wallet_settings_concurrently, TestingSetup)
                             /*num_expected_wallets=*/0);
 }
 
-static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64_t blockTime)
+static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lockTime, std::chrono::seconds mock_time, int64_t blockTime)
 {
     CMutableTransaction tx;
     TxState state = TxStateInactive{};
     tx.nLockTime = lockTime;
-    SetMockTime(mockTime);
+    FakeNodeClock clock{mock_time};
     CBlockIndex* block = nullptr;
     if (blockTime > 0) {
         LOCK(cs_main);
@@ -277,24 +277,24 @@ static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lock
 BOOST_AUTO_TEST_CASE(ComputeTimeSmart)
 {
     // New transaction should use clock time if lower than block time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 1, 100, 120), 100);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 1, 100s, 120), 100);
 
     // Test that updating existing transaction does not change smart time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 1, 200, 220), 100);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 1, 200s, 220), 100);
 
     // New transaction should use clock time if there's no block time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 2, 300, 0), 300);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 2, 300s, 0), 300);
 
     // New transaction should use block time if lower than clock time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 3, 420, 400), 400);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 3, 420s, 400), 400);
 
     // New transaction should use latest entry time if higher than
     // min(block time, clock time).
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 4, 500, 390), 400);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 4, 500s, 390), 400);
 
     // If there are future entries, new transaction should use time of the
     // newest entry that is no more than 300 seconds ahead of the clock time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 5, 50, 600), 300);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 5, 50s, 600), 300);
 }
 
 void TestLoadWallet(const std::string& name, DatabaseFormat format, std::function<void(std::shared_ptr<CWallet>)> f)


### PR DESCRIPTION
This switches the remaining cases in the unit tests from `SetMockTime` to `FakeNodeClock` for clarity, as explained in the commit messages.