### PR TITLE
doc: Add release notes for 32489 (exportwatchonlywallet RPC)

### DIFF
--- a/doc/release-notes-32489.md
+++ b/doc/release-notes-32489.md
@@ -1,0 +1,15 @@
+New RPCs
+--------
+
+A new `exportwatchonlywallet` RPC creates a watchonly wallet file from an
+existing descriptor wallet. The exported file contains the wallet's public
+descriptors (with derived key caches where needed), transactions, and address
+book data, but no private keys. It can be imported on another node using the
+existing `restorewallet` RPC.
+
+Wallet
+------
+
+The [Offline Signing Tutorial](/doc/offline-signing-tutorial.md) has been
+updated to use `exportwatchonlywallet` for setting up the online watch-only
+wallet, replacing the previous manual descriptor import workflow.


### PR DESCRIPTION
This is a follow-up to #32489.