### PR TITLE
lint: have git-subtree-check check for backportability

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1146,8 +1146,17 @@ To update the subtree:
 
 ```sh
 git fetch libmultiprocess
+git checkout <previous subtree merge commit>
 git subtree pull --prefix=src/ipc/libmultiprocess libmultiprocess master --squash
+test/lint/git-subtree-check.sh src/ipc/libmultiprocess
 ```
+
+Normally, the new subtree merge commit should be based on the previous subtree
+merge commit, so if subtree changes need to be backported, the same commit can
+be merged into release branches and the changes do not need to be rereviewed.
+However, if there have been API changes causing subtree code and Bitcoin Core
+code to be incompatible, this may not be possible and a later base commit can be
+used instead (pass `--incompatible` to `git-subtree-check.sh` in this case.)
 
 The ultimate upstream of the few externally managed subtrees are:
 

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -83,14 +83,20 @@ git-subtree-check.sh
 Run this script from the root of the repository to verify that a subtree matches the contents of
 the commit it claims to have been updated to.
 
+It also checks that the most recent subtree merge in `COMMIT`'s history is stacked on the
+previous subtree merge, as recommended in the
+[developer notes](/doc/developer-notes.md#subtrees), so the merge commit can be reused
+verbatim when backporting; if not, the script errors.
+
 ```
-Usage: test/lint/git-subtree-check.sh [--remote] DIR [COMMIT]
+Usage: test/lint/git-subtree-check.sh [--remote] [--incompatible] DIR [COMMIT]
        test/lint/git-subtree-check.sh -?
 ```
 
 - `DIR` is the prefix within the repository to check.
 - `COMMIT` is the commit to check, if it is not provided, HEAD will be used.
 - `--remote` checks that subtree commit is present in repository.
+- `--incompatible` allows a merge that is not stacked on the previous subtree merge.
 
 To do a full check with `--remote`, make sure that you have fetched the upstream repository branch in which the subtree is
 maintained:

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -84,15 +84,15 @@ Run this script from the root of the repository to verify that a subtree matches
 the commit it claims to have been updated to.
 
 ```
-Usage: test/lint/git-subtree-check.sh [-r] DIR [COMMIT]
+Usage: test/lint/git-subtree-check.sh [--remote] DIR [COMMIT]
        test/lint/git-subtree-check.sh -?
 ```
 
 - `DIR` is the prefix within the repository to check.
 - `COMMIT` is the commit to check, if it is not provided, HEAD will be used.
-- `-r` checks that subtree commit is present in repository.
+- `--remote` checks that subtree commit is present in repository.
 
-To do a full check with `-r`, make sure that you have fetched the upstream repository branch in which the subtree is
+To do a full check with `--remote`, make sure that you have fetched the upstream repository branch in which the subtree is
 maintained:
 * for `src/crc32c`: https://github.com/bitcoin-core/crc32c-subtree.git (branch bitcoin-fork)
 * for `src/crypto/ctaes`: https://github.com/bitcoin-core/ctaes.git (branch master)

--- a/test/lint/git-subtree-check.sh
+++ b/test/lint/git-subtree-check.sh
@@ -6,14 +6,20 @@
 export LC_ALL=C
 
 check_remote=0
+incompatible=0
 
 usage()
 {
-      echo "Usage: $0 [--remote] DIR [COMMIT]"
+      echo "Usage: $0 [--remote] [--incompatible] DIR [COMMIT]"
       echo "       $0 -?"
       echo ""
       echo "Checks that a certain prefix is pure subtree, and optionally whether the"
       echo "referenced commit is present in any fetched remote."
+      echo ""
+      echo "Also checks that the most recent subtree merge reachable from COMMIT is stacked"
+      echo "on the previous subtree merge (its first parent is that merge). Stacking lets the"
+      echo "merge commit be reused verbatim (same hash) when backporting to release branches,"
+      echo "so a backport only needs its hash confirmed instead of a fresh review."
       echo ""
       echo "DIR is the prefix within the repository to check."
       echo "COMMIT is the commit to check, if it is not provided, HEAD will be used."
@@ -23,12 +29,17 @@ usage()
       echo ""
       echo "            git fetch https://github.com/bitcoin-core/secp256k1.git"
       echo "            test/lint/git-subtree-check.sh --remote src/secp256k1"
+      echo ""
+      echo "--incompatible Allow a subtree merge that is not stacked on the previous subtree"
+      echo "               merge. Needed when the previous Bitcoin Core code is not compatible"
+      echo "               with the new update"
 }
 
 while [ $# -gt 0 ]; do
     case "$1" in
         -\? | -h | --help) usage; exit 1 ;;
         -r | --remote) check_remote=1 ;;
+        --incompatible) incompatible=1 ;;
         --) shift; break ;;
         -*) echo "Unknown option: $1" >&2; usage; exit 1 ;;
         *) break ;;
@@ -52,11 +63,12 @@ fi
 find_latest_squash()
 {
     dir="$1"
+    from="$2"
     sq=
     main=
     sub=
     git log --grep="^git-subtree-dir: $dir/*\$" \
-        --pretty=format:'START %H%n%s%n%n%b%nEND%n' "$COMMIT" |
+        --pretty=format:'START %H%n%s%n%n%b%nEND%n' "$from" |
     while read a b _; do
         case "$a" in
             START) sq="$b" ;;
@@ -81,7 +93,7 @@ find_latest_squash()
 }
 
 # find latest subtree update
-latest_squash="$(find_latest_squash "$DIR")"
+latest_squash="$(find_latest_squash "$DIR" "$COMMIT")"
 if [ -z "$latest_squash" ]; then
     echo "ERROR: $DIR is not a subtree" >&2
     exit 2
