### PR TITLE
refactor: Change some validation.cpp methods to return BlockValidationState

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -44,9 +44,8 @@ static void CheckBlockTest(benchmark::Bench& bench)
             assert(block.vtx.size() == 1557);
         })
         .run([&] {
-            BlockValidationState validationState;
-            const bool checked{CheckBlock(block, validationState, chain_params->GetConsensus())};
-            assert(checked);
+            const BlockValidationState validationState{CheckBlock(block, chain_params->GetConsensus())};
+            assert(validationState.IsValid());
         });
 }
 

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -70,8 +70,8 @@ static void DuplicateInputs(benchmark::Bench& bench)
     block.hashMerkleRoot = BlockMerkleRoot(block);
 
     bench.run([&] {
-        BlockValidationState cvstate{};
-        assert(!CheckBlock(block, cvstate, chainparams.GetConsensus(), false, false));
+        const BlockValidationState cvstate{CheckBlock(block, chainparams.GetConsensus(), false, false)};
+        assert(!cvstate.IsValid());
         assert(cvstate.GetRejectReason() == "bad-txns-inputs-duplicate");
     });
 }

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -123,7 +123,17 @@ public:
 };
 
 class TxValidationState : public ValidationState<TxValidationResult> {};
-class BlockValidationState : public ValidationState<BlockValidationResult> {};
+class BlockValidationState : public ValidationState<BlockValidationResult> {
+public:
+    //! Factory helper method to create an Invalid BlockValidationState
+    static BlockValidationState InvalidState(BlockValidationResult result,
+        const std::string& reject_reason = "", const std::string& debug_message = "")
+    {
+        BlockValidationState state;
+        (void)state.Invalid(result, reject_reason, debug_message);
+        return state;
+    }
+};
 
 // These implement the weight = (stripped_size * 4) + witness_size formula,
 // using only serialization with and without witness data. As witness_size

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1354,11 +1354,9 @@ btck_BlockValidationState* btck_chainstate_manager_process_block_header(
 {
     try {
         auto& chainman = btck_ChainstateManager::get(chainstate_manager).m_chainman;
+        auto state = chainman->ProcessNewBlockHeaders({&btck_BlockHeader::get(header), 1}, /*min_pow_checked=*/true);
 
-        auto state = btck_BlockValidationState::create();
-        bool result{chainman->ProcessNewBlockHeaders({&btck_BlockHeader::get(header), 1}, /*min_pow_checked=*/true, btck_BlockValidationState::get(state))};
-        assert(result == btck_BlockValidationState::get(state).IsValid());
-        return state;
+        return btck_BlockValidationState::create(std::move(state));
     } catch (const std::exception& e) {
         LogError("Failed to process block header: %s", e.what());
         return nullptr;

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1154,9 +1154,9 @@ int btck_block_check(const btck_Block* block, const btck_ConsensusParams* consen
     const bool check_pow    = (flags & btck_BlockCheckFlags_POW) != 0;
     const bool check_merkle = (flags & btck_BlockCheckFlags_MERKLE) != 0;
 
-    const bool result = CheckBlock(*btck_Block::get(block), state, btck_ConsensusParams::get(consensus_params), /*fCheckPOW=*/check_pow, /*fCheckMerkleRoot=*/check_merkle);
+    state = CheckBlock(*btck_Block::get(block), btck_ConsensusParams::get(consensus_params), /*fCheckPOW=*/check_pow, /*fCheckMerkleRoot=*/check_merkle);
 
-    return result ? 1 : 0;
+    return state.IsValid() ? 1 : 0;
 }
 
 size_t btck_block_count_transactions(const btck_Block* block)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3118,12 +3118,12 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
     bool received_new_header{last_received_header == nullptr};
 
     // Now process all the headers.
-    BlockValidationState state;
-    const bool processed{m_chainman.ProcessNewBlockHeaders(headers,
+    BlockValidationState state{m_chainman.ProcessNewBlockHeaders(headers,
                                                            /*min_pow_checked=*/true,
-                                                           state, &pindexLast)};
-    if (!processed) {
-        if (state.IsInvalid()) {
+                                                           &pindexLast)};
+    if (!state.IsValid()) {
+        // ProcessNewBlockHeaders only sets Invalid, never Error state.
+        if (Assume(state.IsInvalid())) {
             if (!pfrom.IsInboundConn() && state.GetResult() == BlockValidationResult::BLOCK_CACHED_INVALID) {
                 // Warn user if outgoing peers send us headers of blocks that we previously marked as invalid.
                 LogWarning("%s (received from peer=%i). "
@@ -3132,12 +3132,12 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
                            state.GetDebugMessage(), pfrom.GetId());
             }
             MaybePunishNodeForBlock(pfrom.GetId(), state, via_compact_block, "invalid header received");
-            return;
         }
+        return;
     }
     assert(pindexLast);
 
-    if (processed && received_new_header) {
+    if (received_new_header) {
         LogBlockHeader(*pindexLast, pfrom, /*via_compact_block=*/false);
     }
 
@@ -4603,12 +4603,13 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         const CBlockIndex *pindex = nullptr;
-        BlockValidationState state;
-        if (!m_chainman.ProcessNewBlockHeaders({{cmpctblock.header}}, /*min_pow_checked=*/true, state, &pindex)) {
-            if (state.IsInvalid()) {
+        BlockValidationState state{m_chainman.ProcessNewBlockHeaders({{cmpctblock.header}}, /*min_pow_checked=*/true, &pindex)};
+        if (!state.IsValid()) {
+            // ProcessNewBlockHeaders only sets Invalid, never Error state.
+            if (Assume(state.IsInvalid())) {
                 MaybePunishNodeForBlock(pfrom.GetId(), state, /*via_compact_block=*/true, "invalid header via cmpctblock");
-                return;
             }
+            return;
         }
 
         // If AcceptBlockHeader returned valid, it set pindex

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4611,7 +4611,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             }
         }
 
-        // If AcceptBlockHeader returned true, it set pindex
+        // If AcceptBlockHeader returned valid, it set pindex
         Assert(pindex);
         if (received_new_header) {
             LogBlockHeader(*pindex, pfrom, /*via_compact_block=*/true);

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -7,6 +7,7 @@
 #include <arith_uint256.h>
 #include <chain.h>
 #include <consensus/params.h>
+#include <consensus/validation.h>
 #include <crypto/hex_base.h>
 #include <dbwrapper.h>
 #include <flatfile.h>
@@ -969,7 +970,8 @@ bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFileP
     bool out_of_space;
     size_t bytes_allocated = m_undo_file_seq.Allocate(pos, nAddSize, out_of_space);
     if (out_of_space) {
-        return FatalError(m_opts.notifications, state, _("Disk space is too low!"));
+        state = FatalError(m_opts.notifications, _("Disk space is too low!"));
+        return false;
     }
     if (bytes_allocated != 0 && IsPruneMode()) {
         m_check_for_pruning = true;
@@ -997,7 +999,8 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
         AutoFile file{OpenUndoFile(pos)};
         if (file.IsNull()) {
             LogError("OpenUndoFile failed for %s while writing block undo", pos.ToString());
-            return FatalError(m_opts.notifications, state, _("Failed to write undo data."));
+            state = FatalError(m_opts.notifications, _("Failed to write undo data."));
+            return false;
         }
         {
             BufferedWriter fileout{file};
@@ -1018,7 +1021,8 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
         // Make sure that the file is closed before we call `FlushUndoFile`.
         if (file.fclose() != 0) {
             LogError("Failed to close block undo file %s: %s", pos.ToString(), SysErrorString(errno));
-            return FatalError(m_opts.notifications, state, _("Failed to close block undo file."));
+            state = FatalError(m_opts.notifications, _("Failed to close block undo file."));
+            return false;
         }
 
         // rev files are written in block height order, whereas blk files are written as blocks come in (often out of order)

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1164,8 +1164,7 @@ static RPCMethod submitheader()
         }
     }
 
-    BlockValidationState state;
-    chainman.ProcessNewBlockHeaders({{h}}, /*min_pow_checked=*/true, state);
+    BlockValidationState state{chainman.ProcessNewBlockHeaders({{h}}, /*min_pow_checked=*/true)};
     if (state.IsValid()) return UniValue::VNULL;
     if (state.IsError()) {
         throw JSONRPCError(RPC_VERIFY_ERROR, state.ToString());

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -127,8 +127,7 @@ bool BuildChainTestingSetup::BuildChain(const CBlockIndex* pindex,
     for (auto& block : chain) {
         block = std::make_shared<CBlock>(CreateBlock(pindex, no_txns, coinbase_script_pub_key));
 
-        BlockValidationState state;
-        if (!Assert(m_node.chainman)->ProcessNewBlockHeaders({{*block}}, true, state, &pindex)) {
+        if (!Assert(m_node.chainman)->ProcessNewBlockHeaders({{*block}}, true, &pindex).IsValid()) {
             return false;
         }
     }

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -30,22 +30,21 @@ BOOST_FIXTURE_TEST_CASE(chainstate_write_interval, TestingSetup)
     const auto sub{std::make_shared<TestSubscriber>()};
     m_node.validation_signals->RegisterSharedValidationInterface(sub);
     auto& chainstate{Assert(m_node.chainman)->ActiveChainstate()};
-    BlockValidationState state_dummy{};
     FakeNodeClock clock{};
 
     // The first periodic flush sets m_next_write and does not flush
-    chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    (void)chainstate.FlushStateToDisk(FlushStateMode::PERIODIC);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(!sub->m_did_flush);
 
     // The periodic flush interval is between 50 and 70 minutes (inclusive)
     clock += DATABASE_WRITE_INTERVAL_MIN - 1min;
-    chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    (void)chainstate.FlushStateToDisk(FlushStateMode::PERIODIC);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(!sub->m_did_flush);
 
     clock += DATABASE_WRITE_INTERVAL_MAX;
-    chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    (void)chainstate.FlushStateToDisk(FlushStateMode::PERIODIC);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(sub->m_did_flush);
 }
@@ -84,7 +83,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     BOOST_CHECK_EQUAL(second_from_tip->pprev, chainstate.m_chain.Tip());
 
     // Set m_next_write to current time
-    chainstate.FlushStateToDisk(state_dummy, FlushStateMode::FORCE_FLUSH);
+    (void)chainstate.FlushStateToDisk(FlushStateMode::FORCE_FLUSH);
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), second_from_tip->pprev);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     // The periodic flush interval is between 50 and 70 minutes (inclusive)

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -103,7 +103,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             LOCK(cs_main);
             BlockValidationState state{CheckBlock(block, params.GetConsensus())};
             BOOST_CHECK(state.IsValid());
-            BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
+            state = m_node.chainman->AcceptBlock(new_block, &new_block_index, true, nullptr, nullptr, true);
+            BOOST_CHECK(state.IsValid());
             CCoinsViewCache view(&chainstate.CoinsTip());
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
         }

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -101,8 +101,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             new_block = std::make_shared<CBlock>(block);
 
             LOCK(cs_main);
-            BlockValidationState state;
-            BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
+            BlockValidationState state{CheckBlock(block, params.GetConsensus())};
+            BOOST_CHECK(state.IsValid());
             BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
             CCoinsViewCache view(&chainstate.CoinsTip());
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -31,23 +31,19 @@ FUZZ_TARGET(block, .init = initialize_block)
         return;
     }
     const Consensus::Params& consensus_params = Params().GetConsensus();
-    BlockValidationState validation_state_pow_and_merkle;
-    const bool valid_incl_pow_and_merkle = CheckBlock(block, validation_state_pow_and_merkle, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ true);
+    BlockValidationState validation_state_pow_and_merkle{CheckBlock(block, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ true)};
     assert(validation_state_pow_and_merkle.IsValid() || validation_state_pow_and_merkle.IsInvalid() || validation_state_pow_and_merkle.IsError());
     (void)validation_state_pow_and_merkle.Error("");
-    BlockValidationState validation_state_pow;
-    const bool valid_incl_pow = CheckBlock(block, validation_state_pow, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ false);
+    const BlockValidationState validation_state_pow{CheckBlock(block, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ false)};
     assert(validation_state_pow.IsValid() || validation_state_pow.IsInvalid() || validation_state_pow.IsError());
-    BlockValidationState validation_state_merkle;
-    const bool valid_incl_merkle = CheckBlock(block, validation_state_merkle, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ true);
+    const BlockValidationState validation_state_merkle{CheckBlock(block, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ true)};
     assert(validation_state_merkle.IsValid() || validation_state_merkle.IsInvalid() || validation_state_merkle.IsError());
-    BlockValidationState validation_state_none;
-    const bool valid_incl_none = CheckBlock(block, validation_state_none, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ false);
+    const BlockValidationState validation_state_none{CheckBlock(block, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ false)};
     assert(validation_state_none.IsValid() || validation_state_none.IsInvalid() || validation_state_none.IsError());
-    if (valid_incl_pow_and_merkle) {
-        assert(valid_incl_pow && valid_incl_merkle && valid_incl_none);
-    } else if (valid_incl_merkle || valid_incl_pow) {
-        assert(valid_incl_none);
+    if (validation_state_pow_and_merkle.IsValid()) {
+        assert(validation_state_pow.IsValid() && validation_state_merkle.IsValid() && validation_state_none.IsValid());
+    } else if (validation_state_merkle.IsValid() || validation_state_pow.IsValid()) {
+        assert(validation_state_none.IsValid());
     }
     (void)block.GetHash();
     (void)block.ToString();

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -89,8 +89,7 @@ void initialize_chain()
     if constexpr (INVALID) {
         auto& chainman{*setup->m_node.chainman};
         for (const auto& block : chain) {
-            BlockValidationState dummy;
-            bool processed{chainman.ProcessNewBlockHeaders({{*block}}, true, dummy)};
+            bool processed{chainman.ProcessNewBlockHeaders({{*block}}, true).IsValid()};
             Assert(processed);
             const auto* index{WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(block->GetHash()))};
             Assert(index);
@@ -171,8 +170,7 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
         // Consume the bool, but skip the code for the INVALID fuzz target
         if constexpr (!INVALID) {
             for (const auto& block : *g_chain) {
-                BlockValidationState dummy;
-                bool processed{chainman.ProcessNewBlockHeaders({{*block}}, true, dummy)};
+                bool processed{chainman.ProcessNewBlockHeaders({{*block}}, true).IsValid()};
                 Assert(processed);
                 const auto* index{WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(block->GetHash()))};
                 Assert(index);

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -120,8 +120,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::FinalizeBlock(std::shared_ptr<CBlock>
 
     // submit block header, so that miner can get the block height from the
     // global state and the node has the topology of the chain
-    BlockValidationState ignored;
-    BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlockHeaders({{*pblock}}, true, ignored));
+    BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlockHeaders({{*pblock}}, true).IsValid());
 
     return pblock;
 }
@@ -382,5 +381,11 @@ BOOST_AUTO_TEST_CASE(witness_commitment_index)
     pblock.vtx[0] = MakeTransactionRef(std::move(txCoinbase));
 
     BOOST_CHECK_EQUAL(GetWitnessCommitmentIndex(pblock), 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_empty_process_new_block_headers)
+{
+    const auto res{m_node.chainman->ProcessNewBlockHeaders({}, true)};
+    BOOST_CHECK(res.IsValid());
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -156,9 +156,8 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
         LOCK(::cs_main);
         state = CheckBlock(*pblockone, chainparams.GetConsensus());
         BOOST_CHECK(state.IsValid());
-        bool accepted = chainman.AcceptBlock(
-            pblockone, state, &pindex, true, nullptr, &newblock, true);
-        BOOST_CHECK(accepted);
+        state = chainman.AcceptBlock(pblockone, &pindex, true, nullptr, &newblock, true);
+        BOOST_CHECK(state.IsValid());
     }
 
     // UpdateTip is called here

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -154,8 +154,8 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
     // once it is changed to support multiple chainstates.
     {
         LOCK(::cs_main);
-        bool checked = CheckBlock(*pblockone, state, chainparams.GetConsensus());
-        BOOST_CHECK(checked);
+        state = CheckBlock(*pblockone, chainparams.GetConsensus());
+        BOOST_CHECK(state.IsValid());
         bool accepted = chainman.AcceptBlock(
             pblockone, state, &pindex, true, nullptr, &newblock, true);
         BOOST_CHECK(accepted);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3884,10 +3884,10 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
  * Note: If the witness commitment is expected (i.e. `expect_witness_commitment
  * = true`), then the block is required to have at least one transaction and the
  * first transaction needs to have at least one input. */
-static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_commitment, BlockValidationState& state)
+[[nodiscard]] static BlockValidationState CheckWitnessMalleation(const CBlock& block, bool expect_witness_commitment)
 {
     if (expect_witness_commitment) {
-        if (block.m_checked_witness_commitment) return true;
+        if (block.m_checked_witness_commitment) return BlockValidationState{};
 
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != NO_WITNESS_COMMITMENT) {
@@ -3895,7 +3895,7 @@ static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_comm
             const auto& witness_stack{block.vtx[0]->vin[0].scriptWitness.stack};
 
             if (witness_stack.size() != 1 || witness_stack[0].size() != 32) {
-                return state.Invalid(
+                return BlockValidationState::InvalidState(
                     /*result=*/BlockValidationResult::BLOCK_MUTATED,
                     /*reject_reason=*/"bad-witness-nonce-size",
                     /*debug_message=*/strprintf("%s : invalid witness reserved value size", __func__));
@@ -3908,28 +3908,28 @@ static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_comm
 
             CHash256().Write(hash_witness).Write(witness_stack[0]).Finalize(hash_witness);
             if (memcmp(hash_witness.begin(), &block.vtx[0]->vout[commitpos].scriptPubKey[6], 32)) {
-                return state.Invalid(
+                return BlockValidationState::InvalidState(
                     /*result=*/BlockValidationResult::BLOCK_MUTATED,
                     /*reject_reason=*/"bad-witness-merkle-match",
                     /*debug_message=*/strprintf("%s : witness merkle commitment mismatch", __func__));
             }
 
             block.m_checked_witness_commitment = true;
-            return true;
+            return BlockValidationState{};
         }
     }
 
     // No witness data is allowed in blocks that don't commit to witness data, as this would otherwise leave room for spam
     for (const auto& tx : block.vtx) {
         if (tx->HasWitness()) {
-            return state.Invalid(
+            return BlockValidationState::InvalidState(
                 /*result=*/BlockValidationResult::BLOCK_MUTATED,
                 /*reject_reason=*/"unexpected-witness",
                 /*debug_message=*/strprintf("%s : unexpected witness data found", __func__));
         }
     }
 
-    return true;
+    return BlockValidationState{};
 }
 
 BlockValidationState CheckBlock(const CBlock& block, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot)
@@ -4070,8 +4070,7 @@ bool IsBlockMutated(const CBlock& block, bool check_witness_root)
         // here as it requires at least 224 bits of work.
     }
 
-    BlockValidationState state;
-    if (!CheckWitnessMalleation(block, check_witness_root, state)) {
+    if (const auto state = CheckWitnessMalleation(block, check_witness_root); !state.IsValid()) {
         LogDebug(BCLog::VALIDATION, "Block mutated: %s\n", state.ToString());
         return true;
     }
@@ -4192,7 +4191,8 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     // * There must be at least one output whose scriptPubKey is a single 36-byte push, the first 4 bytes of which are
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness reserved value). In case there are
     //   multiple, the last one is used.
-    if (!CheckWitnessMalleation(block, DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT), state)) {
+    state = CheckWitnessMalleation(block, DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT));
+    if (!state.IsValid()) {
         return false;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2329,7 +2329,8 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // is enforced in ContextualCheckBlockHeader(); we wouldn't want to
     // re-enforce that rule here (at least until we make it impossible for
     // the clock to go backward).
-    if (!CheckBlock(block, state, params.GetConsensus(), !fJustCheck, !fJustCheck)) {
+    state = CheckBlock(block, params.GetConsensus(), !fJustCheck, !fJustCheck);
+    if (!state.IsValid()) {
         if (state.GetResult() == BlockValidationResult::BLOCK_MUTATED) {
             // We don't write down blocks to disk if they may have been
             // corrupted, so this should be impossible unless we're having hardware
@@ -3931,29 +3932,27 @@ static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_comm
     return true;
 }
 
-bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot)
+BlockValidationState CheckBlock(const CBlock& block, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot)
 {
     // These are checks that are independent of context.
 
     if (block.fChecked)
-        return true;
+        return BlockValidationState{};
 
     // Check that the header is valid (particularly PoW).  This is mostly
     // redundant with the call in AcceptBlockHeader.
-    state = CheckBlockHeader(block, consensusParams, fCheckPOW);
-    if (!state.IsValid())
-        return false;
+    if (const auto state = CheckBlockHeader(block, consensusParams, fCheckPOW); !state.IsValid())
+        return state;
 
     // Signet only: check block solution
     if (consensusParams.signet_blocks && fCheckPOW && !CheckSignetBlockSolution(block, consensusParams)) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-signet-blksig", "signet block signature validation failure");
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CONSENSUS, "bad-signet-blksig", "signet block signature validation failure");
     }
 
     // Check the merkle root.
     if (fCheckMerkleRoot) {
-        state = CheckMerkleRoot(block);
-        if (!state.IsValid()) {
-            return false;
+        if (const auto state = CheckMerkleRoot(block); !state.IsValid()) {
+            return state;
         }
     }
 
@@ -3964,15 +3963,19 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
     // checks that use witness data may be performed here.
 
     // Size limits
-    if (block.vtx.empty() || block.vtx.size() * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT || ::GetSerializeSize(TX_NO_WITNESS(block)) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT)
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-length", "size limits failed");
+    if (block.vtx.empty() || block.vtx.size() * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT || ::GetSerializeSize(TX_NO_WITNESS(block)) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT) {
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-length", "size limits failed");
+    }
 
     // First transaction must be coinbase, the rest must not be
-    if (block.vtx.empty() || !block.vtx[0]->IsCoinBase())
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-missing", "first tx is not coinbase");
-    for (unsigned int i = 1; i < block.vtx.size(); i++)
-        if (block.vtx[i]->IsCoinBase())
-            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-multiple", "more than one coinbase");
+    if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-missing", "first tx is not coinbase");
+    }
+    for (unsigned int i = 1; i < block.vtx.size(); i++) {
+        if (block.vtx[i]->IsCoinBase()) {
+            return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-multiple", "more than one coinbase");
+        }
+    }
 
     // Check transactions
     // Must check for duplicate inputs (see CVE-2018-17144)
@@ -3982,8 +3985,8 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
             // CheckBlock() does context-free validation checks. The only
             // possible failures are consensus failures.
             assert(tx_state.GetResult() == TxValidationResult::TX_CONSENSUS);
-            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, tx_state.GetRejectReason(),
-                                 strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), tx_state.GetDebugMessage()));
+            return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CONSENSUS, tx_state.GetRejectReason(),
+                strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), tx_state.GetDebugMessage()));
         }
     }
     // This underestimates the number of sigops, because unlike ConnectBlock it
