### PR TITLE
crypto: accept empty HMAC keys

### DIFF
--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -7,13 +7,14 @@
 #include <crypto/sha256.h>
 #include <support/cleanse.h>
 
+#include <algorithm>
 #include <cstring>
 
 CHMAC_SHA256::CHMAC_SHA256(const unsigned char* key, size_t keylen)
 {
     unsigned char rkey[64];
     if (keylen <= 64) {
-        memcpy(rkey, key, keylen);
+        std::copy(key, key + keylen, rkey);
         memset(rkey + keylen, 0, 64 - keylen);
     } else {
         CSHA256().Write(key, keylen).Finalize(rkey);

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -7,13 +7,14 @@
 #include <crypto/sha512.h>
 #include <support/cleanse.h>
 
+#include <algorithm>
 #include <cstring>
 
 CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
 {
     unsigned char rkey[128];
     if (keylen <= 128) {
-        memcpy(rkey, key, keylen);
+        std::copy(key, key + keylen, rkey);
         memset(rkey + keylen, 0, 128 - keylen);
     } else {
         CSHA512().Write(key, keylen).Finalize(rkey);

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -468,6 +468,8 @@ BOOST_AUTO_TEST_CASE(sha512_testvectors) {
 }
 
 BOOST_AUTO_TEST_CASE(hmac_sha256_testvectors) {
+    // HMAC with an empty key and message
+    TestHMACSHA256("", "", "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad");
     // test cases 1, 2, 3, 4, 6 and 7 of RFC 4231
     TestHMACSHA256("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                    "4869205468657265",
@@ -521,6 +523,8 @@ BOOST_AUTO_TEST_CASE(hmac_sha256_testvectors) {
 }
 
 BOOST_AUTO_TEST_CASE(hmac_sha512_testvectors) {
+    // HMAC with an empty key and message
+    TestHMACSHA512("", "", "b936cee86c9f87aa5d3c6f2e84cb5a4239a5fe50480a6ec66b70ab5b1f4ac6730c6c515421b327ec1d69402e53dfb49ad7381eb067b338fd7b0cb22247225d47");
     // test cases 1, 2, 3, 4, 6 and 7 of RFC 4231
     TestHMACSHA512("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                    "4869205468657265",

--- a/src/test/fuzz/crypto.cpp
+++ b/src/test/fuzz/crypto.cpp
@@ -21,11 +21,6 @@ FUZZ_TARGET(crypto)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     std::vector<uint8_t> data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
-    if (data.empty()) {
-        auto new_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4096);
-        auto x = fuzzed_data_provider.ConsumeIntegral<uint8_t>();
-        data.resize(new_size, x);
-    }
 
     CHash160 hash160;
     CHash256 hash256;
@@ -45,11 +40,6 @@ FUZZ_TARGET(crypto)
             [&] {
                 if (fuzzed_data_provider.ConsumeBool()) {
                     data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
-                    if (data.empty()) {
-                        auto new_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4096);
-                        auto x = fuzzed_data_provider.ConsumeIntegral<uint8_t>();
-                        data.resize(new_size, x);
-                    }
                 }
 
                 (void)hash160.Write(data);

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -13,16 +13,7 @@ FUZZ_TARGET(eval_script)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const auto flags = script_verify_flags::from_int(fuzzed_data_provider.ConsumeIntegral<script_verify_flags::value_type>());
-    const std::vector<uint8_t> script_bytes = [&] {
-        if (fuzzed_data_provider.remaining_bytes() != 0) {
-            return fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>();
-        } else {
-            // Avoid UBSan warning:
-            //   test/fuzz/FuzzedDataProvider.h:212:17: runtime error: null pointer passed as argument 1, which is declared to never be null
-            //   /usr/include/string.h:43:28: note: nonnull attribute specified here
-            return std::vector<uint8_t>();
-        }
-    }();
+    const std::vector<uint8_t> script_bytes = fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>();
     const CScript script(script_bytes.begin(), script_bytes.end());
     for (const auto sig_version : {SigVersion::BASE, SigVersion::WITNESS_V0}) {
         std::vector<std::vector<unsigned char>> stack;


### PR DESCRIPTION
**Problem:** `CHMAC_SHA256` and `CHMAC_SHA512` use `memcpy` to copy key bytes.
Empty vectors can provide a null `data()` pointer, which triggers a UBSan null-pointer warning even for zero-length copies and forces the crypto fuzz target to avoid empty inputs.

**Fix:** Use [`std::copy`](https://godbolt.org/z/fzsP1jf17), which has defined semantics for empty ranges, add empty-key HMAC test vectors, and let the crypto fuzz target pass empty byte vectors directly.
Remove the stale `eval_script` empty-input guard in a separate commit because `ConsumeRemainingBytes()` already returns before copying when no bytes remain.