### PR TITLE
cmpctblock: refactor: Delete unnecessary code in `PartiallyDownloadedBlock::InitData()`

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -122,7 +122,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             if (!txn_available[idit->second]) {
                 txn_available[idit->second] = txit->GetSharedTx();
                 mempool_count++;
-            } else if (txn_available[idit->second]) {
+            } else {
                 // If we find two mempool txn that match the short id, just request it.
                 // This should be rare enough that the extra bandwidth doesn't matter,
                 // but eating a round-trip due to FillBlock failure would be annoying
@@ -153,8 +153,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
                 // but eating a round-trip due to FillBlock failure would be annoying
                 // Note that we don't want duplication between extra_txn and mempool to
                 // trigger this case, so we compare witness hashes first
-                if (txn_available[idit->second] &&
-                        txn_available[idit->second]->GetWitnessHash() != extra_txn[i].second->GetWitnessHash()) {
+                if (txn_available[idit->second]->GetWitnessHash() != extra_txn[i].second->GetWitnessHash()) {
                     txn_available[idit->second].reset();
                     mempool_count--;
                     extra_count--;

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -113,25 +113,21 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     if (shorttxids.size() != cmpctblock.shorttxids.size())
         return READ_STATUS_FAILED; // Short ID collision
 
-    std::vector<bool> have_txn(txn_available.size());
     {
     LOCK(pool->cs);
     for (const auto& [wtxid, txit] : pool->txns_randomized) {
         uint64_t shortid = cmpctblock.GetShortID(wtxid);
         std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(shortid);
         if (idit != shorttxids.end()) {
-            if (!have_txn[idit->second]) {
+            if (!txn_available[idit->second]) {
                 txn_available[idit->second] = txit->GetSharedTx();
-                have_txn[idit->second]  = true;
                 mempool_count++;
-            } else {
+            } else if (txn_available[idit->second]) {
                 // If we find two mempool txn that match the short id, just request it.
                 // This should be rare enough that the extra bandwidth doesn't matter,
                 // but eating a round-trip due to FillBlock failure would be annoying
-                if (txn_available[idit->second]) {
-                    txn_available[idit->second].reset();
-                    mempool_count--;
-                }
+                txn_available[idit->second].reset();
+                mempool_count--;
             }
         }
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
@@ -146,9 +142,8 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         uint64_t shortid = cmpctblock.GetShortID(extra_txn[i].first);
         std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(shortid);
         if (idit != shorttxids.end()) {
-            if (!have_txn[idit->second]) {
+            if (!txn_available[idit->second]) {
                 txn_available[idit->second] = extra_txn[i].second;
-                have_txn[idit->second]  = true;
                 mempool_count++;
                 extra_count++;
             } else {


### PR DESCRIPTION
This is a refactor that was split out of work related to #35558.


First, `have_txn` is redundant, since `txn_available` is a vector of `shared_ptr`:

https://github.com/bitcoin/bitcoin/blob/bd1771fc0cd248438e87b028b096f59ffc976d18/src/blockencodings.h#L135


resized:

https://github.com/bitcoin/bitcoin/blob/bd1771fc0cd248438e87b028b096f59ffc976d18/src/blockencodings.cpp#L70

Which means all of its members are [value-initialized](https://en.cppreference.com/cpp/named_req/DefaultInsertable) which for a `shared_ptr` [means](https://en.cppreference.com/cpp/memory/shared_ptr/shared_ptr) "Constructs a shared_ptr with no managed object, i.e. empty shared_ptr." and [`std::shared_ptr<T>::operator bool`](https://en.cppreference.com/cpp/memory/shared_ptr/operator_bool) returns `false` for empty `shared_ptr`'s.

In fact, the existing code already relies on this behavior:

https://github.com/bitcoin/bitcoin/blob/a8823c099618559fdf6116fe17c9afd311e88890/src/blockencodings.cpp#L161

Second, 
```c
if (a) {
    b()
} else {
    if(!a) {
        c()
    }
}
```

is equivalent to

```c
if (a) {
    b()
} else {
    c()
}
```

so I make this change.