### PR TITLE
refactor: test: Unroll `&&` conditions in macros

### DIFF
--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -81,11 +81,15 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     // Previously, precision was limited to three decimal digits
     // due to only supporting satoshis per kB, so CFeeRate(CAmount(1), 1001) was equal to CFeeRate(0)
     // Since #32750, higher precision is maintained.
-    BOOST_CHECK(CFeeRate(CAmount(1), 1001) > CFeeRate(0) && CFeeRate(CAmount(1), 1001) < CFeeRate(1));
-    BOOST_CHECK(CFeeRate(CAmount(2), 1001) > CFeeRate(1) && CFeeRate(CAmount(2), 1001) < CFeeRate(2));
+    BOOST_CHECK(CFeeRate(CAmount(1), 1001) > CFeeRate(0));
+    BOOST_CHECK(CFeeRate(CAmount(1), 1001) < CFeeRate(1));
+    BOOST_CHECK(CFeeRate(CAmount(2), 1001) > CFeeRate(1));
+    BOOST_CHECK(CFeeRate(CAmount(2), 1001) < CFeeRate(2));
     // some more integer checks
-    BOOST_CHECK(CFeeRate(CAmount(26), 789) > CFeeRate(32) && CFeeRate(CAmount(26), 789) < CFeeRate(33));
-    BOOST_CHECK(CFeeRate(CAmount(27), 789) > CFeeRate(34) && CFeeRate(CAmount(27), 789) < CFeeRate(35));
+    BOOST_CHECK(CFeeRate(CAmount(26), 789) > CFeeRate(32));
+    BOOST_CHECK(CFeeRate(CAmount(26), 789) < CFeeRate(33));
+    BOOST_CHECK(CFeeRate(CAmount(27), 789) > CFeeRate(34));
+    BOOST_CHECK(CFeeRate(CAmount(27), 789) < CFeeRate(35));
     // Maximum size in bytes, should not crash
     CFeeRate(MAX_MONEY, std::numeric_limits<int32_t>::max()).GetFeePerK();
 

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -204,24 +204,33 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
     testArgs.SetupArgs({a, b, ccc, d});
     BOOST_CHECK(testArgs.ParseParameters(0, argv_test, error));
     testArgs.LockSettings([&](const common::Settings& s) {
-        BOOST_CHECK(s.command_line_options.empty() && s.ro_config.empty());
+        BOOST_CHECK(s.command_line_options.empty());
+        BOOST_CHECK(s.ro_config.empty());
     });
 
     BOOST_CHECK(testArgs.ParseParameters(1, argv_test, error));
     testArgs.LockSettings([&](const common::Settings& s) {
-        BOOST_CHECK(s.command_line_options.empty() && s.ro_config.empty());
+        BOOST_CHECK(s.command_line_options.empty());
+        BOOST_CHECK(s.ro_config.empty());
     });
 
     BOOST_CHECK(testArgs.ParseParameters(7, argv_test, error));
     // expectation: -ignored is ignored (program name argument),
     // -a, -b and -ccc end up in map, -d ignored because it is after
     // a non-option argument (non-GNU option parsing)
-    BOOST_CHECK(testArgs.IsArgSet("-a") && testArgs.IsArgSet("-b") && testArgs.IsArgSet("-ccc")
-                && !testArgs.IsArgSet("f") && !testArgs.IsArgSet("-d"));
+    BOOST_CHECK(testArgs.IsArgSet("-a"));
+    BOOST_CHECK(testArgs.IsArgSet("-b"));
+    BOOST_CHECK(testArgs.IsArgSet("-ccc"));
+    BOOST_CHECK(!testArgs.IsArgSet("f"));
+    BOOST_CHECK(!testArgs.IsArgSet("-d"));
     testArgs.LockSettings([&](const common::Settings& s) {
-        BOOST_CHECK(s.command_line_options.size() == 3 && s.ro_config.empty());
-        BOOST_CHECK(s.command_line_options.contains("a") && s.command_line_options.contains("b") && s.command_line_options.contains("ccc")
-                    && !s.command_line_options.contains("f") && !s.command_line_options.contains("d"));
+        BOOST_CHECK(s.command_line_options.size() == 3);
+        BOOST_CHECK(s.ro_config.empty());
+        BOOST_CHECK(s.command_line_options.contains("a"));
+        BOOST_CHECK(s.command_line_options.contains("b"));
+        BOOST_CHECK(s.command_line_options.contains("ccc"));
+        BOOST_CHECK(!s.command_line_options.contains("f"));
+        BOOST_CHECK(!s.command_line_options.contains("d"));
 
         BOOST_CHECK(s.command_line_options.at("a").size() == 1);
         BOOST_CHECK(s.command_line_options.at("a").front().get_str() == "");
@@ -329,7 +338,8 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArg)
 
     // Nothing else should be in the map
     testArgs.LockSettings([&](const common::Settings& s) {
-        BOOST_CHECK(s.command_line_options.size() == 6 && s.ro_config.empty());
+        BOOST_CHECK(s.command_line_options.size() == 6);
+        BOOST_CHECK(s.ro_config.empty());
     });
 
     // The -no prefix should get stripped on the way in.
@@ -397,8 +407,8 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArgEdgeCases)
     // Command line overrides, but doesn't erase old setting
     BOOST_CHECK(!testArgs.IsArgNegated("-bar"));
     BOOST_CHECK(testArgs.GetArg("-bar", "xxx") == "");
