### PR TITLE
doc: correct MiniMiner constructor comment

### DIFF
--- a/src/node/mini_miner.h
+++ b/src/node/mini_miner.h
@@ -131,8 +131,8 @@ public:
     std::set<Txid> GetMockTemplateTxids() const { return m_in_block; }
 
     /** Constructor that takes a list of outpoints that may or may not belong to transactions in the
-     * mempool. Copies out information about the relevant transactions in the mempool into
-     * MiniMinerMempoolEntrys.
+     * mempool. Copies information about the relevant transactions from the mempool into
+     * `m_entries_by_txid`.
     */
     MiniMiner(const CTxMemPool& mempool, const std::vector<COutPoint>& outpoints);
 


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests may be closed immediately if they:
- do not have a rationale and clear improvement
- do not adhere to doc/AI_POLICY.md

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui first.
See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->

The constructor comment refers to `MiniMinerMempoolEntrys`, which is not an existing type or member. 

The implementation stores the relevant mempool transaction data in `m_entries_by_txid`, so update the comment to name the actual destination.
