### PR TITLE
fuzz: Remove `ConsumeUniValue`

### DIFF
--- a/src/ipc/test/fuzz/ipc.cpp
+++ b/src/ipc/test/fuzz/ipc.cpp
@@ -123,7 +123,8 @@ FUZZ_TARGET(ipc, .init = initialize_ipc)
                 assert(ipc.m_client->passScript(script) == expected);
             },
             [&] {
-                UniValue value = ConsumeUniValue(fuzzed_data_provider);
+                UniValue value;
+                if (!value.read(fuzzed_data_provider.ConsumeRandomLengthString(512))) return;
                 assert(ipc.m_client->passUniValue(value).write() == value.write());
             },
             [&] {

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -237,16 +237,6 @@ CKey ConsumePrivateKey(FuzzedDataProvider& fuzzed_data_provider, std::optional<b
     return key;
 }
 
-UniValue ConsumeUniValue(FuzzedDataProvider& fuzzed_data_provider) noexcept
-{
-    UniValue value{UniValue::VOBJ};
-    value.pushKV("bool", fuzzed_data_provider.ConsumeBool());
-    value.pushKV("number", fuzzed_data_provider.ConsumeIntegralInRange<int>(-1'000'000, 1'000'000));
-    value.pushKV("string", "ipc fuzz");
-
-    return value;
-}
-
 bool ContainsSpentInput(const CTransaction& tx, const CCoinsViewCache& inputs) noexcept
 {
     for (const CTxIn& tx_in : tx.vin) {

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_H
 #define BITCOIN_TEST_FUZZ_UTIL_H
 
-#include <univalue.h>
 #include <addresstype.h>
 #include <arith_uint256.h>
 #include <coins.h>
@@ -228,8 +227,6 @@ template <class Dur>
 [[nodiscard]] CTxDestination ConsumeTxDestination(FuzzedDataProvider& fuzzed_data_provider) noexcept;
 
 [[nodiscard]] CKey ConsumePrivateKey(FuzzedDataProvider& fuzzed_data_provider, std::optional<bool> compressed = std::nullopt) noexcept;
-
-[[nodiscard]] UniValue ConsumeUniValue(FuzzedDataProvider& fuzzed_data_provider) noexcept;
 
 template <typename T>
 [[nodiscard]] bool MultiplicationOverflow(const T i, const T j) noexcept


### PR DESCRIPTION
Addresses https://github.com/bitcoin/bitcoin/pull/35118#discussion_r3514230802.

`ConsumeUniValue` isn't that useful as a shared fuzz helper, as it just returns the same hard-coded fields. This PR removes it and updates the `ipc` target to read a UniValue directly from fuzzer input instead. This is similar to what the `parse_univalue` target already does, and lets `ipc` test with different JSON values instead of one fixed value.