### PR TITLE
Revert "build: exclude mptest target from compile commands"

### DIFF
--- a/cmake/libmultiprocess.cmake
+++ b/cmake/libmultiprocess.cmake
@@ -34,5 +34,5 @@ function(add_libmultiprocess subdir)
   # exclusion, tools like clang-tidy and IWYU that make use of compilation
   # database would complain that the generated c++ source files do not exist. An
   # alternate fix could build "mpexamples" by default like "mptests" above.
-  set_target_properties(mpcalculator mpprinter mpexample mptest PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+  set_target_properties(mpcalculator mpprinter mpexample PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 endfunction()


### PR DESCRIPTION
This reverts commit 4731049ba4f8a820cc4aa13a745e41bdfbee284a (#35418), which broke the build with `-DBUILD_TESTS=OFF`:
```bash
-- Performing Test HAVE_PTHREAD_GETTHREADID_NP - Failed
CMake Error at cmake/libmultiprocess.cmake:37 (set_target_properties):
  set_target_properties Can not find target to add properties to: mptest
Call Stack (most recent call first):
  src/CMakeLists.txt:24 (add_libmultiprocess)
```

Reported by `afiore` on IRC.