### PR TITLE
kernel, validation: Add btck_chainstate_manager_set_clock_time

### DIFF
--- a/src/bench/blockencodings.cpp
+++ b/src/bench/blockencodings.cpp
@@ -30,7 +30,7 @@
 static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     LockPoints lp;
-    TryAddToMempool(pool, CTxMemPoolEntry(tx, fee, /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/4, lp));
+    TryAddToMempool(pool, CTxMemPoolEntry(tx, fee, /*time=*/{}, /*entry_height=*/1, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/4, lp));
 }
 
 namespace {

--- a/src/bench/mempool_ephemeral_spends.cpp
+++ b/src/bench/mempool_ephemeral_spends.cpp
@@ -24,7 +24,7 @@
 
 static void AddTx(const CTransactionRef& tx, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
-    int64_t nTime{0};
+    MempoolTime nTime{};
     unsigned int nHeight{1};
     uint64_t sequence{0};
     bool spendsCoinbase{false};

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -21,7 +21,7 @@
 
 static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
-    int64_t nTime = 0;
+    MempoolTime nTime{};
     unsigned int nHeight = 1;
     uint64_t sequence = 0;
     bool spendsCoinbase = false;

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -23,7 +23,7 @@ class CCoinsViewCache;
 
 static void AddTx(const CTransactionRef& tx, CTxMemPool& pool, FastRandomContext& det_rand) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
-    int64_t nTime = 0;
+    MempoolTime nTime{};
     unsigned int nHeight = 1;
     uint64_t sequence = 0;
     bool spendsCoinbase = false;

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -22,7 +22,7 @@
 static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     LockPoints lp;
-    TryAddToMempool(pool, CTxMemPoolEntry(tx, fee, /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/4, lp));
+    TryAddToMempool(pool, CTxMemPoolEntry(tx, fee, /*time=*/{}, /*entry_height=*/1, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/4, lp));
 }
 
 static void RpcMempool(benchmark::Bench& bench)

--- a/src/chain.h
+++ b/src/chain.h
@@ -428,12 +428,14 @@ public:
     }
 
     /** Check whether this chain's tip exists, has enough work, and is recent. */
-    bool IsTipRecent(const arith_uint256& min_chain_work, std::chrono::seconds max_tip_age) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    bool IsTipRecent(const arith_uint256& min_chain_work, std::chrono::seconds max_tip_age, NodeClock::time_point now) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         const auto tip{Tip()};
+        // Use seconds precision: if max_tip_age is very large (e.g. INT64_MAX),
+        // subtracting it from a nanosecond time_point would overflow int64.
         return tip &&
                tip->nChainWork >= min_chain_work &&
-               tip->Time() >= Now<NodeSeconds>() - max_tip_age;
+               tip->Time() >= std::chrono::time_point_cast<std::chrono::seconds>(now) - max_tip_age;
     }
 
     /** Set/initialize a chain with a given tip. */

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -35,14 +35,17 @@
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/task_runner.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstring>
 #include <exception>
 #include <functional>
+#include <limits>
 #include <list>
 #include <memory>
 #include <span>
@@ -1352,6 +1355,15 @@ btck_BlockValidationState* btck_chainstate_manager_process_block_header(
         LogError("Failed to process block header: %s", e.what());
         return nullptr;
     }
+}
+
+int btck_chainstate_manager_set_clock_time(btck_ChainstateManager* chainstate_manager, int64_t now_seconds)
+{
+    constexpr int64_t max_time{std::numeric_limits<uint32_t>::max()};
+    if (now_seconds < 0 || now_seconds > max_time) return -1;
+    auto& chainman = btck_ChainstateManager::get(chainstate_manager).m_chainman;
+    chainman->m_clock_now_seconds.store(std::chrono::seconds{now_seconds}, std::memory_order_relaxed);
+    return 0;
 }
 
 const btck_Chain* btck_chainstate_manager_get_active_chain(const btck_ChainstateManager* chainman)

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -40,6 +40,7 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstring>
 #include <exception>
@@ -1414,6 +1415,15 @@ btck_BlockValidationState* btck_chainstate_manager_process_block_header(
         LogError("Failed to process block header: %s", e.what());
         return nullptr;
     }
+}
+
+int btck_chainstate_manager_set_clock_time(btck_ChainstateManager* chainstate_manager, int64_t now_seconds)
+{
+    constexpr int64_t max_time{std::numeric_limits<uint32_t>::max()};
+    if (now_seconds < 0 || now_seconds > max_time) return -1;
+    auto& chainman = btck_ChainstateManager::get(chainstate_manager).m_chainman;
+    chainman->m_clock_now_seconds.store(std::chrono::seconds{now_seconds}, std::memory_order_relaxed);
+    return 0;
 }
 
 const btck_Chain* btck_chainstate_manager_get_active_chain(const btck_ChainstateManager* chainman)

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1249,6 +1249,10 @@ BITCOINKERNEL_API const btck_BlockTreeEntry* btck_chainstate_manager_get_best_en
 /**
  * @brief Processes and validates the provided btck_BlockHeader.
  *
+ * Time-sensitive checks (e.g. the future-time check) use the chainstate
+ * manager's current time, which can be overridden via
+ * @ref btck_chainstate_manager_set_clock_time.
+ *
  * @param[in] chainstate_manager        Non-null.
  * @param[in] header                    Non-null btck_BlockHeader to be validated.
  * @return                              The btck_BlockValidationState containing validation result, or null on error.
@@ -1256,6 +1260,26 @@ BITCOINKERNEL_API const btck_BlockTreeEntry* btck_chainstate_manager_get_best_en
 BITCOINKERNEL_API btck_BlockValidationState* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_process_block_header(
     btck_ChainstateManager* chainstate_manager,
     const btck_BlockHeader* header) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Override the current time used by this chainstate manager.
+ *
+ * Affects all time-sensitive operations scoped to this chainstate manager:
+ * the block header future-time check, the IBD latch (IsTipRecent), header
+ * sync progress estimates, and the verification progress value passed to
+ * block tip callbacks.
+ *
+ * @param[in] chainstate_manager  Non-null.
+ * @param[in] now_seconds         Unix epoch seconds in the range
+ *                                [1, 4294967295], or 0 to restore the
+ *                                system clock. The upper bound matches the
+ *                                maximum value of a block header timestamp.
+ * @return                        0 on success, non-zero if now_seconds is
+ *                                negative or exceeds 4294967295.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_set_clock_time(
+    btck_ChainstateManager* chainstate_manager,
+    int64_t now_seconds) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
  * @brief Triggers the start of a reindex if the wipe options were previously
@@ -1281,6 +1305,10 @@ BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_i
  * the block's validity. Detailed information on the validity of the block can
  * be retrieved by registering the `block_checked` callback in the validation
  * interface.
+ *
+ * Time-sensitive checks (e.g. the future-time check) and the IBD latch use
+ * the chainstate manager's current time, which can be overridden
+ * via @ref btck_chainstate_manager_set_clock_time.
  *
  * @param[in] chainstate_manager Non-null.
  * @param[in] block              Non-null, block to be validated.

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1284,6 +1284,10 @@ BITCOINKERNEL_API const btck_BlockTreeEntry* btck_chainstate_manager_get_best_en
 /**
  * @brief Processes and validates the provided btck_BlockHeader.
  *
+ * Time-sensitive checks (e.g. the future-time check) use the chainstate
+ * manager's current time, which can be overridden via
+ * @ref btck_chainstate_manager_set_clock_time.
+ *
  * @param[in] chainstate_manager        Non-null.
  * @param[in] header                    Non-null btck_BlockHeader to be validated.
  * @return                              The btck_BlockValidationState containing validation result, or null on error.
@@ -1291,6 +1295,26 @@ BITCOINKERNEL_API const btck_BlockTreeEntry* btck_chainstate_manager_get_best_en
 BITCOINKERNEL_API btck_BlockValidationState* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_process_block_header(
     btck_ChainstateManager* chainstate_manager,
     const btck_BlockHeader* header) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Override the current time used by this chainstate manager.
+ *
+ * Affects all time-sensitive operations scoped to this chainstate manager:
+ * the block header future-time check, the IBD latch (IsTipRecent), header
+ * sync progress estimates, and the verification progress value passed to
+ * block tip callbacks.
+ *
+ * @param[in] chainstate_manager  Non-null.
+ * @param[in] now_seconds         Unix epoch seconds in the range
+ *                                [1, 4294967295], or 0 to restore the
+ *                                system clock. The upper bound matches the
+ *                                maximum value of a block header timestamp.
+ * @return                        0 on success, non-zero if now_seconds is
+ *                                negative or exceeds 4294967295.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_set_clock_time(
+    btck_ChainstateManager* chainstate_manager,
+    int64_t now_seconds) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
  * @brief Triggers the start of a reindex if the wipe options were previously
@@ -1316,6 +1340,10 @@ BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_i
  * the block's validity. Detailed information on the validity of the block can
  * be retrieved by registering the `block_checked` callback in the validation
  * interface.
+ *
+ * Time-sensitive checks (e.g. the future-time check) and the IBD latch use
+ * the chainstate manager's current time, which can be overridden
+ * via @ref btck_chainstate_manager_set_clock_time.
  *
  * @param[in] chainstate_manager Non-null.
  * @param[in] block              Non-null, block to be validated.

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -8,6 +8,7 @@
 #include <kernel/bitcoinkernel.h>
 
 #include <array>
+#include <chrono>
 #include <exception>
 #include <functional>
 #include <memory>
@@ -1323,6 +1324,13 @@ public:
     {
         auto state = btck_chainstate_manager_process_block_header(get(), header.get());
         return BlockValidationState{state};
+    }
+
+    void SetClockTime(std::optional<std::chrono::seconds> now)
+    {
+        if (btck_chainstate_manager_set_clock_time(get(), now ? now->count() : 0) != 0) {
+            throw std::runtime_error("timestamp out of range");
+        }
     }
 
     ChainView GetChain() const

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -1386,6 +1386,13 @@ public:
         return BlockValidationState{state};
     }
 
+    void SetClockTime(std::optional<std::chrono::seconds> now)
+    {
+        if (btck_chainstate_manager_set_clock_time(get(), now ? now->count() : 0) != 0) {
+            throw std::runtime_error("timestamp out of range");
+        }
+    }
+
     ChainView GetChain() const
     {
         return ChainView{btck_chainstate_manager_get_active_chain(get())};

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -50,6 +50,8 @@ struct CompareIteratorByHash {
     }
 };
 
+using MempoolTime = NodeClock::time_point;
+
 /** \class CTxMemPoolEntry
  *
  * CTxMemPoolEntry stores data about the corresponding transaction, as well
@@ -74,7 +76,7 @@ private:
     const CAmount nFee;             //!< Cached to avoid expensive parent-transaction lookups
     const int32_t nTxWeight;         //!< ... and avoid recomputing tx weight (also used for GetTxSize())
     const size_t nUsageSize;        //!< ... and total memory usage
-    const int64_t nTime;            //!< Local time when entering the mempool
+    const MempoolTime nTime; //!< Local time when entering the mempool
     const uint64_t entry_sequence;  //!< Sequence number used to determine whether this transaction is too recent for relay
     const unsigned int entryHeight; //!< Chain height when entering the mempool
     const bool spendsCoinbase;      //!< keep track of transactions that spend a coinbase
@@ -85,7 +87,7 @@ private:
 public:
     virtual ~CTxMemPoolEntry() = default;
     CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
-                    int64_t time, unsigned int entry_height, uint64_t entry_sequence,
+                    MempoolTime time, unsigned int entry_height, uint64_t entry_sequence,
                     bool spends_coinbase,
                     int64_t sigops_cost, LockPoints lp)
         : tx{tx},
@@ -113,7 +115,7 @@ public:
     }
     int32_t GetAdjustedWeight() const { return GetSigOpsAdjustedWeight(nTxWeight, sigOpCost, ::nBytesPerSigOp); }
     int32_t GetTxWeight() const { return nTxWeight; }
-    std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }
+    MempoolTime GetTime() const { return nTime; }
     unsigned int GetHeight() const { return entryHeight; }
     uint64_t GetSequence() const { return entry_sequence; }
     int64_t GetSigOpCost() const { return sigOpCost; }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -248,7 +248,7 @@ ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const C
     for (auto& chainstate : chainman.m_chainstates) {
         if (!is_coinsview_empty(*chainstate)) {
             const CBlockIndex* tip = chainstate->m_chain.Tip();
-            if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
+            if (tip && tip->Time() > chainman.Now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
                 return {ChainstateLoadStatus::FAILURE, _("The block database contains a block which appears to be from the future. "
                                                          "This may be due to your computer's date and time being set incorrectly. "
                                                          "Only rebuild the block database if you are sure that your computer's date and time are correct")};

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -95,6 +95,13 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
             if (opts.use_current_time) {
                 nTime = TicksSinceEpoch<std::chrono::seconds>(now);
             }
+            // Reject nTime values that cannot be represented as MempoolTime.
+            constexpr int64_t MAX_MEMPOOL_TIME{
+                std::chrono::time_point_cast<std::chrono::seconds>(MempoolTime::max())
+                    .time_since_epoch().count()};
+            if (nTime < 0 || nTime > MAX_MEMPOOL_TIME) {
+                throw std::runtime_error(strprintf("Mempool entry nTime value %d is out of range", nTime));
+            }
 
             CAmount amountdelta = nFeeDelta;
             if (amountdelta && opts.apply_fee_delta_priority) {
@@ -102,7 +109,7 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
             }
             if (nTime > TicksSinceEpoch<std::chrono::seconds>(now - pool.m_opts.expiry)) {
                 LOCK(cs_main);
-                const auto& accepted = AcceptToMemoryPool(active_chainstate, tx, nTime, /*bypass_limits=*/false, /*test_accept=*/false);
+                const auto& accepted = AcceptToMemoryPool(active_chainstate, tx, NodeSeconds{std::chrono::seconds{nTime}}, /*bypass_limits=*/false, /*test_accept=*/false);
                 if (accepted.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                     ++count;
                 } else {
@@ -195,7 +202,7 @@ bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path, FopenFn mock
         LogInfo("Writing %u mempool transactions to file...\n", mempool_transactions_to_write);
         for (const auto& i : vinfo) {
             file << TX_WITH_WITNESS(*(i.tx));
-            file << int64_t{count_seconds(i.m_time)};
+            file << int64_t{TicksSinceEpoch<std::chrono::seconds>(i.m_time)};
             file << int64_t{i.nFeeDelta};
             mapDeltas.erase(i.tx->GetHash());
         }

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -529,7 +529,7 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
 
     info.pushKV("vsize", e.GetTxSize());
     info.pushKV("weight", e.GetTxWeight());
-    info.pushKV("time", count_seconds(e.GetTime()));
+    info.pushKV("time", TicksSinceEpoch<std::chrono::seconds>(e.GetTime()));
     info.pushKV("height", e.GetHeight());
     info.pushKV("descendantcount", descendant_count);
     info.pushKV("descendantsize", descendant_size);

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -548,7 +548,7 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
     info.pushKV("vsize", e.GetTxSize());
     info.pushKV("vsize_bip141", GetVirtualTransactionSize(e.GetTx()));
     info.pushKV("weight", e.GetTxWeight());
-    info.pushKV("time", count_seconds(e.GetTime()));
+    info.pushKV("time", TicksSinceEpoch<std::chrono::seconds>(e.GetTime()));
     info.pushKV("height", e.GetHeight());
     info.pushKV("descendantcount", descendant_count);
     info.pushKV("descendantsize", descendant_size);

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -57,7 +57,7 @@ struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
     {
         LOCK(cs);
-        lastRollingFeeUpdate = GetTime();
+        lastRollingFeeUpdate = Now();
         blockSinceLastRollingFeeBump = true;
     }
 };
