### PR TITLE
test: Add missing test case for getdata requests from blocks-only peers

### DIFF
--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -6,7 +6,7 @@
 
 import time
 
-from test_framework.messages import msg_tx, msg_inv, CInv, MSG_WTX
+from test_framework.messages import msg_getdata, msg_tx, msg_inv, CInv, MSG_WTX
 from test_framework.p2p import P2PInterface, P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -92,6 +92,16 @@ class P2PBlocksOnly(BitcoinTestFramework):
         conn = self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=0, connection_type="block-relay-only")
         assert_equal(self.nodes[0].getpeerinfo()[0]['relaytxes'], False)
         self.check_p2p_inv_violation(conn)
+
+        self.log.info(
+            "Check that getdata(tx) from a block-relay-only connection is ignored"
+        )
+        conn = self.nodes[0].add_outbound_p2p_connection(
+            P2PInterface(), p2p_idx=0, connection_type="block-relay-only"
+        )
+        conn.send_and_ping(msg_getdata([CInv(t=MSG_WTX, h=0x12345)]))
+        assert_equal(self.nodes[0].getpeerinfo()[0]["relaytxes"], False)
+        assert "notfound" not in conn.last_message
 
         self.log.info("Check that txs from RPC are not sent to blockrelay connection")
         conn = self.nodes[0].add_outbound_p2p_connection(P2PTxInvStore(), p2p_idx=1, connection_type="block-relay-only")


### PR DESCRIPTION
ProcessGetData starts by eagerly processing getdata requests. In this loop, a special case checks for peers that have not requested transaction announcements (ie blocksonly) and ignores those requests.  This test prevents regressions for that special case, which is currently not covered by existing tests.