### PR TITLE
Encapsulation for CTransaction

### DIFF
--- a/contrib/devtools/bitcoin-tidy/CMakeLists.txt
+++ b/contrib/devtools/bitcoin-tidy/CMakeLists.txt
@@ -25,8 +25,14 @@ find_program(CLANG_TIDY_EXE REQUIRED NAMES "clang-tidy-${LLVM_VERSION_MAJOR}" "c
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Found clang-tidy: ${CLANG_TIDY_EXE}")
 
-add_library(bitcoin-tidy MODULE bitcoin-tidy.cpp nontrivial-threadlocal.cpp)
+add_library(bitcoin-tidy MODULE)
 target_include_directories(bitcoin-tidy SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
+
+target_sources(bitcoin-tidy PRIVATE
+    bitcoin-tidy.cpp
+    nontrivial-threadlocal.cpp
+    use-observers.cpp
+)
 
 # Disable RTTI and exceptions as necessary
 if (MSVC)

--- a/contrib/devtools/bitcoin-tidy/bitcoin-tidy.cpp
+++ b/contrib/devtools/bitcoin-tidy/bitcoin-tidy.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "nontrivial-threadlocal.h"
+#include "use-observers.h"
 
 #include <clang-tidy/ClangTidyModule.h>
 
@@ -12,6 +13,7 @@ public:
     void addCheckFactories(clang::tidy::ClangTidyCheckFactories& CheckFactories) override
     {
         CheckFactories.registerCheck<bitcoin::NonTrivialThreadLocal>("bitcoin-nontrivial-threadlocal");
+        CheckFactories.registerCheck<UseObservers>("bitcoin-use-observers");
     }
 };
 

--- a/contrib/devtools/bitcoin-tidy/use-observers.cpp
+++ b/contrib/devtools/bitcoin-tidy/use-observers.cpp
@@ -1,0 +1,55 @@
+#include "use-observers.h"
+
+#include <clang/Lex/Lexer.h>
+
+using namespace clang;
+using namespace clang::ast_matchers;
+
+void UseObservers::registerMatchers(MatchFinder* Finder)
+{
+  Finder->addMatcher(
+    memberExpr(
+      unless(hasAncestor(functionDecl(anyOf(isImplicit(), isDefaulted())))),
+      member(fieldDecl(hasAttr(attr::Annotate))))
+      .bind("member"),
+    this);
+}
+
+void UseObservers::check(MatchFinder::MatchResult const& Result)
+{
+  auto const* ME = Result.Nodes.getNodeAs<MemberExpr>("member");
+  if (!ME || ME->isImplicitAccess()) {
+    return;
+  }
+
+  SourceLocation Loc = ME->getMemberLoc();
+  if (Loc.isMacroID()) {
+    SourceManager const& SM = *Result.SourceManager;
+    LangOptions const& LO = Result.Context->getLangOpts();
+
+    StringRef MacroName = clang::Lexer::getImmediateMacroName(Loc, SM, LO);
+    if (MacroName == "READWRITE" || MacroName == "VARINT") {
+      return;
+    }
+  }
+
+  auto const* FD = dyn_cast<FieldDecl>(ME->getMemberDecl());
+  if (!FD) {
+    return;
+  }
+
+  std::string Observer;
+  for (auto const* Attr : FD->specific_attrs<AnnotateAttr>()) {
+    StringRef Annotation = Attr->getAnnotation();
+    if (Annotation.consume_front("observer:")) {
+      Observer = Annotation.str();
+      break;
+    }
+  }
+  if (Observer.empty()) {
+    return;
+  }
+
+  diag(ME->getMemberLoc(), "replace direct member access with observer")
+    << FixItHint::CreateReplacement(ME->getMemberLoc(), Observer + "()");
+}

--- a/contrib/devtools/bitcoin-tidy/use-observers.h
+++ b/contrib/devtools/bitcoin-tidy/use-observers.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <clang-tidy/ClangTidyCheck.h>
+
+class UseObservers : public clang::tidy::ClangTidyCheck
+{
+public:
+  using ClangTidyCheck::ClangTidyCheck;
+
+private:
+  void registerMatchers(clang::ast_matchers::MatchFinder* Finder) override;
+  void check(clang::ast_matchers::MatchFinder::MatchResult const& Res) override;
+};

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -24,4 +24,13 @@
 #  error No known always_inline attribute for this platform.
 #endif
 
+#if defined(__clang__)
+#  if __has_attribute(annotate)
+#    define USE_OBSERVER(X) [[clang::annotate("observer:" #X)]]
+#  endif
+#endif
+#ifndef USE_OBSERVER
+#  define USE_OBSERVER(X)
+#endif
+
 #endif // BITCOIN_ATTRIBUTES_H

--- a/src/bench/blockencodings.cpp
+++ b/src/bench/blockencodings.cpp
@@ -99,7 +99,7 @@ static void BlockEncodingBench(benchmark::Bench& bench, size_t n_pool, size_t n_
     std::shuffle(refs.begin(), refs.end(), rng);
 
     for (size_t i = 0; i < n_pool; ++i) {
-        AddTx(refs[i], /*fee=*/refs[i]->vout[0].nValue, pool);
+        AddTx(refs[i], /*fee=*/refs[i]->GetOutputs()[0].nValue, pool);
     }
     for (size_t i = n_pool; i < n_pool + n_extra; ++i) {
         extratxn.emplace_back(refs[i]->GetWitnessHash(), refs[i]);

--- a/src/bench/blockencodings.cpp
+++ b/src/bench/blockencodings.cpp
@@ -97,7 +97,7 @@ static void BlockEncodingBench(benchmark::Bench& bench, size_t n_pool, size_t n_
     std::shuffle(refs.begin(), refs.end(), rng);
 
     for (size_t i = 0; i < n_pool; ++i) {
-        AddTx(refs[i], /*fee=*/refs[i]->vout[0].nValue, pool);
+        AddTx(refs[i], /*fee=*/refs[i]->GetOutputs()[0].nValue, pool);
     }
     for (size_t i = n_pool; i < n_pool + n_extra; ++i) {
         extratxn.emplace_back(refs[i]->GetWitnessHash(), refs[i]);

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -76,7 +76,7 @@ static void CoinSelection(benchmark::Bench& bench)
     // Create coins from the amounts assigning them various output types
     wallet::CoinsResult available_coins;
     for (const auto& wtx : wtxs) {
-        const auto txout = wtx->GetTx()->vout.at(0);
+        const auto txout = wtx->GetTx()->GetOutputs().at(0);
         OutputType outtype;
         int input_bytes;
         int y{det_rand.randrange(100)};

--- a/src/bench/mempool_ephemeral_spends.cpp
+++ b/src/bench/mempool_ephemeral_spends.cpp
@@ -73,7 +73,7 @@ static void MempoolCheckEphemeralSpends(benchmark::Bench& bench)
     const CTransactionRef tx2_r{MakeTransactionRef(tx2)};
 
     AddTx(tx1_r, pool);
-    assert(tx2_r->vin.back().prevout == COutPoint(parent_txid, tx1_r->vout.size() - 1));
+    assert(tx2_r->GetInputs().back().prevout == COutPoint(parent_txid, tx1_r->GetOutputs().size() - 1));
 
     uint32_t iteration{0};
 

--- a/src/bench/mempool_ephemeral_spends.cpp
+++ b/src/bench/mempool_ephemeral_spends.cpp
@@ -71,7 +71,7 @@ static void MempoolCheckEphemeralSpends(benchmark::Bench& bench)
     const CTransactionRef tx2_r{MakeTransactionRef(tx2)};
 
     AddTx(tx1_r, pool);
-    assert(tx2_r->vin.back().prevout == COutPoint(parent_txid, tx1_r->vout.size() - 1));
+    assert(tx2_r->GetInputs().back().prevout == COutPoint(parent_txid, tx1_r->GetOutputs().size() - 1));
 
     uint32_t iteration{0};
 

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -70,14 +70,14 @@ static std::vector<CTransactionRef> CreateCoinCluster(FastRandomContext& det_ran
             // biased towards taking min_ancestors parents, but maybe more
             size_t n_to_take = det_rand.randrange(2) == 0 ?
                                min_ancestors :
-                               min_ancestors + det_rand.randrange(coin.ref->vout.size() - coin.vin_left);
+                               min_ancestors + det_rand.randrange(coin.ref->GetOutputs().size() - coin.vin_left);
             for (size_t i = 0; i < n_to_take; ++i) {
                 tx.vin.emplace_back();
                 tx.vin.back().prevout = COutPoint(hash, coin.vin_left++);
                 tx.vin.back().scriptSig = CScript() << coin.tx_count;
                 tx.vin.back().scriptWitness.stack.push_back(CScriptNum(coin.tx_count).getvch());
             }
-            if (coin.vin_left == coin.ref->vin.size()) {
+            if (coin.vin_left == coin.ref->GetInputs().size()) {
                 coin = available_coins.back();
                 available_coins.pop_back();
             }

--- a/src/bench/txorphanage.cpp
+++ b/src/bench/txorphanage.cpp
@@ -222,7 +222,7 @@ static void OrphanageEraseAll(benchmark::Bench& bench, bool block_or_disconnect)
 
             // Note that we shouldn't be able to hit the weight limit with these small transactions.
             const int64_t weight_limit{std::min<int64_t>(weight_left_for_peer, MAX_STANDARD_TX_WEIGHT)};
-            auto ptx = MakeTransactionSpendingUpTo(block_tx->vin, /*start_input=*/start_input, /*num_inputs=*/INPUTS_PER_TX, /*weight_limit=*/weight_limit);
+            auto ptx = MakeTransactionSpendingUpTo(block_tx->GetInputs(), /*start_input=*/start_input, /*num_inputs=*/INPUTS_PER_TX, /*weight_limit=*/weight_limit);
 
             assert(GetTransactionWeight(*ptx) <= MAX_STANDARD_TX_WEIGHT);
             assert(!orphanage->HaveTx(ptx->GetWitnessHash()));

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -190,7 +190,7 @@ static GCSFilter::ElementSet BasicFilterElements(const CBlock& block,
     GCSFilter::ElementSet elements;
 
     for (const CTransactionRef& tx : block.vtx) {
-        for (const CTxOut& txout : tx->vout) {
+        for (const CTxOut& txout : tx->GetOutputs()) {
             const CScript& script = txout.scriptPubKey;
             if (script.empty() || script[0] == OP_RETURN) continue;
             elements.emplace(script.begin(), script.end());

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -133,11 +133,11 @@ void CCoinsViewCache::EmplaceCoinInternalDANGER(const COutPoint& outpoint, Coin&
 void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool check_for_overwrite) {
     bool fCoinbase = tx.IsCoinBase();
     const Txid& txid = tx.GetHash();
-    for (size_t i = 0; i < tx.vout.size(); ++i) {
+    for (size_t i = 0; i < tx.GetOutputs().size(); ++i) {
         bool overwrite = check_for_overwrite ? cache.HaveCoin(COutPoint(txid, i)) : fCoinbase;
         // Coinbase transactions can always be overwritten, in order to correctly
         // deal with the pre-BIP30 occurrences of duplicate coinbase transactions.
-        cache.AddCoin(COutPoint(txid, i), Coin(tx.vout[i], nHeight, fCoinbase), overwrite);
+        cache.AddCoin(COutPoint(txid, i), Coin(tx.GetOutputs()[i], nHeight, fCoinbase), overwrite);
     }
 }
 
@@ -322,8 +322,8 @@ unsigned int CCoinsViewCache::GetCacheSize() const {
 bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
 {
     if (!tx.IsCoinBase()) {
-        for (unsigned int i = 0; i < tx.vin.size(); i++) {
-            if (!HaveCoin(tx.vin[i].prevout)) {
+        for (unsigned int i = 0; i < tx.GetInputs().size(); i++) {
+            if (!HaveCoin(tx.GetInputs()[i].prevout)) {
                 return false;
             }
         }
@@ -386,7 +386,7 @@ CCoinsViewCache::ResetGuard CoinsViewOverlay::StartFetching(const CBlock& block 
         std::unordered_set<Txid, SaltedCoinsCacheHasher> earlier_txids;
         earlier_txids.reserve(block.vtx.size());
         for (const auto& tx : block.vtx | std::views::drop(1)) {
-            for (const auto& input : tx->vin) {
+            for (const auto& input : tx->GetInputs()) {
                 if (!earlier_txids.contains(input.prevout.hash)) m_inputs.emplace_back(input.prevout);
             }
             earlier_txids.emplace(tx->GetHash());

--- a/src/common/bloom.cpp
+++ b/src/common/bloom.cpp
@@ -102,9 +102,9 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (contains(hash.ToUint256()))
         fFound = true;
 
-    for (unsigned int i = 0; i < tx.vout.size(); i++)
+    for (unsigned int i = 0; i < tx.GetOutputs().size(); i++)
     {
-        const CTxOut& txout = tx.vout[i];
+        const CTxOut& txout = tx.GetOutputs()[i];
         // Match if the filter contains any arbitrary script data element in any scriptPubKey in tx
         // If this matches, also add the specific output that was matched.
         // This means clients don't have to update the filter themselves when a new relevant tx
@@ -137,7 +137,7 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (fFound)
         return true;
 
-    for (const CTxIn& txin : tx.vin)
+    for (const CTxIn& txin : tx.GetInputs())
     {
         // Match if the filter contains an outpoint tx spends
         if (contains(txin.prevout))

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -19,9 +19,9 @@
 bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
 {
     // Basic checks that don't depend on any context
-    if (tx.vin.empty())
+    if (tx.GetInputs().empty())
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-vin-empty");
-    if (tx.vout.empty())
+    if (tx.GetOutputs().empty())
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-empty");
     // Size limits (this doesn't take the witness into account, as that hasn't been checked for malleability)
     if (::GetSerializeSize(TX_NO_WITNESS(tx)) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT) {
@@ -30,7 +30,7 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
 
     // Check for negative or overflow output values (see CVE-2010-5139)
     CAmount nValueOut = 0;
-    for (const auto& txout : tx.vout)
+    for (const auto& txout : tx.GetOutputs())
     {
         if (txout.nValue < 0)
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-negative");
@@ -47,19 +47,19 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
     // Failure to run this check will result in either a crash or an inflation bug, depending on the implementation of
     // the underlying coins database.
     std::set<COutPoint> vInOutPoints;
-    for (const auto& txin : tx.vin) {
+    for (const auto& txin : tx.GetInputs()) {
         if (!vInOutPoints.insert(txin.prevout).second)
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
     }
 
     if (tx.IsCoinBase())
     {
-        if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
+        if (tx.GetInputs()[0].scriptSig.size() < 2 || tx.GetInputs()[0].scriptSig.size() > 100)
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cb-length");
     }
     else
     {
-        for (const auto& txin : tx.vin)
+        for (const auto& txin : tx.GetInputs())
             if (txin.prevout.IsNull())
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-prevout-null");
     }

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -22,9 +22,9 @@
 
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
 {
-    if (tx.nLockTime == 0)
+    if (tx.GetLockTime() == 0)
         return true;
-    if ((int64_t)tx.nLockTime < ((int64_t)tx.nLockTime < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
+    if ((int64_t)tx.GetLockTime() < ((int64_t)tx.GetLockTime() < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
         return true;
 
     // Even if tx.nLockTime isn't satisfied by nBlockHeight/nBlockTime, a
@@ -35,7 +35,7 @@ bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
     // also check that the spending input's nSequence != SEQUENCE_FINAL,
     // ensuring that an unsatisfied nLockTime value will actually cause
     // IsFinalTx() to return false here:
-    for (const auto& txin : tx.vin) {
+    for (const auto& txin : tx.GetInputs()) {
         if (!(txin.nSequence == CTxIn::SEQUENCE_FINAL))
             return false;
     }
@@ -44,7 +44,7 @@ bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
 
 std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx, int flags, std::vector<int>& prevHeights, const CBlockIndex& block)
 {
-    assert(prevHeights.size() == tx.vin.size());
+    assert(prevHeights.size() == tx.GetInputs().size());
 
     // Will be set to the equivalent height- and time-based nLockTime
     // values that would be necessary to satisfy all relative lock-
@@ -54,7 +54,7 @@ std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx, int flags
     int nMinHeight = -1;
     int64_t nMinTime = -1;
 
-    bool fEnforceBIP68 = tx.version >= 2 && flags & LOCKTIME_VERIFY_SEQUENCE;
+    bool fEnforceBIP68 = tx.GetVersion() >= 2 && flags & LOCKTIME_VERIFY_SEQUENCE;
 
     // Do not enforce sequence numbers as a relative lock time
     // unless we have been instructed to
@@ -62,8 +62,8 @@ std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx, int flags
         return std::make_pair(nMinHeight, nMinTime);
     }
 
-    for (size_t txinIndex = 0; txinIndex < tx.vin.size(); txinIndex++) {
-        const CTxIn& txin = tx.vin[txinIndex];
+    for (size_t txinIndex = 0; txinIndex < tx.GetInputs().size(); txinIndex++) {
+        const CTxIn& txin = tx.GetInputs()[txinIndex];
 
         // Sequence numbers with the most significant bit set are not
         // treated as relative lock-times, nor are they given any
@@ -118,11 +118,11 @@ bool SequenceLocks(const CTransaction &tx, int flags, std::vector<int>& prevHeig
 unsigned int GetLegacySigOpCount(const CTransaction& tx)
 {
     unsigned int nSigOps = 0;
-    for (const auto& txin : tx.vin)
+    for (const auto& txin : tx.GetInputs())
     {
         nSigOps += txin.scriptSig.GetSigOpCount(false);
     }
-    for (const auto& txout : tx.vout)
+    for (const auto& txout : tx.GetOutputs())
     {
         nSigOps += txout.scriptPubKey.GetSigOpCount(false);
     }
@@ -135,13 +135,13 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& in
         return 0;
 
     unsigned int nSigOps = 0;
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++)
     {
-        const Coin& coin = inputs.AccessCoin(tx.vin[i].prevout);
+        const Coin& coin = inputs.AccessCoin(tx.GetInputs()[i].prevout);
         assert(!coin.IsSpent());
         const CTxOut &prevout = coin.out;
         if (prevout.scriptPubKey.IsPayToScriptHash())
-            nSigOps += prevout.scriptPubKey.GetSigOpCount(tx.vin[i].scriptSig);
+            nSigOps += prevout.scriptPubKey.GetSigOpCount(tx.GetInputs()[i].scriptSig);
     }
     return nSigOps;
 }
@@ -157,12 +157,12 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
         nSigOps += GetP2SHSigOpCount(tx, inputs) * WITNESS_SCALE_FACTOR;
     }
 
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++)
     {
-        const Coin& coin = inputs.AccessCoin(tx.vin[i].prevout);
+        const Coin& coin = inputs.AccessCoin(tx.GetInputs()[i].prevout);
         assert(!coin.IsSpent());
         const CTxOut &prevout = coin.out;
-        nSigOps += CountWitnessSigOps(tx.vin[i].scriptSig, prevout.scriptPubKey, tx.vin[i].scriptWitness, flags);
+        nSigOps += CountWitnessSigOps(tx.GetInputs()[i].scriptSig, prevout.scriptPubKey, tx.GetInputs()[i].scriptWitness, flags);
     }
     return nSigOps;
 }
@@ -176,8 +176,8 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
     }
 
     CAmount nValueIn = 0;
-    for (unsigned int i = 0; i < tx.vin.size(); ++i) {
-        const COutPoint &prevout = tx.vin[i].prevout;
+    for (unsigned int i = 0; i < tx.GetInputs().size(); ++i) {
+        const COutPoint &prevout = tx.GetInputs()[i].prevout;
         const Coin& coin = inputs.AccessCoin(prevout);
         assert(!coin.IsSpent());
 

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -156,8 +156,8 @@ inline int GetWitnessCommitmentIndex(const CBlock& block)
 {
     int commitpos = NO_WITNESS_COMMITMENT;
     if (!block.vtx.empty()) {
-        for (size_t o = 0; o < block.vtx[0]->vout.size(); o++) {
-            const CTxOut& vout = block.vtx[0]->vout[o];
+        for (size_t o = 0; o < block.vtx[0]->GetOutputs().size(); o++) {
+            const CTxOut& vout = block.vtx[0]->GetOutputs()[o];
             if (vout.scriptPubKey.size() >= MINIMUM_WITNESS_COMMITMENT &&
                 vout.scriptPubKey[0] == OP_RETURN &&
                 vout.scriptPubKey[1] == 0x24 &&

--- a/src/core_io.cpp
+++ b/src/core_io.cpp
@@ -431,14 +431,14 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
 
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("hash", tx.GetWitnessHash().GetHex());
-    entry.pushKV("version", tx.version);
+    entry.pushKV("version", tx.GetVersion());
     entry.pushKV("size", tx.ComputeTotalSize());
     entry.pushKV("vsize", (GetTransactionWeight(tx) + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR);
     entry.pushKV("weight", GetTransactionWeight(tx));
-    entry.pushKV("locktime", tx.nLockTime);
+    entry.pushKV("locktime", tx.GetLockTime());
 
     UniValue vin{UniValue::VARR};
-    vin.reserve(tx.vin.size());
+    vin.reserve(tx.GetInputs().size());
 
     // If available, use Undo data to calculate the fee. Note that txundo == nullptr
     // for coinbase transactions and for transactions where undo data is unavailable.
@@ -446,8 +446,8 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
     CAmount amt_total_in = 0;
     CAmount amt_total_out = 0;
 
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        const CTxIn& txin = tx.vin[i];
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++) {
+        const CTxIn& txin = tx.GetInputs()[i];
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase()) {
             in.pushKV("coinbase", HexStr(txin.scriptSig));
@@ -459,10 +459,10 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
             o.pushKV("hex", HexStr(txin.scriptSig));
             in.pushKV("scriptSig", std::move(o));
         }
-        if (!tx.vin[i].scriptWitness.IsNull()) {
+        if (!tx.GetInputs()[i].scriptWitness.IsNull()) {
             UniValue txinwitness(UniValue::VARR);
-            txinwitness.reserve(tx.vin[i].scriptWitness.stack.size());
-            for (const auto& item : tx.vin[i].scriptWitness.stack) {
+            txinwitness.reserve(tx.GetInputs()[i].scriptWitness.stack.size());
+            for (const auto& item : tx.GetInputs()[i].scriptWitness.stack) {
                 txinwitness.push_back(HexStr(item));
             }
             in.pushKV("txinwitness", std::move(txinwitness));
@@ -491,9 +491,9 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
     entry.pushKV("vin", std::move(vin));
 
     UniValue vout(UniValue::VARR);
-    vout.reserve(tx.vout.size());
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
-        const CTxOut& txout = tx.vout[i];
+    vout.reserve(tx.GetOutputs().size());
+    for (unsigned int i = 0; i < tx.GetOutputs().size(); i++) {
+        const CTxOut& txout = tx.GetOutputs()[i];
 
         UniValue out(UniValue::VOBJ);
 

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -30,11 +30,11 @@ static inline size_t RecursiveDynamicUsage(const CTxOut& out) {
 }
 
 static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
-    size_t mem = memusage::DynamicUsage(tx.vin) + memusage::DynamicUsage(tx.vout);
-    for (std::vector<CTxIn>::const_iterator it = tx.vin.begin(); it != tx.vin.end(); it++) {
+    size_t mem = memusage::DynamicUsage(tx.GetInputs()) + memusage::DynamicUsage(tx.GetOutputs());
+    for (std::vector<CTxIn>::const_iterator it = tx.GetInputs().begin(); it != tx.GetInputs().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
-    for (std::vector<CTxOut>::const_iterator it = tx.vout.begin(); it != tx.vout.end(); it++) {
+    for (std::vector<CTxOut>::const_iterator it = tx.GetOutputs().begin(); it != tx.GetOutputs().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
     return mem;

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -131,8 +131,8 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
                 continue;
             }
 
-            for (uint32_t j = 0; j < tx->vout.size(); ++j) {
-                const CTxOut& out{tx->vout[j]};
+            for (uint32_t j = 0; j < tx->GetOutputs().size(); ++j) {
+                const CTxOut& out{tx->GetOutputs()[j]};
                 const Coin coin{out, block.height, is_coinbase};
                 const COutPoint outpoint{tx->GetHash(), j};
 
@@ -161,7 +161,7 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 
                 for (size_t j = 0; j < tx_undo.vprevout.size(); ++j) {
                     const Coin& coin{tx_undo.vprevout[j]};
-                    const COutPoint outpoint{tx->vin[j].prevout.hash, tx->vin[j].prevout.n};
+                    const COutPoint outpoint{tx->GetInputs()[j].prevout.hash, tx->GetInputs()[j].prevout.n};
 
                     RemoveCoinHash(m_muhash, outpoint, coin);
 
@@ -358,8 +358,8 @@ bool CoinStatsIndex::RevertBlock(const interfaces::BlockInfo& block)
             continue;
         }
 
-        for (uint32_t j = 0; j < tx->vout.size(); ++j) {
-            const CTxOut& out{tx->vout[j]};
+        for (uint32_t j = 0; j < tx->GetOutputs().size(); ++j) {
+            const CTxOut& out{tx->GetOutputs()[j]};
             const COutPoint outpoint{tx->GetHash(), j};
             const Coin coin{out, block.height, is_coinbase};
 
@@ -374,7 +374,7 @@ bool CoinStatsIndex::RevertBlock(const interfaces::BlockInfo& block)
 
             for (size_t j = 0; j < tx_undo.vprevout.size(); ++j) {
                 const Coin& coin{tx_undo.vprevout[j]};
-                const COutPoint outpoint{tx->vin[j].prevout.hash, tx->vin[j].prevout.n};
+                const COutPoint outpoint{tx->GetInputs()[j].prevout.hash, tx->GetInputs()[j].prevout.n};
                 ApplyCoinHash(m_muhash, outpoint, coin);
             }
         }

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -118,7 +118,7 @@ static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const
     CDiskTxPos pos({block.file_number, block.data_pos}, GetSizeOfCompactSize(block.data->vtx.size()));
     for (const auto& tx : block.data->vtx) {
         if (!tx->IsCoinBase()) {
-            for (const auto& input : tx->vin) {
+            for (const auto& input : tx->GetInputs()) {
                 items.emplace_back(input.prevout, pos);
             }
         }
@@ -170,7 +170,7 @@ util::Expected<std::optional<TxoSpender>, std::string> TxoSpenderIndex::FindSpen
     // and return it if it does spend the provided outpoint
     for (it->Seek(std::pair{DB_TXOSPENDERINDEX, prefix}); it->Valid() && it->GetKey(key) && key.hash == prefix; it->Next()) {
         if (const auto spender{ReadTransaction(key.pos)}) {
-            for (const auto& input : spender->tx->vin) {
+            for (const auto& input : spender->tx->GetInputs()) {
                 if (input.prevout == txo) {
                     return std::optional{*spender};
                 }

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -523,30 +523,30 @@ btck_Transaction* btck_transaction_create(const void* raw_transaction, size_t ra
 
 size_t btck_transaction_count_outputs(const btck_Transaction* transaction)
 {
-    return btck_Transaction::get(transaction)->vout.size();
+    return btck_Transaction::get(transaction)->GetOutputs().size();
 }
 
 const btck_TransactionOutput* btck_transaction_get_output_at(const btck_Transaction* transaction, size_t output_index)
 {
     const CTransaction& tx = *btck_Transaction::get(transaction);
-    assert(output_index < tx.vout.size());
-    return btck_TransactionOutput::ref(&tx.vout[output_index]);
+    assert(output_index < tx.GetOutputs().size());
+    return btck_TransactionOutput::ref(&tx.GetOutputs()[output_index]);
 }
 
 size_t btck_transaction_count_inputs(const btck_Transaction* transaction)
 {
-    return btck_Transaction::get(transaction)->vin.size();
+    return btck_Transaction::get(transaction)->GetInputs().size();
 }
 
 const btck_TransactionInput* btck_transaction_get_input_at(const btck_Transaction* transaction, size_t input_index)
 {
-    assert(input_index < btck_Transaction::get(transaction)->vin.size());
-    return btck_TransactionInput::ref(&btck_Transaction::get(transaction)->vin[input_index]);
+    assert(input_index < btck_Transaction::get(transaction)->GetInputs().size());
+    return btck_TransactionInput::ref(&btck_Transaction::get(transaction)->GetInputs()[input_index]);
 }
 
 uint32_t btck_transaction_get_locktime(const btck_Transaction* transaction)
 {
-    return btck_Transaction::get(transaction)->nLockTime;
+    return btck_Transaction::get(transaction)->GetLockTime();
 }
 
 const btck_Txid* btck_transaction_get_txid(const btck_Transaction* transaction)
@@ -631,7 +631,7 @@ btck_PrecomputedTransactionData* btck_precomputed_transaction_data_create(
         const CTransaction& tx{*btck_Transaction::get(tx_to)};
         auto txdata{btck_PrecomputedTransactionData::create()};
         if (spent_outputs_ != nullptr && spent_outputs_len > 0) {
-            assert(spent_outputs_len == tx.vin.size());
+            assert(spent_outputs_len == tx.GetInputs().size());
             std::vector<CTxOut> spent_outputs;
             spent_outputs.reserve(spent_outputs_len);
             for (size_t i = 0; i < spent_outputs_len; i++) {
@@ -676,7 +676,7 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
     }
 
     const CTransaction& tx{*btck_Transaction::get(tx_to)};
-    assert(input_index < tx.vin.size());
+    assert(input_index < tx.GetInputs().size());
 
     const PrecomputedTransactionData& txdata{precomputed_txdata ? btck_PrecomputedTransactionData::get(precomputed_txdata) : PrecomputedTransactionData(tx)};
 
@@ -687,9 +687,9 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
 
     if (status) *status = btck_ScriptVerifyStatus_OK;
 
-    bool result = VerifyScript(tx.vin[input_index].scriptSig,
+    bool result = VerifyScript(tx.GetInputs()[input_index].scriptSig,
                                btck_ScriptPubkey::get(script_pubkey),
-                               &tx.vin[input_index].scriptWitness,
+                               &tx.GetInputs()[input_index].scriptWitness,
                                script_verify_flags::from_int(flags),
                                TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
                                nullptr);

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -521,30 +521,30 @@ btck_Transaction* btck_transaction_create(const void* raw_transaction, size_t ra
 
 size_t btck_transaction_count_outputs(const btck_Transaction* transaction)
 {
-    return btck_Transaction::get(transaction)->vout.size();
+    return btck_Transaction::get(transaction)->GetOutputs().size();
 }
 
 const btck_TransactionOutput* btck_transaction_get_output_at(const btck_Transaction* transaction, size_t output_index)
 {
     const CTransaction& tx = *btck_Transaction::get(transaction);
-    assert(output_index < tx.vout.size());
-    return btck_TransactionOutput::ref(&tx.vout[output_index]);
+    assert(output_index < tx.GetOutputs().size());
+    return btck_TransactionOutput::ref(&tx.GetOutputs()[output_index]);
 }
 
 size_t btck_transaction_count_inputs(const btck_Transaction* transaction)
 {
-    return btck_Transaction::get(transaction)->vin.size();
+    return btck_Transaction::get(transaction)->GetInputs().size();
 }
 
 const btck_TransactionInput* btck_transaction_get_input_at(const btck_Transaction* transaction, size_t input_index)
 {
-    assert(input_index < btck_Transaction::get(transaction)->vin.size());
-    return btck_TransactionInput::ref(&btck_Transaction::get(transaction)->vin[input_index]);
+    assert(input_index < btck_Transaction::get(transaction)->GetInputs().size());
+    return btck_TransactionInput::ref(&btck_Transaction::get(transaction)->GetInputs()[input_index]);
 }
 
 uint32_t btck_transaction_get_locktime(const btck_Transaction* transaction)
 {
-    return btck_Transaction::get(transaction)->nLockTime;
+    return btck_Transaction::get(transaction)->GetLockTime();
 }
 
 const btck_Txid* btck_transaction_get_txid(const btck_Transaction* transaction)
@@ -629,7 +629,7 @@ btck_PrecomputedTransactionData* btck_precomputed_transaction_data_create(
         const CTransaction& tx{*btck_Transaction::get(tx_to)};
         auto txdata{btck_PrecomputedTransactionData::create()};
         if (spent_outputs_ != nullptr && spent_outputs_len > 0) {
-            assert(spent_outputs_len == tx.vin.size());
+            assert(spent_outputs_len == tx.GetInputs().size());
             std::vector<CTxOut> spent_outputs;
             spent_outputs.reserve(spent_outputs_len);
             for (size_t i = 0; i < spent_outputs_len; i++) {
@@ -674,7 +674,7 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
     }
 
     const CTransaction& tx{*btck_Transaction::get(tx_to)};
-    assert(input_index < tx.vin.size());
+    assert(input_index < tx.GetInputs().size());
 
     const PrecomputedTransactionData& txdata{precomputed_txdata ? btck_PrecomputedTransactionData::get(precomputed_txdata) : PrecomputedTransactionData(tx)};
 
@@ -685,9 +685,9 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
 
     if (status) *status = btck_ScriptVerifyStatus_OK;
 
-    bool result = VerifyScript(tx.vin[input_index].scriptSig,
+    bool result = VerifyScript(tx.GetInputs()[input_index].scriptSig,
                                btck_ScriptPubkey::get(script_pubkey),
-                               &tx.vin[input_index].scriptWitness,
+                               &tx.GetInputs()[input_index].scriptWitness,
                                script_verify_flags::from_int(flags),
                                TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
                                nullptr);

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -209,15 +209,15 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
 
     const CTransactionRef& final_coinbase{pblock->vtx[0]};
     if (final_coinbase->HasWitness()) {
-        const auto& witness_stack{final_coinbase->vin[0].scriptWitness.stack};
+        const auto& witness_stack{final_coinbase->GetInputs()[0].scriptWitness.stack};
         // Consensus requires the coinbase witness stack to have exactly one
         // element of 32 bytes.
         Assert(witness_stack.size() == 1 && witness_stack[0].size() == 32);
         coinbase_tx.witness = uint256(witness_stack[0]);
     }
     if (const int witness_index = GetWitnessCommitmentIndex(*pblock); witness_index != NO_WITNESS_COMMITMENT) {
-        Assert(witness_index >= 0 && static_cast<size_t>(witness_index) < final_coinbase->vout.size());
-        coinbase_tx.required_outputs.push_back(final_coinbase->vout[witness_index]);
+        Assert(witness_index >= 0 && static_cast<size_t>(witness_index) < final_coinbase->GetOutputs().size());
+        coinbase_tx.required_outputs.push_back(final_coinbase->GetOutputs()[witness_index]);
     }
 
     LogInfo("CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);

--- a/src/node/mini_miner.cpp
+++ b/src/node/mini_miner.cpp
@@ -270,7 +270,7 @@ void MiniMiner::BuildMockTemplate(std::optional<CFeeRate> target_feerate)
                 auto iter = to_process.begin();
                 Assume(iter != to_process.end());
                 ancestors.insert(*iter);
-                for (const auto& input : (*iter)->second.GetTx().vin) {
+                for (const auto& input : (*iter)->second.GetTx().GetInputs()) {
                     if (auto parent_it{m_entries_by_txid.find(input.prevout.hash)}; parent_it != m_entries_by_txid.end()) {
                         if (!ancestors.contains(parent_it)) {
                             to_process.insert(parent_it);
@@ -409,7 +409,7 @@ std::optional<CAmount> MiniMiner::CalculateTotalBumpFees(const CFeeRate& target_
     while (!to_process.empty()) {
         auto iter = to_process.begin();
         const CTransaction& tx = (*iter)->second.GetTx();
-        for (const auto& input : tx.vin) {
+        for (const auto& input : tx.GetInputs()) {
             if (auto parent_it{m_entries_by_txid.find(input.prevout.hash)}; parent_it != m_entries_by_txid.end()) {
                 if (!has_been_processed.contains(input.prevout.hash)) {
                     to_process.insert(parent_it);

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -51,7 +51,7 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
             in_amt += utxo.nValue;
             input_analysis.has_utxo = true;
         } else {
-            if (input.non_witness_utxo && input.prev_out >= input.non_witness_utxo->vout.size()) {
+            if (input.non_witness_utxo && input.prev_out >= input.non_witness_utxo->GetOutputs().size()) {
                 result.SetInvalid(strprintf("PSBT is not valid. Input %u specifies invalid prevout", i));
                 return result;
             }

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -53,7 +53,7 @@ TransactionError BroadcastTransaction(NodeContext& node,
         // If the transaction is already confirmed in the chain, don't do anything
         // and return early.
         CCoinsViewCache &view = node.chainman->ActiveChainstate().CoinsTip();
-        for (size_t o = 0; o < tx->vout.size(); o++) {
+        for (size_t o = 0; o < tx->GetOutputs().size(); o++) {
             const Coin& existingCoin = view.AccessCoin(COutPoint(txid, o));
             // IsSpent doesn't mean the coin is spent, it means the output doesn't exist.
             // So if the output does exist, then this transaction exists in the chain.

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -335,8 +335,8 @@ void TxDownloadManagerImpl::MempoolAcceptedTx(const CTransactionRef& tx)
 std::vector<Txid> TxDownloadManagerImpl::GetUniqueParents(const CTransaction& tx)
 {
     std::vector<Txid> unique_parents;
-    unique_parents.reserve(tx.vin.size());
-    for (const CTxIn& txin : tx.vin) {
+    unique_parents.reserve(tx.GetInputs().size());
+    for (const CTxIn& txin : tx.GetInputs()) {
         // We start with all parents, and then remove duplicates below.
         unique_parents.push_back(txin.prevout.hash);
     }

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -338,8 +338,8 @@ void TxDownloadManagerImpl::MempoolAcceptedTx(const CTransactionRef& tx)
 std::vector<Txid> TxDownloadManagerImpl::GetUniqueParents(const CTransaction& tx)
 {
     std::vector<Txid> unique_parents;
-    unique_parents.reserve(tx.vin.size());
-    for (const CTxIn& txin : tx.vin) {
+    unique_parents.reserve(tx.GetInputs().size());
+    for (const CTxIn& txin : tx.GetInputs()) {
         // We start with all parents, and then remove duplicates below.
         unique_parents.push_back(txin.prevout.hash);
     }

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -64,7 +64,7 @@ class TxOrphanageImpl final : public TxOrphanage {
          * small number of inputs (9 or fewer) are counted as 1 to make it easier to reason about each peer's limits in
          * terms of "normal" transactions. */
         TxOrphanage::Count GetLatencyScore() const {
-            return 1 + (m_tx->vin.size() / 10);
+            return 1 + (m_tx->GetInputs().size() / 10);
         }
     };
 
@@ -253,7 +253,7 @@ void TxOrphanageImpl::Erase(Iter<Tag> it)
 
         // Remove references in m_outpoint_to_orphan_wtxids
         const auto& wtxid{it->m_tx->GetWitnessHash()};
-        for (const auto& input : it->m_tx->vin) {
+        for (const auto& input : it->m_tx->GetInputs()) {
             auto it_prev = m_outpoint_to_orphan_wtxids.find(input.prevout);
             if (it_prev != m_outpoint_to_orphan_wtxids.end()) {
                 it_prev->second.erase(wtxid);
@@ -329,7 +329,7 @@ bool TxOrphanageImpl::AddTx(const CTransactionRef& tx, NodeId peer)
 
     // Add links in m_outpoint_to_orphan_wtxids
     if (brand_new) {
-        for (const auto& input : tx->vin) {
+        for (const auto& input : tx->GetInputs()) {
             auto& wtxids_for_prevout = m_outpoint_to_orphan_wtxids.try_emplace(input.prevout).first->second;
             wtxids_for_prevout.emplace(wtxid);
         }
@@ -533,7 +533,7 @@ std::vector<std::pair<Wtxid, NodeId>> TxOrphanageImpl::AddChildrenToWorkSet(cons
 {
     std::vector<std::pair<Wtxid, NodeId>> ret;
     auto& index_by_wtxid = m_orphans.get<ByWtxid>();
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
+    for (unsigned int i = 0; i < tx.GetOutputs().size(); i++) {
         const auto it_by_prev = m_outpoint_to_orphan_wtxids.find(COutPoint(tx.GetHash(), i));
         if (it_by_prev != m_outpoint_to_orphan_wtxids.end()) {
             for (const auto& wtxid : it_by_prev->second) {
@@ -621,7 +621,7 @@ void TxOrphanageImpl::EraseForBlock(const CBlock& block)
         const CTransaction& block_tx = *ptx;
 
         // Which orphan pool entries must we evict?
-        for (const auto& input : block_tx.vin) {
+        for (const auto& input : block_tx.GetInputs()) {
             auto it_prev = m_outpoint_to_orphan_wtxids.find(input.prevout);
             if (it_prev != m_outpoint_to_orphan_wtxids.end()) {
                 // Copy all wtxids to wtxids_to_erase.
@@ -664,7 +664,7 @@ std::vector<CTransactionRef> TxOrphanageImpl::GetChildrenFromSamePeer(const CTra
         --it_upper;
         if (!Assume(it_upper->m_announcer == peer)) break;
         // Check if this tx spends from parent.
-        for (const auto& input : it_upper->m_tx->vin) {
+        for (const auto& input : it_upper->m_tx->GetInputs()) {
             if (input.prevout.hash == parent_txid) {
                 children_found.emplace_back(it_upper->m_tx);
                 break;
@@ -705,7 +705,7 @@ void TxOrphanageImpl::SanityCheck() const
     std::set<Wtxid> reconstructed_reconsiderable_wtxids;
 
     for (auto it = m_orphans.begin(); it != m_orphans.end(); ++it) {
-        for (const auto& input : it->m_tx->vin) {
+        for (const auto& input : it->m_tx->GetInputs()) {
             all_outpoints.insert(input.prevout);
         }
         unique_wtxids_to_scores.emplace(it->m_tx->GetWitnessHash(), std::make_pair(it->GetMemUsage(), it->GetLatencyScore() - 1));

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -64,7 +64,7 @@ class TxOrphanageImpl final : public TxOrphanage {
          * small number of inputs (9 or fewer) are counted as 1 to make it easier to reason about each peer's limits in
          * terms of "normal" transactions. */
         TxOrphanage::Count GetLatencyScore() const {
-            return 1 + (m_tx->vin.size() / 10);
+            return 1 + (m_tx->GetInputs().size() / 10);
         }
     };
 
@@ -253,7 +253,7 @@ void TxOrphanageImpl::Erase(Iter<Tag> it)
 
         // Remove references in m_outpoint_to_orphan_wtxids
         const auto& wtxid{it->m_tx->GetWitnessHash()};
-        for (const auto& input : it->m_tx->vin) {
+        for (const auto& input : it->m_tx->GetInputs()) {
             auto it_prev = m_outpoint_to_orphan_wtxids.find(input.prevout);
             if (it_prev != m_outpoint_to_orphan_wtxids.end()) {
                 it_prev->second.erase(wtxid);
@@ -329,7 +329,7 @@ bool TxOrphanageImpl::AddTx(const CTransactionRef& tx, NodeId peer)
 
     // Add links in m_outpoint_to_orphan_wtxids
     if (brand_new) {
-        for (const auto& input : tx->vin) {
+        for (const auto& input : tx->GetInputs()) {
             auto& wtxids_for_prevout = m_outpoint_to_orphan_wtxids.try_emplace(input.prevout).first->second;
             wtxids_for_prevout.emplace(wtxid);
         }
@@ -535,7 +535,7 @@ std::vector<std::pair<Wtxid, NodeId>> TxOrphanageImpl::AddChildrenToWorkSet(cons
 
     std::vector<std::pair<Wtxid, NodeId>> ret;
     auto& index_by_wtxid = m_orphans.get<ByWtxid>();
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
+    for (unsigned int i = 0; i < tx.GetOutputs().size(); i++) {
         const auto it_by_prev = m_outpoint_to_orphan_wtxids.find(COutPoint(tx.GetHash(), i));
         if (it_by_prev != m_outpoint_to_orphan_wtxids.end()) {
             for (const auto& wtxid : it_by_prev->second) {
@@ -623,7 +623,7 @@ void TxOrphanageImpl::EraseForBlock(const CBlock& block)
         const CTransaction& block_tx = *ptx;
 
         // Which orphan pool entries must we evict?
-        for (const auto& input : block_tx.vin) {
+        for (const auto& input : block_tx.GetInputs()) {
             auto it_prev = m_outpoint_to_orphan_wtxids.find(input.prevout);
             if (it_prev != m_outpoint_to_orphan_wtxids.end()) {
                 // Copy all wtxids to wtxids_to_erase.
@@ -666,7 +666,7 @@ std::vector<CTransactionRef> TxOrphanageImpl::GetChildrenFromSamePeer(const CTra
         --it_upper;
         if (!Assume(it_upper->m_announcer == peer)) break;
         // Check if this tx spends from parent.
-        for (const auto& input : it_upper->m_tx->vin) {
+        for (const auto& input : it_upper->m_tx->GetInputs()) {
             if (input.prevout.hash == parent_txid) {
                 children_found.emplace_back(it_upper->m_tx);
                 break;
@@ -707,7 +707,7 @@ void TxOrphanageImpl::SanityCheck() const
     std::set<Wtxid> reconstructed_reconsiderable_wtxids;
 
     for (auto it = m_orphans.begin(); it != m_orphans.end(); ++it) {
-        for (const auto& input : it->m_tx->vin) {
+        for (const auto& input : it->m_tx->GetInputs()) {
             all_outpoints.insert(input.prevout);
         }
         unique_wtxids_to_scores.emplace(it->m_tx->GetWitnessHash(), std::make_pair(it->GetMemUsage(), it->GetLatencyScore() - 1));

--- a/src/policy/ephemeral_policy.cpp
+++ b/src/policy/ephemeral_policy.cpp
@@ -46,7 +46,7 @@ bool CheckEphemeralSpends(const Package& package, CFeeRate dust_relay_rate, cons
         std::unordered_set<Txid, SaltedTxidHasher> processed_parent_set;
         std::unordered_set<COutPoint, SaltedOutpointHasher> unspent_parent_dust;
 
-        for (const auto& tx_input : tx->vin) {
+        for (const auto& tx_input : tx->GetInputs()) {
             const Txid& parent_txid{tx_input.prevout.hash};
             // Skip parents we've already checked dust for
             if (processed_parent_set.contains(parent_txid)) continue;
@@ -61,8 +61,8 @@ bool CheckEphemeralSpends(const Package& package, CFeeRate dust_relay_rate, cons
 
             // Check for dust on parents
             if (parent_ref) {
-                for (uint32_t out_index = 0; out_index < parent_ref->vout.size(); out_index++) {
-                    const auto& tx_output = parent_ref->vout[out_index];
+                for (uint32_t out_index = 0; out_index < parent_ref->GetOutputs().size(); out_index++) {
+                    const auto& tx_output = parent_ref->GetOutputs()[out_index];
                     if (IsDust(tx_output, dust_relay_rate)) {
                         unspent_parent_dust.insert(COutPoint(parent_txid, out_index));
                     }
@@ -78,7 +78,7 @@ bool CheckEphemeralSpends(const Package& package, CFeeRate dust_relay_rate, cons
 
         // Now that we have gathered parents' dust, make sure it's spent
         // by the child
-        for (const auto& tx_input : tx->vin) {
+        for (const auto& tx_input : tx->GetInputs()) {
             unspent_parent_dust.erase(tx_input.prevout);
         }
 

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -25,7 +25,7 @@ bool IsTopoSortedPackage(const Package& txns, std::unordered_set<Txid, SaltedTxi
     // txns. If any transaction's input spends a tx in that set, we've found a parent placed later
     // than its child.
     for (const auto& tx : txns) {
-        for (const auto& input : tx->vin) {
+        for (const auto& input : tx->GetInputs()) {
             if (later_txids.contains(input.prevout.hash)) {
                 // The parent is a subsequent transaction in the package.
                 return false;
@@ -54,14 +54,14 @@ bool IsConsistentPackage(const Package& txns)
     // Don't allow any conflicting transactions, i.e. spending the same inputs, in a package.
     std::unordered_set<COutPoint, SaltedOutpointHasher> inputs_seen;
     for (const auto& tx : txns) {
-        if (tx->vin.empty()) {
+        if (tx->GetInputs().empty()) {
             // This function checks consistency based on inputs, and we can't do that if there are
             // no inputs. Duplicate empty transactions are also not consistent with one another.
             // This doesn't create false negatives, as unconfirmed transactions are not allowed to
             // have no inputs.
             return false;
         }
-        for (const auto& input : tx->vin) {
+        for (const auto& input : tx->GetInputs()) {
             if (inputs_seen.contains(input.prevout)) {
                 // This input is also present in another tx in the package.
                 return false;
@@ -70,7 +70,7 @@ bool IsConsistentPackage(const Package& txns)
         // Batch-add all the inputs for a tx at a time. If we added them 1 at a time, we could
         // catch duplicate inputs within a single tx.  This is a more severe, consensus error,
         // and we want to report that from CheckTransaction instead.
-        std::transform(tx->vin.cbegin(), tx->vin.cend(), std::inserter(inputs_seen, inputs_seen.end()),
+        std::transform(tx->GetInputs().cbegin(), tx->GetInputs().cend(), std::inserter(inputs_seen, inputs_seen.end()),
                        [](const auto& input) { return input.prevout; });
     }
     return true;
@@ -124,7 +124,7 @@ bool IsChildWithParents(const Package& package)
     // The package is expected to be sorted, so the last transaction is the child.
     const auto& child = package.back();
     std::unordered_set<Txid, SaltedTxidHasher> input_txids;
-    std::transform(child->vin.cbegin(), child->vin.cend(),
+    std::transform(child->GetInputs().cbegin(), child->GetInputs().cend(),
                    std::inserter(input_txids, input_txids.end()),
                    [](const auto& input) { return input.prevout.hash; });
 
@@ -141,7 +141,7 @@ bool IsChildWithParentsTree(const Package& package)
                    [](const auto& ptx) { return ptx->GetHash(); });
     // Each parent must not have an input who is one of the other parents.
     return std::all_of(package.cbegin(), package.cend() - 1, [&](const auto& ptx) {
-        for (const auto& input : ptx->vin) {
+        for (const auto& input : ptx->GetInputs()) {
             if (parent_txids.contains(input.prevout.hash)) return false;
         }
         return true;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -71,8 +71,8 @@ bool IsDust(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
 std::vector<uint32_t> GetDust(const CTransaction& tx, CFeeRate dust_relay_rate)
 {
     std::vector<uint32_t> dust_outputs;
-    for (uint32_t i{0}; i < tx.vout.size(); ++i) {
-        if (IsDust(tx.vout[i], dust_relay_rate)) dust_outputs.push_back(i);
+    for (uint32_t i{0}; i < tx.GetOutputs().size(); ++i) {
+        if (IsDust(tx.GetOutputs()[i], dust_relay_rate)) dust_outputs.push_back(i);
     }
     return dust_outputs;
 }
@@ -99,7 +99,7 @@ bool IsStandard(const CScript& scriptPubKey, TxoutType& whichType)
 
 bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason)
 {
-    if (tx.version > TX_MAX_STANDARD_VERSION || tx.version < TX_MIN_STANDARD_VERSION) {
+    if (tx.GetVersion() > TX_MAX_STANDARD_VERSION || tx.GetVersion() < TX_MIN_STANDARD_VERSION) {
         reason = "version";
         return false;
     }
@@ -114,7 +114,7 @@ bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_dat
         return false;
     }
 
-    for (const CTxIn& txin : tx.vin)
+    for (const CTxIn& txin : tx.GetInputs())
     {
         // Biggest 'standard' txin involving only keys is a 15-of-15 P2SH
         // multisig with compressed keys (remember the MAX_SCRIPT_ELEMENT_SIZE byte limit on
@@ -136,7 +136,7 @@ bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_dat
 
     unsigned int datacarrier_bytes_left = max_datacarrier_bytes.value_or(0);
     TxoutType whichType;
-    for (const CTxOut& txout : tx.vout) {
+    for (const CTxOut& txout : tx.GetOutputs()) {
         if (!::IsStandard(txout.scriptPubKey, whichType)) {
             reason = "scriptpubkey";
             return false;
@@ -172,7 +172,7 @@ static bool CheckSigopsBIP54(const CTransaction& tx, const CCoinsViewCache& inpu
     Assert(!tx.IsCoinBase());
 
     unsigned int sigops{0};
-    for (const auto& txin: tx.vin) {
+    for (const auto& txin: tx.GetInputs()) {
         const auto& prev_txo{inputs.AccessCoin(txin.prevout).out};
 
         // Unlike the existing block wide sigop limit which counts sigops present in the block
@@ -223,8 +223,8 @@ TxValidationState ValidateInputsStandardness(const CTransaction& tx, const CCoin
         return state;
     }
 
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        const CTxOut& prev = mapInputs.AccessCoin(tx.vin[i].prevout).out;
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++) {
+        const CTxOut& prev = mapInputs.AccessCoin(tx.GetInputs()[i].prevout).out;
 
         std::vector<std::vector<unsigned char> > vSolutions;
         TxoutType whichType = Solver(prev.scriptPubKey, vSolutions);
@@ -242,7 +242,7 @@ TxValidationState ValidateInputsStandardness(const CTransaction& tx, const CCoin
             std::vector<std::vector<unsigned char> > stack;
             ScriptError serror;
             // convert the scriptSig into a stack, so we can inspect the redeemScript
-            if (!EvalScript(stack, tx.vin[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker(), SigVersion::BASE, &serror)) {
+            if (!EvalScript(stack, tx.GetInputs()[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker(), SigVersion::BASE, &serror)) {
                 state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "bad-txns-nonstandard-inputs", strprintf("p2sh scriptsig malformed (input %u: %s)", i, ScriptErrorString(serror)));
                 return state;
             }
@@ -267,14 +267,14 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     if (tx.IsCoinBase())
         return true; // Coinbases are skipped
 
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++)
     {
         // We don't care if witness for this input is empty, since it must not be bloated.
         // If the script is invalid without witness, it would be caught sooner or later during validation.
-        if (tx.vin[i].scriptWitness.IsNull())
+        if (tx.GetInputs()[i].scriptWitness.IsNull())
             continue;
 
-        const CTxOut &prev = mapInputs.AccessCoin(tx.vin[i].prevout).out;
+        const CTxOut &prev = mapInputs.AccessCoin(tx.GetInputs()[i].prevout).out;
 
         // get the scriptPubKey corresponding to this input:
         CScript prevScript = prev.scriptPubKey;
@@ -290,7 +290,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             // If the scriptPubKey is P2SH, we try to extract the redeemScript casually by converting the scriptSig
             // into a stack. We do not check IsPushOnly nor compare the hash as these will be done later anyway.
             // If the check fails at this stage, we know that this txid must be a bad one.
-            if (!EvalScript(stack, tx.vin[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker(), SigVersion::BASE))
+            if (!EvalScript(stack, tx.GetInputs()[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker(), SigVersion::BASE))
                 return false;
             if (stack.empty())
                 return false;
@@ -307,13 +307,13 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 
         // Check P2WSH standard limits
         if (witnessversion == 0 && witnessprogram.size() == WITNESS_V0_SCRIPTHASH_SIZE) {
-            if (tx.vin[i].scriptWitness.stack.back().size() > MAX_STANDARD_P2WSH_SCRIPT_SIZE)
+            if (tx.GetInputs()[i].scriptWitness.stack.back().size() > MAX_STANDARD_P2WSH_SCRIPT_SIZE)
                 return false;
-            size_t sizeWitnessStack = tx.vin[i].scriptWitness.stack.size() - 1;
+            size_t sizeWitnessStack = tx.GetInputs()[i].scriptWitness.stack.size() - 1;
             if (sizeWitnessStack > MAX_STANDARD_P2WSH_STACK_ITEMS)
                 return false;
             for (unsigned int j = 0; j < sizeWitnessStack; j++) {
-                if (tx.vin[i].scriptWitness.stack[j].size() > MAX_STANDARD_P2WSH_STACK_ITEM_SIZE)
+                if (tx.GetInputs()[i].scriptWitness.stack[j].size() > MAX_STANDARD_P2WSH_STACK_ITEM_SIZE)
                     return false;
             }
         }
@@ -323,7 +323,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         // - No annexes
         if (witnessversion == 1 && witnessprogram.size() == WITNESS_V1_TAPROOT_SIZE && !p2sh) {
             // Taproot spend (non-P2SH-wrapped, version 1, witness program size 32; see BIP 341)
-            std::span stack{tx.vin[i].scriptWitness.stack};
+            std::span stack{tx.GetInputs()[i].scriptWitness.stack};
             if (stack.size() >= 2 && !stack.back().empty() && stack.back()[0] == ANNEX_TAG) {
                 // Annexes are nonstandard as long as no semantics are defined for them.
                 return false;
@@ -359,7 +359,7 @@ bool SpendsNonAnchorWitnessProg(const CTransaction& tx, const CCoinsViewCache& p
 
     int version;
     std::vector<uint8_t> program;
-    for (const auto& txin: tx.vin) {
+    for (const auto& txin: tx.GetInputs()) {
         const auto& prev_spk{prevouts.AccessCoin(txin.prevout).out.scriptPubKey};
 
         // Note this includes not-yet-defined witness programs.

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -148,8 +148,8 @@ std::vector<uint32_t> GetDust(const CTransaction& tx, CFeeRate dust_relay_rate);
 // Changing the default transaction version requires a two step process: first
 // adapting relay policy by bumping TX_MAX_STANDARD_VERSION, and then later
 // allowing the new transaction version in the wallet/RPC.
-static constexpr decltype(CTransaction::version) TX_MIN_STANDARD_VERSION{1};
-static constexpr decltype(CTransaction::version) TX_MAX_STANDARD_VERSION{3};
+static constexpr uint32_t TX_MIN_STANDARD_VERSION{1};
+static constexpr uint32_t TX_MAX_STANDARD_VERSION{3};
 
 /**
 * Check for standard transaction types

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -148,8 +148,8 @@ std::vector<uint32_t> GetDust(const CTransaction& tx, CFeeRate dust_relay_rate);
 // Changing the default transaction version requires a two step process: first
 // adapting relay policy by bumping TX_MAX_STANDARD_VERSION, and then later
 // allowing the new transaction version in the wallet/RPC.
-inline constexpr decltype(CTransaction::version) TX_MIN_STANDARD_VERSION{1};
-inline constexpr decltype(CTransaction::version) TX_MAX_STANDARD_VERSION{3};
+inline constexpr uint32_t TX_MIN_STANDARD_VERSION{1};
+inline constexpr uint32_t TX_MAX_STANDARD_VERSION{3};
 
 /**
 * Check for standard transaction types

--- a/src/policy/truc_policy.cpp
+++ b/src/policy/truc_policy.cpp
@@ -43,12 +43,12 @@ struct ParentInfo {
     /** Wtxid used for debug string */
     const Wtxid& m_wtxid;
     /** version used to check inheritance of TRUC and non-TRUC */
-    decltype(CTransaction::version) m_version;
+    uint32_t m_version;
     /** If parent is in mempool, whether it has any descendants in mempool. */
     bool m_has_mempool_descendant;
 
     ParentInfo() = delete;
-    ParentInfo(const Txid& txid, const Wtxid& wtxid, decltype(CTransaction::version) version, bool has_mempool_descendant) :
+    ParentInfo(const Txid& txid, const Wtxid& wtxid, uint32_t version, bool has_mempool_descendant) :
         m_txid{txid}, m_wtxid{wtxid}, m_version{version},
         m_has_mempool_descendant{has_mempool_descendant}
     {}

--- a/src/policy/truc_policy.cpp
+++ b/src/policy/truc_policy.cpp
@@ -20,7 +20,7 @@ std::vector<size_t> FindInPackageParents(const Package& package, const CTransact
     std::vector<size_t> in_package_parents;
 
     std::set<Txid> possible_parents;
-    for (auto &input : ptx->vin) {
+    for (auto &input : ptx->GetInputs()) {
         possible_parents.insert(input.prevout.hash);
     }
 
@@ -66,7 +66,7 @@ std::optional<std::string> PackageTRUCChecks(const CTxMemPool& pool, const CTran
     const auto in_package_parents{FindInPackageParents(package, ptx)};
 
     // Now we have all parents, so we can start checking TRUC rules.
-    if (ptx->version == TRUC_VERSION) {
+    if (ptx->GetVersion() == TRUC_VERSION) {
         // SingleTRUCChecks should have checked this already.
         if (!Assume(vsize <= TRUC_MAX_VSIZE)) {
             return strprintf("version=3 tx %s (wtxid=%s) is too big: %u > %u virtual bytes",
@@ -100,14 +100,14 @@ std::optional<std::string> PackageTRUCChecks(const CTxMemPool& pool, const CTran
                     const auto& mempool_parent = &mempool_parents[0].get();
                     return ParentInfo{mempool_parent->GetTx().GetHash(),
                                       mempool_parent->GetTx().GetWitnessHash(),
-                                      mempool_parent->GetTx().version,
+                                      mempool_parent->GetTx().GetVersion(),
                                       /*has_mempool_descendant=*/pool.GetDescendantCount(*mempool_parent) > 1};
                 } else {
                     auto& parent_index = in_package_parents.front();
                     auto& package_parent = package.at(parent_index);
                     return ParentInfo{package_parent->GetHash(),
                                       package_parent->GetWitnessHash(),
-                                      package_parent->version,
+                                      package_parent->GetVersion(),
                                       /*has_mempool_descendant=*/false};
                 }
             }();
@@ -123,7 +123,7 @@ std::optional<std::string> PackageTRUCChecks(const CTxMemPool& pool, const CTran
                 // Skip same tx.
                 if (&(*package_tx) == &(*ptx)) continue;
 
-                for (auto& input : package_tx->vin) {
+                for (auto& input : package_tx->GetInputs()) {
                     // Fail if we find another tx with the same parent. We don't check whether the
                     // sibling is to-be-replaced (done in SingleTRUCChecks) because these transactions
                     // are within the same package.
@@ -149,14 +149,14 @@ std::optional<std::string> PackageTRUCChecks(const CTxMemPool& pool, const CTran
     } else {
         // Non-TRUC transactions cannot have TRUC parents.
         for (auto it : mempool_parents) {
-            if (it.get().GetTx().version == TRUC_VERSION) {
+            if (it.get().GetTx().GetVersion() == TRUC_VERSION) {
                 return strprintf("non-version=3 tx %s (wtxid=%s) cannot spend from version=3 tx %s (wtxid=%s)",
                                  ptx->GetHash().ToString(), ptx->GetWitnessHash().ToString(),
                                  it.get().GetSharedTx()->GetHash().ToString(), it.get().GetSharedTx()->GetWitnessHash().ToString());
             }
         }
         for (const auto& index: in_package_parents) {
-            if (package.at(index)->version == TRUC_VERSION) {
+            if (package.at(index)->GetVersion() == TRUC_VERSION) {
                 return strprintf("non-version=3 tx %s (wtxid=%s) cannot spend from version=3 tx %s (wtxid=%s)",
                                  ptx->GetHash().ToString(),
                                  ptx->GetWitnessHash().ToString(),
@@ -177,12 +177,12 @@ std::optional<std::pair<std::string, CTransactionRef>> SingleTRUCChecks(const CT
     // Check TRUC and non-TRUC inheritance.
     for (const auto& entry_ref : mempool_parents) {
         const auto& entry = &entry_ref.get();
-        if (ptx->version != TRUC_VERSION && entry->GetTx().version == TRUC_VERSION) {
+        if (ptx->GetVersion() != TRUC_VERSION && entry->GetTx().GetVersion() == TRUC_VERSION) {
             return std::make_pair(strprintf("non-version=3 tx %s (wtxid=%s) cannot spend from version=3 tx %s (wtxid=%s)",
                              ptx->GetHash().ToString(), ptx->GetWitnessHash().ToString(),
                              entry->GetSharedTx()->GetHash().ToString(), entry->GetSharedTx()->GetWitnessHash().ToString()),
                 nullptr);
-        } else if (ptx->version == TRUC_VERSION && entry->GetTx().version != TRUC_VERSION) {
+        } else if (ptx->GetVersion() == TRUC_VERSION && entry->GetTx().GetVersion() != TRUC_VERSION) {
             return std::make_pair(strprintf("version=3 tx %s (wtxid=%s) cannot spend from non-version=3 tx %s (wtxid=%s)",
                              ptx->GetHash().ToString(), ptx->GetWitnessHash().ToString(),
                              entry->GetSharedTx()->GetHash().ToString(), entry->GetSharedTx()->GetWitnessHash().ToString()),
@@ -195,7 +195,7 @@ std::optional<std::pair<std::string, CTransactionRef>> SingleTRUCChecks(const CT
     static_assert(TRUC_DESCENDANT_LIMIT == 2);
 
     // The rest of the rules only apply to transactions with version=3.
-    if (ptx->version != TRUC_VERSION) return std::nullopt;
+    if (ptx->GetVersion() != TRUC_VERSION) return std::nullopt;
 
     if (vsize > TRUC_MAX_VSIZE) {
         return std::make_pair(strprintf("version=3 tx %s (wtxid=%s) is too big: %u > %u virtual bytes",

--- a/src/policy/truc_policy.h
+++ b/src/policy/truc_policy.h
@@ -17,7 +17,7 @@
 
 // This module enforces rules for BIP 431 TRUC transactions which help make
 // RBF abilities more robust. A transaction with version=3 is treated as TRUC.
-static constexpr decltype(CTransaction::version) TRUC_VERSION{3};
+static constexpr uint32_t TRUC_VERSION{3};
 
 // TRUC only allows 1 parent and 1 child when unconfirmed. This translates to a descendant set size
 // of 2 and ancestor set size of 2.

--- a/src/policy/truc_policy.h
+++ b/src/policy/truc_policy.h
@@ -17,7 +17,7 @@
 
 // This module enforces rules for BIP 431 TRUC transactions which help make
 // RBF abilities more robust. A transaction with version=3 is treated as TRUC.
-inline constexpr decltype(CTransaction::version) TRUC_VERSION{3};
+inline constexpr uint32_t TRUC_VERSION{3};
 
 // TRUC only allows 1 parent and 1 child when unconfirmed. This translates to a descendant set size
 // of 2 and ancestor set size of 2.

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -64,7 +64,7 @@ std::string CTxOut::ToString() const
 }
 
 CMutableTransaction::CMutableTransaction() : version{CTransaction::CURRENT_VERSION}, nLockTime{0} {}
-CMutableTransaction::CMutableTransaction(const CTransaction& tx) : vin(tx.vin), vout(tx.vout), version{tx.version}, nLockTime{tx.nLockTime} {}
+CMutableTransaction::CMutableTransaction(const CTransaction& tx) : vin(tx.GetInputs()), vout(tx.GetOutputs()), version{tx.GetVersion()}, nLockTime{tx.GetLockTime()} {}
 
 Txid CMutableTransaction::GetHash() const
 {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -242,7 +242,7 @@ void SerializeTransaction(const TxType& tx, Stream& s, const TransactionSerParam
 {
     const bool fAllowWitness = params.allow_witness;
 
-    s << tx.version;
+    s << tx.GetVersion();
     unsigned char flags = 0;
     // Consistency check
     if (fAllowWitness) {
@@ -257,14 +257,14 @@ void SerializeTransaction(const TxType& tx, Stream& s, const TransactionSerParam
         s << vinDummy;
         s << flags;
     }
-    s << tx.vin;
-    s << tx.vout;
+    s << tx.GetInputs();
+    s << tx.GetOutputs();
     if (flags & 1) {
-        for (size_t i = 0; i < tx.vin.size(); i++) {
-            s << tx.vin[i].scriptWitness.stack;
+        for (size_t i = 0; i < tx.GetInputs().size(); i++) {
+            s << tx.GetInputs()[i].scriptWitness.stack;
         }
     }
-    s << tx.nLockTime;
+    s << tx.GetLockTime();
 }
 
 template<typename TxType>

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -309,6 +309,11 @@ public:
     explicit CTransaction(const CMutableTransaction& tx);
     explicit CTransaction(CMutableTransaction&& tx);
 
+    auto GetVersion() const -> uint32_t { return version; }
+    auto GetInputs() const LIFETIMEBOUND -> const std::vector<CTxIn>& { return vin; }
+    auto GetOutputs() const LIFETIMEBOUND -> const std::vector<CTxOut>& { return vout; }
+    auto GetLockTime() const -> uint32_t { return nLockTime; }
+
     template <typename Stream>
     inline void Serialize(Stream& s) const {
         SerializeTransaction(*this, s, s.template GetParams<TransactionSerParams>());
@@ -363,6 +368,11 @@ struct CMutableTransaction
 
     explicit CMutableTransaction();
     explicit CMutableTransaction(const CTransaction& tx);
+
+    auto GetVersion() const -> uint32_t { return version; }
+    auto GetInputs() const LIFETIMEBOUND -> const std::vector<CTxIn>& { return vin; }
+    auto GetOutputs() const LIFETIMEBOUND -> const std::vector<CTxOut>& { return vout; }
+    auto GetLockTime() const -> uint32_t { return nLockTime; }
 
     template <typename Stream>
     inline void Serialize(Stream& s) const {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -283,31 +283,17 @@ public:
     // Default transaction version.
     static constexpr uint32_t CURRENT_VERSION{2};
 
-    // The local variables are made const to prevent unintended modification
-    // without updating the cached hash value. However, CTransaction is not
-    // actually immutable; deserialization and assignment are implemented,
-    // and bypass the constness. This is safe, as they update the entire
-    // structure, including the hash.
-    USE_OBSERVER(GetInputs) const std::vector<CTxIn> vin;
-    USE_OBSERVER(GetOutputs) const std::vector<CTxOut> vout;
-    USE_OBSERVER(GetVersion) const uint32_t version;
-    USE_OBSERVER(GetLockTime) const uint32_t nLockTime;
-
-private:
-    /** Memory only. */
-    const bool m_has_witness;
-    const Txid hash;
-    const Wtxid m_witness_hash;
-
-    Txid ComputeHash() const;
-    Wtxid ComputeWitnessHash() const;
-
-    bool ComputeHasWitness() const;
-
-public:
     /** Convert a CMutableTransaction into a CTransaction. */
     explicit CTransaction(const CMutableTransaction& tx);
     explicit CTransaction(CMutableTransaction&& tx);
+
+    CTransaction(const CTransaction&) = default;
+
+    // As long as transactions are passed around via `std::shared_ptr<const CTransaction>`,
+    // assignment should be disabled. The footgun is that shared pointer to const can only
+    // prevent modification through that handle. It cannot guarantee that no non-const
+    // alias exists, which would allow spooky action at a distance.
+    CTransaction& operator=(const CTransaction&) = delete;
 
     auto GetVersion() const -> uint32_t { return version; }
     auto GetInputs() const LIFETIMEBOUND -> const std::vector<CTxIn>& { return vin; }
@@ -356,6 +342,21 @@ public:
     std::string ToString() const;
 
     bool HasWitness() const { return m_has_witness; }
+
+private:
+    Txid ComputeHash() const;
+    Wtxid ComputeWitnessHash() const;
+    bool ComputeHasWitness() const;
+
+    std::vector<CTxIn> vin;
+    std::vector<CTxOut> vout;
+    uint32_t version;
+    uint32_t nLockTime;
+
+    /** Memory only. */
+    bool m_has_witness;
+    Txid hash;
+    Wtxid m_witness_hash;
 };
 
 /** A mutable version of CTransaction. */

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -288,10 +288,10 @@ public:
     // actually immutable; deserialization and assignment are implemented,
     // and bypass the constness. This is safe, as they update the entire
     // structure, including the hash.
-    const std::vector<CTxIn> vin;
-    const std::vector<CTxOut> vout;
-    const uint32_t version;
-    const uint32_t nLockTime;
+    USE_OBSERVER(GetInputs) const std::vector<CTxIn> vin;
+    USE_OBSERVER(GetOutputs) const std::vector<CTxOut> vout;
+    USE_OBSERVER(GetVersion) const uint32_t version;
+    USE_OBSERVER(GetLockTime) const uint32_t nLockTime;
 
 private:
     /** Memory only. */

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -269,13 +269,13 @@ bool PartiallySignedTransaction::AddOutput(const PSBTOutput& psbtout)
 bool PSBTInput::GetUTXO(CTxOut& utxo) const
 {
     if (non_witness_utxo) {
-        if (prev_out >= non_witness_utxo->vout.size()) {
+        if (prev_out >= non_witness_utxo->GetOutputs().size()) {
             return false;
         }
         if (non_witness_utxo->GetHash() != prev_txid) {
             return false;
         }
-        utxo = non_witness_utxo->vout[prev_out];
+        utxo = non_witness_utxo->GetOutputs()[prev_out];
     } else if (!witness_utxo.IsNull()) {
         utxo = witness_utxo;
     } else {
@@ -563,13 +563,13 @@ bool PSBTInputSignedAndVerified(const PartiallySignedTransaction& psbt, unsigned
     if (input.non_witness_utxo) {
         // If we're taking our information from a non-witness UTXO, verify that it matches the prevout.
         COutPoint prevout = input.GetOutPoint();
-        if (prevout.n >= input.non_witness_utxo->vout.size()) {
+        if (prevout.n >= input.non_witness_utxo->GetOutputs().size()) {
             return false;
         }
         if (input.non_witness_utxo->GetHash() != prevout.hash) {
             return false;
         }
-        utxo = input.non_witness_utxo->vout[prevout.n];
+        utxo = input.non_witness_utxo->GetOutputs()[prevout.n];
     } else if (!input.witness_utxo.IsNull()) {
         utxo = input.witness_utxo;
     } else {
@@ -668,13 +668,13 @@ PSBTError SignPSBTInput(const SigningProvider& provider, PartiallySignedTransact
     if (input.non_witness_utxo) {
         // If we're taking our information from a non-witness UTXO, verify that it matches the prevout.
         COutPoint prevout = input.GetOutPoint();
-        if (prevout.n >= input.non_witness_utxo->vout.size()) {
+        if (prevout.n >= input.non_witness_utxo->GetOutputs().size()) {
             return PSBTError::MISSING_INPUTS;
         }
         if (input.non_witness_utxo->GetHash() != prevout.hash) {
             return PSBTError::MISSING_INPUTS;
         }
-        utxo = input.non_witness_utxo->vout[prevout.n];
+        utxo = input.non_witness_utxo->GetOutputs()[prevout.n];
     } else if (!input.witness_utxo.IsNull()) {
         utxo = input.witness_utxo;
         // When we're taking our information from a witness UTXO, we can't verify it is actually data from

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -270,13 +270,13 @@ bool PartiallySignedTransaction::AddOutput(const PSBTOutput& psbtout)
 bool PSBTInput::GetUTXO(CTxOut& utxo) const
 {
     if (non_witness_utxo) {
-        if (prev_out >= non_witness_utxo->vout.size()) {
+        if (prev_out >= non_witness_utxo->GetOutputs().size()) {
             return false;
         }
         if (non_witness_utxo->GetHash() != prev_txid) {
             return false;
         }
-        utxo = non_witness_utxo->vout[prev_out];
+        utxo = non_witness_utxo->GetOutputs()[prev_out];
     } else if (!witness_utxo.IsNull()) {
         utxo = witness_utxo;
     } else {
@@ -554,13 +554,13 @@ bool PSBTInputSignedAndVerified(const PartiallySignedTransaction& psbt, unsigned
     if (input.non_witness_utxo) {
         // If we're taking our information from a non-witness UTXO, verify that it matches the prevout.
         COutPoint prevout = input.GetOutPoint();
-        if (prevout.n >= input.non_witness_utxo->vout.size()) {
+        if (prevout.n >= input.non_witness_utxo->GetOutputs().size()) {
             return false;
         }
         if (input.non_witness_utxo->GetHash() != prevout.hash) {
             return false;
         }
-        utxo = input.non_witness_utxo->vout[prevout.n];
+        utxo = input.non_witness_utxo->GetOutputs()[prevout.n];
     } else if (!input.witness_utxo.IsNull()) {
         utxo = input.witness_utxo;
     } else {
@@ -660,13 +660,13 @@ util::Expected<void, PSBTError> SignPSBTInput(const SigningProvider& provider, P
     if (input.non_witness_utxo) {
         // If we're taking our information from a non-witness UTXO, verify that it matches the prevout.
         COutPoint prevout = input.GetOutPoint();
-        if (prevout.n >= input.non_witness_utxo->vout.size()) {
+        if (prevout.n >= input.non_witness_utxo->GetOutputs().size()) {
             return util::Unexpected{PSBTError::MISSING_INPUTS};
         }
         if (input.non_witness_utxo->GetHash() != prevout.hash) {
             return util::Unexpected{PSBTError::MISSING_INPUTS};
         }
-        utxo = input.non_witness_utxo->vout[prevout.n];
+        utxo = input.non_witness_utxo->GetOutputs()[prevout.n];
     } else if (!input.witness_utxo.IsNull()) {
         utxo = input.witness_utxo;
         // When we're taking our information from a witness UTXO, we can't verify it is actually data from

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -1580,14 +1580,14 @@ public:
                     if (input.non_witness_utxo->GetHash() != tx->vin[i].prevout.hash) {
                         throw std::ios_base::failure("Non-witness UTXO does not match outpoint hash");
                     }
-                    if (tx->vin[i].prevout.n >= input.non_witness_utxo->vout.size()) {
+                    if (tx->vin[i].prevout.n >= input.non_witness_utxo->GetOutputs().size()) {
                         throw std::ios_base::failure("Input specifies output index that does not exist");
                     }
                 } else {
                     if (input.non_witness_utxo->GetHash() != input.prev_txid) {
                         throw std::ios_base::failure("Non-witness UTXO does not match outpoint hash");
                     }
-                    if (input.prev_out >= input.non_witness_utxo->vout.size()) {
+                    if (input.prev_out >= input.non_witness_utxo->GetOutputs().size()) {
                         throw std::ios_base::failure("Input specifies output index that does not exist");
                     }
                 }

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -1577,14 +1577,14 @@ public:
                     if (input.non_witness_utxo->GetHash() != tx->vin[i].prevout.hash) {
                         throw std::ios_base::failure("Non-witness UTXO does not match outpoint hash");
                     }
-                    if (tx->vin[i].prevout.n >= input.non_witness_utxo->vout.size()) {
+                    if (tx->vin[i].prevout.n >= input.non_witness_utxo->GetOutputs().size()) {
                         throw std::ios_base::failure("Input specifies output index that does not exist");
                     }
                 } else {
                     if (input.non_witness_utxo->GetHash() != input.prev_txid) {
                         throw std::ios_base::failure("Non-witness UTXO does not match outpoint hash");
                     }
-                    if (input.prev_out >= input.non_witness_utxo->vout.size()) {
+                    if (input.prev_out >= input.non_witness_utxo->GetOutputs().size()) {
                         throw std::ios_base::failure("Input specifies output index that does not exist");
                     }
                 }

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -177,7 +177,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
         // Coinbase
         //
         CAmount nUnmatured = 0;
-        for (const CTxOut& txout : wtx.tx->vout)
+        for (const CTxOut& txout : wtx.tx->GetOutputs())
             nUnmatured += wallet.getCredit(txout);
         strHTML += "<b>" + tr("Credit") + ":</b> ";
         if (status.is_in_main_chain)
@@ -203,7 +203,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
             // Debit
             //
             auto mine = wtx.txout_is_mine.begin();
-            for (const CTxOut& txout : wtx.tx->vout)
+            for (const CTxOut& txout : wtx.tx->GetOutputs())
             {
                 // Ignore change
                 bool toSelf = *(mine++);
@@ -251,13 +251,13 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
             // Mixed debit transaction
             //
             auto mine = wtx.txin_is_mine.begin();
-            for (const CTxIn& txin : wtx.tx->vin) {
+            for (const CTxIn& txin : wtx.tx->GetInputs()) {
                 if (*(mine++)) {
                     strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet.getDebit(txin)) + "<br>";
                 }
             }
             mine = wtx.txout_is_mine.begin();
-            for (const CTxOut& txout : wtx.tx->vout) {
+            for (const CTxOut& txout : wtx.tx->GetOutputs()) {
                 if (*(mine++)) {
                     strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet.getCredit(txout)) + "<br>";
                 }
@@ -311,10 +311,10 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     if (node.getLogCategories() != BCLog::NONE)
     {
         strHTML += "<hr><br>" + tr("Debug information") + "<br><br>";
-        for (const CTxIn& txin : wtx.tx->vin)
+        for (const CTxIn& txin : wtx.tx->GetInputs())
             if(wallet.txinIsMine(txin))
                 strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet.getDebit(txin)) + "<br>";
-        for (const CTxOut& txout : wtx.tx->vout)
+        for (const CTxOut& txout : wtx.tx->GetOutputs())
             if(wallet.txoutIsMine(txout))
                 strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet.getCredit(txout)) + "<br>";
 
@@ -324,7 +324,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
         strHTML += "<br><b>" + tr("Inputs") + ":</b>";
         strHTML += "<ul>";
 
-        for (const CTxIn& txin : wtx.tx->vin)
+        for (const CTxIn& txin : wtx.tx->GetInputs())
         {
             COutPoint prevout = txin.prevout;
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -48,9 +48,9 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
     if (all_from_me || !any_from_me) {
         CAmount nTxFee = nDebit - wtx.tx->GetValueOut();
 
-        for(unsigned int i = 0; i < wtx.tx->vout.size(); i++)
+        for(unsigned int i = 0; i < wtx.tx->GetOutputs().size(); i++)
         {
-            const CTxOut& txout = wtx.tx->vout[i];
+            const CTxOut& txout = wtx.tx->GetOutputs()[i];
 
             if (all_from_me) {
                 // Change is only really possible if we're the sender

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -51,7 +51,7 @@ void WalletModelTransaction::reassignAmounts(int nChangePosRet)
         {
             if (i == nChangePosRet)
                 i++;
-            rcp.amount = walletTransaction->vout[i].nValue;
+            rcp.amount = walletTransaction->GetOutputs()[i].nValue;
             i++;
         }
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -194,11 +194,11 @@ UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex
 /** Serialize coinbase transaction metadata */
 UniValue coinbaseTxToJSON(const CTransaction& coinbase_tx)
 {
-    CHECK_NONFATAL(!coinbase_tx.vin.empty());
-    const CTxIn& vin_0{coinbase_tx.vin[0]};
+    CHECK_NONFATAL(!coinbase_tx.GetInputs().empty());
+    const CTxIn& vin_0{coinbase_tx.GetInputs()[0]};
     UniValue coinbase_tx_obj(UniValue::VOBJ);
-    coinbase_tx_obj.pushKV("version", coinbase_tx.version);
-    coinbase_tx_obj.pushKV("locktime", coinbase_tx.nLockTime);
+    coinbase_tx_obj.pushKV("version", coinbase_tx.GetVersion());
+    coinbase_tx_obj.pushKV("locktime", coinbase_tx.GetLockTime());
     coinbase_tx_obj.pushKV("sequence", vin_0.nSequence);
     coinbase_tx_obj.pushKV("coinbase", HexStr(vin_0.scriptSig));
     const auto& witness_stack{vin_0.scriptWitness.stack};
@@ -2079,11 +2079,11 @@ static RPCMethod getblockstats()
 
     for (size_t i = 0; i < block.vtx.size(); ++i) {
         const auto& tx = block.vtx.at(i);
-        outputs += tx->vout.size();
+        outputs += tx->GetOutputs().size();
 
         CAmount tx_total_out = 0;
         if (loop_outputs) {
-            for (const CTxOut& out : tx->vout) {
+            for (const CTxOut& out : tx->GetOutputs()) {
                 tx_total_out += out.nValue;
 
                 uint64_t out_size{GetSerializeSize(out) + PER_UTXO_OVERHEAD};
@@ -2104,7 +2104,7 @@ static RPCMethod getblockstats()
             continue;
         }
 
-        inputs += tx->vin.size(); // Don't count coinbase's fake input
+        inputs += tx->GetInputs().size(); // Don't count coinbase's fake input
         total_out += tx_total_out; // Don't count coinbase reward
 
         int64_t tx_size = 0;
@@ -2517,7 +2517,7 @@ static bool CheckBlockFilterMatches(BlockManager& blockman, const CBlockIndex& b
 
     // Check if any of the outputs match the scriptPubKey
     for (const auto& tx : block.vtx) {
-        if (std::any_of(tx->vout.cbegin(), tx->vout.cend(), [&](const auto& txout) {
+        if (std::any_of(tx->GetOutputs().cbegin(), tx->GetOutputs().cend(), [&](const auto& txout) {
                 return needles.contains(std::vector<unsigned char>(txout.scriptPubKey.begin(), txout.scriptPubKey.end()));
             })) {
             return true;
@@ -2884,9 +2884,9 @@ static RPCMethod getdescriptoractivity()
                 // skip coinbase; spends can't happen there.
                 const auto& txundo = block_undo.vtxundo.at(i - 1);
 
-                for (size_t vin_idx = 0; vin_idx < tx->vin.size(); ++vin_idx) {
+                for (size_t vin_idx = 0; vin_idx < tx->GetInputs().size(); ++vin_idx) {
                     const auto& coin = txundo.vprevout.at(vin_idx);
-                    const auto& txin = tx->vin.at(vin_idx);
+                    const auto& txin = tx->GetInputs().at(vin_idx);
                     if (scripts_to_watch.contains(coin.out.scriptPubKey)) {
                         activity.push_back(AddSpend(
                                     coin.out.scriptPubKey, coin.out.nValue, tx, vin_idx, txin, blockindex));
@@ -2894,8 +2894,8 @@ static RPCMethod getdescriptoractivity()
                 }
             }
 
-            for (size_t vout_idx = 0; vout_idx < tx->vout.size(); ++vout_idx) {
-                const auto& vout = tx->vout.at(vout_idx);
+            for (size_t vout_idx = 0; vout_idx < tx->GetOutputs().size(); ++vout_idx) {
+                const auto& vout = tx->GetOutputs().at(vout_idx);
                 if (scripts_to_watch.contains(vout.scriptPubKey)) {
                     activity.push_back(AddReceive(vout, blockindex, vout_idx, tx));
                 }
@@ -2917,10 +2917,10 @@ static RPCMethod getdescriptoractivity()
         for (const CTxMemPoolEntry& e : mempool.entryAll()) {
             const auto& tx = e.GetSharedTx();
 
-            for (size_t vin_idx = 0; vin_idx < tx->vin.size(); ++vin_idx) {
+            for (size_t vin_idx = 0; vin_idx < tx->GetInputs().size(); ++vin_idx) {
                 CScript scriptPubKey;
                 CAmount value;
-                const auto& txin = tx->vin.at(vin_idx);
+                const auto& txin = tx->GetInputs().at(vin_idx);
                 std::optional<Coin> coin = coins_view.GetCoin(txin.prevout);
 
                 // Check if the previous output is in the chain
@@ -2929,10 +2929,10 @@ static RPCMethod getdescriptoractivity()
                     // child transaction of another transaction in the mempool.
                     CTransactionRef prev_tx = CHECK_NONFATAL(mempool.get(txin.prevout.hash));
 
-                    if (txin.prevout.n >= prev_tx->vout.size()) {
+                    if (txin.prevout.n >= prev_tx->GetOutputs().size()) {
                         throw std::runtime_error("Invalid output index");
                     }
-                    const CTxOut& out = prev_tx->vout[txin.prevout.n];
+                    const CTxOut& out = prev_tx->GetOutputs()[txin.prevout.n];
                     scriptPubKey = out.scriptPubKey;
                     value = out.nValue;
                 } else {
@@ -2949,8 +2949,8 @@ static RPCMethod getdescriptoractivity()
                 }
             }
 
-            for (size_t vout_idx = 0; vout_idx < tx->vout.size(); ++vout_idx) {
-                const auto& vout = tx->vout.at(vout_idx);
+            for (size_t vout_idx = 0; vout_idx < tx->GetOutputs().size(); ++vout_idx) {
+                const auto& vout = tx->GetOutputs().at(vout_idx);
                 if (scripts_to_watch.contains(vout.scriptPubKey)) {
                     activity.push_back(AddReceive(vout, nullptr, vout_idx, tx));
                 }

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -564,7 +564,7 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
 
     const CTransaction& tx = e.GetTx();
     std::set<std::string> setDepends;
-    for (const CTxIn& txin : tx.vin)
+    for (const CTxIn& txin : tx.GetInputs())
     {
         if (pool.exists(txin.prevout.hash))
             setDepends.insert(txin.prevout.hash.ToString());

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -568,7 +568,7 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
 
     const CTransaction& tx = e.GetTx();
     std::set<std::string> setDepends;
-    for (const CTxIn& txin : tx.vin)
+    for (const CTxIn& txin : tx.GetInputs())
     {
         if (pool.exists(txin.prevout.hash))
             setDepends.insert(txin.prevout.hash.ToString());

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -946,7 +946,7 @@ static RPCMethod getblocktemplate()
         entry.pushKV("hash", tx.GetWitnessHash().GetHex());
 
         UniValue deps(UniValue::VARR);
-        for (const CTxIn &in : tx.vin)
+        for (const CTxIn &in : tx.GetInputs())
         {
             if (setTxIndex.contains(in.prevout.hash))
                 deps.push_back(setTxIndex[in.prevout.hash]);
@@ -1029,7 +1029,7 @@ static RPCMethod getblocktemplate()
     result.pushKV("previousblockhash", block.hashPrevBlock.GetHex());
     result.pushKV("transactions", std::move(transactions));
     result.pushKV("coinbaseaux", std::move(aux));
-    result.pushKV("coinbasevalue", block.vtx[0]->vout[0].nValue);
+    result.pushKV("coinbasevalue", block.vtx[0]->GetOutputs()[0].nValue);
     result.pushKV("longpollid", tip.GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", GetMinimumTime(pindexPrev, consensusParams.DifficultyAdjustmentInterval()));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -53,7 +53,7 @@ using node::GetTransaction;
 using node::NodeContext;
 using node::PSBTAnalysis;
 
-static constexpr decltype(CTransaction::version) DEFAULT_RAWTX_VERSION{CTransaction::CURRENT_VERSION};
+static constexpr uint32_t DEFAULT_RAWTX_VERSION{CTransaction::CURRENT_VERSION};
 
 static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry,
                      Chainstate& active_chainstate, const CTxUndo* txundo = nullptr,

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1195,7 +1195,7 @@ static RPCMethod decodepsbt()
             have_a_utxo = true;
         }
         if (input.non_witness_utxo) {
-            txout = input.non_witness_utxo->vout[input.prev_out];
+            txout = input.non_witness_utxo->GetOutputs()[input.prev_out];
 
             UniValue non_wit(UniValue::VOBJ);
             TxToUniv(*input.non_witness_utxo, /*block_hash=*/uint256(), /*entry=*/non_wit, /*include_hex=*/false);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1308,7 +1308,7 @@ public:
         if (fAnyoneCanPay)
             nInput = nIn;
         // Serialize the prevout
-        ::Serialize(s, txTo.vin[nInput].prevout);
+        ::Serialize(s, txTo.GetInputs()[nInput].prevout);
         // Serialize the script
         if (nInput != nIn)
             // Blank out other inputs' signatures
@@ -1320,7 +1320,7 @@ public:
             // let the others update at will
             ::Serialize(s, int32_t{0});
         else
-            ::Serialize(s, txTo.vin[nInput].nSequence);
+            ::Serialize(s, txTo.GetInputs()[nInput].nSequence);
     }
 
     /** Serialize an output of txTo */
@@ -1330,26 +1330,26 @@ public:
             // Do not lock-in the txout payee at other indices as txin
             ::Serialize(s, CTxOut());
         else
-            ::Serialize(s, txTo.vout[nOutput]);
+            ::Serialize(s, txTo.GetOutputs()[nOutput]);
     }
 
     /** Serialize txTo */
     template<typename S>
     void Serialize(S &s) const {
         // Serialize version
-        ::Serialize(s, txTo.version);
+        ::Serialize(s, txTo.GetVersion());
         // Serialize vin
-        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.vin.size();
+        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.GetInputs().size();
         ::WriteCompactSize(s, nInputs);
         for (unsigned int nInput = 0; nInput < nInputs; nInput++)
              SerializeInput(s, nInput);
         // Serialize vout
-        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1 : txTo.vout.size());
+        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1 : txTo.GetOutputs().size());
         ::WriteCompactSize(s, nOutputs);
         for (unsigned int nOutput = 0; nOutput < nOutputs; nOutput++)
              SerializeOutput(s, nOutput);
         // Serialize nLockTime
-        ::Serialize(s, txTo.nLockTime);
+        ::Serialize(s, txTo.GetLockTime());
     }
 };
 
@@ -1358,7 +1358,7 @@ template <class T>
 uint256 GetPrevoutsSHA256(const T& txTo)
 {
     HashWriter ss{};
-    for (const auto& txin : txTo.vin) {
+    for (const auto& txin : txTo.GetInputs()) {
         ss << txin.prevout;
     }
     return ss.GetSHA256();
@@ -1369,7 +1369,7 @@ template <class T>
 uint256 GetSequencesSHA256(const T& txTo)
 {
     HashWriter ss{};
-    for (const auto& txin : txTo.vin) {
+    for (const auto& txin : txTo.GetInputs()) {
         ss << txin.nSequence;
     }
     return ss.GetSHA256();
@@ -1380,7 +1380,7 @@ template <class T>
 uint256 GetOutputsSHA256(const T& txTo)
 {
     HashWriter ss{};
-    for (const auto& txout : txTo.vout) {
+    for (const auto& txout : txTo.GetOutputs()) {
         ss << txout;
     }
     return ss.GetSHA256();
@@ -1416,15 +1416,15 @@ void PrecomputedTransactionData::Init(const T& txTo, std::vector<CTxOut>&& spent
 
     m_spent_outputs = std::move(spent_outputs);
     if (!m_spent_outputs.empty()) {
-        assert(m_spent_outputs.size() == txTo.vin.size());
+        assert(m_spent_outputs.size() == txTo.GetInputs().size());
         m_spent_outputs_ready = true;
     }
 
     // Determine which precomputation-impacting features this transaction uses.
     bool uses_bip143_segwit = force;
     bool uses_bip341_taproot = force;
-    for (size_t inpos = 0; inpos < txTo.vin.size() && !(uses_bip143_segwit && uses_bip341_taproot); ++inpos) {
-        if (!txTo.vin[inpos].scriptWitness.IsNull()) {
+    for (size_t inpos = 0; inpos < txTo.GetInputs().size() && !(uses_bip143_segwit && uses_bip341_taproot); ++inpos) {
+        if (!txTo.GetInputs()[inpos].scriptWitness.IsNull()) {
             if (m_spent_outputs_ready && m_spent_outputs[inpos].scriptPubKey.size() == 2 + WITNESS_V1_TAPROOT_SIZE &&
                 m_spent_outputs[inpos].scriptPubKey[0] == OP_1) {
                 // Treat every witness-bearing spend with 34-byte scriptPubKey that starts with OP_1 as a Taproot
@@ -1509,7 +1509,7 @@ bool SignatureHashSchnorr(uint256& hash_out, ScriptExecutionData& execdata, cons
     default:
         assert(false);
     }
-    assert(in_pos < tx_to.vin.size());
+    assert(in_pos < tx_to.GetInputs().size());
     if (!(cache.m_bip341_taproot_ready && cache.m_spent_outputs_ready)) {
         return HandleMissingData(mdb);
     }
@@ -1527,8 +1527,8 @@ bool SignatureHashSchnorr(uint256& hash_out, ScriptExecutionData& execdata, cons
     ss << hash_type;
 
     // Transaction level data
-    ss << tx_to.version;
-    ss << tx_to.nLockTime;
+    ss << tx_to.GetVersion();
+    ss << tx_to.GetLockTime();
     if (input_type != SIGHASH_ANYONECANPAY) {
         ss << cache.m_prevouts_single_hash;
         ss << cache.m_spent_amounts_single_hash;
@@ -1545,9 +1545,9 @@ bool SignatureHashSchnorr(uint256& hash_out, ScriptExecutionData& execdata, cons
     const uint8_t spend_type = (ext_flag << 1) + (have_annex ? 1 : 0); // The low bit indicates whether an annex is present.
     ss << spend_type;
     if (input_type == SIGHASH_ANYONECANPAY) {
-        ss << tx_to.vin[in_pos].prevout;
+        ss << tx_to.GetInputs()[in_pos].prevout;
         ss << cache.m_spent_outputs[in_pos];
-        ss << tx_to.vin[in_pos].nSequence;
+        ss << tx_to.GetInputs()[in_pos].nSequence;
     } else {
         ss << in_pos;
     }
@@ -1557,10 +1557,10 @@ bool SignatureHashSchnorr(uint256& hash_out, ScriptExecutionData& execdata, cons
 
     // Data about the output (if only one).
     if (output_type == SIGHASH_SINGLE) {
-        if (in_pos >= tx_to.vout.size()) return false;
+        if (in_pos >= tx_to.GetOutputs().size()) return false;
         if (!execdata.m_output_hash) {
             HashWriter sha_single_output{};
-            sha_single_output << tx_to.vout[in_pos];
+            sha_single_output << tx_to.GetOutputs()[in_pos];
             execdata.m_output_hash = sha_single_output.GetSHA256();
         }
         ss << execdata.m_output_hash.value();
@@ -1609,12 +1609,12 @@ void SigHashCache::Store(int32_t hash_type, const CScript& script_code, const Ha
 template <class T>
 uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn, int32_t nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache, SigHashCache* sighash_cache)
 {
-    assert(nIn < txTo.vin.size());
+    assert(nIn < txTo.GetInputs().size());
 
     if (sigversion != SigVersion::WITNESS_V0) {
         // Check for invalid use of SIGHASH_SINGLE
         if ((nHashType & 0x1f) == SIGHASH_SINGLE) {
-            if (nIn >= txTo.vout.size()) {
+            if (nIn >= txTo.GetOutputs().size()) {
                 //  nOut out of range
                 return uint256::ONE;
             }
@@ -1646,28 +1646,28 @@ uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn
 
         if ((nHashType & 0x1f) != SIGHASH_SINGLE && (nHashType & 0x1f) != SIGHASH_NONE) {
             hashOutputs = cacheready ? cache->hashOutputs : SHA256Uint256(GetOutputsSHA256(txTo));
-        } else if ((nHashType & 0x1f) == SIGHASH_SINGLE && nIn < txTo.vout.size()) {
+        } else if ((nHashType & 0x1f) == SIGHASH_SINGLE && nIn < txTo.GetOutputs().size()) {
             HashWriter inner_ss{};
-            inner_ss << txTo.vout[nIn];
+            inner_ss << txTo.GetOutputs()[nIn];
             hashOutputs = inner_ss.GetHash();
         }
 
         // Version
-        ss << txTo.version;
+        ss << txTo.GetVersion();
         // Input prevouts/nSequence (none/all, depending on flags)
         ss << hashPrevouts;
         ss << hashSequence;
         // The input being signed (replacing the scriptSig with scriptCode + amount)
         // The prevout may already be contained in hashPrevout, and the nSequence
         // may already be contain in hashSequence.
-        ss << txTo.vin[nIn].prevout;
+        ss << txTo.GetInputs()[nIn].prevout;
         ss << scriptCode;
         ss << amount;
-        ss << txTo.vin[nIn].nSequence;
+        ss << txTo.GetInputs()[nIn].nSequence;
         // Outputs (none/one/all, depending on flags)
         ss << hashOutputs;
         // Locktime
-        ss << txTo.nLockTime;
+        ss << txTo.GetLockTime();
     } else {
         // Wrapper to serialize only the necessary parts of the transaction being signed
         CTransactionSignatureSerializer<T> txTmp(txTo, scriptCode, nIn, nHashType);
@@ -1762,14 +1762,14 @@ bool GenericTransactionSignatureChecker<T>::CheckLockTime(const CScriptNum& nLoc
     // unless the type of nLockTime being tested is the same as
     // the nLockTime in the transaction.
     if (!(
-        (txTo->nLockTime <  LOCKTIME_THRESHOLD && nLockTime <  LOCKTIME_THRESHOLD) ||
-        (txTo->nLockTime >= LOCKTIME_THRESHOLD && nLockTime >= LOCKTIME_THRESHOLD)
+        (txTo->GetLockTime() <  LOCKTIME_THRESHOLD && nLockTime <  LOCKTIME_THRESHOLD) ||
+        (txTo->GetLockTime() >= LOCKTIME_THRESHOLD && nLockTime >= LOCKTIME_THRESHOLD)
     ))
         return false;
 
     // Now that we know we're comparing apples-to-apples, the
     // comparison is a simple numeric one.
-    if (nLockTime > (int64_t)txTo->nLockTime)
+    if (nLockTime > (int64_t)txTo->GetLockTime())
         return false;
 
     // Finally the nLockTime feature can be disabled in IsFinalTx()
@@ -1782,7 +1782,7 @@ bool GenericTransactionSignatureChecker<T>::CheckLockTime(const CScriptNum& nLoc
     // prevent this condition. Alternatively we could test all
     // inputs, but testing just this input minimizes the data
     // required to prove correct CHECKLOCKTIMEVERIFY execution.
-    if (CTxIn::SEQUENCE_FINAL == txTo->vin[nIn].nSequence)
+    if (CTxIn::SEQUENCE_FINAL == txTo->GetInputs()[nIn].nSequence)
         return false;
 
     return true;
@@ -1793,11 +1793,11 @@ bool GenericTransactionSignatureChecker<T>::CheckSequence(const CScriptNum& nSeq
 {
     // Relative lock times are supported by comparing the passed
     // in operand to the sequence number of the input.
-    const int64_t txToSequence = (int64_t)txTo->vin[nIn].nSequence;
+    const int64_t txToSequence = (int64_t)txTo->GetInputs()[nIn].nSequence;
 
     // Fail if the transaction's version number is not set high
     // enough to trigger BIP 68 rules.
-    if (txTo->version < 2)
+    if (txTo->GetVersion() < 2)
         return false;
 
     // Sequence numbers with their most significant bit set are not

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -138,14 +138,14 @@ bool CheckSignetBlockSolution(const CBlock& block, const Consensus::Params& cons
         return false;
     }
 
-    const CScript& scriptSig = signet_txs->m_to_sign.vin[0].scriptSig;
-    const CScriptWitness& witness = signet_txs->m_to_sign.vin[0].scriptWitness;
+    const CScript& scriptSig = signet_txs->m_to_sign.GetInputs()[0].scriptSig;
+    const CScriptWitness& witness = signet_txs->m_to_sign.GetInputs()[0].scriptWitness;
 
     PrecomputedTransactionData txdata;
-    txdata.Init(signet_txs->m_to_sign, {signet_txs->m_to_spend.vout[0]});
-    TransactionSignatureChecker sigcheck(&signet_txs->m_to_sign, /* nInIn= */ 0, /* amountIn= */ signet_txs->m_to_spend.vout[0].nValue, txdata, MissingDataBehavior::ASSERT_FAIL);
+    txdata.Init(signet_txs->m_to_sign, {signet_txs->m_to_spend.GetOutputs()[0]});
+    TransactionSignatureChecker sigcheck(&signet_txs->m_to_sign, /* nInIn= */ 0, /* amountIn= */ signet_txs->m_to_spend.GetOutputs()[0].nValue, txdata, MissingDataBehavior::ASSERT_FAIL);
 
-    if (!VerifyScript(scriptSig, signet_txs->m_to_spend.vout[0].scriptPubKey, &witness, BLOCK_SCRIPT_VERIFY_FLAGS, sigcheck)) {
+    if (!VerifyScript(scriptSig, signet_txs->m_to_spend.GetOutputs()[0].scriptPubKey, &witness, BLOCK_SCRIPT_VERIFY_FLAGS, sigcheck)) {
         LogDebug(BCLog::VALIDATION, "CheckSignetBlockSolution: Errors in block (block solution invalid)\n");
         return false;
     }

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -451,7 +451,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
             result[utxod->first].Clear();
             // If not coinbase restore prevout
             if (!tx.IsCoinBase()) {
-                result[tx.vin[0].prevout] = orig_coin;
+                result[tx.GetInputs()[0].prevout] = orig_coin;
             }
 
             // Disconnect the tx from the current UTXO
@@ -460,7 +460,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
             BOOST_CHECK(stack.back()->SpendCoin(utxod->first));
             // restore inputs
             if (!tx.IsCoinBase()) {
-                const COutPoint &out = tx.vin[0].prevout;
+                const COutPoint &out = tx.GetInputs()[0].prevout;
                 Coin coin = undo.vprevout[0];
                 ApplyTxInUndo(std::move(coin), *(stack.back()), out);
             }
@@ -470,7 +470,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
             // Update the utxoset
             utxoset.erase(utxod->first);
             if (!tx.IsCoinBase())
-                utxoset.insert(tx.vin[0].prevout);
+                utxoset.insert(tx.GetInputs()[0].prevout);
         }
 
         // Once every 1000 iterations and at the end, verify the full cache.

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -444,7 +444,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
             result[utxod->first].Clear();
             // If not coinbase restore prevout
             if (!tx.IsCoinBase()) {
-                result[tx.vin[0].prevout] = orig_coin;
+                result[tx.GetInputs()[0].prevout] = orig_coin;
             }
 
             // Disconnect the tx from the current UTXO
@@ -453,7 +453,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
             BOOST_CHECK(stack.back()->SpendCoin(utxod->first));
             // restore inputs
             if (!tx.IsCoinBase()) {
-                const COutPoint &out = tx.vin[0].prevout;
+                const COutPoint &out = tx.GetInputs()[0].prevout;
                 Coin coin = undo.vprevout[0];
                 ApplyTxInUndo(std::move(coin), *(stack.back()), out);
             }
@@ -463,7 +463,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
             // Update the utxoset
             utxoset.erase(utxod->first);
             if (!tx.IsCoinBase())
-                utxoset.insert(tx.vin[0].prevout);
+                utxoset.insert(tx.GetInputs()[0].prevout);
         }
 
         // Once every 1000 iterations and at the end, verify the full cache.

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -59,7 +59,7 @@ void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
     std::unordered_set<Txid, SaltedCoinsCacheHasher> txids{};
     txids.reserve(block.vtx.size() - 1);
     for (const auto& tx : block.vtx | std::views::drop(1)) {
-        for (const auto& in : tx->vin) {
+        for (const auto& in : tx->GetInputs()) {
             if (txids.contains(in.prevout.hash)) continue;
             Coin coin{};
             if (!spent) coin.out.nValue = 1;
@@ -79,9 +79,9 @@ void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
 
     for (const auto& tx : block.vtx) {
         if (tx->IsCoinBase()) {
-            BOOST_CHECK(!cache.HaveCoinInCache(tx->vin[0].prevout));
+            BOOST_CHECK(!cache.HaveCoinInCache(tx->GetInputs()[0].prevout));
         } else {
-            for (const auto& in : tx->vin) {
+            for (const auto& in : tx->GetInputs()) {
                 const auto& outpoint{in.prevout};
                 const auto& first{cache.AccessCoin(outpoint)};
                 const auto& second{cache.AccessCoin(outpoint)};
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     const auto reset_guard{view.StartFetching(block)};
-    const auto& outpoint{block.vtx[1]->vin[0].prevout};
+    const auto& outpoint{block.vtx[1]->GetInputs()[0].prevout};
 
     BOOST_CHECK(view.HaveCoin(outpoint));
     BOOST_CHECK(view.GetCoin(outpoint).has_value());
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
     CheckCache(block, view);
     // Check that no coins have been moved up to main cache from db
     for (const auto& tx : block.vtx) {
-        for (const auto& in : tx->vin) {
+        for (const auto& in : tx->GetInputs()) {
             BOOST_CHECK(!main_cache.HaveCoinInCache(in.prevout));
         }
     }
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
     const auto reset_guard{view.StartFetching(block)};
     CheckCache(block, view);
 
-    const auto& outpoint{block.vtx[1]->vin[0].prevout};
+    const auto& outpoint{block.vtx[1]->GetInputs()[0].prevout};
     view.SetBestBlock(uint256::ONE);
     BOOST_CHECK(view.SpendCoin(outpoint));
     view.Flush();
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     const auto reset_guard{view.StartFetching(block)};
     for (const auto& tx : block.vtx) {
-        for (const auto& in : tx->vin) {
+        for (const auto& in : tx->GetInputs()) {
             const auto& c{view.AccessCoin(in.prevout)};
             BOOST_CHECK(c.IsSpent());
             BOOST_CHECK(!view.HaveCoin(in.prevout));
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     const auto reset_guard{view.StartFetching(block)};
     for (const auto& tx : block.vtx) {
-        for (const auto& in : tx->vin) {
+        for (const auto& in : tx->GetInputs()) {
             const auto& c{view.AccessCoin(in.prevout)};
             BOOST_CHECK(c.IsSpent());
             BOOST_CHECK(!view.HaveCoin(in.prevout));
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(fetch_out_of_order_input_uses_normal_lookup)
     std::unordered_set<Txid, SaltedCoinsCacheHasher> txids;
     txids.reserve(block.vtx.size() - 1);
     for (const auto& tx : block.vtx | std::views::drop(1)) {
-        for (const auto& input : tx->vin) {
+        for (const auto& input : tx->GetInputs()) {
             if (!txids.contains(input.prevout.hash)) fetched_inputs.push_back(input.prevout);
         }
         txids.emplace(tx->GetHash());

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -217,7 +217,7 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
             size_t random_idx = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, mempool_size - 1);
             CTransactionRef tx = WITH_LOCK(mempool.cs, return mempool.txns_randomized[random_idx].second->GetSharedTx(););
             outpoint = COutPoint(tx->GetHash(), 0);
-            amount_in = tx->vout[0].nValue;
+            amount_in = tx->GetOutputs()[0].nValue;
         } else if (info.size() != 0 && fuzzed_data_provider.ConsumeBool()) {
             // These blocks (and txs) may be invalid, use a spent output, or not be in the main chain.
             auto info_it = info.begin();
@@ -225,7 +225,7 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
             auto tx_it = info_it->block->vtx.begin();
             std::advance(tx_it, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, info_it->block->vtx.size() - 1));
             outpoint = COutPoint(tx_it->get()->GetHash(), 0);
-            amount_in = tx_it->get()->vout[0].nValue;
+            amount_in = tx_it->get()->GetOutputs()[0].nValue;
         } else {
             auto coinbase_it = mature_coinbase.begin();
             std::advance(coinbase_it, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, mature_coinbase.size() - 1));

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -187,7 +187,7 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
             size_t random_idx = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, mempool_size - 1);
             CTransactionRef tx = WITH_LOCK(mempool.cs, return mempool.txns_randomized[random_idx].second->GetSharedTx(););
             outpoint = COutPoint(tx->GetHash(), 0);
-            amount_in = tx->vout[0].nValue;
+            amount_in = tx->GetOutputs()[0].nValue;
         } else if (info.size() != 0 && fuzzed_data_provider.ConsumeBool()) {
             // These blocks (and txs) may be invalid, use a spent output, or not be in the main chain.
             auto info_it = info.begin();
@@ -195,7 +195,7 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
             auto tx_it = info_it->block->vtx.begin();
             std::advance(tx_it, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, info_it->block->vtx.size() - 1));
             outpoint = COutPoint(tx_it->get()->GetHash(), 0);
-            amount_in = tx_it->get()->vout[0].nValue;
+            amount_in = tx_it->get()->GetOutputs()[0].nValue;
         } else {
             auto coinbase_it = mature_coinbase.begin();
             std::advance(coinbase_it, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, mature_coinbase.size() - 1));

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -299,7 +299,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
             [&] {
                 const CTransaction transaction{random_mutable_transaction};
                 bool is_spent = false;
-                for (const CTxOut& tx_out : transaction.vout) {
+                for (const CTxOut& tx_out : transaction.GetOutputs()) {
                     if (Coin{tx_out, 0, transaction.IsCoinBase()}.IsSpent()) {
                         is_spent = true;
                     }
@@ -311,7 +311,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                 }
                 const int height{int(fuzzed_data_provider.ConsumeIntegral<uint32_t>() >> 1)};
                 const bool check_for_overwrite{transaction.IsCoinBase() || [&] {
-                    for (uint32_t i{0}; i < transaction.vout.size(); ++i) {
+                    for (uint32_t i{0}; i < transaction.GetOutputs().size(); ++i) {
                         if (coins_view_cache.PeekCoin(COutPoint{transaction.GetHash(), i})) return true;
                     }
                     return fuzzed_data_provider.ConsumeBool();
@@ -356,7 +356,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                     return;
                 }
                 const auto flags = script_verify_flags::from_int(fuzzed_data_provider.ConsumeIntegral<script_verify_flags::value_type>());
-                if (!transaction.vin.empty() && (flags & SCRIPT_VERIFY_WITNESS) != 0 && (flags & SCRIPT_VERIFY_P2SH) == 0) {
+                if (!transaction.GetInputs().empty() && (flags & SCRIPT_VERIFY_WITNESS) != 0 && (flags & SCRIPT_VERIFY_P2SH) == 0) {
                     // Avoid:
                     // script/interpreter.cpp:1705: size_t CountWitnessSigOps(const CScript &, const CScript &, const CScriptWitness &, unsigned int): Assertion `(flags & SCRIPT_VERIFY_P2SH) != 0' failed.
                     return;

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -292,7 +292,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
             [&] {
                 const CTransaction transaction{random_mutable_transaction};
                 bool is_spent = false;
-                for (const CTxOut& tx_out : transaction.vout) {
+                for (const CTxOut& tx_out : transaction.GetOutputs()) {
                     if (Coin{tx_out, 0, transaction.IsCoinBase()}.IsSpent()) {
                         is_spent = true;
                     }
@@ -304,7 +304,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                 }
                 const int height{int(fuzzed_data_provider.ConsumeIntegral<uint32_t>() >> 1)};
                 const bool check_for_overwrite{transaction.IsCoinBase() || [&] {
-                    for (uint32_t i{0}; i < transaction.vout.size(); ++i) {
+                    for (uint32_t i{0}; i < transaction.GetOutputs().size(); ++i) {
                         if (coins_view_cache.PeekCoin(COutPoint{transaction.GetHash(), i})) return true;
                     }
                     return fuzzed_data_provider.ConsumeBool();
@@ -349,7 +349,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                     return;
                 }
                 const auto flags = script_verify_flags::from_int(fuzzed_data_provider.ConsumeIntegral<script_verify_flags::value_type>());
-                if (!transaction.vin.empty() && (flags & SCRIPT_VERIFY_WITNESS) != 0 && (flags & SCRIPT_VERIFY_P2SH) == 0) {
+                if (!transaction.GetInputs().empty() && (flags & SCRIPT_VERIFY_WITNESS) != 0 && (flags & SCRIPT_VERIFY_P2SH) == 0) {
                     // Avoid:
                     // script/interpreter.cpp:1705: size_t CountWitnessSigOps(const CScript &, const CScript &, const CScriptWitness &, unsigned int): Assertion `(flags & SCRIPT_VERIFY_P2SH) != 0' failed.
                     return;

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -82,10 +82,10 @@ FUZZ_TARGET(mini_miner, .init = initialize_miner)
             }
         }
 
-        if (fuzzed_data_provider.ConsumeBool() && !tx->vout.empty()) {
+        if (fuzzed_data_provider.ConsumeBool() && !tx->GetOutputs().empty()) {
             // Add outpoint from this tx (may or not be spent by a later tx)
             outpoints.emplace_back(tx->GetHash(),
-                                          (uint32_t)fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, tx->vout.size()));
+                                          (uint32_t)fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, tx->GetOutputs().size()));
         } else {
             // Add some random outpoint (will be interpreted as confirmed or not yet submitted
             // to mempool).

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -91,7 +91,7 @@ struct OutpointsUpdater final : public CValidationInterface {
         // for coins spent we always want to be able to rbf so they're not removed
 
         // outputs from this tx can now be spent
-        for (uint32_t index{0}; index < tx.info.m_tx->vout.size(); ++index) {
+        for (uint32_t index{0}; index < tx.info.m_tx->GetOutputs().size(); ++index) {
             m_mempool_outpoints.insert(COutPoint{tx.info.m_tx->GetHash(), index});
         }
     }
@@ -99,12 +99,12 @@ struct OutpointsUpdater final : public CValidationInterface {
     void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t /* mempool_sequence */) override
     {
         // outpoints spent by this tx are now available
-        for (const auto& input : tx->vin) {
+        for (const auto& input : tx->GetInputs()) {
             // Could already exist if this was a replacement
             m_mempool_outpoints.insert(input.prevout);
         }
         // outpoints created by this tx no longer exist
-        for (uint32_t index{0}; index < tx->vout.size(); ++index) {
+        for (uint32_t index{0}; index < tx->GetOutputs().size(); ++index) {
             m_mempool_outpoints.erase(COutPoint{tx->GetHash(), index});
         }
     }
@@ -200,7 +200,7 @@ std::optional<COutPoint> GetChildEvictingPrevout(const CTxMemPool& tx_pool)
                 Assert(children.size() == 1);
                 // Find an input that doesn't spend from parent's txid
                 const auto& only_child = children.begin()->get().GetTx();
-                for (const auto& tx_input : only_child.vin) {
+                for (const auto& tx_input : only_child.GetInputs()) {
                     if (tx_input.prevout.hash != tx_info.tx->GetHash()) {
                         return tx_input.prevout;
                     }
@@ -308,17 +308,17 @@ FUZZ_TARGET(ephemeral_package_eval, .init = initialize_tx_pool)
                 auto tx = MakeTransactionRef(tx_mut);
                 // Restore previously removed outpoints, except in-package outpoints (to allow RBF)
                 if (!last_tx) {
-                    for (const auto& in : tx->vin) {
+                    for (const auto& in : tx->GetInputs()) {
                         Assert(outpoints.insert(in.prevout).second);
                     }
                     // Cache the in-package outpoints being made
-                    for (size_t i = 0; i < tx->vout.size(); ++i) {
+                    for (size_t i = 0; i < tx->GetOutputs().size(); ++i) {
                         package_outpoints.emplace(tx->GetHash(), i);
                     }
                 }
                 // We need newly-created values for the duration of this run
-                for (size_t i = 0; i < tx->vout.size(); ++i) {
-                    outpoints_value[COutPoint(tx->GetHash(), i)] = tx->vout[i].nValue;
+                for (size_t i = 0; i < tx->GetOutputs().size(); ++i) {
+                    outpoints_value[COutPoint(tx->GetHash(), i)] = tx->GetOutputs()[i].nValue;
                 }
                 return tx;
             }());
@@ -468,18 +468,18 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
                 auto tx = MakeTransactionRef(tx_mut);
                 // Restore previously removed outpoints, except in-package outpoints
                 if (!last_tx) {
-                    for (const auto& in : tx->vin) {
+                    for (const auto& in : tx->GetInputs()) {
                         // It's a fake input, or a new input, or a duplicate
                         Assert(in == CTxIn() || outpoints.insert(in.prevout).second || dup_input);
                     }
                     // Cache the in-package outpoints being made
-                    for (size_t i = 0; i < tx->vout.size(); ++i) {
+                    for (size_t i = 0; i < tx->GetOutputs().size(); ++i) {
                         package_outpoints.emplace(tx->GetHash(), i);
                     }
                 }
                 // We need newly-created values for the duration of this run
-                for (size_t i = 0; i < tx->vout.size(); ++i) {
-                    outpoints_value[COutPoint(tx->GetHash(), i)] = tx->vout[i].nValue;
+                for (size_t i = 0; i < tx->GetOutputs().size(); ++i) {
+                    outpoints_value[COutPoint(tx->GetHash(), i)] = tx->GetOutputs()[i].nValue;
                 }
                 return tx;
             }());

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -42,7 +42,7 @@ FUZZ_TARGET(script_flags)
         ds >> fuzzed_flags;
 
         std::vector<CTxOut> spent_outputs;
-        for (unsigned i = 0; i < tx.vin.size(); ++i) {
+        for (unsigned i = 0; i < tx.GetInputs().size(); ++i) {
             CTxOut prevout;
             ds >> prevout;
             if (!MoneyRange(prevout.nValue)) {
@@ -54,12 +54,12 @@ FUZZ_TARGET(script_flags)
         PrecomputedTransactionData txdata;
         txdata.Init(tx, std::move(spent_outputs));
 
-        for (unsigned i = 0; i < tx.vin.size(); ++i) {
+        for (unsigned i = 0; i < tx.GetInputs().size(); ++i) {
             const CTxOut& prevout = txdata.m_spent_outputs.at(i);
             const TransactionSignatureChecker checker{&tx, i, prevout.nValue, txdata, MissingDataBehavior::ASSERT_FAIL};
 
             ScriptError serror;
-            const bool ret = VerifyScript(tx.vin.at(i).scriptSig, prevout.scriptPubKey, &tx.vin.at(i).scriptWitness, verify_flags, checker, &serror);
+            const bool ret = VerifyScript(tx.GetInputs().at(i).scriptSig, prevout.scriptPubKey, &tx.GetInputs().at(i).scriptWitness, verify_flags, checker, &serror);
             assert(ret == (serror == SCRIPT_ERR_OK));
 
             // Verify that removing flags from a passing test or adding flags to a failing test does not change the result
@@ -71,7 +71,7 @@ FUZZ_TARGET(script_flags)
             if (!IsValidFlagCombination(verify_flags)) return;
 
             ScriptError serror_fuzzed;
-            const bool ret_fuzzed = VerifyScript(tx.vin.at(i).scriptSig, prevout.scriptPubKey, &tx.vin.at(i).scriptWitness, verify_flags, checker, &serror_fuzzed);
+            const bool ret_fuzzed = VerifyScript(tx.GetInputs().at(i).scriptSig, prevout.scriptPubKey, &tx.GetInputs().at(i).scriptWitness, verify_flags, checker, &serror_fuzzed);
             assert(ret_fuzzed == (serror_fuzzed == SCRIPT_ERR_OK));
 
             assert(ret_fuzzed == ret);

--- a/src/test/fuzz/script_interpreter.cpp
+++ b/src/test/fuzz/script_interpreter.cpp
@@ -25,7 +25,7 @@ FUZZ_TARGET(script_interpreter)
         if (mtx) {
             const CTransaction tx_to{*mtx};
             const unsigned int in = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
-            if (in < tx_to.vin.size()) {
+            if (in < tx_to.GetInputs().size()) {
                 auto n_hash_type = fuzzed_data_provider.ConsumeIntegral<int>();
                 auto amount = ConsumeMoney(fuzzed_data_provider);
                 auto sigversion = fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0});

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -106,7 +106,7 @@ FUZZ_TARGET(script_sign, .init = initialize_script_sign)
             }
             CMutableTransaction script_tx_to = tx_to;
             CMutableTransaction sign_transaction_tx_to = tx_to;
-            if (n_in < tx_to.vin.size() && tx_to.vin[n_in].prevout.n < tx_from.vout.size()) {
+            if (n_in < tx_to.vin.size() && tx_to.vin[n_in].prevout.n < tx_from.GetOutputs().size()) {
                 SignatureData empty;
                 (void)SignSignature(provider, tx_from, tx_to, n_in, fuzzed_data_provider.ConsumeIntegral<int>(), empty);
             }

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -377,7 +377,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
 
             auto tx = MakeTransactionRef(tx_mut);
             // Restore previously removed outpoints
-            for (const auto& in : tx->vin) {
+            for (const auto& in : tx->GetInputs()) {
                 Assert(outpoints_rbf.insert(in.prevout).second);
             }
             return tx;
@@ -438,12 +438,12 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
         // Helper to insert spent and created outpoints of a tx into collections
         using Sets = std::vector<std::reference_wrapper<std::set<COutPoint>>>;
         const auto insert_tx = [](Sets created_by_tx, Sets consumed_by_tx, const auto& tx) {
-            for (size_t i{0}; i < tx.vout.size(); ++i) {
+            for (size_t i{0}; i < tx.GetOutputs().size(); ++i) {
                 for (auto& set : created_by_tx) {
                     Assert(set.get().emplace(tx.GetHash(), i).second);
                 }
             }
-            for (const auto& in : tx.vin) {
+            for (const auto& in : tx.GetInputs()) {
                 for (auto& set : consumed_by_tx) {
                     Assert(set.get().insert(in.prevout).second);
                 }

--- a/src/test/fuzz/txdownloadman.cpp
+++ b/src/test/fuzz/txdownloadman.cpp
@@ -361,7 +361,7 @@ FUZZ_TARGET(txdownloadman_impl, .init = initialize)
 
                 node::RejectedTxTodo todo = txdownload_impl.MempoolRejectedTx(rand_tx, state, rand_peer, first_time_failure);
                 Assert(first_time_failure || !todo.m_should_add_extra_compact_tx);
-                if (!reject_contains_wtxid) Assert(todo.m_unique_parents.size() <= rand_tx->vin.size());
+                if (!reject_contains_wtxid) Assert(todo.m_unique_parents.size() <= rand_tx->GetInputs().size());
             },
             [&] {
                 auto gtxid = fuzzed_data_provider.ConsumeBool() ?

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -96,7 +96,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
             // Check that all txns returned from GetChildrenFrom* are indeed a direct child of this tx.
             NodeId peer_id = fuzzed_data_provider.ConsumeIntegral<NodeId>();
             for (const auto& child : orphanage->GetChildrenFromSamePeer(ptx_potential_parent, peer_id)) {
-                assert(std::any_of(child->vin.cbegin(), child->vin.cend(), [&](const auto& input) {
+                assert(std::any_of(child->GetInputs().cbegin(), child->GetInputs().cend(), [&](const auto& input) {
                     return input.prevout.hash == ptx_potential_parent->GetHash();
                 }));
             }
@@ -314,7 +314,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
                     bool have_tx_and_peer = orphanage->HaveTxFromPeer(wtxid, peer_id);
                     if (peer_is_protected && !have_tx_and_peer &&
                         (orphanage->UsageByPeer(peer_id) + tx_weight > honest_mem_limit ||
-                        orphanage->LatencyScoreFromPeer(peer_id) + (tx->vin.size() / 10) + 1 > honest_latency_limit)) {
+                        orphanage->LatencyScoreFromPeer(peer_id) + (tx->GetInputs().size() / 10) + 1 > honest_latency_limit)) {
                         // We never want our protected peer oversized or over-announced
                     } else {
                         orphanage->AddTx(tx, peer_id);
@@ -329,7 +329,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
                     {
                         if (peer_is_protected && !have_tx_and_peer &&
                             (orphanage->UsageByPeer(peer_id) + tx_weight > honest_mem_limit ||
-                            orphanage->LatencyScoreFromPeer(peer_id) + (tx->vin.size() / 10) + 1 > honest_latency_limit)) {
+                            orphanage->LatencyScoreFromPeer(peer_id) + (tx->GetInputs().size() / 10) + 1 > honest_latency_limit)) {
                             // We never want our protected peer oversized
                         } else {
                             orphanage->AddAnnouncer(tx->GetWitnessHash(), peer_id);
@@ -435,8 +435,8 @@ FUZZ_TARGET(txorphanage_sim)
             for (auto& [child, parent] : deps) {
                 if (child == t) {
                     auto& partx = txn[txorder[parent]];
-                    assert(partx->version == 1);
-                    COutPoint outpoint(partx->GetHash(), rng.randrange<size_t>(partx->vout.size()));
+                    assert(partx->GetVersion() == 1);
+                    COutPoint outpoint(partx->GetHash(), rng.randrange<size_t>(partx->GetOutputs().size()));
                     tx.vin.emplace_back(outpoint);
                     tx.vin.back().scriptSig.resize(provider.ConsumeIntegralInRange<unsigned>(16, 200));
                 }
@@ -552,7 +552,7 @@ FUZZ_TARGET(txorphanage_sim)
         int64_t usage{0};
         for (auto& ann : sim_announcements) {
             if (ann.announcer != peer) continue;
-            count += 1 + (txn[ann.tx]->vin.size() / 10);
+            count += 1 + (txn[ann.tx]->GetInputs().size() / 10);
             usage += GetTransactionWeight(*txn[ann.tx]);
         }
         return std::max<ByRatioNegSize<FeeFrac>>(FeeFrac{count, max_count}, FeeFrac{usage, max_usage});
@@ -608,7 +608,7 @@ FUZZ_TARGET(txorphanage_sim)
                 for (unsigned tx = 0; tx < NUM_TX; ++tx) {
                     if ((pattern >> tx) & 1) {
                         block.vtx.emplace_back(txn[tx]);
-                        for (auto& txin : block.vtx.back()->vin) {
+                        for (auto& txin : block.vtx.back()->GetInputs()) {
                             spent.insert(txin.prevout);
                         }
                     }
@@ -616,7 +616,7 @@ FUZZ_TARGET(txorphanage_sim)
                 std::shuffle(block.vtx.begin(), block.vtx.end(), rng);
                 real->EraseForBlock(block);
                 std::erase_if(sim_announcements, [&](auto& ann) {
-                    for (auto& txin : txn[ann.tx]->vin) {
+                    for (auto& txin : txn[ann.tx]->GetInputs()) {
                         if (spent.contains(txin.prevout)) return true;
                     }
                     return false;
@@ -633,7 +633,7 @@ FUZZ_TARGET(txorphanage_sim)
                     if (!have_tx_fn(child_tx)) continue;
                     if (have_reconsiderable_fn(child_tx)) continue;
                     bool child_of = false;
-                    for (auto& txin : txn[child_tx]->vin) {
+                    for (auto& txin : txn[child_tx]->GetInputs()) {
                         if (txin.prevout.hash == txn[tx]->GetHash()) {
                             child_of = true;
                             break;
@@ -693,7 +693,7 @@ FUZZ_TARGET(txorphanage_sim)
             for (unsigned tx = 0; tx < NUM_TX; ++tx) {
                 if (have_tx_fn(tx)) {
                     total_usage += GetTransactionWeight(*txn[tx]);
-                    total_latency_score += txn[tx]->vin.size() / 10;
+                    total_latency_score += txn[tx]->GetInputs().size() / 10;
                 }
             }
             auto num_peers = count_peers_fn();
@@ -750,7 +750,7 @@ FUZZ_TARGET(txorphanage_sim)
         bool sim_have_tx = have_tx_fn(tx);
         if (sim_have_tx) {
             orphan_usage += GetTransactionWeight(*txn[tx]);
-            total_latency_score += txn[tx]->vin.size() / 10;
+            total_latency_score += txn[tx]->GetInputs().size() / 10;
         }
         unique_orphans += sim_have_tx;
         auto orphans_it = std::find_if(all_orphans.begin(), all_orphans.end(), [&](auto& orph) { return orph.tx->GetWitnessHash() == txn[tx]->GetWitnessHash(); });
@@ -784,7 +784,7 @@ FUZZ_TARGET(txorphanage_sim)
                     if (ann.announcer != peer) continue;
                     if (ann.reconsider != (phase == 1)) continue;
                     bool matching_parent{false};
-                    for (const auto& vin : txn[ann.tx]->vin) {
+                    for (const auto& vin : txn[ann.tx]->GetInputs()) {
                         if (vin.prevout.hash == txn[tx]->GetHash()) matching_parent = true;
                     }
                     if (!matching_parent) continue;

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -96,7 +96,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
             // Check that all txns returned from GetChildrenFrom* are indeed a direct child of this tx.
             NodeId peer_id = fuzzed_data_provider.ConsumeIntegral<NodeId>();
             for (const auto& child : orphanage->GetChildrenFromSamePeer(ptx_potential_parent, peer_id)) {
-                assert(std::any_of(child->vin.cbegin(), child->vin.cend(), [&](const auto& input) {
+                assert(std::any_of(child->GetInputs().cbegin(), child->GetInputs().cend(), [&](const auto& input) {
                     return input.prevout.hash == ptx_potential_parent->GetHash();
                 }));
             }
@@ -316,7 +316,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
                     bool have_tx_and_peer = orphanage->HaveTxFromPeer(wtxid, peer_id);
                     if (peer_is_protected && !have_tx_and_peer &&
                         (orphanage->UsageByPeer(peer_id) + tx_weight > honest_mem_limit ||
-                        orphanage->LatencyScoreFromPeer(peer_id) + (tx->vin.size() / 10) + 1 > honest_latency_limit)) {
+                        orphanage->LatencyScoreFromPeer(peer_id) + (tx->GetInputs().size() / 10) + 1 > honest_latency_limit)) {
                         // We never want our protected peer oversized or over-announced
                     } else {
                         orphanage->AddTx(tx, peer_id);
@@ -331,7 +331,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
                     {
                         if (peer_is_protected && !have_tx_and_peer &&
                             (orphanage->UsageByPeer(peer_id) + tx_weight > honest_mem_limit ||
-                            orphanage->LatencyScoreFromPeer(peer_id) + (tx->vin.size() / 10) + 1 > honest_latency_limit)) {
+                            orphanage->LatencyScoreFromPeer(peer_id) + (tx->GetInputs().size() / 10) + 1 > honest_latency_limit)) {
                             // We never want our protected peer oversized
                         } else {
                             orphanage->AddAnnouncer(tx->GetWitnessHash(), peer_id);
@@ -437,8 +437,8 @@ FUZZ_TARGET(txorphanage_sim)
             for (auto& [child, parent] : deps) {
                 if (child == t) {
                     auto& partx = txn[txorder[parent]];
-                    assert(partx->version == 1);
-                    COutPoint outpoint(partx->GetHash(), rng.randrange<size_t>(partx->vout.size()));
+                    assert(partx->GetVersion() == 1);
+                    COutPoint outpoint(partx->GetHash(), rng.randrange<size_t>(partx->GetOutputs().size()));
                     tx.vin.emplace_back(outpoint);
                     tx.vin.back().scriptSig.resize(provider.ConsumeIntegralInRange<unsigned>(16, 200));
                 }
@@ -554,7 +554,7 @@ FUZZ_TARGET(txorphanage_sim)
         int64_t usage{0};
         for (auto& ann : sim_announcements) {
             if (ann.announcer != peer) continue;
-            count += 1 + (txn[ann.tx]->vin.size() / 10);
+            count += 1 + (txn[ann.tx]->GetInputs().size() / 10);
             usage += GetTransactionWeight(*txn[ann.tx]);
         }
         return std::max<ByRatioNegSize<FeeFrac>>(FeeFrac{count, max_count}, FeeFrac{usage, max_usage});
@@ -610,7 +610,7 @@ FUZZ_TARGET(txorphanage_sim)
                 for (unsigned tx = 0; tx < NUM_TX; ++tx) {
                     if ((pattern >> tx) & 1) {
                         block.vtx.emplace_back(txn[tx]);
-                        for (auto& txin : block.vtx.back()->vin) {
+                        for (auto& txin : block.vtx.back()->GetInputs()) {
                             spent.insert(txin.prevout);
                         }
                     }
@@ -618,7 +618,7 @@ FUZZ_TARGET(txorphanage_sim)
                 std::shuffle(block.vtx.begin(), block.vtx.end(), rng);
                 real->EraseForBlock(block);
                 std::erase_if(sim_announcements, [&](auto& ann) {
-                    for (auto& txin : txn[ann.tx]->vin) {
+                    for (auto& txin : txn[ann.tx]->GetInputs()) {
                         if (spent.contains(txin.prevout)) return true;
                     }
                     return false;
@@ -635,7 +635,7 @@ FUZZ_TARGET(txorphanage_sim)
                     if (!have_tx_fn(child_tx)) continue;
                     if (have_reconsiderable_fn(child_tx)) continue;
                     bool child_of = false;
-                    for (auto& txin : txn[child_tx]->vin) {
+                    for (auto& txin : txn[child_tx]->GetInputs()) {
                         if (txin.prevout.hash == txn[tx]->GetHash()) {
                             child_of = true;
                             break;
@@ -695,7 +695,7 @@ FUZZ_TARGET(txorphanage_sim)
             for (unsigned tx = 0; tx < NUM_TX; ++tx) {
                 if (have_tx_fn(tx)) {
                     total_usage += GetTransactionWeight(*txn[tx]);
-                    total_latency_score += txn[tx]->vin.size() / 10;
+                    total_latency_score += txn[tx]->GetInputs().size() / 10;
                 }
             }
             auto num_peers = count_peers_fn();
@@ -752,7 +752,7 @@ FUZZ_TARGET(txorphanage_sim)
         bool sim_have_tx = have_tx_fn(tx);
         if (sim_have_tx) {
             orphan_usage += GetTransactionWeight(*txn[tx]);
-            total_latency_score += txn[tx]->vin.size() / 10;
+            total_latency_score += txn[tx]->GetInputs().size() / 10;
         }
         unique_orphans += sim_have_tx;
         auto orphans_it = std::find_if(all_orphans.begin(), all_orphans.end(), [&](auto& orph) { return orph.tx->GetWitnessHash() == txn[tx]->GetWitnessHash(); });
@@ -786,7 +786,7 @@ FUZZ_TARGET(txorphanage_sim)
                     if (ann.announcer != peer) continue;
                     if (ann.reconsider != (phase == 1)) continue;
                     bool matching_parent{false};
-                    for (const auto& vin : txn[ann.tx]->vin) {
+                    for (const auto& vin : txn[ann.tx]->GetInputs()) {
                         if (vin.prevout.hash == txn[tx]->GetHash()) matching_parent = true;
                     }
                     if (!matching_parent) continue;

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -239,7 +239,7 @@ CKey ConsumePrivateKey(FuzzedDataProvider& fuzzed_data_provider, std::optional<b
 
 bool ContainsSpentInput(const CTransaction& tx, const CCoinsViewCache& inputs) noexcept
 {
-    for (const CTxIn& tx_in : tx.vin) {
+    for (const CTxIn& tx_in : tx.GetInputs()) {
         const Coin& coin = inputs.AccessCoin(tx_in.prevout);
         if (coin.IsSpent()) {
             return true;

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -138,7 +138,7 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
                 outfile << coinbase->GetHash();
                 WriteCompactSize(outfile, 1); // number of coins for the hash
                 WriteCompactSize(outfile, 0); // index of coin
-                outfile << Coin(coinbase->vout[0], height, /*fCoinBaseIn=*/true);
+                outfile << Coin(coinbase->GetOutputs()[0], height, /*fCoinBaseIn=*/true);
                 height++;
             }
         }
@@ -150,7 +150,7 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
             outfile << coinbase->GetHash();
             WriteCompactSize(outfile, 1);   // number of coins for the hash
             WriteCompactSize(outfile, 999); // index of coin
-            outfile << Coin{coinbase->vout[0], /*nHeightIn=*/999, /*fCoinBaseIn=*/false};
+            outfile << Coin{coinbase->GetOutputs()[0], /*nHeightIn=*/999, /*fCoinBaseIn=*/false};
         }
         assert(outfile.fclose() == 0);
     }

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -84,13 +84,13 @@ FUZZ_TARGET(utxo_total_supply)
         // get last tx
         const CTransaction& tx = *current_block->vtx.back();
         // get last out
-        const uint32_t i = tx.vout.size() - 1;
+        const uint32_t i = tx.GetOutputs().size() - 1;
         // store it
-        txos.emplace_back(COutPoint{tx.GetHash(), i}, tx.vout.at(i));
-        if (current_block->vtx.size() == 1 && tx.vout.at(i).scriptPubKey[0] == OP_RETURN) {
+        txos.emplace_back(COutPoint{tx.GetHash(), i}, tx.GetOutputs().at(i));
+        if (current_block->vtx.size() == 1 && tx.GetOutputs().at(i).scriptPubKey[0] == OP_RETURN) {
             // also store coinbase
-            const uint32_t i = tx.vout.size() - 2;
-            txos.emplace_back(COutPoint{tx.GetHash(), i}, tx.vout.at(i));
+            const uint32_t i = tx.GetOutputs().size() - 2;
+            txos.emplace_back(COutPoint{tx.GetHash(), i}, tx.GetOutputs().at(i));
         }
     };
     const auto AppendRandomTxo = [&](CMutableTransaction& tx) {
@@ -171,7 +171,7 @@ FUZZ_TARGET(utxo_total_supply)
                 if (was_valid) {
                     if (duplicate_coinbase_height == ActiveHeight()) {
                         // we mined the duplicate coinbase
-                        assert(current_block->vtx.at(0)->vin.at(0).scriptSig == duplicate_coinbase_script);
+                        assert(current_block->vtx.at(0)->GetInputs().at(0).scriptSig == duplicate_coinbase_script);
                     }
 
                     circulation += GetBlockSubsidy(ActiveHeight(), Params().GetConsensus());

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -333,7 +333,7 @@ std::vector<CTransactionRef> CreateBigSigOpsCluster(const CTransactionRef& first
     tx.vin[0].prevout.n = 0;
     tx.vout.resize(50);
     for (auto &out : tx.vout) {
-        out.nValue = first_tx->vout[0].nValue / 50;
+        out.nValue = first_tx->GetOutputs()[0].nValue / 50;
         out.scriptPubKey = CScript() << OP_1;
     }
 
@@ -352,7 +352,7 @@ std::vector<CTransactionRef> CreateBigSigOpsCluster(const CTransactionRef& first
         tx2.vin[0].prevout.n = i;
         tx2.vin[0].scriptSig = CScript() << OP_1;
         tx2.vout.resize(20);
-        tx2.vout[0].nValue = parent_tx->vout[i].nValue - CENT;
+        tx2.vout[0].nValue = parent_tx->GetOutputs()[i].nValue - CENT;
         for (auto &out : tx2.vout) {
             out.nValue = 0;
             out.scriptPubKey = CScript() << OP_0 << OP_0 << OP_0 << OP_NOP << OP_CHECKMULTISIG << OP_1;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -350,7 +350,7 @@ std::vector<CTransactionRef> CreateBigSigOpsCluster(const CTransactionRef& first
     tx.vin[0].prevout.n = 0;
     tx.vout.resize(50);
     for (auto &out : tx.vout) {
-        out.nValue = first_tx->vout[0].nValue / 50;
+        out.nValue = first_tx->GetOutputs()[0].nValue / 50;
         out.scriptPubKey = CScript() << OP_1;
     }
 

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -46,15 +46,15 @@ static inline bool sanity_check(const std::vector<CTransactionRef>& transactions
         if (fee == 0) continue;
         auto outpoint_ = outpoint; // structured bindings can't be captured in C++17, so we need to use a variable
         const bool found = std::any_of(transactions.cbegin(), transactions.cend(), [&](const auto& tx) {
-            return outpoint_.hash == tx->GetHash() && outpoint_.n < tx->vout.size();
+            return outpoint_.hash == tx->GetHash() && outpoint_.n < tx->GetOutputs().size();
         });
         if (!found) return false;
     }
     for (const auto& tx : transactions) {
         // If tx has multiple outputs, they must all have the same bumpfee (if they exist).
-        if (tx->vout.size() > 1) {
+        if (tx->GetOutputs().size() > 1) {
             std::set<CAmount> distinct_bumpfees;
-            for (size_t i{0}; i < tx->vout.size(); ++i) {
+            for (size_t i{0}; i < tx->GetOutputs().size(); ++i) {
                 const auto bumpfee = bumpfees.find(COutPoint{tx->GetHash(), static_cast<uint32_t>(i)});
                 if (bumpfee != bumpfees.end()) distinct_bumpfees.insert(bumpfee->second);
             }

--- a/src/test/script_assets_tests.cpp
+++ b/src/test/script_assets_tests.cpp
@@ -122,7 +122,7 @@ static void AssetTest(const UniValue& test, SignatureCache& signature_cache)
             // "final": true tests are valid for all flags. Others are only valid with flags that are
             // a subset of test_flags.
             if (fin || ((flags & test_flags) == flags)) {
-                bool ret = VerifyScript(tx.vin[idx].scriptSig, prevouts[idx].scriptPubKey, &tx.vin[idx].scriptWitness, flags, txcheck, nullptr);
+                bool ret = VerifyScript(tx.GetInputs()[idx].scriptSig, prevouts[idx].scriptPubKey, &tx.GetInputs()[idx].scriptWitness, flags, txcheck, nullptr);
                 BOOST_CHECK(ret);
             }
         }
@@ -139,7 +139,7 @@ static void AssetTest(const UniValue& test, SignatureCache& signature_cache)
         for (const auto flags : ALL_CONSENSUS_FLAGS) {
             // If a test is supposed to fail with test_flags, it should also fail with any superset thereof.
             if ((flags & test_flags) == test_flags) {
-                bool ret = VerifyScript(tx.vin[idx].scriptSig, prevouts[idx].scriptPubKey, &tx.vin[idx].scriptWitness, flags, txcheck, nullptr);
+                bool ret = VerifyScript(tx.GetInputs()[idx].scriptSig, prevouts[idx].scriptPubKey, &tx.GetInputs()[idx].scriptWitness, flags, txcheck, nullptr);
                 BOOST_CHECK(!ret);
             }
         }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -130,7 +130,7 @@ void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, const CScript
     ScriptError err;
     const CTransaction txCredit{BuildCreditingTransaction(scriptPubKey, nValue)};
     CMutableTransaction tx = BuildSpendingTransaction(scriptSig, scriptWitness, txCredit);
-    BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, &scriptWitness, flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err) == expect, message);
+    BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, &scriptWitness, flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err) == expect, message);
     BOOST_CHECK_MESSAGE(err == scriptError, FormatScriptError(err) + " where " + FormatScriptError((ScriptError_t)scriptError) + " expected: " + message);
 
     // Verify that removing flags from a passing test or adding flags to a failing test does not change the result.
@@ -140,7 +140,7 @@ void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, const CScript
         // Weed out some invalid flag combinations.
         if (combined_flags & SCRIPT_VERIFY_CLEANSTACK && ~combined_flags & (SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS)) continue;
         if (combined_flags & SCRIPT_VERIFY_WITNESS && ~combined_flags & SCRIPT_VERIFY_P2SH) continue;
-        BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, &scriptWitness, combined_flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err) == expect, message + strprintf(" (with flags %x)", combined_flags.as_int()));
+        BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, &scriptWitness, combined_flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err) == expect, message + strprintf(" (with flags %x)", combined_flags.as_int()));
     }
 }
 }; // struct ScriptTest
@@ -373,7 +373,7 @@ public:
     {
         TestBuilder copy = *this; // Make a copy so we can rollback the push.
         DoPush();
-        test.DoTest(creditTx->vout[0].scriptPubKey, spendTx.vin[0].scriptSig, scriptWitness, flags, comment, scriptError, nValue);
+        test.DoTest(creditTx->GetOutputs()[0].scriptPubKey, spendTx.vin[0].scriptSig, scriptWitness, flags, comment, scriptError, nValue);
         *this = copy;
         return *this;
     }
@@ -399,7 +399,7 @@ public:
             array.push_back(std::move(wit));
         }
         array.push_back(FormatScript(spendTx.vin[0].scriptSig));
-        array.push_back(FormatScript(creditTx->vout[0].scriptPubKey));
+        array.push_back(FormatScript(creditTx->GetOutputs()[0].scriptPubKey));
         array.push_back(FormatScriptFlags(flags));
         array.push_back(FormatScriptError((ScriptError_t)scriptError));
         array.push_back(comment);
@@ -1074,18 +1074,18 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG12)
     CMutableTransaction txTo12 = BuildSpendingTransaction(CScript(), CScriptWitness(), txFrom12);
 
     CScript goodsig1 = sign_multisig(scriptPubKey12, key1, CTransaction(txTo12));
-    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
     txTo12.vout[0].nValue = 2;
-    BOOST_CHECK(!VerifyScript(goodsig1, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(goodsig1, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     CScript goodsig2 = sign_multisig(scriptPubKey12, key2, CTransaction(txTo12));
-    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     CScript badsig1 = sign_multisig(scriptPubKey12, key3, CTransaction(txTo12));
-    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 }
 
@@ -1106,54 +1106,54 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG23)
     std::vector<CKey> keys;
     keys.push_back(key1); keys.push_back(key2);
     CScript goodsig1 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key1); keys.push_back(key3);
     CScript goodsig2 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key2); keys.push_back(key3);
     CScript goodsig3 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(VerifyScript(goodsig3, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig3, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key2); keys.push_back(key2); // Can't reuse sig
     CScript badsig1 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key2); keys.push_back(key1); // sigs must be in correct order
     CScript badsig2 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig2, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig2, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key3); keys.push_back(key2); // sigs must be in correct order
     CScript badsig3 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig3, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig3, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key4); keys.push_back(key2); // sigs must match pubkeys
     CScript badsig4 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig4, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig4, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key1); keys.push_back(key4); // sigs must match pubkeys
     CScript badsig5 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig5, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig5, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear(); // Must have signatures
     CScript badsig6 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig6, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig6, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
 }
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -26,7 +26,7 @@
 // Old script.cpp SignatureHash function
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
-    if (nIn >= txTo.vin.size())
+    if (nIn >= txTo.GetInputs().size())
     {
         return uint256::ONE;
     }

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -73,7 +73,7 @@ static ScriptError VerifyWithFlag(const CTransaction& output, const CMutableTran
 {
     ScriptError error;
     CTransaction inputi(input);
-    bool ret = VerifyScript(inputi.vin[0].scriptSig, output.vout[0].scriptPubKey, &inputi.vin[0].scriptWitness, flags, TransactionSignatureChecker(&inputi, 0, output.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &error);
+    bool ret = VerifyScript(inputi.GetInputs()[0].scriptSig, output.GetOutputs()[0].scriptPubKey, &inputi.GetInputs()[0].scriptWitness, flags, TransactionSignatureChecker(&inputi, 0, output.GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &error);
     BOOST_CHECK((ret == true) == (error == SCRIPT_ERR_OK));
 
     return error;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -90,8 +90,8 @@ bool CheckTxScripts(const CTransaction& tx, const std::map<COutPoint, CScript>& 
 {
     bool tx_valid = true;
     ScriptError err = expect_valid ? SCRIPT_ERR_UNKNOWN_ERROR : SCRIPT_ERR_OK;
-    for (unsigned int i = 0; i < tx.vin.size() && tx_valid; ++i) {
-        const CTxIn input = tx.vin[i];
+    for (unsigned int i = 0; i < tx.GetInputs().size() && tx_valid; ++i) {
+        const CTxIn input = tx.GetInputs()[i];
         const CAmount amount = map_prevout_values.contains(input.prevout) ? map_prevout_values.at(input.prevout) : 0;
         try {
             tx_valid = VerifyScript(input.scriptSig, map_prevout_scriptPubKeys.at(input.prevout),
@@ -427,10 +427,10 @@ static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const 
     DataStream ssout;
     ssout << TX_WITH_WITNESS(outputm);
     ssout >> TX_WITH_WITNESS(output);
-    assert(output->vin.size() == 1);
-    assert(output->vin[0] == outputm.vin[0]);
-    assert(output->vout.size() == 1);
-    assert(output->vout[0] == outputm.vout[0]);
+    assert(output->GetInputs().size() == 1);
+    assert(output->GetInputs()[0] == outputm.vin[0]);
+    assert(output->GetOutputs().size() == 1);
+    assert(output->GetOutputs()[0] == outputm.vout[0]);
 
     CMutableTransaction inputm;
     inputm.version = 1;
@@ -457,7 +457,7 @@ static void CheckWithFlag(const CTransactionRef& output, const CMutableTransacti
 {
     ScriptError error;
     CTransaction inputi(input);
-    bool ret = VerifyScript(inputi.vin[0].scriptSig, output->vout[0].scriptPubKey, &inputi.vin[0].scriptWitness, flags, TransactionSignatureChecker(&inputi, 0, output->vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &error);
+    bool ret = VerifyScript(inputi.GetInputs()[0].scriptSig, output->GetOutputs()[0].scriptPubKey, &inputi.GetInputs()[0].scriptWitness, flags, TransactionSignatureChecker(&inputi, 0, output->GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &error);
     assert(ret == success);
 }
 
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
 
     for(uint32_t i = 0; i < mtx.vin.size(); i++) {
         std::vector<CScriptCheck> vChecks;
-        vChecks.emplace_back(coins[tx.vin[i].prevout.n].out, tx, signature_cache, i, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false, &txdata);
+        vChecks.emplace_back(coins[tx.GetInputs()[i].prevout.n].out, tx, signature_cache, i, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false, &txdata);
         control.Add(std::move(vChecks));
     }
 
@@ -561,9 +561,9 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
 SignatureData CombineSignatures(const CMutableTransaction& input1, const CMutableTransaction& input2, const CTransactionRef tx)
 {
     SignatureData sigdata;
-    sigdata = DataFromTransaction(input1, 0, tx->vout[0]);
-    sigdata.MergeSignatureData(DataFromTransaction(input2, 0, tx->vout[0]));
-    ProduceSignature(DUMMY_SIGNING_PROVIDER, MutableTransactionSignatureCreator(input1, 0, tx->vout[0].nValue, {.sighash_type = SIGHASH_DEFAULT}), tx->vout[0].scriptPubKey, sigdata);
+    sigdata = DataFromTransaction(input1, 0, tx->GetOutputs()[0]);
+    sigdata.MergeSignatureData(DataFromTransaction(input2, 0, tx->GetOutputs()[0]));
+    ProduceSignature(DUMMY_SIGNING_PROVIDER, MutableTransactionSignatureCreator(input1, 0, tx->GetOutputs()[0].nValue, {.sighash_type = SIGHASH_DEFAULT}), tx->GetOutputs()[0].scriptPubKey, sigdata);
     return sigdata;
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -90,8 +90,8 @@ bool CheckTxScripts(const CTransaction& tx, const std::map<COutPoint, CScript>& 
 {
     bool tx_valid = true;
     ScriptError err = expect_valid ? SCRIPT_ERR_UNKNOWN_ERROR : SCRIPT_ERR_OK;
-    for (unsigned int i = 0; i < tx.vin.size() && tx_valid; ++i) {
-        const CTxIn input = tx.vin[i];
+    for (unsigned int i = 0; i < tx.GetInputs().size() && tx_valid; ++i) {
+        const CTxIn input = tx.GetInputs()[i];
         const CAmount amount = map_prevout_values.contains(input.prevout) ? map_prevout_values.at(input.prevout) : 0;
         try {
             tx_valid = VerifyScript(input.scriptSig, map_prevout_scriptPubKeys.at(input.prevout),
@@ -428,10 +428,10 @@ static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const 
     DataStream ssout;
     ssout << TX_WITH_WITNESS(outputm);
     ssout >> TX_WITH_WITNESS(output);
-    assert(output->vin.size() == 1);
-    assert(output->vin[0] == outputm.vin[0]);
-    assert(output->vout.size() == 1);
-    assert(output->vout[0] == outputm.vout[0]);
+    assert(output->GetInputs().size() == 1);
+    assert(output->GetInputs()[0] == outputm.vin[0]);
+    assert(output->GetOutputs().size() == 1);
+    assert(output->GetOutputs()[0] == outputm.vout[0]);
 
     CMutableTransaction inputm;
     inputm.version = 1;
@@ -458,7 +458,7 @@ static void CheckWithFlag(const CTransactionRef& output, const CMutableTransacti
 {
     ScriptError error;
     CTransaction inputi(input);
-    bool ret = VerifyScript(inputi.vin[0].scriptSig, output->vout[0].scriptPubKey, &inputi.vin[0].scriptWitness, flags, TransactionSignatureChecker(&inputi, 0, output->vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &error);
+    bool ret = VerifyScript(inputi.GetInputs()[0].scriptSig, output->GetOutputs()[0].scriptPubKey, &inputi.GetInputs()[0].scriptWitness, flags, TransactionSignatureChecker(&inputi, 0, output->GetOutputs()[0].nValue, MissingDataBehavior::ASSERT_FAIL), &error);
     assert(ret == success);
 }
 
@@ -551,7 +551,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
 
     for(uint32_t i = 0; i < mtx.vin.size(); i++) {
         std::vector<CScriptCheck> vChecks;
-        vChecks.emplace_back(coins[tx.vin[i].prevout.n].out, tx, signature_cache, i, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false, &txdata);
+        vChecks.emplace_back(coins[tx.GetInputs()[i].prevout.n].out, tx, signature_cache, i, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false, &txdata);
         control.Add(std::move(vChecks));
     }
 
@@ -562,9 +562,9 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
 SignatureData CombineSignatures(const CMutableTransaction& input1, const CMutableTransaction& input2, const CTransactionRef tx)
 {
     SignatureData sigdata;
-    sigdata = DataFromTransaction(input1, 0, tx->vout[0]);
-    sigdata.MergeSignatureData(DataFromTransaction(input2, 0, tx->vout[0]));
-    ProduceSignature(DUMMY_SIGNING_PROVIDER, MutableTransactionSignatureCreator(input1, 0, tx->vout[0].nValue, {.sighash_type = SIGHASH_DEFAULT}), tx->vout[0].scriptPubKey, sigdata);
+    sigdata = DataFromTransaction(input1, 0, tx->GetOutputs()[0]);
+    sigdata.MergeSignatureData(DataFromTransaction(input2, 0, tx->GetOutputs()[0]));
+    ProduceSignature(DUMMY_SIGNING_PROVIDER, MutableTransactionSignatureCreator(input1, 0, tx->GetOutputs()[0].nValue, {.sighash_type = SIGHASH_DEFAULT}), tx->GetOutputs()[0].scriptPubKey, sigdata);
     return sigdata;
 }
 

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -15,7 +15,7 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
 {
     // Setup phase:
     // Mine blocks for coinbase maturity, so we can spend some coinbase outputs in the test.
-    const CScript& coinbase_script = m_coinbase_txns[0]->vout[0].scriptPubKey;
+    const CScript& coinbase_script = m_coinbase_txns[0]->GetOutputs()[0].scriptPubKey;
     for (int i = 0; i < 10; i++) CreateAndProcessBlock({}, coinbase_script);
 
     // Spend 10 outputs

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -477,8 +477,8 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
 
         auto parents{pool.GetParents(entry.FromTx(tx_many_sigops))};
         // legacy uses fAccurate = false, and the maximum number of multisig keys is used
-        const int64_t total_sigops{static_cast<int64_t>(tx_many_sigops->vin.size()) * static_cast<int64_t>(script_multisig.GetSigOpCount(/*fAccurate=*/false))};
-        BOOST_CHECK_EQUAL(total_sigops, tx_many_sigops->vin.size() * MAX_PUBKEYS_PER_MULTISIG);
+        const int64_t total_sigops{static_cast<int64_t>(tx_many_sigops->GetInputs().size()) * static_cast<int64_t>(script_multisig.GetSigOpCount(/*fAccurate=*/false))};
+        BOOST_CHECK_EQUAL(total_sigops, tx_many_sigops->GetInputs().size() * MAX_PUBKEYS_PER_MULTISIG);
         const int64_t bip141_vsize{GetVirtualTransactionSize(*tx_many_sigops)};
         // Weight limit is not reached...
         BOOST_CHECK(SingleTRUCChecks(pool, tx_many_sigops, parents, empty_conflicts_set, bip141_vsize) == std::nullopt);

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -159,7 +159,7 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify
             // was invalid, or we didn't add to cache.
             std::vector<CScriptCheck> scriptchecks;
             BOOST_CHECK(CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
-            BOOST_CHECK_EQUAL(scriptchecks.size(), tx.vin.size());
+            BOOST_CHECK_EQUAL(scriptchecks.size(), tx.GetInputs().size());
         }
     }
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -580,7 +580,7 @@ std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContex
     std::vector<CTransactionRef> mempool_transactions;
     std::deque<std::pair<COutPoint, CAmount>> unspent_prevouts, undo_info;
     std::transform(m_coinbase_txns.begin(), m_coinbase_txns.end(), std::back_inserter(unspent_prevouts),
-        [](const auto& tx){ return std::make_pair(COutPoint(tx->GetHash(), 0), tx->vout[0].nValue); });
+        [](const auto& tx){ return std::make_pair(COutPoint(tx->GetHash(), 0), tx->GetOutputs()[0].nValue); });
     while (num_transactions > 0 && !unspent_prevouts.empty()) {
         // The number of inputs and outputs are randomly chosen, between 1-5
         // and 1-25 respectively.

--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -36,7 +36,7 @@ CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CSc
     txSpend.vin[0].scriptSig = scriptSig;
     txSpend.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
     txSpend.vout[0].scriptPubKey = CScript();
-    txSpend.vout[0].nValue = txCredit.vout[0].nValue;
+    txSpend.vout[0].nValue = txCredit.GetOutputs()[0].nValue;
 
     return txSpend;
 }
@@ -106,8 +106,8 @@ bool SignSignature(const SigningProvider &provider, const CTransaction& txFrom, 
 {
     assert(nIn < txTo.vin.size());
     const CTxIn& txin = txTo.vin[nIn];
-    assert(txin.prevout.n < txFrom.vout.size());
-    const CTxOut& txout = txFrom.vout[txin.prevout.n];
+    assert(txin.prevout.n < txFrom.GetOutputs().size());
+    const CTxOut& txout = txFrom.GetOutputs()[txin.prevout.n];
 
     return SignSignature(provider, txout.scriptPubKey, txTo, nIn, txout.nValue, nHashType, sig_data);
 }

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -173,7 +173,7 @@ void CheckMempoolEphemeralInvariants(const CTxMemPool& tx_pool)
         // Only-child should be spending the dust
         const auto& only_child = children.begin()->get().GetTx();
         COutPoint dust_outpoint{tx_info.tx->GetHash(), dust_indexes[0]};
-        Assert(std::any_of(only_child.vin.begin(), only_child.vin.end(), [&dust_outpoint](const CTxIn& txin) {
+        Assert(std::any_of(only_child.GetInputs().begin(), only_child.GetInputs().end(), [&dust_outpoint](const CTxIn& txin) {
             return txin.prevout == dust_outpoint;
             }));
     }
@@ -187,7 +187,7 @@ void CheckMempoolTRUCInvariants(const CTxMemPool& tx_pool)
         auto [desc_count, desc_size, desc_fees] = tx_pool.CalculateDescendantData(entry);
         auto [anc_count, anc_size, anc_fees] = tx_pool.CalculateAncestorData(entry);
 
-        if (tx_info.tx->version == TRUC_VERSION) {
+        if (tx_info.tx->GetVersion() == TRUC_VERSION) {
             // Check that special maximum virtual size is respected
             Assert(entry.GetTxSize() <= TRUC_MAX_VSIZE);
 
@@ -201,12 +201,12 @@ void CheckMempoolTRUCInvariants(const CTxMemPool& tx_pool)
                 Assert(entry.GetTxSize() <= TRUC_CHILD_MAX_VSIZE);
                 // All TRUC transactions must only have TRUC unconfirmed parents.
                 const auto& parents = tx_pool.GetParents(entry);
-                Assert(parents.begin()->get().GetSharedTx()->version == TRUC_VERSION);
+                Assert(parents.begin()->get().GetSharedTx()->GetVersion() == TRUC_VERSION);
             }
         } else if (anc_count > 1) {
             // All non-TRUC transactions must only have non-TRUC unconfirmed parents.
             for (const auto& parent : tx_pool.GetParents(entry)) {
-                Assert(parent.get().GetSharedTx()->version != TRUC_VERSION);
+                Assert(parent.get().GetSharedTx()->GetVersion() != TRUC_VERSION);
             }
         }
     }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -139,7 +139,7 @@ std::shared_ptr<const CBlock> MinerTestingSetup::BadBlock(const uint256& prev_ha
 
     CMutableTransaction coinbase_spend;
     coinbase_spend.vin.emplace_back(COutPoint(pblock->vtx[0]->GetHash(), 0), CScript(), 0);
-    coinbase_spend.vout.push_back(pblock->vtx[0]->vout[0]);
+    coinbase_spend.vout.push_back(pblock->vtx[0]->GetOutputs()[0]);
 
     CTransactionRef tx = MakeTransactionRef(coinbase_spend);
     pblock->vtx.push_back(tx);
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
             CMutableTransaction mtx;
             mtx.vin.emplace_back(COutPoint{last_mined->vtx[0]->GetHash(), 1}, CScript{});
             mtx.vin[0].scriptWitness.stack.push_back(WITNESS_STACK_ELEM_OP_TRUE);
-            mtx.vout.push_back(last_mined->vtx[0]->vout[1]);
+            mtx.vout.push_back(last_mined->vtx[0]->GetOutputs()[1]);
             mtx.vout[0].nValue -= 1000;
             txs.push_back(MakeTransactionRef(mtx));
 

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(block_malleation)
         return tx;
     };
     auto insert_witness_commitment = [](CBlock& block, uint256 commitment) {
-        assert(!block.vtx.empty() && block.vtx[0]->IsCoinBase() && !block.vtx[0]->vout.empty());
+        assert(!block.vtx.empty() && block.vtx[0]->IsCoinBase() && !block.vtx[0]->GetOutputs().empty());
 
         CMutableTransaction mtx{*block.vtx[0]};
         CHash256().Write(commitment).Write(std::vector<unsigned char>(32, 0x00)).Finalize(commitment);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -76,7 +76,7 @@ std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> CTxMemPool::GetParents(const CT
     LOCK(cs);
     std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> ret;
     std::set<Txid> inputs;
-    for (const auto& txin : entry.GetTx().vin) {
+    for (const auto& txin : entry.GetTx().GetInputs()) {
         inputs.insert(txin.prevout.hash);
     }
     for (const auto& hash : inputs) {
@@ -146,8 +146,8 @@ CTxMemPool::setEntries CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEnt
     const CTransaction &tx = entry.GetTx();
 
     // Get parents of this transaction that are in the mempool
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        std::optional<txiter> piter = GetIter(tx.vin[i].prevout.hash);
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++) {
+        std::optional<txiter> piter = GetIter(tx.GetInputs()[i].prevout.hash);
         if (piter) {
             staged_parents.insert(*piter);
         }
@@ -236,8 +236,8 @@ void CTxMemPool::addNewTransaction(CTxMemPool::txiter newit)
     cachedInnerUsage += entry.DynamicMemoryUsage();
 
     const CTransaction& tx = newit->GetTx();
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        mapNextTx.insert(std::make_pair(&tx.vin[i].prevout, newit));
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++) {
+        mapNextTx.insert(std::make_pair(&tx.GetInputs()[i].prevout, newit));
     }
     // Don't bother worrying about child transactions of this one.
     // Normal case of a new transaction arriving is that there can't be any
@@ -281,7 +281,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count()
     );
 
-    for (const CTxIn& txin : it->GetTx().vin)
+    for (const CTxIn& txin : it->GetTx().GetInputs())
         mapNextTx.erase(txin.prevout);
 
     RemoveUnbroadcastTx(it->GetTx().GetHash(), true /* add logging because unchecked */);
@@ -389,7 +389,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx)
 {
     // Remove transactions which depend on inputs of tx, recursively
     AssertLockHeld(cs);
-    for (const CTxIn &txin : tx.vin) {
+    for (const CTxIn &txin : tx.GetInputs()) {
         auto it = mapNextTx.find(txin.prevout);
         if (it != mapNextTx.end()) {
             const CTransaction &txConflict = it->second->GetTx();
@@ -487,12 +487,12 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
 
         std::set<CTxMemPoolEntry::CTxMemPoolEntryRef, CompareIteratorByHash> setParentCheck;
         std::set<CTxMemPoolEntry::CTxMemPoolEntryRef, CompareIteratorByHash> setParentsStored;
-        for (const CTxIn &txin : tx.vin) {
+        for (const CTxIn &txin : tx.GetInputs()) {
             // Check that every mempool transaction's inputs refer to available coins, or other mempool tx's.
             indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end()) {
                 const CTransaction& tx2 = it2->GetTx();
-                assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
+                assert(tx2.GetOutputs().size() > txin.prevout.n && !tx2.GetOutputs()[txin.prevout.n].IsNull());
                 setParentCheck.insert(*it2);
             }
             // We are iterating through the mempool entries sorted
@@ -534,7 +534,7 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
         CAmount txfee = 0;
         assert(!tx.IsCoinBase());
         assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, txfee));
-        for (const auto& input: tx.vin) mempoolDuplicate.SpendCoin(input.prevout);
+        for (const auto& input: tx.GetInputs()) mempoolDuplicate.SpendCoin(input.prevout);
         AddCoins(mempoolDuplicate, tx, std::numeric_limits<int>::max());
     }
     for (auto it = mapNextTx.cbegin(); it != mapNextTx.cend(); it++) {
@@ -781,8 +781,8 @@ std::vector<CTxMemPool::txiter> CTxMemPool::GetIterVec(const std::vector<Txid>& 
 
 bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 {
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
-        if (exists(tx.vin[i].prevout.hash))
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++)
+        if (exists(tx.GetInputs()[i].prevout.hash))
             return false;
     return true;
 }
@@ -802,8 +802,8 @@ std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
     // transactions. First checking the underlying cache risks returning a pruned entry instead.
     CTransactionRef ptx = mempool.get(outpoint.hash);
     if (ptx) {
-        if (outpoint.n < ptx->vout.size()) {
-            Coin coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false);
+        if (outpoint.n < ptx->GetOutputs().size()) {
+            Coin coin(ptx->GetOutputs()[outpoint.n], MEMPOOL_HEIGHT, false);
             m_non_base_coins.emplace(outpoint);
             return coin;
         }
@@ -814,8 +814,8 @@ std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
 
 void CCoinsViewMemPool::PackageAddTransaction(const CTransactionRef& tx)
 {
-    for (unsigned int n = 0; n < tx->vout.size(); ++n) {
-        m_temp_added.emplace(COutPoint(tx->GetHash(), n), Coin(tx->vout[n], MEMPOOL_HEIGHT, false));
+    for (unsigned int n = 0; n < tx->GetOutputs().size(); ++n) {
+        m_temp_added.emplace(COutPoint(tx->GetHash(), n), Coin(tx->GetOutputs()[n], MEMPOOL_HEIGHT, false));
         m_non_base_coins.emplace(tx->GetHash(), n);
     }
 }
@@ -947,7 +947,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         }
         if (pvNoSpendsRemaining) {
             for (const CTransaction& tx : txn) {
-                for (const CTxIn& txin : tx.vin) {
+                for (const CTxIn& txin : tx.GetInputs()) {
                     if (exists(txin.prevout.hash)) continue;
                     pvNoSpendsRemaining->push_back(txin.prevout);
                 }
@@ -1102,7 +1102,7 @@ void CTxMemPool::ChangeSet::ProcessDependencies()
     LOCK(m_pool->cs);
     Assume(!m_dependencies_processed); // should only call this once.
     for (const auto& entryptr : m_entry_vec) {
-        for (const auto &txin : entryptr->GetSharedTx()->vin) {
+        for (const auto &txin : entryptr->GetSharedTx()->GetInputs()) {
             std::optional<txiter> piter = m_pool->GetIter(txin.prevout.hash);
             if (!piter) {
                 auto it = m_to_add.find(txin.prevout.hash);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -76,7 +76,7 @@ std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> CTxMemPool::GetParents(const CT
     LOCK(cs);
     std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> ret;
     std::set<Txid> inputs;
-    for (const auto& txin : entry.GetTx().vin) {
+    for (const auto& txin : entry.GetTx().GetInputs()) {
         inputs.insert(txin.prevout.hash);
     }
     for (const auto& hash : inputs) {
@@ -146,8 +146,8 @@ CTxMemPool::setEntries CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEnt
     const CTransaction &tx = entry.GetTx();
 
     // Get parents of this transaction that are in the mempool
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        std::optional<txiter> piter = GetIter(tx.vin[i].prevout.hash);
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++) {
+        std::optional<txiter> piter = GetIter(tx.GetInputs()[i].prevout.hash);
         if (piter) {
             staged_parents.insert(*piter);
         }
@@ -236,8 +236,8 @@ void CTxMemPool::addNewTransaction(CTxMemPool::txiter newit)
     cachedInnerUsage += entry.DynamicMemoryUsage();
 
     const CTransaction& tx = newit->GetTx();
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        mapNextTx.insert(std::make_pair(&tx.vin[i].prevout, newit));
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++) {
+        mapNextTx.insert(std::make_pair(&tx.GetInputs()[i].prevout, newit));
     }
     // Don't bother worrying about child transactions of this one.
     // Normal case of a new transaction arriving is that there can't be any
@@ -281,7 +281,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count()
     );
 
-    for (const CTxIn& txin : it->GetTx().vin)
+    for (const CTxIn& txin : it->GetTx().GetInputs())
         mapNextTx.erase(txin.prevout);
 
     RemoveUnbroadcastTx(it->GetTx().GetHash(), true /* add logging because unchecked */);
@@ -389,7 +389,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx)
 {
     // Remove transactions which depend on inputs of tx, recursively
     AssertLockHeld(cs);
-    for (const CTxIn &txin : tx.vin) {
+    for (const CTxIn &txin : tx.GetInputs()) {
         auto it = mapNextTx.find(txin.prevout);
         if (it != mapNextTx.end()) {
             const CTransaction &txConflict = it->second->GetTx();
@@ -485,12 +485,12 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
 
         std::set<CTxMemPoolEntry::CTxMemPoolEntryRef, CompareIteratorByHash> setParentCheck;
         std::set<CTxMemPoolEntry::CTxMemPoolEntryRef, CompareIteratorByHash> setParentsStored;
-        for (const CTxIn &txin : tx.vin) {
+        for (const CTxIn &txin : tx.GetInputs()) {
             // Check that every mempool transaction's inputs refer to available coins, or other mempool tx's.
             indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end()) {
                 const CTransaction& tx2 = it2->GetTx();
-                assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
+                assert(tx2.GetOutputs().size() > txin.prevout.n && !tx2.GetOutputs()[txin.prevout.n].IsNull());
                 setParentCheck.insert(*it2);
             }
             // We are iterating through the mempool entries sorted
@@ -532,7 +532,7 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
         CAmount txfee = 0;
         assert(!tx.IsCoinBase());
         assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, txfee));
-        for (const auto& input: tx.vin) mempoolDuplicate.SpendCoin(input.prevout);
+        for (const auto& input: tx.GetInputs()) mempoolDuplicate.SpendCoin(input.prevout);
         AddCoins(mempoolDuplicate, tx, std::numeric_limits<int>::max());
     }
     for (auto it = mapNextTx.cbegin(); it != mapNextTx.cend(); it++) {
@@ -779,8 +779,8 @@ std::vector<CTxMemPool::txiter> CTxMemPool::GetIterVec(const std::vector<Txid>& 
 
 bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 {
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
-        if (exists(tx.vin[i].prevout.hash))
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++)
+        if (exists(tx.GetInputs()[i].prevout.hash))
             return false;
     return true;
 }
@@ -800,8 +800,8 @@ std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
     // transactions. First checking the underlying cache risks returning a pruned entry instead.
     CTransactionRef ptx = mempool.get(outpoint.hash);
     if (ptx) {
-        if (outpoint.n < ptx->vout.size()) {
-            Coin coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false);
+        if (outpoint.n < ptx->GetOutputs().size()) {
+            Coin coin(ptx->GetOutputs()[outpoint.n], MEMPOOL_HEIGHT, false);
             m_non_base_coins.emplace(outpoint);
             return coin;
         }
@@ -812,8 +812,8 @@ std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
 
 void CCoinsViewMemPool::PackageAddTransaction(const CTransactionRef& tx)
 {
-    for (unsigned int n = 0; n < tx->vout.size(); ++n) {
-        m_temp_added.emplace(COutPoint(tx->GetHash(), n), Coin(tx->vout[n], MEMPOOL_HEIGHT, false));
+    for (unsigned int n = 0; n < tx->GetOutputs().size(); ++n) {
+        m_temp_added.emplace(COutPoint(tx->GetHash(), n), Coin(tx->GetOutputs()[n], MEMPOOL_HEIGHT, false));
         m_non_base_coins.emplace(tx->GetHash(), n);
     }
 }
@@ -945,7 +945,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         }
         if (pvNoSpendsRemaining) {
             for (const CTransaction& tx : txn) {
-                for (const CTxIn& txin : tx.vin) {
+                for (const CTxIn& txin : tx.GetInputs()) {
                     if (exists(txin.prevout.hash)) continue;
                     pvNoSpendsRemaining->push_back(txin.prevout);
                 }
@@ -1100,7 +1100,7 @@ void CTxMemPool::ChangeSet::ProcessDependencies()
     LOCK(m_pool->cs);
     Assume(!m_dependencies_processed); // should only call this once.
     for (const auto& entryptr : m_entry_vec) {
-        for (const auto &txin : entryptr->GetSharedTx()->vin) {
+        for (const auto &txin : entryptr->GetSharedTx()->GetInputs()) {
             std::optional<txiter> piter = m_pool->GetIter(txin.prevout.hash);
             if (!piter) {
                 auto it = m_to_add.find(txin.prevout.hash);

--- a/src/util/rbf.cpp
+++ b/src/util/rbf.cpp
@@ -10,7 +10,7 @@
 
 bool SignalsOptInRBF(const CTransaction &tx)
 {
-    for (const CTxIn &txin : tx.vin) {
+    for (const CTxIn &txin : tx.GetInputs()) {
         if (txin.nSequence <= MAX_BIP125_RBF_SEQUENCE) {
             return true;
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -192,9 +192,9 @@ std::optional<std::vector<int>> CalculatePrevHeights(
     const CTransaction& tx)
 {
     std::vector<int> prev_heights;
-    prev_heights.resize(tx.vin.size());
-    for (size_t i = 0; i < tx.vin.size(); ++i) {
-        if (auto coin{coins.GetCoin(tx.vin[i].prevout)}) {
+    prev_heights.resize(tx.GetInputs().size());
+    for (size_t i = 0; i < tx.GetInputs().size(); ++i) {
+        if (auto coin{coins.GetCoin(tx.GetInputs()[i].prevout)}) {
             prev_heights[i] = coin->nHeight == MEMPOOL_HEIGHT
                               ? tip.nHeight + 1 // Assume all mempool transaction confirm in the next block.
                               : coin->nHeight;
@@ -376,7 +376,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
 
         // If the transaction spends any coinbase outputs, it must be mature.
         if (it->GetSpendsCoinbase()) {
-            for (const CTxIn& txin : tx.vin) {
+            for (const CTxIn& txin : tx.GetInputs()) {
                 if (m_mempool->exists(txin.prevout.hash)) continue;
                 const Coin& coin{CoinsTip().AccessCoin(txin.prevout)};
                 assert(!coin.IsSpent());
@@ -411,7 +411,7 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
     AssertLockHeld(pool.cs);
 
     assert(!tx.IsCoinBase());
-    for (const CTxIn& txin : tx.vin) {
+    for (const CTxIn& txin : tx.GetInputs()) {
         const Coin& coin = view.AccessCoin(txin.prevout);
 
         // This coin was checked in PreChecks and MemPoolAccept
@@ -426,8 +426,8 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
         const CTransactionRef& txFrom = pool.get(txin.prevout.hash);
         if (txFrom) {
             assert(txFrom->GetHash() == txin.prevout.hash);
-            assert(txFrom->vout.size() > txin.prevout.n);
-            assert(txFrom->vout[txin.prevout.n] == coin.out);
+            assert(txFrom->GetOutputs().size() > txin.prevout.n);
+            assert(txFrom->GetOutputs()[txin.prevout.n] == coin.out);
         } else {
             const Coin& coinFromUTXOSet = coins_tip.AccessCoin(txin.prevout);
             assert(!coinFromUTXOSet.IsSpent());
@@ -835,7 +835,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }
 
     // Check for conflicts with in-memory transactions
-    for (const CTxIn &txin : tx.vin)
+    for (const CTxIn &txin : tx.GetInputs())
     {
         const CTransaction* ptxConflicting = m_pool.GetConflictTx(txin.prevout);
         if (ptxConflicting) {
@@ -851,7 +851,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     const CCoinsViewCache& coins_cache = m_active_chainstate.CoinsTip();
     // do all inputs exist?
-    for (const CTxIn& txin : tx.vin) {
+    for (const CTxIn& txin : tx.GetInputs()) {
         if (!coins_cache.HaveCoinInCache(txin.prevout)) {
             coins_to_uncache.push_back(txin.prevout);
         }
@@ -861,7 +861,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // later (via coins_to_uncache) if this tx turns out to be invalid.
         if (!m_view.HaveCoin(txin.prevout)) {
             // Are inputs missing because we already have the tx?
-            for (size_t out = 0; out < tx.vout.size(); out++) {
+            for (size_t out = 0; out < tx.GetOutputs().size(); out++) {
                 // Optimistically just do efficient check of cache for outputs
                 if (coins_cache.HaveCoinInCache(COutPoint(hash, out))) {
                     return state.Invalid(TxValidationResult::TX_CONFLICT, "txn-already-known");
@@ -915,7 +915,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // Keep track of transactions that spend a coinbase, which we re-scan
     // during reorgs to ensure COINBASE_MATURITY is still met.
     bool fSpendsCoinbase = false;
-    for (const CTxIn &txin : tx.vin) {
+    for (const CTxIn &txin : tx.GetInputs()) {
         const Coin &coin = m_view.AccessCoin(txin.prevout);
         if (coin.IsCoinBase()) {
             fSpendsCoinbase = true;
@@ -2012,8 +2012,8 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txund
 {
     // mark inputs spent
     if (!tx.IsCoinBase()) {
-        txundo.vprevout.reserve(tx.vin.size());
-        for (const CTxIn &txin : tx.vin) {
+        txundo.vprevout.reserve(tx.GetInputs().size());
+        for (const CTxIn &txin : tx.GetInputs()) {
             txundo.vprevout.emplace_back();
             bool is_spent = inputs.SpendCoin(txin.prevout, &txundo.vprevout.back());
             assert(is_spent);
@@ -2024,13 +2024,13 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txund
 }
 
 std::optional<std::pair<ScriptError, std::string>> CScriptCheck::operator()() {
-    const CScript &scriptSig = ptxTo->vin[nIn].scriptSig;
-    const CScriptWitness *witness = &ptxTo->vin[nIn].scriptWitness;
+    const CScript &scriptSig = ptxTo->GetInputs()[nIn].scriptSig;
+    const CScriptWitness *witness = &ptxTo->GetInputs()[nIn].scriptWitness;
     ScriptError error{SCRIPT_ERR_UNKNOWN_ERROR};
     if (VerifyScript(scriptSig, m_tx_out.scriptPubKey, witness, m_flags, CachingTransactionSignatureChecker(ptxTo, nIn, m_tx_out.nValue, cacheStore, *m_signature_cache, *txdata), &error)) {
         return std::nullopt;
     } else {
-        auto debug_str = strprintf("input %i of %s (wtxid %s), spending %s:%i", nIn, ptxTo->GetHash().ToString(), ptxTo->GetWitnessHash().ToString(), ptxTo->vin[nIn].prevout.hash.ToString(), ptxTo->vin[nIn].prevout.n);
+        auto debug_str = strprintf("input %i of %s (wtxid %s), spending %s:%i", nIn, ptxTo->GetHash().ToString(), ptxTo->GetWitnessHash().ToString(), ptxTo->GetInputs()[nIn].prevout.hash.ToString(), ptxTo->GetInputs()[nIn].prevout.n);
         return std::make_pair(error, std::move(debug_str));
     }
 }
@@ -2079,7 +2079,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     if (tx.IsCoinBase()) return true;
 
     if (pvChecks) {
-        pvChecks->reserve(tx.vin.size());
+        pvChecks->reserve(tx.GetInputs().size());
     }
 
     // First check if script executions have been cached with the same
@@ -2097,9 +2097,9 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
 
     if (!txdata.m_spent_outputs_ready) {
         std::vector<CTxOut> spent_outputs;
-        spent_outputs.reserve(tx.vin.size());
+        spent_outputs.reserve(tx.GetInputs().size());
 
-        for (const auto& txin : tx.vin) {
+        for (const auto& txin : tx.GetInputs()) {
             const COutPoint& prevout = txin.prevout;
             const Coin& coin = inputs.AccessCoin(prevout);
             assert(!coin.IsSpent());
@@ -2107,9 +2107,9 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         }
         txdata.Init(tx, std::move(spent_outputs));
     }
-    assert(txdata.m_spent_outputs.size() == tx.vin.size());
+    assert(txdata.m_spent_outputs.size() == tx.GetInputs().size());
 
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++) {
 
         // We very carefully only pass in things to CScriptCheck which
         // are clearly committed to by tx' witness hash. This provides
@@ -2222,12 +2222,12 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
 
         // Check that all outputs are available and match the outputs in the block itself
         // exactly.
-        for (size_t o = 0; o < tx.vout.size(); o++) {
-            if (!tx.vout[o].scriptPubKey.IsUnspendable()) {
+        for (size_t o = 0; o < tx.GetOutputs().size(); o++) {
+            if (!tx.GetOutputs()[o].scriptPubKey.IsUnspendable()) {
                 COutPoint out(hash, o);
                 Coin coin;
                 bool is_spent = view.SpendCoin(out, &coin);
-                if (!is_spent || tx.vout[o] != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.IsCoinBase()) {
+                if (!is_spent || tx.GetOutputs()[o] != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.IsCoinBase()) {
                     if (!is_bip30_exception) {
                         fClean = false; // transaction output mismatch
                     }
@@ -2238,13 +2238,13 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
         // restore inputs
         if (i > 0) { // not coinbases
             CTxUndo &txundo = blockUndo.vtxundo[i-1];
-            if (txundo.vprevout.size() != tx.vin.size()) {
+            if (txundo.vprevout.size() != tx.GetInputs().size()) {
                 LogError("DisconnectBlock(): transaction and undo data inconsistent\n");
                 return DISCONNECT_FAILED;
             }
-            for (unsigned int j = tx.vin.size(); j > 0;) {
+            for (unsigned int j = tx.GetInputs().size(); j > 0;) {
                 --j;
-                const COutPoint& out = tx.vin[j].prevout;
+                const COutPoint& out = tx.GetInputs()[j].prevout;
                 int res = ApplyTxInUndo(std::move(txundo.vprevout[j]), view, out);
                 if (res == DISCONNECT_FAILED) return DISCONNECT_FAILED;
                 fClean = fClean && res != DISCONNECT_UNCLEAN;
@@ -2478,7 +2478,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // duplicate earlier coinbases.
     if (fEnforceBIP30 || pindex->nHeight >= BIP34_IMPLIES_BIP30_LIMIT) {
         for (const auto& tx : block.vtx) {
-            for (size_t o = 0; o < tx->vout.size(); o++) {
+            for (size_t o = 0; o < tx->GetOutputs().size(); o++) {
                 if (view.HaveCoin(COutPoint(tx->GetHash(), o))) {
                     state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-txns-BIP30",
                                   "tried to overwrite transaction");
@@ -2537,7 +2537,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         if (!state.IsValid()) break;
         const CTransaction &tx = *(block.vtx[i]);
 
-        nInputs += tx.vin.size();
+        nInputs += tx.GetInputs().size();
 
         if (!tx.IsCoinBase())
         {
@@ -2560,9 +2560,9 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // Check that transaction is BIP68 final
             // BIP68 lock checks (as opposed to nLockTime checks) must
             // be in ConnectBlock because they require the UTXO set
-            prevheights.resize(tx.vin.size());
-            for (size_t j = 0; j < tx.vin.size(); j++) {
-                prevheights[j] = view.AccessCoin(tx.vin[j].prevout).nHeight;
+            prevheights.resize(tx.GetInputs().size());
+            for (size_t j = 0; j < tx.GetInputs().size(); j++) {
+                prevheights[j] = view.AccessCoin(tx.GetInputs()[j].prevout).nHeight;
             }
 
             if (!SequenceLocks(tx, nLockTimeFlags, prevheights, *pindex)) {
@@ -3890,8 +3890,8 @@ static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_comm
 
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != NO_WITNESS_COMMITMENT) {
-            assert(!block.vtx.empty() && !block.vtx[0]->vin.empty());
-            const auto& witness_stack{block.vtx[0]->vin[0].scriptWitness.stack};
+            assert(!block.vtx.empty() && !block.vtx[0]->GetInputs().empty());
+            const auto& witness_stack{block.vtx[0]->GetInputs()[0].scriptWitness.stack};
 
             if (witness_stack.size() != 1 || witness_stack[0].size() != 32) {
                 return state.Invalid(
@@ -3906,7 +3906,7 @@ static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_comm
             uint256 hash_witness = BlockWitnessMerkleRoot(block);
 
             CHash256().Write(hash_witness).Write(witness_stack[0]).Finalize(hash_witness);
-            if (memcmp(hash_witness.begin(), &block.vtx[0]->vout[commitpos].scriptPubKey[6], 32)) {
+            if (memcmp(hash_witness.begin(), &block.vtx[0]->GetOutputs()[commitpos].scriptPubKey[6], 32)) {
                 return state.Invalid(
                     /*result=*/BlockValidationResult::BLOCK_MUTATED,
                     /*reject_reason=*/"bad-witness-merkle-match",
@@ -4168,8 +4168,8 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB))
     {
         CScript expect = CScript() << nHeight;
-        if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
-            !std::equal(expect.begin(), expect.end(), block.vtx[0]->vin[0].scriptSig.begin())) {
+        if (block.vtx[0]->GetInputs()[0].scriptSig.size() < expect.size() ||
+            !std::equal(expect.begin(), expect.end(), block.vtx[0]->GetInputs()[0].scriptSig.begin())) {
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-height", "block height mismatch in coinbase");
         }
     }
@@ -4787,7 +4787,7 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
 
     for (const CTransactionRef& tx : block.vtx) {
         if (!tx->IsCoinBase()) {
-            for (const CTxIn &txin : tx->vin) {
+            for (const CTxIn &txin : tx->GetInputs()) {
                 inputs.SpendCoin(txin.prevout);
             }
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -192,9 +192,9 @@ std::optional<std::vector<int>> CalculatePrevHeights(
     const CTransaction& tx)
 {
     std::vector<int> prev_heights;
-    prev_heights.resize(tx.vin.size());
-    for (size_t i = 0; i < tx.vin.size(); ++i) {
-        if (auto coin{coins.GetCoin(tx.vin[i].prevout)}) {
+    prev_heights.resize(tx.GetInputs().size());
+    for (size_t i = 0; i < tx.GetInputs().size(); ++i) {
+        if (auto coin{coins.GetCoin(tx.GetInputs()[i].prevout)}) {
             prev_heights[i] = coin->nHeight == MEMPOOL_HEIGHT
                               ? tip.nHeight + 1 // Assume all mempool transaction confirm in the next block.
                               : coin->nHeight;
@@ -376,7 +376,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
 
         // If the transaction spends any coinbase outputs, it must be mature.
         if (it->GetSpendsCoinbase()) {
-            for (const CTxIn& txin : tx.vin) {
+            for (const CTxIn& txin : tx.GetInputs()) {
                 if (m_mempool->exists(txin.prevout.hash)) continue;
                 const Coin& coin{CoinsTip().AccessCoin(txin.prevout)};
                 assert(!coin.IsSpent());
@@ -411,7 +411,7 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
     AssertLockHeld(pool.cs);
 
     assert(!tx.IsCoinBase());
-    for (const CTxIn& txin : tx.vin) {
+    for (const CTxIn& txin : tx.GetInputs()) {
         const Coin& coin = view.AccessCoin(txin.prevout);
 
         // This coin was checked in PreChecks and MemPoolAccept
@@ -426,8 +426,8 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
         const CTransactionRef& txFrom = pool.get(txin.prevout.hash);
         if (txFrom) {
             assert(txFrom->GetHash() == txin.prevout.hash);
-            assert(txFrom->vout.size() > txin.prevout.n);
-            assert(txFrom->vout[txin.prevout.n] == coin.out);
+            assert(txFrom->GetOutputs().size() > txin.prevout.n);
+            assert(txFrom->GetOutputs()[txin.prevout.n] == coin.out);
         } else {
             const Coin& coinFromUTXOSet = coins_tip.AccessCoin(txin.prevout);
             assert(!coinFromUTXOSet.IsSpent());
@@ -835,7 +835,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }
 
     // Check for conflicts with in-memory transactions
-    for (const CTxIn &txin : tx.vin)
+    for (const CTxIn &txin : tx.GetInputs())
     {
         const CTransaction* ptxConflicting = m_pool.GetConflictTx(txin.prevout);
         if (ptxConflicting) {
@@ -851,7 +851,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     const CCoinsViewCache& coins_cache = m_active_chainstate.CoinsTip();
     // do all inputs exist?
-    for (const CTxIn& txin : tx.vin) {
+    for (const CTxIn& txin : tx.GetInputs()) {
         if (!coins_cache.HaveCoinInCache(txin.prevout)) {
             coins_to_uncache.push_back(txin.prevout);
         }
@@ -861,7 +861,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // later (via coins_to_uncache) if this tx turns out to be invalid.
         if (!m_view.HaveCoin(txin.prevout)) {
             // Are inputs missing because we already have the tx?
-            for (size_t out = 0; out < tx.vout.size(); out++) {
+            for (size_t out = 0; out < tx.GetOutputs().size(); out++) {
                 // Optimistically just do efficient check of cache for outputs
                 if (coins_cache.HaveCoinInCache(COutPoint(hash, out))) {
                     return state.Invalid(TxValidationResult::TX_CONFLICT, "txn-already-known");
@@ -915,7 +915,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // Keep track of transactions that spend a coinbase, which we re-scan
     // during reorgs to ensure COINBASE_MATURITY is still met.
     bool fSpendsCoinbase = false;
-    for (const CTxIn &txin : tx.vin) {
+    for (const CTxIn &txin : tx.GetInputs()) {
         const Coin &coin = m_view.AccessCoin(txin.prevout);
         if (coin.IsCoinBase()) {
             fSpendsCoinbase = true;
@@ -2010,8 +2010,8 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txund
 {
     // mark inputs spent
     if (!tx.IsCoinBase()) {
-        txundo.vprevout.reserve(tx.vin.size());
-        for (const CTxIn &txin : tx.vin) {
+        txundo.vprevout.reserve(tx.GetInputs().size());
+        for (const CTxIn &txin : tx.GetInputs()) {
             txundo.vprevout.emplace_back();
             bool is_spent = inputs.SpendCoin(txin.prevout, &txundo.vprevout.back());
             assert(is_spent);
@@ -2022,13 +2022,13 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txund
 }
 
 std::optional<std::pair<ScriptError, std::string>> CScriptCheck::operator()() {
-    const CScript &scriptSig = ptxTo->vin[nIn].scriptSig;
-    const CScriptWitness *witness = &ptxTo->vin[nIn].scriptWitness;
+    const CScript &scriptSig = ptxTo->GetInputs()[nIn].scriptSig;
+    const CScriptWitness *witness = &ptxTo->GetInputs()[nIn].scriptWitness;
     ScriptError error{SCRIPT_ERR_UNKNOWN_ERROR};
     if (VerifyScript(scriptSig, m_tx_out.scriptPubKey, witness, m_flags, CachingTransactionSignatureChecker(ptxTo, nIn, m_tx_out.nValue, cacheStore, *m_signature_cache, *txdata), &error)) {
         return std::nullopt;
     } else {
-        auto debug_str = strprintf("input %i of %s (wtxid %s), spending %s:%i", nIn, ptxTo->GetHash().ToString(), ptxTo->GetWitnessHash().ToString(), ptxTo->vin[nIn].prevout.hash.ToString(), ptxTo->vin[nIn].prevout.n);
+        auto debug_str = strprintf("input %i of %s (wtxid %s), spending %s:%i", nIn, ptxTo->GetHash().ToString(), ptxTo->GetWitnessHash().ToString(), ptxTo->GetInputs()[nIn].prevout.hash.ToString(), ptxTo->GetInputs()[nIn].prevout.n);
         return std::make_pair(error, std::move(debug_str));
     }
 }
@@ -2077,7 +2077,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     if (tx.IsCoinBase()) return true;
 
     if (pvChecks) {
-        pvChecks->reserve(tx.vin.size());
+        pvChecks->reserve(tx.GetInputs().size());
     }
 
     // First check if script executions have been cached with the same
@@ -2095,9 +2095,9 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
 
     if (!txdata.m_spent_outputs_ready) {
         std::vector<CTxOut> spent_outputs;
-        spent_outputs.reserve(tx.vin.size());
+        spent_outputs.reserve(tx.GetInputs().size());
 
-        for (const auto& txin : tx.vin) {
+        for (const auto& txin : tx.GetInputs()) {
             const COutPoint& prevout = txin.prevout;
             const Coin& coin = inputs.AccessCoin(prevout);
             assert(!coin.IsSpent());
@@ -2105,9 +2105,9 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         }
         txdata.Init(tx, std::move(spent_outputs));
     }
-    assert(txdata.m_spent_outputs.size() == tx.vin.size());
+    assert(txdata.m_spent_outputs.size() == tx.GetInputs().size());
 
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
+    for (unsigned int i = 0; i < tx.GetInputs().size(); i++) {
 
         // We very carefully only pass in things to CScriptCheck which
         // are clearly committed to by tx' witness hash. This provides
@@ -2220,12 +2220,12 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
 
         // Check that all outputs are available and match the outputs in the block itself
         // exactly.
-        for (size_t o = 0; o < tx.vout.size(); o++) {
-            if (!tx.vout[o].scriptPubKey.IsUnspendable()) {
+        for (size_t o = 0; o < tx.GetOutputs().size(); o++) {
+            if (!tx.GetOutputs()[o].scriptPubKey.IsUnspendable()) {
                 COutPoint out(hash, o);
                 Coin coin;
                 bool is_spent = view.SpendCoin(out, &coin);
-                if (!is_spent || tx.vout[o] != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.IsCoinBase()) {
+                if (!is_spent || tx.GetOutputs()[o] != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.IsCoinBase()) {
                     if (!is_bip30_exception) {
                         fClean = false; // transaction output mismatch
                     }
@@ -2236,13 +2236,13 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
         // restore inputs
         if (i > 0) { // not coinbases
             CTxUndo &txundo = blockUndo.vtxundo[i-1];
-            if (txundo.vprevout.size() != tx.vin.size()) {
+            if (txundo.vprevout.size() != tx.GetInputs().size()) {
                 LogError("DisconnectBlock(): transaction and undo data inconsistent\n");
                 return DISCONNECT_FAILED;
             }
-            for (unsigned int j = tx.vin.size(); j > 0;) {
+            for (unsigned int j = tx.GetInputs().size(); j > 0;) {
                 --j;
-                const COutPoint& out = tx.vin[j].prevout;
+                const COutPoint& out = tx.GetInputs()[j].prevout;
                 int res = ApplyTxInUndo(std::move(txundo.vprevout[j]), view, out);
                 if (res == DISCONNECT_FAILED) return DISCONNECT_FAILED;
                 fClean = fClean && res != DISCONNECT_UNCLEAN;
@@ -2476,7 +2476,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // duplicate earlier coinbases.
     if (fEnforceBIP30 || pindex->nHeight >= BIP34_IMPLIES_BIP30_LIMIT) {
         for (const auto& tx : block.vtx) {
-            for (size_t o = 0; o < tx->vout.size(); o++) {
+            for (size_t o = 0; o < tx->GetOutputs().size(); o++) {
                 if (view.HaveCoin(COutPoint(tx->GetHash(), o))) {
                     state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-txns-BIP30",
                                   "tried to overwrite transaction");
@@ -2535,7 +2535,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         if (!state.IsValid()) break;
         const CTransaction &tx = *(block.vtx[i]);
 
-        nInputs += tx.vin.size();
+        nInputs += tx.GetInputs().size();
 
         if (!tx.IsCoinBase())
         {
@@ -2558,9 +2558,9 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // Check that transaction is BIP68 final
             // BIP68 lock checks (as opposed to nLockTime checks) must
             // be in ConnectBlock because they require the UTXO set
-            prevheights.resize(tx.vin.size());
-            for (size_t j = 0; j < tx.vin.size(); j++) {
-                prevheights[j] = view.AccessCoin(tx.vin[j].prevout).nHeight;
+            prevheights.resize(tx.GetInputs().size());
+            for (size_t j = 0; j < tx.GetInputs().size(); j++) {
+                prevheights[j] = view.AccessCoin(tx.GetInputs()[j].prevout).nHeight;
             }
 
             if (!SequenceLocks(tx, nLockTimeFlags, prevheights, *pindex)) {
@@ -3893,8 +3893,8 @@ static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_comm
 
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != NO_WITNESS_COMMITMENT) {
-            assert(!block.vtx.empty() && !block.vtx[0]->vin.empty());
-            const auto& witness_stack{block.vtx[0]->vin[0].scriptWitness.stack};
+            assert(!block.vtx.empty() && !block.vtx[0]->GetInputs().empty());
+            const auto& witness_stack{block.vtx[0]->GetInputs()[0].scriptWitness.stack};
 
             if (witness_stack.size() != 1 || witness_stack[0].size() != 32) {
                 return state.Invalid(
@@ -3909,7 +3909,7 @@ static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_comm
             uint256 hash_witness = BlockWitnessMerkleRoot(block);
 
             CHash256().Write(hash_witness).Write(witness_stack[0]).Finalize(hash_witness);
-            if (memcmp(hash_witness.begin(), &block.vtx[0]->vout[commitpos].scriptPubKey[6], 32)) {
+            if (memcmp(hash_witness.begin(), &block.vtx[0]->GetOutputs()[commitpos].scriptPubKey[6], 32)) {
                 return state.Invalid(
                     /*result=*/BlockValidationResult::BLOCK_MUTATED,
                     /*reject_reason=*/"bad-witness-merkle-match",
@@ -4171,8 +4171,8 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB))
     {
         CScript expect = CScript() << nHeight;
-        if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
-            !std::equal(expect.begin(), expect.end(), block.vtx[0]->vin[0].scriptSig.begin())) {
+        if (block.vtx[0]->GetInputs()[0].scriptSig.size() < expect.size() ||
+            !std::equal(expect.begin(), expect.end(), block.vtx[0]->GetInputs()[0].scriptSig.begin())) {
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-height", "block height mismatch in coinbase");
         }
     }
@@ -4790,7 +4790,7 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
 
     for (const CTransactionRef& tx : block.vtx) {
         if (!tx->IsCoinBase()) {
-            for (const CTxIn &txin : tx->vin) {
+            for (const CTxIn &txin : tx->GetInputs()) {
                 inputs.SpendCoin(txin.prevout);
             }
         }

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -180,7 +180,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     const CTransactionRef& tx = wtx.GetTx();
 
     // Make sure that original_change_index is valid
-    if (original_change_index.has_value() && original_change_index.value() >= tx->vout.size()) {
+    if (original_change_index.has_value() && original_change_index.value() >= tx->GetOutputs().size()) {
         errors.emplace_back(Untranslated("Change position is out of range"));
         return Result::INVALID_PARAMETER;
     }
@@ -190,11 +190,11 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     std::map<COutPoint, Coin> coins;
     CAmount input_value = 0;
     std::vector<CTxOut> spent_outputs;
-    for (const CTxIn& txin : tx->vin) {
+    for (const CTxIn& txin : tx->GetInputs()) {
         coins[txin.prevout]; // Create empty map entry keyed by prevout.
     }
     wallet.chain().findCoins(coins);
-    for (const CTxIn& txin : tx->vin) {
+    for (const CTxIn& txin : tx->GetInputs()) {
         const Coin& coin = coins.at(txin.prevout);
         if (coin.out.IsNull()) {
             errors.emplace_back(Untranslated(strprintf("%s:%u is already spent", txin.prevout.hash.GetHex(), txin.prevout.n)));
@@ -211,8 +211,8 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     // Figure out if we need to compute the input weight, and do so if necessary
     PrecomputedTransactionData txdata;
     txdata.Init(*tx, std::move(spent_outputs), /* force=*/ true);
-    for (unsigned int i = 0; i < tx->vin.size(); ++i) {
-        const CTxIn& txin = tx->vin.at(i);
+    for (unsigned int i = 0; i < tx->GetInputs().size(); ++i) {
+        const CTxIn& txin = tx->GetInputs().at(i);
         const Coin& coin = coins.at(txin.prevout);
 
         if (new_coin_control.IsExternalSelected(txin.prevout)) {
@@ -239,7 +239,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
 
     // Calculate the old output amount.
     CAmount output_value = 0;
-    for (const auto& old_output : tx->vout) {
+    for (const auto& old_output : tx->GetOutputs()) {
         output_value += old_output.nValue;
     }
 
@@ -250,7 +250,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     // outputs with its contents, otherwise use original outputs.
     std::vector<CRecipient> recipients;
     CAmount new_outputs_value = 0;
-    const auto& txouts = outputs.empty() ? tx->vout : outputs;
+    const auto& txouts = outputs.empty() ? tx->GetOutputs() : outputs;
     for (size_t i = 0; i < txouts.size(); ++i) {
         const CTxOut& output = txouts.at(i);
         CTxDestination dest;
@@ -305,7 +305,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     // A2 and A3 where A2 and A3 don't conflict (or alternatively bump A to A2 and A2
     // to A3 where A and A3 don't conflict). If both later get confirmed then the sender
     // has accidentally double paid.
-    for (const auto& inputs : tx->vin) {
+    for (const auto& inputs : tx->GetInputs()) {
         new_coin_control.Select(COutPoint(inputs.prevout));
     }
     new_coin_control.m_allow_other_inputs = true;

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -181,7 +181,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     const CTransactionRef& tx = wtx.GetTx();
 
     // Make sure that original_change_index is valid
-    if (original_change_index.has_value() && original_change_index.value() >= tx->vout.size()) {
+    if (original_change_index.has_value() && original_change_index.value() >= tx->GetOutputs().size()) {
         errors.emplace_back(Untranslated("Change position is out of range"));
         return Result::INVALID_PARAMETER;
     }
@@ -191,11 +191,11 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     std::map<COutPoint, Coin> coins;
     CAmount input_value = 0;
     std::vector<CTxOut> spent_outputs;
-    for (const CTxIn& txin : tx->vin) {
+    for (const CTxIn& txin : tx->GetInputs()) {
         coins[txin.prevout]; // Create empty map entry keyed by prevout.
     }
     wallet.chain().findCoins(coins);
-    for (const CTxIn& txin : tx->vin) {
+    for (const CTxIn& txin : tx->GetInputs()) {
         const Coin& coin = coins.at(txin.prevout);
         if (coin.out.IsNull()) {
             errors.emplace_back(Untranslated(strprintf("%s:%u is already spent", txin.prevout.hash.GetHex(), txin.prevout.n)));
@@ -212,8 +212,8 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     // Figure out if we need to compute the input weight, and do so if necessary
     PrecomputedTransactionData txdata;
     txdata.Init(*tx, std::move(spent_outputs), /* force=*/ true);
-    for (unsigned int i = 0; i < tx->vin.size(); ++i) {
-        const CTxIn& txin = tx->vin.at(i);
+    for (unsigned int i = 0; i < tx->GetInputs().size(); ++i) {
+        const CTxIn& txin = tx->GetInputs().at(i);
         const Coin& coin = coins.at(txin.prevout);
 
         if (new_coin_control.IsExternalSelected(txin.prevout)) {
@@ -240,7 +240,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
 
     // Calculate the old output amount.
     CAmount output_value = 0;
-    for (const auto& old_output : tx->vout) {
+    for (const auto& old_output : tx->GetOutputs()) {
         output_value += old_output.nValue;
     }
 
@@ -251,7 +251,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     // outputs with its contents, otherwise use original outputs.
     std::vector<CRecipient> recipients;
     CAmount new_outputs_value = 0;
-    const auto& txouts = outputs.empty() ? tx->vout : outputs;
+    const auto& txouts = outputs.empty() ? tx->GetOutputs() : outputs;
     for (size_t i = 0; i < txouts.size(); ++i) {
         const CTxOut& output = txouts.at(i);
         CTxDestination dest;
@@ -306,7 +306,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     // A2 and A3 where A2 and A3 don't conflict (or alternatively bump A to A2 and A2
     // to A3 where A and A3 don't conflict). If both later get confirmed then the sender
     // has accidentally double paid.
-    for (const auto& inputs : tx->vin) {
+    for (const auto& inputs : tx->GetInputs()) {
         new_coin_control.Select(COutPoint(inputs.prevout));
     }
     new_coin_control.m_allow_other_inputs = true;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -58,14 +58,14 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
     LOCK(wallet.cs_wallet);
     WalletTx result;
     result.tx = wtx.GetTx();
-    result.txin_is_mine.reserve(result.tx->vin.size());
-    for (const auto& txin : result.tx->vin) {
+    result.txin_is_mine.reserve(result.tx->GetInputs().size());
+    for (const auto& txin : result.tx->GetInputs()) {
         result.txin_is_mine.emplace_back(InputIsMine(wallet, txin));
     }
-    result.txout_is_mine.reserve(result.tx->vout.size());
-    result.txout_address.reserve(result.tx->vout.size());
-    result.txout_address_is_mine.reserve(result.tx->vout.size());
-    for (const auto& txout : result.tx->vout) {
+    result.txout_is_mine.reserve(result.tx->GetOutputs().size());
+    result.txout_address.reserve(result.tx->GetOutputs().size());
+    result.txout_address_is_mine.reserve(result.tx->GetOutputs().size());
+    for (const auto& txout : result.tx->GetOutputs()) {
         result.txout_is_mine.emplace_back(wallet.IsMine(txout));
         result.txout_is_change.push_back(OutputIsChange(wallet, txout));
         result.txout_address.emplace_back();
@@ -99,7 +99,7 @@ WalletTxStatus MakeWalletTxStatus(const CWallet& wallet, const CWalletTx& wtx)
     result.blocks_to_maturity = wallet.GetTxBlocksToMaturity(wtx);
     result.depth_in_main_chain = wallet.GetTxDepthInMainChain(wtx);
     result.time_received = wtx.nTimeReceived;
-    result.lock_time = wtx.GetTx()->nLockTime;
+    result.lock_time = wtx.GetTx()->GetLockTime();
     result.is_trusted = CachedTxIsTrusted(wallet, wtx);
     result.is_abandoned = wtx.isAbandoned();
     result.is_coinbase = wtx.IsCoinBase();
@@ -114,7 +114,7 @@ WalletTxOut MakeWalletTxOut(const CWallet& wallet,
     int depth) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     WalletTxOut result;
-    result.txout = wtx.GetTx()->vout[n];
+    result.txout = wtx.GetTx()->GetOutputs()[n];
     result.time = wtx.GetTxTime();
     result.depth_in_main_chain = depth;
     result.is_spent = wallet.IsSpent(COutPoint(wtx.GetHash(), n));

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -59,14 +59,14 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
     LOCK(wallet.cs_wallet);
     WalletTx result;
     result.tx = wtx.GetTx();
-    result.txin_is_mine.reserve(result.tx->vin.size());
-    for (const auto& txin : result.tx->vin) {
+    result.txin_is_mine.reserve(result.tx->GetInputs().size());
+    for (const auto& txin : result.tx->GetInputs()) {
         result.txin_is_mine.emplace_back(InputIsMine(wallet, txin));
     }
-    result.txout_is_mine.reserve(result.tx->vout.size());
-    result.txout_address.reserve(result.tx->vout.size());
-    result.txout_address_is_mine.reserve(result.tx->vout.size());
-    for (const auto& txout : result.tx->vout) {
+    result.txout_is_mine.reserve(result.tx->GetOutputs().size());
+    result.txout_address.reserve(result.tx->GetOutputs().size());
+    result.txout_address_is_mine.reserve(result.tx->GetOutputs().size());
+    for (const auto& txout : result.tx->GetOutputs()) {
         result.txout_is_mine.emplace_back(wallet.IsMine(txout));
         result.txout_is_change.push_back(OutputIsChange(wallet, txout));
         result.txout_address.emplace_back();
@@ -100,7 +100,7 @@ WalletTxStatus MakeWalletTxStatus(const CWallet& wallet, const CWalletTx& wtx)
     result.blocks_to_maturity = wallet.GetTxBlocksToMaturity(wtx);
     result.depth_in_main_chain = wallet.GetTxDepthInMainChain(wtx);
     result.time_received = wtx.nTimeReceived;
-    result.lock_time = wtx.GetTx()->nLockTime;
+    result.lock_time = wtx.GetTx()->GetLockTime();
     result.is_trusted = CachedTxIsTrusted(wallet, wtx);
     result.is_abandoned = wtx.isAbandoned();
     result.is_coinbase = wtx.IsCoinBase();
@@ -115,7 +115,7 @@ WalletTxOut MakeWalletTxOut(const CWallet& wallet,
     int depth) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     WalletTxOut result;
-    result.txout = wtx.GetTx()->vout[n];
+    result.txout = wtx.GetTx()->GetOutputs()[n];
     result.time = wtx.GetTxTime();
     result.depth_in_main_chain = depth;
     result.is_spent = wallet.IsSpent(COutPoint(wtx.GetHash(), n));

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -14,8 +14,8 @@ bool InputIsMine(const CWallet& wallet, const CTxIn& txin)
 {
     AssertLockHeld(wallet.cs_wallet);
     const CWalletTx* prev = wallet.GetWalletTx(txin.prevout.hash);
-    if (prev && txin.prevout.n < prev->GetTx()->vout.size()) {
-        return wallet.IsMine(prev->GetTx()->vout[txin.prevout.n]);
+    if (prev && txin.prevout.n < prev->GetTx()->GetOutputs().size()) {
+        return wallet.IsMine(prev->GetTx()->GetOutputs()[txin.prevout.n]);
     }
     return false;
 }
@@ -23,7 +23,7 @@ bool InputIsMine(const CWallet& wallet, const CTxIn& txin)
 bool AllInputsMine(const CWallet& wallet, const CTransaction& tx)
 {
     LOCK(wallet.cs_wallet);
-    for (const CTxIn& txin : tx.vin) {
+    for (const CTxIn& txin : tx.GetInputs()) {
         if (!InputIsMine(wallet, txin)) return false;
     }
     return true;
@@ -40,7 +40,7 @@ CAmount OutputGetCredit(const CWallet& wallet, const CTxOut& txout)
 CAmount TxGetCredit(const CWallet& wallet, const CTransaction& tx)
 {
     CAmount nCredit = 0;
-    for (const CTxOut& txout : tx.vout)
+    for (const CTxOut& txout : tx.GetOutputs())
     {
         nCredit += OutputGetCredit(wallet, txout);
         if (!MoneyRange(nCredit))
@@ -88,7 +88,7 @@ CAmount TxGetChange(const CWallet& wallet, const CTransaction& tx)
 {
     LOCK(wallet.cs_wallet);
     CAmount nChange = 0;
-    for (const CTxOut& txout : tx.vout)
+    for (const CTxOut& txout : tx.GetOutputs())
     {
         nChange += OutputGetChange(wallet, txout);
         if (!MoneyRange(nChange))
@@ -121,7 +121,7 @@ CAmount CachedTxGetCredit(const CWallet& wallet, const CWalletTx& wtx, bool avoi
 
 CAmount CachedTxGetDebit(const CWallet& wallet, const CWalletTx& wtx, bool avoid_reuse)
 {
-    if (wtx.GetTx()->vin.empty())
+    if (wtx.GetTx()->GetInputs().empty())
         return 0;
 
     return GetCachableAmount(wallet, wtx, CWalletTx::DEBIT, avoid_reuse);
@@ -155,9 +155,9 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
 
     LOCK(wallet.cs_wallet);
     // Sent/received.
-    for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); ++i)
+    for (unsigned int i = 0; i < wtx.GetTx()->GetOutputs().size(); ++i)
     {
-        const CTxOut& txout = wtx.GetTx()->vout[i];
+        const CTxOut& txout = wtx.GetTx()->GetOutputs()[i];
         bool ismine = wallet.IsMine(txout);
         // Only need to handle txouts if AT LEAST one of these is true:
         //   1) they debit from us (sent)
@@ -218,12 +218,12 @@ bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txi
     if (!wtx.InMempool()) return false;
 
     // Trusted if all inputs are from us and are in the mempool:
-    for (const CTxIn& txin : wtx.GetTx()->vin)
+    for (const CTxIn& txin : wtx.GetTx()->GetInputs())
     {
         // Transactions not sent by us: not trusted
         const CWalletTx* parent = wallet.GetWalletTx(txin.prevout.hash);
         if (parent == nullptr) return false;
-        const CTxOut& parentOut = parent->GetTx()->vout[txin.prevout.n];
+        const CTxOut& parentOut = parent->GetTx()->GetOutputs()[txin.prevout.n];
         // Check that this specific input being spent is trusted
         if (!wallet.IsMine(parentOut)) return false;
         // If we've already trusted this parent, continue
@@ -332,16 +332,16 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
     {
         const CWalletTx& wtx = walletEntry.second;
 
-        if (wtx.GetTx()->vin.size() > 0)
+        if (wtx.GetTx()->GetInputs().size() > 0)
         {
             bool any_mine = false;
             // group all input addresses with each other
-            for (const CTxIn& txin : wtx.GetTx()->vin)
+            for (const CTxIn& txin : wtx.GetTx()->GetInputs())
             {
                 CTxDestination address;
                 if(!InputIsMine(wallet, txin)) /* If this input isn't mine, ignore it */
                     continue;
-                if(!ExtractDestination(wallet.mapWallet.at(txin.prevout.hash).GetTx()->vout[txin.prevout.n].scriptPubKey, address))
+                if(!ExtractDestination(wallet.mapWallet.at(txin.prevout.hash).GetTx()->GetOutputs()[txin.prevout.n].scriptPubKey, address))
                     continue;
                 grouping.insert(address);
                 any_mine = true;
@@ -350,7 +350,7 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
             // group change with input addresses
             if (any_mine)
             {
-               for (const CTxOut& txout : wtx.GetTx()->vout)
+               for (const CTxOut& txout : wtx.GetTx()->GetOutputs())
                    if (OutputIsChange(wallet, txout))
                    {
                        CTxDestination txoutAddr;
@@ -367,7 +367,7 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
         }
 
         // group lone addrs by themselves
-        for (const auto& txout : wtx.GetTx()->vout)
+        for (const auto& txout : wtx.GetTx()->GetOutputs())
             if (wallet.IsMine(txout))
             {
                 CTxDestination address;

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -66,7 +66,7 @@ static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool b
             continue;
         }
 
-        for (const CTxOut& txout : wtx.GetTx()->vout) {
+        for (const CTxOut& txout : wtx.GetTx()->GetOutputs()) {
             if (output_scripts.contains(txout.scriptPubKey)) {
                 amount += txout.nValue;
             }
@@ -310,7 +310,7 @@ RPCMethod lockunspent()
 
         const CWalletTx& trans = it->second;
 
-        if (outpt.n >= trans.GetTx()->vout.size()) {
+        if (outpt.n >= trans.GetTx()->GetOutputs().size()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout index out of bounds");
         }
 

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1474,17 +1474,17 @@ RPCMethod sendall()
                         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Input not available. UTXO (%s:%d) was already spent.", input.prevout.hash.ToString(), input.prevout.n));
                     }
                     const CWalletTx* tx{pwallet->GetWalletTx(input.prevout.hash)};
-                    if (!tx || input.prevout.n >= tx->GetTx()->vout.size() || !pwallet->IsMine(tx->GetTx()->vout[input.prevout.n])) {
+                    if (!tx || input.prevout.n >= tx->GetTx()->GetOutputs().size() || !pwallet->IsMine(tx->GetTx()->GetOutputs()[input.prevout.n])) {
                         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Input not found. UTXO (%s:%d) is not part of wallet.", input.prevout.hash.ToString(), input.prevout.n));
                     }
                     if (pwallet->GetTxDepthInMainChain(*tx) == 0) {
-                        if (tx->GetTx()->version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
+                        if (tx->GetTx()->GetVersion() == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
                             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't spend unconfirmed version 3 pre-selected input with a version %d tx", coin_control.m_version));
-                        } else if (coin_control.m_version == TRUC_VERSION && tx->GetTx()->version != TRUC_VERSION) {
-                            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't spend unconfirmed version %d pre-selected input with a version 3 tx", tx->GetTx()->version));
+                        } else if (coin_control.m_version == TRUC_VERSION && tx->GetTx()->GetVersion() != TRUC_VERSION) {
+                            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't spend unconfirmed version %d pre-selected input with a version 3 tx", tx->GetTx()->GetVersion()));
                         }
                     }
-                    total_input_value += tx->GetTx()->vout[input.prevout.n].nValue;
+                    total_input_value += tx->GetTx()->GetOutputs()[input.prevout.n].nValue;
                 }
             } else {
                 CoinFilterParams coins_params;

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1475,17 +1475,17 @@ RPCMethod sendall()
                         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Input not available. UTXO (%s:%d) was already spent.", input.prevout.hash.ToString(), input.prevout.n));
                     }
                     const CWalletTx* tx{pwallet->GetWalletTx(input.prevout.hash)};
-                    if (!tx || input.prevout.n >= tx->GetTx()->vout.size() || !pwallet->IsMine(tx->GetTx()->vout[input.prevout.n])) {
+                    if (!tx || input.prevout.n >= tx->GetTx()->GetOutputs().size() || !pwallet->IsMine(tx->GetTx()->GetOutputs()[input.prevout.n])) {
                         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Input not found. UTXO (%s:%d) is not part of wallet.", input.prevout.hash.ToString(), input.prevout.n));
                     }
                     if (pwallet->GetTxDepthInMainChain(*tx) == 0) {
-                        if (tx->GetTx()->version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
+                        if (tx->GetTx()->GetVersion() == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
                             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't spend unconfirmed version 3 pre-selected input with a version %d tx", coin_control.m_version));
-                        } else if (coin_control.m_version == TRUC_VERSION && tx->GetTx()->version != TRUC_VERSION) {
-                            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't spend unconfirmed version %d pre-selected input with a version 3 tx", tx->GetTx()->version));
+                        } else if (coin_control.m_version == TRUC_VERSION && tx->GetTx()->GetVersion() != TRUC_VERSION) {
+                            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't spend unconfirmed version %d pre-selected input with a version 3 tx", tx->GetTx()->GetVersion()));
                         }
                     }
-                    total_input_value += tx->GetTx()->vout[input.prevout.n].nValue;
+                    total_input_value += tx->GetTx()->GetOutputs()[input.prevout.n].nValue;
                 }
             } else {
                 CoinFilterParams coins_params;

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -116,7 +116,7 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, cons
             continue;
         }
 
-        for (const CTxOut& txout : wtx.GetTx()->vout) {
+        for (const CTxOut& txout : wtx.GetTx()->GetOutputs()) {
             CTxDestination address;
             if (!ExtractDestination(txout.scriptPubKey, address))
                 continue;
@@ -365,7 +365,7 @@ static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nM
             }
             UniValue entry(UniValue::VOBJ);
             MaybePushAddress(entry, r.destination);
-            PushParentDescriptors(wallet, wtx.GetTx()->vout.at(r.vout).scriptPubKey, entry);
+            PushParentDescriptors(wallet, wtx.GetTx()->GetOutputs().at(r.vout).scriptPubKey, entry);
             if (wtx.IsCoinBase())
             {
                 if (wallet.GetTxDepthInMainChain(wtx) < 1)

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -116,7 +116,7 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, cons
             continue;
         }
 
-        for (const CTxOut& txout : wtx.GetTx()->vout) {
+        for (const CTxOut& txout : wtx.GetTx()->GetOutputs()) {
             CTxDestination address;
             if (!ExtractDestination(txout.scriptPubKey, address))
                 continue;
@@ -360,7 +360,7 @@ static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nM
             }
             UniValue entry(UniValue::VOBJ);
             MaybePushAddress(entry, r.destination);
-            PushParentDescriptors(wallet, wtx.GetTx()->vout.at(r.vout).scriptPubKey, entry);
+            PushParentDescriptors(wallet, wtx.GetTx()->GetOutputs().at(r.vout).scriptPubKey, entry);
             if (wtx.IsCoinBase())
             {
                 if (wallet.GetTxDepthInMainChain(wtx) < 1)

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1373,10 +1373,10 @@ std::optional<PSBTError> DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTran
         if (!input.witness_utxo.IsNull()) {
             script = input.witness_utxo.scriptPubKey;
         } else if (input.non_witness_utxo) {
-            if (input.prev_out >= input.non_witness_utxo->vout.size()) {
+            if (input.prev_out >= input.non_witness_utxo->GetOutputs().size()) {
                 return PSBTError::MISSING_INPUTS;
             }
-            script = input.non_witness_utxo->vout[input.prev_out].scriptPubKey;
+            script = input.non_witness_utxo->GetOutputs()[input.prev_out].scriptPubKey;
         } else {
             // There's no UTXO so we can just skip this now
             continue;

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -144,7 +144,7 @@ static std::optional<int64_t> GetSignedTxinWeight(const CWallet* wallet, const C
 TxSize CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, const std::vector<CTxOut>& txouts, const CCoinControl* coin_control)
 {
     // version + nLockTime + input count + output count
-    int64_t weight = (4 + 4 + GetSizeOfCompactSize(tx.vin.size()) + GetSizeOfCompactSize(tx.vout.size())) * WITNESS_SCALE_FACTOR;
+    int64_t weight = (4 + 4 + GetSizeOfCompactSize(tx.GetInputs().size()) + GetSizeOfCompactSize(tx.GetOutputs().size())) * WITNESS_SCALE_FACTOR;
     // Whether any input spends a witness program. Necessary to run before the next loop over the
     // inputs in order to accurately compute the compactSize length for the witness data per input.
     bool is_segwit = std::any_of(txouts.begin(), txouts.end(), [&](const CTxOut& txo) {
@@ -156,11 +156,11 @@ TxSize CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *walle
     if (is_segwit) weight += 2;
 
     // Add the size of the transaction outputs.
-    for (const auto& txo : tx.vout) weight += GetSerializeSize(txo) * WITNESS_SCALE_FACTOR;
+    for (const auto& txo : tx.GetOutputs()) weight += GetSerializeSize(txo) * WITNESS_SCALE_FACTOR;
 
     // Add the size of the transaction inputs as if they were signed.
     for (uint32_t i = 0; i < txouts.size(); i++) {
-        const auto txin_weight = GetSignedTxinWeight(wallet, coin_control, tx.vin[i], txouts[i], is_segwit, wallet->CanGrindR());
+        const auto txin_weight = GetSignedTxinWeight(wallet, coin_control, tx.GetInputs()[i], txouts[i], is_segwit, wallet->CanGrindR());
         if (!txin_weight) return TxSize{-1, -1};
         assert(*txin_weight > -1);
         weight += *txin_weight;
@@ -174,12 +174,12 @@ TxSize CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *walle
 {
     std::vector<CTxOut> txouts;
     // Look up the inputs. The inputs are either in the wallet, or in coin_control.
-    for (const CTxIn& input : tx.vin) {
+    for (const CTxIn& input : tx.GetInputs()) {
         const auto mi = wallet->mapWallet.find(input.prevout.hash);
         // Can not estimate size without knowing the input details
         if (mi != wallet->mapWallet.end()) {
-            assert(input.prevout.n < mi->second.GetTx()->vout.size());
-            txouts.emplace_back(mi->second.GetTx()->vout.at(input.prevout.n));
+            assert(input.prevout.n < mi->second.GetTx()->GetOutputs().size());
+            txouts.emplace_back(mi->second.GetTx()->GetOutputs().at(input.prevout.n));
         } else if (coin_control) {
             const auto& txout{coin_control->GetExternalOutput(input.prevout)};
             if (!txout) return TxSize{-1, -1};
@@ -281,10 +281,10 @@ util::Result<CoinsResult> FetchSelectedInputs(const CWallet& wallet, const CCoin
             }
             const CWalletTx& parent_tx = txo->GetWalletTx();
             if (wallet.GetTxDepthInMainChain(parent_tx) == 0) {
-                if (parent_tx.GetTx()->version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
+                if (parent_tx.GetTx()->GetVersion() == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
                     return util::Error{strprintf(_("Can't spend unconfirmed version 3 pre-selected input with a version %d tx"), coin_control.m_version)};
-                } else if (coin_control.m_version == TRUC_VERSION && parent_tx.GetTx()->version != TRUC_VERSION) {
-                    return util::Error{strprintf(_("Can't spend unconfirmed version %d pre-selected input with a version 3 tx"), parent_tx.GetTx()->version)};
+                } else if (coin_control.m_version == TRUC_VERSION && parent_tx.GetTx()->GetVersion() != TRUC_VERSION) {
+                    return util::Error{strprintf(_("Can't spend unconfirmed version %d pre-selected input with a version 3 tx"), parent_tx.GetTx()->GetVersion())};
                 }
             }
         } else {
@@ -396,7 +396,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
             if (nDepth == 0 && params.check_version_trucness) {
                 if (coinControl->m_version == TRUC_VERSION) {
-                    if (wtx.GetTx()->version != TRUC_VERSION) continue;
+                    if (wtx.GetTx()->GetVersion() != TRUC_VERSION) continue;
                     // this unconfirmed v3 transaction already has a child
                     if (wtx.truc_child_in_mempool.has_value()) continue;
 
@@ -405,7 +405,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
                     wallet.chain().getTransactionAncestry(wtx.GetTx()->GetHash(), ancestors, unused_cluster_count);
                     if (ancestors > 1) continue;
                 } else {
-                    if (wtx.GetTx()->version == TRUC_VERSION) continue;
+                    if (wtx.GetTx()->GetVersion() == TRUC_VERSION) continue;
                 }
             }
 
@@ -468,7 +468,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
         auto available_output_type = GetOutputType(type, is_from_p2sh);
         auto available_output = COutput(outpoint, output, nDepth, input_bytes, solvable, tx_safe, wtx.GetTxTime(), tx_from_me, feerate);
-        if (wtx.GetTx()->version == TRUC_VERSION && nDepth == 0 && params.check_version_trucness) {
+        if (wtx.GetTx()->GetVersion() == TRUC_VERSION && nDepth == 0 && params.check_version_trucness) {
             unconfirmed_truc_coins.emplace_back(available_output_type, available_output);
             auto [it, _] = truc_txid_by_value.try_emplace(wtx.GetTx()->GetHash(), 0);
             it->second += output.nValue;
@@ -528,17 +528,17 @@ const CTxOut& FindNonChangeParentOutput(const CWallet& wallet, const COutPoint& 
 
     const CTransaction* ptx = wtx->GetTx().get();
     int n = outpoint.n;
-    while (OutputIsChange(wallet, ptx->vout[n]) && ptx->vin.size() > 0) {
-        const COutPoint& prevout = ptx->vin[0].prevout;
+    while (OutputIsChange(wallet, ptx->GetOutputs()[n]) && ptx->GetInputs().size() > 0) {
+        const COutPoint& prevout = ptx->GetInputs()[0].prevout;
         const CWalletTx* it = wallet.GetWalletTx(prevout.hash);
-        if (!it || it->GetTx()->vout.size() <= prevout.n ||
-            !wallet.IsMine(it->GetTx()->vout[prevout.n])) {
+        if (!it || it->GetTx()->GetOutputs().size() <= prevout.n ||
+            !wallet.IsMine(it->GetTx()->GetOutputs()[prevout.n])) {
             break;
         }
         ptx = it->GetTx().get();
         n = prevout.n;
     }
-    return ptx->vout[n];
+    return ptx->GetOutputs()[n];
 }
 
 std::map<CTxDestination, std::vector<COutput>> ListCoins(const CWallet& wallet)
@@ -1472,7 +1472,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(
 
         // Reuse the change destination from the first creation attempt to avoid skipping BIP44 indexes
         if (txr_ungrouped.change_pos) {
-            ExtractDestination(txr_ungrouped.tx->vout[*txr_ungrouped.change_pos].scriptPubKey, tmp_cc.destChange);
+            ExtractDestination(txr_ungrouped.tx->GetOutputs()[*txr_ungrouped.change_pos].scriptPubKey, tmp_cc.destChange);
         }
 
         auto txr_grouped = CreateTransactionInternal(wallet, vecSend, change_pos, tmp_cc, sign);
@@ -1539,7 +1539,7 @@ util::Result<CreatedTransactionResult> FundTransaction(CWallet& wallet, const CM
     }
 
     if (lockUnspents) {
-        for (const CTxIn& txin : res->tx->vin) {
+        for (const CTxIn& txin : res->tx->GetInputs()) {
             wallet.LockCoin(txin.prevout, /*persist=*/false);
         }
     }

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -144,7 +144,7 @@ static std::optional<int64_t> GetSignedTxinWeight(const CWallet* wallet, const C
 TxSize CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, const std::vector<CTxOut>& txouts, const CCoinControl* coin_control)
 {
     // version + nLockTime + input count + output count
-    int64_t weight = (4 + 4 + GetSizeOfCompactSize(tx.vin.size()) + GetSizeOfCompactSize(tx.vout.size())) * WITNESS_SCALE_FACTOR;
+    int64_t weight = (4 + 4 + GetSizeOfCompactSize(tx.GetInputs().size()) + GetSizeOfCompactSize(tx.GetOutputs().size())) * WITNESS_SCALE_FACTOR;
     // Whether any input spends a witness program. Necessary to run before the next loop over the
     // inputs in order to accurately compute the compactSize length for the witness data per input.
     bool is_segwit = std::any_of(txouts.begin(), txouts.end(), [&](const CTxOut& txo) {
@@ -156,11 +156,11 @@ TxSize CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *walle
     if (is_segwit) weight += 2;
 
     // Add the size of the transaction outputs.
-    for (const auto& txo : tx.vout) weight += GetSerializeSize(txo) * WITNESS_SCALE_FACTOR;
+    for (const auto& txo : tx.GetOutputs()) weight += GetSerializeSize(txo) * WITNESS_SCALE_FACTOR;
 
     // Add the size of the transaction inputs as if they were signed.
     for (uint32_t i = 0; i < txouts.size(); i++) {
-        const auto txin_weight = GetSignedTxinWeight(wallet, coin_control, tx.vin[i], txouts[i], is_segwit, wallet->CanGrindR());
+        const auto txin_weight = GetSignedTxinWeight(wallet, coin_control, tx.GetInputs()[i], txouts[i], is_segwit, wallet->CanGrindR());
         if (!txin_weight) return TxSize{-1, -1};
         assert(*txin_weight > -1);
         weight += *txin_weight;
@@ -174,12 +174,12 @@ TxSize CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *walle
 {
     std::vector<CTxOut> txouts;
     // Look up the inputs. The inputs are either in the wallet, or in coin_control.
-    for (const CTxIn& input : tx.vin) {
+    for (const CTxIn& input : tx.GetInputs()) {
         const auto mi = wallet->mapWallet.find(input.prevout.hash);
         // Can not estimate size without knowing the input details
         if (mi != wallet->mapWallet.end()) {
-            assert(input.prevout.n < mi->second.GetTx()->vout.size());
-            txouts.emplace_back(mi->second.GetTx()->vout.at(input.prevout.n));
+            assert(input.prevout.n < mi->second.GetTx()->GetOutputs().size());
+            txouts.emplace_back(mi->second.GetTx()->GetOutputs().at(input.prevout.n));
         } else if (coin_control) {
             const auto& txout{coin_control->GetExternalOutput(input.prevout)};
             if (!txout) return TxSize{-1, -1};
@@ -281,10 +281,10 @@ util::Result<CoinsResult> FetchSelectedInputs(const CWallet& wallet, const CCoin
             }
             const CWalletTx& parent_tx = txo->GetWalletTx();
             if (wallet.GetTxDepthInMainChain(parent_tx) == 0) {
-                if (parent_tx.GetTx()->version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
+                if (parent_tx.GetTx()->GetVersion() == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
                     return util::Error{strprintf(_("Can't spend unconfirmed version 3 pre-selected input with a version %d tx"), coin_control.m_version)};
-                } else if (coin_control.m_version == TRUC_VERSION && parent_tx.GetTx()->version != TRUC_VERSION) {
-                    return util::Error{strprintf(_("Can't spend unconfirmed version %d pre-selected input with a version 3 tx"), parent_tx.GetTx()->version)};
+                } else if (coin_control.m_version == TRUC_VERSION && parent_tx.GetTx()->GetVersion() != TRUC_VERSION) {
+                    return util::Error{strprintf(_("Can't spend unconfirmed version %d pre-selected input with a version 3 tx"), parent_tx.GetTx()->GetVersion())};
                 }
             }
         } else {
@@ -396,7 +396,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
             if (nDepth == 0 && params.check_version_trucness) {
                 if (coinControl->m_version == TRUC_VERSION) {
-                    if (wtx.GetTx()->version != TRUC_VERSION) continue;
+                    if (wtx.GetTx()->GetVersion() != TRUC_VERSION) continue;
                     // this unconfirmed v3 transaction already has a child
                     if (wtx.truc_child_in_mempool.has_value()) continue;
 
@@ -405,7 +405,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
                     wallet.chain().getTransactionAncestry(wtx.GetTx()->GetHash(), ancestors, unused_cluster_count);
                     if (ancestors > 1) continue;
                 } else {
-                    if (wtx.GetTx()->version == TRUC_VERSION) continue;
+                    if (wtx.GetTx()->GetVersion() == TRUC_VERSION) continue;
                 }
             }
 
@@ -468,7 +468,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
         auto available_output_type = GetOutputType(type, is_from_p2sh);
         auto available_output = COutput(outpoint, output, nDepth, input_bytes, solvable, tx_safe, wtx.GetTxTime(), tx_from_me, feerate);
-        if (wtx.GetTx()->version == TRUC_VERSION && nDepth == 0 && params.check_version_trucness) {
+        if (wtx.GetTx()->GetVersion() == TRUC_VERSION && nDepth == 0 && params.check_version_trucness) {
             unconfirmed_truc_coins.emplace_back(available_output_type, available_output);
             auto [it, _] = truc_txid_by_value.try_emplace(wtx.GetTx()->GetHash(), 0);
             it->second += output.nValue;
@@ -528,17 +528,17 @@ const CTxOut& FindNonChangeParentOutput(const CWallet& wallet, const COutPoint& 
 
     const CTransaction* ptx = wtx->GetTx().get();
     int n = outpoint.n;
-    while (OutputIsChange(wallet, ptx->vout[n]) && ptx->vin.size() > 0) {
-        const COutPoint& prevout = ptx->vin[0].prevout;
+    while (OutputIsChange(wallet, ptx->GetOutputs()[n]) && ptx->GetInputs().size() > 0) {
+        const COutPoint& prevout = ptx->GetInputs()[0].prevout;
         const CWalletTx* it = wallet.GetWalletTx(prevout.hash);
-        if (!it || it->GetTx()->vout.size() <= prevout.n ||
-            !wallet.IsMine(it->GetTx()->vout[prevout.n])) {
+        if (!it || it->GetTx()->GetOutputs().size() <= prevout.n ||
+            !wallet.IsMine(it->GetTx()->GetOutputs()[prevout.n])) {
             break;
         }
         ptx = it->GetTx().get();
         n = prevout.n;
     }
-    return ptx->vout[n];
+    return ptx->GetOutputs()[n];
 }
 
 std::map<CTxDestination, std::vector<COutput>> ListCoins(const CWallet& wallet)
@@ -1478,7 +1478,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(
 
         // Reuse the change destination from the first creation attempt to avoid skipping BIP44 indexes
         if (txr_ungrouped.change_pos) {
-            ExtractDestination(txr_ungrouped.tx->vout[*txr_ungrouped.change_pos].scriptPubKey, tmp_cc.destChange);
+            ExtractDestination(txr_ungrouped.tx->GetOutputs()[*txr_ungrouped.change_pos].scriptPubKey, tmp_cc.destChange);
         }
 
         auto txr_grouped = CreateTransactionInternal(wallet, vecSend, change_pos, tmp_cc, sign);
@@ -1545,7 +1545,7 @@ util::Result<CreatedTransactionResult> FundTransaction(CWallet& wallet, const CM
     }
 
     if (lockUnspents) {
-        for (const CTxIn& txin : res->tx->vin) {
+        for (const CTxIn& txin : res->tx->GetInputs()) {
             wallet.LockCoin(txin.prevout, /*persist=*/false);
         }
     }

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -76,7 +76,7 @@ static void add_coin(CoinsResult& available_coins, CWallet& wallet, const CAmoun
     auto ret = wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateInactive{}));
     assert(ret.second);
     CWalletTx& wtx = (*ret.first).second;
-    const auto& txout = wtx.GetTx()->vout.at(nInput);
+    const auto& txout = wtx.GetTx()->GetOutputs().at(nInput);
     available_coins.Add(OutputType::BECH32, {COutPoint(wtx.GetHash(), nInput), txout, nAge, custom_size == 0 ? CalculateMaximumSignedInputSize(txout, &wallet, /*coin_control=*/nullptr) : custom_size, /*solvable=*/true, /*safe=*/true, wtx.GetTxTime(), fIsFromMe, feerate});
 }
 

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -44,7 +44,7 @@ static void addCoin(CoinsResult& coins,
     auto ret = wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateInactive{}));
     assert(ret.second);
     CWalletTx& wtx = (*ret.first).second;
-    const auto& txout = wtx.GetTx()->vout.at(0);
+    const auto& txout = wtx.GetTx()->GetOutputs().at(0);
     coins.Add(*Assert(OutputTypeFromDestination(dest)),
               {COutPoint(wtx.GetHash(), 0),
                    txout,

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -53,8 +53,8 @@ BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
         auto res = CreateTransaction(*wallet, {recipient}, /*change_pos=*/std::nullopt, coin_control);
         BOOST_CHECK(res);
         const auto& txr = *res;
-        BOOST_CHECK_EQUAL(txr.tx->vout.size(), 1);
-        BOOST_CHECK_EQUAL(txr.tx->vout[0].nValue, recipient.nAmount + leftover_input_amount - txr.fee);
+        BOOST_CHECK_EQUAL(txr.tx->GetOutputs().size(), 1);
+        BOOST_CHECK_EQUAL(txr.tx->GetOutputs()[0].nValue, recipient.nAmount + leftover_input_amount - txr.fee);
         BOOST_CHECK_GT(txr.fee, 0);
         return txr.fee;
     };

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -52,8 +52,8 @@ BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
         auto res = CreateTransaction(*wallet, {recipient}, /*change_pos=*/std::nullopt, coin_control);
         BOOST_CHECK(res);
         const auto& txr = *res;
-        BOOST_CHECK_EQUAL(txr.tx->vout.size(), 1);
-        BOOST_CHECK_EQUAL(txr.tx->vout[0].nValue, recipient.nAmount + leftover_input_amount - txr.fee);
+        BOOST_CHECK_EQUAL(txr.tx->GetOutputs().size(), 1);
+        BOOST_CHECK_EQUAL(txr.tx->GetOutputs()[0].nValue, recipient.nAmount + leftover_input_amount - txr.fee);
         BOOST_CHECK_GT(txr.fee, 0);
         return txr.fee;
     };

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -48,12 +48,12 @@ BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 static CMutableTransaction TestSimpleSpend(const CTransaction& from, uint32_t index, const CKey& key, const CScript& pubkey)
 {
     CMutableTransaction mtx;
-    mtx.vout.emplace_back(from.vout[index].nValue - DEFAULT_TRANSACTION_MAXFEE, pubkey);
+    mtx.vout.emplace_back(from.GetOutputs()[index].nValue - DEFAULT_TRANSACTION_MAXFEE, pubkey);
     mtx.vin.push_back({CTxIn{from.GetHash(), index}});
     FillableSigningProvider keystore;
     keystore.AddKey(key);
     std::map<COutPoint, Coin> coins;
-    coins[mtx.vin[0].prevout].out = from.vout[index];
+    coins[mtx.vin[0].prevout].out = from.GetOutputs()[index];
     std::map<int, bilingual_str> input_errors;
     BOOST_CHECK(SignTransaction(mtx, &keystore, coins, {.sighash_type = SIGHASH_ALL}, input_errors));
     return mtx;
@@ -491,7 +491,7 @@ void TestCoinsResult(ListCoinsTest& context, OutputType out_type, CAmount amount
     filter.skip_locked = false;
     CoinsResult available_coins = AvailableCoins(*context.wallet, nullptr, std::nullopt, filter);
     // Lock outputs so they are not spent in follow-up transactions
-    for (uint32_t i = 0; i < wtx.GetTx()->vout.size(); i++) context.wallet->LockCoin({wtx.GetHash(), i}, /*persist=*/false);
+    for (uint32_t i = 0; i < wtx.GetTx()->GetOutputs().size(); i++) context.wallet->LockCoin({wtx.GetHash(), i}, /*persist=*/false);
     for (const auto& [type, size] : expected_coins_sizes) BOOST_CHECK_EQUAL(size, available_coins.coins[type].size());
 }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -48,12 +48,12 @@ BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 static CMutableTransaction TestSimpleSpend(const CTransaction& from, uint32_t index, const CKey& key, const CScript& pubkey)
 {
     CMutableTransaction mtx;
-    mtx.vout.emplace_back(from.vout[index].nValue - DEFAULT_TRANSACTION_MAXFEE, pubkey);
+    mtx.vout.emplace_back(from.GetOutputs()[index].nValue - DEFAULT_TRANSACTION_MAXFEE, pubkey);
     mtx.vin.push_back({CTxIn{from.GetHash(), index}});
     FillableSigningProvider keystore;
     keystore.AddKey(key);
     std::map<COutPoint, Coin> coins;
-    coins[mtx.vin[0].prevout].out = from.vout[index];
+    coins[mtx.vin[0].prevout].out = from.GetOutputs()[index];
     std::map<int, bilingual_str> input_errors;
     BOOST_CHECK(SignTransaction(mtx, &keystore, coins, {.sighash_type = SIGHASH_ALL}, input_errors));
     return mtx;
@@ -489,7 +489,7 @@ void TestCoinsResult(ListCoinsTest& context, OutputType out_type, CAmount amount
     filter.skip_locked = false;
     CoinsResult available_coins = AvailableCoins(*context.wallet, nullptr, std::nullopt, filter);
     // Lock outputs so they are not spent in follow-up transactions
-    for (uint32_t i = 0; i < wtx.GetTx()->vout.size(); i++) context.wallet->LockCoin({wtx.GetHash(), i}, /*persist=*/false);
+    for (uint32_t i = 0; i < wtx.GetTx()->GetOutputs().size(); i++) context.wallet->LockCoin({wtx.GetHash(), i}, /*persist=*/false);
     for (const auto& [type, size] : expected_coins_sizes) BOOST_CHECK_EQUAL(size, available_coins.coins[type].size());
 }
 

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -442,7 +442,7 @@ public:
     : m_wtx(wtx),
     m_output(output)
     {
-        Assume(std::ranges::find(wtx.GetTx()->vout, output) != wtx.GetTx()->vout.end());
+        Assume(std::ranges::find(wtx.GetTx()->GetOutputs(), output) != wtx.GetTx()->GetOutputs().end());
     }
 
     const CWalletTx& GetWalletTx() const { return m_wtx; }

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -431,7 +431,7 @@ public:
     : m_wtx(wtx),
     m_output(output)
     {
-        Assume(std::ranges::find(wtx.GetTx()->vout, output) != wtx.GetTx()->vout.end());
+        Assume(std::ranges::find(wtx.GetTx()->GetOutputs(), output) != wtx.GetTx()->GetOutputs().end());
     }
 
     const CWalletTx& GetWalletTx() const { return m_wtx; }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -704,7 +704,7 @@ std::set<Txid> CWallet::GetConflicts(const Txid& txid) const
 
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
 
-    for (const CTxIn& txin : wtx.GetTx()->vin)
+    for (const CTxIn& txin : wtx.GetTx()->GetInputs())
     {
         if (mapTxSpends.count(txin.prevout) <= 1)
             continue;  // No conflict if zero or one spends
@@ -719,7 +719,7 @@ bool CWallet::HasWalletSpend(const CTransactionRef& tx) const
 {
     AssertLockHeld(cs_wallet);
     const Txid& txid = tx->GetHash();
-    for (unsigned int i = 0; i < tx->vout.size(); ++i) {
+    for (unsigned int i = 0; i < tx->GetOutputs().size(); ++i) {
         if (IsSpent(COutPoint(txid, i))) {
             return true;
         }
@@ -836,7 +836,7 @@ void CWallet::AddToSpends(const CWalletTx& wtx)
     if (wtx.IsCoinBase()) // Coinbases don't spend anything!
         return;
 
-    for (const CTxIn& txin : wtx.GetTx()->vin)
+    for (const CTxIn& txin : wtx.GetTx()->GetInputs())
         AddToSpends(txin.prevout, wtx.GetHash());
 }
 
@@ -1032,7 +1032,7 @@ void CWallet::SetSpentKeyState(WalletBatch& batch, const Txid& hash, unsigned in
     if (!srctx) return;
 
     CTxDestination dst;
-    if (ExtractDestination(srctx->GetTx()->vout[n].scriptPubKey, dst)) {
+    if (ExtractDestination(srctx->GetTx()->GetOutputs()[n].scriptPubKey, dst)) {
         if (IsMine(dst)) {
             if (used != IsAddressPreviouslySpent(dst)) {
                 if (used) {
@@ -1069,7 +1069,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
         // Mark used destinations
         std::set<CTxDestination> tx_destinations;
 
-        for (const CTxIn& txin : tx->vin) {
+        for (const CTxIn& txin : tx->GetInputs()) {
             const COutPoint& op = txin.prevout;
             SetSpentKeyState(batch, op.hash, op.n, true, tx_destinations);
         }
@@ -1112,7 +1112,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
             desc_tx->MarkDirty();
             batch.WriteTx(*desc_tx);
             MarkInputsDirty(desc_tx->GetTx());
-            for (unsigned int i = 0; i < desc_tx->GetTx()->vout.size(); ++i) {
+            for (unsigned int i = 0; i < desc_tx->GetTx()->GetOutputs().size(); ++i) {
                 COutPoint outpoint(desc_tx->GetHash(), i);
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(outpoint);
                 for (TxSpends::const_iterator it = range.first; it != range.second; ++it) {
@@ -1191,7 +1191,7 @@ bool CWallet::LoadToWallet(CWalletTx&& wtx_in)
     }
     wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
     AddToSpends(wtx);
-    for (const CTxIn& txin : wtx.GetTx()->vin) {
+    for (const CTxIn& txin : wtx.GetTx()->GetInputs()) {
         auto it = mapWallet.find(txin.prevout.hash);
         if (it != mapWallet.end()) {
             CWalletTx& prevtx = it->second;
@@ -1216,7 +1216,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
         AssertLockHeld(cs_wallet);
 
         if (auto* conf = std::get_if<TxStateConfirmed>(&state)) {
-            for (const CTxIn& txin : tx.vin) {
+            for (const CTxIn& txin : tx.GetInputs()) {
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(txin.prevout);
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
@@ -1238,7 +1238,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
              */
 
             // loop though all outputs
-            for (const CTxOut& txout: tx.vout) {
+            for (const CTxOut& txout: tx.GetOutputs()) {
                 for (const auto& spk_man : GetScriptPubKeyMans(txout.scriptPubKey)) {
                     for (auto &dest : spk_man->MarkUnusedAddresses(txout.scriptPubKey)) {
                         // If internal flag is not defined try to infer it from the ScriptPubKeyMan
@@ -1285,7 +1285,7 @@ void CWallet::UpdateTrucSiblingConflicts(const CWalletTx& parent_wtx, const Txid
 {
     // Find all other txs in our wallet that spend utxos from this parent
     // so that we can mark them as mempool-conflicted by this new tx.
-    for (long unsigned int i = 0; i < parent_wtx.GetTx()->vout.size(); i++) {
+    for (long unsigned int i = 0; i < parent_wtx.GetTx()->GetOutputs().size(); i++) {
         for (auto range = mapTxSpends.equal_range(COutPoint(parent_wtx.GetTx()->GetHash(), i)); range.first != range.second; range.first++) {
             const Txid& sibling_txid = range.first->second;
             // Skip the child_tx itself
@@ -1300,7 +1300,7 @@ void CWallet::UpdateTrucSiblingConflicts(const CWalletTx& parent_wtx, const Txid
 
 void CWallet::MarkInputsDirty(const CTransactionRef& tx)
 {
-    for (const CTxIn& txin : tx->vin) {
+    for (const CTxIn& txin : tx->GetInputs()) {
         auto it = mapWallet.find(txin.prevout.hash);
         if (it != mapWallet.end()) {
             it->second.MarkDirty();
@@ -1400,7 +1400,7 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
             wtx.MarkDirty();
             if (batch) batch->WriteTx(wtx);
             // Iterate over all its outputs, and update those tx states as well (if applicable)
-            for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); ++i) {
+            for (unsigned int i = 0; i < wtx.GetTx()->GetOutputs().size(); ++i) {
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(COutPoint(now, i));
                 for (TxSpends::const_iterator iter = range.first; iter != range.second; ++iter) {
                     if (!done.contains(iter->second)) {
@@ -1443,7 +1443,7 @@ void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
 
     const Txid& txid = tx->GetHash();
 
-    for (const CTxIn& tx_in : tx->vin) {
+    for (const CTxIn& tx_in : tx->GetInputs()) {
         // For each wallet transaction spending this prevout..
         for (auto range = mapTxSpends.equal_range(tx_in.prevout); range.first != range.second; range.first++) {
             const Txid& spent_id = range.first->second;
@@ -1456,11 +1456,11 @@ void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
 
     }
 
-    if (tx->version == TRUC_VERSION) {
+    if (tx->GetVersion() == TRUC_VERSION) {
         // Unconfirmed TRUC transactions are only allowed a 1-parent-1-child topology.
         // For any unconfirmed v3 parents (there should be a maximum of 1 except in reorgs),
         // record this child so the wallet doesn't try to spend any other outputs
-        for (const CTxIn& tx_in : tx->vin) {
+        for (const CTxIn& tx_in : tx->GetInputs()) {
             auto parent_it = mapWallet.find(tx_in.prevout.hash);
             if (parent_it != mapWallet.end()) {
                 CWalletTx& parent_wtx = parent_it->second;
@@ -1513,7 +1513,7 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
 
     const Txid& txid = tx->GetHash();
 
-    for (const CTxIn& tx_in : tx->vin) {
+    for (const CTxIn& tx_in : tx->GetInputs()) {
         // Iterate over all wallet transactions spending txin.prev
         // and recursively mark them as no longer conflicting with
         // txid
@@ -1526,12 +1526,12 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
         }
     }
 
-    if (tx->version == TRUC_VERSION) {
+    if (tx->GetVersion() == TRUC_VERSION) {
         // If this tx has a parent, unset its truc_child_in_mempool to make it possible
         // to spend from the parent again. If this tx was replaced by another
         // child of the same parent, transactionAddedToMempool
         // will update truc_child_in_mempool
-        for (const CTxIn& tx_in : tx->vin) {
+        for (const CTxIn& tx_in : tx->GetInputs()) {
             auto parent_it = mapWallet.find(tx_in.prevout.hash);
             if (parent_it != mapWallet.end()) {
                 CWalletTx& parent_wtx = parent_it->second;
@@ -1590,7 +1590,7 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
         // meaning they should never be relayed standalone via the p2p protocol.
         SyncTransaction(ptx, TxStateInactive{/*abandoned=*/index == 0});
 
-        for (const CTxIn& tx_in : ptx->vin) {
+        for (const CTxIn& tx_in : ptx->GetInputs()) {
             // No other wallet transactions conflicted with this transaction
             if (!mapTxSpends.contains(tx_in.prevout)) continue;
 
@@ -1680,7 +1680,7 @@ bool CWallet::IsMine(const CScript& script) const
 bool CWallet::IsMine(const CTransaction& tx) const
 {
     AssertLockHeld(cs_wallet);
-    for (const CTxOut& txout : tx.vout)
+    for (const CTxOut& txout : tx.GetOutputs())
         if (IsMine(txout))
             return true;
     return false;
@@ -1693,16 +1693,16 @@ bool CWallet::IsMine(const COutPoint& outpoint) const
     if (!wtx) {
         return false;
     }
-    if (outpoint.n >= wtx->GetTx()->vout.size()) {
+    if (outpoint.n >= wtx->GetTx()->GetOutputs().size()) {
         return false;
     }
-    return IsMine(wtx->GetTx()->vout[outpoint.n]);
+    return IsMine(wtx->GetTx()->GetOutputs()[outpoint.n]);
 }
 
 bool CWallet::IsFromMe(const CTransaction& tx) const
 {
     LOCK(cs_wallet);
-    for (const CTxIn& txin : tx.vin) {
+    for (const CTxIn& txin : tx.GetInputs()) {
         if (GetTXO(txin.prevout)) return true;
     }
     return false;
@@ -1711,7 +1711,7 @@ bool CWallet::IsFromMe(const CTransaction& tx) const
 CAmount CWallet::GetDebit(const CTransaction& tx) const
 {
     CAmount nDebit = 0;
-    for (const CTxIn& txin : tx.vin)
+    for (const CTxIn& txin : tx.GetInputs())
     {
         nDebit += GetDebit(txin);
         if (!MoneyRange(nDebit))
@@ -2176,12 +2176,12 @@ bool CWallet::SignTransaction(CMutableTransaction& tx) const
     std::map<COutPoint, Coin> coins;
     for (auto& input : tx.vin) {
         const auto mi = mapWallet.find(input.prevout.hash);
-        if(mi == mapWallet.end() || input.prevout.n >= mi->second.GetTx()->vout.size()) {
+        if(mi == mapWallet.end() || input.prevout.n >= mi->second.GetTx()->GetOutputs().size()) {
             return false;
         }
         const CWalletTx& wtx = mi->second;
         int prev_height = wtx.state<TxStateConfirmed>() ? wtx.state<TxStateConfirmed>()->confirmed_block_height : 0;
-        coins[input.prevout] = Coin(wtx.GetTx()->vout[input.prevout.n], prev_height, wtx.IsCoinBase());
+        coins[input.prevout] = Coin(wtx.GetTx()->GetOutputs()[input.prevout.n], prev_height, wtx.IsCoinBase());
     }
     std::map<int, bilingual_str> input_errors;
     return SignTransaction(tx, coins, SIGHASH_DEFAULT, input_errors);
@@ -2360,7 +2360,7 @@ void CWallet::CommitTransaction(
     }
 
     // Notify that old coins are spent
-    for (const CTxIn& txin : tx->vin) {
+    for (const CTxIn& txin : tx->GetInputs()) {
         CWalletTx &coin = mapWallet.at(txin.prevout.hash);
         coin.MarkDirty();
         NotifyTransactionChanged(coin.GetHash(), CT_UPDATED);
@@ -2471,7 +2471,7 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
         for (const auto& it : erased_txs) {
             const Txid hash{it->first};
             wtxOrdered.erase(it->second.m_it_wtxOrdered);
-            for (const auto& txin : it->second.GetTx()->vin) {
+            for (const auto& txin : it->second.GetTx()->GetInputs()) {
                 auto range = mapTxSpends.equal_range(txin.prevout);
                 for (auto iter = range.first; iter != range.second; ++iter) {
                     if (iter->second == hash) {
@@ -2480,7 +2480,7 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
                     }
                 }
             }
-            for (unsigned int i = 0; i < it->second.GetTx()->vout.size(); ++i) {
+            for (unsigned int i = 0; i < it->second.GetTx()->GetOutputs().size(); ++i) {
                 m_txos.erase(COutPoint(hash, i));
             }
             mapWallet.erase(it);
@@ -2645,9 +2645,9 @@ void CWallet::MarkDestinationsDirty(const std::set<CTxDestination>& destinations
     for (auto& entry : mapWallet) {
         CWalletTx& wtx = entry.second;
         if (wtx.m_is_cache_empty) continue;
-        for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); i++) {
+        for (unsigned int i = 0; i < wtx.GetTx()->GetOutputs().size(); i++) {
             CTxDestination dst;
-            if (ExtractDestination(wtx.GetTx()->vout[i].scriptPubKey, dst) && destinations.contains(dst)) {
+            if (ExtractDestination(wtx.GetTx()->GetOutputs()[i].scriptPubKey, dst) && destinations.contains(dst)) {
                 wtx.MarkDirty();
                 break;
             }
@@ -4612,8 +4612,8 @@ void CWallet::WriteBestBlock() const
 void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
 {
     AssertLockHeld(cs_wallet);
-    for (uint32_t i = 0; i < wtx.GetTx()->vout.size(); ++i) {
-        const CTxOut& txout = wtx.GetTx()->vout.at(i);
+    for (uint32_t i = 0; i < wtx.GetTx()->GetOutputs().size(); ++i) {
+        const CTxOut& txout = wtx.GetTx()->GetOutputs().at(i);
         if (!IsMine(txout)) continue;
         COutPoint outpoint(wtx.GetHash(), i);
         if (m_txos.contains(outpoint)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -693,7 +693,7 @@ std::set<Txid> CWallet::GetConflicts(const Txid& txid) const
 
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
 
-    for (const CTxIn& txin : wtx.GetTx()->vin)
+    for (const CTxIn& txin : wtx.GetTx()->GetInputs())
     {
         if (mapTxSpends.count(txin.prevout) <= 1)
             continue;  // No conflict if zero or one spends
@@ -708,7 +708,7 @@ bool CWallet::HasWalletSpend(const CTransactionRef& tx) const
 {
     AssertLockHeld(cs_wallet);
     const Txid& txid = tx->GetHash();
-    for (unsigned int i = 0; i < tx->vout.size(); ++i) {
+    for (unsigned int i = 0; i < tx->GetOutputs().size(); ++i) {
         if (IsSpent(COutPoint(txid, i))) {
             return true;
         }
@@ -825,7 +825,7 @@ void CWallet::AddToSpends(const CWalletTx& wtx)
     if (wtx.IsCoinBase()) // Coinbases don't spend anything!
         return;
 
-    for (const CTxIn& txin : wtx.GetTx()->vin)
+    for (const CTxIn& txin : wtx.GetTx()->GetInputs())
         AddToSpends(txin.prevout, wtx.GetHash());
 }
 
@@ -1021,7 +1021,7 @@ void CWallet::SetSpentKeyState(WalletBatch& batch, const Txid& hash, unsigned in
     if (!srctx) return;
 
     CTxDestination dst;
-    if (ExtractDestination(srctx->GetTx()->vout[n].scriptPubKey, dst)) {
+    if (ExtractDestination(srctx->GetTx()->GetOutputs()[n].scriptPubKey, dst)) {
         if (IsMine(dst)) {
             if (used != IsAddressPreviouslySpent(dst)) {
                 if (used) {
@@ -1058,7 +1058,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
         // Mark used destinations
         std::set<CTxDestination> tx_destinations;
 
-        for (const CTxIn& txin : tx->vin) {
+        for (const CTxIn& txin : tx->GetInputs()) {
             const COutPoint& op = txin.prevout;
             SetSpentKeyState(batch, op.hash, op.n, true, tx_destinations);
         }
@@ -1101,7 +1101,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
             desc_tx->MarkDirty();
             batch.WriteTx(*desc_tx);
             MarkInputsDirty(desc_tx->GetTx());
-            for (unsigned int i = 0; i < desc_tx->GetTx()->vout.size(); ++i) {
+            for (unsigned int i = 0; i < desc_tx->GetTx()->GetOutputs().size(); ++i) {
                 COutPoint outpoint(desc_tx->GetHash(), i);
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(outpoint);
                 for (TxSpends::const_iterator it = range.first; it != range.second; ++it) {
@@ -1180,7 +1180,7 @@ bool CWallet::LoadToWallet(CWalletTx&& wtx_in)
     }
     wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
     AddToSpends(wtx);
-    for (const CTxIn& txin : wtx.GetTx()->vin) {
+    for (const CTxIn& txin : wtx.GetTx()->GetInputs()) {
         auto it = mapWallet.find(txin.prevout.hash);
         if (it != mapWallet.end()) {
             CWalletTx& prevtx = it->second;
@@ -1205,7 +1205,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
         AssertLockHeld(cs_wallet);
 
         if (auto* conf = std::get_if<TxStateConfirmed>(&state)) {
-            for (const CTxIn& txin : tx.vin) {
+            for (const CTxIn& txin : tx.GetInputs()) {
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(txin.prevout);
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
@@ -1227,7 +1227,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
              */
 
             // loop though all outputs
-            for (const CTxOut& txout: tx.vout) {
+            for (const CTxOut& txout: tx.GetOutputs()) {
                 for (const auto& spk_man : GetScriptPubKeyMans(txout.scriptPubKey)) {
                     for (auto &dest : spk_man->MarkUnusedAddresses(txout.scriptPubKey)) {
                         // If internal flag is not defined try to infer it from the ScriptPubKeyMan
@@ -1274,7 +1274,7 @@ void CWallet::UpdateTrucSiblingConflicts(const CWalletTx& parent_wtx, const Txid
 {
     // Find all other txs in our wallet that spend utxos from this parent
     // so that we can mark them as mempool-conflicted by this new tx.
-    for (long unsigned int i = 0; i < parent_wtx.GetTx()->vout.size(); i++) {
+    for (long unsigned int i = 0; i < parent_wtx.GetTx()->GetOutputs().size(); i++) {
         for (auto range = mapTxSpends.equal_range(COutPoint(parent_wtx.GetTx()->GetHash(), i)); range.first != range.second; range.first++) {
             const Txid& sibling_txid = range.first->second;
             // Skip the child_tx itself
@@ -1289,7 +1289,7 @@ void CWallet::UpdateTrucSiblingConflicts(const CWalletTx& parent_wtx, const Txid
 
 void CWallet::MarkInputsDirty(const CTransactionRef& tx)
 {
-    for (const CTxIn& txin : tx->vin) {
+    for (const CTxIn& txin : tx->GetInputs()) {
         auto it = mapWallet.find(txin.prevout.hash);
         if (it != mapWallet.end()) {
             it->second.MarkDirty();
@@ -1389,7 +1389,7 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
             wtx.MarkDirty();
             if (batch) batch->WriteTx(wtx);
             // Iterate over all its outputs, and update those tx states as well (if applicable)
-            for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); ++i) {
+            for (unsigned int i = 0; i < wtx.GetTx()->GetOutputs().size(); ++i) {
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(COutPoint(now, i));
                 for (TxSpends::const_iterator iter = range.first; iter != range.second; ++iter) {
                     if (!done.contains(iter->second)) {
@@ -1432,7 +1432,7 @@ void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
 
     const Txid& txid = tx->GetHash();
 
-    for (const CTxIn& tx_in : tx->vin) {
+    for (const CTxIn& tx_in : tx->GetInputs()) {
         // For each wallet transaction spending this prevout..
         for (auto range = mapTxSpends.equal_range(tx_in.prevout); range.first != range.second; range.first++) {
             const Txid& spent_id = range.first->second;
@@ -1445,11 +1445,11 @@ void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
 
     }
 
-    if (tx->version == TRUC_VERSION) {
+    if (tx->GetVersion() == TRUC_VERSION) {
         // Unconfirmed TRUC transactions are only allowed a 1-parent-1-child topology.
         // For any unconfirmed v3 parents (there should be a maximum of 1 except in reorgs),
         // record this child so the wallet doesn't try to spend any other outputs
-        for (const CTxIn& tx_in : tx->vin) {
+        for (const CTxIn& tx_in : tx->GetInputs()) {
             auto parent_it = mapWallet.find(tx_in.prevout.hash);
             if (parent_it != mapWallet.end()) {
                 CWalletTx& parent_wtx = parent_it->second;
@@ -1502,7 +1502,7 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
 
     const Txid& txid = tx->GetHash();
 
-    for (const CTxIn& tx_in : tx->vin) {
+    for (const CTxIn& tx_in : tx->GetInputs()) {
         // Iterate over all wallet transactions spending txin.prev
         // and recursively mark them as no longer conflicting with
         // txid
@@ -1515,12 +1515,12 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
         }
     }
 
-    if (tx->version == TRUC_VERSION) {
+    if (tx->GetVersion() == TRUC_VERSION) {
         // If this tx has a parent, unset its truc_child_in_mempool to make it possible
         // to spend from the parent again. If this tx was replaced by another
         // child of the same parent, transactionAddedToMempool
         // will update truc_child_in_mempool
-        for (const CTxIn& tx_in : tx->vin) {
+        for (const CTxIn& tx_in : tx->GetInputs()) {
             auto parent_it = mapWallet.find(tx_in.prevout.hash);
             if (parent_it != mapWallet.end()) {
                 CWalletTx& parent_wtx = parent_it->second;
@@ -1579,7 +1579,7 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
         // meaning they should never be relayed standalone via the p2p protocol.
         SyncTransaction(ptx, TxStateInactive{/*abandoned=*/index == 0});
 
-        for (const CTxIn& tx_in : ptx->vin) {
+        for (const CTxIn& tx_in : ptx->GetInputs()) {
             // No other wallet transactions conflicted with this transaction
             if (!mapTxSpends.contains(tx_in.prevout)) continue;
 
@@ -1669,7 +1669,7 @@ bool CWallet::IsMine(const CScript& script) const
 bool CWallet::IsMine(const CTransaction& tx) const
 {
     AssertLockHeld(cs_wallet);
-    for (const CTxOut& txout : tx.vout)
+    for (const CTxOut& txout : tx.GetOutputs())
         if (IsMine(txout))
             return true;
     return false;
@@ -1682,16 +1682,16 @@ bool CWallet::IsMine(const COutPoint& outpoint) const
     if (!wtx) {
         return false;
     }
-    if (outpoint.n >= wtx->GetTx()->vout.size()) {
+    if (outpoint.n >= wtx->GetTx()->GetOutputs().size()) {
         return false;
     }
-    return IsMine(wtx->GetTx()->vout[outpoint.n]);
+    return IsMine(wtx->GetTx()->GetOutputs()[outpoint.n]);
 }
 
 bool CWallet::IsFromMe(const CTransaction& tx) const
 {
     LOCK(cs_wallet);
-    for (const CTxIn& txin : tx.vin) {
+    for (const CTxIn& txin : tx.GetInputs()) {
         if (GetTXO(txin.prevout)) return true;
     }
     return false;
@@ -1700,7 +1700,7 @@ bool CWallet::IsFromMe(const CTransaction& tx) const
 CAmount CWallet::GetDebit(const CTransaction& tx) const
 {
     CAmount nDebit = 0;
-    for (const CTxIn& txin : tx.vin)
+    for (const CTxIn& txin : tx.GetInputs())
     {
         nDebit += GetDebit(txin);
         if (!MoneyRange(nDebit))
@@ -2165,12 +2165,12 @@ bool CWallet::SignTransaction(CMutableTransaction& tx) const
     std::map<COutPoint, Coin> coins;
     for (auto& input : tx.vin) {
         const auto mi = mapWallet.find(input.prevout.hash);
-        if(mi == mapWallet.end() || input.prevout.n >= mi->second.GetTx()->vout.size()) {
+        if(mi == mapWallet.end() || input.prevout.n >= mi->second.GetTx()->GetOutputs().size()) {
             return false;
         }
         const CWalletTx& wtx = mi->second;
         int prev_height = wtx.state<TxStateConfirmed>() ? wtx.state<TxStateConfirmed>()->confirmed_block_height : 0;
-        coins[input.prevout] = Coin(wtx.GetTx()->vout[input.prevout.n], prev_height, wtx.IsCoinBase());
+        coins[input.prevout] = Coin(wtx.GetTx()->GetOutputs()[input.prevout.n], prev_height, wtx.IsCoinBase());
     }
     std::map<int, bilingual_str> input_errors;
     return SignTransaction(tx, coins, SIGHASH_DEFAULT, input_errors);
@@ -2349,7 +2349,7 @@ void CWallet::CommitTransaction(
     }
 
     // Notify that old coins are spent
-    for (const CTxIn& txin : tx->vin) {
+    for (const CTxIn& txin : tx->GetInputs()) {
         CWalletTx &coin = mapWallet.at(txin.prevout.hash);
         coin.MarkDirty();
         NotifyTransactionChanged(coin.GetHash(), CT_UPDATED);
@@ -2460,7 +2460,7 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
         for (const auto& it : erased_txs) {
             const Txid hash{it->first};
             wtxOrdered.erase(it->second.m_it_wtxOrdered);
-            for (const auto& txin : it->second.GetTx()->vin) {
+            for (const auto& txin : it->second.GetTx()->GetInputs()) {
                 auto range = mapTxSpends.equal_range(txin.prevout);
                 for (auto iter = range.first; iter != range.second; ++iter) {
                     if (iter->second == hash) {
@@ -2469,7 +2469,7 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
                     }
                 }
             }
-            for (unsigned int i = 0; i < it->second.GetTx()->vout.size(); ++i) {
+            for (unsigned int i = 0; i < it->second.GetTx()->GetOutputs().size(); ++i) {
                 m_txos.erase(COutPoint(hash, i));
             }
             mapWallet.erase(it);
@@ -2634,9 +2634,9 @@ void CWallet::MarkDestinationsDirty(const std::set<CTxDestination>& destinations
     for (auto& entry : mapWallet) {
         CWalletTx& wtx = entry.second;
         if (wtx.m_is_cache_empty) continue;
-        for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); i++) {
+        for (unsigned int i = 0; i < wtx.GetTx()->GetOutputs().size(); i++) {
             CTxDestination dst;
-            if (ExtractDestination(wtx.GetTx()->vout[i].scriptPubKey, dst) && destinations.contains(dst)) {
+            if (ExtractDestination(wtx.GetTx()->GetOutputs()[i].scriptPubKey, dst) && destinations.contains(dst)) {
                 wtx.MarkDirty();
                 break;
             }
@@ -4589,8 +4589,8 @@ void CWallet::WriteBestBlock() const
 void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
 {
     AssertLockHeld(cs_wallet);
-    for (uint32_t i = 0; i < wtx.GetTx()->vout.size(); ++i) {
-        const CTxOut& txout = wtx.GetTx()->vout.at(i);
+    for (uint32_t i = 0; i < wtx.GetTx()->GetOutputs().size(); ++i) {
+        const CTxOut& txout = wtx.GetTx()->GetOutputs().at(i);
         if (!IsMine(txout)) continue;
         COutPoint outpoint(wtx.GetHash(), i);
         if (m_txos.contains(outpoint)) {


### PR DESCRIPTION
`CTransaction` currently exposes its data members publicly and marks them `const`. This makes the implementation details of the type part of its interface, while using `const` data members to enforce immutability has several undesirable consequences.

This PR encapsulates the data members behind public observer functions. The existing users of `CTransaction` are migrated to the observers, after which the data members are made private and non-`const`.

The refactoring is deliberately split into three steps:

1. Add observer functions corresponding to the existing data members.
2. Migrate all users from direct data-member access to the observers.
3. Make the data members private.

The migration is automated with a new `bitcoin-tidy` `use-observers` check. This both makes the large mechanical change straightforward and provides a reusable tool for similar refactorings.

The split into separate commits allows reviewers to review handwritten changes independently of the automated changes. It also simplifies rebasing: if the mechanical migration conflicts, individual files can be reset to their new base versions and the migration tool can be run on them again. This works because the old interface remains available until the final commit, so the reset code is still valid while the mechanical migration is reapplied.

This PR does not change the semantics of `CTransaction`. In particular, regular value semantics are intentionally left for a subsequent change.

### Why Encapsulation? Why `CTransaction`?

Public data members make the representation of a type part of its API. Once access goes through observers, the representation can change without requiring its users to change as well.

This establishes a clean boundary between the transaction's data and functionality that operates on it. In particular, it allows serialization/deserialization and other functionality to be separated from the type itself in subsequent refactorings.

This work is part of the broader interface-segregation direction described in #35904, but is not a prerequisite for the stateless validation library proposed there. The encapsulation has value independently of that work.

`CTransaction` is a good type to start this migration with: it is widely used, its interface is relatively simple, and its data members are already effectively immutable. This allows the migration to establish the pattern and tooling without first requiring changes to the semantics of the type.