### PR TITLE
test: fix `--perf` profiling

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -717,7 +717,7 @@ class TestNode():
             self.log.warning("Can't profile with perf; must install perf-tools")
             return None
 
-        if not test_success('readelf -S {} | grep .debug_str'.format(shlex.quote(self.binary))):
+        if not test_success('readelf -S {} | grep .debug_str'.format(shlex.quote(self.binaries.paths.bitcoind))):
             self.log.warning(
                 "perf output won't be very useful without debug symbols compiled into bitcoind")
 
@@ -749,7 +749,7 @@ class TestNode():
         subp.wait(timeout=10)
 
         stderr = subp.stderr.read().decode()
-        if 'Consider tweaking /proc/sys/kernel/perf_event_paranoid' in stderr:
+        if 'Consider adjusting /proc/sys/kernel/perf_event_paranoid' in stderr:
             self.log.warning(
                 "perf couldn't collect data! Try "
                 "'sudo sysctl -w kernel.perf_event_paranoid=-1'")


### PR DESCRIPTION
Functional test profiling with `--perf` (introduced in #14519) is currently broken, as `TestNode._start_perf` accesses the `self.binary` attribute which doesn't exist anymore since commit 0d2eefca8bf3cb64e3f2f912ed32118524430967 / PR #31866. Fix that by using the proper field `self.binaries.paths.bitcoind`.

Also, perf's error output for missing kernel permissions changed slightly in 2020 (s/tweaking/adjusting) (see https://github.com/torvalds/linux/commit/c1034eb069201f3f3c40f34f3d937ecb8049d0cf), so adapt our matching string as well in order to show the "couldn't collect data" warning if necessary. Relying on a certain output string is obviously brittle, so we might want to do something smarter there.

This is a minimum-diff-fix that works on my machine (arm64, Ubuntu 25.04, Kernel 6.17.0-8-qcom-x1e, perf 6.1.174). I think the feature is useful in principle, but considering that no one noticed for more than a year that it's broken, it seems that no one really uses it, and an alternative might also be to remove it. Curious to hear opinions.