### PR TITLE
descriptors: check duplicate keys in all multipath Miniscript branches

### DIFF
--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -2245,6 +2245,8 @@ struct KeyParser {
     const SigningProvider* m_in;
     //! List of multipath expanded keys contained in the Miniscript.
     mutable std::vector<std::vector<std::unique_ptr<PubkeyProvider>>> m_keys;
+    //! Multipath branch used when comparing and formatting keys.
+    mutable size_t m_multipath_index{0};
     //! Used to detect key parsing errors within a Miniscript.
     mutable std::string m_key_parsing_error;
     //! The script context we're operating within (Tapscript or P2WSH).
@@ -2257,7 +2259,7 @@ struct KeyParser {
         : m_out(out), m_in(in), m_script_ctx(ctx), m_expr_index(key_exp_index) {}
 
     bool KeyCompare(const Key& a, const Key& b) const {
-        return *m_keys.at(a).at(0) < *m_keys.at(b).at(0);
+        return *m_keys.at(a).at(m_multipath_index) < *m_keys.at(b).at(m_multipath_index);
     }
 
     ParseScriptContext ParseContext() const {
@@ -2280,7 +2282,7 @@ struct KeyParser {
 
     std::optional<std::string> ToString(const Key& key, bool&) const
     {
-        return m_keys.at(key).at(0)->ToString();
+        return m_keys.at(key).at(m_multipath_index)->ToString();
     }
 
     template<typename I> std::optional<Key> FromPKBytes(I begin, I end) const
@@ -2727,6 +2729,19 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
                     }
                 } else if (vec.size() != num_multipath) {
                     error = strprintf("Miniscript: Multipath derivation paths have mismatched lengths");
+                    return {};
+                }
+            }
+
+            // Duplicate keys were checked above for branch 0. Check every remaining branch now
+            // that all multipath key vectors have been expanded to the same length.
+            for (size_t i = 1; i < num_multipath; ++i) {
+                parser.m_multipath_index = i;
+                node->DuplicateKeyCheck(parser);
+                if (!node->CheckDuplicateKey()) {
+                    const auto* insane_node = &node.value();
+                    if (const auto sub = node->FindInsaneSub()) insane_node = sub;
+                    error = *insane_node->ToString(parser) + " is not sane: contains duplicate public keys";
                     return {};
                 }
             }

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -2236,6 +2236,8 @@ struct KeyParser {
     const SigningProvider* m_in;
     //! List of multipath expanded keys contained in the Miniscript.
     mutable std::vector<std::vector<std::unique_ptr<PubkeyProvider>>> m_keys;
+    //! Multipath branch used when comparing and formatting keys.
+    mutable size_t m_multipath_index{0};
     //! Used to detect key parsing errors within a Miniscript.
     mutable std::string m_key_parsing_error;
     //! The script context we're operating within (Tapscript or P2WSH).
@@ -2251,8 +2253,8 @@ struct KeyParser {
         // Deriving a hardened step needs the private key, so use the provider that was filled
         // while parsing, or the one we are inferring from, rather than an empty one.
         const SigningProvider& provider{m_out ? *m_out : (m_in ? *m_in : DUMMY_SIGNING_PROVIDER)};
-        const PubkeyProvider& key_a{*m_keys.at(a).at(0)};
-        const PubkeyProvider& key_b{*m_keys.at(b).at(0)};
+        const PubkeyProvider& key_a{*m_keys.at(a).at(m_multipath_index)};
+        const PubkeyProvider& key_b{*m_keys.at(b).at(m_multipath_index)};
         FlatSigningProvider out_a, out_b;
         const std::optional<CPubKey> pub_a{key_a.GetPubKey(0, provider, out_a)};
         const std::optional<CPubKey> pub_b{key_b.GetPubKey(0, provider, out_b)};
@@ -2283,7 +2285,7 @@ struct KeyParser {
 
     std::optional<std::string> ToString(const Key& key, bool&) const
     {
-        return m_keys.at(key).at(0)->ToString();
+        return m_keys.at(key).at(m_multipath_index)->ToString();
     }
 
     template<typename I> std::optional<Key> FromPKBytes(I begin, I end) const
@@ -2730,6 +2732,19 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
                     }
                 } else if (vec.size() != num_multipath) {
                     error = strprintf("Miniscript: Multipath derivation paths have mismatched lengths");
+                    return {};
+                }
+            }
+
+            // Duplicate keys were checked above for branch 0. Check every remaining branch now
+            // that all multipath key vectors have been expanded to the same length.
+            for (size_t i = 1; i < num_multipath; ++i) {
+                parser.m_multipath_index = i;
+                node->DuplicateKeyCheck(parser);
+                if (!node->CheckDuplicateKey()) {
+                    const auto* insane_node = &node.value();
+                    if (const auto sub = node->FindInsaneSub()) insane_node = sub;
+                    error = *insane_node->ToString(parser) + " is not sane: contains duplicate public keys";
                     return {};
                 }
             }

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -1288,6 +1288,27 @@ BOOST_AUTO_TEST_CASE(descriptor_test)
     CheckUnparsable("tr(musig(tuus(oldepk(gg)ggggfgg)<,z(((((((((((((((((((((st)", "tr(musig(tuus(oldepk(gg)ggggfgg)<,z(((((((((((((((((((((st)","tr(): Too many ')' in musig() expression");
 }
 
