### PR TITLE
mining: add getInfo() IPC method

### DIFF
--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -112,6 +112,10 @@ public:
     //! Returns the hash and height for the tip of this chain
     virtual std::optional<BlockRef> getTip() = 0;
 
+    //! Returns mining-related information relevant for the next block,
+    //! or nullopt if there is no tip.
+    virtual std::optional<node::MiningInfo> getInfo() = 0;
+
     /**
      * Waits for the connected tip to change. During node initialization, this will
      * wait until the tip is connected (regardless of `timeout`).

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -28,6 +28,7 @@ interface Mining $Proxy.wrap("interfaces::Mining") {
     submitBlock @7 (context :Proxy.Context, block: Data) -> (reason: Text, debug: Text, result: Bool);
     getTransactionsByTxID @8 (context :Proxy.Context, txids: List(Data)) -> (result: List(Data));
     getTransactionsByWitnessID @9 (context :Proxy.Context, wtxids: List(Data)) -> (result: List(Data));
+    getInfo @10 (context :Proxy.Context) -> (result: MiningInfo, hasResult: Bool);
 }
 
 interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {
@@ -57,6 +58,13 @@ struct BlockWaitOptions $Proxy.wrap("node::BlockWaitOptions") {
 struct BlockCheckOptions $Proxy.wrap("node::BlockCheckOptions") {
     checkMerkleRoot @0 :Bool = true $Proxy.name("check_merkle_root");
     checkPow @1 :Bool = true $Proxy.name("check_pow");
+}
+
+struct MiningInfo $Proxy.wrap("node::MiningInfo") {
+    bits @0 :UInt32;
+    minTime @1 :Int64 $Proxy.name("min_time");
+    time @2 :Int64;
+    tip @3 :Common.BlockRef;
 }
 
 struct CoinbaseTx $Proxy.wrap("node::CoinbaseTx") {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -99,6 +99,7 @@ using node::BlockAssembler;
 using node::BlockCreateOptions;
 using node::BlockWaitOptions;
 using node::CoinbaseTx;
+using node::MiningInfo;
 using util::Join;
 
 namespace node {
@@ -972,6 +973,11 @@ public:
     std::optional<BlockRef> getTip() override
     {
         return GetTip(chainman());
+    }
+
+    std::optional<MiningInfo> getInfo() override
+    {
+        return GetMiningInfo(chainman());
     }
 
     std::optional<BlockRef> waitTipChanged(uint256 current_tip, MillisecondsDouble timeout) override

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -514,6 +514,25 @@ std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainma
     return nullptr;
 }
 
+std::optional<MiningInfo> GetMiningInfo(ChainstateManager& chainman)
+{
+    LOCK(::cs_main);
+    const CBlockIndex* tip{chainman.ActiveChain().Tip()};
+    if (!tip) return std::nullopt;
+
+    const Consensus::Params& consensus{chainman.GetConsensus()};
+    CBlockHeader next_header;
+    UpdateTime(&next_header, consensus, tip);
+    next_header.nBits = GetNextWorkRequired(tip, &next_header, consensus);
+
+    return MiningInfo{
+        .bits = next_header.nBits,
+        .min_time = GetMinimumTime(tip, consensus.DifficultyAdjustmentInterval()),
+        .time = next_header.GetBlockTime(),
+        .tip = {tip->GetBlockHash(), tip->nHeight},
+    };
+}
+
 std::optional<BlockRef> GetTip(ChainstateManager& chainman)
 {
     LOCK(::cs_main);

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -148,6 +148,9 @@ std::unique_ptr<CBlockTemplate> WaitAndCreateNewBlock(ChainstateManager& chainma
                                                       const BlockCreateOptions& create_options,
                                                       bool& interrupt_wait);
 
+/* Locks cs_main and returns mining-related information for the next block if the active chain has a tip; otherwise, returns nullopt. */
+std::optional<MiningInfo> GetMiningInfo(ChainstateManager& chainman);
+
 /* Locks cs_main and returns the block hash and block height of the active chain if it exists; otherwise, returns nullopt.*/
 std::optional<BlockRef> GetTip(ChainstateManager& chainman);
 

--- a/src/node/mining_types.h
+++ b/src/node/mining_types.h
@@ -12,6 +12,7 @@
 #define BITCOIN_NODE_MINING_TYPES_H
 
 #include <consensus/amount.h>
+#include <interfaces/types.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
@@ -25,6 +26,20 @@
 #include <vector>
 
 namespace node {
+
+/**
+ * Mining-related information.
+ */
+struct MiningInfo {
+    /** Next block difficulty target in compact form. */
+    uint32_t bits;
+    /** Minimum valid next block timestamp. */
+    int64_t min_time;
+    /** Current next block timestamp, adjusted to satisfy min_time. */
+    int64_t time;
+    /** Current chain tip. */
+    interfaces::BlockRef tip;
+};
 
 /**
  * Block template creation options. These override node defaults, but can't

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from io import BytesIO
 from test_framework.blocktools import (
     NULL_OUTPOINT,
+    nbits_str,
     script_BIP34_coinbase_height,
     WITNESS_COMMITMENT_HEADER,
 )
@@ -137,6 +138,20 @@ class IPCMiningTest(BitcoinTestFramework):
             blockref = await mining.getTip(ctx)
             current_block_height = self.nodes[0].getchaintips()[0]["height"]
             assert_equal(blockref.result.height, current_block_height)
+
+            self.log.debug("Test next block mining info")
+            mock_time = self.nodes[0].getblockchaininfo()["time"] + 1
+            self.nodes[0].setmocktime(mock_time)
+            rpc_info = self.nodes[0].getmininginfo()
+            block_template = self.nodes[0].getblocktemplate({"rules": ["segwit"]})
+            ipc_info = await mining.getInfo(ctx)
+            assert ipc_info.hasResult
+            assert_equal(ipc_info.result.tip.height + 1, rpc_info["next"]["height"])
+            assert_equal(bytes(ipc_info.result.tip.hash)[::-1].hex(), block_template["previousblockhash"])
+            assert_equal(nbits_str(ipc_info.result.bits), rpc_info["next"]["bits"])
+            assert_equal(ipc_info.result.minTime, block_template["mintime"])
+            assert_equal(ipc_info.result.time, block_template["curtime"])
+            self.nodes[0].setmocktime(0)
 
             self.log.debug("Mine a block")
             newblockref = (await wait_and_do(


### PR DESCRIPTION
This lets IPC clients fetch information relevant to the next block, without having to generate a template.

Similar to the `getmininginfo` RPC, but with a minimal set of fields based on known needs for the Stratum v2 Job Declarator Server Role[^0], including `minTime` and `time` which the RPC doesn't provide. Can easily be expanded later for other use cases.

It echos the tip so clients can check for race conditions, e.g. when they call `getInfo()` immediately after `waitTipChanged()`.

Based on discussion in https://github.com/stratum-mining/sv2-apps/issues/268. Two alternative solutions to that issue:
1. add `min_time` to the `getmininginfo` RPC
2. call `createNewBlock(mempool: false)` followed by `getBlockHeader()` on the empty block to get `nBits`, but for `minTime` you need `getblocktemplate` (which returns a full block)


[^0]: https://stratumprotocol.org/specification/06-job-declaration-protocol/