### PR TITLE
build: guard forced inlining

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,8 @@ if(WIN32)
 
     target_compile_definitions(core_interface INTERFACE
       _UNICODE;UNICODE
+      # Match GCC/Clang's size-optimization macro for the inline guard.
+      $<$<CONFIG:MinSizeRel>:__OPTIMIZE_SIZE__=1>
     )
     target_compile_options(core_interface INTERFACE
       /utf-8

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -16,12 +16,15 @@
 #  define LIFETIMEBOUND
 #endif
 
-#if defined(__GNUC__)
-#  define ALWAYS_INLINE inline __attribute__((always_inline))
-#elif defined(_MSC_VER)
-#  define ALWAYS_INLINE __forceinline
-#else
-#  error No known always_inline attribute for this platform.
+#if !defined(_DEBUG) && !defined(__NO_INLINE__) && !defined(__OPTIMIZE_SIZE__)
+#  if (defined(__GNUC__) || defined(__clang__)) && defined(__OPTIMIZE__)
+#    define ALWAYS_INLINE inline __attribute__((always_inline))
+#  elif defined(_MSC_VER)
+#    define ALWAYS_INLINE __forceinline
+#  endif
+#endif
+#ifndef ALWAYS_INLINE
+#  define ALWAYS_INLINE inline
 #endif
 
 #endif // BITCOIN_ATTRIBUTES_H

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -18,13 +18,13 @@
 
 #if !defined(_DEBUG) && !defined(__NO_INLINE__) && !defined(__OPTIMIZE_SIZE__)
 #  if (defined(__GNUC__) || defined(__clang__)) && defined(__OPTIMIZE__)
-#    define ALWAYS_INLINE inline __attribute__((always_inline))
+#    define FORCE_INLINE inline __attribute__((always_inline))
 #  elif defined(_MSC_VER)
-#    define ALWAYS_INLINE __forceinline
+#    define FORCE_INLINE __forceinline
 #  endif
 #endif
-#ifndef ALWAYS_INLINE
-#  define ALWAYS_INLINE inline
+#ifndef FORCE_INLINE
+#  define FORCE_INLINE inline
 #endif
 
 #endif // BITCOIN_ATTRIBUTES_H

--- a/src/crypto/sha256_avx2.cpp
+++ b/src/crypto/sha256_avx2.cpp
@@ -37,7 +37,7 @@ __m256i inline sigma0(__m256i x) { return Xor(Or(ShR(x, 7), ShL(x, 25)), Or(ShR(
 __m256i inline sigma1(__m256i x) { return Xor(Or(ShR(x, 17), ShL(x, 15)), Or(ShR(x, 19), ShL(x, 13)), ShR(x, 10)); }
 
 /** One round of SHA-256. */
-void ALWAYS_INLINE Round(__m256i a, __m256i b, __m256i c, __m256i& d, __m256i e, __m256i f, __m256i g, __m256i& h, __m256i k)
+void FORCE_INLINE Round(__m256i a, __m256i b, __m256i c, __m256i& d, __m256i e, __m256i f, __m256i g, __m256i& h, __m256i k)
 {
     __m256i t1 = Add(h, Sigma1(e), Ch(e, f, g), k);
     __m256i t2 = Add(Sigma0(a), Maj(a, b, c));

--- a/src/crypto/sha256_sse41.cpp
+++ b/src/crypto/sha256_sse41.cpp
@@ -37,7 +37,7 @@ __m128i inline sigma0(__m128i x) { return Xor(Or(ShR(x, 7), ShL(x, 25)), Or(ShR(
 __m128i inline sigma1(__m128i x) { return Xor(Or(ShR(x, 17), ShL(x, 15)), Or(ShR(x, 19), ShL(x, 13)), ShR(x, 10)); }
 
 /** One round of SHA-256. */
-void ALWAYS_INLINE Round(__m128i a, __m128i b, __m128i c, __m128i& d, __m128i e, __m128i f, __m128i g, __m128i& h, __m128i k)
+void FORCE_INLINE Round(__m128i a, __m128i b, __m128i c, __m128i& d, __m128i e, __m128i f, __m128i g, __m128i& h, __m128i k)
 {
     __m128i t1 = Add(h, Sigma1(e), Ch(e, f, g), k);
     __m128i t2 = Add(Sigma0(a), Maj(a, b, c));

--- a/src/crypto/sha256_x86_shani.cpp
+++ b/src/crypto/sha256_x86_shani.cpp
@@ -20,37 +20,37 @@ alignas(__m128i) const uint8_t MASK[16] = {0x03, 0x02, 0x01, 0x00, 0x07, 0x06, 0
 alignas(__m128i) const uint8_t INIT0[16] = {0x8c, 0x68, 0x05, 0x9b, 0x7f, 0x52, 0x0e, 0x51, 0x85, 0xae, 0x67, 0xbb, 0x67, 0xe6, 0x09, 0x6a};
 alignas(__m128i) const uint8_t INIT1[16] = {0x19, 0xcd, 0xe0, 0x5b, 0xab, 0xd9, 0x83, 0x1f, 0x3a, 0xf5, 0x4f, 0xa5, 0x72, 0xf3, 0x6e, 0x3c};
 
-void ALWAYS_INLINE QuadRound(__m128i& state0, __m128i& state1, uint64_t k1, uint64_t k0)
+void FORCE_INLINE QuadRound(__m128i& state0, __m128i& state1, uint64_t k1, uint64_t k0)
 {
     const __m128i msg = _mm_set_epi64x(k1, k0);
     state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
     state0 = _mm_sha256rnds2_epu32(state0, state1, _mm_shuffle_epi32(msg, 0x0e));
 }
 
-void ALWAYS_INLINE QuadRound(__m128i& state0, __m128i& state1, __m128i m, uint64_t k1, uint64_t k0)
+void FORCE_INLINE QuadRound(__m128i& state0, __m128i& state1, __m128i m, uint64_t k1, uint64_t k0)
 {
     const __m128i msg = _mm_add_epi32(m, _mm_set_epi64x(k1, k0));
     state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
     state0 = _mm_sha256rnds2_epu32(state0, state1, _mm_shuffle_epi32(msg, 0x0e));
 }
 
-void ALWAYS_INLINE ShiftMessageA(__m128i& m0, __m128i m1)
+void FORCE_INLINE ShiftMessageA(__m128i& m0, __m128i m1)
 {
     m0 = _mm_sha256msg1_epu32(m0, m1);
 }
 
-void ALWAYS_INLINE ShiftMessageC(__m128i& m0, __m128i m1, __m128i& m2)
+void FORCE_INLINE ShiftMessageC(__m128i& m0, __m128i m1, __m128i& m2)
 {
     m2 = _mm_sha256msg2_epu32(_mm_add_epi32(m2, _mm_alignr_epi8(m1, m0, 4)), m1);
 }
 
-void ALWAYS_INLINE ShiftMessageB(__m128i& m0, __m128i m1, __m128i& m2)
+void FORCE_INLINE ShiftMessageB(__m128i& m0, __m128i m1, __m128i& m2)
 {
     ShiftMessageC(m0, m1, m2);
     ShiftMessageA(m0, m1);
 }
 
-void ALWAYS_INLINE Shuffle(__m128i& s0, __m128i& s1)
+void FORCE_INLINE Shuffle(__m128i& s0, __m128i& s1)
 {
     const __m128i t1 = _mm_shuffle_epi32(s0, 0xB1);
     const __m128i t2 = _mm_shuffle_epi32(s1, 0x1B);
@@ -58,7 +58,7 @@ void ALWAYS_INLINE Shuffle(__m128i& s0, __m128i& s1)
     s1 = _mm_blend_epi16(t2, t1, 0xF0);
 }
 
-void ALWAYS_INLINE Unshuffle(__m128i& s0, __m128i& s1)
+void FORCE_INLINE Unshuffle(__m128i& s0, __m128i& s1)
 {
     const __m128i t1 = _mm_shuffle_epi32(s0, 0x1B);
     const __m128i t2 = _mm_shuffle_epi32(s1, 0xB1);
@@ -66,12 +66,12 @@ void ALWAYS_INLINE Unshuffle(__m128i& s0, __m128i& s1)
     s1 = _mm_alignr_epi8(t2, t1, 0x08);
 }
 
-__m128i ALWAYS_INLINE Load(const unsigned char* in)
+__m128i FORCE_INLINE Load(const unsigned char* in)
 {
     return _mm_shuffle_epi8(_mm_loadu_si128((const __m128i*)in), _mm_load_si128((const __m128i*)MASK));
 }
 
-void ALWAYS_INLINE Save(unsigned char* out, __m128i s)
+void FORCE_INLINE Save(unsigned char* out, __m128i s)
 {
     _mm_storeu_si128((__m128i*)out, _mm_shuffle_epi8(s, _mm_load_si128((const __m128i*)MASK)));
 }


### PR DESCRIPTION
**Problem:** This is a follow-up to the force-inline discussion in https://github.com/bitcoin-core/secp256k1/pull/1859#pullrequestreview-4491819905.

**Fix:** Rename `ALWAYS_INLINE` to `FORCE_INLINE`, matching the secp256k1 follow-up naming, and gate forced inlining to optimized non-size builds.
We currently have only a few `FORCE_INLINE` call sites, and this PR changes those cases narrowly: optimized non-size builds keep forced inlining, while debug, no-inline, size-optimized, and unknown compiler modes fall back to plain `inline`.

**Size check:** Linux `bitcoind` sizes from the reproducer below.

| Config | Base | Guard |
|---|---:|---:|
| Debug | 202,587,200 | 202,313,624 |
| Release | 19,117,016 | 19,117,016 |
| RelWithDebInfo | 309,241,040 | 309,241,040 |
| MinSizeRel | 14,539,624 | 14,515,016 |

**Reproducer:**

<details><summary>`bitcoind` size comparisons</summary>

```bash
COMMITS="1a2523e901a6c7c876c8a0817601e77d83f394b9 0c4d6e95946626bffbd9f0e9587d5a9819dbdd77" && \
ROOT=$(mktemp -d) && OLD=$(git symbolic-ref --short -q HEAD || git rev-parse HEAD) && \
trap 'git switch -q "$OLD" 2>/dev/null || git switch -q --detach "$OLD"' EXIT && \
for commit in $COMMITS; do \
  git switch -q --detach "$commit" && short=$(git rev-parse --short=12 HEAD) && \
  for cfg in Debug Release RelWithDebInfo MinSizeRel; do \
    b="$ROOT/$short-$cfg" && log="$b.log" && \
    cmake -S . -B "$b" -G Ninja -DCMAKE_BUILD_TYPE="$cfg" >"$log" 2>&1 && \
    cmake --build "$b" -j "$(nproc)" --target bitcoind >>"$log" 2>&1 && \
    printf '%s %s %s\n' "$short" "$cfg" "$(stat -c%s "$b/bin/bitcoind")" || { cat "$log"; exit 1; }; \
  done; \
done
```
</details>

Note: Rebase this change on #35215 to exercise more representative `FORCE_INLINE` call sites.
