### PR TITLE
doc: fix v31.1 LevelDB PR link

### DIFF
--- a/doc/release-notes/release-notes-31.1.md
+++ b/doc/release-notes/release-notes-31.1.md
@@ -53,7 +53,7 @@ the enabled privacy network.
 
 ### Leveldb
 
-- #61(bitcoin-core/leveldb): Disable seek compaction
+- bitcoin-core/leveldb-subtree#61: Disable seek compaction
 
 ### P2P
 


### PR DESCRIPTION
**Problem:** The [v31.1 release page](https://bitcoincore.org/en/releases/31.1/#leveldb) links the LevelDB entry to https://github.com/bitcoin/bitcoin/pull/61 instead of https://github.com/bitcoin-core/leveldb-subtree/pull/61.

**Fix:** Use the correct cross-repository PR reference in the v31.1 release notes so the published link points to the LevelDB subtree PR.

**Report:** https://x.com/maciejsoltysiak/status/2074953263913341270