### PR TITLE
leveldb: move unused block-cache budget to write buffers

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -139,7 +139,9 @@ static void SetMaxOpenFiles(leveldb::Options *options) {
 static leveldb::Options GetOptions(size_t nCacheSize)
 {
     leveldb::Options options;
-    options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
+    constexpr bool cache_table_blocks{sizeof(void*) < 8};
+    // LevelDB does not cache mmap-backed uncompressed table blocks.
+    options.block_cache = leveldb::NewLRUCache(cache_table_blocks ? nCacheSize / 2 : 0);
     options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     options.compression = leveldb::kNoCompression;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -142,7 +142,8 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     constexpr bool cache_table_blocks{sizeof(void*) < 8};
     // LevelDB does not cache mmap-backed uncompressed table blocks.
     options.block_cache = leveldb::NewLRUCache(cache_table_blocks ? nCacheSize / 2 : 0);
-    options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
+    // Up to two write buffers may be held in memory simultaneously.
+    options.write_buffer_size = nCacheSize / (cache_table_blocks ? 4 : 2);
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     options.compression = leveldb::kNoCompression;
     options.info_log = new CBitcoinLevelDBLogger();


### PR DESCRIPTION
**Problem:** `CDBWrapper` reserves half of each DB cache budget for LevelDB's block cache, which only helps when table-block contents are cacheable.
On 64-bit builds LevelDB [uses mmap reads](https://github.com/bitcoin/bitcoin/blob/3c76bd435681ee2ebaa1f407ac23736d9c3b331b/src/leveldb/util/env_posix.cc#L45-L46) and, for our uncompressed table files, [marks mmap-backed contents non-cacheable](https://github.com/bitcoin/bitcoin/blob/3c76bd435681ee2ebaa1f407ac23736d9c3b331b/src/leveldb/table/format.cc#L106).
LevelDB [only inserts cacheable blocks](https://github.com/bitcoin/bitcoin/blob/3c76bd435681ee2ebaa1f407ac23736d9c3b331b/src/leveldb/table/table.cc#L182-L185), so the normal 64-bit path does not populate it.

**Discussion:** This came up in Sipa's [leveldb-subtree#63 resource-limit notes](https://github.com/bitcoin-core/leveldb-subtree/pull/63#issuecomment-4735688019), the follow-up note on [#34636](https://github.com/bitcoin/bitcoin/pull/34636#issuecomment-4742611924), and the [IRC discussion](https://bitcoin-irc.chaincode.com/bitcoin-core-dev/2026-06-18#1229400). The IRC thread also [suggested](https://bitcoin-irc.chaincode.com/bitcoin-core-dev/2026-06-18#1229421) moving that budget to `write_buffer_size`, where #34636 still controls useful per-DB cache budgets; the block cache still matters on 32-bit or non-mmap fallback paths.

**Fix:** Use a zero-capacity LevelDB block cache on 64-bit builds (instead of `nullptr`, which defaults to 8 MiB) and move the freed half of the DB cache budget to `write_buffer_size`, following Andrew's IRC suggestion.
Keep the existing block-cache/write-buffer split on 32-bit builds, where mmap is disabled and the block cache can still be used.

**Benchmarks:** Both commits were benchmarked with `reindex-chainstate` to height 954459 and showed no meaningful runtime change.

<details><summary>Measurements</summary>

<details><summary>reindex-chainstate | 954459 blocks | dbcache 1024 | ssd-ryzen | x86_64 | AMD Ryzen 7 3700X 8-Core Processor | 16 threads | 62Gi RAM | SSD</summary>

```bash
for DBCACHE in 1024; do \
    COMMITS="3c76bd435681ee2ebaa1f407ac23736d9c3b331b ecb530c63dab1802dc756d14180730dc7e15e15b a479f8a071a6719b5ff6f389af3c3f4c0cf40c36"; \
    STOP=954459; CC=gcc; CXX=g++; \
    BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
    (echo ""; for c in $COMMITS; do git fetch -q origin "$c" 2>/dev/null || true; git log -1 --pretty='%h %s' "$c" || exit 1; done) && \
    (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) threads | $(free -h | awk '/^Mem:/{print $2}') RAM | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 1 && echo HDD || echo SSD)"; echo "") && \
    hyperfine \
    --sort command \
    --runs 1 \
    --export-json "$BASE_DIR/rdx-$(sed -E 's/([a-f0-9]{8})[a-f0-9]* ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json" \
    --parameter-list COMMIT ${COMMITS// /,} \
    --prepare "killall -9 bitcoind 2>/dev/null; rm -f ./build/bin/bitcoind; git clean -fxd; git reset --hard {COMMIT} && \
      CC=$CC CXX=$CXX cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C build bitcoind -j1 && \
        ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -printtoconsole=0 && sleep 20 && rm -f $DATA_DIR/debug.log && rm -rfd $DATA_DIR/indexes" \
      --conclude "killall bitcoind || true; sleep 5; \
        grep -q 'height=0' $DATA_DIR/debug.log && \
        grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && \
        grep -q 'height=$STOP' $DATA_DIR/debug.log && \
        grep 'Bitcoin Core version' $DATA_DIR/debug.log | grep -q \"\$(git rev-parse --short=12 {COMMIT})\" && \
        cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-\$(date +%s).log" \
    "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0"; \
done

3c76bd4356 Merge bitcoin/bitcoin#35603: build: QRencode cleanups
ecb530c63d db: avoid unused LevelDB block cache on 64-bit
a479f8a071 db: move unused block cache to write buffer

2026-06-30 | reindex-chainstate | 954459 blocks | dbcache 1024 | ssd-ryzen | x86_64 | AMD Ryzen 7 3700X 8-Core Processor | 16 threads | 62Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)
  Time (abs ≡):        15597.417 s               [User: 28075.099 s, System: 1965.047 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e15e15b)
  Time (abs ≡):        15573.304 s               [User: 28109.013 s, System: 1961.319 s]
 
Benchmark 3: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0cf40c36)
  Time (abs ≡):        15664.809 s               [User: 28159.343 s, System: 1962.872 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e15e15b)
        1.01          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0cf40c36)
```
</details>

<details><summary>reindex-chainstate | 954459 blocks | dbcache 1024 | rpi5-16-3 | aarch64 | Cortex-A76 | 4 threads | 15Gi RAM | SSD</summary>

```bash
for DBCACHE in 1024; do \
    COMMITS="0e95e1abdb47adbc3342a2123f9f1be43d9a4f55 69a953f70dc9a4f322a6c99d0e66acb548609e3b"; \
    STOP=954459; CC=gcc; CXX=g++; \
    BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
    (echo ""; for c in $COMMITS; do git fetch -q origin "$c" 2>/dev/null || true; git log -1 --pretty='%h %s' "$c" || exit 1; done) && \
    (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) threads | $(free -h | awk '/^Mem:/{print $2}') RAM | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 1 && echo HDD || echo SSD)"; echo "") && \
    hyperfine \
    --sort command \
    --runs 1 \
    --export-json "$BASE_DIR/rdx-$(sed -E 's/([a-f0-9]{8})[a-f0-9]* ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json" \
    --parameter-list COMMIT ${COMMITS// /,} \
    --prepare "killall -9 bitcoind 2>/dev/null; rm -f ./build/bin/bitcoind; git clean -fxd; git reset --hard {COMMIT} && \
      CC=$CC CXX=$CXX cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C build bitcoind -j1 && \
        ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -printtoconsole=0 && sleep 20 && rm -f $DATA_DIR/debug.log && rm -rfd $DATA_DIR/indexes" \
      --conclude "killall bitcoind || true; sleep 5; \
        grep -q 'height=0' $DATA_DIR/debug.log && \
        grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && \
        grep -q 'height=$STOP' $DATA_DIR/debug.log && \
        grep 'Bitcoin Core version' $DATA_DIR/debug.log | grep -q \"\$(git rev-parse --short=12 {COMMIT})\" && \
        cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-\$(date +%s).log" \
    "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0"; \
done

0e95e1abdb Merge bitcoin/bitcoin#35437: migrate: Handle HD chains that have identical seeds but different IDs
69a953f70d db: disable block cache on 64-bit

2026-06-25 | reindex-chainstate | 954459 blocks | dbcache 1024 | rpi5-16-3 | aarch64 | Cortex-A76 | 4 threads | 15Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 0e95e1abdb47adbc3342a2123f9f1be43d9a4f55)
  Time (abs ≡):        42596.443 s               [User: 62966.911 s, System: 3139.874 s]

Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 69a953f70dc9a4f322a6c99d0e66acb548609e3b)
  Time (abs ≡):        41961.797 s               [User: 61711.896 s, System: 3097.761 s]

Relative speed comparison
        1.02          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 0e95e1abdb47adbc3342a2123f9f1be43d9a4f55)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 69a953f70dc9a4f322a6c99d0e66acb548609e3b)
```
</details>


<details><summary>reindex-chainstate | 954459 blocks | dbcache 1024/10000 | i9-ssd | x86_64 | Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz | 16 threads | 62Gi RAM | SSD</summary>

```bash
for DBCACHE in 1024 10000; do \
    COMMITS="3c76bd435681ee2ebaa1f407ac23736d9c3b331b ecb530c63dab1802dc756d14180730dc7e15e15b a479f8a071a6719b5ff6f389af3c3f4c0cf40c36"; \
    STOP=954459; CC=gcc; CXX=g++; \
    BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
    (echo ""; for c in $COMMITS; do git fetch -q origin "$c" 2>/dev/null || true; git log -1 --pretty='%h %s' "$c" || exit 1; done) && \
    (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) threads | $(free -h | awk '/^Mem:/{print $2}') RAM | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 1 && echo HDD || echo SSD)"; echo "") && \
    hyperfine \
    --sort command \
    --runs 1 \
    --export-json "$BASE_DIR/rdx-$(sed -E 's/([a-f0-9]{8})[a-f0-9]* ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json" \
    --parameter-list COMMIT ${COMMITS// /,} \
    --prepare "killall -9 bitcoind 2>/dev/null; rm -f ./build/bin/bitcoind; git clean -fxd; git reset --hard {COMMIT} && \
      CC=$CC CXX=$CXX cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C build bitcoind -j1 && \
        ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -printtoconsole=0 && sleep 20 && rm -f $DATA_DIR/debug.log && rm -rfd $DATA_DIR/indexes" \
      --conclude "killall bitcoind || true; sleep 5; \
        grep -q 'height=0' $DATA_DIR/debug.log && \
        grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && \
        grep -q 'height=$STOP' $DATA_DIR/debug.log && \
        grep 'Bitcoin Core version' $DATA_DIR/debug.log | grep -q \"\$(git rev-parse --short=12 {COMMIT})\" && \
        cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-\$(date +%s).log" \
    "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0"; \
done

3c76bd4356 Merge bitcoin/bitcoin#35603: build: QRencode cleanups
ecb530c63d db: avoid unused LevelDB block cache on 64-bit
a479f8a071 db: move unused block cache to write buffer

2026-06-29 | reindex-chainstate | 954459 blocks | dbcache 1024 | i9-ssd | x86_64 | Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz | 16 threads | 62Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)
  Time (abs ≡):        20098.397 s               [User: 34707.701 s, System: 1066.261 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e15e15b)
  Time (abs ≡):        19834.950 s               [User: 34606.900 s, System: 1092.158 s]
 
Benchmark 3: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0cf40c36)
  Time (abs ≡):        19844.219 s               [User: 34655.128 s, System: 1080.368 s]
 
Relative speed comparison
        1.01          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e15e15b)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=1024 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0cf40c36)

3c76bd4356 Merge bitcoin/bitcoin#35603: build: QRencode cleanups
ecb530c63d db: avoid unused LevelDB block cache on 64-bit
a479f8a071 db: move unused block cache to write buffer

2026-06-30 | reindex-chainstate | 954459 blocks | dbcache 10000 | i9-ssd | x86_64 | Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz | 16 threads | 62Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)
  Time (abs ≡):        17918.808 s               [User: 28933.064 s, System: 695.944 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e15e15b)
  Time (abs ≡):        18161.775 s               [User: 29001.097 s, System: 683.110 s]
 
Benchmark 3: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0cf40c36)
  Time (abs ≡):        18055.186 s               [User: 28973.671 s, System: 691.071 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)
        1.01          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e15e15b)
        1.01          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0cf40c36)
```
</details>

</details>