### PR TITLE
zmq: fail startup when address is in use

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1830,7 +1830,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
 #ifdef ENABLE_ZMQ
-    g_zmq_notification_interface = CZMQNotificationInterface::Create(
+    auto zmq_notification_interface{CZMQNotificationInterface::Create(
         [&chainman = node.chainman](std::vector<std::byte>& block, const CBlockIndex& index) {
             assert(chainman);
             if (auto ret{chainman->m_blockman.ReadRawBlock(WITH_LOCK(cs_main, return index.GetBlockPos()))}) {
@@ -1838,7 +1838,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 return true;
             }
             return false;
-        });
+        })};
+    if (!zmq_notification_interface) return InitError(util::ErrorString(zmq_notification_interface));
+    g_zmq_notification_interface = std::move(*zmq_notification_interface);
 
     if (g_zmq_notification_interface) {
         validation_signals.RegisterValidationInterface(g_zmq_notification_interface.get());

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -33,6 +33,7 @@ public:
     void SetType(const std::string &t) { type = t; }
     std::string GetAddress() const { return address; }
     void SetAddress(const std::string &a) { address = a; }
+    const std::string& GetFatalError() const { return m_fatal_error; }
     int GetOutboundMessageHighWaterMark() const { return outbound_message_high_water_mark; }
     void SetOutboundMessageHighWaterMark(const int sndhwm) {
         if (sndhwm >= 0) {
@@ -60,6 +61,7 @@ protected:
     void* psocket{nullptr};
     std::string type;
     std::string address;
+    std::string m_fatal_error;
     int outbound_message_high_water_mark{DEFAULT_ZMQ_SNDHWM}; // aka SNDHWM
 };
 

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -79,7 +79,7 @@ util::Result<std::unique_ptr<CZMQNotificationInterface>> CZMQNotificationInterfa
         notificationInterface->notifiers = std::move(notifiers);
 
         if (notificationInterface->Initialize()) {
-            return std::move(notificationInterface);
+            return notificationInterface;
         }
         if (!notificationInterface->m_fatal_error.empty()) {
             return util::Error{Untranslated(notificationInterface->m_fatal_error)};

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -12,6 +12,8 @@
 #include <primitives/transaction.h>
 #include <util/check.h>
 #include <util/log.h>
+#include <util/result.h>
+#include <util/translation.h>
 #include <zmq/zmqabstractnotifier.h>
 #include <zmq/zmqpublishnotifier.h>
 #include <zmq/zmqutil.h>
@@ -41,7 +43,7 @@ std::list<const CZMQAbstractNotifier*> CZMQNotificationInterface::GetActiveNotif
     return result;
 }
 
-std::unique_ptr<CZMQNotificationInterface> CZMQNotificationInterface::Create(std::function<bool(std::vector<std::byte>&, const CBlockIndex&)> get_block_by_index)
+util::Result<std::unique_ptr<CZMQNotificationInterface>> CZMQNotificationInterface::Create(std::function<bool(std::vector<std::byte>&, const CBlockIndex&)> get_block_by_index)
 {
     std::map<std::string, CZMQNotifierFactory> factories;
     factories["pubhashblock"] = CZMQAbstractNotifier::Create<CZMQPublishHashBlockNotifier>;
@@ -77,11 +79,14 @@ std::unique_ptr<CZMQNotificationInterface> CZMQNotificationInterface::Create(std
         notificationInterface->notifiers = std::move(notifiers);
 
         if (notificationInterface->Initialize()) {
-            return notificationInterface;
+            return std::move(notificationInterface);
+        }
+        if (!notificationInterface->m_fatal_error.empty()) {
+            return util::Error{Untranslated(notificationInterface->m_fatal_error)};
         }
     }
 
-    return nullptr;
+    return std::unique_ptr<CZMQNotificationInterface>{};
 }
 
 // Called at startup to conditionally set up ZMQ socket(s)
@@ -107,6 +112,9 @@ bool CZMQNotificationInterface::Initialize()
             LogDebug(BCLog::ZMQ, "Notifier %s ready (address = %s)\n", notifier->GetType(), notifier->GetAddress());
         } else {
             LogDebug(BCLog::ZMQ, "Notifier %s failed (address = %s)\n", notifier->GetType(), notifier->GetAddress());
+            if (!notifier->GetFatalError().empty()) {
+                m_fatal_error = notifier->GetFatalError();
+            }
             return false;
         }
     }

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -6,6 +6,7 @@
 #define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
 #include <primitives/transaction.h>
+#include <util/result.h>
 #include <validationinterface.h>
 
 #include <cstddef>
@@ -13,6 +14,7 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <string>
 #include <vector>
 
 class CBlockIndex;
@@ -25,7 +27,7 @@ public:
 
     std::list<const CZMQAbstractNotifier*> GetActiveNotifiers() const;
 