-    BOOST_CHECK(testArgs.GetArgs("-bar").size() == 1
-                && testArgs.GetArgs("-bar").front() == "");
+    BOOST_REQUIRE(testArgs.GetArgs("-bar").size() == 1);
+    BOOST_CHECK(testArgs.GetArgs("-bar").front() == "");
 }
 
 BOOST_AUTO_TEST_CASE(util_ReadConfigStream)
@@ -498,22 +508,22 @@ BOOST_AUTO_TEST_CASE(util_ReadConfigStream)
         BOOST_CHECK(test_args.GetBoolArg("-iii", def) == def);
     }
 
-    BOOST_CHECK(test_args.GetArgs("-a").size() == 1
-                && test_args.GetArgs("-a").front() == "");
-    BOOST_CHECK(test_args.GetArgs("-b").size() == 1
-                && test_args.GetArgs("-b").front() == "1");
-    BOOST_CHECK(test_args.GetArgs("-ccc").size() == 2
-                && test_args.GetArgs("-ccc").front() == "argument"
-                && test_args.GetArgs("-ccc").back() == "multiple");
+    BOOST_REQUIRE(test_args.GetArgs("-a").size() == 1);
+    BOOST_CHECK(test_args.GetArgs("-a").front() == "");
+    BOOST_REQUIRE(test_args.GetArgs("-b").size() == 1);
+    BOOST_CHECK(test_args.GetArgs("-b").front() == "1");
+    BOOST_REQUIRE(test_args.GetArgs("-ccc").size() == 2);
+    BOOST_CHECK(test_args.GetArgs("-ccc").front() == "argument");
+    BOOST_CHECK(test_args.GetArgs("-ccc").back() == "multiple");
     BOOST_CHECK(test_args.GetArgs("-fff").size() == 0);
     BOOST_CHECK(test_args.GetArgs("-nofff").size() == 0);
-    BOOST_CHECK(test_args.GetArgs("-ggg").size() == 1
-                && test_args.GetArgs("-ggg").front() == "1");
+    BOOST_REQUIRE(test_args.GetArgs("-ggg").size() == 1);
+    BOOST_CHECK(test_args.GetArgs("-ggg").front() == "1");
     BOOST_CHECK(test_args.GetArgs("-noggg").size() == 0);
     BOOST_CHECK(test_args.GetArgs("-h").size() == 0);
     BOOST_CHECK(test_args.GetArgs("-noh").size() == 0);
-    BOOST_CHECK(test_args.GetArgs("-i").size() == 1
-                && test_args.GetArgs("-i").front() == "1");
+    BOOST_REQUIRE(test_args.GetArgs("-i").size() == 1);
+    BOOST_CHECK(test_args.GetArgs("-i").front() == "1");
     BOOST_CHECK(test_args.GetArgs("-noi").size() == 0);
     BOOST_CHECK(test_args.GetArgs("-zzz").size() == 0);
 

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -267,8 +267,14 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
     arith_uint256 TmpL;
     for (unsigned int i = 0; i < 256; ++i) {
         TmpL= OneL<< i;
-        BOOST_CHECK( TmpL >= ZeroL && TmpL > ZeroL && ZeroL < TmpL && ZeroL <= TmpL);
-        BOOST_CHECK( TmpL >= 0 && TmpL > 0 && 0 < TmpL && 0 <= TmpL);
+        BOOST_CHECK(TmpL >= ZeroL);
+        BOOST_CHECK(TmpL > ZeroL);
+        BOOST_CHECK(ZeroL < TmpL);
+        BOOST_CHECK(ZeroL <= TmpL);
+        BOOST_CHECK(TmpL >= 0);
+        BOOST_CHECK(TmpL > 0);
+        BOOST_CHECK(0 < TmpL);
+        BOOST_CHECK(0 <= TmpL);
         TmpL |= R1L;
         BOOST_CHECK( TmpL >= R1L ); BOOST_CHECK( (TmpL == R1L) != (TmpL > R1L)); BOOST_CHECK( (TmpL == R1L) || !( TmpL <= R1L));
         BOOST_CHECK( R1L <= TmpL ); BOOST_CHECK( (R1L == TmpL) != (R1L < TmpL)); BOOST_CHECK( (TmpL == R1L) || !( R1L >= TmpL));

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
         std::vector<unsigned char> expected = ParseHex(test[0].get_str());
         std::string base58string = test[1].get_str();
         BOOST_CHECK_MESSAGE(DecodeBase58(base58string, result, 256), strTest);
-        BOOST_CHECK_MESSAGE(result.size() == expected.size() && std::equal(result.begin(), result.end(), expected.begin()), strTest);
+        BOOST_CHECK_MESSAGE(std::ranges::equal(result ,expected), strTest);
     }
 
     BOOST_CHECK(!DecodeBase58("invalid"s, result, 100));

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -197,7 +197,8 @@ BOOST_AUTO_TEST_CASE(bip32_max_depth) {
     }
 
     // But trying to derive a non-existent 256th depth will fail!
