### PR TITLE
test: cover feeThreshold = MAX_MONEY in interface_ipc_mining.py

### DIFF
--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -24,6 +24,7 @@ from test_framework.messages import (
     DEFAULT_BLOCK_RESERVED_WEIGHT,
     MAX_BLOCK_SIGOPS_COST,
     MAX_BLOCK_WEIGHT,
+    MAX_MONEY,
     from_hex,
     msg_headers,
     ser_uint256,
@@ -262,35 +263,53 @@ class IPCMiningTest(BitcoinTestFramework):
                 txsigops = await template.getTxSigops(ctx)
                 assert_equal(len(txsigops.result), 0)
 
-                self.log.debug("Wait for a new template")
+                self.log.debug("Wait for a new template, get one after the tip updates")
                 waitoptions = self.capnp_modules['mining'].BlockWaitOptions()
-                waitoptions.timeout = self.default_ipc_timeout
-                waitoptions.feeThreshold = 1
+                # Ignore fee increases, wait only for the tip update
+                waitoptions.feeThreshold = MAX_MONEY
+                # The current waitNext() implementation only checks fees once
+                # per second and at the timeout deadline. Temporarily increase
+                # the timeout to allow a fee check to happen before the deadline.
+                waitoptions.timeout = 2000.0 * self.options.timeout_factor
+                self.miniwallet.send_self_transfer(fee_rate=10, from_node=self.nodes[0])
                 template2 = await wait_and_do(
                     mining_wait_next_template(template, stack, ctx, waitoptions),
-                    lambda: self.generate(self.nodes[0], 1))
+                    # This mines the transaction, so it won't be in the next template
+                    lambda: self.generate(self.nodes[0], 1),
+                    # Sleep past the first fee check (currently after 1s), so
+                    # that waitNext would return early if MAX_MONEY was ignored.
+                    sleep_time=1.1 * self.options.timeout_factor)
                 assert template2 is not None
                 block2 = await mining_get_block(template2, ctx)
+                # If waitNext had returned for a fee increase instead of tip
+                # update, this template would include the mempool transaction.
                 assert_equal(len(block2.vtx), 1)
 
                 self.log.debug("Wait for another, but time out")
+                # Temporarily decrease the timeout since we want to hit the
+                # deadline, which in the current implementation triggers a
+                # final fee check, and see what happens.
+                waitoptions.timeout = 100
+                self.miniwallet.send_self_transfer(fee_rate=10, from_node=self.nodes[0])
                 template3 = await mining_wait_next_template(template2, stack, ctx, waitoptions)
                 assert template3 is None
 
+                waitoptions.timeout = self.default_ipc_timeout
                 self.log.debug("Wait for another, get one after increase in fees in the mempool")
+                waitoptions.feeThreshold = 1
                 template4 = await wait_and_do(
                     mining_wait_next_template(template2, stack, ctx, waitoptions),
                     lambda: self.miniwallet.send_self_transfer(fee_rate=10, from_node=self.nodes[0]))
                 assert template4 is not None
                 block3 = await mining_get_block(template4, ctx)
-                assert_equal(len(block3.vtx), 2)
+                assert_equal(len(block3.vtx), 3)
 
                 self.log.debug("Wait again, this should return the same template, since the fee threshold is zero")
                 waitoptions.feeThreshold = 0
                 template5 = await mining_wait_next_template(template4, stack, ctx, waitoptions)
                 assert template5 is not None
                 block4 = await mining_get_block(template5, ctx)
-                assert_equal(len(block4.vtx), 2)
+                assert_equal(len(block4.vtx), 3)
                 waitoptions.feeThreshold = 1
 
                 self.log.debug("Wait for another, get one after increase in fees in the mempool")
@@ -299,7 +318,7 @@ class IPCMiningTest(BitcoinTestFramework):
                     lambda: self.miniwallet.send_self_transfer(fee_rate=10, from_node=self.nodes[0]))
                 assert template6 is not None
                 block4 = await mining_get_block(template6, ctx)
