### PR TITLE
sign: Remove FillableSigningProvider

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -686,8 +686,7 @@ reported in the `debug.log` file.
 
 Re-architecting the core code so there are better-defined interfaces
 between the various components is a goal, with any necessary locking
-done by the components (e.g. see the self-contained `FillableSigningProvider` class
-and its `cs_KeyStore` lock for example).
+done by the components.
 
 ## Threads
 

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -27,7 +27,7 @@ static void CCoinsCaching(benchmark::Bench& bench)
 {
     ECC_Context ecc_context{};
 
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     CCoinsViewCache coins{&CoinsViewEmpty::Get()};
     std::vector<CMutableTransaction> dummyTransactions =
         SetupDummyInputs(keystore, coins, {11 * COIN, 50 * COIN, 21 * COIN, 22 * COIN});

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -590,7 +590,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
 
     if (!registers.contains("privatekeys"))
         throw std::runtime_error("privatekeys register variable must be set.");
-    FillableSigningProvider tempKeystore;
+    FlatSigningProvider tempKeystore;
     UniValue keysObj = registers["privatekeys"];
 
     for (unsigned int kidx = 0; kidx < keysObj.size(); kidx++) {
@@ -600,7 +600,13 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
         if (!key.IsValid()) {
             throw std::runtime_error("privatekey not valid");
         }
-        tempKeystore.AddKey(key);
+        CPubKey pubkey = key.GetPubKey();
+        tempKeystore.keys.emplace(pubkey.GetID(), key);
+        tempKeystore.pubkeys.emplace(pubkey.GetID(), pubkey);
+        if (pubkey.IsCompressed()) {
+            CScript p2wpkh = GetScriptForDestination(WitnessV0KeyHash(pubkey.GetID()));
+            tempKeystore.scripts.emplace(CScriptID(p2wpkh), p2wpkh);
+        }
     }
 
     // Add previous txouts given in the RPC call:
@@ -659,12 +665,12 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
                 UniValue v = prevOut["redeemScript"];
                 std::vector<unsigned char> rsData(ParseHexUV(v, "redeemScript"));
                 CScript redeemScript(rsData.begin(), rsData.end());
-                tempKeystore.AddCScript(redeemScript);
+                tempKeystore.scripts.emplace(CScriptID(redeemScript), redeemScript);
             }
         }
     }
 
-    const FillableSigningProvider& keystore = tempKeystore;
+    const FlatSigningProvider& keystore = tempKeystore;
 
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
 

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -63,7 +63,6 @@ extern const std::string UNIX_EPOCH_TIME;
  */
 extern const std::string EXAMPLE_ADDRESS[2];
 
-class FillableSigningProvider;
 class CScript;
 struct Sections;
 

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -9,7 +9,6 @@
 #include <script/interpreter.h>
 #include <script/keyorigin.h>
 #include <util/check.h>
-#include <util/log.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -157,114 +156,6 @@ FlatSigningProvider& FlatSigningProvider::Merge(FlatSigningProvider&& b)
     // We shouldn't be merging 2 different sessions, just overwrite with b's sessions.
     if (!musig2_secnonces) musig2_secnonces = b.musig2_secnonces;
     return *this;
-}
-
-void FillableSigningProvider::ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey)
-{
-    AssertLockHeld(cs_KeyStore);
-    CKeyID key_id = pubkey.GetID();
-    // This adds the redeemscripts necessary to detect P2WPKH and P2SH-P2WPKH
-    // outputs. Technically P2WPKH outputs don't have a redeemscript to be
-    // spent. However, our current IsMine logic requires the corresponding
-    // P2SH-P2WPKH redeemscript to be present in the wallet in order to accept
-    // payment even to P2WPKH outputs.
-    // Also note that having superfluous scripts in the keystore never hurts.
-    // They're only used to guide recursion in signing and IsMine logic - if
-    // a script is present but we can't do anything with it, it has no effect.
-    // "Implicitly" refers to fact that scripts are derived automatically from
-    // existing keys, and are present in memory, even without being explicitly
-    // loaded (e.g. from a file).
-    if (pubkey.IsCompressed()) {
-        CScript script = GetScriptForDestination(WitnessV0KeyHash(key_id));
-        // This does not use AddCScript, as it may be overridden.
-        CScriptID id(script);
-        mapScripts[id] = std::move(script);
-    }
-}
-
-bool FillableSigningProvider::GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const
-{
-    CKey key;
-    if (!GetKey(address, key)) {
-        return false;
-    }
-    vchPubKeyOut = key.GetPubKey();
-    return true;
-}
-
-bool FillableSigningProvider::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)
-{
-    LOCK(cs_KeyStore);
-    mapKeys[pubkey.GetID()] = key;
-    ImplicitlyLearnRelatedKeyScripts(pubkey);
-    return true;
-}
-
-bool FillableSigningProvider::HaveKey(const CKeyID &address) const
-{
-    LOCK(cs_KeyStore);
-    return mapKeys.contains(address);
-}
-
-std::set<CKeyID> FillableSigningProvider::GetKeys() const
-{
-    LOCK(cs_KeyStore);
-    std::set<CKeyID> set_address;
-    for (const auto& mi : mapKeys) {
-        set_address.insert(mi.first);
-    }
-    return set_address;
-}
-
-bool FillableSigningProvider::GetKey(const CKeyID &address, CKey &keyOut) const
-{
-    LOCK(cs_KeyStore);
-    KeyMap::const_iterator mi = mapKeys.find(address);
-    if (mi != mapKeys.end()) {
-        keyOut = mi->second;
-        return true;
-    }
-    return false;
-}
-
-bool FillableSigningProvider::AddCScript(const CScript& redeemScript)
-{
-    if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE) {
-        LogError("FillableSigningProvider::AddCScript(): redeemScripts > %i bytes are invalid\n", MAX_SCRIPT_ELEMENT_SIZE);
-        return false;
-    }
-
-    LOCK(cs_KeyStore);
-    mapScripts[CScriptID(redeemScript)] = redeemScript;
-    return true;
-}
-
-bool FillableSigningProvider::HaveCScript(const CScriptID& hash) const
-{
-    LOCK(cs_KeyStore);
-    return mapScripts.contains(hash);
-}
-
-std::set<CScriptID> FillableSigningProvider::GetCScripts() const
-{
-    LOCK(cs_KeyStore);
-    std::set<CScriptID> set_script;
-    for (const auto& mi : mapScripts) {
-        set_script.insert(mi.first);
-    }
-    return set_script;
-}
-
-bool FillableSigningProvider::GetCScript(const CScriptID &hash, CScript& redeemScriptOut) const
-{
-    LOCK(cs_KeyStore);
-    ScriptMap::const_iterator mi = mapScripts.find(hash);
-    if (mi != mapScripts.end())
-    {
-        redeemScriptOut = (*mi).second;
-        return true;
-    }
-    return false;
 }
 
 CKeyID GetKeyForDestination(const SigningProvider& store, const CTxDestination& dest)

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -12,7 +12,6 @@
 #include <pubkey.h>
 #include <script/keyorigin.h>
 #include <script/script.h>
