### PR TITLE
ci: Alpine 3.24

### DIFF
--- a/ci/test/00_setup_env_native_alpine_musl.sh
+++ b/ci/test/00_setup_env_native_alpine_musl.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_alpine_musl
-export CI_IMAGE_NAME_TAG="mirror.gcr.io/alpine:3.23"
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/alpine:3.24"
 export CI_BASE_PACKAGES="build-base musl-dev pkgconf curl ccache make ninja git python3-dev py3-pip which patch xz procps rsync util-linux bison e2fsprogs cmake dash linux-headers"
 export PIP_PACKAGES="--break-system-packages pyzmq pycapnp"
 export DEP_OPTS="DEBUG=1"


### PR DESCRIPTION
Switch to [Alpine 3.24](https://www.alpinelinux.org/posts/Alpine-3.24.0-released.html) in the Alpine CI job.