### PR TITLE
log: expose `-logratelimit` in normal help

### DIFF
--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -38,7 +38,7 @@ void AddLoggingArgs(ArgsManager& argsman)
     argsman.AddArg("-logsourcelocations", strprintf("Prepend debug output with name of the originating source location (source file, line number and function name) (default: %u)", DEFAULT_LOGSOURCELOCATIONS), ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMICROS), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-loglevelalways", strprintf("Always prepend a category and level (default: %u)", DEFAULT_LOGLEVELALWAYS), ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
-    argsman.AddArg("-logratelimit", strprintf("Apply rate limiting to unconditional logging to mitigate disk-filling attacks (default: %u)", BCLog::DEFAULT_LOGRATELIMIT), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-logratelimit", strprintf("Apply rate limiting to unconditional logging to mitigate disk-filling attacks (default: %u)", BCLog::DEFAULT_LOGRATELIMIT), ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-printtoconsole", "Send trace/debug info to console (default: 1 when no -daemon. To disable logging to file, set -nodebuglogfile)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-shrinkdebugfile", "Shrink debug log file on client startup (default: 1 when no -debug)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
 }


### PR DESCRIPTION
Follow-up to https://github.com/bitcoin/bitcoin/pull/32604#issuecomment-4804334291

**Problem:** `-logratelimit` is currently registered as `DEBUG_ONLY`, so users who are not reading `-help-debug` are unlikely to discover the supported escape hatch when rate limiting interferes with diagnosis or log processing.

**Fix:** Expose the existing option in normal help while keeping rate limiting enabled by default.
Add argsman coverage to assert that `-logratelimit` is not `DEBUG_ONLY` and appears in the default help text.

**Reproducer:** you can check manually by grepping the help page or by adding a temporary unit test - before and after the change and see the difference.

<details><summary>bitcoind -help(-debug)</summary>

```bash
cmake -B build && cmake --build build -j -t bitcoind
build/bin/bitcoind -help-debug | grep -A2 logratelimit
build/bin/bitcoind -help | grep -A2 logratelimit
```
</details>

<details><summary>util_LogRateLimitHelp</summary>

```patch
diff --git a/src/test/argsman_tests.cpp b/src/test/argsman_tests.cpp
index da0d684050..0e918afd6b 100644
--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/args.h>
+#include <init/common.h>
 #include <sync.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
@@ -710,6 +711,14 @@ BOOST_AUTO_TEST_CASE(util_AddCommand_clearargs_replaces_command_options)
     BOOST_CHECK(details.empty());
 }
 
+BOOST_AUTO_TEST_CASE(util_LogRateLimitHelp)
+{
+    ArgsManager args;
+    init::AddLoggingArgs(args);
+    BOOST_CHECK_EQUAL(*Assert(args.GetArgFlags("-logratelimit")) & ArgsManager::DEBUG_ONLY, 0U);
+    BOOST_CHECK(args.GetHelpMessage().find("-logratelimit") != std::string::npos);
+}
+
 BOOST_AUTO_TEST_CASE(util_GetChainTypeString)
 {
     TestArgsManager test_args;
```

</details>
