### PR TITLE
rpc: Properly throw on internal I/O errors in GetTransaction

### DIFF
--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -90,31 +90,32 @@ bool TxIndex::CustomAppend(const interfaces::BlockInfo& block)
 
 BaseIndex::DB& TxIndex::GetDB() const { return *m_db; }
 
-bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx) const
+util::Expected<CTransactionRef, std::string> TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash) const
 {
     CDiskTxPos postx;
     if (!m_db->ReadTxPos(tx_hash, postx)) {
-        return false;
+        return CTransactionRef{};
     }
 
     AutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, true)};
     if (file.IsNull()) {
         LogError("OpenBlockFile failed");
-        return false;
+        return util::Unexpected{std::string{"I/O error while opening block file via txindex"}};
     }
     CBlockHeader header;
+    CTransactionRef tx;
     try {
         file >> header;
         file.seek(postx.nTxOffset, SEEK_CUR);
         file >> TX_WITH_WITNESS(tx);
     } catch (const std::exception& e) {
         LogError("Deserialize or I/O error - %s", e.what());
-        return false;
+        return util::Unexpected{std::string{"I/O error while deserializing transaction via txindex: "} + e.what()};
     }
     if (tx->GetHash() != tx_hash) {
         LogError("txid mismatch");
-        return false;
+        return util::Unexpected{std::string{"txid mismatch while reading transaction via txindex"}};
     }
     block_hash = header.GetHash();
-    return true;
+    return tx;
 }

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -7,9 +7,11 @@
 
 #include <index/base.h>
 #include <primitives/transaction.h>
+#include <util/expected.h>
 
 #include <cstddef>
 #include <memory>
+#include <string>
 
 class uint256;
 namespace interfaces {
@@ -49,9 +51,8 @@ public:
     ///
     /// @param[in]   tx_hash  The hash of the transaction to be returned.
     /// @param[out]  block_hash  The hash of the block the transaction is found in.
-    /// @param[out]  tx  The transaction itself.
-    /// @return  true if transaction is found, false otherwise
-    bool FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx) const;
+    /// @return  The tx if found, nullptr if not found, or an error string for I/O issues.
+    util::Expected<CTransactionRef, std::string> FindTx(const Txid& tx_hash, uint256& block_hash) const;
 };
 
 /// The global transaction index, used in GetTransaction. May be null.

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -139,7 +139,7 @@ TransactionError BroadcastTransaction(NodeContext& node,
     return TransactionError::OK;
 }
 
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const Txid& hash, const BlockManager& blockman, uint256& hashBlock)
+util::Expected<CTransactionRef, std::string> GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const Txid& hash, const BlockManager& blockman, uint256& hashBlock)
 {
     if (mempool && !block_index) {
         CTransactionRef ptx = mempool->get(hash);
@@ -147,7 +147,11 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
     }
     if (g_txindex) {
         uint256 block_hash;
-        CTransactionRef tx{g_txindex->FindTx(hash, block_hash).value_or(nullptr/*error handling fixed in the next commit*/)};
+        const auto tx_res = g_txindex->FindTx(hash, block_hash);
+        if (!tx_res) {
+            return util::Unexpected{tx_res.error()};
+        }
+        const CTransactionRef& tx{*tx_res};
         if (tx) {
             if (!block_index || block_index->GetBlockHash() == block_hash) {
                 // Don't return the transaction if the provided block hash doesn't match.
@@ -167,8 +171,10 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
                     return tx;
                 }
             }
+        } else {
+            return util::Unexpected{std::string{"I/O error reading block data"}};
         }
     }
