### PR TITLE
ci: cache BSD sdk sources separately

### DIFF
--- a/.github/actions/cache/restore/action.yml
+++ b/.github/actions/cache/restore/action.yml
@@ -27,6 +27,15 @@ runs:
           depends-sources-${{ env.CONTAINER_NAME }}-
         provider: ${{ inputs.provider }}
 
+    - name: Restore SDK sources cache
+      id: sdk-sources
+      if: ${{ env.SDK_SOURCES_CACHE_ENABLED == 'true' }}
+      uses: ./.github/actions/cache/restore/internal
+      with:
+        path: ${{ env.SDK_SOURCES_PATH }}
+        key: depends-sdk-sources-${{ env.CONTAINER_NAME }}-${{ env.SDK_SOURCES_HASH }}
+        provider: ${{ inputs.provider }}
+
     - name: Restore built depends cache
       id: depends-built
       uses: ./.github/actions/cache/restore/internal
@@ -51,5 +60,6 @@ runs:
       shell: bash
       run: |
         echo "depends-sources-cache-hit=${{ steps.depends-sources.outputs.cache-hit }}" >> $GITHUB_ENV
+        echo "sdk-sources-cache-hit=${{ steps.sdk-sources.outputs.cache-hit }}" >> $GITHUB_ENV
         echo "depends-built-cache-hit=${{ steps.depends-built.outputs.cache-hit }}" >> $GITHUB_ENV
         echo "previous-releases-cache-hit=${{ steps.previous-releases.outputs.cache-hit }}" >> $GITHUB_ENV

--- a/.github/actions/cache/save/action.yml
+++ b/.github/actions/cache/save/action.yml
@@ -11,6 +11,7 @@ runs:
       shell: bash
       run: |
         echo "depends sources direct cache hit to primary key: ${{ env.depends-sources-cache-hit }}"
+        echo "sdk sources direct cache hit to primary key: ${{ env.sdk-sources-cache-hit }}"
         echo "depends built direct cache hit to primary key: ${{ env.depends-built-cache-hit }}"
         echo "previous releases direct cache hit to primary key: ${{ env.previous-releases-cache-hit }}"
 
@@ -28,6 +29,14 @@ runs:
       with:
         path: ${{ env.SOURCES_PATH }}
         key: depends-sources-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
+        provider: ${{ inputs.provider }}
+
+    - name: Save SDK sources cache
+      uses: ./.github/actions/cache/save/internal
+      if: ${{ (env.SDK_SOURCES_CACHE_ENABLED == 'true') && (github.ref_name == github.event.repository.default_branch) && (env.sdk-sources-cache-hit != 'true') }}
+      with:
+        path: ${{ env.SDK_SOURCES_PATH }}
+        key: depends-sdk-sources-${{ env.CONTAINER_NAME }}-${{ env.SDK_SOURCES_HASH }}
         provider: ${{ inputs.provider }}
 
     - name: Save built depends cache

--- a/.github/actions/configure-environment/action.yml
+++ b/.github/actions/configure-environment/action.yml
@@ -12,12 +12,14 @@ runs:
         echo "DEPENDS_DIR=${{ runner.temp }}/depends" >> "$GITHUB_ENV"
         echo "BASE_CACHE=${{ runner.temp }}/depends/built" >> $GITHUB_ENV
         echo "SOURCES_PATH=${{ runner.temp }}/depends/sources" >> $GITHUB_ENV