-#include <sync.h>
 #include <uint256.h>
 
 #include <compare>
@@ -256,79 +255,6 @@ struct FlatSigningProvider final : public SigningProvider
     void DeleteMuSig2Session(const uint256& session_id) const override;
 
     FlatSigningProvider& Merge(FlatSigningProvider&& b) LIFETIMEBOUND;
-};
-
-/** Fillable signing provider that keeps keys in an address->secret map */
-class FillableSigningProvider : public SigningProvider
-{
-protected:
-    using KeyMap = std::map<CKeyID, CKey>;
-    using ScriptMap = std::map<CScriptID, CScript>;
-
-    /**
-     * Map of key id to unencrypted private keys known by the signing provider.
-     * Map may be empty if the provider has another source of keys, like an
-     * encrypted store.
-     */
-    KeyMap mapKeys GUARDED_BY(cs_KeyStore);
-
-    /**
-     * Map of script id to scripts known by the signing provider.
-     *
-     * This map originally just held P2SH redeemScripts, and was used by wallet
-     * code to look up script ids referenced in "OP_HASH160 <script id>
-     * OP_EQUAL" P2SH outputs. Later in 605e8473a7d it was extended to hold
-     * P2WSH witnessScripts as well, and used to look up nested scripts
-     * referenced in "OP_0 <script hash>" P2WSH outputs. Later in commits
-     * f4691ab3a9d and 248f3a76a82, it was extended once again to hold segwit
-     * "OP_0 <key or script hash>" scriptPubKeys, in order to give the wallet a
-     * way to distinguish between segwit outputs that it generated addresses for
-     * and wanted to receive payments from, and segwit outputs that it never
-     * generated addresses for, but it could spend just because of having keys.
-     * (Before segwit activation it was also important to not treat segwit
-     * outputs to arbitrary wallet keys as payments, because these could be
-     * spent by anyone without even needing to sign with the keys.)
-     *
-     * Some of the scripts stored in mapScripts are memory-only and
-     * intentionally not saved to disk. Specifically, scripts added by
-     * ImplicitlyLearnRelatedKeyScripts(pubkey) calls are not written to disk so
-     * future wallet code can have flexibility to be more selective about what
-     * transaction outputs it recognizes as payments, instead of having to treat
-     * all outputs spending to keys it knows as payments. By contrast,
-     * mapScripts entries added by AddCScript(script),
-     * LearnRelatedScripts(pubkey, type), and LearnAllRelatedScripts(pubkey)
-     * calls are saved because they are all intentionally used to receive
-     * payments.
-     *
-     * The FillableSigningProvider::mapScripts script map should not be confused
-     * with LegacyScriptPubKeyMan::setWatchOnly script set. The two collections
-     * can hold the same scripts, but they serve different purposes. The
-     * setWatchOnly script set is intended to expand the set of outputs the
-     * wallet considers payments. Every output with a script it contains is
-     * considered to belong to the wallet, regardless of whether the script is
-     * solvable or signable. By contrast, the scripts in mapScripts are only
-     * used for solving, and to restrict which outputs are considered payments
-     * by the wallet. An output with a script in mapScripts, unlike
-     * setWatchOnly, is not automatically considered to belong to the wallet if
-     * it can't be solved and signed for.
-     */
-    ScriptMap mapScripts GUARDED_BY(cs_KeyStore);
-
-    void ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
-
-public:
-    mutable RecursiveMutex cs_KeyStore;
-
-    virtual bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
-    virtual bool AddKey(const CKey &key) { return AddKeyPubKey(key, key.GetPubKey()); }
-    virtual bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
-    virtual bool HaveKey(const CKeyID &address) const override;
-    virtual std::set<CKeyID> GetKeys() const;
-    virtual bool GetKey(const CKeyID &address, CKey &keyOut) const override;
-    virtual bool AddCScript(const CScript& redeemScript);
-    virtual bool HaveCScript(const CScriptID &hash) const override;
-    virtual std::set<CScriptID> GetCScripts() const;
-    virtual bool GetCScript(const CScriptID &hash, CScript& redeemScriptOut) const override;
 };
 
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -132,22 +132,14 @@ FUZZ_TARGET(key, .init = initialize_key)
         assert(tx_multisig_script.HasValidOps());
         assert(tx_multisig_script.size() == 37);
 
-        FillableSigningProvider fillable_signing_provider;
-        assert(!IsSegWitOutput(fillable_signing_provider, tx_pubkey_script));
-        assert(!IsSegWitOutput(fillable_signing_provider, tx_multisig_script));
-        assert(fillable_signing_provider.GetKeys().size() == 0);
-        assert(!fillable_signing_provider.HaveKey(pubkey.GetID()));
+        FlatSigningProvider signing_provider;
+        assert(!IsSegWitOutput(signing_provider, tx_pubkey_script));
+        assert(!IsSegWitOutput(signing_provider, tx_multisig_script));
+        assert(!signing_provider.HaveKey(pubkey.GetID()));
 
