### PR TITLE
implement randomize ports

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -106,6 +106,7 @@
 
 #include <algorithm>
 #include <any>
+#include <array>
 #include <cerrno>
 #include <condition_variable>
 #include <cstddef>
@@ -595,6 +596,8 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-peerblockfilters", strprintf("Serve compact block filters to peers per BIP 157 (default: %u)", DEFAULT_PEERBLOCKFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-txreconciliation", strprintf("Enable transaction reconciliations per BIP 330 (default: %d)", DEFAULT_TXRECONCILIATION_ENABLE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-port=<port>", strprintf("Listen for connections on <port> (default: %u, testnet3: %u, testnet4: %u, signet: %u, regtest: %u). Not relevant for I2P (see doc/i2p.md). If set to a value x, the default onion listening port will be set to x+1.", defaultChainParams->GetDefaultPort(), testnetChainParams->GetDefaultPort(), testnet4ChainParams->GetDefaultPort(), signetChainParams->GetDefaultPort(), regtestChainParams->GetDefaultPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+    argsman.AddArg(RANDOMIZE_P2P_PORT_ARG, strprintf("Randomize the listening P2P port on first startup and reuse it on later startups. This option cannot be used with -port. Randomized ports are selected from %u-%u (default: 0)", RANDOMIZED_P2P_PORT_MIN, RANDOMIZED_P2P_PORT_MAX), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+    argsman.AddArg(strprintf("%s=<port>", RANDOMIZED_P2P_PORT_ARG), "", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::HIDDEN);
     const std::string proxy_doc_for_value =
 #ifdef HAVE_SOCKADDR_UN
         "<ip>[:<port>]|unix:<path>";
@@ -1276,6 +1279,170 @@ bool CheckHostPortOptions(const ArgsManager& args) {
     return true;
 }
 
+static constexpr std::array<uint16_t, 5> RESERVED_P2P_PORTS{
+    8333, 18333, 38333, 48333, 18444};
+
+static std::string RandomizedP2PPortSettingName()
+{
+    return std::string{RANDOMIZED_P2P_PORT_ARG}.substr(1);
+}
+
+static bool ValidateRandomizedP2PPort(uint16_t port, const std::string& option)
+{
+    if (std::find(RESERVED_P2P_PORTS.begin(), RESERVED_P2P_PORTS.end(), port) != RESERVED_P2P_PORTS.end()) {
+        return InitError(strprintf(_("%s cannot be set to reserved P2P port %u when -randomizep2pport is enabled."), option, port));
+    }
+    if (port < RANDOMIZED_P2P_PORT_MIN || port > RANDOMIZED_P2P_PORT_MAX) {
+        return InitError(strprintf(_("%s must be in the randomized P2P port range %u-%u when -randomizep2pport is enabled."), option, RANDOMIZED_P2P_PORT_MIN, RANDOMIZED_P2P_PORT_MAX));
+    }
+    if (IsBadPort(port)) {
+        return InitError(strprintf(_("%s cannot be set to port %u when -randomizep2pport is enabled because this port is considered \"bad\". See doc/p2p-bad-ports.md for details."), option, port));
+    }
+    return true;
+}
+
+static std::optional<uint16_t> GetExplicitPort(const std::string& host_port)
+{
+    std::string host;
+    uint16_t port{0};
+    if (!SplitHostPort(host_port, port, host)) return std::nullopt;
+    if (port == 0) return std::nullopt;
+    return port;
+}
+
+static bool ValidateRandomizedP2PPortArgs(const ArgsManager& args)
+{
+    for (const std::string& bind_arg : args.GetArgs("-bind")) {
+        const size_t index{bind_arg.rfind('=')};
+        const std::string bind_host_port{index == std::string::npos ? bind_arg : bind_arg.substr(0, index)};
+        if (const auto port{GetExplicitPort(bind_host_port)}) {
+            if (!ValidateRandomizedP2PPort(*port, "-bind")) return false;
+        }
+    }
+
+    for (const std::string& whitebind_arg : args.GetArgs("-whitebind")) {
+        NetWhitebindPermissions whitebind;
+        bilingual_str error;
+        if (!NetWhitebindPermissions::TryParse(whitebind_arg, whitebind, error)) return InitError(error);
+        if (!ValidateRandomizedP2PPort(whitebind.m_service.GetPort(), "-whitebind")) return false;
+    }
+
+    return true;
+}
+
+static bool HasExplicitAdvertisedP2PPort(const ArgsManager& args)
+{
+    for (const std::string& bind_arg : args.GetArgs("-bind")) {
+        const size_t index{bind_arg.rfind('=')};
+        if (index != std::string::npos) continue;
+        if (GetExplicitPort(bind_arg)) return true;
+    }
+
+    for (const std::string& whitebind_arg : args.GetArgs("-whitebind")) {
+        NetWhitebindPermissions whitebind;
+        bilingual_str error;
+        if (NetWhitebindPermissions::TryParse(whitebind_arg, whitebind, error) &&
+            !NetPermissions::HasFlag(whitebind.m_flags, NetPermissionFlags::NoBan)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool BindUsesDefaultP2PPort(const std::string& bind_arg)
+{
+    const size_t index{bind_arg.rfind('=')};
+    const std::string bind_host_port{index == std::string::npos ? bind_arg : bind_arg.substr(0, index)};
+    return !GetExplicitPort(bind_host_port);
+}
+
+static bool NeedsGeneratedP2PPort(const ArgsManager& args)
+{
+    if (args.IsArgSet("-port")) return false;
+    if (!HasExplicitAdvertisedP2PPort(args)) return true;
+    const auto bind_args{args.GetArgs("-bind")};
+    return std::any_of(bind_args.begin(), bind_args.end(), BindUsesDefaultP2PPort);
+}
+
+static bool CanBindListenPort(const CService& addr_bind)
+{
+    struct sockaddr_storage sockaddr;
+    socklen_t len{sizeof(sockaddr)};
+    if (!addr_bind.GetSockAddr(reinterpret_cast<struct sockaddr*>(&sockaddr), &len)) return false;
+
+    std::unique_ptr<Sock> sock{CreateSock(addr_bind.GetSAFamily(), SOCK_STREAM, IPPROTO_TCP)};
+    if (!sock) return false;
+
+    const int one{1};
+    sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    if (addr_bind.IsIPv6()) {
+#ifdef IPV6_V6ONLY
+        sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one));
+#endif
+#ifdef WIN32
+        const int prot_level{PROTECTION_LEVEL_UNRESTRICTED};
+        sock->SetSockOpt(IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, &prot_level, sizeof(prot_level));
+#endif
+    }
+
+    return sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) != SOCKET_ERROR &&
+           sock->Listen(SOMAXCONN) != SOCKET_ERROR;
+}
+
+static bool GeneratedP2PPortIsAvailable(uint16_t port)
+{
+    struct in_addr inaddr_any;
+    inaddr_any.s_addr = htonl(INADDR_ANY);
+    if (!CanBindListenPort(CService{inaddr_any, port})) return false;
+
+    return CanBindListenPort(DefaultOnionServiceTarget(port + 1));
+}
+
+static bool InitRandomizedP2PPort(ArgsManager& args, std::optional<uint16_t>& generated_port)
+{
+    if (!args.GetBoolArg(RANDOMIZE_P2P_PORT_ARG, false)) return true;
+
+    if (args.IsArgSet("-port")) {
+        return InitError(strprintf(_("%s cannot be used with -port. Choose either a randomized P2P port or an explicit P2P port."), RANDOMIZE_P2P_PORT_ARG));
+    }
+
+    if (!args.GetBoolArg("-listen", DEFAULT_LISTEN)) return true;
+
+    if (!ValidateRandomizedP2PPortArgs(args)) return false;
+
+    if (const auto port_arg{args.GetArg(RANDOMIZED_P2P_PORT_ARG)}) {
+        const auto port{ToIntegral<uint16_t>(*port_arg)};
+        if (!port || *port == 0) return InitError(InvalidPortErrMsg(RANDOMIZED_P2P_PORT_ARG, *port_arg));
+        if (!ValidateRandomizedP2PPort(*port, RANDOMIZED_P2P_PORT_ARG)) return false;
+        return ValidateRandomizedP2PPort(GetListenPort(), "listening port");
+    }
+
+    if (!NeedsGeneratedP2PPort(args)) {
+        return ValidateRandomizedP2PPort(GetListenPort(), "listening port");
+    }
+
+    if (!args.GetSettingsPath()) {
+        return InitError(strprintf(_("%s requires the dynamic settings file when -port is not set. Remove -nosettings or set -port manually."), RANDOMIZE_P2P_PORT_ARG));
+    }
+
+    FastRandomContext rng;
+    static constexpr int MAX_RANDOMIZED_P2P_PORT_TRIES{512};
+    for (int i{0}; i < MAX_RANDOMIZED_P2P_PORT_TRIES; ++i) {
+        const uint16_t port{static_cast<uint16_t>(RANDOMIZED_P2P_PORT_MIN + rng.randrange<uint32_t>(RANDOMIZED_P2P_PORT_MAX - RANDOMIZED_P2P_PORT_MIN + 1))};
+        if (!ValidateRandomizedP2PPort(port, RANDOMIZED_P2P_PORT_ARG)) return false;
+        if (!GeneratedP2PPortIsAvailable(port)) continue;
+
+        args.ForceSetArg(RANDOMIZED_P2P_PORT_ARG, ToString(port));
+        generated_port = port;
+        LogInfo("Using randomized P2P port %u\n", port);
+        return true;
+    }
+
+    return InitError(strprintf(_("Unable to find an available randomized P2P port in range %u-%u."), RANDOMIZED_P2P_PORT_MIN, RANDOMIZED_P2P_PORT_MAX));
+}
+
 /**
  * @brief Checks for duplicate bindings across all binding configurations.
  *
@@ -1437,8 +1604,9 @@ static ChainstateLoadResult InitAndLoadChainstate(
 
 bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 {
-    const ArgsManager& args = *Assert(node.args);
+    ArgsManager& args = *Assert(node.args);
     const CChainParams& chainparams = Params();
+    std::optional<uint16_t> generated_randomized_p2p_port;
 
     auto opt_max_upload = ParseByteUnits(args.GetArg("-maxuploadtarget", DEFAULT_MAX_UPLOAD_TARGET), ByteUnit::M);
     if (!opt_max_upload) {
@@ -1540,6 +1708,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // Check port numbers
     if (!CheckHostPortOptions(args)) return false;
+    if (!InitRandomizedP2PPort(args, generated_randomized_p2p_port)) return false;
 
     // Configure reachable networks before we start the RPC server.
     // This is necessary for -rpcallowip to distinguish CJDNS from other RFC4193
@@ -1819,10 +1988,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     for (const std::string& strAddr : args.GetArgs("-externalip")) {
         const std::optional<CService> addrLocal{Lookup(strAddr, GetListenPort(), fNameLookup)};
-        if (addrLocal.has_value() && addrLocal->IsValid())
+        if (addrLocal.has_value() && addrLocal->IsValid()) {
+            if (args.GetBoolArg(RANDOMIZE_P2P_PORT_ARG, false) && !args.IsArgSet("-port") && !ValidateRandomizedP2PPort(addrLocal->GetPort(), "-externalip")) return false;
             AddLocal(addrLocal.value(), LOCAL_MANUAL);
-        else
+        } else {
             return InitError(ResolveErrMsg("externalip", strAddr));
+        }
     }
 
 #ifdef ENABLE_ZMQ
@@ -2130,8 +2301,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.m_capture_messages = args.GetBoolArg("-capturemessages", false);
 
     // Port to bind to if `-bind=addr` is provided without a `:port` suffix.
-    const uint16_t default_bind_port =
-        static_cast<uint16_t>(args.GetIntArg("-port", Params().GetDefaultPort()));
+    const uint16_t default_port{static_cast<uint16_t>(
+        args.GetBoolArg(RANDOMIZE_P2P_PORT_ARG, false) ?
+            args.GetIntArg(RANDOMIZED_P2P_PORT_ARG, Params().GetDefaultPort()) :
+            Params().GetDefaultPort())};
+    const uint16_t default_bind_port{static_cast<uint16_t>(args.GetIntArg("-port", default_port))};
 
     const uint16_t default_bind_port_onion = default_bind_port + 1;
 
@@ -2319,6 +2493,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     if (!node.connman->Start(scheduler, connOptions)) {
         return false;
+    }
+    if (generated_randomized_p2p_port) {
+        args.LockSettings([&](common::Settings& settings) {
+            settings.rw_settings[RandomizedP2PPortSettingName()] = static_cast<int64_t>(*generated_randomized_p2p_port);
+        });
+        std::vector<std::string> details;
+        if (!args.WriteSettingsFile(&details)) {
+            return InitError(_("Settings file could not be written"), details);
+        }
     }
 
     // ********************************************************* Step 13: finished

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -158,8 +158,13 @@ uint16_t GetListenPort()
         }
     }
 
-    // Otherwise, if -port= is provided, use that. Otherwise use the default port.
-    return static_cast<uint16_t>(gArgs.GetIntArg("-port", Params().GetDefaultPort()));
+    const uint16_t default_port{static_cast<uint16_t>(
+        gArgs.GetBoolArg(RANDOMIZE_P2P_PORT_ARG, false) && !gArgs.IsArgSet("-port") ?
+            gArgs.GetIntArg(RANDOMIZED_P2P_PORT_ARG, Params().GetDefaultPort()) :
+            Params().GetDefaultPort())};
+
+    // Otherwise, if -port= is provided, use that. Otherwise use the default or randomized port.
+    return static_cast<uint16_t>(gArgs.GetIntArg("-port", default_port));
 }
 
 // Determine the "best" local address for a particular peer.

--- a/src/net.h
+++ b/src/net.h
@@ -98,6 +98,11 @@ static constexpr bool DEFAULT_FIXEDSEEDS{true};
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
+static constexpr const char* RANDOMIZE_P2P_PORT_ARG{"-randomizep2pport"};
+static constexpr const char* RANDOMIZED_P2P_PORT_ARG{"-randomizedp2pport"};
+static constexpr uint16_t RANDOMIZED_P2P_PORT_MIN{49152};
+static constexpr uint16_t RANDOMIZED_P2P_PORT_MAX{65534};
+
 static constexpr bool DEFAULT_V2_TRANSPORT{true};
 
 typedef int64_t NodeId;

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -46,11 +46,15 @@ BOOST_AUTO_TEST_CASE(cnode_listen_port)
     // test default
     uint16_t port{GetListenPort()};
     BOOST_CHECK(port == Params().GetDefaultPort());
-    // test set port
-    uint16_t altPort = 12345;
-    BOOST_CHECK(gArgs.SoftSetArg("-port", ToString(altPort)));
+    // test persisted randomized port ignored until the feature is enabled
+    uint16_t randomized_port = 50000;
+    BOOST_CHECK(gArgs.SoftSetArg(RANDOMIZED_P2P_PORT_ARG, ToString(randomized_port)));
     port = GetListenPort();
-    BOOST_CHECK(port == altPort);
+    BOOST_CHECK(port == Params().GetDefaultPort());
+    // test persisted randomized port
+    BOOST_CHECK(gArgs.SoftSetBoolArg(RANDOMIZE_P2P_PORT_ARG, true));
+    port = GetListenPort();
+    BOOST_CHECK(port == randomized_port);
 }
 
 BOOST_AUTO_TEST_CASE(cnode_simple_test)

--- a/test/functional/feature_randomize_p2p_port.py
+++ b/test/functional/feature_randomize_p2p_port.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test -randomizep2pport."""
+
+from contextlib import contextmanager
+import json
+import socket
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import ErrorMatch
+from test_framework.util import (
+    assert_equal,
+    p2p_port,
+)
+
+RANDOMIZED_PORT_MIN = 49152
+RANDOMIZED_PORT_MAX = 65534
+RANDOMIZED_PORT_SETTING = "randomizedp2pport"
+EXTERNAL_IP = "42.42.42.42"
+
+
+@contextmanager
+def listening_socket(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("0.0.0.0", port))
+    sock.listen()
+    try:
+        yield
+    finally:
+        sock.close()
+
+
+class RandomizeP2PPortTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+        for node in self.nodes:
+            node.has_explicit_bind = True
+            node.replace_in_config([(f"port={p2p_port(node.index)}\n", "")])
+
+    def get_persisted_port(self, node):
+        settings = json.loads((node.chain_path / "settings.json").read_text())
+        return int(settings[RANDOMIZED_PORT_SETTING])
+
+    def assert_valid_randomized_port(self, port):
+        assert RANDOMIZED_PORT_MIN <= port <= RANDOMIZED_PORT_MAX
+        assert port not in [8333, 18333, 38333, 48333, 18444]
+
+    def assert_external_ip_port(self, node, port):
+        local_address = next((addr for addr in node.getnetworkinfo()["localaddresses"] if addr["address"] == EXTERNAL_IP), None)
+        assert local_address is not None
+        assert_equal(local_address["port"], port)
+
+    def run_test(self):
+        node0, node1, node2 = self.nodes
+
+        self.log.info("A first start without -port generates and persists a randomized P2P port")
+        self.start_node(0, extra_args=["-randomizep2pport=1", f"-externalip={EXTERNAL_IP}"])
+        port0 = self.get_persisted_port(node0)
+        self.assert_valid_randomized_port(port0)
+        self.assert_external_ip_port(node0, port0)
+
+        self.log.info("Restart reuses the persisted randomized P2P port")
+        self.restart_node(0, extra_args=["-randomizep2pport=1", f"-externalip={EXTERNAL_IP}"])
+        assert_equal(self.get_persisted_port(node0), port0)
+        self.assert_external_ip_port(node0, port0)
+
+        self.log.info("Another randomized node can connect to the persisted random port")
+        self.start_node(1, extra_args=["-randomizep2pport=1"])
+        node1.addnode(node=f"127.0.0.1:{port0}", command="onetry", v2transport=False)
+        self.wait_until(lambda: node0.getnetworkinfo()["connections_in"] >= 1)
+
+        self.stop_node(1)
+        self.stop_node(0)
+
+        self.log.info("A blocked persisted randomized port fails without rerandomizing")
+        with listening_socket(port0):
+            node0.assert_start_raises_init_error(
+                extra_args=["-randomizep2pport=1"],
+                expected_msg=rf"Error: Unable to bind to .*:{port0} on this computer",
+                match=ErrorMatch.PARTIAL_REGEX,
+            )
+        assert_equal(self.get_persisted_port(node0), port0)
+
+        self.log.info("A blocked manual -port fails immediately")
+        manual_port = port0
+        with listening_socket(manual_port):
+            node0.assert_start_raises_init_error(
+                extra_args=[f"-port={manual_port}"],
+                expected_msg=rf"Error: Unable to bind to .*:{manual_port} on this computer",
+                match=ErrorMatch.PARTIAL_REGEX,
+            )
+
+        self.log.info("-randomizep2pport cannot be used with -port")
+        node0.assert_start_raises_init_error(
+            extra_args=["-randomizep2pport=1", f"-port={p2p_port(node2.index)}"],
+            expected_msg="Error: -randomizep2pport cannot be used with -port. Choose either a randomized P2P port or an explicit P2P port.",
+        )
+
+        self.log.info("Invalid randomized bind ports are rejected while remote port 8333 remains allowed")
+        node0.assert_start_raises_init_error(
+            extra_args=["-randomizep2pport=1", "-bind=127.0.0.1:8333"],
+            expected_msg="Error: -bind cannot be set to reserved P2P port 8333 when -randomizep2pport is enabled.",
+        )
+        node0.assert_start_raises_init_error(
+            extra_args=["-randomizep2pport=1", "-bind=127.0.0.1:49151"],
+            expected_msg="Error: -bind must be in the randomized P2P port range 49152-65534 when -randomizep2pport is enabled.",
+        )
+
+        self.start_node(2, extra_args=["-randomizep2pport=1", "-connect=127.0.0.1:8333"])
+        self.stop_node(2)
+
+
+if __name__ == '__main__':
+    RandomizeP2PPortTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -317,6 +317,7 @@ BASE_SCRIPTS = [
     'p2p_private_broadcast.py',
     'rpc_getblockstats.py',
     'feature_port.py',
+    'feature_randomize_p2p_port.py',
     'feature_bind_port_externalip.py',
     'wallet_create_tx.py',
     'wallet_send.py',


### PR DESCRIPTION
Adds a new opt-in `-randomizep2pport` mode that selects a non-default clearnet P2P listening port on first startup, persists it to the dynamic settings file, and reuses it on later restarts.

The feature is independent from fixed `-port` usage. `-randomizep2pport` and `-port` are mutually exclusive: users can either let Bitcoin Core manage a randomized persisted P2P port, or explicitly choose one with `-port`, but not both.

## Behavior

- Adds `-randomizep2pport=1`.
- Selects a listening port from `49152-65534` when no randomized port has been persisted yet.
- Persists the selected port in `settings.json` as a hidden network-specific setting.
- Reuses the persisted randomized port on later restarts.
- Rejects reserved Bitcoin P2P ports, test-chain default P2P ports, bad ports, and ports outside the randomized range for randomized local listening or advertised ports.
- Rejects using `-randomizep2pport` together with `-port`.
- If the first generated candidate is unavailable during initial selection, tries another candidate instead of failing immediately.
- If the persisted randomized port is unavailable on restart, fails startup instead of silently selecting a new port.
- Keeps remote peer ports unrestricted, so connections to existing peers on `8333` and other advertised ports continue to work.
- Keeps `Params().GetDefaultPort()`, `CConnman::GetDefaultPort()`, DNS seed behavior, addrman behavior, and chain params unchanged.

## Notes

This is best-effort on the public P2P network. Bitcoin Core can listen on and advertise the randomized port, but remote peers still need to learn that port through address relay, RPC, manual configuration, or external discovery before they can connect.

This does not change outbound compatibility with the existing network: nodes can still connect to legacy peers using `8333`.

Onion/I2P behavior is unchanged.

## Tests

- `cmake --build build --target bitcoind -j2`
- `cmake --build build --target test_bitcoin -j2`
- `build/bin/test_bitcoin --run_test=net_tests`
- `test/functional/feature_randomize_p2p_port.py --configfile build/test/config.ini`