### PR TITLE
kernel: expose contextual block validation (`TestBlockValidity()`)

### DIFF
--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1382,6 +1382,24 @@ int btck_chainstate_manager_process_block(
     return result ? 0 : -1;
 }
 
+int btck_chainstate_manager_test_block_validity(
+    btck_ChainstateManager* chainman,
+    const btck_Block* block,
+    btck_BlockCheckFlags flags,
+    btck_BlockValidationState* validation_state)
+{
+    auto& chainman_ref = *btck_ChainstateManager::get(chainman).m_chainman;
+
+    const bool check_pow    = (flags & btck_BlockCheckFlags_POW) != 0;
+    const bool check_merkle = (flags & btck_BlockCheckFlags_MERKLE) != 0;
+
+    LOCK(chainman_ref.GetMutex());
+    auto& state = btck_BlockValidationState::get(validation_state);
+    state = TestBlockValidity(chainman_ref.ActiveChainstate(), *btck_Block::get(block), check_pow, check_merkle);
+
+    return state.IsValid() ? 1 : 0;
+}
+
 btck_BlockValidationState* btck_chainstate_manager_process_block_header(
     btck_ChainstateManager* chainstate_manager,
     const btck_BlockHeader* header)

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -430,6 +430,13 @@ typedef uint32_t btck_TxValidationResult;
 #define btck_TxValidationResult_RECONSIDERABLE      ((btck_TxValidationResult)(11)) //!< fails some policy, but might be acceptable if submitted in a (different) package
 #define btck_TxValidationResult_UNKNOWN             ((btck_TxValidationResult)(12)) //!< transaction was not validated because package failed
 
+/** Bitflags to control the optional context-free block checks (proof of work and merkle root). */
+typedef uint32_t btck_BlockCheckFlags;
+#define btck_BlockCheckFlags_BASE   ((btck_BlockCheckFlags)0)                                                        //!< run the base context-free block checks only
+#define btck_BlockCheckFlags_POW    ((btck_BlockCheckFlags)(1U << 0))                                                //!< run CheckProofOfWork via CheckBlockHeader
+#define btck_BlockCheckFlags_MERKLE ((btck_BlockCheckFlags)(1U << 1))                                                //!< verify merkle root (and mutation detection)
+#define btck_BlockCheckFlags_ALL    ((btck_BlockCheckFlags)(btck_BlockCheckFlags_POW | btck_BlockCheckFlags_MERKLE)) //!< enable all optional context-free block checks
+
 /**
  * Holds the validation interface callbacks. The user data pointer may be used
  * to point to user-defined structures to make processing the validation
@@ -1315,6 +1322,29 @@ BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_p
     int* new_block) BITCOINKERNEL_ARG_NONNULL(1, 2, 3);
 
 /**
+ * @brief Test whether a block would be valid as the next block extending the
+ * current active tip, without connecting it to the chain.
+ * On top of the context-free checks performed by btck_block_check, this also
+ * runs the contextual header checks, the contextual block checks, and a full
+ * script/utxo validation pass against a temporary copy of the utxo set. Neither
+ * the chainstate, the utxo set, nor the block index are modified.
+ *
+ * @param[in]     chainstate_manager Non-null.
+ * @param[in]     block              Non-null, block to validate.
+ * @param[in]     flags              Bitmask of btck_BlockCheckFlags controlling the
+ *                                   optional POW and merkle-root checks. Use
+ *                                   btck_BlockCheckFlags_BASE to skip both.
+ * @param[out]    validation_state   Non-null, previously created with
+ *                                   btck_block_validation_state_create.
+ * @return                           1 if the block passed the checks, 0 otherwise.
+ */
+BITCOINKERNEL_API int btck_chainstate_manager_test_block_validity(
+    btck_ChainstateManager* chainstate_manager,
+    const btck_Block* block,
+    btck_BlockCheckFlags flags,
+    btck_BlockValidationState* validation_state) BITCOINKERNEL_ARG_NONNULL(1, 2, 4);
+
+/**
  * @brief Returns the best known currently active chain. Its lifetime is
  * dependent on the chainstate manager. It can be thought of as a view on a
  * vector of block tree entries that form the best chain. The returned chain
@@ -1386,13 +1416,6 @@ BITCOINKERNEL_API btck_Block* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_create
  */
 BITCOINKERNEL_API btck_Block* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_copy(
     const btck_Block* block) BITCOINKERNEL_ARG_NONNULL(1);
