### PR TITLE
Indexes: Harden the flush-error notification invariant

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -747,14 +747,18 @@ bool BlockManager::ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index
     return true;
 }
 
+bool BlockManager::FlushFile(const FlatFileSeq& file_seq, const FlatFilePos& pos, bool finalize, const bilingual_str& flush_error_message)
+{
+    if (file_seq.Flush(pos, finalize)) return true;
+    m_opts.notifications.flushError(flush_error_message);
+    return false;
+}
+
 bool BlockManager::FlushUndoFile(int block_file, bool finalize)
 {
     FlatFilePos undo_pos_old(block_file, m_blockfile_info[block_file].nUndoSize);
-    if (!m_undo_file_seq.Flush(undo_pos_old, finalize)) {
-        m_opts.notifications.flushError(_("Flushing undo file to disk failed. This is likely the result of an I/O error."));
-        return false;
-    }
-    return true;
+    return FlushFile(m_undo_file_seq, undo_pos_old, finalize,
+                     _("Flushing undo file to disk failed. This is likely the result of an I/O error."));
 }
 
 bool BlockManager::FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo)
@@ -772,8 +776,8 @@ bool BlockManager::FlushBlockFile(int blockfile_num, bool fFinalize, bool finali
     assert(static_cast<int>(m_blockfile_info.size()) > blockfile_num);
 
     FlatFilePos block_pos_old(blockfile_num, m_blockfile_info[blockfile_num].nSize);
-    if (!m_block_file_seq.Flush(block_pos_old, fFinalize)) {
-        m_opts.notifications.flushError(_("Flushing block file to disk failed. This is likely the result of an I/O error."));
+    if (!FlushFile(m_block_file_seq, block_pos_old, fFinalize,
+                   _("Flushing block file to disk failed. This is likely the result of an I/O error."))) {
         success = false;
     }
     // we do not always flush the undo file, as the chain tip may be lagging behind the incoming blocks,

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -209,6 +209,10 @@ private:
     bool LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    /** Flush a block or undo file sequence to disk, emitting the flush-error
+     *  notification on failure. Returns false if the flush failed. */
+    [[nodiscard]] bool FlushFile(const FlatFileSeq& file_seq, const FlatFilePos& pos, bool finalize, const bilingual_str& flush_error_message);
+
     /** Return false if block file or undo file flushing fails. */
     [[nodiscard]] bool FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -196,6 +196,7 @@ class BlockManager
 {
     friend Chainstate;
     friend ChainstateManager;
+    friend struct BlockManagerTest;
 
 private:
     const CChainParams& GetParams() const { return m_opts.chainparams; }

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -11,6 +11,8 @@
 #include <script/solver.h>
 #include <primitives/block.h>
 #include <util/chaintype.h>
+#include <util/fs.h>
+#include <util/translation.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -18,11 +20,33 @@
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
 
+#include <string>
+
 using kernel::CBlockFileInfo;
 using node::STORAGE_HEADER_BYTES;
 using node::BlockManager;
 using node::KernelNotifications;
 using node::MAX_BLOCKFILE_SIZE;
+
+namespace node {
+//! Test accessor for BlockManager's private flush methods (befriended in blockstorage.h).
+struct BlockManagerTest {
+    static bool FlushBlockFile(BlockManager& blockman, int file_num, bool finalize, bool finalize_undo)
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    {
+        return blockman.FlushBlockFile(file_num, finalize, finalize_undo);
+    }
+};
+} // namespace node
+
+namespace {
+//! KernelNotifications that only counts flush-error notifications.
+struct CountingNotifications : KernelNotifications {
+    using KernelNotifications::KernelNotifications;
+    int flush_errors{0};
+    void flushError(const bilingual_str&) override { ++flush_errors; }
+};
+} // namespace
 
 // use BasicTestingSetup here for the data directory configuration, setup, and cleanup
 BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
@@ -322,6 +346,61 @@ BOOST_FIXTURE_TEST_CASE(prune_lock_update_and_delete, TestingSetup)
 
     // Deleting a non-existent lock returns false
     BOOST_CHECK(!blockman.DeletePruneLock("nonexistent"));
+}
+
+static BlockManager::Options TestBlockManagerOptions(const ArgsManager& args, const CChainParams& params, CountingNotifications& notifications)
+{
+    return BlockManager::Options{
+        .chainparams = params,
+        .blocks_dir = args.GetBlocksDirPath(),
+        .notifications = notifications,
+        .block_tree_db_params = DBParams{
+            .path = args.GetDataDirNet() / "blocks" / "index",
+            .cache_bytes = 0,
+        },
+    };
+}
+
+// FlushBlockFile() flushes both the block and the undo file and returns false if
+// either fails. It must never report a failure without emitting the flush-error
+// notification. Exercise each failure source separately.
+BOOST_AUTO_TEST_CASE(blockmanager_flush_notifies_on_block_failure)
+{
+    const auto params{CreateChainParams(ArgsManager{}, ChainType::MAIN)};
+    CountingNotifications notifications{Assert(m_node.shutdown_request), m_node.exit_status, *Assert(m_node.warnings)};
+    BlockManager blockman{*Assert(m_node.shutdown_signal), TestBlockManagerOptions(m_args, *params, notifications)};
+
+    LOCK(::cs_main);
+    BOOST_REQUIRE_EQUAL(blockman.WriteBlock(params->GenesisBlock(), 0).nPos, STORAGE_HEADER_BYTES);
+
+    // Replace blk00000.dat with a directory so the block flush's open fails.
+    const fs::path blk_file{blockman.GetBlockPosFilename(FlatFilePos{0, 0})};
+    BOOST_REQUIRE(fs::remove(blk_file));
+    BOOST_REQUIRE(fs::create_directory(blk_file));
+
+    BOOST_CHECK(!node::BlockManagerTest::FlushBlockFile(blockman, /*file_num=*/0, /*finalize=*/false, /*finalize_undo=*/false));
+    BOOST_CHECK_EQUAL(notifications.flush_errors, 1);
+}
+
+BOOST_AUTO_TEST_CASE(blockmanager_flush_notifies_on_undo_failure)
+{
+    const auto params{CreateChainParams(ArgsManager{}, ChainType::MAIN)};
+    CountingNotifications notifications{Assert(m_node.shutdown_request), m_node.exit_status, *Assert(m_node.warnings)};
+    BlockManager blockman{*Assert(m_node.shutdown_signal), TestBlockManagerOptions(m_args, *params, notifications)};
+
+    LOCK(::cs_main);
+    BOOST_REQUIRE_EQUAL(blockman.WriteBlock(params->GenesisBlock(), 0).nPos, STORAGE_HEADER_BYTES);
+
+    // Leave blk00000.dat intact; make the undo flush fail by putting a directory
+    // where rev00000.dat would be opened (blk?????.dat -> rev?????.dat).
+    fs::path rev_file{blockman.GetBlockPosFilename(FlatFilePos{0, 0})};
+    std::string rev_name{rev_file.filename().string()};
+    rev_name.replace(0, 3, "rev");
+    rev_file = rev_file.parent_path() / rev_name;
+    BOOST_REQUIRE(fs::create_directory(rev_file));
+
+    BOOST_CHECK(!node::BlockManagerTest::FlushBlockFile(blockman, /*file_num=*/0, /*finalize=*/false, /*finalize_undo=*/false));
+    BOOST_CHECK_EQUAL(notifications.flush_errors, 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -2,12 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <node/blockstorage.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/fs.h>
 #include <validation.h>
 #include <validationinterface.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <cstdlib>
 
 using kernel::ChainstateRole;
 
@@ -103,6 +107,26 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK_EQUAL(sub->m_flushed_at_block, second_from_tip);
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), second_from_tip);
+}
+
+BOOST_FIXTURE_TEST_CASE(chainstate_flush_failure_boundary, TestChain100Setup)
+{
+    const auto inject_file_open_failure{[](const fs::path& file) { Assert(fs::remove(file)); Assert(fs::create_directory(file)); }};
+    auto& chainstate{Assert(m_node.chainman)->ActiveChainstate()};
+    BlockValidationState state{};
+
+    BOOST_REQUIRE(chainstate.FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH) && state.IsValid());
+    const auto* old_flushed{WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock())};
+
+    mineBlocks(1);
+    const auto* new_tip{WITH_LOCK(::cs_main, return chainstate.m_chain.Tip())};
+    BOOST_REQUIRE_NE(old_flushed, new_tip);
+    inject_file_open_failure(WITH_LOCK(::cs_main, return chainstate.m_blockman.GetBlockPosFilename(new_tip->GetBlockPos())));
+
+    const bool flushed{chainstate.FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH)};
+    BOOST_CHECK_EQUAL(m_node.exit_status.load(), EXIT_FAILURE);
+    BOOST_CHECK(flushed && state.IsValid()); // TODO: Return the flush error
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), new_tip); // TODO: Keep the previous flushed block
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -125,8 +125,8 @@ BOOST_FIXTURE_TEST_CASE(chainstate_flush_failure_boundary, TestChain100Setup)
 
     const bool flushed{chainstate.FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH)};
     BOOST_CHECK_EQUAL(m_node.exit_status.load(), EXIT_FAILURE);
