### PR TITLE
test: Constrain optional<T> operator<< by streamability

### DIFF
--- a/src/test/util/common.h
+++ b/src/test/util/common.h
@@ -41,6 +41,7 @@ inline std::ostream& operator<<(std::ostream& os, const T& e)
 }
 
 template <typename T>
+    requires requires(std::ostream& os, const T& v) { os << v; }
 inline std::ostream& operator<<(std::ostream& os, const std::optional<T>& v)
 {
     return v ? os << *v


### PR DESCRIPTION
Should be a relatively uncontroversial change from #35587. Without this constraint, an operator<<(std::ostream&, const std::optional<T>&) overload is selectable for any T, even when T itself has no operator<<