### PR TITLE
depends: Make tarball creation from local directory reproducible

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -47,7 +47,11 @@ endef
 define fetch_local_dir_sha256
     if ! [ -f $($(1)_source) ] || [ -n "$$(find $($(1)_local_dir) -newer $($(1)_source) | head -n1)" ]; then \
         mkdir -p $(dir $($(1)_source)) && \
-        $(build_TAR) -c -f $($(1)_source) -C $($(1)_local_dir) . && \
+        ( \
+          cd $($(1)_local_dir) && \
+          find . -print0 | TZ=UTC xargs -0r $(build_TOUCH) && \
+          find . | LC_ALL=C sort | $(build_TAR) --no-recursion -c -f $($(1)_source) -T - \
+        ) && \
         rm -f $($(1)_fetched); \
     fi && \
     if ! [ -f $($(1)_fetched) ] || [ -n "$$(find $($(1)_source) -newer $($(1)_fetched))" ]; then \


### PR DESCRIPTION
This guarantees `$(package)_sha256_hash` reproducibility regardless of the default behavior of `$(build_TAR)` and fixes [caching](https://github.com/bitcoin/bitcoin/pull/36006#issuecomment-5328809116) for the `native_libmultiprocess` package.

Steps to reproduce the issue using the master branch @ 2a9e35d293b308e81811fa93ad2e5e8ed20e66e0:
```console
$ mkdir a && cd a && git init
$ git remote add origin https://github.com/bitcoin/bitcoin.git
$ git fetch --depth 1 origin 2a9e35d293b308e81811fa93ad2e5e8ed20e66e0
$ git checkout FETCH_HEAD
$ cd depends
$ gmake print-native_libmultiprocess_sha256_hash  # Hash A. Compare with Hash B.
native_libmultiprocess_sha256_hash=7dd817bfc0ee23c408299907aff13fefb0bd3a54ec66dc14ea15b0cc38c3d9ce
$ cd ../../ && sleep 2
$ mkdir b && cd b && git init
$ git remote add origin https://github.com/bitcoin/bitcoin.git
$ git fetch --depth 1 origin 2a9e35d293b308e81811fa93ad2e5e8ed20e66e0
$ git checkout FETCH_HEAD
$ cd depends
$ gmake print-native_libmultiprocess_sha256_hash  # Hash B. Compare with Hash A.
native_libmultiprocess_sha256_hash=34d6f79560c0ff7a4f46bd6bfb4693076546b41f071b6dbf879da45ac8384688
```