-    static std::unique_ptr<CZMQNotificationInterface> Create(std::function<bool(std::vector<std::byte>&, const CBlockIndex&)> get_block_by_index);
+    static util::Result<std::unique_ptr<CZMQNotificationInterface>> Create(std::function<bool(std::vector<std::byte>&, const CBlockIndex&)> get_block_by_index);
 
 protected:
     bool Initialize();
@@ -43,6 +45,7 @@ private:
 
     void* pcontext{nullptr};
     std::list<std::unique_ptr<CZMQAbstractNotifier>> notifiers;
+    std::string m_fatal_error;
 };
 
 extern std::unique_ptr<CZMQNotificationInterface> g_zmq_notification_interface;

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -18,6 +18,7 @@
 
 #include <zmq.h>
 
+#include <cerrno>
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
@@ -95,6 +96,7 @@ static bool IsZMQAddressIPV6(const std::string &zmq_address)
 bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
 {
     assert(!psocket);
+    m_fatal_error.clear();
 
     // check if address is being used by other publish notifier
     std::multimap<std::string, CZMQAbstractPublishNotifier*>::iterator i = mapPublishNotifiers.find(address);
@@ -138,7 +140,11 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         rc = zmq_bind(psocket, address.c_str());
         if (rc != 0)
         {
+            const int zmq_errno_value{zmq_errno()};
             zmqError("Failed to bind address");
+            if (zmq_errno_value == EADDRINUSE) {
+                m_fatal_error = "Unable to bind ZMQ address " + address + ": " + zmq_strerror(zmq_errno_value);
+            }
             zmq_close(psocket);
             return false;
         }

--- a/src/zmq/zmqutil.cpp
+++ b/src/zmq/zmqutil.cpp
@@ -8,10 +8,9 @@
 
 #include <zmq.h>
 
-#include <cerrno>
 #include <string>
 
 void zmqError(const std::string& str)
 {
-    LogDebug(BCLog::ZMQ, "Error: %s, msg: %s\n", str, zmq_strerror(errno));
+    LogDebug(BCLog::ZMQ, "Error: %s, msg: %s\n", str, zmq_strerror(zmq_errno()));
 }

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the ZMQ notification interface."""
 import os
+import re
 import struct
 import tempfile
 from io import BytesIO
@@ -17,6 +18,7 @@ from test_framework.blocktools import (
     create_block,
 )
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import ErrorMatch
 from test_framework.messages import (
     CBlock,
     hash256,
@@ -116,9 +118,10 @@ class ZMQTest (BitcoinTestFramework):
         self.skip_if_no_bitcoind_zmq()
 
     def run_test(self):
-        self.wallet = MiniWallet(self.nodes[0])
         self.ctx = zmq.Context()
         try:
+            self.test_address_already_in_use()
+            self.wallet = MiniWallet(self.nodes[0])
             self.test_basic()
             if test_unix_socket():
                 self.test_basic(unix=True)
@@ -180,6 +183,21 @@ class ZMQTest (BitcoinTestFramework):
             self.sync_blocks()
 
         return subscribers
+
+    def test_address_already_in_use(self):
+        self.log.info("Test that ZMQ fails startup if the address is already in use")
+        address = f"tcp://127.0.0.1:{self.zmq_port_base + 3}"
+        self.restart_node(0, [f"-zmqpubrawblock={address}"])
+        self.stop_node(1)
+
+        self.nodes[1].assert_start_raises_init_error(
+            extra_args=[f"-zmqpubrawblock={address}"],
+            expected_msg=re.escape(f"Error: Unable to bind ZMQ address {address}"),
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+        self.restart_node(0)
+        self.start_node(1)
 
     def test_basic(self, unix = False):
         self.log.info(f"Running basic test with {'ipc' if unix else 'tcp'} protocol")


### PR DESCRIPTION
Fixes #33715.

When a second node is configured to publish ZMQ notifications on an address that is already bound by another process, the notifier currently fails to initialize but the node continues starting up. This leaves `getzmqnotifications` empty and only reports the bind failure in debug logs.

This changes ZMQ initialization so that an `EADDRINUSE` failure from `zmq_bind` is propagated as an init error. The behavior remains scoped to an address-in-use bind failure, preserving the existing behavior that invalid ZMQ arguments do not take down the node.

A functional test was added to `interface_zmq.py` that starts one node with `-zmqpubrawblock=<address>` and verifies that a second node configured with the same address fails during startup.

Tested with:

- `python3 -m py_compile test/functional/interface_zmq.py`
- `git diff --check`
- `cmake --build build-clang --target bitcoind -j 8`
- `python3 build-clang/test/functional/interface_zmq.py --configfile=build-clang/test/config.ini --cachedir=/private/tmp/bitcoin_zmq_cache_33715_a --tmpdir=/private/tmp/bitcoin_zmq_tmp_33715_b`
