### PR TITLE
test: Move cluster_linearize.h contents into cluster_linearize namespace

### DIFF
--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -17,9 +17,7 @@
 #include <utility>
 #include <vector>
 
-namespace {
-
-using namespace cluster_linearize;
+namespace cluster_linearize {
 
 using TestBitSet = BitSet<32>;
 
@@ -99,7 +97,7 @@ using TestBitSet = BitSet<32>;
 struct DepGraphFormatter
 {
     /** Convert x>=0 to 2x (even), x<0 to -2x-1 (odd). */
-    [[maybe_unused]] static uint64_t SignedToUnsigned(int64_t x) noexcept
+    static uint64_t SignedToUnsigned(int64_t x) noexcept
     {
         if (x < 0) {
             return 2 * uint64_t(-(x + 1)) + 1;
@@ -109,7 +107,7 @@ struct DepGraphFormatter
     }
 
     /** Convert even x to x/2 (>=0), odd x to -(x/2)-1 (<0). */
-    [[maybe_unused]] static int64_t UnsignedToSigned(uint64_t x) noexcept
+    static int64_t UnsignedToSigned(uint64_t x) noexcept
     {
         if (x & 1) {
             return -int64_t(x / 2) - 1;
@@ -416,6 +414,6 @@ inline uint64_t MaxOptimalLinearizationCost(DepGraphIndex cluster_count)
     return COSTS[cluster_count] * 2;
 }
 
-} // namespace
+} // namespace cluster_linearize
 
 #endif // BITCOIN_TEST_UTIL_CLUSTER_LINEARIZE_H


### PR DESCRIPTION
Clang recently enabled `-Wunused-template` under `-Wall` (see https://github.com/llvm/llvm-project/pull/206123, https://github.com/llvm/llvm-project/pull/207848, https://github.com/llvm/llvm-project/pull/208001). Our codebase [triggers](https://my.cdash.org/builds/3714664/build) some of these warnings.

This PR:
1. Avoids Clang's `-Wunused-template` warnings in `src/test/util/cluster_linearize.h` when building the `bench_bitcoin` and `fuzz` targets.

2. Follows the C++ Core Guidelines: "[SF.21: Don't use an unnamed (anonymous) namespace in a header](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf21-dont-use-an-unnamed-anonymous-namespace-in-a-header)".

3. Drops `[[maybe_unused]]` annotations, which are no longer needed after changing the linkage from internal to external.

Along with https://github.com/bitcoin/bitcoin/pull/35679, this resolves all instances of this warning in the test/bench/fuzz code.

Another related change: https://github.com/bitcoin-core/minisketch/pull/102.

---

Steps to reproduce on the master branch @ 70d9ec7f3d452789d04dce81dc02db0b3b778bb5:
```console
$ CXXFLAGS="-Wunused-template" cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_BENCH=ON
$ cmake --build build -t test_bitcoin
$ cmake --build build -t bench_bitcoin
[19/62] Building CXX object src/bench/CMakeFiles/bench_bitcoin.dir/cluster_linearize.cpp.o
In file included from /home/hebasto/dev/bitcoin/src/bench/cluster_linearize.cpp:9:
/home/hebasto/dev/bitcoin/src/test/util/cluster_linearize.h:122:17: warning: unused function template 'Ser' [-Wunused-template]
  122 |     static void Ser(Stream& s, const DepGraph<SetType>& depgraph)
      |                 ^~~
/home/hebasto/dev/bitcoin/src/test/util/cluster_linearize.h:286:6: warning: unused function template 'SanityCheck' [-Wunused-template]
  286 | void SanityCheck(const DepGraph<SetType>& depgraph)
      |      ^~~~~~~~~~~
/home/hebasto/dev/bitcoin/src/test/util/cluster_linearize.h:383:6: warning: unused function template 'SanityCheck' [-Wunused-template]
  383 | void SanityCheck(const DepGraph<SetType>& depgraph, std::span<const DepGraphIndex> linearization)
      |      ^~~~~~~~~~~
3 warnings generated.
[62/62] Linking CXX executable bin/bench_bitcoin
```