### PR TITLE
private broadcast: define and use new RPC_LIMIT_EXCEEDED error code ( + other follow-ups)

### DIFF
--- a/src/private_broadcast.cpp
+++ b/src/private_broadcast.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 
 
-[[nodiscard]] PrivateBroadcast::AddResult PrivateBroadcast::Add(const CTransactionRef& tx)
+PrivateBroadcast::AddResult PrivateBroadcast::Add(const CTransactionRef& tx)
     EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
 {
     LOCK(m_mutex);

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -72,6 +72,7 @@ enum RPCErrorCode
     RPC_VERIFY_ALREADY_IN_UTXO_SET  = -27, //!< Transaction already in utxo set
     RPC_IN_WARMUP                   = -28, //!< Client still warming up
     RPC_METHOD_DEPRECATED           = -32, //!< RPC method is deprecated
+    RPC_LIMIT_EXCEEDED              = -37, //!< A bounded resource is currently at capacity
 
     //! Aliases for backward compatibility
     RPC_TRANSACTION_ERROR           = RPC_VERIFY_ERROR,

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -396,7 +396,7 @@ RPCErrorCode RPCErrorFromTransactionError(TransactionError terr)
         case TransactionError::ALREADY_IN_UTXO_SET:
             return RPC_VERIFY_ALREADY_IN_UTXO_SET;
         case TransactionError::PRIVATE_BROADCAST_FULL:
-            return RPC_OUT_OF_MEMORY;
+            return RPC_LIMIT_EXCEEDED;
         default: break;
     }
     return RPC_TRANSACTION_ERROR;

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -9,7 +9,18 @@
 #include <util/time.h>
 
 #include <algorithm>
+#include <ostream>
 #include <boost/test/unit_test.hpp>
+
+std::ostream& operator<<(std::ostream& os, PrivateBroadcast::AddResult r)
+{
+    switch (r) {
+    case PrivateBroadcast::AddResult::Added: return os << "Added";
+    case PrivateBroadcast::AddResult::AlreadyPresent: return os << "AlreadyPresent";
+    case PrivateBroadcast::AddResult::QueueFull: return os << "QueueFull";
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
 
 BOOST_FIXTURE_TEST_SUITE(private_broadcast_tests, BasicTestingSetup)
 
@@ -44,15 +55,15 @@ BOOST_AUTO_TEST_CASE(basic)
     // Make a transaction and add it.
     const auto tx1{MakeDummyTx(/*id=*/1, /*num_witness=*/0)};
 
-    BOOST_CHECK(pb.Add(tx1) == PrivateBroadcast::AddResult::Added);
-    BOOST_CHECK(pb.Add(tx1) == PrivateBroadcast::AddResult::AlreadyPresent);
+    BOOST_CHECK_EQUAL(pb.Add(tx1), PrivateBroadcast::AddResult::Added);
+    BOOST_CHECK_EQUAL(pb.Add(tx1), PrivateBroadcast::AddResult::AlreadyPresent);
 
     // Make another transaction with same txid, different wtxid and add it.
     const auto tx2{MakeDummyTx(/*id=*/1, /*num_witness=*/1)};
     BOOST_REQUIRE(tx1->GetHash() == tx2->GetHash());
     BOOST_REQUIRE(tx1->GetWitnessHash() != tx2->GetWitnessHash());
 
-    BOOST_CHECK(pb.Add(tx2) == PrivateBroadcast::AddResult::Added);
+    BOOST_CHECK_EQUAL(pb.Add(tx2), PrivateBroadcast::AddResult::Added);
     const auto find_tx_info{[](auto& infos, const CTransactionRef& tx) -> const PrivateBroadcast::TxBroadcastInfo& {
         const auto it{std::ranges::find(infos, tx->GetWitnessHash(), [](const auto& info) { return info.tx->GetWitnessHash(); })};
         BOOST_REQUIRE(it != infos.end());
@@ -146,7 +157,7 @@ BOOST_AUTO_TEST_CASE(stale_unpicked_tx)
 
     PrivateBroadcast pb;
     const auto tx{MakeDummyTx(/*id=*/42, /*num_witness=*/0)};
-    BOOST_REQUIRE(pb.Add(tx) == PrivateBroadcast::AddResult::Added);
+    BOOST_REQUIRE_EQUAL(pb.Add(tx), PrivateBroadcast::AddResult::Added);
 
     // Unpicked transactions use the longer INITIAL_STALE_DURATION.
     BOOST_CHECK_EQUAL(pb.GetStale().size(), 0);
@@ -169,7 +180,7 @@ BOOST_AUTO_TEST_CASE(rejection_at_cap)
     txs.reserve(num_cap);
     for (size_t i{0}; i < num_cap; ++i) {
         auto tx{MakeDummyTx(/*id=*/static_cast<uint32_t>(i), /*num_witness=*/0)};
-        BOOST_REQUIRE(pb.Add(tx) == PrivateBroadcast::AddResult::Added);
+        BOOST_REQUIRE_EQUAL(pb.Add(tx), PrivateBroadcast::AddResult::Added);
         txs.push_back(std::move(tx));
     }
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), num_cap);
@@ -177,7 +188,7 @@ BOOST_AUTO_TEST_CASE(rejection_at_cap)
     // Further distinct transactions are rejected, and the queue is unchanged.
     for (size_t i{0}; i < num_over; ++i) {
         const auto tx{MakeDummyTx(/*id=*/static_cast<uint32_t>(num_cap + i), /*num_witness=*/0)};
-        BOOST_CHECK(pb.Add(tx) == PrivateBroadcast::AddResult::QueueFull);
+        BOOST_CHECK_EQUAL(pb.Add(tx), PrivateBroadcast::AddResult::QueueFull);
     }
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), num_cap);
 