-    return nullptr;
+    return CTransactionRef{};
 }
 } // namespace node

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -146,9 +146,9 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
         if (ptx) return ptx;
     }
     if (g_txindex) {
-        CTransactionRef tx;
         uint256 block_hash;
-        if (g_txindex->FindTx(hash, block_hash, tx)) {
+        CTransactionRef tx{g_txindex->FindTx(hash, block_hash).value_or(nullptr/*error handling fixed in the next commit*/)};
+        if (tx) {
             if (!block_index || block_index->GetBlockHash() == block_hash) {
                 // Don't return the transaction if the provided block hash doesn't match.
                 // The case where a transaction appears in multiple blocks (e.g. reorgs or

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -9,6 +9,9 @@
 #include <node/types.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
+#include <util/expected.h>
+
+#include <string>
 
 class CBlockIndex;
 class CTxMemPool;
@@ -68,9 +71,9 @@ static const CAmount DEFAULT_MAX_BURN_AMOUNT{0};
  * @param[in]  hash            The txid
  * @param[in]  blockman        Used to access and read blocks from disk
  * @param[out] hashBlock       The block hash, if the tx was found via -txindex or block_index
- * @returns                    The tx if found, otherwise nullptr
+ * @returns                    The tx if found, nullptr if not found, or an error string for I/O issues
  */
-CTransactionRef GetTransaction(const CBlockIndex* block_index, const CTxMemPool* mempool, const Txid& hash, const BlockManager& blockman, uint256& hashBlock);
+util::Expected<CTransactionRef, std::string> GetTransaction(const CBlockIndex* block_index, const CTxMemPool* mempool, const Txid& hash, const BlockManager& blockman, uint256& hashBlock);
 } // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -855,7 +855,11 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     const NodeContext* const node = GetNodeContext(context, req);
     if (!node) return false;
     uint256 hashBlock = uint256();
-    const CTransactionRef tx{GetTransaction(/*block_index=*/nullptr, node->mempool.get(), *hash,  node->chainman->m_blockman, hashBlock)};
+    const auto tx_res{GetTransaction(/*block_index=*/nullptr, node->mempool.get(), *hash,  node->chainman->m_blockman, hashBlock)};
+    if (!tx_res) {
+        return RESTERR(req, HTTP_INTERNAL_SERVER_ERROR, tx_res.error());
+    }
+    const auto& tx{*tx_res};
     if (!tx) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -148,22 +148,12 @@ PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std
         // The `non_witness_utxo` is the whole previous transaction
         if (psbt_input.non_witness_utxo) continue;
 
-        CTransactionRef tx;
-
-        // Look in the txindex
-        if (g_txindex) {
-            uint256 block_hash;
-            auto res{g_txindex->FindTx(psbt_input.prev_txid, block_hash)};
-            if (res) {
-                tx = *res;
-            } else {
-                throw JSONRPCError(RPC_INTERNAL_ERROR, res.error());
-            }
+        uint256 block_hash;
+        const auto tx_res = GetTransaction(/*block_index=*/nullptr, node.mempool.get(), psbt_input.prev_txid, node.chainman->m_blockman, block_hash);
+        if (!tx_res) {
+            throw JSONRPCError(RPC_INTERNAL_ERROR, tx_res.error());
         }
-        // If we still don't have it look in the mempool
-        if (!tx) {
-            tx = node.mempool->get(psbt_input.prev_txid);
-        }
+        const CTransactionRef& tx{*tx_res};
         if (tx) {
             psbt_input.non_witness_utxo = tx;
         } else {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -153,7 +153,12 @@ PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std
         // Look in the txindex
         if (g_txindex) {
             uint256 block_hash;
-            g_txindex->FindTx(psbt_input.prev_txid, block_hash, tx);
+            auto res{g_txindex->FindTx(psbt_input.prev_txid, block_hash)};
+            if (res) {
+                tx = *res;
+            } else {
+                throw JSONRPCError(RPC_INTERNAL_ERROR, res.error());
+            }
         }
         // If we still don't have it look in the mempool
         if (!tx) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -305,7 +305,11 @@ static RPCMethod getrawtransaction()
     }
 
     uint256 hash_block;
-    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), txid, chainman.m_blockman, hash_block);
+    const auto tx_res = GetTransaction(blockindex, node.mempool.get(), txid, chainman.m_blockman, hash_block);
+    if (!tx_res) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, tx_res.error());
+    }
+    const auto& tx{*tx_res};
     if (!tx) {
         std::string errmsg;
         if (blockindex) {

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -86,7 +86,11 @@ static RPCMethod gettxoutproof()
             }
 
             if (pblockindex == nullptr) {
-                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.m_blockman, hashBlock);
+                const auto tx_res = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.m_blockman, hashBlock);
+                if (!tx_res) {
+                    throw JSONRPCError(RPC_INTERNAL_ERROR, tx_res.error());
+                }
+                const auto& tx{*tx_res};
                 if (!tx || hashBlock.IsNull()) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
                 }

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -6,6 +6,7 @@
 #include <chainparams.h>
 #include <index/txindex.h>
 #include <interfaces/chain.h>
+#include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <util/byte_units.h>
 #include <validation.h>
@@ -19,12 +20,11 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     TxIndex txindex(interfaces::MakeChain(m_node), 1_MiB, true);
     BOOST_REQUIRE(txindex.Init());
 
-    CTransactionRef tx_disk;
     uint256 block_hash;
 
     // Transaction should not be found in the index before it is started.
     for (const auto& txn : m_coinbase_txns) {
-        BOOST_CHECK(!txindex.FindTx(txn->GetHash(), block_hash, tx_disk));
+        BOOST_CHECK(!*Assert(txindex.FindTx(txn->GetHash(), block_hash)));
     }
 
     // BlockUntilSyncedToCurrentChain should return false before txindex is started.