-        const bool ok_add_key = fillable_signing_provider.AddKey(key);
+        const bool ok_add_key = signing_provider.keys.emplace(key.GetPubKey().GetID(), key).second;
         assert(ok_add_key);
-        assert(fillable_signing_provider.HaveKey(pubkey.GetID()));
-
-        FillableSigningProvider fillable_signing_provider_pub;
-        assert(!fillable_signing_provider_pub.HaveKey(pubkey.GetID()));
-
-        const bool ok_add_key_pubkey = fillable_signing_provider_pub.AddKeyPubKey(key, pubkey);
-        assert(ok_add_key_pubkey);
-        assert(fillable_signing_provider_pub.HaveKey(pubkey.GetID()));
+        assert(signing_provider.HaveKey(pubkey.GetID()));
 
         TxoutType which_type_tx_pubkey;
         const bool is_standard_tx_pubkey = IsStandard(tx_pubkey_script, which_type_tx_pubkey);
@@ -188,20 +180,22 @@ FUZZ_TARGET(key, .init = initialize_key)
         CKeyID key_id = pubkey.GetID();
         assert(!key_id.IsNull());
         assert(key_id == CKeyID{key_id});
-        assert(key_id == GetKeyForDestination(fillable_signing_provider, tx_destination));
+        assert(key_id == GetKeyForDestination(signing_provider, tx_destination));
 
+        const bool ok_add_pubkey = signing_provider.pubkeys.emplace(key.GetPubKey().GetID(), key.GetPubKey()).second;
+        assert(ok_add_pubkey);
         CPubKey pubkey_out;
-        const bool ok_get_pubkey = fillable_signing_provider.GetPubKey(key_id, pubkey_out);
+        const bool ok_get_pubkey = signing_provider.GetPubKey(key_id, pubkey_out);
         assert(ok_get_pubkey);
 
         CKey key_out;
-        const bool ok_get_key = fillable_signing_provider.GetKey(key_id, key_out);
+        const bool ok_get_key = signing_provider.GetKey(key_id, key_out);
         assert(ok_get_key);
-        assert(fillable_signing_provider.GetKeys().size() == 1);
-        assert(fillable_signing_provider.HaveKey(key_id));
+        assert(signing_provider.keys.size() == 1);
+        assert(signing_provider.HaveKey(key_id));
 
         KeyOriginInfo key_origin_info;
-        const bool ok_get_key_origin = fillable_signing_provider.GetKeyOrigin(key_id, key_origin_info);
+        const bool ok_get_key_origin = signing_provider.GetKeyOrigin(key_id, key_origin_info);
         assert(!ok_get_key_origin);
     }
 

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -79,10 +79,10 @@ FUZZ_TARGET(script_sign, .init = initialize_script_sign)
         signature_data_1.MergeSignatureData(signature_data_2);
     }
 
-    FillableSigningProvider provider;
+    FlatSigningProvider provider;
     CKey k = ConsumePrivateKey(fuzzed_data_provider);
     if (k.IsValid()) {
-        provider.AddKey(k);
+        provider.keys.emplace(k.GetPubKey().GetID(), k);
     }
 
     {

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -184,12 +184,12 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 BOOST_AUTO_TEST_CASE(multisig_Sign)
 {
     // Test SignSignature() (and therefore the version of Solver() that signs transactions)
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     CKey key[4];
     for (int i = 0; i < 4; i++)
     {
         key[i].MakeNewKey(true);
-        BOOST_CHECK(keystore.AddKey(key[i]));
+        BOOST_CHECK(keystore.keys.emplace(key[i].GetPubKey().GetID(), key[i]).second);
     }
 
     CScript a_and_b;

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -429,8 +429,9 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     std::unique_ptr<node::TxOrphanage> orphanage{node::MakeTxOrphanage()};
     CKey key;
     MakeNewKeyWithFastRandomContext(key, m_rng);
-    FillableSigningProvider keystore;
-    BOOST_CHECK(keystore.AddKey(key));
+    FlatSigningProvider keystore;
+    BOOST_CHECK(keystore.keys.emplace(key.GetPubKey().GetID(), key).second);
+    BOOST_CHECK(keystore.pubkeys.emplace(key.GetPubKey().GetID(), key.GetPubKey()).second);
 
     FakeNodeClock clock{};
 

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -64,12 +64,13 @@ BOOST_AUTO_TEST_CASE(sign)
     // scriptPubKey: HASH160 <hash> EQUAL
 
     // Test SignSignature() (and therefore the version of Solver() that signs transactions)
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     CKey key[4];
     for (int i = 0; i < 4; i++)
     {
         key[i].MakeNewKey(true);
-        BOOST_CHECK(keystore.AddKey(key[i]));
+        BOOST_CHECK(keystore.keys.emplace(key[i].GetPubKey().GetID(), key[i]).second);
+        BOOST_CHECK(keystore.pubkeys.emplace(key[i].GetPubKey().GetID(), key[i].GetPubKey()).second);
     }
 
     // 8 Scripts: checking all combinations of
@@ -82,7 +83,7 @@ BOOST_AUTO_TEST_CASE(sign)
     CScript evalScripts[4];
     for (int i = 0; i < 4; i++)
     {
-        BOOST_CHECK(keystore.AddCScript(standardScripts[i]));
+        BOOST_CHECK(keystore.scripts.emplace(CScriptID(standardScripts[i]), standardScripts[i]).second);
         evalScripts[i] = GetScriptForDestination(ScriptHash(standardScripts[i]));
     }
 
@@ -161,14 +162,15 @@ BOOST_AUTO_TEST_CASE(norecurse)
 BOOST_AUTO_TEST_CASE(set)
 {
     // Test the CScript::Set* methods
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     CKey key[4];
     std::vector<CPubKey> keys;
     keys.reserve(4);
     for (int i = 0; i < 4; i++)
     {
         key[i].MakeNewKey(true);
-        BOOST_CHECK(keystore.AddKey(key[i]));
+        BOOST_CHECK(keystore.keys.emplace(key[i].GetPubKey().GetID(), key[i]).second);
+        BOOST_CHECK(keystore.pubkeys.emplace(key[i].GetPubKey().GetID(), key[i].GetPubKey()).second);
         keys.push_back(key[i].GetPubKey());
     }
 
@@ -182,7 +184,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         outer[i] = GetScriptForDestination(ScriptHash(inner[i]));
-        BOOST_CHECK(keystore.AddCScript(inner[i]));
+        BOOST_CHECK(keystore.scripts.emplace(CScriptID(inner[i]), inner[i]).second);
     }
 
     CMutableTransaction txFrom;  // Funding transaction:
@@ -278,12 +280,13 @@ BOOST_AUTO_TEST_CASE(switchover)
 BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
 {
     CCoinsViewCache coins{&CoinsViewEmpty::Get()};
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     CKey key[6];
     for (int i = 0; i < 6; i++)
     {
         key[i].MakeNewKey(true);
-        BOOST_CHECK(keystore.AddKey(key[i]));
+        BOOST_CHECK(keystore.keys.emplace(key[i].GetPubKey().GetID(), key[i]).second);
+        BOOST_CHECK(keystore.pubkeys.emplace(key[i].GetPubKey().GetID(), key[i].GetPubKey()).second);
     }
     std::vector<CPubKey> keys;
     keys.reserve(3);
@@ -295,7 +298,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
 
     // First three are standard:
     CScript pay1 = GetScriptForDestination(PKHash(key[0].GetPubKey()));
-    BOOST_CHECK(keystore.AddCScript(pay1));
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(pay1), pay1).second);
     CScript pay1of3 = GetScriptForMultisig(1, keys);
 
     txFrom.vout[0].scriptPubKey = GetScriptForDestination(ScriptHash(pay1)); // P2SH (OP_CHECKSIG)
@@ -312,7 +315,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     oneAndTwo << OP_3 << OP_CHECKMULTISIGVERIFY;
     oneAndTwo << OP_2 << ToByteVector(key[3].GetPubKey()) << ToByteVector(key[4].GetPubKey()) << ToByteVector(key[5].GetPubKey());
     oneAndTwo << OP_3 << OP_CHECKMULTISIG;
-    BOOST_CHECK(keystore.AddCScript(oneAndTwo));
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(oneAndTwo), oneAndTwo).second);
     txFrom.vout[3].scriptPubKey = GetScriptForDestination(ScriptHash(oneAndTwo));
     txFrom.vout[3].nValue = 4000;
 