-    BOOST_CHECK(key_parent.nDepth == 255 && pubkey_parent.nDepth == 255);
+    BOOST_CHECK(key_parent.nDepth == 255);
+    BOOST_CHECK(pubkey_parent.nDepth == 255);
     BOOST_CHECK(!key_parent.Derive(key_child, 0));
     BOOST_CHECK(!pubkey_parent.Derive(pubkey_child, 0));
 }

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -233,7 +233,8 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Catches_Failure)
         }
         auto result = control.Complete();
         if (i > 0) {
-            BOOST_REQUIRE(result.has_value() && *result == static_cast<int>(17 * i));
+            BOOST_REQUIRE(result.has_value());
+            BOOST_REQUIRE(*result == static_cast<int>(17 * i));
         } else {
             BOOST_REQUIRE(!result.has_value());
         }

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -21,7 +21,8 @@ std::list<CoinsCachePair> CreatePairs(CoinsCachePair& sentinel)
         auto node{std::prev(nodes.end())};
         CCoinsCacheEntry::SetDirty(*node, sentinel);
 
-        BOOST_CHECK(node->second.IsDirty() && !node->second.IsFresh());
+        BOOST_CHECK(node->second.IsDirty());
+        BOOST_CHECK(!node->second.IsFresh());
         BOOST_CHECK_EQUAL(node->second.Next(), &sentinel);
         BOOST_CHECK_EQUAL(sentinel.second.Prev(), &(*node));
 
@@ -63,7 +64,8 @@ BOOST_AUTO_TEST_CASE(linked_list_iteration)
 
     // Delete the nodes from the list to make sure there are no dangling pointers
     for (auto it{nodes.begin()}; it != nodes.end(); it = nodes.erase(it)) {
-        BOOST_CHECK(!it->second.IsDirty() && !it->second.IsFresh());
+        BOOST_CHECK(!it->second.IsDirty());
+        BOOST_CHECK(!it->second.IsFresh());
     }
 }
 
@@ -105,9 +107,11 @@ BOOST_AUTO_TEST_CASE(linked_list_random_deletion)
     nodes.erase(n2);
     // Check that n1 now points to n3, and n3 still points to n4
     // Also check that state was not altered
-    BOOST_CHECK(n1->second.IsDirty() && !n1->second.IsFresh());
+    BOOST_CHECK(n1->second.IsDirty());
+    BOOST_CHECK(!n1->second.IsFresh());
     BOOST_CHECK_EQUAL(n1->second.Next(), &(*n3));
-    BOOST_CHECK(n3->second.IsDirty() && !n3->second.IsFresh());
+    BOOST_CHECK(n3->second.IsDirty());
+    BOOST_CHECK(!n3->second.IsFresh());
     BOOST_CHECK_EQUAL(n3->second.Next(), &(*n4));
     BOOST_CHECK_EQUAL(n3->second.Prev(), &(*n1));
 
@@ -116,7 +120,8 @@ BOOST_AUTO_TEST_CASE(linked_list_random_deletion)
     nodes.erase(n1);
     // Check that sentinel now points to n3, and n3 still points to n4
     // Also check that state was not altered
-    BOOST_CHECK(n3->second.IsDirty() && !n3->second.IsFresh());
+    BOOST_CHECK(n3->second.IsDirty());
+    BOOST_CHECK(!n3->second.IsFresh());
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &(*n3));
     BOOST_CHECK_EQUAL(n3->second.Next(), &(*n4));
     BOOST_CHECK_EQUAL(n3->second.Prev(), &sentinel);
@@ -126,7 +131,8 @@ BOOST_AUTO_TEST_CASE(linked_list_random_deletion)
     nodes.erase(n4);
     // Check that sentinel still points to n3, and n3 points to sentinel
     // Also check that state was not altered
-    BOOST_CHECK(n3->second.IsDirty() && !n3->second.IsFresh());
+    BOOST_CHECK(n3->second.IsDirty());
+    BOOST_CHECK(!n3->second.IsFresh());
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &(*n3));
     BOOST_CHECK_EQUAL(n3->second.Next(), &sentinel);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &(*n3));
@@ -148,7 +154,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
 
     // Check that setting DIRTY inserts it into linked list and sets state
     CCoinsCacheEntry::SetDirty(n1, sentinel);
-    BOOST_CHECK(n1.second.IsDirty() && !n1.second.IsFresh());
+    BOOST_CHECK(n1.second.IsDirty());
+    BOOST_CHECK(!n1.second.IsFresh());
     BOOST_CHECK_EQUAL(n1.second.Next(), &sentinel);
     BOOST_CHECK_EQUAL(n1.second.Prev(), &sentinel);
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
@@ -156,7 +163,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
 
     // Check that setting FRESH on new node inserts it after n1
     CCoinsCacheEntry::SetFresh(n2, sentinel);
-    BOOST_CHECK(n2.second.IsFresh() && !n2.second.IsDirty());
+    BOOST_CHECK(n2.second.IsFresh());
+    BOOST_CHECK(!n2.second.IsDirty());
     BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
     BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
     BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
@@ -164,7 +172,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
 
     // Check that we can set extra state, but they don't change our position
     CCoinsCacheEntry::SetFresh(n1, sentinel);
-    BOOST_CHECK(n1.second.IsDirty() && n1.second.IsFresh());
+    BOOST_CHECK(n1.second.IsDirty());
+    BOOST_CHECK(n1.second.IsFresh());
     BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
     BOOST_CHECK_EQUAL(n1.second.Prev(), &sentinel);
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
@@ -172,7 +181,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
 
     // Check that we can clear state then re-set it
     n1.second.SetClean();
