### PR TITLE
cli: Fix multisig error message spacing

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -383,7 +383,7 @@ static void MutateTxAddOutMultiSig(CMutableTransaction& tx, const std::string& s
 
     if (required < 1 || required > MAX_PUBKEYS_PER_MULTISIG || numkeys < 1 || numkeys > MAX_PUBKEYS_PER_MULTISIG || numkeys < required)
         throw std::runtime_error("multisig parameter mismatch. Required " \
-                            + ToString(required) + " of " + ToString(numkeys) + "signatures.");
+                            + ToString(required) + " of " + ToString(numkeys) + " signatures.");
 
     // extract and validate PUBKEYs
     std::vector<CPubKey> pubkeys;

--- a/test/functional/data/util/bitcoin-util-test.json
+++ b/test/functional/data/util/bitcoin-util-test.json
@@ -722,6 +722,12 @@
     "description": "Try to parse a multisig number outside the allowed range"
   },
   { "exec": "./bitcoin-tx",
+    "args": ["-create", "outmultisig=1:4:3:02a5:021:02df", "nversion=1"],
+    "return_code": 1,
+    "error_txt": "error: multisig parameter mismatch. Required 4 of 3 signatures.",
+    "description": "Try to parse a multisig with more required signatures than pubkeys"
+  },
+  { "exec": "./bitcoin-tx",
     "args": ["-create", "outmultisig=1:2:3:02a5613bd857b7048924264d1e70e08fb2a7e6527d32b7ab1bb993ac59964ff397:021ac43c7ff740014c3b33737ede99c967e4764553d1b2b83db77c83b8715fa72d:02df2089105c77f266fa11a9d33f05c735234075f2e8780824c6b709415f9fb485", "nversion=1"],
     "output_cmp": "txcreatemultisig1.hex",
     "description": "Creates a new transaction with a single 2-of-3 multisig output"


### PR DESCRIPTION
This fixes a small user-facing error-message typo in `bitcoin-tx`.

When `outmultisig` is given mismatched parameters, the current error joins the
number of keys and "signatures" without a space, e.g. `Required 4 of
3signatures.`

The change also adds coverage alongside the existing malformed `outmultisig`
cases in `bitcoin-util-test.json`.

Tested:

- `python3 -m json.tool test/functional/data/util/bitcoin-util-test.json`
- `git diff --cached --check`

Not run:

- `test/functional/test_runner.py tool_utils.py`, because `cmake` is not
  installed in this environment and there is no configured build directory.
