### PR TITLE
kernel: Add script evaluation tracer

### DIFF
--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -119,6 +119,12 @@ if(bitcoinkernel_type STREQUAL "STATIC_LIBRARY")
   target_compile_definitions(bitcoinkernel PUBLIC BITCOINKERNEL_STATIC)
 endif()
 
+option(ENABLE_SCRIPT_TRACE "Enable script execution trace hooks" OFF)
+if(ENABLE_SCRIPT_TRACE)
+  target_sources(bitcoinkernel PRIVATE ../script/trace.cpp)
+  target_compile_definitions(bitcoinkernel PRIVATE ENABLE_SCRIPT_TRACE)
+endif()
+
 configure_file(${PROJECT_SOURCE_DIR}/libbitcoinkernel.pc.in ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc @ONLY)
 install(FILES ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" COMPONENT libbitcoinkernel)
 

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -24,6 +24,10 @@
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/script_error.h>
+#ifdef ENABLE_SCRIPT_TRACE
+#include <script/trace.h>
+#endif
 #include <script/verify_flags.h>
 #include <serialize.h>
 #include <streams.h>
@@ -682,13 +686,14 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
     }
 
     if (status) *status = btck_ScriptVerifyStatus_OK;
+    ScriptError error = ScriptError::SCRIPT_ERR_OK;
 
     bool result = VerifyScript(tx.vin[input_index].scriptSig,
                                btck_ScriptPubkey::get(script_pubkey),
                                &tx.vin[input_index].scriptWitness,
                                script_verify_flags::from_int(flags),
                                TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
-                               nullptr);
+                               &error);
     return result ? 1 : 0;
 }
 
