### PR TITLE
Remove myself as security contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,6 @@ The following keys may be used to communicate sensitive information to developer
 
 | Name | Fingerprint |
 |------|-------------|
-| Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
 | Michael Ford | E777 299F C265 DD04 7930  70EB 944D 35F9 AC3D B76A |
 | Ava Chow | 1528 1230 0785 C964 44D3  334D 1756 5732 E08E 5E41 |
 | Niklas Gögge | 2CBB F208 E594 BF43 9B5F 276C 7465 CFFF 6793 242E |


### PR DESCRIPTION
Making the same change here as in https://github.com/bitcoin-core/bitcoincore.org/pull/1264. I remain involved in security discussions, but don't feel like functioning as a first-line contact anymore.