### PR TITLE
doc: Clarify build docs about `pkgconf` / `pkg-config` requirements

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -10,7 +10,7 @@ This guide describes how to build bitcoind, command-line utilities, and GUI on F
 Run the following as root to install the base dependencies for building.
 
 ```bash
-pkg install boost-libs cmake git pkgconf
+pkg install boost-libs cmake git
 ```
 
 SQLite is required for the wallet:
@@ -66,7 +66,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 
 Bitcoin Core can provide notifications via ZeroMQ. To compile ZMQ support, install the following dependency and pass `-DWITH_ZMQ=ON` when configuring.
 ```bash
-pkg install libzmq4
+pkg install libzmq4 pkgconf
 ```
 
 #### Test Suite Dependencies

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -12,7 +12,7 @@ Install the required dependencies the usual way you [install software on NetBSD]
 The example commands below use `pkgin`.
 
 ```bash
-pkgin install git cmake pkg-config boost
+pkgin install git cmake boost
 ```
 
 NetBSD currently ships with an older version of `gcc` than is needed to build. You should upgrade your `gcc` and then pass this new version to the CMake configuration.
@@ -84,7 +84,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 
 Bitcoin Core can provide notifications via ZeroMQ. To compile ZMQ support, install the following dependency and pass `-DWITH_ZMQ=ON` when configuring.
 ```bash
-pkgin install zeromq
+pkgin install zeromq pkg-config
 ```
 
 #### Test Suite Dependencies

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -50,7 +50,7 @@ See [dependencies.md](dependencies.md) for a complete overview.
 To install, run the following from your terminal:
 
 ``` bash
-brew install cmake boost pkgconf capnp
+brew install cmake boost capnp
 ```
 
 #### Wallet Dependencies
@@ -110,7 +110,7 @@ Support for ZMQ notifications requires the following dependency.
 Skip if you do not need ZMQ functionality.
 
 ``` bash
-brew install zeromq
+brew install zeromq pkgconf
 ```
 
 Check out the [further configuration](#further-configuration) section for more information.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -44,12 +44,14 @@ You can either build from self-compiled [depends](/depends/README.md) or
 install the dependencies from your distribution package manager. Dependencies
 for additional features in later columns are optional.
 
-| Package manager         | Required build dependencies | SQLite (wallet) | Cap'n Proto (IPC) | ZMQ | USDT | Qt and libqrencode (GUI) |
+| Package manager         | Required build dependencies | SQLite (wallet) | Cap'n Proto (IPC) | ZMQ <sup><a href="#note1">[1]</a></sup> | USDT | Qt and libqrencode (GUI) |
 | ----------------------- | --------------------------- | --------------- | ----------------- | --- | ---- | ------------------------ |
-| Debian / Ubuntu (`apt`) | `build-essential cmake pkgconf python3 libboost-dev` | `libsqlite3-dev` | `libcapnp-dev capnproto` | `libzmq3-dev` | `systemtap-sdt-dev` | `qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libgl-dev qt6-wayland libqrencode-dev` |
-| Fedora (`dnf`)          | `gcc-c++ cmake make python3 boost-devel` | `sqlite-devel` | `capnproto capnproto-devel` | `zeromq-devel` | `systemtap-sdt-devel` | `qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland qrencode-devel` |
-| Alpine (`apk`)          | `build-base cmake linux-headers pkgconf python3 boost-dev` | `sqlite-dev` | `capnproto capnproto-dev` | `zeromq-dev` | Not supported | `qt6-qtbase-dev qt6-qttools-dev libqrencode-dev` |
-| Arch (`pacman`)         | `gcc make cmake pkgconf python boost` | `sqlite` | `capnproto` | `zeromq` | `systemtap` | `qt6-base qt6-tools qt6-wayland qrencode` |
+| Debian / Ubuntu (`apt`) | `build-essential cmake python3 libboost-dev` | `libsqlite3-dev` | `libcapnp-dev capnproto` | `libzmq3-dev pkgconf` | `systemtap-sdt-dev` | `qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libgl-dev qt6-wayland libqrencode-dev` |
+| Fedora (`dnf`)          | `gcc-c++ cmake make python3 boost-devel` | `sqlite-devel` | `capnproto capnproto-devel` | `zeromq-devel pkgconf` | `systemtap-sdt-devel` | `qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland qrencode-devel` |
+| Alpine (`apk`)          | `build-base cmake linux-headers python3 boost-dev` | `sqlite-dev` | `capnproto capnproto-dev` | `zeromq-dev` | Not supported | `qt6-qtbase-dev qt6-qttools-dev libqrencode-dev` |
+| Arch (`pacman`)         | `gcc make cmake python boost` | `sqlite` | `capnproto` | `zeromq` | `systemtap` | `qt6-base qt6-tools qt6-wayland qrencode` |
+
+<a id="note1"></a>1. Some ZMQ packages do not vendor the CMake config files, which requires `pkgconf` or `pkg-config` to be installed.
 
 For Debian "oldstable", or earlier Ubuntu LTS releases, you may need to pick a
 later compiler version, according to the [dependencies](/doc/dependencies.md)


### PR DESCRIPTION
Since https://github.com/bitcoin/bitcoin/pull/34411, `pkgconf`/`pkg-config` is no longer strictly required. 

It is currently required for ZeroMQ on several major distributions and operating systems, including Debian, Ubuntu, the BSD derivatives, and Gentoo.

Regarding QRencode, our [`FindQRencode.cmake`](https://github.com/bitcoin/bitcoin/blob/master/cmake/module/FindQRencode.cmake) module treats `pkgconf`/`pkg-config` as optional and can successfully locate the package without it.

This PR amends https://github.com/bitcoin/bitcoin/pull/34411 and updates the build notes accordingly.

Addresses https://github.com/bitcoin/bitcoin/pull/34411#pullrequestreview-4553185425.