### PR TITLE
doc: document -blocknotify, -walletnotify and other -*notify options

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -80,6 +80,7 @@ The Bitcoin repo's [root README](/README.md) contains relevant information on th
 - [Init Scripts (systemd/upstart/openrc)](init.md)
 - [Managing Wallets](managing-wallets.md)
 - [Multisig Tutorial](multisig-tutorial.md)
+- [Notifications (shell commands)](notifications.md)
 - [Offline Signing Tutorial](offline-signing-tutorial.md)
 - [P2P bad ports definition and list](p2p-bad-ports.md)
 - [PSBT support](psbt.md)

--- a/doc/notifications.md
+++ b/doc/notifications.md
@@ -1,0 +1,20 @@
+# Shell Command Notifications
+
+Bitcoin Core can execute user-supplied shell commands when certain events occur,
+configured through the `-*notify` startup options. They are only available on
+platforms built with shell command support. See the `--help` output for each
+option's placeholders and details.
+
+Each notification (except `-shutdownnotify`) runs its command in a new detached
+thread, so commands may run concurrently and complete in any order. There is no
+ordering guarantee, even within a single topic. Consumers that need consistent
+state should query the node (e.g. via RPC) rather than rely on the values passed
+to the command.
+
+The available options are:
+
+- `-blocknotify` — when the best block changes
+- `-walletnotify` — when a wallet transaction is added or updated
+- `-alertnotify` — when a node warning is raised
+- `-startupnotify` — once on startup
+- `-shutdownnotify` — immediately before shutdown begins


### PR DESCRIPTION
Partially addresses #14278, which asks for documentation of the user-facing `-*notify` behaviors. The five shell-command notification options currently have no documentation outside of `--help` text, and several behaviors are only discoverable by reading the source.

Adds `doc/notifications.md` (indexed in `doc/README.md`) covering:

**`-blocknotify`**
- Suppressed during initial block download and reindex — only fires once the node reaches the post-init sync state (`src/init.cpp`, `NotifyBlockTip_connect` handler)
- Each event runs the command in a detached thread, so **there is no ordering guarantee** between successive notifications — this directly documents the behavior behind the ordering question raised in #14278 and the test discrepancy noted in #14275

**`-walletnotify`**
- Fires on mempool entry, confirmation, and when a transaction returns to unconfirmed due to a conflict with a newly connected block (`CWallet::transactionRemovedFromMempool`)
- Documents all four substitutions (`%s`, `%b`, `%h`, `%w`) and the Windows limitation for `%w`

**`-alertnotify`**
- Fires once per distinct warning condition; message is sanitized and single-quoted before substitution (`src/node/kernel_notifications.cpp`)

**`-startupnotify` / `-shutdownnotify`**
- Startup command does not block initialization; shutdown commands may be specified multiple times, run in parallel, and shutdown waits for them to complete (`src/init.cpp`)

All described behavior is derived directly from the source.