### PR TITLE
scripted-diff: Rename `Sock::{RECV,SEND,ERR}`

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -912,11 +912,11 @@ bool HTTPClient::SendRequest(std::string_view request)
         Sock::Event event{0};
         auto time_left = std::chrono::duration_cast<std::chrono::milliseconds>(
             deadline - std::chrono::steady_clock::now());
-        if (time_left.count() <= 0 || !m_socket->Wait(time_left, Sock::SEND, &event)) {
+        if (time_left.count() <= 0 || !m_socket->Wait(time_left, Sock::SendEvent, &event)) {
             return false;
         }
 
-        if (!(event & Sock::SEND)) {
+        if (!(event & Sock::SendEvent)) {
             continue;
         }
 
@@ -1122,10 +1122,10 @@ std::optional<std::string> HTTPClient::Recv(const std::chrono::time_point<std::c
 {
     auto wait_for_readable{[this](std::chrono::milliseconds timeout) -> bool {
         Sock::Event event{0};
-        if (!m_socket->Wait(timeout, Sock::RECV, &event)) {
+        if (!m_socket->Wait(timeout, Sock::RecvEvent, &event)) {
             return false;
         }
-        return (event & Sock::RECV) != 0;
+        return (event & Sock::RecvEvent) != 0;
     }};
 
     auto time_left = std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/common/pcp.cpp
+++ b/src/common/pcp.cpp
@@ -247,7 +247,7 @@ std::optional<std::vector<uint8_t>> PCPSendRecv(Sock &sock, const std::string &p
         while ((cur_time = time_point_cast<milliseconds>(MockableSteadyClock::now())) < deadline) {
             if (interrupt) return std::nullopt;
             Sock::Event occurred = 0;
-            if (!sock.Wait(deadline - cur_time, Sock::RECV, &occurred)) {
+            if (!sock.Wait(deadline - cur_time, Sock::RecvEvent, &occurred)) {
                 LogWarning("%s: Could not wait on socket: %s\n", protocol, NetworkErrorString(WSAGetLastError()));
                 return std::nullopt; // Network-level error, probably no use retrying.
             }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -841,9 +841,9 @@ void HTTPServer::SocketHandlerConnected(const IOReadiness& io_readiness) const
         }
         const std::shared_ptr<HTTPRemoteClient>& client{it->second};
 
-        bool send_ready = events.occurred & Sock::SEND;
-        bool recv_ready = events.occurred & Sock::RECV;
-        bool err_ready = events.occurred & Sock::ERR;
+        bool send_ready = events.occurred & Sock::SendEvent;
+        bool recv_ready = events.occurred & Sock::RecvEvent;
+        bool err_ready = events.occurred & Sock::ErrorEvent;
 
         if (send_ready) {
             // Try to send as much data as is ready for this client.
@@ -909,7 +909,7 @@ void HTTPServer::SocketHandlerListening(const Sock::EventsPerSock& events_per_so
             return;
         }
         const auto it = events_per_sock.find(sock);
-        if (it != events_per_sock.end() && it->second.occurred & Sock::RECV) {
+        if (it != events_per_sock.end() && it->second.occurred & Sock::RecvEvent) {
             CService addr_accepted;
 
             auto sock_accepted{AcceptConnection(*sock, addr_accepted)};
@@ -926,7 +926,7 @@ HTTPServer::IOReadiness HTTPServer::GenerateWaitSockets() const
     IOReadiness io_readiness;
 
     for (const auto& sock : m_listen) {
-        io_readiness.events_per_sock.emplace(sock, Sock::Events{Sock::RECV});
+        io_readiness.events_per_sock.emplace(sock, Sock::Events{Sock::RecvEvent});
     }
 
     for (const auto& http_client : m_connected) {
@@ -935,7 +935,7 @@ HTTPServer::IOReadiness HTTPServer::GenerateWaitSockets() const
 
         // Check if client is ready to send data. Don't try to receive again
         // until the send buffer is cleared (all data sent to client).
-        Sock::Event event = (http_client->m_send_ready ? Sock::SEND : Sock::RECV);
+        Sock::Event event = (http_client->m_send_ready ? Sock::SendEvent : Sock::RecvEvent);
         io_readiness.events_per_sock.emplace(sock, Sock::Events{event});
         io_readiness.httpclients_per_sock.emplace(sock, http_client);
     }

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -333,8 +333,8 @@ private:
     struct IOReadiness {
         /**
          * Map of socket -> socket events. For example:
-         * socket1 -> { requested = SEND|RECV, occurred = RECV }
-         * socket2 -> { requested = SEND, occurred = SEND }
+         * socket1 -> { requested = SendEvent|RecvEvent, occurred = RecvEvent }
+         * socket2 -> { requested = SendEvent, occurred = SendEvent }
          */
         Sock::EventsPerSock events_per_sock;
 

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -164,7 +164,7 @@ bool Session::Accept(Connection& conn)
 
     while (!m_interrupt->interrupted()) {
         Sock::Event occurred;
-        if (!conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RECV, &occurred)) {
+        if (!conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RecvEvent, &occurred)) {
             errmsg = "wait on socket failed";
             break;
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2089,7 +2089,7 @@ Sock::EventsPerSock CConnman::GenerateWaitSockets(std::span<CNode* const> nodes)
     Sock::EventsPerSock events_per_sock;
 
     for (const ListenSocket& hListenSocket : vhListenSocket) {
-        events_per_sock.emplace(hListenSocket.sock, Sock::Events{Sock::RECV});
+        events_per_sock.emplace(hListenSocket.sock, Sock::Events{Sock::RecvEvent});
     }
 
     for (CNode* pnode : nodes) {
@@ -2107,7 +2107,7 @@ Sock::EventsPerSock CConnman::GenerateWaitSockets(std::span<CNode* const> nodes)
 
         LOCK(pnode->m_sock_mutex);
         if (pnode->m_sock) {
-            Sock::Event event = (select_send ? Sock::SEND : 0) | (select_recv ? Sock::RECV : 0);
+            Sock::Event event = (select_send ? Sock::SendEvent : 0) | (select_recv ? Sock::RecvEvent : 0);
             events_per_sock.emplace(pnode->m_sock, Sock::Events{event});
         }
     }
@@ -2169,9 +2169,9 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
             }
             const auto it = events_per_sock.find(pnode->m_sock);
             if (it != events_per_sock.end()) {
-                recvSet = it->second.occurred & Sock::RECV;
-                sendSet = it->second.occurred & Sock::SEND;
-                errorSet = it->second.occurred & Sock::ERR;
+                recvSet = it->second.occurred & Sock::RecvEvent;
+                sendSet = it->second.occurred & Sock::SendEvent;
+                errorSet = it->second.occurred & Sock::ErrorEvent;
             }
         }
 
@@ -2255,7 +2255,7 @@ void CConnman::SocketHandlerListening(const Sock::EventsPerSock& events_per_sock
             return;
         }
         const auto it = events_per_sock.find(listen_socket.sock);
-        if (it != events_per_sock.end() && it->second.occurred & Sock::RECV) {
+        if (it != events_per_sock.end() && it->second.occurred & Sock::RecvEvent) {
             AcceptConnection(listen_socket);
         }
     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -333,7 +333,7 @@ static IntrRecvError InterruptibleRecv(uint8_t* data, size_t len, std::chrono::m
                 // we're approaching the end of the specified total timeout
                 const auto remaining = std::chrono::milliseconds{endTime - curTime};
                 const auto timeout = std::min(remaining, std::chrono::milliseconds{MAX_WAIT_FOR_IO});
-                if (!sock.Wait(timeout, Sock::RECV)) {
+                if (!sock.Wait(timeout, Sock::RecvEvent)) {
                     return IntrRecvError::NetworkError;
                 }
             } else {
@@ -603,7 +603,7 @@ static bool ConnectToSocket(const Sock& sock,
             // Connection didn't actually fail, but is being established
             // asynchronously. Thus, use async I/O api (select/poll)
             // synchronously to check for successful connection with a timeout.
-            const Sock::Event requested = Sock::RECV | Sock::SEND;
+            const Sock::Event requested = Sock::RecvEvent | Sock::SendEvent;
             Sock::Event occurred;
             if (!sock.Wait(timeout, requested, &occurred)) {
                 LogInfo("wait for connect to %s failed: %s\n",

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -63,7 +63,7 @@ void PSBTOperationsDialog::openWithPSBT(PartiallySignedTransaction psbtx)
         if (err) {
             showStatus(tr("Failed to load transaction: %1")
                            .arg(QString::fromStdString(PSBTErrorString(*err).translated)),
-                       StatusLevel::ERR);
+                       StatusLevel::Error);
             return;
         }
         m_ui->signTransactionButton->setEnabled(!complete && !m_wallet_model->wallet().privateKeysDisabled() && n_could_sign > 0);
@@ -87,22 +87,22 @@ void PSBTOperationsDialog::signTransaction()
 
     if (err) {
         showStatus(tr("Failed to sign transaction: %1")
-            .arg(QString::fromStdString(PSBTErrorString(*err).translated)), StatusLevel::ERR);
+            .arg(QString::fromStdString(PSBTErrorString(*err).translated)), StatusLevel::Error);
         return;
     }
 
     updateTransactionDisplay();
 
     if (!complete && !ctx.isValid()) {
-        showStatus(tr("Cannot sign inputs while wallet is locked."), StatusLevel::WARN);
+        showStatus(tr("Cannot sign inputs while wallet is locked."), StatusLevel::Warn);
     } else if (!complete && n_signed < 1) {
-        showStatus(tr("Could not sign any more inputs."), StatusLevel::WARN);
+        showStatus(tr("Could not sign any more inputs."), StatusLevel::Warn);
     } else if (!complete) {
         showStatus(tr("Signed %n input(s), but more signatures are still required.", "", n_signed),
-            StatusLevel::INFO);
+            StatusLevel::Info);
     } else {
         showStatus(tr("Signed transaction successfully. Transaction is ready to broadcast."),
-            StatusLevel::INFO);
+            StatusLevel::Info);
         m_ui->broadcastTransactionButton->setEnabled(true);
     }
 }
@@ -113,7 +113,7 @@ void PSBTOperationsDialog::broadcastTransaction()
     if (!FinalizeAndExtractPSBT(*m_transaction_data, mtx)) {
         // This is never expected to fail unless we were given a malformed PSBT
         // (e.g. with an invalid signature.)
-        showStatus(tr("Unknown error processing transaction."), StatusLevel::ERR);
+        showStatus(tr("Unknown error processing transaction."), StatusLevel::Error);
         return;
     }
 
@@ -124,10 +124,10 @@ void PSBTOperationsDialog::broadcastTransaction()
 
     if (error == TransactionError::OK) {
         showStatus(tr("Transaction broadcast successfully! Transaction ID: %1")
-            .arg(QString::fromStdString(tx->GetHash().GetHex())), StatusLevel::INFO);
+            .arg(QString::fromStdString(tx->GetHash().GetHex())), StatusLevel::Info);
     } else {
         showStatus(tr("Transaction broadcast failed: %1")
-            .arg(QString::fromStdString(TransactionErrorString(error).translated)), StatusLevel::ERR);
+            .arg(QString::fromStdString(TransactionErrorString(error).translated)), StatusLevel::Error);
     }
 }
 
@@ -135,7 +135,7 @@ void PSBTOperationsDialog::copyToClipboard() {
     DataStream ssTx{};
     ssTx << *m_transaction_data;
     GUIUtil::setClipboard(EncodeBase64(ssTx.str()).c_str());
-    showStatus(tr("PSBT copied to clipboard."), StatusLevel::INFO);
+    showStatus(tr("PSBT copied to clipboard."), StatusLevel::Info);
 }
 
 void PSBTOperationsDialog::saveTransaction() {
@@ -167,7 +167,7 @@ void PSBTOperationsDialog::saveTransaction() {
     std::ofstream out{filename.toLocal8Bit().data(), std::ofstream::out | std::ofstream::binary};
     out << ssTx.str();
     out.close();
-    showStatus(tr("PSBT saved to disk."), StatusLevel::INFO);
+    showStatus(tr("PSBT saved to disk."), StatusLevel::Info);
 }
 
 void PSBTOperationsDialog::updateTransactionDisplay() {
@@ -228,15 +228,15 @@ QString PSBTOperationsDialog::renderTransaction(const PartiallySignedTransaction
 void PSBTOperationsDialog::showStatus(const QString &msg, StatusLevel level) {
     m_ui->statusBar->setText(msg);
     switch (level) {
-        case StatusLevel::INFO: {
+        case StatusLevel::Info: {
             m_ui->statusBar->setStyleSheet("QLabel { background-color : lightgreen }");
             break;
         }
-        case StatusLevel::WARN: {
+        case StatusLevel::Warn: {
             m_ui->statusBar->setStyleSheet("QLabel { background-color : orange }");
             break;
         }
-        case StatusLevel::ERR: {
+        case StatusLevel::Error: {
             m_ui->statusBar->setStyleSheet("QLabel { background-color : red }");
             break;
         }
@@ -265,32 +265,32 @@ void PSBTOperationsDialog::showTransactionStatus(const PartiallySignedTransactio
 
     switch (analysis.next) {
         case PSBTRole::UPDATER: {
-            showStatus(tr("Transaction is missing some information about inputs."), StatusLevel::WARN);
+            showStatus(tr("Transaction is missing some information about inputs."), StatusLevel::Warn);
             break;
         }
         case PSBTRole::SIGNER: {
             QString need_sig_text = tr("Transaction still needs signature(s).");
-            StatusLevel level = StatusLevel::INFO;
+            StatusLevel level = StatusLevel::Info;
             if (!m_wallet_model) {
                 need_sig_text += " " + tr("(But no wallet is loaded.)");
-                level = StatusLevel::WARN;
+                level = StatusLevel::Warn;
             } else if (m_wallet_model->wallet().privateKeysDisabled()) {
                 need_sig_text += " " + tr("(But this wallet cannot sign transactions.)");
-                level = StatusLevel::WARN;
+                level = StatusLevel::Warn;
             } else if (n_could_sign < 1) {
                 need_sig_text += " " + tr("(But this wallet does not have the right keys.)"); // XXX wording
-                level = StatusLevel::WARN;
+                level = StatusLevel::Warn;
             }
             showStatus(need_sig_text, level);
             break;
         }
         case PSBTRole::FINALIZER:
         case PSBTRole::EXTRACTOR: {
-            showStatus(tr("Transaction is fully signed and ready for broadcast."), StatusLevel::INFO);
+            showStatus(tr("Transaction is fully signed and ready for broadcast."), StatusLevel::Info);
             break;
         }
         default: {
-            showStatus(tr("Transaction status is unknown."), StatusLevel::ERR);
+            showStatus(tr("Transaction status is unknown."), StatusLevel::Error);
             break;
         }
     }

--- a/src/qt/psbtoperationsdialog.h
+++ b/src/qt/psbtoperationsdialog.h
@@ -40,9 +40,9 @@ private:
     ClientModel* m_client_model;
 
     enum class StatusLevel {
-        INFO,
-        WARN,
-        ERR
+        Info,
+        Warn,
+        Error
     };
 
     size_t couldSignInputs(const PartiallySignedTransaction &psbtx);

--- a/src/test/pcp_tests.cpp
+++ b/src/test/pcp_tests.cpp
@@ -191,14 +191,14 @@ public:
               Event* occurred = nullptr) const override
     {
         // Only handles receive events.
-        if (AtEndOfScript() || requested != Sock::RECV) {
+        if (AtEndOfScript() || requested != Sock::RecvEvent) {
             m_clock += timeout;
         } else {
             std::chrono::milliseconds delay = std::min(m_time_left, timeout);
             m_clock += delay;
             m_time_left -= delay;
             if (CurOp().op == TestOp::RECV && m_time_left == 0s && occurred != nullptr) {
-                *occurred = Sock::RECV;
+                *occurred = Sock::RecvEvent;
             }
             if (CurOp().op == TestOp::NOP) {
                 // This was a pure delay operation, move to the next op.

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(wait)
 {
     TcpSocketPair socks = TcpSocketPair{};
 
-    std::thread waiter([&socks]() { (void)socks.receiver.Wait(24h, Sock::RECV); });
+    std::thread waiter([&socks]() { (void)socks.receiver.Wait(24h, Sock::RecvEvent); });
 
     BOOST_REQUIRE_EQUAL(socks.sender.Send("a", 1, 0), 1);
 

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -400,17 +400,17 @@ bool DynSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_
     for (;;) {
         // Check all sockets for readiness without waiting.
         for (auto& [sock, events] : events_per_sock) {
-            if ((events.requested & Sock::SEND) != 0) {
+            if ((events.requested & Sock::SendEvent) != 0) {
                 // Always ready for Send().
-                events.occurred |= Sock::SEND;
+                events.occurred |= Sock::SendEvent;
                 at_least_one_event_occurred = true;
             }
 
-            if ((events.requested & Sock::RECV) != 0) {
+            if ((events.requested & Sock::RecvEvent) != 0) {
                 auto dyn_sock = reinterpret_cast<const DynSock*>(sock.get());
                 uint8_t b;
                 if (dyn_sock->m_pipes->recv.GetBytes(&b, 1, MSG_PEEK) == 1 || (dyn_sock->m_accept_sockets && !dyn_sock->m_accept_sockets->Empty())) {
-                    events.occurred |= Sock::RECV;
+                    events.occurred |= Sock::RecvEvent;
                     at_least_one_event_occurred = true;
                 }
             }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -133,16 +133,16 @@ bool TorControlConnection::WaitForData(std::chrono::milliseconds timeout)
     if (!m_sock) return false;
 
     Sock::Event event{0};
-    if (!m_sock->Wait(timeout, Sock::RECV, &event)) {
+    if (!m_sock->Wait(timeout, Sock::RecvEvent, &event)) {
         return false;
     }
-    if (event & Sock::ERR) {
+    if (event & Sock::ErrorEvent) {
         LogDebug(BCLog::TOR, "Socket error detected");
         Disconnect();
         return false;
     }
 
-    return (event & Sock::RECV);
+    return (event & Sock::RecvEvent);
 }
 
 bool TorControlConnection::ReceiveAndProcess()

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -168,10 +168,10 @@ bool Sock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per
         pfds.emplace_back();
         auto& pfd = pfds.back();
         pfd.fd = sock->m_socket;
-        if (events.requested & RECV) {
+        if (events.requested & RecvEvent) {
             pfd.events |= POLLIN;
         }
-        if (events.requested & SEND) {
+        if (events.requested & SendEvent) {
             pfd.events |= POLLOUT;
         }
     }
@@ -186,13 +186,13 @@ bool Sock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per
         assert(sock->m_socket == static_cast<SOCKET>(pfds[i].fd));
         events.occurred = 0;
         if (pfds[i].revents & POLLIN) {
-            events.occurred |= RECV;
+            events.occurred |= RecvEvent;
         }
         if (pfds[i].revents & POLLOUT) {
-            events.occurred |= SEND;
+            events.occurred |= SendEvent;
         }
         if (pfds[i].revents & (POLLERR | POLLHUP)) {
-            events.occurred |= ERR;
+            events.occurred |= ErrorEvent;
         }
         ++i;
     }
@@ -212,10 +212,10 @@ bool Sock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per
             return false;
         }
         const auto& s = sock->m_socket;
-        if (events.requested & RECV) {
+        if (events.requested & RecvEvent) {
             FD_SET(s, &recv);
         }
-        if (events.requested & SEND) {
+        if (events.requested & SendEvent) {
             FD_SET(s, &send);
         }
         FD_SET(s, &err);
@@ -232,13 +232,13 @@ bool Sock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per
         const auto& s = sock->m_socket;
         events.occurred = 0;
         if (FD_ISSET(s, &recv)) {
-            events.occurred |= RECV;
+            events.occurred |= RecvEvent;
         }
         if (FD_ISSET(s, &send)) {
-            events.occurred |= SEND;
+            events.occurred |= SendEvent;
         }
         if (FD_ISSET(s, &err)) {
-            events.occurred |= ERR;
+            events.occurred |= ErrorEvent;
         }
     }
 
@@ -283,7 +283,7 @@ void Sock::SendComplete(std::span<const unsigned char> data,
         // Wait for a short while (or the socket to become ready for sending) before retrying
         // if nothing was sent.
         const auto wait_time = std::min(deadline - now, std::chrono::milliseconds{MAX_WAIT_FOR_IO});
-        (void)Wait(wait_time, SEND);
+        (void)Wait(wait_time, SendEvent);
     }
 }
 
@@ -373,7 +373,7 @@ std::string Sock::RecvUntilTerminator(uint8_t terminator,
 
         // Wait for a short while (or the socket to become ready for reading) before retrying.
         const auto wait_time = std::min(deadline - now, std::chrono::milliseconds{MAX_WAIT_FOR_IO});
-        (void)Wait(wait_time, RECV);
+        (void)Wait(wait_time, RecvEvent);
     }
 }
 

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -72,15 +72,15 @@ int Sock::Listen(int backlog) const
 std::unique_ptr<Sock> Sock::Accept(sockaddr* addr, socklen_t* addr_len) const
 {
 #ifdef WIN32
-    static constexpr auto ERR = INVALID_SOCKET;
+    static constexpr auto accept_error = INVALID_SOCKET;
 #else
-    static constexpr auto ERR = SOCKET_ERROR;
+    static constexpr auto accept_error = SOCKET_ERROR;
 #endif
 
     std::unique_ptr<Sock> sock;
 
     const auto socket = accept(m_socket, addr, addr_len);
-    if (socket != ERR) {
+    if (socket != accept_error) {
         try {
             sock = std::make_unique<Sock>(socket);
         } catch (const std::exception&) {

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -148,25 +148,25 @@ public:
     /**
      * If passed to `Wait()`, then it will wait for readiness to read from the socket.
      */
-    static constexpr Event RECV = 0b001;
+    static constexpr Event RecvEvent = 0b001;
 
     /**
      * If passed to `Wait()`, then it will wait for readiness to send to the socket.
      */
-    static constexpr Event SEND = 0b010;
+    static constexpr Event SendEvent = 0b010;
 
     /**
      * Ignored if passed to `Wait()`, but could be set in the occurred events if an
      * exceptional condition has occurred on the socket or if it has been disconnected.
      */
-    static constexpr Event ERR = 0b100;
+    static constexpr Event ErrorEvent = 0b100;
 
     /**
      * Wait for readiness for input (recv) or output (send).
      * @param[in] timeout Wait this much for at least one of the requested events to occur.
-     * @param[in] requested Wait for those events, bitwise-or of `RECV` and `SEND`.
+     * @param[in] requested Wait for those events, bitwise-or of `RecvEvent` and `SendEvent`.
      * @param[out] occurred If not nullptr and the function returns `true`, then this
-     * indicates which of the requested events occurred (`ERR` will be added, even if
+     * indicates which of the requested events occurred (`ErrorEvent` will be added, even if
      * not requested, if an exceptional event occurs on the socket).
      * A timeout is indicated by return value of `true` and `occurred` being set to 0.
      * @return true on success (or timeout, if `occurred` of 0 is returned), false otherwise


### PR DESCRIPTION
The `ERR` macro is [defined](https://github.com/illumos/illumos-gate/blob/10a869258e300c530ae56b29aa3bf43461ca98ff/usr/src/uts/intel/sys/regset.h#L101) on illumos-based systems in the `regset.h` header included by the Boost.Test framework, which causes a compilation error:
- on [OmniOS](https://github.com/hebasto/bitcoin-core-nightly/actions/runs/28006958700):
```
[484/792] Building CXX object src/test/CMakeFiles/test_bitcoin.dir/main.cpp.o
FAILED: [code=1] src/test/CMakeFiles/test_bitcoin.dir/main.cpp.o 
/usr/bin/g++ -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_NO_CXX98_FUNCTION_BASE -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/build/src -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src/univalue/include -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src/minisketch/include -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src/secp256k1/include -isystem /usr/gnu/include -pthread -O2 -g -std=c++20 -fno-extended-identifiers -fmacro-prefix-map=/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src=. -fstack-reuse=none -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wbidi-chars=any -Wundef -Wno-unused-parameter -Werror -MD -MT src/test/CMakeFiles/test_bitcoin.dir/main.cpp.o -MF src/test/CMakeFiles/test_bitcoin.dir/main.cpp.o.d -o src/test/CMakeFiles/test_bitcoin.dir/main.cpp.o -c /home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src/test/main.cpp 
In file included from /usr/include/sys/procfs_isa.h:39,
                 from /usr/include/sys/procfs.h:66,
                 from /usr/include/procfs.h:45,
                 from /usr/local/include/boost/test/impl/debug.ipp:85,
                 from /usr/local/include/boost/test/included/unit_test.hpp:20,
                 from /home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src/test/main.cpp:10:
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src/util/sock.h:162:28: error: expected unqualified-id before numeric constant
  162 |     static constexpr Event ERR = 0b100;
      |                            ^~~
```
- on [OpenIndiana](https://github.com/hebasto/bitcoin-core-nightly/actions/runs/28006958536/job/82891036242):
```
[44](https://github.com/hebasto/bitcoin-core-nightly/actions/runs/28006958536/job/82891036242#step:7:545)
[ 59%] Building CXX object src/test/CMakeFiles/test_bitcoin.dir/main.cpp.o
[ 59%] Building CXX object src/test/CMakeFiles/test_bitcoin.dir/addrman_tests.cpp.o
In file included from /usr/include/sys/procfs_isa.h:39,
                 from /usr/include/sys/procfs.h:66,
                 from /usr/include/procfs.h:45,
                 from /usr/include/boost/test/impl/debug.ipp:85,
                 from /usr/include/boost/test/included/unit_test.hpp:20,
                 from /home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src/test/main.cpp:10:
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/src/util/sock.h:162:28: error: expected unqualified-id before numeric constant
  162 |     static constexpr Event ERR = 0b100;
      |                            ^~~
```

---

`StatusLevel::{INFO,WARN,ERR}` has also been renamed to ensure future-proofing and consistency.