-    BOOST_CHECK(!n1.second.IsDirty() && !n1.second.IsFresh());
+    BOOST_CHECK(!n1.second.IsDirty());
+    BOOST_CHECK(!n1.second.IsFresh());
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
     BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
@@ -180,7 +190,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
 
     // Calling `SetClean` a second time has no effect
     n1.second.SetClean();
-    BOOST_CHECK(!n1.second.IsDirty() && !n1.second.IsFresh());
+    BOOST_CHECK(!n1.second.IsDirty());
+    BOOST_CHECK(!n1.second.IsFresh());
     BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
     BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
     BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
@@ -188,7 +199,8 @@ BOOST_AUTO_TEST_CASE(linked_list_set_state)
 
     // Adding DIRTY re-inserts it after n2
     CCoinsCacheEntry::SetDirty(n1, sentinel);
-    BOOST_CHECK(n1.second.IsDirty() && !n1.second.IsFresh());
+    BOOST_CHECK(n1.second.IsDirty());
+    BOOST_CHECK(!n1.second.IsFresh());
     BOOST_CHECK_EQUAL(n2.second.Next(), &n1);
     BOOST_CHECK_EQUAL(n1.second.Prev(), &n2);
     BOOST_CHECK_EQUAL(n1.second.Next(), &sentinel);

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -41,13 +41,17 @@ BOOST_FIXTURE_TEST_SUITE(key_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(key_test1)
 {
     CKey key1  = DecodeSecret(strSecret1);
-    BOOST_CHECK(key1.IsValid() && !key1.IsCompressed());
+    BOOST_CHECK(key1.IsValid());
+    BOOST_CHECK(!key1.IsCompressed());
     CKey key2  = DecodeSecret(strSecret2);
-    BOOST_CHECK(key2.IsValid() && !key2.IsCompressed());
+    BOOST_CHECK(key2.IsValid());
+    BOOST_CHECK(!key2.IsCompressed());
     CKey key1C = DecodeSecret(strSecret1C);
-    BOOST_CHECK(key1C.IsValid() && key1C.IsCompressed());
+    BOOST_CHECK(key1C.IsValid());
+    BOOST_CHECK(key1C.IsCompressed());
     CKey key2C = DecodeSecret(strSecret2C);
-    BOOST_CHECK(key2C.IsValid() && key2C.IsCompressed());
+    BOOST_CHECK(key2C.IsValid());
+    BOOST_CHECK(key2C.IsCompressed());
     CKey bad_key = DecodeSecret(strAddressBad);
     BOOST_CHECK(!bad_key.IsValid());
 

--- a/src/test/miniscript_tests.cpp
+++ b/src/test/miniscript_tests.cpp
@@ -636,13 +636,15 @@ BOOST_AUTO_TEST_CASE(fixed_tests)
     ms_stack_limit += "pk(" + HexStr(g_testdata->pubkeys[0]) + ")";
     ms_stack_limit.insert(ms_stack_limit.end(), count, ')');
     const auto ms_stack_ok{miniscript::FromString(ms_stack_limit, tap_converter)};
-    BOOST_CHECK(ms_stack_ok && ms_stack_ok->CheckStackSize());
+    BOOST_REQUIRE(ms_stack_ok);
+    BOOST_CHECK(ms_stack_ok->CheckStackSize());
     Test(ms_stack_limit, "?", "?", TESTMODE_VALID | TESTMODE_NONMAL | TESTMODE_NEEDSIG | TESTMODE_P2WSH_INVALID, 4 * count + 1, 1, {}, {}, 1 + count + 1);
     // But one more element on the stack during execution will make it fail. And we'd detect that.
     count++;
     ms_stack_limit = "and_b(older(1),a:" + ms_stack_limit + ")";
     const auto ms_stack_nok{miniscript::FromString(ms_stack_limit, tap_converter)};
-    BOOST_CHECK(ms_stack_nok && !ms_stack_nok->CheckStackSize());
+    BOOST_REQUIRE(ms_stack_nok);
+    BOOST_CHECK(!ms_stack_nok->CheckStackSize());
     Test(ms_stack_limit, "?", "?", TESTMODE_VALID | TESTMODE_NONMAL | TESTMODE_NEEDSIG | TESTMODE_P2WSH_INVALID, 4 * count + 1, 1, {}, {}, 1 + count + 1);
 
     // Misc unit tests
@@ -677,32 +679,45 @@ BOOST_AUTO_TEST_CASE(fixed_tests)
     // (for now) have 'd:' be 'u'. This tests we can't use a 'd:' wrapper for a thresh, which requires
     // its subs to all be 'u' (taken from https://github.com/rust-bitcoin/rust-miniscript/discussions/341).
     const auto ms_minimalif = miniscript::FromString("thresh(3,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),sc:pk_k(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556),sc:pk_k(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798),sdv:older(32))", wsh_converter);
-    BOOST_CHECK(ms_minimalif && !ms_minimalif->IsValid());
+    BOOST_REQUIRE(ms_minimalif);
+    BOOST_CHECK(!ms_minimalif->IsValid());
     // A Miniscript with duplicate keys is not sane
     const auto ms_dup1 = miniscript::FromString("and_v(v:pk(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),pk(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65))", wsh_converter);
-    BOOST_CHECK(ms_dup1);
-    BOOST_CHECK(!ms_dup1->IsSane() && !ms_dup1->CheckDuplicateKey());
+    BOOST_REQUIRE(ms_dup1);
+    BOOST_CHECK(!ms_dup1->IsSane());
+    BOOST_CHECK(!ms_dup1->CheckDuplicateKey());
     // Same with a disjunction, and different key nodes (pk and pkh)
     const auto ms_dup2 = miniscript::FromString("or_b(c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),ac:pk_h(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65))", wsh_converter);
-    BOOST_CHECK(ms_dup2 && !ms_dup2->IsSane() && !ms_dup2->CheckDuplicateKey());
+    BOOST_REQUIRE(ms_dup2);
+    BOOST_CHECK(!ms_dup2->IsSane());
+    BOOST_CHECK(!ms_dup2->CheckDuplicateKey());
     // Same when the duplicates are leaves or a larger tree
     const auto ms_dup3 = miniscript::FromString("or_i(and_b(pk(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),s:pk(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556)),and_b(older(1),s:pk(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65)))", wsh_converter);
-    BOOST_CHECK(ms_dup3 && !ms_dup3->IsSane() && !ms_dup3->CheckDuplicateKey());
+    BOOST_REQUIRE(ms_dup3);
+    BOOST_CHECK(!ms_dup3->IsSane());
+    BOOST_CHECK(!ms_dup3->CheckDuplicateKey());
     // Same when the duplicates are on different levels in the tree
     const auto ms_dup4 = miniscript::FromString("thresh(2,pkh(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),s:pk(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556),a:and_b(dv:older(1),s:pk(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65)))", wsh_converter);
-    BOOST_CHECK(ms_dup4 && !ms_dup4->IsSane() && !ms_dup4->CheckDuplicateKey());
+    BOOST_REQUIRE(ms_dup4);
+    BOOST_CHECK(!ms_dup4->IsSane());
+    BOOST_CHECK(!ms_dup4->CheckDuplicateKey());
     // Sanity check the opposite is true, too. An otherwise sane Miniscript with no duplicate keys is sane.
     const auto ms_nondup = miniscript::FromString("pk(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65)", wsh_converter);
-    BOOST_CHECK(ms_nondup && ms_nondup->CheckDuplicateKey() && ms_nondup->IsSane());
+    BOOST_REQUIRE(ms_nondup);
+    BOOST_CHECK(ms_nondup->CheckDuplicateKey());
+    BOOST_CHECK(ms_nondup->IsSane());
     // Test we find the first insane sub closer to be a leaf node. This fragment is insane for two reasons:
     // 1. It can be spent without a signature
     // 2. It contains timelock mixes
     // We'll report the timelock mix error, as it's "deeper" (closer to be a leaf node) than the "no 's' property"
     // error is.
     const auto ms_ins = miniscript::FromString("or_i(and_b(after(1),a:after(1000000000)),pk(03cdabb7f2dce7bfbd8a0b9570c6fd1e712e5d64045e9d6b517b3d5072251dc204))", wsh_converter);
-    BOOST_CHECK(ms_ins && ms_ins->IsValid() && !ms_ins->IsSane());
+    BOOST_REQUIRE(ms_ins);
+    BOOST_CHECK(ms_ins->IsValid());
+    BOOST_CHECK(!ms_ins->IsSane());
     const auto insane_sub = ms_ins->FindInsaneSub();
-    BOOST_CHECK(insane_sub && *insane_sub->ToString(wsh_converter) == "and_b(after(1),a:after(1000000000))");
+    BOOST_REQUIRE(insane_sub);
+    BOOST_CHECK(*insane_sub->ToString(wsh_converter) == "and_b(after(1),a:after(1000000000))");
 
     // Numbers can't be prefixed by a sign.
     BOOST_CHECK(!miniscript::FromString("after(-1)", wsh_converter));

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1383,14 +1383,16 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
     for (int i = 0; i < 10; ++i) {
         V2TransportTester tester(m_rng, true);
         auto ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         tester.SendKey();
         tester.SendGarbage();
         tester.ReceiveKey();
         tester.SendGarbageTerm();
         tester.SendVersion();
         ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         tester.ReceiveGarbage();
         tester.ReceiveVersion();
         tester.CompareSessionIDs();
@@ -1400,10 +1402,15 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.SendMessage(0, {}); // Invalidly encoded message
         tester.SendMessage("tx", msg_data_2); // 12-character encoded message type
         ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->size() == 3);
-        BOOST_CHECK((*ret)[0] && (*ret)[0]->m_type == "cmpctblock" && std::ranges::equal((*ret)[0]->m_recv, MakeByteSpan(msg_data_1)));
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->size() == 3);
+        BOOST_REQUIRE((*ret)[0]);
+        BOOST_CHECK((*ret)[0]->m_type == "cmpctblock");
+        BOOST_CHECK(std::ranges::equal((*ret)[0]->m_recv, MakeByteSpan(msg_data_1)));
         BOOST_CHECK(!(*ret)[1]);
-        BOOST_CHECK((*ret)[2] && (*ret)[2]->m_type == "tx" && std::ranges::equal((*ret)[2]->m_recv, MakeByteSpan(msg_data_2)));
+        BOOST_REQUIRE((*ret)[2]);
+        BOOST_CHECK((*ret)[2]->m_type == "tx");
+        BOOST_CHECK(std::ranges::equal((*ret)[2]->m_recv, MakeByteSpan(msg_data_2)));
 
         // Then send a message with a bit error, expecting failure. It's possible this failure does
         // not occur immediately (when the length descriptor was modified), but it should come
@@ -1426,12 +1433,14 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.SendKey();
         tester.SendGarbage();
         auto ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         tester.ReceiveKey();
         tester.SendGarbageTerm();
         tester.SendVersion();
         ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         tester.ReceiveGarbage();
         tester.ReceiveVersion();
         tester.CompareSessionIDs();
@@ -1440,9 +1449,14 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.SendMessage(uint8_t(14), msg_data_1); // inv short id
         tester.SendMessage(uint8_t(19), msg_data_2); // pong short id
         ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->size() == 2);
