### PR TITLE
script: prevent stale sighash caches across transactions

### DIFF
--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -77,7 +77,6 @@ static void VerifyScriptBench(benchmark::Bench& bench, ScriptType script_type)
     CMutableTransaction txSpend = BuildSpendingTransaction(/*scriptSig=*/{}, /*scriptWitness=*/{}, CTransaction(txCredit));
 
     // Sign spending transaction, precompute transaction data
-    PrecomputedTransactionData txdata;
     {
         const std::map<COutPoint, Coin> coins{
             {txSpend.vin[0].prevout, Coin(txCredit.vout[0], /*nHeightIn=*/100, /*fCoinBaseIn=*/false)}
@@ -87,8 +86,8 @@ static void VerifyScriptBench(benchmark::Bench& bench, ScriptType script_type)
         assert(complete);
         // Weak sanity check on witness data to ensure we produced the intended spending type
         assert(txSpend.vin[0].scriptWitness.stack.size() == ExpectedWitnessStackSize(script_type));
-        txdata.Init(txSpend, /*spent_outputs=*/{txCredit.vout[0]});
     }
+    PrecomputedTransactionData txdata{txSpend, /*spent_outputs=*/{txCredit.vout[0]}};
 
     // Benchmark.
     bench.unit("script").run([&] {

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -627,21 +627,16 @@ btck_PrecomputedTransactionData* btck_precomputed_transaction_data_create(
 {
     try {
         const CTransaction& tx{*btck_Transaction::get(tx_to)};
-        auto txdata{btck_PrecomputedTransactionData::create()};
+        std::vector<CTxOut> spent_outputs;
         if (spent_outputs_ != nullptr && spent_outputs_len > 0) {
             assert(spent_outputs_len == tx.vin.size());
-            std::vector<CTxOut> spent_outputs;
             spent_outputs.reserve(spent_outputs_len);
             for (size_t i = 0; i < spent_outputs_len; i++) {
                 const CTxOut& tx_out{btck_TransactionOutput::get(spent_outputs_[i])};
                 spent_outputs.push_back(tx_out);
             }
-            btck_PrecomputedTransactionData::get(txdata).Init(tx, std::move(spent_outputs));
-        } else {
-            btck_PrecomputedTransactionData::get(txdata).Init(tx, {});
         }
-
-        return txdata;
+        return btck_PrecomputedTransactionData::create(tx, std::move(spent_outputs));
     } catch (...) {
         return nullptr;
     }

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -630,18 +630,14 @@ std::optional<PrecomputedTransactionData> PrecomputePSBTData(const PartiallySign
         return std::nullopt;
     }
     const CMutableTransaction& tx = *unsigned_tx;
-    bool have_all_spent_outputs = true;
     std::vector<CTxOut> utxos;
     for (const PSBTInput& input : psbt.inputs) {
-        if (!input.GetUTXO(utxos.emplace_back())) have_all_spent_outputs = false;
+        if (!input.GetUTXO(utxos.emplace_back())) {
+            utxos.clear();
+            break;
+        }
     }
-    PrecomputedTransactionData txdata;
-    if (have_all_spent_outputs) {
-        txdata.Init(tx, std::move(utxos), true);
-    } else {
-        txdata.Init(tx, {}, true);
-    }
-    return txdata;
+    return PrecomputedTransactionData{tx, std::move(utxos), /*force=*/true};
 }
 
 PSBTError SignPSBTInput(const SigningProvider& provider, PartiallySignedTransaction& psbt, int index, const PrecomputedTransactionData* txdata, const common::PSBTFillOptions& options,  SignatureData* out_sigdata)

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1462,16 +1462,16 @@ void PrecomputedTransactionData::Init(const T& txTo, std::vector<CTxOut>&& spent
 }
 
 template <class T>
-PrecomputedTransactionData::PrecomputedTransactionData(const T& txTo)
+PrecomputedTransactionData::PrecomputedTransactionData(const T& txTo, std::vector<CTxOut>&& spent_outputs, bool force)
 {
-    Init(txTo, {});
+    Init(txTo, std::move(spent_outputs), force);
 }
 
 // explicit instantiation
 template void PrecomputedTransactionData::Init(const CTransaction& txTo, std::vector<CTxOut>&& spent_outputs, bool force);
 template void PrecomputedTransactionData::Init(const CMutableTransaction& txTo, std::vector<CTxOut>&& spent_outputs, bool force);
-template PrecomputedTransactionData::PrecomputedTransactionData(const CTransaction& txTo);
-template PrecomputedTransactionData::PrecomputedTransactionData(const CMutableTransaction& txTo);
+template PrecomputedTransactionData::PrecomputedTransactionData(const CTransaction& txTo, std::vector<CTxOut>&& spent_outputs, bool force);
+template PrecomputedTransactionData::PrecomputedTransactionData(const CMutableTransaction& txTo, std::vector<CTxOut>&& spent_outputs, bool force);
 
 const HashWriter HASHER_TAPSIGHASH{TaggedHash("TapSighash")};
 const HashWriter HASHER_TAPLEAF{TaggedHash("TapLeaf")};

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -182,9 +182,7 @@ struct PrecomputedTransactionData
     //! Whether m_spent_outputs is initialized.
     bool m_spent_outputs_ready = false;
 
-    PrecomputedTransactionData() = default;
-
-    /** Initialize this PrecomputedTransactionData with transaction data.
+    /** Construct this PrecomputedTransactionData with transaction data.
      *
      * @param[in]   tx             The transaction for which data is being precomputed.
      * @param[in]   spent_outputs  The CTxOuts being spent, one for each tx.vin, in order.
@@ -192,10 +190,11 @@ struct PrecomputedTransactionData
      *                             regardless of what is in the inputs (used at signing
      *                             time, when the inputs aren't filled in yet). */
     template <class T>
-    void Init(const T& tx, std::vector<CTxOut>&& spent_outputs, bool force = false);
-
-    template <class T>
     explicit PrecomputedTransactionData(const T& tx, std::vector<CTxOut>&& spent_outputs = {}, bool force = false);
+
+private:
+    template <class T>
+    void Init(const T& tx, std::vector<CTxOut>&& spent_outputs, bool force);
 };
 
 enum class SigVersion

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -195,7 +195,7 @@ struct PrecomputedTransactionData
     void Init(const T& tx, std::vector<CTxOut>&& spent_outputs, bool force = false);
 
     template <class T>
-    explicit PrecomputedTransactionData(const T& tx);
+    explicit PrecomputedTransactionData(const T& tx, std::vector<CTxOut>&& spent_outputs = {}, bool force = false);
 };
 
 enum class SigVersion

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -1029,21 +1029,18 @@ bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, 
     // transaction to avoid rehashing.
     const CTransaction txConst(mtx);
 
-    PrecomputedTransactionData txdata;
     std::vector<CTxOut> spent_outputs;
     for (unsigned int i = 0; i < mtx.vin.size(); ++i) {
         CTxIn& txin = mtx.vin[i];
         auto coin = coins.find(txin.prevout);
         if (coin == coins.end() || coin->second.IsSpent()) {
-            txdata.Init(txConst, /*spent_outputs=*/{}, /*force=*/true);
+            spent_outputs.clear();
             break;
         } else {
             spent_outputs.emplace_back(coin->second.out.nValue, coin->second.out.scriptPubKey);
         }
     }
-    if (spent_outputs.size() == mtx.vin.size()) {
-        txdata.Init(txConst, std::move(spent_outputs), true);
-    }
+    PrecomputedTransactionData txdata{txConst, std::move(spent_outputs), /*force=*/true};
 
     // Sign what we can:
     for (unsigned int i = 0; i < mtx.vin.size(); ++i) {

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -141,8 +141,7 @@ bool CheckSignetBlockSolution(const CBlock& block, const Consensus::Params& cons
     const CScript& scriptSig = signet_txs->m_to_sign.vin[0].scriptSig;
     const CScriptWitness& witness = signet_txs->m_to_sign.vin[0].scriptWitness;
 
-    PrecomputedTransactionData txdata;
-    txdata.Init(signet_txs->m_to_sign, {signet_txs->m_to_spend.vout[0]});
+    PrecomputedTransactionData txdata{signet_txs->m_to_sign, {signet_txs->m_to_spend.vout[0]}};
     TransactionSignatureChecker sigcheck(&signet_txs->m_to_sign, /* nInIn= */ 0, /* amountIn= */ signet_txs->m_to_spend.vout[0].nValue, txdata, MissingDataBehavior::ASSERT_FAIL);
 
     if (!VerifyScript(scriptSig, signet_txs->m_to_spend.vout[0].scriptPubKey, &witness, BLOCK_SCRIPT_VERIFY_FLAGS, sigcheck)) {

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -445,8 +445,7 @@ void DoCheck(std::string prv, std::string pub, const std::string& norm_pub, int 
                     spend.vin[0].nSequence = spender_nsequence;
                     spend.vout.resize(1);
                     std::vector<CTxOut> utxos(1);
-                    PrecomputedTransactionData txdata;
-                    txdata.Init(spend, std::move(utxos), /*force=*/true);
+                    PrecomputedTransactionData txdata{spend, std::move(utxos), /*force=*/true};
                     MutableTransactionSignatureCreator creator{spend, 0, CAmount{0}, &txdata, {.sighash_type = SIGHASH_DEFAULT}};
                     SignatureData sigdata;
                     // We assume there is no collision between the hashes (eg h1=SHA256(SHA256(x)) and h2=SHA256(x))

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -159,8 +159,7 @@ void Test(const std::string& str)
     if (test.exists("success")) {
         tx.vin[idx].scriptSig = ScriptFromHex(test["success"]["scriptSig"].get_str());
         tx.vin[idx].scriptWitness = ScriptWitnessFromJSON(test["success"]["witness"]);
-        PrecomputedTransactionData txdata;
-        txdata.Init(tx, std::vector<CTxOut>(prevouts));
+        PrecomputedTransactionData txdata{tx, std::vector<CTxOut>(prevouts)};
         MutableTransactionSignatureChecker txcheck(&tx, idx, prevouts[idx].nValue, txdata, MissingDataBehavior::ASSERT_FAIL);
         for (const auto flags : ALL_FLAGS) {
             // "final": true tests are valid for all flags. Others are only valid with flags that are
@@ -174,8 +173,7 @@ void Test(const std::string& str)
     if (test.exists("failure")) {
         tx.vin[idx].scriptSig = ScriptFromHex(test["failure"]["scriptSig"].get_str());
         tx.vin[idx].scriptWitness = ScriptWitnessFromJSON(test["failure"]["witness"]);
-        PrecomputedTransactionData txdata;
-        txdata.Init(tx, std::vector<CTxOut>(prevouts));
+        PrecomputedTransactionData txdata{tx, std::vector<CTxOut>(prevouts)};
         MutableTransactionSignatureChecker txcheck(&tx, idx, prevouts[idx].nValue, txdata, MissingDataBehavior::ASSERT_FAIL);
         for (const auto flags : ALL_FLAGS) {
             // If a test is supposed to fail with test_flags, it should also fail with any superset thereof.

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -51,8 +51,7 @@ FUZZ_TARGET(script_flags)
             }
             spent_outputs.push_back(prevout);
         }
-        PrecomputedTransactionData txdata;
-        txdata.Init(tx, std::move(spent_outputs));
+        PrecomputedTransactionData txdata{tx, std::move(spent_outputs)};
 
         for (unsigned i = 0; i < tx.vin.size(); ++i) {
             const CTxOut& prevout = txdata.m_spent_outputs.at(i);

--- a/src/test/fuzz/script_sigcache.cpp
+++ b/src/test/fuzz/script_sigcache.cpp
@@ -36,7 +36,8 @@ FUZZ_TARGET(script_sigcache, .init = initialize_script_sigcache)
     const unsigned int n_in = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
     const CAmount amount = ConsumeMoney(fuzzed_data_provider);
     const bool store = fuzzed_data_provider.ConsumeBool();
-    PrecomputedTransactionData tx_data;
+    // The exercised checker paths never read txdata, so keep its construction free of per-iteration hashing.
+    PrecomputedTransactionData tx_data{CMutableTransaction{}};
     CachingTransactionSignatureChecker caching_transaction_signature_checker{mutable_transaction ? &tx : nullptr, n_in, amount, store, signature_cache, tx_data};
     if (fuzzed_data_provider.ConsumeBool()) {
         const auto random_bytes = fuzzed_data_provider.ConsumeBytes<unsigned char>(64);

--- a/src/test/script_assets_tests.cpp
+++ b/src/test/script_assets_tests.cpp
@@ -114,8 +114,7 @@ static void AssetTest(const UniValue& test, SignatureCache& signature_cache)
         mtx.vin[idx].scriptSig = ScriptFromHex(test["success"]["scriptSig"].get_str());
         mtx.vin[idx].scriptWitness = ScriptWitnessFromJSON(test["success"]["witness"]);
         CTransaction tx(mtx);
-        PrecomputedTransactionData txdata;
-        txdata.Init(tx, std::vector<CTxOut>(prevouts));
+        PrecomputedTransactionData txdata{tx, std::vector<CTxOut>(prevouts)};
         CachingTransactionSignatureChecker txcheck(&tx, idx, prevouts[idx].nValue, true, signature_cache, txdata);
 
         for (const auto flags : ALL_CONSENSUS_FLAGS) {
@@ -132,8 +131,7 @@ static void AssetTest(const UniValue& test, SignatureCache& signature_cache)
         mtx.vin[idx].scriptSig = ScriptFromHex(test["failure"]["scriptSig"].get_str());
         mtx.vin[idx].scriptWitness = ScriptWitnessFromJSON(test["failure"]["witness"]);
         CTransaction tx(mtx);
-        PrecomputedTransactionData txdata;
-        txdata.Init(tx, std::vector<CTxOut>(prevouts));
+        PrecomputedTransactionData txdata{tx, std::vector<CTxOut>(prevouts)};
         CachingTransactionSignatureChecker txcheck(&tx, idx, prevouts[idx].nValue, true, signature_cache, txdata);
 
         for (const auto flags : ALL_CONSENSUS_FLAGS) {

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1648,8 +1648,7 @@ BOOST_AUTO_TEST_CASE(bip341_keypath_test_vectors)
             utxos.emplace_back(amount, script);
         }
 
-        PrecomputedTransactionData txdata;
-        txdata.Init(tx, std::vector<CTxOut>{utxos}, true);
+        PrecomputedTransactionData txdata{tx, std::vector<CTxOut>{utxos}, /*force=*/true};
 
         BOOST_CHECK(txdata.m_bip341_taproot_ready);
         BOOST_CHECK_EQUAL(HexStr(txdata.m_spent_amounts_single_hash), vec["intermediary"]["hashAmounts"].get_str());

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -15,13 +15,13 @@
 #include <test/util/json.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <univalue.h>
 #include <util/strencodings.h>
-
-#include <iostream>
 
 #include <boost/test/unit_test.hpp>
 
-#include <univalue.h>
+#include <iostream>
+#include <type_traits>
 
 // Old script.cpp SignatureHash function
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
@@ -295,6 +295,33 @@ BOOST_AUTO_TEST_CASE(sighash_caching)
             BOOST_CHECK(cache.Load(hash_type, scriptcode, dummy) || expect_one);
         }
     }
+}
+
+static_assert(!std::is_default_constructible_v<PrecomputedTransactionData>);
+
+BOOST_AUTO_TEST_CASE(precomputed_transaction_data_constructor)
+{
+    CMutableTransaction tx;
+    tx.vin.emplace_back(Txid::FromUint256(uint256::ONE), 0);
+    tx.vout.emplace_back(1, CScript{} << OP_TRUE);
+
+    auto check_ready{[](const PrecomputedTransactionData& txdata, bool bip143, bool bip341, bool spent_outputs) {
+        BOOST_CHECK_EQUAL(txdata.m_bip143_segwit_ready, bip143);
+        BOOST_CHECK_EQUAL(txdata.m_bip341_taproot_ready, bip341);
+        BOOST_CHECK_EQUAL(txdata.m_spent_outputs_ready, spent_outputs);
+    }};
+
+    PrecomputedTransactionData txdata_defaults{tx};
+    check_ready(txdata_defaults, /*bip143=*/false, /*bip341=*/false, /*spent_outputs=*/false);
+
+    PrecomputedTransactionData txdata_forced{tx, /*spent_outputs=*/{}, /*force=*/true};
+    check_ready(txdata_forced, /*bip143=*/true, /*bip341=*/false, /*spent_outputs=*/false);
+
+    PrecomputedTransactionData txdata_with_spent_outputs{tx, /*spent_outputs=*/{CTxOut{3, CScript{} << OP_TRUE}}};
+    check_ready(txdata_with_spent_outputs, /*bip143=*/false, /*bip341=*/false, /*spent_outputs=*/true);
+
+    PrecomputedTransactionData txdata_forced_with_spent_outputs{tx, /*spent_outputs=*/{CTxOut{3, CScript{} << OP_TRUE}}, /*force=*/true};
+    check_ready(txdata_forced_with_spent_outputs, /*bip143=*/true, /*bip341=*/true, /*spent_outputs=*/true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -15,6 +15,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <optional>
+
 struct Dersig100Setup : public TestChain100Setup {
     Dersig100Setup()
         : TestChain100Setup{ChainType::REGTEST, {.extra_args = {"-testactivationheight=dersig@102"}}} {}
@@ -22,7 +24,7 @@ struct Dersig100Setup : public TestChain100Setup {
 
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
-                       bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
+                       bool cacheFullScriptStore, std::optional<PrecomputedTransactionData>& txdata,
                        ValidationCache& validation_cache,
                        std::vector<CScriptCheck>* pvChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -122,7 +124,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
 // any script flag that is implemented as an upgraded NOP code.
 static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify_flags failing_flags, bool add_to_cache, CCoinsViewCache& active_coins_tip, ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
-    PrecomputedTransactionData txdata;
+    std::optional<PrecomputedTransactionData> txdata;
 
     FastRandomContext insecure_rand(true);
 
@@ -214,7 +216,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         LOCK(cs_main);
 
         TxValidationState state;
-        PrecomputedTransactionData ptd_spend_tx;
+        std::optional<PrecomputedTransactionData> ptd_spend_tx;
 
         BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, nullptr));
 
@@ -283,7 +285,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         // Make it valid, and check again
         invalid_with_cltv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
         TxValidationState state;
-        PrecomputedTransactionData txdata;
+        std::optional<PrecomputedTransactionData> txdata;
         BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_cltv_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
     }
 
@@ -311,7 +313,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         // Make it valid, and check again
         invalid_with_csv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
         TxValidationState state;
-        PrecomputedTransactionData txdata;
+        std::optional<PrecomputedTransactionData> txdata;
         BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_csv_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
     }
 
@@ -372,7 +374,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         tx.vin[1].scriptWitness.SetNull();
 
         TxValidationState state;
-        PrecomputedTransactionData txdata;
+        std::optional<PrecomputedTransactionData> txdata;
         // This transaction is now invalid under segwit, because of the second input.
         BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -148,10 +148,10 @@ const CBlockIndex* Chainstate::FindForkInGlobalIndex(const CBlockLocator& locato
 
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
-                       bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
+                       bool cacheFullScriptStore, std::optional<PrecomputedTransactionData>& txdata,
                        ValidationCache& validation_cache,
                        std::vector<CScriptCheck>* pvChecks = nullptr)
-                       EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool CheckFinalTxAtTip(const CBlockIndex& active_chain_tip, const CTransaction& tx)
 {
@@ -402,10 +402,10 @@ void Chainstate::MaybeUpdateMempoolForReorg(
 * transaction again during block validation.
 * */
 static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationState& state,
-                const CCoinsViewCache& view, const CTxMemPool& pool,
-                script_verify_flags flags, PrecomputedTransactionData& txdata, CCoinsViewCache& coins_tip,
-                ValidationCache& validation_cache)
-                EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
+                                           const CCoinsViewCache& view, const CTxMemPool& pool,
+                                           script_verify_flags flags, std::optional<PrecomputedTransactionData>& txdata, CCoinsViewCache& coins_tip,
+                                           ValidationCache& validation_cache)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(pool.cs);
@@ -667,7 +667,7 @@ private:
         TxValidationState m_state;
         /** A temporary cache containing serialized transaction data for signature verification.
          * Reused across PolicyScriptChecks and ConsensusScriptChecks. */
-        PrecomputedTransactionData m_precomputed_txdata;
+        std::optional<PrecomputedTransactionData> m_precomputed_txdata;
     };
 
     // Run the policy checks on a given transaction, excluding any script checks.
@@ -2072,7 +2072,7 @@ ValidationCache::ValidationCache(const size_t script_execution_cache_bytes, cons
  */
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
-                       bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
+                       bool cacheFullScriptStore, std::optional<PrecomputedTransactionData>& txdata,
                        ValidationCache& validation_cache,
                        std::vector<CScriptCheck>* pvChecks)
 {
@@ -2095,7 +2095,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         return true;
     }
 
-    if (!txdata.m_spent_outputs_ready) {
+    if (!txdata) {
         std::vector<CTxOut> spent_outputs;
         spent_outputs.reserve(tx.vin.size());
 
@@ -2105,9 +2105,9 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
             assert(!coin.IsSpent());
             spent_outputs.emplace_back(coin.out);
         }
-        txdata.Init(tx, std::move(spent_outputs));
+        txdata.emplace(tx, std::move(spent_outputs));
     }
-    assert(txdata.m_spent_outputs.size() == tx.vin.size());
+    assert(txdata->m_spent_outputs.size() == tx.vin.size());
 
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
 
@@ -2118,7 +2118,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         // spent being checked as a part of CScriptCheck.
 
         // Verify signature
-        CScriptCheck check(txdata.m_spent_outputs[i], tx, validation_cache.m_signature_cache, i, flags, cacheSigStore, &txdata);
+        CScriptCheck check(txdata->m_spent_outputs[i], tx, validation_cache.m_signature_cache, i, flags, cacheSigStore, &*txdata);
         if (pvChecks) {
             pvChecks->emplace_back(std::move(check));
         } else if (auto result = check(); result.has_value()) {
@@ -2520,10 +2520,11 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     // Precomputed transaction data pointers must not be invalidated
     // until after `control` has run the script checks (potentially
-    // in multiple threads). Preallocate the vector size so a new allocation
+    // in multiple threads). Preallocate the vector when checks can run so emplacing txdata
     // doesn't invalidate pointers into the vector, and keep txsdata in scope
     // for as long as `control`.
-    std::vector<PrecomputedTransactionData> txsdata(block.vtx.size());
+    std::vector<std::optional<PrecomputedTransactionData>> txsdata(fScriptChecks ? block.vtx.size() : 0);
+
     std::optional<CCheckQueueControl<CScriptCheck>> control;
     if (auto& queue = m_chainman.GetCheckQueue(); queue.HasThreads() && fScriptChecks) control.emplace(queue);
 

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -210,8 +210,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     }
 
     // Figure out if we need to compute the input weight, and do so if necessary
-    PrecomputedTransactionData txdata;
-    txdata.Init(*tx, std::move(spent_outputs), /* force=*/ true);
+    PrecomputedTransactionData txdata{*tx, std::move(spent_outputs), /*force=*/true};
     for (unsigned int i = 0; i < tx->vin.size(); ++i) {
         const CTxIn& txin = tx->vin.at(i);
         const Coin& coin = coins.at(txin.prevout);


### PR DESCRIPTION
**Problem:** `PrecomputedTransactionData` could be default-constructed and filled later with `Init()`.
That allowed an object to exist without transaction-specific data and left a public reuse path that was easy to get wrong.
The old `Init()` guard only checked [`m_spent_outputs_ready`](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/script/interpreter.cpp#L1415), which remained false after forced initialization without spent outputs even though `force=true` cached the BIP143 prevout, sequence, and output hashes for witness-v0 sighash.

**Fix:** Remove default construction and public `Init()` so each `PrecomputedTransactionData` object is built for one transaction.
Callers that already have the transaction and optional spent outputs construct it directly.
Validation stores txdata in `std::optional` and emplaces it only after a script-cache miss, keeping precomputation lazy.
`ConnectBlock()` also leaves txdata storage empty when assumevalid skips script checks, covering #35663.
