### PR TITLE
http: linger-close after parse errors so clients can read the reply

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -47,6 +47,16 @@
 //! the sleep time needs to be small to avoid new sockets stalling.
 static constexpr auto SELECT_TIMEOUT{50ms};
 
+/**
+ * Maximum time to drain input after flushing an error reply and half-closing
+ * the send side. This bounds clients that do not close their side.
+ *
+ * Closing with unread input can reset the connection and hide the reply on
+ * Windows (https://github.com/bitcoin/bitcoin/issues/35632). For oversized
+ * requests the client may still be uploading when this timeout expires.
+ */
+static constexpr auto LINGERING_CLOSE_TIMEOUT{1s};
+
 //! Explicit alias for setting socket option methods.
 static constexpr int SOCKET_OPTION_TRUE{1};
 
@@ -182,9 +192,8 @@ static void MaybeDispatchRequestToWorker(std::shared_ptr<HTTPRequest> hreq)
                 err_msg = "unknown error";
             }
             // Reply so the client doesn't hang waiting for the response.
-            req->WriteHeader("Connection", "close");
             // TODO: Implement specific error formatting for the REST and JSON-RPC servers responses.
-            req->WriteReply(HTTP_INTERNAL_SERVER_ERROR, err_msg);
+            req->WriteReply(HTTP_INTERNAL_SERVER_ERROR, err_msg, /*force_close=*/true);
         };
 
         if (auto res = g_threadpool_http.Submit(std::move(item)); !res.has_value()) {
@@ -262,6 +271,23 @@ void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)
 
 namespace http_bitcoin {
 using util::Split;
+
+/**
+ * Queue a parse-error reply and enable a lingering close.
+ *
+ * Runs only on the HTTP I/O thread. The send path starts the timeout and
+ * half-closes after flushing the reply; the receive path then drains to EOF.
+ */
+static void SendErrorReplyAndLingerClose(HTTPRequest& req, HTTPRemoteClient& client, HTTPStatusCode status)
+{
+    client.m_lingering_close = true;
+    // Keep the connection alive until the reply is flushed.
+    client.m_connection_busy = true;
+    // Further input is drained directly from the socket.
+    client.m_recv_buffer.clear();
+
+    req.WriteReply(status, std::span<const std::byte>{}, /*force_close=*/true);
+}
 
 std::optional<std::string> HTTPHeaders::FindFirst(const std::string_view key) const
 {
@@ -512,7 +538,7 @@ bool HTTPRequest::LoadBody(LineReader& reader)
     }
 }
 
-void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body)
+void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body, bool force_close)
 {
     HTTPResponse res;
 
@@ -570,7 +596,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
     }
 
     auto connection_header{m_headers.FindFirst("Connection")};
-    if (connection_header && ToLower(connection_header.value()) == "close") {
+    if (force_close || (connection_header && ToLower(connection_header.value()) == "close")) {
         // Might not exist already but we need to replace it, not append to it
         res.m_headers.RemoveAll("Connection");
 
@@ -892,18 +918,24 @@ void HTTPServer::SocketHandlerConnected(const IOReadiness& io_readiness) const
                 // Prevent disconnect until all requests are completely handled.
                 client->m_connection_busy = true;
 
-                // Copy data from socket buffer to client receive buffer
-                client->m_recv_buffer.insert(
-                    client->m_recv_buffer.end(),
-                    buf,
-                    buf + nrecv);
+                if (client->m_lingering_close) {
+                    // Drain without parsing another request.
+                } else {
+                    // Copy data from socket buffer to client receive buffer
+                    client->m_recv_buffer.insert(
+                        client->m_recv_buffer.end(),
+                        buf,
+                        buf + nrecv);
+                }
             }
         }
         // Process as much received data as we can.
         // This executes for every client whether or not reading or writing
         // took place because it also (might) parse a request we have already
         // received and pass it to a worker thread.
-        MaybeDispatchRequestsFromClient(client);
+        if (!client->m_lingering_close) {
+            MaybeDispatchRequestsFromClient(client);
+        }
     }
 }
 
@@ -998,8 +1030,8 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
                 client->m_id,
                 e.what());
 