-        BOOST_CHECK((*ret)[0] && (*ret)[0]->m_type == "inv" && std::ranges::equal((*ret)[0]->m_recv, MakeByteSpan(msg_data_1)));
-        BOOST_CHECK((*ret)[1] && (*ret)[1]->m_type == "pong" && std::ranges::equal((*ret)[1]->m_recv, MakeByteSpan(msg_data_2)));
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->size() == 2);
+        BOOST_REQUIRE((*ret)[0]);
+        BOOST_CHECK((*ret)[0]->m_type == "inv");
+        BOOST_CHECK(std::ranges::equal((*ret)[0]->m_recv, MakeByteSpan(msg_data_1)));
+        BOOST_REQUIRE((*ret)[1]);
+        BOOST_CHECK((*ret)[1]->m_type == "pong");
+        BOOST_CHECK(std::ranges::equal((*ret)[1]->m_recv, MakeByteSpan(msg_data_2)));
 
         // Then send a too-large message.
         auto msg_data_3 = m_rng.randbytes<uint8_t>(4005000);
@@ -1471,7 +1485,8 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
             tester.SendGarbage(garb_len);
         }
         auto ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         if (!send_immediately) {
             tester.SendKey();
             tester.SendGarbage(garb_len);
@@ -1485,7 +1500,8 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         }
         tester.SendVersion(ver_data, false);
         ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         tester.ReceiveGarbage();
         tester.ReceiveVersion();
         tester.CompareSessionIDs();