@@ -345,7 +345,7 @@ FUZZ_TARGET(ephemeral_package_eval, .init = initialize_tx_pool)
         const auto result_package = WITH_LOCK(::cs_main,
                                     return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, /*client_maxfeerate=*/{}));
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), tx_pool.Now(),
                                    /*bypass_limits=*/false, /*test_accept=*/!single_submit));
 
         if (!single_submit && result_package.m_state.GetResult() != PackageValidationResult::PCKG_POLICY) {
@@ -522,7 +522,7 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
 
         // Always set bypass_limits to false because it is not supported in ProcessNewPackage and
         // can be a source of divergence.
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), tx_pool.Now(),
                                    /*bypass_limits=*/false, /*test_accept=*/!single_submit));
         const bool passed = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
 

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -57,7 +57,7 @@ struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
     {
         LOCK(cs);
-        lastRollingFeeUpdate = GetTime();
+        lastRollingFeeUpdate = Now();
         blockSinceLastRollingFeeBump = true;
     }
 };
@@ -344,7 +344,7 @@ FUZZ_TARGET(ephemeral_package_eval, .init = initialize_tx_pool)
         const auto result_package = WITH_LOCK(::cs_main,
                                     return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, /*client_maxfeerate=*/{}));
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), tx_pool.Now(),
                                    /*bypass_limits=*/false, /*test_accept=*/!single_submit));
 
         if (!single_submit && result_package.m_state.GetResult() != PackageValidationResult::PCKG_POLICY) {
@@ -520,7 +520,7 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
 
         // Always set bypass_limits to false because it is not supported in ProcessNewPackage and
         // can be a source of divergence.
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), tx_pool.Now(),
                                    /*bypass_limits=*/false, /*test_accept=*/!single_submit));
         const bool passed = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
 

--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -198,7 +198,7 @@ FUZZ_TARGET(package_rbf, .init = initialize_package_rbf)
         changeset->StageRemoval(txiter);
     }
     changeset->StageAddition(replacement_entry.GetSharedTx(), replacement_fees,
-            replacement_entry.GetTime().count(), replacement_entry.GetHeight(),
+            replacement_entry.GetTime(), replacement_entry.GetHeight(),
             replacement_entry.GetSequence(), replacement_entry.GetSpendsCoinbase(),
             replacement_entry.GetSigOpCost(), replacement_entry.GetLockPoints());
     // Calculate the chunks for a replacement.

--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -197,7 +197,7 @@ FUZZ_TARGET(package_rbf, .init = initialize_package_rbf)
         changeset->StageRemoval(txiter);
     }
     changeset->StageAddition(replacement_entry.GetSharedTx(), replacement_fees,
-            replacement_entry.GetTime().count(), replacement_entry.GetHeight(),
+            replacement_entry.GetTime(), replacement_entry.GetHeight(),
             replacement_entry.GetSequence(), replacement_entry.GetSpendsCoinbase(),
             replacement_entry.GetSigOpCost(), replacement_entry.GetLockPoints());
     // Calculate the chunks for a replacement.

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -62,7 +62,7 @@ struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
     {
         LOCK(cs);
-        lastRollingFeeUpdate = GetTime();
+        lastRollingFeeUpdate = Now();
         blockSinceLastRollingFeeBump = true;
     }
 };
@@ -135,7 +135,7 @@ void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, Cha
         // Now try to add those transactions back, as though a reorg happened.
         std::vector<Txid> hashes_to_update;
         for (const auto& tx : block_template->block.vtx) {
-            const auto res = AcceptToMemoryPool(chainstate, tx, GetTime(), true, /*test_accept=*/false);
+            const auto res = AcceptToMemoryPool(chainstate, tx, tx_pool.Now(), true, /*test_accept=*/false);
             if (res.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                 hashes_to_update.push_back(tx->GetHash());
             } else {
@@ -159,7 +159,7 @@ void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, Cha
     if (fuzzed_data_provider.ConsumeBool()) {
         // Try expiry
         LOCK2(::cs_main, tx_pool.cs);
-        tx_pool.Expire(GetMockTime() - std::chrono::seconds(fuzzed_data_provider.ConsumeIntegral<uint32_t>()));
+        tx_pool.Expire(tx_pool.Now() - std::chrono::seconds(fuzzed_data_provider.ConsumeIntegral<uint32_t>()));
     }
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
     g_setup->m_node.validation_signals->SyncWithValidationInterfaceQueue();
@@ -369,7 +369,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
                    it->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
         }
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), /*bypass_limits=*/false, /*test_accept=*/false));
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, tx_pool.Now(), /*bypass_limits=*/false, /*test_accept=*/false));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         node.validation_signals->SyncWithValidationInterfaceQueue();
         node.validation_signals->UnregisterSharedValidationInterface(txr);
@@ -477,7 +477,7 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
         ever_bypassed_limits |= bypass_limits;
 
         const auto tx = MakeTransactionRef(mut_tx);
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, tx_pool.Now(), bypass_limits, /*test_accept=*/false));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         if (accepted) {
             txids.push_back(tx->GetHash());

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -62,7 +62,7 @@ struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
     {
         LOCK(cs);
-        lastRollingFeeUpdate = GetTime();
+        lastRollingFeeUpdate = Now();
         blockSinceLastRollingFeeBump = true;
     }
 };
@@ -161,7 +161,7 @@ void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, Cha
         // Now try to add those transactions back, as though a reorg happened.
         std::vector<Txid> hashes_to_update;
         for (const auto& tx : block_template->block.vtx) {
-            const auto res = AcceptToMemoryPool(chainstate, tx, GetTime(), true, /*test_accept=*/false);
+            const auto res = AcceptToMemoryPool(chainstate, tx, tx_pool.Now(), true, /*test_accept=*/false);
             if (res.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                 hashes_to_update.push_back(tx->GetHash());
             } else {
@@ -207,7 +207,7 @@ void Finish(FuzzedDataProvider& fuzzed_data_provider, MockedTxPool& tx_pool, Cha
     if (fuzzed_data_provider.ConsumeBool()) {
         // Try expiry
         LOCK2(::cs_main, tx_pool.cs);
-        tx_pool.Expire(GetMockTime() - std::chrono::seconds(fuzzed_data_provider.ConsumeIntegral<uint32_t>()));
+        tx_pool.Expire(tx_pool.Now() - std::chrono::seconds(fuzzed_data_provider.ConsumeIntegral<uint32_t>()));
     }
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
     g_setup->m_node.validation_signals->SyncWithValidationInterfaceQueue();
@@ -416,7 +416,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
                    it->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
         }
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), /*bypass_limits=*/false, /*test_accept=*/false));
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, tx_pool.Now(), /*bypass_limits=*/false, /*test_accept=*/false));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         node.validation_signals->SyncWithValidationInterfaceQueue();
         node.validation_signals->UnregisterSharedValidationInterface(txr);
