### PR TITLE
lint: remove redundant test suite uniqueness check

### DIFF
--- a/test/lint/lint-tests.py
+++ b/test/lint/lint-tests.py
@@ -27,7 +27,8 @@ def grep_boost_test_suites():
     return subprocess.check_output(command, text=True)
 
 
-def check_matching_test_names(test_suite_list):
+def main():
+    test_suite_list = grep_boost_test_suites().splitlines()
     not_matching = [
         x
         for x in test_suite_list
@@ -42,46 +43,7 @@ def check_matching_test_names(test_suite_list):
             f"{not_matching}\n"
         )
         print(error_msg)
-        return 1
-    return 0
-
-
-def get_duplicates(input_list):
-    """
-    From https://stackoverflow.com/a/9835819
-    """
-    seen = set()
-    dupes = set()
-    for x in input_list:
-        if x in seen:
-            dupes.add(x)
-        else:
-            seen.add(x)
-    return dupes
-
-
-def check_unique_test_names(test_suite_list):
-    output = [re.search(r"\((.*?)[,)]", x) for x in test_suite_list]
-    output = [x.group(1) for x in output if x is not None]
-    output = get_duplicates(output)
-    output = sorted(list(output))
-
-    if len(output) > 0:
-        output = "\n".join(output)
-        error_msg = (
-            "Test suite names must be unique. The following test suite names\n"
-            f"appear to be used more than once:\n\n{output}"
-        )
-        print(error_msg)
-        return 1
-    return 0
-
-
-def main():
-    test_suite_list = grep_boost_test_suites().splitlines()
-    exit_code = check_matching_test_names(test_suite_list)
-    exit_code |= check_unique_test_names(test_suite_list)
-    sys.exit(exit_code)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to https://github.com/bitcoin/bitcoin/pull/35451#discussion_r3403672298.

**Problem:** That duplicate check in `test/lint/lint-tests.py` is redundant now: CMake already registers each Boost test suite as a CTest test name and rejects duplicates there.

**Fix:** Remove the `check_unique_test_names` path and its now-unused duplicate helper and inline remaining helper into `main()`.

**Reproducers:** These throwaway patches pass `test/lint/lint-tests.py` and fail during CMake test registration.

<details><summary>Internal `src/test` duplicate</summary>

```diff
diff --git a/src/test/base32_tests.cpp b/src/test/base32_tests.cpp
index 051a8fcd25..3b50bff724 100644
--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -54,3 +54,7 @@ BOOST_AUTO_TEST_CASE(base32_padding)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(base32_tests)
+BOOST_AUTO_TEST_CASE(base32_duplicate_probe) { BOOST_CHECK(true); }
+BOOST_AUTO_TEST_SUITE_END()
```
</details>
<details><summary>Internal `src/wallet/test` duplicate</summary>

```diff
diff --git a/src/wallet/test/wallet_rpc_tests.cpp b/src/wallet/test/wallet_rpc_tests.cpp
index 8bf5eab443..854d010ec0 100644
--- a/src/wallet/test/wallet_rpc_tests.cpp
+++ b/src/wallet/test/wallet_rpc_tests.cpp
@@ -37,5 +37,10 @@ BOOST_AUTO_TEST_CASE(ensure_unique_wallet_name)
     BOOST_CHECK_THROW(TestWalletName("/wallet/foobar", "foo"), UniValue);
 }
 
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(wallet_rpc_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_CASE(wallet_rpc_duplicate_probe) { BOOST_CHECK(true); }
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet
```
</details>
<details><summary>Cross `src/test` and `src/wallet/test` duplicate</summary>

```diff
diff --git a/src/wallet/test/CMakeLists.txt b/src/wallet/test/CMakeLists.txt
index 524c7218f4..04628e0327 100644
--- a/src/wallet/test/CMakeLists.txt
+++ b/src/wallet/test/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(test_bitcoin
   PRIVATE
     init_test_fixture.cpp
     wallet_test_fixture.cpp
+    base32_tests.cpp
     db_tests.cpp
     coinselector_tests.cpp
     coinselection_tests.cpp
diff --git a/src/wallet/test/base32_tests.cpp b/src/wallet/test/base32_tests.cpp
new file mode 100644
index 0000000000..da91d87dca
--- /dev/null
+++ b/src/wallet/test/base32_tests.cpp
@@ -0,0 +1,5 @@
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(base32_tests)
+BOOST_AUTO_TEST_CASE(wallet_cross_duplicate_probe) { BOOST_CHECK(true); }
+BOOST_AUTO_TEST_SUITE_END()
```
</details>

The CMake failures are in the form:

```text
CMake Error at src/test/CMakeLists.txt:199 (add_test):
  add_test given test NAME "<duplicate_suite>" which already exists in this
  directory.
```