-    BOOST_CHECK(flushed && state.IsValid()); // TODO: Return the flush error
-    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), new_tip); // TODO: Keep the previous flushed block
+    BOOST_CHECK(!flushed && state.IsError());
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), old_flushed);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2792,10 +2792,9 @@ bool Chainstate::FlushStateToDisk(
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
 
                 // First make sure all block and undo data is flushed to disk.
-                // TODO: Handle return error, or add detailed comment why it is
-                // safe to not return an error upon failure.
                 if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
-                    LogWarning("%s: Failed to flush block file.\n", __func__);
+                    // FlushChainstateBlockFile() already emitted the flush-error notification.
+                    return state.Error("Failed to flush block or undo file");
                 }
             }
 


### PR DESCRIPTION
This is a follow-up to #35714 as it has the two commits of that PR, do not merge or review before that PR

#35714 makes `FlushStateToDisk()` return `state.Error(...)` when `FlushChainstateBlockFile()` fails, relying on the comment `// FlushChainstateBlockFile() already emitted the flush-error notification.`

That invariant holds today, but it is not guaranteed by construction: it depends on every `success = false` branch inside `FlushBlockFile`/`FlushUndoFile` emitting the notification on its own. A future flush source (a new file type, a new error branch) that sets `success = false` **without** notifying would make `FlushStateToDisk()` return an error without `AbortNode()`.

This PR makes sure that **whenever a flush reports failure, the flush-error notification has been emitted**:

- **test: cover FlushBlockFile flush-error notifications**: lower-level `BlockManager` tests (as suggested in the #35714 review) that inject a failure on the block file and on the undo file separately and assert each failure emits `flushError`.
- **blockstorage: encapsulate flush+notify in FlushFile**:  a single `FlushFile()` helper couples the flush and the notification; `FlushBlockFile`/`FlushUndoFile` delegate to it. Behaviour is unchanged.