+        echo "SDK_SOURCES_PATH=${{ runner.temp }}/depends/sdk-sources" >> $GITHUB_ENV
         echo "PREVIOUS_RELEASES_DIR=${{ runner.temp }}/previous_releases" >> $GITHUB_ENV
 
     - name: Set cache hashes
       shell: bash
       run: |
         echo "DEPENDS_HASH=$(git ls-tree HEAD depends "$FILE_ENV" | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+        echo "SDK_SOURCES_HASH=$(git ls-tree HEAD ci/test/01_setup_bsd.sh "$FILE_ENV" | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
         echo "PREVIOUS_RELEASES_HASH=$(git ls-tree HEAD test/get_previous_releases.py | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
     - name: Get container name
@@ -25,3 +27,11 @@ runs:
       run: |
         source $FILE_ENV
         echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+
+    - name: Configure SDK sources cache
+      shell: bash
+      run: |
+        source $FILE_ENV
+        if [[ -n "${NETBSD_VERSION:-}" || -n "${FREEBSD_VERSION:-}" || -n "${OPENBSD_VERSION:-}" ]]; then
+          echo "SDK_SOURCES_CACHE_ENABLED=true" >> "$GITHUB_ENV"
+        fi

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -118,44 +118,4 @@ if [ -n "$XCODE_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${OSX_SDK_BASENAME}" ]
   tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
 fi
 
-if [ -n "$NETBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}" ]; then
-  mkdir -p "${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}"
-  for NETBSD_SDK_FILENAME in base.tar.xz comp.tar.xz; do
-    NETBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${NETBSD_SDK_FILENAME}"
-    if [ ! -f "$NETBSD_SDK_PATH" ]; then
-      ${CI_RETRY_EXE} curl --location --fail "https://cdn.netbsd.org/pub/NetBSD/NetBSD-${NETBSD_VERSION}/amd64/binary/sets/${NETBSD_SDK_FILENAME}" -o "$NETBSD_SDK_PATH"
-    fi
-    tar -C "${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}" -xf "$NETBSD_SDK_PATH"
-  done
-fi
-
-if [ -n "$FREEBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" ]; then
-  FREEBSD_SDK_FILENAME="base-${FREEBSD_VERSION}.txz"
-  FREEBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${FREEBSD_SDK_FILENAME}"
-  if [ ! -f "$FREEBSD_SDK_PATH" ]; then
-    ${CI_RETRY_EXE} curl --location --fail "https://download.freebsd.org/releases/amd64/${FREEBSD_VERSION}-RELEASE/base.txz" -o "$FREEBSD_SDK_PATH"
-  fi
-  mkdir -p "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}"
-  tar -C "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" -xf "$FREEBSD_SDK_PATH"
-fi
-
-if [ -n "$OPENBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}" ]; then
-  mkdir -p "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}"
-  for OPENBSD_SDK_FILENAME in base79.tgz comp79.tgz; do
-    OPENBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${OPENBSD_SDK_FILENAME}"
-    if [ ! -f "$OPENBSD_SDK_PATH" ]; then
-      ${CI_RETRY_EXE} curl --location --fail "https://cdn.openbsd.org/pub/OpenBSD/${OPENBSD_VERSION}/amd64/${OPENBSD_SDK_FILENAME}" -o "$OPENBSD_SDK_PATH"
-    fi
-    tar -C "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}" -xf "$OPENBSD_SDK_PATH"
-    (
-      # The SDK has versioned shared libs, but no unversioned libfoo.so symlink,
-      # which breaks linking the kernel with lld. Create the symlinks.
-      cd "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}/usr/lib"
-      ln -sf libc++abi.so.*.*  libc++abi.so
-      ln -sf libc++.so.*.*     libc++.so
-      ln -sf libpthread.so.*.* libpthread.so
-    )
-  done
-fi
-
 echo -n "done" > "${CFG_DONE}"

--- a/ci/test/01_setup_bsd.sh
+++ b/ci/test/01_setup_bsd.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+set -o errexit -o pipefail -o xtrace
+
+if [ "${DANGER_RUN_CI_ON_HOST}" != "1" ]; then
+  echo "This script will make unsafe local and global modifications, so it can only be run inside a container and requires DANGER_RUN_CI_ON_HOST=1"
+  exit 1
+fi
+
+mkdir -p "${DEPENDS_DIR}/SDKs" "${DEPENDS_DIR}/sdk-sources"
+
+if [ -n "$NETBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}" ]; then
+  mkdir -p "${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}"
+  for NETBSD_SDK_FILENAME in base.tar.xz comp.tar.xz; do
+    NETBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${NETBSD_SDK_FILENAME}"
+    if [ ! -f "$NETBSD_SDK_PATH" ]; then
+      ${CI_RETRY_EXE} curl --location --fail "https://cdn.netbsd.org/pub/NetBSD/NetBSD-${NETBSD_VERSION}/amd64/binary/sets/${NETBSD_SDK_FILENAME}" -o "$NETBSD_SDK_PATH"
+    fi
+    tar -C "${DEPENDS_DIR}/SDKs/${NETBSD_SDK_BASENAME}" -xf "$NETBSD_SDK_PATH"
+  done
+fi
+
+if [ -n "$FREEBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" ]; then
+  FREEBSD_SDK_FILENAME="base-${FREEBSD_VERSION}.txz"
+  FREEBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${FREEBSD_SDK_FILENAME}"
+  if [ ! -f "$FREEBSD_SDK_PATH" ]; then
+    ${CI_RETRY_EXE} curl --location --fail "https://download.freebsd.org/releases/amd64/${FREEBSD_VERSION}-RELEASE/base.txz" -o "$FREEBSD_SDK_PATH"
+  fi
+  mkdir -p "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}"
+  tar -C "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" -xf "$FREEBSD_SDK_PATH"
+fi
+
+if [ -n "$OPENBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}" ]; then
+  mkdir -p "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}"
+  for OPENBSD_SDK_FILENAME in base79.tgz comp79.tgz; do
+    OPENBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${OPENBSD_SDK_FILENAME}"
+    if [ ! -f "$OPENBSD_SDK_PATH" ]; then
+      ${CI_RETRY_EXE} curl --location --fail "https://cdn.openbsd.org/pub/OpenBSD/${OPENBSD_VERSION}/amd64/${OPENBSD_SDK_FILENAME}" -o "$OPENBSD_SDK_PATH"
+    fi
+    tar -C "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}" -xf "$OPENBSD_SDK_PATH"
+    (
+      # The SDK has versioned shared libs, but no unversioned libfoo.so symlink,
+      # which breaks linking the kernel with lld. Create the symlinks.
+      cd "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}/usr/lib"
+      ln -sf libc++abi.so.*.*  libc++abi.so
+      ln -sf libc++.so.*.*     libc++.so
+      ln -sf libpthread.so.*.* libpthread.so
+    )
+  done
+fi

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -21,6 +21,10 @@ def run(cmd, **kwargs):
 
 
 def main():
+    sdk_sources_path = Path(
+        os.environ.get("SDK_SOURCES_PATH", f"{os.environ['DEPENDS_DIR']}/sdk-sources")
+    )
+
     print("Export only allowed settings:")
     settings = run(
         ["bash", "-c", "grep export ./ci/test/00_setup_env*.sh"],
@@ -52,6 +56,7 @@ def main():
         print("Create missing folders")
         for create_dir in [
                 os.environ["CCACHE_DIR"],
+                sdk_sources_path,
                 os.environ["PREVIOUS_RELEASES_DIR"],
         ]:
             Path(create_dir).mkdir(parents=True, exist_ok=True)
@@ -82,13 +87,14 @@ def main():
             time.sleep(3)
             run(cmd_build)
 
-        for suffix in ["ccache", "depends", "depends_sources", "previous_releases"]:
+        for suffix in ["ccache", "depends", "depends_sources", "previous_releases", "sdk_sources"]:
             run(["docker", "volume", "create", f"{os.environ['CONTAINER_NAME']}_{suffix}"], check=False)
 
         CI_CCACHE_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_ccache,dst={os.environ['CCACHE_DIR']}"
         CI_DEPENDS_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_depends,dst={os.environ['DEPENDS_DIR']}/built"
         CI_DEPENDS_SOURCES_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_depends_sources,dst={os.environ['DEPENDS_DIR']}/sources"
         CI_PREVIOUS_RELEASES_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_previous_releases,dst={os.environ['PREVIOUS_RELEASES_DIR']}"
+        CI_SDK_SOURCES_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_sdk_sources,dst={os.environ['DEPENDS_DIR']}/sdk-sources"
         CI_BUILD_MOUNT = []
 
         if os.getenv("DANGER_CI_ON_HOST_FOLDERS"):
@@ -98,6 +104,7 @@ def main():
                     f"{os.environ['DEPENDS_DIR']}/built",
                     f"{os.environ['DEPENDS_DIR']}/sources",
                     os.environ["PREVIOUS_RELEASES_DIR"],
+                    sdk_sources_path,
                     os.environ["BASE_BUILD_DIR"],  # Unset by default, must be defined externally
             ]:
                 Path(create_dir).mkdir(parents=True, exist_ok=True)
@@ -106,6 +113,7 @@ def main():
             CI_DEPENDS_MOUNT = f"type=bind,src={os.environ['DEPENDS_DIR']}/built,dst={os.environ['DEPENDS_DIR']}/built"
             CI_DEPENDS_SOURCES_MOUNT = f"type=bind,src={os.environ['DEPENDS_DIR']}/sources,dst={os.environ['DEPENDS_DIR']}/sources"
             CI_PREVIOUS_RELEASES_MOUNT = f"type=bind,src={os.environ['PREVIOUS_RELEASES_DIR']},dst={os.environ['PREVIOUS_RELEASES_DIR']}"
+            CI_SDK_SOURCES_MOUNT = f"type=bind,src={sdk_sources_path},dst={os.environ['DEPENDS_DIR']}/sdk-sources"
             CI_BUILD_MOUNT = [f"--mount=type=bind,src={os.environ['BASE_BUILD_DIR']},dst={os.environ['BASE_BUILD_DIR']}"]
 
         if os.getenv("DANGER_CI_ON_HOST_CCACHE_FOLDER"):
@@ -141,6 +149,7 @@ def main():
             f"--mount={CI_DEPENDS_MOUNT}",
             f"--mount={CI_DEPENDS_SOURCES_MOUNT}",
             f"--mount={CI_PREVIOUS_RELEASES_MOUNT}",
+            f"--mount={CI_SDK_SOURCES_MOUNT}",
             *CI_BUILD_MOUNT,
             f"--env-file={env_file}",
             f"--name={os.environ['CONTAINER_NAME']}",

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -21,9 +21,20 @@ def run(cmd, **kwargs):
 
 
 def main():
-    sdk_sources_path = Path(
-        os.environ.get("SDK_SOURCES_PATH", f"{os.environ['DEPENDS_DIR']}/sdk-sources")
-    )
+    depends_dir = Path(os.environ["DEPENDS_DIR"])
+    cache_paths = {
+        "ccache": (Path(os.environ["CCACHE_DIR"]), Path(os.environ["CCACHE_DIR"])),
+        "depends": (depends_dir / "built", depends_dir / "built"),
+        "depends_sources": (depends_dir / "sources", depends_dir / "sources"),
+        "previous_releases": (
+            Path(os.environ["PREVIOUS_RELEASES_DIR"]),
+            Path(os.environ["PREVIOUS_RELEASES_DIR"]),
+        ),
+        "sdk_sources": (
+            Path(os.environ.get("SDK_SOURCES_PATH", str(depends_dir / "sdk-sources"))),
+            depends_dir / "sdk-sources",
+        ),
+    }
 
     print("Export only allowed settings:")
     settings = run(
@@ -54,12 +65,8 @@ def main():
     if os.getenv("DANGER_RUN_CI_ON_HOST"):
         print("Running on host system without docker wrapper")
         print("Create missing folders")
-        for create_dir in [
-                os.environ["CCACHE_DIR"],
-                sdk_sources_path,
-                os.environ["PREVIOUS_RELEASES_DIR"],
-        ]:
-            Path(create_dir).mkdir(parents=True, exist_ok=True)
+        for source, _ in cache_paths.values():
+            source.mkdir(parents=True, exist_ok=True)
 
         # Modify PATH to prepend the retry script, needed for CI_RETRY_EXE
         os.environ["PATH"] = f"{os.environ['BASE_ROOT_DIR']}/ci/retry:{os.environ['PATH']}"
@@ -87,40 +94,33 @@ def main():
             time.sleep(3)
             run(cmd_build)
 
-        for suffix in ["ccache", "depends", "depends_sources", "previous_releases", "sdk_sources"]:
+        for suffix in cache_paths:
             run(["docker", "volume", "create", f"{os.environ['CONTAINER_NAME']}_{suffix}"], check=False)
 
-        CI_CCACHE_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_ccache,dst={os.environ['CCACHE_DIR']}"
-        CI_DEPENDS_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_depends,dst={os.environ['DEPENDS_DIR']}/built"
-        CI_DEPENDS_SOURCES_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_depends_sources,dst={os.environ['DEPENDS_DIR']}/sources"
-        CI_PREVIOUS_RELEASES_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_previous_releases,dst={os.environ['PREVIOUS_RELEASES_DIR']}"
-        CI_SDK_SOURCES_MOUNT = f"type=volume,src={os.environ['CONTAINER_NAME']}_sdk_sources,dst={os.environ['DEPENDS_DIR']}/sdk-sources"
+        cache_mounts = {
+            suffix: f"type=volume,src={os.environ['CONTAINER_NAME']}_{suffix},dst={destination}"
+            for suffix, (_, destination) in cache_paths.items()
+        }
         CI_BUILD_MOUNT = []
 
         if os.getenv("DANGER_CI_ON_HOST_FOLDERS"):
             # ensure the directories exist
-            for create_dir in [
-                    os.environ["CCACHE_DIR"],
-                    f"{os.environ['DEPENDS_DIR']}/built",
-                    f"{os.environ['DEPENDS_DIR']}/sources",
-                    os.environ["PREVIOUS_RELEASES_DIR"],
-                    sdk_sources_path,
-                    os.environ["BASE_BUILD_DIR"],  # Unset by default, must be defined externally
-            ]:
-                Path(create_dir).mkdir(parents=True, exist_ok=True)
+            for source, _ in cache_paths.values():
+                source.mkdir(parents=True, exist_ok=True)
+            Path(os.environ["BASE_BUILD_DIR"]).mkdir(parents=True, exist_ok=True)
 
-            CI_CCACHE_MOUNT = f"type=bind,src={os.environ['CCACHE_DIR']},dst={os.environ['CCACHE_DIR']}"
-            CI_DEPENDS_MOUNT = f"type=bind,src={os.environ['DEPENDS_DIR']}/built,dst={os.environ['DEPENDS_DIR']}/built"
-            CI_DEPENDS_SOURCES_MOUNT = f"type=bind,src={os.environ['DEPENDS_DIR']}/sources,dst={os.environ['DEPENDS_DIR']}/sources"
-            CI_PREVIOUS_RELEASES_MOUNT = f"type=bind,src={os.environ['PREVIOUS_RELEASES_DIR']},dst={os.environ['PREVIOUS_RELEASES_DIR']}"
-            CI_SDK_SOURCES_MOUNT = f"type=bind,src={sdk_sources_path},dst={os.environ['DEPENDS_DIR']}/sdk-sources"
+            cache_mounts = {
+                suffix: f"type=bind,src={source},dst={destination}"
+                for suffix, (source, destination) in cache_paths.items()
+            }
             CI_BUILD_MOUNT = [f"--mount=type=bind,src={os.environ['BASE_BUILD_DIR']},dst={os.environ['BASE_BUILD_DIR']}"]
 
         if os.getenv("DANGER_CI_ON_HOST_CCACHE_FOLDER"):
-            if not os.path.isdir(os.environ["CCACHE_DIR"]):
+            ccache_path, ccache_destination = cache_paths["ccache"]
+            if not ccache_path.is_dir():
                 print(f"Error: Directory '{os.environ['CCACHE_DIR']}' must be created in advance.")
                 sys.exit(1)
-            CI_CCACHE_MOUNT = f"type=bind,src={os.environ['CCACHE_DIR']},dst={os.environ['CCACHE_DIR']}"
+            cache_mounts["ccache"] = f"type=bind,src={ccache_path},dst={ccache_destination}"
 
         run(["docker", "network", "create", "--ipv6", "--subnet", "1111:1111::/112", "ci-ip6net"], check=False)
         run(["docker", "network", "create", "--subnet", "1.1.1.0/24", "ci-ip4net"], check=False)
@@ -145,11 +145,7 @@ def main():
             "--cap-add=LINUX_IMMUTABLE",
             *shlex.split(os.getenv("CI_CONTAINER_CAP", "")),
             f"--mount=type=bind,src={os.environ['BASE_READ_ONLY_DIR']},dst={os.environ['BASE_READ_ONLY_DIR']},readonly",
-            f"--mount={CI_CCACHE_MOUNT}",
-            f"--mount={CI_DEPENDS_MOUNT}",
-            f"--mount={CI_DEPENDS_SOURCES_MOUNT}",
-            f"--mount={CI_PREVIOUS_RELEASES_MOUNT}",
-            f"--mount={CI_SDK_SOURCES_MOUNT}",
+            *[f"--mount={mount}" for mount in cache_mounts.values()],
             *CI_BUILD_MOUNT,
             f"--env-file={env_file}",
             f"--name={os.environ['CONTAINER_NAME']}",

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -183,6 +183,7 @@ def main():
         f"{os.environ['BASE_ROOT_DIR']}",
     ])
     ci_exec([f"{os.environ['BASE_ROOT_DIR']}/ci/test/01_base_install.sh"])
+    ci_exec([f"{os.environ['BASE_ROOT_DIR']}/ci/test/01_setup_bsd.sh"])
     ci_exec([f"{os.environ['BASE_ROOT_DIR']}/ci/test/03_test_script.sh"])
 
     if not os.getenv("DANGER_RUN_CI_ON_HOST"):


### PR DESCRIPTION
Sometimes CI jobs need to (re)download *BSD SDK archives, and these downloads can delay or fail the job, as has been happening recently.

The SDKs are currently downloaded and extracted _while building the CI image itself_; this means that when the relevant image-build cache is missed or invalidated, the SDK archives are downloaded again, which is unnecessary.

Instead, cache the BSD SDK archives separately and mount them into the runtime container. Move the BSD SDK setup out of `01_base_install.sh` and run it after the container starts, so it is no longer part of the image build and the BSD SDKs are no longer part of the image build cache/layers.

This means rebuilding the BSD images no longer relies on pulling the SDK archives, reducing reliance and load we have on archive servers in many cases.

While touching 02_run_container.py and adding new paths to it, unify path handling for all caches a bit more.