### PR TITLE
cmpctblock: Improve logging of `cmpctblock` message reconstruction statistics [part of prefill series]

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -221,11 +221,11 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
     if (util::log::ShouldDebugLog(BCLog::CMPCTBLOCK)) {
         const uint256 hash{block.GetHash()};
         uint32_t tx_missing_size{0};
-        for (const auto& tx : vtx_missing) tx_missing_size += tx->ComputeTotalSize();
+        for (const auto& tx : vtx_missing) { tx_missing_size += tx->ComputeTotalSize(); }
         LogDebug(BCLog::CMPCTBLOCK, "Successfully reconstructed block %s with %u txn prefilled, %u txn from mempool (incl at least %u from extra pool) and %u txn (%u bytes) requested\n", hash.ToString(), prefilled_count, mempool_count, extra_count, vtx_missing.size(), tx_missing_size);
-        if (vtx_missing.size() < 5) {
+        if (util::log::ShouldTraceLog(BCLog::CMPCTBLOCK)) {
             for (const auto& tx : vtx_missing) {
-                LogDebug(BCLog::CMPCTBLOCK, "Reconstructed block %s required tx %s\n", hash.ToString(), tx->GetHash().ToString());
+                LogTrace(BCLog::CMPCTBLOCK, "Reconstructed block %s required tx %s\n", hash.ToString(), tx->GetHash().ToString());
             }
         }
     }

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -115,6 +115,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
 
     enum class TxSource : uint8_t { NONE, MEMPOOL, EXTRA, COLLIDED };
     std::vector<TxSource> tx_source(txn_available.size(), TxSource::NONE);
+    size_t available_count = 0;
     {
     LOCK(pool->cs);
     for (const auto& [wtxid, txit] : pool->txns_randomized) {
@@ -124,20 +125,20 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             if (tx_source[idit->second] == TxSource::NONE) {
                 txn_available[idit->second] = txit->GetSharedTx();
                 tx_source[idit->second] = TxSource::MEMPOOL;
-                mempool_count++;
+                ++available_count;
             } else if (tx_source[idit->second] != TxSource::COLLIDED) {
                 // If we find two mempool txn that match the short id, just request it.
                 // This should be rare enough that the extra bandwidth doesn't matter,
                 // but eating a round-trip due to FillBlock failure would be annoying
                 txn_available[idit->second].reset();
-                mempool_count--;
+                --available_count;
                 tx_source[idit->second] = TxSource::COLLIDED;
             }
         }
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
         // the performance win of an early exit here is too good to pass up and worth
         // the extra risk.
-        if (mempool_count == shorttxids.size())
+        if (available_count == shorttxids.size())
             break;
     }
     }
@@ -149,8 +150,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             if (tx_source[idit->second] == TxSource::NONE) {
                 txn_available[idit->second] = extra_txn[i].second;
                 tx_source[idit->second] = TxSource::EXTRA;
-                mempool_count++;
-                extra_count++;
+                ++available_count;
             } else if (tx_source[idit->second] != TxSource::COLLIDED &&
                        txn_available[idit->second]->GetWitnessHash() != extra_txn[i].second->GetWitnessHash()) {
                 // If we find two mempool/extra txn that match the short id, just
@@ -160,16 +160,31 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
                 // Note that we don't want duplication between extra_txn and mempool to
                 // trigger this case, so we compare witness hashes first
                 txn_available[idit->second].reset();
-                mempool_count--;
-                extra_count -= (tx_source[idit->second] == TxSource::EXTRA);
+                --available_count;
                 tx_source[idit->second] = TxSource::COLLIDED;
             }
         }
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
         // the performance win of an early exit here is too good to pass up and worth
         // the extra risk.
-        if (mempool_count == shorttxids.size())
+        if (available_count == shorttxids.size())
             break;
