### PR TITLE
Clarify supported *BSD releases and drop outdated workarounds

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -1,8 +1,8 @@
 # FreeBSD Build Guide
 
-**Updated for FreeBSD [15.0](https://www.freebsd.org/releases/15.0R/announce/)**
+Bitcoin Core is supported on all [supported FreeBSD releases](https://www.freebsd.org/security/#sup).
 
-This guide describes how to build bitcoind, command-line utilities, and GUI on FreeBSD.
+This guide describes how to build bitcoind, command-line utilities, and GUI on the most recent production release.
 
 ## Preparation
 

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -1,8 +1,8 @@
 # NetBSD Build Guide
 
-**Updated for NetBSD [10.1](https://netbsd.org/releases/formal-10/NetBSD-10.1.html)**
+Bitcoin Core is supported on all [supported NetBSD releases](https://www.netbsd.org/releases/).
 
-This guide describes how to build bitcoind, command-line utilities, and GUI on NetBSD.
+This guide describes how to build bitcoind, command-line utilities, and GUI on the latest release.
 
 ## Preparation
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,8 +1,8 @@
 # OpenBSD Build Guide
 
-**Updated for OpenBSD [7.8](https://www.openbsd.org/78.html)**
+Bitcoin Core is supported on [the two most recent OpenBSD releases](https://www.openbsd.org/faq/faq5.html#Flavors).
 
-This guide describes how to build bitcoind, command-line utilities, and GUI on OpenBSD.
+This guide describes how to build bitcoind, command-line utilities, and GUI on the latest release.
 
 ## Preparation
 

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -17,8 +17,6 @@
 #elif defined(__FreeBSD__)
 #include <osreldate.h>
 #if __FreeBSD_version >= 1400000
-// Workaround https://github.com/freebsd/freebsd-src/pull/1070.
-#define typeof __typeof
 #include <netlink/netlink.h>
 #include <netlink/netlink_route.h>
 #endif

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -15,11 +15,8 @@
 #if defined(__linux__)
 #include <linux/rtnetlink.h>
 #elif defined(__FreeBSD__)
-#include <osreldate.h>
-#if __FreeBSD_version >= 1400000
 #include <netlink/netlink.h>
 #include <netlink/netlink_route.h>
-#endif
 #elif defined(WIN32)
 #include <iphlpapi.h>
 #elif defined(__APPLE__)
@@ -60,10 +57,8 @@ std::optional<CNetAddr> FromSockAddr(const struct sockaddr* addr, std::optional<
     return std::nullopt;
 }
 
-// Linux and FreeBSD 14.0+. For FreeBSD 13.2 the code can be compiled but
-// running it requires loading a special kernel module, otherwise socket(AF_NETLINK,...)
-// will fail, so we skip that.
-#if defined(__linux__) || (defined(__FreeBSD__) && __FreeBSD_version >= 1400000)
+// Linux and FreeBSD.
+#if defined(__linux__) || defined(__FreeBSD__)
 
 // Good for responses containing ~ 10,000-15,000 routes.
 static constexpr ssize_t NETLINK_MAX_RESPONSE_SIZE{1'048'576};


### PR DESCRIPTION
This PR establishes a baseline for the oldest *BSD releases supported by Bitcoin Core. Clarifying these minimum requirements paves the way for dropping compatibility code and workarounds for unsupported versions.

The obsolete FreeBSD-specific workaround and version check have been dropped.