@@ -3993,13 +3996,14 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
     {
         nSigOps += GetLegacySigOpCount(*tx);
     }
-    if (nSigOps * WITNESS_SCALE_FACTOR > MAX_BLOCK_SIGOPS_COST)
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-sigops", "out-of-bounds SigOpCount");
+    if (nSigOps * WITNESS_SCALE_FACTOR > MAX_BLOCK_SIGOPS_COST) {
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-sigops", "out-of-bounds SigOpCount");
+    }
 
     if (fCheckPOW && fCheckMerkleRoot)
         block.fChecked = true;
 
-    return true;
+    return BlockValidationState{};
 }
 
 void ChainstateManager::UpdateUncommittedBlockStructures(CBlock& block, const CBlockIndex* pindexPrev) const
@@ -4370,8 +4374,11 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
 
     const CChainParams& params{GetParams()};
 
-    if (!CheckBlock(block, state, params.GetConsensus()) ||
-        !ContextualCheckBlock(block, state, *this, pindex->pprev)) {
+    state = CheckBlock(block, params.GetConsensus());
+    if (state.IsValid()) {
+        ContextualCheckBlock(block, state, *this, pindex->pprev);
+    }
+    if (!state.IsValid()) {
         if (Assume(state.IsInvalid())) {
             ActiveChainstate().InvalidBlockFound(pindex, state);
         }
@@ -4443,12 +4450,12 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         // malleability that cause CheckBlock() to fail; see e.g. CVE-2012-2459 and
         // https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-February/016697.html.  Because CheckBlock() is
         // not very expensive, the anti-DoS benefits of caching failure (of a definitely-invalid block) are not substantial.
-        bool ret = CheckBlock(*block, state, GetConsensus());
-        if (ret) {
+        state = CheckBlock(*block, GetConsensus());
+        if (state.IsValid()) {
             // Store to disk
-            ret = AcceptBlock(block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
+            (void)AcceptBlock(block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
         }
-        if (!ret) {
+        if (!state.IsValid()) {
             if (m_options.signals) {
                 m_options.signals->BlockChecked(block, state);
             }
@@ -4510,10 +4517,10 @@ BlockValidationState TestBlockValidity(
     }
 
     // For signets CheckBlock() verifies the challenge iff fCheckPow is set.
-    if (!CheckBlock(block, state, chainstate.m_chainman.GetConsensus(), /*fCheckPow=*/check_pow, /*fCheckMerkleRoot=*/check_merkle_root)) {
+    state = CheckBlock(block, chainstate.m_chainman.GetConsensus(), /*fCheckPow=*/check_pow, /*fCheckMerkleRoot=*/check_merkle_root);
+    if (!state.IsValid()) {
         // This should never happen, but belt-and-suspenders don't approve the
         // block if it does.
-        if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
     }
 
@@ -4694,10 +4701,13 @@ VerifyDBResult CVerifyDB::VerifyDB(
             return VerifyDBResult::CORRUPTED_BLOCK_DB;
         }
         // check level 1: verify block validity
-        if (nCheckLevel >= 1 && !CheckBlock(block, state, consensus_params)) {
-            LogError("Verification error: found bad block at %d, hash=%s (%s)",
-                      pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
-            return VerifyDBResult::CORRUPTED_BLOCK_DB;
+        if (nCheckLevel >= 1) {
+            state = CheckBlock(block, consensus_params);
+            if (!state.IsValid()) {
+                LogError("Verification error: found bad block at %d, hash=%s (%s)",
+                          pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
+                return VerifyDBResult::CORRUPTED_BLOCK_DB;
+            }
         }
         // check level 2: verify undo validity
         if (nCheckLevel >= 2 && pindex) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3841,13 +3841,13 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     }
 }
 
-static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
+[[nodiscard]] static BlockValidationState CheckBlockHeader(const CBlockHeader& block, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
     // Check proof of work matches claimed amount
-    if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
-        return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "high-hash", "proof of work failed");
-
-    return true;
+    if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams)) {
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_INVALID_HEADER, "high-hash", "proof of work failed");
+    }
+    return BlockValidationState{};
 }
 
 static bool CheckMerkleRoot(const CBlock& block, BlockValidationState& state)
@@ -3940,7 +3940,8 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
 
     // Check that the header is valid (particularly PoW).  This is mostly
     // redundant with the call in AcceptBlockHeader.
-    if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
+    state = CheckBlockHeader(block, consensusParams, fCheckPOW);
+    if (!state.IsValid())
         return false;
 
     // Signet only: check block solution
@@ -4220,7 +4221,8 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             return true;
         }
 
-        if (!CheckBlockHeader(block, state, GetConsensus())) {
+        state = CheckBlockHeader(block, GetConsensus());
+        if (!state.IsValid()) {
             LogDebug(BCLog::VALIDATION, "%s: Consensus::CheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4151,7 +4151,7 @@ arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers)
  *  in ConnectBlock().
  *  Note that -reindex-chainstate skips the validation that happens here!
  */
-static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
+[[nodiscard]] static BlockValidationState ContextualCheckBlock(const CBlock& block, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
 {
     const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
 
@@ -4169,7 +4169,7 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     // Check that all transactions are finalized
     for (const auto& tx : block.vtx) {
         if (!IsFinalTx(*tx, nHeight, nLockTimeCutoff)) {
-            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-txns-nonfinal", "non-final transaction");
+            return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CONSENSUS, "bad-txns-nonfinal", "non-final transaction");
         }
     }
 
@@ -4179,7 +4179,7 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
         CScript expect = CScript() << nHeight;
         if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
             !std::equal(expect.begin(), expect.end(), block.vtx[0]->vin[0].scriptSig.begin())) {
-            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-height", "block height mismatch in coinbase");
+            return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-height", "block height mismatch in coinbase");
         }
     }
 
@@ -4191,9 +4191,9 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     // * There must be at least one output whose scriptPubKey is a single 36-byte push, the first 4 bytes of which are
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness reserved value). In case there are
     //   multiple, the last one is used.
-    state = CheckWitnessMalleation(block, DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT));
-    if (!state.IsValid()) {
-        return false;
+    if (const auto state = CheckWitnessMalleation(block, DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT));
+        !state.IsValid()) {
+        return state;
     }
 
     // After the coinbase witness reserved value and commitment are verified,
@@ -4203,10 +4203,10 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     // the block hash, so we couldn't mark the block as permanently
     // failed).
     if (GetBlockWeight(block) > MAX_BLOCK_WEIGHT) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-weight", strprintf("%s : weight limit failed", __func__));
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-weight", strprintf("%s : weight limit failed", __func__));
     }
 
-    return true;
+    return BlockValidationState{};
 }
 
 BlockValidationState ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, CBlockIndex** ppindex, bool min_pow_checked)
@@ -4376,7 +4376,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
 
     state = CheckBlock(block, params.GetConsensus());
     if (state.IsValid()) {
-        ContextualCheckBlock(block, state, *this, pindex->pprev);
+        state = ContextualCheckBlock(block, *this, pindex->pprev);
     }
     if (!state.IsValid()) {
         if (Assume(state.IsInvalid())) {
@@ -4544,8 +4544,8 @@ BlockValidationState TestBlockValidity(
         return state;
     }
 
-    if (!ContextualCheckBlock(block, state, chainstate.m_chainman, tip)) {
-        if (state.IsValid()) NONFATAL_UNREACHABLE();
+    state = ContextualCheckBlock(block, chainstate.m_chainman, tip);
+    if (!state.IsValid()) {
         return state;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4258,19 +4258,19 @@ BlockValidationState ChainstateManager::AcceptBlockHeader(const CBlockHeader& bl
 }
 
 // Exposed wrapper for AcceptBlockHeader
-bool ChainstateManager::ProcessNewBlockHeaders(std::span<const CBlockHeader> headers, bool min_pow_checked, BlockValidationState& state, const CBlockIndex** ppindex)
+BlockValidationState ChainstateManager::ProcessNewBlockHeaders(std::span<const CBlockHeader> headers, bool min_pow_checked, const CBlockIndex** ppindex)
 {
     AssertLockNotHeld(cs_main);
     {
         LOCK(cs_main);
         for (const CBlockHeader& header : headers) {
             CBlockIndex *pindex = nullptr; // Use a temp pindex instead of ppindex to avoid a const_cast
-            state = AcceptBlockHeader(header, &pindex, min_pow_checked);
+            BlockValidationState state{AcceptBlockHeader(header, &pindex, min_pow_checked)};
             CheckBlockIndex();
-
             if (!state.IsValid()) {
-                return false;
+                return state;
             }
+
             if (ppindex) {
                 *ppindex = pindex;
             }
@@ -4285,7 +4285,8 @@ bool ChainstateManager::ProcessNewBlockHeaders(std::span<const CBlockHeader> hea
             LogInfo("Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
         }
     }
-    return true;
+
+    return BlockValidationState{};
 }
 
 void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1806,8 +1806,7 @@ MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTra
         );
     }
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
-    BlockValidationState state_dummy;
-    active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    (void)active_chainstate.FlushStateToDisk(FlushStateMode::PERIODIC);
     return result;
 }
 
@@ -1838,8 +1837,7 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
         }
     }
     // Ensure the coins cache is still within limits.
-    BlockValidationState state_dummy;
-    active_chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
+    (void)active_chainstate.FlushStateToDisk(FlushStateMode::PERIODIC);
     return result;
 }
 
@@ -2714,8 +2712,7 @@ CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState(
     return CoinsCacheSizeState::OK;
 }
 
-bool Chainstate::FlushStateToDisk(
-    BlockValidationState &state,
+BlockValidationState Chainstate::FlushStateToDisk(
     FlushStateMode mode,
     int nManualPruneHeight)
 {
@@ -2790,8 +2787,7 @@ bool Chainstate::FlushStateToDisk(
 
             // Ensure we can write block index
             if (!CheckDiskSpace(m_blockman.m_opts.blocks_dir)) {
-                state = FatalError(m_chainman.GetNotifications(), _("Disk space is too low!"));
-                return false;
+                return FatalError(m_chainman.GetNotifications(), _("Disk space is too low!"));
             }
             {
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
@@ -2824,8 +2820,7 @@ bool Chainstate::FlushStateToDisk(
                 // an overestimation, as most will delete an existing entry or
                 // overwrite one. Still, use a conservative safety factor of 2.
                 if (!CheckDiskSpace(m_chainman.m_options.datadir, 48 * 2 * 2 * CoinsTip().GetDirtyCount())) {
-                    state = FatalError(m_chainman.GetNotifications(), _("Disk space is too low!"));
-                    return false;
+                    return FatalError(m_chainman.GetNotifications(), _("Disk space is too low!"));
                 }
                 // Flush the chainstate (which may refer to block index entries).
                 empty_cache ? CoinsTip().Flush() : CoinsTip().Sync();
@@ -2859,25 +2854,22 @@ bool Chainstate::FlushStateToDisk(
         }
     }
     } catch (const std::runtime_error& e) {
-        state = FatalError(m_chainman.GetNotifications(), strprintf(_("System error while flushing: %s"), e.what()));
-        return false;
+        return FatalError(m_chainman.GetNotifications(), strprintf(_("System error while flushing: %s"), e.what()));
     }
-    return true;
+    return BlockValidationState{};
 }
 
 void Chainstate::ForceFlushStateToDisk(bool wipe_cache)
 {
-    BlockValidationState state;
-    if (!this->FlushStateToDisk(state, wipe_cache ? FlushStateMode::FORCE_FLUSH : FlushStateMode::FORCE_SYNC)) {
+    if (auto state = this->FlushStateToDisk(wipe_cache ? FlushStateMode::FORCE_FLUSH : FlushStateMode::FORCE_SYNC); !state.IsValid()) {
         LogWarning("Failed to force flush state (%s)", state.ToString());
     }
 }
 
 void Chainstate::PruneAndFlush()
 {
-    BlockValidationState state;
     m_blockman.m_check_for_pruning = true;
-    if (!this->FlushStateToDisk(state, FlushStateMode::NONE)) {
+    if (auto state = this->FlushStateToDisk(FlushStateMode::NONE); !state.IsValid()) {
         LogWarning("Failed to flush state (%s)", state.ToString());
     }
 }
@@ -2994,7 +2986,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     }
 
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FlushStateMode::IF_NEEDED)) {
+    state = FlushStateToDisk(FlushStateMode::IF_NEEDED);
+    if (!state.IsValid()) {
         return false;
     }
 
@@ -3088,7 +3081,8 @@ bool Chainstate::ConnectTip(
              Ticks<SecondsDouble>(m_chainman.time_flush),
              Ticks<MillisecondsDouble>(m_chainman.time_flush) / m_chainman.num_blocks_total);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FlushStateMode::IF_NEEDED)) {
+    state = FlushStateToDisk(FlushStateMode::IF_NEEDED);
+    if (!state.IsValid()) {
         return false;
     }
     const auto time_5{SteadyClock::now()};
@@ -3478,7 +3472,8 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
             }
 
             // Write changes periodically to disk, after relay.
-            if (!FlushStateToDisk(state, FlushStateMode::PERIODIC)) {
+            state = FlushStateToDisk(FlushStateMode::PERIODIC);
+            if (!state.IsValid()) {
                 return false;
             }
 
@@ -4431,9 +4426,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     // callers can't mistreat a flush failure as a block validation failure.
     // The fatal error notification inside FlushStateToDisk still fires,
     // so the node will shut down on unrecoverable flush errors regardless.
-    // For state a dummy value is used, and the return value is ignored.
-    BlockValidationState flush_state_ignore;
-    (void)ActiveChainstate().FlushStateToDisk(flush_state_ignore, FlushStateMode::NONE);
+    (void)ActiveChainstate().FlushStateToDisk(FlushStateMode::NONE);
 
     CheckBlockIndex();
 
@@ -4581,9 +4574,8 @@ BlockValidationState TestBlockValidity(
 /* This function is called from the RPC code for pruneblockchain */
 void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight)
 {
-    BlockValidationState state;
-    if (!active_chainstate.FlushStateToDisk(
-            state, FlushStateMode::NONE, nManualPruneHeight)) {
+    if (auto state = active_chainstate.FlushStateToDisk(
+            FlushStateMode::NONE, nManualPruneHeight); !state.IsValid()) {
         LogWarning("Failed to flush state after manual prune (%s)", state.ToString());
     }
 }
@@ -5525,15 +5517,14 @@ bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
     LogInfo("[%s] resized coinstip cache to %.1f MiB",
         this->ToString(), coinstip_size / double(1_MiB));
 
-    BlockValidationState state;
     bool ret;
 
     if (coinstip_size > old_coinstip_size) {
         // Likely no need to flush if cache sizes have grown.
-        ret = FlushStateToDisk(state, FlushStateMode::IF_NEEDED);
+        ret = FlushStateToDisk(FlushStateMode::IF_NEEDED).IsValid();
     } else {
         // Otherwise, flush state to disk and deallocate the in-memory coins map.
-        ret = FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH);
+        ret = FlushStateToDisk(FlushStateMode::FORCE_FLUSH).IsValid();
     }
     return ret;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2145,10 +2145,12 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     return true;
 }
 
-bool FatalError(Notifications& notifications, BlockValidationState& state, const bilingual_str& message)
+BlockValidationState FatalError(Notifications& notifications, const bilingual_str& message)
 {
     notifications.fatalError(message);
-    return state.Error(message.original);
+    BlockValidationState state;
+    (void)state.Error(message.original);
+    return state;
 }
 
 /**
@@ -2335,7 +2337,8 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // We don't write down blocks to disk if they may have been
             // corrupted, so this should be impossible unless we're having hardware
             // problems.
-            return FatalError(m_chainman.GetNotifications(), state, _("Corrupt block found indicating potential hardware failure."));
+            state = FatalError(m_chainman.GetNotifications(), _("Corrupt block found indicating potential hardware failure."));
+            return false;
         }
         LogError("%s: Consensus::CheckBlock: %s\n", __func__, state.ToString());
         return false;
@@ -2787,7 +2790,8 @@ bool Chainstate::FlushStateToDisk(
 
             // Ensure we can write block index
             if (!CheckDiskSpace(m_blockman.m_opts.blocks_dir)) {
-                return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
+                state = FatalError(m_chainman.GetNotifications(), _("Disk space is too low!"));
+                return false;
             }
             {
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
@@ -2820,7 +2824,8 @@ bool Chainstate::FlushStateToDisk(
                 // an overestimation, as most will delete an existing entry or
                 // overwrite one. Still, use a conservative safety factor of 2.
                 if (!CheckDiskSpace(m_chainman.m_options.datadir, 48 * 2 * 2 * CoinsTip().GetDirtyCount())) {
-                    return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
+                    state = FatalError(m_chainman.GetNotifications(), _("Disk space is too low!"));
+                    return false;
                 }
                 // Flush the chainstate (which may refer to block index entries).
                 empty_cache ? CoinsTip().Flush() : CoinsTip().Sync();
@@ -2854,7 +2859,8 @@ bool Chainstate::FlushStateToDisk(
         }
     }
     } catch (const std::runtime_error& e) {
-        return FatalError(m_chainman.GetNotifications(), state, strprintf(_("System error while flushing: %s"), e.what()));
+        state = FatalError(m_chainman.GetNotifications(), strprintf(_("System error while flushing: %s"), e.what()));
+        return false;
     }
     return true;
 }
@@ -3039,7 +3045,8 @@ bool Chainstate::ConnectTip(
     if (!block_to_connect) {
         std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
         if (!m_blockman.ReadBlock(*pblockNew, *pindexNew)) {
-            return FatalError(m_chainman.GetNotifications(), state, _("Failed to read block."));
+            state = FatalError(m_chainman.GetNotifications(), _("Failed to read block."));
+            return false;
         }
         block_to_connect = std::move(pblockNew);
     } else {
@@ -3225,7 +3232,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
             // If we're unable to disconnect a block during normal operation,
             // then that is a failure of our local system -- we should abort
             // rather than stay on a less work chain.
-            FatalError(m_chainman.GetNotifications(), state, _("Failed to disconnect block."));
+            state = FatalError(m_chainman.GetNotifications(), _("Failed to disconnect block."));
             return false;
         }
         fBlocksDisconnected = true;
@@ -4408,7 +4415,8 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         }
         ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        return FatalError(GetNotifications(), state, strprintf(_("System error while saving block to disk: %s"), e.what()));
+        state = FatalError(GetNotifications(), strprintf(_("System error while saving block to disk: %s"), e.what()));
+        return false;
     }
 
     // TODO: FlushStateToDisk() handles flushing of both block and chainstate

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4324,7 +4324,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
+BlockValidationState ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
 {
     const CBlock& block = *pblock;
 
@@ -4334,11 +4334,12 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     CBlockIndex *pindexDummy = nullptr;
     CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
 
-    state = AcceptBlockHeader(block, &pindex, min_pow_checked);
-    CheckBlockIndex();
-
-    if (!state.IsValid())
-        return false;
+    {
+        BlockValidationState accept_state{AcceptBlockHeader(block, &pindex, min_pow_checked)};
+        CheckBlockIndex();
+        if (!accept_state.IsValid())
+            return accept_state;
+    }
 
     // Check all requested blocks that we do not already have for validity and
     // save them to disk. Skip processing of unrequested blocks as an anti-DoS
@@ -4361,31 +4362,33 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
 
     // TODO: deal better with return value and error conditions for duplicate
     // and unrequested blocks.
-    if (fAlreadyHave) return true;
+    if (fAlreadyHave) return BlockValidationState{};
     if (!fRequested) {  // If we didn't ask for it:
-        if (pindex->nTx != 0) return true;    // This is a previously-processed block that was pruned
-        if (!fHasMoreOrSameWork) return true; // Don't process less-work chains
-        if (fTooFarAhead) return true;        // Block height is too high
+        if (pindex->nTx != 0) return BlockValidationState{};    // This is a previously-processed block that was pruned
+        if (!fHasMoreOrSameWork) return BlockValidationState{}; // Don't process less-work chains
+        if (fTooFarAhead) return BlockValidationState{};        // Block height is too high
 
         // Protect against DoS attacks from low-work chains.
         // If our tip is behind, a peer could try to send us
         // low-work blocks on a fake chain that we would never
         // request; don't process these.
-        if (pindex->nChainWork < MinimumChainWork()) return true;
+        if (pindex->nChainWork < MinimumChainWork()) return BlockValidationState{};
     }
 
     const CChainParams& params{GetParams()};
 
-    state = CheckBlock(block, params.GetConsensus());
-    if (state.IsValid()) {
-        state = ContextualCheckBlock(block, *this, pindex->pprev);
-    }
-    if (!state.IsValid()) {
-        if (Assume(state.IsInvalid())) {
-            ActiveChainstate().InvalidBlockFound(pindex, state);
+    {
+        BlockValidationState state{CheckBlock(block, params.GetConsensus())};
+        if (state.IsValid()) {
+            state = ContextualCheckBlock(block, *this, pindex->pprev);
         }
-        LogError("%s: %s\n", __func__, state.ToString());
-        return false;
+        if (!state.IsValid()) {
+            if (Assume(state.IsInvalid())) {
+                ActiveChainstate().InvalidBlockFound(pindex, state);
+            }
+            LogError("%s: %s\n", __func__, state.ToString());
+            return state;
+        }
     }
 
     // Header is valid/has work, merkle tree and segwit merkle tree are good...RELAY NOW
@@ -4404,14 +4407,14 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         } else {
             blockPos = m_blockman.WriteBlock(block, pindex->nHeight);
             if (blockPos.IsNull()) {
-                state.Error(strprintf("%s: Failed to find position to write new block to disk", __func__));
-                return false;
+                BlockValidationState error_state;
+                error_state.Error(strprintf("%s: Failed to find position to write new block to disk", __func__));
+                return error_state;
             }
         }
         ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        state = FatalError(GetNotifications(), strprintf(_("System error while saving block to disk: %s"), e.what()));
-        return false;
+        return FatalError(GetNotifications(), strprintf(_("System error while saving block to disk: %s"), e.what()));
     }
 
     // TODO: FlushStateToDisk() handles flushing of both block and chainstate
@@ -4430,7 +4433,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
 
     CheckBlockIndex();
 
-    return true;
+    return BlockValidationState{};
 }
 
 bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block)
@@ -4454,7 +4457,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         state = CheckBlock(*block, GetConsensus());
         if (state.IsValid()) {
             // Store to disk
-            (void)AcceptBlock(block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
+            state = AcceptBlock(block, &pindex, force_processing, nullptr, new_block, min_pow_checked);
         }
         if (!state.IsValid()) {
             if (m_options.signals) {
@@ -5076,8 +5079,8 @@ void ChainstateManager::LoadExternalBlockFile(
                         blkdat >> TX_WITH_WITNESS(*pblock);
                         nRewind = blkdat.GetPos();
 
-                        BlockValidationState state;
-                        if (AcceptBlock(pblock, state, nullptr, true, dbp, nullptr, true)) {
+                        BlockValidationState state{AcceptBlock(pblock, nullptr, true, dbp, nullptr, true)};
+                        if (state.IsValid()) {
                             nLoaded++;
                         }
                         if (state.IsError()) {
@@ -5134,8 +5137,7 @@ void ChainstateManager::LoadExternalBlockFile(
                             const auto& block_hash{pblockrecursive->GetHash()};
                             LogDebug(BCLog::REINDEX, "%s: Processing out of order child %s of %s", __func__, block_hash.ToString(), head.ToString());
                             LOCK(cs_main);
-                            BlockValidationState dummy;
-                            if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr, true)) {
+                            if (auto state{AcceptBlock(pblockrecursive, nullptr, true, &it->second, nullptr, true)}; state.IsValid()) {
                                 nLoaded++;
                                 queue.push_back(block_hash);
                             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4202,7 +4202,7 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     return true;
 }
 
-bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValidationState& state, CBlockIndex** ppindex, bool min_pow_checked)
+BlockValidationState ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, CBlockIndex** ppindex, bool min_pow_checked)
 {
     AssertLockHeld(cs_main);
 
@@ -4217,16 +4217,15 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
                 *ppindex = pindex;
             if (pindex->nStatus & BLOCK_FAILED_VALID) {
                 LogDebug(BCLog::VALIDATION, "%s: block %s is marked invalid\n", __func__, hash.ToString());
-                return state.Invalid(BlockValidationResult::BLOCK_CACHED_INVALID, "duplicate-invalid",
-                                     strprintf("block %s was previously marked invalid", hash.ToString()));
+                return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_CACHED_INVALID, "duplicate-invalid",
+                    strprintf("block %s was previously marked invalid", hash.ToString()));
             }
-            return true;
+            return BlockValidationState{};
         }
 
-        state = CheckBlockHeader(block, GetConsensus());
-        if (!state.IsValid()) {
+        if (const auto state = CheckBlockHeader(block, GetConsensus()); !state.IsValid()) {
             LogDebug(BCLog::VALIDATION, "%s: Consensus::CheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
-            return false;
+            return state;
         }
 
         // Get prev block index
@@ -4234,29 +4233,28 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
         BlockMap::iterator mi{m_blockman.m_block_index.find(block.hashPrevBlock)};
         if (mi == m_blockman.m_block_index.end()) {
             LogDebug(BCLog::VALIDATION, "header %s has prev block not found: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
-            return state.Invalid(BlockValidationResult::BLOCK_MISSING_PREV, "prev-blk-not-found");
+            return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_MISSING_PREV, "prev-blk-not-found");
         }
         pindexPrev = &((*mi).second);
         if (pindexPrev->nStatus & BLOCK_FAILED_VALID) {
             LogDebug(BCLog::VALIDATION, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
-            return state.Invalid(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
+            return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
         }
-        state = ContextualCheckBlockHeader(block, *this, pindexPrev);
-        if (!state.IsValid()) {
+        if (const auto state = ContextualCheckBlockHeader(block, *this, pindexPrev); !state.IsValid()) {
             LogDebug(BCLog::VALIDATION, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
-            return false;
+            return state;
         }
     }
     if (!min_pow_checked) {
         LogDebug(BCLog::VALIDATION, "%s: not adding new block header %s, missing anti-dos proof-of-work validation\n", __func__, hash.ToString());
-        return state.Invalid(BlockValidationResult::BLOCK_HEADER_LOW_WORK, "too-little-chainwork");
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_HEADER_LOW_WORK, "too-little-chainwork");
     }
     CBlockIndex* pindex{m_blockman.AddToBlockIndex(block, m_best_header)};
 
     if (ppindex)
         *ppindex = pindex;
 
-    return true;
+    return BlockValidationState{};
 }
 
 // Exposed wrapper for AcceptBlockHeader
@@ -4267,10 +4265,10 @@ bool ChainstateManager::ProcessNewBlockHeaders(std::span<const CBlockHeader> hea
         LOCK(cs_main);
         for (const CBlockHeader& header : headers) {
             CBlockIndex *pindex = nullptr; // Use a temp pindex instead of ppindex to avoid a const_cast
-            bool accepted{AcceptBlockHeader(header, state, &pindex, min_pow_checked)};
+            state = AcceptBlockHeader(header, &pindex, min_pow_checked);
             CheckBlockIndex();
 
-            if (!accepted) {
+            if (!state.IsValid()) {
                 return false;
             }
             if (ppindex) {
@@ -4326,10 +4324,10 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     CBlockIndex *pindexDummy = nullptr;
     CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
 
-    bool accepted_header{AcceptBlockHeader(block, state, &pindex, min_pow_checked)};
+    state = AcceptBlockHeader(block, &pindex, min_pow_checked);
     CheckBlockIndex();
 
-    if (!accepted_header)
+    if (!state.IsValid())
         return false;
 
     // Check all requested blocks that we do not already have for validity and

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4094,7 +4094,7 @@ arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers)
  *  v0.12 and v0.15 (when no additional protection was in place) whereby an attacker could unboundedly
  *  grow our in-memory block index. See https://bitcoincore.org/en/2024/07/03/disclose-header-spam.
  */
-static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+[[nodiscard]] static BlockValidationState ContextualCheckBlockHeader(const CBlockHeader& block, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
     AssertLockHeld(::cs_main);
     assert(pindexPrev != nullptr);
@@ -4102,12 +4102,14 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
 
     // Check proof of work
     const Consensus::Params& consensusParams = chainman.GetConsensus();
-    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
-        return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-diffbits", "incorrect proof of work");
+    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams)) {
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-diffbits", "incorrect proof of work");
+    }
 
     // Check timestamp against prev
