### PR TITLE
init: fix reindex deadlock by waking cv after interrupt

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2045,10 +2045,16 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     /// \anchor initload
-    node.background_init_thread = std::thread(&util::TraceThread, "initload", [=, &chainman, &args, &node] {
+    node.background_init_thread = std::thread(&util::TraceThread, "initload", [=, &chainman, &args, &kernel_notifications, &node] {
         ScheduleBatchPriority();
         // Import blocks and ActivateBestChain()
         ImportBlocks(chainman, vImportFiles);
+        // An interrupted import may return without activating genesis. Wake
+        // the init thread's genesis wait, which is otherwise only notified
+        // on blockTip, and that never fires when the import was interrupted
+        // before activating genesis. This wakeup lets the wait observe the
+        // shutdown request.
+        WITH_LOCK(kernel_notifications.m_tip_block_mutex, kernel_notifications.m_tip_block_cv.notify_all());
         WITH_LOCK(::cs_main, chainman.UpdateIBDStatus());
         if (args.GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {
             LogInfo("Stopping after block import");

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -63,6 +63,7 @@ class InitTest(BitcoinTestFramework):
                 node.process.terminate()
             assert_equal(0, node.process.wait())
 
+        reindex_log_line = b'Reindexing block file blk00000.dat'
         lines_to_terminate_after = [
             b'Validating signatures for all blocks',
             b'scheduler thread start',
@@ -87,16 +88,20 @@ class InitTest(BitcoinTestFramework):
         ]
         if self.is_wallet_compiled():
             lines_to_terminate_after.append(b'Verifying wallet')
+        lines_to_terminate_after.append(reindex_log_line)
 
         for terminate_line in lines_to_terminate_after:
             self.log.info(f"Starting node and will terminate after line {terminate_line}")
             with node.busy_wait_for_debug_log([terminate_line]):
+                extra_args = [*ALL_INDEX_ARGS]
+                if terminate_line == reindex_log_line:
+                    extra_args += ['-reindex']
                 if platform.system() == 'Windows':
                     # CREATE_NEW_PROCESS_GROUP is required in order to be able
                     # to terminate the child without terminating the test.
-                    node.start(extra_args=ALL_INDEX_ARGS, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+                    node.start(extra_args=extra_args, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
                 else:
-                    node.start(extra_args=ALL_INDEX_ARGS)
+                    node.start(extra_args=extra_args)
             self.log.debug("Terminating node after terminate line was found")
             sigterm_node()
 


### PR DESCRIPTION
During startup with `-reindex`, the block index and chainstate are wiped, and
the normal `LoadGenesisBlock()` startup path is skipped while block files are
being indexed. The init thread can then wait for genesis to be processed via the
tip-block condition variable.

If shutdown is requested after the init thread enters that wait but before the
import thread activates genesis, the reindex scan can return early without
calling the later `LoadGenesisBlock()` fallback or `ActivateBestChains()`.
Because no block tip is connected, the block-tip notification never fires. The
wait predicate would accept `ShutdownRequested(node)`, but it is not evaluated
again unless the condition variable is notified.

Notify the tip-block condition variable after `ImportBlocks()` returns so the
genesis wait can observe shutdown and exit cleanly.

Described in detail https://github.com/bitcoin/bitcoin/pull/35621#issuecomment-4876059120


The current test covers the path, but won't fail deterministically. You can use L0rinc suggested patch for a deterministic patch that demonstrate the deadlock on master https://github.com/bitcoin/bitcoin/pull/35652#pullrequestreview-4627988553  