### PR TITLE
test: raise `feature_reindex` RPC timeout

### DIFF
--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -20,6 +20,7 @@ from test_framework.util import (
 
 class ReindexTest(BitcoinTestFramework):
     def set_test_params(self):
+        self.rpc_timeout *= 2  # To avoid timeout when generating the reindex chain
         self.setup_clean_chain = True
         self.num_nodes = 1
 


### PR DESCRIPTION
**Problem:** I often hit a timeout in `feature_reindex.py` when running functional tests locally in parallel in debug mode (especially on battery or in power-saving mode).
**Fix:** Increase the test-local RPC timeout for the reindex mining setup.
