### PR TITLE
wallet: Replace mapWallet and wtxOrdered with a boost::multi_index

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -174,6 +174,7 @@ if(ENABLE_WALLET)
       bitcoin_wallet
       bitcoin_common
       bitcoin_util
+      $<TARGET_NAME_IF_EXISTS:Boost::headers>
     )
     install_binary_component(bitcoin-wallet HAS_MANPAGE)
   endif()

--- a/src/wallet/export.cpp
+++ b/src/wallet/export.cpp
@@ -158,14 +158,14 @@ util::Result<std::string> ExportWatchOnlyWallet(const CWallet& wallet, const fs:
             }
 
             // Copy the transactions
-            for (const auto& [txid, wtx] : wallet.mapWallet) {
+            for (const auto& wtx : wallet.m_txs_by_txid) {
                 DataStream wtx_ser;
                 wtx_ser << wtx;
                 CWalletTx copy_wtx(deserialize, wtx_ser, wtx.GetTxs());
                 if (!watchonly_wallet->LoadToWallet(std::move(copy_wtx))) {
-                    return util::Error{strprintf(_("Error: Could not add tx %s to watchonly wallet"), txid.GetHex())};
+                    return util::Error{strprintf(_("Error: Could not add tx %s to watchonly wallet"), wtx.GetHash().GetHex())};
                 }
-                watchonly_batch.WriteTx(*watchonly_wallet->GetWalletTx(txid));
+                watchonly_batch.WriteTx(*watchonly_wallet->GetWalletTx(wtx.GetHash()));
             }
 
             // Copy address book

--- a/src/wallet/export.cpp
+++ b/src/wallet/export.cpp
@@ -165,7 +165,7 @@ util::Result<std::string> ExportWatchOnlyWallet(const CWallet& wallet, const fs:
                 if (!watchonly_wallet->LoadToWallet(std::move(copy_wtx))) {
                     return util::Error{strprintf(_("Error: Could not add tx %s to watchonly wallet"), txid.GetHex())};
                 }
-                watchonly_batch.WriteTx(watchonly_wallet->mapWallet.at(txid));
+                watchonly_batch.WriteTx(*watchonly_wallet->GetWalletTx(txid));
             }
 
             // Copy address book

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -172,12 +172,12 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
 
     LOCK(wallet.cs_wallet);
     errors.clear();
-    auto it = wallet.mapWallet.find(txid);
-    if (it == wallet.mapWallet.end()) {
+    const CWalletTx* pwtx = wallet.GetWalletTx(txid);
+    if (!pwtx) {
         errors.emplace_back(Untranslated("Invalid or non-wallet transaction id"));
         return Result::INVALID_ADDRESS_OR_KEY;
     }
-    const CWalletTx& wtx = it->second;
+    const CWalletTx& wtx = *pwtx;
     const CTransactionRef& tx = wtx.GetTx();
 
     // Make sure that original_change_index is valid
@@ -356,12 +356,12 @@ Result CommitTransaction(CWallet& wallet, const Txid& txid, CMutableTransaction&
     if (!errors.empty()) {
         return Result::MISC_ERROR;
     }
-    auto it = txid.IsNull() ? wallet.mapWallet.end() : wallet.mapWallet.find(txid);
-    if (it == wallet.mapWallet.end()) {
+    const CWalletTx* old_wtx = txid.IsNull() ? nullptr : wallet.GetWalletTx(txid);
+    if (!old_wtx) {
         errors.emplace_back(Untranslated("Invalid or non-wallet transaction id"));
         return Result::MISC_ERROR;
     }
-    const CWalletTx& oldWtx = it->second;
+    const CWalletTx& oldWtx = *old_wtx;
 
     // make sure the transaction still has no descendants and hasn't been mined in the meantime
     Result result = PreconditionChecks(wallet, oldWtx, /* require_mine=*/ false, errors);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -323,8 +323,8 @@ public:
     {
         LOCK(m_wallet->cs_wallet);
         std::set<WalletTx> result;
-        for (const auto& entry : m_wallet->mapWallet) {
-            result.emplace(MakeWalletTx(*m_wallet, entry.second));
+        for (const auto& entry : m_wallet->m_txs_by_txid) {
+            result.emplace(MakeWalletTx(*m_wallet, entry));
         }
         return result;
     }

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -304,18 +304,18 @@ public:
     CTransactionRef getTx(const Txid& txid) override
     {
         LOCK(m_wallet->cs_wallet);
-        auto mi = m_wallet->mapWallet.find(txid);
-        if (mi != m_wallet->mapWallet.end()) {
-            return mi->second.GetTx();
+        const CWalletTx* wtx = m_wallet->GetWalletTx(txid);
+        if (wtx) {
+            return wtx->GetTx();
         }
         return {};
     }
     WalletTx getWalletTx(const Txid& txid) override
     {
         LOCK(m_wallet->cs_wallet);
-        auto mi = m_wallet->mapWallet.find(txid);
-        if (mi != m_wallet->mapWallet.end()) {
-            return MakeWalletTx(*m_wallet, mi->second);
+        const CWalletTx* wtx = m_wallet->GetWalletTx(txid);
+        if (wtx) {
+            return MakeWalletTx(*m_wallet, *wtx);
         }
         return {};
     }
@@ -337,14 +337,14 @@ public:
         if (!locked_wallet) {
             return false;
         }
-        auto mi = m_wallet->mapWallet.find(txid);
-        if (mi == m_wallet->mapWallet.end()) {
+        const CWalletTx* wtx = m_wallet->GetWalletTx(txid);
+        if (!wtx) {
             return false;
         }
         num_blocks = m_wallet->GetLastBlockHeight();
         block_time = -1;
         CHECK_NONFATAL(m_wallet->chain().findBlock(m_wallet->GetLastBlockHash(), FoundBlock().time(block_time)));
-        tx_status = MakeWalletTxStatus(*m_wallet, mi->second);
+        tx_status = MakeWalletTxStatus(*m_wallet, *wtx);
         return true;
     }
     WalletTx getWalletTxDetails(const Txid& txid,
@@ -355,14 +355,14 @@ public:
         int& num_blocks) override
     {
         LOCK(m_wallet->cs_wallet);
-        auto mi = m_wallet->mapWallet.find(txid);
-        if (mi != m_wallet->mapWallet.end()) {
+        const CWalletTx* wtx = m_wallet->GetWalletTx(txid);
+        if (wtx) {
             num_blocks = m_wallet->GetLastBlockHeight();
-            in_mempool = mi->second.InMempool();
-            messages = mi->second.m_messages;
-            payment_requests = mi->second.m_payment_requests;
-            tx_status = MakeWalletTxStatus(*m_wallet, mi->second);
-            return MakeWalletTx(*m_wallet, mi->second);
+            in_mempool = wtx->InMempool();
+            messages = wtx->m_messages;
+            payment_requests = wtx->m_payment_requests;
+            tx_status = MakeWalletTxStatus(*m_wallet, *wtx);
+            return MakeWalletTx(*m_wallet, *wtx);
         }
         return {};
     }
@@ -456,11 +456,11 @@ public:
         result.reserve(outputs.size());
         for (const auto& output : outputs) {
             result.emplace_back();
-            auto it = m_wallet->mapWallet.find(output.hash);
-            if (it != m_wallet->mapWallet.end()) {
-                int depth = m_wallet->GetTxDepthInMainChain(it->second);
+            const CWalletTx* wtx = m_wallet->GetWalletTx(output.hash);
+            if (wtx) {
+                int depth = m_wallet->GetTxDepthInMainChain(*wtx);
                 if (depth >= 0) {
-                    result.back() = MakeWalletTxOut(*m_wallet, it->second, output.n, depth);
+                    result.back() = MakeWalletTxOut(*m_wallet, *wtx, output.n, depth);
                 }
             }
         }

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -115,7 +115,7 @@ CAmount CachedTxGetCredit(const CWallet& wallet, const CWalletTx& wtx, bool avoi
     if (wallet.IsTxImmatureCoinBase(wtx))
         return 0;
 
-    // GetBalance can assume transactions in mapWallet won't change
+    // GetBalance can assume transactions in m_txs won't change
     return GetCachableAmount(wallet, wtx, CWalletTx::CREDIT, avoid_reuse);
 }
 
@@ -328,9 +328,9 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
     std::set< std::set<CTxDestination> > groupings;
     std::set<CTxDestination> grouping;
 
-    for (const auto& walletEntry : wallet.mapWallet)
+    for (const auto& walletEntry : wallet.m_txs_by_txid)
     {
-        const CWalletTx& wtx = walletEntry.second;
+        const CWalletTx& wtx = walletEntry;
 
         if (wtx.GetTx()->vin.size() > 0)
         {

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -341,7 +341,7 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
                 CTxDestination address;
                 if(!InputIsMine(wallet, txin)) /* If this input isn't mine, ignore it */
                     continue;
-                if(!ExtractDestination(wallet.mapWallet.at(txin.prevout.hash).GetTx()->vout[txin.prevout.n].scriptPubKey, address))
+                if(!ExtractDestination(wallet.GetWalletTx(txin.prevout.hash)->GetTx()->vout[txin.prevout.n].scriptPubKey, address))
                     continue;
                 grouping.insert(address);
                 any_mine = true;

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -56,7 +56,7 @@ static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool b
 
     // Tally
     CAmount amount = 0;
-    for (const auto& [_, wtx] : wallet.mapWallet) {
+    for (const auto& wtx : wallet.m_txs_by_txid) {
         int depth{wallet.GetTxDepthInMainChain(wtx)};
         if (depth < min_depth
             // Coinbase with less than 1 confirmation is no longer in the main chain

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -303,12 +303,12 @@ RPCMethod lockunspent()
 
         const COutPoint outpt(txid, nOutput);
 
-        const auto it = pwallet->mapWallet.find(outpt.hash);
-        if (it == pwallet->mapWallet.end()) {
+        const CWalletTx* wtx = pwallet->GetWalletTx(outpt.hash);
+        if (!wtx) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, unknown transaction");
         }
 
-        const CWalletTx& trans = it->second;
+        const CWalletTx& trans = *wtx;
 
         if (outpt.n >= trans.GetTx()->vout.size()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout index out of bounds");

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -659,11 +659,10 @@ RPCMethod listsinceblock()
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
         }
         for (const CTransactionRef& tx : block.vtx) {
-            auto it = wallet.mapWallet.find(tx->GetHash());
-            if (it != wallet.mapWallet.end()) {
+            if (const CWalletTx* wtx = wallet.GetWalletTx(tx->GetHash())) {
                 // We want all transactions regardless of confirmation count to appear here,
                 // even negative confirmation ones, hence the big negative.
-                ListTransactions(wallet, it->second, -100000000, true, removed, filter_label, include_change);
+                ListTransactions(wallet, *wtx, -100000000, true, removed, filter_label, include_change);
             }
         }
         blockId = block.hashPrevBlock;
@@ -756,11 +755,11 @@ RPCMethod gettransaction()
     bool verbose = request.params[2].isNull() ? false : request.params[2].get_bool();
 
     UniValue entry(UniValue::VOBJ);
-    auto it = pwallet->mapWallet.find(hash);
-    if (it == pwallet->mapWallet.end()) {
+    const CWalletTx* pwtx = pwallet->GetWalletTx(hash);
+    if (!pwtx) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
     }
-    const CWalletTx& wtx = it->second;
+    const CWalletTx& wtx = *pwtx;
 
     CAmount nCredit = CachedTxGetCredit(*pwallet, wtx, /*avoid_reuse=*/false);
     CAmount nDebit = CachedTxGetDebit(*pwallet, wtx, /*avoid_reuse=*/false);
@@ -830,7 +829,7 @@ RPCMethod abandontransaction()
 
     Txid hash{Txid::FromUint256(ParseHashV(request.params[0], "txid"))};
 
-    if (!pwallet->mapWallet.contains(hash)) {
+    if (!pwallet->GetWalletTx(hash)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
     }
     if (!pwallet->AbandonTransaction(hash)) {

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -104,7 +104,7 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, cons
 
     // Tally
     std::map<CTxDestination, tallyitem> mapTally;
-    for (const auto& [_, wtx] : wallet.mapWallet) {
+    for (const auto& wtx : wallet.m_txs_by_txid) {
 
         int nDepth = wallet.GetTxDepthInMainChain(wtx);
         if (nDepth < nMinDepth)
@@ -509,13 +509,8 @@ RPCMethod listtransactions()
     {
         LOCK(pwallet->cs_wallet);
 
-        const CWallet::TxItems & txOrdered = pwallet->wtxOrdered;
-
-        // iterate backwards until we have nCount items to return:
-        for (CWallet::TxItems::const_reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
-        {
-            CWalletTx *const pwtx = (*it).second;
-            ListTransactions(*pwallet, *pwtx, 0, true, ret, filter_label);
+        for (auto it = pwallet->m_txs_by_pos.rbegin(); it != pwallet->m_txs_by_pos.rend(); ++it) {
+            ListTransactions(*pwallet, *it, 0, true, ret, filter_label);
             if ((int)ret.size() >= (nCount+nFrom)) break;
         }
     }
@@ -643,7 +638,7 @@ RPCMethod listsinceblock()
 
     UniValue transactions(UniValue::VARR);
 
-    for (const auto& [_, tx] : wallet.mapWallet) {
+    for (const auto& tx : wallet.m_txs_by_txid) {
 
         if (depth == -1 || abs(wallet.GetTxDepthInMainChain(tx)) < depth) {
             ListTransactions(wallet, tx, 0, true, transactions, filter_label, include_change);

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -91,7 +91,7 @@ static RPCMethod getwalletinfo()
     obj.pushKV("walletname", pwallet->GetName());
     obj.pushKV("walletversion", latest_legacy_wallet_minversion);
     obj.pushKV("format", pwallet->GetDatabase().Format());
-    obj.pushKV("txcount", pwallet->mapWallet.size());
+    obj.pushKV("txcount", pwallet->m_txs.size());
     obj.pushKV("keypoolsize", kpExternalSize);
     obj.pushKV("keypoolsize_hd_internal", pwallet->GetKeyPoolSize() - kpExternalSize);
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -175,11 +175,11 @@ TxSize CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *walle
     std::vector<CTxOut> txouts;
     // Look up the inputs. The inputs are either in the wallet, or in coin_control.
     for (const CTxIn& input : tx.vin) {
-        const auto mi = wallet->mapWallet.find(input.prevout.hash);
+        const CWalletTx* wtx = wallet->GetWalletTx(input.prevout.hash);
         // Can not estimate size without knowing the input details
-        if (mi != wallet->mapWallet.end()) {
-            assert(input.prevout.n < mi->second.GetTx()->vout.size());
-            txouts.emplace_back(mi->second.GetTx()->vout.at(input.prevout.n));
+        if (wtx) {
+            assert(input.prevout.n < wtx->GetTx()->vout.size());
+            txouts.emplace_back(wtx->GetTx()->vout.at(input.prevout.n));
         } else if (coin_control) {
             const auto& txout{coin_control->GetExternalOutput(input.prevout)};
             if (!txout) return TxSize{-1, -1};

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -288,7 +288,7 @@ util::Result<CoinsResult> FetchSelectedInputs(const CWallet& wallet, const CCoin
                 }
             }
         } else {
-            // The input is external. We did not find the tx in mapWallet.
+            // The input is external. We did not find the tx in m_txs.
             const auto out{coin_control.GetExternalOutput(outpoint)};
             if (!out) {
                 return util::Error{strprintf(_("Not found pre-selected input %s"), outpoint.ToString())};

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -70,14 +70,13 @@ static void add_coin(CoinsResult& available_coins, CWallet& wallet, const CAmoun
     if (spendable) {
         tx.vout[nInput].scriptPubKey = GetScriptForDestination(*Assert(wallet.GetNewDestination(OutputType::BECH32, "")));
     }
-    Txid txid = tx.GetHash();
 
     LOCK(wallet.cs_wallet);
-    auto ret = wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateInactive{}));
-    assert(ret.second);
-    CWalletTx& wtx = (*ret.first).second;
-    const auto& txout = wtx.GetTx()->vout.at(nInput);
-    available_coins.Add(OutputType::BECH32, {COutPoint(wtx.GetHash(), nInput), txout, nAge, custom_size == 0 ? CalculateMaximumSignedInputSize(txout, &wallet, /*coin_control=*/nullptr) : custom_size, /*solvable=*/true, /*safe=*/true, wtx.GetTxTime(), fIsFromMe, feerate});
+
+    CWalletTx* wtx = wallet.AddToWallet(MakeTransactionRef(std::move(tx)), TxStateInactive{});
+    assert(wtx);
+    const auto& txout = wtx->GetTx()->vout.at(nInput);
+    available_coins.Add(OutputType::BECH32, {COutPoint(wtx->GetHash(), nInput), txout, nAge, custom_size == 0 ? CalculateMaximumSignedInputSize(txout, &wallet, /*coin_control=*/nullptr) : custom_size, /*solvable=*/true, /*safe=*/true, wtx->GetTxTime(), fIsFromMe, feerate});
 }
 
 // Helpers

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -73,10 +73,10 @@ static void add_coin(CoinsResult& available_coins, CWallet& wallet, const CAmoun
 
     LOCK(wallet.cs_wallet);
 
-    CWalletTx* wtx = wallet.AddToWallet(MakeTransactionRef(std::move(tx)), TxStateInactive{});
+    std::optional<WalletTxs::iterator> wtx = wallet.AddToWallet(MakeTransactionRef(std::move(tx)), TxStateInactive{});
     assert(wtx);
-    const auto& txout = wtx->GetTx()->vout.at(nInput);
-    available_coins.Add(OutputType::BECH32, {COutPoint(wtx->GetHash(), nInput), txout, nAge, custom_size == 0 ? CalculateMaximumSignedInputSize(txout, &wallet, /*coin_control=*/nullptr) : custom_size, /*solvable=*/true, /*safe=*/true, wtx->GetTxTime(), fIsFromMe, feerate});
+    const auto& txout = (*wtx)->GetTx()->vout.at(nInput);
+    available_coins.Add(OutputType::BECH32, {COutPoint((*wtx)->GetHash(), nInput), txout, nAge, custom_size == 0 ? CalculateMaximumSignedInputSize(txout, &wallet, /*coin_control=*/nullptr) : custom_size, /*solvable=*/true, /*safe=*/true, (*wtx)->GetTxTime(), fIsFromMe, feerate});
 }
 
 // Helpers

--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -69,7 +69,7 @@ FUZZ_TARGET(wallet_create_transaction, .init = initialize_setup)
         tx.vout[0].nValue = n_value;
         tx.vout[0].scriptPubKey = GetScriptForDestination(fuzzed_wallet.GetDestination(fuzzed_data_provider));
         LOCK(fuzzed_wallet.wallet->cs_wallet);
-        CWalletTx* wtx = fuzzed_wallet.wallet->AddToWallet(MakeTransactionRef(std::move(tx)), TxStateConfirmed{chainstate.m_chain.Tip()->GetBlockHash(), chainstate.m_chain.Height(), /*index=*/0});
+        std::optional<WalletTxs::iterator> wtx = fuzzed_wallet.wallet->AddToWallet(MakeTransactionRef(std::move(tx)), TxStateConfirmed{chainstate.m_chain.Tip()->GetBlockHash(), chainstate.m_chain.Height(), /*index=*/0});
         assert(wtx);
     }
 

--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -69,10 +69,8 @@ FUZZ_TARGET(wallet_create_transaction, .init = initialize_setup)
         tx.vout[0].nValue = n_value;
         tx.vout[0].scriptPubKey = GetScriptForDestination(fuzzed_wallet.GetDestination(fuzzed_data_provider));
         LOCK(fuzzed_wallet.wallet->cs_wallet);
-        auto txid{tx.GetHash()};
-        auto ret{fuzzed_wallet.wallet->mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateConfirmed{chainstate.m_chain.Tip()->GetBlockHash(), chainstate.m_chain.Height(), /*index=*/0}))};
-        assert(ret.second);
-        fuzzed_wallet.wallet->RefreshTXOsFromTx(ret.first->second);
+        CWalletTx* wtx = fuzzed_wallet.wallet->AddToWallet(MakeTransactionRef(std::move(tx)), TxStateConfirmed{chainstate.m_chain.Tip()->GetBlockHash(), chainstate.m_chain.Height(), /*index=*/0});
+        assert(wtx);
     }
 
     std::vector<CRecipient> recipients;

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -39,20 +39,18 @@ static void addCoin(CoinsResult& coins,
     tx.vout[0].nValue = nValue;
     tx.vout[0].scriptPubKey = GetScriptForDestination(dest);
 
-    const auto txid{tx.GetHash()};
     LOCK(wallet.cs_wallet);
-    auto ret = wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateInactive{}));
-    assert(ret.second);
-    CWalletTx& wtx = (*ret.first).second;
-    const auto& txout = wtx.GetTx()->vout.at(0);
+    CWalletTx* wtx = wallet.AddToWallet(MakeTransactionRef(std::move(tx)), TxStateInactive{});
+    assert(wtx);
+    const auto& txout = wtx->GetTx()->vout.at(0);
     coins.Add(*Assert(OutputTypeFromDestination(dest)),
-              {COutPoint(wtx.GetHash(), 0),
+              {COutPoint(wtx->GetHash(), 0),
                    txout,
                    depth,
                    CalculateMaximumSignedInputSize(txout, &wallet, /*coin_control=*/nullptr),
                    /*solvable=*/ true,
                    /*safe=*/ true,
-                   wtx.GetTxTime(),
+                   wtx->GetTxTime(),
                    is_from_me,
                    fee_rate});
 }

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -40,17 +40,17 @@ static void addCoin(CoinsResult& coins,
     tx.vout[0].scriptPubKey = GetScriptForDestination(dest);
 
     LOCK(wallet.cs_wallet);
-    CWalletTx* wtx = wallet.AddToWallet(MakeTransactionRef(std::move(tx)), TxStateInactive{});
+    std::optional<WalletTxs::iterator> wtx = wallet.AddToWallet(MakeTransactionRef(std::move(tx)), TxStateInactive{});
     assert(wtx);
-    const auto& txout = wtx->GetTx()->vout.at(0);
+    const auto& txout = (*wtx)->GetTx()->vout.at(0);
     coins.Add(*Assert(OutputTypeFromDestination(dest)),
-              {COutPoint(wtx->GetHash(), 0),
+              {COutPoint((*wtx)->GetHash(), 0),
                    txout,
                    depth,
                    CalculateMaximumSignedInputSize(txout, &wallet, /*coin_control=*/nullptr),
                    /*solvable=*/ true,
                    /*safe=*/ true,
-                   wtx->GetTxTime(),
+                   (*wtx)->GetTxTime(),
                    is_from_me,
                    fee_rate});
 }

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
     };
     CTransactionRef prev_tx1;
     s_prev_tx1 >> TX_WITH_WITNESS(prev_tx1);
-    CWalletTx* wtx1 = m_wallet.AddToWallet(std::move(prev_tx1), TxStateInactive{});
+    std::optional<WalletTxs::iterator> wtx1 = m_wallet.AddToWallet(std::move(prev_tx1), TxStateInactive{});
     assert(wtx1);
 
     DataStream s_prev_tx2{
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
     };
     CTransactionRef prev_tx2;
     s_prev_tx2 >> TX_WITH_WITNESS(prev_tx2);
-    CWalletTx* wtx2= m_wallet.AddToWallet(std::move(prev_tx2), TxStateInactive{});
+    std::optional<WalletTxs::iterator> wtx2= m_wallet.AddToWallet(std::move(prev_tx2), TxStateInactive{});
     assert(wtx2);
 
     // Import descriptors for keys and scripts

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -41,14 +41,16 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
     };
     CTransactionRef prev_tx1;
     s_prev_tx1 >> TX_WITH_WITNESS(prev_tx1);
-    m_wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(prev_tx1->GetHash()), std::forward_as_tuple(prev_tx1, TxStateInactive{}));
+    CWalletTx* wtx1 = m_wallet.AddToWallet(std::move(prev_tx1), TxStateInactive{});
+    assert(wtx1);
 
     DataStream s_prev_tx2{
         "0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f618765000000"_hex,
     };
     CTransactionRef prev_tx2;
     s_prev_tx2 >> TX_WITH_WITNESS(prev_tx2);
-    m_wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(prev_tx2->GetHash()), std::forward_as_tuple(prev_tx2, TxStateInactive{}));
+    CWalletTx* wtx2= m_wallet.AddToWallet(std::move(prev_tx2), TxStateInactive{});
+    assert(wtx2);
 
     // Import descriptors for keys and scripts
     import_descriptor(m_wallet, "sh(multi(2,xprv9s21ZrQH143K2LE7W4Xf3jATf9jECxSb7wj91ZnmY4qEJrS66Qru9RFqq8xbkgT32ya6HqYJweFdJUEDf5Q6JFV7jMiUws7kQfe6Tv4RbfN/0h/0h/0h,xprv9s21ZrQH143K2LE7W4Xf3jATf9jECxSb7wj91ZnmY4qEJrS66Qru9RFqq8xbkgT32ya6HqYJweFdJUEDf5Q6JFV7jMiUws7kQfe6Tv4RbfN/0h/0h/1h))");

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -406,7 +406,7 @@ public:
         CMutableTransaction blocktx;
         {
             LOCK(wallet->cs_wallet);
-            blocktx = CMutableTransaction(*wallet->mapWallet.at(tx->GetHash()).GetTx());
+            blocktx = CMutableTransaction(*wallet->GetWalletTx(tx->GetHash())->GetTx());
         }
         CreateAndProcessBlock({CMutableTransaction(blocktx)}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
 
@@ -662,8 +662,8 @@ BOOST_FIXTURE_TEST_CASE(CreateWallet, TestChain100Setup)
     BOOST_CHECK_EQUAL(addtx_count, 3);
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK(wallet->mapWallet.contains(block_tx.GetHash()));
-        BOOST_CHECK(wallet->mapWallet.contains(mempool_tx.GetHash()));
+        BOOST_CHECK(wallet->GetWalletTx(block_tx.GetHash()));
+        BOOST_CHECK(wallet->GetWalletTx(mempool_tx.GetHash()));
     }
 
 
@@ -701,8 +701,8 @@ BOOST_FIXTURE_TEST_CASE(CreateWallet, TestChain100Setup)
     BOOST_CHECK_EQUAL(addtx_count, 2 + 2);
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK(wallet->mapWallet.contains(block_tx.GetHash()));
-        BOOST_CHECK(wallet->mapWallet.contains(mempool_tx.GetHash()));
+        BOOST_CHECK(wallet->GetWalletTx(block_tx.GetHash()));
+        BOOST_CHECK(wallet->GetWalletTx(mempool_tx.GetHash()));
     }
 
 
@@ -741,13 +741,13 @@ BOOST_FIXTURE_TEST_CASE(RemoveTxs, TestChain100Setup)
 
         LOCK(wallet->cs_wallet);
         BOOST_CHECK(wallet->HasWalletSpend(prev_tx));
-        BOOST_CHECK(wallet->mapWallet.contains(block_hash));
+        BOOST_CHECK(wallet->GetWalletTx(block_hash));
 
         std::vector<Txid> vHashIn{ block_hash };
         BOOST_CHECK(wallet->RemoveTxs(vHashIn));
 
         BOOST_CHECK(!wallet->HasWalletSpend(prev_tx));
-        BOOST_CHECK(!wallet->mapWallet.contains(block_hash));
+        BOOST_CHECK(!wallet->GetWalletTx(block_hash));
     }
 
     TestUnloadWallet(std::move(wallet));

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -413,10 +413,9 @@ public:
         LOCK(wallet->cs_wallet);
         LOCK(Assert(m_node.chainman)->GetMutex());
         wallet->SetLastBlockProcessed(wallet->GetLastBlockHeight() + 1, m_node.chainman->ActiveChain().Tip()->GetBlockHash());
-        auto it = wallet->mapWallet.find(tx->GetHash());
-        BOOST_CHECK(it != wallet->mapWallet.end());
-        it->second.m_state = TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1};
-        return it->second;
+        CWalletTx* wtx = wallet->AddToWallet(tx, TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1});
+        BOOST_CHECK(wtx);
+        return *wtx;
     }
 
     std::unique_ptr<CWallet> wallet;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -293,13 +293,13 @@ static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lock
         block->phashBlock = &hash;
         state = TxStateConfirmed{hash, block->nHeight, /*index=*/0};
     }
-    return wallet.AddToWallet(MakeTransactionRef(tx), state, [&](CWalletTx& wtx, bool /* new_tx */) {
+    return (*wallet.AddToWallet(MakeTransactionRef(tx), state, [&](CWalletTx& wtx, bool /* new_tx */) {
         // Assign wtx.m_state to simplify test and avoid the need to simulate
         // reorg events. Without this, AddToWallet asserts false when the same
         // transaction is confirmed in different blocks.
         wtx.m_state = state;
         return true;
-    })->nTimeSmart;
+    }))->nTimeSmart;
 }
 
 // Simple test to verify assignment of CWalletTx::nSmartTime value. Could be
@@ -393,7 +393,7 @@ public:
         wallet.reset();
     }
 
-    CWalletTx& AddTx(CRecipient recipient)
+    const CWalletTx& AddTx(CRecipient recipient)
     {
         CTransactionRef tx;
         CCoinControl dummy;
@@ -413,9 +413,9 @@ public:
         LOCK(wallet->cs_wallet);
         LOCK(Assert(m_node.chainman)->GetMutex());
         wallet->SetLastBlockProcessed(wallet->GetLastBlockHeight() + 1, m_node.chainman->ActiveChain().Tip()->GetBlockHash());
-        CWalletTx* wtx = wallet->AddToWallet(tx, TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1});
+        std::optional<WalletTxs::iterator> wtx = wallet->AddToWallet(tx, TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1});
         BOOST_CHECK(wtx);
-        return *wtx;
+        return **wtx;
     }
 
     std::unique_ptr<CWallet> wallet;
@@ -483,7 +483,7 @@ void TestCoinsResult(ListCoinsTest& context, OutputType out_type, CAmount amount
 {
     LOCK(context.wallet->cs_wallet);
     util::Result<CTxDestination> dest = Assert(context.wallet->GetNewDestination(out_type, ""));
-    CWalletTx& wtx = context.AddTx(CRecipient{*dest, amount, /*fSubtractFeeFromAmount=*/true});
+    const CWalletTx& wtx = context.AddTx(CRecipient{*dest, amount, /*fSubtractFeeFromAmount=*/true});
     CoinFilterParams filter;
     filter.skip_locked = false;
     CoinsResult available_coins = AvailableCoins(*context.wallet, nullptr, std::nullopt, filter);

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -359,8 +359,9 @@ public:
     // those with witnesses are preferred, followed by least weight.
     bool Update(CTransactionRef tx, const TxState& arg_state);
 
-    //! make sure balances are recalculated
-    void MarkDirty()
+    //! Make sure balances are recalculated
+    //! This function is not actually const, all of its changes are to mutable members.
+    void MarkDirty() const
     {
         m_amounts[DEBIT].Reset();
         m_amounts[CREDIT].Reset();

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -219,7 +219,6 @@ public:
     // Cached value for whether the transaction spends any inputs known to the wallet
     mutable std::optional<bool> m_cached_from_me{std::nullopt};
     int64_t nOrderPos; //!< position in ordered transaction list
-    std::multimap<int64_t, CWalletTx*>::const_iterator m_it_wtxOrdered;
 
     // memory only
     enum AmountType { DEBIT, CREDIT, AMOUNTTYPE_ENUM_ELEMENTS };
@@ -397,7 +396,7 @@ public:
     const std::map<Wtxid, CTransactionRef>& GetTxs() const { return m_txs; }
 
     // Disable copying of CWalletTx objects to prevent bugs where instances get
-    // copied in and out of the mapWallet map, and fields are updated in the
+    // copied in and out of the m_txs map, and fields are updated in the
     // wrong copy.
     CWalletTx(const CWalletTx&) = delete;
     CWalletTx& operator=(const CWalletTx&) = delete;
@@ -412,13 +411,6 @@ private:
     //! Set m_canonical_wtxid to the best variant under the unconfirmed rule
     //! (witnessed preferred, then least weight). Ignores state.
     void RecomputeCanonical();
-};
-
-struct WalletTxOrderComparator {
-    bool operator()(const CWalletTx* a, const CWalletTx* b) const
-    {
-        return a->nOrderPos < b->nOrderPos;
-    }
 };
 
 class WalletTXO

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -533,18 +533,13 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
     return wallet;
 }
 
-/** @defgroup mapWallet
- *
- * @{
- */
-
 const CWalletTx* CWallet::GetWalletTx(const Txid& hash) const
 {
     AssertLockHeld(cs_wallet);
-    const auto it = mapWallet.find(hash);
-    if (it == mapWallet.end())
+    const auto it = m_txs_by_txid.find(hash);
+    if (it == m_txs_by_txid.end())
         return nullptr;
-    return &(it->second);
+    return &*it;
 }
 
 void CWallet::UpgradeDescriptorCache()
@@ -744,22 +739,25 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
     for (TxSpends::iterator it = range.first; it != range.second; ++it)
     {
         const Txid& hash = it->second;
-        CWalletTx* copyTo = &mapWallet.at(hash);
-        if (copyFrom == copyTo) continue;
+        const auto& dst_it = m_txs_by_txid.find(hash);
+        if (copyFrom->GetWitnessHash() == dst_it->GetWitnessHash()) return;
         assert(copyFrom && "Oldest wallet transaction in range assumed to have been found.");
-        if (!copyFrom->IsEquivalentTo(*copyTo)) continue;
-        copyTo->m_from = copyFrom->m_from;
-        copyTo->m_message = copyFrom->m_message;
-        copyTo->m_comment = copyFrom->m_comment;
-        copyTo->m_comment_to = copyFrom->m_comment_to;
-        copyTo->m_replaces_txid = copyFrom->m_replaces_txid;
-        copyTo->m_replaced_by_txid = copyFrom->m_replaced_by_txid;
-        copyTo->m_messages = copyFrom->m_messages;
-        copyTo->m_payment_requests = copyFrom->m_payment_requests;
+        if (!copyFrom->IsEquivalentTo(*dst_it)) return;
+        WalletTxs::node_type dst_nh = m_txs_by_txid.extract(dst_it);
+        CWalletTx& copyTo = dst_nh.value();
+        copyTo.m_from = copyFrom->m_from;
+        copyTo.m_message = copyFrom->m_message;
+        copyTo.m_comment = copyFrom->m_comment;
+        copyTo.m_comment_to = copyFrom->m_comment_to;
+        copyTo.m_replaces_txid = copyFrom->m_replaces_txid;
+        copyTo.m_replaced_by_txid = copyFrom->m_replaced_by_txid;
+        copyTo.m_messages = copyFrom->m_messages;
+        copyTo.m_payment_requests = copyFrom->m_payment_requests;
         // nTimeReceived not copied on purpose
-        copyTo->nTimeSmart = copyFrom->nTimeSmart;
+        copyTo.nTimeSmart = copyFrom->nTimeSmart;
         // nOrderPos not copied on purpose
         // cached members not copied on purpose
+        m_txs_by_txid.insert(std::move(dst_nh));
     }
 }
 
@@ -910,29 +908,28 @@ DBErrors CWallet::ReorderTransactions()
     // Probably a bad idea to change the output of this
 
     // First: get all CWalletTx into a sorted-by-time multimap.
-    typedef std::multimap<int64_t, CWalletTx*> TxItems;
-    TxItems txByTime;
+    std::multimap<int64_t, WalletTxs::iterator> txByTime;
 
-    for (auto& entry : mapWallet)
-    {
-        CWalletTx* wtx = &entry.second;
-        txByTime.insert(std::make_pair(wtx->nTimeReceived, wtx));
+    for (auto it = m_txs_by_txid.begin(); it != m_txs_by_txid.end(); ++it) {
+        txByTime.emplace(it->nTimeReceived, it);
     }
 
     nOrderPosNext = 0;
     std::vector<int64_t> nOrderPosOffsets;
-    for (TxItems::iterator it = txByTime.begin(); it != txByTime.end(); ++it)
-    {
-        CWalletTx *const pwtx = (*it).second;
-        int64_t& nOrderPos = pwtx->nOrderPos;
+    for (const auto& [_, it] : txByTime) {
+        WalletTxs::node_type wtx_nh = m_txs_by_txid.extract(it);
+        CWalletTx& wtx = wtx_nh.value();
+        int64_t& nOrderPos = wtx.nOrderPos;
 
         if (nOrderPos == -1)
         {
             nOrderPos = nOrderPosNext++;
             nOrderPosOffsets.push_back(nOrderPos);
 
-            if (!batch.WriteTx(*pwtx))
+            m_txs_by_txid.insert(std::move(wtx_nh));
+            if (!batch.WriteTx(wtx)) {
                 return DBErrors::LOAD_FAIL;
+            }
         }
         else
         {
@@ -945,12 +942,14 @@ DBErrors CWallet::ReorderTransactions()
             nOrderPos += nOrderPosOff;
             nOrderPosNext = std::max(nOrderPosNext, nOrderPos + 1);
 
+            m_txs_by_txid.insert(std::move(wtx_nh));
             if (!nOrderPosOff)
                 continue;
 
             // Since we're changing the order, write it back
-            if (!batch.WriteTx(*pwtx))
+            if (!batch.WriteTx(wtx)) {
                 return DBErrors::LOAD_FAIL;
+            }
         }
     }
     batch.WriteOrderPosNext(nOrderPosNext);
@@ -972,10 +971,9 @@ int64_t CWallet::IncOrderPosNext(WalletBatch* batch)
 
 void CWallet::MarkDirty()
 {
-    {
-        LOCK(cs_wallet);
-        for (auto& [_, wtx] : mapWallet)
-            wtx.MarkDirty();
+    LOCK(cs_wallet);
+    for (const CWalletTx& wtx : m_txs_by_txid) {
+        wtx.MarkDirty();
     }
 }
 
@@ -983,20 +981,21 @@ bool CWallet::MarkReplaced(const Txid& originalHash, const Txid& newHash)
 {
     LOCK(cs_wallet);
 
-    auto mi = mapWallet.find(originalHash);
+    WalletTxs::node_type nh = m_txs_by_txid.extract(originalHash);
 
     // There is a bug if MarkReplaced is not called on an existing wallet transaction.
-    assert(mi != mapWallet.end());
-
-    CWalletTx& wtx = (*mi).second;
+    assert(!nh.empty());
 
     // Ensure for now that we're not overwriting data
+    CWalletTx& wtx = nh.value();
     Assert(!wtx.m_replaced_by_txid);
 
     wtx.m_replaced_by_txid = newHash;
 
     // Refresh mempool status without waiting for transactionRemovedFromMempool or transactionAddedToMempool
     RefreshMempoolStatus(wtx, chain());
+
+    m_txs_by_txid.insert(std::move(nh));
 
     WalletBatch batch(GetDatabase());
 
@@ -1043,7 +1042,7 @@ bool CWallet::IsSpentKey(const CScript& scriptPubKey) const
     return false;
 }
 
-CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx, bool rescanning_old_block)
+std::optional<WalletTxs::iterator> CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx, bool rescanning_old_block)
 {
     LOCK(cs_wallet);
 
@@ -1064,16 +1063,15 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     }
 
     // Inserts only if not already there, returns tx inserted or tx found
-    auto ret = mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(hash), std::forward_as_tuple(tx, state));
-    CWalletTx& wtx = (*ret.first).second;
-    bool fInsertedNew = ret.second;
+    auto [it, fInsertedNew] = m_txs_by_txid.emplace(tx, state);
+    WalletTxs::node_type wtx_nh = m_txs_by_txid.extract(it);
+    CWalletTx& wtx = wtx_nh.value();
+
     bool fUpdated = update_wtx && update_wtx(wtx, fInsertedNew);
     if (fInsertedNew) {
         wtx.nTimeReceived = GetTime();
         wtx.nOrderPos = IncOrderPosNext(&batch);
-        wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
         wtx.nTimeSmart = ComputeTimeSmart(wtx, rescanning_old_block);
-        AddToSpends(wtx);
 
         // Update birth time when tx time is older than it.
         MaybeUpdateBirthTime(wtx.GetTxTime());
@@ -1084,30 +1082,45 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
         fUpdated |= wtx.Update(tx, state);
     }
 
+    // Break debit/credit balance caches:
+    wtx.MarkDirty();
+
+    it = m_txs_by_txid.insert(std::move(wtx_nh)).position;
+
+    const CWalletTx& const_wtx = *it;
+    if (fInsertedNew) {
+        // AddToSpends requires the tx that we are adding to already be in m_txs,
+        // so we can only call it after re-insertion of the node handle.
+        AddToSpends(const_wtx);
+    }
+
     // Mark inactive coinbase transactions and their descendants as abandoned
-    if (wtx.IsCoinBase() && wtx.isInactive()) {
-        std::vector<CWalletTx*> txs{&wtx};
+    if (const_wtx.IsCoinBase() && const_wtx.isInactive()) {
+        std::vector<WalletTxs::iterator> txs{it};
 
         TxStateInactive inactive_state = TxStateInactive{/*abandoned=*/true};
 
         while (!txs.empty()) {
-            CWalletTx* desc_tx = txs.back();
+            WalletTxs::iterator desc_it= txs.back();
             txs.pop_back();
-            desc_tx->m_state = inactive_state;
+            WalletTxs::node_type desc_tx_nh = m_txs_by_txid.extract(desc_it);
+            CWalletTx& desc_tx = desc_tx_nh.value();
+            desc_tx.m_state = inactive_state;
             // Break caches since we have changed the state
-            desc_tx->MarkDirty();
-            batch.WriteTx(*desc_tx);
-            MarkInputsDirty(desc_tx->GetTx());
-            for (unsigned int i = 0; i < desc_tx->GetTx()->vout.size(); ++i) {
-                COutPoint outpoint(desc_tx->GetHash(), i);
+            desc_tx.MarkDirty();
+            batch.WriteTx(desc_tx);
+            MarkInputsDirty(desc_tx.GetTx());
+            for (unsigned int i = 0; i < desc_tx.GetTx()->vout.size(); ++i) {
+                COutPoint outpoint(desc_tx.GetHash(), i);
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(outpoint);
                 for (TxSpends::const_iterator it = range.first; it != range.second; ++it) {
-                    const auto wit = mapWallet.find(it->second);
-                    if (wit != mapWallet.end()) {
-                        txs.push_back(&wit->second);
+                    const auto wit = m_txs_by_txid.find(it->second);
+                    if (wit != m_txs_by_txid.end()) {
+                        txs.push_back(wit);
                     }
                 }
             }
+            m_txs_by_txid.insert(std::move(desc_tx_nh));
         }
     }
 
@@ -1120,14 +1133,11 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
 
     // Write to disk
     if (fInsertedNew || fUpdated)
-        if (!batch.WriteTx(wtx))
-            return nullptr;
-
-    // Break debit/credit balance caches:
-    wtx.MarkDirty();
+        if (!batch.WriteTx(const_wtx))
+            return std::nullopt;
 
     // Cache the outputs that belong to the wallet
-    RefreshTXOsFromTx(wtx);
+    RefreshTXOsFromTx(const_wtx);
 
     // Notify UI of new or updated transaction
     NotifyTransactionChanged(hash, fInsertedNew ? CT_NEW : CT_UPDATED);
@@ -1139,7 +1149,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     if (!strCmd.empty())
     {
         ReplaceAll(strCmd, "%s", hash.GetHex());
-        if (auto* conf = wtx.state<TxStateConfirmed>())
+        if (auto* conf = const_wtx.state<TxStateConfirmed>())
         {
             ReplaceAll(strCmd, "%b", conf->confirmed_block_hash.GetHex());
             ReplaceAll(strCmd, "%h", ToString(conf->confirmed_block_height));
@@ -1160,22 +1170,25 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     }
 #endif
 
-    return &wtx;
+    return it;
 }
 
 bool CWallet::LoadToWallet(CWalletTx&& wtx_in)
 {
-    const auto& ins = mapWallet.emplace(wtx_in.GetHash(), std::move(wtx_in));
-    CWalletTx& wtx = ins.first->second;
-    if (!ins.second) {
+    auto [it, inserted] = m_txs_by_txid.emplace(std::move(wtx_in));
+    if (!inserted) {
         return false;
     }
     // If wallet doesn't have a chain (e.g when using bitcoin-wallet tool),
     // don't bother to update txn.
     if (HaveChain()) {
-      wtx.updateState(chain());
+        WalletTxs::node_type wtx_nh = m_txs_by_txid.extract(it);
+        wtx_nh.value().updateState(chain());
+        it = m_txs_by_txid.insert(std::move(wtx_nh)).position;
     }
-    wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
+
+    const CWalletTx& wtx = *it;
+
     AddToSpends(wtx);
     for (const CTxIn& txin : wtx.GetTx()->vin) {
         const CWalletTx* prevtx = GetWalletTx(txin.prevout.hash);
@@ -1247,7 +1260,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             // Block disconnection override an abandoned tx as unconfirmed
             // which means user may have to call abandontransaction again
             TxState tx_state = std::visit([](auto&& s) -> TxState { return s; }, state);
-            CWalletTx* wtx = AddToWallet(MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, rescanning_old_block);
+            std::optional<WalletTxs::iterator> wtx = AddToWallet(MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, rescanning_old_block);
             if (!wtx) {
                 // Can only be nullptr if there was a db write error (missing db, read-only db or a db engine internal writing error).
                 // As we only store arriving transaction in this process, and we don't want an inconsistent state, let's throw an error.
@@ -1286,9 +1299,9 @@ void CWallet::UpdateTrucSiblingConflicts(const CWalletTx& parent_wtx, const Txid
 void CWallet::MarkInputsDirty(const CTransactionRef& tx)
 {
     for (const CTxIn& txin : tx->vin) {
-        auto it = mapWallet.find(txin.prevout.hash);
-        if (it != mapWallet.end()) {
-            it->second.MarkDirty();
+        auto it = m_txs_by_txid.find(txin.prevout.hash);
+        if (it != m_txs_by_txid.end()) {
+            it->MarkDirty();
         }
     }
 }
@@ -1296,15 +1309,12 @@ void CWallet::MarkInputsDirty(const CTransactionRef& tx)
 bool CWallet::AbandonTransaction(const Txid& hashTx)
 {
     LOCK(cs_wallet);
-    auto it = mapWallet.find(hashTx);
-    assert(it != mapWallet.end());
-    return AbandonTransaction(it->second);
-}
 
-bool CWallet::AbandonTransaction(CWalletTx& tx)
-{
+    const CWalletTx* tx = GetWalletTx(hashTx);
+    assert(tx);
+
     // Can't mark abandoned if confirmed or in mempool
-    if (GetTxDepthInMainChain(tx) != 0 || tx.InMempool()) {
+    if (GetTxDepthInMainChain(*tx) != 0 || tx->InMempool()) {
         return false;
     }
 
@@ -1326,7 +1336,7 @@ bool CWallet::AbandonTransaction(CWalletTx& tx)
     // Note: If the reorged coinbase is re-added to the main chain, the descendants that have not had their
     // states change will remain abandoned and will require manual broadcast if the user wants them.
 
-    RecursiveUpdateTxState(tx.GetHash(), try_updating_state);
+    RecursiveUpdateTxState(hashTx, try_updating_state);
 
     return true;
 }
@@ -1376,10 +1386,9 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
         Txid now = *todo.begin();
         todo.erase(now);
         done.insert(now);
-        auto it = mapWallet.find(now);
-        assert(it != mapWallet.end());
-        CWalletTx& wtx = it->second;
-
+        WalletTxs::node_type wtx_nh = m_txs_by_txid.extract(now);
+        assert(!wtx_nh.empty());
+        CWalletTx& wtx = wtx_nh.value();
         TxUpdate update_state = try_updating_state(wtx);
         if (update_state != TxUpdate::UNCHANGED) {
             wtx.MarkDirty();
@@ -1402,6 +1411,7 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
             // available of the outputs it spends. So force those to be recomputed
             MarkInputsDirty(wtx.GetTx());
         }
+        m_txs_by_txid.insert(std::move(wtx_nh));
     }
 }
 
@@ -1421,9 +1431,10 @@ void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
     LOCK(cs_wallet);
     SyncTransaction(tx, TxStateInMempool{});
 
-    auto it = mapWallet.find(tx->GetHash());
-    if (it != mapWallet.end()) {
-        RefreshMempoolStatus(it->second, chain());
+    WalletTxs::node_type wtx_nh = m_txs_by_txid.extract(tx->GetHash());
+    if (!wtx_nh.empty()) {
+        RefreshMempoolStatus(wtx_nh.value(), chain());
+        m_txs_by_txid.insert(std::move(wtx_nh));
     }
 
     const Txid& txid = tx->GetHash();
@@ -1446,15 +1457,16 @@ void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
         // For any unconfirmed v3 parents (there should be a maximum of 1 except in reorgs),
         // record this child so the wallet doesn't try to spend any other outputs
         for (const CTxIn& tx_in : tx->vin) {
-            auto parent_it = mapWallet.find(tx_in.prevout.hash);
-            if (parent_it != mapWallet.end()) {
-                CWalletTx& parent_wtx = parent_it->second;
+            WalletTxs::node_type parent_nh = m_txs_by_txid.extract(tx_in.prevout.hash);
+            if (!parent_nh.empty()) {
+                CWalletTx& parent_wtx = parent_nh.value();
                 if (parent_wtx.isUnconfirmed()) {
                     parent_wtx.truc_child_in_mempool = tx->GetHash();
                     // Even though these siblings do not spend the same utxos, they can't
                     // be present in the mempool at the same time because of TRUC policy rules
                     UpdateTrucSiblingConflicts(parent_wtx, txid, /*add_conflict=*/true);
                 }
+                m_txs_by_txid.insert(std::move(parent_nh));
             }
         }
     }
@@ -1462,10 +1474,12 @@ void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
 
 void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) {
     LOCK(cs_wallet);
-    auto it = mapWallet.find(tx->GetHash());
-    if (it != mapWallet.end()) {
-        RefreshMempoolStatus(it->second, chain());
+    WalletTxs::node_type wtx_nh = m_txs_by_txid.extract(tx->GetHash());
+    if (!wtx_nh.empty()) {
+        RefreshMempoolStatus(wtx_nh.value(), chain());
+        m_txs_by_txid.insert(std::move(wtx_nh));
     }
+
     // Handle transactions that were removed from the mempool because they
     // conflict with transactions in a newly connected block.
     if (reason == MemPoolRemovalReason::CONFLICT) {
@@ -1517,13 +1531,14 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
         // child of the same parent, transactionAddedToMempool
         // will update truc_child_in_mempool
         for (const CTxIn& tx_in : tx->vin) {
-            auto parent_it = mapWallet.find(tx_in.prevout.hash);
-            if (parent_it != mapWallet.end()) {
-                CWalletTx& parent_wtx = parent_it->second;
+            WalletTxs::node_type parent_nh = m_txs_by_txid.extract(tx_in.prevout.hash);
+            if (!parent_nh.empty()) {
+                CWalletTx& parent_wtx = parent_nh.value();
                 if (parent_wtx.truc_child_in_mempool == tx->GetHash()) {
                     parent_wtx.truc_child_in_mempool = std::nullopt;
                     UpdateTrucSiblingConflicts(parent_wtx, txid, /*add_conflict=*/false);
                 }
+                m_txs_by_txid.insert(std::move(parent_nh));
             }
         }
     }
@@ -2118,21 +2133,31 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
         LOCK(cs_wallet);
 
         // First filter for the transactions we want to rebroadcast.
-        // We use a set with WalletTxOrderComparator so that rebroadcasting occurs in insertion order
-        std::set<CWalletTx*, WalletTxOrderComparator> to_submit;
-        for (auto& [txid, wtx] : mapWallet) {
+        std::vector<WalletTxs::node_type> to_submit;
+        to_submit.reserve(m_txs_by_pos.size());
+        for (auto it = m_txs_by_pos.begin(); it != m_txs_by_pos.end();) {
+            auto next = std::next(it);
             // Only rebroadcast unconfirmed txs
-            if (!wtx.isUnconfirmed()) continue;
+            if (!it->isUnconfirmed()) {
+                it = next;
+                continue;
+            }
 
             // Attempt to rebroadcast all txes more than 5 minutes older than
             // the last block, or all txs if forcing.
-            if (!force && wtx.nTimeReceived > m_best_block_time - 5 * 60) continue;
-            to_submit.insert(&wtx);
+            if (!force && it->nTimeReceived > m_best_block_time - 5 * 60) {
+                it = next;
+                continue;
+            }
+
+            to_submit.push_back(m_txs_by_pos.extract(it));
+            it = next;
         }
         // Now try submitting the transactions to the memory pool and (optionally) relay them.
-        for (auto wtx : to_submit) {
+        for (WalletTxs::node_type& nh : to_submit) {
             std::string unused_err_string;
-            if (SubmitTxMemoryPoolAndRelay(*wtx, unused_err_string, broadcast_method)) ++submitted_tx_count;
+            if (SubmitTxMemoryPoolAndRelay(nh.value(), unused_err_string, broadcast_method)) ++submitted_tx_count;
+            m_txs_by_pos.insert(std::move(nh));
         }
     } // cs_wallet
 
@@ -2140,8 +2165,6 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
         WalletLogPrintf("%s: resubmit %u unconfirmed transactions\n", __func__, submitted_tx_count);
     }
 }
-
-/** @} */ // end of mapWallet
 
 void MaybeResendWalletTxs(WalletContext& context)
 {
@@ -2328,7 +2351,7 @@ void CWallet::CommitTransaction(
 
     // Add tx to wallet, because if it has change it's also ours,
     // otherwise just for transaction history.
-    CWalletTx* wtx = AddToWallet(tx, TxStateInactive{}, [&](CWalletTx& wtx, bool new_tx) {
+    std::optional<WalletTxs::iterator> wtx = AddToWallet(tx, TxStateInactive{}, [&](CWalletTx& wtx, bool new_tx) {
         if (replaces_txid) wtx.m_replaces_txid = replaces_txid;
         if (comment) wtx.m_comment = comment;
         if (comment_to) wtx.m_comment_to = comment_to;
@@ -2344,9 +2367,9 @@ void CWallet::CommitTransaction(
 
     // Notify that old coins are spent
     for (const CTxIn& txin : tx->vin) {
-        CWalletTx &coin = mapWallet.at(txin.prevout.hash);
-        coin.MarkDirty();
-        NotifyTransactionChanged(coin.GetHash(), CT_UPDATED);
+        auto parent_it = m_txs_by_txid.find(txin.prevout.hash);
+        parent_it->MarkDirty();
+        NotifyTransactionChanged(txin.prevout.hash, CT_UPDATED);
     }
 
     if (!fBroadcastTransactions) {
@@ -2354,11 +2377,13 @@ void CWallet::CommitTransaction(
         return;
     }
 
+    WalletTxs::node_type wtx_nh = m_txs_by_txid.extract(*wtx);
     std::string err_string;
-    if (!SubmitTxMemoryPoolAndRelay(*wtx, err_string, node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL)) {
+    if (!SubmitTxMemoryPoolAndRelay(wtx_nh.value(), err_string, node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL)) {
         WalletLogPrintf("CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", err_string);
         // TODO: if we expect the failure to be long term or permanent, instead delete wtx from the wallet and return failure.
     }
+    m_txs_by_txid.insert(std::move(wtx_nh));
 }
 
 DBErrors CWallet::PopulateWalletFromDB(bilingual_str& error, std::vector<bilingual_str>& warnings)
@@ -2435,11 +2460,11 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
     if (!batch.HasActiveTxn()) return util::Error{strprintf(_("The transactions removal process can only be executed within a db txn"))};
 
     // Check for transaction existence and remove entries from disk
-    std::vector<decltype(mapWallet)::const_iterator> erased_txs;
+    std::vector<WalletTxs::const_iterator> erased_txs;
     bilingual_str str_err;
     for (const Txid& hash : txs_to_remove) {
-        auto it_wtx = mapWallet.find(hash);
-        if (it_wtx == mapWallet.end()) {
+        auto it_wtx = m_txs_by_txid.find(hash);
+        if (it_wtx == m_txs_by_txid.end()) {
             return util::Error{strprintf(_("Transaction %s does not belong to this wallet"), hash.GetHex())};
         }
         if (!batch.EraseTx(hash)) {
@@ -2452,9 +2477,8 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
     batch.RegisterTxnListener({.on_commit=[&, erased_txs]() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
         // Update the in-memory state and notify upper layers about the removals
         for (const auto& it : erased_txs) {
-            const Txid hash{it->first};
-            wtxOrdered.erase(it->second.m_it_wtxOrdered);
-            for (const auto& txin : it->second.GetTx()->vin) {
+            const Txid hash{it->GetHash()};
+            for (const auto& txin : it->GetTx()->vin) {
                 auto range = mapTxSpends.equal_range(txin.prevout);
                 for (auto iter = range.first; iter != range.second; ++iter) {
                     if (iter->second == hash) {
@@ -2463,10 +2487,10 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
                     }
                 }
             }
-            for (unsigned int i = 0; i < it->second.GetTx()->vout.size(); ++i) {
+            for (unsigned int i = 0; i < it->GetTx()->vout.size(); ++i) {
                 m_txos.erase(COutPoint(hash, i));
             }
-            mapWallet.erase(it);
+            m_txs_by_txid.erase(it);
             NotifyTransactionChanged(hash, CT_DELETED);
         }
 
@@ -2625,9 +2649,8 @@ util::Result<CTxDestination> CWallet::GetNewChangeDestination(const OutputType t
 }
 
 void CWallet::MarkDestinationsDirty(const std::set<CTxDestination>& destinations) {
-    for (auto& entry : mapWallet) {
-        CWalletTx& wtx = entry.second;
-        if (wtx.m_is_cache_empty) continue;
+    for (const CWalletTx& wtx : m_txs_by_txid) {
+        if (wtx.m_is_cache_empty) return;
         for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); i++) {
             CTxDestination dst;
             if (ExtractDestination(wtx.GetTx()->vout[i].scriptPubKey, dst) && destinations.contains(dst)) {
@@ -2828,18 +2851,19 @@ unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx, bool rescanning_old
                 int64_t latestNow = wtx.nTimeReceived;
                 int64_t latestEntry = 0;
 
+                LOCK(cs_wallet);
+
                 // Tolerate times up to the last timestamp in the wallet not more than 5 minutes into the future
                 int64_t latestTolerated = latestNow + 300;
-                const TxItems& txOrdered = wtxOrdered;
-                for (auto it = txOrdered.rbegin(); it != txOrdered.rend(); ++it) {
-                    CWalletTx* const pwtx = it->second;
-                    if (pwtx == &wtx) {
+                for (auto it = m_txs_by_pos.rbegin(); it != m_txs_by_pos.rend(); ++it) {
+                    const CWalletTx& pwtx = *it;
+                    if (pwtx.GetWitnessHash() == wtx.GetWitnessHash()) {
                         continue;
                     }
                     int64_t nSmartTime;
-                    nSmartTime = pwtx->nTimeSmart;
+                    nSmartTime = pwtx.nTimeSmart;
                     if (!nSmartTime) {
-                        nSmartTime = pwtx->nTimeReceived;
+                        nSmartTime = pwtx.nTimeReceived;
                     }
                     if (nSmartTime <= latestTolerated) {
                         latestEntry = nSmartTime;
@@ -4017,20 +4041,20 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
             return util::Error{_("Error: Unable to write solvable wallet best block locator record")};
         }
     }
-    for (const auto& [_pos, wtx] : wtxOrdered) {
+    for (const auto& wtx : m_txs_by_pos) {
         // Check it is the watchonly wallet's
         // solvable_wallet doesn't need to be checked because transactions for those scripts weren't being watched for
-        bool is_mine = IsMine(*wtx->GetTx()) || IsFromMe(*wtx->GetTx());
+        bool is_mine = IsMine(*wtx.GetTx()) || IsFromMe(*wtx.GetTx());
         if (data.watchonly_wallet) {
             LOCK(data.watchonly_wallet->cs_wallet);
-            if (data.watchonly_wallet->IsMine(*wtx->GetTx()) || data.watchonly_wallet->IsFromMe(*wtx->GetTx())) {
+            if (data.watchonly_wallet->IsMine(*wtx.GetTx()) || data.watchonly_wallet->IsFromMe(*wtx.GetTx())) {
                 // Add to watchonly wallet
-                const Txid& hash = wtx->GetHash();
+                const Txid& hash = wtx.GetHash();
                 DataStream wtx_ser;
-                wtx_ser << *wtx;
-                CWalletTx copy_wtx(deserialize, wtx_ser, wtx->GetTxs());
+                wtx_ser << wtx;
+                CWalletTx copy_wtx(deserialize, wtx_ser, wtx.GetTxs());
                 if (!data.watchonly_wallet->LoadToWallet(std::move(copy_wtx))) {
-                    return util::Error{strprintf(_("Error: Could not add watchonly tx %s to watchonly wallet"), wtx->GetHash().GetHex())};
+                    return util::Error{strprintf(_("Error: Could not add watchonly tx %s to watchonly wallet"), wtx.GetHash().GetHex())};
                 }
                 watchonly_batch->WriteTx(*data.watchonly_wallet->GetWalletTx(hash));
                 // Mark as to remove from the migrated wallet only if it does not also belong to it
@@ -4042,10 +4066,10 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
         }
         if (!is_mine) {
             // Both not ours and not in the watchonly wallet
-            return util::Error{strprintf(_("Error: Transaction %s in wallet cannot be identified to belong to migrated wallets"), wtx->GetHash().GetHex())};
+            return util::Error{strprintf(_("Error: Transaction %s in wallet cannot be identified to belong to migrated wallets"), wtx.GetHash().GetHex())};
         }
         // Rewrite the transaction so that anything that may have changed about it in memory also persists to disk
-        local_wallet_batch.WriteTx(*wtx);
+        local_wallet_batch.WriteTx(wtx);
     }
 
     // Do the removes
@@ -4130,7 +4154,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
     // migrated records will be presented to the user.
     if (!has_spendable_material) {
         if (!m_address_book.empty()) return util::Error{_("Error: Not all address book records were migrated")};
-        if (!mapWallet.empty()) return util::Error{_("Error: Not all transaction records were migrated")};
+        if (!m_txs.empty()) return util::Error{_("Error: Not all transaction records were migrated")};
     }
 
     return {}; // all good
@@ -4597,7 +4621,7 @@ void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
 void CWallet::RefreshAllTXOs()
 {
     AssertLockHeld(cs_wallet);
-    for (const auto& [_, wtx] : mapWallet) {
+    for (const auto& wtx : m_txs_by_txid) {
         RefreshTXOsFromTx(wtx);
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -686,14 +686,13 @@ std::set<Txid> CWallet::GetConflicts(const Txid& txid) const
     std::set<Txid> result;
     AssertLockHeld(cs_wallet);
 
-    const auto it = mapWallet.find(txid);
-    if (it == mapWallet.end())
+    const CWalletTx* wtx = GetWalletTx(txid);
+    if (!wtx) {
         return result;
-    const CWalletTx& wtx = it->second;
-
+    }
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
 
-    for (const CTxIn& txin : wtx.GetTx()->vin)
+    for (const CTxIn& txin : wtx->GetTx()->vin)
     {
         if (mapTxSpends.count(txin.prevout) <= 1)
             continue;  // No conflict if zero or one spends
@@ -730,7 +729,7 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
     int nMinOrderPos = std::numeric_limits<int>::max();
     const CWalletTx* copyFrom = nullptr;
     for (TxSpends::iterator it = range.first; it != range.second; ++it) {
-        const CWalletTx* wtx = &mapWallet.at(it->second);
+        const CWalletTx* wtx = GetWalletTx(it->second);
         if (wtx->nOrderPos < nMinOrderPos) {
             nMinOrderPos = wtx->nOrderPos;
             copyFrom = wtx;
@@ -775,10 +774,9 @@ bool CWallet::IsSpent(const COutPoint& outpoint) const
 
     for (TxSpends::const_iterator it = range.first; it != range.second; ++it) {
         const Txid& txid = it->second;
-        const auto mit = mapWallet.find(txid);
-        if (mit != mapWallet.end()) {
-            const auto& wtx = mit->second;
-            if (!wtx.isAbandoned() && !wtx.isBlockConflicted() && !wtx.isMempoolConflicted())
+        const CWalletTx* wtx = GetWalletTx(txid);
+        if (wtx) {
+            if (!wtx->isAbandoned() && !wtx->isBlockConflicted() && !wtx->isMempoolConflicted())
                 return true; // Spent
         }
     }
@@ -794,13 +792,12 @@ CWallet::SpendType CWallet::HowSpent(const COutPoint& outpoint) const
 
     for (TxSpends::const_iterator it = range.first; it != range.second; ++it) {
         const Txid& txid = it->second;
-        const auto mit = mapWallet.find(txid);
-        if (mit != mapWallet.end()) {
-            const auto& wtx = mit->second;
-            if (wtx.isConfirmed()) return SpendType::CONFIRMED;
-            if (wtx.InMempool()) {
+        const CWalletTx* wtx = GetWalletTx(txid);
+        if (wtx) {
+            if (wtx->isConfirmed()) return SpendType::CONFIRMED;
+            if (wtx->InMempool()) {
                 st = SpendType::MEMPOOL;
-            } else if (!wtx.isAbandoned() && !wtx.isBlockConflicted() && !wtx.isMempoolConflicted()) {
+            } else if (!wtx->isAbandoned() && !wtx->isBlockConflicted() && !wtx->isMempoolConflicted()) {
                 if (st == SpendType::UNSPENT) st = SpendType::NONMEMPOOL;
             }
         }
@@ -1181,10 +1178,9 @@ bool CWallet::LoadToWallet(CWalletTx&& wtx_in)
     wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
     AddToSpends(wtx);
     for (const CTxIn& txin : wtx.GetTx()->vin) {
-        auto it = mapWallet.find(txin.prevout.hash);
-        if (it != mapWallet.end()) {
-            CWalletTx& prevtx = it->second;
-            if (auto* prev = prevtx.state<TxStateBlockConflicted>()) {
+        const CWalletTx* prevtx = GetWalletTx(txin.prevout.hash);
+        if (prevtx) {
+            if (auto* prev = prevtx->state<TxStateBlockConflicted>()) {
                 MarkConflicted(prev->conflicting_block_hash, prev->conflicting_block_height, wtx.GetHash());
             }
         }
@@ -1217,7 +1213,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             }
         }
 
-        bool fExisted = mapWallet.contains(tx.GetHash());
+        bool fExisted = bool(GetWalletTx(tx.GetHash()));
         if (fExisted || IsMine(tx) || IsFromMe(tx))
         {
             /* Check if any keys in the wallet keypool that were supposed to be unused
@@ -1587,7 +1583,7 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
 
             // For all of the spends that conflict with this transaction
             for (TxSpends::const_iterator _it = range.first; _it != range.second; ++_it) {
-                CWalletTx& wtx = mapWallet.find(_it->second)->second;
+                const CWalletTx& wtx = *GetWalletTx(_it->second);
 
                 if (!wtx.isBlockConflicted()) continue;
 
@@ -2164,11 +2160,11 @@ bool CWallet::SignTransaction(CMutableTransaction& tx) const
     // Build coins map
     std::map<COutPoint, Coin> coins;
     for (auto& input : tx.vin) {
-        const auto mi = mapWallet.find(input.prevout.hash);
-        if(mi == mapWallet.end() || input.prevout.n >= mi->second.GetTx()->vout.size()) {
+        const CWalletTx* pwtx = GetWalletTx(input.prevout.hash);
+        if(!pwtx || input.prevout.n >= pwtx->GetTx()->vout.size()) {
             return false;
         }
-        const CWalletTx& wtx = mi->second;
+        const CWalletTx& wtx = *pwtx;
         int prev_height = wtx.state<TxStateConfirmed>() ? wtx.state<TxStateConfirmed>()->confirmed_block_height : 0;
         coins[input.prevout] = Coin(wtx.GetTx()->vout[input.prevout.n], prev_height, wtx.IsCoinBase());
     }
@@ -2206,12 +2202,10 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, co
         // If we have no utxo, grab it from the wallet.
         if (!input.non_witness_utxo) {
             const Txid& txhash = input.prev_txid;
-            const auto it = mapWallet.find(txhash);
-            if (it != mapWallet.end()) {
-                const CWalletTx& wtx = it->second;
+            if (const CWalletTx* wtx = GetWalletTx(txhash)) {
                 // We only need the non_witness_utxo, which is a superset of the witness_utxo.
                 //   The signing code will switch to the smaller witness_utxo if this is ok.
-                input.non_witness_utxo = wtx.GetTx();
+                input.non_witness_utxo = wtx->GetTx();
             }
         }
     }
@@ -4038,7 +4032,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
                 if (!data.watchonly_wallet->LoadToWallet(std::move(copy_wtx))) {
                     return util::Error{strprintf(_("Error: Could not add watchonly tx %s to watchonly wallet"), wtx->GetHash().GetHex())};
                 }
-                watchonly_batch->WriteTx(data.watchonly_wallet->mapWallet.at(hash));
+                watchonly_batch->WriteTx(*data.watchonly_wallet->GetWalletTx(hash));
                 // Mark as to remove from the migrated wallet only if it does not also belong to it
                 if (!is_mine) {
                     txids_to_delete.push_back(hash);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -38,6 +38,12 @@
 #include <wallet/types.h>
 #include <wallet/walletutil.h>
 
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/indexed_by.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/tag.hpp>
+#include <boost/multi_index_container.hpp>
+
 #include <atomic>
 #include <cassert>
 #include <cstddef>
@@ -302,6 +308,41 @@ struct CRecipient
     bool fSubtractFeeFromAmount;
 };
 
+struct cwallettx_txid
+{
+    using result_type = Txid;
+    result_type operator() (const CWalletTx& wtx) const
+    {
+        return wtx.GetHash();
+    }
+};
+
+struct cwallettx_pos
+{
+    using result_type = int64_t;
+    result_type operator() (const CWalletTx& wtx) const
+    {
+        return wtx.nOrderPos;
+    }
+};
+
+struct index_by_txid {};
+struct index_by_pos {};
+
+using WalletTxs = boost::multi_index_container<
+    CWalletTx,
+    boost::multi_index::indexed_by<
+        boost::multi_index::hashed_unique<
+            boost::multi_index::tag<index_by_txid>,
+            cwallettx_txid, SaltedTxidHasher
+        >,
+        boost::multi_index::ordered_non_unique<
+            boost::multi_index::tag<index_by_pos>,
+            cwallettx_pos
+        >
+    >
+>;
+
 class WalletRescanReserver; //forward declarations for ScanForWalletTransactions/RescanFromTime
 /**
  * A CWallet maintains a set of transactions and balances, and provides the ability to create new transactions.
@@ -476,7 +517,9 @@ public:
     CWallet(interfaces::Chain* chain, const std::string& name, std::unique_ptr<WalletDatabase> database)
         : m_chain(chain),
           m_name(name),
-          m_database(std::move(database))
+          m_database(std::move(database)),
+          m_txs_by_txid(m_txs.get<index_by_txid>()),
+          m_txs_by_pos(m_txs.get<index_by_pos>())
     {
     }
 
@@ -492,12 +535,14 @@ public:
     /** Interface to assert chain access */
     bool HaveChain() const { return m_chain ? true : false; }
 
-    /** Map from txid to CWalletTx for all transactions this wallet is
-     * interested in, including received and sent transactions. */
-    std::unordered_map<Txid, CWalletTx, SaltedTxidHasher> mapWallet GUARDED_BY(cs_wallet);
-
-    typedef std::multimap<int64_t, CWalletTx*> TxItems;
-    TxItems wtxOrdered;
+    /** Container for all transactions this wallet is interested in, including
+     *  received and sent transactions.
+     *  Indexed by txid and nOrderPos
+     *  Use the explicit indexed by references m_txs_by_txid and m_txs_by_pos rather than the actual m_txs
+     */
+    WalletTxs m_txs GUARDED_BY(cs_wallet);
+    WalletTxs::index<index_by_txid>::type& m_txs_by_txid;
+    WalletTxs::index<index_by_pos>::type& m_txs_by_pos;
 
     int64_t nOrderPosNext GUARDED_BY(cs_wallet) = 0;
 
@@ -617,9 +662,9 @@ public:
 
     void MarkDirty();
 
-    //! Callback for updating transaction metadata in mapWallet.
+    //! Callback for updating transaction metadata in m_txs.
     //!
-    //! @param wtx - reference to mapWallet transaction to update
+    //! @param wtx - reference to m_txs transaction to update
     //! @param new_tx - true if wtx is newly inserted, false if it previously existed
     //!
     //! @return true if wtx is changed and needs to be saved to disk, otherwise false
@@ -629,7 +674,7 @@ public:
      * Add the transaction to the wallet, wrapping it up inside a CWalletTx
      * @return the recently added wtx pointer or nullptr if there was a db write error.
      */
-    CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool rescanning_old_block = false);
+    std::optional<WalletTxs::iterator> AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool rescanning_old_block = false);
     bool LoadToWallet(CWalletTx&& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx) override;
     void blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) override;
@@ -872,7 +917,6 @@ public:
 
     /* Mark a transaction (and it in-wallet descendants) as abandoned so its inputs may be respent. */
     bool AbandonTransaction(const Txid& hashTx);
-    bool AbandonTransaction(CWalletTx& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Mark a transaction as replaced by another transaction. */
     bool MarkReplaced(const Txid& originalHash, const Txid& newHash);
@@ -953,7 +997,7 @@ public:
     {
         AssertLockHeld(cs_wallet);
         WalletLogPrintf("setKeyPool.size() = %u\n",      GetKeyPoolSize());
-        WalletLogPrintf("mapWallet.size() = %u\n",       mapWallet.size());
+        WalletLogPrintf("m_txs.size() = %u\n",           m_txs.size());
         WalletLogPrintf("m_address_book.size() = %u\n",  m_address_book.size());
     };
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1086,10 +1086,15 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
 
     // After loading all tx records, abandon any coinbase that is no longer in the active chain.
     // This could happen during an external wallet load, or if the user replaced the chain data.
-    for (auto& [id, wtx] : pwallet->mapWallet) {
+    std::vector<Txid> to_abandon;
+    to_abandon.reserve(pwallet->m_txs.size());
+    for (const auto& wtx : pwallet->m_txs) {
         if (wtx.IsCoinBase() && wtx.isInactive()) {
-            pwallet->AbandonTransaction(wtx);
+            to_abandon.push_back(wtx.GetHash());
         }
+    }
+    for (const Txid& txid : to_abandon) {
+        pwallet->AbandonTransaction(txid);
     }
 
     return result;

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -87,7 +87,7 @@ static void WalletShowInfo(CWallet* wallet_instance)
     tfm::format(std::cout, "Encrypted: %s\n", wallet_instance->HasEncryptionKeys() ? "yes" : "no");
     tfm::format(std::cout, "HD (hd seed available): %s\n", wallet_instance->IsHDEnabled() ? "yes" : "no");
     tfm::format(std::cout, "Keypool Size: %u\n", wallet_instance->GetKeyPoolSize());
-    tfm::format(std::cout, "Transactions: %zu\n", wallet_instance->mapWallet.size());
+    tfm::format(std::cout, "Transactions: %zu\n", wallet_instance->m_txs.size());
     tfm::format(std::cout, "Address Book: %zu\n", wallet_instance->m_address_book.size());
 }
 


### PR DESCRIPTION
The wallet needs to access transactions both by txid, and by insertion order into the wallet. `mapWallet` was the main container for the wallet transactions, and it was keyed by txid. `wtxOrdered` was a secondary container which was keyed by order, and held pointers to the `CWalletTx` objects stored in `mapWallet`. These are replaced by a new boost multi index which indexes on txid and insertion order, allowing us to get rid of the 2 separate containers, and holding raw pointers to `CWalletTx`.