### PR TITLE
test: make TestChain100Setup's m_clock timestamp more readable

### DIFF
--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -227,7 +227,7 @@ struct TestChain100Setup : public TestingSetup {
      */
     std::vector<CTransactionRef> PopulateMempool(FastRandomContext& det_rand, size_t num_transactions, bool submit);
 
-    FakeNodeClock m_clock{std::chrono::seconds{1598887952}};
+    FakeNodeClock m_clock{std::chrono::seconds{1598887952}}; // 2020-08-31, arbitrary
     std::vector<CTransactionRef> m_coinbase_txns; // For convenience, coinbase transactions
     CKey coinbaseKey; // private/public key needed to spend coinbase transactions
 };


### PR DESCRIPTION
The timestamp 1598887952 is used as the initial value of the node's mocked wall-clock in TestChain100Setup. Comment its UTC date to make the magic number more readable.