@@ -1506,11 +1522,18 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.SendMessage("foobar", {}); // test receiving unknown message type
         tester.AddMessage("barfoo", {}); // test sending unknown message type
         ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->size() == 4);
-        BOOST_CHECK((*ret)[0] && (*ret)[0]->m_type == "addrv2" && std::ranges::equal((*ret)[0]->m_recv, MakeByteSpan(msg_data_1)));
-        BOOST_CHECK((*ret)[1] && (*ret)[1]->m_type == "headers" && std::ranges::equal((*ret)[1]->m_recv, MakeByteSpan(msg_data_2)));
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->size() == 4);
+        BOOST_REQUIRE((*ret)[0]);
+        BOOST_CHECK((*ret)[0]->m_type == "addrv2");
+        BOOST_CHECK(std::ranges::equal((*ret)[0]->m_recv, MakeByteSpan(msg_data_1)));
+        BOOST_REQUIRE((*ret)[1]);
+        BOOST_CHECK((*ret)[1]->m_type == "headers");
+        BOOST_CHECK(std::ranges::equal((*ret)[1]->m_recv, MakeByteSpan(msg_data_2)));
         BOOST_CHECK(!(*ret)[2]);
-        BOOST_CHECK((*ret)[3] && (*ret)[3]->m_type == "foobar" && (*ret)[3]->m_recv.empty());
+        BOOST_REQUIRE((*ret)[3]);
+        BOOST_CHECK((*ret)[3]->m_type == "foobar");
+        BOOST_CHECK((*ret)[3]->m_recv.empty());
         tester.ReceiveMessage("barfoo", {});
     }
 
@@ -1518,7 +1541,8 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
     {
         V2TransportTester tester(m_rng, true);
         auto ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         tester.SendKey();
         tester.SendGarbage(V2Transport::MAX_GARBAGE_LEN + 1);
         tester.ReceiveKey();
@@ -1533,7 +1557,8 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.SendKey();
         tester.SendGarbage(V2Transport::MAX_GARBAGE_LEN + 1);
         auto ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         tester.ReceiveKey();
         tester.SendGarbageTerm();
         ret = tester.Interact();
@@ -1544,7 +1569,8 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
     {
         V2TransportTester tester(m_rng, true);
         auto ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         tester.SendKey();
         tester.ReceiveKey();
         /** The number of random garbage bytes before the included first 15 bytes of terminator. */
@@ -1563,7 +1589,8 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.SendGarbageTerm();
         tester.SendVersion();
         ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->empty());
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->empty());
         tester.ReceiveGarbage();
         tester.ReceiveVersion();
         tester.CompareSessionIDs();
@@ -1573,9 +1600,12 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.SendMessage(uint8_t(2), msg_data_1); // "block" short id
         tester.AddMessage("blocktxn", msg_data_2); // schedule blocktxn to be sent to us
         ret = tester.Interact();
-        BOOST_REQUIRE(ret && ret->size() == 2);
+        BOOST_REQUIRE(ret);
+        BOOST_REQUIRE(ret->size() == 2);
         BOOST_CHECK(!(*ret)[0]);
