### PR TITLE
chainparams: delete my DNS seed

### DIFF
--- a/contrib/seeds/README.md
+++ b/contrib/seeds/README.md
@@ -15,8 +15,7 @@ DNS seed, virtu's crawler, and asmap community AS map data. Run the following co
 from the `/contrib/seeds` directory:
 
 ```
-curl https://bitcoin.sipa.be/seeds.txt.gz | gzip -dc > seeds_main.txt
-curl https://21.ninja/seeds.txt.gz | gzip -dc >> seeds_main.txt
+curl https://21.ninja/seeds.txt.gz | gzip -dc > seeds_main.txt
 curl https://mainnet.achownodes.xyz/seeds.txt.gz | gzip -dc >> seeds_main.txt
 curl https://signet.achownodes.xyz/seeds.txt.gz | gzip -dc > seeds_signet.txt
 curl https://testnet.achownodes.xyz/seeds.txt.gz | gzip -dc > seeds_test.txt

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -165,7 +165,6 @@ public:
         // This is fine at runtime as we'll fall back to using them as an addrfetch if they don't support the
         // service bits we want, but we should get them updated to support all service bits wanted by any
         // release ASAP to avoid it where possible.
-        vSeeds.emplace_back("seed.bitcoin.sipa.be."); // Pieter Wuille, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("dnsseed.bluematt.me."); // Matt Corallo, only supports x9
         vSeeds.emplace_back("seed.bitcoin.jonasschnelli.ch."); // Jonas Schnelli, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("seed.btc.petertodd.net."); // Peter Todd, only supports x1, x5, x9, and xd


### PR DESCRIPTION
I plan to shut down my DNS seed server in the future (probably after the release of 32.0), so I request it be removed from the master branch already. It has existed for almost 15 years at this point, and isn't getting much maintenance attention from me anymore.