@@ -321,17 +324,17 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     for (unsigned i = 0; i < MAX_P2SH_SIGOPS; i++)
         fifteenSigops << ToByteVector(key[i%3].GetPubKey());
     fifteenSigops << OP_15 << OP_CHECKMULTISIG;
-    BOOST_CHECK(keystore.AddCScript(fifteenSigops));
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(fifteenSigops), fifteenSigops).second);
     txFrom.vout[4].scriptPubKey = GetScriptForDestination(ScriptHash(fifteenSigops));
     txFrom.vout[4].nValue = 5000;
 
     // vout[5/6] are non-standard because they exceed MAX_P2SH_SIGOPS
     CScript sixteenSigops; sixteenSigops << OP_16 << OP_CHECKMULTISIG;
-    BOOST_CHECK(keystore.AddCScript(sixteenSigops));
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(sixteenSigops), sixteenSigops).second);
     txFrom.vout[5].scriptPubKey = GetScriptForDestination(ScriptHash(sixteenSigops));
     txFrom.vout[5].nValue = 5000;
     CScript twentySigops; twentySigops << OP_CHECKMULTISIG;
-    BOOST_CHECK(keystore.AddCScript(twentySigops));
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(twentySigops), twentySigops).second);
     txFrom.vout[6].scriptPubKey = GetScriptForDestination(ScriptHash(twentySigops));
     txFrom.vout[6].nValue = 3000;
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1271,7 +1271,7 @@ SignatureData CombineSignatures(const CTxOut& txout, const CMutableTransaction& 
 BOOST_AUTO_TEST_CASE(script_combineSigs)
 {
     // Test the ProduceSignature's ability to combine signatures function
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     std::vector<CKey> keys;
     std::vector<CPubKey> pubkeys;
     for (int i = 0; i < 3; i++)
@@ -1279,7 +1279,8 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
         CKey key = GenerateRandomKey(/*compressed=*/i%2 == 1);
         keys.push_back(key);
         pubkeys.push_back(key.GetPubKey());
-        BOOST_CHECK(keystore.AddKey(key));
+        BOOST_CHECK(keystore.keys.emplace(key.GetPubKey().GetID(), key).second);
+        BOOST_CHECK(keystore.pubkeys.emplace(key.GetPubKey().GetID(), key.GetPubKey()).second);
     }
 
     CMutableTransaction txFrom = BuildCreditingTransaction(GetScriptForDestination(PKHash(keys[0].GetPubKey())));
@@ -1309,7 +1310,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
 
     // P2SH, single-signature case:
     CScript pkSingle; pkSingle << ToByteVector(keys[0].GetPubKey()) << OP_CHECKSIG;
-    BOOST_CHECK(keystore.AddCScript(pkSingle));
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(pkSingle), pkSingle).second);
     scriptPubKey = GetScriptForDestination(ScriptHash(pkSingle));
     SignatureData dummy_c;
     BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL, dummy_c));
@@ -1327,7 +1328,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
 
     // Hardest case:  Multisig 2-of-3
     scriptPubKey = GetScriptForMultisig(2, pubkeys);
-    BOOST_CHECK(keystore.AddCScript(scriptPubKey));
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(scriptPubKey), scriptPubKey).second);
     SignatureData dummy_e;
     BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL, dummy_e));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
