### PR TITLE
rpc: tighten setmocktime upper bound to UINT32_MAX

### DIFF
--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -29,6 +29,7 @@
 #include <util/time.h>
 
 #include <cstdint>
+#include <limits>
 #ifdef HAVE_MALLOC_INFO
 #include <malloc.h>
 #endif
@@ -61,7 +62,9 @@ static RPCMethod setmocktime()
     LOCK(cs_main);
 
     const int64_t time{request.params[0].getInt<int64_t>()};
-    constexpr int64_t max_time{Ticks<std::chrono::seconds>(std::chrono::nanoseconds::max())};
+    // block timestamps are uint32_t, so mocking time beyond that is meaningless for anything
+    // consensus-related and can cause integer overflow/truncation issues in time arithmetic.
+    constexpr int64_t max_time{std::numeric_limits<uint32_t>::max()};
     if (time < 0 || time > max_time) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Mocktime must be in the range [0, %s], not %s.", max_time, time));
     }

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -290,6 +290,8 @@ class BlockchainTest(BitcoinTestFramework):
         self.log.info("Check that block timestamps work until year 2106")
         self.generate(self.nodes[0], 8)[-1]
         time_2106 = 2**32 - 1
+        assert_raises_rpc_error(-8, f"Mocktime must be in the range [0, {time_2106}], not -1.", self.nodes[0].setmocktime, -1)
+        assert_raises_rpc_error(-8, f"Mocktime must be in the range [0, {time_2106}], not {time_2106 + 1}.", self.nodes[0].setmocktime, time_2106 + 1)
         self.nodes[0].setmocktime(time_2106)
         last = self.generate(self.nodes[0], 6)[-1]
         assert_equal(self.nodes[0].getblockheader(last)["mediantime"], time_2106)

--- a/test/functional/rpc_uptime.py
+++ b/test/functional/rpc_uptime.py
@@ -10,7 +10,6 @@ Test corresponds to code in rpc/server.cpp.
 import time
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_raises_rpc_error
 
 
 class UptimeTest(BitcoinTestFramework):
@@ -19,11 +18,7 @@ class UptimeTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
-        self._test_negative_time()
         self._test_uptime()
-
-    def _test_negative_time(self):
-        assert_raises_rpc_error(-8, "Mocktime must be in the range [0, 9223372036], not -1.", self.nodes[0].setmocktime, -1)
 
     def _test_uptime(self):
         time.sleep(1) # Do some work before checking uptime


### PR DESCRIPTION
The previous upper bound for `setmocktime` was `std::chrono::nanoseconds::max()` converted to seconds (~year 2262). This was too permissive in two ways:

1. Paths that add an offset to the mocked time can overflow `int64_t` (caught by UBSan). For example, `ContextualCheckBlockHeader` adds a constant to the current time for its future-time check. (see [comment](https://github.com/bitcoin/bitcoin/pull/35496#issuecomment-4678552371))

2. Paths that assign the mocked time to a `uint32_t` field silently truncate it (caught by the integer sanitizer). For example, `miner.cpp` assigns `NodeClock::now()` directly to `pblock->nTime`. (see [comment](https://github.com/bitcoin/bitcoin/pull/35496#issuecomment-4679331674))

`UINT32_MAX` is the natural ceiling since block header `nTime` is `uint32_t`, making mocked values beyond it meaningless for anything consensus-related.