### PR TITLE
wallet, rpc: accept an array of txids in removeprunedfunds

### DIFF
--- a/doc/release-notes-29466.md
+++ b/doc/release-notes-29466.md
@@ -1,0 +1,8 @@
+Updated RPCs
+------------
+
+- `removeprunedfunds` now also accepts an array of transaction ids, which are
+  removed from the wallet in a single atomic batch. Passing a single
+  transaction id as a string remains supported. The argument has been renamed
+  from `txid` to `txids`; clients using named arguments need to update the
+  name.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -295,6 +295,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importmempool", 1, "apply_unbroadcast_set" },
     { "importdescriptors", 0, "requests" },
     { "listdescriptors", 0, "private" },
+    { "removeprunedfunds", 0, "txids", ParamFormat::JSON_OR_STRING },
     { "verifychain", 0, "checklevel" },
     { "verifychain", 1, "nblocks" },
     { "getblockstats", 0, "hash_or_height", ParamFormat::JSON_OR_STRING },

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -96,15 +96,25 @@ RPCMethod removeprunedfunds()
 {
     return RPCMethod{
         "removeprunedfunds",
-        "Deletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will affect wallet balances.\n",
+        "Deletes the specified transactions from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will affect wallet balances.\n"
+        "Removal is atomic: if any of the given transactions cannot be removed, none are.\n",
                 {
-                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hex-encoded id of the transaction you are deleting"},
+                    {"txids", RPCArg::Type::ARR, RPCArg::Optional::NO, "The hex-encoded id of the transaction you are deleting, or an array of ids",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "The hex-encoded id of a transaction you are deleting"},
+                        },
+                        RPCArgOptions{
+                            .skip_type_check = true,
+                            .type_str = {"", "string or json array"},
+                        }},
                 },
                 RPCResult{RPCResult::Type::NONE, "", ""},
                 RPCExamples{
                     HelpExampleCli("removeprunedfunds", "\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"") +
+            "\nRemove multiple transactions in one atomic batch\n"
+            + HelpExampleCli("removeprunedfunds", "'[\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\", \"9414f1681fb1255bd168a806254321a837008dd4480c02226063183deb100204\"]'") +
             "\nAs a JSON-RPC call\n"
-            + HelpExampleRpc("removeprunedfunds", "\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"")
+            + HelpExampleRpc("removeprunedfunds", "[\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\", \"9414f1681fb1255bd168a806254321a837008dd4480c02226063183deb100204\"]")
                 },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -113,10 +123,20 @@ RPCMethod removeprunedfunds()
 
     LOCK(pwallet->cs_wallet);
 
-    Txid hash{Txid::FromUint256(ParseHashV(request.params[0], "txid"))};
-    std::vector<Txid> vHash;
-    vHash.push_back(hash);
-    if (auto res = pwallet->RemoveTxs(vHash); !res) {
+    std::vector<Txid> txids;
+    if (request.params[0].isArray()) {
+        const UniValue& txids_univalue{request.params[0].get_array()};
+        if (txids_univalue.empty()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "txids must not be empty");
+        }
+        txids.reserve(txids_univalue.size());
+        for (const UniValue& txid : txids_univalue.getValues()) {
+            txids.push_back(Txid::FromUint256(ParseHashV(txid, "txid")));
+        }
+    } else {
+        txids.push_back(Txid::FromUint256(ParseHashV(request.params[0], "txid")));
+    }
+    if (auto res = pwallet->RemoveTxs(txids); !res) {
         throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(res).original);
     }
 

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -77,6 +77,11 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
         proof3 = self.nodes[0].gettxoutproof([txnid3])
 
+        txnid4 = self.nodes[0].sendtoaddress(address2, 0.0125)
+        self.generate(self.nodes[0], 1)
+        rawtxn4 = self.nodes[0].gettransaction(txnid4)['hex']
+        proof4 = self.nodes[0].gettxoutproof([txnid4])
+
         self.sync_all()
 
         # Import with no affiliated address
@@ -90,7 +95,10 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         wwatch = self.nodes[1].get_wallet_rpc('wwatch')
         wwatch.importdescriptors([{"desc": self.nodes[0].getaddressinfo(address2)["desc"], "timestamp": "now"}])
         wwatch.importprunedfunds(rawtransaction=rawtxn2, txoutproof=proof2)
-        assert txnid2 in [tx['txid'] for tx in wwatch.listtransactions()]
+        wwatch.importprunedfunds(rawtransaction=rawtxn4, txoutproof=proof4)
+        wwatch_txids = [tx['txid'] for tx in wwatch.listtransactions()]
+        assert txnid2 in wwatch_txids
+        assert txnid4 in wwatch_txids
 
         # Import with private key with no rescan
         w1 = self.nodes[1].get_wallet_rpc(self.default_wallet_name)
@@ -112,9 +120,20 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-4, f'Transaction {txnid1} does not belong to this wallet', w1.removeprunedfunds, txnid1)
         assert txnid1 not in [tx['txid'] for tx in w1.listtransactions()]
 