-    if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())
-        return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-too-old", "block's timestamp is too early");
+    if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast()) {
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_INVALID_HEADER, "time-too-old", "block's timestamp is too early");
+    }
 
     // Testnet4 and regtest only: Check timestamp against prev for difficulty-adjustment
     // blocks to prevent timewarp attacks (see https://github.com/bitcoin/bitcoin/pull/15482).
@@ -4116,25 +4118,25 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
         // interval, except the genesis block.
         if (nHeight % consensusParams.DifficultyAdjustmentInterval() == 0) {
             if (block.GetBlockTime() < pindexPrev->GetBlockTime() - MAX_TIMEWARP) {
-                return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-timewarp-attack", "block's timestamp is too early on diff adjustment block");
+                return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_INVALID_HEADER, "time-timewarp-attack", "block's timestamp is too early on diff adjustment block");
             }
         }
     }
 
     // Check timestamp
     if (block.Time() > NodeClock::now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
-        return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
+        return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
     }
 
     // Reject blocks with outdated version
     if ((block.nVersion < 2 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
         (block.nVersion < 3 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_DERSIG)) ||
         (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CLTV))) {
-            return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, strprintf("bad-version(0x%08x)", block.nVersion),
+            return BlockValidationState::InvalidState(BlockValidationResult::BLOCK_INVALID_HEADER, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
     }
 
-    return true;
+    return BlockValidationState{};
 }
 
 /** NOTE: This function is not currently invoked by ConnectBlock(), so we
@@ -4239,7 +4241,8 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             LogDebug(BCLog::VALIDATION, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
         }
-        if (!ContextualCheckBlockHeader(block, state, *this, pindexPrev)) {
+        state = ContextualCheckBlockHeader(block, *this, pindexPrev);
+        if (!state.IsValid()) {
             LogDebug(BCLog::VALIDATION, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
@@ -4527,8 +4530,8 @@ BlockValidationState TestBlockValidity(
      * - do run ContextualCheckBlock()
      */
 
