### PR TITLE
node: add block template manager and track waitNext fee inflow

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,6 +214,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   net_processing.cpp
   netgroup.cpp
   node/abort.cpp
+  node/block_template_manager.cpp
   node/blockmanager_args.cpp
   node/blockstorage.cpp
   node/caches.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1344,9 +1344,6 @@ static ChainstateLoadResult InitAndLoadChainstate(
     if (!mempool_error.empty()) {
         return {ChainstateLoadStatus::FAILURE_FATAL, mempool_error};
     }
-    auto mining_args{node::ReadMiningArgs(args)};
-    Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
-    node.mining_args = std::move(*mining_args);
     LogInfo("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)",
             cache_sizes.coins / double(1_MiB),
             mempool_opts.max_size_bytes / double(1_MiB));
@@ -1436,7 +1433,9 @@ static ChainstateLoadResult InitAndLoadChainstate(
         std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
         if (status == node::ChainstateLoadStatus::SUCCESS) {
             LogInfo("Block index and chainstate loaded");
-            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman);
+            auto mining_args{node::ReadMiningArgs(args)};
+            Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
+            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman, std::move(*mining_args));
             node.notifications->setChainstateLoaded(true);
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -51,6 +51,7 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <netgroup.h>
+#include <node/block_template_manager.h>
 #include <node/blockmanager_args.h>
 #include <node/blockstorage.h>
 #include <node/caches.h>
@@ -429,6 +430,7 @@ void Shutdown(NodeContext& node)
     if (node.validation_signals) {
         node.validation_signals->UnregisterAllValidationInterfaces();
     }
+    node.block_template_manager.reset();
     node.mempool.reset();
     node.fee_estimator.reset();
     node.chainman.reset();
@@ -1325,6 +1327,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
 {
     // This function may be called twice, so any dirty state must be reset.
     node.notifications->setChainstateLoaded(false); // Drop state, such as a cached tip block
+    node.block_template_manager.reset();
     node.mempool.reset();
     node.chainman.reset(); // Drop state, such as an initialized m_block_tree_db
 
@@ -1433,6 +1436,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
         std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
         if (status == node::ChainstateLoadStatus::SUCCESS) {
             LogInfo("Block index and chainstate loaded");
+            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman);
             node.notifications->setChainstateLoaded(true);
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -375,6 +375,12 @@ void Shutdown(NodeContext& node)
         }
     }
 
+    if (node.block_template_manager) {
+        Assert(node.validation_signals);
+        node.validation_signals->UnregisterValidationInterface(node.block_template_manager.get());
+        node.block_template_manager.reset();
+    }
+
     // FlushStateToDisk generates a ChainStateFlushed callback, which we should avoid missing
     if (node.chainman) {
         LOCK(cs_main);
@@ -430,7 +436,6 @@ void Shutdown(NodeContext& node)
     if (node.validation_signals) {
         node.validation_signals->UnregisterAllValidationInterfaces();
     }
-    node.block_template_manager.reset();
     node.mempool.reset();
     node.fee_estimator.reset();
     node.chainman.reset();
@@ -1915,6 +1920,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     ChainstateManager& chainman = *Assert(node.chainman);
     auto& kernel_notifications{*Assert(node.notifications)};
+    validation_signals.RegisterValidationInterface(Assert(node.block_template_manager).get());
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1435,7 +1435,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
             LogInfo("Block index and chainstate loaded");
             auto mining_args{node::ReadMiningArgs(args)};
             Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
-            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman, std::move(*mining_args));
+            node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*node.mempool, chainman, *node.notifications, std::move(*mining_args));
             node.notifications->setChainstateLoaded(true);
         }
     }

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -8,10 +8,13 @@
 #include <consensus/amount.h>
 #include <consensus/validation.h>
 #include <core_memusage.h>
+#include <kernel/mempool_removal_reason.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
 #include <primitives/transaction.h>
 #include <txgraph.h>
+#include <uint256.h>
+#include <util/feefrac.h>
 #include <util/overflow.h>
 #include <util/time.h>
 
@@ -19,6 +22,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <set>
 
 class CBlockIndex;
@@ -197,6 +201,20 @@ struct NewMempoolTransactionInfo {
           m_submitted_in_package{submitted_in_package},
           m_chainstate_is_current{chainstate_is_current},
           m_has_no_mempool_parents{has_no_mempool_parents} {}
+};
+
+struct MemPoolChunk {
+    FeePerWeight m_fee_rate;
+    std::vector<CTransactionRef> m_transactions;
+    int64_t m_sigops_cost{0};
+    std::optional<uint256> m_chunk_hash;
+};
+
+struct MemPoolChunksUpdate {
+    std::vector<MemPoolChunk> old_chunks;
+    std::vector<MemPoolChunk> new_chunks;
+    MemPoolRemovalReason reason;
+    std::optional<unsigned int> block_height{std::nullopt};
 };
 
 #endif // BITCOIN_KERNEL_MEMPOOL_ENTRY_H

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/block_template_manager.h>
+
+#include <node/miner.h>
+#include <validation.h>
+
+namespace node {
+
+BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManager& chainman)
+    : m_mempool(mempool), m_chainman(chainman)
+{
+}
+
+std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const BlockCreateOptions& options)
+{
+    return BlockAssembler{m_chainman.ActiveChainstate(), &m_mempool, options}.CreateNewBlock();
+}
+
+} // namespace node

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -4,12 +4,16 @@
 
 #include <node/block_template_manager.h>
 
+#include <consensus/consensus.h>
+#include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <interfaces/types.h>
+#include <kernel/types.h>
 #include <node/kernel_notifications.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
 #include <util/check.h>
+#include <util/hasher.h>
 #include <util/signalinterrupt.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -29,13 +33,79 @@ BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManage
 {
 }
 
-std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const BlockCreateOptions& options)
+std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const BlockCreateOptions& options, uint64_t* tracking_id)
 {
-    return BlockAssembler{
-        m_chainman.ActiveChainstate(),
+    const auto merged_options{MergeMiningOptions(options, m_init_block_create_options)};
+    // Keep the mempool unchanged between template assembly and snapshot
+    // insertion, while avoiding holding m_mutex across CreateNewBlock().
+    LOCK2(::cs_main, m_mempool.cs);
+    auto block_template = BlockAssembler{
+        m_chainman.CurrentChainstate(),
         &m_mempool,
-        MergeMiningOptions(options, m_init_block_create_options),
+        merged_options,
     }.CreateNewBlock();
+    if (!tracking_id) return block_template;
+    const auto resolved_options = FlattenMiningOptions(merged_options);
+    const auto min_fee_per_vsize = resolved_options.block_min_fee_rate->GetFeePerVSize();
+    TemplateSnapshot snapshot;
+    snapshot.tip_hash = block_template->block.hashPrevBlock;
+    snapshot.options = resolved_options;
+    snapshot.min_feerate = FeePerWeight{min_fee_per_vsize.fee, min_fee_per_vsize.size * WITNESS_SCALE_FACTOR};
+    snapshot.max_weight = static_cast<int64_t>(*resolved_options.block_max_weight);
+    snapshot.reserved_weight = static_cast<int64_t>(*resolved_options.block_reserved_weight);
+    snapshot.total_weight = snapshot.reserved_weight;
+    snapshot.reserved_sigops = static_cast<int64_t>(resolved_options.coinbase_output_max_additional_sigops);
+    snapshot.total_sigops = snapshot.reserved_sigops;
+    snapshot.height = block_template->m_height;
+    snapshot.lock_time_cutoff = block_template->m_lock_time_cutoff;
+    for (const auto& chunk : block_template->m_template_chunks) {
+        auto wtxids{chunk.chunk_wtxids};
+        snapshot.AddChunk(GetHashFromWitnesses(wtxids), {chunk.feerate, chunk.weight, chunk.sigops_cost});
+    }
+    LOCK(m_mutex);
+    Assume(m_next_template_id != 0);
+    *tracking_id = m_next_template_id++;
+    m_template_snapshots[*tracking_id] = std::move(snapshot);
+    return block_template;
+}
+
+// Connect and disconnect callbacks prune old-tip templates. They may run after
+// a kernel tip wakeup creates a new-tip template, so do not clear all snapshots.
+void BlockTemplateManager::BlockConnected(
+    const kernel::ChainstateRole& role,
+    const std::shared_ptr<const CBlock>& block,
+    const CBlockIndex* /*unused*/)
+{
+    // Ignore block being connected to historical chain, not current chain.
+    if (role.historical) return;
+    const uint256& old_tip_hash = block->hashPrevBlock;
+    LOCK(m_mutex);
+    std::erase_if(m_template_snapshots, [&](const auto& entry) {
+        return entry.second.tip_hash == old_tip_hash;
+    });
+}
+
+void BlockTemplateManager::BlockDisconnected(
+    const std::shared_ptr<const CBlock>& block,
+    const CBlockIndex* /*unused*/)
+{
+    const uint256 old_tip_hash = block->GetHash();
+    LOCK(m_mutex);
+    std::erase_if(m_template_snapshots, [&](const auto& entry) {
+        return entry.second.tip_hash == old_tip_hash;
+    });
+}
+
+static int64_t ChunkWeight(const MemPoolChunk& chunk)
+{
+    return std::accumulate(chunk.m_transactions.begin(), chunk.m_transactions.end(), int64_t{0},
+                           [](int64_t sum, const auto& tx) { return sum + GetTransactionWeight(*tx); });
+}
+
+static bool IsFinalChunk(const MemPoolChunk& chunk, int height, int64_t lock_time_cutoff)
+{
+    return std::all_of(chunk.m_transactions.begin(), chunk.m_transactions.end(),
+                       [&](const auto& tx) { return IsFinalTx(*tx, height, lock_time_cutoff); });
 }
 
 namespace {
@@ -334,8 +404,77 @@ void TemplateSnapshot::SanityCheck() const
         Assume(tracked_chunk->second.feerate == feerate_entry.feerate);
     }
     Assume(recomputed_fees == total_fees);
-    Assume(recomputed_weight == total_weight);
-    Assume(recomputed_sigops == total_sigops);
+    Assume(reserved_weight + recomputed_weight == total_weight);
+    Assume(reserved_sigops + recomputed_sigops == total_sigops);
+}
+
+void BlockTemplateManager::MempoolUpdated(const MemPoolChunksUpdate& mempool_chunks)
+{
+    if (mempool_chunks.reason == MemPoolRemovalReason::BLOCK ||
+        mempool_chunks.reason == MemPoolRemovalReason::CONFLICT) {
+        // Chain transitions prune tracked templates built on the old tip via
+        // BlockConnected/BlockDisconnected.
+        return;
+    }
+    LOCK(m_mutex);
+    if (m_template_snapshots.empty()) return;
+
+    for (const auto& chunk : mempool_chunks.old_chunks) {
+        const auto& hash = *Assume(chunk.m_chunk_hash);
+        for (auto& [_, snapshot] : m_template_snapshots) {
+            snapshot.RemoveChunk(hash);
+        }
+    }
+    for (const auto& chunk : mempool_chunks.new_chunks) {
+        const auto& hash = *Assume(chunk.m_chunk_hash);
+        const int64_t weight = ChunkWeight(chunk);
+        for (auto& [_, snapshot] : m_template_snapshots) {
+            if (!snapshot.options.use_mempool) continue;
+            // Mempool add callbacks can be delivered after a snapshot already
+            // tracks the chunk. Treat duplicate adds as idempotent before
+            // TrimToFit(), otherwise the incoming chunk's weight could be
+            // considered twice and unnecessarily stage evictions.
+            if (snapshot.template_chunks.contains(hash)) continue;
+            if (ByRatio{chunk.m_fee_rate} < ByRatio{snapshot.min_feerate}) continue;
+            if (!IsFinalChunk(chunk, snapshot.height, snapshot.lock_time_cutoff)) continue;
+            if (snapshot.TrimToFit(weight, chunk.m_sigops_cost, chunk.m_fee_rate)) {
+                snapshot.AddChunk(hash, {chunk.m_fee_rate, weight, chunk.m_sigops_cost});
+            }
+        }
+    }
+}
+
+bool BlockTemplateManager::IsTrackingFeeInflow(uint64_t template_id) const
+{
+    LOCK(m_mutex);
+    return m_template_snapshots.contains(template_id);
+}
+
+void BlockTemplateManager::StopTrackingFeeInflow(uint64_t template_id)
+{
+    LOCK(m_mutex);
+    m_template_snapshots.erase(template_id);
+}
+
+void BlockTemplateManager::SanityCheck() const
+{
+    LOCK(m_mutex);
+    for (const auto& [_, snapshot] : m_template_snapshots) {
+        snapshot.SanityCheck();
+        Assume(snapshot.total_fees >= 0);
+        Assume(snapshot.total_weight >= 0);
+        if (snapshot.template_chunks.empty()) {
+            Assume(snapshot.total_weight <= snapshot.max_weight);
+        } else {
+            Assume(snapshot.total_weight < snapshot.max_weight);
+        }
+        Assume(snapshot.total_sigops >= 0);
+        if (snapshot.template_chunks.empty()) {
+            Assume(snapshot.total_sigops <= MAX_BLOCK_SIGOPS_COST);
+        } else {
+            Assume(snapshot.total_sigops < MAX_BLOCK_SIGOPS_COST);
+        }
+    }
 }
 
 } // namespace node

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -62,6 +62,9 @@ std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const Bl
         auto wtxids{chunk.chunk_wtxids};
         snapshot.AddChunk(GetHashFromWitnesses(wtxids), {chunk.feerate, chunk.weight, chunk.sigops_cost});
     }
+    // Baseline uses the same modified-fee basis as total_fees so the staleness
+    // delta is zero at creation and reflects only later mempool fee inflow.
+    snapshot.original_fees = snapshot.total_fees;
     LOCK(m_mutex);
     Assume(m_next_template_id != 0);
     *tracking_id = m_next_template_id++;
@@ -454,6 +457,18 @@ void BlockTemplateManager::StopTrackingFeeInflow(uint64_t template_id)
 {
     LOCK(m_mutex);
     m_template_snapshots.erase(template_id);
+}
+
+bool BlockTemplateManager::IsStale(const BlockCreateOptions& options,
+                                   uint64_t template_id,
+                                   CAmount fee_threshold) const
+{
+    LOCK(m_mutex);
+    const auto snapshot = m_template_snapshots.find(template_id);
+    if (snapshot == m_template_snapshots.end()) return false;
+    if (snapshot->second.options != FlattenMiningOptions(options)) return false;
+    const CAmount fee_delta = snapshot->second.total_fees - snapshot->second.original_fees;
+    return fee_delta >= fee_threshold;
 }
 
 void BlockTemplateManager::SanityCheck() const

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -30,7 +30,11 @@ BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManage
 
 std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const BlockCreateOptions& options)
 {
-    return BlockAssembler{m_chainman.ActiveChainstate(), &m_mempool, options}.CreateNewBlock();
+    return BlockAssembler{
+        m_chainman.ActiveChainstate(),
+        &m_mempool,
+        MergeMiningOptions(options, m_init_block_create_options),
+    }.CreateNewBlock();
 }
 
 namespace {

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -4,9 +4,12 @@
 
 #include <node/block_template_manager.h>
 
+#include <consensus/validation.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
+#include <util/check.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 namespace node {
 
@@ -19,6 +22,62 @@ BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManage
 std::unique_ptr<CBlockTemplate> BlockTemplateManager::CreateNewTemplate(const BlockCreateOptions& options)
 {
     return BlockAssembler{m_chainman.ActiveChainstate(), &m_mempool, options}.CreateNewBlock();
+}
+
+namespace {
+class SubmitBlockStateCatcher final : public CValidationInterface
+{
+public:
+    uint256 m_hash;
+    bool m_found{false};
+    BlockValidationState m_state;
+
+    explicit SubmitBlockStateCatcher(const uint256& hash) : m_hash{hash} {}
+
+protected:
+    void BlockChecked(const std::shared_ptr<const CBlock>& block, const BlockValidationState& state) override
+    {
+        if (block->GetHash() != m_hash) return;
+        // ProcessNewBlock emits BlockChecked synchronously while holding cs_main,
+        // so SubmitBlock can read these fields after ProcessNewBlock returns
+        // without extra synchronization.
+        m_found = true;
+        m_state = state;
+    }
+};
+} // namespace
+
+bool BlockTemplateManager::SubmitBlock(const std::shared_ptr<const CBlock>& block, bool* new_block, std::string& reason, std::string& debug)
+{
+    reason.clear();
+    debug.clear();
+
+    // This follows the submitblock RPC's validation-state capture pattern, but
+    // is intentionally kept separate from the RPC implementation. The RPC entry
+    // point decodes hex, formats BIP22/JSONRPC results, and calls
+    // UpdateUncommittedBlockStructures() for legacy witness handling. IPC
+    // callers submit already-formed blocks and need bool + reason/debug
+    // results, while submitSolution() preserves its duplicate-as-success
+    // behavior.
+    auto sc = std::make_shared<SubmitBlockStateCatcher>(block->GetHash());
+    CHECK_NONFATAL(m_chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
+    bool accepted = m_chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/new_block);
+    CHECK_NONFATAL(m_chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);
+
+    if (new_block && !*new_block && accepted) {
+        reason = "duplicate";
+    } else if (!sc->m_found) {
+        // A block can be accepted and stored without being connected, for
+        // example if it does not have more work than the current tip. In that
+        // case no BlockChecked callback is emitted, so the validation result is
+        // inconclusive. Mining::submitBlock treats this as an error for mining
+        // clients, but it does not mean the block is invalid.
+        reason = "inconclusive";
+    } else if (!sc->m_state.IsValid()) {
+        reason = sc->m_state.GetRejectReason();
+        debug = sc->m_state.GetDebugMessage();
+    }
+    return accepted;
 }
 
 } // namespace node

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -5,17 +5,26 @@
 #include <node/block_template_manager.h>
 
 #include <consensus/validation.h>
+#include <interfaces/types.h>
+#include <node/kernel_notifications.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
 #include <util/check.h>
+#include <util/signalinterrupt.h>
 #include <validation.h>
 #include <validationinterface.h>
 
+#include <algorithm>
+#include <numeric>
+
 namespace node {
 
+using interfaces::BlockRef;
+
 BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManager& chainman,
+                                           KernelNotifications& notifications,
                                            BlockCreateOptions init_block_create_options)
-    : m_mempool(mempool), m_chainman(chainman), m_init_block_create_options(std::move(init_block_create_options))
+    : m_mempool(mempool), m_chainman(chainman), m_notifications(notifications), m_init_block_create_options(std::move(init_block_create_options))
 {
 }
 
@@ -78,6 +87,173 @@ bool BlockTemplateManager::SubmitBlock(const std::shared_ptr<const CBlock>& bloc
         debug = sc->m_state.GetDebugMessage();
     }
     return accepted;
+}
+
+std::optional<BlockRef> BlockTemplateManager::GetTip()
+{
+    LOCK(::cs_main);
+    CBlockIndex* tip{m_chainman.ActiveChain().Tip()};
+    if (!tip) return {};
+    return BlockRef{tip->GetBlockHash(), tip->nHeight};
+}
+
+void BlockTemplateManager::InterruptWait(bool& interrupt_wait)
+{
+    LOCK(m_notifications.m_tip_block_mutex);
+    interrupt_wait = true;
+    m_notifications.m_tip_block_cv.notify_all();
+}
+
+std::unique_ptr<CBlockTemplate> BlockTemplateManager::WaitAndCreateNewBlock(
+    const std::unique_ptr<CBlockTemplate>& block_template,
+    const BlockWaitOptions& wait_options,
+    const BlockCreateOptions& create_options,
+    bool& interrupt_wait)
+{
+    // Delay calculating the current template fees, just in case a new block
+    // comes in before the next tick.
+    CAmount current_fees = -1;
+
+    // Alternate waiting for a new tip and checking if fees have risen.
+    // The latter check is expensive so we only run it once per second.
+    auto now{NodeClock::now()};
+    const auto deadline = now + wait_options.timeout;
+    const MillisecondsDouble tick{1000};
+    const bool allow_min_difficulty{m_chainman.GetParams().GetConsensus().fPowAllowMinDifficultyBlocks};
+
+    do {
+        bool tip_changed{false};
+        {
+            WAIT_LOCK(m_notifications.m_tip_block_mutex, lock);
+            // Note that wait_until() checks the predicate before waiting
+            m_notifications.m_tip_block_cv.wait_until(lock, std::min(now + tick, deadline), [&]() EXCLUSIVE_LOCKS_REQUIRED(m_notifications.m_tip_block_mutex) {
+                AssertLockHeld(m_notifications.m_tip_block_mutex);
+                const auto tip_block{m_notifications.TipBlock()};
+                // We assume tip_block is set, because this is an instance
+                // method on BlockTemplate and no template could have been
+                // generated before a tip exists.
+                tip_changed = Assume(tip_block) && tip_block != block_template->block.hashPrevBlock;
+                return tip_changed || m_chainman.m_interrupt || interrupt_wait;
+            });
+            if (interrupt_wait) {
+                interrupt_wait = false;
+                return nullptr;
+            }
+        }
+
+        if (m_chainman.m_interrupt) return nullptr;
+        // At this point the tip changed, a full tick went by or we reached
+        // the deadline.
+
+        // Must release m_tip_block_mutex before locking cs_main, to avoid deadlocks.
+        LOCK(::cs_main);
+
+        // On test networks return a minimum difficulty block after 20 minutes
+        if (!tip_changed && allow_min_difficulty) {
+            const NodeClock::time_point tip_time{std::chrono::seconds{m_chainman.ActiveChain().Tip()->GetBlockTime()}};
+            if (now > tip_time + 20min) {
+                tip_changed = true;
+            }
+        }
+
+        /**
+         * We determine if fees increased compared to the previous template by generating
+         * a fresh template. There may be more efficient ways to determine how much
+         * (approximate) fees for the next block increased, perhaps more so after
+         * Cluster Mempool.
+         *
+         * We'll also create a new template if the tip changed during this iteration.
+         */
+        if (wait_options.fee_threshold < MAX_MONEY || tip_changed) {
+            auto new_tmpl{CreateNewTemplate(create_options)};
+
+            // If the tip changed, return the new template regardless of its fees.
+            if (tip_changed) return new_tmpl;
+
+            // Calculate the original template total fees if we haven't already
+            if (current_fees == -1) {
+                current_fees = std::accumulate(block_template->vTxFees.begin(), block_template->vTxFees.end(), CAmount{0});
+            }
+
+            // Check if fees increased enough to return the new template
+            const CAmount new_fees = std::accumulate(new_tmpl->vTxFees.begin(), new_tmpl->vTxFees.end(), CAmount{0});
+            Assume(wait_options.fee_threshold != MAX_MONEY);
+            if (new_fees >= current_fees + wait_options.fee_threshold) return new_tmpl;
+        }
+
+        now = NodeClock::now();
+    } while (now < deadline);
+
+    return nullptr;
+}
+
+bool BlockTemplateManager::CooldownIfHeadersAhead(const BlockRef& last_tip, bool& interrupt_mining)
+{
+    uint256 last_tip_hash{last_tip.hash};
+
+    while (const std::optional<int> remaining = m_chainman.BlocksAheadOfTip()) {
+        const int cooldown_seconds = std::clamp(*remaining, 3, 20);
+        const auto cooldown_deadline{MockableSteadyClock::now() + std::chrono::seconds{cooldown_seconds}};
+
+        {
+            WAIT_LOCK(m_notifications.m_tip_block_mutex, lock);
+            m_notifications.m_tip_block_cv.wait_until(lock, cooldown_deadline, [&]() EXCLUSIVE_LOCKS_REQUIRED(m_notifications.m_tip_block_mutex) {
+                const auto tip_block = m_notifications.TipBlock();
+                return m_chainman.m_interrupt || interrupt_mining || (tip_block && *tip_block != last_tip_hash);
+            });
+            if (m_chainman.m_interrupt || interrupt_mining) {
+                interrupt_mining = false;
+                return false;
+            }
+
+            // If the tip changed during the wait, extend the deadline
+            const auto tip_block = m_notifications.TipBlock();
+            if (tip_block && *tip_block != last_tip_hash) {
+                last_tip_hash = *tip_block;
+                continue;
+            }
+        }
+
+        // No tip change and the cooldown window has expired.
+        if (MockableSteadyClock::now() >= cooldown_deadline) break;
+    }
+
+    return true;
+}
+
+std::optional<BlockRef> BlockTemplateManager::WaitTipChanged(const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt)
+{
+    Assume(timeout >= 0ms); // No internal callers should use a negative timeout
+    if (timeout < 0ms) timeout = 0ms;
+    if (timeout > std::chrono::years{100}) timeout = std::chrono::years{100}; // Upper bound to avoid UB in std::chrono
+    auto deadline{std::chrono::steady_clock::now() + timeout};
+    {
+        WAIT_LOCK(m_notifications.m_tip_block_mutex, lock);
+        // For callers convenience, wait longer than the provided timeout
+        // during startup for the tip to be non-null. That way this function
+        // always returns valid tip information when possible and only
+        // returns null when shutting down, not when timing out.
+        m_notifications.m_tip_block_cv.wait(lock, [&]() EXCLUSIVE_LOCKS_REQUIRED(m_notifications.m_tip_block_mutex) {
+            return m_notifications.TipBlock() || m_chainman.m_interrupt || interrupt;
+        });
+        if (m_chainman.m_interrupt || interrupt) {
+            interrupt = false;
+            return {};
+        }
+        // At this point TipBlock is set, so continue to wait until it is
+        // different from `current_tip` provided by caller.
+        m_notifications.m_tip_block_cv.wait_until(lock, deadline, [&]() EXCLUSIVE_LOCKS_REQUIRED(m_notifications.m_tip_block_mutex) {
+            return Assume(m_notifications.TipBlock()) != current_tip || m_chainman.m_interrupt || interrupt;
+        });
+        if (m_chainman.m_interrupt || interrupt) {
+            interrupt = false;
+            return {};
+        }
+    }
+
+    // Must release m_tip_block_mutex before GetTip() locks cs_main, to
+    // avoid deadlocks.
+    return GetTip();
 }
 
 } // namespace node

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -225,6 +225,12 @@ bool BlockTemplateManager::CooldownIfHeadersAhead(const BlockRef& last_tip, bool
     return true;
 }
 
