### PR TITLE
external_signer: validate fingerprint from enumerate response

### DIFF
--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -48,6 +48,9 @@ bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalS
             throw std::runtime_error(strprintf("'%s' received invalid response, missing signer fingerprint", command));
         }
         const std::string& fingerprintStr{fingerprint.get_str()};
+        if (fingerprintStr.size() != 8 || !IsHex(fingerprintStr)) {
+            throw std::runtime_error(strprintf("'%s' received invalid fingerprint, must be 8 hex characters", command));
+        }
         // Skip duplicate signer
         bool duplicate = false;
         for (const ExternalSigner& signer : signers) {

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -85,6 +85,12 @@ class RPCSignerTest(BitcoinTestFramework):
         ]})
         self.clear_mock_result(self.nodes[1])
 
+        # Invalid fingerprints are rejected
+        for fingerprint in ["", "0000001", "000000001", "0000000g", "zzzzzzzz"]:
+            self.set_mock_result(self.nodes[1], '0 [{"type": "trezor", "model": "trezor_t", "fingerprint": "%s"}]' % fingerprint)
+            assert_raises_rpc_error(-1, 'invalid fingerprint', self.nodes[1].enumeratesigners)
+            self.clear_mock_result(self.nodes[1])
+
         assert_equal({'fingerprint': '00000001', 'name': 'trezor_t'} in self.nodes[1].enumeratesigners()['signers'], True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
`enumeratesigners` takes the `fingerprint` field from the external signer's `enumerate` output and stores it without checking it. That value is later handed back to the signer command as `--fingerprint <value>` (e.g. in `displayaddress`), so a malformed value propagates unchecked.

A master key fingerprint is 4 bytes, i.e. 8 hex characters. This adds a check that the reported fingerprint is exactly 8 hex characters and throws a clear error otherwise. A functional test covers empty, wrong-length, and non-hex inputs.
