### PR TITLE
util: Abort in CheckDiskSpace/FlatFileSeq::Open on rare exceptions

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -846,6 +846,7 @@ std::string HelpMessageOpt(std::string_view option, std::string_view help_param,
 
 const std::vector<std::string> TEST_OPTIONS_DOC{
     "addrman (use deterministic addrman)",
+    "blockfilterindex_small_chunks (use smaller block filter index file chunks)",
     "reindex_after_failure_noninteractive_yes (When asked for a reindex after failure interactively, simulate as-if answered with 'yes')",
     "bip94 (enforce BIP94 consensus rules)",
 };

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -10,6 +10,8 @@
 #include <util/log.h>
 #include <util/overflow.h>
 
+#include <cstdlib>
+#include <iostream>
 #include <stdexcept>
 
 FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
@@ -38,7 +40,14 @@ FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool read_only) const
         return nullptr;
     }
     fs::path path = FileName(pos);
-    fs::create_directories(path.parent_path());
+    std::error_code ec;
+    fs::create_directories(path.parent_path(), ec);
+    if (ec) {
+        const auto msg{tfm::format("Unable to create directory %s: %s", fs::PathToString(path.parent_path()), ec.message())};
+        std::cerr << msg << std::endl;
+        LogError("%s", msg);
+        std::abort();
+    }
     FILE* file = fsbridge::fopen(path, read_only ? "rb": "rb+");
     if (!file && !read_only)
         file = fsbridge::fopen(path, "wb+");

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -94,7 +94,8 @@ BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, Blo
     fs::create_directories(path);
 
     m_db = std::make_unique<BaseIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
-    m_filter_fileseq = std::make_unique<FlatFileSeq>(std::move(path), "fltr", FLTR_FILE_CHUNK_SIZE);
+    const uint32_t chunk_size{HasTestOption(gArgs, "blockfilterindex_small_chunks") ? 1024  : FLTR_FILE_CHUNK_SIZE};
+    m_filter_fileseq = std::make_unique<FlatFileSeq>(std::move(path), "fltr", chunk_size);
 }
 
 interfaces::Chain::NotifyOptions BlockFilterIndex::CustomOptions()

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -6,6 +6,7 @@
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <util/fs_helpers.h>
+
 #include <random.h>
 #include <sync.h>
 #include <tinyformat.h>
@@ -16,7 +17,9 @@
 #include <util/syserror.h>
 
 #include <cerrno>
+#include <cstdlib>
 #include <fstream>
+#include <iostream>
 #include <limits>
 #include <map>
 #include <memory>
@@ -94,7 +97,14 @@ bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
 {
     constexpr uint64_t min_disk_space{50_MiB};
 
-    uint64_t free_bytes_available = fs::space(dir).available;
+    std::error_code ec;
+    const uint64_t free_bytes_available = fs::space(dir, ec).available;
+    if (ec) {
+        const auto msg{tfm::format("Unable to query disk space for %s: %s", fs::PathToString(dir), ec.message())};
+        std::cerr << msg << std::endl;
+        LogError("%s", msg);
+        std::abort();
+    }
     return free_bytes_available >= min_disk_space + additional_bytes;
 }
 

--- a/test/functional/feature_io_errors.py
+++ b/test/functional/feature_io_errors.py
@@ -47,7 +47,7 @@ class BlockstoreIOErrorTest(BitcoinTestFramework):
 
         with (
             simulate_io_error(node.blocks_path),
-            node.assert_debug_log(["EXCEPTION: "]),
+            node.assert_debug_log(["Unable to query disk space"]),
         ):
             self.log.info("Mock scheduler to run disk space check")
             try:
@@ -58,7 +58,7 @@ class BlockstoreIOErrorTest(BitcoinTestFramework):
             node.wait_until_stopped(
                 expect_error=True,
                 expected_ret_code=-6,
-                expected_stderr=re.compile(".*EXCEPTION: .*"),
+                expected_stderr=re.compile("Unable to query disk space.*"),
             )
 
     def test_blockfilterindex_allocation_failure(self):
@@ -81,7 +81,7 @@ class BlockstoreIOErrorTest(BitcoinTestFramework):
 
         with (
             simulate_io_error(index_path),
-            node.assert_debug_log(["EXCEPTION: "]),
+            node.assert_debug_log(["Unable to query disk space"]),
         ):
             try:
                 self.generate(node, 1)
@@ -91,7 +91,7 @@ class BlockstoreIOErrorTest(BitcoinTestFramework):
             node.wait_until_stopped(
                 expect_error=True,
                 expected_ret_code=-6,
-                expected_stderr=re.compile(".*EXCEPTION: .*"),
+                expected_stderr=re.compile("Unable to query disk space.*"),
             )
 
     def test_block_file_out_of_space_error(self):