+std::optional<BlockRef> BlockTemplateManager::WaitTipChanged(const uint256& current_tip, MillisecondsDouble timeout)
+{
+    bool interrupt_wait{false};
+    return WaitTipChanged(current_tip, timeout, interrupt_wait);
+}
+
 std::optional<BlockRef> BlockTemplateManager::WaitTipChanged(const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt)
 {
     Assume(timeout >= 0ms); // No internal callers should use a negative timeout

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -5,12 +5,14 @@
 #include <node/block_template_manager.h>
 
 #include <node/miner.h>
+#include <node/mining_args.h>
 #include <validation.h>
 
 namespace node {
 
-BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManager& chainman)
-    : m_mempool(mempool), m_chainman(chainman)
+BlockTemplateManager::BlockTemplateManager(CTxMemPool& mempool, ChainstateManager& chainman,
+                                           BlockCreateOptions init_block_create_options)
+    : m_mempool(mempool), m_chainman(chainman), m_init_block_create_options(std::move(init_block_create_options))
 {
 }
 

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <numeric>
+#include <vector>
 
 namespace node {
 
@@ -264,6 +265,77 @@ std::optional<BlockRef> BlockTemplateManager::WaitTipChanged(const uint256& curr
     // Must release m_tip_block_mutex before GetTip() locks cs_main, to
     // avoid deadlocks.
     return GetTip();
+}
+
+void TemplateSnapshot::RemoveChunk(const uint256& hash)
+{
+    auto tracked_chunk = template_chunks.find(hash);
+    if (tracked_chunk == template_chunks.end()) return;
+    total_fees -= tracked_chunk->second.feerate.fee;
+    total_weight -= tracked_chunk->second.weight;
+    total_sigops -= tracked_chunk->second.sigops_cost;
+    Assume(chunks_by_feerate.erase({tracked_chunk->second.feerate, hash}) == 1);
+    template_chunks.erase(tracked_chunk);
+}
+
+bool TemplateSnapshot::TrimToFit(int64_t needed_weight, int64_t needed_sigops, const FeePerWeight& incoming_feerate)
+{
+    const auto fits = [&](int64_t weight, int64_t sigops) {
+        return weight + needed_weight < max_weight &&
+               sigops + needed_sigops < MAX_BLOCK_SIGOPS_COST;
+    };
+    if (fits(total_weight, total_sigops)) return true;
+    // Collect candidates first so unsuccessful trims leave the snapshot unchanged.
+    std::vector<uint256> chunks_to_evict;
+    int64_t simulated_weight = total_weight;
+    int64_t simulated_sigops = total_sigops;
+    for (auto feerate_entry = chunks_by_feerate.begin(); feerate_entry != chunks_by_feerate.end(); ++feerate_entry) {
+        if (fits(simulated_weight, simulated_sigops)) break;
+        if (ByRatio{incoming_feerate} <= ByRatio{feerate_entry->feerate}) break;
+        const auto tracked_chunk = template_chunks.find(feerate_entry->hash);
+        if (!Assume(tracked_chunk != template_chunks.end())) return false;
+        simulated_weight -= tracked_chunk->second.weight;
+        simulated_sigops -= tracked_chunk->second.sigops_cost;
+        chunks_to_evict.push_back(feerate_entry->hash);
+    }
+    if (!fits(simulated_weight, simulated_sigops)) return false;
+    for (const auto& hash : chunks_to_evict) {
+        RemoveChunk(hash);
+    }
+    return true;
+}
+
+void TemplateSnapshot::AddChunk(const uint256& hash, const TrackedChunk& chunk)
+{
+    // Remove any previous entry so the feerate index and aggregate totals stay in sync.
+    RemoveChunk(hash);
+    template_chunks[hash] = chunk;
+    total_fees += chunk.feerate.fee;
+    total_weight += chunk.weight;
+    total_sigops += chunk.sigops_cost;
+    Assume(chunks_by_feerate.insert({chunk.feerate, hash}).second);
+}
+
+void TemplateSnapshot::SanityCheck() const
+{
+    Assume(template_chunks.size() == chunks_by_feerate.size());
+    CAmount recomputed_fees{0};
+    int64_t recomputed_weight{0};
+    int64_t recomputed_sigops{0};
+    for (const auto& [hash, chunk] : template_chunks) {
+        Assume(chunks_by_feerate.contains({chunk.feerate, hash}));
+        recomputed_fees += chunk.feerate.fee;
+        recomputed_weight += chunk.weight;
+        recomputed_sigops += chunk.sigops_cost;
+    }
+    for (const auto& feerate_entry : chunks_by_feerate) {
+        const auto tracked_chunk = template_chunks.find(feerate_entry.hash);
+        Assert(tracked_chunk != template_chunks.end());
+        Assume(tracked_chunk->second.feerate == feerate_entry.feerate);
+    }
+    Assume(recomputed_fees == total_fees);
+    Assume(recomputed_weight == total_weight);
+    Assume(recomputed_sigops == total_sigops);
 }
 
 } // namespace node

--- a/src/node/block_template_manager.cpp
+++ b/src/node/block_template_manager.cpp
@@ -183,19 +183,15 @@ void BlockTemplateManager::InterruptWait(bool& interrupt_wait)
 }
 
 std::unique_ptr<CBlockTemplate> BlockTemplateManager::WaitAndCreateNewBlock(
-    const std::unique_ptr<CBlockTemplate>& block_template,
-    const BlockWaitOptions& wait_options,
-    const BlockCreateOptions& create_options,
-    bool& interrupt_wait)
+    const uint256& prev_block_hash,
+    uint64_t template_id,
+    const BlockWaitOptions& options,
+    const BlockCreateOptions& assemble_options,
+    bool& interrupt_wait,
+    uint64_t& new_template_id)
 {
-    // Delay calculating the current template fees, just in case a new block
-    // comes in before the next tick.
-    CAmount current_fees = -1;
-
-    // Alternate waiting for a new tip and checking if fees have risen.
-    // The latter check is expensive so we only run it once per second.
     auto now{NodeClock::now()};
-    const auto deadline = now + wait_options.timeout;
+    const auto deadline = now + options.timeout;
     const MillisecondsDouble tick{1000};
     const bool allow_min_difficulty{m_chainman.GetParams().GetConsensus().fPowAllowMinDifficultyBlocks};
 
@@ -207,10 +203,7 @@ std::unique_ptr<CBlockTemplate> BlockTemplateManager::WaitAndCreateNewBlock(
             m_notifications.m_tip_block_cv.wait_until(lock, std::min(now + tick, deadline), [&]() EXCLUSIVE_LOCKS_REQUIRED(m_notifications.m_tip_block_mutex) {
                 AssertLockHeld(m_notifications.m_tip_block_mutex);
                 const auto tip_block{m_notifications.TipBlock()};
-                // We assume tip_block is set, because this is an instance
-                // method on BlockTemplate and no template could have been
-                // generated before a tip exists.
-                tip_changed = Assume(tip_block) && tip_block != block_template->block.hashPrevBlock;
+                tip_changed = Assume(tip_block) && tip_block != prev_block_hash;
                 return tip_changed || m_chainman.m_interrupt || interrupt_wait;
             });
             if (interrupt_wait) {
@@ -220,43 +213,22 @@ std::unique_ptr<CBlockTemplate> BlockTemplateManager::WaitAndCreateNewBlock(
         }
 
         if (m_chainman.m_interrupt) return nullptr;
-        // At this point the tip changed, a full tick went by or we reached
-        // the deadline.
 
         // Must release m_tip_block_mutex before locking cs_main, to avoid deadlocks.
-        LOCK(::cs_main);
-
-        // On test networks return a minimum difficulty block after 20 minutes
         if (!tip_changed && allow_min_difficulty) {
+            LOCK(::cs_main);
             const NodeClock::time_point tip_time{std::chrono::seconds{m_chainman.ActiveChain().Tip()->GetBlockTime()}};
             if (now > tip_time + 20min) {
                 tip_changed = true;
             }
         }
 
-        /**
-         * We determine if fees increased compared to the previous template by generating
-         * a fresh template. There may be more efficient ways to determine how much
-         * (approximate) fees for the next block increased, perhaps more so after
-         * Cluster Mempool.
-         *
-         * We'll also create a new template if the tip changed during this iteration.
-         */
-        if (wait_options.fee_threshold < MAX_MONEY || tip_changed) {
-            auto new_tmpl{CreateNewTemplate(create_options)};
+        if (tip_changed) {
+            return CreateNewTemplate(assemble_options, &new_template_id);
+        }
 
-            // If the tip changed, return the new template regardless of its fees.
-            if (tip_changed) return new_tmpl;
-
-            // Calculate the original template total fees if we haven't already
-            if (current_fees == -1) {
-                current_fees = std::accumulate(block_template->vTxFees.begin(), block_template->vTxFees.end(), CAmount{0});
-            }
-
-            // Check if fees increased enough to return the new template
-            const CAmount new_fees = std::accumulate(new_tmpl->vTxFees.begin(), new_tmpl->vTxFees.end(), CAmount{0});
-            Assume(wait_options.fee_threshold != MAX_MONEY);
-            if (new_fees >= current_fees + wait_options.fee_threshold) return new_tmpl;
+        if (IsStale(assemble_options, template_id, options.fee_threshold)) {
+            return CreateNewTemplate(assemble_options, &new_template_id);
         }
 
         now = NodeClock::now();
@@ -466,7 +438,7 @@ bool BlockTemplateManager::IsStale(const BlockCreateOptions& options,
     LOCK(m_mutex);
     const auto snapshot = m_template_snapshots.find(template_id);
     if (snapshot == m_template_snapshots.end()) return false;
-    if (snapshot->second.options != FlattenMiningOptions(options)) return false;
+    if (snapshot->second.options != FlattenMiningOptions(MergeMiningOptions(options, m_init_block_create_options))) return false;
     const CAmount fee_delta = snapshot->second.total_fees - snapshot->second.original_fees;
     return fee_delta >= fee_threshold;
 }

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -1,0 +1,34 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H
+#define BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H
+
+#include <node/mining_types.h>
+
+#include <memory>
+
+class ChainstateManager;
+class CTxMemPool;
+
+namespace node {
+struct CBlockTemplate;
+
+/** Creates block templates. */
+class BlockTemplateManager
+{
+private:
+    CTxMemPool& m_mempool;
+    ChainstateManager& m_chainman;
+
+public:
+    explicit BlockTemplateManager(CTxMemPool& mempool,
+                                  ChainstateManager& chainman);
+
+    /** Create a fresh block template. */
+    std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);
+};
+} // namespace node
+
+#endif // BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -21,10 +21,15 @@ class BlockTemplateManager
 private:
     CTxMemPool& m_mempool;
     ChainstateManager& m_chainman;
+    const BlockCreateOptions m_init_block_create_options;
 
 public:
     explicit BlockTemplateManager(CTxMemPool& mempool,
-                                  ChainstateManager& chainman);
+                                  ChainstateManager& chainman,
+                                  BlockCreateOptions init_block_create_options = {});
+
+    /** @return a copy of the block create options set during node init. */
+    BlockCreateOptions GetInitBlockCreateOptions() const { return m_init_block_create_options; }
 
     /** Create a fresh block template. */
     std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -5,10 +5,16 @@
 #ifndef BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H
 #define BITCOIN_NODE_BLOCK_TEMPLATE_MANAGER_H
 
+#include <consensus/amount.h>
 #include <node/mining_types.h>
+#include <uint256.h>
+#include <util/feefrac.h>
 
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <optional>
+#include <set>
 
 class CBlock;
 class ChainstateManager;
@@ -21,6 +27,66 @@ struct BlockRef;
 namespace node {
 class KernelNotifications;
 struct CBlockTemplate;
+
+/** Data structure for incrementally tracking chunks from a block template.
+ *
+ * Chunks are indexed by hash for mempool-removal updates, and by feerate for
+ * trimming when a higher-feerate chunk arrives. The feerate index is maintained
+ * incrementally, avoiding a full sort on every TrimToFit() call.
+ *
+ * Invariant: template_chunks and chunks_by_feerate contain the same chunk
+ * hashes, and total_fees/total_weight/total_sigops are their aggregate totals.
+ */
+struct TemplateSnapshot {
+    /** Chunk metadata captured from the template: adjusted feerate, weight,
+     *  and sigops. */
+    struct TrackedChunk {
+        FeePerWeight feerate;
+        int64_t weight;
+        int64_t sigops_cost;
+    };
+    /** Feerate index key. The hash distinguishes chunks with equal feerates
+     *  and allows direct erasure using metadata from template_chunks. */
+    struct FeerateIndexEntry {
+        FeePerWeight feerate;
+        uint256 hash;
+        friend bool operator<(const FeerateIndexEntry& left, const FeerateIndexEntry& right)
+        {
+            const auto feerate_order = ByRatio{left.feerate} <=> ByRatio{right.feerate};
+            return feerate_order != 0 ? feerate_order < 0 : left.hash < right.hash;
+        }
+    };
+    /** Owns tracked chunk metadata keyed by chunk hash. */
+    std::map<uint256, TrackedChunk> template_chunks;
+    /** Keeps chunks sorted so TrimToFit() can scan lowest-feerate chunks first. */
+    std::set<FeerateIndexEntry> chunks_by_feerate;
+    /** Minimum feerate accepted by the original template. */
+    FeePerWeight min_feerate;
+    /** Exclusive block weight limit used when deciding if new chunks fit. */
+    int64_t max_weight{0};
+    /** Aggregate fees of all currently tracked chunks. */
+    CAmount total_fees{0};
+    /** Aggregate weight of all currently tracked chunks. */
+    int64_t total_weight{0};
+    /** Aggregate sigops cost of all currently tracked chunks. */
+    int64_t total_sigops{0};
+    /** Chain height used for finality checks against new chunks. */
+    int height{0};
+    /** Median-time-past cutoff used for finality checks against new chunks. */
+    int64_t lock_time_cutoff{0};
+    /** Remove a chunk by hash in O(log n). */
+    void RemoveChunk(const uint256& hash);
+    /** Add a chunk in O(log n). */
+    void AddChunk(const uint256& hash, const TrackedChunk& chunk);
+    /** Evict lowest-feerate chunks to make room for @p needed_weight and @p needed_sigops.
+     *  Only commits evictions if the chunk will fit afterward.
+     *  Returns true if the incoming chunk fits after eviction.
+     *  Runs in O(s log n), where s is the number of scanned chunks. */
+    bool TrimToFit(int64_t needed_weight, int64_t needed_sigops, const FeePerWeight& incoming_feerate);
+    /** Verify the chunk indexes and cached fee, weight, and sigops totals.
+     *  Runs in O(n log n). */
+    void SanityCheck() const;
+};
 
 /** Creates block templates. */
 class BlockTemplateManager

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -13,6 +13,7 @@
 #include <util/time.h>
 #include <validationinterface.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -38,7 +39,9 @@ struct CBlockTemplate;
  * incrementally, avoiding a full sort on every TrimToFit() call.
  *
  * Invariant: template_chunks and chunks_by_feerate contain the same chunk
- * hashes, and total_fees/total_weight/total_sigops are their aggregate totals.
+ * hashes. Cached totals equal their aggregates, with reserved_weight included
+ * in total_weight. Non-empty snapshots have total_weight < max_weight; empty
+ * snapshots may have total_weight == max_weight.
  */
 struct TemplateSnapshot {
     /** Chunk metadata captured from the template: adjusted feerate, weight,
@@ -73,6 +76,8 @@ struct TemplateSnapshot {
     int64_t max_weight{0};
     /** Weight reserved before transaction selection. */
     int64_t reserved_weight{0};
+    /** Fees in the original template, used as the staleness baseline. */
+    CAmount original_fees{0};
     /** Aggregate fees of all currently tracked chunks. */
     CAmount total_fees{0};
     /** Reserved weight plus the weight of all currently tracked chunks. */
@@ -99,13 +104,17 @@ struct TemplateSnapshot {
     void SanityCheck() const;
 };
 
-/** Block template creation and fee-inflow tracking.
+/** Block template creation and staleness detection.
  *
  * Tracks chunk feerates and total fees at creation time. On every mempool
  * update, chunks that left the mempool are dropped from the record. New
  * chunks at or above the block minimum fee rate that pass sigops and finality
  * checks are added: directly if weight remains, or by evicting tracked
  * chunks whose feerate is lower than the incoming chunk.
+ *
+ * A template is stale once the tracked fee improvement reaches the requested
+ * threshold. The fee improvement is the lower-bound difference between the
+ * current tracked chunk fees and the original template fees.
  *
  * Block connection (non-historical) and disconnection prune records built on
  * the old tip of each transition.
@@ -134,8 +143,13 @@ public:
 
     /** Create a fresh block template, applying init-time defaults to any unset
      *  options. When @p tracking_id is non-null, the template is tracked for
-     *  fee inflow and its identifier is returned there. */
+     *  staleness and its identifier is returned there. */
     std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options, uint64_t* tracking_id = nullptr)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** @return true if fee inflow exceeds @p fee_threshold. Returns false if no
+     *  tracked entry exists for @p template_id or if the options do not match. */
+    bool IsStale(const BlockCreateOptions& options, uint64_t template_id, CAmount fee_threshold) const
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** @return true if fee-inflow tracking is active for the given template id. */

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -8,12 +8,18 @@
 #include <node/mining_types.h>
 
 #include <memory>
+#include <optional>
 
 class CBlock;
 class ChainstateManager;
 class CTxMemPool;
 
+namespace interfaces {
+struct BlockRef;
+} // namespace interfaces
+
 namespace node {
+class KernelNotifications;
 struct CBlockTemplate;
 
 /** Creates block templates. */
@@ -22,11 +28,13 @@ class BlockTemplateManager
 private:
     CTxMemPool& m_mempool;
     ChainstateManager& m_chainman;
+    KernelNotifications& m_notifications;
     const BlockCreateOptions m_init_block_create_options;
 
 public:
     explicit BlockTemplateManager(CTxMemPool& mempool,
                                   ChainstateManager& chainman,
+                                  KernelNotifications& notifications,
                                   BlockCreateOptions init_block_create_options = {});
 
     /** @return a copy of the block create options set during node init. */
@@ -37,6 +45,46 @@ public:
 
     /** Submit a block via ProcessNewBlock and capture validation state. */
     bool SubmitBlock(const std::shared_ptr<const CBlock>& block, bool* new_block, std::string& reason, std::string& debug);
+
+    /** @return the active chain tip, or nullopt if none exists. */
+    std::optional<interfaces::BlockRef> GetTip();
+
+    /** Wait for the tip to differ from @p current_tip or timeout.
+     *  Waits indefinitely during startup for a non-null tip. */
+    std::optional<interfaces::BlockRef> WaitTipChanged(const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt);
+
+    /**
+     * Wait while the best known header extends the current chain tip AND at
+     * least one block is being added to the tip every 3 seconds. If the tip is
+     * sufficiently far behind, allow up to 20 seconds for the next tip update.
+     *
+     * It's not safe to keep waiting, because a malicious miner could announce
+     * a header and delay revealing the block, causing all other miners using
+     * this software to stall. At the same time, we need to balance between the
+     * default waiting time being brief, but not ending the cooldown prematurely
+     * when a random block is slow to download (or process).
+     *
+     * The cooldown only applies to createNewBlock(), which is typically called
+     * once per connected client. Subsequent templates are provided by
+     * waitNext().
+     *
+     * @param last_tip tip at the start of the cooldown window.
+     * @param interrupt_mining set to true to interrupt the cooldown.
+     *
+     * @returns false if interrupted.
+     */
+    bool CooldownIfHeadersAhead(const interfaces::BlockRef& last_tip, bool& interrupt_mining);
+
+    /** Interrupt a blocking wait. */
+    void InterruptWait(bool& interrupt_wait);
+
+    /** Return a new block template when fees rise to a certain threshold or
+     *  after a new tip; return nullptr if timeout is reached. */
+    std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(
+        const std::unique_ptr<CBlockTemplate>& block_template,
+        const BlockWaitOptions& wait_options,
+        const BlockCreateOptions& create_options,
+        bool& interrupt_wait);
 };
 } // namespace node
 

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -211,13 +211,16 @@ public:
     /** Interrupt a blocking wait. */
     void InterruptWait(bool& interrupt_wait);
 
-    /** Return a new block template when fees rise to a certain threshold or
-     *  after a new tip; return nullptr if timeout is reached. */
+    /** Wait for fee inflow or tip change, then return a new template. On
+     *  success the replacement's tracking id is written to @p new_template_id.
+     *  @return nullptr on timeout or interrupt. */
     std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(
-        const std::unique_ptr<CBlockTemplate>& block_template,
-        const BlockWaitOptions& wait_options,
-        const BlockCreateOptions& create_options,
-        bool& interrupt_wait)
+        const uint256& prev_block_hash,
+        uint64_t template_id,
+        const BlockWaitOptions& options,
+        const BlockCreateOptions& assemble_options,
+        bool& interrupt_wait,
+        uint64_t& new_template_id)
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 };
 } // namespace node

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -53,6 +53,11 @@ public:
      *  Waits indefinitely during startup for a non-null tip. */
     std::optional<interfaces::BlockRef> WaitTipChanged(const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt);
 
+    /** Convenience overload for in-process callers (e.g. RPC) that have no
+     *  interrupt handle. Takes the timeout by value so the caller's variable is
+     *  left unchanged; the wait still ends on chain shutdown. */
+    std::optional<interfaces::BlockRef> WaitTipChanged(const uint256& current_tip, MillisecondsDouble timeout = MillisecondsDouble::max());
+
     /**
      * Wait while the best known header extends the current chain tip AND at
      * least one block is being added to the tip every 3 seconds. If the tip is

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -7,8 +7,11 @@
 
 #include <consensus/amount.h>
 #include <node/mining_types.h>
+#include <sync.h>
 #include <uint256.h>
 #include <util/feefrac.h>
+#include <util/time.h>
+#include <validationinterface.h>
 
 #include <cstdint>
 #include <map>
@@ -60,16 +63,24 @@ struct TemplateSnapshot {
     std::map<uint256, TrackedChunk> template_chunks;
     /** Keeps chunks sorted so TrimToFit() can scan lowest-feerate chunks first. */
     std::set<FeerateIndexEntry> chunks_by_feerate;
+    /** Active chain tip this template was built on. */
+    uint256 tip_hash;
+    /** Options identify which template request this snapshot belongs to. */
+    BlockCreateOptions options;
     /** Minimum feerate accepted by the original template. */
     FeePerWeight min_feerate;
     /** Exclusive block weight limit used when deciding if new chunks fit. */
     int64_t max_weight{0};
+    /** Weight reserved before transaction selection. */
+    int64_t reserved_weight{0};
     /** Aggregate fees of all currently tracked chunks. */
     CAmount total_fees{0};
-    /** Aggregate weight of all currently tracked chunks. */
+    /** Reserved weight plus the weight of all currently tracked chunks. */
     int64_t total_weight{0};
     /** Aggregate sigops cost of all currently tracked chunks. */
     int64_t total_sigops{0};
+    /** Sigops reserved before transaction selection. */
+    int64_t reserved_sigops{0};
     /** Chain height used for finality checks against new chunks. */
     int height{0};
     /** Median-time-past cutoff used for finality checks against new chunks. */
@@ -88,26 +99,63 @@ struct TemplateSnapshot {
     void SanityCheck() const;
 };
 
-/** Creates block templates. */
-class BlockTemplateManager
+/** Block template creation and fee-inflow tracking.
+ *
+ * Tracks chunk feerates and total fees at creation time. On every mempool
+ * update, chunks that left the mempool are dropped from the record. New
+ * chunks at or above the block minimum fee rate that pass sigops and finality
+ * checks are added: directly if weight remains, or by evicting tracked
+ * chunks whose feerate is lower than the incoming chunk.
+ *
+ * Block connection (non-historical) and disconnection prune records built on
+ * the old tip of each transition.
+ */
+class BlockTemplateManager : public CValidationInterface
 {
 private:
     CTxMemPool& m_mempool;
     ChainstateManager& m_chainman;
     KernelNotifications& m_notifications;
     const BlockCreateOptions m_init_block_create_options;
+    mutable Mutex m_mutex;
+    /** Tracked template snapshots keyed by unique nonzero identifier. */
+    std::map<uint64_t, TemplateSnapshot> m_template_snapshots GUARDED_BY(m_mutex);
+    uint64_t m_next_template_id GUARDED_BY(m_mutex){1};
 
 public:
     explicit BlockTemplateManager(CTxMemPool& mempool,
                                   ChainstateManager& chainman,
                                   KernelNotifications& notifications,
                                   BlockCreateOptions init_block_create_options = {});
+    virtual ~BlockTemplateManager() = default;
 
     /** @return a copy of the block create options set during node init. */
     BlockCreateOptions GetInitBlockCreateOptions() const { return m_init_block_create_options; }
 
-    /** Create a fresh block template, applying init-time defaults to any unset options. */
-    std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);
+    /** Create a fresh block template, applying init-time defaults to any unset
+     *  options. When @p tracking_id is non-null, the template is tracked for
+     *  fee inflow and its identifier is returned there. */
+    std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options, uint64_t* tracking_id = nullptr)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** @return true if fee-inflow tracking is active for the given template id. */
+    bool IsTrackingFeeInflow(uint64_t template_id) const
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Stop tracking fee inflow for the given template id. */
+    void StopTrackingFeeInflow(uint64_t template_id)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Test-only: verify invariants. */
+    void SanityCheck() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    // CValidationInterface overrides
+    void BlockConnected(const kernel::ChainstateRole& role, const std::shared_ptr<const CBlock>&, const CBlockIndex*) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    void BlockDisconnected(const std::shared_ptr<const CBlock>&, const CBlockIndex*) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    void MempoolUpdated(const MemPoolChunksUpdate& mempool_chunks) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Submit a block via ProcessNewBlock and capture validation state. */
     bool SubmitBlock(const std::shared_ptr<const CBlock>& block, bool* new_block, std::string& reason, std::string& debug);
@@ -155,7 +203,8 @@ public:
         const std::unique_ptr<CBlockTemplate>& block_template,
         const BlockWaitOptions& wait_options,
         const BlockCreateOptions& create_options,
-        bool& interrupt_wait);
+        bool& interrupt_wait)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 };
 } // namespace node
 

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -40,7 +40,7 @@ public:
     /** @return a copy of the block create options set during node init. */
     BlockCreateOptions GetInitBlockCreateOptions() const { return m_init_block_create_options; }
 
-    /** Create a fresh block template. */
+    /** Create a fresh block template, applying init-time defaults to any unset options. */
     std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);
 
     /** Submit a block via ProcessNewBlock and capture validation state. */

--- a/src/node/block_template_manager.h
+++ b/src/node/block_template_manager.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+class CBlock;
 class ChainstateManager;
 class CTxMemPool;
 
@@ -33,6 +34,9 @@ public:
 
     /** Create a fresh block template. */
     std::unique_ptr<CBlockTemplate> CreateNewTemplate(const BlockCreateOptions& options);
+
+    /** Submit a block via ProcessNewBlock and capture validation state. */
+    bool SubmitBlock(const std::shared_ptr<const CBlock>& block, bool* new_block, std::string& reason, std::string& debug);
 };
 } // namespace node
 

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -13,6 +13,7 @@
 #include <net.h>
 #include <net_processing.h>
 #include <netgroup.h>
+#include <node/block_template_manager.h>
 #include <node/kernel_notifications.h>
 #include <node/warnings.h>
 #include <policy/fees/block_policy_estimator.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_NODE_CONTEXT_H
 #define BITCOIN_NODE_CONTEXT_H
 
-#include <node/mining_types.h>
-
 #include <atomic>
 #include <cstdlib>
 #include <functional>
@@ -84,11 +82,6 @@ struct NodeContext {
     //! Reference to chain client that should used to load or create wallets
     //! opened by the gui.
     std::unique_ptr<interfaces::Mining> mining;
-    //! Mining options used to create block templates. This value member is an
-    //! exception to the dependency guidance above because BlockCreateOptions is
-    //! a minimal dependency. It could be moved to the BlockTemplateCache
-    //! proposed in bitcoin/bitcoin#33421.
-    BlockCreateOptions mining_args;
     interfaces::WalletLoader* wallet_loader{nullptr};
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -43,6 +43,7 @@ class SignalInterrupt;
 }
 
 namespace node {
+class BlockTemplateManager;
 class KernelNotifications;
 class Warnings;
 
@@ -93,6 +94,7 @@ struct NodeContext {
     std::function<void()> rpc_interruption_point = [] {};
     //! Issues blocking calls about sync status, errors and warnings
     std::unique_ptr<KernelNotifications> notifications;
+    std::unique_ptr<BlockTemplateManager> block_template_manager;
     //! Issues calls about blocks and transactions
     std::unique_ptr<ValidationSignals> validation_signals;
     std::atomic<int> exit_status{EXIT_SUCCESS};

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -33,6 +33,7 @@
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/coin.h>
 #include <node/context.h>
@@ -1000,7 +1001,8 @@ public:
             // Also wait during the final catch-up moments after IBD.
             if (!CooldownIfHeadersAhead(chainman(), notifications(), *maybe_tip, m_interrupt_mining)) return {};
         }
-        const BlockCreateOptions create_options{MergeMiningOptions(options, m_node.mining_args)};
+        auto& block_template_manager = *Assert(m_node.block_template_manager);
+        const BlockCreateOptions create_options{MergeMiningOptions(options, block_template_manager.GetInitBlockCreateOptions())};
         return std::make_unique<BlockTemplateImpl>(create_options,
                                                    BlockAssembler{
                                                        chainman().ActiveChainstate(),

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -879,11 +879,20 @@ class BlockTemplateImpl : public BlockTemplate
 public:
     explicit BlockTemplateImpl(BlockCreateOptions create_options,
                                std::unique_ptr<CBlockTemplate> block_template,
+                               uint64_t template_id,
                                const NodeContext& node) : m_create_options(std::move(create_options)),
                                                           m_block_template(std::move(block_template)),
+                                                          m_template_id(template_id),
                                                           m_node(node)
     {
         assert(m_block_template);
+    }
+
+    ~BlockTemplateImpl() override
+    {
+        if (m_node.block_template_manager) {
+            m_node.block_template_manager->StopTrackingFeeInflow(m_template_id);
+        }
     }
 
     CBlockHeader getBlockHeader() override
@@ -927,9 +936,15 @@ public:
 
     std::unique_ptr<BlockTemplate> waitNext(BlockWaitOptions options) override
     {
+        uint64_t new_template_id{0};
         auto new_template = block_template_manager().WaitAndCreateNewBlock(
-            m_block_template, options, m_create_options, m_interrupt_wait);
-        if (new_template) return std::make_unique<BlockTemplateImpl>(m_create_options, std::move(new_template), m_node);
+            m_block_template->block.hashPrevBlock,
+            m_template_id,
+            options,
+            m_create_options,
+            m_interrupt_wait,
+            new_template_id);
+        if (new_template) return std::make_unique<BlockTemplateImpl>(m_create_options, std::move(new_template), new_template_id, m_node);
         return nullptr;
     }
 
@@ -941,6 +956,10 @@ public:
     const BlockCreateOptions m_create_options;
 
     const std::unique_ptr<CBlockTemplate> m_block_template;
+    // Identifier of this template's fee-inflow tracking snapshot, or 0 when
+    // untracked. Owned here rather than on CBlockTemplate so the assembler's
+    // template struct stays free of tracking state.
+    const uint64_t m_template_id;
 
     bool m_interrupt_wait{false};
     node::BlockTemplateManager& block_template_manager() { return *Assert(m_node.block_template_manager); }
@@ -993,9 +1012,9 @@ public:
             // Also wait during the final catch-up moments after IBD.
             if (!block_template_manager().CooldownIfHeadersAhead(*maybe_tip, m_interrupt_mining)) return {};
         }
-        auto& block_template_manager = *Assert(m_node.block_template_manager);
-        auto new_template = block_template_manager.CreateNewTemplate(options);
-        return std::make_unique<BlockTemplateImpl>(options, std::move(new_template), m_node);
+        uint64_t template_id{0};
+        auto new_template = block_template_manager().CreateNewTemplate(options, &template_id);
+        return std::make_unique<BlockTemplateImpl>(options, std::move(new_template), template_id, m_node);
     }
 
     void interrupt() override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -924,7 +924,7 @@ public:
         AddMerkleRootAndCoinbase(m_block_template->block, std::move(coinbase), version, timestamp, nonce);
         std::string reason;
         std::string debug;
