### PR TITLE
net: prevent duplication manual connections (take 2)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -356,6 +356,25 @@ bool CConnman::AlreadyConnectedToAddress(const CNetAddr& addr) const
     return std::ranges::any_of(m_nodes, [&addr](CNode* node) { return node->addr == addr; });
 }
 
+std::string CConnman::ManualConnectionKey(const std::string& dest) const
+{
+    const CService resolved{MaybeFlipIPv6toCJDNS(LookupNumeric(dest, GetDefaultPort(dest)))};
+    return resolved.IsValid() ? resolved.ToStringAddrPort() : dest;
+}
+
+bool CConnman::MarkManualConnectionInProgress(const std::string& key) EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex)
+{
+    LOCK(m_nodes_mutex);
+    return m_manual_connection_in_progress.insert(key).second;
+}
+
+void CConnman::ClearManualConnectionInProgress(const std::string& key) EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex)
+{
+    LOCK(m_nodes_mutex);
+    const auto erased{m_manual_connection_in_progress.erase(key)};
+    Assume(erased == 1);
+}
+
 bool CConnman::CheckIncomingNonce(uint64_t nonce)
 {
     LOCK(m_nodes_mutex);
@@ -3055,16 +3074,26 @@ void CConnman::ThreadOpenAddedConnections()
     AssertLockNotHeld(m_reconnections_mutex);
     AssertLockNotHeld(m_unused_i2p_sessions_mutex);
 
+    std::unordered_set<std::string> logged_connected;
     while (true)
     {
         CountingSemaphoreGrant<> grant(*semAddnode);
-        std::vector<AddedNodeInfo> vInfo = GetAddedNodeInfo(/*include_connected=*/false);
+        std::vector<AddedNodeInfo> vInfo = GetAddedNodeInfo(/*include_connected=*/true);
+        std::unordered_set<std::string> current_added_nodes;
         bool tried = false;
         for (const AddedNodeInfo& info : vInfo) {
+            current_added_nodes.insert(info.m_params.m_added_node);
+            if (info.fConnected) {
+                if (logged_connected.insert(info.m_params.m_added_node).second) {
+                    LogDebug(BCLog::NET, "Skipping manual connection to %s, already connected\n", info.m_params.m_added_node);
+                }
+                continue;
+            }
+            logged_connected.erase(info.m_params.m_added_node);
             if (!grant) {
-                // If we've used up our semaphore and need a new one, let's not wait here since while we are waiting
-                // the addednodeinfo state might change.
-                break;
+                // If we've used up our semaphore, do not wait here since while
+                // we are waiting the addednodeinfo state might change.
+                continue;
             }
             tried = true;
             OpenNetworkConnection(/*addrConnect=*/CAddress{CService{}, NODE_NONE},
@@ -3077,6 +3106,7 @@ void CConnman::ThreadOpenAddedConnections()
             if (!m_interrupt_net->sleep_for(500ms)) return;
             grant = CountingSemaphoreGrant<>(*semAddnode, /*fTry=*/true);
         }
+        std::erase_if(logged_connected, [&](const auto& node) { return !current_added_nodes.contains(node); });
         // See if any reconnections are desired.
         PerformReconnections();
         // Retry every 60 seconds if a connection was attempted, otherwise two seconds
@@ -3117,10 +3147,26 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect,
         return false;
     }
 
+    std::optional<std::string> manual_connection;
+    if (conn_type == ConnectionType::MANUAL) {
+        if (pszDest) {
+            manual_connection = ManualConnectionKey(pszDest);
+        } else if (addrConnect.IsValid()) {
+            manual_connection = addrConnect.ToStringAddrPort();
+        }
+        if (manual_connection && !MarkManualConnectionInProgress(*manual_connection)) {
+            LogInfo("Not opening manual connection to %s, connection already in progress\n",
+                    pszDest ? pszDest : addrConnect.ToStringAddrPort());
+            return false;
+        }
+    }
+
     CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure, conn_type, use_v2transport, proxy_override);
 
-    if (!pnode)
+    if (!pnode) {
+        if (manual_connection) ClearManualConnectionInProgress(*manual_connection);
         return false;
+    }
     pnode->grantOutbound = std::move(grant_outbound);
 
     m_msgproc->InitializeNode(*pnode, m_local_services);
@@ -3131,6 +3177,7 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect,
         // update connection count by network
         if (pnode->IsManualOrFullOutboundConn()) ++m_network_conn_counts[pnode->addr.GetNetwork()];
     }