+BOOST_AUTO_TEST_CASE(multipath_miniscript_duplicate_keys)
+{
+    const std::string xpub{"xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ"};
+
+    FlatSigningProvider provider;
+    std::string error;
+    const auto valid{Parse("wsh(or_i(pk(" + xpub + "/<0;1>),pk(" + xpub + "/<2;3>)))", provider, error)};
+    BOOST_CHECK_EQUAL(valid.size(), 2);
+    BOOST_CHECK(error.empty());
+
+    CheckUnparsable(
+        "",
+        "wsh(or_i(pk(" + xpub + "/<0;1>),pk(" + xpub + "/<2;1>)))",
+        "or_i(pk(" + xpub + "/1),pk(" + xpub + "/1)) is not sane: contains duplicate public keys");
+
+    CheckUnparsable(
+        "",
+        "tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,or_i(pk(" + xpub + "/<0;1;2>),pk(" + xpub + "/<3;4;2>)))",
+        "or_i(pk(" + xpub + "/2),pk(" + xpub + "/2)) is not sane: contains duplicate public keys");
+}
+
 BOOST_AUTO_TEST_CASE(descriptor_literal_null_byte)
 {
     // Trailing '\0' string literal should be ignored.

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -1302,6 +1302,27 @@ BOOST_AUTO_TEST_CASE(descriptor_test)
     CheckUnparsable("tr(musig(tuus(oldepk(gg)ggggfgg)<,z(((((((((((((((((((((st)", "tr(musig(tuus(oldepk(gg)ggggfgg)<,z(((((((((((((((((((((st)","tr(): Too many ')' in musig() expression");
 }
 
+BOOST_AUTO_TEST_CASE(multipath_miniscript_duplicate_keys)
+{
+    const std::string xpub{"xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ"};
+
+    FlatSigningProvider provider;
+    std::string error;
+    const auto valid{Parse("wsh(or_i(pk(" + xpub + "/<0;1>),pk(" + xpub + "/<2;3>)))", provider, error)};
+    BOOST_CHECK_EQUAL(valid.size(), 2);
+    BOOST_CHECK(error.empty());
+
+    CheckUnparsable(
+        "",
+        "wsh(or_i(pk(" + xpub + "/<0;1>),pk(" + xpub + "/<2;1>)))",
+        "or_i(pk(" + xpub + "/1),pk(" + xpub + "/1)) is not sane: contains duplicate public keys");
+
+    CheckUnparsable(
+        "",
+        "tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,or_i(pk(" + xpub + "/<0;1;2>),pk(" + xpub + "/<3;4;2>)))",
+        "or_i(pk(" + xpub + "/2),pk(" + xpub + "/2)) is not sane: contains duplicate public keys");
+}
+
 BOOST_AUTO_TEST_CASE(descriptor_literal_null_byte)
 {
     // Trailing '\0' string literal should be ignored.


### PR DESCRIPTION
Fixes #35629.

Multipath Miniscript descriptors performed duplicate-key sanity checking while parsing the template, when key comparison used the first multipath branch. As a result, duplicate keys present only in a later branch were accepted.

Select each expanded multipath branch and rerun the existing duplicate-key check before constructing the final descriptors. If a branch contains a duplicate, report the offending concrete Miniscript expression.

The regression test covers:

- a valid two-branch `wsh` control;
- a duplicate in the second `wsh` branch;
- a duplicate in the third of three `tr` branches.

Tested with:

```
build/bin/test_bitcoin --run_test=descriptor_tests/multipath_miniscript_duplicate_keys
build/bin/test_bitcoin --run_test=descriptor_tests
build/bin/test_bitcoin
```