@@ -1391,7 +1392,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
  */
 BOOST_AUTO_TEST_CASE(sign_invalid_miniscript)
 {
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     SignatureData sig_data;
     CMutableTransaction prev, curr;
 
@@ -1412,7 +1413,7 @@ BOOST_AUTO_TEST_CASE(sign_invalid_miniscript)
 /* P2A input should be considered signed. */
 BOOST_AUTO_TEST_CASE(sign_paytoanchor)
 {
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     SignatureData sig_data;
     CMutableTransaction prev, curr;
     prev.vout.emplace_back(0, GetScriptForDestination(PayToAnchor{}));

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(test_Get)
     BOOST_CHECK(ValidateInputsStandardness(CTransaction(t1), coins).IsValid());
 }
 
-static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const CScript& outscript, CTransactionRef& output, CMutableTransaction& input, bool success = true)
+static void CreateCreditAndSpend(const FlatSigningProvider& keystore, const CScript& outscript, CTransactionRef& output, CMutableTransaction& input, bool success = true)
 {
     CMutableTransaction outputm;
     outputm.version = 1;
@@ -493,9 +493,10 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
     mtx.version = 1;
 
     CKey key = GenerateRandomKey(); // Need to use compressed keys in segwit or the signing will fail
-    FillableSigningProvider keystore;
-    BOOST_CHECK(keystore.AddKeyPubKey(key, key.GetPubKey()));
+    FlatSigningProvider keystore;
     CKeyID hash = key.GetPubKey().GetID();
+    BOOST_CHECK(keystore.keys.emplace(hash, key).second);
+    BOOST_CHECK(keystore.pubkeys.emplace(hash, key.GetPubKey()).second);
     CScript scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(hash.begin(), hash.end());
 
     std::vector<int> sigHashes;
@@ -569,7 +570,7 @@ SignatureData CombineSignatures(const CMutableTransaction& input1, const CMutabl
 
 BOOST_AUTO_TEST_CASE(test_witness)
 {
-    FillableSigningProvider keystore, keystore2;
+    FlatSigningProvider keystore, keystore2;
     CKey key1 = GenerateRandomKey();
     CKey key2 = GenerateRandomKey();
     CKey key3 = GenerateRandomKey();
@@ -580,10 +581,14 @@ BOOST_AUTO_TEST_CASE(test_witness)
     CPubKey pubkey3 = key3.GetPubKey();
     CPubKey pubkey1L = key1L.GetPubKey();
     CPubKey pubkey2L = key2L.GetPubKey();
-    BOOST_CHECK(keystore.AddKeyPubKey(key1, pubkey1));
-    BOOST_CHECK(keystore.AddKeyPubKey(key2, pubkey2));
-    BOOST_CHECK(keystore.AddKeyPubKey(key1L, pubkey1L));
-    BOOST_CHECK(keystore.AddKeyPubKey(key2L, pubkey2L));
+    BOOST_CHECK(keystore.keys.emplace(pubkey1.GetID(), key1).second);
+    BOOST_CHECK(keystore.pubkeys.emplace(pubkey1.GetID(), pubkey1).second);
+    BOOST_CHECK(keystore.keys.emplace(pubkey2.GetID(), key2).second);
+    BOOST_CHECK(keystore.pubkeys.emplace(pubkey2.GetID(), pubkey2).second);
+    BOOST_CHECK(keystore.keys.emplace(pubkey1L.GetID(), key1L).second);
+    BOOST_CHECK(keystore.pubkeys.emplace(pubkey1L.GetID(), pubkey1L).second);
+    BOOST_CHECK(keystore.keys.emplace(pubkey2L.GetID(), key2L).second);
+    BOOST_CHECK(keystore.pubkeys.emplace(pubkey2L.GetID(), pubkey2L).second);
     CScript scriptPubkey1, scriptPubkey2, scriptPubkey1L, scriptPubkey2L, scriptMulti;
     scriptPubkey1 << ToByteVector(pubkey1) << OP_CHECKSIG;
     scriptPubkey2 << ToByteVector(pubkey2) << OP_CHECKSIG;
@@ -593,25 +598,26 @@ BOOST_AUTO_TEST_CASE(test_witness)
     oneandthree.push_back(pubkey1);
     oneandthree.push_back(pubkey3);
     scriptMulti = GetScriptForMultisig(2, oneandthree);
-    BOOST_CHECK(keystore.AddCScript(scriptPubkey1));
-    BOOST_CHECK(keystore.AddCScript(scriptPubkey2));
-    BOOST_CHECK(keystore.AddCScript(scriptPubkey1L));
-    BOOST_CHECK(keystore.AddCScript(scriptPubkey2L));
-    BOOST_CHECK(keystore.AddCScript(scriptMulti));
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(scriptPubkey1), scriptPubkey1).second);
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(scriptPubkey2), scriptPubkey2).second);
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(scriptPubkey1L), scriptPubkey1L).second);
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(scriptPubkey2L), scriptPubkey2L).second);
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(scriptMulti), scriptMulti).second);
     CScript destination_script_1, destination_script_2, destination_script_1L, destination_script_2L, destination_script_multi;
     destination_script_1 = GetScriptForDestination(WitnessV0KeyHash(pubkey1));
     destination_script_2 = GetScriptForDestination(WitnessV0KeyHash(pubkey2));
     destination_script_1L = GetScriptForDestination(WitnessV0KeyHash(pubkey1L));
     destination_script_2L = GetScriptForDestination(WitnessV0KeyHash(pubkey2L));
     destination_script_multi = GetScriptForDestination(WitnessV0ScriptHash(scriptMulti));
