### PR TITLE
test: Inline incorrect check in `util_tests`

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -883,8 +883,7 @@ BOOST_AUTO_TEST_CASE(test_ToIntegralHex)
     BOOST_CHECK_EQUAL(*n, 0);
     n = ToIntegral<uint64_t>("FfFfFfFfFfFfFfFf", 16);
     BOOST_CHECK_EQUAL(*n, 0xFfFfFfFfFfFfFfFfULL);
-    n = ToIntegral<int64_t>("-1", 16);
-    BOOST_CHECK_EQUAL(*n, -1);
+    BOOST_CHECK_EQUAL(*ToIntegral<int64_t>("-1", 16), -1);
     // Invalid values
     BOOST_CHECK(!ToIntegral<uint64_t>("", 16));
     BOOST_CHECK(!ToIntegral<uint64_t>("-1", 16));


### PR DESCRIPTION
Assigning `ToIntegral<int64_t>("-1")` to the `optional<uint64_t>` `n` is a silent underflow. `BOOST_CHECK_EQUAL` then promotes `int` to `uint64_t`, which also underflows. The correct check is to do this inline. Part of clean up in #35587

<details>
<summary>gdb</summary>

```
(gdb) next
886	    n = ToIntegral<int64_t>("-1", 16);
1: n = {<std::_Optional_base<unsigned long, true, true>> = {<std::_Optional_base_impl<unsigned long, std::_Optional_base<unsigned long, true, true> >> = {<No data fields>}, _M_payload = {<std::_Optional_payload_base<unsigned long>> = {_M_payload = {
          _M_empty = {<No data fields>}, _M_value = 18446744073709551615},
        _M_engaged = true}, <No data fields>}}, <std::_Enable_copy_move<true, true, true, true, std::optional<unsigned long> >> = {<No data fields>}, <No data fields>}
2: n = {<std::_Optional_base<unsigned long, true, true>> = {<std::_Optional_base_impl<unsigned long, std::_Optional_base<unsigned long, true, true> >> = {<No data fields>}, _M_payload = {<std::_Optional_payload_base<unsigned long>> = {_M_payload = {
          _M_empty = {<No data fields>}, _M_value = 18446744073709551615},
        _M_engaged = true}, <No data fields>}}, <std::_Enable_copy_move<true, true, true, true, std::optional<unsigned long> >> = {<No data fields>}, <No data fields>}
(gdb) next
887	    BOOST_CHECK_EQUAL(*n, -1);
1: n = {<std::_Optional_base<unsigned long, true, true>> = {<std::_Optional_base_impl<unsigned long, std::_Optional_base<unsigned long, true, true> >> = {<No data fields>}, _M_payload = {<std::_Optional_payload_base<unsigned long>> = {_M_payload = {
          _M_empty = {<No data fields>}, _M_value = 18446744073709551615},
        _M_engaged = true}, <No data fields>}}, <std::_Enable_copy_move<true, true, true, true, std::optional<unsigned long> >> = {<No data fields>}, <No data fields>}
2: n = {<std::_Optional_base<unsigned long, true, true>> = {<std::_Optional_base_impl<unsigned long, std::_Optional_base<unsigned long, true, true> >> = {<No data fields>}, _M_payload = {<std::_Optional_payload_base<unsigned long>> = {_M_payload = {
          _M_empty = {<No data fields>}, _M_value = 18446744073709551615},
        _M_engaged = true}, <No data fields>}}, <std::_Enable_copy_move<true, true, true, true, std::optional<unsigned long> >> = {<No data fields>}, <No data fields>}
```
</details>