### PR TITLE
lint: Require scripted-diff script to succeed

### DIFF
--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -41,7 +41,7 @@ for commit in $(git rev-list --reverse "$1"); do
         else
             echo "Running script for: $commit" >&2
             echo "$SCRIPT" >&2
-            (eval "$SCRIPT")
+            (eval "$SCRIPT") && \
             git --no-pager diff --exit-code "$commit" && echo "OK" >&2 || (echo "Failed" >&2; false) || RET=1
         fi
         git reset --quiet --hard HEAD


### PR DESCRIPTION
Previous version of commit-script-check.sh would succeed as long as git diff succeeded.

Can be verified through adding a failing scripted diff commit such as:
```
git commit --allow-empty -m $'scripted-diff: foo\n\n-BEGIN VERIFY SCRIPT-\nadsasd\n-END VERIFY SCRIPT-\n'
```
...and running...
```
cargo run --manifest-path ./test/lint/test_runner/Cargo.toml -- --lint=scripted_diff
```