### PR TITLE
fuzz: remove unsupported coins cache cursor fuzz probe

### DIFF
--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -221,30 +221,19 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
             });
     }
 
-    {
-        bool expected_code_path = false;
-        try {
-            (void)coins_view_cache.Cursor();
-        } catch (const std::logic_error&) {
-            expected_code_path = true;
-        }
-        assert(expected_code_path);
-        (void)coins_view_cache.DynamicMemoryUsage();
-        (void)coins_view_cache.EstimateSize();
-        (void)coins_view_cache.GetBestBlock();
-        (void)coins_view_cache.GetCacheSize();
-        (void)coins_view_cache.GetHeadBlocks();
-        (void)coins_view_cache.HaveInputs(CTransaction{random_mutable_transaction});
-    }
+    (void)coins_view_cache.DynamicMemoryUsage();
+    (void)coins_view_cache.EstimateSize();
+    (void)coins_view_cache.GetBestBlock();
+    (void)coins_view_cache.GetCacheSize();
+    (void)coins_view_cache.GetHeadBlocks();
+    (void)coins_view_cache.HaveInputs(CTransaction{random_mutable_transaction});
 
-    {
-        if (is_db && backend_coins_view == original_backend) {
-            assert(backend_coins_view->Cursor());
-        }
-        (void)backend_coins_view->EstimateSize();
-        (void)backend_coins_view->GetBestBlock();
-        (void)backend_coins_view->GetHeadBlocks();
+    if (is_db && backend_coins_view == original_backend) {
+        assert(backend_coins_view->Cursor());
     }
+    (void)backend_coins_view->EstimateSize();
+    (void)backend_coins_view->GetBestBlock();
+    (void)backend_coins_view->GetHeadBlocks();
 
     if (fuzzed_data_provider.ConsumeBool()) {
         CallOneOf(


### PR DESCRIPTION
**Problem:** The `coins_view` fuzz target checked that `CCoinsViewCache::Cursor()` throws, but that method is intentionally unsupported and always throws: https://github.com/bitcoin/bitcoin/blob/93c6ea147422199777ddbc5f6d04134b82420b76/src/coins.h#L450-L452

**Fix:** Remove the input-independent throw check from the fuzz target. The target still exercises the useful cache/view behavior, and keeps DB-backed cursor coverage where cursor iteration is supported.
Some leftover scope-guards were also [removed](https://github.com/bitcoin/bitcoin/pull/35562/changes?diff=split&w=1).

This was extracted from review discussion in https://github.com/bitcoin/bitcoin/pull/35295#discussion_r3420576781.