@@ -116,6 +128,25 @@ if [ "$tree_actual_tree" != "$tree_commit" ]; then
     git diff "$tree_commit" "$tree_actual_tree" >&2
     echo "FAIL: subtree directory was touched without subtree merge" >&2
     exit 1
+fi
+
+# Unless --incompatible was passed, require the subtree merge's first parent to
+# be the previous subtree merge commit.
+if [ "$incompatible" = "0" ]; then
+    # The subtree merge is the merge that introduced the squash $old: the last
+    # commit on the ancestry path from $old to $COMMIT.
+    merge="$(git rev-list --ancestry-path --merges "$old..$COMMIT" | tail -1)"
+    if [ -z "$merge" ]; then
+        echo "ERROR: could not find the subtree merge introducing squash $old in $COMMIT" >&2
+        exit 1
+    fi
+    prev_squash="$(find_latest_squash "$DIR" "$merge^1")"
+    prev_squash="${prev_squash%% *}"
+    if [ -n "$prev_squash" ] && [ "$(git rev-parse -q --verify "$merge^1^2")" != "$prev_squash" ]; then
+        echo "ERROR: subtree contents are valid, but subtree merge $merge first parent $(git rev-parse "$merge^1") is not the previous subtree merge (squash $prev_squash). This means the subtree update may not be possible to backport directly to release branches." >&2
+        echo "If it was necessary to use a later parent commit due to incompatible changes in the subtree, pass --incompatible to disable this check." >&2
+        exit 1
+    fi
 fi
 
 if [ "$check_remote" != "0" ]; then

--- a/test/lint/git-subtree-check.sh
+++ b/test/lint/git-subtree-check.sh
@@ -6,10 +6,10 @@
 export LC_ALL=C
 
 check_remote=0
-while getopts "?hr" opt; do
-  case $opt in
-    '?' | h)
-      echo "Usage: $0 [-r] DIR [COMMIT]"
+
+usage()
+{
+      echo "Usage: $0 [--remote] DIR [COMMIT]"
       echo "       $0 -?"
       echo ""
       echo "Checks that a certain prefix is pure subtree, and optionally whether the"
@@ -18,19 +18,23 @@ while getopts "?hr" opt; do
       echo "DIR is the prefix within the repository to check."
       echo "COMMIT is the commit to check, if it is not provided, HEAD will be used."
       echo ""
-      echo "-r      Check that subtree commit is present in repository."
-      echo "        To do this check, fetch the subtreed remote first. Example:"
+      echo "--remote Check that subtree commit is present in repository."
+      echo "         To do this check, fetch the subtreed remote first. Example:"
       echo ""
       echo "            git fetch https://github.com/bitcoin-core/secp256k1.git"
-      echo "            test/lint/git-subtree-check.sh -r src/secp256k1"
-      exit 1
-    ;;
-    r)
-      check_remote=1
-    ;;
-  esac
+      echo "            test/lint/git-subtree-check.sh --remote src/secp256k1"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -\? | -h | --help) usage; exit 1 ;;
+        -r | --remote) check_remote=1 ;;
+        --) shift; break ;;
+        -*) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+        *) break ;;
+    esac
+    shift
 done
-shift $((OPTIND-1))
 
 if [ -z "$1" ]; then
     echo "Need to provide a DIR, see $0 -?"

--- a/test/lint/test_runner/src/lint_repo_hygiene.rs
+++ b/test/lint/test_runner/src/lint_repo_hygiene.rs
@@ -8,7 +8,7 @@ use crate::util::{commit_range, get_subtrees, LintResult};
 
 pub fn lint_subtree() -> LintResult {
     // This only checks that the trees are pure subtrees, it is not doing a full
-    // check with -r to not have to fetch all the remotes.
+    // check with --remote to not have to fetch all the remotes.
     let mut good = true;
     for subtree in get_subtrees() {
         good &= Command::new("test/lint/git-subtree-check.sh")

--- a/test/lint/test_runner/src/lint_repo_hygiene.rs
+++ b/test/lint/test_runner/src/lint_repo_hygiene.rs
@@ -9,9 +9,14 @@ use crate::util::{commit_range, get_subtrees, LintResult};
 pub fn lint_subtree() -> LintResult {
     // This only checks that the trees are pure subtrees, it is not doing a full
     // check with --remote to not have to fetch all the remotes.
+    //
+    // Pass --incompatible to skip the "stacked on the previous subtree merge"
+    // check: the linter cannot know whether an update had to be based on a later
+    // commit, so it does not enforce stacking.
     let mut good = true;
     for subtree in get_subtrees() {
         good &= Command::new("test/lint/git-subtree-check.sh")
+            .arg("--incompatible")
             .arg(subtree)
             .status()
             .expect("command_error")


### PR DESCRIPTION
A subtree update is easier to backport when its merge commit is based on the previous subtree merge instead of on a newer `master` commit. The exact same merge commit can then be reused on release branches, making the backport trivial to verify without rereviewing a newly generated subtree merge.

Update `git-subtree-check.sh` to locate the merge that introduced the latest subtree squash reachable from `COMMIT` and error if its first parent is not the previous subtree merge.

Sometimes subtree and Bitcoin Core API changes are incompatible, making it necessary to base an update on a later commit. Add `--incompatible` to explicitly skip the backportability check in that case.

The CI lint job always sets `--incompatible`, so we rely on reviewers to run the new check.

As a preparatory refactor, replace `getopts` with explicit option parsing and add `--remote` as the preferred long alias for `-r`.

Example that passes:

```sh
test/lint/git-subtree-check.sh src/ipc/libmultiprocess 66b4e30e
```

Example that errors because the update is not based on the previous subtree merge:

```sh
test/lint/git-subtree-check.sh src/ipc/libmultiprocess 02afa661
```