@@ -35,16 +35,13 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     // Check that txindex excludes genesis block transactions.
     const CBlock& genesis_block = Params().GenesisBlock();
     for (const auto& txn : genesis_block.vtx) {
-        BOOST_CHECK(!txindex.FindTx(txn->GetHash(), block_hash, tx_disk));
+        BOOST_CHECK(!*Assert(txindex.FindTx(txn->GetHash(), block_hash)));
     }
 
     // Check that txindex has all txs that were in the chain before it started.
     for (const auto& txn : m_coinbase_txns) {
-        if (!txindex.FindTx(txn->GetHash(), block_hash, tx_disk)) {
-            BOOST_ERROR("FindTx failed");
-        } else if (tx_disk->GetHash() != txn->GetHash()) {
-            BOOST_ERROR("Read incorrect tx");
-        }
+        const CTransactionRef tx_disk = *Assert(txindex.FindTx(txn->GetHash(), block_hash));
+        BOOST_REQUIRE_EQUAL(tx_disk->GetHash(), txn->GetHash());
     }
 
     // Check that new transactions in new blocks make it into the index.
@@ -55,11 +52,8 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
         const CTransaction& txn = *block.vtx[0];
 
         BOOST_CHECK(txindex.BlockUntilSyncedToCurrentChain());
-        if (!txindex.FindTx(txn.GetHash(), block_hash, tx_disk)) {
-            BOOST_ERROR("FindTx failed");
-        } else if (tx_disk->GetHash() != txn.GetHash()) {
-            BOOST_ERROR("Read incorrect tx");
-        }
+        const CTransactionRef tx_disk = *Assert(txindex.FindTx(txn.GetHash(), block_hash));
+        BOOST_REQUIRE_EQUAL(tx_disk->GetHash(), txn.GetHash());
     }
 
     // shutdown sequence (c.f. Shutdown() in init.cpp)

--- a/test/functional/feature_io_errors.py
+++ b/test/functional/feature_io_errors.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+"""Test handling of I/O errors."""
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+from test_framework.wallet import MiniWallet
+
+
+class IOErrorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.uses_wallet = None
+
+    def test_blk_dat_io_error(self):
+        self.log.info("Test RPCs throw on I/O errors")
+
+        node = self.nodes[0]
+        self.restart_node(0, ["-txindex"])
+        self.wait_until(lambda: node.getindexinfo()["txindex"]["synced"])
+        wallet = MiniWallet(node)
+
+        tx = wallet.send_self_transfer(from_node=node)
+        txid = tx["txid"]
+        self.generate(node, 1)
+        if self.is_wallet_compiled():
+            psbt = node.createpsbt(inputs=[{"txid": txid, "vout": 0}], outputs=[])
+
+        blk_dat = node.blocks_path / "blk00000.dat"
+        blk_dat_moved = node.blocks_path / "blk00000.dat.moved"
+        blk_dat.rename(blk_dat_moved)
+
+        msg = "I/O error while opening block file via txindex"
+        if self.is_wallet_compiled():
+            assert_raises_rpc_error(-32603, msg, node.utxoupdatepsbt, psbt)
+
+        blk_dat_moved.rename(blk_dat)
+
+    def run_test(self):
+        self.test_blk_dat_io_error()
+
+
+if __name__ == "__main__":
+    IOErrorTest(__file__).main()

--- a/test/functional/feature_io_errors.py
+++ b/test/functional/feature_io_errors.py
@@ -25,7 +25,8 @@ class IOErrorTest(BitcoinTestFramework):
 
         tx = wallet.send_self_transfer(from_node=node)
         txid = tx["txid"]
-        self.generate(node, 1)
+        tx2 = wallet.send_self_transfer(from_node=node, utxo_to_spend=tx["new_utxo"])
+        block = self.generate(node, 1)[0]
         if self.is_wallet_compiled():
             psbt = node.createpsbt(inputs=[{"txid": txid, "vout": 0}], outputs=[])
 
@@ -34,8 +35,14 @@ class IOErrorTest(BitcoinTestFramework):
         blk_dat.rename(blk_dat_moved)
 
         msg = "I/O error while opening block file via txindex"
+        assert_raises_rpc_error(-32603, msg, node.gettxoutproof, [txid])
+        assert_raises_rpc_error(-32603, msg, node.getrawtransaction, txid)
         if self.is_wallet_compiled():
             assert_raises_rpc_error(-32603, msg, node.utxoupdatepsbt, psbt)
+        msg = "I/O error reading block data"
+        assert_raises_rpc_error(-32603, msg, node.getrawtransaction, "a" * 64, blockhash=block)
+        msg = "Can't read block from disk"
+        assert_raises_rpc_error(-32603, msg, node.gettxoutproof, [tx2["txid"]])
 
         blk_dat_moved.rename(blk_dat)
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -190,6 +190,7 @@ BASE_SCRIPTS = [
     'wallet_txn_clone.py',
     'wallet_txn_clone.py --segwit',
     'rpc_getchaintips.py',
+    'feature_io_errors.py',
     'rpc_misc.py',
     'p2p_1p1c_network.py',
     'interface_rest.py',


### PR DESCRIPTION
Currently the GetTransaction return value is a nullable transaction
pointer, where nullptr represents two different outcomes: I/O error and
missing tx.

Reporting a confirmed transaction as missing is wrong, so properly
return an error instead.