### PR TITLE
private_broadcast: fix HavePendingTransactions() cascade that leaks tx origin

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1754,7 +1754,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
     }
     if (node.IsPrivateBroadcastConn() &&
         !m_tx_for_private_broadcast.DidNodeConfirmReception(nodeid) &&
-        m_tx_for_private_broadcast.HavePendingTransactions()) {
+        m_tx_for_private_broadcast.HavePendingTransactions(NUM_PRIVATE_BROADCAST_PER_TX)) {
 
         m_connman.m_private_broadcast.NumToOpenAdd(1);
     }

--- a/src/private_broadcast.cpp
+++ b/src/private_broadcast.cpp
@@ -79,11 +79,15 @@ bool PrivateBroadcast::DidNodeConfirmReception(const NodeId& nodeid)
     return false;
 }
 
-bool PrivateBroadcast::HavePendingTransactions()
+bool PrivateBroadcast::HavePendingTransactions(size_t sufficient_confirmations)
     EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
 {
     LOCK(m_mutex);
-    return !m_transactions.empty();
+    for (const auto& [tx, state] : m_transactions) {
+        const Priority p{DerivePriority(state.send_statuses)};
+        if (p.num_confirmed < sufficient_confirmations) return true;
+    }
+    return false;
 }
 
 std::vector<CTransactionRef> PrivateBroadcast::GetStale() const

--- a/src/private_broadcast.h
+++ b/src/private_broadcast.h
@@ -106,9 +106,12 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /**
-     * Check if there are transactions that need to be broadcast.
+     * Check if there are transactions that still need to be broadcast.
+     * @param[in] sufficient_confirmations A transaction is not considered pending once
+     *            it has been confirmed by at least this many recipients. Pass SIZE_MAX
+     *            (the default) to consider any un-removed transaction as pending.
      */
-    bool HavePendingTransactions()
+    bool HavePendingTransactions(size_t sufficient_confirmations = SIZE_MAX)
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /**

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -158,4 +158,45 @@ BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
     BOOST_CHECK_EQUAL(stale_state[0], tx);
 }
 
+BOOST_AUTO_TEST_CASE(have_pending_transactions_threshold)
+{
+    PrivateBroadcast pb;
+
+    in_addr ipv4Addr;
+    ipv4Addr.s_addr = 0xa0b0c001;
+
+    // No transactions: HavePendingTransactions always false.
+    BOOST_CHECK(!pb.HavePendingTransactions());
+    BOOST_CHECK(!pb.HavePendingTransactions(3));
+
+    const auto tx{MakeDummyTx(/*id=*/7, /*num_witness=*/0)};
+    BOOST_REQUIRE(pb.Add(tx));
+
+    // Before any send: pending regardless of threshold (0 < 3).
+    BOOST_CHECK(pb.HavePendingTransactions());
+    BOOST_CHECK(pb.HavePendingTransactions(3));
+
+    // Send to 2 peers and confirm both.
+    for (uint16_t port = 1; port <= 2; ++port) {
+        NodeId nid{port};
+        BOOST_REQUIRE(pb.PickTxForSend(nid, CService{ipv4Addr, port}).has_value());
+        pb.NodeConfirmedReception(nid);
+    }
+
+    // 2 confirmations out of 3 needed: still pending.
+    BOOST_CHECK(pb.HavePendingTransactions(3));
+
+    // Send to a 3rd peer and confirm.
+    pb.PickTxForSend(/*will_send_to_nodeid=*/3, CService{ipv4Addr, 3});
+    pb.NodeConfirmedReception(3);
+
+    // 3 confirmations: not pending when threshold is 3, but still present in the
+    // system (not yet removed), so the old !m_transactions.empty() would have returned
+    // true — demonstrating the bug this test guards against.
+    BOOST_CHECK(!pb.HavePendingTransactions(3));
+
+    // Default threshold (SIZE_MAX) still sees the tx as present.
+    BOOST_CHECK(pb.HavePendingTransactions());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes #35529

## Problem

`HavePendingTransactions()` returned `!m_transactions.empty()`, which is `true` for any transaction still in the map — including those already confirmed by all `NUM_PRIVATE_BROADCAST_PER_TX` (3) peers. Transactions remain in `m_transactions` for up to ~1-3 minutes after full confirmation (until `GetStale()` + `ReattemptPrivateBroadcast` remove them via `STALE_DURATION`).

During that window, `FinalizeNode` incorrectly opens a replacement connection whenever any private-broadcast connection closes without confirming — even though the transaction is fully confirmed. The replacement calls `PickTxForSend`, which picks the fully-confirmed transaction and sends it to a 4th peer, violating the privacy guarantee of private broadcast.

**Adversary scenario**: A network-level adversary running several Bitcoin nodes can deliberately disconnect private-broadcast connections without responding to PING, triggering an unbounded cascade of replacements. Each additional connection the victim opens to an adversary-controlled node confirms that this IP originated the transaction — deanonymizing the sender with no special exploit code required.

## Fix

- `HavePendingTransactions()` now accepts a `sufficient_confirmations` parameter (default `SIZE_MAX` preserves all existing callers' semantics — "any tx in system = pending").
- The `FinalizeNode` call site passes `NUM_PRIVATE_BROADCAST_PER_TX`, so a replacement is only opened when at least one transaction genuinely has fewer than 3 confirmations.
- A new unit test `have_pending_transactions_threshold` demonstrates that after 3 confirmations, `HavePendingTransactions(3)` returns `false` while the transaction is still present in `m_transactions` — directly covering the previously-buggy path.

## Changes

| File | Change |
|---|---|
| `src/private_broadcast.h` | Add `sufficient_confirmations` parameter with docstring |
| `src/private_broadcast.cpp` | Replace `!m_transactions.empty()` with per-tx confirmation count loop |
| `src/net_processing.cpp` | Pass `NUM_PRIVATE_BROADCAST_PER_TX` at the `FinalizeNode` call site |
| `src/test/private_broadcast_tests.cpp` | Add `have_pending_transactions_threshold` test case |

## Test plan

- [ ] `./build/src/test/test_bitcoin --run_test=private_broadcast_tests/have_pending_transactions_threshold`
- [ ] `./build/src/test/test_bitcoin --run_test=private_broadcast_tests` (all existing tests pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)