### PR TITLE
wallet: Introduce WalletError with machine-readable error code

### DIFF
--- a/src/wallet/types.h
+++ b/src/wallet/types.h
@@ -15,6 +15,7 @@
 #define BITCOIN_WALLET_TYPES_H
 
 #include <policy/fees/block_policy_estimator.h>
+#include <util/translation.h>
 
 namespace wallet {
 /**
@@ -40,6 +41,33 @@ struct CreatedTransactionResult
 
     CreatedTransactionResult(CTransactionRef _tx, CAmount _fee, std::optional<unsigned int> _change_pos, const FeeCalculation& _fee_calc)
             : tx(_tx), fee(_fee), fee_calc(_fee_calc), change_pos(_change_pos) {}
+};
+
+//! Machine-readable wallet error codes.
+//!
+//! @note Add new codes only when callers need to handle the condition
+//! differently. For errors that should only be displayed to the user, use
+//! WalletErrorCode::GenericError and provide the user-facing details in WalletError::message.
+enum class WalletErrorCode {
+    //! Generic wallet error. Callers may present the accompanying message to
+    //! the user.
+    GenericError,
+
+    //! The wallet is locked and the operation requires access to private keys.
+    //! Callers may ask the user to unlock the wallet and retry the operation.
+    UnlockNeeded,
+};
+
+//! Wallet-layer error with both programmatic and user-facing information.
+//!
+//! Wallet methods should return a specific WalletErrorCode only when callers
+//! can handle that condition differently. Otherwise, use WalletErrorCode::GenericError
+//! and describe the failure in `message`.
+struct WalletError {
+    //! Machine-readable error code for callers that need programmatic handling.
+    WalletErrorCode code;
+    //! User-facing translated error message
+    bilingual_str message;
 };
 
 } // namespace wallet


### PR DESCRIPTION
Per discussion in https://github.com/bitcoin/bitcoin/pull/35436#issuecomment-4923786884, `WalletError` is split out so that it can be reused by multiple wallet interface changes (#34861 in particular)

----

Introduce a `wallet::WalletError`, a generic wallet-layer error type that contains
- a machine-readable `WalletErrorCode` for programmatic handling
- a translated user-facing `bilingual_str` message

The initial enum is intentionally small. `WALLET_ERROR` is used for generic failures that callers should display to the user. The intention is to have more specific codes only when the callers can handle the condition differently.