-    BOOST_CHECK(keystore.AddCScript(destination_script_1));
-    BOOST_CHECK(keystore.AddCScript(destination_script_2));
-    BOOST_CHECK(keystore.AddCScript(destination_script_1L));
-    BOOST_CHECK(keystore.AddCScript(destination_script_2L));
-    BOOST_CHECK(keystore.AddCScript(destination_script_multi));
-    BOOST_CHECK(keystore2.AddCScript(scriptMulti));
-    BOOST_CHECK(keystore2.AddCScript(destination_script_multi));
-    BOOST_CHECK(keystore2.AddKeyPubKey(key3, pubkey3));
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(destination_script_1), destination_script_1).second);
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(destination_script_2), destination_script_2).second);
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(destination_script_1L), destination_script_1L).second);
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(destination_script_2L), destination_script_2L).second);
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(destination_script_multi), destination_script_multi).second);
+    BOOST_CHECK(keystore2.scripts.emplace(CScriptID(scriptMulti), scriptMulti).second);
+    BOOST_CHECK(keystore2.scripts.emplace(CScriptID(destination_script_multi), destination_script_multi).second);
+    BOOST_CHECK(keystore2.keys.emplace(pubkey3.GetID(), key3).second);
+    BOOST_CHECK(keystore2.pubkeys.emplace(pubkey3.GetID(), pubkey3).second);
 
     CTransactionRef output1, output2;
     CMutableTransaction input1, input2;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(basic_transaction_tests)
 
 BOOST_AUTO_TEST_CASE(test_Get)
 {
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     CCoinsViewCache coins{&CoinsViewEmpty::Get()};
     std::vector<CMutableTransaction> dummyTransactions =
         SetupDummyInputs(keystore, coins, {11*CENT, 50*CENT, 21*CENT, 22*CENT});
@@ -747,7 +747,7 @@ BOOST_AUTO_TEST_CASE(test_witness)
 
 BOOST_AUTO_TEST_CASE(test_IsStandard)
 {
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     CCoinsViewCache coins{&CoinsViewEmpty::Get()};
     std::vector<CMutableTransaction> dummyTransactions =
         SetupDummyInputs(keystore, coins, {11*CENT, 50*CENT, 21*CENT, 22*CENT});

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -173,9 +173,10 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
     CScript p2pkh_scriptPubKey = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
     CScript p2wpkh_scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));
 
-    FillableSigningProvider keystore;
-    BOOST_CHECK(keystore.AddKey(coinbaseKey));
-    BOOST_CHECK(keystore.AddCScript(p2pk_scriptPubKey));
+    FlatSigningProvider keystore;
+    BOOST_CHECK(keystore.keys.emplace(coinbaseKey.GetPubKey().GetID(), coinbaseKey).second);
+    BOOST_CHECK(keystore.pubkeys.emplace(coinbaseKey.GetPubKey().GetID(), coinbaseKey.GetPubKey()).second);
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(p2pk_scriptPubKey), p2pk_scriptPubKey).second);
 
     // flags to test: SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, SCRIPT_VERIFY_CHECKSEQUENCE_VERIFY, SCRIPT_VERIFY_NULLDUMMY, uncompressed pubkey thing
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -493,9 +493,10 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
     mempool_txn.vout = outputs;
 
     // - Add the signing key to a keystore
-    FillableSigningProvider keystore;
+    FlatSigningProvider keystore;
     for (const auto& input_signing_key : input_signing_keys) {
-        keystore.AddKey(input_signing_key);
+        keystore.keys.emplace(input_signing_key.GetPubKey().GetID(), input_signing_key);
+        keystore.pubkeys.emplace(input_signing_key.GetPubKey().GetID(), input_signing_key.GetPubKey());
     }
     // - Populate a CoinsViewCache with the unspent output
     CCoinsViewCache coins_cache{&CoinsViewEmpty::Get()};

--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -41,7 +41,7 @@ CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CSc
     return txSpend;
 }
 
