### PR TITLE
cmake: Fix WITH_EXTERNAL_LIBMULTIPROCESS + BUILD_FUZZ_BINARY

### DIFF
--- a/src/ipc/test/fuzz/CMakeLists.txt
+++ b/src/ipc/test/fuzz/CMakeLists.txt
@@ -3,4 +3,4 @@
 # file COPYING or https://opensource.org/license/mit/.
 
 target_sources(fuzz PRIVATE ${PROJECT_SOURCE_DIR}/src/ipc/test/fuzz/ipc.cpp)
-target_link_libraries(fuzz bitcoin_ipc_fuzz multiprocess)
+target_link_libraries(fuzz bitcoin_ipc_fuzz Libmultiprocess::multiprocess)


### PR DESCRIPTION
CMake `WITH_EXTERNAL_LIBMULTIPROCESS` and `BUILD_FUZZ_BINARY` options stopped working together recently due to #35118 commit 037ad77071419367fd679da71d5c39853d1e622e because an non-namespaced `Libmultiprocess::multiprocess` target name was referenced.

 Fix by specifying the full target name which is better for readability anyway.