@@ -523,7 +523,7 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
         ever_bypassed_limits |= bypass_limits;
 
         const auto tx = MakeTransactionRef(mut_tx);
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, tx_pool.Now(), bypass_limits, /*test_accept=*/false));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         if (accepted) {
             txids.push_back(tx->GetHash());

--- a/src/test/fuzz/util/mempool.cpp
+++ b/src/test/fuzz/util/mempool.cpp
@@ -22,7 +22,7 @@ CTxMemPoolEntry ConsumeTxMemPoolEntry(FuzzedDataProvider& fuzzed_data_provider, 
     // Reproduce using CFeeRate(348732081484775, 10).GetFeePerK()
     const CAmount fee{ConsumeMoney(fuzzed_data_provider, /*max=*/std::numeric_limits<CAmount>::max() / CAmount{100'000})};
     assert(MoneyRange(fee));
-    const int64_t time = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+    const MempoolTime time{ConsumeTime(fuzzed_data_provider)};
     const uint64_t entry_sequence{fuzzed_data_provider.ConsumeIntegral<uint64_t>()};
     const auto entry_height{fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0, max_height)};
     const bool spends_coinbase = fuzzed_data_provider.ConsumeBool();

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -35,7 +35,8 @@ FUZZ_TARGET(utxo_total_supply)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    FakeNodeClock clock{ConsumeTime(fuzzed_data_provider, /*min=*/1296688602)}; // regtest genesis block timestamp
+    const auto fuzzed_time{ConsumeTime(fuzzed_data_provider, /*min=*/1296688602)}; // regtest genesis block timestamp
+    FakeNodeClock clock{fuzzed_time}; // global mock satisfies _now_nondet() calls in FlushStateToDisk
     /** The testing setup that creates a chainman only (no chainstate) */
     ChainTestingSetup test_setup{
         ChainType::REGTEST,
@@ -45,10 +46,12 @@ FUZZ_TARGET(utxo_total_supply)
             },
         },
     };
-    // Create chainstate
-    test_setup.LoadVerifyActivateChainstate();
     auto& node{test_setup.m_node};
     auto& chainman{*Assert(test_setup.m_node.chainman)};
+    // Set per-chainman clock before loading chainstate so IBD checks use it
+    chainman.m_clock_now_seconds.store(fuzzed_time.time_since_epoch(), std::memory_order_relaxed);
+    // Create chainstate
+    test_setup.LoadVerifyActivateChainstate();
 
     const auto ActiveHeight = [&]() {
         LOCK(chainman.GetMutex());

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -1386,3 +1386,38 @@ BOOST_AUTO_TEST_CASE(btck_transaction_check_tests)
         "ffffffff00ffffffff000100000000000000000000000000000000000000000000000000000000"
         "00000000000000ffffffff010000000000000000015100000000");
 }
+
+BOOST_AUTO_TEST_CASE(btck_chainstate_manager_set_clock_time_tests)
+{
+    auto test_directory{TestDirectory{"set_clock_time_test_bitcoin_kernel"}};
+    auto notifications{std::make_shared<TestKernelNotifications>()};
+    auto context{create_context(notifications, ChainType::REGTEST)};
+    auto chainman{create_chainman(
+        test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
+        /*block_tree_db_in_memory=*/true, /*chainstate_db_in_memory=*/true, context)};
+
+    // Out-of-range timestamps are rejected
+    constexpr std::chrono::seconds max_time{std::numeric_limits<uint32_t>::max()};
+    BOOST_CHECK_EXCEPTION(chainman->SetClockTime(std::chrono::seconds{-1}), std::runtime_error, HasReason("timestamp out of range"));
+    BOOST_CHECK_EXCEPTION(chainman->SetClockTime(max_time + std::chrono::seconds{1}), std::runtime_error, HasReason("timestamp out of range"));
+
+    Block block{hex_string_to_byte_vec(REGTEST_BLOCK_DATA[0])};
+    BlockHeader header{block.GetHeader()};
+    const std::chrono::seconds block_time{header.Timestamp()};
+
+    // With time set 3h before the header, it appears >2h in the future: rejected
+    chainman->SetClockTime(block_time - std::chrono::hours{3});
+    BlockValidationState future_state{chainman->ProcessBlockHeader(header)};
+    BOOST_CHECK(future_state.GetValidationMode() == ValidationMode::INVALID);
+    BOOST_CHECK(future_state.GetBlockValidationResult() == BlockValidationResult::TIME_FUTURE);
+
+    // With time at the uint32_t max, the header is far in the past: accepted.
+    // Also confirms the future-time check doesn't overflow at the upper bound.
+    chainman->SetClockTime(max_time);
+    BlockValidationState ok_state{chainman->ProcessBlockHeader(header)};
+    BOOST_CHECK(ok_state.GetValidationMode() == ValidationMode::VALID);
+    BOOST_CHECK(ok_state.GetBlockValidationResult() == BlockValidationResult::UNSET);
+
+    // Restore real-time behavior
+    chainman->SetClockTime(std::nullopt);
+}

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -1470,3 +1470,38 @@ BOOST_AUTO_TEST_CASE(btck_set_mock_time_tests)
     BOOST_CHECK(ok_state.GetValidationMode() == ValidationMode::VALID);
     BOOST_CHECK(ok_state.GetBlockValidationResult() == BlockValidationResult::UNSET);
 }
+
+BOOST_AUTO_TEST_CASE(btck_chainstate_manager_set_clock_time_tests)
+{
+    auto test_directory{TestDirectory{"set_clock_time_test_bitcoin_kernel"}};
+    auto notifications{std::make_shared<TestKernelNotifications>()};
+    auto context{create_context(notifications, ChainType::REGTEST)};
+    auto chainman{create_chainman(
+        test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
+        /*block_tree_db_in_memory=*/true, /*chainstate_db_in_memory=*/true, context)};
+
+    // Out-of-range timestamps are rejected
+    constexpr std::chrono::seconds max_time{std::numeric_limits<uint32_t>::max()};
+    BOOST_CHECK_EXCEPTION(chainman->SetClockTime(std::chrono::seconds{-1}), std::runtime_error, HasReason("timestamp out of range"));
+    BOOST_CHECK_EXCEPTION(chainman->SetClockTime(max_time + std::chrono::seconds{1}), std::runtime_error, HasReason("timestamp out of range"));
+
+    Block block{hex_string_to_byte_vec(REGTEST_BLOCK_DATA[0])};
+    BlockHeader header{block.GetHeader()};
+    const std::chrono::seconds block_time{header.Timestamp()};
+
+    // With time set 3h before the header, it appears >2h in the future: rejected
+    chainman->SetClockTime(block_time - std::chrono::hours{3});
+    BlockValidationState future_state{chainman->ProcessBlockHeader(header)};
+    BOOST_CHECK(future_state.GetValidationMode() == ValidationMode::INVALID);
+    BOOST_CHECK(future_state.GetBlockValidationResult() == BlockValidationResult::TIME_FUTURE);
+
+    // With time at the uint32_t max, the header is far in the past: accepted.
+    // Also confirms the future-time check doesn't overflow at the upper bound.
+    chainman->SetClockTime(max_time);
+    BlockValidationState ok_state{chainman->ProcessBlockHeader(header)};
+    BOOST_CHECK(ok_state.GetValidationMode() == ValidationMode::VALID);
+    BOOST_CHECK(ok_state.GetBlockValidationResult() == BlockValidationResult::UNSET);
+
+    // Restore real-time behavior
+    chainman->SetClockTime(std::nullopt);
+}

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -277,8 +277,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     auto changeset = pool.GetChangeSet();
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx3, tx2_fee, {}, 1, 0, false, 4, LockPoints());
     const auto res1 = ImprovesFeerateDiagram(*changeset);
     BOOST_CHECK(res1.has_value());
     BOOST_CHECK(res1.value().first == DiagramCheckError::FAILURE);
@@ -289,8 +289,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     changeset = pool.GetChangeSet();
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee+1, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee+1, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx3, tx2_fee, {}, 1, 0, false, 4, LockPoints());
     BOOST_CHECK(ImprovesFeerateDiagram(*changeset) == std::nullopt);
 
     changeset.reset();
@@ -299,8 +299,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     changeset = pool.GetChangeSet();
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee+1, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee+1, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx3, tx2_fee, {}, 1, 0, false, 4, LockPoints());
     const auto res2 = ImprovesFeerateDiagram(*changeset);
     BOOST_CHECK(res2.has_value());
     BOOST_CHECK(res2.value().first == DiagramCheckError::FAILURE);
@@ -316,8 +316,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     changeset = pool.GetChangeSet();
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee, {}, 1, 0, false, 4, LockPoints());
     BOOST_CHECK(ImprovesFeerateDiagram(*changeset) == std::nullopt);
     changeset.reset();
 
@@ -330,8 +330,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
     changeset->StageRemoval(entry5);
-    changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee + entry5->GetModifiedFee() + 1, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee + entry5->GetModifiedFee() + 1, {}, 1, 0, false, 4, LockPoints());
     const auto res3 = ImprovesFeerateDiagram(*changeset);
     BOOST_CHECK(res3 == std::nullopt);
 }
@@ -360,7 +360,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
     {
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_low);
-        changeset->StageAddition(replacement_tx, 0, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, 0, {}, 1, 0, false, 4, LockPoints());
         const auto replace_one{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_one.has_value());
         std::vector<FeeFrac> expected_old_chunks{{low_fee, low_size}};
@@ -373,7 +373,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
     {
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_low);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_one_fee{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_one_fee.has_value());
         std::vector<FeeFrac> expected_old_diagram{{low_fee, low_size}};
@@ -392,7 +392,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_low);
         changeset->StageRemoval(entry_high);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_single_chunk{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_single_chunk.has_value());
         std::vector<FeeFrac> expected_old_chunks{{low_fee + high_fee, low_size + high_size}};
@@ -405,7 +405,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
     {
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_high);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_cpfp_child{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_cpfp_child.has_value());
         std::vector<FeeFrac> expected_old_chunks{{low_fee + high_fee, low_size + high_size}};
@@ -429,7 +429,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_high_2);
         changeset->StageRemoval(entry_low_2);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_two_chunks_single_cluster{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_two_chunks_single_cluster.has_value());
         std::vector<FeeFrac> expected_old_chunks{{high_fee, high_size_2}, {low_fee, low_size_2}};
@@ -456,7 +456,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
         changeset->StageRemoval(conflict_1_entry);
         changeset->StageRemoval(conflict_2_entry);
         changeset->StageRemoval(conflict_3_entry);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_multiple_clusters{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_multiple_clusters.has_value());
         BOOST_CHECK(replace_multiple_clusters->first.size() == 3);
@@ -474,7 +474,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
         changeset->StageRemoval(conflict_2_entry);
         changeset->StageRemoval(conflict_3_entry);
         changeset->StageRemoval(conflict_1_child_entry);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_multiple_clusters_2{changeset->CalculateChunksForRBF()};
 
         BOOST_CHECK(replace_multiple_clusters_2.has_value());

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -272,8 +272,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     auto changeset = pool.GetChangeSet();
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx3, tx2_fee, {}, 1, 0, false, 4, LockPoints());
     const auto res1 = ImprovesFeerateDiagram(*changeset);
     BOOST_CHECK(res1.has_value());
     BOOST_CHECK(res1.value().first == DiagramCheckError::FAILURE);
@@ -284,8 +284,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     changeset = pool.GetChangeSet();
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee+1, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee+1, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx3, tx2_fee, {}, 1, 0, false, 4, LockPoints());
     BOOST_CHECK(ImprovesFeerateDiagram(*changeset) == std::nullopt);
 
     changeset.reset();
@@ -294,8 +294,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     changeset = pool.GetChangeSet();
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee+1, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(tx3, tx2_fee, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee+1, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx3, tx2_fee, {}, 1, 0, false, 4, LockPoints());
     const auto res2 = ImprovesFeerateDiagram(*changeset);
     BOOST_CHECK(res2.has_value());
     BOOST_CHECK(res2.value().first == DiagramCheckError::FAILURE);
@@ -311,8 +311,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     changeset = pool.GetChangeSet();
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
-    changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee, {}, 1, 0, false, 4, LockPoints());
     BOOST_CHECK(ImprovesFeerateDiagram(*changeset) == std::nullopt);
     changeset.reset();
 
@@ -325,8 +325,8 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     changeset->StageRemoval(entry1);
     changeset->StageRemoval(entry2);
     changeset->StageRemoval(entry5);
-    changeset->StageAddition(tx1_conflict, tx1_fee, 0, 1, 0, false, 4, LockPoints());
-    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee + entry5->GetModifiedFee() + 1, 0, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(tx1_conflict, tx1_fee, {}, 1, 0, false, 4, LockPoints());
+    changeset->StageAddition(entry4.GetSharedTx(), tx2_fee + entry5->GetModifiedFee() + 1, {}, 1, 0, false, 4, LockPoints());
     const auto res3 = ImprovesFeerateDiagram(*changeset);
     BOOST_CHECK(res3 == std::nullopt);
 }
@@ -355,7 +355,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
     {
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_low);
-        changeset->StageAddition(replacement_tx, 0, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, 0, {}, 1, 0, false, 4, LockPoints());
         const auto replace_one{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_one.has_value());
         std::vector<FeeFrac> expected_old_chunks{{low_fee, low_size}};
@@ -368,7 +368,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
     {
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_low);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_one_fee{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_one_fee.has_value());
         std::vector<FeeFrac> expected_old_diagram{{low_fee, low_size}};
@@ -387,7 +387,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_low);
         changeset->StageRemoval(entry_high);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_single_chunk{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_single_chunk.has_value());
         std::vector<FeeFrac> expected_old_chunks{{low_fee + high_fee, low_size + high_size}};
