### PR TITLE
iwyu: Fix warning in `bench/pool.cpp`

### DIFF
--- a/src/bench/pool.cpp
+++ b/src/bench/pool.cpp
@@ -10,7 +10,6 @@
 #include <functional>
 #include <unordered_map>
 #include <utility>
-#include <variant>
 
 template <typename Map>
 void BenchFillClearMap(benchmark::Bench& bench, Map& map)


### PR DESCRIPTION
This PR resolves a silent merge conflict between recently merged #35414 and #35101 (47d68cd981fb2985acca0b4d2b8d79dbdccb136d).