-        return SubmitBlock(chainman(), std::make_shared<const CBlock>(m_block_template->block), /*new_block=*/nullptr, reason, debug);
+        return block_template_manager().SubmitBlock(std::make_shared<const CBlock>(m_block_template->block), /*new_block=*/nullptr, reason, debug);
     }
 
     std::unique_ptr<BlockTemplate> waitNext(BlockWaitOptions options) override
@@ -952,6 +952,7 @@ public:
     bool m_interrupt_wait{false};
     ChainstateManager& chainman() { return *Assert(m_node.chainman); }
     KernelNotifications& notifications() { return *Assert(m_node.notifications); }
+    node::BlockTemplateManager& block_template_manager() { return *Assert(m_node.block_template_manager); }
     const NodeContext& m_node;
 };
 
@@ -1030,7 +1031,7 @@ public:
     {
         auto block = std::make_shared<const CBlock>(block_in);
         bool new_block;
-        const bool accepted = SubmitBlock(chainman(), block, &new_block, reason, debug);
+        const bool accepted = block_template_manager().SubmitBlock(block, &new_block, reason, debug);
         // ProcessNewBlock() can accept and store a block before it is checked
         // for validity. Treat duplicates as errors for mining clients, and only
         // return success when validation completed without setting a reason.
@@ -1066,6 +1067,7 @@ public:
     const NodeContext* context() override { return &m_node; }
     ChainstateManager& chainman() { return *Assert(m_node.chainman); }
     KernelNotifications& notifications() { return *Assert(m_node.notifications); }
+    node::BlockTemplateManager& block_template_manager() { return *Assert(m_node.block_template_manager); }
     // Treat as if guarded by notifications().m_tip_block_mutex
     bool m_interrupt_mining{false};
     const NodeContext& m_node;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -41,7 +41,6 @@
 #include <node/kernel_notifications.h>
 #include <node/miner.h>
 #include <node/mini_miner.h>
-#include <node/mining_args.h>
 #include <node/mining_types.h>
 #include <node/transaction.h>
 #include <node/types.h>
@@ -96,7 +95,6 @@ using interfaces::Node;
 using interfaces::Rpc;
 using interfaces::WalletLoader;
 using kernel::ChainstateRole;
-using node::BlockAssembler;
 using node::BlockCreateOptions;
 using node::BlockWaitOptions;
 using node::CoinbaseTx;
@@ -996,14 +994,8 @@ public:
             if (!block_template_manager().CooldownIfHeadersAhead(*maybe_tip, m_interrupt_mining)) return {};
         }
         auto& block_template_manager = *Assert(m_node.block_template_manager);
-        const BlockCreateOptions create_options{MergeMiningOptions(options, block_template_manager.GetInitBlockCreateOptions())};
-        return std::make_unique<BlockTemplateImpl>(create_options,
-                                                   BlockAssembler{
-                                                       chainman().ActiveChainstate(),
-                                                       m_node.mempool.get(),
-                                                       create_options,
-                                                   }.CreateNewBlock(),
-                                                   m_node);
+        auto new_template = block_template_manager.CreateNewTemplate(options);
+        return std::make_unique<BlockTemplateImpl>(options, std::move(new_template), m_node);
     }
 
     void interrupt() override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -929,20 +929,15 @@ public:
 
     std::unique_ptr<BlockTemplate> waitNext(BlockWaitOptions options) override
     {
-        auto new_template = WaitAndCreateNewBlock(chainman(),
-                                                  notifications(),
-                                                  m_node.mempool.get(),
-                                                  m_block_template,
-                                                  /*wait_options=*/options,
-                                                  /*create_options=*/m_create_options,
-                                                  /*interrupt_wait=*/m_interrupt_wait);
+        auto new_template = block_template_manager().WaitAndCreateNewBlock(
+            m_block_template, options, m_create_options, m_interrupt_wait);
         if (new_template) return std::make_unique<BlockTemplateImpl>(m_create_options, std::move(new_template), m_node);
         return nullptr;
     }
 
     void interruptWait() override
     {
-        InterruptWait(notifications(), m_interrupt_wait);
+        block_template_manager().InterruptWait(m_interrupt_wait);
     }
 
     const BlockCreateOptions m_create_options;
@@ -950,8 +945,6 @@ public:
     const std::unique_ptr<CBlockTemplate> m_block_template;
 
     bool m_interrupt_wait{false};
-    ChainstateManager& chainman() { return *Assert(m_node.chainman); }
-    KernelNotifications& notifications() { return *Assert(m_node.notifications); }
     node::BlockTemplateManager& block_template_manager() { return *Assert(m_node.block_template_manager); }
     const NodeContext& m_node;
 };
@@ -973,12 +966,12 @@ public:
 
     std::optional<BlockRef> getTip() override
     {
-        return GetTip(chainman());
+        return block_template_manager().GetTip();
     }
 
     std::optional<BlockRef> waitTipChanged(uint256 current_tip, MillisecondsDouble timeout) override
     {
-        return WaitTipChanged(chainman(), notifications(), current_tip, timeout, m_interrupt_mining);
+        return block_template_manager().WaitTipChanged(current_tip, timeout, m_interrupt_mining);
     }
 
     std::unique_ptr<BlockTemplate> createNewBlock(const BlockCreateOptions& options, bool cooldown) override
@@ -1000,7 +993,7 @@ public:
             }
 
             // Also wait during the final catch-up moments after IBD.
-            if (!CooldownIfHeadersAhead(chainman(), notifications(), *maybe_tip, m_interrupt_mining)) return {};
+            if (!block_template_manager().CooldownIfHeadersAhead(*maybe_tip, m_interrupt_mining)) return {};
         }
         auto& block_template_manager = *Assert(m_node.block_template_manager);
         const BlockCreateOptions create_options{MergeMiningOptions(options, block_template_manager.GetInitBlockCreateOptions())};
@@ -1015,7 +1008,7 @@ public:
 
     void interrupt() override
     {
-        InterruptWait(notifications(), m_interrupt_mining);
+        block_template_manager().InterruptWait(m_interrupt_mining);
     }
 
     bool checkBlock(const CBlock& block, const node::BlockCheckOptions& options, std::string& reason, std::string& debug) override

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -14,9 +14,7 @@
 #include <consensus/params.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
-#include <interfaces/types.h>
 #include <node/blockstorage.h>
-#include <node/kernel_notifications.h>
 #include <node/mining_args.h>
 #include <node/mining_types.h>
 #include <policy/feerate.h>
@@ -34,19 +32,14 @@
 #include <util/feefrac.h>
 #include <util/log.h>
 #include <util/result.h>
-#include <util/signalinterrupt.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
-#include <validationinterface.h>
 #include <versionbits.h>
 
 #include <algorithm>
-#include <compare>
-#include <condition_variable>
 #include <cstddef>
 #include <functional>
-#include <numeric>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -360,179 +353,6 @@ void AddMerkleRootAndCoinbase(CBlock& block, CTransactionRef coinbase, uint32_t 
     block.m_checked_witness_commitment = false;
     block.m_checked_merkle_root = false;
     block.fChecked = false;
-}
-
-void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wait)
-{
-    LOCK(kernel_notifications.m_tip_block_mutex);
-    interrupt_wait = true;
-    kernel_notifications.m_tip_block_cv.notify_all();
-}
-
-std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainman,
-                                                      KernelNotifications& kernel_notifications,
-                                                      CTxMemPool* mempool,
-                                                      const std::unique_ptr<CBlockTemplate>& block_template,
-                                                      const BlockWaitOptions& wait_options,
-                                                      const BlockCreateOptions& create_options,
-                                                      bool& interrupt_wait)
-{
-    // Delay calculating the current template fees, just in case a new block
-    // comes in before the next tick.
-    CAmount current_fees = -1;
-
-    // Alternate waiting for a new tip and checking if fees have risen.
-    // The latter check is expensive so we only run it once per second.
-    auto now{NodeClock::now()};
-    const auto deadline = now + wait_options.timeout;
-    const MillisecondsDouble tick{1000};
-    const bool allow_min_difficulty{chainman.GetParams().GetConsensus().fPowAllowMinDifficultyBlocks};
-
-    do {
-        bool tip_changed{false};
-        {
-            WAIT_LOCK(kernel_notifications.m_tip_block_mutex, lock);
-            // Note that wait_until() checks the predicate before waiting
-            kernel_notifications.m_tip_block_cv.wait_until(lock, std::min(now + tick, deadline), [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
-                AssertLockHeld(kernel_notifications.m_tip_block_mutex);
-                const auto tip_block{kernel_notifications.TipBlock()};
-                // We assume tip_block is set, because this is an instance
-                // method on BlockTemplate and no template could have been
-                // generated before a tip exists.
-                tip_changed = Assume(tip_block) && tip_block != block_template->block.hashPrevBlock;
-                return tip_changed || chainman.m_interrupt || interrupt_wait;
-            });
-            if (interrupt_wait) {
-                interrupt_wait = false;
-                return nullptr;
-            }
-        }
-
-        if (chainman.m_interrupt) return nullptr;
-        // At this point the tip changed, a full tick went by or we reached
-        // the deadline.
-
-        // Must release m_tip_block_mutex before locking cs_main, to avoid deadlocks.
-        LOCK(::cs_main);
-
-        // On test networks return a minimum difficulty block after 20 minutes
-        if (!tip_changed && allow_min_difficulty) {
-            const NodeClock::time_point tip_time{std::chrono::seconds{chainman.ActiveChain().Tip()->GetBlockTime()}};
-            if (now > tip_time + 20min) {
-                tip_changed = true;
-            }
-        }
-
-        /**
-         * We determine if fees increased compared to the previous template by generating
-         * a fresh template. There may be more efficient ways to determine how much
-         * (approximate) fees for the next block increased, perhaps more so after
-         * Cluster Mempool.
-         *
-         * We'll also create a new template if the tip changed during this iteration.
-         */
-        if (wait_options.fee_threshold < MAX_MONEY || tip_changed) {
-            auto new_tmpl{BlockAssembler{
-                chainman.ActiveChainstate(),
-                mempool,
-                create_options
-                }.CreateNewBlock()};
-
-            // If the tip changed, return the new template regardless of its fees.
-            if (tip_changed) return new_tmpl;
-
-            // Calculate the original template total fees if we haven't already
-            if (current_fees == -1) {
-                current_fees = std::accumulate(block_template->vTxFees.begin(), block_template->vTxFees.end(), CAmount{0});
-            }
-
-            // Check if fees increased enough to return the new template
-            const CAmount new_fees = std::accumulate(new_tmpl->vTxFees.begin(), new_tmpl->vTxFees.end(), CAmount{0});
-            Assume(wait_options.fee_threshold != MAX_MONEY);
-            if (new_fees >= current_fees + wait_options.fee_threshold) return new_tmpl;
-        }
-
-        now = NodeClock::now();
-    } while (now < deadline);
-
-    return nullptr;
-}
-
-std::optional<BlockRef> GetTip(ChainstateManager& chainman)
-{
-    LOCK(::cs_main);
-    CBlockIndex* tip{chainman.ActiveChain().Tip()};
-    if (!tip) return {};
-    return BlockRef{tip->GetBlockHash(), tip->nHeight};
-}
-
-bool CooldownIfHeadersAhead(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const BlockRef& last_tip, bool& interrupt_mining)
-{
-    uint256 last_tip_hash{last_tip.hash};
-
-    while (const std::optional<int> remaining = chainman.BlocksAheadOfTip()) {
-        const int cooldown_seconds = std::clamp(*remaining, 3, 20);
-        const auto cooldown_deadline{MockableSteadyClock::now() + std::chrono::seconds{cooldown_seconds}};
-
-        {
-            WAIT_LOCK(kernel_notifications.m_tip_block_mutex, lock);
-            kernel_notifications.m_tip_block_cv.wait_until(lock, cooldown_deadline, [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
-                const auto tip_block = kernel_notifications.TipBlock();
-                return chainman.m_interrupt || interrupt_mining || (tip_block && *tip_block != last_tip_hash);
-            });
-            if (chainman.m_interrupt || interrupt_mining) {
-                interrupt_mining = false;
-                return false;
-            }
-
-            // If the tip changed during the wait, extend the deadline
-            const auto tip_block = kernel_notifications.TipBlock();
-            if (tip_block && *tip_block != last_tip_hash) {
-                last_tip_hash = *tip_block;
-                continue;
-            }
-        }
-
-        // No tip change and the cooldown window has expired.
-        if (MockableSteadyClock::now() >= cooldown_deadline) break;
-    }
-
-    return true;
-}
-
-std::optional<BlockRef> WaitTipChanged(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt)
-{
-    Assume(timeout >= 0ms); // No internal callers should use a negative timeout
-    if (timeout < 0ms) timeout = 0ms;
-    if (timeout > std::chrono::years{100}) timeout = std::chrono::years{100}; // Upper bound to avoid UB in std::chrono
-    auto deadline{std::chrono::steady_clock::now() + timeout};
-    {
-        WAIT_LOCK(kernel_notifications.m_tip_block_mutex, lock);
-        // For callers convenience, wait longer than the provided timeout
-        // during startup for the tip to be non-null. That way this function
-        // always returns valid tip information when possible and only
-        // returns null when shutting down, not when timing out.
-        kernel_notifications.m_tip_block_cv.wait(lock, [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
-            return kernel_notifications.TipBlock() || chainman.m_interrupt || interrupt;
-        });
-        if (chainman.m_interrupt || interrupt) {
-            interrupt = false;
-            return {};
-        }
-        // At this point TipBlock is set, so continue to wait until it is
-        // different then `current_tip` provided by caller.
-        kernel_notifications.m_tip_block_cv.wait_until(lock, deadline, [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
-            return Assume(kernel_notifications.TipBlock()) != current_tip || chainman.m_interrupt || interrupt;
-        });
-        if (chainman.m_interrupt || interrupt) {
-            interrupt = false;
-            return {};
-        }
-    }
-
-    // Must release m_tip_block_mutex before getTip() locks cs_main, to
-    // avoid deadlocks.
-    return GetTip(chainman);
 }
 
 } // namespace node

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -133,6 +133,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     CBlockIndex* pindexPrev = m_chainstate.m_chain.Tip();
     assert(pindexPrev != nullptr);
     nHeight = pindexPrev->nHeight + 1;
+    pblocktemplate->m_height = nHeight;
 
     pblock->nVersion = m_chainstate.m_chainman.m_versionbitscache.ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
     // -regtest only: allow overriding block.nVersion with
@@ -143,6 +144,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
 
     pblock->nTime = TicksSinceEpoch<std::chrono::seconds>(NodeClock::now());
     m_lock_time_cutoff = pindexPrev->GetMedianTimePast();
+    pblocktemplate->m_lock_time_cutoff = m_lock_time_cutoff;
 
     if (m_mempool) {
         LOCK(m_mempool->cs);

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -325,10 +325,15 @@ void BlockAssembler::addChunks()
 
             // This chunk will fit, so add it to the block.
             nConsecutiveFailed = 0;
+            std::vector<Wtxid> chunk_wtxids;
+            chunk_wtxids.reserve(selected_transactions.size());
+            int64_t chunk_weight{0};
             for (const auto& tx : selected_transactions) {
+                chunk_weight += tx.get().GetTxWeight();
                 AddToBlock(tx);
+                chunk_wtxids.emplace_back(tx.get().GetTx().GetWitnessHash());
             }
-            pblocktemplate->m_package_feerates.emplace_back(chunk_feerate_vsize);
+            pblocktemplate->m_template_chunks.push_back({chunk_feerate, std::move(chunk_wtxids), chunk_weight, chunk_sig_ops});
         }
 
         selected_transactions.clear();

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -362,62 +362,6 @@ void AddMerkleRootAndCoinbase(CBlock& block, CTransactionRef coinbase, uint32_t 
     block.fChecked = false;
 }
 
-namespace {
-class SubmitBlockStateCatcher final : public CValidationInterface
-{
-public:
-    uint256 m_hash;
-    bool m_found{false};
-    BlockValidationState m_state;
-
-    explicit SubmitBlockStateCatcher(const uint256& hash) : m_hash{hash} {}
-
-protected:
-    void BlockChecked(const std::shared_ptr<const CBlock>& block, const BlockValidationState& state) override
-    {
-        if (block->GetHash() != m_hash) return;
-        // ProcessNewBlock emits BlockChecked synchronously while holding cs_main,
-        // so SubmitBlock can read these fields after ProcessNewBlock returns
-        // without extra synchronization.
-        m_found = true;
-        m_state = state;
-    }
-};
-} // namespace
-
-bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock>& block, bool* new_block, std::string& reason, std::string& debug)
-{
-    reason.clear();
-    debug.clear();
-
-    // This follows the submitblock RPC's validation-state capture pattern, but
-    // is intentionally kept separate from the RPC implementation. The RPC entry
-    // point decodes hex, formats BIP22/JSONRPC results, and calls
-    // UpdateUncommittedBlockStructures() for legacy witness handling. IPC
-    // callers submit already-formed blocks and need bool + reason/debug
-    // results, while submitSolution() preserves its duplicate-as-success
-    // behavior.
-    auto sc = std::make_shared<SubmitBlockStateCatcher>(block->GetHash());
-    CHECK_NONFATAL(chainman.m_options.signals)->RegisterSharedValidationInterface(sc);
-    bool accepted = chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, /*new_block=*/new_block);
-    CHECK_NONFATAL(chainman.m_options.signals)->UnregisterSharedValidationInterface(sc);
-
-    if (new_block && !*new_block && accepted) {
-        reason = "duplicate";
-    } else if (!sc->m_found) {
-        // A block can be accepted and stored without being connected, for
-        // example if it does not have more work than the current tip. In that
-        // case no BlockChecked callback is emitted, so the validation result is
-        // inconclusive. Mining::submitBlock treats this as an error for mining
-        // clients, but it does not mean the block is invalid.
-        reason = "inconclusive";
-    } else if (!sc->m_state.IsValid()) {
-        reason = sc->m_state.GetRejectReason();
-        debug = sc->m_state.GetDebugMessage();
-    }
-    return accepted;
-}
-
 void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wait)
 {
     LOCK(kernel_notifications.m_tip_block_mutex);

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -29,6 +29,13 @@ struct Params;
 } // namespace Consensus
 namespace node {
 
+struct TemplateChunk {
+    FeePerWeight feerate;
+    std::vector<Wtxid> chunk_wtxids;
+    int64_t weight; //!< Actual serialized weight (may differ from feerate.size which is sigops-adjusted).
+    int64_t sigops_cost;
+};
+
 struct CBlockTemplate
 {
     CBlock block;
@@ -36,9 +43,10 @@ struct CBlockTemplate
     std::vector<CAmount> vTxFees;
     // Sigops per transaction, not including coinbase transaction (unlike CBlock::vtx).
     std::vector<int64_t> vTxSigOpsCost;
-    /* A vector of package fee rates, ordered by the sequence in which
-     * packages are selected for inclusion in the block template.*/
-    std::vector<FeePerVSize> m_package_feerates;
+    /* Chunks included in the block template, ordered by selection sequence.
+     * Each entry records the chunk feerate, unadjusted weight, sigops cost,
+     * and the wtxids of the transactions in the chunk. */
+    std::vector<TemplateChunk> m_template_chunks;
     /*
      * Template containing all coinbase transaction fields that are set by our
      * miner code.

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -13,12 +13,10 @@
 #include <threadsafety.h>
 #include <txmempool.h>
 #include <util/feefrac.h>
-#include <util/time.h>
 
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <string>
 #include <vector>
 
 class CBlockIndex;
@@ -29,15 +27,7 @@ class ChainstateManager;
 namespace Consensus {
 struct Params;
 } // namespace Consensus
-class uint256;
-namespace interfaces {
-struct BlockRef;
-} // namespace interfaces
-
-using interfaces::BlockRef;
-
 namespace node {
-class KernelNotifications;
 
 struct CBlockTemplate
 {
@@ -129,50 +119,6 @@ void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
 /* Compute the block's merkle root, insert or replace the coinbase transaction and the merkle root into the block */
 void AddMerkleRootAndCoinbase(CBlock& block, CTransactionRef coinbase, uint32_t version, uint32_t timestamp, uint32_t nonce);
-
-/* Interrupt a blocking call. */
-void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wait);
-/**
- * Return a new block template when fees rise to a certain threshold or after a
- * new tip; return nullopt if timeout is reached.
- */
-std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainman,
-                                                      KernelNotifications& kernel_notifications,
-                                                      CTxMemPool* mempool,
-                                                      const std::unique_ptr<CBlockTemplate>& block_template,
-                                                      const BlockWaitOptions& wait_options,
-                                                      const BlockCreateOptions& create_options,
-                                                      bool& interrupt_wait);
-
-/* Locks cs_main and returns the block hash and block height of the active chain if it exists; otherwise, returns nullopt.*/
-std::optional<BlockRef> GetTip(ChainstateManager& chainman);
-
-/* Waits for the connected tip to change until timeout has elapsed. During node initialization, this will wait until the tip is connected (regardless of `timeout`).
- * Returns the current tip, or nullopt if the node is shutting down or interrupt()
- * is called.
- */
-std::optional<BlockRef> WaitTipChanged(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const uint256& current_tip, MillisecondsDouble& timeout, bool& interrupt);
-
-/**
- * Wait while the best known header extends the current chain tip AND at least
- * one block is being added to the tip every 3 seconds. If the tip is
- * sufficiently far behind, allow up to 20 seconds for the next tip update.
- *
- * It’s not safe to keep waiting, because a malicious miner could announce a
- * header and delay revealing the block, causing all other miners using this
- * software to stall. At the same time, we need to balance between the default
- * waiting time being brief, but not ending the cooldown prematurely when a
- * random block is slow to download (or process).
- *
- * The cooldown only applies to createNewBlock(), which is typically called
- * once per connected client. Subsequent templates are provided by waitNext().
- *
- * @param last_tip tip at the start of the cooldown window.
- * @param interrupt_mining set to true to interrupt the cooldown.
- *
- * @returns false if interrupted.
- */
-bool CooldownIfHeadersAhead(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const BlockRef& last_tip, bool& interrupt_mining);
 } // namespace node
 
 #endif // BITCOIN_NODE_MINER_H

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -52,6 +52,10 @@ struct CBlockTemplate
      * miner code.
      */
     CoinbaseTx m_coinbase_tx;
+    //! Height of the block template.
+    int m_height{0};
+    //! Median-time-past cutoff used for transaction finality checks.
+    int64_t m_lock_time_cutoff{0};
 };
 
 /** Generate a new block, without valid proof-of-work */

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -130,10 +130,6 @@ void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 /* Compute the block's merkle root, insert or replace the coinbase transaction and the merkle root into the block */
 void AddMerkleRootAndCoinbase(CBlock& block, CTransactionRef coinbase, uint32_t version, uint32_t timestamp, uint32_t nonce);
 
-//! Submit a block and capture the validation state via the BlockChecked callback.
-//! Returns whether ProcessNewBlock accepted the block.
-bool SubmitBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock>& block, bool* new_block, std::string& reason, std::string& debug);
-
 /* Interrupt a blocking call. */
 void InterruptWait(KernelNotifications& kernel_notifications, bool& interrupt_wait);
 /**

--- a/src/node/mining_types.h
+++ b/src/node/mining_types.h
@@ -89,6 +89,7 @@ struct BlockCreateOptions {
      * Should only be disabled for tests / benchmarks.
      */
     bool test_block_validity{true};
+    bool operator==(const BlockCreateOptions&) const = default;
 };
 
 struct BlockWaitOptions {

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -7,6 +7,7 @@
 #include <primitives/transaction.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/hasher.h>
 
 #include <algorithm>
 #include <cassert>
@@ -151,20 +152,9 @@ bool IsChildWithParentsTree(const Package& package)
 uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions)
 {
     // Create a vector of the wtxids.
-    std::vector<Wtxid> wtxids_copy;
-    std::transform(transactions.cbegin(), transactions.cend(), std::back_inserter(wtxids_copy),
+    std::vector<Wtxid> wtxids;
+    std::transform(transactions.cbegin(), transactions.cend(), std::back_inserter(wtxids),
         [](const auto& tx){ return tx->GetWitnessHash(); });
 
-    // Sort in ascending order
-    std::sort(wtxids_copy.begin(), wtxids_copy.end(), [](const auto& lhs, const auto& rhs) {
-        return std::lexicographical_compare(std::make_reverse_iterator(lhs.end()), std::make_reverse_iterator(lhs.begin()),
-                                            std::make_reverse_iterator(rhs.end()), std::make_reverse_iterator(rhs.begin()));
-    });
-
-    // Get sha256 hash of the wtxids concatenated in this order
-    HashWriter hashwriter;
-    for (const auto& wtxid : wtxids_copy) {
-        hashwriter << wtxid;
-    }
-    return hashwriter.GetSHA256();
+    return GetHashFromWitnesses(wtxids);
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -22,11 +22,12 @@
 #include <hash.h>
 #include <index/blockfilterindex.h>
 #include <index/coinstatsindex.h>
-#include <interfaces/mining.h>
+#include <interfaces/types.h>
 #include <kernel/coinstats.h>
 #include <logging/timer.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/transaction.h>
@@ -70,7 +71,6 @@ using kernel::CCoinsStats;
 using kernel::CoinStatsHashType;
 
 using interfaces::BlockRef;
-using interfaces::Mining;
 using node::BlockManager;
 using node::NodeContext;
 using node::SnapshotMetadata;
@@ -326,15 +326,15 @@ static RPCMethod waitfornewblock()
     if (timeout < 0) throw JSONRPCError(RPC_MISC_ERROR, "Negative timeout");
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
-    // If the caller provided a current_tip value, pass it to waitTipChanged().
+    // If the caller provided a current_tip value, pass it to WaitTipChanged().
     //
-    // If the caller did not provide a current tip hash, call getTip() to get
+    // If the caller did not provide a current tip hash, call GetTip() to get
     // one and wait for the tip to be different from this value. This mode is
     // less reliable because if the tip changed between waitfornewblock calls,
     // it will need to change a second time before this call returns.
-    BlockRef current_block{CHECK_NONFATAL(miner.getTip()).value()};
+    BlockRef current_block{CHECK_NONFATAL(block_template_manager.GetTip()).value()};
 
     uint256 tip_hash{request.params[1].isNull()
         ? current_block.hash
@@ -342,8 +342,8 @@ static RPCMethod waitfornewblock()
 
     // If the user provided an invalid current_tip then this call immediately
     // returns the current tip.
-    std::optional<BlockRef> block = timeout ? miner.waitTipChanged(tip_hash, std::chrono::milliseconds(timeout)) :
-                                              miner.waitTipChanged(tip_hash);
+    std::optional<BlockRef> block = timeout ? block_template_manager.WaitTipChanged(tip_hash, std::chrono::milliseconds(timeout)) :
+                                              block_template_manager.WaitTipChanged(tip_hash);
 
     // Return current block upon shutdown
     if (block) current_block = *block;
@@ -388,10 +388,10 @@ static RPCMethod waitforblock()
     if (timeout < 0) throw JSONRPCError(RPC_MISC_ERROR, "Negative timeout");
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
     // Abort if RPC came out of warmup too early
-    BlockRef current_block{CHECK_NONFATAL(miner.getTip()).value()};
+    BlockRef current_block{CHECK_NONFATAL(block_template_manager.GetTip()).value()};
 
     const auto deadline{std::chrono::steady_clock::now() + 1ms * timeout};
     while (current_block.hash != hash) {
@@ -400,9 +400,9 @@ static RPCMethod waitforblock()
             auto now{std::chrono::steady_clock::now()};
             if (now >= deadline) break;
             const MillisecondsDouble remaining{deadline - now};
-            block = miner.waitTipChanged(current_block.hash, remaining);
+            block = block_template_manager.WaitTipChanged(current_block.hash, remaining);
         } else {
-            block = miner.waitTipChanged(current_block.hash);
+            block = block_template_manager.WaitTipChanged(current_block.hash);
         }
         // Return current block upon shutdown
         if (!block) break;
@@ -450,10 +450,10 @@ static RPCMethod waitforblockheight()
     if (timeout < 0) throw JSONRPCError(RPC_MISC_ERROR, "Negative timeout");
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
     // Abort if RPC came out of warmup too early
-    BlockRef current_block{CHECK_NONFATAL(miner.getTip()).value()};
+    BlockRef current_block{CHECK_NONFATAL(block_template_manager.GetTip()).value()};
 
     const auto deadline{std::chrono::steady_clock::now() + 1ms * timeout};
 
@@ -463,9 +463,9 @@ static RPCMethod waitforblockheight()
             auto now{std::chrono::steady_clock::now()};
             if (now >= deadline) break;
             const MillisecondsDouble remaining{deadline - now};
-            block = miner.waitTipChanged(current_block.hash, remaining);
+            block = block_template_manager.WaitTipChanged(current_block.hash, remaining);
         } else {
-            block = miner.waitTipChanged(current_block.hash);
+            block = block_template_manager.WaitTipChanged(current_block.hash);
         }
         // Return current block on shutdown
         if (!block) break;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -23,6 +23,7 @@
 #include <key_io.h>
 #include <net.h>
 #include <netbase.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/miner.h>
@@ -502,7 +503,7 @@ static RPCMethod getmininginfo()
     obj.pushKV("target", GetTarget(tip, chainman.GetConsensus().powLimit).GetHex());
     obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
     obj.pushKV("pooledtx", mempool.size());
-    const auto mining_options{node::FlattenMiningOptions(node.mining_args)};
+    const auto mining_options{node::FlattenMiningOptions(CHECK_NONFATAL(node.block_template_manager)->GetInitBlockCreateOptions())};
     obj.pushKV("blockmintxfee", ValueFromAmount(CHECK_NONFATAL(mining_options.block_min_fee_rate)->GetFeePerK()));
     obj.pushKV("chain", chainman.GetParams().GetChainTypeString());
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -5,7 +5,6 @@
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
-#include <interfaces/mining.h>
 
 #include <addresstype.h>
 #include <arith_uint256.h>
@@ -79,8 +78,6 @@
 #include <vector>
 
 using interfaces::BlockRef;
-using interfaces::BlockTemplate;
-using interfaces::Mining;
 using node::BlockAssembler;
 using node::GetMinimumTime;
 using node::NodeContext;
@@ -193,15 +190,15 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock&& block, uint64_t&
     return true;
 }
 
-static UniValue generateBlocks(ChainstateManager& chainman, Mining& miner, const CScript& coinbase_output_script, int nGenerate, uint64_t nMaxTries)
+static UniValue generateBlocks(ChainstateManager& chainman, node::BlockTemplateManager& block_template_manager, const CScript& coinbase_output_script, int nGenerate, uint64_t nMaxTries)
 {
     UniValue blockHashes(UniValue::VARR);
     while (nGenerate > 0 && !chainman.m_interrupt) {
-        std::unique_ptr<BlockTemplate> block_template(miner.createNewBlock({ .coinbase_output_script = coinbase_output_script }, /*cooldown=*/false));
+        std::unique_ptr<node::CBlockTemplate> block_template{block_template_manager.CreateNewTemplate({.coinbase_output_script = coinbase_output_script})};
         CHECK_NONFATAL(block_template);
 
         std::shared_ptr<const CBlock> block_out;
-        if (!GenerateBlock(chainman, block_template->getBlock(), nMaxTries, block_out, /*process_new_block=*/true)) {
+        if (!GenerateBlock(chainman, CBlock{block_template->block}, nMaxTries, block_out, /*process_new_block=*/true)) {
             break;
         }
 
@@ -278,10 +275,10 @@ static RPCMethod generatetodescriptor()
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
     ChainstateManager& chainman = EnsureChainman(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
-    return generateBlocks(chainman, miner, coinbase_output_script, num_blocks, max_tries);
+    return generateBlocks(chainman, block_template_manager, coinbase_output_script, num_blocks, max_tries);
 },
     };
 }
@@ -324,12 +321,12 @@ static RPCMethod generatetoaddress()
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
     ChainstateManager& chainman = EnsureChainman(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
     CScript coinbase_output_script = GetScriptForDestination(destination);
 
-    return generateBlocks(chainman, miner, coinbase_output_script, num_blocks, max_tries);
+    return generateBlocks(chainman, block_template_manager, coinbase_output_script, num_blocks, max_tries);
 },
     };
 }
