### PR TITLE
Mempool leak through the eviction policy (#31211)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1695,6 +1695,13 @@ bool CConnman::AttemptToEvictConnection()
 {
     AssertLockNotHeld(m_nodes_mutex);
 
+    std::vector<NodeId> recent_tx_providers;
+    {
+        LOCK(m_recent_tx_mutex);
+        recent_tx_providers = m_recent_tx_providers;
+    }
+    std::set<NodeId> recent_tx_providers_set(recent_tx_providers.begin(), recent_tx_providers.end());
+
     std::vector<NodeEvictionCandidate> vEvictionCandidates;
     {
 
@@ -1717,6 +1724,7 @@ bool CConnman::AttemptToEvictConnection()
                 .m_network = node->ConnectedThroughNetwork(),
                 .m_noban = node->HasPermission(NetPermissionFlags::NoBan),
                 .m_conn_type = node->m_conn_type,
+                .m_provided_recent_tx = recent_tx_providers_set.count(node->GetId()) > 0,
             };
             vEvictionCandidates.push_back(candidate);
         }
@@ -2025,12 +2033,68 @@ void CConnman::NotifyNumConnectionsChanged()
         }
     }
 }
+void CConnman::AddRecentTxProvider(NodeId id)
+{
+    LOCK(m_recent_tx_mutex);
+    if (m_recent_tx_providers.size() < 1000) {
+        m_recent_tx_providers.push_back(id);
+    } else {
+        m_recent_tx_providers[m_recent_tx_idx] = id;
+        m_recent_tx_idx = (m_recent_tx_idx + 1) % 1000;
+    }
+}
 
+/**
+ * Return true if we should disconnect the peer for failing an inactivity check.
+ */
 bool CConnman::ShouldRunInactivityChecks(const CNode& node, NodeClock::time_point now) const
 {
     return node.m_connected + m_peer_connect_timeout < now;
 }
 