@@ -400,7 +400,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
     {
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_high);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_cpfp_child{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_cpfp_child.has_value());
         std::vector<FeeFrac> expected_old_chunks{{low_fee + high_fee, low_size + high_size}};
@@ -424,7 +424,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
         auto changeset = pool.GetChangeSet();
         changeset->StageRemoval(entry_high_2);
         changeset->StageRemoval(entry_low_2);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_two_chunks_single_cluster{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_two_chunks_single_cluster.has_value());
         std::vector<FeeFrac> expected_old_chunks{{high_fee, high_size_2}, {low_fee, low_size_2}};
@@ -451,7 +451,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
         changeset->StageRemoval(conflict_1_entry);
         changeset->StageRemoval(conflict_2_entry);
         changeset->StageRemoval(conflict_3_entry);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_multiple_clusters{changeset->CalculateChunksForRBF()};
         BOOST_CHECK(replace_multiple_clusters.has_value());
         BOOST_CHECK(replace_multiple_clusters->first.size() == 3);
@@ -469,7 +469,7 @@ BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
         changeset->StageRemoval(conflict_2_entry);
         changeset->StageRemoval(conflict_3_entry);
         changeset->StageRemoval(conflict_1_child_entry);
-        changeset->StageAddition(replacement_tx, high_fee, 0, 1, 0, false, 4, LockPoints());
+        changeset->StageAddition(replacement_tx, high_fee, {}, 1, 0, false, 4, LockPoints());
         const auto replace_multiple_clusters_2{changeset->CalculateChunksForRBF()};
 
         BOOST_CHECK(replace_multiple_clusters_2.has_value());

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -608,7 +608,7 @@ std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContex
             LockPoints lp;
             auto changeset = m_node.mempool->GetChangeSet();
             changeset->StageAddition(ptx, /*fee=*/(total_in - num_outputs * amount_per_output),
-                    /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0,
+                    /*time=*/{}, /*entry_height=*/1, /*entry_sequence=*/0,
                     /*spends_coinbase=*/false, /*sigops_cost=*/4, lp);
             if (changeset->CheckMemPoolPolicyLimits()) {
                 changeset->Apply();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -609,7 +609,7 @@ std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContex
             LockPoints lp;
             auto changeset = m_node.mempool->GetChangeSet();
             changeset->StageAddition(ptx, /*fee=*/(total_in - num_outputs * amount_per_output),
-                    /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0,
+                    /*time=*/{}, /*entry_height=*/1, /*entry_sequence=*/0,
                     /*spends_coinbase=*/false, /*sigops_cost=*/4, lp);
             if (changeset->CheckMemPoolPolicyLimits()) {
                 changeset->Apply();

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -38,7 +38,7 @@ CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CMutableTransaction& tx) co
 
 CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CTransactionRef& tx) const
 {
-    return CTxMemPoolEntry{tx, nFee, TicksSinceEpoch<std::chrono::seconds>(time), nHeight, m_sequence, spendsCoinbase, sigOpCost, lp};
+    return CTxMemPoolEntry{tx, nFee, time, nHeight, m_sequence, spendsCoinbase, sigOpCost, lp};
 }
 
 std::optional<std::string> CheckPackageMempoolAcceptResult(const Package& txns,
@@ -217,7 +217,7 @@ void TryAddToMempool(CTxMemPool& tx_pool, const CTxMemPoolEntry& entry)
     LOCK2(cs_main, tx_pool.cs);
     auto changeset = tx_pool.GetChangeSet();
     changeset->StageAddition(entry.GetSharedTx(), entry.GetFee(),
-            entry.GetTime().count(), entry.GetHeight(), entry.GetSequence(),
+            entry.GetTime(), entry.GetHeight(), entry.GetSequence(),
             entry.GetSpendsCoinbase(), entry.GetSigOpCost(), entry.GetLockPoints());
     if (changeset->CheckMemPoolPolicyLimits()) changeset->Apply();
 }
@@ -249,7 +249,7 @@ void MockMempoolMinFee(const CFeeRate& target_feerate, CTxMemPool& mempool)
     {
         auto changeset = mempool.GetChangeSet();
         changeset->StageAddition(tx, /*fee=*/tx_fee,
-                /*time=*/0, /*entry_height=*/1, /*entry_sequence=*/0,
+                /*time=*/{}, /*entry_height=*/1, /*entry_sequence=*/0,
                 /*spends_coinbase=*/true, /*sigops_cost=*/1, lp);
         changeset->Apply();
     }

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -16,6 +16,7 @@
 #include <test/util/logging.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <test/util/validation.h>
 #include <uint256.h>
 #include <util/byte_units.h>