-    if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman, tip)) {
-        if (state.IsValid()) NONFATAL_UNREACHABLE();
+    state = ContextualCheckBlockHeader(block, chainstate.m_chainman, tip);
+    if (!state.IsValid()) {
         return state;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3850,14 +3850,14 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     return BlockValidationState{};
 }
 
-static bool CheckMerkleRoot(const CBlock& block, BlockValidationState& state)
+[[nodiscard]] static BlockValidationState CheckMerkleRoot(const CBlock& block)
 {
-    if (block.m_checked_merkle_root) return true;
+    if (block.m_checked_merkle_root) return BlockValidationState{};
 
     bool mutated;
     uint256 merkle_root = BlockMerkleRoot(block, &mutated);
     if (block.hashMerkleRoot != merkle_root) {
-        return state.Invalid(
+        return BlockValidationState::InvalidState(
             /*result=*/BlockValidationResult::BLOCK_MUTATED,
             /*reject_reason=*/"bad-txnmrklroot",
             /*debug_message=*/"hashMerkleRoot mismatch");
@@ -3867,14 +3867,14 @@ static bool CheckMerkleRoot(const CBlock& block, BlockValidationState& state)
     // of transactions in a block without affecting the merkle root of a block,
     // while still invalidating it.
     if (mutated) {
-        return state.Invalid(
+        return BlockValidationState::InvalidState(
             /*result=*/BlockValidationResult::BLOCK_MUTATED,
             /*reject_reason=*/"bad-txns-duplicate",
             /*debug_message=*/"duplicate transaction");
     }
 
     block.m_checked_merkle_root = true;
-    return true;
+    return BlockValidationState{};
 }
 
 /** CheckWitnessMalleation performs checks for block malleation with regard to
@@ -3950,8 +3950,11 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
     }
 
     // Check the merkle root.
-    if (fCheckMerkleRoot && !CheckMerkleRoot(block, state)) {
-        return false;
+    if (fCheckMerkleRoot) {
+        state = CheckMerkleRoot(block);
+        if (!state.IsValid()) {
+            return false;
+        }
     }
 
     // All potential-corruption validation must be done before we do any
@@ -4043,8 +4046,7 @@ bool HasValidProofOfWork(std::span<const CBlockHeader> headers, const Consensus:
 
 bool IsBlockMutated(const CBlock& block, bool check_witness_root)
 {
-    BlockValidationState state;
-    if (!CheckMerkleRoot(block, state)) {
+    if (const auto state = CheckMerkleRoot(block); !state.IsValid()) {
         LogDebug(BCLog::VALIDATION, "Block mutated: %s\n", state.ToString());
         return true;
     }
@@ -4064,6 +4066,7 @@ bool IsBlockMutated(const CBlock& block, bool check_witness_root)
         // here as it requires at least 224 bits of work.
     }
 
+    BlockValidationState state;
     if (!CheckWitnessMalleation(block, check_witness_root, state)) {
         LogDebug(BCLog::VALIDATION, "Block mutated: %s\n", state.ToString());
         return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4521,8 +4521,8 @@ BlockValidationState TestBlockValidity(
     }
 
     // For signets CheckBlock() verifies the challenge iff fCheckPow is set.
-    state = CheckBlock(block, chainstate.m_chainman.GetConsensus(), /*fCheckPow=*/check_pow, /*fCheckMerkleRoot=*/check_merkle_root);
-    if (!state.IsValid()) {
+    if (const auto state = CheckBlock(block, chainstate.m_chainman.GetConsensus(), /*fCheckPow=*/check_pow, /*fCheckMerkleRoot=*/check_merkle_root);
+        !state.IsValid()) {
         // This should never happen, but belt-and-suspenders don't approve the
         // block if it does.
         return state;
@@ -4543,13 +4543,11 @@ BlockValidationState TestBlockValidity(
      * - do run ContextualCheckBlock()
      */
 
-    state = ContextualCheckBlockHeader(block, chainstate.m_chainman, tip);
-    if (!state.IsValid()) {
+    if (const auto state = ContextualCheckBlockHeader(block, chainstate.m_chainman, tip); !state.IsValid()) {
         return state;
     }
 
-    state = ContextualCheckBlock(block, chainstate.m_chainman, tip);
-    if (!state.IsValid()) {
+    if (const auto state = ContextualCheckBlock(block, chainstate.m_chainman, tip); !state.IsValid()) {
         return state;
     }
 
@@ -4563,15 +4561,14 @@ BlockValidationState TestBlockValidity(
     CCoinsViewCache view_dummy(&chainstate.CoinsTip());
 
     // Set fJustCheck to true in order to update, and not clear, validation caches.
-    if(!chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true)) {
+    if (!chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
+    } else {
+        if (!state.IsValid()) NONFATAL_UNREACHABLE();
     }
 
-    // Ensure no check returned successfully while also setting an invalid state.
-    if (!state.IsValid()) NONFATAL_UNREACHABLE();
-
-    return state;
+    return BlockValidationState{};
 }
 
 /* This function is called from the RPC code for pruneblockchain */

--- a/src/validation.h
+++ b/src/validation.h
@@ -737,10 +737,9 @@ public:
      * If FlushStateMode::NONE is used, then FlushStateToDisk(...) won't do anything
      * besides checking if we need to prune.
      *
-     * @returns true unless a system error occurred
+     * @returns a validation result with `IsValid() == true` unless a system error occurred
      */
-    bool FlushStateToDisk(
-        BlockValidationState& state,
+    [[nodiscard]] BlockValidationState FlushStateToDisk(
         FlushStateMode mode,
         int nManualPruneHeight = 0);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -104,7 +104,7 @@ extern const std::vector<std::string> CHECKLEVEL_DOC;
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
-bool FatalError(kernel::Notifications& notifications, BlockValidationState& state, const bilingual_str& message);
+[[nodiscard]] BlockValidationState FatalError(kernel::Notifications& notifications, const bilingual_str& message);
 
 /** Prune block files up to a given height */
 void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight);

--- a/src/validation.h
+++ b/src/validation.h
@@ -1293,15 +1293,14 @@ public:
      * @param[in]   min_pow_checked True if proof-of-work anti-DoS checks have
      *                              been done by caller for headers chain
      *
-     * @param[out]  state       The state of the block validation.
      * @param[out]  ppindex     Optional return parameter to get the
      *                          CBlockIndex pointer for this block.
      * @param[out]  fNewBlock   Optional return parameter to indicate if the
      *                          block is new to our storage.
      *
-     * @returns   False if the block or header is invalid, or if saving to disk fails (likely a fatal error); true otherwise.
+     * @returns BlockValidationState indicating the result. IsValid() is false if the block or header is invalid, or if saving to disk fails (likely a fatal error); true otherwise.
      */
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    [[nodiscard]] BlockValidationState AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -392,7 +392,7 @@ public:
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
+[[nodiscard]] BlockValidationState CheckBlock(const CBlock& block, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
 /**
  * Verify a block, including transactions.

--- a/src/validation.h
+++ b/src/validation.h
@@ -968,6 +968,7 @@ private:
      * Caller must set min_pow_checked=true in order to add a new header to the
      * block index (permanent memory storage), indicating that the header is
      * known to be part of a sufficiently high-work chain (anti-dos check).
+     * Can return Valid or Invalid result, but not Error.
      */
     [[nodiscard]] BlockValidationState AcceptBlockHeader(
         const CBlockHeader& block,
@@ -1275,11 +1276,12 @@ public:
      *
      * @param[in]  headers The block headers themselves
      * @param[in]  min_pow_checked  True if proof-of-work anti-DoS checks have been done by caller for headers chain
-     * @param[out] state This may be set to an Error state if any error occurred processing them
      * @param[out] ppindex If set, the pointer will be set to point to the last new block index object for the given headers
-     * @returns false if AcceptBlockHeader fails on any of the headers, true otherwise (including if headers were already known)
+     * @returns BlockValidationState indicating the result. IsValid() returns true if all headers
+     *          were accepted. On failure, IsInvalid() is false and the state contains the specific
+     *          validation failure reason. Never returns Error state.
      */
-    bool ProcessNewBlockHeaders(std::span<const CBlockHeader> headers, bool min_pow_checked, BlockValidationState& state, const CBlockIndex** ppindex = nullptr) LOCKS_EXCLUDED(cs_main);
+    [[nodiscard]] BlockValidationState ProcessNewBlockHeaders(std::span<const CBlockHeader> headers, bool min_pow_checked, const CBlockIndex** ppindex = nullptr) LOCKS_EXCLUDED(cs_main);
 
     /**
      * Sufficiently validate a block for disk storage (and store on disk).

--- a/src/validation.h
+++ b/src/validation.h
@@ -969,9 +969,8 @@ private:
      * block index (permanent memory storage), indicating that the header is
      * known to be part of a sufficiently high-work chain (anti-dos check).
      */
-    bool AcceptBlockHeader(
+    [[nodiscard]] BlockValidationState AcceptBlockHeader(
         const CBlockHeader& block,
-        BlockValidationState& state,
         CBlockIndex** ppindex,
         bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     friend Chainstate;


### PR DESCRIPTION
**Summary**. Refactor validation result to be a return value instead of an output parameter in several `validation.cpp` methods.

**Motivation**. The benefits of the change are:
- Exclude the potentially inconsistent case when the bool return value and the returned `state` are inconsistent
- Exclude the ambiguity whether the passed in value of state is used or not (not obvious in chained calls)
- Remove the possibility of unintuitive interaction between subsequent calls with the same state. In case of a validation error, a failure reason is set if the state was valid, but not if it was already invalid.
- Slightly simpler: It's more evident which is the result; one less parameters.

This has grown out from #33856, mentioned in [comment here](https://github.com/bitcoin/bitcoin/pull/33856#pullrequestreview-4276791829) and [here](https://github.com/bitcoin/bitcoin/pull/33856#issuecomment-4477751949).

**Details**. Many methods follow the scheme where the validation state is returned in an output parameter (`BlockValidationState& state`), and and additional `bool` return value indicating success. In success case the convention is that `state.IsValid()` and the return value are both true. After the change there is only a `BlockValidationState` return value, which is either success (`state.IsValid() == true`), or an invalid/error case.

This change is a highly localized refactor, but touching a sensitive file.

Relevant methods called by `ProcessNewBlockHeaders` and `AcceptBlock` (directly and indirectly) are touched.

Changes are separated into commits by touched methods, ordered by bottom-to-top in the call hierarchy.
