### PR TITLE
wallet: store all witness variants of a transaction

### DIFF
--- a/doc/release-notes-35501.md
+++ b/doc/release-notes-35501.md
@@ -1,0 +1,4 @@
+RPC
+---
+
+- `gettransaction`, `listtransactions`, and `listsinceblock` now have an `alternate_wtxids` field which lists the wtxids of all transactions that have the same txid.

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -76,7 +76,7 @@ static void CoinSelection(benchmark::Bench& bench)
     // Create coins from the amounts assigning them various output types
     wallet::CoinsResult available_coins;
     for (const auto& wtx : wtxs) {
-        const auto txout = wtx->tx->vout.at(0);
+        const auto txout = wtx->GetTx()->vout.at(0);
         OutputType outtype;
         int input_bytes;
         int y{det_rand.randrange(100)};

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <compare>
 #include <cstdint>
 #include <cstring>
 #include <optional>
@@ -62,7 +63,12 @@ public:
      * @note Does NOT match the ordering on the corresponding \ref
      *       base_uint::CompareTo, which starts comparing from the end.
      */
-    constexpr int Compare(const base_blob& other) const { return std::memcmp(m_data.data(), other.m_data.data(), WIDTH); }
+    constexpr int Compare(const base_blob& other) const {
+        auto cmp = m_data <=> other.m_data;
+        if (cmp < 0) return -1;
+        if (cmp > 0) return 1;
+        return 0;
+    }
 
     friend constexpr bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
     friend constexpr bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }

