### PR TITLE
wallet: validate descriptor cache xpub length before decoding

### DIFF
--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -2,11 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include <wallet/test/util.h>
-#include <wallet/wallet.h>
+#include <script/descriptor.h>
 #include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
+#include <wallet/test/util.h>
+#include <wallet/wallet.h>
+#include <wallet/walletdb.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -90,6 +92,47 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_descriptors, TestingSetup)
         BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB(_error, _warnings), DBErrors::CORRUPT);
         BOOST_CHECK(found); // The error must be logged
     }
+}
+
+BOOST_FIXTURE_TEST_CASE(wallet_load_descriptor_bad_cache, TestingSetup)
+{
+    // A descriptor cache record whose serialized extended public key is not
+    // BIP32_EXTKEY_SIZE bytes long must be reported as corruption. Otherwise
+    // CExtPubKey::Decode() reads a fixed 74 bytes off the end of the shorter
+    // deserialized buffer.
+    bilingual_str error;
+    std::vector<bilingual_str> warnings;
+    std::unique_ptr<WalletDatabase> database = CreateMockableWalletDatabase();
+
+    // Parse a ranged descriptor so a parent-xpub cache record is expected on load.
+    const std::string desc_str = "wpkh([d34db33f/84h/0h/0h]xpub6DJ2dNUysrn5Vt36jH2KLBT2i1auw1tTSSomg8PhqNiUtx8QX2SvC9nrHu81fT41fvDUnhMjEzQgXnQjKEu3oaqMSzhSrHMxyyoEAmUHQbY/0/*)#cjjspncu";
+    FlatSigningProvider keys;
+    std::string parse_error;
+    auto parsed = Parse(desc_str, keys, parse_error, /*require_checksum=*/false);
+    BOOST_REQUIRE(!parsed.empty());
+    WalletDescriptor wallet_descriptor(std::move(parsed.at(0)), /*creation_time=*/0, /*range_start=*/0, /*range_end=*/1, /*next_index=*/0);
+    const uint256 desc_id = wallet_descriptor.id;
+
+    {
+        WalletBatch batch(*database);
+        BOOST_CHECK(batch.WriteDescriptor(desc_id, wallet_descriptor));
+    }
+    {
+        // Write a parent-cache record whose value is a truncated xpub.
+        std::unique_ptr<DatabaseBatch> batch = database->MakeBatch();
+        const std::vector<unsigned char> truncated_xpub(BIP32_EXTKEY_SIZE - 1, 0);
+        BOOST_CHECK(batch->Write(std::make_pair(std::make_pair(std::string{"walletdescriptorcache"}, desc_id), uint32_t{0}), truncated_xpub));
+    }
+
+    bool found = false;
+    DebugLogHelper log_helper("descriptor cache xpub has an unexpected length", [&](const std::string* s) {
+        found = true;
+        return false;
+    });
+
+    const std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", std::move(database)));
+    BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB(error, warnings), DBErrors::CORRUPT);
+    BOOST_CHECK(found);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -801,6 +801,10 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
 
             std::vector<unsigned char> ser_xpub(BIP32_EXTKEY_SIZE);
             value >> ser_xpub;
+            if (ser_xpub.size() != BIP32_EXTKEY_SIZE) {
+                err = "Error reading wallet database: descriptor cache xpub has an unexpected length";
+                return DBErrors::CORRUPT;
+            }
             CExtPubKey xpub;
             xpub.Decode(ser_xpub.data());
             if (parent) {
@@ -824,6 +828,10 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
 
             std::vector<unsigned char> ser_xpub(BIP32_EXTKEY_SIZE);
             value >> ser_xpub;
+            if (ser_xpub.size() != BIP32_EXTKEY_SIZE) {
+                err = "Error reading wallet database: descriptor cache xpub has an unexpected length";
+                return DBErrors::CORRUPT;
+            }
             CExtPubKey xpub;
             xpub.Decode(ser_xpub.data());
             cache.CacheLastHardenedExtPubKey(key_exp_index, xpub);


### PR DESCRIPTION
guard both descriptor-cache loaders in LoadDescriptorWalletRecords so a wallet record whose serialized xpub is shorter than BIP32_EXTKEY_SIZE is rejected as corrupt instead of having CExtPubKey::Decode read a fixed 74 bytes past the end of the deserialized buffer, matching the length check key_io already does before Decode.