-        wwatch.removeprunedfunds(txnid2)
-        assert txnid2 not in [tx['txid'] for tx in wwatch.listtransactions()]
+        # Removal is atomic: if any txid in the array fails, none are removed
+        assert_raises_rpc_error(-4, f'Transaction {txnid1} does not belong to this wallet', w1.removeprunedfunds, [txnid3, txnid1])
+        assert txnid3 in [tx['txid'] for tx in w1.listtransactions()]
 
+        assert_raises_rpc_error(-8, 'txids must not be empty', w1.removeprunedfunds, [])
+        assert_raises_rpc_error(-8, 'txid must be of length 64', w1.removeprunedfunds, ['beef'])
+
+        # Remove multiple transactions in one call
+        wwatch.removeprunedfunds([txnid2, txnid4])
+        wwatch_txids = [tx['txid'] for tx in wwatch.listtransactions()]
+        assert txnid2 not in wwatch_txids
+        assert txnid4 not in wwatch_txids
+
+        # A single txid passed as a plain string remains supported
         w1.removeprunedfunds(txnid3)
         assert txnid3 not in [tx['txid'] for tx in w1.listtransactions()]
 


### PR DESCRIPTION
Closes #29466.

`removeprunedfunds` only accepted a single txid, but the underlying `CWallet::RemoveTxs` already takes a vector and performs the removal in one atomic db transaction. This PR lets the RPC accept an array of txids so many transactions can be removed in a single wallet db transaction. A single txid string remains supported for backwards compatibility (via `ParamFormat::JSON_OR_STRING` in the bitcoin-cli conversion table, following the `getblockstats` `hash_or_height` precedent).

This adopts and reworks #29468 (by leo-aa88, credited as co-author) and addresses the feedback given there and in #32501:

* **Backwards compatibility** (raised in #29468): a plain string is still accepted, both positionally and as a named argument. The argument is renamed `txid` → `txids`; keeping a `txid` alias is not possible because `rpc_help.py` enforces that arguments named `txid` are plain strings API-wide.
* **Performance justification** (requested in #29468): benchmarked on regtest (macOS 26, arm64, SQLite wallet), removing imported pruned-funds transactions:

  | method | N=250 | N=1000 |
  |---|---|---|
  | individual RPC calls | 0.031s | 0.129s |
  | one JSON-RPC batch of individual calls | 0.011s | 0.048s |
  | one array call (this PR) | 0.001s | 0.005s |

  The JSON-RPC batch row addresses the "just use batch RPC calls" alternative raised in #29468: batching requests removes HTTP overhead, but the server still runs one wallet db txn per call — per the discussion in #29466, wallet db writes cannot be batched by batching RPC requests. The gains grow with wallet size and disk sync cost.
* **Atomicity documented and tested**: `RemoveTxs` runs within one db txn, so if any txid cannot be removed, none are. The functional test covers this (a failing array leaves the other transactions in place), plus empty-array and invalid-hex errors, and the legacy single-string form.

Testing done: `wallet_importprunedfunds.py`, `wallet_resendwallettransactions.py`, and `rpc_help.py` pass locally; all `bitcoin-cli` forms exercised manually (bare string, array of two, named `txids=`, empty array, invalid hex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)