--- a/src/wallet/export.cpp
+++ b/src/wallet/export.cpp
@@ -161,7 +161,7 @@ util::Result<std::string> ExportWatchOnlyWallet(const CWallet& wallet, const fs:
             for (const auto& [txid, wtx] : wallet.mapWallet) {
                 DataStream wtx_ser;
                 wtx_ser << wtx;
-                CWalletTx copy_wtx(deserialize, wtx_ser);
+                CWalletTx copy_wtx(deserialize, wtx_ser, wtx.GetTxs());
                 if (!watchonly_wallet->LoadToWallet(std::move(copy_wtx))) {
                     return util::Error{strprintf(_("Error: Could not add tx %s to watchonly wallet"), txid.GetHex())};
                 }

--- a/src/wallet/export.cpp
+++ b/src/wallet/export.cpp
@@ -159,12 +159,10 @@ util::Result<std::string> ExportWatchOnlyWallet(const CWallet& wallet, const fs:
 
             // Copy the transactions
             for (const auto& [txid, wtx] : wallet.mapWallet) {
-                if (!watchonly_wallet->LoadToWallet(txid, [&](CWalletTx& ins_wtx, bool new_tx) EXCLUSIVE_LOCKS_REQUIRED(watchonly_wallet->cs_wallet) {
-                    if (!new_tx) return false;
-                    ins_wtx.SetTx(wtx.tx);
-                    ins_wtx.CopyFrom(wtx);
-                    return true;
-                })) {
+                DataStream wtx_ser;
+                wtx_ser << wtx;
+                CWalletTx copy_wtx(deserialize, wtx_ser);
+                if (!watchonly_wallet->LoadToWallet(std::move(copy_wtx))) {
                     return util::Error{strprintf(_("Error: Could not add tx %s to watchonly wallet"), txid.GetHex())};
                 }
                 watchonly_batch.WriteTx(watchonly_wallet->mapWallet.at(txid));

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -24,7 +24,7 @@ namespace wallet {
 //! mined, or conflicts with a mined transaction. Return a feebumper::Result.
 static feebumper::Result PreconditionChecks(const CWallet& wallet, const CWalletTx& wtx, bool require_mine, std::vector<bilingual_str>& errors) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
-    if (wallet.HasWalletSpend(wtx.tx)) {
+    if (wallet.HasWalletSpend(wtx.GetTx())) {
         errors.emplace_back(Untranslated("Transaction has descendants in the wallet"));
         return feebumper::Result::INVALID_PARAMETER;
     }
@@ -49,7 +49,7 @@ static feebumper::Result PreconditionChecks(const CWallet& wallet, const CWallet
     if (require_mine) {
         // check that original tx consists entirely of our inputs
         // if not, we can't bump the fee, because the wallet has no way of knowing the value of the other inputs (thus the fee)
-        if (!AllInputsMine(wallet, *wtx.tx)) {
+        if (!AllInputsMine(wallet, *wtx.GetTx())) {
             errors.emplace_back(Untranslated("Transaction contains inputs that don't belong to this wallet"));
             return feebumper::Result::WALLET_ERROR;
         }
@@ -123,7 +123,7 @@ static CFeeRate EstimateFeeRate(const CWallet& wallet, const CWalletTx& wtx, con
     // Get the fee rate of the original transaction. This is calculated from
     // the tx fee/vsize, so it may have been rounded down. Add 1 satoshi to the
     // result.
-    int64_t txSize = GetVirtualTransactionSize(*(wtx.tx));
+    int64_t txSize = GetVirtualTransactionSize(*(wtx.GetTx()));
     CFeeRate feerate(old_fee, txSize);
     feerate += CFeeRate(1);
 
@@ -178,9 +178,10 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
         return Result::INVALID_ADDRESS_OR_KEY;
     }
     const CWalletTx& wtx = it->second;
+    const CTransactionRef& tx = wtx.GetTx();
 
     // Make sure that original_change_index is valid
-    if (original_change_index.has_value() && original_change_index.value() >= wtx.tx->vout.size()) {
+    if (original_change_index.has_value() && original_change_index.value() >= tx->vout.size()) {
         errors.emplace_back(Untranslated("Change position is out of range"));
         return Result::INVALID_PARAMETER;
     }
@@ -190,11 +191,11 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     std::map<COutPoint, Coin> coins;
     CAmount input_value = 0;
     std::vector<CTxOut> spent_outputs;
-    for (const CTxIn& txin : wtx.tx->vin) {
+    for (const CTxIn& txin : tx->vin) {
         coins[txin.prevout]; // Create empty map entry keyed by prevout.
     }
     wallet.chain().findCoins(coins);
-    for (const CTxIn& txin : wtx.tx->vin) {
+    for (const CTxIn& txin : tx->vin) {
         const Coin& coin = coins.at(txin.prevout);
         if (coin.out.IsNull()) {
             errors.emplace_back(Untranslated(strprintf("%s:%u is already spent", txin.prevout.hash.GetHex(), txin.prevout.n)));
@@ -210,9 +211,9 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
 
     // Figure out if we need to compute the input weight, and do so if necessary
     PrecomputedTransactionData txdata;
-    txdata.Init(*wtx.tx, std::move(spent_outputs), /* force=*/ true);
-    for (unsigned int i = 0; i < wtx.tx->vin.size(); ++i) {
-        const CTxIn& txin = wtx.tx->vin.at(i);
+    txdata.Init(*tx, std::move(spent_outputs), /* force=*/ true);
+    for (unsigned int i = 0; i < tx->vin.size(); ++i) {
+        const CTxIn& txin = tx->vin.at(i);
         const Coin& coin = coins.at(txin.prevout);
 
         if (new_coin_control.IsExternalSelected(txin.prevout)) {
@@ -223,7 +224,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
             // In order to do this, we verify the script with a special SignatureChecker which
             // will observe the signatures verified and record their sizes.
             SignatureWeights weights;
-            TransactionSignatureChecker tx_checker(wtx.tx.get(), i, coin.out.nValue, txdata, MissingDataBehavior::FAIL);
+            TransactionSignatureChecker tx_checker(tx.get(), i, coin.out.nValue, txdata, MissingDataBehavior::FAIL);
             SignatureWeightChecker size_checker(weights, tx_checker);
             VerifyScript(txin.scriptSig, coin.out.scriptPubKey, &txin.scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS, size_checker);
             // Add the difference between max and current to input_weight so that it represents the largest the input could be
@@ -239,7 +240,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
 
     // Calculate the old output amount.
     CAmount output_value = 0;
-    for (const auto& old_output : wtx.tx->vout) {
+    for (const auto& old_output : tx->vout) {
         output_value += old_output.nValue;
     }
 
@@ -250,7 +251,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     // outputs with its contents, otherwise use original outputs.
     std::vector<CRecipient> recipients;
     CAmount new_outputs_value = 0;
-    const auto& txouts = outputs.empty() ? wtx.tx->vout : outputs;
+    const auto& txouts = outputs.empty() ? tx->vout : outputs;
     for (size_t i = 0; i < txouts.size(); ++i) {
         const CTxOut& output = txouts.at(i);
         CTxDestination dest;
@@ -282,7 +283,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
         // The user provided a feeRate argument.
         // We calculate this here to avoid compiler warning on the cs_wallet lock
         // We need to make a temporary transaction with no input witnesses as the dummy signer expects them to be empty for external inputs
-        CMutableTransaction temp_mtx{*wtx.tx};
+        CMutableTransaction temp_mtx{*tx};
         for (auto& txin : temp_mtx.vin) {
             txin.scriptSig.clear();
             txin.scriptWitness.SetNull();
@@ -305,7 +306,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     // A2 and A3 where A2 and A3 don't conflict (or alternatively bump A to A2 and A2
     // to A3 where A and A3 don't conflict). If both later get confirmed then the sender
     // has accidentally double paid.
-    for (const auto& inputs : wtx.tx->vin) {
+    for (const auto& inputs : tx->vin) {
         new_coin_control.Select(COutPoint(inputs.prevout));
     }
     new_coin_control.m_allow_other_inputs = true;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -57,15 +57,15 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
 {
     LOCK(wallet.cs_wallet);
     WalletTx result;
-    result.tx = wtx.tx;
-    result.txin_is_mine.reserve(wtx.tx->vin.size());
-    for (const auto& txin : wtx.tx->vin) {
+    result.tx = wtx.GetTx();
+    result.txin_is_mine.reserve(result.tx->vin.size());
+    for (const auto& txin : result.tx->vin) {
         result.txin_is_mine.emplace_back(InputIsMine(wallet, txin));
     }
-    result.txout_is_mine.reserve(wtx.tx->vout.size());
-    result.txout_address.reserve(wtx.tx->vout.size());
-    result.txout_address_is_mine.reserve(wtx.tx->vout.size());
-    for (const auto& txout : wtx.tx->vout) {
+    result.txout_is_mine.reserve(result.tx->vout.size());
+    result.txout_address.reserve(result.tx->vout.size());
+    result.txout_address_is_mine.reserve(result.tx->vout.size());
+    for (const auto& txout : result.tx->vout) {
         result.txout_is_mine.emplace_back(wallet.IsMine(txout));
         result.txout_is_change.push_back(OutputIsChange(wallet, txout));
         result.txout_address.emplace_back();
@@ -99,7 +99,7 @@ WalletTxStatus MakeWalletTxStatus(const CWallet& wallet, const CWalletTx& wtx)
     result.blocks_to_maturity = wallet.GetTxBlocksToMaturity(wtx);
     result.depth_in_main_chain = wallet.GetTxDepthInMainChain(wtx);
     result.time_received = wtx.nTimeReceived;
-    result.lock_time = wtx.tx->nLockTime;
+    result.lock_time = wtx.GetTx()->nLockTime;
     result.is_trusted = CachedTxIsTrusted(wallet, wtx);
     result.is_abandoned = wtx.isAbandoned();
     result.is_coinbase = wtx.IsCoinBase();
@@ -114,7 +114,7 @@ WalletTxOut MakeWalletTxOut(const CWallet& wallet,
     int depth) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     WalletTxOut result;
-    result.txout = wtx.tx->vout[n];
+    result.txout = wtx.GetTx()->vout[n];
     result.time = wtx.GetTxTime();
     result.depth_in_main_chain = depth;
     result.is_spent = wallet.IsSpent(COutPoint(wtx.GetHash(), n));
@@ -305,7 +305,7 @@ public:
         LOCK(m_wallet->cs_wallet);
         auto mi = m_wallet->mapWallet.find(txid);
         if (mi != m_wallet->mapWallet.end()) {
-            return mi->second.tx;
+            return mi->second.GetTx();
         }
         return {};
     }

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -14,8 +14,8 @@ bool InputIsMine(const CWallet& wallet, const CTxIn& txin)
 {
     AssertLockHeld(wallet.cs_wallet);
     const CWalletTx* prev = wallet.GetWalletTx(txin.prevout.hash);
-    if (prev && txin.prevout.n < prev->tx->vout.size()) {
-        return wallet.IsMine(prev->tx->vout[txin.prevout.n]);
+    if (prev && txin.prevout.n < prev->GetTx()->vout.size()) {
+        return wallet.IsMine(prev->GetTx()->vout[txin.prevout.n]);
     }
     return false;
 }
@@ -101,7 +101,7 @@ static CAmount GetCachableAmount(const CWallet& wallet, const CWalletTx& wtx, CW
 {
     auto& amount = wtx.m_amounts[type];
     if (!amount.IsCached(avoid_reuse)) {
-        amount.Set(avoid_reuse, type == CWalletTx::DEBIT ? wallet.GetDebit(*wtx.tx) : TxGetCredit(wallet, *wtx.tx));
+        amount.Set(avoid_reuse, type == CWalletTx::DEBIT ? wallet.GetDebit(*wtx.GetTx()) : TxGetCredit(wallet, *wtx.GetTx()));
         wtx.m_is_cache_empty = false;
     }
     return amount.Get(avoid_reuse);
@@ -121,7 +121,7 @@ CAmount CachedTxGetCredit(const CWallet& wallet, const CWalletTx& wtx, bool avoi
 
 CAmount CachedTxGetDebit(const CWallet& wallet, const CWalletTx& wtx, bool avoid_reuse)
 {
-    if (wtx.tx->vin.empty())
+    if (wtx.GetTx()->vin.empty())
         return 0;
 
     return GetCachableAmount(wallet, wtx, CWalletTx::DEBIT, avoid_reuse);
@@ -131,7 +131,7 @@ CAmount CachedTxGetChange(const CWallet& wallet, const CWalletTx& wtx)
 {
     if (wtx.fChangeCached)
         return wtx.nChangeCached;
-    wtx.nChangeCached = TxGetChange(wallet, *wtx.tx);
+    wtx.nChangeCached = TxGetChange(wallet, *wtx.GetTx());
     wtx.fChangeCached = true;
     return wtx.nChangeCached;
 }
@@ -149,15 +149,15 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
     CAmount nDebit = CachedTxGetDebit(wallet, wtx, /*avoid_reuse=*/false);
     if (nDebit > 0) // debit>0 means we signed/sent this transaction
     {
-        CAmount nValueOut = wtx.tx->GetValueOut();
+        CAmount nValueOut = wtx.GetTx()->GetValueOut();
         nFee = nDebit - nValueOut;
     }
 
     LOCK(wallet.cs_wallet);
     // Sent/received.
-    for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i)
+    for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); ++i)
     {
-        const CTxOut& txout = wtx.tx->vout[i];
+        const CTxOut& txout = wtx.GetTx()->vout[i];
         bool ismine = wallet.IsMine(txout);
         // Only need to handle txouts if AT LEAST one of these is true:
         //   1) they debit from us (sent)
@@ -196,7 +196,7 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
 bool CachedTxIsFromMe(const CWallet& wallet, const CWalletTx& wtx)
 {
     if (!wtx.m_cached_from_me.has_value()) {
-        wtx.m_cached_from_me = wallet.IsFromMe(*wtx.tx);
+        wtx.m_cached_from_me = wallet.IsFromMe(*wtx.GetTx());
     }
     return wtx.m_cached_from_me.value();
 }
@@ -218,12 +218,12 @@ bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txi
     if (!wtx.InMempool()) return false;
 
     // Trusted if all inputs are from us and are in the mempool:
-    for (const CTxIn& txin : wtx.tx->vin)
+    for (const CTxIn& txin : wtx.GetTx()->vin)
     {
         // Transactions not sent by us: not trusted
         const CWalletTx* parent = wallet.GetWalletTx(txin.prevout.hash);
         if (parent == nullptr) return false;
-        const CTxOut& parentOut = parent->tx->vout[txin.prevout.n];
+        const CTxOut& parentOut = parent->GetTx()->vout[txin.prevout.n];
         // Check that this specific input being spent is trusted
         if (!wallet.IsMine(parentOut)) return false;
         // If we've already trusted this parent, continue
@@ -332,16 +332,16 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
     {
         const CWalletTx& wtx = walletEntry.second;
 
-        if (wtx.tx->vin.size() > 0)
+        if (wtx.GetTx()->vin.size() > 0)
         {
             bool any_mine = false;
             // group all input addresses with each other
-            for (const CTxIn& txin : wtx.tx->vin)
+            for (const CTxIn& txin : wtx.GetTx()->vin)
             {
                 CTxDestination address;
                 if(!InputIsMine(wallet, txin)) /* If this input isn't mine, ignore it */
                     continue;
-                if(!ExtractDestination(wallet.mapWallet.at(txin.prevout.hash).tx->vout[txin.prevout.n].scriptPubKey, address))
+                if(!ExtractDestination(wallet.mapWallet.at(txin.prevout.hash).GetTx()->vout[txin.prevout.n].scriptPubKey, address))
                     continue;
                 grouping.insert(address);
                 any_mine = true;
@@ -350,7 +350,7 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
             // group change with input addresses
             if (any_mine)
             {
-               for (const CTxOut& txout : wtx.tx->vout)
+               for (const CTxOut& txout : wtx.GetTx()->vout)
                    if (OutputIsChange(wallet, txout))
                    {
                        CTxDestination txoutAddr;
@@ -367,7 +367,7 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
         }
 
         // group lone addrs by themselves
-        for (const auto& txout : wtx.tx->vout)
+        for (const auto& txout : wtx.GetTx()->vout)
             if (wallet.IsMine(txout))
             {
                 CTxDestination address;

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -66,7 +66,7 @@ static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool b
             continue;
         }
 
-        for (const CTxOut& txout : wtx.tx->vout) {
+        for (const CTxOut& txout : wtx.GetTx()->vout) {
             if (output_scripts.contains(txout.scriptPubKey)) {
                 amount += txout.nValue;
             }
@@ -309,7 +309,7 @@ RPCMethod lockunspent()
 
         const CWalletTx& trans = it->second;
 
-        if (outpt.n >= trans.tx->vout.size()) {
+        if (outpt.n >= trans.GetTx()->vout.size()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout index out of bounds");
         }
 

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1478,17 +1478,17 @@ RPCMethod sendall()
                         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Input not available. UTXO (%s:%d) was already spent.", input.prevout.hash.ToString(), input.prevout.n));
                     }
                     const CWalletTx* tx{pwallet->GetWalletTx(input.prevout.hash)};
-                    if (!tx || input.prevout.n >= tx->tx->vout.size() || !pwallet->IsMine(tx->tx->vout[input.prevout.n])) {
+                    if (!tx || input.prevout.n >= tx->GetTx()->vout.size() || !pwallet->IsMine(tx->GetTx()->vout[input.prevout.n])) {
                         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Input not found. UTXO (%s:%d) is not part of wallet.", input.prevout.hash.ToString(), input.prevout.n));
                     }
                     if (pwallet->GetTxDepthInMainChain(*tx) == 0) {
-                        if (tx->tx->version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
+                        if (tx->GetTx()->version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
                             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't spend unconfirmed version 3 pre-selected input with a version %d tx", coin_control.m_version));
-                        } else if (coin_control.m_version == TRUC_VERSION && tx->tx->version != TRUC_VERSION) {
-                            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't spend unconfirmed version %d pre-selected input with a version 3 tx", tx->tx->version));
+                        } else if (coin_control.m_version == TRUC_VERSION && tx->GetTx()->version != TRUC_VERSION) {
+                            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't spend unconfirmed version %d pre-selected input with a version 3 tx", tx->GetTx()->version));
                         }
                     }
-                    total_input_value += tx->tx->vout[input.prevout.n].nValue;
+                    total_input_value += tx->GetTx()->vout[input.prevout.n].nValue;
                 }
             } else {
                 CoinFilterParams coins_params;

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -53,7 +53,7 @@ static void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, UniValue
     if (chain.rpcEnableDeprecated("bip125")) {
         std::string rbfStatus = "no";
         if (confirms <= 0) {
-            RBFTransactionState rbfState = chain.isRBFOptIn(*wtx.tx);
+            RBFTransactionState rbfState = chain.isRBFOptIn(*wtx.GetTx());
             if (rbfState == RBFTransactionState::UNKNOWN)
                 rbfStatus = "unknown";
             else if (rbfState == RBFTransactionState::REPLACEABLE_BIP125)
@@ -110,7 +110,7 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, cons
             continue;
         }
 
-        for (const CTxOut& txout : wtx.tx->vout) {
+        for (const CTxOut& txout : wtx.GetTx()->vout) {
             CTxDestination address;
             if (!ExtractDestination(txout.scriptPubKey, address))
                 continue;
@@ -354,7 +354,7 @@ static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nM
             }
             UniValue entry(UniValue::VOBJ);
             MaybePushAddress(entry, r.destination);
-            PushParentDescriptors(wallet, wtx.tx->vout.at(r.vout).scriptPubKey, entry);
+            PushParentDescriptors(wallet, wtx.GetTx()->vout.at(r.vout).scriptPubKey, entry);
             if (wtx.IsCoinBase())
             {
                 if (wallet.GetTxDepthInMainChain(wtx) < 1)
@@ -755,7 +755,7 @@ RPCMethod gettransaction()
     CAmount nCredit = CachedTxGetCredit(*pwallet, wtx, /*avoid_reuse=*/false);
     CAmount nDebit = CachedTxGetDebit(*pwallet, wtx, /*avoid_reuse=*/false);
     CAmount nNet = nCredit - nDebit;
-    CAmount nFee = (CachedTxIsFromMe(*pwallet, wtx) ? wtx.tx->GetValueOut() - nDebit : 0);
+    CAmount nFee = (CachedTxIsFromMe(*pwallet, wtx) ? wtx.GetTx()->GetValueOut() - nDebit : 0);
 
     entry.pushKV("amount", ValueFromAmount(nNet - nFee));
     if (CachedTxIsFromMe(*pwallet, wtx))
@@ -767,11 +767,11 @@ RPCMethod gettransaction()
     ListTransactions(*pwallet, wtx, 0, false, details, /*filter_label=*/std::nullopt);
     entry.pushKV("details", std::move(details));
 
-    entry.pushKV("hex", EncodeHexTx(*wtx.tx));
+    entry.pushKV("hex", EncodeHexTx(*wtx.GetTx()));
 
     if (verbose) {
         UniValue decoded(UniValue::VOBJ);
-        TxToUniv(*wtx.tx,
+        TxToUniv(*wtx.GetTx(),
                 /*block_hash=*/uint256(),
                 /*entry=*/decoded,
                 /*include_hex=*/false,

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -38,6 +38,12 @@ static void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, UniValue
     }
     entry.pushKV("txid", wtx.GetHash().GetHex());
     entry.pushKV("wtxid", wtx.GetWitnessHash().GetHex());
+    UniValue alternate_wtxids(UniValue::VARR);
+    for (const auto& [wtxid, _] : wtx.GetTxs()) {
+        if (wtxid == wtx.GetWitnessHash()) continue;
+        alternate_wtxids.push_back(wtxid.GetHex());
+    }
+    entry.pushKV("alternate_wtxids", alternate_wtxids);
     UniValue conflicts(UniValue::VARR);
     for (const Txid& conflict : wallet.GetTxConflicts(wtx))
         conflicts.push_back(conflict.GetHex());
@@ -395,6 +401,10 @@ static std::vector<RPCResult> TransactionDescriptionString()
            {RPCResult::Type::NUM_TIME, "blocktime", /*optional=*/true, "The block time expressed in " + UNIX_EPOCH_TIME + "."},
            {RPCResult::Type::STR_HEX, "txid", "The transaction id."},
            {RPCResult::Type::STR_HEX, "wtxid", "The hash of serialized transaction, including witness data."},
+           {RPCResult::Type::ARR, "alternate_wtxids", "The wtxids of transactions with different witness data but the same txid.",
+           {
+               {RPCResult::Type::STR_HEX, "wtxid", "The witness transaction id."},
+           }},
            {RPCResult::Type::ARR, "walletconflicts", "Confirmed transactions that have been detected by the wallet to conflict with this transaction.",
            {
                {RPCResult::Type::STR_HEX, "txid", "The transaction id."},

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -178,8 +178,8 @@ TxSize CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *walle
         const auto mi = wallet->mapWallet.find(input.prevout.hash);
         // Can not estimate size without knowing the input details
         if (mi != wallet->mapWallet.end()) {
-            assert(input.prevout.n < mi->second.tx->vout.size());
-            txouts.emplace_back(mi->second.tx->vout.at(input.prevout.n));
+            assert(input.prevout.n < mi->second.GetTx()->vout.size());
+            txouts.emplace_back(mi->second.GetTx()->vout.at(input.prevout.n));
         } else if (coin_control) {
             const auto& txout{coin_control->GetExternalOutput(input.prevout)};
             if (!txout) return TxSize{-1, -1};
@@ -281,10 +281,10 @@ util::Result<CoinsResult> FetchSelectedInputs(const CWallet& wallet, const CCoin
             }
             const CWalletTx& parent_tx = txo->GetWalletTx();
             if (wallet.GetTxDepthInMainChain(parent_tx) == 0) {
-                if (parent_tx.tx->version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
+                if (parent_tx.GetTx()->version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
                     return util::Error{strprintf(_("Can't spend unconfirmed version 3 pre-selected input with a version %d tx"), coin_control.m_version)};
-                } else if (coin_control.m_version == TRUC_VERSION && parent_tx.tx->version != TRUC_VERSION) {
-                    return util::Error{strprintf(_("Can't spend unconfirmed version %d pre-selected input with a version 3 tx"), parent_tx.tx->version)};
+                } else if (coin_control.m_version == TRUC_VERSION && parent_tx.GetTx()->version != TRUC_VERSION) {
+                    return util::Error{strprintf(_("Can't spend unconfirmed version %d pre-selected input with a version 3 tx"), parent_tx.GetTx()->version)};
                 }
             }
         } else {
@@ -396,16 +396,16 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
             if (nDepth == 0 && params.check_version_trucness) {
                 if (coinControl->m_version == TRUC_VERSION) {
-                    if (wtx.tx->version != TRUC_VERSION) continue;
+                    if (wtx.GetTx()->version != TRUC_VERSION) continue;
                     // this unconfirmed v3 transaction already has a child
                     if (wtx.truc_child_in_mempool.has_value()) continue;
 
                     // this unconfirmed v3 transaction has a parent: spending would create a third generation
                     size_t ancestors, unused_cluster_count;
-                    wallet.chain().getTransactionAncestry(wtx.tx->GetHash(), ancestors, unused_cluster_count);
+                    wallet.chain().getTransactionAncestry(wtx.GetTx()->GetHash(), ancestors, unused_cluster_count);
                     if (ancestors > 1) continue;
                 } else {
-                    if (wtx.tx->version == TRUC_VERSION) continue;
+                    if (wtx.GetTx()->version == TRUC_VERSION) continue;
                 }
             }
 
@@ -468,9 +468,9 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
         auto available_output_type = GetOutputType(type, is_from_p2sh);
         auto available_output = COutput(outpoint, output, nDepth, input_bytes, solvable, tx_safe, wtx.GetTxTime(), tx_from_me, feerate);
-        if (wtx.tx->version == TRUC_VERSION && nDepth == 0 && params.check_version_trucness) {
+        if (wtx.GetTx()->version == TRUC_VERSION && nDepth == 0 && params.check_version_trucness) {
             unconfirmed_truc_coins.emplace_back(available_output_type, available_output);
-            auto [it, _] = truc_txid_by_value.try_emplace(wtx.tx->GetHash(), 0);
+            auto [it, _] = truc_txid_by_value.try_emplace(wtx.GetTx()->GetHash(), 0);
             it->second += output.nValue;
         } else {
             result.Add(available_output_type, available_output);
@@ -526,16 +526,16 @@ const CTxOut& FindNonChangeParentOutput(const CWallet& wallet, const COutPoint& 
     AssertLockHeld(wallet.cs_wallet);
     const CWalletTx* wtx{Assert(wallet.GetWalletTx(outpoint.hash))};
 
-    const CTransaction* ptx = wtx->tx.get();
+    const CTransaction* ptx = wtx->GetTx().get();
     int n = outpoint.n;
     while (OutputIsChange(wallet, ptx->vout[n]) && ptx->vin.size() > 0) {
         const COutPoint& prevout = ptx->vin[0].prevout;
         const CWalletTx* it = wallet.GetWalletTx(prevout.hash);
-        if (!it || it->tx->vout.size() <= prevout.n ||
-            !wallet.IsMine(it->tx->vout[prevout.n])) {
+        if (!it || it->GetTx()->vout.size() <= prevout.n ||
+            !wallet.IsMine(it->GetTx()->vout[prevout.n])) {
             break;
         }
-        ptx = it->tx.get();
+        ptx = it->GetTx().get();
         n = prevout.n;
     }
     return ptx->vout[n];

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -76,7 +76,7 @@ static void add_coin(CoinsResult& available_coins, CWallet& wallet, const CAmoun
     auto ret = wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateInactive{}));
     assert(ret.second);
     CWalletTx& wtx = (*ret.first).second;
-    const auto& txout = wtx.tx->vout.at(nInput);
+    const auto& txout = wtx.GetTx()->vout.at(nInput);
     available_coins.Add(OutputType::BECH32, {COutPoint(wtx.GetHash(), nInput), txout, nAge, custom_size == 0 ? CalculateMaximumSignedInputSize(txout, &wallet, /*coin_control=*/nullptr) : custom_size, /*solvable=*/true, /*safe=*/true, wtx.GetTxTime(), fIsFromMe, feerate});
 }
 

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -44,7 +44,7 @@ static void addCoin(CoinsResult& coins,
     auto ret = wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateInactive{}));
     assert(ret.second);
     CWalletTx& wtx = (*ret.first).second;
-    const auto& txout = wtx.tx->vout.at(0);
+    const auto& txout = wtx.GetTx()->vout.at(0);
     coins.Add(*Assert(OutputTypeFromDestination(dest)),
               {COutPoint(wtx.GetHash(), 0),
                    txout,

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -406,7 +406,7 @@ public:
         CMutableTransaction blocktx;
         {
             LOCK(wallet->cs_wallet);
-            blocktx = CMutableTransaction(*wallet->mapWallet.at(tx->GetHash()).tx);
+            blocktx = CMutableTransaction(*wallet->mapWallet.at(tx->GetHash()).GetTx());
         }
         CreateAndProcessBlock({CMutableTransaction(blocktx)}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
 
@@ -489,7 +489,7 @@ void TestCoinsResult(ListCoinsTest& context, OutputType out_type, CAmount amount
     filter.skip_locked = false;
     CoinsResult available_coins = AvailableCoins(*context.wallet, nullptr, std::nullopt, filter);
     // Lock outputs so they are not spent in follow-up transactions
-    for (uint32_t i = 0; i < wtx.tx->vout.size(); i++) context.wallet->LockCoin({wtx.GetHash(), i}, /*persist=*/false);
+    for (uint32_t i = 0; i < wtx.GetTx()->vout.size(); i++) context.wallet->LockCoin({wtx.GetHash(), i}, /*persist=*/false);
     for (const auto& [type, size] : expected_coins_sizes) BOOST_CHECK_EQUAL(size, available_coins.coins[type].size());
 }
 

--- a/src/wallet/transaction.cpp
+++ b/src/wallet/transaction.cpp
@@ -11,8 +11,8 @@ using interfaces::FoundBlock;
 namespace wallet {
 bool CWalletTx::IsEquivalentTo(const CWalletTx& _tx) const
 {
-        CMutableTransaction tx1 {*this->tx};
-        CMutableTransaction tx2 {*_tx.tx};
+        CMutableTransaction tx1 {*this->GetTx()};
+        CMutableTransaction tx2 {*_tx.GetTx()};
         for (auto& txin : tx1.vin) {
             txin.scriptSig = CScript();
             txin.scriptWitness.SetNull();

--- a/src/wallet/transaction.cpp
+++ b/src/wallet/transaction.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/transaction.h>
 
+#include <consensus/validation.h>
 #include <interfaces/chain.h>
 
 using interfaces::FoundBlock;
@@ -54,5 +55,73 @@ void CWalletTx::updateState(interfaces::Chain& chain)
     } else if (auto* conf = state<TxStateBlockConflicted>()) {
         lookup_block(conf->conflicting_block_hash, conf->conflicting_block_height, m_state);
     }
+
+    // If the above downgraded a previously-confirmed witness variant back to unconfirmed,
+    // the canonical choice is no longer pinned by confirmation. Re-apply the least-weight rule.
+    if (!isConfirmed()) RecomputeCanonical();
+}
+
+bool CWalletTx::Update(CTransactionRef new_tx, const TxState& new_state)
+{
+    Assert(new_tx);
+    if (!Assume(GetHash() == new_tx->GetHash())) {
+        return false;
+    }
+    bool ret = false;
+    const auto& [tx_pair, inserted] = m_txs.emplace(new_tx->GetWitnessHash(), std::move(new_tx));
+    if (inserted) {
+        ret = true;
+    }
+    const auto& [wtxid, tx] = *tx_pair;
+
+    if (new_state.index() != m_state.index()) {
+        m_state = new_state;
+        if (state<TxStateConfirmed>()) {
+            m_canonical_wtxid = wtxid;
+        }
+        ret = true;
+    } else {
+        assert(TxStateSerializedIndex(m_state) == TxStateSerializedIndex(new_state));
+        assert(TxStateSerializedBlockHash(m_state) == TxStateSerializedBlockHash(new_state));
+    }
+
+    // While unconfirmed, derive the canonical variant from all known variants
+    if (!isConfirmed()) {
+        const Wtxid prev_canonical = m_canonical_wtxid;
+        RecomputeCanonical();
+        if (m_canonical_wtxid != prev_canonical) {
+            ret = true;
+        }
+    }
+
+    return ret;
+}
+
+void CWalletTx::RecomputeCanonical()
+{
+    // Recompute the canonical variant among the witness variants. They share
+    // the txid but differ in the wtxid. Prefer variant with witness data and
+    // the least weight.
+    Assert(!m_txs.empty());
+
+    // Returns true if 'a' should be preferred over 'b'
+    auto is_better = [](const CTransactionRef& a, const CTransactionRef& b) {
+        // A witnessed variant always beats a witnessless one
+        if (a->HasWitness() != b->HasWitness()) return a->HasWitness();
+        // Otherwise the lighter one wins
+        return GetTransactionWeight(*a) < GetTransactionWeight(*b);
+    };
+
+    auto it = m_txs.begin();
+    auto best_wtxid = it->first;
+    const CTransactionRef* best = &it->second;
+    it = std::next(it);
+    for (; it != m_txs.end(); it = std::next(it)) {
+        if (is_better(it->second, *best)) {
+            best = &it->second;
+            best_wtxid = it->first;
+        }
+    }
+    m_canonical_wtxid = best_wtxid;
 }
 } // namespace wallet

--- a/src/wallet/transaction.cpp
+++ b/src/wallet/transaction.cpp
@@ -55,9 +55,4 @@ void CWalletTx::updateState(interfaces::Chain& chain)
         lookup_block(conf->conflicting_block_hash, conf->conflicting_block_height, m_state);
     }
 }
-
-void CWalletTx::CopyFrom(const CWalletTx& _tx)
-{
-    *this = _tx;
-}
 } // namespace wallet

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -353,11 +353,11 @@ public:
 
     CTransactionRef GetTx() const { return m_txs.at(m_canonical_wtxid); }
 
-    void SetTx(CTransactionRef arg)
-    {
-        Assert(arg);
-        m_txs.emplace(arg->GetWitnessHash(), std::move(arg));
-    }
+    // Update the state of this wallet transaction along with a transaction that may have a different wtxid.
+    // If the given transaction has a different wtxid, the transaction is stored if it has not been seen before.
+    // The canonical wtxid is also updated. The tx that is confirmed becomes canonical. For unconfirmed txs,
+    // those with witnesses are preferred, followed by least weight.
+    bool Update(CTransactionRef tx, const TxState& arg_state);
 
     //! make sure balances are recalculated
     void MarkDirty()
@@ -408,6 +408,9 @@ private:
     Wtxid m_canonical_wtxid;
     std::map<Wtxid, CTransactionRef> m_txs;
 
+    //! Set m_canonical_wtxid to the best variant under the unconfirmed rule
+    //! (witnessed preferred, then least weight). Ignores state.
+    void RecomputeCanonical();
 };
 
 struct WalletTxOrderComparator {

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -382,15 +382,11 @@ public:
     const Wtxid& GetWitnessHash() const LIFETIMEBOUND { return tx->GetWitnessHash(); }
     bool IsCoinBase() const { return tx->IsCoinBase(); }
 
-private:
     // Disable copying of CWalletTx objects to prevent bugs where instances get
     // copied in and out of the mapWallet map, and fields are updated in the
     // wrong copy.
-    CWalletTx(const CWalletTx&) = default;
-    CWalletTx& operator=(const CWalletTx&) = default;
-public:
-    // Instead have an explicit copy function
-    void CopyFrom(const CWalletTx&);
+    CWalletTx(const CWalletTx&) = delete;
+    CWalletTx& operator=(const CWalletTx&) = delete;
 
     // Enable the default move constructor
     CWalletTx(CWalletTx&&) = default;

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -234,7 +234,7 @@ public:
     mutable bool fChangeCached;
     mutable CAmount nChangeCached;
 
-    CWalletTx(CTransactionRef tx, const TxState& state) : tx(std::move(Assert(tx))), m_state(state)
+    CWalletTx(CTransactionRef tx, const TxState& state) : m_state(state), tx(std::move(Assert(tx)))
     {
         Init();
     }
@@ -254,7 +254,6 @@ public:
         nOrderPos = -1;
     }
 
-    CTransactionRef tx;
     TxState m_state;
 
     // Set of mempool transactions that conflict
@@ -343,6 +342,8 @@ public:
         }
     }
 
+    CTransactionRef GetTx() const { return tx; }
+
     void SetTx(CTransactionRef arg)
     {
         tx = std::move(arg);
@@ -390,6 +391,9 @@ public:
 
     // Enable the default move constructor
     CWalletTx(CWalletTx&&) = default;
+
+private:
+    CTransactionRef tx;
 };
 
 struct WalletTxOrderComparator {
@@ -410,7 +414,7 @@ public:
     : m_wtx(wtx),
     m_output(output)
     {
-        Assume(std::ranges::find(wtx.tx->vout, output) != wtx.tx->vout.end());
+        Assume(std::ranges::find(wtx.GetTx()->vout, output) != wtx.GetTx()->vout.end());
     }
 
     const CWalletTx& GetWalletTx() const { return m_wtx; }

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -234,9 +234,15 @@ public:
     mutable bool fChangeCached;
     mutable CAmount nChangeCached;
 
-    CWalletTx(CTransactionRef tx, const TxState& state) : tx(std::move(tx)), m_state(state)
+    CWalletTx(CTransactionRef tx, const TxState& state) : tx(std::move(Assert(tx))), m_state(state)
     {
         Init();
+    }
+
+    template <typename Stream>
+    CWalletTx(deserialize_type, Stream& s) : m_state(TxStateInactive{})
+    {
+        Unserialize(s);
     }
 
     void Init()
@@ -385,6 +391,9 @@ private:
 public:
     // Instead have an explicit copy function
     void CopyFrom(const CWalletTx&);
+
+    // Enable the default move constructor
+    CWalletTx(CWalletTx&&) = default;
 };
 
 struct WalletTxOrderComparator {

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -234,15 +234,21 @@ public:
     mutable bool fChangeCached;
     mutable CAmount nChangeCached;
 
-    CWalletTx(CTransactionRef tx, const TxState& state) : m_state(state), tx(std::move(Assert(tx)))
+    CWalletTx(CTransactionRef tx, const TxState& state) : m_state(state)
     {
+        Assert(tx);
+        m_canonical_wtxid = tx->GetWitnessHash();
+        m_txs.emplace(tx->GetWitnessHash(), std::move(tx));
         Init();
     }
 
     template <typename Stream>
-    CWalletTx(deserialize_type, Stream& s) : m_state(TxStateInactive{})
+    CWalletTx(deserialize_type, Stream& s, const std::map<Wtxid, CTransactionRef>& variants) : m_state(TxStateInactive{})
     {
         Unserialize(s);
+        // Merge witness variants
+        m_txs.insert(variants.begin(), variants.end());
+        Assert(m_txs.contains(GetWitnessHash()));
     }
 
     void Init()
@@ -297,7 +303,7 @@ public:
         uint32_t dummy_int = 0; // Used to be fTimeReceivedIsTxTime
         uint256 serializedHash = TxStateSerializedBlockHash(m_state);
         int serializedIndex = TxStateSerializedIndex(m_state);
-        s << TX_WITH_WITNESS(tx) << serializedHash << dummy_vector1 << serializedIndex << dummy_vector2 << string_values << msgs_reqs << dummy_int << nTimeReceived << dummy_bool << dummy_bool;
+        s << TX_WITH_WITNESS(GetTx()) << serializedHash << dummy_vector1 << serializedIndex << dummy_vector2 << string_values << msgs_reqs << dummy_int << nTimeReceived << dummy_bool << dummy_bool;
     }
 
     template<typename Stream>
@@ -313,7 +319,10 @@ public:
         int serializedIndex;
         std::map<std::string, std::string> string_values;
         std::vector<std::pair<std::string, std::string>> msgs_reqs;
-        s >> TX_WITH_WITNESS(tx) >> serialized_block_hash >> dummy_vector1 >> serializedIndex >> dummy_vector2 >> string_values >> msgs_reqs >> dummy_int >> nTimeReceived >> dummy_bool >> dummy_bool;
+        CTransactionRef canonical_tx;
+        s >> TX_WITH_WITNESS(canonical_tx) >> serialized_block_hash >> dummy_vector1 >> serializedIndex >> dummy_vector2 >> string_values >> msgs_reqs >> dummy_int >> nTimeReceived >> dummy_bool >> dummy_bool;
+        m_canonical_wtxid = canonical_tx->GetWitnessHash();
+        m_txs.emplace(m_canonical_wtxid, std::move(canonical_tx));
 
         m_state = TxStateInterpretSerialized({serialized_block_hash, serializedIndex});
 
@@ -342,11 +351,12 @@ public:
         }
     }
 
-    CTransactionRef GetTx() const { return tx; }
+    CTransactionRef GetTx() const { return m_txs.at(m_canonical_wtxid); }
 
     void SetTx(CTransactionRef arg)
     {
-        tx = std::move(arg);
+        Assert(arg);
+        m_txs.emplace(arg->GetWitnessHash(), std::move(arg));
     }
 
     //! make sure balances are recalculated
@@ -379,9 +389,11 @@ public:
     bool isInactive() const { return state<TxStateInactive>(); }
     bool isUnconfirmed() const { return !isAbandoned() && !isBlockConflicted() && !isMempoolConflicted() && !isConfirmed(); }
     bool isConfirmed() const { return state<TxStateConfirmed>(); }
-    const Txid& GetHash() const LIFETIMEBOUND { return tx->GetHash(); }
-    const Wtxid& GetWitnessHash() const LIFETIMEBOUND { return tx->GetWitnessHash(); }
-    bool IsCoinBase() const { return tx->IsCoinBase(); }
+    const Txid& GetHash() const LIFETIMEBOUND { return GetTx()->GetHash(); }
+    const Wtxid& GetWitnessHash() const LIFETIMEBOUND { return GetTx()->GetWitnessHash(); }
+    bool IsCoinBase() const { return GetTx()->IsCoinBase(); }
+
+    const std::map<Wtxid, CTransactionRef>& GetTxs() const { return m_txs; }
 
     // Disable copying of CWalletTx objects to prevent bugs where instances get
     // copied in and out of the mapWallet map, and fields are updated in the
@@ -393,7 +405,9 @@ public:
     CWalletTx(CWalletTx&&) = default;
 
 private:
-    CTransactionRef tx;
+    Wtxid m_canonical_wtxid;
+    std::map<Wtxid, CTransactionRef> m_txs;
+
 };
 
 struct WalletTxOrderComparator {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1084,22 +1084,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
 
     if (!fInsertedNew)
     {
-        if (state.index() != wtx.m_state.index()) {
-            wtx.m_state = state;
-            fUpdated = true;
-        } else {
-            assert(TxStateSerializedIndex(wtx.m_state) == TxStateSerializedIndex(state));
-            assert(TxStateSerializedBlockHash(wtx.m_state) == TxStateSerializedBlockHash(state));
-        }
-        // If we have a witness-stripped version of this transaction, and we
-        // see a new version with a witness, then we must be upgrading a pre-segwit
-        // wallet.  Store the new version of the transaction with the witness,
-        // as the stripped-version must be invalid.
-        // TODO: Store all versions of the transaction, instead of just one.
-        if (tx->HasWitness() && !wtx.GetTx()->HasWitness()) {
-            wtx.SetTx(tx);
-            fUpdated = true;
-        }
+        fUpdated |= wtx.Update(tx, state);
     }
 
     // Mark inactive coinbase transactions and their descendants as abandoned

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -693,7 +693,7 @@ std::set<Txid> CWallet::GetConflicts(const Txid& txid) const
 
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
 
-    for (const CTxIn& txin : wtx.tx->vin)
+    for (const CTxIn& txin : wtx.GetTx()->vin)
     {
         if (mapTxSpends.count(txin.prevout) <= 1)
             continue;  // No conflict if zero or one spends
@@ -825,7 +825,7 @@ void CWallet::AddToSpends(const CWalletTx& wtx)
     if (wtx.IsCoinBase()) // Coinbases don't spend anything!
         return;
 
-    for (const CTxIn& txin : wtx.tx->vin)
+    for (const CTxIn& txin : wtx.GetTx()->vin)
         AddToSpends(txin.prevout, wtx.GetHash());
 }
 
@@ -1021,7 +1021,7 @@ void CWallet::SetSpentKeyState(WalletBatch& batch, const Txid& hash, unsigned in
     if (!srctx) return;
 
     CTxDestination dst;
-    if (ExtractDestination(srctx->tx->vout[n].scriptPubKey, dst)) {
+    if (ExtractDestination(srctx->GetTx()->vout[n].scriptPubKey, dst)) {
         if (IsMine(dst)) {
             if (used != IsAddressPreviouslySpent(dst)) {
                 if (used) {
@@ -1096,7 +1096,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
         // wallet.  Store the new version of the transaction with the witness,
         // as the stripped-version must be invalid.
         // TODO: Store all versions of the transaction, instead of just one.
-        if (tx->HasWitness() && !wtx.tx->HasWitness()) {
+        if (tx->HasWitness() && !wtx.GetTx()->HasWitness()) {
             wtx.SetTx(tx);
             fUpdated = true;
         }
@@ -1115,8 +1115,8 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
             // Break caches since we have changed the state
             desc_tx->MarkDirty();
             batch.WriteTx(*desc_tx);
-            MarkInputsDirty(desc_tx->tx);
-            for (unsigned int i = 0; i < desc_tx->tx->vout.size(); ++i) {
+            MarkInputsDirty(desc_tx->GetTx());
+            for (unsigned int i = 0; i < desc_tx->GetTx()->vout.size(); ++i) {
                 COutPoint outpoint(desc_tx->GetHash(), i);
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(outpoint);
                 for (TxSpends::const_iterator it = range.first; it != range.second; ++it) {
@@ -1195,7 +1195,7 @@ bool CWallet::LoadToWallet(CWalletTx&& wtx_in)
     }
     wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
     AddToSpends(wtx);
-    for (const CTxIn& txin : wtx.tx->vin) {
+    for (const CTxIn& txin : wtx.GetTx()->vin) {
         auto it = mapWallet.find(txin.prevout.hash);
         if (it != mapWallet.end()) {
             CWalletTx& prevtx = it->second;
@@ -1289,8 +1289,8 @@ void CWallet::UpdateTrucSiblingConflicts(const CWalletTx& parent_wtx, const Txid
 {
     // Find all other txs in our wallet that spend utxos from this parent
     // so that we can mark them as mempool-conflicted by this new tx.
-    for (long unsigned int i = 0; i < parent_wtx.tx->vout.size(); i++) {
-        for (auto range = mapTxSpends.equal_range(COutPoint(parent_wtx.tx->GetHash(), i)); range.first != range.second; range.first++) {
+    for (long unsigned int i = 0; i < parent_wtx.GetTx()->vout.size(); i++) {
+        for (auto range = mapTxSpends.equal_range(COutPoint(parent_wtx.GetTx()->GetHash(), i)); range.first != range.second; range.first++) {
             const Txid& sibling_txid = range.first->second;
             // Skip the child_tx itself
             if (sibling_txid == child_txid) continue;
@@ -1404,7 +1404,7 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
             wtx.MarkDirty();
             if (batch) batch->WriteTx(wtx);
             // Iterate over all its outputs, and update those tx states as well (if applicable)
-            for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i) {
+            for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); ++i) {
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(COutPoint(now, i));
                 for (TxSpends::const_iterator iter = range.first; iter != range.second; ++iter) {
                     if (!done.contains(iter->second)) {
@@ -1419,7 +1419,7 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
 
             // If a transaction changes its tx state, that usually changes the balance
             // available of the outputs it spends. So force those to be recomputed
-            MarkInputsDirty(wtx.tx);
+            MarkInputsDirty(wtx.GetTx());
         }
     }
 }
@@ -1615,7 +1615,7 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
                     return TxUpdate::UNCHANGED;
                 };
 
-                RecursiveUpdateTxState(wtx.tx->GetHash(), try_updating_state);
+                RecursiveUpdateTxState(wtx.GetTx()->GetHash(), try_updating_state);
             }
         }
     }
@@ -1697,10 +1697,10 @@ bool CWallet::IsMine(const COutPoint& outpoint) const
     if (!wtx) {
         return false;
     }
-    if (outpoint.n >= wtx->tx->vout.size()) {
+    if (outpoint.n >= wtx->GetTx()->vout.size()) {
         return false;
     }
-    return IsMine(wtx->tx->vout[outpoint.n]);
+    return IsMine(wtx->GetTx()->vout[outpoint.n]);
 }
 
 bool CWallet::IsFromMe(const CTransaction& tx) const
@@ -2066,7 +2066,7 @@ bool CWallet::SubmitTxMemoryPoolAndRelay(CWalletTx& wtx,
     // If broadcast fails for any reason, trying to set wtx.m_state here would be incorrect.
     // If transaction was previously in the mempool, it should be updated when
     // TransactionRemovedFromMempool fires.
-    bool ret = chain().broadcastTransaction(wtx.tx, m_default_max_tx_fee, broadcast_method, err_string);
+    bool ret = chain().broadcastTransaction(wtx.GetTx(), m_default_max_tx_fee, broadcast_method, err_string);
     if (ret) wtx.m_state = TxStateInMempool{};
     return ret;
 }
@@ -2180,12 +2180,12 @@ bool CWallet::SignTransaction(CMutableTransaction& tx) const
     std::map<COutPoint, Coin> coins;
     for (auto& input : tx.vin) {
         const auto mi = mapWallet.find(input.prevout.hash);
-        if(mi == mapWallet.end() || input.prevout.n >= mi->second.tx->vout.size()) {
+        if(mi == mapWallet.end() || input.prevout.n >= mi->second.GetTx()->vout.size()) {
             return false;
         }
         const CWalletTx& wtx = mi->second;
         int prev_height = wtx.state<TxStateConfirmed>() ? wtx.state<TxStateConfirmed>()->confirmed_block_height : 0;
-        coins[input.prevout] = Coin(wtx.tx->vout[input.prevout.n], prev_height, wtx.IsCoinBase());
+        coins[input.prevout] = Coin(wtx.GetTx()->vout[input.prevout.n], prev_height, wtx.IsCoinBase());
     }
     std::map<int, bilingual_str> input_errors;
     return SignTransaction(tx, coins, SIGHASH_DEFAULT, input_errors);
@@ -2226,7 +2226,7 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, co
                 const CWalletTx& wtx = it->second;
                 // We only need the non_witness_utxo, which is a superset of the witness_utxo.
                 //   The signing code will switch to the smaller witness_utxo if this is ok.
-                input.non_witness_utxo = wtx.tx;
+                input.non_witness_utxo = wtx.GetTx();
             }
         }
     }
@@ -2475,7 +2475,7 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
         for (const auto& it : erased_txs) {
             const Txid hash{it->first};
             wtxOrdered.erase(it->second.m_it_wtxOrdered);
-            for (const auto& txin : it->second.tx->vin) {
+            for (const auto& txin : it->second.GetTx()->vin) {
                 auto range = mapTxSpends.equal_range(txin.prevout);
                 for (auto iter = range.first; iter != range.second; ++iter) {
                     if (iter->second == hash) {
@@ -2484,7 +2484,7 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
                     }
                 }
             }
-            for (unsigned int i = 0; i < it->second.tx->vout.size(); ++i) {
+            for (unsigned int i = 0; i < it->second.GetTx()->vout.size(); ++i) {
                 m_txos.erase(COutPoint(hash, i));
             }
             mapWallet.erase(it);
@@ -2649,9 +2649,9 @@ void CWallet::MarkDestinationsDirty(const std::set<CTxDestination>& destinations
     for (auto& entry : mapWallet) {
         CWalletTx& wtx = entry.second;
         if (wtx.m_is_cache_empty) continue;
-        for (unsigned int i = 0; i < wtx.tx->vout.size(); i++) {
+        for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); i++) {
             CTxDestination dst;
-            if (ExtractDestination(wtx.tx->vout[i].scriptPubKey, dst) && destinations.contains(dst)) {
+            if (ExtractDestination(wtx.GetTx()->vout[i].scriptPubKey, dst) && destinations.contains(dst)) {
                 wtx.MarkDirty();
                 break;
             }
@@ -4041,10 +4041,10 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
     for (const auto& [_pos, wtx] : wtxOrdered) {
         // Check it is the watchonly wallet's
         // solvable_wallet doesn't need to be checked because transactions for those scripts weren't being watched for
-        bool is_mine = IsMine(*wtx->tx) || IsFromMe(*wtx->tx);
+        bool is_mine = IsMine(*wtx->GetTx()) || IsFromMe(*wtx->GetTx());
         if (data.watchonly_wallet) {
             LOCK(data.watchonly_wallet->cs_wallet);
-            if (data.watchonly_wallet->IsMine(*wtx->tx) || data.watchonly_wallet->IsFromMe(*wtx->tx)) {
+            if (data.watchonly_wallet->IsMine(*wtx->GetTx()) || data.watchonly_wallet->IsFromMe(*wtx->GetTx())) {
                 // Add to watchonly wallet
                 const Txid& hash = wtx->GetHash();
                 DataStream wtx_ser;
@@ -4604,8 +4604,8 @@ void CWallet::WriteBestBlock() const
 void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
 {
     AssertLockHeld(cs_wallet);
-    for (uint32_t i = 0; i < wtx.tx->vout.size(); ++i) {
-        const CTxOut& txout = wtx.tx->vout.at(i);
+    for (uint32_t i = 0; i < wtx.GetTx()->vout.size(); ++i) {
+        const CTxOut& txout = wtx.GetTx()->vout.at(i);
         if (!IsMine(txout)) continue;
         COutPoint outpoint(wtx.GetHash(), i);
         if (m_txos.contains(outpoint)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1181,11 +1181,11 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     return &wtx;
 }
 
-bool CWallet::LoadToWallet(const Txid& hash, const UpdateWalletTxFn& fill_wtx)
+bool CWallet::LoadToWallet(CWalletTx&& wtx_in)
 {
-    const auto& ins = mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(hash), std::forward_as_tuple(nullptr, TxStateInactive{}));
+    const auto& ins = mapWallet.emplace(wtx_in.GetHash(), std::move(wtx_in));
     CWalletTx& wtx = ins.first->second;
-    if (!fill_wtx(wtx, ins.second)) {
+    if (!ins.second) {
         return false;
     }
     // If wallet doesn't have a chain (e.g when using bitcoin-wallet tool),
@@ -1193,9 +1193,7 @@ bool CWallet::LoadToWallet(const Txid& hash, const UpdateWalletTxFn& fill_wtx)
     if (HaveChain()) {
       wtx.updateState(chain());
     }
-    if (/* insertion took place */ ins.second) {
-        wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
-    }
+    wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
     AddToSpends(wtx);
     for (const CTxIn& txin : wtx.tx->vin) {
         auto it = mapWallet.find(txin.prevout.hash);
@@ -4049,13 +4047,10 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
             if (data.watchonly_wallet->IsMine(*wtx->tx) || data.watchonly_wallet->IsFromMe(*wtx->tx)) {
                 // Add to watchonly wallet
                 const Txid& hash = wtx->GetHash();
-                const CWalletTx& to_copy_wtx = *wtx;
-                if (!data.watchonly_wallet->LoadToWallet(hash, [&](CWalletTx& ins_wtx, bool new_tx) EXCLUSIVE_LOCKS_REQUIRED(data.watchonly_wallet->cs_wallet) {
-                    if (!new_tx) return false;
-                    ins_wtx.SetTx(to_copy_wtx.tx);
-                    ins_wtx.CopyFrom(to_copy_wtx);
-                    return true;
-                })) {
+                DataStream wtx_ser;
+                wtx_ser << *wtx;
+                CWalletTx copy_wtx(deserialize, wtx_ser);
+                if (!data.watchonly_wallet->LoadToWallet(std::move(copy_wtx))) {
                     return util::Error{strprintf(_("Error: Could not add watchonly tx %s to watchonly wallet"), wtx->GetHash().GetHex())};
                 }
                 watchonly_batch->WriteTx(data.watchonly_wallet->mapWallet.at(hash));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4049,7 +4049,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
                 const Txid& hash = wtx->GetHash();
                 DataStream wtx_ser;
                 wtx_ser << *wtx;
-                CWalletTx copy_wtx(deserialize, wtx_ser);
+                CWalletTx copy_wtx(deserialize, wtx_ser, wtx->GetTxs());
                 if (!data.watchonly_wallet->LoadToWallet(std::move(copy_wtx))) {
                     return util::Error{strprintf(_("Error: Could not add watchonly tx %s to watchonly wallet"), wtx->GetHash().GetHex())};
                 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -630,7 +630,7 @@ public:
      * @return the recently added wtx pointer or nullptr if there was a db write error.
      */
     CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool rescanning_old_block = false);
-    bool LoadToWallet(const Txid& hash, const UpdateWalletTxFn& fill_wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool LoadToWallet(CWalletTx&& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx) override;
     void blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) override;
     void blockDisconnected(const interfaces::BlockInfo& block) override;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -992,27 +992,23 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
         DBErrors result = DBErrors::LOAD_OK;
         Txid hash;
         key >> hash;
-        // LoadToWallet call below creates a new CWalletTx that fill_wtx
-        // callback fills with transaction metadata.
-        auto fill_wtx = [&](CWalletTx& wtx, bool new_tx) {
-            if(!new_tx) {
-                // There's some corruption here since the tx we just tried to load was already in the wallet.
-                err = "Error: Corrupt transaction found. This can be fixed by removing transactions from wallet and rescanning.";
-                result = DBErrors::CORRUPT;
-                return false;
+        try {
+            CWalletTx wtx{deserialize, value};
+            if (wtx.GetHash() != hash) {
+                result = std::max(result, DBErrors::NEED_RESCAN);
             }
-            value >> wtx;
-            if (wtx.GetHash() != hash)
-                return false;
 
-            if (wtx.nOrderPos == -1)
+            if (wtx.nOrderPos == -1) {
                 any_unordered = true;
+            }
 
-            return true;
-        };
-        if (!pwallet->LoadToWallet(hash, fill_wtx)) {
-            // Use std::max as fill_wtx may have already set result to CORRUPT
-            result = std::max(result, DBErrors::NEED_RESCAN);
+            if (!pwallet->LoadToWallet(std::move(wtx))) {
+                err = "Error: Corrupt transaction found. This can be fixed by removing transactions from wallet and rescanning.";
+                return DBErrors::CORRUPT;
+            }
+        } catch (const std::exception& e) {
+            err = strprintf("Error: Corrupt tx record found: %s" ,e.what());
+            return DBErrors::CORRUPT;
         }
         return result;
     });

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -52,6 +52,7 @@ const std::string POOL{"pool"};
 const std::string PURPOSE{"purpose"};
 const std::string SETTINGS{"settings"};
 const std::string TX{"tx"};
+const std::string WTX_VARIANT{"wtxvariant"};
 const std::string VERSION{"version"};
 const std::string WALLETDESCRIPTOR{"walletdescriptor"};
 const std::string WALLETDESCRIPTORCACHE{"walletdescriptorcache"};
@@ -97,12 +98,24 @@ bool WalletBatch::ErasePurpose(const std::string& strAddress)
 
 bool WalletBatch::WriteTx(const CWalletTx& wtx)
 {
-    return WriteIC(std::make_pair(DBKeys::TX, wtx.GetHash()), wtx);
+    const Txid txid = wtx.GetHash();
+    // Persist all witness variants. Including the canonical one
+    for (const auto& [wtxid, tx] : wtx.GetTxs()) {
+        if (!WriteWtxVariant(txid, tx)) return false;
+    }
+    return WriteIC(std::make_pair(DBKeys::TX, txid), wtx);
 }
 
 bool WalletBatch::EraseTx(Txid hash)
 {
-    return EraseIC(std::make_pair(DBKeys::TX, hash.ToUint256()));
+    if (!EraseIC(std::make_pair(DBKeys::TX, hash.ToUint256()))) return false;
+    // Drop all witness variant records too, so none are left dangling
+    return m_batch->ErasePrefix(DataStream() << DBKeys::WTX_VARIANT << hash);
+}
+
+bool WalletBatch::WriteWtxVariant(const Txid& txid, const CTransactionRef& tx)
+{
+    return WriteIC(std::make_pair(DBKeys::WTX_VARIANT, std::make_pair(txid, tx->GetWitnessHash())), TX_WITH_WITNESS(tx));
 }
 
 bool WalletBatch::WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, const bool overwrite)
@@ -980,6 +993,37 @@ static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) E
     return result;
 }
 
+static std::map<Wtxid, CTransactionRef> ReadWtxVariants(DatabaseBatch& batch, const Txid& txid)
+{
+    std::map<Wtxid, CTransactionRef> variants;
+
+    DataStream prefix;
+    prefix << DBKeys::WTX_VARIANT << txid;
+    std::unique_ptr<DatabaseCursor> cursor = batch.GetNewPrefixCursor(prefix);
+    if (!cursor) {
+        throw std::runtime_error(strprintf("Error getting database cursor for '%s' records", DBKeys::WTX_VARIANT));
+    }
+
+    DataStream key;
+    DataStream value;
+    while (true) {
+        DatabaseCursor::Status status = cursor->Next(key, value);
+        if (status == DatabaseCursor::Status::DONE) break;
+        if (status == DatabaseCursor::Status::FAIL) {
+            throw std::runtime_error(strprintf("Error reading '%s' record", DBKeys::WTX_VARIANT));
+        }
+        CTransactionRef tx;
+        value >> TX_WITH_WITNESS(tx);
+        if (tx->GetHash() != txid) {
+            throw std::runtime_error(strprintf("Corrupted witness variant, tx hash differs"));
+        }
+        if (!variants.emplace(tx->GetWitnessHash(), std::move(tx)).second) {
+            throw std::runtime_error(strprintf("Duplicate witness variant"));
+        }
+    }
+    return variants;
+}
+
 static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_unordered) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     AssertLockHeld(pwallet->cs_wallet);
@@ -988,12 +1032,12 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
     // Load tx record
     any_unordered = false;
     LoadResult tx_res = LoadRecords(pwallet, batch, DBKeys::TX,
-        [&any_unordered] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
+        [&any_unordered, &batch] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
         DBErrors result = DBErrors::LOAD_OK;
         Txid hash;
         key >> hash;
         try {
-            CWalletTx wtx{deserialize, value};
+            CWalletTx wtx{deserialize, value, ReadWtxVariants(batch, hash)};
             if (wtx.GetHash() != hash) {
                 result = std::max(result, DBErrors::NEED_RESCAN);
             }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -7,6 +7,7 @@
 #define BITCOIN_WALLET_WALLETDB_H
 
 #include <key.h>
+#include <primitives/transaction.h>
 #include <primitives/transaction_identifier.h>
 #include <script/sign.h>
 #include <wallet/db.h>
@@ -79,6 +80,7 @@ extern const std::string POOL;
 extern const std::string PURPOSE;
 extern const std::string SETTINGS;
 extern const std::string TX;
+extern const std::string WTX_VARIANT;
 extern const std::string VERSION;
 extern const std::string WALLETDESCRIPTOR;
 extern const std::string WALLETDESCRIPTORCKEY;
@@ -230,6 +232,7 @@ public:
 
     bool WriteTx(const CWalletTx& wtx);
     bool EraseTx(Txid hash);
+    bool WriteWtxVariant(const Txid& txid, const CTransactionRef& tx);
 
     bool WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, bool overwrite);
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -19,6 +19,7 @@ import os
 import shutil
 
 from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.extendedkey import ExtendedPrivateKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.descriptors import descsum_create
 from test_framework.messages import ser_string
@@ -26,6 +27,7 @@ from test_framework.messages import ser_string
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
+    assert_not_equal,
     assert_raises_rpc_error,
 )
 
@@ -190,6 +192,76 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         node_master.getblockcount()
         # Reset settings for any subsequent test
         os.remove(settings_path)
+
+    def test_downgrade_preserves_witness_variants(self, node_master, node_miner, node_old):
+        # Ensure the wallet keeps every witness variant of a tx during a downgrade. An old
+        # release updating the tx record must not drop them.
+        self.log.info("Test that witness variants survive a downgrade that rewrites the tx record")
+
+        # Earlier tests may have restarted node_master or dropped its peers
+        self.connect_nodes(node_miner.index, node_master.index)
+        self.connect_nodes(node_master.index, node_old.index)
+        self.sync_blocks([node_miner, node_master, node_old])
+
+        wallet_name = "altwit_downgrade"
+        node_master.createwallet(wallet_name)
+        wallet = node_master.get_wallet_rpc(wallet_name)
+
+        xprvs = [ExtendedPrivateKey.generate() for _ in range(0, 2)]
+        xpubs = [xprv.pubkey() for xprv in xprvs]
+
+        # Taproot descriptor with a public-only internal key: the wallet can only
+        # spend via the script path, so the key path is signed separately below.
+        script_path_desc = descsum_create(f"tr({xpubs[0].to_string()}/*,pk({xprvs[1].to_string()}/*))")
+        assert_equal(wallet.importdescriptors([{"desc": script_path_desc, "active": True, "timestamp": "now"}])[0]["success"], True)
+
+        # Fund tr output owned by the wallet
+        node_miner.sendtoaddress(wallet.getnewaddress(address_type="bech32m"), 1)
+        self.sync_mempools([node_miner, node_master])
+        self.generate(node_miner, 1, sync_fun=self.no_op)
+        self.sync_blocks([node_miner, node_master, node_old])
+        wallet.syncwithvalidationinterfacequeue()
+
+        # Two witness variants of the same spend: same txid, different wtxid
+        psbt = wallet.walletcreatefundedpsbt(outputs=[{node_miner.getnewaddress(): 0.5}])["psbt"]
+        script_path_tx = wallet.finalizepsbt(wallet.walletprocesspsbt(psbt=psbt, finalize=False)["psbt"])["hex"]
+        script_path_wtxid = node_master.decoderawtransaction(script_path_tx)["hash"]
+
+        key_path_desc = descsum_create(f"tr({xprvs[0].to_string()}/*,pk({xpubs[1].to_string()}/*))")
+        key_path_psbt = node_master.descriptorprocesspsbt(psbt=psbt, descriptors=[{"desc": key_path_desc}], finalize=False)["psbt"]
+        key_path_tx = wallet.finalizepsbt(key_path_psbt)["hex"]
+        key_path_wtxid = node_master.decoderawtransaction(key_path_tx)["hash"]
+        assert_not_equal(script_path_wtxid, key_path_wtxid)
+
+        # Store variant A through the mempool; store variant B by mining it. The
+        # confirmed (key path) variant becomes canonical, the script path an alternate.
+        txid = node_master.sendrawtransaction(script_path_tx)
+        wallet.syncwithvalidationinterfacequeue()
+        block_hash = self.generateblock(node_master, node_miner.getnewaddress(), [key_path_tx], sync_fun=self.no_op)["hash"]
+        self.sync_blocks([node_miner, node_master, node_old])
+        wallet.syncwithvalidationinterfacequeue()
+        assert_equal(wallet.gettransaction(txid)["alternate_wtxids"], [script_path_wtxid])
+        wallet.unloadwallet()
+
+        # Downgrade: load on the old release, then force it to rewrite the tx
+        # record by disconnecting the block that confirmed the canonical tx.
+        old_dir = node_old.wallets_path / wallet_name
+        shutil.copytree(node_master.wallets_path / wallet_name, old_dir)
+        node_old.loadwallet(wallet_name)
+        old_wallet = node_old.get_wallet_rpc(wallet_name)
+        assert_equal(old_wallet.gettransaction(txid)["hex"], key_path_tx)
+        old_wallet.invalidateblock(block_hash)
+        old_wallet.syncwithvalidationinterfacequeue()
+        old_wallet.unloadwallet()
+
+        # Re-open on master: the alternate must still be there
+        self.cleanup_folder(node_master.wallets_path / wallet_name)
+        shutil.copytree(old_dir, node_master.wallets_path / wallet_name)
+        node_master.loadwallet(wallet_name)
+        wallet = node_master.get_wallet_rpc(wallet_name)
+        assert_equal(wallet.gettransaction(txid)["alternate_wtxids"], [script_path_wtxid])
+        wallet.unloadwallet()
+
 
     def run_test(self):
         node_miner = self.nodes[0]
@@ -434,6 +506,8 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
 
         self.test_v22_inactivehdchain_path()
         self.test_ignore_legacy_during_startup(legacy_nodes, node_master)
+        node_v25 = self.nodes[2] # note: could be any node prior to v32
+        self.test_downgrade_preserves_witness_variants(node_master, node_miner, node_v25)
 
 if __name__ == '__main__':
     BackwardsCompatibilityTest(__file__).main()

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -563,7 +563,8 @@ class WalletTest(BitcoinTestFramework):
                                  "category": baz["category"],
                                  "vout":     baz["vout"]}
         expected_fields = frozenset({'amount', 'confirmations', 'details', 'fee',
-                                     'hex', 'lastprocessedblock', 'time', 'timereceived', 'trusted', 'txid', 'wtxid', 'walletconflicts', 'mempoolconflicts'})
+                                     'hex', 'lastprocessedblock', 'time', 'timereceived', 'trusted', 'txid', 'wtxid', 'walletconflicts', 'mempoolconflicts',
+                                     'alternate_wtxids'})
         verbose_field = "decoded"
         expected_verbose_fields = expected_fields | {verbose_field}
 

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -11,11 +11,13 @@ import shutil
 
 from test_framework.blocktools import MAX_FUTURE_BLOCK_TIME
 from test_framework.descriptors import descsum_create
+from test_framework.extendedkey import ExtendedPrivateKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_not_equal,
     assert_array_result,
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
     find_vout_for_address,
 )
@@ -96,6 +98,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.run_coinjoin_test()
         self.run_invalid_parameters_test()
         self.test_op_return()
+        self.test_alternate_witness_tx()
         self.test_from_me_status_change()
 
     def run_externally_generated_address_test(self):
@@ -241,6 +244,118 @@ class ListTransactionsTest(BitcoinTestFramework):
             tx_info = wallet.gettransaction(txid)
             assert "fee" in tx_info
             assert_equal(any(detail["category"] == "send" for detail in tx_info["details"]), True)
+
+    def check_tx_variants(self, wallet, txid, canonical_tx_hex, canonical_wtxid, alternate_wtxids):
+        """Assert gettransaction and listtransactions report tx variants properly"""
+        tx_info = wallet.gettransaction(txid)
+        assert_equal(tx_info["hex"], canonical_tx_hex)
+        assert_equal(tx_info["wtxid"], canonical_wtxid)
+        # alternate_wtxids lists the other variants, never the canonical one
+        assert canonical_wtxid not in tx_info["alternate_wtxids"]
+        assert_equal(set(tx_info["alternate_wtxids"]), set(alternate_wtxids))
+
+        # listtransactions exposes the same alternate_wtxids field as gettransaction
+        list_entry = next(entry for entry in wallet.listtransactions() if entry["txid"] == txid)
+        assert_equal(list_entry["alternate_wtxids"], tx_info["alternate_wtxids"])
+
+    # Returns the finalized psbt transaction and its wtxid
+    def finalize_tx_variant(self, wallet, psbt, spend_path):
+        # First check the expected spend path is being used
+        sig_field = {"script": "taproot_script_path_sigs", "key": "taproot_key_path_sig"}
+        present, absent = sig_field[spend_path], sig_field["key" if spend_path == "script" else "script"]
+        psbt_input = self.nodes[0].decodepsbt(psbt)["inputs"][0]
+        assert present in psbt_input and absent not in psbt_input
+
+        # Then finalize and decode
+        tx = wallet.finalizepsbt(psbt)["hex"]
+        return tx, wallet.decoderawtransaction(tx)["hash"]
+
+    def test_alternate_witness_tx(self):
+        self.log.info("Test gettransaction and listtransactions report alternate witnesses and canonical variant")
+        self.nodes[0].createwallet("altwit")
+        default_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        wallet = self.nodes[0].get_wallet_rpc("altwit")
+
+        xprvs = [ExtendedPrivateKey.generate() for _ in range(0, 2)]
+        xpubs = [xprv.pubkey() for xprv in xprvs]
+
+        # Import a taproot descriptor with script paths
+        desc = descsum_create(f"tr({xpubs[0].to_string()}/*,pk({xprvs[1].to_string()}/*))")
+        assert_equal(wallet.importdescriptors([{"desc": desc, "active": True, "timestamp": "now"}])[0]["success"], True)
+        default_wallet.sendtoaddress(wallet.getnewaddress(address_type="bech32m"), 1)
+        self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+        # Isolate node0 for later reorg coverage
+        self.disconnect_nodes(0, 1)
+        self.disconnect_nodes(0, 2)
+
+        # Create output psbt
+        psbt = wallet.walletcreatefundedpsbt(outputs=[{default_wallet.getnewaddress(): 0.5}])["psbt"]
+
+        # Create a script path spend and relay it. With only one variant known it
+        # is trivially canonical and has no alternates
+        self.log.info("Test the only known variant is canonical with no alternates")
+        script_path_psbt = wallet.walletprocesspsbt(psbt=psbt, finalize=False)["psbt"]
+        script_path_tx, script_path_wtxid = self.finalize_tx_variant(wallet, script_path_psbt, spend_path="script")
+        txid = self.nodes[0].sendrawtransaction(script_path_tx)
+        self.check_tx_variants(wallet, txid, script_path_tx, script_path_wtxid, alternate_wtxids=[])
+
+        # Make a key path spend separate from the wallet
+        key_path_desc = descsum_create(f"tr({xprvs[0].to_string()}/*,pk({xpubs[1].to_string()}/*))")
+        key_path_psbt = self.nodes[0].descriptorprocesspsbt(psbt=psbt, descriptors=[{"desc": key_path_desc}], finalize=False)["psbt"]
+        key_path_tx, key_path_wtxid = self.finalize_tx_variant(wallet, key_path_psbt, spend_path="key")
+
+        # Ensure variants share the same txid but differ in wtxid, and the key path is the lighter of the two
+        assert_equal(txid, self.nodes[0].decoderawtransaction(key_path_tx)["txid"])
+        assert_not_equal(script_path_wtxid, key_path_wtxid)
+        assert_greater_than(
+            self.nodes[0].decoderawtransaction(script_path_tx)["weight"],
+            self.nodes[0].decoderawtransaction(key_path_tx)["weight"],
+        )
+
+        # The wallet only learns the key path witness from a block (the mempool
+        # holds one transaction per txid). Mine the key path: a confirmed variant
+        # is canonical, with the script path now listed as its alternate.
+        block = self.generateblock(self.nodes[0], default_wallet.getnewaddress(), [key_path_tx], sync_fun=self.no_op)["hash"]
+        self.check_tx_variants(wallet, txid, key_path_tx, key_path_wtxid, alternate_wtxids=[script_path_wtxid])
+
+        # Reorg that block out so both variants are known and unconfirmed. With no
+        # confirmation to force the choice, the lighter key path is canonical.
+        self.log.info("Test the lighter variant is canonical when both are known and unconfirmed")
+        self.nodes[0].invalidateblock(block)
+        self.nodes[0].syncwithvalidationinterfacequeue()
+        assert_equal(wallet.gettransaction(txid)["confirmations"], 0)
+        self.check_tx_variants(wallet, txid, key_path_tx, key_path_wtxid, alternate_wtxids=[script_path_wtxid])
+
+        # The canonical choice and alternates survive a wallet reload
+        wallet.unloadwallet()
+        self.nodes[0].loadwallet("altwit")
+        self.check_tx_variants(wallet, txid, key_path_tx, key_path_wtxid, alternate_wtxids=[script_path_wtxid])
+
+        # Now confirm the heavier script path instead, on a longer competing chain
+        # from node1, and reconnect so node0 reorgs onto it. The confirmed variant
+        # is canonical even though it is the heavier one.
+        self.log.info("Test a confirmed variant is canonical even when it is the heavier one")
+        self.generate(self.nodes[1], 3, sync_fun=self.no_op)
+        block = self.generateblock(self.nodes[1], default_wallet.getnewaddress(), [script_path_tx], sync_fun=self.no_op)["hash"]
+        self.connect_nodes(0, 1)
+        self.connect_nodes(0, 2)
+        self.sync_all()
+        self.check_tx_variants(wallet, txid, script_path_tx, script_path_wtxid, alternate_wtxids=[key_path_wtxid])
+
+        # The confirmed-canonical choice survive a reload
+        wallet.unloadwallet()
+        self.nodes[0].loadwallet("altwit")
+        self.check_tx_variants(wallet, txid, script_path_tx, script_path_wtxid, alternate_wtxids=[key_path_wtxid])
+
+        self.log.info("Test canonical reverts to the lighter variant when the confirmed one is reorged out")
+        # Both variants are unconfirmed again, so the lighter key path is canonical once more
+        self.disconnect_nodes(0, 1)
+        self.disconnect_nodes(0, 2)
+        self.nodes[0].invalidateblock(block)
+        self.nodes[0].syncwithvalidationinterfacequeue()
+        assert_equal(wallet.gettransaction(txid)["confirmations"], 0)
+        self.check_tx_variants(wallet, txid, key_path_tx, key_path_wtxid, alternate_wtxids=[script_path_wtxid])
+
 
 if __name__ == '__main__':
     ListTransactionsTest(__file__).main()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -184,13 +184,13 @@ class WalletMigrationTest(BitcoinTestFramework):
         return migrate_info, wallet
 
     def test_basic(self):
-        # Remove the deprecated response fields that'd be present in the RPC responses
-        # sent by the old node(s).
-        def remove_deprecated_keys(list):
+        # Update listtransctions' output from old nodes to be compatible
+        def listtransactions_compatibility(list):
             deprecated_keys = {"bip125-replaceable"}
             for obj in list:
                 for key in deprecated_keys:
                     obj.pop(key)
+                obj["alternate_wtxids"] = []
             return list
 
         default = self.master_node.get_wallet_rpc(self.default_wallet_name)
@@ -248,7 +248,7 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         basic1_migrate, basic1 = self.migrate_and_get_rpc("basic1")
         assert_equal(basic1.getbalance(), bal)
-        self.assert_list_txs_equal(basic1.listtransactions(), remove_deprecated_keys(txs))
+        self.assert_list_txs_equal(basic1.listtransactions(), listtransactions_compatibility(txs))
 
         self.log.info("Test backup file can be successfully restored")
         self.old_node.restorewallet("basic1_restored", basic1_migrate['backup_path'])
@@ -256,7 +256,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         basic1_restored_wi = basic1_restored.getwalletinfo()
         assert_equal(basic1_restored_wi['balance'], bal)
         assert_equal(basic1_restored.listaddressgroupings(), addr_gps)
-        self.assert_list_txs_equal(remove_deprecated_keys(basic1_restored.listtransactions()), txs)
+        self.assert_list_txs_equal(listtransactions_compatibility(basic1_restored.listtransactions()), txs)
 
         # restart master node and verify that everything is still there
         self.restart_node(0)
@@ -286,7 +286,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         # Now migrate and test that we still have the same balance/transactions
         _, basic2 = self.migrate_and_get_rpc("basic2")
         assert_equal(basic2.getbalance(), basic2_balance)
-        self.assert_list_txs_equal(basic2.listtransactions(), remove_deprecated_keys(basic2_txs))
+        self.assert_list_txs_equal(basic2.listtransactions(), listtransactions_compatibility(basic2_txs))
 
         # Now test migration on a descriptor wallet
         self.log.info("Test \"nothing to migrate\" when the user tries to migrate a loaded wallet with no legacy data")


### PR DESCRIPTION
When the wallet is presented with a transaction that has the same txid as one already known to the wallet, but has a different witness, instead of ignoring the transaction, store it alongside the known tx. This enables the wallet to be aware of all wtxid variants of its transactions. This also allows for the wallet to be able to calculate fees for replacements better as txs with different witnesses may have different feerates.

Specifically, the wallet stores these alternates in `CWalletTx` and extends the existing `tx` record type to essentially have a vector of transactions appended to the record. In `CWalletTx`, the single transaction is replaced with a map of wtxid to transaction so that all witness variants can still be represented by a single `CWalletTx`. For all of the various things that need the tx from a `CWalletTx`, a single witness variant is chosen to be the canonical tx and returned by `GetTx()`. This canonical tx is written into the same place as the previous single tx was written to in the `tx` record so that wallets can be loaded into previous versions.

To choose the canonical transaction, if any of the variants is confirmed, then that is the canonical one. Otherwise, the witness variant with the least weight is chosen.

An additional change I've included is to make `CWalletTx` RAII. This simplifies some of the implementation and enforces the assumption that a `CWalletTx` always has a transaction.

Lastly, `gettransaction` and `listtransaction` have a new field `alternate_wtxids` to inform users of the wtxids of the witness variants for a transaction, and of course, a test.

Closes #11240 