+    if (manual_connection) ClearManualConnectionInProgress(*manual_connection);
 
     TRACEPOINT(net, outbound_connection,
         pnode->GetId(),

--- a/src/net.h
+++ b/src/net.h
@@ -43,6 +43,7 @@
 #include <memory>
 #include <optional>
 #include <queue>
+#include <string>
 #include <string_view>
 #include <thread>
 #include <unordered_set>
@@ -1563,6 +1564,10 @@ private:
      */
     bool AttemptToEvictConnection(bool evict_tx_relay_peer_only, std::optional<NodeId> protect_peer = std::nullopt) EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
 
+    std::string ManualConnectionKey(const std::string& dest) const;
+    bool MarkManualConnectionInProgress(const std::string& key) EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
+    void ClearManualConnectionInProgress(const std::string& key) EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
+
     /**
      * Open a new P2P connection.
      * @param[in] addrConnect Address to connect to, if `pszDest` is `nullptr`.
@@ -1662,6 +1667,7 @@ private:
     std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);
     std::list<CNode*> m_nodes_disconnected;
     mutable Mutex m_nodes_mutex;
+    std::unordered_set<std::string> m_manual_connection_in_progress GUARDED_BY(m_nodes_mutex);
     std::atomic<NodeId> nLastNodeId{0};
     unsigned int nPrevNodeCount{0};
 

--- a/test/functional/p2p_duplicate_manual_connections.py
+++ b/test/functional/p2p_duplicate_manual_connections.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that -connect and -addnode do not open duplicate manual connections."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    p2p_port,
+)
+
+PENDING_MANUAL_CONNECTION_LOG = "connection already in progress"
+CONNECTED_MANUAL_CONNECTION_LOG = "Skipping manual connection"
+
+
+def outbound_manual_peers(node):
+    return [
+        peer
+        for peer in node.getpeerinfo()
+        if not peer["inbound"] and peer["connection_type"] == "manual"
+    ]
+
+
+def inbound_peers(node):
+    return [peer for peer in node.getpeerinfo() if peer["inbound"]]
+
+
+def pending_manual_connection_logged(node):
+    debug_log = node.debug_log_path.read_text(
+        encoding="utf-8",
+        errors="replace",
+    )
+    return PENDING_MANUAL_CONNECTION_LOG in debug_log
+
+
+def connected_manual_connection_logged(node):
+    debug_log = node.debug_log_path.read_text(
+        encoding="utf-8",
+        errors="replace",
+    )
+    return CONNECTED_MANUAL_CONNECTION_LOG in debug_log
+
+
+def duplicate_manual_connection_observed(node):
+    return (
+        len(inbound_peers(node)) > 1
+        or len(outbound_manual_peers(node)) > 1
+        or node.getconnectioncount() > 2
+    )
+
+
+class DuplicateManualConnectionsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.disable_autoconnect = False
+        self.extra_args = [
+            [
+                "-listen=1",
+                f"-connect=127.0.0.1:{p2p_port(1)}",
+                f"-addnode=127.0.0.1:{p2p_port(1)}",
+            ],
+            [
+                "-listen=1",
+                f"-connect=127.0.0.1:{p2p_port(0)}",
+                f"-addnode=127.0.0.1:{p2p_port(0)}",
+            ],
+        ]
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        self.log.info(
+            "Wait for each node to have one inbound and one outbound manual peer"
+        )
+        self.wait_until(
+            lambda: all(
+                len(inbound_peers(node)) >= 1 and len(outbound_manual_peers(node)) >= 1
+                for node in self.nodes
+            )
+        )
+
+        self.log.info("Wait for the duplicate attempt to be dropped or observed")
+        self.wait_until(
+            lambda: any(
+                pending_manual_connection_logged(node)
+                or connected_manual_connection_logged(node)
+                or duplicate_manual_connection_observed(node)
+                for node in self.nodes
+            )
+        )
+
+        for i, node in enumerate(self.nodes):
+            self.log.info(
+                f"Check node {i} has one inbound and one outbound manual peer"
+            )
+            assert_equal(len(inbound_peers(node)), 1)
+            assert_equal(len(outbound_manual_peers(node)), 1)
+            assert_equal(node.getconnectioncount(), 2)
+
+
+if __name__ == "__main__":
+    DuplicateManualConnectionsTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -335,6 +335,7 @@ BASE_SCRIPTS = [
     'feature_loadblock.py',
     'wallet_assumeutxo.py',
     'p2p_add_connections.py',
+    'p2p_duplicate_manual_connections.py',
     'feature_bind_port_discover.py',
     'p2p_unrequested_blocks.py',
     'p2p_message_capture.py',


### PR DESCRIPTION
Fixes #5299.

`-connect` and `-addnode` can both try to open the same manual connection during startup.
Existing duplicate checks only see peers after they have been inserted into `m_nodes`, so two concurrent manual dial attempts can both pass the checks and create duplicate connections.

Fix this by reserving a manual connection destination before connecting in `OpenNetworkConnection()`.
The reservation is cleared after a failed connection, or after a successful node has been added to `m_nodes`, where the existing connected-peer checks take over.

This is intentionally limited to `ConnectionType::MANUAL`, covering `-connect`, `-addnode`, manual reconnections, and one-shot manual RPC connection attempts only.
Note that this does not try to prevent automatic outbound connections to addnode peers like 21f8426c823fd83c40fd81f08ff2bf39ec6a4575 from #28428 does.

A functional regression test is added for the startup case where two nodes each configure the other with both `-connect` and `-addnode`. This fails before the fixing commit is applied.

In comparison to #27804 this approach tracks in-flight manual connection attempts in `OpenNetworkConnection()`, instead of de-duplicating configuration arguments, which should be much less-brittle. Once the connection succeeds, the existing `m_nodes` duplicate checks take over.

The remaining limitation is that hostnames are keyed by the original string, not resolved IPs. So `-connect=example.com` and `-addnode=<resolved-ip>` are not guaranteed to dedupe during the in-flight window, but I don't want to add DNS lookups in here, so I consider this acceptable.