### PR TITLE
refactor: Drop unneeded `<sys/types.h>` include before `<ifaddrs.h>`

### DIFF
--- a/cmake/module/TestAppendRequiredLibraries.cmake
+++ b/cmake/module/TestAppendRequiredLibraries.cmake
@@ -15,7 +15,6 @@ function(test_append_socket_library target)
   endif()
 
   set(check_socket_source "
-    #include <sys/types.h>
     #include <ifaddrs.h>
 
     int main() {

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -30,7 +30,6 @@
 #endif
 
 #ifdef HAVE_IFADDRS
-#include <sys/types.h>
 #include <ifaddrs.h>
 #endif
 


### PR DESCRIPTION
Pure `getifaddrs()`/`freeifaddrs()` calls do not need any type definitions beyond those provided by `<ifaddrs.h>` itself.

The subsequent `struct ifaddrs` processing in `netif.cpp` does not involve any symbols from `<sys/types.h>`.

Platform-specific manual pages for reviewers' convenience:
- https://www.man7.org/linux/man-pages/man3/getifaddrs.3.html
- https://man.freebsd.org/cgi/man.cgi?query=getifaddrs
- https://man.netbsd.org/getifaddrs.3
- https://man.openbsd.org/getifaddrs.3
- https://www.illumos.org/man/3SOCKET/getifaddrs

Related to https://github.com/bitcoin/bitcoin/pull/34995.