### PR TITLE
ci: disable Qt build in OpenBSD cross job

### DIFF
--- a/ci/test/00_setup_env_openbsd_cross.sh
+++ b/ci/test/00_setup_env_openbsd_cross.sh
@@ -14,7 +14,7 @@ export OPENBSD_VERSION=7.9
 export OPENBSD_SDK_BASENAME="openbsd-${HOST}-${OPENBSD_VERSION}"
 export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} lld-${APT_LLVM_V}"
 export SYSROOT="--sysroot=${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}"
-export DEP_OPTS="build_CC=clang build_CXX=clang++ \
+export DEP_OPTS="NO_QT=1 build_CC=clang build_CXX=clang++ \
  CC='clang --target=${HOST} ${SYSROOT}' \
  CXX='clang++ --target=${HOST} ${SYSROOT} -stdlib=libc++' \
  LDFLAGS='-fuse-ld=lld' \


### PR DESCRIPTION
Disable this for now, until issues with `llvm-ranlib`, and gui deps are fixed:
```bash
libtool: install: chmod 644 /home/runner/work/_temp/depends/work/staging/x86_64-unknown-openbsd/fontconfig/2.12.6-a12d0a13377/home/runner/work/_temp/depends/x86_64-unknown-openbsd/lib/libfontconfig.a
libtool: install: llvm-ranlib-22 -t /home/runner/work/_temp/depends/work/staging/x86_64-unknown-openbsd/fontconfig/2.12.6-a12d0a13377/home/runner/work/_temp/depends/x86_64-unknown-openbsd/lib/libfontconfig.a
llvm-ranlib-22: error: Invalid option: '-t'
make[4]: *** [Makefile:539: install-libLTLIBRARIES] Error 1
```

Followup to #35427.