### PR TITLE
fuzz: Remove unused `DeserializeFromFuzzingInput` params overload

### DIFF
--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -73,17 +73,6 @@ T Deserialize(DataStream&& ds, const P& params)
     return obj;
 }
 
-template <typename T, typename P>
-void DeserializeFromFuzzingInput(FuzzBufferType buffer, T&& obj, const P& params)
-{
-    try {
-        SpanReader{buffer} >> params(obj);
-    } catch (const std::ios_base::failure&) {
-        throw invalid_fuzzing_input_exception();
-    }
-    assert(buffer.empty() || !Serialize(obj, params).empty());
-}
-
 template <typename T>
 DataStream Serialize(const T& obj)
 {

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -58,14 +58,6 @@ struct invalid_fuzzing_input_exception : public std::exception {
 };
 
 template <typename T, typename P>
-DataStream Serialize(const T& obj, const P& params)
-{
-    DataStream ds{};
-    ds << params(obj);
-    return ds;
-}
-
-template <typename T, typename P>
 T Deserialize(DataStream&& ds, const P& params)
 {
     T obj;
@@ -116,7 +108,7 @@ T DeserializeConstructFromFuzzingInput(FuzzBufferType buffer)
 template <typename T, typename P>
 void AssertEqualAfterSerializeDeserialize(const T& obj, const P& params)
 {
-    assert(Deserialize<T>(Serialize(obj, params), params) == obj);
+    assert(Deserialize<T>(Serialize(params(obj)), params) == obj);
 }
 template <typename T>
 void AssertEqualAfterSerializeDeserialize(const T& obj)


### PR DESCRIPTION
Clang recently enabled `-Wunused-template` under `-Wall` (see https://github.com/llvm/llvm-project/pull/206123, https://github.com/llvm/llvm-project/pull/207848, https://github.com/llvm/llvm-project/pull/208001). Our codebase [triggers](https://my.cdash.org/builds/3714664/build) some of these warnings.

This PR handles the simplest case, where the unused template function can simply be removed. Other cases need different approaches, as their usage depends on the actual TU they are compiled in. Those are left for follow-ups.

While cleaning up `src/test/fuzz/deserialize.cpp`, another [suggestion](https://github.com/bitcoin/bitcoin/pull/35679#issuecomment-4907171813) has been addressed.