### PR TITLE
refactor: avoid redundant input lookup in `CheckTxInputs`

### DIFF
--- a/src/bench/connectblock.cpp
+++ b/src/bench/connectblock.cpp
@@ -7,6 +7,7 @@
 #include <chain.h>
 #include <coins.h>
 #include <consensus/amount.h>
+#include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <key.h>
 #include <node/blockstorage.h>
@@ -141,3 +142,48 @@ static void ConnectBlockAllEcdsa(benchmark::Bench& bench)
 BENCHMARK(ConnectBlockAllSchnorr);
 BENCHMARK(ConnectBlockMixedEcdsaSchnorr);
 BENCHMARK(ConnectBlockAllEcdsa);
+
+/*
+ * Benchmarks Consensus::CheckTxInputs in isolation (without script
+ * verification) over a realistic block, so the cost is dominated by UTXO set
+ * lookups. The coins are added to CoinsTip (not to the view being measured),
+ * and a fresh CCoinsViewCache wrapping CoinsTip is constructed on every
+ * batch, so each measured pass actually pulls the coins across the
+ * view/base boundary (like a fresh per-block view would in production)
+ * instead of always hitting an already-warmed local cache.
+ */
+static void CheckTxInputs(benchmark::Bench& bench)
+{
+    const auto test_setup{MakeNoLogFileContext<TestChain100Setup>()};
+    // Same input mix as ConnectBlockMixedEcdsaSchnorr (5 inputs/tx, 1000 txs).
+    auto [keys, outputs]{CreateKeysAndOutputs(test_setup->coinbaseKey, /*num_schnorr=*/1, /*num_ecdsa=*/4)};
+    const auto test_block{CreateTestBlock(*test_setup, keys, outputs)};
+
+    LOCK(cs_main);
+    Chainstate& chainstate{test_setup->m_node.chainman->ActiveChainstate()};
+    const int spend_height{chainstate.m_chain.Height() + 1};
+
+    // Make all prevouts referenced by the block available directly in
+    // CoinsTip. The first transaction spends outputs already in CoinsTip
+    // (created by CreateTestBlock in a previously processed block); the rest
+    // spend outputs of earlier transactions in this block, which we add here.
+    for (const auto& tx : test_block.vtx) {
+        AddCoins(chainstate.CoinsTip(), *tx, spend_height);
+    }
+
+    const size_t num_checked{test_block.vtx.size() - 1}; // all but the coinbase
+    bench.unit("tx").batch(num_checked).run([&] {
+        // Fresh view per batch: every AccessCoin() below must cross into
+        // CoinsTip at least once, instead of reusing a view that already has
+        // every coin resolved from a prior batch.
+        CCoinsViewCache view{&chainstate.CoinsTip()};
+        for (size_t i{1}; i < test_block.vtx.size(); ++i) { // skip coinbase
+            TxValidationState state;
+            CAmount txfee{0};
+            const bool ok{Consensus::CheckTxInputs(*test_block.vtx[i], state, view, spend_height, txfee)};
+            assert(ok);
+        }
+    });
+}
+
+BENCHMARK(CheckTxInputs);

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -163,17 +163,16 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
 
 bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee)
 {
-    // are the actual inputs available?
-    if (!inputs.HaveInputs(tx)) {
-        return state.Invalid(TxValidationResult::TX_MISSING_INPUTS, "bad-txns-inputs-missingorspent",
-                         strprintf("%s: inputs missing/spent", __func__));
-    }
-
     CAmount nValueIn = 0;
     for (unsigned int i = 0; i < tx.vin.size(); ++i) {
         const COutPoint &prevout = tx.vin[i].prevout;
         const Coin& coin = inputs.AccessCoin(prevout);
-        assert(!coin.IsSpent());
+        // AccessCoin returns a spent placeholder Coin for outpoints absent
+        // from the view, so this also covers the "input missing" case.
+        if (coin.IsSpent()) {
+            return state.Invalid(TxValidationResult::TX_MISSING_INPUTS, "bad-txns-inputs-missingorspent",
+                             strprintf("%s: inputs missing/spent", __func__));
+        }
 
         // If prev is coinbase, check that it's matured
         if (coin.IsCoinBase() && nSpendHeight - coin.nHeight < COINBASE_MATURITY) {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -1164,6 +1164,23 @@ BOOST_AUTO_TEST_CASE(checktxinputs_invalid_transactions_test)
                   /*coinbase=*/true,
                   /*spend_height=*/COINBASE_MATURITY,
                   TxValidationResult::TX_PREMATURE_SPEND, /*expected_reason=*/"bad-txns-premature-spend-of-coinbase");
+
+    // Spending an outpoint that is absent from the view (AccessCoin returns a
+    // spent coinEmpty) is reported as missing/spent inputs.
+    {
+        CCoinsViewCache inputs{&CoinsViewEmpty::Get()};
+
+        CMutableTransaction mtx;
+        mtx.vin.emplace_back(COutPoint{Txid::FromUint256(uint256::ONE), 0});
+        mtx.vout.emplace_back(0, CScript() << OP_TRUE);
+
+        TxValidationState state;
+        CAmount txfee{0};
+        BOOST_CHECK(!Consensus::CheckTxInputs(CTransaction{mtx}, state, inputs, /*nSpendHeight=*/2, txfee));
+        BOOST_CHECK(state.IsInvalid());
+        BOOST_CHECK_EQUAL(state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
+        BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-inputs-missingorspent");
+    }
 }
 
 BOOST_AUTO_TEST_CASE(getvalueout_out_of_range_throws)


### PR DESCRIPTION
`Consensus::CheckTxInputs` currently makes two UTXO lookups per input: first through a `HaveInputs()` pre-pass (which internally calls `HaveCoin()` for every input), and then through `AccessCoin()` on the same outpoints in the main validation loop.

`HaveInputs()` has only a single caller (`CheckTxInputs`), and `AccessCoin()` already returns a reference to a spent sentinel `Coin` for any missing outpoint. This means the presence check can be folded into the existing loop without changing behavior.

This PR removes the initial `HaveInputs()` pre-pass and instead checks `coin.IsSpent()` immediately after `AccessCoin()` returns. As a result, `CheckTxInputs` performs one lookup per input instead of two (2N → N, where N is the number of inputs) in the validation path shared by both `ConnectBlock` and mempool acceptance.

`HaveInputs()` itself is **not** removed. It is still used by the coins-view fuzz harness, although this change leaves it with no callers in the validation hot path. Removing it would be a trivial follow-up.



The only observable behavioral difference is which validation error is reported if one input is missing while another input in the same transaction fails for some unrelated reason (for example, coinbase immaturity).

- In `ConnectBlock`, all such failures are ultimately reported as `BLOCK_CONSENSUS`, so the specific failure reason or ordering has no consensus impact.
- In the mempool (`MemPoolAccept::PreChecks`), every input has already been checked with `m_view.HaveCoin()` before `CheckTxInputs()` is called. Missing inputs are handled there as orphan transactions, making the "missing input" path inside `CheckTxInputs()` unreachable during mempool validation.

<details>
<summary><strong>Benchmark</strong> (<code>bench_bitcoin -filter=CheckTxInputs</code>)</summary>

The benchmark below is intentionally designed to measure the cost of the redundant lookup itself, rather than end-to-end block validation.

A fresh `CCoinsViewCache` wrapping `CoinsTip` is constructed for each measured batch (coins are added to `CoinsTip` itself, not to the benchmarked view), so each pass actually crosses the view/base boundary instead of hitting an already-warmed local cache. This closely matches how a fresh per-block view behaves in production.

```bash
BEFORE="d31c26fd1a53300a704bccbf12aae5b050c67ec3"
AFTER="5021cd02fa503f0ea0dc741f7200eba8275a885d"

RESULTS_FILE="$HOME/checktxinputs_bench_results.txt"
: > "$RESULTS_FILE"

echo "machine | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM" | tee -a "$RESULTS_FILE"

ORIG="$(git rev-parse --abbrev-ref HEAD)"

for hash in $BEFORE $AFTER; do
  echo ">>> $hash"
  git checkout "$hash" >/dev/null 2>&1 &&
  cmake --build build -t bench_bitcoin &&
  (
    echo "--- ${hash:0:7} ---"
    ./build/bin/bench_bitcoin -filter=CheckTxInputs -min-time=3000
  ) 2>&1 | tee -a "$RESULTS_FILE"
done

git switch "$ORIG"
```

</details>

|        | ns/tx | tx/s | err% |
|--------|------:|-----:|-----:|
| before | 1,154.31 | 866,316 | 0.4% |
| after  | 985.84 | 1,014,367 | 0.5% |

~14.6% faster. This is smaller than a naive 2N → N lookup-count argument might suggest, because both lookups are `FetchCoin` calls against the same already-resolved cache entry after the first one resolves it. The second lookup is just a cheap lookup in an already-warm cache, not a second trip to the backing store. The real saving is exactly one redundant cache lookup per input, which is what this benchmark isolates.

As a sanity check, I also compared IBD over the same block range before and after this change and observed no measurable difference in synchronization time, which is expected: `CheckTxInputs` accounts for only a small fraction of `ConnectBlock`, where signature verification dominates.

The optimization is therefore real but modest. Its value comes from removing a genuinely redundant lookup without changing consensus behavior, rather than from any meaningful IBD speedup.


### Historical context

This pre-pass originally served a real purpose.

Before April 2017, `CheckTxInputs()` used a per-*txid* `CCoins` cache where `AccessCoins(txid)` returned a raw pointer that could be `NULL`, and a single `CCoins` entry could contain both spent and unspent outputs. In that design, `HaveInputs()` prevented both null-pointer dereferences and spending an already-spent output within an otherwise live entry.

On 2017-04-25, two commits changed this:

- `0003911326` ("Introduce new per-txout CCoinsViewCache functions") introduced `AccessCoin()`, which returns a reference to a sentinel empty coin for missing outpoints.
- `f68cdfe92b` ("Switch from per-tx to per-txout CCoinsViewCache methods in some places") updated `CheckTxInputs()` to use the new API.

From that point onward, missing and already-spent outputs were both represented by `coin.IsSpent()` on the object returned by `AccessCoin()`, making the `HaveInputs()` pre-pass redundant. The validation loop has effectively remained unchanged since then, aside from the later scripted rename from `IsPruned()` to `IsSpent()` (`589827975f`).

This PR simply removes that leftover redundancy.

~~**Edit:** :When I opened this PR, I hadn't reviewed PR #35187, which modifies the same lines. While the primary goal of that PR is different, it also avoids the redundant lookup as a side effect.~~

~~Although that PR was submitted earlier, it is significantly larger and includes more critical and potentially controversial changes (it has already received one concept NACK), so it may take longer to be merged.~~

~~This PR is smaller, focused on a specific issue, and can be evaluated independently. It also doesn't block or conflict with the other PR, since #35187 can still be merged later on top of these changes without any issues.~~ Not anymore