@@ -377,7 +374,7 @@ static RPCMethod generateblock()
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
     const CTxMemPool& mempool = EnsureMemPool(node);
 
     std::vector<CTransactionRef> txs;
@@ -409,10 +406,10 @@ static RPCMethod generateblock()
     {
         LOCK(chainman.GetMutex());
         {
-            std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({.use_mempool = false, .coinbase_output_script = coinbase_output_script}, /*cooldown=*/false)};
+            std::unique_ptr<node::CBlockTemplate> block_template{block_template_manager.CreateNewTemplate({.use_mempool = false, .coinbase_output_script = coinbase_output_script})};
             CHECK_NONFATAL(block_template);
 
-            block = block_template->getBlock();
+            block = block_template->block;
         }
 
         CHECK_NONFATAL(block.vtx.size() == 1);
@@ -503,7 +500,7 @@ static RPCMethod getmininginfo()
     obj.pushKV("target", GetTarget(tip, chainman.GetConsensus().powLimit).GetHex());
     obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
     obj.pushKV("pooledtx", mempool.size());
-    const auto mining_options{node::FlattenMiningOptions(CHECK_NONFATAL(node.block_template_manager)->GetInitBlockCreateOptions())};
+    const auto mining_options{node::FlattenMiningOptions(EnsureBlockTemplateManager(node).GetInitBlockCreateOptions())};
     obj.pushKV("blockmintxfee", ValueFromAmount(CHECK_NONFATAL(mining_options.block_min_fee_rate)->GetFeePerK()));
     obj.pushKV("chain", chainman.GetParams().GetChainTypeString());
 
@@ -739,7 +736,7 @@ static RPCMethod getblocktemplate()
 {
     NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
-    Mining& miner = EnsureMining(node);
+    node::BlockTemplateManager& block_template_manager = EnsureBlockTemplateManager(node);
 
     std::string strMode = "template";
     UniValue lpval = NullUniValue;
@@ -794,13 +791,13 @@ static RPCMethod getblocktemplate()
     if (strMode != "template")
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
 
-    if (!miner.isTestChain()) {
+    if (!chainman.GetParams().IsTestChain()) {
         const CConnman& connman = EnsureConnman(node);
         if (connman.GetNodeCount(ConnectionDirection::Both) == 0) {
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, CLIENT_NAME " is not connected!");
         }
 
-        if (miner.isInitialBlockDownload()) {
+        if (chainman.IsInitialBlockDownload()) {
             throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, CLIENT_NAME " is in initial sync and waiting for blocks...");
         }
     }
@@ -809,7 +806,7 @@ static RPCMethod getblocktemplate()
     const CTxMemPool& mempool = EnsureMemPool(node);
 
     WAIT_LOCK(cs_main, cs_main_lock);
-    uint256 tip{CHECK_NONFATAL(miner.getTip()).value().hash};
+    uint256 tip{CHECK_NONFATAL(block_template_manager.GetTip()).value().hash};
 
     // Long Polling (BIP22)
     if (!lpval.isNull()) {
@@ -854,7 +851,7 @@ static RPCMethod getblocktemplate()
             while (IsRPCRunning()) {
                 // If hashWatchedChain is not a real block hash, this will
                 // return immediately.
-                std::optional<BlockRef> maybe_tip{miner.waitTipChanged(hashWatchedChain, checktxtime)};
+                std::optional<BlockRef> maybe_tip{block_template_manager.WaitTipChanged(hashWatchedChain, checktxtime)};
                 // Node is shutting down
                 if (!maybe_tip) break;
                 tip = maybe_tip->hash;
@@ -868,7 +865,7 @@ static RPCMethod getblocktemplate()
                 checktxtime = std::chrono::seconds(10);
             }
         }
-        tip = CHECK_NONFATAL(miner.getTip()).value().hash;
+        tip = CHECK_NONFATAL(block_template_manager.GetTip()).value().hash;
 
         if (!IsRPCRunning())
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Shutting down");
@@ -890,7 +887,7 @@ static RPCMethod getblocktemplate()
     // Update block
     static CBlockIndex* pindexPrev;
     static int64_t time_start;
-    static std::unique_ptr<BlockTemplate> block_template;
+    static std::unique_ptr<node::CBlockTemplate> block_template;
     if (!pindexPrev || pindexPrev->GetBlockHash() != tip ||
         (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - time_start > 5))
     {
@@ -906,7 +903,7 @@ static RPCMethod getblocktemplate()
         // a delay to each getblocktemplate call. This differs from typical
         // long-lived IPC usage, where the overhead is paid only when creating
         // the initial template.
-        block_template = miner.createNewBlock({}, /*cooldown=*/false);
+        block_template = block_template_manager.CreateNewTemplate({});
         CHECK_NONFATAL(block_template);
 
 
@@ -914,7 +911,7 @@ static RPCMethod getblocktemplate()
         pindexPrev = pindexPrevNew;
     }
     CHECK_NONFATAL(pindexPrev);
-    CBlock block{block_template->getBlock()};
+    CBlock block{block_template->block};
 
     // Update nTime
     UpdateTime(&block, consensusParams, pindexPrev);
@@ -927,8 +924,8 @@ static RPCMethod getblocktemplate()
 
     UniValue transactions(UniValue::VARR);
     std::map<Txid, int64_t> setTxIndex;
-    std::vector<CAmount> tx_fees{block_template->getTxFees()};
-    std::vector<int64_t> tx_sigops{block_template->getTxSigops()};
+    std::vector<CAmount> tx_fees{block_template->vTxFees};
+    std::vector<int64_t> tx_sigops{block_template->vTxSigOpsCost};
 
     int i = 0;
     for (const auto& it : block.vtx) {
@@ -1056,7 +1053,7 @@ static RPCMethod getblocktemplate()
         result.pushKV("signet_challenge", HexStr(consensusParams.signet_challenge));
     }
 
-    if (auto coinbase{block_template->getCoinbaseTx()}; coinbase.required_outputs.size() > 0) {
+    if (auto coinbase{block_template->m_coinbase_tx}; coinbase.required_outputs.size() > 0) {
         CHECK_NONFATAL(coinbase.required_outputs.size() == 1); // Only one output is currently expected
         result.pushKV("default_witness_commitment", HexStr(coinbase.required_outputs[0].scriptPubKey));
     }

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -7,6 +7,7 @@
 #include <chain.h>
 #include <common/args.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
 #include <node/context.h>
 #include <node/miner.h>
 #include <policy/fees/block_policy_estimator.h>
@@ -105,12 +106,12 @@ CConnman& EnsureConnman(const NodeContext& node)
     return *node.connman;
 }
 
-interfaces::Mining& EnsureMining(const NodeContext& node)
+node::BlockTemplateManager& EnsureBlockTemplateManager(const NodeContext& node)
 {
-    if (!node.mining) {
-        throw JSONRPCError(RPC_INTERNAL_ERROR, "Node miner not found");
+    if (!node.block_template_manager) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Block template manager not found");
     }
-    return *node.mining;
+    return *node.block_template_manager;
 }
 
 PeerManager& EnsurePeerman(const NodeContext& node)

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -20,10 +20,8 @@ class PeerManager;
 class BanMan;
 namespace node {
 struct NodeContext;
+class BlockTemplateManager;
 } // namespace node
-namespace interfaces {
-class Mining;
-} // namespace interfaces
 
 node::NodeContext& EnsureAnyNodeContext(const std::any& context);
 CTxMemPool& EnsureMemPool(const node::NodeContext& node);
@@ -37,7 +35,7 @@ ChainstateManager& EnsureAnyChainman(const std::any& context);
 CBlockPolicyEstimator& EnsureFeeEstimator(const node::NodeContext& node);
 CBlockPolicyEstimator& EnsureAnyFeeEstimator(const std::any& context);
 CConnman& EnsureConnman(const node::NodeContext& node);
-interfaces::Mining& EnsureMining(const node::NodeContext& node);
+node::BlockTemplateManager& EnsureBlockTemplateManager(const node::NodeContext& node);
 PeerManager& EnsurePeerman(const node::NodeContext& node);
 AddrMan& EnsureAddrman(const node::NodeContext& node);
 AddrMan& EnsureAnyAddrman(const std::any& context);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(test_bitcoin
   key_tests.cpp
   logging_tests.cpp
   mempool_tests.cpp
+  mempool_update_tests.cpp
   merkle_tests.cpp
   merkleblock_tests.cpp
   miner_tests.cpp

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -9,6 +9,7 @@
 #include <streams.h>
 #include <test/util/random.h>
 #include <test/util/txmempool.h>
+#include <validationinterface.h>
 
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
@@ -67,8 +68,9 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
     auto rand_ctx(FastRandomContext(uint256{42}));
     CBlock block(BuildBlockTestCase(rand_ctx));
 
-    LOCK2(cs_main, pool.cs);
     TryAddToMempool(pool, entry.FromTx(block.vtx[2]));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    LOCK2(cs_main, pool.cs);
     BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
 
     // Do a simple ShortTxIDs RT
@@ -151,8 +153,9 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
     auto rand_ctx(FastRandomContext(uint256{42}));
     CBlock block(BuildBlockTestCase(rand_ctx));
 
-    LOCK2(cs_main, pool.cs);
     TryAddToMempool(pool, entry.FromTx(block.vtx[2]));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    LOCK2(cs_main, pool.cs);
     BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
 
     Txid txhash;
@@ -222,8 +225,9 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
     auto rand_ctx(FastRandomContext(uint256{42}));
     CBlock block(BuildBlockTestCase(rand_ctx));
 
-    LOCK2(cs_main, pool.cs);
     TryAddToMempool(pool, entry.FromTx(block.vtx[1]));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    LOCK2(cs_main, pool.cs);
     BOOST_CHECK_EQUAL(pool.get(block.vtx[1]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
 
     Txid txhash;
@@ -322,8 +326,9 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
     std::vector<std::pair<Wtxid, CTransactionRef>> extra_txn;
     extra_txn.resize(10);
 
-    LOCK2(cs_main, pool.cs);
     TryAddToMempool(pool, entry.FromTx(block.vtx[2]));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    LOCK2(cs_main, pool.cs);
     BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 0);
     // Ensure the non_block_tx is actually not in the block
     for (const auto &block_tx : block.vtx) {

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -10,9 +10,10 @@
 #include <index/base.h>
 #include <index/blockfilterindex.h>
 #include <interfaces/chain.h>
-#include <interfaces/mining.h>
 #include <key.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -89,12 +90,12 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     const std::vector<CMutableTransaction>& txns,
     const CScript& scriptPubKey)
 {
-    auto mining{interfaces::MakeMining(m_node)};
-    auto block_template{mining->createNewBlock({
+    auto& block_template_manager{*Assert(m_node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({
         .coinbase_output_script = scriptPubKey,
-    }, /*cooldown=*/false)};
+    })};
     BOOST_REQUIRE(block_template);
-    CBlock block{block_template->getBlock()};
+    CBlock block{block_template->block};
     block.hashPrevBlock = prev->GetBlockHash();
     block.nTime = prev->nTime + 1;
 

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(fuzz
   block_index.cpp
   block_index_tree.cpp
   blockfilter.cpp
+  blocktemplatemanager.cpp
   bloom_filter.cpp
   buffered_file.cpp
   chain.cpp

--- a/src/test/fuzz/blocktemplatemanager.cpp
+++ b/src/test/fuzz/blocktemplatemanager.cpp
@@ -5,7 +5,9 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
+#include <kernel/chain.h>
 #include <kernel/mempool_entry.h>
+#include <kernel/types.h>
 #include <node/block_template_manager.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
@@ -20,10 +22,15 @@
 #include <test/util/setup_common.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
+#include <util/feefrac.h>
+#include <util/hasher.h>
+#include <util/time.h>
+#include <validationinterface.h>
 
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <optional>
 
 using node::BlockCreateOptions;
@@ -58,69 +65,218 @@ void PopulateRandTransactionsToMempool(FuzzedDataProvider& fuzzed_data_provider,
 FUZZ_TARGET(block_template_manager, .init = initialize_block_template_manager)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    // Keep template creation from consuming bytes needed by the state machine.
+    FuzzedDataProvider template_creation_provider{buffer.data(), buffer.size()};
     const auto& node = g_setup->m_node;
     auto& block_template_manager = *Assert(node.block_template_manager);
     auto& mempool = *Assert(node.mempool);
     SeedRandomStateForTest(SeedRand::ZEROS);
     SetMockTime(WITH_LOCK(node.chainman->GetMutex(),
                           return node.chainman->ActiveTip()->Time()));
+    node.validation_signals->SyncWithValidationInterfaceQueue();
+    const auto chain_tip = WITH_LOCK(node.chainman->GetMutex(), return node.chainman->ActiveTip());
+    const auto block = std::make_shared<const CBlock>();
+    node.validation_signals->BlockConnected(kernel::ChainstateRole{}, block, chain_tip);
+    node.validation_signals->SyncWithValidationInterfaceQueue();
     {
         LOCK(mempool.cs);
         mempool.TrimToSize(0);
     }
-    int weight_budget = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, DEFAULT_BLOCK_MAX_WEIGHT * 10);
-    PopulateRandTransactionsToMempool(fuzzed_data_provider, mempool, weight_budget);
-    LIMITED_WHILE(fuzzed_data_provider.remaining_bytes() > 0, 10)
-    {
-        BlockCreateOptions options;
-        options.test_block_validity = false;
-        if (fuzzed_data_provider.ConsumeBool()) {
-            options.use_mempool = fuzzed_data_provider.ConsumeBool();
-        }
-        if (fuzzed_data_provider.ConsumeBool()) {
-            options.block_reserved_weight = fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(
-                MINIMUM_BLOCK_RESERVED_WEIGHT, DEFAULT_BLOCK_RESERVED_WEIGHT);
-        }
-        if (fuzzed_data_provider.ConsumeBool()) {
-            const CAmount fee_amount = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, COIN);
-            const int32_t fee_size = fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(1, MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR);
-            options.block_min_fee_rate = CFeeRate(fee_amount, fee_size);
-        }
-        if (fuzzed_data_provider.ConsumeBool()) {
-            const uint64_t reserved = options.block_reserved_weight.value_or(DEFAULT_BLOCK_RESERVED_WEIGHT);
-            options.block_max_weight = fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(reserved, DEFAULT_BLOCK_MAX_WEIGHT);
-        }
-        if (fuzzed_data_provider.ConsumeBool()) {
-            options.print_modified_fee = fuzzed_data_provider.ConsumeBool();
-        }
-        if (fuzzed_data_provider.ConsumeBool()) {
-            options.coinbase_output_max_additional_sigops = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, MAX_BLOCK_SIGOPS_COST);
-        }
-        if (fuzzed_data_provider.ConsumeBool()) {
-            options.coinbase_output_script = ConsumeScript(fuzzed_data_provider);
-        }
-        auto block_template = block_template_manager.CreateNewTemplate(options);
-        assert(block_template);
-        const auto resolved{node::FlattenMiningOptions(node::MergeMiningOptions(options, block_template_manager.GetInitBlockCreateOptions()))};
-        const CBlock& block{block_template->block};
-        // Coinbase is first; the per-tx vectors exclude it and track the block.
-        assert(!block.vtx.empty() && block.vtx[0]->IsCoinBase());
-        assert(block_template->vTxFees.size() == block.vtx.size() - 1);
-        assert(block_template->vTxSigOpsCost.size() == block.vtx.size() - 1);
-        // Reserved weight plus selected transactions stays within the limit. The
-        // coinbase is covered by the reserved weight, so it is not counted here.
-        uint64_t weight{*resolved.block_reserved_weight};
-        for (size_t i{1}; i < block.vtx.size(); ++i)
-            weight += GetTransactionWeight(*block.vtx[i]);
-        assert(weight <= *resolved.block_max_weight);
-        // Reserved coinbase sigops plus selected transactions stays within the limit.
-        int64_t sigops = resolved.coinbase_output_max_additional_sigops;
-        for (const int64_t tx_sigops : block_template->vTxSigOpsCost)
-            sigops += tx_sigops;
-        assert(sigops <= MAX_BLOCK_SIGOPS_COST);
-        // Tracked fees are non-negative; without the mempool only the coinbase is included.
-        for (const CAmount fee : block_template->vTxFees)
-            assert(fee >= 0);
-        if (!resolved.use_mempool) assert(block.vtx.size() == 1);
+    const int weight_budget = template_creation_provider.ConsumeIntegralInRange<int>(0, DEFAULT_BLOCK_MAX_WEIGHT * 10);
+    PopulateRandTransactionsToMempool(template_creation_provider, mempool, weight_budget);
+
+    BlockCreateOptions options;
+    options.test_block_validity = false;
+    if (template_creation_provider.ConsumeBool()) {
+        options.use_mempool = template_creation_provider.ConsumeBool();
     }
+    if (template_creation_provider.ConsumeBool()) {
+        options.block_reserved_weight = template_creation_provider.ConsumeIntegralInRange<uint64_t>(
+            MINIMUM_BLOCK_RESERVED_WEIGHT, DEFAULT_BLOCK_RESERVED_WEIGHT);
+    }
+    if (template_creation_provider.ConsumeBool()) {
+        const CAmount fee_amount = template_creation_provider.ConsumeIntegralInRange<CAmount>(0, COIN);
+        const int32_t fee_size = template_creation_provider.ConsumeIntegralInRange<int32_t>(1, MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR);
+        options.block_min_fee_rate = CFeeRate(fee_amount, fee_size);
+    }
+    if (template_creation_provider.ConsumeBool()) {
+        const uint64_t reserved = options.block_reserved_weight.value_or(DEFAULT_BLOCK_RESERVED_WEIGHT);
+        options.block_max_weight = template_creation_provider.ConsumeIntegralInRange<uint64_t>(reserved, DEFAULT_BLOCK_MAX_WEIGHT);
+    }
+    if (template_creation_provider.ConsumeBool()) {
+        options.print_modified_fee = template_creation_provider.ConsumeBool();
+    }
+    if (template_creation_provider.ConsumeBool()) {
+        options.coinbase_output_max_additional_sigops = template_creation_provider.ConsumeIntegralInRange<size_t>(0, MAX_BLOCK_SIGOPS_COST);
+    }
+    if (template_creation_provider.ConsumeBool()) {
+        options.coinbase_output_script = ConsumeScript(template_creation_provider);
+    }
+    auto block_template = block_template_manager.CreateNewTemplate(options);
+    assert(block_template);
+    const auto resolved{node::FlattenMiningOptions(node::MergeMiningOptions(options, block_template_manager.GetInitBlockCreateOptions()))};
+    const CBlock& template_block{block_template->block};
+    // Coinbase is first; the per-tx vectors exclude it and track the block.
+    assert(!template_block.vtx.empty() && template_block.vtx[0]->IsCoinBase());
+    assert(block_template->vTxFees.size() == template_block.vtx.size() - 1);
+    assert(block_template->vTxSigOpsCost.size() == template_block.vtx.size() - 1);
+    // Reserved weight plus selected transactions stays within the limit. The
+    // coinbase is covered by the reserved weight, so it is not counted here.
+    uint64_t weight{*resolved.block_reserved_weight};
+    for (size_t i{1}; i < template_block.vtx.size(); ++i) {
+        weight += GetTransactionWeight(*template_block.vtx[i]);
+    }
+    assert(weight <= *resolved.block_max_weight);
+    // Reserved coinbase sigops plus selected transactions stays within the limit.
+    int64_t sigops = resolved.coinbase_output_max_additional_sigops;
+    for (const int64_t tx_sigops : block_template->vTxSigOpsCost) {
+        sigops += tx_sigops;
+    }
+    assert(sigops <= MAX_BLOCK_SIGOPS_COST);
+    // Tracked fees are non-negative; without the mempool only the coinbase is included.
+    for (const CAmount fee : block_template->vTxFees) {
+        assert(fee >= 0);
+    }
+    if (!resolved.use_mempool) assert(template_block.vtx.size() == 1);
+
+    // Use an empty mempool so fee inflow can be modeled independently.
+    {
+        LOCK(mempool.cs);
+        mempool.TrimToSize(0);
+    }
+    node.validation_signals->SyncWithValidationInterfaceQueue();
+    node.validation_signals->BlockConnected(kernel::ChainstateRole{}, block, chain_tip);
+    node.validation_signals->SyncWithValidationInterfaceQueue();
+
+    BlockCreateOptions staleness_options;
+    staleness_options.test_block_validity = false;
+    // Model the public staleness state independently from TemplateSnapshot.
+    // tracked_template_id keys the lookups.
+    uint64_t tracked_template_id{0};
+    uint256 tracked_tip_hash;
+    bool expect_tracking{false};
+    std::map<uint256, CAmount> expected_chunk_fees;
+    CAmount expected_fee_inflow{0};
+    CAmount previous_fee_threshold{0};
+
+    const auto clear_expected_tracking = [&] {
+        expect_tracking = false;
+        expected_chunk_fees.clear();
+        expected_fee_inflow = 0;
+    };
+    const auto start_tracking = [&] {
+        const auto new_template = block_template_manager.CreateNewTemplate(staleness_options, &tracked_template_id);
+        // The empty mempool makes every accepted chunk post-creation fee inflow.
+        assert(new_template && new_template->m_template_chunks.empty());
+        tracked_tip_hash = new_template->block.hashPrevBlock;
+        expect_tracking = true;
+        expected_chunk_fees.clear();
+        expected_fee_inflow = 0;
+    };
+    const auto assert_staleness = [&](CAmount fee_threshold) {
+        const bool expected_stale = expect_tracking && expected_fee_inflow >= fee_threshold;
+        assert(block_template_manager.IsTrackingFeeInflow(tracked_template_id) == expect_tracking);
+        assert(block_template_manager.IsStale(staleness_options, tracked_template_id, fee_threshold) == expected_stale);
+        assert(!block_template_manager.IsStale(staleness_options, /*template_id=*/0, fee_threshold));
+        BlockCreateOptions different_options{staleness_options};
+        different_options.use_mempool = !different_options.use_mempool;
+        assert(!block_template_manager.IsStale(different_options, tracked_template_id, fee_threshold));
+    };
+    const auto update_mempool = [&] {
+        const uint8_t transaction_nonce = fuzzed_data_provider.ConsumeIntegral<uint8_t>();
+        CMutableTransaction mutable_tx;
+        mutable_tx.version = 2;
+        mutable_tx.vout.emplace_back(0, CScript{} << OP_RETURN << int64_t{transaction_nonce});
+        const auto tx = MakeTransactionRef(std::move(mutable_tx));
+        const auto fee = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(1, COIN);
+        const FeePerWeight feerate{fee, 1};
+        const uint256 chunk_hash = GetHashFromWitnesses({tx->GetWitnessHash()});
+        const bool remove_chunk = fuzzed_data_provider.ConsumeBool();
+        const bool add_chunk = fuzzed_data_provider.ConsumeBool();
+        const auto removal_reason = fuzzed_data_provider.PickValueInArray({
+            MemPoolRemovalReason::EXPIRY,
+            MemPoolRemovalReason::SIZELIMIT,
+            MemPoolRemovalReason::REORG,
+            MemPoolRemovalReason::BLOCK,
+            MemPoolRemovalReason::CONFLICT,
+            MemPoolRemovalReason::REPLACED,
+        });
+        MemPoolChunksUpdate update;
+        update.reason = removal_reason;
+        if (remove_chunk) update.old_chunks.push_back({feerate, {tx}, 0, std::nullopt});
+        if (add_chunk) update.new_chunks.push_back({feerate, {tx}, 0, std::nullopt});
+        node.validation_signals->MempoolUpdated(std::move(update));
+        node.validation_signals->SyncWithValidationInterfaceQueue();
+        // BLOCK and CONFLICT updates are ignored; the corresponding chain
+        // transition prunes templates built on its old tip.
+        if (!expect_tracking ||
+            removal_reason == MemPoolRemovalReason::BLOCK ||
+            removal_reason == MemPoolRemovalReason::CONFLICT) {
+            return;
+        }
+        if (remove_chunk) {
+            if (const auto it = expected_chunk_fees.find(chunk_hash); it != expected_chunk_fees.end()) {
+                expected_fee_inflow -= it->second;
+                expected_chunk_fees.erase(it);
+            }
+        }
+        if (add_chunk && !expected_chunk_fees.contains(chunk_hash)) {
+            expected_fee_inflow += fee;
+            expected_chunk_fees[chunk_hash] = fee;
+        }
+    };
+    const auto stop_or_restart_tracking = [&] {
+        block_template_manager.StopTrackingFeeInflow(tracked_template_id);
+        clear_expected_tracking();
+        if (fuzzed_data_provider.ConsumeBool()) start_tracking();
+    };
+    const auto send_block_notification = [&] {
+        const bool historical = fuzzed_data_provider.ConsumeBool();
+        const bool connect = fuzzed_data_provider.ConsumeBool();
+        CBlock notification_block{*block};
+        if (connect && fuzzed_data_provider.ConsumeBool()) {
+            notification_block.hashPrevBlock = tracked_tip_hash;
+        }
+        const auto notification = std::make_shared<const CBlock>(std::move(notification_block));
+        if (connect) {
+            node.validation_signals->BlockConnected(kernel::ChainstateRole{.historical = historical}, notification, chain_tip);
+        } else {
+            node.validation_signals->BlockDisconnected(notification, chain_tip);
+        }
+        node.validation_signals->SyncWithValidationInterfaceQueue();
+        const uint256 old_tip_hash = connect ? notification->hashPrevBlock : notification->GetHash();
+        if ((!connect || !historical) && tracked_tip_hash == old_tip_hash) clear_expected_tracking();
+    };
+    const auto create_untracked_template = [&] {
+        const auto untracked_template = block_template_manager.CreateNewTemplate(staleness_options);
+        // Untracked templates carry no id; the reserved id 0 is never tracked.
+        assert(untracked_template && !block_template_manager.IsTrackingFeeInflow(0));
+    };
+
+    start_tracking();
+    node.validation_signals->BlockDisconnected(block, chain_tip);
+    node.validation_signals->SyncWithValidationInterfaceQueue();
+    assert(block_template_manager.IsTrackingFeeInflow(tracked_template_id));
+    CBlock matching_connect;
+    matching_connect.hashPrevBlock = tracked_tip_hash;
+    node.validation_signals->BlockConnected(kernel::ChainstateRole{}, std::make_shared<const CBlock>(matching_connect), chain_tip);
+    node.validation_signals->SyncWithValidationInterfaceQueue();
+    clear_expected_tracking();
+    assert(!block_template_manager.IsTrackingFeeInflow(tracked_template_id));
+    start_tracking();
+    LIMITED_WHILE(fuzzed_data_provider.remaining_bytes() > 0, 100)
+    {
+        CallOneOf(fuzzed_data_provider, update_mempool, stop_or_restart_tracking, send_block_notification, create_untracked_template);
+        const CAmount fee_threshold = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, 10 * COIN);
+        assert_staleness(fee_threshold);
+        // Re-query old and exact fee thresholds to ensure IsStale has no query state
+        // and treats equality as sufficient fee inflow.
+        assert_staleness(previous_fee_threshold);
+        assert_staleness(expected_fee_inflow);
+        assert_staleness(expected_fee_inflow + 1);
+        previous_fee_threshold = fee_threshold;
+        block_template_manager.SanityCheck();
+    }
+    node.validation_signals->BlockDisconnected(block, chain_tip);
+    node.validation_signals->SyncWithValidationInterfaceQueue();
 }

--- a/src/test/fuzz/blocktemplatemanager.cpp
+++ b/src/test/fuzz/blocktemplatemanager.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/amount.h>
+#include <consensus/consensus.h>
+#include <consensus/validation.h>
+#include <kernel/mempool_entry.h>
+#include <node/block_template_manager.h>
+#include <node/miner.h>
+#include <node/mining_args.h>
+#include <policy/feerate.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/fuzz/util/mempool.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
+#include <txmempool.h>
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+using node::BlockCreateOptions;
+
+namespace {
+const TestingSetup* g_setup;
+
+void initialize_block_template_manager()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+}
+
+/** Add random transactions to the mempool, bypassing validation. */
+void PopulateRandTransactionsToMempool(FuzzedDataProvider& fuzzed_data_provider, CTxMemPool& mempool, int weight_budget)
+{
+    while (weight_budget > 0 && fuzzed_data_provider.remaining_bytes() > 0) {
+        const std::optional<CMutableTransaction> mutable_tx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider, TX_WITH_WITNESS);
+        if (!mutable_tx) break;
+        auto tx = MakeTransactionRef(*mutable_tx);
+        CTxMemPoolEntry mempool_entry{ConsumeTxMemPoolEntry(fuzzed_data_provider, *tx)};
+        const Txid txid = tx->GetHash();
+        if (mempool.exists(txid)) continue;
+        const int32_t tx_weight = mempool_entry.GetTxWeight();
+        if (tx_weight > weight_budget) break;
+        TryAddToMempool(mempool, mempool_entry);
+        weight_budget -= tx_weight;
+    }
+}
+} // namespace
+
+FUZZ_TARGET(block_template_manager, .init = initialize_block_template_manager)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    const auto& node = g_setup->m_node;
+    auto& block_template_manager = *Assert(node.block_template_manager);
+    auto& mempool = *Assert(node.mempool);
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    SetMockTime(WITH_LOCK(node.chainman->GetMutex(),
+                          return node.chainman->ActiveTip()->Time()));
+    {
+        LOCK(mempool.cs);
+        mempool.TrimToSize(0);
+    }
+    int weight_budget = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, DEFAULT_BLOCK_MAX_WEIGHT * 10);
+    PopulateRandTransactionsToMempool(fuzzed_data_provider, mempool, weight_budget);
+    LIMITED_WHILE(fuzzed_data_provider.remaining_bytes() > 0, 10)
+    {
+        BlockCreateOptions options;
+        options.test_block_validity = false;
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.use_mempool = fuzzed_data_provider.ConsumeBool();
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.block_reserved_weight = fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(
+                MINIMUM_BLOCK_RESERVED_WEIGHT, DEFAULT_BLOCK_RESERVED_WEIGHT);
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            const CAmount fee_amount = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, COIN);
+            const int32_t fee_size = fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(1, MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR);
+            options.block_min_fee_rate = CFeeRate(fee_amount, fee_size);
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            const uint64_t reserved = options.block_reserved_weight.value_or(DEFAULT_BLOCK_RESERVED_WEIGHT);
+            options.block_max_weight = fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(reserved, DEFAULT_BLOCK_MAX_WEIGHT);
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.print_modified_fee = fuzzed_data_provider.ConsumeBool();
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.coinbase_output_max_additional_sigops = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, MAX_BLOCK_SIGOPS_COST);
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            options.coinbase_output_script = ConsumeScript(fuzzed_data_provider);
+        }
+        auto block_template = block_template_manager.CreateNewTemplate(options);
+        assert(block_template);
+        const auto resolved{node::FlattenMiningOptions(node::MergeMiningOptions(options, block_template_manager.GetInitBlockCreateOptions()))};
+        const CBlock& block{block_template->block};
+        // Coinbase is first; the per-tx vectors exclude it and track the block.
+        assert(!block.vtx.empty() && block.vtx[0]->IsCoinBase());
+        assert(block_template->vTxFees.size() == block.vtx.size() - 1);
+        assert(block_template->vTxSigOpsCost.size() == block.vtx.size() - 1);
+        // Reserved weight plus selected transactions stays within the limit. The
+        // coinbase is covered by the reserved weight, so it is not counted here.
+        uint64_t weight{*resolved.block_reserved_weight};
+        for (size_t i{1}; i < block.vtx.size(); ++i)
+            weight += GetTransactionWeight(*block.vtx[i]);
+        assert(weight <= *resolved.block_max_weight);
+        // Reserved coinbase sigops plus selected transactions stays within the limit.
+        int64_t sigops = resolved.coinbase_output_max_additional_sigops;
+        for (const int64_t tx_sigops : block_template->vTxSigOpsCost)
+            sigops += tx_sigops;
+        assert(sigops <= MAX_BLOCK_SIGOPS_COST);
+        // Tracked fees are non-negative; without the mempool only the coinbase is included.
+        for (const CAmount fee : block_template->vTxFees)
+            assert(fee >= 0);
+        if (!resolved.use_mempool) assert(block.vtx.size() == 1);
+    }
+}

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -13,6 +13,7 @@
 #include <net.h>
 #include <net_processing.h>
 #include <netmessagemaker.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/mining_types.h>
 #include <policy/truc_policy.h>
