### PR TITLE
doc: clarify that -maxmempool minimum is derived from cluster size limit

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -22,7 +22,7 @@ The size of some in-memory caches can be reduced. As caches trade off memory usa
 ## Memory pool
 
 - In Bitcoin Core there is a memory pool limiter which can be configured with `-maxmempool=<n>`, where `<n>` is the size in MB (1000). The default value is `300`.
-  - The minimum value for `-maxmempool` is 5.
+  - The minimum value for `-maxmempool` is derived from the mempool's cluster size limit (5 MB by default). Setting a lower value results in a `-maxmempool must be at least N MB` startup error.
   - A lower maximum mempool size means that transactions will be evicted sooner. This will affect any uses of `bitcoind` that process unconfirmed transactions.
 
 - The unused memory allocated to the mempool (default: 300MB) is shared with the UTXO cache, so when trying to reduce memory usage you should limit the mempool, with the `-maxmempool` command line argument.


### PR DESCRIPTION
`doc/reduce-memory.md` states that the minimum value for `-maxmempool` is a fixed `5`. This is no longer accurate: the minimum is computed dynamically from the mempool's cluster size limit.

In [`src/txmempool.cpp`](https://github.com/bitcoin/bitcoin/blob/master/src/txmempool.cpp):

```cpp
int64_t cluster_limit_bytes = opts.limits.cluster_size_vbytes * 40;
if (opts.max_size_bytes < 0 || (opts.max_size_bytes > 0 && opts.max_size_bytes < cluster_limit_bytes)) {
    error = strprintf(_("-maxmempool must be at least %d MB"), std::ceil(cluster_limit_bytes / 1'000'000.0));
}
```

With the default cluster size limit (`DEFAULT_CLUSTER_SIZE_LIMIT_KVB = 101`, i.e. 101,000 vbytes), this works out to `101,000 * 40 = 4.04 MB`, rounded up to `5 MB` — so the documented `5` is correct only by coincidence of the current defaults.

This updates the wording to describe the actual behavior (derived from the cluster size limit, 5 MB by default) and mentions the `-maxmempool must be at least N MB` startup error a user will see if they set it too low.