-        BOOST_CHECK((*ret)[1] && (*ret)[1]->m_type == "block" && std::ranges::equal((*ret)[1]->m_recv, MakeByteSpan(msg_data_1)));
+        BOOST_REQUIRE((*ret)[1]);
+        BOOST_CHECK((*ret)[1]->m_type == "block");
+        BOOST_CHECK(std::ranges::equal((*ret)[1]->m_recv, MakeByteSpan(msg_data_1)));
         tester.ReceiveMessage(uint8_t(3), msg_data_2); // "blocktxn" short id
     }
 

--- a/src/test/pcp_tests.cpp
+++ b/src/test/pcp_tests.cpp
@@ -49,7 +49,10 @@ public:
         const std::optional<CService> local_ipv6{Lookup("2a10:1234:5678:9abc:def0:1234:5678:9abc", 1, false)};
         const std::optional<CService> gateway_ipv4{Lookup("192.168.0.1", 1, false)};
         const std::optional<CService> gateway_ipv6{Lookup("2a10:1234:5678:9abc:def0:0000:0000:0000", 1, false)};
-        BOOST_REQUIRE(local_ipv4 && local_ipv6 && gateway_ipv4 && gateway_ipv6);
+        BOOST_REQUIRE(local_ipv4);
+        BOOST_REQUIRE(local_ipv6);
+        BOOST_REQUIRE(gateway_ipv4);
+        BOOST_REQUIRE(gateway_ipv6);
         default_local_ipv4 = *local_ipv4;
         default_local_ipv6 = *local_ipv6;
         default_gateway_ipv4 = *gateway_ipv4;

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -172,7 +172,8 @@ void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type)
     arith_uint256 pow_compact;
     bool neg, over;
     pow_compact.SetCompact(chainParams->GenesisBlock().nBits, &neg, &over);
-    BOOST_CHECK(!neg && pow_compact != 0);
+    BOOST_CHECK(!neg);
+    BOOST_CHECK(pow_compact != 0);
     BOOST_CHECK(!over);
     BOOST_CHECK(UintToArith256(consensus.powLimit) >= pow_compact);
 

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -209,7 +209,8 @@ BOOST_AUTO_TEST_CASE(mockforward)
     auto now = std::chrono::steady_clock::now();
     int delta = std::chrono::duration_cast<std::chrono::seconds>(first - now).count();
     // should be between 2 & 3 minutes from now
-    BOOST_CHECK(delta > 2*60 && delta < 3*60);
+    BOOST_CHECK(delta > 2*60);
+    BOOST_CHECK(delta < 3*60);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -439,15 +439,20 @@ BOOST_AUTO_TEST_CASE(script_standard_taproot_builder)
     constexpr uint256 hash_3{"31fe7061656bea2a36aa60a2f7ef940578049273746935d296426dc0afd86b68"};
 
     TaprootBuilder builder;
-    BOOST_CHECK(builder.IsValid() && builder.IsComplete());
+    BOOST_CHECK(builder.IsValid());
+    BOOST_CHECK(builder.IsComplete());
     builder.Add(2, script_2, 0xc0);
-    BOOST_CHECK(builder.IsValid() && !builder.IsComplete());
+    BOOST_CHECK(builder.IsValid());
+    BOOST_CHECK(!builder.IsComplete());
     builder.AddOmitted(2, hash_3);
-    BOOST_CHECK(builder.IsValid() && !builder.IsComplete());
+    BOOST_CHECK(builder.IsValid());
+    BOOST_CHECK(!builder.IsComplete());
     builder.Add(1, script_1, 0xc0);
-    BOOST_CHECK(builder.IsValid() && builder.IsComplete());
+    BOOST_CHECK(builder.IsValid());
+    BOOST_CHECK(builder.IsComplete());
     builder.Finalize(key_inner);
-    BOOST_CHECK(builder.IsValid() && builder.IsComplete());
+    BOOST_CHECK(builder.IsValid());
+    BOOST_CHECK(builder.IsComplete());
     BOOST_CHECK_EQUAL(EncodeDestination(builder.GetOutput()), "bc1pj6gaw944fy0xpmzzu45ugqde4rz7mqj5kj0tg8kmr5f0pjq8vnaqgynnge");
 }
 

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -184,10 +184,12 @@ BOOST_AUTO_TEST_CASE(findearliestatleast_edge_test)
     BOOST_CHECK(!chain.FindEarliestAtLeast(0, 9));
 
     CBlockIndex* ret1 = chain.FindEarliestAtLeast(100, 2);
-    BOOST_CHECK(ret1->nTimeMax >= 100 && ret1->nHeight == 2);
+    BOOST_CHECK(ret1->nTimeMax >= 100);
+    BOOST_CHECK(ret1->nHeight == 2);
     BOOST_CHECK(!chain.FindEarliestAtLeast(300, 9));
     CBlockIndex* ret2 = chain.FindEarliestAtLeast(200, 4);
-    BOOST_CHECK(ret2->nTimeMax >= 200 && ret2->nHeight == 4);
+    BOOST_CHECK(ret2->nTimeMax >= 200);
+    BOOST_CHECK(ret2->nHeight == 4);
 }
 
 BOOST_AUTO_TEST_CASE(build_skip_height_test)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -382,7 +382,8 @@ BOOST_AUTO_TEST_CASE(basic_transaction_tests)
     CMutableTransaction tx;
     SpanReader{vch} >> TX_WITH_WITNESS(tx);
     TxValidationState state;