-std::vector<CMutableTransaction> SetupDummyInputs(FillableSigningProvider& keystoreRet, CCoinsViewCache& coinsRet, const std::array<CAmount,4>& nValues)
+std::vector<CMutableTransaction> SetupDummyInputs(FlatSigningProvider& keystoreRet, CCoinsViewCache& coinsRet, const std::array<CAmount,4>& nValues)
 {
     std::vector<CMutableTransaction> dummyTransactions;
     dummyTransactions.resize(2);
@@ -50,7 +50,7 @@ std::vector<CMutableTransaction> SetupDummyInputs(FillableSigningProvider& keyst
     CKey key[4];
     for (int i = 0; i < 4; i++) {
         key[i].MakeNewKey(i % 2);
-        keystoreRet.AddKey(key[i]);
+        keystoreRet.keys.emplace(key[i].GetPubKey().GetID(), key[i]);
     }
 
     // Create some dummy input transactions

--- a/src/test/util/transaction_utils.h
+++ b/src/test/util/transaction_utils.h
@@ -10,7 +10,6 @@
 
 #include <array>
 
-class FillableSigningProvider;
 class CCoinsViewCache;
 
 // create crediting transaction
@@ -25,7 +24,7 @@ CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CSc
 // Helper: create two dummy transactions, each with two outputs.
 // The first has nValues[0] and nValues[1] outputs paid to a TxoutType::PUBKEY,
 // the second nValues[2] and nValues[3] outputs paid to a TxoutType::PUBKEYHASH.
-std::vector<CMutableTransaction> SetupDummyInputs(FillableSigningProvider& keystoreRet, CCoinsViewCache& coinsRet, const std::array<CAmount,4>& nValues);
+std::vector<CMutableTransaction> SetupDummyInputs(FlatSigningProvider& keystoreRet, CCoinsViewCache& coinsRet, const std::array<CAmount,4>& nValues);
 
 // bulk transaction to reach a certain target weight,
 // by appending a single output with padded output script

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -216,7 +216,7 @@ bool LegacyDataSPKM::CheckDecryptionKey(const CKeyingMaterial& master_key)
 {
     {
         LOCK(cs_KeyStore);
-        assert(mapKeys.empty());
+        assert(m_keys.empty());
 
         bool keyPass = mapCryptedKeys.empty(); // Always pass when there are no encrypted keys
         bool keyFail = false;
@@ -297,7 +297,9 @@ bool LegacyDataSPKM::LoadCScript(const CScript& redeemScript)
         return true;
     }
 
-    return FillableSigningProvider::AddCScript(redeemScript);
+    LOCK(cs_KeyStore);
+    m_scripts[CScriptID(redeemScript)] = redeemScript;
+    return true;
 }
 
 void LegacyDataSPKM::LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata& meta)
@@ -315,7 +317,9 @@ void LegacyDataSPKM::LoadScriptMetadata(const CScriptID& script_id, const CKeyMe
 bool LegacyDataSPKM::AddKeyPubKeyInner(const CKey& key, const CPubKey& pubkey)
 {
     LOCK(cs_KeyStore);
-    return FillableSigningProvider::AddKeyPubKey(key, pubkey);
+    m_keys[pubkey.GetID()] = key;
+    ImplicitlyLearnRelatedKeyScripts(pubkey);
+    return true;
 }
 
 bool LegacyDataSPKM::LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, bool checksum_valid)
@@ -331,7 +335,7 @@ bool LegacyDataSPKM::LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<
 bool LegacyDataSPKM::AddCryptedKeyInner(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret)
 {
     LOCK(cs_KeyStore);
-    assert(mapKeys.empty());
+    assert(m_keys.empty());
 
     mapCryptedKeys[vchPubKey.GetID()] = make_pair(vchPubKey, vchCryptedSecret);
     ImplicitlyLearnRelatedKeyScripts(vchPubKey);
@@ -385,7 +389,7 @@ bool LegacyDataSPKM::HaveKey(const CKeyID &address) const
 {
     LOCK(cs_KeyStore);
     if (!m_storage.HasEncryptionKeys()) {
-        return FillableSigningProvider::HaveKey(address);
+        return m_keys.contains(address);
     }
     return mapCryptedKeys.contains(address);
 }
@@ -394,7 +398,12 @@ bool LegacyDataSPKM::GetKey(const CKeyID &address, CKey& keyOut) const
 {
     LOCK(cs_KeyStore);
     if (!m_storage.HasEncryptionKeys()) {
-        return FillableSigningProvider::GetKey(address, keyOut);
+        const auto& it = m_keys.find(address);
+        if (it != m_keys.end()) {
+            keyOut = it->second;
+            return true;
+        }
+        return false;
     }
 
     CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
@@ -444,9 +453,11 @@ bool LegacyDataSPKM::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) con
 {
     LOCK(cs_KeyStore);
     if (!m_storage.HasEncryptionKeys()) {
-        if (!FillableSigningProvider::GetPubKey(address, vchPubKeyOut)) {
+        CKey key;
+        if (!GetKey(address, key)) {
             return GetWatchPubKey(address, vchPubKeyOut);
         }
+        vchPubKeyOut = key.GetPubKey();
         return true;
     }
 
@@ -458,6 +469,47 @@ bool LegacyDataSPKM::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) con
     }
     // Check for watch-only pubkeys
     return GetWatchPubKey(address, vchPubKeyOut);
+}
+
+void LegacyDataSPKM::ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey)
+{
+    AssertLockHeld(cs_KeyStore);
+    CKeyID key_id = pubkey.GetID();
+    // This adds the redeemscripts necessary to detect P2WPKH and P2SH-P2WPKH
+    // outputs. Technically P2WPKH outputs don't have a redeemscript to be
+    // spent. However, our current IsMine logic requires the corresponding
+    // P2SH-P2WPKH redeemscript to be present in the wallet in order to accept
+    // payment even to P2WPKH outputs.
+    // Also note that having superfluous scripts in the keystore never hurts.
+    // They're only used to guide recursion in signing and IsMine logic - if
+    // a script is present but we can't do anything with it, it has no effect.
+    // "Implicitly" refers to fact that scripts are derived automatically from
+    // existing keys, and are present in memory, even without being explicitly
+    // loaded (e.g. from a file).
+    if (pubkey.IsCompressed()) {
+        CScript script = GetScriptForDestination(WitnessV0KeyHash(key_id));
+        // This does not use AddCScript, as it may be overridden.
+        CScriptID id(script);
+        m_scripts[id] = std::move(script);
+    }
+}
+
+bool LegacyDataSPKM::HaveCScript(const CScriptID& hash) const
+{
+    LOCK(cs_KeyStore);
+    return m_scripts.contains(hash);
+}
+
+bool LegacyDataSPKM::GetCScript(const CScriptID& hash, CScript& out) const
+{
+    LOCK(cs_KeyStore);
+    const auto& mi = m_scripts.find(hash);
+    if (mi != m_scripts.end())
+    {
+        out = mi->second;
+        return true;
+    }
+    return false;
 }
 
 std::unordered_set<CScript, SaltedSipHasher> LegacyDataSPKM::GetCandidateScriptPubKeys() const
@@ -474,7 +526,7 @@ std::unordered_set<CScript, SaltedSipHasher> LegacyDataSPKM::GetCandidateScriptP
         candidate_spks.insert(wpkh);
         candidate_spks.insert(GetScriptForDestination(ScriptHash(wpkh)));
     };
