### PR TITLE
nanobench: fix performance counter buffer initialization

### DIFF
--- a/src/bench/nanobench.h
+++ b/src/bench/nanobench.h
@@ -2654,9 +2654,9 @@ private:
     std::map<uint64_t, Target> mIdToTarget{};
 
     // start with minimum size of 3 for read_format
-    std::vector<uint64_t> mCounters{3};
-    std::vector<uint64_t> mCalibratedOverhead{3};
-    std::vector<uint64_t> mLoopOverhead{3};
+    std::vector<uint64_t> mCounters = std::vector<uint64_t>(3);
+    std::vector<uint64_t> mCalibratedOverhead = std::vector<uint64_t>(3);
+    std::vector<uint64_t> mLoopOverhead = std::vector<uint64_t>(3);
 
     uint64_t mTimeEnabledNanos = 0;
     uint64_t mTimeRunningNanos = 0;


### PR DESCRIPTION
**Problem:** The Linux perf counter buffers are documented as starting with three `read_format` metadata slots, but `std::vector<uint64_t>{3}` creates a one-element vector containing `3`.
In normal benchmark runs this is usually hidden because successful `monitor()` calls resize the buffers before `updateResults()`, while failed setup sets `mHasError` before the indexed reads.

**Fix:** Use the vector size constructor so the buffers start with three zero-initialized metadata slots.
This should not change the usual successful benchmark path, but it makes the default object state match the code's indexing assumptions.

**Reproducer:** https://godbolt.org/z/scE8rMd8Y
**Upstream:** https://github.com/martinus/nanobench/pull/138