@@ -105,7 +105,7 @@ class BlockstoreIOErrorTest(BitcoinTestFramework):
 
         with (
             simulate_io_error(node.blocks_path),
-            node.assert_debug_log(["System error while saving block"]),
+            node.assert_debug_log(["Unable to query disk space"]),
         ):
             try:
                 self.generateblock(
@@ -116,10 +116,8 @@ class BlockstoreIOErrorTest(BitcoinTestFramework):
 
             node.wait_until_stopped(
                 expect_error=True,
-                expected_stderr=re.compile(
-                    r"Error: A fatal internal error occurred, see debug.log for details: "
-                    r"System error while saving block to disk: .*"
-                ),
+                expected_ret_code=-6,
+                expected_stderr=re.compile("Unable to query disk space.*"),
             )
 
     def run_test(self):

--- a/test/functional/feature_io_errors.py
+++ b/test/functional/feature_io_errors.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+"""Test handling of I/O errors."""
+
+import contextlib
+import os
+import re
+import stat
+
+from test_framework.test_framework import (
+    BitcoinTestFramework,
+    SkipTest,
+)
+
+
+@contextlib.contextmanager
+def simulate_io_error(target_path):
+    # Make files under target_path inaccessible.
+    # Simulating a detached volume or permission change.
+    backup = target_path.with_name(target_path.name + "_bak")
+    parent_dir = target_path.parent
+    old_mode = stat.S_IMODE(os.stat(parent_dir).st_mode)
+
+    os.rename(target_path, backup)
+    os.chmod(parent_dir, 0o500)  # Prevent dir re-creation
+    try:
+        yield
+    finally:
+        os.chmod(parent_dir, old_mode)
+        os.rename(backup, target_path)
+
+
+class BlockstoreIOErrorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_platform_not_posix()
+        if os.geteuid() == 0:
+            raise SkipTest("Unable to enforce dir permissions")
+
+    def test_scheduler_thread_disk_space_check(self):
+        node = self.nodes[0]
+
+        with (
+            simulate_io_error(node.blocks_path),
+            node.assert_debug_log(["EXCEPTION: "]),
+        ):
+            self.log.info("Mock scheduler to run disk space check")
+            try:
+                node.mockscheduler(5 * 60)
+            except Exception:
+                pass  # Node may shut down
+
+            node.wait_until_stopped(
+                expect_error=True,
+                expected_ret_code=-6,
+                expected_stderr=re.compile(".*EXCEPTION: .*"),
+            )
+
+    def test_blockfilterindex_allocation_failure(self):
+        node = self.nodes[0]
+        self.restart_node(
+            0,
+            [
+                "-test=blockfilterindex_small_chunks",
+                "-blockfilterindex",
+            ],
+        )
+
+        self.wait_until(
+            lambda: node.getindexinfo()["basic block filter index"]["synced"]
+        )
+        index_path = node.chain_path / "indexes" / "blockfilter" / "basic"
+        self.generate(node, 26)  # fill first chunk of the index file
+
+        self.log.info("Generate block to allocate next chunk in blockfilterindex file")
+
+        with (
+            simulate_io_error(index_path),
+            node.assert_debug_log(["EXCEPTION: "]),
+        ):
+            try:
+                self.generate(node, 1)
+            except Exception:
+                pass  # Node may shut down
+
+            node.wait_until_stopped(
+                expect_error=True,
+                expected_ret_code=-6,
+                expected_stderr=re.compile(".*EXCEPTION: .*"),
+            )
+
+    def test_block_file_out_of_space_error(self):
+        node = self.nodes[0]
+        self.restart_node(0, ["-fastprune"])
+
+        self.log.info("Generate block big enough to allocate next chunk in block file")
+        fastprune_chunk_size = 0x4000
+        opreturn = "6a"
+        nulldata = fastprune_chunk_size * "ff"
+
+        with (
+            simulate_io_error(node.blocks_path),
+            node.assert_debug_log(["System error while saving block"]),
+        ):
+            try:
+                self.generateblock(
+                    node, output=f"raw({opreturn}{nulldata})", transactions=[]
+                )
+            except Exception:
+                pass  # Node may shut down
+
+            node.wait_until_stopped(
+                expect_error=True,
+                expected_stderr=re.compile(
+                    r"Error: A fatal internal error occurred, see debug.log for details: "
+                    r"System error while saving block to disk: .*"
+                ),
+            )
+
+    def run_test(self):
+        self.test_scheduler_thread_disk_space_check()
+        self.test_blockfilterindex_allocation_failure()
+        self.test_block_file_out_of_space_error()
+
+
+if __name__ == "__main__":
+    BlockstoreIOErrorTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -190,6 +190,7 @@ BASE_SCRIPTS = [
     'wallet_txn_clone.py',
     'wallet_txn_clone.py --segwit',
     'rpc_getchaintips.py',
+    'feature_io_errors.py',
     'rpc_misc.py',
     'p2p_1p1c_network.py',
     'interface_rest.py',


### PR DESCRIPTION
Currently, exceptions from `CheckDiskSpace` calls in the scheduler thread (e.g. from events for `blockfilterindex` or the scheduled disk space check) are not caught, leading to a program termination:

```
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot get free space: No such file or directory [/tmp/bitcoin_func_test_1xy14g2w/node0/regtest/indexes/blockfilter/basic] 
```

Immediate termination is fine, because those exceptions are unexpected, but it could make sense to be consistent and treat all paths equally and abort the program.

Aborting the program here is fine, because the exceptions happen so rarely, that they are similar in frequency to other unclean shutdown reasons. The exceptions basically can only happen when the user unplugs the external USB drive, but this sounds as likely as an OOM kill (or other kill of the program), which also results in an abort.