@@ -112,13 +113,16 @@ void ResetChainmanAndMempool(TestingSetup& setup)
     SetMockTime(Params().GenesisBlock().Time());
 
     bilingual_str error{};
-    setup.m_node.mempool.reset();
-    setup.m_node.mempool = std::make_unique<CTxMemPool>(MemPoolOptionsForTest(setup.m_node), error);
+    auto& node = setup.m_node;
+    node.block_template_manager.reset();
+    node.mempool.reset();
+    node.mempool = std::make_unique<CTxMemPool>(MemPoolOptionsForTest(node), error);
     Assert(error.empty());
 
-    setup.m_node.chainman.reset();
+    node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();
+    setup.CreateBlockTemplateManager();
 
     node::BlockCreateOptions options;
     options.coinbase_output_script = P2WSH_OP_TRUE;

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -114,7 +114,7 @@ void ResetChainmanAndMempool(TestingSetup& setup)
 
     bilingual_str error{};
     auto& node = setup.m_node;
-    node.block_template_manager.reset();
+    setup.ResetBlockTemplateManager();
     node.mempool.reset();
     node.mempool = std::make_unique<CTxMemPool>(MemPoolOptionsForTest(node), error);
     Assert(error.empty());

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -67,7 +67,6 @@ void initialize_tx_pool()
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
     SetMockTime(WITH_LOCK(g_setup->m_node.chainman->GetMutex(), return g_setup->m_node.chainman->ActiveTip()->Time()));
