### PR TITLE
rpc: allow multiple data outputs

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -99,7 +99,7 @@ static std::vector<RPCArg> CreateTxDoc()
             },
         },
         {"outputs", RPCArg::Type::ARR, RPCArg::Optional::NO, "The outputs specified as key-value pairs.\n"
-                "Each key may only appear once, i.e. there can only be one 'data' output, and no address may be duplicated.\n"
+                "Each address may only appear once, but multiple 'data' outputs are allowed.\n"
                 "At least one output of either type must be specified.\n"
                 "For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also\n"
                 "                             accepted as second parameter.",

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -104,26 +104,25 @@ std::vector<std::pair<CTxDestination, CAmount>> ParseOutputs(const UniValue& out
     // Duplicate checking
     std::set<CTxDestination> destinations;
     std::vector<std::pair<CTxDestination, CAmount>> parsed_outputs;
-    bool has_data{false};
-    for (const std::string& name_ : outputs.getKeys()) {
-        if (name_ == "data") {
-            if (has_data) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, duplicate key: data");
-            }
-            has_data = true;
-            std::vector<unsigned char> data = ParseHexV(outputs[name_].getValStr(), "Data");
+    const std::vector<std::string>& keys{outputs.getKeys()};
+    const std::vector<UniValue>& values{outputs.getValues()};
+    for (size_t i{0}; i < keys.size(); ++i) {
+        const std::string& name{keys[i]};
+        const UniValue& value{values[i]};
+        if (name == "data") {
+            std::vector<unsigned char> data = ParseHexV(value.getValStr(), "Data");
             CTxDestination destination{CNoDestination{CScript() << OP_RETURN << data}};
             CAmount amount{0};
             parsed_outputs.emplace_back(destination, amount);
         } else {
-            CTxDestination destination{DecodeDestination(name_)};
-            CAmount amount{AmountFromValue(outputs[name_])};
+            CTxDestination destination{DecodeDestination(name)};
+            CAmount amount{AmountFromValue(value)};
             if (!IsValidDestination(destination)) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Bitcoin address: ") + name_);
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Bitcoin address: ") + name);
             }
 
             if (!destinations.insert(destination).second) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + name_);
+                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + name);
             }
             parsed_outputs.emplace_back(destination, amount);
         }

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -44,7 +44,13 @@ from test_framework.psbt import (
     PSBT_OUT_TAP_TREE,
     PSBT_OUT_SCRIPT,
 )
-from test_framework.script import CScript, OP_TRUE, SIGHASH_ALL, SIGHASH_ANYONECANPAY
+from test_framework.script import (
+    CScript,
+    OP_RETURN,
+    OP_TRUE,
+    SIGHASH_ALL,
+    SIGHASH_ANYONECANPAY,
+)
 from test_framework.script_util import MIN_STANDARD_TX_NONWITNESS_SIZE
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -504,6 +510,21 @@ class PSBTTest(BitcoinTestFramework):
             ]
             for p in rt_psbts:
                 assert_equal(psbt, p)
+
+    def test_multiple_data_outputs(self):
+        psbt = self.nodes[0].createpsbt(
+            inputs=[],
+            outputs=[{"data": "aa"}, {"data": "bb"}],
+            psbt_version=2,
+        )
+        decoded = self.nodes[0].decodepsbt(psbt)
+        assert_equal(
+            [output["script"]["hex"] for output in decoded["outputs"]],
+            [
+                CScript([OP_RETURN, bytes.fromhex("aa")]).hex(),
+                CScript([OP_RETURN, bytes.fromhex("bb")]).hex(),
+            ],
+        )
 
     def test_psbt_version(self):
         tobump = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
@@ -1418,6 +1439,7 @@ class PSBTTest(BitcoinTestFramework):
         self.test_sighash_adding()
         self.test_psbt_named_parameter_handling()
         self.test_psbt_roundtrip()
+        self.test_multiple_data_outputs()
         self.test_psbt_version()
 
 if __name__ == '__main__':

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -299,8 +299,18 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-3, "Amount out of range", self.nodes[0].createrawtransaction, [], {address: -1})
         assert_raises_rpc_error(-8, "Invalid parameter, duplicated address: %s" % address, self.nodes[0].createrawtransaction, [], multidict([(address, 1), (address, 1)]))
         assert_raises_rpc_error(-8, "Invalid parameter, duplicated address: %s" % address, self.nodes[0].createrawtransaction, [], [{address: 1}, {address: 1}])
-        assert_raises_rpc_error(-8, "Invalid parameter, duplicate key: data", self.nodes[0].createrawtransaction, [], [{"data": 'aa'}, {"data": "bb"}])
-        assert_raises_rpc_error(-8, "Invalid parameter, duplicate key: data", self.nodes[0].createrawtransaction, [], multidict([("data", 'aa'), ("data", "bb")]))
+        for outputs in (
+            [{"data": "aa"}, {"data": "bb"}],
+            multidict([("data", "aa"), ("data", "bb")]),
+        ):
+            tx = tx_from_hex(self.nodes[0].createrawtransaction([{"txid": TXID, "vout": 9}], outputs))
+            assert_equal(
+                [txout.scriptPubKey for txout in tx.vout],
+                [
+                    CScript([OP_RETURN, bytes.fromhex("aa")]),
+                    CScript([OP_RETURN, bytes.fromhex("bb")]),
+                ],
+            )
         assert_raises_rpc_error(-8, "Invalid parameter, key-value pair must contain exactly one key", self.nodes[0].createrawtransaction, [], [{'a': 1, 'b': 2}])
         assert_raises_rpc_error(-8, "Invalid parameter, key-value pair not an object as expected", self.nodes[0].createrawtransaction, [], [['key-value pair1'], ['2']])
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -177,8 +177,6 @@ class BumpFeeTest(BitcoinTestFramework):
                 rbf_node.bumpfee, rbfid, {"outputs": []})
         assert_raises_rpc_error(-8, "Invalid parameter, duplicated address: " + dest_address,
                 rbf_node.bumpfee, rbfid, {"outputs": [{dest_address: 0.1}, {dest_address: 0.2}]})
-        assert_raises_rpc_error(-8, "Invalid parameter, duplicate key: data",
-                rbf_node.bumpfee, rbfid, {"outputs": [{"data": "deadbeef"}, {"data": "deadbeef"}]})
 
         self.log.info("Test original_change_index option")
         assert_raises_rpc_error(-1, "JSON integer out of range", rbf_node.bumpfee, rbfid, {"original_change_index": -1})


### PR DESCRIPTION
## Context

Transaction creation RPCs currently reject more than one `data` output. This restriction prevents callers from creating transactions with multiple `OP_RETURN` outputs.

## Changes

* Allow multiple `data` outputs in `ParseOutputs()`.
* Preserve each `data` output's corresponding payload.
* Keep duplicate Bitcoin address rejection unchanged.
* Update the RPC help text.
* Add functional coverage for multiple `data` outputs in `createrawtransaction` and `createpsbt`.
* Update the `bumpfee` test to reflect the new behavior.


## Testing

```text
rpc_rawtransaction.py 
rpc_psbt.py           
wallet_bumpfee.py     
```

Both data outputs are verified against their expected scripts:

```text
6a01aa
6a01bb
```

Fixes #32478