@@ -194,19 +205,19 @@ BOOST_AUTO_TEST_CASE(rejection_at_cap)
     }
 
     // Re-adding an already-present tx is AlreadyPresent even at the cap (not QueueFull).
-    BOOST_CHECK(pb.Add(txs[0]) == PrivateBroadcast::AddResult::AlreadyPresent);
+    BOOST_CHECK_EQUAL(pb.Add(txs[0]), PrivateBroadcast::AddResult::AlreadyPresent);
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), num_cap);
 
     // Removing one frees exactly one slot for a new transaction.
     BOOST_REQUIRE(pb.Remove(txs[0]).has_value());
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), num_cap - 1);
     const auto fresh{MakeDummyTx(/*id=*/0xffffffff, /*num_witness=*/0)};
-    BOOST_CHECK(pb.Add(fresh) == PrivateBroadcast::AddResult::Added);
+    BOOST_CHECK_EQUAL(pb.Add(fresh), PrivateBroadcast::AddResult::Added);
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), num_cap);
 
-    // A previously-removed tx can be added again as a brand-new entry
+    // A previously-removed tx can be added again as a brand-new entry.
     BOOST_REQUIRE(pb.Remove(fresh).has_value());
-    BOOST_CHECK(pb.Add(txs[0]) == PrivateBroadcast::AddResult::Added);
+    BOOST_CHECK_EQUAL(pb.Add(txs[0]), PrivateBroadcast::AddResult::Added);
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), num_cap);
 }
 

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(rejection_at_cap)
 
     // A previously-removed tx can be added again as a brand-new entry.
     BOOST_REQUIRE(pb.Remove(fresh).has_value());
-    BOOST_CHECK_EQUAL(pb.Add(txs[0]), PrivateBroadcast::AddResult::Added);
+    BOOST_CHECK_EQUAL(pb.Add(fresh), PrivateBroadcast::AddResult::Added);
     BOOST_CHECK_EQUAL(pb.GetBroadcastInfo().size(), num_cap);
 }
 

--- a/test/functional/p2p_private_broadcast_cap.py
+++ b/test/functional/p2p_private_broadcast_cap.py
@@ -71,7 +71,7 @@ class PrivateBroadcastCapTest(BitcoinTestFramework):
         # queue is left unchanged (nothing evicted to make room).
         self.log.info(f"Submitting {OVER_CAP} more; each should be rejected (queue full)")
         for child in children[MAX_TRANSACTIONS:]:
-            assert_raises_rpc_error(-7, "Private broadcast queue is full",
+            assert_raises_rpc_error(-37, "Private broadcast queue is full",
                                     node.sendrawtransaction, child["hex"])
 
         assert_equal(pbinfo["transactions"], node.getprivatebroadcastinfo()["transactions"])


### PR DESCRIPTION
The server isn't running out of memory when the private broadcast transaction queue is full. Add and use a new `-37` (`RPC_LIMIT_EXCEEDED`) code that can be used whenever a resource is bound and currently at capacity.

Addresses https://github.com/bitcoin/bitcoin/pull/35406#discussion_r3535904571

Also includes commits to address other outstanding suggestions/nits from #35406:
- no-op `[[nodiscard]]`: https://github.com/bitcoin/bitcoin/pull/35406#discussion_r3535923165
- use `BOOST_CHECK_EQUAL`: https://github.com/bitcoin/bitcoin/pull/35406#discussion_r3384040078
- improve clarity remove-add test case: https://github.com/bitcoin/bitcoin/pull/35406#discussion_r3519358990