@@ -172,6 +173,11 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
 
 BOOST_FIXTURE_TEST_CASE(chainstatemanager_ibd_exit_after_loading_blocks, ChainTestingSetup)
 {
+    // Freeze the clock to avoid a race where Now<NodeSeconds>() in test setup
+    // and Now<NodeSeconds>() inside IsTipRecent() straddle a second boundary,
+    // causing a spurious failure in the tip_recent=true case.
+    FakeNodeClock clock{};
+
     CBlockIndex tip;
     ChainstateManager& chainman{*Assert(m_node.chainman)};
     auto apply{[&](bool cached_is_ibd, bool loading_blocks, bool tip_exists, bool enough_work, bool tip_recent) {

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -16,11 +16,11 @@
 #include <test/util/logging.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
-#include <test/util/time.h>
 #include <test/util/validation.h>
 #include <uint256.h>
 #include <util/byte_units.h>
 #include <util/result.h>
+#include <util/time.h>
 #include <util/vector.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -173,19 +173,21 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
 
 BOOST_FIXTURE_TEST_CASE(chainstatemanager_ibd_exit_after_loading_blocks, ChainTestingSetup)
 {
-    // Freeze the clock to avoid a race where Now<NodeSeconds>() in test setup
-    // and Now<NodeSeconds>() inside IsTipRecent() straddle a second boundary,
-    // causing a spurious failure in the tip_recent=true case.
-    FakeNodeClock clock{};
-
     CBlockIndex tip;
     ChainstateManager& chainman{*Assert(m_node.chainman)};
+    // Freeze the chainman's clock so the Now() call inside UpdateIBDStatus
+    // always agrees with the tip time we set below, eliminating any race
+    // across a second boundary that would cause the tip_recent=true case to
+    // spuriously fail.
+    const NodeSeconds frozen_now{Now<NodeSeconds>()};
+    chainman.m_clock_now_seconds.store(frozen_now.time_since_epoch(), std::memory_order_relaxed);
+
     auto apply{[&](bool cached_is_ibd, bool loading_blocks, bool tip_exists, bool enough_work, bool tip_recent) {
         LOCK(::cs_main);
         chainman.ResetChainstates();
         chainman.InitializeChainstate(m_node.mempool.get());
 
-        const auto recent_time{Now<NodeSeconds>() - chainman.m_options.max_tip_age};
+        const auto recent_time{frozen_now - chainman.m_options.max_tip_age};
 
         chainman.m_cached_is_ibd.store(cached_is_ibd, std::memory_order_relaxed);
         chainman.m_blockman.m_importing = loading_blocks;

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -16,6 +16,7 @@
 #include <test/util/logging.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <test/util/validation.h>
 #include <uint256.h>
 #include <util/byte_units.h>
@@ -181,6 +182,11 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
 
 BOOST_FIXTURE_TEST_CASE(chainstatemanager_ibd_exit_after_loading_blocks, ChainTestingSetup)
 {
+    // Freeze the clock to avoid a race where Now<NodeSeconds>() in test setup
+    // and Now<NodeSeconds>() inside IsTipRecent() straddle a second boundary,
+    // causing a spurious failure in the tip_recent=true case.
+    FakeNodeClock clock{};
+
     CBlockIndex tip;
     ChainstateManager& chainman{*Assert(m_node.chainman)};
     auto apply{[&](bool cached_is_ibd, bool loading_blocks, bool tip_exists, bool enough_work, bool tip_recent) {

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -16,11 +16,11 @@
 #include <test/util/logging.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
-#include <test/util/time.h>
 #include <test/util/validation.h>
 #include <uint256.h>
 #include <util/byte_units.h>
 #include <util/result.h>
+#include <util/time.h>
 #include <util/vector.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -182,19 +182,21 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
 
 BOOST_FIXTURE_TEST_CASE(chainstatemanager_ibd_exit_after_loading_blocks, ChainTestingSetup)
 {
-    // Freeze the clock to avoid a race where Now<NodeSeconds>() in test setup
-    // and Now<NodeSeconds>() inside IsTipRecent() straddle a second boundary,
-    // causing a spurious failure in the tip_recent=true case.
-    FakeNodeClock clock{};
-
     CBlockIndex tip;
     ChainstateManager& chainman{*Assert(m_node.chainman)};
+    // Freeze the chainman's clock so the Now() call inside UpdateIBDStatus
+    // always agrees with the tip time we set below, eliminating any race
+    // across a second boundary that would cause the tip_recent=true case to
+    // spuriously fail.
+    const NodeSeconds frozen_now{Now<NodeSeconds>()};
+    chainman.m_clock_now_seconds.store(frozen_now.time_since_epoch(), std::memory_order_relaxed);
+
     auto apply{[&](bool cached_is_ibd, bool loading_blocks, bool tip_exists, bool enough_work, bool tip_recent) {
         LOCK(::cs_main);
         chainman.ResetChainstates();
         chainman.InitializeChainstate(m_node.mempool.get());
 
-        const auto recent_time{Now<NodeSeconds>() - chainman.m_options.max_tip_age};
+        const auto recent_time{frozen_now - chainman.m_options.max_tip_age};
 
         chainman.m_cached_is_ibd.store(cached_is_ibd, std::memory_order_relaxed);
         chainman.m_blockman.m_importing = loading_blocks;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -278,7 +278,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         RemovalReasonToString(reason).c_str(),
         it->GetTxSize(),
         it->GetFee(),
-        std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count()
+        TicksSinceEpoch<std::chrono::duration<std::uint64_t>>(it->GetTime())
     );
 
     for (const CTxIn& txin : it->GetTx().vin)
@@ -423,7 +423,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     if (m_opts.signals) {
         m_opts.signals->MempoolTransactionsRemovedForBlock(txs_removed_for_block, nBlockHeight);
     }
-    lastRollingFeeUpdate = GetTime();
+    lastRollingFeeUpdate = Now();
     blockSinceLastRollingFeeBump = true;
     if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
         LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after block.");
@@ -804,11 +804,11 @@ bool CTxMemPool::CheckPolicyLimits(const CTransactionRef& tx)
     // limits would be violated. Note that the changeset will be destroyed
     // when it goes out of scope.
     auto changeset = GetChangeSet();
-    (void) changeset->StageAddition(tx, /*fee=*/0, /*time=*/0, /*entry_height=*/0, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/0, LockPoints{});
+    (void) changeset->StageAddition(tx, /*fee=*/0, /*time=*/{}, /*entry_height=*/0, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/0, LockPoints{});
     return changeset->CheckMemPoolPolicyLimits();
 }
 
-int CTxMemPool::Expire(std::chrono::seconds time)
+int CTxMemPool::Expire(MempoolTime time)
 {
     AssertLockHeld(cs);
     Assume(!m_have_changeset);
@@ -831,9 +831,9 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
     if (!blockSinceLastRollingFeeBump || rollingMinimumFeeRate == 0)
         return CFeeRate(llround(rollingMinimumFeeRate));
 
-    int64_t time = GetTime();
-    if (time > lastRollingFeeUpdate + 10) {
-        double halflife = ROLLING_FEE_HALFLIFE;
+    MempoolTime time = Now();
+    if (time > lastRollingFeeUpdate + 10s) {
+        std::chrono::duration<double> halflife = ROLLING_FEE_HALFLIFE;
         if (DynamicMemoryUsage() < sizelimit / 4)
             halflife /= 4;
         else if (DynamicMemoryUsage() < sizelimit / 2)
@@ -1002,7 +1002,7 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
     return m_pool->m_txgraph->GetMainStagingDiagrams();
 }
 
-CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)
+CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, MempoolTime time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)
 {
     LOCK(m_pool->cs);
     Assume(m_to_add.find(tx->GetHash()) == m_to_add.end());

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -278,7 +278,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         RemovalReasonToString(reason).c_str(),
         it->GetTxSize(),
         it->GetFee(),
-        std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count()
+        TicksSinceEpoch<std::chrono::duration<std::uint64_t>>(it->GetTime())
     );
 
     for (const CTxIn& txin : it->GetTx().vin)
@@ -420,7 +420,7 @@ std::vector<RemovedMempoolTransactionInfo> CTxMemPool::removeForBlock(const std:
             ClearPrioritisation(tx->GetHash());
         }
     }
-    lastRollingFeeUpdate = GetTime();
+    lastRollingFeeUpdate = Now();
     blockSinceLastRollingFeeBump = true;
     if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
         LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after block.");
@@ -852,11 +852,11 @@ bool CTxMemPool::CheckPolicyLimits(const CTransactionRef& tx)
     // limits would be violated. Note that the changeset will be destroyed
     // when it goes out of scope.
     auto changeset = GetChangeSet();
-    (void) changeset->StageAddition(tx, /*fee=*/0, /*time=*/0, /*entry_height=*/0, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/0, LockPoints{});
+    (void) changeset->StageAddition(tx, /*fee=*/0, /*time=*/{}, /*entry_height=*/0, /*entry_sequence=*/0, /*spends_coinbase=*/false, /*sigops_cost=*/0, LockPoints{});
     return changeset->CheckMemPoolPolicyLimits();
 }
 
-int CTxMemPool::Expire(std::chrono::seconds time)
+int CTxMemPool::Expire(MempoolTime time)
 {
     AssertLockHeld(cs);
     Assume(!m_have_changeset);
@@ -879,9 +879,9 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
     if (!blockSinceLastRollingFeeBump || rollingMinimumFeeRate == 0)
         return CFeeRate(llround(rollingMinimumFeeRate));
 
-    int64_t time = GetTime();
-    if (time > lastRollingFeeUpdate + 10) {
-        double halflife = ROLLING_FEE_HALFLIFE;
+    MempoolTime time = Now();
+    if (time > lastRollingFeeUpdate + 10s) {
+        std::chrono::duration<double> halflife = ROLLING_FEE_HALFLIFE;
         if (DynamicMemoryUsage() < sizelimit / 4)
             halflife /= 4;
         else if (DynamicMemoryUsage() < sizelimit / 2)
@@ -1050,7 +1050,7 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
     return m_pool->m_txgraph->GetMainStagingDiagrams();
 }
 
-CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)
+CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, MempoolTime time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)
 {
     LOCK(m_pool->cs);
     Assume(m_to_add.find(tx->GetHash()) == m_to_add.end());

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -114,7 +114,7 @@ struct TxMempoolInfo
     CTransactionRef tx;
 
     /** Time the transaction entered the mempool. */
-    std::chrono::seconds m_time;
+    MempoolTime m_time;
 
     /** Fee of the transaction. */
     CAmount fee;
@@ -192,7 +192,7 @@ protected:
     CAmount m_total_fee GUARDED_BY(cs){0};       //!< sum of all mempool tx's fees (NOT modified fee)
     uint64_t cachedInnerUsage GUARDED_BY(cs){0}; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
-    mutable int64_t lastRollingFeeUpdate GUARDED_BY(cs){GetTime()};
+    mutable MempoolTime lastRollingFeeUpdate GUARDED_BY(cs){Now()};
     mutable bool blockSinceLastRollingFeeBump GUARDED_BY(cs){false};
     mutable double rollingMinimumFeeRate GUARDED_BY(cs){0}; //!< minimum fee to get into the pool, decreases exponentially
 
@@ -209,7 +209,7 @@ protected:
 
 public:
 
-    static const int ROLLING_FEE_HALFLIFE = 60 * 60 * 12; // public only for testing
+    static constexpr auto ROLLING_FEE_HALFLIFE{std::chrono::hours{12}}; // public only for testing
 
     using indexed_transaction_set = boost::multi_index_container<
         CTxMemPoolEntry,
@@ -458,7 +458,7 @@ public:
     void TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpendsRemaining = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Expire all transaction (and their dependencies) in the mempool older than time. Return the number of removed transactions. */
-    int Expire(std::chrono::seconds time) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    int Expire(MempoolTime time) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /**
      * Calculate the ancestor and cluster count for the given transaction.
@@ -573,6 +573,17 @@ public:
         return m_sequence_number;
     }
 
+    /**
+     * Return the current time. Non-static so the time source can be
+     * controlled per instance, enabling dependency injection for testing,
+     * simulation, or other integrations. Also insulates callers from future
+     * changes to the underlying time representation.
+     */
+    MempoolTime Now() const
+    {
+        return NodeClock::now();
+    }
+
 private:
     /** Remove a set of transactions from the mempool.
      *  If a transaction is in this set, then all in-mempool descendants must
@@ -631,7 +642,7 @@ public:
 
         using TxHandle = CTxMemPool::txiter;
 
-        TxHandle StageAddition(const CTransactionRef& tx, CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp);
+        TxHandle StageAddition(const CTransactionRef& tx, CAmount fee, MempoolTime time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp);
 
         void StageRemoval(CTxMemPool::txiter it);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -581,7 +581,10 @@ public:
      */
     MempoolTime Now() const
     {
-        return NodeClock::now();
+        // It's fine to use nondeterministic times in the mempool even though it
+        // gets linked into the kernel library, because it's just an internal
+        // dependency that's not exposed to applications.
+        return NodeClock::_now_nondet();
     }
 
 private:

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -607,7 +607,10 @@ public:
      */
     MempoolTime Now() const
     {
-        return NodeClock::now();
+        // It's fine to use nondeterministic times in the mempool even though it
+        // gets linked into the kernel library, because it's just an internal
+        // dependency that's not exposed to applications.
+        return NodeClock::_now_nondet();
     }
 
 private:

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -114,7 +114,7 @@ struct TxMempoolInfo
     CTransactionRef tx;
 
     /** Time the transaction entered the mempool. */
-    std::chrono::seconds m_time;
+    MempoolTime m_time;
 
     /** Fee of the transaction. */
     CAmount fee;
@@ -192,7 +192,7 @@ protected:
     CAmount m_total_fee GUARDED_BY(cs){0};       //!< sum of all mempool tx's fees (NOT modified fee)
     uint64_t cachedInnerUsage GUARDED_BY(cs){0}; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
-    mutable int64_t lastRollingFeeUpdate GUARDED_BY(cs){GetTime()};
+    mutable MempoolTime lastRollingFeeUpdate GUARDED_BY(cs){Now()};
     mutable bool blockSinceLastRollingFeeBump GUARDED_BY(cs){false};
     mutable double rollingMinimumFeeRate GUARDED_BY(cs){0}; //!< minimum fee to get into the pool, decreases exponentially
 
@@ -209,7 +209,7 @@ protected:
 
 public:
 
-    static constexpr int ROLLING_FEE_HALFLIFE{60 * 60 * 12}; // public only for testing
+    static constexpr auto ROLLING_FEE_HALFLIFE{std::chrono::hours{12}}; // public only for testing
 
     using indexed_transaction_set = boost::multi_index_container<
         CTxMemPoolEntry,
@@ -470,7 +470,7 @@ public:
     void TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpendsRemaining = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Expire all transaction (and their dependencies) in the mempool older than time. Return the number of removed transactions. */
-    int Expire(std::chrono::seconds time) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    int Expire(MempoolTime time) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /**
      * Calculate the ancestor and cluster count for the given transaction.
@@ -599,6 +599,17 @@ public:
         return m_sequence_number;
     }
 
+    /**
+     * Return the current time. Non-static so the time source can be
+     * controlled per instance, enabling dependency injection for testing,
+     * simulation, or other integrations. Also insulates callers from future
+     * changes to the underlying time representation.
+     */
+    MempoolTime Now() const
+    {
+        return NodeClock::now();
+    }
+
 private:
     /** Remove a set of transactions from the mempool.
      *  If a transaction is in this set, then all in-mempool descendants must
@@ -657,7 +668,7 @@ public:
 
         using TxHandle = CTxMemPool::txiter;
 
-        TxHandle StageAddition(const CTransactionRef& tx, CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp);
+        TxHandle StageAddition(const CTransactionRef& tx, CAmount fee, MempoolTime time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp);
 
         void StageRemoval(CTxMemPool::txiter it);
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   threadinterrupt.cpp
   threadnames.cpp
   time.cpp
+  time_nondet.cpp
   tokenpipe.cpp
   ../logging.cpp
   ../random.cpp

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   threadinterrupt.cpp
   threadnames.cpp
   time.cpp
+  time_nondet.cpp
   tokenpipe.cpp
   ../logging.cpp
   ../random.cpp

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -35,7 +35,7 @@ static std::atomic<MockableSteadyClock::mock_time_point::duration> g_mock_steady
 
 static_assert(NodeClock::epoch.time_since_epoch().count() == 0);
 
-NodeClock::time_point NodeClock::now() noexcept
+NodeClock::time_point NodeClock::_now_nondet() noexcept
 {
     const auto mocktime{g_mock_time.load(std::memory_order_relaxed)};
     if (!mocktime.count()) {
@@ -62,7 +62,7 @@ std::chrono::seconds GetMockTime()
     return g_mock_time.load(std::memory_order_relaxed);
 }
 
-MockableSteadyClock::time_point MockableSteadyClock::now() noexcept
+MockableSteadyClock::time_point MockableSteadyClock::_now_nondet() noexcept
 {
     const auto mocktime{g_mock_steady_time.load(std::memory_order_relaxed)};
     if (!mocktime.count()) {
@@ -85,8 +85,6 @@ void MockableSteadyClock::ClearMockTime()
 {
     g_mock_steady_time.store(0ms, std::memory_order_relaxed);
 }
-
-int64_t GetTime() { return GetTime<std::chrono::seconds>().count(); }
 
 std::string FormatISO8601DateTime(int64_t nTime)
 {

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -35,7 +35,7 @@ static std::atomic<MockableSteadyClock::mock_time_point::duration> g_mock_steady
 
 static_assert(NodeClock::epoch.time_since_epoch().count() == 0);
 
-NodeClock::time_point NodeClock::now() noexcept
+NodeClock::time_point NodeClock::_now_nondet() noexcept
 {
     const auto mocktime{g_mock_time.load(std::memory_order_relaxed)};
     if (!mocktime.count()) {
@@ -61,7 +61,7 @@ std::chrono::seconds GetMockTime()
     return g_mock_time.load(std::memory_order_relaxed);
 }
 
-MockableSteadyClock::time_point MockableSteadyClock::now() noexcept
+MockableSteadyClock::time_point MockableSteadyClock::_now_nondet() noexcept
 {
     const auto mocktime{g_mock_steady_time.load(std::memory_order_relaxed)};
     if (!mocktime.count()) {
@@ -84,8 +84,6 @@ void MockableSteadyClock::ClearMockTime()
 {
     g_mock_steady_time.store(0ms, std::memory_order_relaxed);
 }
-
-int64_t GetTime() { return GetTime<std::chrono::seconds>().count(); }
 
 std::string FormatISO8601DateTime(int64_t nTime)
 {

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -26,8 +26,14 @@ using namespace std::chrono_literals;
 /// FakeNodeClock or ::SetMockTime), otherwise the system clock.
 struct NodeClock : public std::chrono::system_clock {
     using time_point = std::chrono::time_point<NodeClock>;
-    /** Return current system time or mocked time, if set */
+    /** Return current system time or mocked time, if set.
+     *  Defined in time_nondet.cpp; not linked into bitcoinkernel. */
     static time_point now() noexcept;
+    /** Same as now(), but callable by kernel code with a scarier name to flag
+     * that it is nondeterministic, and should only be used if it does not
+     * affect validation results (e.g. for logging or flushing), or when kernel
+     * applications have a way to bypass it and stay deterministic. */
+    static time_point _now_nondet() noexcept;
     static std::time_t to_time_t(const time_point&) = delete; // unused
     static time_point from_time_t(std::time_t) = delete;      // unused
     static constexpr time_point epoch{};
@@ -49,9 +55,12 @@ struct MockableSteadyClock : public std::chrono::steady_clock {
 
     using mock_time_point = std::chrono::time_point<MockableSteadyClock, std::chrono::milliseconds>;
     static constexpr mock_time_point::duration INITIAL_MOCK_TIME{1};
-
-    /** Return current system time or mocked time, if set */
+    /** Return current system steady time or mocked time, if set.
+     *  Defined in time_nondet.cpp; not linked into bitcoinkernel. */
     static time_point now() noexcept;
+    /** Same as now(), but callable by kernel code. See \ref
+     * NodeClock::_now_nondet. */
+    static time_point _now_nondet() noexcept;
     static std::time_t to_time_t(const time_point&) = delete; // unused
     static time_point from_time_t(std::time_t) = delete;      // unused
 
@@ -142,6 +151,7 @@ T GetTime()
 {
     return Now<std::chrono::time_point<NodeClock, T>>().time_since_epoch();
 }
+inline int64_t GetTime() { return GetTime<std::chrono::seconds>().count(); }
 
 /**
  * ISO 8601 formatting is preferred. Use the FormatISO8601{DateTime,Date}

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -26,8 +26,14 @@ using namespace std::chrono_literals;
 /// FakeNodeClock or ::SetMockTime), otherwise the system clock.
 struct NodeClock : public std::chrono::system_clock {
     using time_point = std::chrono::time_point<NodeClock>;
-    /** Return current system time or mocked time, if set */
+    /** Return current system time or mocked time, if set.
+     *  Defined in time_nondet.cpp; not linked into bitcoinkernel. */
     static time_point now() noexcept;
+    /** Same as now(), but callable by kernel code with a scarier name to flag
+     * that it is nondeterministic, and should only be used if it does not
+     * affect validation results (e.g. for logging or flushing), or when kernel
+     * applications have a way to bypass it and stay deterministic. */
+    static time_point _now_nondet() noexcept;
     static std::time_t to_time_t(const time_point&) = delete; // unused
     static time_point from_time_t(std::time_t) = delete;      // unused
     static constexpr time_point epoch{};
@@ -49,9 +55,12 @@ struct MockableSteadyClock : public std::chrono::steady_clock {
 
     using mock_time_point = std::chrono::time_point<MockableSteadyClock, std::chrono::milliseconds>;
     static constexpr mock_time_point::duration INITIAL_MOCK_TIME{1};
-
-    /** Return current system time or mocked time, if set */
+    /** Return current system steady time or mocked time, if set.
+     *  Defined in time_nondet.cpp; not linked into bitcoinkernel. */
     static time_point now() noexcept;
+    /** Same as now(), but callable by kernel code. See \ref
+     * NodeClock::_now_nondet. */
+    static time_point _now_nondet() noexcept;
     static std::time_t to_time_t(const time_point&) = delete; // unused
     static time_point from_time_t(std::time_t) = delete;      // unused
 
@@ -134,6 +143,7 @@ T GetTime()
 {
     return Now<std::chrono::time_point<NodeClock, T>>().time_since_epoch();
 }
+inline int64_t GetTime() { return GetTime<std::chrono::seconds>().count(); }
 
 /**
  * ISO 8601 formatting is preferred. Use the FormatISO8601{DateTime,Date}

--- a/src/util/time_nondet.cpp
+++ b/src/util/time_nondet.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Implementations of now() for NodeClock and MockableSteadyClock that delegate
+// to _now_nondet(). This file is linked into bitcoin_util but NOT into
+// bitcoinkernel, so calls from libbitcoinkernel source files produce link errors
+// by design, preventing accidental nondeterminism.
+
+#include <util/time.h>
+
+NodeClock::time_point NodeClock::now() noexcept { return _now_nondet(); }
+
+MockableSteadyClock::time_point MockableSteadyClock::now() noexcept { return _now_nondet(); }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -267,7 +267,7 @@ static void LimitMempoolSize(CTxMemPool& pool, CCoinsViewCache& coins_cache)
 {
     AssertLockHeld(::cs_main);
     AssertLockHeld(pool.cs);
-    int expired = pool.Expire(GetTime<std::chrono::seconds>() - pool.m_opts.expiry);
+    int expired = pool.Expire(pool.Now() - pool.m_opts.expiry);
     if (expired != 0) {
         LogDebug(BCLog::MEMPOOL, "Expired %i transactions from the memory pool\n", expired);
     }
@@ -312,7 +312,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
         while (it != queuedTx.rend()) {
             // ignore validation errors in resurrected transactions
             if (!fAddToMempool || (*it)->IsCoinBase() ||
-                AcceptToMemoryPool(*this, *it, GetTime(),
+                AcceptToMemoryPool(*this, *it, m_mempool->Now(),
                     /*bypass_limits=*/true, /*test_accept=*/false).m_result_type !=
                         MempoolAcceptResult::ResultType::VALID) {
                 // If the transaction doesn't make it in to the mempool, remove any
@@ -448,7 +448,7 @@ public:
     // around easier.
     struct ATMPArgs {
         const CChainParams& m_chainparams;
-        const int64_t m_accept_time;
+        const MempoolTime m_accept_time;
         const bool m_bypass_limits;
         /*
          * Return any outpoints which were not previously present in the coins
@@ -480,7 +480,7 @@ public:
         const std::optional<CFeeRate> m_client_maxfeerate;
 
         /** Parameters for single transaction mempool validation. */
-        static ATMPArgs SingleAccept(const CChainParams& chainparams, int64_t accept_time,
+        static ATMPArgs SingleAccept(const CChainParams& chainparams, MempoolTime accept_time,
                                      bool bypass_limits, std::vector<COutPoint>& coins_to_uncache,
                                      bool test_accept) {
             return ATMPArgs{/*chainparams=*/ chainparams,
@@ -497,7 +497,7 @@ public:
         }
 
         /** Parameters for test package mempool validation through testmempoolaccept. */
-        static ATMPArgs PackageTestAccept(const CChainParams& chainparams, int64_t accept_time,
+        static ATMPArgs PackageTestAccept(const CChainParams& chainparams, MempoolTime accept_time,
                                           std::vector<COutPoint>& coins_to_uncache) {
             return ATMPArgs{/*chainparams=*/ chainparams,
                             /*accept_time=*/ accept_time,
@@ -513,7 +513,7 @@ public:
         }
 
         /** Parameters for child-with-parents package validation. */
-        static ATMPArgs PackageChildWithParents(const CChainParams& chainparams, int64_t accept_time,
+        static ATMPArgs PackageChildWithParents(const CChainParams& chainparams, MempoolTime accept_time,
                                                 std::vector<COutPoint>& coins_to_uncache, const std::optional<CFeeRate>& client_maxfeerate) {
             return ATMPArgs{/*chainparams=*/ chainparams,
                             /*accept_time=*/ accept_time,
@@ -547,7 +547,7 @@ public:
         // Private ctor to avoid exposing details to clients and allowing the possibility of
         // mixing up the order of the arguments. Use static functions above instead.
         ATMPArgs(const CChainParams& chainparams,
-                 int64_t accept_time,
+                 MempoolTime accept_time,
                  bool bypass_limits,
                  std::vector<COutPoint>& coins_to_uncache,
                  bool test_accept,
@@ -785,7 +785,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     const Txid& hash = ws.m_hash;
 
     // Copy/alias what we need out of args
-    const int64_t nAcceptTime = args.m_accept_time;
+    const MempoolTime nAcceptTime = args.m_accept_time;
     const bool bypass_limits = args.m_bypass_limits;
     std::vector<COutPoint>& coins_to_uncache = args.m_coins_to_uncache;
 
@@ -1224,7 +1224,7 @@ void MemPoolAccept::FinalizeSubpackage(const ATMPArgs& args)
                 it->GetTx().GetHash().data(),
                 it->GetTxSize(),
                 it->GetFee(),
-                std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count(),
+                TicksSinceEpoch<std::chrono::duration<std::uint64_t>>(it->GetTime()),
                 tx_or_package_hash.data(),
                 feerate.size,
                 feerate.fee,
@@ -1772,7 +1772,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 } // anon namespace
 
 MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
-                                       int64_t accept_time, bool bypass_limits, bool test_accept)
+                                       MempoolTime accept_time, bool bypass_limits, bool test_accept)
 {
     AssertLockHeld(::cs_main);
     const CChainParams& chainparams{active_chainstate.m_chainman.GetParams()};
@@ -1815,10 +1815,10 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
     auto result = [&]() EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
         AssertLockHeld(cs_main);
         if (test_accept) {
-            auto args = MemPoolAccept::ATMPArgs::PackageTestAccept(chainparams, GetTime(), coins_to_uncache);
+            auto args = MemPoolAccept::ATMPArgs::PackageTestAccept(chainparams, pool.Now(), coins_to_uncache);
             return MemPoolAccept(pool, active_chainstate).AcceptMultipleTransactionsAndCleanup(package, args);
         } else {
-            auto args = MemPoolAccept::ATMPArgs::PackageChildWithParents(chainparams, GetTime(), coins_to_uncache, client_maxfeerate);
+            auto args = MemPoolAccept::ATMPArgs::PackageChildWithParents(chainparams, pool.Now(), coins_to_uncache, client_maxfeerate);
             return MemPoolAccept(pool, active_chainstate).AcceptPackage(package, args);
         }
     }();
@@ -4444,7 +4444,7 @@ MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef&
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
         return MempoolAcceptResult::Failure(state);
     }
-    auto result = AcceptToMemoryPool(active_chainstate, tx, GetTime(), /*bypass_limits=*/ false, test_accept);
+    auto result = AcceptToMemoryPool(active_chainstate, tx, active_chainstate.m_mempool->Now(), /*bypass_limits=*/ false, test_accept);
     active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);
     return result;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -284,7 +284,7 @@ static bool IsCurrentForFeeEstimation(Chainstate& active_chainstate) EXCLUSIVE_L
     if (active_chainstate.m_chainman.IsInitialBlockDownload()) {
         return false;
     }
-    if (active_chainstate.m_chain.Tip()->GetBlockTime() < count_seconds(GetTime<std::chrono::seconds>() - MAX_FEE_ESTIMATION_TIP_AGE))
+    if (active_chainstate.m_chain.Tip()->Time() < active_chainstate.m_chainman.Now() - MAX_FEE_ESTIMATION_TIP_AGE)
         return false;
     if (active_chainstate.m_chain.Height() < active_chainstate.m_chainman.m_best_header->nHeight - 1) {
         return false;
@@ -3275,7 +3275,7 @@ void ChainstateManager::UpdateIBDStatus()
     AssertLockHeld(cs_main);
     if (!m_cached_is_ibd.load(std::memory_order_relaxed)) return;
     if (m_blockman.LoadingBlocks()) return;
-    if (!CurrentChainstate().m_chain.IsTipRecent(MinimumChainWork(), m_options.max_tip_age)) return;
+    if (!CurrentChainstate().m_chain.IsTipRecent(MinimumChainWork(), m_options.max_tip_age, Now())) return;
     LogInfo("Leaving InitialBlockDownload (latching to false)");
     m_cached_is_ibd.store(false, std::memory_order_relaxed);
 }
@@ -4095,7 +4095,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     }
 
     // Check timestamp
-    if (block.Time() > NodeClock::now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
+    if (block.Time() > chainman.Now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
     }
 
@@ -4250,7 +4250,7 @@ bool ChainstateManager::ProcessNewBlockHeaders(std::span<const CBlockHeader> hea
     if (NotifyHeaderTip()) {
         if (IsInitialBlockDownload() && ppindex && *ppindex) {
             const CBlockIndex& last_accepted{**ppindex};
-            int64_t blocks_left{(NodeClock::now() - last_accepted.Time()) / GetConsensus().PowTargetSpacing()};
+            int64_t blocks_left{(Now() - last_accepted.Time()) / GetConsensus().PowTargetSpacing()};
             blocks_left = std::max<int64_t>(0, blocks_left);
             const double progress{100.0 * last_accepted.nHeight / (last_accepted.nHeight + blocks_left)};
             LogInfo("Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
@@ -4277,7 +4277,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
     bool initial_download = IsInitialBlockDownload();
     GetNotifications().headerTip(GetSynchronizationState(initial_download, m_blockman.m_blockfiles_indexed), height, timestamp, /*presync=*/true);
     if (initial_download) {
-        int64_t blocks_left{(NodeClock::now() - NodeSeconds{std::chrono::seconds{timestamp}}) / GetConsensus().PowTargetSpacing()};
+        int64_t blocks_left{(Now() - NodeSeconds{std::chrono::seconds{timestamp}}) / GetConsensus().PowTargetSpacing()};
         blocks_left = std::max<int64_t>(0, blocks_left);
         const double progress{100.0 * height / (height + blocks_left)};
         LogInfo("Pre-synchronizing blockheaders, height: %d (~%.2f%%)\n", height, progress);
@@ -5493,25 +5493,25 @@ double ChainstateManager::GuessVerificationProgress(const CBlockIndex* pindex) c
         return 0.0;
     }
 
-    const int64_t nNow{TicksSinceEpoch<std::chrono::seconds>(NodeClock::now())};
-    const auto block_time{
-        (Assume(m_best_header) && std::abs(nNow - pindex->GetBlockTime()) <= Ticks<std::chrono::seconds>(2h) &&
+    const NodeClock::time_point now{Now()};
+    const NodeClock::time_point block_time{
+        (Assume(m_best_header) && std::chrono::abs(now - pindex->Time()) <= 2h &&
          Assume(m_best_header->nHeight >= pindex->nHeight)) ?
             // When the header is known to be recent, switch to a height-based
             // approach. This ensures the returned value is quantized when
             // close to "1.0", because some users expect it to be. This also
             // avoids relying too much on the exact miner-set timestamp, which
             // may be off.
-            nNow - (m_best_header->nHeight - pindex->nHeight) * GetConsensus().nPowTargetSpacing :
-            pindex->GetBlockTime(),
+            now - std::chrono::seconds((m_best_header->nHeight - pindex->nHeight) * GetConsensus().nPowTargetSpacing) :
+            pindex->Time(),
     };
 
     double fTxTotal;
 
     if (pindex->m_chain_tx_count <= data.tx_count) {
-        fTxTotal = data.tx_count + (nNow - data.nTime) * data.dTxRate;
+        fTxTotal = data.tx_count + (TicksSinceEpoch<std::chrono::seconds>(now) - data.nTime) * data.dTxRate;
     } else {
-        fTxTotal = pindex->m_chain_tx_count + (nNow - block_time) * data.dTxRate;
+        fTxTotal = pindex->m_chain_tx_count + Ticks<std::chrono::seconds>(now - block_time) * data.dTxRate;
     }
 
     return std::min<double>(pindex->m_chain_tx_count / fTxTotal, 1.0);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2756,7 +2756,7 @@ bool Chainstate::FlushStateToDisk(
                 }
             }
         }
-        const auto nNow{NodeClock::now()};
+        const auto nNow{NodeClock::_now_nondet()};
         // The cache is large and we're within 10% and 10 MiB of the limit, but we have time now (not in the middle of a block processing).
         bool fCacheLarge = mode == FlushStateMode::PERIODIC && cache_state >= CoinsCacheSizeState::LARGE;
         // The cache is over the limit, we have to write now.
@@ -2812,7 +2812,7 @@ bool Chainstate::FlushStateToDisk(
                 empty_cache ? CoinsTip().Flush() : CoinsTip().Sync();
                 full_flush_completed = true;
                 TRACEPOINT(utxocache, flush,
-                    int64_t{Ticks<std::chrono::microseconds>(NodeClock::now() - nNow)},
+                    int64_t{Ticks<std::chrono::microseconds>(NodeClock::_now_nondet() - nNow)},
                     (uint32_t)mode,
                     (uint64_t)coins_count,
                     (uint64_t)coins_mem_usage,
@@ -2822,7 +2822,7 @@ bool Chainstate::FlushStateToDisk(
 
         if (should_write || m_next_write == NodeClock::time_point::max()) {
             constexpr auto range{DATABASE_WRITE_INTERVAL_MAX - DATABASE_WRITE_INTERVAL_MIN};
-            m_next_write = FastRandomContext().rand_uniform_delay(NodeClock::now() + DATABASE_WRITE_INTERVAL_MIN, range);
+            m_next_write = FastRandomContext().rand_uniform_delay(NodeClock::_now_nondet() + DATABASE_WRITE_INTERVAL_MIN, range);
         }
     }
     if (full_flush_completed && m_chainman.m_options.signals) {
@@ -4270,7 +4270,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
         if (m_best_header->nChainWork >= UintToArith256(GetConsensus().nMinimumChainWork)) return;
         // Rate limit headers presync updates to 4 per second, as these are not subject to DoS
         // protection.
-        auto now = MockableSteadyClock::now();
+        auto now = MockableSteadyClock::_now_nondet();
         if (now < m_last_presync_update + std::chrono::milliseconds{250}) return;
         m_last_presync_update = now;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2756,7 +2756,7 @@ bool Chainstate::FlushStateToDisk(
                 }
             }
         }
-        const auto nNow{NodeClock::now()};
+        const auto nNow{NodeClock::_now_nondet()};
         // The cache is large and we're within 10% and 10 MiB of the limit, but we have time now (not in the middle of a block processing).
         bool fCacheLarge = mode == FlushStateMode::PERIODIC && cache_state >= CoinsCacheSizeState::LARGE;
         // The cache is over the limit, we have to write now.
@@ -2813,7 +2813,7 @@ bool Chainstate::FlushStateToDisk(
                 m_last_flushed_block = m_blockman.LookupBlockIndex(CoinsTip().GetBestBlock());
                 full_flush_completed = true;
                 TRACEPOINT(utxocache, flush,
-                    int64_t{Ticks<std::chrono::microseconds>(NodeClock::now() - nNow)},
+                    int64_t{Ticks<std::chrono::microseconds>(NodeClock::_now_nondet() - nNow)},
                     (uint32_t)mode,
                     (uint64_t)coins_count,
                     (uint64_t)coins_mem_usage,
@@ -2823,7 +2823,7 @@ bool Chainstate::FlushStateToDisk(
 
         if (should_write || m_next_write == NodeClock::time_point::max()) {
             constexpr auto range{DATABASE_WRITE_INTERVAL_MAX - DATABASE_WRITE_INTERVAL_MIN};
-            m_next_write = FastRandomContext().rand_uniform_delay(NodeClock::now() + DATABASE_WRITE_INTERVAL_MIN, range);
+            m_next_write = FastRandomContext().rand_uniform_delay(NodeClock::_now_nondet() + DATABASE_WRITE_INTERVAL_MIN, range);
         }
     }
     if (full_flush_completed) {
@@ -4288,7 +4288,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
         if (m_best_header->nChainWork >= UintToArith256(GetConsensus().nMinimumChainWork)) return;
         // Rate limit headers presync updates to 4 per second, as these are not subject to DoS
         // protection.
-        auto now = MockableSteadyClock::now();
+        auto now = MockableSteadyClock::_now_nondet();
         if (now < m_last_presync_update + std::chrono::milliseconds{250}) return;
         m_last_presync_update = now;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -292,7 +292,7 @@ static bool IsCurrentForFeeEstimation(Chainstate& active_chainstate) EXCLUSIVE_L
     if (active_chainstate.m_chainman.IsInitialBlockDownload()) {
         return false;
     }
-    if (active_chainstate.m_chain.Tip()->GetBlockTime() < count_seconds(GetTime<std::chrono::seconds>() - MAX_FEE_ESTIMATION_TIP_AGE))
+    if (active_chainstate.m_chain.Tip()->Time() < active_chainstate.m_chainman.Now() - MAX_FEE_ESTIMATION_TIP_AGE)
         return false;
     if (active_chainstate.m_chain.Height() < active_chainstate.m_chainman.m_best_header->nHeight - 1) {
         return false;
@@ -3293,7 +3293,7 @@ void ChainstateManager::UpdateIBDStatus()
     AssertLockHeld(cs_main);
     if (!m_cached_is_ibd.load(std::memory_order_relaxed)) return;
     if (m_blockman.LoadingBlocks()) return;
-    if (!CurrentChainstate().m_chain.IsTipRecent(MinimumChainWork(), m_options.max_tip_age)) return;
+    if (!CurrentChainstate().m_chain.IsTipRecent(MinimumChainWork(), m_options.max_tip_age, Now())) return;
     LogInfo("Leaving InitialBlockDownload (latching to false)");
     m_cached_is_ibd.store(false, std::memory_order_relaxed);
 }
@@ -4113,7 +4113,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     }
 
     // Check timestamp
-    if (block.Time() > NodeClock::now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
+    if (block.Time() > chainman.Now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
     }
 
@@ -4268,7 +4268,7 @@ bool ChainstateManager::ProcessNewBlockHeaders(std::span<const CBlockHeader> hea
     if (NotifyHeaderTip()) {
         if (IsInitialBlockDownload() && ppindex && *ppindex) {
             const CBlockIndex& last_accepted{**ppindex};
-            int64_t blocks_left{(NodeClock::now() - last_accepted.Time()) / GetConsensus().PowTargetSpacing()};
+            int64_t blocks_left{(Now() - last_accepted.Time()) / GetConsensus().PowTargetSpacing()};
             blocks_left = std::max<int64_t>(0, blocks_left);
             const double progress{100.0 * last_accepted.nHeight / (last_accepted.nHeight + blocks_left)};
             LogInfo("Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
@@ -4295,7 +4295,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
     bool initial_download = IsInitialBlockDownload();
     GetNotifications().headerTip(GetSynchronizationState(initial_download, m_blockman.m_blockfiles_indexed), height, timestamp, /*presync=*/true);
     if (initial_download) {
-        int64_t blocks_left{(NodeClock::now() - NodeSeconds{std::chrono::seconds{timestamp}}) / GetConsensus().PowTargetSpacing()};
+        int64_t blocks_left{(Now() - NodeSeconds{std::chrono::seconds{timestamp}}) / GetConsensus().PowTargetSpacing()};
         blocks_left = std::max<int64_t>(0, blocks_left);
         const double progress{100.0 * height / (height + blocks_left)};
         LogInfo("Pre-synchronizing blockheaders, height: %d (~%.2f%%)\n", height, progress);
@@ -5518,25 +5518,25 @@ double ChainstateManager::GuessVerificationProgress(const CBlockIndex* pindex) c
         return 0.0;
     }
 
-    const int64_t nNow{TicksSinceEpoch<std::chrono::seconds>(NodeClock::now())};
-    const auto block_time{
-        (Assume(m_best_header) && std::abs(nNow - pindex->GetBlockTime()) <= Ticks<std::chrono::seconds>(2h) &&
+    const NodeClock::time_point now{Now()};
+    const NodeClock::time_point block_time{
+        (Assume(m_best_header) && std::chrono::abs(now - pindex->Time()) <= 2h &&
          Assume(m_best_header->nHeight >= pindex->nHeight)) ?
             // When the header is known to be recent, switch to a height-based
             // approach. This ensures the returned value is quantized when
             // close to "1.0", because some users expect it to be. This also
             // avoids relying too much on the exact miner-set timestamp, which
             // may be off.
-            nNow - (m_best_header->nHeight - pindex->nHeight) * GetConsensus().nPowTargetSpacing :
-            pindex->GetBlockTime(),
+            now - std::chrono::seconds((m_best_header->nHeight - pindex->nHeight) * GetConsensus().nPowTargetSpacing) :
+            pindex->Time(),
     };
 
     double fTxTotal;
 
     if (pindex->m_chain_tx_count <= data.tx_count) {
-        fTxTotal = data.tx_count + (nNow - data.nTime) * data.dTxRate;
+        fTxTotal = data.tx_count + (TicksSinceEpoch<std::chrono::seconds>(now) - data.nTime) * data.dTxRate;
     } else {
-        fTxTotal = pindex->m_chain_tx_count + (nNow - block_time) * data.dTxRate;
+        fTxTotal = pindex->m_chain_tx_count + Ticks<std::chrono::seconds>(now - block_time) * data.dTxRate;
     }
 
     return std::min<double>(pindex->m_chain_tx_count / fTxTotal, 1.0);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -275,7 +275,7 @@ static void LimitMempoolSize(CTxMemPool& pool, CCoinsViewCache& coins_cache)
 {
     AssertLockHeld(::cs_main);
     AssertLockHeld(pool.cs);
-    int expired = pool.Expire(GetTime<std::chrono::seconds>() - pool.m_opts.expiry);
+    int expired = pool.Expire(pool.Now() - pool.m_opts.expiry);
     if (expired != 0) {
         LogDebug(BCLog::MEMPOOL, "Expired %i transactions from the memory pool\n", expired);
     }
@@ -320,7 +320,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
         while (it != queuedTx.rend()) {
             // ignore validation errors in resurrected transactions
             if (!fAddToMempool || (*it)->IsCoinBase() ||
-                AcceptToMemoryPool(*this, *it, GetTime(),
+                AcceptToMemoryPool(*this, *it, m_mempool->Now(),
                     /*bypass_limits=*/true, /*test_accept=*/false).m_result_type !=
                         MempoolAcceptResult::ResultType::VALID) {
                 // If the transaction doesn't make it in to the mempool, remove any
@@ -455,7 +455,7 @@ public:
     // We put the arguments we're handed into a struct, so we can pass them
     // around easier.
     struct ATMPArgs {
-        const int64_t m_accept_time;
+        const MempoolTime m_accept_time;
         const bool m_bypass_limits;
         /*
          * Return any outpoints which were not previously present in the coins
@@ -487,7 +487,7 @@ public:
         const std::optional<CFeeRate> m_client_maxfeerate;
 
         /** Parameters for single transaction mempool validation. */
-        static ATMPArgs SingleAccept(int64_t accept_time,
+        static ATMPArgs SingleAccept(MempoolTime accept_time,
                                      bool bypass_limits, std::vector<COutPoint>& coins_to_uncache,
                                      bool test_accept) {
             return ATMPArgs{/*accept_time=*/ accept_time,
@@ -503,7 +503,7 @@ public:
         }
 
         /** Parameters for test package mempool validation through testmempoolaccept. */
-        static ATMPArgs PackageTestAccept(int64_t accept_time,
+        static ATMPArgs PackageTestAccept(MempoolTime accept_time,
                                           std::vector<COutPoint>& coins_to_uncache) {
             return ATMPArgs{/*accept_time=*/ accept_time,
                             /*bypass_limits=*/ false,
@@ -518,7 +518,7 @@ public:
         }
 
         /** Parameters for child-with-parents package validation. */
-        static ATMPArgs PackageChildWithParents(int64_t accept_time,
+        static ATMPArgs PackageChildWithParents(MempoolTime accept_time,
                                                 std::vector<COutPoint>& coins_to_uncache, const std::optional<CFeeRate>& client_maxfeerate) {
             return ATMPArgs{/*accept_time=*/ accept_time,
                             /*bypass_limits=*/ false,
@@ -549,7 +549,7 @@ public:
     private:
         // Private ctor to avoid exposing details to clients and allowing the possibility of
         // mixing up the order of the arguments. Use static functions above instead.
-        ATMPArgs(int64_t accept_time,
+        ATMPArgs(MempoolTime accept_time,
                  bool bypass_limits,
                  std::vector<COutPoint>& coins_to_uncache,
                  bool test_accept,
@@ -785,7 +785,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     const Txid& hash = ws.m_hash;
 
     // Copy/alias what we need out of args
-    const int64_t nAcceptTime = args.m_accept_time;
+    const MempoolTime nAcceptTime = args.m_accept_time;
     const bool bypass_limits = args.m_bypass_limits;
     std::vector<COutPoint>& coins_to_uncache = args.m_coins_to_uncache;
 
@@ -1221,7 +1221,7 @@ void MemPoolAccept::FinalizeSubpackage(const ATMPArgs& args)
                 it->GetTx().GetHash().data(),
                 it->GetTxSize(),
                 it->GetFee(),
-                std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count(),
+                TicksSinceEpoch<std::chrono::duration<std::uint64_t>>(it->GetTime()),
                 tx_or_package_hash.data(),
                 feerate.size,
                 feerate.fee,
@@ -1769,7 +1769,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 } // anon namespace
 
 MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
-                                       int64_t accept_time, bool bypass_limits, bool test_accept)
+                                       MempoolTime accept_time, bool bypass_limits, bool test_accept)
 {
     AssertLockHeld(::cs_main);
     assert(active_chainstate.GetMempool() != nullptr);
@@ -1810,10 +1810,10 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
     auto result = [&]() EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
         AssertLockHeld(cs_main);
         if (test_accept) {
-            auto args = MemPoolAccept::ATMPArgs::PackageTestAccept(GetTime(), coins_to_uncache);
+            auto args = MemPoolAccept::ATMPArgs::PackageTestAccept(pool.Now(), coins_to_uncache);
             return MemPoolAccept(pool, active_chainstate).AcceptMultipleTransactionsAndCleanup(package, args);
         } else {
-            auto args = MemPoolAccept::ATMPArgs::PackageChildWithParents(GetTime(), coins_to_uncache, client_maxfeerate);
+            auto args = MemPoolAccept::ATMPArgs::PackageChildWithParents(pool.Now(), coins_to_uncache, client_maxfeerate);
             return MemPoolAccept(pool, active_chainstate).AcceptPackage(package, args);
         }
     }();
@@ -4469,7 +4469,7 @@ MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef&
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
         return MempoolAcceptResult::Failure(state);
     }
-    auto result = AcceptToMemoryPool(active_chainstate, tx, GetTime(), /*bypass_limits=*/ false, test_accept);
+    auto result = AcceptToMemoryPool(active_chainstate, tx, active_chainstate.m_mempool->Now(), /*bypass_limits=*/ false, test_accept);
     active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);
     return result;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -272,7 +272,7 @@ struct PackageMempoolAcceptResult
  * @returns a MempoolAcceptResult indicating whether the transaction was accepted/rejected with reason.
  */
 MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
-                                       int64_t accept_time, bool bypass_limits, bool test_accept)
+                                       MempoolTime accept_time, bool bypass_limits, bool test_accept)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /**

--- a/src/validation.h
+++ b/src/validation.h
@@ -1017,7 +1017,7 @@ public:
     NodeClock::time_point Now() const
     {
         const auto clock{m_clock_now_seconds.load(std::memory_order_relaxed)};
-        return clock != std::chrono::seconds{0} ? NodeSeconds{clock} : NodeClock::now();
+        return clock != std::chrono::seconds{0} ? NodeSeconds{clock} : NodeClock::_now_nondet();
     }
 
     const arith_uint256& MinimumChainWork() const { return *Assert(m_options.minimum_chain_work); }

--- a/src/validation.h
+++ b/src/validation.h
@@ -1007,6 +1007,19 @@ public:
     const CChainParams& GetParams() const { return m_options.chainparams; }
     const Consensus::Params& GetConsensus() const { return m_options.chainparams.GetConsensus(); }
     bool ShouldCheckBlockIndex() const;
+
+    /**
+     * Return the current time for use in validation and IBD checks. Uses the
+     * m_clock_now_seconds value if one has been set, otherwise uses NodeClock.
+     * Prefer this over NodeClock::now() in all validation paths so that kernel
+     * library users can control clock times used for validation.
+     */
+    NodeClock::time_point Now() const
+    {
+        const auto clock{m_clock_now_seconds.load(std::memory_order_relaxed)};
+        return clock != std::chrono::seconds{0} ? NodeSeconds{clock} : NodeClock::now();
+    }
+
     const arith_uint256& MinimumChainWork() const { return *Assert(m_options.minimum_chain_work); }
     const uint256& AssumedValidBlock() const { return *Assert(m_options.assumed_valid_block); }
     kernel::Notifications& GetNotifications() const { return m_options.notifications; };
@@ -1047,6 +1060,13 @@ public:
      * enough work and is recent.
      */
     std::atomic_bool m_cached_is_ibd{true};
+
+    /**
+     * Clock time for validation, scoped to this chainstate manager.
+     * Zero means use NodeClock; any other value is seconds since epoch.
+     * Stored as an atomic so Now() can be called lock-free from any thread.
+     */
+    std::atomic<std::chrono::seconds> m_clock_now_seconds{};
 
     /**
      * Every received block is assigned a unique and increasing identifier, so we

--- a/src/validation.h
+++ b/src/validation.h
@@ -271,7 +271,7 @@ struct PackageMempoolAcceptResult
  * @returns a MempoolAcceptResult indicating whether the transaction was accepted/rejected with reason.
  */
 MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTransactionRef& tx,
-                                       int64_t accept_time, bool bypass_limits, bool test_accept)
+                                       MempoolTime accept_time, bool bypass_limits, bool test_accept)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /**

--- a/src/validation.h
+++ b/src/validation.h
@@ -1018,7 +1018,7 @@ public:
     NodeClock::time_point Now() const
     {
         const auto clock{m_clock_now_seconds.load(std::memory_order_relaxed)};
-        return clock != std::chrono::seconds{0} ? NodeSeconds{clock} : NodeClock::now();
+        return clock != std::chrono::seconds{0} ? NodeSeconds{clock} : NodeClock::_now_nondet();
     }
 
     const arith_uint256& MinimumChainWork() const { return *Assert(m_options.minimum_chain_work); }

--- a/src/validation.h
+++ b/src/validation.h
@@ -1008,6 +1008,19 @@ public:
     const CChainParams& GetParams() const { return m_options.chainparams; }
     const Consensus::Params& GetConsensus() const { return m_options.chainparams.GetConsensus(); }
     bool ShouldCheckBlockIndex() const;
+
+    /**
+     * Return the current time for use in validation and IBD checks. Uses the
+     * m_clock_now_seconds value if one has been set, otherwise uses NodeClock.
+     * Prefer this over NodeClock::now() in all validation paths so that kernel
+     * library users can control clock times used for validation.
+     */
+    NodeClock::time_point Now() const
+    {
+        const auto clock{m_clock_now_seconds.load(std::memory_order_relaxed)};
+        return clock != std::chrono::seconds{0} ? NodeSeconds{clock} : NodeClock::now();
+    }
+
     const arith_uint256& MinimumChainWork() const { return *Assert(m_options.minimum_chain_work); }
     const uint256& AssumedValidBlock() const { return *Assert(m_options.assumed_valid_block); }
     kernel::Notifications& GetNotifications() const { return m_options.notifications; };
@@ -1048,6 +1061,13 @@ public:
      * enough work and is recent.
      */
     std::atomic_bool m_cached_is_ibd{true};
+
+    /**
+     * Clock time for validation, scoped to this chainstate manager.
+     * Zero means use NodeClock; any other value is seconds since epoch.
+     * Stored as an atomic so Now() can be called lock-free from any thread.
+     */
+    std::atomic<std::chrono::seconds> m_clock_now_seconds{};
 
     /**
      * Every received block is assigned a unique and increasing identifier, so we


### PR DESCRIPTION
The main commit in this PR is the second commit adding a `btck_chainstate_manager_set_clock_time` API which lets kernel applications run validation code deterministically without depending on the system clock. This is an alternative to #35496, and one of several alternatives discussed in that PR, with some tradeoffs described in https://github.com/bitcoin/bitcoin/pull/35496#issuecomment-4735710317.

The other commits are indirectly related and could be moved to separate PRs (or dropped):

<details><summary>Details</summary>
<p>

- The first commit fixes a timing race in the `chainstatemanager_ibd_exit_after_loading_blocks` test that happened because test code and validation code (in `UpdateIBDStatus`) were both calling `NodeClock::now()` to get the current clock time, and test relied on the times being the same for `tip_recent=true` checks. The failure this fixes should be rare, but I noticed it when I experimented with making time comparison in `IsTipRecent` more precise.

- The third commit refactors mempool code to use a consistent way of getting and representing clock times, allowing the fourth commit to enforce that no libbitcoinkernel code uses nondeterministic clock times unintentionally. The third and fourth commits do not need to be part of this PR, but I implemented them to be sure the main commit was complete and all call sites were using the right clock times.
</p>
</details>