### PR TITLE
test: avoid out-of-bounds getinfo parsing

### DIFF
--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -51,7 +51,7 @@ def cli_get_info_string_to_dict(cli_get_info_string):
         if "Balances" in line:
             # When "Balances" appears in a line, all of the following lines contain "balance: wallet" until an empty line
             cli_get_info["Balances"] = {}
-            while line_idx < len(lines) and not (lines[line_idx + 1] == ''):
+            while line_idx + 1 < len(lines) and lines[line_idx + 1] != '':
                 line_idx += 1
                 balance, wallet = lines[line_idx].strip().split(" ")
                 # Remove right justification padding


### PR DESCRIPTION
Avoid a possible `IndexError: list index out of range` 