### PR TITLE
guix: CMake-related improvements

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -166,7 +166,7 @@ mkdir -p "$DISTSRC"
           -DWITH_CCACHE=OFF \
           -Werror=dev \
           ${CONFIGFLAGS} \
-          "${CMAKE_EXE_LINKER_FLAGS}"
+          ${CMAKE_EXE_LINKER_FLAGS+"$CMAKE_EXE_LINKER_FLAGS"}
 
     # Build Bitcoin Core
     cmake --build build -j "$JOBS"

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -169,14 +169,14 @@ mkdir -p "$DISTSRC"
           "${CMAKE_EXE_LINKER_FLAGS}"
 
     # Build Bitcoin Core
-    cmake --build build -j "$JOBS" ${V:+--verbose}
+    cmake --build build -j "$JOBS"
 
     mkdir -p "$OUTDIR"
 
     # Make the os-specific installers
     case "$HOST" in
         *mingw*)
-            cmake --build build -j "$JOBS" -t deploy ${V:+--verbose}
+            cmake --build build -j "$JOBS" -t deploy
             mv build/bitcoin-win64-setup.exe "${OUTDIR}/${DISTNAME}-win64-setup-unsigned.exe"
             ;;
     esac
@@ -188,10 +188,10 @@ mkdir -p "$DISTSRC"
     # Install built Bitcoin Core to $INSTALLPATH
     case "$HOST" in
         *darwin*)
-            cmake --install build --strip --prefix "${INSTALLPATH}" ${V:+--verbose}
+            cmake --install build --strip --prefix "${INSTALLPATH}"
             ;;
         *)
-            cmake --install build --prefix "${INSTALLPATH}" ${V:+--verbose}
+            cmake --install build --prefix "${INSTALLPATH}"
             ;;
     esac
 

--- a/contrib/guix/libexec/package.sh
+++ b/contrib/guix/libexec/package.sh
@@ -95,7 +95,7 @@ set -e -o pipefail
             )
             ;;
         *darwin*)
-            cmake --build build --target deploy ${V:+--verbose}
+            cmake --build build --target deploy
             mv build/dist/bitcoin-macos-app.zip "${OUTDIR}/${DISTNAME}-${HOST}-unsigned.zip"
             mkdir -p "unsigned-app-${HOST}"
             cp  --target-directory="unsigned-app-${HOST}" \


### PR DESCRIPTION
This PR introduces the following CMake-related improvements to [`contrib/guix/libexec/build.sh`](https://github.com/bitcoin/bitcoin/blob/master/contrib/guix/libexec/build.sh):

1. Drop redundant CMake `--verbose` options, as verbose output is already controlled by the [`VERBOSE`](https://cmake.org/cmake/help/latest/envvar/VERBOSE.html) environment variable, which has been exported since  85f4a4b0822e3aa10310c4623eff719f301e9263.

2. Fixes the "Ignoring empty string" CMake warning for non-Linux hosts.