### PR TITLE
Fix some Infer's warnings

### DIFF
--- a/src/policy/fees/block_policy_estimator.cpp
+++ b/src/policy/fees/block_policy_estimator.cpp
@@ -878,7 +878,6 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
         feeCalc->best_height = nBestSeenHeight;
     }
 
-    double median = -1;
     EstimationResult tempResult;
 
     // Return failure if trying to analyze a target we're not tracking
@@ -921,7 +920,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
         feeCalc->est = tempResult;
         feeCalc->reason = FeeReason::HALF_ESTIMATE;
     }
-    median = halfEst;
+    double median = halfEst;
     double actualEst = estimateCombinedFee(confTarget, SUCCESS_PCT, true, &tempResult);
     if (actualEst > median) {
         median = actualEst;

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -55,10 +55,6 @@ static void CheckAdd(const int64_t& num1, const int64_t& num2)
     const CScriptNum10 bignum2(num2);
     const CScriptNum scriptnum1(num1);
     const CScriptNum scriptnum2(num2);
-    CScriptNum10 bignum3(num1);
-    CScriptNum10 bignum4(num1);
-    CScriptNum scriptnum3(num1);
-    CScriptNum scriptnum4(num1);
 
     // int64_t overflow is undefined.
     bool invalid = (((num2 > 0) && (num1 > (std::numeric_limits<int64_t>::max() - num2))) ||

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -483,9 +483,8 @@ namespace util
         total_bytes_read += rd_bytes;
         buffer += total_bytes_read;
 
-      } else { // Partial data ? Continue reading
+      } else { // Partial read or EOF, done reading
         total_bytes_read += rd_bytes;
-        fill_sz -= rd_bytes;
         break;
       }
     }
@@ -1260,7 +1259,6 @@ namespace detail {
 
 #ifndef WIN32
   inline void Child::execute_child() {
-    int sys_ret = -1;
     auto& stream = parent_->stream_;
 
     try {
@@ -1304,8 +1302,7 @@ namespace detail {
         subprocess_close(stream.err_write_);
 
       // Replace the current image with the executable
-      sys_ret = execvp(parent_->exe_name_.c_str(), parent_->cargv_.data());
-
+      int sys_ret = execvp(parent_->exe_name_.c_str(), parent_->cargv_.data());
       if (sys_ret == -1) throw OSError("execve failed", errno);
 
     } catch (const OSError& exp) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -995,8 +995,6 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     const Txid& hash = ws.m_hash;
     TxValidationState& state = ws.m_state;
 
-    CFeeRate newFeeRate(ws.m_modified_fees, ws.m_vsize);
-
     CTxMemPool::setEntries all_conflicts;
 
     // Calculate all conflicting entries and enforce Rule #5.

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -68,6 +68,9 @@ util::Result<void> ExternalSignerScriptPubKeyMan::DisplayAddress(const CTxDestin
     // TODO: avoid the need to infer a descriptor from inside a descriptor wallet
     const CScript& scriptPubKey = GetScriptForDestination(dest);
     auto provider = GetSolvingProvider(scriptPubKey);
+    if (!provider)
+        return util::Error{Untranslated("No solving provider found for ScriptPubKey")};
+
     auto descriptor = InferDescriptor(scriptPubKey, *provider);
 
     const UniValue& result = signer.DisplayAddress(descriptor->ToString());

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -535,13 +535,11 @@ void BerkeleyRODatabase::Open()
         throw std::runtime_error("BerkeleyRODatabase: Failed to open database file");
     }
 
-    uint32_t page_size = 4096; // Default page size
-
     // Read the outer metapage
     // Expected page number is 0
     MetaPage outer_meta(0);
     db_file >> outer_meta;
-    page_size = outer_meta.pagesize;
+    uint32_t page_size = outer_meta.pagesize;
 
     // Verify the size of the file is a multiple of the page size
     const int64_t size{db_file.size()};


### PR DESCRIPTION
I fixed two class of warnings reported by the Infer static analyzer tool:
- Dead Store(DEAD_STORE)
- Null Dereference(NULLPTR_DEREFERENCE)