### PR TITLE
wallet: check WriteMasterKey result when changing passphrase

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -642,12 +642,20 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
             }
             if (Unlock(plain_master_key))
             {
-                if (!EncryptMasterKey(strNewWalletPassphrase, plain_master_key, master_key)) {
+                // Work on a copy so that a failure to persist the new master key
+                // does not leave the in-memory state out of sync with disk.
+                CMasterKey new_master_key{master_key};
+                if (!EncryptMasterKey(strNewWalletPassphrase, plain_master_key, new_master_key)) {
                     return false;
                 }
+                if (!WalletBatch(GetDatabase()).WriteMasterKey(master_key_id, new_master_key)) {
+                    WalletLogPrintf("Failed to write master key to wallet database; passphrase unchanged\n");
+                    if (fWasLocked) Lock();
+                    return false;
+                }
+                master_key = new_master_key;
                 WalletLogPrintf("Wallet passphrase changed to an nDeriveIterations of %i\n", master_key.nDeriveIterations);
 
-                WalletBatch(GetDatabase()).WriteMasterKey(master_key_id, master_key);
                 if (fWasLocked)
                     Lock();
                 return true;


### PR DESCRIPTION
`CWallet::ChangeWalletPassphrase` ignores the return value of `WalletBatch::WriteMasterKey`. If the database write fails (e.g. disk full, I/O error), the RPC reports success while the wallet file on disk still requires the **old** passphrase. A user who discards the old passphrase after such a silent failure is locked out of their wallet after a restart.

This PR:

- Re-encrypts into a copy of the `CMasterKey` and only commits it to `mapMasterKeys` after the database write succeeds, so in-memory state never diverges from disk in any failure path. (Previously a failing `EncryptMasterKey` could also leave a mutated `nDeriveIterations` in the map entry.)
- Checks the `WriteMasterKey` return value and returns `false` on failure.
- Logs the write failure and restores the previous lock state before returning, so a failed call leaves the wallet exactly as it was.

The disk-before-memory commit ordering mirrors the intent of `EncryptWallet`, which already treats memory/disk divergence of key material as unacceptable.

Tested with `wallet_tests`/`wallet_crypto_tests` unit tests and the `wallet_encryption.py` functional test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)