+/**
+ * Return true if we have multiple manual or full-relay outbound connections to a given network.
+ */
+bool CConnman::MultipleManualOrFullOutboundConns(Network net) const
+{
+    int count = 0;
+    for (const CNode* node : m_nodes) {
+        if (!node->fDisconnect && node->IsOutboundOrManualConn() && !node->IsBlockOnlyConn() &&
+            node->ConnectedThroughNetwork() == net) {
+            ++count;
+        }
+        if (count >= 2) return true;
+    }
+    return false;
+}
+
+/**
+ * Try to find a connection to evict.
+ *
+ * This checks the netgroup of a node, and the uptime, min ping time,
+ * last block time, and last tx time of a node.
+ * It's protected by the m_nodes_mutex.
+ *
+ * It will protect up to 4 nodes which have sent us novel transactions,
+ * and up to 4 nodes which have sent us novel blocks.
+ * It will also protect up to 4 nodes with the best ping time, and up
+ * to 4 nodes with the best network group.
+ * It will also protect up to 4 nodes which are the oldest.
+ *
+ * It will then evict the node which is the youngest, or the one with
+ * the worst network group.
+ *
+ * This provides a degree of protection from an attacker who wants to
+ * eclipse the node by making a large number of inbound connections.
+ * By protecting a diverse set of peers, we ensure that an attacker
+ * must expend resources to forge these characteristics for their
+ * connections.
+ *
+ * The protection logic is defined in node/eviction.cpp and guarantees
+ * for each of several distinct characteristics which are difficult
+ * to forge.  In order to partition a node the attacker must be
+ * simultaneously better at all of them than honest peers.
+ */
 bool CConnman::InactivityCheck(const CNode& node, NodeClock::time_point now) const
 {
     // Tests that see disconnects after using mocktime can start nodes with a

--- a/src/net.h
+++ b/src/net.h
@@ -1415,7 +1415,13 @@ public:
 
     bool MultipleManualOrFullOutboundConns(Network net) const EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
 
+    void AddRecentTxProvider(NodeId id);
+
 private:
+    Mutex m_recent_tx_mutex;
+    std::vector<NodeId> m_recent_tx_providers GUARDED_BY(m_recent_tx_mutex);
+    size_t m_recent_tx_idx GUARDED_BY(m_recent_tx_mutex){0};
+
     struct ListenSocket {
     public:
         std::shared_ptr<Sock> sock;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4542,6 +4542,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
             ProcessValidTx(pfrom.GetId(), ptx, result.m_replaced_transactions);
             pfrom.m_last_tx_time = GetTime<std::chrono::seconds>();
+            m_connman.AddRecentTxProvider(pfrom.GetId());
         }
         if (state.IsInvalid()) {
             if (auto package_to_validate{ProcessInvalidTx(pfrom.GetId(), ptx, state, /*first_time_failure=*/true)}) {

--- a/src/node/eviction.cpp
+++ b/src/node/eviction.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <random.h>
 #include <vector>
 
 
@@ -35,14 +36,7 @@ static bool CompareNodeBlockTime(const NodeEvictionCandidate &a, const NodeEvict
     return a.m_connected > b.m_connected;
 }
 
-static bool CompareNodeTXTime(const NodeEvictionCandidate &a, const NodeEvictionCandidate &b)
-{
-    // There is a fall-through here because it is common for a node to have more than a few peers that have not yet relayed txn.
-    if (a.m_last_tx_time != b.m_last_tx_time) return a.m_last_tx_time < b.m_last_tx_time;
-    if (a.m_relay_txs != b.m_relay_txs) return b.m_relay_txs;
-    if (a.fBloomFilter != b.fBloomFilter) return a.fBloomFilter;
-    return a.m_connected > b.m_connected;
-}
+
 
 // Pick out the potential block-relay only peers, and sort them by last block time.
 static bool CompareNodeBlockRelayOnlyTime(const NodeEvictionCandidate &a, const NodeEvictionCandidate &b)
@@ -189,9 +183,31 @@ void ProtectEvictionCandidatesByRatio(std::vector<NodeEvictionCandidate>& evicti
     // Protect the 8 nodes with the lowest minimum ping time.
     // An attacker cannot manipulate this metric without physically moving nodes closer to the target.
     EraseLastKElements(vEvictionCandidates, ReverseCompareNodeMinPingTime, 8);
-    // Protect 4 nodes that most recently sent us novel transactions accepted into our mempool.
+    // Protect up to 4 nodes that recently sent us novel transactions accepted into our mempool.
     // An attacker cannot manipulate this metric without performing useful work.
-    EraseLastKElements(vEvictionCandidates, CompareNodeTXTime, 4);
+    // We use a rolling window of recent transactions (m_provided_recent_tx) to prevent
+    // a spy from discovering if a transaction was accepted into our mempool.
+    // We randomly select up to 4 candidates from the rolling window.
+    {
+        std::vector<NodeId> tx_providers;
+        for (const auto& cand : vEvictionCandidates) {
+            if (cand.m_provided_recent_tx) {
+                tx_providers.push_back(cand.id);
+            }
+        }
+        FastRandomContext rng;
+        std::shuffle(tx_providers.begin(), tx_providers.end(), rng);
+        size_t protected_count = 0;
+        for (const NodeId id : tx_providers) {
+            if (protected_count >= 4) break;
+            auto it = std::find_if(vEvictionCandidates.begin(), vEvictionCandidates.end(),
+                                   [id](const NodeEvictionCandidate& n) { return n.id == id; });
+            if (it != vEvictionCandidates.end()) {
+                vEvictionCandidates.erase(it);
+                protected_count++;
+            }
+        }
+    }
     // Protect up to 8 non-tx-relay peers that have sent us novel blocks.
     EraseLastKElements(vEvictionCandidates, CompareNodeBlockRelayOnlyTime, 8,
                        [](const NodeEvictionCandidate& n) { return !n.m_relay_txs && n.fRelevantServices; });

--- a/src/node/eviction.h
+++ b/src/node/eviction.h
@@ -30,6 +30,7 @@ struct NodeEvictionCandidate {
     Network m_network;
     bool m_noban;
     ConnectionType m_conn_type;
+    bool m_provided_recent_tx{false};
 };
 
 /**


### PR DESCRIPTION
Fixes #31211
 
*   Added a circular buffer to `CConnman` (`m_recent_tx_providers`) that stores the `NodeId`s of peers providing the last 1000 accepted transactions.
*   Updated `net_processing.cpp` to call `AddRecentTxProvider` upon a transaction being accepted to the mempool as `VALID`.
*   Modified the candidate population in `AttemptToEvictConnection` to mark peers present in this rolling window via a new `m_provided_recent_tx` flag.
*   Updated `SelectNodeToEvict` in `src/node/eviction.cpp` to remove `CompareNodeTXTime`. Instead, it randomly shuffles all peers flagged as being in the rolling window and protects up to 4 of them.

 
