### PR TITLE
scripted-diff: Rename SteadyClockContext to FakeSteadyClock

### DIFF
--- a/src/test/fuzz/p2p_headers_presync.cpp
+++ b/src/test/fuzz/p2p_headers_presync.cpp
@@ -164,7 +164,7 @@ FUZZ_TARGET(p2p_headers_presync, .init = initialize)
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     // The steady clock is currently only used for logging, so a constant
     // time-point seems acceptable for now.
-    SteadyClockContext steady_ctx{};
+    FakeSteadyClock steady_ctx{};
 
     ChainstateManager& chainman = *g_testing_setup->m_node.chainman;
     CBlockHeader base{chainman.GetParams().GenesisBlock()};

--- a/src/test/fuzz/util/check_globals.cpp
+++ b/src/test/fuzz/util/check_globals.cpp
@@ -44,7 +44,7 @@ struct CheckGlobalsImpl {
                          "The current fuzz target accessed system time.\n\n"
 
                          "This is acceptable, but requires the fuzz target to use \n"
-                         "a FakeNodeClock, SteadyClockContext or call \n"
+                         "a FakeNodeClock, FakeSteadyClock or call \n"
                          "SetMockTime() at the \n" "beginning of processing the \n"
                          "fuzz input.\n\n"
 

--- a/src/test/pcp_tests.cpp
+++ b/src/test/pcp_tests.cpp
@@ -222,7 +222,7 @@ private:
     const std::vector<TestOp> m_script;
     mutable size_t m_script_ptr = 0;
     mutable std::chrono::milliseconds m_time_left;
-    mutable SteadyClockContext m_clock{};
+    mutable FakeSteadyClock m_clock{};
     mutable bool m_connected{false};
     mutable CService m_bound;
     mutable CNetAddr m_local_ip;

--- a/src/test/util/time.h
+++ b/src/test/util/time.h
@@ -25,19 +25,19 @@ private:
 
 /// Helper to initialize the global MockableSteadyClock, let a duration elapse,
 /// and reset it after use in a test.
-class SteadyClockContext : public LimitOne<SteadyClockContext>
+class FakeSteadyClock : public LimitOne<FakeSteadyClock>
 {
     MockableSteadyClock::mock_time_point::duration t{MockableSteadyClock::INITIAL_MOCK_TIME};
 
 public:
     /** Initialize with INITIAL_MOCK_TIME. */
-    explicit SteadyClockContext() { (*this) += 0s; }
+    explicit FakeSteadyClock() { (*this) += 0s; }
 
     /** Unset mocktime */
-    ~SteadyClockContext() { MockableSteadyClock::ClearMockTime(); }
+    ~FakeSteadyClock() { MockableSteadyClock::ClearMockTime(); }
 
-    SteadyClockContext(const SteadyClockContext&) = delete;
-    SteadyClockContext& operator=(const SteadyClockContext&) = delete;
+    FakeSteadyClock(const FakeSteadyClock&) = delete;
+    FakeSteadyClock& operator=(const FakeSteadyClock&) = delete;
 
     /** Change mocktime by the given duration delta */
     void operator+=(std::chrono::milliseconds d)

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -42,7 +42,7 @@ using SteadyMicroseconds = std::chrono::time_point<std::chrono::steady_clock, st
 using SystemClock = std::chrono::system_clock;
 
 /// Version of SteadyClock that is mockable in the context of tests (via
-/// SteadyClockContext, or Self::SetMockTime), otherwise the system steady
+/// FakeSteadyClock, or Self::SetMockTime), otherwise the system steady
 /// clock.
 struct MockableSteadyClock : public std::chrono::steady_clock {
     using time_point = std::chrono::time_point<MockableSteadyClock>;


### PR DESCRIPTION
See: https://github.com/bitcoin/bitcoin/pull/35536#issuecomment-4715945494

`SteadyClockContext` and `FakeNodeClock` are both LimitOne RAII helpers that mock a clock in tests -- the steady clock and the node clock, respectively. Rename the former so the two follow a consistent FakeXClock naming scheme.