-                assert_equal(len(block4.vtx), 3)
+                assert_equal(len(block4.vtx), 4)
 
                 self.log.debug("Wait for another, but time out, since the fee threshold is set now")
                 template7 = await mining_wait_next_template(template6, stack, ctx, waitoptions)

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -24,6 +24,7 @@ from test_framework.messages import (
     DEFAULT_BLOCK_RESERVED_WEIGHT,
     MAX_BLOCK_SIGOPS_COST,
     MAX_BLOCK_WEIGHT,
+    MAX_MONEY,
     from_hex,
     msg_headers,
     ser_uint256,
@@ -267,25 +268,40 @@ class IPCMiningTest(BitcoinTestFramework):
                 txsigops = await template.getTxSigops(ctx)
                 assert_equal(len(txsigops.result), 0)
 
-                self.log.debug("Wait for a new template")
+                self.log.debug("Wait for a new template, get one after the tip updates")
                 waitoptions = self.capnp_modules['mining'].BlockWaitOptions()
-                waitoptions.timeout = self.default_ipc_timeout
-                waitoptions.feeThreshold = 1
+                # Ignore fee increases, wait only for the tip update
+                waitoptions.feeThreshold = MAX_MONEY
+                # Keep the wait alive past the first one-second fee tick.
+                waitoptions.timeout = 2000.0 * self.options.timeout_factor
+                self.miniwallet.send_self_transfer(fee_rate=10, from_node=self.nodes[0])
                 template2 = await wait_and_do(
                     mining_wait_next_template(template, stack, ctx, waitoptions),
-                    lambda: self.generate(self.nodes[0], 1))
+                    # This mines the transaction, so it won't be in the next template
+                    lambda: self.generate(self.nodes[0], 1),
+                    # Mine after that tick, so waitNext would return early for
+                    # the fee increase if MAX_MONEY was ignored.
+                    sleep_time=1.1 * self.options.timeout_factor)
                 assert template2 is not None
                 block2 = await mining_get_block(template2, ctx)
+                # If waitNext had returned for a fee increase instead of tip
+                # update, this template would include the mempool transaction.
                 assert_equal(len(block2.vtx), 1)
 
                 self.log.debug("Wait for another, but time out")
-                template3 = await mining_wait_next_template(template2, stack, ctx, waitoptions)
+                # Temporarily decrease the timeout so the wait reaches its
+                # deadline quickly. MAX_MONEY skips creating a new template,
+                # even when there are new fees in the mempool.
+                waitoptions.timeout = 100
+                self.miniwallet.send_self_transfer(fee_rate=10, from_node=self.nodes[0])
+                with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=["CreateNewBlock()"]):
+                    template3 = await mining_wait_next_template(template2, stack, ctx, waitoptions)
                 assert template3 is None
 
-                self.log.debug("Wait for another, get one after increase in fees in the mempool")
-                template4 = await wait_and_do(
-                    mining_wait_next_template(template2, stack, ctx, waitoptions),
-                    lambda: self.miniwallet.send_self_transfer(fee_rate=10, from_node=self.nodes[0]))
+                waitoptions.timeout = self.default_ipc_timeout
+                self.log.debug("Wait for another, get one for the fees already in the mempool")
+                waitoptions.feeThreshold = 1
+                template4 = await mining_wait_next_template(template2, stack, ctx, waitoptions)
                 assert template4 is not None
                 block3 = await mining_get_block(template4, ctx)
                 assert_equal(len(block3.vtx), 2)

--- a/test/functional/test_framework/ipc_util.py
+++ b/test/functional/test_framework/ipc_util.py
@@ -45,7 +45,7 @@ async def destroying(obj, ctx):
         await obj.destroy(ctx)
 
 
-async def wait_and_do(wait_fn, do_fn):
+async def wait_and_do(wait_fn, do_fn, sleep_time=0.1):
     """Call wait_fn, then sleep, then call do_fn in a parallel task. Wait for
     both tasks to complete."""
     wait_started = asyncio.Event()
@@ -58,7 +58,7 @@ async def wait_and_do(wait_fn, do_fn):
 
     async def do():
         await wait_started.wait()
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(sleep_time)
         # Let do_fn be either a callable or an awaitable object
         if inspect.isawaitable(do_fn):
             await do_fn


### PR DESCRIPTION
This adds coverage for when [BlockWaitOptions](https://github.com/bitcoin/bitcoin/blob/master/src/node/mining_types.h#L94-L113)'s `feeThreshold` is set to `MAX_MONEY`. In other words, when the IPC client is only interested in tip updates, not in fee increases.

This tested ended up in #33922 at some point  https://github.com/bitcoin/bitcoin/pull/33922#issuecomment-3674495132, but doesn't really belong there.