### PR TITLE
txdb: reject undecodable first coin cursor key

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -5,6 +5,7 @@
 #include <addresstype.h>
 #include <clientversion.h>
 #include <coins.h>
+#include <dbwrapper.h>
 #include <streams.h>
 #include <test/util/common.h>
 #include <test/util/poolresourcetester.h>
@@ -19,6 +20,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -1083,6 +1085,21 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
 
     BOOST_CHECK(*Assert(base.GetCoin(outpoint)) == coin);
     BOOST_CHECK_EQUAL(base.GetBestBlock(), block_hash);
+}
+
+BOOST_AUTO_TEST_CASE(malformed_first_coin_key_cursor_invalid)
+{
+    const fs::path path{m_args.GetDataDirBase() / "chainstate"};
+    {
+        CDBWrapper dbw{{.path = path, .cache_bytes = 1_MiB, .wipe_data = true}};
+        dbw.Write(uint8_t{'C'}, Coin{CTxOut{/*nValueIn=*/1, CScript{}}, /*nHeightIn=*/1, /*fCoinBaseIn=*/false});
+    }
+
+    CCoinsViewDB view{{.path = path, .cache_bytes = 1_MiB}, /*options=*/{}};
+    std::unique_ptr cursor{Assert(view.Cursor())};
+    BOOST_CHECK(!cursor->Valid());
+    COutPoint outpoint;
+    BOOST_CHECK(!cursor->GetKey(outpoint));
 }
 
 BOOST_AUTO_TEST_CASE(coins_resource_is_used)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -245,13 +245,12 @@ std::unique_ptr<CCoinsViewCursor> CCoinsViewDB::Cursor() const
        only need read operations on it, use a const-cast to get around
        that restriction.  */
     i->pcursor->Seek(DB_COIN);
-    // Cache key of first record
+    // Cache key of first record, matching Next() for undecodable keys.
+    i->keyTmp.first = 0;
     if (i->pcursor->Valid()) {
-        CoinEntry entry(&i->keyTmp.second);
-        i->pcursor->GetKey(entry);
-        i->keyTmp.first = entry.key;
-    } else {
-        i->keyTmp.first = 0; // Make sure Valid() and GetKey() return false
+        if (CoinEntry entry{&i->keyTmp.second}; i->pcursor->GetKey(entry)) {
+            i->keyTmp.first = entry.key;
+        }
     }
     return i;
 }


### PR DESCRIPTION
**Problem:** `CCoinsViewDB::Cursor()` already handles the case where `Seek(DB_COIN)` finds no coin record, but could still accept an undecodable first coin key as a valid cursor position.
`CCoinsViewDBCursor::Next()` already invalidates the cursor for the same decode failure later in iteration, so initial cursor setup has a small correctness mismatch.

**Fix:** Make initial cursor setup match `Next()`: keep the cached key invalid unless the first key decodes successfully.

Fixes #35172, with credit to the issue author and previous attempts #35191 and #35248.