### PR TITLE
wallet: Make SQLiteDatabase::m_file_path an std::optional<fs::path>

### DIFF
--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -115,9 +115,10 @@ SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const fs::path& file_pa
     : SQLiteDatabase(dir_path, file_path, options, /*additional_flags=*/0)
 {}
 
-SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const fs::path& file_path, const DatabaseOptions& options, int additional_flags)
-    : WalletDatabase(), m_dir_path(dir_path), m_file_path(fs::PathToString(file_path)), m_additional_flags(additional_flags), m_write_semaphore(1), m_use_unsafe_sync(options.use_unsafe_sync)
+SQLiteDatabase::SQLiteDatabase(const fs::path& dir_path, const std::optional<fs::path>& file_path, const DatabaseOptions& options, int additional_flags)
+    : WalletDatabase(), m_dir_path(dir_path), m_file_path(file_path), m_additional_flags(additional_flags), m_write_semaphore(1), m_use_unsafe_sync(options.use_unsafe_sync)
 {
+    Assert(m_file_path.has_value() != bool(m_additional_flags & SQLITE_OPEN_MEMORY));
     {
         LOCK(g_sqlite_mutex);
         if (++g_sqlite_count == 1) {
@@ -258,14 +259,16 @@ void SQLiteDatabase::Open(int additional_flags)
     int flags = SQLITE_OPEN_FULLMUTEX | SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | additional_flags;
 
     if (m_db == nullptr) {
-        if (!(flags & SQLITE_OPEN_MEMORY)) {
+        if (IsOnDisk()) {
             TryCreateDirectories(m_dir_path);
             if (!IsDirWritable(m_dir_path)) {
                 throw std::runtime_error(strprintf("SQLiteDatabase: Failed to open database in directory '%s': directory is not writable", fs::PathToString(m_dir_path)));
             }
         }
 
-        int ret = sqlite3_open_v2(m_file_path.c_str(), &m_db, flags, nullptr);
+        // The constructor Assert guarantees that the file path is absent if and only if SQLITE_OPEN_MEMORY is set.
+        const std::string db_path{IsOnDisk() ? fs::PathToString(*m_file_path) : ":memory:"};
+        int ret = sqlite3_open_v2(db_path.c_str(), &m_db, flags, nullptr);
         if (ret != SQLITE_OK) {
             throw std::runtime_error(strprintf("SQLiteDatabase: Failed to open database: %s\n", sqlite3_errstr(ret)));
         }
@@ -723,7 +726,7 @@ std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const D
 }
 
 InMemoryWalletDatabase::InMemoryWalletDatabase()
-    : SQLiteDatabase(fs::path{}, fs::path{":memory:"}, DatabaseOptions(), SQLITE_OPEN_MEMORY)
+    : SQLiteDatabase(fs::path{}, std::nullopt, DatabaseOptions(), SQLITE_OPEN_MEMORY)
 {}
 
 std::unique_ptr<WalletDatabase> MakeInMemoryWalletDatabase()

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -8,6 +8,7 @@
 #include <sync.h>
 #include <wallet/db.h>
 
+#include <optional>
 #include <semaphore>
 
 struct bilingual_str;
@@ -107,7 +108,7 @@ private:
 
     const fs::path m_dir_path;
 
-    const std::string m_file_path;
+    const std::optional<fs::path> m_file_path;
 
     const int m_additional_flags;
 
@@ -124,8 +125,13 @@ private:
 
     void Open(int additional_flags);
 
+    bool IsOnDisk() const { return m_file_path.has_value(); }
+
 protected:
-    SQLiteDatabase(const fs::path& dir_path, const fs::path& file_path, const DatabaseOptions& options, int additional_flags);
+    //! On-disk: provide a real file_path with no SQLITE_OPEN_MEMORY flag.
+    //! In-memory: pass std::nullopt for file_path and set SQLITE_OPEN_MEMORY.
+    //! The constructor asserts that exactly one of these cases holds.
+    SQLiteDatabase(const fs::path& dir_path, const std::optional<fs::path>& file_path, const DatabaseOptions& options, int additional_flags);
 
 public:
     SQLiteDatabase() = delete;
@@ -154,13 +160,15 @@ public:
      */
     bool Backup(const std::string& dest) const override;
 
-    std::string Filename() override { return m_file_path; }
+    std::string Filename() override { return IsOnDisk() ? fs::PathToString(*m_file_path) : ":memory:"; }
     /** Return paths to all database created files */
     std::vector<fs::path> Files() override
     {
         std::vector<fs::path> files;
-        files.emplace_back(m_dir_path / fs::PathFromString(m_file_path));
-        files.emplace_back(m_dir_path / fs::PathFromString(m_file_path + "-journal"));
+        if (IsOnDisk()) {
+            files.emplace_back(m_dir_path / *m_file_path);
+            files.emplace_back(m_dir_path / (*m_file_path + "-journal"));
+        }
         return files;
     }
     std::string Format() override { return "sqlite"; }
@@ -181,7 +189,6 @@ class InMemoryWalletDatabase : public SQLiteDatabase
 {
 public:
     InMemoryWalletDatabase();
-    std::vector<fs::path> Files() override { return {}; }
 };
 
 std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -306,5 +306,12 @@ BOOST_AUTO_TEST_CASE(in_memory_database_cannot_reopen)
     BOOST_CHECK_THROW(database.Open(), std::runtime_error);
 }
 
+BOOST_AUTO_TEST_CASE(in_memory_database_interface)
+{
+    InMemoryWalletDatabase database;
+    BOOST_CHECK_EQUAL(database.Filename(), ":memory:");
+    BOOST_CHECK(database.Files().empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -63,7 +63,6 @@ public:
 
     bool Backup(const std::string& strDest) const override { return true; }
 
-    std::string Filename() override { return "mockable"; }
     std::string Format() override { return "sqlite-mock"; }
     std::unique_ptr<DatabaseBatch> MakeBatch() override { return std::make_unique<MockableSQLiteBatch>(*this); }
 };


### PR DESCRIPTION
Follow-up to #35655.
Implements the approach proposed by Sjors during [review](https://github.com/bitcoin/bitcoin/pull/35655#issuecomment-4913099450).

<details>
<summary>Make the <code>SQLiteDatabase</code> internal file path optional so that subclasses — such as <code>InMemoryWalletDatabase</code> — with no on-disk persistence don't need to carry an unnecessary placeholder file path.</summary>

- Replace member of `SQLiteDatabase` `const std::string m_file_path` with `const std::optional<fs::path> m_file_path`, so subclasses with no on-disk persistence — such as `InMemoryWalletDatabase` — pass `std::nullopt` instead of storing the SQLite-internal magic string ":memory:" as a placeholder file path.

- An `Assert` in the protected constructor enforces the invariant that `m_file_path` is absent if and only if `SQLITE_OPEN_MEMORY` is set, catching any future misuse at startup.

- Add a private `IsOnDisk()` predicate to replace bare `if (m_file_path)` checks in `Open()`, `Filename()`, and `Files()`. `Files()` now returns an empty vector for in-memory databases through the base class implementation, so the redundant override in `InMemoryWalletDatabase` is removed. The `Filename()` override in `MockableSQLiteDatabase` is also removed, as the base class now correctly returns `":memory:"` for in-memory databases.

</details>

<details>
<summary>Add a test for <code>InMemoryWalletDatabase::Filename()</code> and <code>Files()</code>.</summary>

- Add a test case verifying that `InMemoryWalletDatabase::Filename()` returns `":memory:"` and `Files()` returns an empty vector.

</details>

<ins>_**Note**_:</ins> `InMemoryWalletDatabase` intentionally inherits from `SQLiteDatabase` rather than `WalletDatabase` directly — it uses real SQLite semantics in memory, so all wallet code exercising it gets faithful SQLite behaviour without having to reimplement the full database layer. The optional `m_file_path` formalises the existing design gap rather than introducing one.