### PR TITLE
ci: Use GCC consistently in i686 task

### DIFF
--- a/ci/test/00_setup_env_i686_no_ipc.sh
+++ b/ci/test/00_setup_env_i686_no_ipc.sh
@@ -11,7 +11,7 @@ export CONTAINER_NAME=ci_i686_no_multiprocess
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
 export CI_IMAGE_PLATFORM="linux/amd64"
 export CI_CONTAINER_CAP="--security-opt seccomp=unconfined"
-export PACKAGES="llvm clang g++-multilib"
+export PACKAGES="g++-multilib"
 export DEP_OPTS="DEBUG=1 NO_IPC=1"
 export GOAL="install"
 export CI_LIMIT_STACK_SIZE=1
@@ -19,7 +19,5 @@ export BITCOIN_CONFIG="\
  --preset=dev-mode \
  -DENABLE_IPC=OFF \
  -DCMAKE_BUILD_TYPE=Debug \
- -DCMAKE_C_COMPILER='clang;-m32' \
- -DCMAKE_CXX_COMPILER='clang++;-m32' \
  -DAPPEND_CPPFLAGS='-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE' \
 "


### PR DESCRIPTION
According to the comment removed in commit fae0295a799499268caca9c385ac4d7061543980, clang was only used to avoid OOM. Using GCC today should be fine.

(Meta note: The task can maybe even be removed in a few years, see https://github.com/bitcoin/bitcoin/pull/35230#issue-4397029749)

If OOM is an issue, or even if there is no issue, maybe `DEBUG=1` should be removed, because the `ci/test/00_setup_env_native_alpine_musl.sh` config is already checking `DEBUG=1` with GCC.