-    for (const auto& [_, key] : mapKeys) {
+    for (const auto& [_, key] : m_keys) {
         add_pubkey(key.GetPubKey());
     }
     for (const auto& [_, ckeypair] : mapCryptedKeys) {
@@ -493,7 +545,7 @@ std::unordered_set<CScript, SaltedSipHasher> LegacyDataSPKM::GetCandidateScriptP
         candidate_spks.insert(wsh);
         candidate_spks.insert(GetScriptForDestination(ScriptHash(wsh)));
     };
-    for (const auto& [_, script] : mapScripts) {
+    for (const auto& [_, script] : m_scripts) {
         add_script(script);
     }
 
@@ -544,7 +596,7 @@ std::optional<MigrationData> LegacyDataSPKM::MigrateToDescriptor()
 
     // Get all key ids
     std::set<CKeyID> keyids;
-    for (const auto& key_pair : mapKeys) {
+    for (const auto& key_pair : m_keys) {
         keyids.insert(key_pair.first);
     }
     for (const auto& key_pair : mapCryptedKeys) {

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -172,7 +172,7 @@ using CryptedKeyMap = std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned c
 
 // Manages the data for a LegacyScriptPubKeyMan.
 // This is the minimum necessary to load a legacy wallet so that it can be migrated.
-class LegacyDataSPKM : public ScriptPubKeyMan, public FillableSigningProvider
+class LegacyDataSPKM : public ScriptPubKeyMan, public SigningProvider
 {
 private:
     using WatchOnlySet = std::set<CScript>;
@@ -181,6 +181,8 @@ private:
     CryptedKeyMap mapCryptedKeys GUARDED_BY(cs_KeyStore);
     WatchOnlySet setWatchOnly GUARDED_BY(cs_KeyStore);
     WatchKeyMap mapWatchKeys GUARDED_BY(cs_KeyStore);
+    std::map<CKeyID, CKey> m_keys GUARDED_BY(cs_KeyStore);
+    std::map<CScriptID, CScript> m_scripts GUARDED_BY(cs_KeyStore);
 
     /* the HD chain data model (external chain counters) */
     CHDChain m_hd_chain;
@@ -200,8 +202,12 @@ private:
 
     bool IsMine(const CScript& script) const override;
     bool CanProvide(const CScript& script, SignatureData& sigdata) override;
+
+    void ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 public:
     using ScriptPubKeyMan::ScriptPubKeyMan;
+
+    mutable RecursiveMutex cs_KeyStore;
 
     // Map from Key ID to key metadata.
     std::map<CKeyID, CKeyMetadata> mapKeyMetadata GUARDED_BY(cs_KeyStore);
@@ -215,11 +221,13 @@ public:
     std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const override;
     uint256 GetID() const override { return uint256::ONE; }
 
-    // FillableSigningProvider overrides
+    // SigningProvider overrides
     bool HaveKey(const CKeyID &address) const override;
     bool GetKey(const CKeyID &address, CKey& keyOut) const override;
     bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
+    bool HaveCScript(const CScriptID& hash) const override;
+    bool GetCScript(const CScriptID& hash, CScript& out) const override;
 
     //! Load metadata (used by LoadWallet)
     virtual void LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata &metadata);

--- a/src/wallet/test/fuzz/scriptpubkeyman.cpp
+++ b/src/wallet/test/fuzz/scriptpubkeyman.cpp
@@ -307,7 +307,7 @@ FUZZ_TARGET(spkm_migration, .init = initialize_spkm_migration)
                     }
                 );
                 if (fuzzed_data_provider.ConsumeBool()) script = GetScriptForDestination(ScriptHash(script));
-                if (!legacy_data.HaveCScript(CScriptID(script)) && legacy_data.AddCScript(script)) added_script++;
+                if (!legacy_data.HaveCScript(CScriptID(script)) && legacy_data.LoadCScript(script)) added_script++;
             },
             [&] {
                 CKey key;
@@ -331,7 +331,7 @@ FUZZ_TARGET(spkm_migration, .init = initialize_spkm_migration)
                 }
                 if (pubkeys.size() < num_keys) return;
                 CScript multisig_script{GetScriptForMultisig(num_keys, pubkeys)};
-                if (!legacy_data.HaveCScript(CScriptID(multisig_script)) && legacy_data.AddCScript(multisig_script)) {
+                if (!legacy_data.HaveCScript(CScriptID(multisig_script)) && legacy_data.LoadCScript(multisig_script)) {
                     added_script++;
                 }
             }

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -20,8 +20,9 @@ BOOST_FIXTURE_TEST_SUITE(spend_tests, WalletTestingSetup)
 BOOST_AUTO_TEST_CASE(max_signed_input_size_uses_external_outpoint)
 {
     const CKey key{GenerateRandomKey()};
-    FillableSigningProvider provider;
-    BOOST_REQUIRE(provider.AddKey(key));
+    FlatSigningProvider provider;
+    BOOST_CHECK(provider.keys.emplace(key.GetPubKey().GetID(), key).second);
+    BOOST_CHECK(provider.pubkeys.emplace(key.GetPubKey().GetID(), key.GetPubKey()).second);
 
     const CTxOut txout{COIN, GetScriptForDestination(PKHash{key.GetPubKey()})};
     const COutPoint outpoint{Txid{}, 0};

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -50,8 +50,9 @@ static CMutableTransaction TestSimpleSpend(const CTransaction& from, uint32_t in
     CMutableTransaction mtx;
     mtx.vout.emplace_back(from.vout[index].nValue - DEFAULT_TRANSACTION_MAXFEE, pubkey);
     mtx.vin.push_back({CTxIn{from.GetHash(), index}});
-    FillableSigningProvider keystore;
-    keystore.AddKey(key);
+    FlatSigningProvider keystore;
+    BOOST_CHECK(keystore.keys.emplace(key.GetPubKey().GetID(), key).second);
+    BOOST_CHECK(keystore.pubkeys.emplace(key.GetPubKey().GetID(), key.GetPubKey()).second);
     std::map<COutPoint, Coin> coins;
     coins[mtx.vin[0].prevout].out = from.vout[index];
     std::map<int, bilingual_str> input_errors;
@@ -547,9 +548,10 @@ static size_t CalculateNestedKeyhashInputSize(bool use_max_sig)
     CScript script_pubkey = CScript() << OP_HASH160 << std::vector<unsigned char>(script_id.begin(), script_id.end()) << OP_EQUAL;
 
     // Add inner-script to key store and key to watchonly
-    FillableSigningProvider keystore;
-    keystore.AddCScript(inner_script);
-    keystore.AddKeyPubKey(key, pubkey);
+    FlatSigningProvider keystore;
+    BOOST_CHECK(keystore.scripts.emplace(CScriptID(inner_script), inner_script).second);
+    BOOST_CHECK(keystore.keys.emplace(key.GetPubKey().GetID(), key).second);
+    BOOST_CHECK(keystore.pubkeys.emplace(key.GetPubKey().GetID(), key.GetPubKey()).second);
 
     // Fill in dummy signatures for fee calculation.
     SignatureData sig_data;


### PR DESCRIPTION
`FillableSigningProvider` was initially extracted from the wallet in order to produce the `SigningProvider` encapsulation system that we use today for the wallet and for providing key material to signing. It's primary user was the legacy wallet, but it was also being used as a convenience in a few other places. Since the legacy wallet is removed, there is no need to keep it around as a separate class. Instead, the things that it was doing can be inlined into `LegacyDataSPKM` where the functionality is actually being used to support migrating legacy wallets.

The remaining uses are tests and the `bitcoin-tx` tool, some of which were relying on the implicit addition of segwit scripts when adding a key. However, these can also use `FlatSigningProvider` with explicitly adding the segwit scripts when necessary, and have thusly been converted to do so.