-
     for (int i = 0; i < 2 * COINBASE_MATURITY; ++i) {
         COutPoint prevout{MineBlock(g_setup->m_node, {
             .coinbase_output_script = P2WSH_EMPTY,

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -48,7 +48,7 @@ std::string_view LIMIT_TO_MESSAGE_TYPE{};
 void ResetChainman(TestingSetup& setup)
 {
     SetMockTime(setup.m_node.chainman->GetParams().GenesisBlock().Time());
-    setup.m_node.block_template_manager.reset();
+    setup.ResetBlockTemplateManager();
     setup.m_node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -8,6 +8,7 @@
 #include <kernel/chainparams.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
 #include <node/mining_types.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -47,9 +48,12 @@ std::string_view LIMIT_TO_MESSAGE_TYPE{};
 void ResetChainman(TestingSetup& setup)
 {
     SetMockTime(setup.m_node.chainman->GetParams().GenesisBlock().Time());
+    setup.m_node.block_template_manager.reset();
     setup.m_node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();
+    setup.CreateBlockTemplateManager();
+
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
         node::BlockCreateOptions options;
         MineBlock(setup.m_node, options);

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -8,6 +8,7 @@
 #include <kernel/chainparams.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
 #include <node/mining_types.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -41,9 +42,12 @@ TestingSetup* g_setup;
 void ResetChainman(TestingSetup& setup)
 {
     SetMockTime(setup.m_node.chainman->GetParams().GenesisBlock().Time());
+    setup.m_node.block_template_manager.reset();
     setup.m_node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();
+    setup.CreateBlockTemplateManager();
+
     node::BlockCreateOptions options;
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
         MineBlock(setup.m_node, options);

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -42,7 +42,7 @@ TestingSetup* g_setup;
 void ResetChainman(TestingSetup& setup)
 {
     SetMockTime(setup.m_node.chainman->GetParams().GenesisBlock().Time());
-    setup.m_node.block_template_manager.reset();
+    setup.ResetBlockTemplateManager();
     setup.m_node.chainman.reset();
     setup.m_make_chainman();
     setup.LoadVerifyActivateChainstate();

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -79,8 +79,10 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "enumeratesigners",
     "echoipc",              // avoid assertion failure (Assertion `"EnsureAnyNodeContext(request.context).init" && check' failed.)
     "exportasmap",          // avoid writing to disk
+    "generateblock",        // avoid prohibitively slow execution (builds, mines and submits a block)
     "generatetoaddress",    // avoid prohibitively slow execution (when `num_blocks` is large)
     "generatetodescriptor", // avoid prohibitively slow execution (when `nblocks` is large)
+    "getblocktemplate",     // avoid prohibitively slow execution (longpoll blocks until tip change or timeout)
     "gettxoutproof",        // avoid prohibitively slow execution
     "importmempool",        // avoid reading from disk
     "loadtxoutset",         // avoid reading from disk
@@ -88,6 +90,9 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "savemempool",          // disabled as a precautionary measure: may take a file path argument in the future
     "setban",               // avoid DNS lookups
     "stop",                 // avoid shutdown state
+    "waitforblock",         // avoid prohibitively slow execution (blocks until tip change or timeout)
+    "waitforblockheight",   // avoid prohibitively slow execution (blocks until tip change or timeout)
+    "waitfornewblock",      // avoid prohibitively slow execution (blocks until tip change or timeout)
 };
 
 // RPC commands which are safe for fuzzing.
@@ -113,7 +118,6 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "estimatesmartfee",
     "finalizepsbt",
     "generate",
-    "generateblock",
     "getaddednodeinfo",
     "getaddrmaninfo",
     "getbestblockhash",
@@ -125,7 +129,6 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getblockhash",
     "getblockheader",
     "getblockstats",
-    "getblocktemplate",
     "getchaintips",
     "getchainstates",
     "getchaintxstats",
@@ -188,9 +191,6 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "verifychain",
     "verifymessage",
     "verifytxoutproof",
-    "waitforblock",
-    "waitforblockheight",
-    "waitfornewblock",
 };
 
 std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider, bool& good_data)

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -72,7 +72,6 @@ void initialize_tx_pool()
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
     SetMockTime(WITH_LOCK(g_setup->m_node.chainman->GetMutex(), return g_setup->m_node.chainman->ActiveTip()->Time()));
-
     for (int i = 0; i < 2 * COINBASE_MATURITY; ++i) {
         COutPoint prevout{MineBlock(g_setup->m_node, {
             .coinbase_output_script = P2WSH_OP_TRUE,

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -797,8 +797,8 @@ FUZZ_TARGET(txgraph)
             } else if (sims.size() == 2 && !sims[0].IsOversized() && !sims[1].IsOversized() && command-- == 0) {
                 // GetMainStagingDiagrams()
                 auto [real_main_diagram, real_staged_diagram] = real->GetMainStagingDiagrams();
-                auto real_sum_main = std::accumulate(real_main_diagram.begin(), real_main_diagram.end(), FeeFrac{});
-                auto real_sum_staged = std::accumulate(real_staged_diagram.begin(), real_staged_diagram.end(), FeeFrac{});
+                auto real_sum_main = std::accumulate(real_main_diagram.begin(), real_main_diagram.end(), FeeFrac{}, [](auto acc, const auto& next) { return acc + next.feerate; });
+                auto real_sum_staged = std::accumulate(real_staged_diagram.begin(), real_staged_diagram.end(), FeeFrac{}, [](auto acc, const auto& next) { return acc + next.feerate; });
                 auto real_gain = real_sum_staged - real_sum_main;
                 auto sim_gain = sims[1].SumAll() - sims[0].SumAll();
                 // Just check that the total fee gained/lost and size gained/lost according to the
@@ -807,10 +807,10 @@ FUZZ_TARGET(txgraph)
                 assert(sim_gain == real_gain);
                 // Check that the feerates in each diagram are monotonically decreasing.
                 for (size_t i = 1; i < real_main_diagram.size(); ++i) {
-                    assert(ByRatio{real_main_diagram[i]} <= ByRatio{real_main_diagram[i - 1]});
+                    assert(ByRatio{real_main_diagram[i].feerate} <= ByRatio{real_main_diagram[i - 1].feerate});
                 }
                 for (size_t i = 1; i < real_staged_diagram.size(); ++i) {
-                    assert(ByRatio{real_staged_diagram[i]} <= ByRatio{real_staged_diagram[i - 1]});
+                    assert(ByRatio{real_staged_diagram[i].feerate} <= ByRatio{real_staged_diagram[i - 1].feerate});
                 }
                 break;
             } else if (block_builders.size() < 4 && !main_sim.IsOversized() && command-- == 0) {
@@ -1266,34 +1266,45 @@ FUZZ_TARGET(txgraph)
             auto [main_cmp_diagram, stage_cmp_diagram] = real->GetMainStagingDiagrams();
             // Check that the feerates in each diagram are monotonically decreasing.
             for (size_t i = 1; i < main_cmp_diagram.size(); ++i) {
-                assert(ByRatio{main_cmp_diagram[i]} <= ByRatio{main_cmp_diagram[i - 1]});
+                assert(ByRatio{main_cmp_diagram[i].feerate} <= ByRatio{main_cmp_diagram[i - 1].feerate});
             }
             for (size_t i = 1; i < stage_cmp_diagram.size(); ++i) {
-                assert(ByRatio{stage_cmp_diagram[i]} <= ByRatio{stage_cmp_diagram[i - 1]});
+                assert(ByRatio{stage_cmp_diagram[i].feerate} <= ByRatio{stage_cmp_diagram[i - 1].feerate});
             }
             // Treat the diagrams as sets of chunk feerates, and sort them in the same way so that
             // std::set_difference can be used on them below. The exact ordering does not matter
             // here, but it has to be consistent with the one used in main_real_diagram and
             // stage_real_diagram).
-            std::ranges::sort(main_cmp_diagram, std::greater<ByRatioNegSize<FeeFrac>>{});
-            std::ranges::sort(stage_cmp_diagram, std::greater<ByRatioNegSize<FeeFrac>>{});
+            std::ranges::sort(main_cmp_diagram, TxGraph::Chunk::GreaterFeerate{});
+            std::ranges::sort(stage_cmp_diagram, TxGraph::Chunk::GreaterFeerate{});
+            // extract the chunk feerates from main and staging compare diagrams
+            std::vector<FeeFrac> main_cmp_diagram_feerates, stage_cmp_diagram_feerates;
+            main_cmp_diagram_feerates.reserve(main_cmp_diagram.size());
+            stage_cmp_diagram_feerates.reserve(stage_cmp_diagram.size());
+            for (const auto& chunk : main_cmp_diagram) {
+                main_cmp_diagram_feerates.emplace_back(chunk.feerate);
+            }
+            for (const auto& chunk : stage_cmp_diagram) {
+                stage_cmp_diagram_feerates.emplace_back(chunk.feerate);
+            }
             // Find the chunks that appear in main_diagram but are missing from main_cmp_diagram.
             // This is allowed, because GetMainStagingDiagrams omits clusters in main unaffected
             // by staging.
+
             std::vector<FeeFrac> missing_main_cmp;
             std::set_difference(main_real_diagram.begin(), main_real_diagram.end(),
-                                main_cmp_diagram.begin(), main_cmp_diagram.end(),
+                                main_cmp_diagram_feerates.begin(), main_cmp_diagram_feerates.end(),
                                 std::inserter(missing_main_cmp, missing_main_cmp.end()),
                                 std::greater<ByRatioNegSize<FeeFrac>>{});
-            assert(main_cmp_diagram.size() + missing_main_cmp.size() == main_real_diagram.size());
+            assert(main_cmp_diagram_feerates.size() + missing_main_cmp.size() == main_real_diagram.size());
             // Do the same for chunks in stage_diagram missing from stage_cmp_diagram.
             auto stage_real_diagram = get_diagram_fn(TxGraph::Level::TOP);
             std::vector<FeeFrac> missing_stage_cmp;
             std::set_difference(stage_real_diagram.begin(), stage_real_diagram.end(),
-                                stage_cmp_diagram.begin(), stage_cmp_diagram.end(),
+                                stage_cmp_diagram_feerates.begin(), stage_cmp_diagram_feerates.end(),
                                 std::inserter(missing_stage_cmp, missing_stage_cmp.end()),
                                 std::greater<ByRatioNegSize<FeeFrac>>{});
-            assert(stage_cmp_diagram.size() + missing_stage_cmp.size() == stage_real_diagram.size());
+            assert(stage_cmp_diagram_feerates.size() + missing_stage_cmp.size() == stage_real_diagram.size());
             // The missing chunks must be equal across main & staging (otherwise they couldn't have
             // been omitted).
             assert(missing_main_cmp == missing_stage_cmp);

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -8,6 +8,7 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <kernel/coinstats.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/utxo_snapshot.h>
 #include <primitives/block.h>
@@ -211,9 +212,11 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
         Assert(!dirty_chainman);
     }
     if (dirty_chainman) {
+        setup.m_node.block_template_manager.reset();
         setup.m_node.chainman.reset();
         setup.m_make_chainman();
         setup.LoadVerifyActivateChainstate();
+        setup.CreateBlockTemplateManager();
     }
 }
 

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -212,7 +212,7 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
         Assert(!dirty_chainman);
     }
     if (dirty_chainman) {
-        setup.m_node.block_template_manager.reset();
+        setup.ResetBlockTemplateManager();
         setup.m_node.chainman.reset();
         setup.m_make_chainman();
         setup.LoadVerifyActivateChainstate();

--- a/src/test/mempool_update_tests.cpp
+++ b/src/test/mempool_update_tests.cpp
@@ -1,0 +1,535 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kernel/mempool_entry.h>
+#include <kernel/mempool_removal_reason.h>
+#include <random.h>
+#include <test/util/common.h>
+#include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
+#include <txmempool.h>
+#include <util/hasher.h>
+#include <util/time.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <optional>
+
+class MempoolUpdatesListener : public CValidationInterface
+{
+public:
+    std::vector<MemPoolChunksUpdate> updates;
+    void MempoolUpdated(const MemPoolChunksUpdate& update) override { updates.push_back(update); }
+    void Clear() { updates.clear(); }
+};
+
+struct MemPoolUpdateSetup : TestingSetup {
+    MempoolUpdatesListener listener;
+    CTxMemPool& mpool;
+    MemPoolUpdateSetup() : TestingSetup(ChainType::REGTEST), mpool{*Assert(m_node.mempool)}
+    {
+        m_node.validation_signals->RegisterValidationInterface(&listener);
+    }
+    ~MemPoolUpdateSetup()
+    {
+        m_node.validation_signals->UnregisterValidationInterface(&listener);
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(mempool_update_tests, MemPoolUpdateSetup)
+
+static FastRandomContext det_rand{true};
+
+static CMutableTransaction ConstructTx(CAmount value = 1 * COIN, std::optional<COutPoint> prev_out = std::nullopt)
+{
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    if (prev_out) {
+        tx.vin[0].prevout = prev_out.value();
+    } else {
+        tx.vin[0].prevout = COutPoint{Txid::FromUint256(det_rand.rand256()), 0};
+    }
+    tx.vout.resize(1);
+    tx.vout[0].nValue = value;
+    tx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+    return tx;
+}
+
+// Sort wtxids in reverse-byte lexicographic order to match the canonical
+// ordering used by GetHashFromWitnesses when computing chunk hashes.
+static std::vector<Wtxid> ExpectedWitnesses(const std::vector<CMutableTransaction>& txs)
+{
+    std::vector<Wtxid> wtxids;
+    wtxids.reserve(txs.size());
+    for (const auto& tx : txs) {
+        wtxids.emplace_back(CTransaction(tx).GetWitnessHash());
+    }
+    std::sort(wtxids.begin(), wtxids.end(), [](const auto& lhs, const auto& rhs) {
+        return std::lexicographical_compare(
+            std::make_reverse_iterator(lhs.end()), std::make_reverse_iterator(lhs.begin()),
+            std::make_reverse_iterator(rhs.end()), std::make_reverse_iterator(rhs.begin()));
+    });
+    return wtxids;
+}
+
+static std::vector<Wtxid> ChunkWtxids(const MemPoolChunk& chunk)
+{
+    std::vector<Wtxid> wtxids;
+    wtxids.reserve(chunk.m_transactions.size());
+    for (const auto& tx : chunk.m_transactions)
+        wtxids.emplace_back(tx->GetWitnessHash());
+    std::sort(wtxids.begin(), wtxids.end(), [](const auto& a, const auto& b) {
+        return std::lexicographical_compare(
+            std::make_reverse_iterator(a.end()), std::make_reverse_iterator(a.begin()),
+            std::make_reverse_iterator(b.end()), std::make_reverse_iterator(b.begin()));
+    });
+    return wtxids;
+}
+
+static uint256 ExpectedChunkHash(const std::vector<CMutableTransaction>& txs)
+{
+    auto witnesses = ExpectedWitnesses(txs);
+    return GetHashFromWitnesses(witnesses);
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_NormalAddition)
+{
+    TestMemPoolEntryHelper entry;
+    auto tx = ConstructTx();
+    CAmount fee{100};
+    auto tx_entry = entry.Fee(fee).FromTx(tx);
+    int32_t size{tx_entry.GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, tx_entry);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::REPLACED);
+    BOOST_CHECK(update.old_chunks.empty());
+    BOOST_CHECK_EQUAL(update.new_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.new_chunks[0]) == ExpectedWitnesses({tx}));
+    BOOST_CHECK(update.new_chunks[0].m_chunk_hash == ExpectedChunkHash({tx}));
+    BOOST_CHECK(update.new_chunks[0].m_fee_rate == expected_fee_rate);
+    listener.Clear();
+    // Child pays for low-fee parent
+    auto parent_tx = ConstructTx();
+    CAmount parent_fee{100};
+    auto parent_entry = entry.Fee(parent_fee).FromTx(parent_tx);
+    int32_t parent_size{parent_entry.GetAdjustedWeight()};
+    FeeFrac parent_fee_rate{parent_fee, parent_size};
+    // Child spends parent output and pays a high fee, boosting the package.
+    auto child_tx = ConstructTx(1 * COIN, COutPoint{parent_tx.GetHash(), 0});
+    CAmount child_fee{10000};
+    auto child_entry = entry.Fee(child_fee).FromTx(child_tx);
+    int32_t child_size{child_entry.GetAdjustedWeight()};
+    // Once child is added the two txs form a single chunk; fee rate is combined.
+    FeeFrac expected_cpfp_rate{parent_fee + child_fee, parent_size + child_size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, parent_entry);
+        TryAddToMempool(mpool, child_entry);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    // Two signals: one for parent, one for child.
+    BOOST_CHECK_EQUAL(listener.updates.size(), 2U);
+    // After the child is added the chunk merges parent+child
+    const auto& cpfp_update = listener.updates[1];
+    BOOST_CHECK(cpfp_update.reason == MemPoolRemovalReason::REPLACED);
+    BOOST_CHECK_EQUAL(cpfp_update.old_chunks.size(), 1U);
+    const auto& old_chunk = cpfp_update.old_chunks[0];
+    BOOST_CHECK(ChunkWtxids(old_chunk) == ExpectedWitnesses({parent_tx}));
+    BOOST_CHECK(old_chunk.m_chunk_hash == ExpectedChunkHash({parent_tx}));
+    BOOST_CHECK(old_chunk.m_fee_rate == parent_fee_rate);
+    BOOST_CHECK_EQUAL(cpfp_update.new_chunks.size(), 1U);
+    const auto& cpfp_chunk = cpfp_update.new_chunks[0];
+    BOOST_CHECK(ChunkWtxids(cpfp_chunk) == ExpectedWitnesses({parent_tx, child_tx}));
+    BOOST_CHECK(cpfp_chunk.m_chunk_hash == ExpectedChunkHash({parent_tx, child_tx}));
+    BOOST_CHECK(cpfp_chunk.m_fee_rate == expected_cpfp_rate);
+    listener.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_RBFReplacement)
+{
+    TestMemPoolEntryHelper entry;
+    COutPoint shared_input{Txid::FromUint256(det_rand.rand256()), 0};
+    auto original_tx = ConstructTx();
+    original_tx.vin[0].prevout = shared_input;
+    CAmount original_fee{1000};
+    auto original_entry = entry.Fee(original_fee).FromTx(original_tx);
+    FeeFrac expected_original_rate{original_fee, original_entry.GetAdjustedWeight()};
+    // Replacement pays higher fee to satisfy RBF rules.
+    auto replacement_tx = ConstructTx();
+    replacement_tx.vin[0].prevout = shared_input;
+    CAmount replacement_fee{5000};
+    auto replacement_entry = entry.Fee(replacement_fee).FromTx(replacement_tx);
+    FeeFrac expected_replacement_rate{replacement_fee, replacement_entry.GetAdjustedWeight()};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, original_entry);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    {
+        LOCK2(cs_main, mpool.cs);
+        auto changeset = mpool.GetChangeSet();
+        changeset->StageAddition(replacement_entry.GetSharedTx(), replacement_entry.GetFee(), replacement_entry.GetTime().count(),
+                                 replacement_entry.GetHeight(), replacement_entry.GetSequence(), replacement_entry.GetSpendsCoinbase(),
+                                 replacement_entry.GetSigOpCost(), replacement_entry.GetLockPoints());
+        auto conflict_iter = mpool.GetIter(original_entry.GetSharedTx()->GetHash());
+        Assert(conflict_iter.has_value());
+        changeset->StageRemoval(conflict_iter.value());
+        changeset->Apply();
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::REPLACED);
+    // Old diagram: original tx's chunk is gone.
+    BOOST_CHECK_EQUAL(update.old_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.old_chunks[0]) == ExpectedWitnesses({original_tx}));
+    BOOST_CHECK(update.old_chunks[0].m_chunk_hash == ExpectedChunkHash({original_tx}));
+    BOOST_CHECK(update.old_chunks[0].m_fee_rate == expected_original_rate);
+    // New diagram: replacement tx's chunk appears.
+    BOOST_CHECK_EQUAL(update.new_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.new_chunks[0]) == ExpectedWitnesses({replacement_tx}));
+    BOOST_CHECK(update.new_chunks[0].m_chunk_hash == ExpectedChunkHash({replacement_tx}));
+    BOOST_CHECK(update.new_chunks[0].m_fee_rate == expected_replacement_rate);
+    listener.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_ChunkHashDeterminism)
+{
+    TestMemPoolEntryHelper entry;
+    auto tx = ConstructTx();
+    const uint256 expected_hash = ExpectedChunkHash({tx});
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(tx).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    for (int round = 0; round < 2; ++round) {
+        {
+            LOCK2(cs_main, mpool.cs);
+            TryAddToMempool(mpool, entry.Fee(fee).FromTx(tx));
+        }
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+        listener.Clear();
+        {
+            LOCK(mpool.cs);
+            mpool.removeForBlock({MakeTransactionRef(tx)}, /*nBlockHeight=*/1);
+        }
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+        BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+        BOOST_CHECK_EQUAL(listener.updates[0].new_chunks.size(), 0U);
+        BOOST_CHECK_EQUAL(listener.updates[0].old_chunks.size(), 1U);
+        BOOST_CHECK(listener.updates[0].reason == MemPoolRemovalReason::BLOCK);
+        BOOST_CHECK(listener.updates[0].block_height.value() == 1);
+        const auto& chunk = listener.updates[0].old_chunks[0];
+        // Both rounds must produce the same witnesses and hash, matching the expected values.
+        BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({tx}));
+        BOOST_CHECK(chunk.m_chunk_hash == expected_hash);
+        BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_BlockConnection)
+{
+    TestMemPoolEntryHelper entry;
+    // Build a CPFP cluster: low-fee parent + high-fee child.
+    // Together they form one chunk with the combined package fee rate.
+    auto parent_tx = ConstructTx();
+    CAmount parent_fee{100};
+    auto parent_entry = entry.Fee(parent_fee).FromTx(parent_tx);
+    int32_t parent_size{parent_entry.GetAdjustedWeight()};
+    auto child_tx = ConstructTx(1 * COIN, COutPoint{parent_tx.GetHash(), 0});
+    CAmount child_fee{10000};
+    auto child_entry = entry.Fee(child_fee).FromTx(child_tx);
+    int32_t child_size{child_entry.GetAdjustedWeight()};
+    FeeFrac expected_cluster_rate{parent_fee + child_fee, parent_size + child_size};
+    FeeFrac expected_child_solo_rate{child_fee, child_size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, parent_entry);
+        TryAddToMempool(mpool, child_entry);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    // Mine the parent; child remains but is now its own solo chunk.
+    {
+        LOCK(mpool.cs);
+        mpool.removeForBlock({MakeTransactionRef(parent_tx)}, /*nBlockHeight=*/2);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::BLOCK);
+    BOOST_CHECK(listener.updates[0].block_height.value() == 2);
+    // Old diagram: the merged parent+child chunk.
+    BOOST_CHECK_EQUAL(update.old_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.old_chunks[0]) == ExpectedWitnesses({parent_tx, child_tx}));
+    BOOST_CHECK(update.old_chunks[0].m_chunk_hash == ExpectedChunkHash({parent_tx, child_tx}));
+    BOOST_CHECK(update.old_chunks[0].m_fee_rate == expected_cluster_rate);
+
+    // New diagram: child is now a solo chunk with its own fee rate.
+    BOOST_CHECK_EQUAL(update.new_chunks.size(), 1U);
+    BOOST_CHECK(ChunkWtxids(update.new_chunks[0]) == ExpectedWitnesses({child_tx}));
+    BOOST_CHECK(update.new_chunks[0].m_chunk_hash == ExpectedChunkHash({child_tx}));
+    BOOST_CHECK(update.new_chunks[0].m_fee_rate == expected_child_solo_rate);
+
+    BOOST_CHECK(!mpool.exists(parent_tx.GetHash()));
+    BOOST_CHECK(mpool.exists(child_tx.GetHash()));
+    listener.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_BlockConflict)
+{
+    TestMemPoolEntryHelper entry;
+    COutPoint shared_input{Txid::FromUint256(det_rand.rand256()), 0};
+    auto mempool_tx = ConstructTx();
+    mempool_tx.vin[0].prevout = shared_input;
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(mempool_tx).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee).FromTx(mempool_tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+
+    // block_tx spends the same input; evicts mempool_tx as a conflict.
+    auto block_tx = ConstructTx();
+    block_tx.vin[0].prevout = shared_input;
+    block_tx.vout[0].nValue = 9 * COIN / 10;
+    {
+        LOCK(mpool.cs);
+        mpool.removeForBlock({MakeTransactionRef(block_tx)}, /*nBlockHeight=*/3);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    // One BLOCK update (empty staged set) and one CONFLICT update.
+    BOOST_CHECK_EQUAL(listener.updates.size(), 2U);
+    // Conflict notification comes after block.
+    const auto& update = listener.updates[1];
+    const auto& chunk = update.old_chunks[0];
+    BOOST_CHECK(update.new_chunks.empty());
+    BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({mempool_tx}));
+    BOOST_CHECK(chunk.m_chunk_hash == ExpectedChunkHash({mempool_tx}));
+    BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::CONFLICT);
+    BOOST_CHECK(!update.block_height.has_value());
+    BOOST_CHECK(!mpool.exists(mempool_tx.GetHash()));
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_Expiry)
+{
+    TestMemPoolEntryHelper entry;
+    auto old_tx = ConstructTx();
+    auto fresh_tx = ConstructTx();
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(old_tx).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    const auto old_time = Now<NodeSeconds>() - std::chrono::hours(25);
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee).Time(old_time).FromTx(old_tx));
+        TryAddToMempool(mpool, entry.Fee(1000).Time(Now<NodeSeconds>()).FromTx(fresh_tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    {
+        LOCK2(cs_main, mpool.cs);
+        mpool.Expire((Now<NodeSeconds>() - std::chrono::seconds(1)).time_since_epoch());
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK_EQUAL(update.old_chunks.size(), 1U);
+    const auto& chunk = update.old_chunks[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::EXPIRY);
+    BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({old_tx}));
+    BOOST_CHECK(chunk.m_chunk_hash == ExpectedChunkHash({old_tx}));
+    BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    BOOST_CHECK(update.new_chunks.empty());
+    BOOST_CHECK(!mpool.exists(old_tx.GetHash()));
+    BOOST_CHECK(mpool.exists(fresh_tx.GetHash()));
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_SizeLimit)
+{
+    TestMemPoolEntryHelper entry;
+    auto low_fee_tx = ConstructTx();
+    auto high_fee_tx = ConstructTx();
+    CAmount fee_low{1000};
+    CAmount fee_high{9000};
+    FeeFrac expected_fee_rate_low{fee_low, entry.Fee(fee_low).FromTx(low_fee_tx).GetAdjustedWeight()};
+    auto low_fee_entry = entry.Fee(fee_low).FromTx(low_fee_tx);
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee_high).FromTx(high_fee_tx));
+        TryAddToMempool(mpool, entry.Fee(fee_low).FromTx(low_fee_tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    // Trim to one tx worth of memory; evicts the low fee tx.
+    {
+        LOCK2(cs_main, mpool.cs);
+        mpool.TrimToSize(mpool.DynamicMemoryUsage() - low_fee_entry.DynamicMemoryUsage());
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK_EQUAL(update.old_chunks.size(), 1U);
+    const auto& chunk_low = update.old_chunks[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::SIZELIMIT);
+    BOOST_CHECK(ChunkWtxids(chunk_low) == ExpectedWitnesses({low_fee_tx}));
+    BOOST_CHECK(chunk_low.m_chunk_hash == ExpectedChunkHash({low_fee_tx}));
+    BOOST_CHECK(chunk_low.m_fee_rate == expected_fee_rate_low);
+    BOOST_CHECK(update.new_chunks.empty());
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_RemoveRecursive)
+{
+    TestMemPoolEntryHelper entry;
+    auto tx = ConstructTx();
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(tx).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee).FromTx(tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    {
+        LOCK(mpool.cs);
+        mpool.removeRecursive(CTransaction(tx), MemPoolRemovalReason::REORG);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    BOOST_CHECK_EQUAL(listener.updates[0].old_chunks.size(), 1U);
+    const auto& chunk = listener.updates[0].old_chunks[0];
+    BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({tx}));
+    BOOST_CHECK(chunk.m_chunk_hash == ExpectedChunkHash({tx}));
+    BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    BOOST_CHECK(listener.updates[0].new_chunks.empty());
+}
+
+BOOST_AUTO_TEST_CASE(MempoolUpdated_Reorg)
+{
+    TestMemPoolEntryHelper entry;
+    auto tx_to_invalidate = ConstructTx();
+    auto valid_tx = ConstructTx();
+    CAmount fee{1000};
+    int32_t size{entry.Fee(fee).FromTx(tx_to_invalidate).GetAdjustedWeight()};
+    FeeFrac expected_fee_rate{fee, size};
+    {
+        LOCK2(cs_main, mpool.cs);
+        TryAddToMempool(mpool, entry.Fee(fee).FromTx(tx_to_invalidate));
+        TryAddToMempool(mpool, entry.Fee(1000).FromTx(valid_tx));
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    const Txid tx_to_invalidate_txid = tx_to_invalidate.GetHash();
+    {
+        LOCK2(cs_main, mpool.cs);
+        auto& chainstate = m_node.chainman->ActiveChainstate();
+        mpool.removeForReorg(chainstate.m_chain, [&](CTxMemPool::txiter it)
+                                                     EXCLUSIVE_LOCKS_REQUIRED(mpool.cs, ::cs_main) {
+                                                         AssertLockHeld(mpool.cs);
+                                                         AssertLockHeld(::cs_main);
+                                                         return it->GetTx().GetHash() == tx_to_invalidate_txid;
+                                                     });
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    BOOST_CHECK_EQUAL(listener.updates[0].old_chunks.size(), 1U);
+    const auto& chunk = listener.updates[0].old_chunks[0];
+    BOOST_CHECK(ChunkWtxids(chunk) == ExpectedWitnesses({tx_to_invalidate}));
+    BOOST_CHECK(chunk.m_chunk_hash == ExpectedChunkHash({tx_to_invalidate}));
+    BOOST_CHECK(chunk.m_fee_rate == expected_fee_rate);
+    BOOST_CHECK(listener.updates[0].new_chunks.empty());
+    BOOST_CHECK(!mpool.exists(tx_to_invalidate.GetHash()));
+    BOOST_CHECK(mpool.exists(valid_tx.GetHash()));
+}
+
+// Simulate a scenario where a reorg causes a tx to be added to the mempool
+// and connected to a cluster; this connection causes mempool limits to be exceeded.
+// In production this happens in MaybeUpdateMempoolForReorg:
+// txs are added via AcceptToMemoryPool, then UpdateTransactionsFromBlock
+// connects the parent->child dependency.
+//
+// Here chain[1..cluster_limit] are in-mempool and connected to a tx in a block, but the
+// reorg does not include the parent of chain[1..cluster_limit].
+// chain[0] is then added independently as a cluster of 1. UpdateTransactionsFromBlock scans
+// the mempool for txs that spends an output of chain[1], finds chain[1], and calls AddDependency
+// merging both clusters into one of size cluster_limit+1, which exceeds the limit.
+// Trim() evicts the lowest-fee tail tx.
+BOOST_AUTO_TEST_CASE(MempoolUpdated_UpdateTransactionsFromBlock)
+{
+    TestMemPoolEntryHelper entry;
+    const int chain_len{static_cast<int>(mpool.m_opts.limits.cluster_count + 1)};
+    std::vector<CMutableTransaction> chain;
+    chain.reserve(chain_len);
+    std::vector<Txid> txids;
+    chain.push_back(ConstructTx()); // chain[0]: the re-added parent
+    for (int i = 1; i < chain_len; ++i) {
+        chain.push_back(ConstructTx(1 * COIN, COutPoint{chain[i - 1].GetHash(), 0}));
+    }
+    CAmount normal_fee{1000};
+    CAmount low_fee{100};
+    int32_t last_tx_size{0};
+    {
+        LOCK2(cs_main, mpool.cs);
+        for (int i = 1; i < chain_len; ++i) {
+            CAmount fee = (i == chain_len - 1) ? low_fee : normal_fee;
+            auto curr_entry = entry.Fee(fee).FromTx(chain[i]);
+            if (i == chain_len - 1) last_tx_size = curr_entry.GetAdjustedWeight();
+            TryAddToMempool(mpool, curr_entry);
+        }
+        auto root_entry = entry.Fee(normal_fee).FromTx(chain[0]);
+        TryAddToMempool(mpool, root_entry);
+        txids.push_back(chain[0].GetHash());
+    }
+    // Verify the two clusters are independent before UpdateTransactionsFromBlock.
+    BOOST_CHECK_EQUAL(WITH_LOCK(mpool.cs, return mpool.GetCluster(chain[0].GetHash()).size()), 1);
+    BOOST_CHECK_EQUAL(WITH_LOCK(mpool.cs, return mpool.GetCluster(chain[1].GetHash()).size()), chain_len - 1);
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    listener.Clear();
+    {
+        LOCK2(cs_main, mpool.cs);
+        // Scans mapNextTx for chain[0]'s outputs, finds chain[1], calls
+        // AddDependency(chain[0], chain[1]). Merged cluster = chain_len > limit.
+        // Trim() evicts the lowest-fee tail tx (chain.back()).
+        mpool.UpdateTransactionsFromBlock(txids);
+    }
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    // Both clusters are now merged (minus the evicted tail tx).
+    BOOST_CHECK_EQUAL(WITH_LOCK(mpool.cs, return mpool.GetCluster(chain[0].GetHash()).size()), chain_len - 1);
+    BOOST_CHECK_EQUAL(WITH_LOCK(mpool.cs, return mpool.GetCluster(chain[1].GetHash()).size()), chain_len - 1);
+    BOOST_CHECK_EQUAL(listener.updates.size(), 1U);
+    const auto& update = listener.updates[0];
+    BOOST_CHECK(update.reason == MemPoolRemovalReason::SIZELIMIT);
+    // old_chunks: the merged cluster before eviction, includes the low-fee tail tx.
+    BOOST_CHECK(!update.old_chunks.empty());
+    const auto& evicted_chunk = update.old_chunks.back();
+    BOOST_CHECK(ChunkWtxids(evicted_chunk) == ExpectedWitnesses({chain.back()}));
+    BOOST_CHECK(evicted_chunk.m_chunk_hash == ExpectedChunkHash({chain.back()}));
+    BOOST_CHECK(evicted_chunk.m_fee_rate == FeeFrac(low_fee, last_tx_size));
+    // new_chunks: the merged cluster after eviction, excludes the low-fee tail tx.
+    BOOST_CHECK(!update.new_chunks.empty());
+    BOOST_CHECK_EQUAL(update.new_chunks.size(), update.old_chunks.size() - 1);
+    BOOST_CHECK(!mpool.exists(chain.back().GetHash()));
+    // All other txs must still be present.
+    for (int i = 0; i < chain_len - 1; ++i) {
+        BOOST_CHECK(mpool.exists(chain[i].GetHash()));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -214,6 +214,9 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     BOOST_CHECK(raw_txs[0]);
     BOOST_CHECK(raw_txs[0]->GetHash() == hashParentTx);
     BOOST_CHECK(!raw_txs[1]);
+    // Drain pending MempoolUpdated signals before creating a new template
+    // so stale signals don't pollute the new entry's fee tracking.
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
     block_template = mining->createNewBlock(options, /*cooldown=*/false);
     BOOST_REQUIRE(block_template);
     block = block_template->getBlock();
@@ -266,6 +269,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     TryAddToMempool(tx_mempool, entry.Fee(feeToUse).FromTx(tx));
 
     // A package below the block min tx fee should not make the template stale.
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
     should_be_nullptr = block_template->waitNext({.timeout = MillisecondsDouble{0}, .fee_threshold = 1});
     BOOST_REQUIRE(should_be_nullptr == nullptr);
 
@@ -285,6 +289,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     TryAddToMempool(tx_mempool, entry.Fee(feeToUse + 2).FromTx(tx));
 
     // waitNext() should return if fees for the new template are at least 1 sat up
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
     block_template = block_template->waitNext({.fee_threshold = 1});
     BOOST_REQUIRE(block_template);
     block = block_template->getBlock();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -56,6 +56,7 @@ using interfaces::BlockTemplate;
 using interfaces::Mining;
 using node::BlockAssembler;
 using node::BlockCreateOptions;
+using node::TemplateSnapshot;
 
 namespace miner_tests {
 struct MinerTestingSetup : public TestingSetup {
@@ -951,6 +952,50 @@ BOOST_AUTO_TEST_CASE(block_template_manager)
     BOOST_CHECK(block.vtx[0]->IsCoinBase());
     BOOST_CHECK(block_template->vTxFees.empty());
     BOOST_CHECK(block_template->vTxSigOpsCost.empty());
+}
+
+BOOST_AUTO_TEST_CASE(block_template_manager_template_snapshot)
+{
+    TemplateSnapshot snapshot;
+    const uint256 hash{1};
+    snapshot.AddChunk(hash, {FeePerWeight{1000, 100}, 400, 1});
+    snapshot.AddChunk(hash, {FeePerWeight{2500, 100}, 600, 2});
+    BOOST_CHECK_EQUAL(snapshot.template_chunks.size(), 1U);
+    BOOST_CHECK_EQUAL(snapshot.chunks_by_feerate.size(), 1U);
+    BOOST_CHECK_EQUAL(snapshot.total_fees, 2500);
+    BOOST_CHECK_EQUAL(snapshot.total_weight, 600);
+    BOOST_CHECK_EQUAL(snapshot.total_sigops, 2);
+    snapshot.SanityCheck();
+    snapshot.RemoveChunk(hash);
+    BOOST_CHECK(snapshot.template_chunks.empty());
+    BOOST_CHECK(snapshot.chunks_by_feerate.empty());
+    BOOST_CHECK_EQUAL(snapshot.total_fees, 0);
+    BOOST_CHECK_EQUAL(snapshot.total_weight, 0);
+    BOOST_CHECK_EQUAL(snapshot.total_sigops, 0);
+    snapshot.SanityCheck();
+    snapshot.max_weight = 1'000;
+    const uint256 low_fee_hash{1};
+    const uint256 high_fee_hash{2};
+    const uint256 equal_fee_hash{3};
+    snapshot.AddChunk(low_fee_hash, {FeePerWeight{1'000, 100}, 600, 1});
+    snapshot.AddChunk(high_fee_hash, {FeePerWeight{3'000, 100}, 150, 1});
+    snapshot.AddChunk(equal_fee_hash, {FeePerWeight{3'000, 100}, 150, 1});
+    BOOST_CHECK(snapshot.TrimToFit(/*needed_weight=*/500, /*needed_sigops=*/0, FeePerWeight{2'000, 100}));
+    BOOST_CHECK(!snapshot.template_chunks.contains(low_fee_hash));
+    BOOST_CHECK(snapshot.template_chunks.contains(high_fee_hash));
+    BOOST_CHECK(snapshot.template_chunks.contains(equal_fee_hash));
+    BOOST_CHECK_EQUAL(snapshot.chunks_by_feerate.size(), 2U);
+    BOOST_CHECK_EQUAL(snapshot.total_fees, 6'000);
+    BOOST_CHECK_EQUAL(snapshot.total_weight, 300);
+    BOOST_CHECK_EQUAL(snapshot.total_sigops, 2);
+    snapshot.SanityCheck();
+    BOOST_CHECK(!snapshot.TrimToFit(/*needed_weight=*/700, /*needed_sigops=*/0, FeePerWeight{3'000, 100}));
+    BOOST_CHECK_EQUAL(snapshot.template_chunks.size(), 2U);
+    BOOST_CHECK_EQUAL(snapshot.chunks_by_feerate.size(), 2U);
+    BOOST_CHECK_EQUAL(snapshot.total_fees, 6'000);
+    BOOST_CHECK_EQUAL(snapshot.total_weight, 300);
+    BOOST_CHECK_EQUAL(snapshot.total_sigops, 2);
+    snapshot.SanityCheck();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -60,9 +60,9 @@ using node::TemplateSnapshot;
 
 namespace miner_tests {
 struct MinerTestingSetup : public TestingSetup {
-    void TestPackageSelection(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    void TestBasicMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst, int baseheight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    void TestPrioritisedMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void TestPackageSelection(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst);
+    void TestBasicMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst, int baseheight);
+    void TestPrioritisedMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst);
     bool TestSequenceLocks(const CTransaction& tx, CTxMemPool& tx_mempool) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         CCoinsViewMemPool view_mempool{&m_node.chainman->ActiveChainstate().CoinsTip(), tx_mempool};
@@ -72,7 +72,7 @@ struct MinerTestingSetup : public TestingSetup {
     }
     CTxMemPool& MakeMempool()
     {
-        m_node.block_template_manager.reset();
+        ResetBlockTemplateManager();
         // Delete the previous mempool to ensure with valgrind that the old
         // pointer is not accessed, when the new one should be accessed
         // instead.
@@ -141,8 +141,10 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
         .coinbase_output_script = scriptPubKey,
     };
 
-    LOCK(tx_mempool.cs);
-    BOOST_CHECK(tx_mempool.size() == 0);
+    {
+        LOCK(tx_mempool.cs);
+        BOOST_CHECK(tx_mempool.size() == 0);
+    }
 
     // Block template should only have a coinbase when there's nothing in the mempool
     std::unique_ptr<BlockTemplate> block_template = mining->createNewBlock(options, /*cooldown=*/false);
@@ -274,7 +276,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     // Test that packages above the min relay fee do get included, even if one
     // of the transactions is below the min relay fee
     // Remove the low fee transaction and replace with a higher fee transaction
-    tx_mempool.removeRecursive(CTransaction(tx), MemPoolRemovalReason::REPLACED);
+    WITH_LOCK(tx_mempool.cs, tx_mempool.removeRecursive(CTransaction(tx), MemPoolRemovalReason::REPLACED));
     tx.vout[0].nValue -= 2; // Now we should be just over the min relay fee
     hashLowFeeTx = tx.GetHash();
     TryAddToMempool(tx_mempool, entry.Fee(feeToUse + 2).FromTx(tx));
@@ -540,7 +542,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
 
     {
         CTxMemPool& tx_mempool{MakeMempool()};
-        LOCK(tx_mempool.cs);
+        LOCK2(cs_main, tx_mempool.cs);
 
         // subsidy changing
         int nHeight = m_node.chainman->ActiveChain().Height();
@@ -596,7 +598,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
     }
 
     CTxMemPool& tx_mempool{MakeMempool()};
-    LOCK(tx_mempool.cs);
+    LOCK2(cs_main, tx_mempool.cs);
 
     // non-final txs in mempool
     clock.set(std::chrono::seconds{m_node.chainman->ActiveChain().Tip()->GetMedianTimePast() + 1});
@@ -925,16 +927,20 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         }
     }
 
-    LOCK(cs_main);
-
     TestBasicMining(scriptPubKey, txFirst, baseheight);
-
-    m_node.chainman->ActiveChain().Tip()->nHeight--;
+    {
+        LOCK(cs_main);
+        m_node.chainman->ActiveChain().Tip()->nHeight--;
+        SetMockTime(0);
+    }
 
     TestPackageSelection(scriptPubKey, txFirst);
 
-    m_node.chainman->ActiveChain().Tip()->nHeight--;
-
+    {
+        LOCK(cs_main);
+        m_node.chainman->ActiveChain().Tip()->nHeight--;
+        SetMockTime(0);
+    }
     TestPrioritisedMining(scriptPubKey, txFirst);
 }
 
@@ -952,6 +958,20 @@ BOOST_AUTO_TEST_CASE(block_template_manager)
     BOOST_CHECK(block.vtx[0]->IsCoinBase());
     BOOST_CHECK(block_template->vTxFees.empty());
     BOOST_CHECK(block_template->vTxSigOpsCost.empty());
+    uint64_t template_id_1{0};
+    uint64_t template_id_2{0};
+    auto tracked_template_1 = block_template_manager.CreateNewTemplate(options, &template_id_1);
+    auto tracked_template_2 = block_template_manager.CreateNewTemplate(options, &template_id_2);
+    BOOST_CHECK(tracked_template_1 != nullptr);
+    BOOST_CHECK(tracked_template_2 != nullptr);
+    BOOST_CHECK(template_id_1 != 0);
+    BOOST_CHECK(template_id_2 != 0);
+    BOOST_CHECK(template_id_1 != template_id_2);
+    BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(template_id_1));
+    BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(template_id_2));
+    block_template_manager.StopTrackingFeeInflow(template_id_1);
+    BOOST_CHECK(!block_template_manager.IsTrackingFeeInflow(template_id_1));
+    BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(template_id_2));
 }
 
 BOOST_AUTO_TEST_CASE(block_template_manager_template_snapshot)

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -217,25 +217,31 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     BOOST_CHECK(block.vtx[2]->GetHash() == hashHighFeeTx);
     BOOST_CHECK(block.vtx[3]->GetHash() == hashMediumFeeTx);
 
-    // Test the inclusion of package feerates in the block template and ensure they are sequential.
-    // Can't use the Mining interface because it needs access to m_package_feerates.
-    const auto block_package_feerates = BlockAssembler{
+    // Test template chunks are recorded with correct feerates, weights, sigops, and wtxids.
+    // Can't use the Mining interface because it needs access to m_template_chunks.
+    const auto template_chunks = BlockAssembler{
         m_node.chainman->ActiveChainstate(),
         &tx_mempool,
-        MergeMiningOptions(options, Assert(m_node.block_template_manager)->GetInitBlockCreateOptions()),
-    }.CreateNewBlock()->m_package_feerates;
-    BOOST_CHECK(block_package_feerates.size() == 2);
+        MergeMiningOptions(options,
+                           Assert(m_node.block_template_manager)->GetInitBlockCreateOptions())}
+                                     .CreateNewBlock()
+                                     ->m_template_chunks;
+    BOOST_CHECK_EQUAL(template_chunks.size(), 2U);
 
-    // parent_tx and high_fee_tx are added to the block as a package.
-    const auto combined_txs_fee = parent_tx.GetFee() + high_fee_tx.GetFee();
-    const auto combined_txs_size = parent_tx.GetTxSize() + high_fee_tx.GetTxSize();
-    FeeFrac package_feefrac{combined_txs_fee, combined_txs_size};
-    // The package should be added first.
-    BOOST_CHECK(block_package_feerates[0] == package_feefrac);
+    // parent_tx and high_fee_tx are added to the block as a chunk.
+    BOOST_CHECK_EQUAL(template_chunks[0].feerate.fee, parent_tx.GetFee() + high_fee_tx.GetFee());
+    BOOST_CHECK_EQUAL(template_chunks[0].feerate.size, int32_t(parent_tx.GetTxWeight() + high_fee_tx.GetTxWeight()));
+    BOOST_CHECK_EQUAL(template_chunks[0].weight, parent_tx.GetTxWeight() + high_fee_tx.GetTxWeight());
+    BOOST_CHECK_EQUAL(template_chunks[0].sigops_cost, parent_tx.GetSigOpCost() + high_fee_tx.GetSigOpCost());
+    std::vector<Wtxid> expected_wtxids_0{parent_tx.GetSharedTx()->GetWitnessHash(), high_fee_tx.GetSharedTx()->GetWitnessHash()};
+    BOOST_CHECK(template_chunks[0].chunk_wtxids == expected_wtxids_0);
 
-    // The medium_fee_tx should be added next.
-    FeeFrac medium_tx_feefrac{medium_fee_tx.GetFee(), medium_fee_tx.GetTxSize()};
-    BOOST_CHECK(block_package_feerates[1] == medium_tx_feefrac);
+    BOOST_CHECK_EQUAL(template_chunks[1].feerate.fee, medium_fee_tx.GetFee());
+    BOOST_CHECK_EQUAL(template_chunks[1].feerate.size, int32_t(medium_fee_tx.GetTxWeight()));
+    BOOST_CHECK_EQUAL(template_chunks[1].weight, medium_fee_tx.GetTxWeight());
+    BOOST_CHECK_EQUAL(template_chunks[1].sigops_cost, medium_fee_tx.GetSigOpCost());
+    std::vector<Wtxid> expected_wtxids_1{medium_fee_tx.GetSharedTx()->GetWitnessHash()};
+    BOOST_CHECK(template_chunks[1].chunk_wtxids == expected_wtxids_1);
 
     // Test that a package below the block min tx fee doesn't get included
     tx.vin[0].prevout.hash = hashHighFeeTx;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -222,7 +222,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     const auto block_package_feerates = BlockAssembler{
         m_node.chainman->ActiveChainstate(),
         &tx_mempool,
-        MergeMiningOptions(options, m_node.mining_args),
+        MergeMiningOptions(options, Assert(m_node.block_template_manager)->GetInitBlockCreateOptions()),
     }.CreateNewBlock()->m_package_feerates;
     BOOST_CHECK(block_package_feerates.size() == 2);
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -12,6 +12,7 @@
 #include <interfaces/mining.h>
 #include <interfaces/types.h>
 #include <kernel/chainparams.h>
+#include <kernel/types.h>
 #include <node/block_template_manager.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
@@ -37,6 +38,7 @@
 #include <util/strencodings.h>
 #include <util/translation.h>
 #include <validation.h>
+#include <validationinterface.h>
 #include <versionbits.h>
 
 #include <boost/test/unit_test.hpp>
@@ -239,6 +241,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     std::vector<Wtxid> expected_wtxids_0{parent_tx.GetSharedTx()->GetWitnessHash(), high_fee_tx.GetSharedTx()->GetWitnessHash()};
     BOOST_CHECK(template_chunks[0].chunk_wtxids == expected_wtxids_0);
 
+    // The medium_fee_tx should be added next.
     BOOST_CHECK_EQUAL(template_chunks[1].feerate.fee, medium_fee_tx.GetFee());
     BOOST_CHECK_EQUAL(template_chunks[1].feerate.size, int32_t(medium_fee_tx.GetTxWeight()));
     BOOST_CHECK_EQUAL(template_chunks[1].weight, medium_fee_tx.GetTxWeight());
@@ -262,7 +265,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     Txid hashLowFeeTx = tx.GetHash();
     TryAddToMempool(tx_mempool, entry.Fee(feeToUse).FromTx(tx));
 
-    // waitNext() should return nullptr because there is no better template
+    // A package below the block min tx fee should not make the template stale.
     should_be_nullptr = block_template->waitNext({.timeout = MillisecondsDouble{0}, .fee_threshold = 1});
     BOOST_REQUIRE(should_be_nullptr == nullptr);
 
@@ -974,6 +977,94 @@ BOOST_AUTO_TEST_CASE(block_template_manager)
     BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(template_id_2));
 }
 
+BOOST_AUTO_TEST_CASE(block_template_manager_staleness)
+{
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    auto& block_template_manager = *Assert(m_node.block_template_manager);
+    BlockCreateOptions default_options;
+    default_options.test_block_validity = false;
+    // BlockConnected prunes a tracked entry built on the old tip
+    auto chain_tip = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip());
+    uint64_t id_1{0};
+    auto block_template = block_template_manager.CreateNewTemplate(default_options, &id_1);
+    auto block = std::make_shared<const CBlock>(block_template->block);
+    BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(id_1));
+    m_node.validation_signals->BlockConnected(kernel::ChainstateRole{}, block, chain_tip);
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK(!block_template_manager.IsTrackingFeeInflow(id_1));
+    // BlockConnected with historical role does not prune tracked entries
+    uint64_t id_2{0};
+    auto historical_template = block_template_manager.CreateNewTemplate(default_options, &id_2);
+    BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(id_2));
+    m_node.validation_signals->BlockConnected(kernel::ChainstateRole{.historical = true}, block, chain_tip);
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(id_2));
+    // BlockDisconnected preserves tracked entries built on a different tip
+    m_node.validation_signals->BlockDisconnected(block, chain_tip);
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(id_2));
+    block_template_manager.SanityCheck();
+    // Fee inflow detection via IsStale / CreateNewTemplate
+    const CAmount threshold = 1000;
+    uint64_t cached_id{0};
+    auto cached_template = block_template_manager.CreateNewTemplate(default_options, &cached_id);
+    // Not stale initially
+    BOOST_CHECK(!block_template_manager.IsStale(default_options, cached_id, threshold));
+    // Not stale when no tracked entry exists (0 is never assigned to a template)
+    const uint64_t bogus_id{0};
+    BOOST_CHECK(!block_template_manager.IsStale(default_options, bogus_id, threshold));
+    // Template has no mempool txs, so any new chunk is fee inflow
+    BOOST_CHECK(cached_template->m_template_chunks.empty());
+    MemPoolChunksUpdate update;
+    update.new_chunks.push_back({FeePerWeight{threshold + 1, 100}, {}, 0, std::nullopt});
+    update.reason = MemPoolRemovalReason::REPLACED;
+    m_node.validation_signals->MempoolUpdated(std::move(update));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    // Stale: fee inflow above threshold
+    BOOST_CHECK(block_template_manager.IsStale(default_options, cached_id, threshold));
+    // Creating a tracked template adds a new entry
+    uint64_t new_id{0};
+    auto new_template = block_template_manager.CreateNewTemplate(default_options, &new_id);
+    BOOST_REQUIRE(new_template);
+    BOOST_CHECK(!block_template_manager.IsStale(default_options, new_id, threshold));
+    MemPoolChunksUpdate addition_update;
+    addition_update.new_chunks.push_back({FeePerWeight{threshold + 1, 100}, {}, 0, std::nullopt});
+    addition_update.reason = MemPoolRemovalReason::REPLACED;
+    m_node.validation_signals->MempoolUpdated(std::move(addition_update));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK(block_template_manager.IsStale(default_options, new_id, threshold));
+    // Removing the tracked chunk reverses the fee inflow.
+    MemPoolChunksUpdate removal_update;
+    removal_update.old_chunks.push_back({FeePerWeight{threshold + 1, 100}, {}, 0, std::nullopt});
+    removal_update.reason = MemPoolRemovalReason::EXPIRY;
+    m_node.validation_signals->MempoolUpdated(std::move(removal_update));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK(!block_template_manager.IsStale(default_options, new_id, threshold));
+    block_template_manager.StopTrackingFeeInflow(new_id);
+    BOOST_CHECK(!block_template_manager.IsTrackingFeeInflow(new_id));
+    // BlockConnected prunes the matching tracked entry, so IsStale returns false
+    m_node.validation_signals->BlockConnected(kernel::ChainstateRole{}, block, chain_tip);
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    BOOST_CHECK(!block_template_manager.IsStale(default_options, new_id, threshold));
+    block_template_manager.SanityCheck();
+    // All created templates remain independently tracked.
+    for (size_t i = 0; i < 11; ++i) {
+        uint64_t tracked_id{0};
+        auto tracked_template = block_template_manager.CreateNewTemplate(default_options, &tracked_id);
+        BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(tracked_id));
+    }
+    uint64_t same_time_id_1{0};
+    uint64_t same_time_id_2{0};
+    auto same_time_template_1 = block_template_manager.CreateNewTemplate(default_options, &same_time_id_1);
+    auto same_time_template_2 = block_template_manager.CreateNewTemplate(default_options, &same_time_id_2);
+    BOOST_CHECK(same_time_id_1 != 0);
+    BOOST_CHECK(same_time_id_2 != 0);
+    BOOST_CHECK(same_time_id_1 != same_time_id_2);
+    block_template_manager.StopTrackingFeeInflow(same_time_id_1);
+    BOOST_CHECK(!block_template_manager.IsTrackingFeeInflow(same_time_id_1));
+    BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(same_time_id_2));
+}
+
 BOOST_AUTO_TEST_CASE(block_template_manager_template_snapshot)
 {
     TemplateSnapshot snapshot;
@@ -1016,6 +1107,71 @@ BOOST_AUTO_TEST_CASE(block_template_manager_template_snapshot)
     BOOST_CHECK_EQUAL(snapshot.total_weight, 300);
     BOOST_CHECK_EQUAL(snapshot.total_sigops, 2);
     snapshot.SanityCheck();
+    TemplateSnapshot sigops_limited_snapshot;
+    sigops_limited_snapshot.max_weight = 1'000;
+    sigops_limited_snapshot.reserved_sigops = MAX_BLOCK_SIGOPS_COST;
+    sigops_limited_snapshot.total_sigops = sigops_limited_snapshot.reserved_sigops;
+    BOOST_CHECK(!sigops_limited_snapshot.TrimToFit(/*needed_weight=*/0, /*needed_sigops=*/1, FeePerWeight{4'000, 100}));
+    sigops_limited_snapshot.SanityCheck();
+}
+
+// A duplicate mempool add callback for a chunk already tracked in the
+// snapshot must be idempotent. In a near-full snapshot, re-counting the
+// chunk's weight would otherwise evict a lower-feerate tracked chunk.
+BOOST_AUTO_TEST_CASE(block_template_manager_duplicate_add)
+{
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    auto& block_template_manager = *Assert(m_node.block_template_manager);
+    // Two equal-weight chunks that differ only in the spent output index, so
+    // their wtxid-derived chunk hashes differ.
+    auto make_chunk_tx = [](uint32_t n) {
+        CMutableTransaction mtx;
+        mtx.vin.resize(1);
+        mtx.vin[0].prevout.n = n;
+        mtx.vout.resize(50);
+        for (auto& out : mtx.vout) {
+            out.nValue = 1000;
+            out.scriptPubKey = CScript() << OP_1;
+        }
+        return MakeTransactionRef(mtx);
+    };
+    const auto tx_high = make_chunk_tx(0);
+    const auto tx_low = make_chunk_tx(1);
+    const int32_t chunk_weight = GetTransactionWeight(*tx_high);
+    // Size the block so both chunks fit but a third copy would not: a
+    // double-counted add would have to evict the lower-feerate chunk.
+    BlockCreateOptions options;
+    options.test_block_validity = false;
+    options.block_reserved_weight = DEFAULT_BLOCK_RESERVED_WEIGHT;
+    options.block_max_weight = static_cast<uint64_t>(*options.block_reserved_weight + 2 * chunk_weight + chunk_weight / 2);
+    uint64_t template_id{0};
+    auto block_template = block_template_manager.CreateNewTemplate(options, &template_id);
+    BOOST_REQUIRE(block_template->m_template_chunks.empty());
+    // Track a high-feerate and a lower-feerate chunk via the add path.
+    const CAmount high_fee = 5000;
+    const CAmount low_fee = 2000;
+    MemPoolChunksUpdate add;
+    add.new_chunks.push_back({FeePerWeight{high_fee, chunk_weight}, {tx_high}, 0, std::nullopt});
+    add.new_chunks.push_back({FeePerWeight{low_fee, chunk_weight}, {tx_low}, 0, std::nullopt});
+    add.reason = MemPoolRemovalReason::REPLACED;
+    m_node.validation_signals->MempoolUpdated(std::move(add));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    block_template_manager.SanityCheck();
+    // Combined inflow exceeds the threshold; either chunk alone does not.
+    const CAmount threshold = high_fee + 1;
+    BOOST_CHECK(block_template_manager.IsStale(options, template_id, threshold));
+    // Re-deliver the high-feerate chunk (a stale queued add). With the guard this
+    // is a no-op; without it, the double-counted weight would evict the
+    // lower-feerate chunk and drop the inflow below the threshold.
+    MemPoolChunksUpdate duplicate;
+    duplicate.new_chunks.push_back({FeePerWeight{high_fee, chunk_weight}, {tx_high}, 0, std::nullopt});
+    duplicate.reason = MemPoolRemovalReason::REPLACED;
+    m_node.validation_signals->MempoolUpdated(std::move(duplicate));
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    block_template_manager.SanityCheck();
+    // Still stale: the lower-feerate chunk was not evicted.
+    BOOST_CHECK(block_template_manager.IsStale(options, template_id, threshold));
+    BOOST_CHECK(block_template_manager.IsTrackingFeeInflow(template_id));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -12,6 +12,7 @@
 #include <interfaces/mining.h>
 #include <interfaces/types.h>
 #include <kernel/chainparams.h>
+#include <node/block_template_manager.h>
 #include <node/miner.h>
 #include <node/mining_args.h>
 #include <node/mining_types.h>
@@ -70,6 +71,7 @@ struct MinerTestingSetup : public TestingSetup {
     }
     CTxMemPool& MakeMempool()
     {
+        m_node.block_template_manager.reset();
         // Delete the previous mempool to ensure with valgrind that the old
         // pointer is not accessed, when the new one should be accessed
         // instead.
@@ -82,6 +84,7 @@ struct MinerTestingSetup : public TestingSetup {
         opts.limits.cluster_size_vbytes = 1'200'000;
         m_node.mempool = std::make_unique<CTxMemPool>(opts, error);
         Assert(error.empty());
+        CreateBlockTemplateManager();
         return *m_node.mempool;
     }
     std::unique_ptr<Mining> MakeMining()
@@ -926,6 +929,22 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     m_node.chainman->ActiveChain().Tip()->nHeight--;
 
     TestPrioritisedMining(scriptPubKey, txFirst);
+}
+
+BOOST_AUTO_TEST_CASE(block_template_manager)
+{
+    auto& block_template_manager = *Assert(m_node.block_template_manager);
+    BlockCreateOptions options;
+    options.use_mempool = false;
+    auto block_template = block_template_manager.CreateNewTemplate(options);
+    BOOST_REQUIRE(block_template);
+    const CBlock& block{block_template->block};
+    // Without the mempool the template holds only the coinbase, and the per-tx
+    // fee/sigops vectors exclude it.
+    BOOST_CHECK_EQUAL(block.vtx.size(), 1U);
+    BOOST_CHECK(block.vtx[0]->IsCoinBase());
+    BOOST_CHECK(block_template->vTxFees.empty());
+    BOOST_CHECK(block_template->vTxSigOpsCost.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -5,8 +5,9 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/params.h>
-#include <interfaces/mining.h>
 #include <net_processing.h>
+#include <node/block_template_manager.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <protocol.h>
@@ -31,10 +32,10 @@ static void mineBlock(node::NodeContext& node, FakeNodeClock& clock, std::chrono
 {
     auto curr_time = GetTime<std::chrono::seconds>();
     clock.set(block_time); // update time so the block is created with it
-    auto mining{interfaces::MakeMining(node)};
-    auto block_template{mining->createNewBlock({}, /*cooldown=*/false)};
+    auto& block_template_manager{*Assert(node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({})};
     BOOST_REQUIRE(block_template);
-    CBlock block{block_template->getBlock()};
+    CBlock block{block_template->block};
     while (!CheckProofOfWork(block.GetHash(), block.nBits, node.chainman->GetConsensus())) ++block.nNonce;
     block.fChecked = true; // little speedup
     clock.set(curr_time); // process block at current time

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -9,9 +9,10 @@
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
-#include <interfaces/mining.h>
 #include <key_io.h>
+#include <node/block_template_manager.h>
 #include <node/context.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -131,9 +132,9 @@ COutPoint ProcessBlock(const NodeContext& node, const std::shared_ptr<CBlock>& b
 std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node,
                                      const node::BlockCreateOptions& assembler_options)
 {
-    auto mining = interfaces::MakeMining(node);
-    auto block_template = mining->createNewBlock(assembler_options, /*cooldown=*/false);
-    auto block = std::make_shared<CBlock>(Assert(block_template)->getBlock());
+    auto& block_template_manager = *Assert(node.block_template_manager);
+    auto block_template = block_template_manager.CreateNewTemplate(assembler_options);
+    auto block = std::make_shared<CBlock>(Assert(block_template)->block);
 
     LOCK(cs_main);
     block->nTime = Assert(node.chainman)->ActiveChain().Tip()->GetMedianTimePast() + 1;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -336,7 +336,7 @@ void ChainTestingSetup::CreateBlockTemplateManager()
 {
     auto mining_args{node::ReadMiningArgs(*Assert(m_node.args))};
     Assert(mining_args);
-    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman, std::move(*mining_args));
+    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman, *Assert(m_node.notifications), std::move(*mining_args));
 }
 
 ChainTestingSetup::~ChainTestingSetup()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -334,7 +334,9 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
 
 void ChainTestingSetup::CreateBlockTemplateManager()
 {
-    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman);
+    auto mining_args{node::ReadMiningArgs(*Assert(m_node.args))};
+    Assert(mining_args);
+    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman, std::move(*mining_args));
 }
 
 ChainTestingSetup::~ChainTestingSetup()
@@ -400,9 +402,6 @@ TestingSetup::TestingSetup(
                                                m_node.args->GetIntArg("-checkaddrman", 0));
     m_node.banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     m_node.connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params()); // Deterministic randomness for tests.
-    auto mining_args{node::ReadMiningArgs(*m_node.args)};
-    Assert(mining_args);
-    m_node.mining_args = std::move(*mining_args);
     PeerManager::Options peerman_opts;
     ApplyArgsManOptions(*m_node.args, peerman_opts);
     peerman_opts.deterministic_rng = true;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -17,7 +17,6 @@
 #include <dbwrapper.h>
 #include <init.h>
 #include <interfaces/chain.h>
-#include <interfaces/mining.h>
 #include <kernel/caches.h>
 #include <kernel/context.h>
 #include <key.h>
@@ -452,13 +451,13 @@ CBlock TestChain100Setup::CreateBlock(
     const std::vector<CMutableTransaction>& txns,
     const CScript& scriptPubKey)
 {
-    auto mining{interfaces::MakeMining(m_node)};
-    auto block_template{mining->createNewBlock({
+    auto& block_template_manager{*Assert(m_node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({
         .use_mempool = false,
         .coinbase_output_script = scriptPubKey,
-    }, /*cooldown=*/false)};
+    })};
     Assert(block_template);
-    CBlock block{block_template->getBlock()};
+    CBlock block{block_template->block};
 
     Assert(block.vtx.size() == 1);
     for (const CMutableTransaction& tx : txns) {

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -331,17 +331,36 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
     CreateBlockTemplateManager();
 }
 
+void ChainTestingSetup::ResetBlockTemplateManager()
+{
+    if (m_node.validation_signals && m_node.block_template_manager) {
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+        m_node.validation_signals->UnregisterValidationInterface(m_node.block_template_manager.get());
+    }
+    m_node.block_template_manager.reset();
+}
+
 void ChainTestingSetup::CreateBlockTemplateManager()
 {
+    Assert(!m_node.block_template_manager);
     auto mining_args{node::ReadMiningArgs(*Assert(m_node.args))};
     Assert(mining_args);
     m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman, *Assert(m_node.notifications), std::move(*mining_args));
+    if (m_node.validation_signals) m_node.validation_signals->RegisterValidationInterface(m_node.block_template_manager.get());
 }
 
 ChainTestingSetup::~ChainTestingSetup()
 {
+    // Skip sync if the scheduler is already stopped (e.g. by ~WalletTestingSetup),
+    // because SyncWithValidationInterfaceQueue blocks on a callback that needs a live thread.
+    if (m_node.validation_signals && m_node.scheduler && m_node.scheduler->AreThreadsServicingQueue()) {
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    }
     if (m_node.scheduler) m_node.scheduler->stop();
     if (m_node.validation_signals) m_node.validation_signals->FlushBackgroundCallbacks();
+    if (m_node.validation_signals && m_node.block_template_manager) {
+        m_node.validation_signals->UnregisterValidationInterface(m_node.block_template_manager.get());
+    }
     m_node.block_template_manager.reset();
     m_node.connman.reset();
     m_node.banman.reset();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -26,6 +26,7 @@
 #include <net_processing.h>
 #include <netbase.h>
 #include <netgroup.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
 #include <node/chainstate.h>
 #include <node/context.h>
@@ -328,12 +329,19 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
         m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
     };
     m_make_chainman();
+    CreateBlockTemplateManager();
+}
+
+void ChainTestingSetup::CreateBlockTemplateManager()
+{
+    m_node.block_template_manager = std::make_unique<node::BlockTemplateManager>(*m_node.mempool, *m_node.chainman);
 }
 
 ChainTestingSetup::~ChainTestingSetup()
 {
     if (m_node.scheduler) m_node.scheduler->stop();
     if (m_node.validation_signals) m_node.validation_signals->FlushBackgroundCallbacks();
+    m_node.block_template_manager.reset();
     m_node.connman.reset();
     m_node.banman.reset();
     m_node.addrman.reset();

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -106,6 +106,8 @@ struct ChainTestingSetup : public BasicTestingSetup {
     explicit ChainTestingSetup(ChainType chainType = ChainType::MAIN, TestOpts = {});
     ~ChainTestingSetup();
 
+    void CreateBlockTemplateManager();
+
     // Supplies a chainstate, if one is needed
     void LoadVerifyActivateChainstate();
 };

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -106,6 +106,7 @@ struct ChainTestingSetup : public BasicTestingSetup {
     explicit ChainTestingSetup(ChainType chainType = ChainType::MAIN, TestOpts = {});
     ~ChainTestingSetup();
 
+    void ResetBlockTemplateManager();
     void CreateBlockTemplateManager();
 
     // Supplies a chainstate, if one is needed

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -7,8 +7,9 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
-#include <interfaces/mining.h>
+#include <node/block_template_manager.h>
 #include <node/blockstorage.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -80,12 +81,12 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     static int i = 0;
     static uint64_t time = Params().GenesisBlock().nTime;
 
-    auto mining{interfaces::MakeMining(m_node)};
-    auto block_template{mining->createNewBlock({
+    auto& block_template_manager{*Assert(m_node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({
         .coinbase_output_script = CScript{} << i++ << OP_TRUE,
-    }, /*cooldown=*/false)};
+    })};
     BOOST_REQUIRE(block_template);
-    auto pblock = std::make_shared<CBlock>(block_template->getBlock());
+    auto pblock = std::make_shared<CBlock>(block_template->block);
     pblock->hashPrevBlock = prev_hash;
     pblock->nTime = ++time;
 
@@ -350,12 +351,12 @@ BOOST_AUTO_TEST_CASE(witness_commitment_index)
     LOCK(Assert(m_node.chainman)->GetMutex());
     CScript pubKey;
     pubKey << 1 << OP_TRUE;
-    auto mining{interfaces::MakeMining(m_node)};
-    auto block_template{mining->createNewBlock({
+    auto& block_template_manager{*Assert(m_node.block_template_manager)};
+    auto block_template{block_template_manager.CreateNewTemplate({
         .coinbase_output_script = pubKey,
-    }, /*cooldown=*/false)};
+    })};
     BOOST_REQUIRE(block_template);
-    CBlock pblock{block_template->getBlock()};
+    CBlock pblock{block_template->block};
 
     CTxOut witness;
     witness.scriptPubKey.resize(MINIMUM_WITNESS_COMMITMENT);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -423,7 +423,7 @@ struct SnapshotTestSetup : TestChain100Setup {
         {
             // Process all callbacks referring to the old manager before wiping it.
             m_node.validation_signals->SyncWithValidationInterfaceQueue();
-            m_node.block_template_manager.reset();
+            ResetBlockTemplateManager();
             LOCK(::cs_main);
             chainman.ResetChainstates();
             BOOST_CHECK_EQUAL(chainman.m_chainstates.size(), 0);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -5,6 +5,7 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <kernel/disconnected_transactions.h>
+#include <node/block_template_manager.h>
 #include <node/chainstatemanager_args.h>
 #include <node/kernel_notifications.h>
 #include <node/utxo_snapshot.h>
@@ -422,6 +423,7 @@ struct SnapshotTestSetup : TestChain100Setup {
         {
             // Process all callbacks referring to the old manager before wiping it.
             m_node.validation_signals->SyncWithValidationInterfaceQueue();
+            m_node.block_template_manager.reset();
             LOCK(::cs_main);
             chainman.ResetChainstates();
             BOOST_CHECK_EQUAL(chainman.m_chainstates.size(), 0);
@@ -446,6 +448,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             // new one.
             m_node.chainman.reset();
             m_node.chainman = std::make_unique<ChainstateManager>(*Assert(m_node.shutdown_signal), chainman_opts, blockman_opts);
+            CreateBlockTemplateManager();
         }
         return *Assert(m_node.chainman);
     }

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -220,7 +220,7 @@ public:
      *  the Cluster's QualityLevel improved as a result. */
     virtual std::pair<uint64_t, bool> Relinearize(TxGraphImpl& graph, int level, uint64_t max_cost) noexcept = 0;
     /** For every chunk in the cluster, append its FeeFrac to ret. */
-    virtual void AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept = 0;
+    virtual void AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept = 0;
     /** Add a TrimTxData entry (filling m_chunk_feerate, m_index, m_tx_size) for every
      *  transaction in the Cluster to ret. Implicit dependencies between consecutive transactions
      *  in the linearization are added to deps. Return the Cluster's total transaction size. */
@@ -298,7 +298,7 @@ public:
     void Merge(TxGraphImpl& graph, int level, Cluster& cluster) noexcept final;
     void ApplyDependencies(TxGraphImpl& graph, int level, std::span<std::pair<GraphIndex, GraphIndex>> to_apply) noexcept final;
     std::pair<uint64_t, bool> Relinearize(TxGraphImpl& graph, int level, uint64_t max_cost) noexcept final;
-    void AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept final;
+    void AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept final;
     uint64_t AppendTrimData(std::vector<TrimTxData>& ret, std::vector<std::pair<GraphIndex, GraphIndex>>& deps) const noexcept final;
     void GetAncestorRefs(const TxGraphImpl& graph, std::span<std::pair<Cluster*, DepGraphIndex>>& args, std::vector<TxGraph::Ref*>& output) noexcept final;
     void GetDescendantRefs(const TxGraphImpl& graph, std::span<std::pair<Cluster*, DepGraphIndex>>& args, std::vector<TxGraph::Ref*>& output) noexcept final;
@@ -355,7 +355,7 @@ public:
     void Merge(TxGraphImpl& graph, int level, Cluster& cluster) noexcept final;
     void ApplyDependencies(TxGraphImpl& graph, int level, std::span<std::pair<GraphIndex, GraphIndex>> to_apply) noexcept final;
     std::pair<uint64_t, bool> Relinearize(TxGraphImpl& graph, int level, uint64_t max_cost) noexcept final;
-    void AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept final;
+    void AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept final;
     uint64_t AppendTrimData(std::vector<TrimTxData>& ret, std::vector<std::pair<GraphIndex, GraphIndex>>& deps) const noexcept final;
     void GetAncestorRefs(const TxGraphImpl& graph, std::span<std::pair<Cluster*, DepGraphIndex>>& args, std::vector<TxGraph::Ref*>& output) noexcept final;
     void GetDescendantRefs(const TxGraphImpl& graph, std::span<std::pair<Cluster*, DepGraphIndex>>& args, std::vector<TxGraph::Ref*>& output) noexcept final;
@@ -821,7 +821,7 @@ public:
     bool IsOversized(Level level) noexcept final;
     std::strong_ordering CompareMainOrder(const Ref& a, const Ref& b) noexcept final;
     GraphIndex CountDistinctClusters(std::span<const Ref* const> refs, Level level) noexcept final;
-    std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> GetMainStagingDiagrams() noexcept final;
+    std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>> GetMainStagingDiagrams() noexcept final;
     std::vector<Ref*> Trim() noexcept final;
 
     std::unique_ptr<BlockBuilder> GetBlockBuilder() noexcept final;
@@ -1381,17 +1381,29 @@ void SingletonClusterImpl::Compact() noexcept
     // Nothing to compact; SingletonClusterImpl is constant size.
 }
 
-void GenericClusterImpl::AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept
+void GenericClusterImpl::AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept
 {
-    auto chunk_feerates = ChunkLinearization(m_depgraph, m_linearization);
-    ret.reserve(ret.size() + chunk_feerates.size());
-    ret.insert(ret.end(), chunk_feerates.begin(), chunk_feerates.end());
+    auto linchunking = ChunkLinearizationInfo(m_depgraph, m_linearization);
+    ret.reserve(ret.size() + linchunking.size());
+    LinearizationIndex pos{0};
+    for (auto& [chunk, chunk_feerate] : linchunking) {
+        auto chunk_tx_count = chunk.Count();
+        std::vector<TxGraph::Ref*> refs;
+        refs.reserve(chunk_tx_count);
+        for (unsigned j = 0; j < chunk_tx_count; ++j) {
+            auto cluster_idx = m_linearization[pos];
+            refs.emplace_back(graph.m_entries[m_mapping[cluster_idx]].m_ref);
+            ++pos;
+        }
+        ret.emplace_back(chunk_feerate, std::move(refs));
+    }
 }
 
-void SingletonClusterImpl::AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept
+void SingletonClusterImpl::AppendChunks(const TxGraphImpl& graph, std::vector<TxGraph::Chunk>& ret) const noexcept
 {
     if (GetTxCount()) {
-        ret.push_back(m_feerate);
+        const auto& entry = graph.m_entries[m_graph_index];
+        ret.emplace_back(m_feerate, std::vector<TxGraph::Ref*>{entry.m_ref});
     }
 }
 
@@ -2807,7 +2819,7 @@ TxGraph::GraphIndex TxGraphImpl::CountDistinctClusters(std::span<const Ref* cons
     return ret;
 }
 
-std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> TxGraphImpl::GetMainStagingDiagrams() noexcept
+std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>> TxGraphImpl::GetMainStagingDiagrams() noexcept
 {
     Assume(m_staging_clusterset.has_value());
     MakeAllAcceptable(0);
@@ -2817,20 +2829,20 @@ std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> TxGraphImpl::GetMainStagin
     // For all Clusters in main which conflict with Clusters in staging (i.e., all that are removed
     // by, or replaced in, staging), gather their chunk feerates.
     auto main_clusters = GetConflicts();
-    std::vector<FeeFrac> main_feerates, staging_feerates;
+    std::vector<Chunk> main_chunks, staging_chunks;
     for (Cluster* cluster : main_clusters) {
-        cluster->AppendChunkFeerates(main_feerates);
+        cluster->AppendChunks(*this, main_chunks);
     }
     // Do the same for the Clusters in staging themselves.
     for (int quality = 0; quality < int(QualityLevel::NONE); ++quality) {
         for (const auto& cluster : m_staging_clusterset->m_clusters[quality]) {
-            cluster->AppendChunkFeerates(staging_feerates);
+            cluster->AppendChunks(*this, staging_chunks);
         }
     }
     // Sort both by decreasing feerate to obtain diagrams, and return them.
-    std::ranges::sort(main_feerates, std::greater<ByRatioNegSize<FeeFrac>>{});
-    std::ranges::sort(staging_feerates, std::greater<ByRatioNegSize<FeeFrac>>{});
-    return std::make_pair(std::move(main_feerates), std::move(staging_feerates));
+    std::ranges::sort(main_chunks, Chunk::GreaterFeerate{});
+    std::ranges::sort(staging_chunks, Chunk::GreaterFeerate{});
+    return std::make_pair(std::move(main_chunks), std::move(staging_chunks));
 }
 
 void GenericClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
@@ -2904,6 +2916,19 @@ void GenericClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
     }
     // Verify that each element of m_depgraph occurred in m_linearization.
     assert(m_done == m_depgraph.Positions());
+    // Verify AppendChunks returns correct result.
+    std::vector<TxGraph::Chunk> chunks;
+    AppendChunks(graph, chunks);
+    LinearizationIndex pos{0};
+    assert(chunks.size() == linchunking.size());
+    for (unsigned i = 0; i < chunks.size(); ++i) {
+        for (auto ref : chunks[i].refs) {
+            auto cluster_idx = m_linearization[pos];
+            assert(ref == graph.m_entries[m_mapping[cluster_idx]].m_ref);
+            pos += 1;
+        }
+        assert(chunks[i].feerate == linchunking[i].feerate);
+    }
 }
 
 void SingletonClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
@@ -2926,6 +2951,11 @@ void SingletonClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) cons
                 assert(chunk_data.m_chunk_count == LinearizationIndex(-1));
             }
         }
+        // Verify AppendChunks returns correct result.
+        std::vector<TxGraph::Chunk> chunks;
+        AppendChunks(graph, chunks);
+        assert(chunks.size() == 1);
+        assert((chunks.back() == TxGraph::Chunk{m_feerate, {entry.m_ref}}));
     }
 }
 

--- a/src/txgraph.h
+++ b/src/txgraph.h
@@ -61,6 +61,24 @@ public:
      */
     class Ref;
 
+    /** Datatype representing a chunk along with its feerate and all the tx refs in the chunk. */
+    struct Chunk {
+        FeePerWeight feerate;
+        std::vector<Ref*> refs;
+        Chunk(const FeeFrac& f, std::vector<Ref*> r) noexcept : feerate{f.fee, f.size}, refs{std::move(r)} {}
+        bool operator==(const Chunk& other) const noexcept
+        {
+            return feerate == other.feerate && refs == other.refs;
+        }
+        /** Comparator for sorting chunks by descending feerate; ties broken by smaller size. */
+        struct GreaterFeerate {
+            bool operator()(const Chunk& a, const Chunk& b) const noexcept
+            {
+                return ByRatioNegSize{a.feerate} > ByRatioNegSize{b.feerate};
+            }
+        };
+    };
+
     enum class Level {
         TOP, //!< Refers to staging if it exists, main otherwise.
         MAIN //!< Always refers to the main graph, whether staging is present or not.
@@ -167,10 +185,9 @@ public:
      *  not be oversized. */
     virtual GraphIndex CountDistinctClusters(std::span<const Ref* const>, Level level) noexcept = 0;
     /** For both main and staging (which must both exist and not be oversized), return the combined
-     *  respective feerate diagrams, including chunks from all clusters, but excluding clusters
-     *  that appear identically in both. Use FeeFrac rather than FeePerWeight so CompareChunks is
-     *  usable without type-conversion. */
-    virtual std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> GetMainStagingDiagrams() noexcept = 0;
+     *  respective feerate diagrams, including chunks (feerate and refs) from all clusters, but
+     *  excluding clusters that appear identically in both. */
+    virtual std::pair<std::vector<Chunk>, std::vector<Chunk>> GetMainStagingDiagrams() noexcept = 0;
     /** Remove transactions (including their own descendants) according to a fast but best-effort
      *  strategy such that the TxGraph's cluster and size limits are respected. Applies to staging
      *  if it exists, and to main otherwise. Returns the list of all removed transactions in

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -88,7 +88,8 @@ std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> CTxMemPool::GetParents(const CT
     return ret;
 }
 
-void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<Txid>& vHashesToUpdate)
+
+void CTxMemPool::addDependenciesFromBlock(const std::vector<Txid>& vHashesToUpdate)
 {
     AssertLockHeld(cs);
 
@@ -111,7 +112,12 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<Txid>& vHashesToU
             }
         }
     }
+}
 
+void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<Txid>& vHashesToUpdate)
+{
+    AssertLockHeld(cs);
+    addDependenciesFromBlock(vHashesToUpdate);
     auto txs_to_remove = m_txgraph->Trim(); // Enforce cluster size limits.
     for (auto txptr : txs_to_remove) {
         const CTxMemPoolEntry& entry = *(static_cast<const CTxMemPoolEntry*>(txptr));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1008,7 +1008,17 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
         return util::Error{Untranslated("cluster size limit exceeded")};
     }
 
-    return m_pool->m_txgraph->GetMainStagingDiagrams();
+    std::vector<FeeFrac> old_diagram, new_diagram;
+    auto diagrams = m_pool->m_txgraph->GetMainStagingDiagrams();
+    old_diagram.reserve(diagrams.first.size());
+    new_diagram.reserve(diagrams.second.size());
+    for (auto& chunk : diagrams.first) {
+        old_diagram.emplace_back(chunk.feerate);
+    }
+    for (auto& chunk : diagrams.second) {
+        new_diagram.emplace_back(chunk.feerate);
+    }
+    return std::make_pair(old_diagram, new_diagram);
 }
 
 CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -54,6 +54,24 @@ bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
     return true;
 }
 
+static std::vector<MemPoolChunk> MakeMemPoolChunks(const std::vector<TxGraph::Chunk>& chunks)
+{
+    std::vector<MemPoolChunk> result;
+    result.reserve(chunks.size());
+    for (const auto& chunk : chunks) {
+        std::vector<CTransactionRef> txs;
+        int64_t sigops{0};
+        txs.reserve(chunk.refs.size());
+        for (const auto& ref : chunk.refs) {
+            const auto& entry = static_cast<const CTxMemPoolEntry&>(*ref);
+            txs.emplace_back(entry.GetSharedTx());
+            sigops += entry.GetSigOpCost();
+        }
+        result.push_back({chunk.feerate, std::move(txs), sigops, std::nullopt});
+    }
+    return result;
+}
+
 std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> CTxMemPool::GetChildren(const CTxMemPoolEntry& entry) const
 {
     std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> ret;
@@ -92,24 +110,15 @@ std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> CTxMemPool::GetParents(const CT
 void CTxMemPool::addDependenciesFromBlock(const std::vector<Txid>& vHashesToUpdate)
 {
     AssertLockHeld(cs);
-
-    // Iterate in reverse, so that whenever we are looking at a transaction
-    // we are sure that all in-mempool descendants have already been processed.
+    // Iterate in reverse so that when processing a transaction, all its
+    // in-mempool descendants have already been processed.
     for (const Txid& hash : vHashesToUpdate | std::views::reverse) {
-        // calculate children from mapNextTx
         txiter it = mapTx.find(hash);
-        if (it == mapTx.end()) {
-            continue;
-        }
+        if (it == mapTx.end()) continue;
         auto iter = mapNextTx.lower_bound(COutPoint(hash, 0));
-        {
-            for (; iter != mapNextTx.end() && iter->first->hash == hash; ++iter) {
-                txiter childIter = iter->second;
-                assert(childIter != mapTx.end());
-                // Add dependencies that are discovered between transactions in the
-                // block and transactions that were in the mempool to txgraph.
-                m_txgraph->AddDependency(/*parent=*/*it, /*child=*/*childIter);
-            }
+        for (; iter != mapNextTx.end() && iter->first->hash == hash; ++iter) {
+            assert(iter->second != mapTx.end());
+            m_txgraph->AddDependency(/*parent=*/*it, /*child=*/*iter->second);
         }
     }
 }
@@ -117,11 +126,42 @@ void CTxMemPool::addDependenciesFromBlock(const std::vector<Txid>& vHashesToUpda
 void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<Txid>& vHashesToUpdate)
 {
     AssertLockHeld(cs);
+    Assume(!m_have_changeset);
+    // Add parent->child dependencies discovered between re-added transactions
+    // and existing mempool transactions on a staging graph, then check whether
+    // any clusters now exceed the size limit.
+    auto changeSet = GetChangeSet();
     addDependenciesFromBlock(vHashesToUpdate);
-    auto txs_to_remove = m_txgraph->Trim(); // Enforce cluster size limits.
-    for (auto txptr : txs_to_remove) {
-        const CTxMemPoolEntry& entry = *(static_cast<const CTxMemPoolEntry*>(txptr));
-        removeUnchecked(mapTx.iterator_to(entry), MemPoolRemovalReason::SIZELIMIT);
+    auto txs_to_remove = m_txgraph->Trim();
+    setEntries iters;
+    if (!txs_to_remove.empty()) {
+        // Clusters exceed the size limit after adding new dependencies.
+        // Abort the current staging graph (which contains the oversized clusters)
+        // and start fresh; an oversized graph cannot produce a valid fee rate diagram.
+        // Then evict the transactions discovered by Trim() and re-add dependencies.
+        // With the oversized txs gone, GetMainStagingDiagrams produces a correct
+        // before/after diff: old = pre-dependency clusters (main),
+        // new = post-dependency clusters without evicted txs (staging).
+        changeSet.reset();
+        changeSet = GetChangeSet();
+        for (auto txptr : txs_to_remove) {
+            m_txgraph->RemoveTransaction(*txptr);
+            iters.insert(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*txptr)));
+        }
+        // It is safe to add dependencies here without first evicting iters from
+        // mapTx/mapNextTx: AddDependency is a no-op when either parent or child
+        // is absent from the graph, so evicted txs are simply skipped.
+        addDependenciesFromBlock(vHashesToUpdate);
+    }
+    changeSet->SnapshotDiagrams();
+    auto& chunks = changeSet->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+    m_txgraph->CommitStaging();
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(
+        MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::SIZELIMIT});
+    RemoveStaged(iters, MemPoolRemovalReason::SIZELIMIT);
+    if (!m_txgraph->DoWork(/*max_cost=*/POST_CHANGE_COST)) {
+        LogDebug(BCLog::MEMPOOL, "Mempool in non-optimal ordering after reorg.");
     }
 }
 
@@ -212,8 +252,13 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
 void CTxMemPool::Apply(ChangeSet* changeset)
 {
     AssertLockHeld(cs);
+    if (changeset->m_fee_rate_diagrams.first.empty() && changeset->m_fee_rate_diagrams.second.empty()) {
+        changeset->SnapshotDiagrams();
+    }
+    auto& chunks = changeset->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
     m_txgraph->CommitStaging();
-
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::REPLACED});
     RemoveStaged(changeset->m_to_remove, MemPoolRemovalReason::REPLACED);
 
     for (size_t i=0; i<changeset->m_entry_vec.size(); ++i) {
@@ -331,9 +376,15 @@ void CTxMemPool::removeRecursive(CTxMemPool::txiter to_remove, MemPoolRemovalRea
     AssertLockHeld(cs);
     Assume(!m_have_changeset);
     auto descendants = m_txgraph->GetDescendants(*to_remove, TxGraph::Level::MAIN);
+    auto changeSet = GetChangeSet();
     for (auto tx: descendants) {
-        removeUnchecked(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*tx)), reason);
+        changeSet->StageRemoval(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*tx)));
     }
+    changeSet->SnapshotDiagrams();
+    auto& chunks = changeSet->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, reason});
+    RemoveStaged(changeSet->GetRemovals(), reason);
 }
 
 void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReason reason)
