### PR TITLE
Treat empty settings file as missing

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -84,19 +84,22 @@ bool ReadSettings(const fs::path& path, std::map<std::string, SettingsValue>& va
       return false;
     }
 
-    SettingsValue in;
-    if (!in.read(std::string{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()})) {
-        errors.emplace_back(strprintf("Settings file %s does not contain valid JSON. This is probably caused by disk corruption or a crash, "
-                                      "and can be fixed by removing the file, which will reset settings to default values.",
-                                      fs::PathToString(path)));
-        return false;
-    }
-
+    const std::string contents{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
     if (file.fail()) {
         errors.emplace_back(strprintf("Failed reading settings file %s", fs::PathToString(path)));
         return false;
     }
     file.close(); // Done with file descriptor. Release while copying data.
+
+    if (contents.empty()) return true;
+
+    SettingsValue in;
+    if (!in.read(contents)) {
+        errors.emplace_back(strprintf("Settings file %s does not contain valid JSON. This is probably caused by disk corruption or a crash, "
+                                      "and can be fixed by removing the file, which will reset settings to default values.",
+                                      fs::PathToString(path)));
+        return false;
+    }
 
     if (!in.isObject()) {
         errors.emplace_back(strprintf("Found non-object value %s in settings file %s", in.write(), fs::PathToString(path)));

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -82,6 +82,12 @@ BOOST_AUTO_TEST_CASE(ReadWrite)
     BOOST_CHECK(values.empty());
     BOOST_CHECK(errors.empty());
 
+    // Check no errors if file is empty.
+    WriteText(path, "");
+    BOOST_CHECK(common::ReadSettings(path, values, errors));
+    BOOST_CHECK(values.empty());
+    BOOST_CHECK(errors.empty());
+
     // Check duplicate keys not allowed and that values returns empty if a duplicate is found.
     WriteText(path, R"({
         "dupe": "string",


### PR DESCRIPTION
An empty settings file can be left behind after manual creation or failed writes. Treat it like an absent file so startup continues with default settings while still rejecting malformed non-empty JSON.