### PR TITLE
p2p: Prefill compact blocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,7 @@ if(WIN32)
   target_compile_definitions(core_interface INTERFACE
     _WIN32_WINNT=0x0A00
     _WIN32_IE=0x0A00
+    NTDDI_VERSION=0x0A000003 # Windows 10 1703
     WIN32_LEAN_AND_MEAN
     NOMINMAX
   )

--- a/src/bench/blockencodings.cpp
+++ b/src/bench/blockencodings.cpp
@@ -22,6 +22,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <set>
 #include <span>
 #include <utility>
 #include <vector>
@@ -55,7 +56,7 @@ private:
     }
 
 public:
-    BenchCBHAST(InsecureRandomContext& rng, int txs) : CBlockHeaderAndShortTxIDs(DummyBlock(), rng.rand64())
+    BenchCBHAST(InsecureRandomContext& rng, int txs) : CBlockHeaderAndShortTxIDs(DummyBlock(), rng.rand64(), /*prefill_candidates=*/{})
     {
         shorttxids.reserve(txs);
         while (txs-- > 0) {

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -18,18 +18,25 @@
 
 #include <unordered_map>
 
-CBlockHeaderAndShortTxIDs::CBlockHeaderAndShortTxIDs(const CBlock& block, uint64_t nonce)
+CBlockHeaderAndShortTxIDs::CBlockHeaderAndShortTxIDs(const CBlock& block, uint64_t nonce, const std::set<uint32_t>& prefill_candidates)
     : nonce(nonce),
-      shorttxids(block.vtx.size() - 1),
-      prefilledtxn(1),
       header(block)
 {
+    prefilledtxn.reserve(prefill_candidates.size());
+    shorttxids.reserve(block.vtx.size() - prefill_candidates.size());
     FillShortTxIDSelector();
-    // TODO: Use our mempool prior to block acceptance to predictively fill more than just the coinbase
-    prefilledtxn[0] = {0, block.vtx[0]};
-    for (size_t i = 1; i < block.vtx.size(); i++) {
-        const CTransaction& tx = *block.vtx[i];
-        shorttxids[i - 1] = GetShortID(tx.GetWitnessHash());
+
+    uint16_t prefill_index = 0;
+    for (size_t i = 0; i < block.vtx.size(); i++) {
+        // Always prefill the coinbase transaction.
+        if(prefill_candidates.contains(i) || i == 0) {
+            prefilledtxn.push_back({prefill_index, block.vtx[i]});
+            prefill_index = 0;
+        } else {
+            const CTransaction& tx = *block.vtx[i];
+            shorttxids.push_back(GetShortID(tx.GetWitnessHash()));
+            prefill_index++;
+        }
     }
 }
 

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -221,11 +221,11 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
     if (util::log::ShouldDebugLog(BCLog::CMPCTBLOCK)) {
         const uint256 hash{block.GetHash()};
         uint32_t tx_missing_size{0};
-        for (const auto& tx : vtx_missing) tx_missing_size += tx->ComputeTotalSize();
+        for (const auto& tx : vtx_missing) { tx_missing_size += tx->ComputeTotalSize(); }
         LogDebug(BCLog::CMPCTBLOCK, "Successfully reconstructed block %s with %u txn prefilled, %u txn from mempool (incl at least %u from extra pool) and %u txn (%u bytes) requested\n", hash.ToString(), prefilled_count, mempool_count, extra_count, vtx_missing.size(), tx_missing_size);
-        if (vtx_missing.size() < 5) {
+        if (util::log::ShouldTraceLog(BCLog::CMPCTBLOCK)) {
             for (const auto& tx : vtx_missing) {
-                LogDebug(BCLog::CMPCTBLOCK, "Reconstructed block %s required tx %s\n", hash.ToString(), tx->GetHash().ToString());
+                LogTrace(BCLog::CMPCTBLOCK, "Reconstructed block %s required tx %s\n", hash.ToString(), tx->GetHash().ToString());
             }
         }
     }

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -115,6 +115,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
 
     enum class TxSource : uint8_t { NONE, MEMPOOL, EXTRA, COLLIDED };
     std::vector<TxSource> tx_source(txn_available.size(), TxSource::NONE);
+    size_t available_count = 0;
     {
     LOCK(pool->cs);
     for (const auto& [wtxid, txit] : pool->txns_randomized) {
@@ -124,20 +125,20 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             if (tx_source[idit->second] == TxSource::NONE) {
                 txn_available[idit->second] = txit->GetSharedTx();
                 tx_source[idit->second] = TxSource::MEMPOOL;
-                mempool_count++;
+                available_count++;
             } else if (tx_source[idit->second] != TxSource::COLLIDED) {
                 // If we find two mempool txn that match the short id, just request it.
                 // This should be rare enough that the extra bandwidth doesn't matter,
                 // but eating a round-trip due to FillBlock failure would be annoying
                 txn_available[idit->second].reset();
-                mempool_count--;
+                available_count--;
                 tx_source[idit->second] = TxSource::COLLIDED;
             }
         }
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
         // the performance win of an early exit here is too good to pass up and worth
         // the extra risk.
-        if (mempool_count == shorttxids.size())
+        if (available_count == shorttxids.size())
             break;
     }
     }
@@ -149,8 +150,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             if (tx_source[idit->second] == TxSource::NONE) {
                 txn_available[idit->second] = extra_txn[i].second;
                 tx_source[idit->second] = TxSource::EXTRA;
-                mempool_count++;
-                extra_count++;
+                available_count++;
             } else if (tx_source[idit->second] != TxSource::COLLIDED &&
                        txn_available[idit->second]->GetWitnessHash() != extra_txn[i].second->GetWitnessHash()) {
                 // If we find two mempool/extra txn that match the short id, just
@@ -160,16 +160,31 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
                 // Note that we don't want duplication between extra_txn and mempool to
                 // trigger this case, so we compare witness hashes first
                 txn_available[idit->second].reset();
-                mempool_count--;
-                extra_count -= (tx_source[idit->second] == TxSource::EXTRA);
+                available_count--;
                 tx_source[idit->second] = TxSource::COLLIDED;
             }
         }
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
         // the performance win of an early exit here is too good to pass up and worth
         // the extra risk.
-        if (mempool_count == shorttxids.size())
+        if (available_count == shorttxids.size())
             break;
+    }
+
+    if (util::log::ShouldDebugLog(BCLog::CMPCTBLOCK)) {
+        Assume(txn_available.size() == tx_source.size());
+        for (size_t i = 0; i < txn_available.size(); i++) {
+            switch (tx_source[i]) {
+                case TxSource::MEMPOOL:
+                    mempool_count++;
+                    break;
+                case TxSource::EXTRA:
+                    extra_count++;
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 
     LogDebug(BCLog::CMPCTBLOCK, "Initialized PartiallyDownloadedBlock for block %s using a cmpctblock of %u bytes\n", cmpctblock.header.GetHash().ToString(), GetSerializeSize(cmpctblock));

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -86,35 +86,39 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     }
 
 
-    int32_t lastprefilledindex = -1;
-    for (size_t i = 0; i < cmpctblock.prefilledtxn.size(); i++) {
-        if (cmpctblock.prefilledtxn[i].tx->IsNull())
-            return READ_STATUS_INVALID;
+    {
+        int32_t lastprefilledindex = -1;
+        LOCK(pool->cs);
+        for (size_t i = 0; i < cmpctblock.prefilledtxn.size(); i++) {
+            if (cmpctblock.prefilledtxn[i].tx->IsNull())
+                return READ_STATUS_INVALID;
 
-        lastprefilledindex += cmpctblock.prefilledtxn[i].index + 1; //index is a uint16_t, so can't overflow here
-        if (lastprefilledindex > std::numeric_limits<uint16_t>::max())
-            return READ_STATUS_INVALID;
-        if ((uint32_t)lastprefilledindex > cmpctblock.shorttxids.size() + i) {
-            // If we are inserting a tx at an index greater than our full list of shorttxids
-            // plus the number of prefilled txn we've inserted, then we have txn for which we
-            // have neither a prefilled txn or a shorttxid!
-            return READ_STATUS_INVALID;
-        }
+            lastprefilledindex += cmpctblock.prefilledtxn[i].index + 1; //index is a uint16_t, so can't overflow here
+            if (lastprefilledindex > std::numeric_limits<uint16_t>::max())
+                return READ_STATUS_INVALID;
+            if ((uint32_t)lastprefilledindex > cmpctblock.shorttxids.size() + i) {
+                // If we are inserting a tx at an index greater than our full list of shorttxids
+                // plus the number of prefilled txn we've inserted, then we have txn for which we
+                // have neither a prefilled txn or a shorttxid!
+                return READ_STATUS_INVALID;
+            }
+            txn_available[lastprefilledindex] = cmpctblock.prefilledtxn[i].tx;
 
-        if (debug_log) {
-            size_t tx_size = cmpctblock.prefilledtxn[i].tx->ComputeTotalSize();
-            prefilled_size += tx_size;
-
+            size_t tx_size = debug_log ? cmpctblock.prefilledtxn[i].tx->ComputeTotalSize() : 0;
+            // Only consider prefilled transactions that were NOT in our mempool as candidates
+            // that WE want to prefill.
             auto tx_wtxid =  cmpctblock.prefilledtxn[i].tx->GetWitnessHash();
-            if (pool->exists(tx_wtxid)) {
+            if (!pool->exists(tx_wtxid)) {
+                prefill_candidates.insert(lastprefilledindex);
+                if (debug_log && std::binary_search(extra_wtxids.begin(), extra_wtxids.end(), tx_wtxid)) {
+                    redundant_prefilled_ep_count++;
+                    redundant_prefilled_ep_size += tx_size;
+                }
+            } else if (debug_log) {
                 redundant_prefilled_mp_count++;
                 redundant_prefilled_mp_size += tx_size;
-            } else if (std::binary_search(extra_wtxids.begin(), extra_wtxids.end(), tx_wtxid)) {
-                redundant_prefilled_ep_count++;
-                redundant_prefilled_ep_size += tx_size;
             }
         }
-        txn_available[lastprefilledindex] = cmpctblock.prefilledtxn[i].tx;
     }
 
     // Calculate map of txids -> positions and check mempool to see what we have (or don't)
@@ -179,6 +183,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         if (idit != shorttxids.end()) {
             if (tx_source[idit->second] == TxSource::NONE) {
                 txn_available[idit->second] = extra_txn[i].second;
+                prefill_candidates.insert(idit->second);
                 tx_source[idit->second] = TxSource::EXTRA;
                 available_count++;
             } else if (tx_source[idit->second] != TxSource::COLLIDED &&
@@ -234,6 +239,11 @@ bool PartiallyDownloadedBlock::IsTxAvailable(size_t index) const
     return txn_available[index] != nullptr;
 }
 
+std::set<uint32_t> PartiallyDownloadedBlock::PrefillCandidates() const
+{
+    return prefill_candidates;
+}
+
 ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing, bool segwit_active)
 {
     if (header.IsNull()) return READ_STATUS_INVALID;
@@ -247,6 +257,7 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
             if (tx_missing_offset >= vtx_missing.size()) {
                 return READ_STATUS_INVALID;
             }
+            prefill_candidates.insert(i);
             block.vtx[i] = vtx_missing[tx_missing_offset++];
         } else {
             block.vtx[i] = std::move(txn_available[i]);

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -9,6 +9,7 @@
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>
+#include <logging/categories.h>
 #include <random.h>
 #include <streams.h>
 #include <txmempool.h>
@@ -69,6 +70,22 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     header = cmpctblock.header;
     txn_available.resize(cmpctblock.BlockTxCount());
 
+    std::vector<Wtxid> extra_wtxids{};
+
+    bool debug_log = util::log::ShouldDebugLog(BCLog::CMPCTBLOCK);
+
+    if (debug_log) {
+        prefilled_count = cmpctblock.prefilledtxn.size();
+
+        // A sorted vec of extra_txn's for cheaply checking if prefills
+        // were redundant with the extrapool.
+        for (const auto& [id, tx] : extra_txn) {
+            extra_wtxids.push_back(id);
+        }
+        std::sort(extra_wtxids.begin(), extra_wtxids.end());
+    }
+
+
     int32_t lastprefilledindex = -1;
     for (size_t i = 0; i < cmpctblock.prefilledtxn.size(); i++) {
         if (cmpctblock.prefilledtxn[i].tx->IsNull())
@@ -83,9 +100,22 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             // have neither a prefilled txn or a shorttxid!
             return READ_STATUS_INVALID;
         }
+
+        if (debug_log) {
+            size_t tx_size = cmpctblock.prefilledtxn[i].tx->ComputeTotalSize();
+            prefilled_size += tx_size;
+
+            auto tx_wtxid =  cmpctblock.prefilledtxn[i].tx->GetWitnessHash();
+            if (pool->exists(tx_wtxid)) {
+                redundant_prefilled_mp_count++;
+                redundant_prefilled_mp_size += tx_size;
+            } else if (std::binary_search(extra_wtxids.begin(), extra_wtxids.end(), tx_wtxid)) {
+                redundant_prefilled_ep_count++;
+                redundant_prefilled_ep_size += tx_size;
+            }
+        }
         txn_available[lastprefilledindex] = cmpctblock.prefilledtxn[i].tx;
     }
-    prefilled_count = cmpctblock.prefilledtxn.size();
 
     // Calculate map of txids -> positions and check mempool to see what we have (or don't)
     // Because well-formed cmpctblock messages will have a (relatively) uniform distribution
@@ -177,9 +207,13 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             switch (tx_source[i]) {
                 case TxSource::MEMPOOL:
                     mempool_count++;
+                    Assume(txn_available[i]);
+                    mempool_size += txn_available[i]->ComputeTotalSize();
                     break;
                 case TxSource::EXTRA:
                     extra_count++;
+                    Assume(txn_available[i]);
+                    extra_size += txn_available[i]->ComputeTotalSize();
                     break;
                 default:
                     break;
@@ -237,7 +271,25 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
         const uint256 hash{block.GetHash()};
         uint32_t tx_missing_size{0};
         for (const auto& tx : vtx_missing) { tx_missing_size += tx->ComputeTotalSize(); }
-        LogDebug(BCLog::CMPCTBLOCK, "Successfully reconstructed block %s with %u txn prefilled, %u txn from mempool (incl at least %u from extra pool) and %u txn (%u bytes) requested\n", hash.ToString(), prefilled_count, mempool_count, extra_count, vtx_missing.size(), tx_missing_size);
+        LogDebug(BCLog::CMPCTBLOCK,
+            "Successfully reconstructed block %s with %u txn prefilled (%u bytes), "
+            "%u txn from mempool (%u bytes), "
+            "%u txn from extrapool (%u bytes), "
+            "and %u txn requested (%u bytes)",
+            hash.ToString(),
+            prefilled_count, prefilled_size,
+            mempool_count, mempool_size,
+            extra_count, extra_size,
+            vtx_missing.size(), tx_missing_size);
+        LogDebug(BCLog::CMPCTBLOCK,
+            "%u txn (%u bytes) of the prefill were redundant, "
+            "%u txn (%u bytes) were present in the mempool, "
+            "%u txn (%u bytes) were present in the extrapool. ",
+            redundant_prefilled_mp_count + redundant_prefilled_ep_count,
+            redundant_prefilled_mp_size + redundant_prefilled_ep_size,
+            redundant_prefilled_mp_count, redundant_prefilled_mp_size,
+            redundant_prefilled_ep_count, redundant_prefilled_ep_size);
+
         if (util::log::ShouldTraceLog(BCLog::CMPCTBLOCK)) {
             for (const auto& tx : vtx_missing) {
                 LogTrace(BCLog::CMPCTBLOCK, "Reconstructed block %s required tx %s\n", hash.ToString(), tx->GetHash().ToString());

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -111,8 +111,10 @@ public:
 
     /**
      * @param[in]  nonce  This should be randomly generated, and is used for the siphash secret key
+     * @param[in]  prefill_candidates  A set of transaction candidate indexes that should be prefilled for compact block annoucements
+
      */
-    CBlockHeaderAndShortTxIDs(const CBlock& block, uint64_t nonce);
+    CBlockHeaderAndShortTxIDs(const CBlock& block, uint64_t nonce, const std::set<uint32_t>& prefill_candidates);
 
     uint64_t GetShortID(const Wtxid& wtxid) const;
 

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -133,7 +133,16 @@ public:
 class PartiallyDownloadedBlock {
 protected:
     std::vector<CTransactionRef> txn_available;
+
     size_t prefilled_count = 0, mempool_count = 0, extra_count = 0;
+    size_t prefilled_size = 0, mempool_size = 0, extra_size = 0;
+
+    // Either it was already present in our mempool...
+    size_t redundant_prefilled_mp_count = 0, redundant_prefilled_mp_size = 0;
+    // or maybe it was present in our extrapool...
+    size_t redundant_prefilled_ep_count = 0, redundant_prefilled_ep_size = 0;
+
+
     const CTxMemPool* pool;
 public:
     CBlockHeader header;

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -144,6 +144,14 @@ protected:
 
 
     const CTxMemPool* pool;
+    // Keep track of the block position of transactions that we didn't have in
+    // our mempool while reconstructing this compact block. We can use these to
+    // predictively prefill transactions in our compact block annoucements.
+    // This includes transactions that:
+    // - were prefilled by the cmpctblock announcer and were not in our mempool
+    // - transactions we found in our extra_pool (but not mempool)
+    // - transactions we had to request from the announcer
+    std::set<uint32_t> prefill_candidates{ /*coinbase=*/0 };
 public:
     CBlockHeader header;
 
@@ -156,6 +164,7 @@ public:
     // extra_txn is a list of extra transactions to look at, in <witness hash, reference> form
     ReadStatus InitData(const CBlockHeaderAndShortTxIDs& cmpctblock, const std::vector<std::pair<Wtxid, CTransactionRef>>& extra_txn);
     bool IsTxAvailable(size_t index) const;
+    std::set<uint32_t> PrefillCandidates() const;
     // segwit_active enforces witness mutation checks just before reporting a healthy status
     ReadStatus FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing, bool segwit_active);
 };

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -136,4 +136,9 @@ typedef SSIZE_T ssize_t;
 #include <netinet/tcp.h>    // IWYU pragma: export
 #endif
 
+// Querying bytes in the send buffer on these platforms requires ioctl
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)
+#include <sys/ioctl.h>  // IWYU pragma: export
+#endif
+
 #endif // BITCOIN_COMPAT_COMPAT_H

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -23,7 +23,6 @@
 #include <net/if.h>      // IWYU pragma: export
 #include <netdb.h>       // IWYU pragma: export
 #include <netinet/in.h>  // IWYU pragma: export
-#include <netinet/tcp.h> // IWYU pragma: export
 #include <sys/mman.h>    // IWYU pragma: export
 #include <sys/select.h>  // IWYU pragma: export
 #include <sys/socket.h>  // IWYU pragma: export
@@ -123,6 +122,18 @@ typedef SSIZE_T ssize_t;
 #if defined(SIO_TCP_INFO)
 #define WIN32_TCPINFO_SUPPORTED
 #endif
+#endif
+
+// linux/tcp.h contains the definition of the extended tcp_info struct, which
+// has the tcpi_snd_wnd field.
+#if defined(__linux__)
+#include <linux/tcp.h>  // IWYU pragma: export
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+#define TCP_INFO_HAS_SEND_WND
+#endif
+#elif !defined(WIN32)
+#include <netinet/tcp.h>    // IWYU pragma: export
 #endif
 
 #endif // BITCOIN_COMPAT_COMPAT_H

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -115,4 +115,14 @@ typedef SSIZE_T ssize_t;
 #define MSG_DONTWAIT 0
 #endif
 
+// Windows 10 1703 is required for SIO_TCP_INFO, which we need at build time to
+// support TCP_INFO_v0 fetching.
+// https://learn.microsoft.com/en-us/windows/win32/api/mstcpip/ns-mstcpip-tcp_info_v0#requirements
+#if defined(WIN32)
+#include <mstcpip.h>    // IWYU pragma: export
+#if defined(SIO_TCP_INFO)
+#define WIN32_TCPINFO_SUPPORTED
+#endif
+#endif
+
 #endif // BITCOIN_COMPAT_COMPAT_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -915,6 +915,16 @@ size_t V1Transport::GetSendMemoryUsage() const noexcept
     return m_message_to_send.GetMemoryUsage();
 }
 
+size_t V1Transport::GetMessageHeaderSize() const noexcept
+{
+    return CMessageHeader::HEADER_SIZE;
+}
+
+size_t V1Transport::GetMessageSize(const CSerializedNetMsg& msg) const noexcept
+{
+    return msg.data.size() + GetMessageHeaderSize();
+}
+
 namespace {
 
 /** List of short messages as defined in BIP324, in order.
@@ -1581,6 +1591,27 @@ size_t V2Transport::GetSendMemoryUsage() const noexcept
     if (m_send_state == SendState::V1) return m_v1_fallback.GetSendMemoryUsage();
 
     return sizeof(m_send_buffer) + memusage::DynamicUsage(m_send_buffer);
+}
+
+size_t V2Transport::GetMessageHeaderSize(const std::string& m_type) const noexcept
+{
+    // Headers are either one byte with short encoding, or 13.
+    // https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki#v2-bitcoin-p2p-message-structure
+    auto msg_type_len = 1 + (V2_MESSAGE_MAP(m_type) ? 0 : CMessageHeader::MESSAGE_TYPE_SIZE);
+    return msg_type_len + BIP324Cipher::EXPANSION;
+}
+
+size_t V2Transport::GetMessageSize(const CSerializedNetMsg& msg) const noexcept
+{
+    SendState send_state;
+    {
+        LOCK(m_send_mutex);
+        send_state = m_send_state;
+
+        if (send_state != SendState::V1) return GetMessageHeaderSize(msg.m_type) + msg.data.size();
+    }
+    Assume(send_state == SendState::V1);
+    return m_v1_fallback.GetMessageSize(msg);
 }
 
 Transport::Info V2Transport::GetInfo() const noexcept

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -4202,6 +4202,41 @@ std::optional<std::pair<CNetMessage, bool>> CNode::PollMessage()
     return std::make_pair(std::move(msgs.front()), !m_msg_process_queue.empty());
 }
 
+std::pair<uint32_t, uint32_t> CNode::WindowBytesTotalAndAvailable()
+{
+    uint32_t window_size{0}, bytes_available{0}, bytes_inflight, bytes_inqueue;
+    {
+        LOCK(m_sock_mutex);
+        if (m_sock) {
+            auto tcp_info = TCPInfo{*m_sock};
+            window_size = tcp_info.GetTCPWindowSize();
+            if (window_size == 0) {
+                return {0, 0};
+            }
+            // Bytes sitting in the OS's send queue + un'ACKed bytes on the wire.
+            bytes_inflight = m_sock->GetOSBytesQueued(tcp_info);
+        } else {
+            return {0, 0};
+        }
+    }
+
+    // Bytes sitting in our application layer queue for this CNode.
+    bytes_inqueue = GetSendQueueSize();
+
+    Assume(window_size > 0);
+    // Bytes between the previous and next window boundary that are used.
+    auto bytes_used = (bytes_inflight + bytes_inqueue) % window_size;
+
+    // How many bytes we can use before reaching the next window boundary.
+    bytes_available = window_size - bytes_used;
+
+    LogDebug(BCLog::NET,
+       "WindowBytes: Total: %d bytes, In flight: %d bytes, In send queue: %d, Available: %d",
+       window_size, bytes_inflight, bytes_inqueue, bytes_available);
+
+    return {window_size, bytes_available};
+}
+
 bool CConnman::NodeFullyConnected(const CNode* pnode)
 {
     return pnode && pnode->fSuccessfullyConnected && !pnode->fDisconnect;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -925,6 +925,16 @@ size_t V1Transport::GetMessageSize(const CSerializedNetMsg& msg) const noexcept
     return msg.data.size() + GetMessageHeaderSize();
 }
 
+size_t V1Transport::GetSendMessageSize() const noexcept
+{
+    LOCK(m_send_mutex);
+    if (m_sending_header) {
+        return m_header_to_send.size() - m_bytes_sent + m_message_to_send.data.size();
+    } else {
+        return m_message_to_send.data.size() - m_bytes_sent;
+    }
+}
+
 namespace {
 
 /** List of short messages as defined in BIP324, in order.
@@ -1614,6 +1624,20 @@ size_t V2Transport::GetMessageSize(const CSerializedNetMsg& msg) const noexcept
     return m_v1_fallback.GetMessageSize(msg);
 }
 
+size_t V2Transport::GetSendMessageSize() const noexcept
+{
+    SendState send_state;
+    {
+        LOCK(m_send_mutex);
+        send_state = m_send_state;
+
+        if (send_state != SendState::V1) return m_send_buffer.size() - m_send_pos;
+    }
+
+    Assume(send_state == SendState::V1);
+    return m_v1_fallback.GetSendMessageSize();
+}
+
 Transport::Info V2Transport::GetInfo() const noexcept
 {
     AssertLockNotHeld(m_recv_mutex);
@@ -1648,9 +1672,11 @@ std::pair<size_t, bool> CConnman::SocketSendData(CNode& node) const
             // there is an existing message still being sent, or (for v2 transports) when the
             // handshake has not yet completed.
             size_t memusage = it->GetMemoryUsage();
+            size_t sersize = node.m_transport->GetMessageSize(*it);
             if (node.m_transport->SetMessageToSend(*it)) {
                 // Update memory usage of send buffer (as *it will be deleted).
                 node.m_send_memusage -= memusage;
+                node.m_send_size -= sersize;
                 ++it;
             }
         }
@@ -1709,6 +1735,7 @@ std::pair<size_t, bool> CConnman::SocketSendData(CNode& node) const
 
     if (it == node.vSendMsg.end()) {
         assert(node.m_send_memusage == 0);
+        Assume(node.m_send_size == 0);
     }
     node.vSendMsg.erase(node.vSendMsg.begin(), it);
     return {nSentSize, data_left};
@@ -4233,6 +4260,7 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 
         // Update memory usage of send buffer.
         pnode->m_send_memusage += msg.GetMemoryUsage();
+        pnode->m_send_size += pnode->m_transport->GetMessageSize(msg);
         if (pnode->m_send_memusage + pnode->m_transport->GetSendMemoryUsage() > nSendBufferMaxSize) pnode->fPauseSend = true;
         // Move message to vSendMsg queue.
         pnode->vSendMsg.push_back(std::move(msg));

--- a/src/net.h
+++ b/src/net.h
@@ -367,6 +367,8 @@ public:
     /** Return the memory usage of this transport attributable to buffered data to send. */
     virtual size_t GetSendMemoryUsage() const noexcept = 0;
 
+    virtual size_t GetMessageSize(const CSerializedNetMsg &msg) const noexcept = 0;
+
     // 3. Miscellaneous functions.
 
     /** Whether upon disconnections, a reconnect with V1 is warranted. */
@@ -422,6 +424,9 @@ private:
     /** How many bytes have been sent so far (from m_header_to_send, or from m_message_to_send.data). */
     size_t m_bytes_sent GUARDED_BY(m_send_mutex) {0};
 
+    /** Return the message header size. */
+    size_t GetMessageHeaderSize() const noexcept;
+
 public:
     explicit V1Transport(NodeId node_id) noexcept;
 
@@ -452,6 +457,7 @@ public:
     BytesToSend GetBytesToSend(bool have_next_message) const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
     void MarkBytesSent(size_t bytes_sent) noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
     size_t GetSendMemoryUsage() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
+    size_t GetMessageSize(const CSerializedNetMsg &msg) const noexcept override;
     bool ShouldReconnectV1() const noexcept override { return false; }
 };
 
@@ -639,6 +645,9 @@ private:
     /** Process bytes in m_recv_buffer, while in VERSION/APP state. */
     bool ProcessReceivedPacketBytes() noexcept EXCLUSIVE_LOCKS_REQUIRED(m_recv_mutex);
 
+    /** Given a message type, return the message header size. */
+    size_t GetMessageHeaderSize(const std::string &m_type) const noexcept;
+
 public:
     static constexpr uint32_t MAX_GARBAGE_LEN = 4095;
 
@@ -662,6 +671,7 @@ public:
     BytesToSend GetBytesToSend(bool have_next_message) const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
     void MarkBytesSent(size_t bytes_sent) noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
     size_t GetSendMemoryUsage() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
+    size_t GetMessageSize(const CSerializedNetMsg &msg) const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
 
     // Miscellaneous functions.
     bool ShouldReconnectV1() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex, !m_send_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -1004,6 +1004,8 @@ public:
 
     void CloseSocketDisconnect() EXCLUSIVE_LOCKS_REQUIRED(!m_sock_mutex);
 
+    std::pair<uint32_t, uint32_t> WindowBytesTotalAndAvailable() EXCLUSIVE_LOCKS_REQUIRED(!m_sock_mutex, !cs_vSend);
+
     void CopyStats(CNodeStats& stats) EXCLUSIVE_LOCKS_REQUIRED(!m_subver_mutex, !m_addr_local_mutex, !cs_vSend, !cs_vRecv);
 
     std::string ConnectionTypeAsString() const { return ::ConnectionTypeAsString(m_conn_type); }

--- a/src/net.h
+++ b/src/net.h
@@ -369,6 +369,9 @@ public:
 
     virtual size_t GetMessageSize(const CSerializedNetMsg &msg) const noexcept = 0;
 
+    /** Return the expected serialized size of the buffered data. */
+    virtual size_t GetSendMessageSize() const noexcept = 0;
+
     // 3. Miscellaneous functions.
 
     /** Whether upon disconnections, a reconnect with V1 is warranted. */
@@ -458,6 +461,7 @@ public:
     void MarkBytesSent(size_t bytes_sent) noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
     size_t GetSendMemoryUsage() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
     size_t GetMessageSize(const CSerializedNetMsg &msg) const noexcept override;
+    size_t GetSendMessageSize() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
     bool ShouldReconnectV1() const noexcept override { return false; }
 };
 
@@ -672,6 +676,7 @@ public:
     void MarkBytesSent(size_t bytes_sent) noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
     size_t GetSendMemoryUsage() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
     size_t GetMessageSize(const CSerializedNetMsg &msg) const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
+    size_t GetSendMessageSize() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex);
 
     // Miscellaneous functions.
     bool ShouldReconnectV1() const noexcept override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex, !m_send_mutex);
@@ -710,6 +715,8 @@ public:
 
     /** Sum of GetMemoryUsage of all vSendMsg entries. */
     size_t m_send_memusage GUARDED_BY(cs_vSend){0};
+    /** Total length of all vSendMsg entries. */
+    size_t m_send_size GUARDED_BY(cs_vSend){0};
     /** Total number of bytes sent on the wire to this peer. */
     uint64_t nSendBytes GUARDED_BY(cs_vSend){0};
     /** Messages still to be fed to m_transport->SetMessageToSend. */
@@ -717,6 +724,16 @@ public:
     Mutex cs_vSend;
     Mutex m_sock_mutex;
     Mutex cs_vRecv;
+
+    /** Length in bytes of messages in our send buffer:
+     * vSendMsg + the message stuck inside the m_transport right now.
+     */
+    size_t GetSendQueueSize() EXCLUSIVE_LOCKS_REQUIRED(!cs_vSend)
+    {
+        AssertLockNotHeld(cs_vSend);
+        LOCK(cs_vSend);
+        return m_send_size + m_transport->GetSendMessageSize();
+    }
 
     uint64_t nRecvBytes GUARDED_BY(cs_vRecv){0};
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -949,7 +949,7 @@ private:
     Mutex m_most_recent_block_mutex;
     struct {
         std::shared_ptr<const CBlock> block;
-        std::shared_ptr<const CBlockHeaderAndShortTxIDs> compact_block;
+        std::shared_future<CSerializedNetMsg> cmpctblock_msg_fut;
         uint256 hash;
         std::unique_ptr<const std::map<GenTxid, CTransactionRef>> txs;
     } m_most_recent_pow_block GUARDED_BY(m_most_recent_block_mutex);
@@ -2228,8 +2228,6 @@ void PeerManagerImpl::BlockDisconnected(const std::shared_ptr<const CBlock> &blo
  */
 void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock)
 {
-    auto pcmpctblock = std::make_shared<const CBlockHeaderAndShortTxIDs>(*pblock, FastRandomContext().rand64());
-
     LOCK(cs_main);
 
     if (pindex->nHeight <= m_highest_fast_announce)
@@ -2238,10 +2236,14 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
 
     if (!DeploymentActiveAt(*pindex, m_chainman, Consensus::DEPLOYMENT_SEGWIT)) return;
 
-    uint256 hashBlock(pblock->GetHash());
-    const std::shared_future<CSerializedNetMsg> lazy_ser{
-        std::async(std::launch::deferred, [&] { return NetMsg::Make(NetMsgType::CMPCTBLOCK, *pcmpctblock); })};
+    std::shared_future<CSerializedNetMsg> lazy_ser{
+        std::async(std::launch::async, [pblock = pblock]  {
+            const CBlockHeaderAndShortTxIDs cb{*pblock, FastRandomContext().rand64()};
+            return NetMsg::Make(NetMsgType::CMPCTBLOCK, cb);
+        })
+    };
 
+    uint256 hashBlock(pblock->GetHash());
     {
         auto most_recent_block_txs = std::make_unique<std::map<GenTxid, CTransactionRef>>();
         for (const auto& tx : pblock->vtx) {
@@ -2252,7 +2254,7 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
         LOCK(m_most_recent_block_mutex);
         m_most_recent_pow_block.hash = hashBlock;
         m_most_recent_pow_block.block = pblock;
-        m_most_recent_pow_block.compact_block = pcmpctblock;
+        m_most_recent_pow_block.cmpctblock_msg_fut = lazy_ser;
         m_most_recent_pow_block.txs = std::move(most_recent_block_txs);
     }
 
@@ -2566,11 +2568,13 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
     }
 
     std::shared_ptr<const CBlock> a_recent_block;
-    std::shared_ptr<const CBlockHeaderAndShortTxIDs> a_recent_compact_block;
+    std::shared_future<CSerializedNetMsg> a_recent_cmpct_block_msg_fut;
+    uint256 a_recent_block_hash;
     {
         LOCK(m_most_recent_block_mutex);
         a_recent_block = m_most_recent_pow_block.block;
-        a_recent_compact_block = m_most_recent_pow_block.compact_block;
+        a_recent_block_hash = m_most_recent_pow_block.hash;
+        a_recent_cmpct_block_msg_fut = m_most_recent_pow_block.cmpctblock_msg_fut;
     }
 
     bool need_activate_chain = false;
@@ -2639,7 +2643,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
     }
 
     std::shared_ptr<const CBlock> pblock;
-    if (a_recent_block && a_recent_block->GetHash() == inv.hash) {
+    if (a_recent_block && a_recent_block_hash == inv.hash) {
         pblock = a_recent_block;
     } else if (inv.IsMsgWitnessBlk()) {
         // Fast-path: in this case it is possible to serve the block directly from disk,
@@ -2704,8 +2708,8 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
             // and we don't feel like constructing the object for them, so
             // instead we respond with the full, non-compact block.
             if (can_direct_fetch && pindex->nHeight >= tip->nHeight - MAX_CMPCTBLOCK_DEPTH) {
-                if (a_recent_compact_block && a_recent_compact_block->header.GetHash() == inv.hash) {
-                    MakeAndPushMessage(pfrom, NetMsgType::CMPCTBLOCK, *a_recent_compact_block);
+                if (a_recent_block && a_recent_block_hash == inv.hash) {
+                    PushMessage(pfrom, a_recent_cmpct_block_msg_fut.get().Copy());
                 } else {
                     CBlockHeaderAndShortTxIDs cmpctblock{*pblock, m_rng.rand64()};
                     MakeAndPushMessage(pfrom, NetMsgType::CMPCTBLOCK, cmpctblock);
@@ -6233,7 +6237,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                     {
                         LOCK(m_most_recent_block_mutex);
                         if (m_most_recent_pow_block.hash == pBestIndex->GetBlockHash()) {
-                            cached_cmpctblock_msg = NetMsg::Make(NetMsgType::CMPCTBLOCK, *m_most_recent_pow_block.compact_block);
+                            cached_cmpctblock_msg = m_most_recent_pow_block.cmpctblock_msg_fut.get().Copy();
                         }
                     }
                     if (cached_cmpctblock_msg.has_value()) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -947,10 +947,12 @@ private:
 
     // All of the following cache a recent block, and are protected by m_most_recent_block_mutex
     Mutex m_most_recent_block_mutex;
-    std::shared_ptr<const CBlock> m_most_recent_block GUARDED_BY(m_most_recent_block_mutex);
-    std::shared_ptr<const CBlockHeaderAndShortTxIDs> m_most_recent_compact_block GUARDED_BY(m_most_recent_block_mutex);
-    uint256 m_most_recent_block_hash GUARDED_BY(m_most_recent_block_mutex);
-    std::unique_ptr<const std::map<GenTxid, CTransactionRef>> m_most_recent_block_txs GUARDED_BY(m_most_recent_block_mutex);
+    struct {
+        std::shared_ptr<const CBlock> block;
+        std::shared_ptr<const CBlockHeaderAndShortTxIDs> compact_block;
+        uint256 hash;
+        std::unique_ptr<const std::map<GenTxid, CTransactionRef>> txs;
+    } m_most_recent_pow_block GUARDED_BY(m_most_recent_block_mutex);
 
     // Data about the low-work headers synchronization, aggregated from all peers' HeadersSyncStates.
     /** Mutex guarding the other m_headers_presync_* variables. */
@@ -2248,10 +2250,10 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
         }
 
         LOCK(m_most_recent_block_mutex);
-        m_most_recent_block_hash = hashBlock;
-        m_most_recent_block = pblock;
-        m_most_recent_compact_block = pcmpctblock;
-        m_most_recent_block_txs = std::move(most_recent_block_txs);
+        m_most_recent_pow_block.hash = hashBlock;
+        m_most_recent_pow_block.block = pblock;
+        m_most_recent_pow_block.compact_block = pcmpctblock;
+        m_most_recent_pow_block.txs = std::move(most_recent_block_txs);
     }
 
     m_connman.ForEachNode([this, pindex, &lazy_ser, &hashBlock](CNode* pnode) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
@@ -2567,8 +2569,8 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
     std::shared_ptr<const CBlockHeaderAndShortTxIDs> a_recent_compact_block;
     {
         LOCK(m_most_recent_block_mutex);
-        a_recent_block = m_most_recent_block;
-        a_recent_compact_block = m_most_recent_compact_block;
+        a_recent_block = m_most_recent_pow_block.block;
+        a_recent_compact_block = m_most_recent_pow_block.compact_block;
     }
 
     bool need_activate_chain = false;
@@ -2744,9 +2746,9 @@ CTransactionRef PeerManagerImpl::FindTxForGetData(const Peer::TxRelay& tx_relay,
     // Or it might be from the most recent block
     {
         LOCK(m_most_recent_block_mutex);
-        if (m_most_recent_block_txs != nullptr) {
-            auto it = m_most_recent_block_txs->find(gtxid);
-            if (it != m_most_recent_block_txs->end()) return it->second;
+        if (m_most_recent_pow_block.txs != nullptr) {
+            auto it = m_most_recent_pow_block.txs->find(gtxid);
+            if (it != m_most_recent_pow_block.txs->end()) return it->second;
         }
     }
 
@@ -4496,7 +4498,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             std::shared_ptr<const CBlock> a_recent_block;
             {
                 LOCK(m_most_recent_block_mutex);
-                a_recent_block = m_most_recent_block;
+                a_recent_block = m_most_recent_pow_block.block;
             }
             BlockValidationState state;
             if (!m_chainman.ActiveChainstate().ActivateBestChain(state, a_recent_block)) {
@@ -4560,8 +4562,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         std::shared_ptr<const CBlock> recent_block;
         {
             LOCK(m_most_recent_block_mutex);
-            if (m_most_recent_block_hash == req.blockhash)
-                recent_block = m_most_recent_block;
+            if (m_most_recent_pow_block.hash == req.blockhash)
+                recent_block = m_most_recent_pow_block.block;
             // Unlock m_most_recent_block_mutex to avoid cs_main lock inversion
         }
         if (recent_block) {
@@ -6230,8 +6232,8 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                     std::optional<CSerializedNetMsg> cached_cmpctblock_msg;
                     {
                         LOCK(m_most_recent_block_mutex);
-                        if (m_most_recent_block_hash == pBestIndex->GetBlockHash()) {
-                            cached_cmpctblock_msg = NetMsg::Make(NetMsgType::CMPCTBLOCK, *m_most_recent_compact_block);
+                        if (m_most_recent_pow_block.hash == pBestIndex->GetBlockHash()) {
+                            cached_cmpctblock_msg = NetMsg::Make(NetMsgType::CMPCTBLOCK, *m_most_recent_pow_block.compact_block);
                         }
                     }
                     if (cached_cmpctblock_msg.has_value()) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -795,6 +795,11 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(g_msgproc_mutex);
 
     void SendBlockTransactions(CNode& pfrom, Peer& peer, const CBlock& block, const BlockTransactionsRequest& req);
+    /** Send a compact block for pindex if it's our m_most_recent_pow_block and
+     *  return true, otherwise return false.
+     */
+    bool SendCompactBlock(CNode& pnode, const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(!m_most_recent_block_mutex);
+
 
     /** Send a message to a peer */
     void PushMessage(CNode& node, CSerializedNetMsg&& msg) const { m_connman.PushMessage(&node, std::move(msg)); }
@@ -2243,8 +2248,8 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
         })
     };
 
-    uint256 hashBlock(pblock->GetHash());
     {
+        uint256 hashBlock(pblock->GetHash());
         auto most_recent_block_txs = std::make_unique<std::map<GenTxid, CTransactionRef>>();
         for (const auto& tx : pblock->vtx) {
             most_recent_block_txs->emplace(tx->GetHash(), tx);
@@ -2254,11 +2259,11 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
         LOCK(m_most_recent_block_mutex);
         m_most_recent_pow_block.hash = hashBlock;
         m_most_recent_pow_block.block = pblock;
-        m_most_recent_pow_block.cmpctblock_msg_fut = lazy_ser;
+        m_most_recent_pow_block.cmpctblock_msg_fut = std::move(lazy_ser);
         m_most_recent_pow_block.txs = std::move(most_recent_block_txs);
     }
 
-    m_connman.ForEachNode([this, pindex, &lazy_ser, &hashBlock](CNode* pnode) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+    m_connman.ForEachNode([this, pindex](CNode* pnode) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         AssertLockHeld(::cs_main);
 
         if (pnode->GetCommonVersion() < INVALID_CB_NO_BAN_VERSION || pnode->fDisconnect)
@@ -2268,16 +2273,39 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
         // If the peer has, or we announced to them the previous block already,
         // but we don't think they have this one, go ahead and announce it
         if (state.m_requested_hb_cmpctblocks && !PeerHasHeader(&state, pindex) && PeerHasHeader(&state, pindex->pprev)) {
-
-            LogDebug(BCLog::NET, "%s sending header-and-ids %s to peer=%d\n", "PeerManager::NewPoWValidBlock",
-                    hashBlock.ToString(), pnode->GetId());
-
-            const CSerializedNetMsg& ser_cmpctblock{lazy_ser.get()};
-            PushMessage(*pnode, ser_cmpctblock.Copy());
-            state.pindexBestHeaderSent = pindex;
+            SendCompactBlock(*pnode, pindex);
         }
     });
 }
+
+bool PeerManagerImpl::SendCompactBlock(CNode& pnode, const CBlockIndex* pindex)
+{
+    std::shared_future<CSerializedNetMsg> cb_fut;
+    {
+        LOCK(m_most_recent_block_mutex);
+
+        if (m_most_recent_pow_block.hash != pindex->GetBlockHash()) {
+            return false;
+        }
+
+        cb_fut = m_most_recent_pow_block.cmpctblock_msg_fut;
+        if (!cb_fut.valid()) {
+            return false;
+        }
+    }
+
+    LogDebug(BCLog::NET, "%s sending header-and-ids %s to peer=%d\n", __func__,
+            pindex->GetBlockHash().ToString(), pnode.GetId());
+    PushMessage(pnode, cb_fut.get().Copy());
+
+    {
+        LOCK(cs_main);
+        CNodeState &state = *State(pnode.GetId());
+        state.pindexBestHeaderSent = pindex;
+    }
+    return true;
+}
+
 
 /**
  * Update our best height and announce any block hashes which weren't previously
@@ -2568,13 +2596,11 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
     }
 
     std::shared_ptr<const CBlock> a_recent_block;
-    std::shared_future<CSerializedNetMsg> a_recent_cmpct_block_msg_fut;
     uint256 a_recent_block_hash;
     {
         LOCK(m_most_recent_block_mutex);
         a_recent_block = m_most_recent_pow_block.block;
         a_recent_block_hash = m_most_recent_pow_block.hash;
-        a_recent_cmpct_block_msg_fut = m_most_recent_pow_block.cmpctblock_msg_fut;
     }
 
     bool need_activate_chain = false;
@@ -2708,9 +2734,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
             // and we don't feel like constructing the object for them, so
             // instead we respond with the full, non-compact block.
             if (can_direct_fetch && pindex->nHeight >= tip->nHeight - MAX_CMPCTBLOCK_DEPTH) {
-                if (a_recent_block && a_recent_block_hash == inv.hash) {
-                    PushMessage(pfrom, a_recent_cmpct_block_msg_fut.get().Copy());
-                } else {
+                if (!SendCompactBlock(pfrom, pindex)) {
                     CBlockHeaderAndShortTxIDs cmpctblock{*pblock, m_rng.rand64()};
                     MakeAndPushMessage(pfrom, NetMsgType::CMPCTBLOCK, cmpctblock);
                 }
@@ -6230,26 +6254,19 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                 if (vHeaders.size() == 1 && state.m_requested_hb_cmpctblocks) {
                     // We only send up to 1 block as header-and-ids, as otherwise
                     // probably means we're doing an initial-ish-sync or they're slow
-                    LogDebug(BCLog::NET, "%s sending header-and-ids %s to peer=%d\n", __func__,
-                            vHeaders.front().GetHash().ToString(), node.GetId());
 
-                    std::optional<CSerializedNetMsg> cached_cmpctblock_msg;
-                    {
-                        LOCK(m_most_recent_block_mutex);
-                        if (m_most_recent_pow_block.hash == pBestIndex->GetBlockHash()) {
-                            cached_cmpctblock_msg = m_most_recent_pow_block.cmpctblock_msg_fut.get().Copy();
-                        }
-                    }
-                    if (cached_cmpctblock_msg.has_value()) {
-                        PushMessage(node, std::move(cached_cmpctblock_msg.value()));
-                    } else {
+                    if (!SendCompactBlock(node, pBestIndex)) {
+                        // This is unlikely since it means that we have
+                        // connected another block since vHeaders was assembled.
+                        LogDebug(BCLog::NET, "%s sending header-and-ids %s to peer=%d\n", __func__,
+                                vHeaders.front().GetHash().ToString(), node.GetId());
                         CBlock block;
                         const bool ret{m_chainman.m_blockman.ReadBlock(block, *pBestIndex)};
                         assert(ret);
                         CBlockHeaderAndShortTxIDs cmpctblock{block, m_rng.rand64()};
                         MakeAndPushMessage(node, NetMsgType::CMPCTBLOCK, cmpctblock);
+                        state.pindexBestHeaderSent = pBestIndex;
                     }
-                    state.pindexBestHeaderSent = pBestIndex;
                 } else if (peer.m_prefers_headers) {
                     if (vHeaders.size() > 1) {
                         LogDebug(BCLog::NET, "%s: %u headers, range (%s, %s), to peer=%d\n", __func__,

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2848,6 +2848,11 @@ void PeerManagerImpl::SendBlockTransactions(CNode& pfrom, Peer& peer, const CBlo
         uint32_t tx_requested_size{0};
         for (const auto& tx : resp.txn) tx_requested_size += tx->ComputeTotalSize();
         LogDebug(BCLog::CMPCTBLOCK, "%s sent us a GETBLOCKTXN for block %s, sending a BLOCKTXN with %u txns. (%u bytes)", pfrom.LogPeer(), block.GetHash().ToString(), resp.txn.size(), tx_requested_size);
+        if (util::log::ShouldTraceLog(BCLog::CMPCTBLOCK)) {
+            for(const auto& txn : resp.txn) {
+                LogDebug(BCLog::CMPCTBLOCK, "    - txid: %s", txn->GetHash().ToString());
+            }
+        }
     }
     MakeAndPushMessage(pfrom, NetMsgType::BLOCKTXN, resp);
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -957,6 +957,11 @@ private:
         std::shared_future<CSerializedNetMsg> cmpctblock_msg_fut;
         uint256 hash;
         std::unique_ptr<const std::map<GenTxid, CTransactionRef>> txs;
+        /** A pair of block hash and prefill candidates for our compact block
+         * annoucements. If a transaction index is in the set, it indicates that
+         * the transaction is likely a good candidate to prefill in a
+         * compact block annoucements related to the block hash. */
+        std::pair<uint256, std::set<uint32_t>> prefill_candidates;
     } m_most_recent_pow_block GUARDED_BY(m_most_recent_block_mutex);
 
     // Data about the low-work headers synchronization, aggregated from all peers' HeadersSyncStates.
@@ -3786,6 +3791,14 @@ void PeerManagerImpl::ProcessCompactBlockTxns(CNode& pfrom, Peer& peer, const Bl
             }
         } else {
             // Block is okay for further processing
+            if (status == READ_STATUS_OK) {
+                // If CheckBlock succeeds, we can update our cache of the compact block prefill
+                // candidates: transactions we didn't have in our mempool, but which helped us
+                // to recontruct the block. Other nodes might need the same transactions and we
+                // will prefill our compact block announcements with them.
+                LOCK(m_most_recent_block_mutex);
+                m_most_recent_pow_block.prefill_candidates = std::make_pair(block_transactions.blockhash, partialBlock.PrefillCandidates());
+            }
             RemoveBlockRequest(block_transactions.blockhash, pfrom.GetId()); // it is now an empty pointer
             fBlockRead = true;
             // mapBlockSource is used for potentially punishing peers and

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1098,6 +1098,10 @@ private:
     /** Update tracking information about which blocks a peer is assumed to have. */
     void UpdateBlockAvailability(NodeId nodeid, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool CanDirectFetch() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    /** Returns true if either the best block the peer has INV'ed to us or the
+     *  best header we've sent the peer is equal to or a child of pindex.
+     */
+    bool PeerHasHeader(CNodeState *state, const CBlockIndex *pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
      * Estimates the distance, in blocks, between the best-known block and the network chain tip.
@@ -1453,8 +1457,14 @@ bool PeerManagerImpl::CanDirectFetch()
     return m_chainman.ActiveChain().Tip()->Time() > NodeClock::now() - m_chainparams.GetConsensus().PowTargetSpacing() * 20;
 }
 
-static bool PeerHasHeader(CNodeState *state, const CBlockIndex *pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool PeerManagerImpl::PeerHasHeader(CNodeState *state, const CBlockIndex *pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    // We don't expect this to ever happen in the current code, but future users
+    // of PeerHasHeader() would expect this behavior.
+    if(!Assume(pindex)) {
+        return false;
+    }
+
     if (state->pindexBestKnownBlock && pindex == state->pindexBestKnownBlock->GetAncestor(pindex->nHeight))
         return true;
     if (state->pindexBestHeaderSent && pindex == state->pindexBestHeaderSent->GetAncestor(pindex->nHeight))

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -955,6 +955,7 @@ private:
     struct {
         std::shared_ptr<const CBlock> block;
         std::shared_future<CSerializedNetMsg> cmpctblock_msg_fut;
+        std::shared_future<CSerializedNetMsg> prefill_cb_msg_fut;
         uint256 hash;
         std::unique_ptr<const std::map<GenTxid, CTransactionRef>> txs;
         /** A pair of block hash and prefill candidates for our compact block
@@ -2256,12 +2257,30 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
 
     if (!DeploymentActiveAt(*pindex, m_chainman, Consensus::DEPLOYMENT_SEGWIT)) return;
 
-    std::shared_future<CSerializedNetMsg> lazy_ser{
+    std::shared_future<CSerializedNetMsg> cb_msg_fut{
         std::async(std::launch::async, [pblock = pblock]  {
-            const CBlockHeaderAndShortTxIDs cb{*pblock, FastRandomContext().rand64()};
+            const CBlockHeaderAndShortTxIDs cb{*pblock, FastRandomContext().rand64(), {}};
             return NetMsg::Make(NetMsgType::CMPCTBLOCK, cb);
         })
     };
+
+    std::set<uint32_t> prefill_candidates{};
+    {
+        LOCK(m_most_recent_block_mutex);
+        if (pblock->GetHash() == m_most_recent_pow_block.prefill_candidates.first) {
+            prefill_candidates = m_most_recent_pow_block.prefill_candidates.second;
+        }
+    }
+
+    // Make a prefilled compact block for peers where our TCP window is large enough to prefill
+    // transactions.
+    std::shared_future<CSerializedNetMsg> prefilled_cb_msg_fut;
+    if (prefill_candidates.size() > 1) {
+        prefilled_cb_msg_fut = std::async(std::launch::async, [pblock = pblock, prefill_candidates = std::move(prefill_candidates)]  {
+            const CBlockHeaderAndShortTxIDs cb{*pblock, FastRandomContext().rand64(), prefill_candidates};
+            return NetMsg::Make(NetMsgType::CMPCTBLOCK, cb);
+        });
+    }
 
     {
         uint256 hashBlock(pblock->GetHash());
@@ -2274,7 +2293,8 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
         LOCK(m_most_recent_block_mutex);
         m_most_recent_pow_block.hash = hashBlock;
         m_most_recent_pow_block.block = pblock;
-        m_most_recent_pow_block.cmpctblock_msg_fut = std::move(lazy_ser);
+        m_most_recent_pow_block.cmpctblock_msg_fut = std::move(cb_msg_fut);
+        m_most_recent_pow_block.prefill_cb_msg_fut = std::move(prefilled_cb_msg_fut);
         m_most_recent_pow_block.txs = std::move(most_recent_block_txs);
     }
 
@@ -2295,7 +2315,7 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
 
 bool PeerManagerImpl::SendCompactBlock(CNode& pnode, const CBlockIndex* pindex)
 {
-    std::shared_future<CSerializedNetMsg> cb_fut;
+    std::shared_future<CSerializedNetMsg> cb_fut, prefilled_cb_fut;
     {
         LOCK(m_most_recent_block_mutex);
 
@@ -2304,20 +2324,64 @@ bool PeerManagerImpl::SendCompactBlock(CNode& pnode, const CBlockIndex* pindex)
         }
 
         cb_fut = m_most_recent_pow_block.cmpctblock_msg_fut;
+        // If we don't have the non-prefilled cb, we don't have any.
         if (!cb_fut.valid()) {
             return false;
         }
+
+        prefilled_cb_fut = m_most_recent_pow_block.prefill_cb_msg_fut;
     }
 
-    LogDebug(BCLog::NET, "%s sending header-and-ids %s to peer=%d\n", __func__,
-            pindex->GetBlockHash().ToString(), pnode.GetId());
-    PushMessage(pnode, cb_fut.get().Copy());
+    bool send_prefill{false};
+    if (prefilled_cb_fut.valid()) {
+        // Return the number of additional TCP windows (forced roundtrips) needed to send.
+        auto windows_used = [](uint32_t msg_bytes, uint32_t total_bytes, uint32_t available_bytes) -> uint32_t {
+            Assume(total_bytes > 0);
+
+            if (msg_bytes <= available_bytes) {
+                return 0;
+            } else {
+                return CeilDiv((msg_bytes - available_bytes),  total_bytes);
+            }
+        };
+
+        auto [window_total, window_avail] = pnode.WindowBytesTotalAndAvailable();
+        // 0 when no valid window data could be retrieved for the socket.
+        // We only want to send prefilled blocks if we have the relevant
+        // info about the connection.
+        if (window_total > 0) {
+            const auto prefilled_size = pnode.m_transport->GetMessageSize(prefilled_cb_fut.get());
+            auto prefilled_windows = windows_used(prefilled_size, window_total, window_avail);
+            const auto not_prefilled_size = pnode.m_transport->GetMessageSize(cb_fut.get());
+            auto not_prefilled_windows = windows_used(not_prefilled_size, window_total, window_avail);
+
+            if (prefilled_windows <= not_prefilled_windows) {
+                send_prefill = true;
+            }
+            LogDebug(BCLog::CMPCTBLOCK,
+                "Prefilled CB (%d bytes) would use %d additional TCP windows, "
+                " non-prefilled CB (%d bytes) would use %d additional TCP windows.",
+                prefilled_size,
+                prefilled_windows,
+                not_prefilled_size,
+                not_prefilled_windows);
+        }
+    }
+    auto msg = send_prefill ? prefilled_cb_fut.get().Copy() : cb_fut.get().Copy();
+
+    LogDebug(BCLog::CMPCTBLOCK, "Sending %s cmpctblock %s (%d bytes) %s",
+        send_prefill ? "prefilled" : "not-prefilled",
+        pindex->GetBlockHash().ToString(), msg.data.size(),
+        pnode.LogPeer());
+
+    PushMessage(pnode, std::move(msg));
 
     {
         LOCK(cs_main);
         CNodeState &state = *State(pnode.GetId());
         state.pindexBestHeaderSent = pindex;
     }
+
     return true;
 }
 
@@ -2750,7 +2814,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
             // instead we respond with the full, non-compact block.
             if (can_direct_fetch && pindex->nHeight >= tip->nHeight - MAX_CMPCTBLOCK_DEPTH) {
                 if (!SendCompactBlock(pfrom, pindex)) {
-                    CBlockHeaderAndShortTxIDs cmpctblock{*pblock, m_rng.rand64()};
+                    CBlockHeaderAndShortTxIDs cmpctblock{*pblock, m_rng.rand64(), {}};
                     MakeAndPushMessage(pfrom, NetMsgType::CMPCTBLOCK, cmpctblock);
                 }
             } else {
@@ -6286,7 +6350,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                         CBlock block;
                         const bool ret{m_chainman.m_blockman.ReadBlock(block, *pBestIndex)};
                         assert(ret);
-                        CBlockHeaderAndShortTxIDs cmpctblock{block, m_rng.rand64()};
+                        CBlockHeaderAndShortTxIDs cmpctblock{block, m_rng.rand64(), {}};
                         MakeAndPushMessage(node, NetMsgType::CMPCTBLOCK, cmpctblock);
                         state.pindexBestHeaderSent = pBestIndex;
                     }

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
         BOOST_CHECK_EQUAL(partial_block_with_extra_collision.InitData(cmpctblock, extra_txn), READ_STATUS_OK);
         BOOST_CHECK(partial_block_with_extra_collision.IsTxAvailable(1));
         BOOST_CHECK(!partial_block_with_extra_collision.IsTxAvailable(2));
-        BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetMempoolCount(), 1U);
+        BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetMempoolCount(), 0U);
         BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetExtraCount(), 1U);
 
         // Now also collide the extra-sourced slot: both counters decrement exactly once.

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -73,7 +73,8 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
 
     // Do a simple ShortTxIDs RT
     {
-        CBlockHeaderAndShortTxIDs shortIDs{block, rand_ctx.rand64()};
+        const std::set<uint32_t> prefill_candidates{};
+        const CBlockHeaderAndShortTxIDs shortIDs{block, rand_ctx.rand64(), prefill_candidates};
 
         DataStream stream{};
         stream << shortIDs;
@@ -130,8 +131,8 @@ public:
         stream << orig;
         stream >> *this;
     }
-    explicit TestHeaderAndShortIDs(const CBlock& block, FastRandomContext& ctx) :
-        TestHeaderAndShortIDs(CBlockHeaderAndShortTxIDs{block, ctx.rand64()}) {}
+    explicit TestHeaderAndShortIDs(const CBlock& block, FastRandomContext& ctx, std::set<uint32_t> prefill) :
+        TestHeaderAndShortIDs(CBlockHeaderAndShortTxIDs{block, ctx.rand64(), prefill}) {}
 
     uint64_t GetShortID(const Wtxid& txhash) const {
         DataStream stream{};
@@ -166,7 +167,7 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
 
     // Test with pre-forwarding tx 1, but not coinbase
     {
-        TestHeaderAndShortIDs shortIDs(block, rand_ctx);
+        TestHeaderAndShortIDs shortIDs(block, rand_ctx, {});
         shortIDs.prefilledtxn.resize(1);
         shortIDs.prefilledtxn[0] = {1, block.vtx[1]};
         shortIDs.shorttxids.resize(2);
@@ -237,7 +238,7 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
 
     // Test with pre-forwarding coinbase + tx 2 with tx 1 in mempool
     {
-        TestHeaderAndShortIDs shortIDs(block, rand_ctx);
+        TestHeaderAndShortIDs shortIDs(block, rand_ctx, {});
         shortIDs.prefilledtxn.resize(2);
         shortIDs.prefilledtxn[0] = {0, block.vtx[0]};
         shortIDs.prefilledtxn[1] = {1, block.vtx[2]}; // id == 1 as it is 1 after index 1
@@ -294,7 +295,8 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
 
     // Test simple header round-trip with only coinbase
     {
-        CBlockHeaderAndShortTxIDs shortIDs{block, rand_ctx.rand64()};
+        const std::set<uint32_t> prefill_candidates{};
+        const CBlockHeaderAndShortTxIDs shortIDs{block, rand_ctx.rand64(), prefill_candidates};
 
         DataStream stream{};
         stream << shortIDs;
@@ -347,7 +349,8 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
     BOOST_CHECK_EQUAL(pool.get(block.vtx[1]->GetHash()), nullptr);
 
     {
-        const CBlockHeaderAndShortTxIDs cmpctblock{block, rand_ctx.rand64()};
+        const std::set<uint32_t> prefill_candidates{};
+        const CBlockHeaderAndShortTxIDs cmpctblock{block, rand_ctx.rand64(), prefill_candidates};
         PartiallyDownloadedBlock partial_block(&pool);
         PartiallyDownloadedBlock partial_block_with_extra(&pool);
 

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -78,24 +78,19 @@ class FuzzedCBlockHeaderAndShortTxIDs : public CBlockHeaderAndShortTxIDs
     using CBlockHeaderAndShortTxIDs::CBlockHeaderAndShortTxIDs;
 
 public:
-    void AddPrefilledTx(PrefilledTransaction&& prefilledtx)
-    {
-        prefilledtxn.push_back(std::move(prefilledtx));
-    }
-
     void RemoveCoinbasePrefill()
     {
         prefilledtxn.erase(prefilledtxn.begin());
+        if (prefilledtxn.size() > 0) {
+            // Because the prefill indices are the distance from the last
+            // prefill, the front prefill index is now one greater.
+            prefilledtxn.front().index += 1;
+        }
     }
 
     void InsertCoinbaseShortTxID(uint64_t shorttxid)
     {
         shorttxids.insert(shorttxids.begin(), shorttxid);
-    }
-
-    void EraseShortTxIDs(size_t index)
-    {
-        shorttxids.erase(shorttxids.begin() + index);
     }
 
     size_t PrefilledTxCount() {
@@ -346,43 +341,27 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
                     info.push_back(block_info);
                 }
 
-                uint64_t nonce = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
-                FuzzedCBlockHeaderAndShortTxIDs cmpctblock(*cblock, nonce);
+                const size_t num_txs = cblock->vtx.size();
+                std::set<uint32_t> prefill_candidates{};
+                for (uint32_t i = 0; i < num_txs; i++) {
+                    if (fuzzed_data_provider.ConsumeBool()) {
+                        prefill_candidates.insert(i);
+                    }
+                }
 
+                uint64_t nonce = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+                FuzzedCBlockHeaderAndShortTxIDs cmpctblock(*cblock, nonce, prefill_candidates);
                 if (fuzzed_data_provider.ConsumeBool()) {
                     CBlockHeaderAndShortTxIDs base_cmpctblock = cmpctblock;
                     net_msg = NetMsg::Make(NetMsgType::CMPCTBLOCK, base_cmpctblock);
                     return;
                 }
 
-                int prev_idx = 0;
-                size_t num_erased = 1;
-                size_t num_txs = cblock->vtx.size();
-
-                for (size_t i = 0; i < num_txs; ++i) {
-                    if (i == 0) {
-                        // Handle the coinbase specially. We either keep it prefilled or remove it.
-                        if (fuzzed_data_provider.ConsumeBool()) continue;
-
-                        // Remove the prefilled coinbase.
-                        num_erased = 0;
-                        uint64_t coinbase_shortid = cmpctblock.GetShortID(cblock->vtx[0]->GetWitnessHash());
-                        cmpctblock.RemoveCoinbasePrefill();
-                        cmpctblock.InsertCoinbaseShortTxID(coinbase_shortid);
-                        continue;
-                    }
-
-                    if (fuzzed_data_provider.ConsumeBool()) continue;
-
-                    uint16_t prefill_idx = num_erased == 0 ? i : i - prev_idx - 1;
-                    prev_idx = i;
-                    CTransactionRef txref = cblock->vtx[i];
-                    PrefilledTransaction prefilledtx = {/*index=*/prefill_idx, txref};
-                    cmpctblock.AddPrefilledTx(std::move(prefilledtx));
-
-                    // Remove from shorttxids since we've prefilled. Subtract however many txs have been prefilled.
-                    cmpctblock.EraseShortTxIDs(i - num_erased);
-                    ++num_erased;
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    // Remove the prefilled coinbase.
+                    uint64_t coinbase_shortid = cmpctblock.GetShortID(cblock->vtx[0]->GetWitnessHash());
+                    cmpctblock.RemoveCoinbasePrefill();
+                    cmpctblock.InsertCoinbaseShortTxID(coinbase_shortid);
                 }
 
                 assert(cmpctblock.PrefilledTxCount() + cmpctblock.ShortTxIDCount() == num_txs);

--- a/src/test/fuzz/p2p_headers_presync.cpp
+++ b/src/test/fuzz/p2p_headers_presync.cpp
@@ -208,7 +208,7 @@ FUZZ_TARGET(p2p_headers_presync, .init = initialize)
             [&]() NO_THREAD_SAFETY_ANALYSIS {
                 // Send a compact block
                 auto block = finalized_block();
-                CBlockHeaderAndShortTxIDs cmpct_block{block, fuzzed_data_provider.ConsumeIntegral<uint64_t>()};
+                CBlockHeaderAndShortTxIDs cmpct_block{block, fuzzed_data_provider.ConsumeIntegral<uint64_t>(), {}};
 
                 all_headers.push_back(block);
 

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -56,7 +56,7 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
         return;
     }
 
-    CBlockHeaderAndShortTxIDs cmpctblock{*block, fuzzed_data_provider.ConsumeIntegral<uint64_t>()};
+    CBlockHeaderAndShortTxIDs cmpctblock{*block, fuzzed_data_provider.ConsumeIntegral<uint64_t>(), {}};
 
     bilingual_str error;
     CTxMemPool pool{MemPoolOptionsForTest(g_setup->m_node), error};

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -18,6 +18,16 @@ using namespace std::chrono_literals;
 
 BOOST_FIXTURE_TEST_SUITE(sock_tests, BasicTestingSetup)
 
+static bool SocketIsClosed(const Sock &s)
+{
+    // Notice that if another thread is running and creates its own socket after `s` has been
+    // closed, it may be assigned the same file descriptor number. In this case, our test will
+    // wrongly pretend that the socket is not closed.
+    int type;
+    socklen_t len = sizeof(type);
+    return s.GetSockOpt(SOL_SOCKET, SO_TYPE, reinterpret_cast<char*>(&type), &len) == SOCKET_ERROR;
+}
+
 static bool SocketIsClosed(const SOCKET& s)
 {
     // Notice that if another thread is running and creates its own socket after `s` has been
@@ -86,11 +96,13 @@ struct TcpSocketPair {
     Sock sender;
     Sock receiver;
 
-    TcpSocketPair()
+    TcpSocketPair(bool connect = true)
         : sender{Sock{CreateSocket()}},
         receiver{Sock{CreateSocket()}}
     {
-        connect_pair();
+        if (connect) {
+            connect_pair();
+        }
     }
 
     TcpSocketPair(const TcpSocketPair&) = delete;
@@ -146,7 +158,7 @@ BOOST_AUTO_TEST_CASE(send_and_receive)
 
 BOOST_AUTO_TEST_CASE(wait)
 {
-    TcpSocketPair socks = TcpSocketPair{};
+    TcpSocketPair socks{};
 
     std::thread waiter([&socks]() { (void)socks.receiver.Wait(24h, Sock::RecvEvent); });
 
@@ -160,7 +172,7 @@ BOOST_AUTO_TEST_CASE(recv_until_terminator_limit)
     constexpr auto timeout = 1min; // High enough so that it is never hit.
     CThreadInterrupt interrupt;
 
-    TcpSocketPair socks = TcpSocketPair{};
+    TcpSocketPair socks{};
 
     std::thread receiver([&socks, &timeout, &interrupt]() {
         constexpr size_t max_data{10};
@@ -179,6 +191,19 @@ BOOST_AUTO_TEST_CASE(recv_until_terminator_limit)
     BOOST_REQUIRE_NO_THROW(socks.sender.SendComplete("89a\n", timeout, interrupt));
 
     receiver.join();
+}
+
+BOOST_AUTO_TEST_CASE(tcp_info)
+{
+    TcpSocketPair socks{/*connect=*/false};
+    TCPInfo sender_info{socks.sender}, receiver_info{socks.receiver};
+    // Test that we can acquire a valid TCP_INFO structure on all
+    // supported platforms.
+    BOOST_CHECK(sender_info.m_valid);
+    BOOST_CHECK(receiver_info.m_valid);
+
+    BOOST_CHECK(!SocketIsClosed(socks.sender));
+    BOOST_CHECK(!SocketIsClosed(socks.receiver));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -196,11 +196,31 @@ BOOST_AUTO_TEST_CASE(recv_until_terminator_limit)
 BOOST_AUTO_TEST_CASE(tcp_info)
 {
     TcpSocketPair socks{/*connect=*/false};
+
+    // Set some small multiple of 8 as receiver advertised window, as long as we
+    // are below MSS this will be the window size.
+    int sender_rcvbuf = 8 * 160;
+    socklen_t sender_rcvbuf_len{sizeof(sender_rcvbuf)};
+    BOOST_CHECK(!socks.sender.SetSockOpt(SOL_SOCKET, SO_RCVBUF, &sender_rcvbuf, sender_rcvbuf_len));
+
+    int receiver_rcvbuf = 8 * 150;
+    socklen_t receiver_rcvbuf_len{sizeof(receiver_rcvbuf)};
+    BOOST_CHECK(!socks.receiver.SetSockOpt(SOL_SOCKET, SO_RCVBUF, &receiver_rcvbuf, receiver_rcvbuf_len));
+
+    // Now connect.
+    socks.connect_pair();
+
     TCPInfo sender_info{socks.sender}, receiver_info{socks.receiver};
     // Test that we can acquire a valid TCP_INFO structure on all
     // supported platforms.
     BOOST_CHECK(sender_info.m_valid);
     BOOST_CHECK(receiver_info.m_valid);
+
+#if !defined(__APPLE__)
+    // macOS ignores SO_RCVBUF if sysctl param net.inet.tcp.doautorcvbuf == 1
+    BOOST_CHECK_EQUAL(sender_info.GetTCPWindowSize(), receiver_rcvbuf);
+    BOOST_CHECK_EQUAL(receiver_info.GetTCPWindowSize(), sender_rcvbuf);
+#endif
 
     BOOST_CHECK(!SocketIsClosed(socks.sender));
     BOOST_CHECK(!SocketIsClosed(socks.receiver));

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -101,6 +101,7 @@ void ConnmanTestMsg::FlushSendBuffer(CNode& node) const
     LOCK(node.cs_vSend);
     node.vSendMsg.clear();
     node.m_send_memusage = 0;
+    node.m_send_size = 0;
     while (true) {
         const auto& [to_send, _more, _msg_type] = node.m_transport->GetBytesToSend(false);
         if (to_send.empty()) break;

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -8,12 +8,12 @@
 #include <span.h>
 #include <tinyformat.h>
 #include <util/check.h>
-#include <util/log.h>
 #include <util/syserror.h>
 #include <util/threadinterrupt.h>
 #include <util/time.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <compare>
 #include <exception>
 #include <memory>
@@ -108,6 +108,51 @@ int Sock::SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt
 int Sock::GetSockName(sockaddr* name, socklen_t* name_len) const
 {
     return getsockname(m_socket, name, name_len);
+}
+
+int Sock::GetOSBytesQueued(const TCPInfo &info)
+{
+    if (m_socket == INVALID_SOCKET) {
+        return 0;
+    }
+
+    int bytes_queued{0};
+#if (defined(__linux__) || defined(__FreeBSD__))
+    if (ioctl(m_socket, TIOCOUTQ, &bytes_queued)) {
+        LogError("sock: Error getting queued bytes: ioctl(TIOCOUTQ): %s\n", NetworkErrorString(errno));
+        return 0;
+    }
+#elif defined(__NetBSD__) // https://man.netbsd.org/ioctl.2
+    if (ioctl(m_socket, FIONWRITE, &bytes_queued)) {
+        LogError("sock: Error getting queued bytes: ioctl(FIONWRITE): %s\n", NetworkErrorString(errno));
+        return 0;
+    }
+#elif defined(__APPLE__) && defined(SO_NWRITE)
+    // Apple's online manpage reference is out-of-date or inaccurate and omits this,
+    // but this is documented in the `man 2 getsockopt` on MacOS devices.
+    // https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/man/man2/getsockopt.2#L170
+    socklen_t result_len{sizeof(bytes_queued)};
+    if (GetSockOpt(SOL_SOCKET, SO_NWRITE, &bytes_queued, &result_len)) {
+        LogError("sock: Error getting queued bytes: getsockopt(SO_NWRITE): %s\n", NetworkErrorString(errno));
+        return 0;
+    }
+#elif defined(__OpenBSD__)
+    if (!info.m_valid) {
+        LogError("sock: Error getting queued bytes: Acquiring TCP info: %s\n", NetworkErrorString(errno));
+        return 0;
+    }
+
+    // Index of Next byte to send - index of oldest unacked byte.
+    bytes_queued = info.m_tcp_info.tcpi_snd_nxt - info.m_tcp_info.tcpi_snd_una;
+#elif defined(WIN32_TCPINFO_SUPPORTED)
+    if (!info.m_valid) {
+        LogError("sock: Error getting queued bytes: Acquiring TCP info: %s\n", NetworkErrorString(errno));
+        return 0;
+    }
+    bytes_queued = info.m_tcp_info.BytesInFlight;
+#endif
+
+    return std::max(0, bytes_queued);
 }
 
 bool Sock::SetNonBlocking() const

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -31,6 +31,8 @@ inline bool IOErrorIsPermanent(int err)
     return err != WSAEAGAIN && err != WSAEINTR && err != WSAEWOULDBLOCK && err != WSAEINPROGRESS;
 }
 
+class TCPInfo;
+
 /**
  * RAII helper class that manages a socket and closes it automatically when it goes out of scope.
  */
@@ -153,6 +155,12 @@ public:
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
     [[nodiscard]] virtual int GetSockName(sockaddr* name, socklen_t* name_len) const;
+
+    /**
+     * To the degree to which the platform supports it, get the number of bytes
+     * in the socket output queue: unsent + unack'ed.
+     */
+    [[nodiscard]] virtual int GetOSBytesQueued(const TCPInfo& info);
 
     /**
      * Set the non-blocking option on the socket.

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -9,9 +9,11 @@
 #include <logging.h>
 #include <util/time.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -359,6 +361,55 @@ public:
 #endif
         if (!m_valid) {
             LogError("Error getting TCP Info: %s", NetworkErrorString(WSAGetLastError()));
+        }
+    }
+
+    size_t GetTCPWindowSize()
+    {
+        if (!m_valid) {
+            return 0;
+        }
+
+        uint32_t cwnd_bytes{};
+        std::optional<uint32_t> peer_rwnd_bytes{std::nullopt};
+
+// Linux: tcpi_snd_wnd introduced in 5.4 https://github.com/torvalds/linux/commit/8f7baad7f03543451af27f5380fc816b008aa1f2
+// The logic around peer_rwnd_bytes being optional can be removed once the minimum supported kernel is 5.4 or greater.
+#if defined(__linux__)
+        // We can only create the runtime check if tcpi_snd_wnd is available at compile-time.
+        #if defined(TCP_INFO_HAS_SEND_WND)
+            // Offset + field length is the minimum struct size.
+            size_t snd_wnd_reqd_size = offsetof(struct tcp_info, tcpi_snd_wnd) + sizeof(m_tcp_info.tcpi_snd_wnd);
+            if (m_tcp_info_len >= snd_wnd_reqd_size) {
+                peer_rwnd_bytes = m_tcp_info.tcpi_snd_wnd;
+            }
+        #endif
+        // Unlike other platforms, on linux tcpi_snd_cwnd is reported in packets,
+        // not bytes.
+        uint64_t cwnd_bytes_temp = uint64_t(m_tcp_info.tcpi_snd_cwnd) * m_tcp_info.tcpi_snd_mss;
+        if (cwnd_bytes_temp > UINT32_MAX) {
+            // cwnd_bytes is u32, we overflowed.
+            return 0;
+        }
+        cwnd_bytes = cwnd_bytes_temp;
+/*
+ * FreeBSD: Available since 6.0: https://cgit.freebsd.org/src/tree/sys/netinet/tcp.h?h=releng/6.0#n214 (commit: https://cgit.freebsd.org/src/commit/?id=b8af5dfa81f1fdca5ed77f8f339a5b522d10e714)
+ * OSX: Available since 10.11: https://developer.apple.com/documentation/kernel/tcp_connection_info/1562043-tcpi_snd_wnd
+ * NetBSD: Available since 10.2: https://github.com/NetBSD/src/blame/6cee2c5b88e06440257c4c8ad704f388954c9fb0/sys/netinet/tcp.h#L202
+ * OpenBSD: Available since 7.2: https://cvsweb.openbsd.org/src/sys/netinet/tcp.h?rev=1.23&content-type=text/x-cvsweb-markup
+ */
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+        // congestion send window (# of segments) * mss (max segment size)
+        cwnd_bytes = m_tcp_info.tcpi_snd_cwnd;
+        peer_rwnd_bytes = m_tcp_info.tcpi_snd_wnd;
+#elif defined(WIN32_TCPINFO_SUPPORTED)
+        cwnd_bytes = m_tcp_info.Cwnd;
+        peer_rwnd_bytes = m_tcp_info.SndWnd;
+#endif
+        if(peer_rwnd_bytes.has_value()) {
+            return std::min(cwnd_bytes, peer_rwnd_bytes.value());
+        } else {
+            return cwnd_bytes;
         }
     }
 };

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_SOCK_H
 
 #include <compat/compat.h>
+#include <logging.h>
 #include <util/time.h>
 
 #include <cstdint>
@@ -113,6 +114,26 @@ public:
                                          int opt_name,
                                          void* opt_val,
                                          socklen_t* opt_len) const;
+
+#if defined(WIN32)
+    /**
+     * WSAIoctl wrapper
+     * https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsaioctl
+     */
+    [[nodiscard]] int WSAIoctl(DWORD                                dwIoControlCode,
+                               LPVOID                               lpvInBuffer,
+                               DWORD                                cbInBuffer,
+                               LPVOID                               lpvOutBuffer,
+                               DWORD                                cbOutBuffer,
+                               LPDWORD                              lpcbBytesReturned,
+                               LPWSAOVERLAPPED                      lpOverlapped,
+                               LPWSAOVERLAPPED_COMPLETION_ROUTINE   lpCompletionRoutine)
+    {
+        return ::WSAIoctl(m_socket, dwIoControlCode, lpvInBuffer, cbInBuffer,
+                          lpvOutBuffer, cbOutBuffer, lpcbBytesReturned,
+                          lpOverlapped, lpCompletionRoutine);
+    }
+#endif
 
     /**
      * setsockopt(2) wrapper. Equivalent to
@@ -291,5 +312,55 @@ private:
 
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
+
+/**
+ * Wrap platform specific data structures that contain information about TCP
+ * connections, tcp_info on /Linux|e.BSD/, tcp_connection_info on macos, and
+ * TCP_INFO_V0 on Windows.
+ */
+class TCPInfo
+{
+public:
+    bool m_valid{true};
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    struct tcp_info m_tcp_info;
+    socklen_t m_tcp_info_len{sizeof(m_tcp_info)};
+#elif defined(__APPLE__)
+    struct tcp_connection_info m_tcp_info;
+    socklen_t m_tcp_info_len{sizeof(m_tcp_info)};
+#elif defined(WIN32_TCPINFO_SUPPORTED)
+    TCP_INFO_v0 m_tcp_info;
+    DWORD m_tcp_info_len{sizeof(m_tcp_info)};
+#endif
+
+    TCPInfo(Sock &s) {
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+        m_valid = !s.GetSockOpt(IPPROTO_TCP, TCP_INFO, &m_tcp_info, &m_tcp_info_len);
+#elif defined(__APPLE__)
+        m_valid = !s.GetSockOpt(IPPROTO_TCP, TCP_CONNECTION_INFO, &m_tcp_info, &m_tcp_info_len);
+#elif defined(WIN32_TCPINFO_SUPPORTED)
+        DWORD version{0};
+
+        // Windows 10 1703 is required for SIO_TCP_INFO, but this
+        // will fail at runtime with WSAEOPNOTSUPP if the runtime
+        // platform is too old.
+        m_valid = !s.WSAIoctl(/*dwIoControlCode=*/SIO_TCP_INFO,
+                              /*lpvInBuffer=*/&version,
+                              /*cbInBuffer=*/sizeof(version),
+                              /*lpvOutBuffer=*/&m_tcp_info,
+                              /*cbOutBuffer=*/sizeof(m_tcp_info),
+                              /*lpcpBytesReturned=*/&m_tcp_info_len,
+                              /*lpvOverlapped=*/nullptr,
+                              /*lpCompletionRoutine=*/nullptr);
+#else
+        m_valid = false;
+        LogWarning("Error getting TCP Info, platform not supported!");
+        return;
+#endif
+        if (!m_valid) {
+            LogError("Error getting TCP Info: %s", NetworkErrorString(WSAGetLastError()));
+        }
+    }
+};
 
 #endif // BITCOIN_UTIL_SOCK_H


### PR DESCRIPTION
> ---> Review before this: #35724

This is an implementation based on 0xB10C's [proposal][proposal] and [implementation][implementation] of prefilling CMPCTBLOCK messages with what we[^1] needed during CMPCTBLOCK reconstruction in the hopes of providing everything our peers will need to reconstruct without having to ask us for transactions.

Although full support for receiving prefills is [implemented][cb-og-pr] in Bitcoin Core, the only prefills sent presently are coinbases. The goal of prefilling is to improve compact block reconstruction rates, which reduces the number of roundtrips needed to propagate blocks per-hop, which reduces the amount of time needed for blocks to propagate on the network, which mitigates selfish mining attacks by lowering the stale rate and the ratio $γ$ of honest miners a selfish miner is able to recruit in a block race.[^2] The tradeoff of prefilling is that it uses a small amount of extra bandwidth and makes propagation slightly worse when the predictions are bad.

My primary contribution is limiting the prefill based on the connection's TCP window. Exceeding the boundary of the current TCP window will result in a ~[roundtrip][roundtrip] at the network layer,[^3] and any time a roundtrip is going to be incurred anyways, it would be [better][better] to let our peer tell us exactly what they are missing in a roundtrip instead of hazarding a guess, which risks sending redundant information.[^4]

## Prefill do

In measurements I took from 2026-02-15 to 2026-03-16, a node receiving prefilled `CMPCTBLOCK`s limited to the TCP window size was able to reconstruct 89.7% of compact blocks received without a GETBLOCKTXN roundtrip, and a node receiving typical `CMPCTBLOCK`s with only coinbases prefilled was able to reconstruct 56.9% of blocks received without a GETBLOCKTXN roundtrip.[^5]

The mean prefill sent was 1,694.64 bytes and the median was 897 bytes. If all the bytes of every prefill were redundant [^6], the cost of prefilling 1,694.64 bytes would be 1.39 MiB per node in wasted bandwidth per day (counting both the sending and the receiving bandwidth for all 3 HB peers).

## Prefill why

There are changes that are likely more effective at improving propagation times than prefilling, for example:
- [Using a sketch instead of shortids][sketch-shortid] in CMPCTBLOCK messages
- Using a UDP connection with FEC as [the FIBRE project does][the-fibre-project-does]
- Sharing [block templates][block-templates]

The advantage of this approach is that it requires no protocol changes and is entirely backwards compatible with existing node software that has implemented the `CMPCTBLOCK` [protocol][protocol]. Concretely: An old version of Bitcoin Core that knows nothing about this PR can enjoy faster block reconstructions if it connects to a peer that prefills blocks. I think these benefits are worth the tradeoff of violating the layer cake and taking transport matters into our own hands.

## Prefill what

- The transactions which we were missing during reconstruction and received in a `GETBLOCKTXN->BLOCKTXN` round trip with our peer.
- The transactions which were pulled from our extrapool during reconstruction.[^7]
- Any transactions that were prefilled to us that we didn't already have in our mempool.

The reasons to like this heuristic are that it's simple, per-block rather than per-peer, makes sense on paper, and seems to be effective in practice.

## Prefill when

To avoid having to generate unique CMPCTBLOCK messages for each of our peers, which might be costly[^8], we (lazily[^9]) build and cache 2 CMPCTBLOCK messages: one prefilled and one not prefilled.

At sending time we check the available bytes in our peer's TCP window, and if the total number of TCP windows occupied by the prefilled block is equal to the total number of windows occupied by the nonprefilled block, then we send the prefilled block.

----

## TCP Windows

Discussed in greater detail [elsewhere][elsewhere], I'll try to summarize here:

In [RFC 793][rfc-793], TCP was specified with receiver advertised window sizes because receivers allocate some buffer size to a given TCP connection, and this receiver advertised window represents the most **unacknowledged** data a receiver will process before dropping bytes on the ground or something awful like that. So the sender of a message over a TCP connection will only send up to the last acknowledged byte + the receiver's advertised window size in order to avoid filling up their peer's receive buffer.

It was later discovered that TCP was susceptible to ["congestion collapse"][congestion-collapse], which can probably describe any congestion feedback loop but in TCP is where packets being dropped due to congestion results in retransmissions that cause even more congestion. TCP implementers addressed this with "congestion control" algorithms which decide on the sending side to limit the number of bytes to send dynamically, based on how frequently packets are dropped on a TCP connection. For a more concrete account of various congestion control algorithms see [RFC 5681][rfc-5681]. A user's TCP implementation (typically in their OS kernel) will compute a window size dynamically for each TCP connection usually increasing as packets sent are ACKnowledged and decreasing when packets sent are dropped.

Computed congestion control window sizes vary:
- per-connection
- over connection lifetime
- with the congestion control algorithm used by the system TCP implementation
- with user configuration of the TCP implementation.

There is not likely to be any way to guess or predict what the TCP window will be very effectively, and we must query the TCP implementation in order to learn what our connection window sizes are.

The usable window size is the smaller of the receiver advertised window and the sender computed congestion control window, but in practice the congestion control window is far smaller. In my observation node, the mean Bitcoin P2P congestion window observed was 17,360.52 bytes and the median was 14,480 bytes.

[^1]: 'We' refers to the Royal Node.
[^2]: (2013) Eyal and Sirer *Majority is not Enough* (pg. 8) https://arxiv.org/pdf/1311.0243 The claim that lowering block propagation times lowers γ probably needs serious analysis, but my hand-waving argument is that the faster public network-wide block propagation is, the more expensive any proportional propagation time advantage over the public network becomes, and γ is a function of propagation time advantage.
[^3]: A network layer roundtrip will be faster than an application layer roundtrip, although probably not by much for most connections. Since at the application layer there will be some time your message spends waiting to be processed by your peer, at least for peers that use single-threaded message processing like Bitcoin Core does presently.
[^4]: In practice exceeding the TCP window is ~not quite as bad as I've implied here and in the delving post: because the window is sliding, once the first 1.5 round-trips are completed there is a continuous stream as ACKnowledgements for the oldest segments arrive and the newest segments are fired out. The effect of this more precisely is that if a message exceeds a window boundary, the minimum travel time of the message becomes 1.5 round-trip-time (RTT) instead of 0.5 RTT and the throughput limit of the connection becomes $\text{window size} / \text{RTT}$. I am working on a more complete write-up that takes this more precise cost into consideration, but I think approximating it as a ~round trip is reasonable.
[^5]: In reality, not all of the prefill is redundant otherwise prefilling would not be very useful. In my observation node that received prefilled compact blocks, the mean redundant prefill bytes was 865.62 bytes/block. 2 HB announcements will always be redundant so: 1.17 MiB per node in wasted bandwidth per day if one CMPCTBLOCK announcement only has 865.62 redundant bytes.
[^6]: I will share a write-up describing my full experimental setup and data soon. It was mostly identical to the set up described here: https://delvingbitcoin.org/t/stats-on-compact-block-reconstructions/1052/34 I had one node running a prefilling branch, and another node set up to only receive CMPCTBLOCK messages from the prefilling node. My infrastructure as code observation set up: https://github.com/davidgumberg/prefill-research and the script I used to analyze the results: https://radicle.network/nodes/iris.radicle.network/rad:z37pH1UAxFvazXnfAMS5qbcUjQaP6/tree/leave/scripts/prefill.py
[^7]: The reason to pluck from the extrapool is because it is very likely to differ between nodes.
[^8]: But maybe there is some cost here that is worth trading off, it's not something I've explored.
[^9]: This is based on andrewtoth's #26755.

[proposal]: https://delvingbitcoin.org/t/stats-on-compact-block-reconstructions/1052/24
[cb-og-pr]: https://github.com/bitcoin/bitcoin/pull/8068
[sketch-shortid]: https://delvingbitcoin.org/t/stats-on-compact-block-reconstructions/1052/30
[the-fibre-project-does]: https://github.com/bitcoinfibre/bitcoinfibre/blob/master/src/udprelay.cpp
[roundtrip]: https://en.wikipedia.org/wiki/TCP_window_scale_option#TCP_windows
[better]: https://delvingbitcoin.org/t/stats-on-compact-block-reconstructions/1052/34
[rfc-793]: https://www.rfc-editor.org/rfc/rfc793.html#section-2.6
[elsewhere]: https://delvingbitcoin.org/t/stats-on-compact-block-reconstructions/1052/34
[congestion-collapse]: https://dl.acm.org/doi/epdf/10.1145/52325.52356
[rfc-5681]: https://datatracker.ietf.org/doc/html/rfc5681
[block-templates]: https://delvingbitcoin.org/t/sharing-block-templates/1906
[implementation]: https://github.com/0xB10C/bitcoin/tree/2025-03-prefill-cmpctblocks
[protocol]: https://github.com/bitcoin/bips/blob/master/bip-0152.mediawiki


> LLM Disclosure: LLMs were used frequently as a research tool while investigating this topic, but no code or text in this PR was generated with an LLM.