@@ -356,10 +407,15 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
             ++iter;
         }
         auto all_removes = m_txgraph->GetDescendantsUnion(to_remove, TxGraph::Level::MAIN);
+        auto changeSet = GetChangeSet();
         for (auto ref : all_removes) {
-            auto tx = mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref));
-            removeUnchecked(tx, reason);
+            changeSet->StageRemoval(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref)));
         }
+        changeSet->SnapshotDiagrams();
+        auto& chunks = changeSet->GetFeeRateDiagramChunks();
+        auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+        if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, reason});
+        RemoveStaged(changeSet->GetRemovals(), reason);
     }
 }
 
@@ -379,10 +435,16 @@ void CTxMemPool::removeForReorg(CChain& chain, std::function<bool(txiter)> check
 
     auto all_to_remove = m_txgraph->GetDescendantsUnion(to_remove, TxGraph::Level::MAIN);
 
+    auto changeSet = GetChangeSet();
     for (auto ref : all_to_remove) {
-        auto it = mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref));
-        removeUnchecked(it, MemPoolRemovalReason::REORG);
+        changeSet->StageRemoval(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref)));
     }
+    changeSet->SnapshotDiagrams();
+    auto& chunks = changeSet->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::REORG});
+    RemoveStaged(changeSet->GetRemovals(), MemPoolRemovalReason::REORG);
+
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         assert(TestLockPointValidity(chain, it->GetLockPoints()));
     }
