### PR TITLE
lint: Require scripted-diff script to succeed (take 2)

### DIFF
--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (c) 2017-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -41,8 +41,12 @@ for commit in $(git rev-list --reverse "$1"); do
         else
             echo "Running script for: $commit" >&2
             echo "$SCRIPT" >&2
-            (eval "$SCRIPT") && \
-            git --no-pager diff --exit-code "$commit" && echo "OK" >&2 || (echo "Failed" >&2; false) || RET=1
+            if bash -o errexit -o nounset -o pipefail -c "$SCRIPT" && git --no-pager diff --exit-code "$commit"; then
+                echo "OK" >&2
+            else
+                echo "Failed" >&2
+                RET=1
+            fi
         fi
         git reset --quiet --hard HEAD
      else


### PR DESCRIPTION
Currently, scripted diffs may silently pass with errors.

Fix this issue by calling the script from a Bash instance with error checking enabled: `bash -o errexit -o nounset -o pipefail -c "$SCRIPT"`.

Also, use Bash (not sh) when launching the script itself, because Bash is required anyway.

Can be tested by running something like this and observing the behavior before and after:


```
git commit --allow-empty -m $'scripted-diff: foo\n\n-BEGIN VERIFY SCRIPT-\n  false;falseasfsafsaf;true;false|cat; echo "${NO_UN_SET}"|cat  \n-END VERIFY SCRIPT-\n' && ./test/lint/commit-script-check.sh HEAD~..HEAD ; echo $?
```

Alternatively, an ancient brittle script can be tested:

```
./test/lint/commit-script-check.sh fb65dde147f63422c4148b089c2f5be0bf5ba80f~..fb65dde147f63422c4148b089c2f5be0bf5ba80f