### PR TITLE
ci: bump MSan fuzz timeout from 150 to 180 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,7 @@ jobs:
           - name: 'MSan, fuzz'
             warp-runner: 'warp-ubuntu-latest-x64-8x'
             fallback-runner: 'ubuntu-latest'
-            timeout-minutes: 150
+            timeout-minutes: 180
             file-env: './ci/test/00_setup_env_native_fuzz_with_msan.sh'
 
           - name: 'MSan'


### PR DESCRIPTION
The MSan fuzz job is cutting it a bit close on forks (with no cache hits):

Examples from `Sjors/bitcoin`:

- PR 116 timed out after 2h30m, and would have finished ~5 mins later: https://github.com/Sjors/bitcoin/actions/runs/27465468297/job/81187008305?pr=116
- PR 117 passed in 2h24m47s: https://github.com/Sjors/bitcoin/actions/runs/27465461797/job/81186956747?pr=117
- PR 118 passed in 2h18m22s: https://github.com/Sjors/bitcoin/actions/runs/27465761345/job/81187860567?pr=118

Bumping the timeout to 180 minutes should make these timeouts sufficiently rare, and not make much of a difference here.