### PR TITLE
wallet: fix only default RBF to true when unset

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -228,7 +228,7 @@ static void SetFeeEstimateMode(const CWallet& wallet, CCoinControl& cc, const Un
         cc.m_feerate = CFeeRate{AmountFromValue(fee_rate, /*decimals=*/3)};
         if (override_min_fee) cc.fOverrideFeeRate = true;
         // Default RBF to true for explicit fee_rate, if unset.
-        if (!cc.m_signal_bip125_rbf) cc.m_signal_bip125_rbf = true;
+        if (!cc.m_signal_bip125_rbf.has_value()) cc.m_signal_bip125_rbf = true;
         return;
     }
     if (!estimate_mode.isNull() && !FeeModeFromString(estimate_mode.get_str(), cc.m_fee_mode)) {


### PR DESCRIPTION
In `SetFeeEstimateMode()`, `m_signal_bip125_rbf` should only be set to the default value (`true`) when it is unset.

Currently, the code uses `!m_signal_bip125_rbf`, which evaluates to `true` both when the `std::optional` is `unset` and when it contains `false`. As a result, an explicitly set `false` is incorrectly overwritten with `true`.

Fix this by checking `has_value()` instead, so only the `unset` case receives the default value.

For extra context see the PR where it was detected https://github.com/bitcoin/bitcoin/pull/35433#discussion_r3537193890