+    }
+
+    if (util::log::ShouldDebugLog(BCLog::CMPCTBLOCK)) {
+        Assume(txn_available.size() == tx_source.size());
+        for (size_t i = 0; i < txn_available.size(); i++) {
+            switch (tx_source[i]) {
+                case TxSource::MEMPOOL:
+                    ++mempool_count;
+                    break;
+                case TxSource::EXTRA:
+                    ++extra_count;
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 
     LogDebug(BCLog::CMPCTBLOCK, "Initialized PartiallyDownloadedBlock for block %s using a cmpctblock of %u bytes\n", cmpctblock.header.GetHash().ToString(), GetSerializeSize(cmpctblock));

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -9,6 +9,7 @@
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>
+#include <logging/categories.h>
 #include <random.h>
 #include <streams.h>
 #include <txmempool.h>
@@ -69,6 +70,22 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     header = cmpctblock.header;
     txn_available.resize(cmpctblock.BlockTxCount());
 
+    std::vector<Wtxid> extra_wtxids{};
+
+    bool debug_log = util::log::ShouldDebugLog(BCLog::CMPCTBLOCK);
+
+    if (debug_log) {
+        prefilled_count = cmpctblock.prefilledtxn.size();
+
+        // A sorted vec of extra_txn's for cheaply checking if prefills
+        // were redundant with the extrapool.
+        for (const auto& [id, tx] : extra_txn) {
+            extra_wtxids.push_back(id);
+        }
+        std::sort(extra_wtxids.begin(), extra_wtxids.end());
+    }
+
+
     int32_t lastprefilledindex = -1;
     for (size_t i = 0; i < cmpctblock.prefilledtxn.size(); i++) {
         if (cmpctblock.prefilledtxn[i].tx->IsNull())
@@ -83,9 +100,22 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             // have neither a prefilled txn or a shorttxid!
             return READ_STATUS_INVALID;
         }
+
+        if (debug_log) {
+            size_t tx_size = cmpctblock.prefilledtxn[i].tx->ComputeTotalSize();
+            prefilled_size += tx_size;
+
+            auto tx_wtxid =  cmpctblock.prefilledtxn[i].tx->GetWitnessHash();
+            if (pool->exists(tx_wtxid)) {
+                redundant_prefilled_mempool_count++;
+                redundant_prefilled_mempool_size += tx_size;
+            } else if (std::binary_search(extra_wtxids.begin(), extra_wtxids.end(), tx_wtxid)) {
+                redundant_prefilled_extrapool_count++;
+                redundant_prefilled_extrapool_size += tx_size;
+            }
+        }
         txn_available[lastprefilledindex] = cmpctblock.prefilledtxn[i].tx;
     }
-    prefilled_count = cmpctblock.prefilledtxn.size();
 
     // Calculate map of txids -> positions and check mempool to see what we have (or don't)
     // Because well-formed cmpctblock messages will have a (relatively) uniform distribution
@@ -177,9 +207,13 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             switch (tx_source[i]) {
                 case TxSource::MEMPOOL:
                     ++mempool_count;
+                    Assume(txn_available[i]);
+                    mempool_size += txn_available[i]->ComputeTotalSize();
                     break;
                 case TxSource::EXTRA:
                     ++extra_count;
+                    Assume(txn_available[i]);
+                    extra_size += txn_available[i]->ComputeTotalSize();
                     break;
                 default:
                     break;
@@ -237,7 +271,25 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
         const uint256 hash{block.GetHash()};
         uint32_t tx_missing_size{0};
         for (const auto& tx : vtx_missing) { tx_missing_size += tx->ComputeTotalSize(); }
-        LogDebug(BCLog::CMPCTBLOCK, "Successfully reconstructed block %s with %u txn prefilled, %u txn from mempool (incl at least %u from extra pool) and %u txn (%u bytes) requested\n", hash.ToString(), prefilled_count, mempool_count, extra_count, vtx_missing.size(), tx_missing_size);
+        LogDebug(BCLog::CMPCTBLOCK,
+            "Successfully reconstructed block %s with %u txn prefilled (%u bytes), "
+            "%u txn from mempool (%u bytes), "
+            "%u txn from extrapool (%u bytes), "
+            "and %u txn requested (%u bytes)",
+            hash.ToString(),
+            prefilled_count, prefilled_size,
+            mempool_count, mempool_size,
+            extra_count, extra_size,
+            vtx_missing.size(), tx_missing_size);
+        LogDebug(BCLog::CMPCTBLOCK,
+            "%u txn (%u bytes) of the prefill were redundant, "
+            "%u txn (%u bytes) were present in the mempool, "
+            "%u txn (%u bytes) were present in the extrapool. ",
+            redundant_prefilled_mempool_count + redundant_prefilled_extrapool_count,
+            redundant_prefilled_mempool_size + redundant_prefilled_extrapool_size,
+            redundant_prefilled_mempool_count, redundant_prefilled_mempool_size,
+            redundant_prefilled_extrapool_count, redundant_prefilled_extrapool_size);
+
         if (util::log::ShouldTraceLog(BCLog::CMPCTBLOCK)) {
             for (const auto& tx : vtx_missing) {
                 LogTrace(BCLog::CMPCTBLOCK, "Reconstructed block %s required tx %s\n", hash.ToString(), tx->GetHash().ToString());

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -115,6 +115,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
 
     enum class TxSource : uint8_t { NONE, MEMPOOL, EXTRA, COLLIDED };
     std::vector<TxSource> tx_source(txn_available.size(), TxSource::NONE);
+    size_t available_count = 0;
     {
     LOCK(pool->cs);
     for (const auto& [wtxid, txit] : pool->txns_randomized) {
@@ -124,20 +125,20 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             if (tx_source[idit->second] == TxSource::NONE) {
                 txn_available[idit->second] = txit->GetSharedTx();
                 tx_source[idit->second] = TxSource::MEMPOOL;
-                mempool_count++;
+                available_count++;
             } else if (tx_source[idit->second] != TxSource::COLLIDED) {
                 // If we find two mempool txn that match the short id, just request it.
                 // This should be rare enough that the extra bandwidth doesn't matter,
                 // but eating a round-trip due to FillBlock failure would be annoying
                 txn_available[idit->second].reset();
-                mempool_count--;
+                available_count--;
                 tx_source[idit->second] = TxSource::COLLIDED;
             }
         }
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
         // the performance win of an early exit here is too good to pass up and worth
         // the extra risk.
-        if (mempool_count == shorttxids.size())
+        if (available_count == shorttxids.size())
             break;
     }
     }
@@ -149,8 +150,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             if (tx_source[idit->second] == TxSource::NONE) {
                 txn_available[idit->second] = extra_txn[i].second;
                 tx_source[idit->second] = TxSource::EXTRA;
-                mempool_count++;
-                extra_count++;
+                available_count++;
             } else if (tx_source[idit->second] != TxSource::COLLIDED &&
                        txn_available[idit->second]->GetWitnessHash() != extra_txn[i].second->GetWitnessHash()) {
                 // If we find two mempool/extra txn that match the short id, just
@@ -160,16 +160,31 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
                 // Note that we don't want duplication between extra_txn and mempool to
                 // trigger this case, so we compare witness hashes first
                 txn_available[idit->second].reset();
-                mempool_count--;
-                extra_count -= (tx_source[idit->second] == TxSource::EXTRA);
+                available_count--;
                 tx_source[idit->second] = TxSource::COLLIDED;
             }
         }
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
         // the performance win of an early exit here is too good to pass up and worth
         // the extra risk.
-        if (mempool_count == shorttxids.size())
+        if (available_count == shorttxids.size())
             break;
+    }
+
+    if (util::log::ShouldDebugLog(BCLog::CMPCTBLOCK)) {
+        Assume(txn_available.size() == tx_source.size());
+        for (size_t i = 0; i < txn_available.size(); i++) {
+            switch (tx_source[i]) {
+                case TxSource::MEMPOOL:
+                    mempool_count++;
+                    break;
+                case TxSource::EXTRA:
+                    extra_count++;
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 
     LogDebug(BCLog::CMPCTBLOCK, "Initialized PartiallyDownloadedBlock for block %s using a cmpctblock of %u bytes\n", cmpctblock.header.GetHash().ToString(), GetSerializeSize(cmpctblock));

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -9,6 +9,7 @@
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>
+#include <logging/categories.h>
 #include <random.h>
 #include <streams.h>
 #include <txmempool.h>
@@ -69,6 +70,22 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     header = cmpctblock.header;
     txn_available.resize(cmpctblock.BlockTxCount());
 
+    std::vector<Wtxid> extra_wtxids{};
+
+    bool debug_log = util::log::ShouldDebugLog(BCLog::CMPCTBLOCK);
+
+    if (debug_log) {
+        prefilled_count = cmpctblock.prefilledtxn.size();
+
+        // A sorted vec of extra_txn's for cheaply checking if prefills
+        // were redundant with the extrapool.
+        for (const auto& [id, tx] : extra_txn) {
+            extra_wtxids.push_back(id);
+        }
+        std::sort(extra_wtxids.begin(), extra_wtxids.end());
+    }
+
+
     int32_t lastprefilledindex = -1;
     for (size_t i = 0; i < cmpctblock.prefilledtxn.size(); i++) {
         if (cmpctblock.prefilledtxn[i].tx->IsNull())
@@ -83,9 +100,22 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             // have neither a prefilled txn or a shorttxid!
             return READ_STATUS_INVALID;
         }
+
+        if (debug_log) {
+            size_t tx_size = cmpctblock.prefilledtxn[i].tx->ComputeTotalSize();
+            prefilled_size += tx_size;
+
+            auto tx_wtxid =  cmpctblock.prefilledtxn[i].tx->GetWitnessHash();
+            if (pool->exists(tx_wtxid)) {
+                redundant_prefilled_mp_count++;
+                redundant_prefilled_mp_size += tx_size;
+            } else if (std::binary_search(extra_wtxids.begin(), extra_wtxids.end(), tx_wtxid)) {
+                redundant_prefilled_ep_count++;
+                redundant_prefilled_ep_size += tx_size;
+            }
+        }
         txn_available[lastprefilledindex] = cmpctblock.prefilledtxn[i].tx;
     }
-    prefilled_count = cmpctblock.prefilledtxn.size();
 
     // Calculate map of txids -> positions and check mempool to see what we have (or don't)
     // Because well-formed cmpctblock messages will have a (relatively) uniform distribution
@@ -177,9 +207,13 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             switch (tx_source[i]) {
                 case TxSource::MEMPOOL:
                     mempool_count++;
+                    Assume(txn_available[i]);
+                    mempool_size += txn_available[i]->ComputeTotalSize();
                     break;
                 case TxSource::EXTRA:
                     extra_count++;
+                    Assume(txn_available[i]);
+                    extra_size += txn_available[i]->ComputeTotalSize();
                     break;
                 default:
                     break;
@@ -237,7 +271,25 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
         const uint256 hash{block.GetHash()};
         uint32_t tx_missing_size{0};
         for (const auto& tx : vtx_missing) { tx_missing_size += tx->ComputeTotalSize(); }
-        LogDebug(BCLog::CMPCTBLOCK, "Successfully reconstructed block %s with %u txn prefilled, %u txn from mempool (incl at least %u from extra pool) and %u txn (%u bytes) requested\n", hash.ToString(), prefilled_count, mempool_count, extra_count, vtx_missing.size(), tx_missing_size);
+        LogDebug(BCLog::CMPCTBLOCK,
+            "Successfully reconstructed block %s with %u txn prefilled (%u bytes), "
+            "%u txn from mempool (%u bytes), "
+            "%u txn from extrapool (%u bytes), "
+            "and %u txn requested (%u bytes)",
+            hash.ToString(),
+            prefilled_count, prefilled_size,
+            mempool_count, mempool_size,
+            extra_count, extra_size,
+            vtx_missing.size(), tx_missing_size);
+        LogDebug(BCLog::CMPCTBLOCK,
+            "%u txn (%u bytes) of the prefill were redundant, "
+            "%u txn (%u bytes) were present in the mempool, "
+            "%u txn (%u bytes) were present in the extrapool. ",
+            redundant_prefilled_mp_count + redundant_prefilled_ep_count,
+            redundant_prefilled_mp_size + redundant_prefilled_ep_size,
+            redundant_prefilled_mp_count, redundant_prefilled_mp_size,
+            redundant_prefilled_ep_count, redundant_prefilled_ep_size);
+
         if (util::log::ShouldTraceLog(BCLog::CMPCTBLOCK)) {
             for (const auto& tx : vtx_missing) {
                 LogTrace(BCLog::CMPCTBLOCK, "Reconstructed block %s required tx %s\n", hash.ToString(), tx->GetHash().ToString());

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -133,7 +133,16 @@ public:
 class PartiallyDownloadedBlock {
 protected:
     std::vector<CTransactionRef> txn_available;
+
     size_t prefilled_count = 0, mempool_count = 0, extra_count = 0;
+    size_t prefilled_size = 0, mempool_size = 0, extra_size = 0;
+
+    // Either it was already present in our mempool...
+    size_t redundant_prefilled_mp_count = 0, redundant_prefilled_mp_size = 0;
+    // or maybe it was present in our extrapool...
+    size_t redundant_prefilled_ep_count = 0, redundant_prefilled_ep_size = 0;
+
+
     const CTxMemPool* pool;
 public:
     CBlockHeader header;

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -133,7 +133,18 @@ public:
 class PartiallyDownloadedBlock {
 protected:
     std::vector<CTransactionRef> txn_available;
+
+    // All of these count and size values are only set if logging is enabled.
+    // If you want to use them for something else, change that.
     size_t prefilled_count = 0, mempool_count = 0, extra_count = 0;
+    size_t prefilled_size = 0, mempool_size = 0, extra_size = 0;
+
+    // For tracking redundant prefills, only set if logging is enabled.
+    // Either it was already present in our mempool...
+    size_t redundant_prefilled_mempool_count = 0, redundant_prefilled_mempool_size = 0;
+    // or maybe it was present in our extrapool...
+    size_t redundant_prefilled_extrapool_count = 0, redundant_prefilled_extrapool_size = 0;
+
     const CTxMemPool* pool;
 public:
     CBlockHeader header;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2848,6 +2848,23 @@ void PeerManagerImpl::SendBlockTransactions(CNode& pfrom, Peer& peer, const CBlo
         uint32_t tx_requested_size{0};
         for (const auto& tx : resp.txn) tx_requested_size += tx->ComputeTotalSize();
         LogDebug(BCLog::CMPCTBLOCK, "%s sent us a GETBLOCKTXN for block %s, sending a BLOCKTXN with %u txns. (%u bytes)", pfrom.LogPeer(), block.GetHash().ToString(), resp.txn.size(), tx_requested_size);
+        if (util::log::ShouldTraceLog(BCLog::CMPCTBLOCK)) {
+            std::string missing_txids{};
+
+            static constexpr size_t txid_str_len = Txid::size() * 2;
+            missing_txids.reserve((txid_str_len + 2) * resp.txn.size());
+
+            bool first = true;
+            for(const auto& txn : resp.txn) {
+                if (!first) {
+                    missing_txids += ", ";
+                }
+                missing_txids += txn->GetHash().ToString();
+                first = false;
+            }
+
+            LogTrace(BCLog::CMPCTBLOCK, "%s sent a GETBLOCKTXN for block %s requesting the following transactions: %s", pfrom.LogPeer(), block.GetHash().ToString(), missing_txids);
+        }
     }
     MakeAndPushMessage(pfrom, NetMsgType::BLOCKTXN, resp);
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2848,6 +2848,11 @@ void PeerManagerImpl::SendBlockTransactions(CNode& pfrom, Peer& peer, const CBlo
         uint32_t tx_requested_size{0};
         for (const auto& tx : resp.txn) tx_requested_size += tx->ComputeTotalSize();
         LogDebug(BCLog::CMPCTBLOCK, "%s sent us a GETBLOCKTXN for block %s, sending a BLOCKTXN with %u txns. (%u bytes)", pfrom.LogPeer(), block.GetHash().ToString(), resp.txn.size(), tx_requested_size);
+        if (util::log::ShouldTraceLog(BCLog::CMPCTBLOCK)) {
+            for(const auto& txn : resp.txn) {
+                LogDebug(BCLog::CMPCTBLOCK, "    - txid: %s", txn->GetHash().ToString());
+            }
+        }
     }
     MakeAndPushMessage(pfrom, NetMsgType::BLOCKTXN, resp);
 }

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
         BOOST_CHECK_EQUAL(partial_block_with_extra_collision.InitData(cmpctblock, extra_txn), READ_STATUS_OK);
         BOOST_CHECK(partial_block_with_extra_collision.IsTxAvailable(1));
         BOOST_CHECK(!partial_block_with_extra_collision.IsTxAvailable(2));
-        BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetMempoolCount(), 1U);
+        BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetMempoolCount(), 0U);
         BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetExtraCount(), 1U);
 
         // Now also collide the extra-sourced slot: both counters decrement exactly once.


### PR DESCRIPTION
Split from #35558, this makes it easier to observe compact block reconstruction performance by:

- At debuglevel=trace logging all missing TX's in a CMPCTBLOCK, and all missing TX's requested from us.
- Logging the sizes and counts of tx's used from the prefill, mempool, and extrapool.
- Logging the sizes and sources of redundant transactions in the prefill section of received `CMPCTBLOCK`s. 