@@ -416,12 +478,22 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     std::vector<RemovedMempoolTransactionInfo> txs_removed_for_block;
     if (mapTx.size() || mapNextTx.size() || mapDeltas.size()) {
         txs_removed_for_block.reserve(vtx.size());
-        for (const auto& tx : vtx) {
-            txiter it = mapTx.find(tx->GetHash());
-            if (it != mapTx.end()) {
-                txs_removed_for_block.emplace_back(*it);
-                removeUnchecked(it, MemPoolRemovalReason::BLOCK);
+        {
+            auto changeSet = GetChangeSet();
+            for (const auto& tx : vtx) {
+                txiter it = mapTx.find(tx->GetHash());
+                if (it != mapTx.end()) {
+                    txs_removed_for_block.emplace_back(*it);
+                    changeSet->StageRemoval(it);
+                }
             }
+            changeSet->SnapshotDiagrams();
+            auto& chunks = changeSet->GetFeeRateDiagramChunks();
+            auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+            if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::BLOCK, nBlockHeight});
+            RemoveStaged(changeSet->GetRemovals(), MemPoolRemovalReason::BLOCK);
+        }
+        for (const auto& tx : vtx) {
             removeConflicts(*tx);
             ClearPrioritisation(tx->GetHash());
         }
@@ -838,7 +910,15 @@ int CTxMemPool::Expire(std::chrono::seconds time)
     for (txiter removeit : toremove) {
         CalculateDescendants(removeit, stage);
     }
-    RemoveStaged(stage, MemPoolRemovalReason::EXPIRY);
+    auto changeSet = GetChangeSet();
+    for (auto it : stage) {
+        changeSet->StageRemoval(it);
+    }
+    changeSet->SnapshotDiagrams();
+    auto& chunks = changeSet->GetFeeRateDiagramChunks();
+    auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+    if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::EXPIRY});
+    RemoveStaged(changeSet->GetRemovals(), MemPoolRemovalReason::EXPIRY);
     return stage.size();
 }
 
@@ -904,13 +984,15 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
             }
         }
 
-        setEntries stage;
+        auto changeSet = GetChangeSet();
         for (auto ref : worst_chunk) {
-            stage.insert(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref)));
+            changeSet->StageRemoval(mapTx.iterator_to(static_cast<const CTxMemPoolEntry&>(*ref)));
         }
-        for (auto e : stage) {
-            removeUnchecked(e, MemPoolRemovalReason::SIZELIMIT);
-        }
+        changeSet->SnapshotDiagrams();
+        auto& chunks = changeSet->GetFeeRateDiagramChunks();
+        auto diagrams = std::make_pair(MakeMemPoolChunks(chunks.first), MakeMemPoolChunks(chunks.second));
+        if (m_opts.signals) m_opts.signals->MempoolUpdated(MemPoolChunksUpdate{diagrams.first, diagrams.second, MemPoolRemovalReason::SIZELIMIT});
+        RemoveStaged(changeSet->GetRemovals(), MemPoolRemovalReason::SIZELIMIT);
         if (pvNoSpendsRemaining) {
             for (const CTransaction& tx : txn) {
                 for (const CTxIn& txin : tx.vin) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1007,18 +1007,22 @@ util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::
     if (!CheckMemPoolPolicyLimits()) {
         return util::Error{Untranslated("cluster size limit exceeded")};
     }
-
     std::vector<FeeFrac> old_diagram, new_diagram;
-    auto diagrams = m_pool->m_txgraph->GetMainStagingDiagrams();
-    old_diagram.reserve(diagrams.first.size());
-    new_diagram.reserve(diagrams.second.size());
-    for (auto& chunk : diagrams.first) {
+    m_fee_rate_diagrams = m_pool->m_txgraph->GetMainStagingDiagrams();
+    old_diagram.reserve(m_fee_rate_diagrams.first.size());
+    new_diagram.reserve(m_fee_rate_diagrams.second.size());
+    for (auto& chunk : m_fee_rate_diagrams.first) {
         old_diagram.emplace_back(chunk.feerate);
     }
-    for (auto& chunk : diagrams.second) {
+    for (auto& chunk : m_fee_rate_diagrams.second) {
         new_diagram.emplace_back(chunk.feerate);
     }
     return std::make_pair(old_diagram, new_diagram);
+}
+
+const std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>>& CTxMemPool::ChangeSet::GetFeeRateDiagramChunks() const
+{
+    return m_fee_rate_diagrams;
 }
 
 CTxMemPool::ChangeSet::TxHandle CTxMemPool::ChangeSet::StageAddition(const CTransactionRef& tx, const CAmount fee, int64_t time, unsigned int entry_height, uint64_t entry_sequence, bool spends_coinbase, int64_t sigops_cost, LockPoints lp)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -799,7 +799,8 @@ void CTxMemPool::RemoveUnbroadcastTx(const Txid& txid, const bool unchecked) {
     }
 }
 
-void CTxMemPool::RemoveStaged(setEntries &stage, MemPoolRemovalReason reason) {
+void CTxMemPool::RemoveStaged(const setEntries& stage, MemPoolRemovalReason reason)
+{
     AssertLockHeld(cs);
     for (txiter it : stage) {
         removeUnchecked(it, reason);
@@ -1003,10 +1004,15 @@ std::vector<CTxMemPool::txiter> CTxMemPool::GatherClusters(const std::vector<Txi
 util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CTxMemPool::ChangeSet::CalculateChunksForRBF()
 {
     LOCK(m_pool->cs);
-
     if (!CheckMemPoolPolicyLimits()) {
         return util::Error{Untranslated("cluster size limit exceeded")};
     }
+    return SnapshotDiagrams();
+}
+
+std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> CTxMemPool::ChangeSet::SnapshotDiagrams()
+{
+    LOCK(m_pool->cs);
     std::vector<FeeFrac> old_diagram, new_diagram;
     m_fee_rate_diagrams = m_pool->m_txgraph->GetMainStagingDiagrams();
     old_diagram.reserve(m_fee_rate_diagrams.first.size());

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -685,6 +685,8 @@ public:
          */
         util::Result<std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>>> CalculateChunksForRBF();
 
+        const std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>>& GetFeeRateDiagramChunks() const;
+
         size_t GetTxCount() const { return m_entry_vec.size(); }
         const CTransaction& GetAddedTxn(size_t index) const { return m_entry_vec.at(index)->GetTx(); }
 
@@ -698,6 +700,7 @@ public:
         std::vector<CTxMemPool::txiter> m_entry_vec; // track the added transactions' insertion order
         // map from the m_to_add index to the ancestors for the transaction
         std::map<CTxMemPool::txiter, CTxMemPool::setEntries, CompareIteratorByHash> m_ancestors;
+        std::pair<std::vector<TxGraph::Chunk>, std::vector<TxGraph::Chunk>> m_fee_rate_diagrams;
         CTxMemPool::setEntries m_to_remove;
         bool m_dependencies_processed{false};
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -600,6 +600,9 @@ private:
 
     /* Removal from the mempool also triggers removal of the entry's Ref from txgraph. */
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+    void addDependenciesFromBlock(const std::vector<Txid>& vHashesToUpdate) EXCLUSIVE_LOCKS_REQUIRED(cs);
+
 public:
     /*
      * CTxMemPool::ChangeSet:

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -593,7 +593,7 @@ private:
      *  also be in the set, unless this transaction is being removed for being
      *  in a block.
      */
-    void RemoveStaged(setEntries& stage, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void RemoveStaged(const setEntries& stage, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /* Helper for the public removeRecursive() */
     void removeRecursive(txiter to_remove, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -694,6 +694,7 @@ public:
 
     private:
         void ProcessDependencies();
+        std::pair<std::vector<FeeFrac>, std::vector<FeeFrac>> SnapshotDiagrams();
 
         CTxMemPool* m_pool;
         CTxMemPool::indexed_transaction_set m_to_add;

--- a/src/util/hasher.cpp
+++ b/src/util/hasher.cpp
@@ -5,7 +5,11 @@
 #include <util/hasher.h>
 
 #include <crypto/siphash.h>
+#include <hash.h>
 #include <random.h>
+
+#include <algorithm>
+#include <iterator>
 
 SaltedUint256Hasher::SaltedUint256Hasher() : m_hasher{
     FastRandomContext().rand64(),
@@ -35,4 +39,19 @@ SaltedSipHasher::SaltedSipHasher() :
 size_t SaltedSipHasher::operator()(const std::span<const unsigned char>& script) const
 {
     return CSipHasher(m_k0, m_k1).Write(script).Finalize();
+}
+
+uint256 GetHashFromWitnesses(std::vector<Wtxid> wtxids)
+{
+    // Sort in ascending order
+    std::sort(wtxids.begin(), wtxids.end(), [](const auto& lhs, const auto& rhs) {
+        return std::lexicographical_compare(
+            std::make_reverse_iterator(lhs.end()), std::make_reverse_iterator(lhs.begin()),
+            std::make_reverse_iterator(rhs.end()), std::make_reverse_iterator(rhs.begin()));
+    });
+
+    // Get sha256 hash of the wtxids concatenated in this order
+    HashWriter hw;
+    for (const auto& wtxid : wtxids) hw << wtxid;
+    return hw.GetSHA256();
 }

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstring>
 #include <span>
+#include <vector>
 
 class SaltedUint256Hasher
 {
@@ -115,5 +116,8 @@ public:
 
     size_t operator()(const std::span<const unsigned char>& script) const;
 };
+
+/** Sorts (a local copy of) a set of wtxids and hashes them into a single hash. */
+uint256 GetHashFromWitnesses(std::vector<Wtxid> wtxids);
 
 #endif // BITCOIN_UTIL_HASHER_H

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -13,6 +13,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <util/check.h>
+#include <util/hasher.h>
 #include <util/log.h>
 #include <util/task_runner.h>
 
@@ -237,6 +238,29 @@ void ValidationSignals::MempoolTransactionsRemovedForBlock(const std::vector<Rem
                           txs_removed_for_block.size());
     auto event = [txs_removed_for_block, nBlockHeight, this] {
         m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.MempoolTransactionsRemovedForBlock(txs_removed_for_block, nBlockHeight); });
+    };
+    ENQUEUE_AND_LOG_EVENT(std::move(event), std::move(log_msg));
+}
+
+void ValidationSignals::MempoolUpdated(MemPoolChunksUpdate mempool_chunks)
+{
+    auto compute_hash = [](MemPoolChunk& chunk) {
+        std::vector<Wtxid> wtxids;
+        wtxids.reserve(chunk.m_transactions.size());
+        for (const auto& tx : chunk.m_transactions)
+            wtxids.emplace_back(tx->GetWitnessHash());
+        chunk.m_chunk_hash = GetHashFromWitnesses(wtxids);
+    };
+    for (auto& chunk : mempool_chunks.old_chunks)
+        compute_hash(chunk);
+    for (auto& chunk : mempool_chunks.new_chunks)
+        compute_hash(chunk);
+    auto log_msg = LOG_MSG("%s: old chunks=%s new chunks=%s reason for removal=%s", __func__,
+                           mempool_chunks.old_chunks.size(),
+                           mempool_chunks.new_chunks.size(),
+                           RemovalReasonToString(mempool_chunks.reason));
+    auto event = [mempool_chunks, this] {
+        m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.MempoolUpdated(mempool_chunks); });
     };
     ENQUEUE_AND_LOG_EVENT(std::move(event), std::move(log_msg));
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -30,6 +30,7 @@ struct CBlockLocator;
 enum class MemPoolRemovalReason;
 struct RemovedMempoolTransactionInfo;
 struct NewMempoolTransactionInfo;
+struct MemPoolChunksUpdate;
 
 /**
  * Implement this to subscribe to events generated in validation and mempool
@@ -115,6 +116,13 @@ protected:
      * Called on a background thread.
      */
     virtual void MempoolTransactionsRemovedForBlock(const std::vector<RemovedMempoolTransactionInfo>& txs_removed_for_block, unsigned int nBlockHeight) {}
+    /**
+     * Notifies listeners of each mempool update via a MemPoolChunksUpdate
+     * describing the chunks that left and entered the mempool.
+     *
+     * Called on a background thread.
+     */
+    virtual void MempoolUpdated(const MemPoolChunksUpdate& mempool_chunks) {}
     /**
      * Notifies listeners of a block being connected.
      *
@@ -225,6 +233,7 @@ public:
     void MempoolTransactionsRemovedForBlock(const std::vector<RemovedMempoolTransactionInfo>&, unsigned int nBlockHeight);
     void BlockConnected(const kernel::ChainstateRole&, std::shared_ptr<const CBlock>, const CBlockIndex* pindex);
     void BlockDisconnected(std::shared_ptr<const CBlock>, const CBlockIndex* pindex);
+    void MempoolUpdated(MemPoolChunksUpdate);
     void ChainStateFlushed(const kernel::ChainstateRole&, const CBlockLocator&);
     void BlockChecked(const std::shared_ptr<const CBlock>&, const BlockValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -443,11 +443,11 @@ class ZMQTest (BitcoinTestFramework):
         mempool_seq += 1
         assert_equal((bump_txid, "A", mempool_seq), seq.receive_sequence())
         mempool_seq += 1
-        # Conflict announced first, then block
+        # Block txs seq slots consumed first, then conflict evicted, then block announced
+        mempool_seq += len(more_tx)
         assert_equal((bump_txid, "R", mempool_seq), seq.receive_sequence())
         mempool_seq += 1
         assert_equal((tip, "C", None), seq.receive_sequence())
-        mempool_seq += len(more_tx)
         # Last tx
         assert_equal((orig_txid_2, "A", mempool_seq), seq.receive_sequence())
         mempool_seq += 1


### PR DESCRIPTION
### Motivation

  The mining interface and rpc helpers (`WaitAndCreateNewBlock` and friends) are free functions scattered across `src/node/miner.cpp`, and every caller has to pass `ChainstateManager` and `KernelNotifications` into them, which is verbose. `SubmitBlock` spins up a short-lived `CValidationInterface` subscriber on every call just to read back the block validation state. This PR adds a BlockTemplateManager  that holds that state and exposes those helpers as methods, so callers don't have to  thread chainman/notifications (or a throwaway subscriber) around.

 It also removes a redundant pattern in `waitNext`. Currently, to decide whether mempool fee  inflow rose enough to be worth a new template, waitNext locks `cs_main` and assembles a  full block template every tick just to sum its fees and compare. After cluster mempool see https://delvingbitcoin.org/t/determining-blocktemplate-fee-increase-using-fee-rate-diagram/2052, we shouldn't have to build a whole block template to answer that question. This PR uses the #34803 mempool notifications to record the previous template state and track the inflow above the lowest  included chunk, and only assembles and returns a new template once that inflow is above the threshold.

 I  added a fuzz harness and unit tests for the manager. The fuzz test already caught a bug in the miner where it skips legitimate transactions due to an incorrect block chunk size limit check #35580.

 ### Changes

  - Populate the tx refs in the fee rate diagrams
  - Cache fee rate diagrams as chunks in ChangeSet and add SnapshotDiagrams
  - Add a `MempoolUpdated` notification that returns the before and after diagrams
  - Track the selected chunk information after each mempool update
  - Add fee-inflow staleness detection per template
  - Introduce a `BlockTemplateManager` wrapper around `BlockAssembler` that holds state and
    creates templates, and move the free functions (mining args, SubmitBlock, GetTip,
    WaitTipChanged, CooldownIfHeadersAhead, WaitAndCreateNewBlock) onto it as methods
  - Use the tracked inflow in waitNext instead of rebuilding a template each tick
  - Route in-process RPC and test template creation through `BlockTemplateManager` instead
    of the IPC Mining interface, which also drops the per-access block copies the IPC
    accessors (getBlock) forced
  - Add a fuzz test and unit tests


  There are now two entry points for template creation. Mining clients go through the IPC
  Mining interface and get tracked templates, while in-process RPC and tests call  BlockTemplateManager directly and get untracked ones. This is deliberate: one-shot RPC  templates don't need staleness tracking, and it also avoids process-static RPC caches owning BlockTemplateImpl objects whose destructor reaches back into NodeContext at shutdown.

50% of the code addition here are tests ~1090 lines