-            req->WriteReply(HTTP_CONTENT_TOO_LARGE);
-            client->m_disconnect = true;
+            // The client may still be uploading when the linger timeout expires.
+            SendErrorReplyAndLingerClose(*req, *client, HTTP_CONTENT_TOO_LARGE);
             return;
         } catch (const std::runtime_error& e) {
             LogDebug(
@@ -1009,9 +1041,7 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
                 client->m_id,
                 e.what());
 
-            // We failed to read a complete request from the buffer
-            req->WriteReply(HTTP_BAD_REQUEST);
-            client->m_disconnect = true;
+            SendErrorReplyAndLingerClose(*req, *client, HTTP_BAD_REQUEST);
             return;
         }
 
@@ -1045,6 +1075,7 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
 void HTTPServer::DisconnectClients()
 {
     const auto now{Now<SteadySeconds>()};
+    const auto now_ms{Now<SteadyMilliseconds>()};
     size_t erased = std::erase_if(m_connected,
                                   [&](auto& client) {
                                         // First check for idle timeout. We reset the timer when we send and receive data,
@@ -1055,13 +1086,22 @@ void HTTPServer::DisconnectClients()
                                         const bool is_idle{m_rpcservertimeout.count() > 0 &&
                                                            now - client->m_idle_since.load() > m_rpcservertimeout &&
                                                            !client->m_req_busy};
+                                        const bool lingering_close_expired{
+                                            client->m_lingering_close &&
+                                            client->m_lingering_half_closed &&
+                                            now_ms >= client->m_lingering_close_deadline};
 
-                                        // Disconnect this client due to error, end of communication, or idle timeout.
+                                        // Disconnect on error, EOF, idle timeout, or a stalled lingering close.
                                         // May drop unsent data if we are closing due to error.
-                                        if (client->m_disconnect || is_idle) {
+                                        if (client->m_disconnect || is_idle || lingering_close_expired) {
                                             if (is_idle) {
                                                 LogDebug(BCLog::HTTP,
                                                          "HTTP client idle timeout %s (id=%llu)",
+                                                         client->m_origin,
+                                                         client->m_id);
+                                            } else if (lingering_close_expired && !client->m_disconnect) {
+                                                LogDebug(BCLog::HTTP,
+                                                         "HTTP client lingering-close fallback timeout %s (id=%llu)",
                                                          client->m_origin,
                                                          client->m_id);
                                             }
@@ -1189,6 +1229,31 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
         // on an already-empty m_send_buffer because the connection might have just been opened.
         if (m_send_buffer.empty()) {
             m_send_ready = false;
+
+            if (m_lingering_close) {
+                // The reply is flushed. Half-close once, then drain to EOF.
+                m_connection_busy = true;
+                // Arm the deadline before publishing half_closed so DisconnectClients
+                // never observes half_closed == true with the unset (max) deadline.
+                // Writers are serialized by m_send_mutex; the release on exchange
+                // synchronizes with the reader's load of the flag.
+                if (!m_lingering_half_closed.load()) {
+                    m_lingering_close_deadline = Now<SteadyMilliseconds>() + LINGERING_CLOSE_TIMEOUT;
+                    if (!m_lingering_half_closed.exchange(true)) {
+                        const int shut_ret{WITH_LOCK(m_sock_mutex, return m_sock->ShutdownSend();)};
+                        if (shut_ret != 0) {
+                            LogDebug(
+                                BCLog::HTTP,
+                                "shutdown(SD_SEND) failed for client %s (id=%llu): %s; continuing drain",
+                                m_origin,
+                                m_id,
+                                NetworkErrorString(WSAGetLastError()));
+                        }
+                    }
+                }
+                return true;
+            }
+
             m_connection_busy = false;
 
             // Our work is done here

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -180,10 +180,16 @@ public:
     bool LoadBody(LineReader& reader);
     /// @}
 
-    void WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body = {});
-    void WriteReply(HTTPStatusCode status, std::string_view reply_body_view)
+    /**
+     * Queue an HTTP response for this request's client.
+     * @param[in] force_close If true, send Connection: close and mark the client
+     *                        non-keep-alive so the connection is closed after the
+     *                        response is flushed (or after a lingering close drain).
+     */
+    void WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body = {}, bool force_close = false);
+    void WriteReply(HTTPStatusCode status, std::string_view reply_body_view, bool force_close = false)
     {
-        WriteReply(status, std::as_bytes(std::span{reply_body_view}));
+        WriteReply(status, std::as_bytes(std::span{reply_body_view}), force_close);
     }
 
     // These methods reimplement the API from http_libevent::HTTPRequest
@@ -460,6 +466,9 @@ public:
      * In lieu of an intermediate transport class like p2p uses,
      * we copy data from the socket buffer to the client object
      * and attempt to read HTTP requests from here.
+     *
+     * Only the HTTP I/O thread may access this buffer. Workers receive
+     * already-parsed HTTPRequest objects.
      */
     std::vector<std::byte> m_recv_buffer{};
 
@@ -478,6 +487,7 @@ public:
      * Written to by http worker threads, read and erased by HTTPServer I/O thread
      */
     /// @{
+    //! Lock order: always acquire m_send_mutex before m_sock_mutex (never the reverse).
     Mutex m_send_mutex;
     std::vector<std::byte> m_send_buffer GUARDED_BY(m_send_mutex);
     /// @}
@@ -496,6 +506,7 @@ public:
      * Mutex that serializes the Send() and Recv() calls on `m_sock`. Reading
      * from the client occurs in the I/O thread but writing back to a client
      * may occur in a worker thread.
+     * Must be acquired after m_send_mutex when both are needed.
      */
     Mutex m_sock_mutex;
 
@@ -509,7 +520,8 @@ public:
     std::shared_ptr<Sock> m_sock GUARDED_BY(m_sock_mutex);
 
     //! Initialized to true while server waits for first request from client.
-    //! Set to false after data is written to m_send_buffer and then that buffer is flushed to client.
+    //! Set to false after m_send_buffer is flushed, unless a lingering close is in progress
+    //! (then kept true so DisconnectAllClients() waits for the drain).
     //! Reset to true when we receive new request data from client.
     //! Checked during DisconnectClients() and set by read/write operations
     //! called in either the HTTPServer I/O loop or by a worker thread during an "optimistic send".
@@ -527,6 +539,28 @@ public:
     //! Might be set in a worker thread or in the I/O thread. When set to `true` we disconnect,
     //! possibly overriding all other disconnect flags.
     std::atomic_bool m_disconnect{false};
+
+    /**
+     * Linger after a parse error so unread request bytes can be drained.
+     *
+     * Set by the I/O thread and read by the send path, which may run on a worker.
+     */
+    std::atomic_bool m_lingering_close{false};
+
+    /**
+     * True after the error reply is flushed and the send side is half-closed.
+     * Set by the send path and read by the I/O thread.
+     * The deadline is written before this becomes true so a reader that sees
+     * true never observes the unset (max) deadline.
+     */
+    std::atomic_bool m_lingering_half_closed{false};
+
+    /**
+     * Fallback deadline while waiting for peer EOF after the half-close.
+     * Written under m_send_mutex before m_lingering_half_closed is published;
+     * read by the I/O thread only after observing that flag.
+     */
+    SteadyMilliseconds m_lingering_close_deadline{SteadyMilliseconds::max()};
 
     //! Timestamp of last send or receive activity, used for -rpcservertimeout.
     //! Due to optimistic sends it may be updated in either a worker thread or in the

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -198,6 +198,8 @@ public:
 
     ssize_t Recv(void* buf, size_t len, int flags) const override;
 
+    int ShutdownSend() const override { return 0; }
+
     int Connect(const sockaddr*, socklen_t) const override;
 
     int Bind(const sockaddr*, socklen_t) const override;

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -176,6 +176,8 @@ public:
 
     ssize_t Recv(void* buf, size_t len, int flags) const override;
 
+    int ShutdownSend() const override { return 0; }
+
     int Connect(const sockaddr*, socklen_t) const override;
 
     int Bind(const sockaddr*, socklen_t) const override;

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -54,6 +54,15 @@ ssize_t Sock::Recv(void* buf, size_t len, int flags) const
     return recv(m_socket, static_cast<char*>(buf), len, flags);
 }
 
+int Sock::ShutdownSend() const
+{
+#ifdef WIN32
+    return shutdown(m_socket, SD_SEND);
+#else
+    return shutdown(m_socket, SHUT_WR);
+#endif
+}
+
 int Sock::Connect(const sockaddr* addr, socklen_t addr_len) const
 {
     return connect(m_socket, addr, addr_len);

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -79,6 +79,12 @@ public:
     [[nodiscard]] virtual ssize_t Recv(void* buf, size_t len, int flags) const;
 
     /**
+     * Half-close the send side while leaving the receive side open.
+     * Equivalent to `shutdown(m_socket, SHUT_WR)` or `shutdown(m_socket, SD_SEND)`.
+     */
+    [[nodiscard]] virtual int ShutdownSend() const;
+
+    /**
      * connect(2) wrapper. Equivalent to `connect(m_socket, addr, addrlen)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */

--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -8,6 +8,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, str_to_b64str
 
 import http.client
+import os
 import time
 import urllib.parse
 
@@ -552,21 +553,31 @@ class HTTPBasicsTest (BitcoinTestFramework):
 
     def check_whitespace_in_headers(self):
         self.log.info("Check that requests with whitespace in headers are rejected")
-        # Extra whitespace before colon in header.
-        conn = BitcoinHTTPConnection(self.node)
-        conn.headers = {"Authorization ": f"Basic {str_to_b64str(conn.authpair)}"}
-        response = conn.post('/', '{"method": "getbestblockhash"}')
-        assert_equal(response.status, http.client.BAD_REQUEST)
+        # On Windows, closing immediately after writing a mid-parse 400 can RST
+        # the connection before http.client reads the reply (issue #35632).
+        # Default run is a single shot; set BITCOIN_TEST_HTTP_WHITESPACE_STRESS=N
+        # (e.g. 100) for a repeatable close-timing stress loop.
+        iterations = int(os.environ.get("BITCOIN_TEST_HTTP_WHITESPACE_STRESS", "1"))
+        assert iterations >= 1
+        if iterations > 1:
+            self.log.info(f"Repeating whitespace-header checks {iterations} times (stress)")
 
-        # Extra whitespace at start of new line.
-        # "line folding" as defined in
-        # https://www.rfc-editor.org/rfc/rfc2616#section-2.2
-        # is considered unsafe and is explicitly deprecated in
-        # https://www.rfc-editor.org/rfc/rfc7230#section-3.2.4
-        conn = BitcoinHTTPConnection(self.node)
-        conn.headers = {"Authorization": f"Basic \n {str_to_b64str(conn.authpair)}"}
-        response = conn.post('/', '{"method": "getbestblockhash"}')
-        assert_equal(response.status, http.client.BAD_REQUEST)
+        for _ in range(iterations):
+            # Extra whitespace before colon in header.
+            conn = BitcoinHTTPConnection(self.node)
+            conn.headers = {"Authorization ": f"Basic {str_to_b64str(conn.authpair)}"}
+            response = conn.post('/', '{"method": "getbestblockhash"}')
+            assert_equal(response.status, http.client.BAD_REQUEST)
+
+            # Extra whitespace at start of new line.
+            # "line folding" as defined in
+            # https://www.rfc-editor.org/rfc/rfc2616#section-2.2
+            # is considered unsafe and is explicitly deprecated in
+            # https://www.rfc-editor.org/rfc/rfc7230#section-3.2.4
+            conn = BitcoinHTTPConnection(self.node)
+            conn.headers = {"Authorization": f"Basic \n {str_to_b64str(conn.authpair)}"}
+            response = conn.post('/', '{"method": "getbestblockhash"}')
+            assert_equal(response.status, http.client.BAD_REQUEST)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On Windows the malformed HTTP requests  intermittently lose their error response. The server queues the reply and closes the connection right away and sometimes before it has finished reading everything the client sent. 
Windows reacts to that by resetting the TCP connection and the reset carries the queued response away with it  so as the client never sees the 400 

as we saw this in `check_whitespace_in_headers` instead of the expected HTTP 400 the client will occasionally get a bare `ConnectionAbortedError`.

so decided to change how the server closes connections after a parse error so as it gives the client a  chance to read the response before it hangs up:

1. Queue the 400 or 413 response with `Connection: close`.
2. Wait for the response to actually leave the send buffer.
3. Half-close the socket's write side with `shutdown(SD_SEND/SHUT_WR)` so the client can still finish reading while we stop sending.
4. Keep draining whatever the client sends until it hits EOF or a permanent socket error.
5. Only force-close after one secondand only as a fallback for a client that never finishes.

also added `Sock::ShutdownSend()` to wrap the platform-specific half-close call and made sure the linger state is consistent whether it's touched from the I/O thread or from a worker's send path.
