### PR TITLE
build: QRencode cleanups

### DIFF
--- a/cmake/module/FindQRencode.cmake
+++ b/cmake/module/FindQRencode.cmake
@@ -14,23 +14,15 @@ This is a wrapper around find_package()/pkg_check_modules() commands that:
 
 #]=======================================================================]
 
-find_package(PkgConfig QUIET)
-if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_QRencode QUIET libqrencode)
-endif()
-
 find_path(QRencode_INCLUDE_DIR
   NAMES qrencode.h
-  HINTS ${PC_QRencode_INCLUDE_DIRS}
 )
 
 find_library(QRencode_LIBRARY_RELEASE
   NAMES qrencode
-  HINTS ${PC_QRencode_LIBRARY_DIRS}
 )
 find_library(QRencode_LIBRARY_DEBUG
   NAMES qrencoded qrencode
-  HINTS ${PC_QRencode_LIBRARY_DIRS}
 )
 include(SelectLibraryConfigurations)
 select_library_configurations(QRencode)
@@ -38,7 +30,6 @@ select_library_configurations(QRencode)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(QRencode
   REQUIRED_VARS QRencode_LIBRARY QRencode_INCLUDE_DIR
-  VERSION_VAR PC_QRencode_VERSION
 )
 
 if(QRencode_FOUND)

--- a/cmake/module/FindQRencode.cmake
+++ b/cmake/module/FindQRencode.cmake
@@ -17,33 +17,25 @@ This is a wrapper around find_package()/pkg_check_modules() commands that:
 find_path(QRencode_INCLUDE_DIR
   NAMES qrencode.h
 )
-
 find_library(QRencode_LIBRARY_RELEASE
   NAMES qrencode
 )
 find_library(QRencode_LIBRARY_DEBUG
   NAMES qrencoded qrencode
 )
-include(SelectLibraryConfigurations)
-select_library_configurations(QRencode)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(QRencode
-  REQUIRED_VARS QRencode_LIBRARY QRencode_INCLUDE_DIR
+  REQUIRED_VARS QRencode_LIBRARY_RELEASE QRencode_INCLUDE_DIR
 )
 
-if(QRencode_FOUND)
-  if(NOT TARGET QRencode::QRencode)
-    add_library(QRencode::QRencode UNKNOWN IMPORTED)
-  endif()
-  if(QRencode_LIBRARY_RELEASE)
-    set_property(TARGET QRencode::QRencode APPEND PROPERTY
-      IMPORTED_CONFIGURATIONS RELEASE
-    )
-    set_target_properties(QRencode::QRencode PROPERTIES
-      IMPORTED_LOCATION_RELEASE "${QRencode_LIBRARY_RELEASE}"
-    )
-  endif()
+if(QRencode_FOUND AND NOT TARGET QRencode::QRencode)
+  add_library(QRencode::QRencode UNKNOWN IMPORTED)
+  set_target_properties(QRencode::QRencode PROPERTIES
+    IMPORTED_CONFIGURATIONS RELEASE
+    IMPORTED_LOCATION_RELEASE "${QRencode_LIBRARY_RELEASE}"
+    INTERFACE_INCLUDE_DIRECTORIES "${QRencode_INCLUDE_DIR}"
+  )
   if(QRencode_LIBRARY_DEBUG)
     set_property(TARGET QRencode::QRencode APPEND PROPERTY
       IMPORTED_CONFIGURATIONS DEBUG
@@ -52,11 +44,10 @@ if(QRencode_FOUND)
       IMPORTED_LOCATION_DEBUG "${QRencode_LIBRARY_DEBUG}"
     )
   endif()
-  set_target_properties(QRencode::QRencode PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${QRencode_INCLUDE_DIR}"
-  )
 endif()
 
 mark_as_advanced(
   QRencode_INCLUDE_DIR
+  QRencode_LIBRARY_RELEASE
+  QRencode_LIBRARY_DEBUG
 )

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -30,5 +30,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf share
+  rm -rf share lib/pkgconfig
 endef


### PR DESCRIPTION
This PR addresses:
- [this](https://github.com/bitcoin/bitcoin/pull/35602#issuecomment-4799507779) comment:
  > If it works without pkg-config, then we should remove the usage of pkgconfig entirely, rather than say it will work without it, and leave the dependency in the code?

- and [this](https://github.com/bitcoin/bitcoin/pull/35602#issuecomment-4799947803) one:
  > While cleaning up this module, you may also get rid of `SelectLibraryConfigurations`. We don't want that `QRencode_LIBRARY` or `QRencode_LIBRARIES` is used anywhere; there is no need to set a variable with that name.