### PR TITLE
bench: replace CreateMockableWalletDatabase with MakeInMemoryWalletDatabase

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -16,7 +16,7 @@
 #include <wallet/coinselection.h>
 #include <wallet/db.h>
 #include <wallet/spend.h>
-#include <wallet/test/util.h>
+#include <wallet/sqlite.h>
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
@@ -50,7 +50,7 @@ static void addCoin(const CAmount& nValue, std::vector<std::unique_ptr<CWalletTx
 static void CoinSelection(benchmark::Bench& bench)
 {
     const auto test_setup = MakeNoLogFileContext<TestingSetup>();
-    CWallet wallet(test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase());
+    CWallet wallet(test_setup->m_node.chain.get(), "", MakeInMemoryWalletDatabase());
     std::vector<std::unique_ptr<CWalletTx>> wtxs;
     LOCK(wallet.cs_wallet);
 

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -17,6 +17,7 @@
 #include <validation.h>
 #include <wallet/db.h>
 #include <wallet/receive.h>
+#include <wallet/sqlite.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
@@ -35,7 +36,7 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
     // Set clock to genesis block, so the descriptors/keys creation time don't interfere with the blocks scanning process.
     // The reason is 'generatetoaddress', which creates a chain with deterministic timestamps in the past.
     FakeNodeClock clock{test_setup->m_node.chainman->GetParams().GenesisBlock().Time()};
-    CWallet wallet{test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase()};
+    CWallet wallet{test_setup->m_node.chain.get(), "", MakeInMemoryWalletDatabase()};
     {
         LOCK(wallet.cs_wallet);
         wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -29,6 +29,7 @@
 #include <wallet/coinselection.h>
 #include <wallet/db.h>
 #include <wallet/spend.h>
+#include <wallet/sqlite.h>
 #include <wallet/test/util.h>
 #include <wallet/types.h>
 #include <wallet/wallet.h>
@@ -44,7 +45,7 @@
 
 using kernel::ChainstateRole;
 using wallet::CWallet;
-using wallet::CreateMockableWalletDatabase;
+using wallet::MakeInMemoryWalletDatabase;
 using wallet::WALLET_FLAG_DESCRIPTORS;
 
 struct TipBlock
@@ -120,7 +121,7 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
 
     // Set clock to genesis block, so the descriptors/keys creation time don't interfere with the blocks scanning process.
     FakeNodeClock clock{test_setup->m_node.chainman->GetParams().GenesisBlock().Time()};
-    CWallet wallet{test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase()};
+    CWallet wallet{test_setup->m_node.chain.get(), "", MakeInMemoryWalletDatabase()};
     {
         LOCK(wallet.cs_wallet);
         wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
@@ -175,7 +176,7 @@ static void AvailableCoins(benchmark::Bench& bench, const std::vector<OutputType
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
     // Set clock to genesis block, so the descriptors/keys creation time don't interfere with the blocks scanning process.
     FakeNodeClock clock{test_setup->m_node.chainman->GetParams().GenesisBlock().Time()};
-    CWallet wallet{test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase()};
+    CWallet wallet{test_setup->m_node.chain.get(), "", MakeInMemoryWalletDatabase()};
     {
         LOCK(wallet.cs_wallet);
         wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);

--- a/src/bench/wallet_encrypt.cpp
+++ b/src/bench/wallet_encrypt.cpp
@@ -16,6 +16,7 @@
 #include <wallet/context.h>
 #include <wallet/crypter.h>
 #include <wallet/db.h>
+#include <wallet/sqlite.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
@@ -64,7 +65,7 @@ static void WalletEncrypt(benchmark::Bench& bench, unsigned int key_count)
                 TestUnloadWallet(std::move(wallet));
             }
 
-            std::unique_ptr<WalletDatabase> database = CreateMockableWalletDatabase();
+            std::unique_ptr<WalletDatabase> database = MakeInMemoryWalletDatabase();
             wallet = TestCreateWallet(std::move(database), context, create_flags);
 
             {

--- a/src/bench/wallet_ismine.cpp
+++ b/src/bench/wallet_ismine.cpp
@@ -14,6 +14,7 @@
 #include <util/check.h>
 #include <wallet/context.h>
 #include <wallet/db.h>
+#include <wallet/sqlite.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
@@ -37,7 +38,7 @@ static void WalletIsMine(benchmark::Bench& bench, int num_combo = 0)
     // Setup the wallet
     // Loading the wallet will also create it
     uint64_t create_flags = WALLET_FLAG_DESCRIPTORS;
-    auto database = CreateMockableWalletDatabase();
+    auto database = MakeInMemoryWalletDatabase();
     auto wallet = TestCreateWallet(std::move(database), context, create_flags);
 
     // For a descriptor wallet, fill with num_combo combo descriptors with random keys


### PR DESCRIPTION
Benchmarks don't need mock-specific behaviour (overridden `Filename()`, `Format()`, or the exposed batch-level `WriteKey()`). Replace `CreateMockableWalletDatabase()` with `MakeInMemoryWalletDatabase()` across all 6 call sites in `src/bench/` (5 files - 4 wallet bench files + 1 in coin_selection), using the same in-memory SQLite path that production code uses.

`wallet_migration.cpp` is excluded: it calls `GetOrCreateLegacyDataSPKM()` which asserts `Format() == "sqlite-mock"`, a deliberate signal that allows legacy SPKM setup in `test/bench` contexts. `MockableSQLiteDatabase` is still correct there.

For `coin_selection.cpp`, which had no other dependencies on `wallet/test/util.h`, the include is switched to `<wallet/sqlite.h>`. The remaining 4 files retain `wallet/test/util.h` for other utilities but also add an explicit `<wallet/sqlite.h>` include as required by IWYU.

Follow-up suggested in #35655.  
  