-    BOOST_CHECK_MESSAGE(CheckTransaction(CTransaction(tx), state) && state.IsValid(), "Simple deserialized transaction should be valid.");
+    BOOST_CHECK_MESSAGE(CheckTransaction(CTransaction(tx), state), "Simple deserialized transaction should be valid.");
+    BOOST_CHECK_MESSAGE(state.IsValid(), "Simple deserialized transaction should be valid.");
 
     // Check that duplicate txins fail
     tx.vin.push_back(tx.vin[0]);

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -1161,7 +1161,8 @@ BOOST_AUTO_TEST_CASE(package_rbf_tests)
             child_key, child_spk, coinbase_value - 199 - 1300, /*submit=*/false));
 
         // In all packages, the parents conflict with each other
-        BOOST_CHECK(tx_parent_1->GetHash() != tx_parent_2->GetHash() && tx_parent_2->GetHash() != tx_parent_3->GetHash());
+        BOOST_CHECK(tx_parent_1->GetHash() != tx_parent_2->GetHash());
+        BOOST_CHECK(tx_parent_2->GetHash() != tx_parent_3->GetHash());
 
         // 1 parent paying 200sat, 1 child paying 200sat.
         Package package1{tx_parent_1, tx_child_1};

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -295,7 +295,8 @@ void check_computeblockversion(VersionBitsCache& versionbitscache, const Consens
     BOOST_REQUIRE(nStartTime < nTimeout);
     BOOST_REQUIRE(nStartTime >= 0);
     BOOST_REQUIRE(nTimeout <= std::numeric_limits<uint32_t>::max() || nTimeout == Consensus::BIP9Deployment::NO_TIMEOUT);
-    BOOST_REQUIRE(0 <= bit && bit < 32);
+    BOOST_REQUIRE(0 <= bit);
+    BOOST_REQUIRE(bit < 32);
     // Make sure that no deployment tries to set an invalid bit.
     BOOST_REQUIRE(((1 << bit) & VERSIONBITS_TOP_MASK) == 0);
     BOOST_REQUIRE(min_activation_height >= 0);
@@ -459,7 +460,8 @@ BOOST_FIXTURE_TEST_CASE(versionbits_computeblockversion, BlockVersionTest)
             const uint32_t dep_mask{uint32_t{1} << dep_info.bit};
             BOOST_CHECK(!(chain_all_vbits & dep_mask));
             chain_all_vbits |= dep_mask;
-            BOOST_CHECK(0 <= dep_info.bit && dep_info.bit < VERSIONBITS_MAX_NUM_BITS);
+            BOOST_CHECK(0 <= dep_info.bit);
+            BOOST_CHECK(dep_info.bit < VERSIONBITS_MAX_NUM_BITS);
             if (chain_type != ChainType::REGTEST) {
                 if (dep == Consensus::DEPLOYMENT_TESTDUMMY) {
                     BOOST_CHECK_EQUAL(dep_info.nStartTime, Consensus::BIP9Deployment::NEVER_ACTIVE);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -137,7 +137,8 @@ BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
         {
             CBlockLocator locator;
             BOOST_CHECK(WalletBatch{wallet.GetDatabase()}.ReadBestBlock(locator));
-            BOOST_CHECK(!locator.IsNull() && locator.vHave.front() == newTip->GetBlockHash());
+            BOOST_REQUIRE(!locator.IsNull());
+            BOOST_CHECK(locator.vHave.front() == newTip->GetBlockHash());
         }
 
         CWallet::ScanResult result = wallet.ScanForWalletTransactions(/*start_block=*/oldTip->GetBlockHash(), /*start_height=*/oldTip->nHeight, /*max_height=*/{}, reserver, /*save_progress=*/true);
@@ -150,7 +151,8 @@ BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
         {
             CBlockLocator locator;
             BOOST_CHECK(WalletBatch{wallet.GetDatabase()}.ReadBestBlock(locator));
-            BOOST_CHECK(!locator.IsNull() && locator.vHave.front() == newTip->GetBlockHash());
+            BOOST_REQUIRE(!locator.IsNull());
+            BOOST_CHECK(locator.vHave.front() == newTip->GetBlockHash());
         }
     }
 


### PR DESCRIPTION
Picked from #35713. Given that I think this is a strict debugging improvement, I opened as a separate pull:

Using `&&` in `BOOST_CHECK` is problematic as failures will not indicate which condition failed. By unrolling these checks, the user knows exactly which expression is the failing case.

As an example, here is a line that would be particularly hard to debug if it failed:

```
src/test/net_tests.cpp

BOOST_CHECK((*ret)[1] && (*ret)[1]->m_type == "headers" && std::ranges::equal((*ret)[1]->m_recv, MakeByteSpan(msg_data_2)));
```

If any one of these conditions fail, the whole expression fails, with no values printed or indication as to which condition failed.

This is also required when using test macros that support value decomposition, which requires `&&` and `||` are `delete`. Examples include `BOOST_TEST`, doctest, Catch2, etc.

ref: https://catch2-temp.readthedocs.io/en/latest/assertions.html#other-limitations
ref: https://fekir.info/post/decomposing-an-expression/