-
-/** Bitflags to control context-free block checks (optional). */
-typedef uint32_t btck_BlockCheckFlags;
-#define btck_BlockCheckFlags_BASE   ((btck_BlockCheckFlags)0)                                                        //!< run the base context-free block checks only
-#define btck_BlockCheckFlags_POW    ((btck_BlockCheckFlags)(1U << 0))                                                //!< run CheckProofOfWork via CheckBlockHeader
-#define btck_BlockCheckFlags_MERKLE ((btck_BlockCheckFlags)(1U << 1))                                                //!< verify merkle root (and mutation detection)
-#define btck_BlockCheckFlags_ALL    ((btck_BlockCheckFlags)(btck_BlockCheckFlags_POW | btck_BlockCheckFlags_MERKLE)) //!< enable all optional context-free block checks
 
 /**
  * @brief Perform context-free validation checks on a btck_Block.

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -1375,6 +1375,11 @@ public:
         return res == 0;
     }
 
+    bool TestBlockValidity(const Block& block, BlockCheckFlags flags, BlockValidationState& state)
+    {
+        return btck_chainstate_manager_test_block_validity(get(), block.get(), static_cast<btck_BlockCheckFlags>(flags), state.get()) == 1;
+    }
+
     BlockValidationState ProcessBlockHeader(const BlockHeader& header)
     {
         auto state = btck_chainstate_manager_process_block_header(get(), header.get());

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -1014,6 +1014,39 @@ BOOST_AUTO_TEST_CASE(btck_check_block_context_free)
                           HasReason{"failed to instantiate btck object"});
 }
 
+BOOST_AUTO_TEST_CASE(btck_test_block_validity_tests)
+{
+    auto test_directory{TestDirectory{"test_block_validity_bitcoin_kernel"}};
+    auto notifications{std::make_shared<TestKernelNotifications>()};
+    auto context{create_context(notifications, ChainType::MAINNET)};
+    auto chainman{create_chainman(
+        test_directory, /*reindex=*/false, /*wipe_chainstate=*/false,
+        /*block_tree_db_in_memory=*/false, /*chainstate_db_in_memory=*/false, context)};
+
+    // Mainnet block 1.
+    auto raw_block = hex_string_to_byte_vec("010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e362990101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000");
+    Block block{raw_block};
+    BlockValidationState state;
+
+    // The block builds on the current tip (genesis), so it validates
+    // contextually without being connected to the chain.
+    BOOST_CHECK(chainman->TestBlockValidity(block, BlockCheckFlags::ALL, state));
+    BOOST_CHECK(state.GetValidationMode() == ValidationMode::VALID);
+
+    // TestBlockValidity must not connect the block, tip remains unchanged.
+    BOOST_CHECK_EQUAL(chainman->GetChain().Height(), 0);
+
+    // Connect the block
+    bool new_block = false;
+    BOOST_CHECK(chainman->ProcessBlock(block, &new_block));
+    BOOST_CHECK(new_block);
+    BOOST_CHECK_EQUAL(chainman->GetChain().Height(), 1);
+
+    // The same block no longer builds on the tip
+    BOOST_CHECK(!chainman->TestBlockValidity(block, BlockCheckFlags::ALL, state));
+    BOOST_CHECK(state.GetValidationMode() == ValidationMode::INVALID);
+}
+
 BOOST_AUTO_TEST_CASE(btck_chainman_mainnet_tests)
 {
     auto test_directory{TestDirectory{"mainnet_test_bitcoin_kernel"}};


### PR DESCRIPTION
The kernel library currently exposes two API for block validation:

- `btck_block_check` : context-free checks only, and
- `btck_chainstate_manager_process_block` : full validation that also connects the block, persists it to disk, updates indexes and fires notifications.

We could expose `TestBlockValidity()` using `btck_chainstate_manager_test_block_validity` that would fully validate a block in the context of current tip and that doesn't commit it. This could be beneficial for mining softwares and for testing purpose that would  do contextual header/block checks and full script/UTXO validation as read only operation.