### PR TITLE
fuzz: cover async chainstate compaction

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1078,7 +1078,7 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     cache.Sync();
 
     BOOST_CHECK_EQUAL(level2_files(base), 0);
-    WITH_LOCK(::cs_main, return base.CompactFull()).wait();
+    WITH_LOCK(::cs_main, return base.CompactFullAsync()).wait();
     BOOST_CHECK_EQUAL(level2_files(base), 1);
 
     BOOST_CHECK(*Assert(base.GetCoin(outpoint)) == coin);

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -7,6 +7,7 @@
 #include <consensus/tx_check.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
+#include <kernel/cs_main.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
@@ -92,7 +93,8 @@ void initialize_coins_view()
 
 void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& coins_view_cache, CCoinsView* backend_coins_view)
 {
-    const bool is_db{dynamic_cast<CCoinsViewDB*>(backend_coins_view) != nullptr};
+    auto* const db{dynamic_cast<CCoinsViewDB*>(backend_coins_view)};
+    const bool is_db{db != nullptr};
     bool good_data{true};
     auto* original_backend{backend_coins_view};
 
@@ -123,6 +125,9 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
             },
             [&] {
                 coins_view_cache.Sync();
+            },
+            [&] {
+                if (db) WITH_LOCK(::cs_main, (void)db->CompactFullAsync());
             },
             [&] {
                 uint256 best_block{ConsumeUInt256(fuzzed_data_provider)};

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -195,7 +195,7 @@ std::optional<std::string> CCoinsViewDB::GetDBProperty(const std::string& proper
     return m_db->GetProperty(property);
 }
 
-std::shared_future<void> CCoinsViewDB::CompactFull()
+std::shared_future<void> CCoinsViewDB::CompactFullAsync()
 {
     AssertLockHeld(::cs_main);
     if (m_compaction.valid() && m_compaction.wait_for(std::chrono::seconds{0}) != std::future_status::ready) return m_compaction;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -62,7 +62,7 @@ public:
     void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
 
     //! Perform a full compaction of the underlying LevelDB on a one-shot background thread.
-    std::shared_future<void> CompactFull() EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
+    std::shared_future<void> CompactFullAsync() EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
 
     //! Return an underlying LevelDB property value, if available.
     std::optional<std::string> GetDBProperty(const std::string& property);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2840,7 +2840,7 @@ bool Chainstate::FlushStateToDisk(
 
         if (!m_chainman.m_interrupt && ShouldCompactChainstate(m_chainman.IsInitialBlockDownload())) {
             try {
-                CoinsDB().CompactFull();
+                CoinsDB().CompactFullAsync();
             } catch (const std::exception& e) {
                 LogWarning("Failed to start chainstate compaction (%s)", e.what());
             }


### PR DESCRIPTION
**Problem:** #35465 added async chainstate compaction, but the `coins_view_db` fuzz target did not exercise scheduling compaction alongside ordinary coins view operations.
The async wrapper also shared the `CompactFull()` name with the blocking `CDBWrapper` primitive.

**Fix:** Rename the coins DB wrapper to `CompactFullAsync()` and let `coins_view_db` randomly schedule it under `cs_main` (like in production).
The fuzz operation only starts compaction and any running job is joined by the `CCoinsViewDB` destructor at the end of the fuzz input.