### PR TITLE
util: Prevent file overwriting in fallback `AllocateFileRange` implementation

### DIFF
--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -188,11 +188,18 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
     // Windows-specific version
     HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
     LARGE_INTEGER nFileSize;
-    int64_t nEndPos = (int64_t)offset + length;
-    nFileSize.u.LowPart = nEndPos & 0xFFFFFFFF;
-    nFileSize.u.HighPart = nEndPos >> 32;
-    SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
-    SetEndOfFile(hFile);
+    if (!GetFileSizeEx(hFile, &nFileSize)) {
+        return;
+    }
+    int64_t nEndPos{static_cast<int64_t>(offset) + length};
+    int64_t nCurrentSize{(int64_t{nFileSize.u.HighPart} << 32) | nFileSize.u.LowPart};
+    if (nEndPos > nCurrentSize) {
+        nFileSize.u.LowPart  = nEndPos & 0xFFFFFFFF;
+        nFileSize.u.HighPart = nEndPos >> 32;
+        if (SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN)) {
+            SetEndOfFile(hFile);
+        }
+    }
 #elif defined(__APPLE__)
     // OSX specific version
     // NOTE: Contrary to other OS versions, the OSX version assumes that

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -223,16 +223,22 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
 #endif
     // Fallback version
     // TODO: just write one byte per block
-    static const char buf[65536] = {};
-    if (fseek(file, offset, SEEK_SET)) {
+    if (fseeko(file, 0, SEEK_END) != 0) {
         return;
     }
-    while (length > 0) {
-        unsigned int now = 65536;
-        if (length < now)
-            now = length;
-        fwrite(buf, 1, now, file); // allowed to fail; this function is advisory anyway
-        length -= now;
+    off_t file_size{ftello(file)};
+    if (file_size < 0) {
+        return;
+    }
+    off_t end_pos{static_cast<off_t>(offset) + length};
+    if (end_pos > file_size) {
+        static const uint8_t buf[65536] = {};
+        off_t remaining{end_pos - file_size};
+        while (remaining > 0) {
+            off_t chunk{(remaining < 65536) ? remaining : 65536};
+            fwrite(buf, 1, static_cast<size_t>(chunk), file); // allowed to fail; this function is advisory anyway
+            remaining -= chunk;
+        }
     }
 #endif
 }


### PR DESCRIPTION
this PR picks up #33164

on systems where `posix_fallocate()` is unavailable, the fallback
implementation of `AllocateFileRange()` can overwrite parts of
`blk00000.dat` with zeroes. as a result, `-reindex` appears to complete
successfully, but only the genesis block is recovered

this PR fixes the fallback path so that when reindexing happens, the
existing blocks are correctly restored instead of getting clobbered

the second commit (fdec41914f2218c3c8bfe033a2612c6029854a1a) takes some
inspiration from #33228, specifically this commit
2c113ebc2d3ab559ccaf400a1953724bb15b1574.

fixes #33128