### PR TITLE
cmake: Use target file name for manpage installation

### DIFF
--- a/cmake/module/InstallBinaryComponent.cmake
+++ b/cmake/module/InstallBinaryComponent.cmake
@@ -23,7 +23,7 @@ function(install_binary_component component)
     COMPONENT ${component}
   )
   if(INSTALL_MAN AND IC_HAS_MANPAGE)
-    install(FILES ${PROJECT_SOURCE_DIR}/doc/man/${target_name}.1
+    install(FILES ${PROJECT_SOURCE_DIR}/doc/man/$<TARGET_FILE_BASE_NAME:${target_name}>.1
       DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
       COMPONENT ${component}
     )


### PR DESCRIPTION
The manpage file name is expected to coincide with the name of the installed executable file. The latter defaults to the logical target name, but diverges from it if any of the following target properties is set:
 - [`OUTPUT_NAME`](https://cmake.org/cmake/help/latest/prop_tgt/OUTPUT_NAME.html)
 - [`OUTPUT_NAME_<CONFIG>`](https://cmake.org/cmake/help/latest/prop_tgt/OUTPUT_NAME_CONFIG.html)
 - [`RUNTIME_OUTPUT_NAME`](https://cmake.org/cmake/help/latest/prop_tgt/RUNTIME_OUTPUT_NAME.html)
 - [`RUNTIME_OUTPUT_NAME_<CONFIG>`](https://cmake.org/cmake/help/latest/prop_tgt/RUNTIME_OUTPUT_NAME_CONFIG.html)

Use the [`$<TARGET_FILE_BASE_NAME>`](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:TARGET_FILE_BASE_NAME) generator expression, which resolves all of the properties above, instead of the logical target name.

No change in behavior for any current target, as none of them sets any of these properties.

---

Found this useful when replacing the `bitcoin-qt` target with the new `bitcoin-qml` one in the QML GUI staging branch.