@@ -1498,4 +1503,68 @@ int btck_transaction_check(const btck_Transaction* tx, btck_TxValidationState* v
     state = TxValidationState{};
     const bool ok = CheckTransaction(*btck_Transaction::get(tx), state);
     return ok ? 1 : 0;
+}
+
+int btck_script_trace_register_callback(btck_ScriptTraceCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
+{
+#ifndef ENABLE_SCRIPT_TRACE
+    (void)callback;
+    if (user_data_destroy_callback) user_data_destroy_callback(user_data);
+    return 1;
+#else
+    std::shared_ptr<void> owned_user_data{user_data, [user_data_destroy_callback](void* user_data) {
+        if (user_data && user_data_destroy_callback) user_data_destroy_callback(user_data);
+    }};
+
+    auto wrapper = [owned_user_data, callback](const ScriptTraceFrame& frame) {
+        std::vector<const unsigned char*> stack_ptrs;
+        std::vector<size_t> stack_sizes;
+        stack_ptrs.reserve(frame.stack.size());
+        stack_sizes.reserve(frame.stack.size());
+        for (const auto& item : frame.stack) {
+            stack_ptrs.push_back(item.data());
+            stack_sizes.push_back(item.size());
+        }
+
+        std::vector<const unsigned char*> altstack_ptrs;
+        std::vector<size_t> altstack_sizes;
+        altstack_ptrs.reserve(frame.altstack.size());
+        altstack_sizes.reserve(frame.altstack.size());
+        for (const auto& item : frame.altstack) {
+            altstack_ptrs.push_back(item.data());
+            altstack_sizes.push_back(item.size());
+        }
+
+        btck_ScriptTraceFrame btck_frame;
+        btck_frame.kind = static_cast<btck_ScriptTraceFrameKind>(frame.kind);
+        btck_frame.stack_items = stack_ptrs.data();
+        btck_frame.stack_item_sizes = stack_sizes.data();
+        btck_frame.stack_size = frame.stack.size();
+        btck_frame.script = frame.script.data();
+        btck_frame.script_size = frame.script.size();
+        btck_frame.opcode_pos = frame.opcode_pos;
+        btck_frame.altstack_items = altstack_ptrs.data();
+        btck_frame.altstack_item_sizes = altstack_sizes.data();
+        btck_frame.altstack_size = frame.altstack.size();
+        btck_frame.f_exec = frame.exec ? 1 : 0;
+        btck_frame.opcode = frame.opcode;
+        btck_frame.op_count = frame.op_count;
+        btck_frame.sig_version = frame.sig_version;
+        btck_frame.tapleaf_hash = frame.tapleaf_hash;
+        btck_frame.codeseparator_pos = frame.codeseparator_pos;
+        btck_frame.script_error = frame.script_error;
+
+        callback(owned_user_data.get(), &btck_frame);
+    };
+
+    ScriptTraceRegisterCallback(std::move(wrapper));
+    return 0;
+#endif // ENABLE_SCRIPT_TRACE
+}
+
+void btck_script_trace_unregister_callback()
+{
+#ifdef ENABLE_SCRIPT_TRACE
+    ScriptTraceRegisterCallback(nullptr);
+#endif // ENABLE_SCRIPT_TRACE
 }

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -24,6 +24,8 @@
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/script_error.h>
+#include <script/trace.h>
 #include <script/verify_flags.h>
 #include <serialize.h>
 #include <streams.h>
@@ -231,6 +233,34 @@ btck_Warning cast_btck_warning(kernel::Warning warning)
         return btck_Warning_UNKNOWN_NEW_RULES_ACTIVATED;
     case kernel::Warning::LARGE_WORK_INVALID_CHAIN:
         return btck_Warning_LARGE_WORK_INVALID_CHAIN;
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
+
+btck_ScriptTraceFrameKind cast_btck_trace_frame_kind(ScriptTraceFrameKind kind)
+{
+    switch (kind) {
+    case ScriptTraceFrameKind::Begin:
+        return btck_ScriptTraceFrameKind_BEGIN;
+    case ScriptTraceFrameKind::Step:
+        return btck_ScriptTraceFrameKind_STEP;
+    case ScriptTraceFrameKind::End:
+        return btck_ScriptTraceFrameKind_END;
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
+
+btck_SigVersion cast_btck_sig_version(SigVersion version)
+{
+    switch(version) {
+    case SigVersion::BASE:
+        return btck_SigVersion_BASE;
+    case SigVersion::TAPSCRIPT:
+        return btck_SigVersion_TAPSCRIPT;
+    case SigVersion::TAPROOT:
+        return btck_SigVersion_TAPROOT;
+    case SigVersion::WITNESS_V0:
+        return btck_SigVersion_WITNESS_V0;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
@@ -509,6 +539,9 @@ struct btck_Txid: Handle<btck_Txid, Txid> {};
 struct btck_PrecomputedTransactionData : Handle<btck_PrecomputedTransactionData, PrecomputedTransactionData> {};
 struct btck_BlockHeader: Handle<btck_BlockHeader, CBlockHeader> {};
 struct btck_ConsensusParams: Handle<btck_ConsensusParams, Consensus::Params> {};
+struct btck_ScriptTraceFrame: Handle<btck_ScriptTraceFrame, ScriptTraceFrame> {};
+struct btck_ScriptEvalStack : Handle<btck_ScriptEvalStack, std::span<const std::vector<unsigned char>>> {};
+struct btck_ScriptEvalStackItem : Handle<btck_ScriptEvalStackItem, std::vector<unsigned char>> {};
 
 btck_Transaction* btck_transaction_create(const void* raw_transaction, size_t raw_transaction_len)
 {
@@ -686,13 +719,14 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
     }
 
     if (status) *status = btck_ScriptVerifyStatus_OK;
+    ScriptError error = ScriptError::SCRIPT_ERR_OK;
 
     bool result = VerifyScript(tx.vin[input_index].scriptSig,
                                btck_ScriptPubkey::get(script_pubkey),
                                &tx.vin[input_index].scriptWitness,
                                script_verify_flags::from_int(flags),
                                TransactionSignatureChecker(&tx, input_index, amount, txdata, MissingDataBehavior::FAIL),
-                               nullptr);
+                               &error);
     return result ? 1 : 0;
 }
 
@@ -1559,4 +1593,113 @@ int btck_set_mock_time(int64_t timestamp)
     }
     SetMockTime(std::chrono::seconds{timestamp});
     return 0;
+}
+
+int btck_script_trace_register_callback(btck_ScriptTraceCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
+{
+#ifndef ENABLE_SCRIPT_TRACE
+    (void)callback;
+    if (user_data_destroy_callback) user_data_destroy_callback(user_data);
+    return 1;
+#else
+    std::shared_ptr<void> owned_user_data{user_data, [user_data_destroy_callback](void* user_data) {
+        if (user_data && user_data_destroy_callback) user_data_destroy_callback(user_data);
+    }};
+
+    auto wrapper = [owned_user_data, callback](const ScriptTraceFrame& frame) {
+        callback(owned_user_data.get(), btck_ScriptTraceFrame::ref(&frame));
+    };
+
+    ScriptTraceRegisterCallback(std::move(wrapper));
+    return 0;
+#endif // ENABLE_SCRIPT_TRACE
+}
+
+btck_ScriptTraceFrameKind btck_script_trace_frame_get_kind(const btck_ScriptTraceFrame* frame)
+{
+    return cast_btck_trace_frame_kind(btck_ScriptTraceFrame::get(frame).kind);
+}
+
+const btck_ScriptEvalStack* btck_script_trace_frame_get_stack(const btck_ScriptTraceFrame* frame)
+{
+    return btck_ScriptEvalStack::ref(&btck_ScriptTraceFrame::get(frame).stack);
+}
+
+const btck_ScriptEvalStack* btck_script_trace_frame_get_altstack(const btck_ScriptTraceFrame* frame)
+{
+    return btck_ScriptEvalStack::ref(&btck_ScriptTraceFrame::get(frame).altstack);
+}
+
+size_t btck_script_eval_stack_count_items(const btck_ScriptEvalStack* stack)
+{
+    return btck_ScriptEvalStack::get(stack).size();
+}
+
+const btck_ScriptEvalStackItem* btck_script_eval_stack_get_item_at(const btck_ScriptEvalStack* stack, size_t index)
+{
+    const auto& items{btck_ScriptEvalStack::get(stack)};
+    assert(index < items.size());
+    return btck_ScriptEvalStackItem::ref(&items[index]);
+}
+
+int btck_script_eval_stack_item_to_bytes(const btck_ScriptEvalStackItem* item, btck_WriteBytes writer, void* user_data)
+{
+    const auto& bytes{btck_ScriptEvalStackItem::get(item)};
+    return writer(bytes.data(), bytes.size(), user_data);
+}
+
+int btck_script_trace_frame_get_script(const btck_ScriptTraceFrame* frame, btck_WriteBytes writer, void* user_data)
+{
+    const CScript& script{btck_ScriptTraceFrame::get(frame).script};
+    return writer(script.data(), script.size(), user_data);
+}
+
+uint32_t btck_script_trace_frame_get_opcode_pos(const btck_ScriptTraceFrame* frame)
+{
+    return btck_ScriptTraceFrame::get(frame).opcode_pos;
+}
+
+int btck_script_trace_frame_get_exec(const btck_ScriptTraceFrame* frame)
+{
+    return btck_ScriptTraceFrame::get(frame).exec ? 1 : 0;
+}
+
+uint8_t btck_script_trace_frame_get_opcode(const btck_ScriptTraceFrame* frame)
+{
+    return btck_ScriptTraceFrame::get(frame).opcode;
+}
+
+int btck_script_trace_frame_get_op_count(const btck_ScriptTraceFrame* frame)
+{
+    return btck_ScriptTraceFrame::get(frame).op_count;
+}
+
+btck_SigVersion btck_script_trace_frame_get_sig_version(const btck_ScriptTraceFrame* frame)
+{
+    return cast_btck_sig_version(static_cast<SigVersion>(btck_ScriptTraceFrame::get(frame).sig_version));
+}
+
+int btck_script_trace_frame_get_tapleaf_hash(const btck_ScriptTraceFrame* frame, unsigned char output[32])
+{
+    const auto* hash{btck_ScriptTraceFrame::get(frame).tapleaf_hash};
+    if (!hash) return -1;
+    std::memcpy(output, hash, 32);
+    return 0;
+}
+
+uint32_t btck_script_trace_frame_get_codeseparator_pos(const btck_ScriptTraceFrame* frame)
+{
+    return btck_ScriptTraceFrame::get(frame).codeseparator_pos;
+}
+
+int32_t btck_script_trace_frame_get_script_error(const btck_ScriptTraceFrame* frame)
+{
+    return static_cast<int32_t>(btck_ScriptTraceFrame::get(frame).script_error);
+}
+
+void btck_script_trace_unregister_callback()
+{
+#ifdef ENABLE_SCRIPT_TRACE
+    ScriptTraceRegisterCallback(nullptr);
+#endif // ENABLE_SCRIPT_TRACE
 }

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1972,6 +1972,88 @@ BITCOINKERNEL_API void btck_block_header_destroy(btck_BlockHeader* header);
 
 ///@}
 
+/** @name ScriptTrace
+ * Functions for script execution tracing.
+ */
+///@{
+
+typedef uint8_t btck_ScriptTraceFrameKind;
+#define btck_ScriptTraceFrameKind_BEGIN ((btck_ScriptTraceFrameKind)(0))
+#define btck_ScriptTraceFrameKind_STEP  ((btck_ScriptTraceFrameKind)(1))
+#define btck_ScriptTraceFrameKind_END   ((btck_ScriptTraceFrameKind)(2))
+
+typedef uint8_t btck_SigVersion;
+#define btck_SigVersion_BASE       ((btck_SigVersion)(0))
+#define btck_SigVersion_WITNESS_V0 ((btck_SigVersion)(1))
+#define btck_SigVersion_TAPROOT    ((btck_SigVersion)(2))
+#define btck_SigVersion_TAPSCRIPT  ((btck_SigVersion)(3))
+
+/**
+ * Snapshot of script execution state passed to the trace callback.
+ */
+typedef struct {
+    btck_ScriptTraceFrameKind kind;             //!< Whether this is a begin, step, or end frame.
+    const unsigned char* const* stack_items;    //!< The stack has stack_size items. Item i has stack_item_sizes[i] size.
+    const size_t* stack_item_sizes;
+    size_t stack_size;
+    const unsigned char* script;                //!< The script being evaluated.
+    size_t script_size;
+    uint32_t opcode_pos;                        //!< Index of the current opcode (counting opcodes, not bytes).
+    const unsigned char* const* altstack_items; //!< The altstack has altstack_size items. Item i has altstack_item_sizes[i] size.
+    const size_t* altstack_item_sizes;
+    size_t altstack_size;
+    int f_exec;                                 //!< Non-zero if this opcode is evaluated. Zero if it is skipped in a conditional branch.
+    uint8_t opcode;                             //!< The current opcode under evaluation. Only meaningful in step frames.
+    int op_count;                               //!< Counter towards the ops per script limit.
+    btck_SigVersion sig_version;                //!< Signature version.
+    const unsigned char* tapleaf_hash;          //!< Either null if not evaluating a tapleaf, or points to exactly 32 bytes (and sig_version is TAPSCRIPT).
+    uint32_t codeseparator_pos;                 //!< Opcode position of the last evaluated OP_CODESEPARATOR. 0xFFFFFFFF if none.
+    int32_t script_error;                       //!< Script error code. Only meaningful in end frames.
+} btck_ScriptTraceFrame;
+
+/**
+ * Callback function type for script trace frames.
+ *
+ * Called during script execution with the current execution state.
+ *
+ * @param[in] user_data  User-defined opaque pointer passed through from registration.
+ * @param[in] state      Pointer to the current execution state snapshot. Data
+ *                       in the struct is only valid for the duration of this callback.
+ */
+typedef void (*btck_ScriptTraceCallback)(
+    void* user_data,
+    const btck_ScriptTraceFrame* state);
+
+/**
+ * @brief Register a global script trace callback.
+ *
+ * Only one callback can be registered at a time. Registering a new callback
+ * replaces the previous one. The callback fires on entry of the script
+ * evaluator, on exit, and once per instruction - after the opcode is decoded
+ * and before it is dispatched/executed.
+ *
+ * @param[in] callback                   The callback function to register.
+ * @param[in] user_data                  User-defined opaque pointer passed to the callback.
+ * @param[in] user_data_destroy_callback Nullable, function for freeing the user data.
+ * @return                               0 if the script trace feature is available.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_script_trace_register_callback(
+    btck_ScriptTraceCallback callback,
+    void* user_data,
+    btck_DestroyCallback user_data_destroy_callback) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Unregister the global script trace callback.
+ *
+ * Unregistration is not synchronized with callback execution. Script
+ * evaluations already in progress complete with the previously registered
+ * callback. Script evaluations started after this call won't invoke the
+ * callback anymore.
+ */
+BITCOINKERNEL_API void btck_script_trace_unregister_callback();
+
+///@}
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -338,6 +338,21 @@ typedef struct btck_Txid btck_Txid;
  */
 typedef struct btck_BlockHeader btck_BlockHeader;
 
+/**
+ * Opaque data structure for holding a btck_ScriptTraceFrame.
+ */
+typedef struct btck_ScriptTraceFrame btck_ScriptTraceFrame;
+
+/**
+ * Opaque data structure for holding a view to a stack used in script evaluation.
+ */
+typedef struct btck_ScriptEvalStack btck_ScriptEvalStack;
+
+/**
+ * Opaque data structure for holding a view to an item in the stack used in script evaluation.
+ */
+typedef struct btck_ScriptEvalStackItem btck_ScriptEvalStackItem;
+
 /** Current sync state passed to tip changed callbacks. */
 typedef uint8_t btck_SynchronizationState;
 #define btck_SynchronizationState_INIT_REINDEX ((btck_SynchronizationState)(0))
@@ -2085,6 +2100,125 @@ BITCOINKERNEL_API void btck_block_header_destroy(btck_BlockHeader* header);
  *                      valid [0, 4294967295] range.
  */
 BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_set_mock_time(int64_t timestamp);
+
+///@}
+
+/** @name ScriptTrace
+ * Functions for script execution tracing.
+ */
+///@{
+
+typedef uint8_t btck_ScriptTraceFrameKind;
+#define btck_ScriptTraceFrameKind_BEGIN ((btck_ScriptTraceFrameKind)(0))
+#define btck_ScriptTraceFrameKind_STEP  ((btck_ScriptTraceFrameKind)(1))
+#define btck_ScriptTraceFrameKind_END   ((btck_ScriptTraceFrameKind)(2))
+
+typedef uint8_t btck_SigVersion;
+#define btck_SigVersion_BASE       ((btck_SigVersion)(0))
+#define btck_SigVersion_WITNESS_V0 ((btck_SigVersion)(1))
+#define btck_SigVersion_TAPROOT    ((btck_SigVersion)(2))
+#define btck_SigVersion_TAPSCRIPT  ((btck_SigVersion)(3))
+
+/**
+ * Callback function type for script trace frames.
+ *
+ * Called during script execution with the current execution state.
+ *
+ * @param[in] user_data  User-defined opaque pointer passed through from registration.
+ * @param[in] frame      Pointer to the current execution state snapshot. Data
+ *                       in the struct is only valid for the duration of this callback.
+ */
+typedef void (*btck_ScriptTraceCallback)(
+    void* user_data,
+    const btck_ScriptTraceFrame* frame);
+
+/// Whether this is a begin, step, or end frame.
+BITCOINKERNEL_API btck_ScriptTraceFrameKind btck_script_trace_frame_get_kind(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// The returned pointer is unowned and only valid for the lifetime of the frame.
+BITCOINKERNEL_API const btck_ScriptEvalStack* btck_script_trace_frame_get_stack(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// The returned pointer is unowned and only valid for the lifetime of the frame.
+BITCOINKERNEL_API const btck_ScriptEvalStack* btck_script_trace_frame_get_altstack(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// The script being evaluated
+BITCOINKERNEL_API int btck_script_trace_frame_get_script(
+    const btck_ScriptTraceFrame* frame, btck_WriteBytes writer, void* user_data) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/// Index of the current opcode under evaluation (counting opcodes, not bytes)
+BITCOINKERNEL_API uint32_t btck_script_trace_frame_get_opcode_pos(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// Non-zero if this opcode is evaluated. Zero if it is skipped in a conditional branch. Only meaningful in step frames.
+BITCOINKERNEL_API int btck_script_trace_frame_get_exec(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// The current opcode under evaluation. Only meaningful in step frames.
+BITCOINKERNEL_API uint8_t btck_script_trace_frame_get_opcode(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// Counter towards the ops script limit.
+BITCOINKERNEL_API int btck_script_trace_frame_get_op_count(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// The signature version.
+BITCOINKERNEL_API btck_SigVersion btck_script_trace_frame_get_sig_version(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// Returns 0 and writes 32 bytes on success, non-zero if there is no tapleaf hash.
+BITCOINKERNEL_API int btck_script_trace_frame_get_tapleaf_hash(
+    const btck_ScriptTraceFrame* frame, unsigned char output[32]) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/// Opcode position of the last evaluated OP_CODESEPARATOR. 0xFFFFFFFF if none.
+BITCOINKERNEL_API uint32_t btck_script_trace_frame_get_codeseparator_pos(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// Script error code. Only meaningful in end frames.
+BITCOINKERNEL_API int32_t btck_script_trace_frame_get_script_error(
+    const btck_ScriptTraceFrame* frame) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// The number of items contained in the script evaluation stack.
+BITCOINKERNEL_API size_t btck_script_eval_stack_count_items(
+    const btck_ScriptEvalStack* stack) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// Get one of the items in the script evaluation stack.
+BITCOINKERNEL_API const btck_ScriptEvalStackItem* btck_script_eval_stack_get_item_at(
+    const btck_ScriptEvalStack* stack, size_t index) BITCOINKERNEL_ARG_NONNULL(1);
+
+/// Write out bytes from one of the items in the script evaluation stack.
+BITCOINKERNEL_API int btck_script_eval_stack_item_to_bytes(
+    const btck_ScriptEvalStackItem* item, btck_WriteBytes writer, void* user_data) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Register a global script trace callback.
+ *
+ * Only one callback can be registered at a time. Registering a new callback
+ * replaces the previous one. The callback fires on entry of the script
+ * evaluator, on exit, and once per instruction - after the opcode is decoded
+ * and before it is dispatched/executed.
+ *
+ * @param[in] callback                   The callback function to register.
+ * @param[in] user_data                  User-defined opaque pointer passed to the callback.
+ * @param[in] user_data_destroy_callback Nullable, function for freeing the user data.
+ * @return                               0 if the script trace feature is available.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_script_trace_register_callback(
+    btck_ScriptTraceCallback callback,
+    void* user_data,
+    btck_DestroyCallback user_data_destroy_callback) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Unregister the global script trace callback.
+ *
+ * Unregistration is not synchronized with callback execution. Script
+ * evaluations already in progress complete with the previously registered
+ * callback. Script evaluations started after this call won't invoke the
+ * callback anymore.
+ */
+BITCOINKERNEL_API void btck_script_trace_unregister_callback();
 
 ///@}
 

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -7,6 +7,7 @@
 
 #include <kernel/bitcoinkernel.h>
 
+#include <algorithm>
 #include <array>
 #include <exception>
 #include <functional>
@@ -118,6 +119,19 @@ enum class BlockCheckFlags : btck_BlockCheckFlags {
     POW = btck_BlockCheckFlags_POW,
     MERKLE = btck_BlockCheckFlags_MERKLE,
     ALL = btck_BlockCheckFlags_ALL
+};
+
+enum class ScriptTraceFrameKind : btck_ScriptTraceFrameKind {
+    BEGIN = btck_ScriptTraceFrameKind_BEGIN,
+    STEP = btck_ScriptTraceFrameKind_STEP,
+    END = btck_ScriptTraceFrameKind_END,
+};
+
+enum class SigVersion : btck_SigVersion {
+    BASE = btck_SigVersion_BASE,
+    WITNESS_V0 = btck_SigVersion_WITNESS_V0,
+    TAPROOT = btck_SigVersion_TAPROOT,
+    TAPSCRIPT = btck_SigVersion_TAPSCRIPT,
 };
 
 template <typename T>
@@ -1357,6 +1371,71 @@ public:
         return btck_block_spent_outputs_read(get(), entry.get());
     }
 };
+
+struct ScriptTraceFrame {
+    ScriptTraceFrameKind m_kind;
+    std::vector<std::vector<unsigned char>> m_stack;
+    std::vector<std::vector<unsigned char>> m_altstack;
+    std::vector<unsigned char> m_script;
+    std::optional<std::array<unsigned char, 32>> m_tapleaf_hash;
+    uint32_t m_opcode_pos;
+    bool m_exec;
+    uint8_t m_opcode;
+    int m_op_count;
+    SigVersion m_sig_version;
+    uint32_t m_codeseparator_pos;
+    int32_t m_script_error;
+
+    explicit ScriptTraceFrame(const btck_ScriptTraceFrame& frame)
+        : m_kind{static_cast<ScriptTraceFrameKind>(frame.kind)},
+          m_script(frame.script, frame.script + frame.script_size),
+          m_opcode_pos{frame.opcode_pos},
+          m_exec{frame.f_exec != 0},
+          m_opcode{frame.opcode},
+          m_op_count{frame.op_count},
+          m_sig_version{static_cast<SigVersion>(frame.sig_version)},
+          m_codeseparator_pos{frame.codeseparator_pos},
+          m_script_error{frame.script_error}
+    {
+        m_stack.reserve(frame.stack_size);
+        for (size_t i = 0; i < frame.stack_size; ++i) {
+            m_stack.emplace_back(frame.stack_items[i],
+                                 frame.stack_items[i] + frame.stack_item_sizes[i]);
+        }
+
+        m_altstack.reserve(frame.altstack_size);
+        for (size_t i = 0; i < frame.altstack_size; ++i) {
+            m_altstack.emplace_back(frame.altstack_items[i],
+                                    frame.altstack_items[i] + frame.altstack_item_sizes[i]);
+        }
+
+        if (frame.tapleaf_hash) {
+            m_tapleaf_hash.emplace();
+            std::copy_n(frame.tapleaf_hash, 32, m_tapleaf_hash->begin());
+        }
+    }
+};
+
+template <typename T>
+concept ScriptTraceT = requires(T a, ScriptTraceFrame trace) {
+    { a.ScriptTrace(trace) } -> std::same_as<void>;
+};
+
+template <ScriptTraceT T>
+void ScriptTraceSetCallback(std::unique_ptr<T> trace)
+{
+    if (btck_script_trace_register_callback(
+            +[](void* user_data, const btck_ScriptTraceFrame* trace) { static_cast<T*>(user_data)->ScriptTrace(ScriptTraceFrame{*trace}); },
+            trace.release(),
+            +[](void* user_data) { delete static_cast<T*>(user_data); }) != 0) {
+        throw std::runtime_error("Script Tracing is not available. Compile bitcoin kernel with ENABLE_SCRIPT_TRACE");
+    }
+}
+
+inline void ScriptTraceUnsetCallback()
+{
+    btck_script_trace_unregister_callback();
+}
 
 } // namespace btck
 

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -121,6 +121,19 @@ enum class BlockCheckFlags : btck_BlockCheckFlags {
     ALL = btck_BlockCheckFlags_ALL
 };
 
+enum class ScriptTraceFrameKind : btck_ScriptTraceFrameKind {
+    BEGIN = btck_ScriptTraceFrameKind_BEGIN,
+    STEP = btck_ScriptTraceFrameKind_STEP,
+    END = btck_ScriptTraceFrameKind_END,
+};
+
+enum class SigVersion : btck_SigVersion {
+    BASE = btck_SigVersion_BASE,
+    WITNESS_V0 = btck_SigVersion_WITNESS_V0,
+    TAPROOT = btck_SigVersion_TAPROOT,
+    TAPSCRIPT = btck_SigVersion_TAPSCRIPT,
+};
+
 template <typename T>
 struct is_bitmask_enum : std::false_type {
 };
@@ -1421,6 +1434,82 @@ inline void set_mock_time(std::chrono::seconds timestamp)
     if (btck_set_mock_time(timestamp.count()) != 0) {
         throw std::runtime_error("timestamp out of range");
     }
+}
+
+class ScriptEvalStackItemView : public View<btck_ScriptEvalStackItem>
+{
+public:
+    explicit ScriptEvalStackItemView(const btck_ScriptEvalStackItem* ptr) : View{ptr} {}
+
+    std::vector<std::byte> ToBytes() const
+    {
+        return write_bytes(get(), btck_script_eval_stack_item_to_bytes);
+    }
+};
+
+class ScriptEvalStackView : public View<btck_ScriptEvalStack>
+{
+public:
+    explicit ScriptEvalStackView(const btck_ScriptEvalStack* ptr) : View{ptr} {}
+
+    size_t CountItems() const { return btck_script_eval_stack_count_items(get()); }
+
+    ScriptEvalStackItemView GetItem(size_t index) const
+    {
+        return ScriptEvalStackItemView{btck_script_eval_stack_get_item_at(get(), index)};
+    }
+
+    MAKE_RANGE_METHOD(Items, ScriptEvalStackView, &ScriptEvalStackView::CountItems, &ScriptEvalStackView::GetItem, *this)
+};
+
+class ScriptTraceFrameView : public View<btck_ScriptTraceFrame> {
+public:
+    explicit ScriptTraceFrameView(const btck_ScriptTraceFrame* ptr) : View{ptr} {}
+
+    ScriptTraceFrameKind Kind() const { return static_cast<ScriptTraceFrameKind>(btck_script_trace_frame_get_kind(get())); }
+
+    ScriptEvalStackView GetStack() const { return ScriptEvalStackView{btck_script_trace_frame_get_stack(get())}; }
+    ScriptEvalStackView GetAltstack() const { return ScriptEvalStackView{btck_script_trace_frame_get_altstack(get())}; }
+
+    std::vector<std::byte> GetScript() const
+    {
+        return write_bytes(get(), btck_script_trace_frame_get_script);
+    }
+    uint32_t OpcodePos() const { return btck_script_trace_frame_get_opcode_pos(get()); }
+    bool Exec() const { return btck_script_trace_frame_get_exec(get()) != 0; }
+    uint8_t Opcode() const { return btck_script_trace_frame_get_opcode(get()); }
+    int OpCount() const { return btck_script_trace_frame_get_op_count(get()); }
+    SigVersion GetSigVersion() const { return static_cast<SigVersion>(btck_script_trace_frame_get_sig_version(get())); }
+    uint32_t CodeseparatorPos() const { return btck_script_trace_frame_get_codeseparator_pos(get()); }
+    int32_t GetScriptError() const { return btck_script_trace_frame_get_script_error(get()); }
+
+    std::optional<std::array<unsigned char, 32>> TapleafHash() const
+    {
+        std::array<unsigned char, 32> hash;
+        if (btck_script_trace_frame_get_tapleaf_hash(get(), hash.data()) != 0) return std::nullopt;
+        return hash;
+    }
+};
+
+template <typename T>
+concept ScriptTraceT = requires(T a, const ScriptTraceFrameView& frame) {
+    { a.ScriptTrace(frame) } -> std::same_as<void>;
+};
+
+template <ScriptTraceT T>
+void ScriptTraceSetCallback(std::unique_ptr<T> trace)
+{
+    if (btck_script_trace_register_callback(
+            +[](void* user_data, const btck_ScriptTraceFrame* trace) { static_cast<T*>(user_data)->ScriptTrace(ScriptTraceFrameView{trace}); },
+            trace.release(),
+            +[](void* user_data) { delete static_cast<T*>(user_data); }) != 0) {
+        throw std::runtime_error("Script Tracing is not available. Compile bitcoin kernel with ENABLE_SCRIPT_TRACE");
+    }
+}
+
+inline void ScriptTraceUnsetCallback()
+{
+    btck_script_trace_unregister_callback();
 }
 
 } // namespace btck

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -11,6 +11,7 @@
 #include <prevector.h>
 #include <pubkey.h>
 #include <script/script.h>
+#include <script/trace.h>
 #include <serialize.h>
 #include <span.h>
 #include <tinyformat.h>
@@ -444,6 +445,8 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
     execdata.m_codeseparator_pos = 0xFFFFFFFFUL;
     execdata.m_codeseparator_pos_init = true;
 
+    SCRIPT_TRACE_SCOPE(stack, script, opcode_pos, altstack, [&vfExec]() { return vfExec.all_true(); }, nOpCount, sigversion, execdata.m_tapleaf_hash_init ? execdata.m_tapleaf_hash.data() : nullptr, execdata.m_codeseparator_pos, serror);
+
     try
     {
         for (; pc < pend; ++opcode_pos) {
@@ -452,8 +455,12 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
             //
             // Read instruction
             //
-            if (!script.GetOp(pc, opcode, vchPushValue))
+            if (!script.GetOp(pc, opcode, vchPushValue)) {
                 return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+            }
+
+            SCRIPT_TRACE_STEP(fExec, opcode);
+
             if (vchPushValue.size() > MAX_SCRIPT_ELEMENT_SIZE)
                 return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -11,6 +11,7 @@
 #include <prevector.h>
 #include <pubkey.h>
 #include <script/script.h>
+#include <script/trace.h>
 #include <serialize.h>
 #include <span.h>
 #include <tinyformat.h>
@@ -444,6 +445,8 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
     execdata.m_codeseparator_pos = 0xFFFFFFFFUL;
     execdata.m_codeseparator_pos_init = true;
 
+    SCRIPT_TRACE_SCOPE(stack, script, opcode_pos, altstack, nOpCount, sigversion, execdata.m_tapleaf_hash_init ? execdata.m_tapleaf_hash.data() : nullptr, execdata.m_codeseparator_pos, serror);
+
     try
     {
         for (; pc < pend; ++opcode_pos) {
@@ -452,8 +455,12 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
             //
             // Read instruction
             //
-            if (!script.GetOp(pc, opcode, vchPushValue))
+            if (!script.GetOp(pc, opcode, vchPushValue)) {
                 return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+            }
+
+            SCRIPT_TRACE_STEP(fExec, opcode);
+
             if (vchPushValue.size() > MAX_SCRIPT_ELEMENT_SIZE)
                 return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
 

--- a/src/script/trace.cpp
+++ b/src/script/trace.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/trace.h>
+
+#include <sync.h>
+
+#include <exception>
+#include <utility>
+
+static GlobalMutex g_script_trace_mutex;
+static ScriptTraceCallback g_script_trace_callback GUARDED_BY(g_script_trace_mutex){nullptr};
+
+void TraceScript(const ScriptTraceCallback& callback, const ScriptTraceFrame& trace_frame)
+{
+    if (callback) {
+        try {
+            callback(trace_frame);
+        } catch (...) {
+            std::terminate();
+        }
+    }
+}
+
+void ScriptTraceRegisterCallback(ScriptTraceCallback callback)
+{
+    // Copy the callback in case another thread is busy invoking the callback
+    ScriptTraceCallback old_callback;
+    {
+        LOCK(g_script_trace_mutex);
+        old_callback = std::move(g_script_trace_callback);
+        g_script_trace_callback = std::move(callback);
+    }
+}
+
+ScriptTraceCallback ScriptTraceGetCallback()
+{
+    return WITH_LOCK(g_script_trace_mutex, return g_script_trace_callback);
+}

--- a/src/script/trace.h
+++ b/src/script/trace.h
@@ -1,0 +1,119 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_TRACE_H
+#define BITCOIN_SCRIPT_TRACE_H
+
+#include <script/script.h>
+#include <script/script_error.h>
+
+#include <functional>
+#include <span>
+#include <vector>
+
+enum class ScriptTraceFrameKind : uint8_t {
+    Begin = 0,
+    Step = 1,
+    End = 2,
+};
+
+struct ScriptTraceFrame {
+    ScriptTraceFrameKind kind;
+    std::span<const std::vector<unsigned char>> stack;
+    std::span<const std::vector<unsigned char>> altstack;
+    const CScript& script;
+    uint32_t opcode_pos;
+    bool exec;
+    uint8_t opcode;
+    int op_count;
+    uint8_t sig_version;
+    const unsigned char* tapleaf_hash;
+    uint32_t codeseparator_pos;
+    ScriptError script_error;
+};
+
+using ScriptTraceCallback = std::function<void(const ScriptTraceFrame&)>;
+
+void TraceScript(const ScriptTraceCallback& callback, const ScriptTraceFrame& frame);
+void ScriptTraceRegisterCallback(ScriptTraceCallback callback);
+ScriptTraceCallback ScriptTraceGetCallback();
+
+#ifdef ENABLE_SCRIPT_TRACE
+
+struct ScriptTraceScope {
+    const ScriptTraceCallback m_callback;
+    std::vector<std::vector<unsigned char>>& m_stack;
+    const CScript& m_script;
+    uint32_t& m_opcode_pos;
+    std::vector<std::vector<unsigned char>>& m_altstack;
+    std::function<bool()> m_exec_fn;
+    int& m_op_count;
+    uint8_t m_sig_version;
+    const unsigned char* m_tapleaf_hash;
+    uint32_t& m_codeseparator_pos;
+    const ScriptError* m_error;
+
+    ScriptTraceScope(std::vector<std::vector<unsigned char>>& stack, const CScript& script, uint32_t& opcode_pos,
+                          std::vector<std::vector<unsigned char>>& altstack, std::function<bool()> exec_fn,
+                          int& nOpCount, uint8_t sigversion, const unsigned char* tapleaf_hash,
+                          uint32_t& codeseparator_pos, const ScriptError* error) :
+        m_callback{ScriptTraceGetCallback()},
+        m_stack{stack},
+        m_script{script},
+        m_opcode_pos{opcode_pos},
+        m_altstack{altstack},
+        m_exec_fn{std::move(exec_fn)},
+        m_op_count{nOpCount},
+        m_sig_version{sigversion},
+        m_tapleaf_hash{tapleaf_hash},
+        m_codeseparator_pos{codeseparator_pos},
+        m_error{error}
+    {
+        Emit(ScriptTraceFrameKind::Begin, m_exec_fn(), /*opcode=*/0, SCRIPT_ERR_OK);
+    }
+
+    void Step(bool exec, uint8_t opcode)
+    {
+        Emit(ScriptTraceFrameKind::Step, exec, opcode, SCRIPT_ERR_OK);
+    }
+
+    ~ScriptTraceScope()
+    {
+        Emit(ScriptTraceFrameKind::End, m_exec_fn(), /*opcode=*/0, m_error ? *m_error : SCRIPT_ERR_UNKNOWN_ERROR);
+    }
+
+private:
+    void Emit(ScriptTraceFrameKind kind, bool exec, uint8_t opcode, ScriptError error) const
+    {
+        if (!m_callback) return;
+        auto frame = ScriptTraceFrame{
+            .kind = kind,
+            .stack = m_stack,
+            .altstack = m_altstack,
+            .script = m_script,
+            .opcode_pos = m_opcode_pos,
+            .exec = exec,
+            .opcode = opcode,
+            .op_count = m_op_count,
+            .sig_version = m_sig_version,
+            .tapleaf_hash = m_tapleaf_hash,
+            .codeseparator_pos = m_codeseparator_pos,
+            .script_error = error,
+        };
+        TraceScript(m_callback, frame);
+    }
+};
+
+#define SCRIPT_TRACE_SCOPE(stack, script, opcode_pos, altstack, exec_fn, nOpCount, sigversion, tapleaf_hash, codeseparator_pos, error) \
+    ScriptTraceScope script_trace_scope { stack, script, opcode_pos, altstack, exec_fn, nOpCount, static_cast<uint8_t>(sigversion), tapleaf_hash, codeseparator_pos, error }
+
+#define SCRIPT_TRACE_STEP(fExec, opcode) \
+    script_trace_scope.Step(fExec, static_cast<uint8_t>(opcode))
+
+#else
+#define SCRIPT_TRACE_SCOPE(stack, script, opcode_pos, altstack, exec_fn, nOpCount, sigversion, tapleaf_hash, codeseparator_pos, error) static_assert(true)
+#define SCRIPT_TRACE_STEP(fExec, opcode) static_assert(true)
+#endif // ENABLE_SCRIPT_TRACE
+
+#endif // BITCOIN_SCRIPT_TRACE_H

--- a/src/script/trace.h
+++ b/src/script/trace.h
@@ -1,0 +1,118 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_TRACE_H
+#define BITCOIN_SCRIPT_TRACE_H
+
+#include <script/script.h>
+#include <script/script_error.h>
+
+#include <functional>
+#include <span>
+#include <vector>
+
+enum class ScriptTraceFrameKind : uint8_t {
+    Begin = 0,
+    Step = 1,
+    End = 2,
+};
+
+struct ScriptTraceFrame {
+    ScriptTraceFrameKind kind;
+    std::span<const std::vector<unsigned char>> stack;
+    std::span<const std::vector<unsigned char>> altstack;
+    const CScript& script;
+    uint32_t opcode_pos;
+    bool exec;
+    uint8_t opcode;
+    int op_count;
+    uint8_t sig_version;
+    const unsigned char* tapleaf_hash;
+    uint32_t codeseparator_pos;
+    ScriptError script_error;
+};
+
+using ScriptTraceCallback = std::function<void(const ScriptTraceFrame&)>;
+
+void TraceScript(const ScriptTraceCallback& callback, const ScriptTraceFrame& frame);
+void ScriptTraceRegisterCallback(ScriptTraceCallback callback);
+ScriptTraceCallback ScriptTraceGetCallback();
+
+#ifdef ENABLE_SCRIPT_TRACE
+
+struct ScriptTraceScope {
+    const ScriptTraceCallback m_callback;
+    std::vector<std::vector<unsigned char>>& m_stack;
+    const CScript& m_script;
+    uint32_t& m_opcode_pos;
+    std::vector<std::vector<unsigned char>>& m_altstack;
+    int& m_op_count;
+    uint8_t m_sig_version;
+    const unsigned char* m_tapleaf_hash;
+    uint32_t& m_codeseparator_pos;
+    const ScriptError* m_error;
+
+    ScriptTraceScope(std::vector<std::vector<unsigned char>>& stack, const CScript& script, uint32_t& opcode_pos,
+                          std::vector<std::vector<unsigned char>>& altstack,
+                          int& nOpCount, uint8_t sigversion, const unsigned char* tapleaf_hash,
+                          uint32_t& codeseparator_pos, const ScriptError* error) :
+        m_callback{ScriptTraceGetCallback()},
+        m_stack{stack},
+        m_script{script},
+        m_opcode_pos{opcode_pos},
+        m_altstack{altstack},
+        m_op_count{nOpCount},
+        m_sig_version{sigversion},
+        m_tapleaf_hash{tapleaf_hash},
+        m_codeseparator_pos{codeseparator_pos},
+        m_error{error}
+    {
+        assert(!m_callback || error);
+        Emit(ScriptTraceFrameKind::Begin, /*exec=*/true, /*opcode=*/0, SCRIPT_ERR_OK);
+    }
+
+    void Step(bool exec, uint8_t opcode)
+    {
+        Emit(ScriptTraceFrameKind::Step, exec, opcode, SCRIPT_ERR_OK);
+    }
+
+    ~ScriptTraceScope()
+    {
+        Emit(ScriptTraceFrameKind::End, /*exec=*/true, /*opcode=*/0, m_error ? *m_error : SCRIPT_ERR_UNKNOWN_ERROR);
+    }
+
+private:
+    void Emit(ScriptTraceFrameKind kind, bool exec, uint8_t opcode, ScriptError error) const
+    {
+        if (!m_callback) return;
+        auto frame = ScriptTraceFrame{
+            .kind = kind,
+            .stack = m_stack,
+            .altstack = m_altstack,
+            .script = m_script,
+            .opcode_pos = m_opcode_pos,
+            .exec = exec,
+            .opcode = opcode,
+            .op_count = m_op_count,
+            .sig_version = m_sig_version,
+            .tapleaf_hash = m_tapleaf_hash,
+            .codeseparator_pos = m_codeseparator_pos,
+            .script_error = error,
+        };
+        TraceScript(m_callback, frame);
+    }
+};
+
+#define SCRIPT_TRACE_SCOPE(stack, script, opcode_pos, altstack, nOpCount, sigversion, tapleaf_hash, codeseparator_pos, error) \
+    ScriptTraceScope script_trace_scope { stack, script, opcode_pos, altstack, nOpCount, static_cast<uint8_t>(sigversion), tapleaf_hash, codeseparator_pos, error }
+
+#define SCRIPT_TRACE_STEP(fExec, opcode) \
+    script_trace_scope.Step(fExec, static_cast<uint8_t>(opcode))
+
+#else
+#define SCRIPT_TRACE_SCOPE(stack, script, opcode_pos, altstack, nOpCount, sigversion, tapleaf_hash, codeseparator_pos, error) static_assert(true)
+#define SCRIPT_TRACE_STEP(fExec, opcode) static_assert(true)
+#endif // ENABLE_SCRIPT_TRACE
+
+#endif // BITCOIN_SCRIPT_TRACE_H

--- a/src/test/kernel/CMakeLists.txt
+++ b/src/test/kernel/CMakeLists.txt
@@ -9,6 +9,10 @@ target_link_libraries(test_kernel
     Boost::headers
 )
 
+if(ENABLE_SCRIPT_TRACE)
+  target_compile_definitions(test_kernel PRIVATE ENABLE_SCRIPT_TRACE)
+endif()
+
 add_windows_application_manifest(test_kernel)
 
 add_test(NAME test_kernel COMMAND test_kernel)

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -389,6 +389,56 @@ void CheckRange(const RangeType& range, size_t expected_size)
     BOOST_CHECK(it2 == it + 1);
 }
 
+
+struct ScriptTracer {
+    std::vector<ScriptTraceFrame>& m_state;
+
+    void ScriptTrace(ScriptTraceFrame state)
+    {
+        m_state.emplace_back(state);
+    }
+};
+
+BOOST_AUTO_TEST_CASE(btck_script_trace_tests)
+{
+    std::vector<ScriptTraceFrame> states;
+#ifndef ENABLE_SCRIPT_TRACE
+    BOOST_CHECK_EXCEPTION(
+            ScriptTraceSetCallback(std::make_unique<ScriptTracer>(states)),
+            std::runtime_error,
+            HasReason("Script Tracing is not available. Compile bitcoin kernel with ENABLE_SCRIPT_TRACE"));
+    // Should be no-op
+    ScriptTraceUnsetCallback();
+#else
+    ScriptTraceSetCallback(std::make_unique<ScriptTracer>(states));
+
+    auto legacy_spent_script_pubkey{ScriptPubkey{hex_string_to_byte_vec("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac")}};
+    auto legacy_spending_tx{Transaction{hex_string_to_byte_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")}};
+    auto status{ScriptVerifyStatus::OK};
+    BOOST_CHECK(legacy_spent_script_pubkey.Verify(
+        /*amount=*/0,
+        /*tx_to=*/legacy_spending_tx,
+        /*precomputed_txdata=*/nullptr,
+        /*input_index=*/0,
+        VERIFY_ALL_PRE_TAPROOT,
+        status));
+    BOOST_CHECK(status == ScriptVerifyStatus::OK);
+
+    ScriptTraceUnsetCallback();
+
+    BOOST_CHECK_EQUAL(states.size(), 11);
+    BOOST_CHECK(states[0].m_kind == ScriptTraceFrameKind::BEGIN);
+    BOOST_CHECK(states[3].m_kind == ScriptTraceFrameKind::END);
+    BOOST_CHECK(states[4].m_kind == ScriptTraceFrameKind::BEGIN);
+    BOOST_CHECK(states[10].m_kind == ScriptTraceFrameKind::END);
+    for (int i : {1, 2, 5, 6, 7, 8, 9}) {
+        BOOST_CHECK(states[i].m_kind == ScriptTraceFrameKind::STEP);
+    }
+    BOOST_CHECK_EQUAL(states[3].m_script_error, 0);
+    BOOST_CHECK_EQUAL(states[10].m_script_error, 0);
+#endif
+}
+
 BOOST_AUTO_TEST_CASE(btck_transaction_tests)
 {
     auto tx_data{hex_string_to_byte_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")};

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -392,6 +392,80 @@ void CheckRange(const RangeType& range, size_t expected_size)
     BOOST_CHECK(it2 == it + 1);
 }
 
+struct ScriptTracer {
+    struct Snapshot {
+        ScriptTraceFrameKind m_kind;
+        int32_t m_script_error;
+    };
+    std::vector<Snapshot>& m_state;
+
+    void ScriptTrace(const ScriptTraceFrameView& frame)
+    {
+        m_state.push_back({frame.Kind(), frame.GetScriptError()});
+    }
+};
+
+BOOST_AUTO_TEST_CASE(btck_script_trace_tests)
+{
+    std::vector<ScriptTracer::Snapshot> states;
+#ifndef ENABLE_SCRIPT_TRACE
+    BOOST_CHECK_EXCEPTION(
+            ScriptTraceSetCallback(std::make_unique<ScriptTracer>(states)),
+            std::runtime_error,
+            HasReason("Script Tracing is not available. Compile bitcoin kernel with ENABLE_SCRIPT_TRACE"));
+    // Should be no-op
+    ScriptTraceUnsetCallback();
+#else
+    ScriptTraceSetCallback(std::make_unique<ScriptTracer>(states));
+
+    auto legacy_spent_script_pubkey{ScriptPubkey{hex_string_to_byte_vec("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac")}};
+    auto legacy_spending_tx{Transaction{hex_string_to_byte_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")}};
+    auto status{ScriptVerifyStatus::OK};
+    BOOST_CHECK(legacy_spent_script_pubkey.Verify(
+        /*amount=*/0,
+        /*tx_to=*/legacy_spending_tx,
+        /*precomputed_txdata=*/nullptr,
+        /*input_index=*/0,
+        VERIFY_ALL_PRE_TAPROOT,
+        status));
+    BOOST_CHECK(status == ScriptVerifyStatus::OK);
+
+    const auto frame_count = states.size();
+    ScriptTraceUnsetCallback();
+
+    BOOST_CHECK(legacy_spent_script_pubkey.Verify(
+        /*amount=*/0,
+        /*tx_to=*/legacy_spending_tx,
+        /*precomputed_txdata=*/nullptr,
+        /*input_index=*/0,
+        VERIFY_ALL_PRE_TAPROOT,
+        status));
+    BOOST_CHECK_EQUAL(states.size(), frame_count);
+
+    BOOST_REQUIRE_EQUAL(states.size(), 11);
+    BOOST_CHECK(states[0].m_kind == ScriptTraceFrameKind::BEGIN);
+    BOOST_CHECK(states[3].m_kind == ScriptTraceFrameKind::END);
+    BOOST_CHECK(states[4].m_kind == ScriptTraceFrameKind::BEGIN);
+    BOOST_CHECK(states[10].m_kind == ScriptTraceFrameKind::END);
+    for (int i : {1, 2, 5, 6, 7, 8, 9}) {
+        BOOST_CHECK(states[i].m_kind == ScriptTraceFrameKind::STEP);
+    }
+    BOOST_CHECK_EQUAL(states[3].m_script_error, 0);
+    BOOST_CHECK_EQUAL(states[10].m_script_error, 0);
+
+    ScriptTraceSetCallback(std::make_unique<ScriptTracer>(states));
+    BOOST_CHECK(legacy_spent_script_pubkey.Verify(
+        /*amount=*/0,
+        /*tx_to=*/legacy_spending_tx,
+        /*precomputed_txdata=*/nullptr,
+        /*input_index=*/0,
+        VERIFY_ALL_PRE_TAPROOT,
+        status));
+    BOOST_CHECK_EQUAL(states.size(), 22);
+    ScriptTraceUnsetCallback();
+#endif
+}
+
 BOOST_AUTO_TEST_CASE(btck_transaction_tests)
 {
     auto tx_data{hex_string_to_byte_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")};


### PR DESCRIPTION
This adds a callback hook to the kernel library C header for getting the current script evaluation state on each script evaluation step. This can be used for debugging scripts and gives external applications a view into how Bitcoin Core does script evaluation.

The initial sketch for this work was prepared on rust-bitcoinkernel: https://github.com/sedited/rust-bitcoinkernel/tree/feature_script_debug . That branch also includes a very rudimentary script debugger showcasing the use case for this patch. Clankers seems to do a decent job at coding up prototypes for more featureful debuggers, which seems like a fun project to hack on if anybody else wants to give it a try.

This feature is gated behind the ENABLE_SCRIPT_TRACE flag. To compile with the feature enabled, pass `-DENABLE_SCRIPT_TRACE=ON`. If the feature is not manually enabled, the trace hooks are stubbed out.

The traces are divided into separate frames. RAII is used to guarantee that every script evaluation has at least its start and end state captured. Each instruction generates a unique frame as well.

The ScriptError in the VerifyScript invocation run when calling script_pubkey_verify is added in order to be able to surface the error code in the trace frames.

Another use case could also be using the frames to ensure that the script interpreter is actually doing what we think it is doing during the script tests. This might prevent unit test bugs in the future, i.e. when [error conditions shadow actual behaviour](https://github.com/bitcoin/bitcoin/pull/33961), and could also be interesting for fuzzing the script interpreter.