### PR TITLE
coins: prevent DB resize from invalidating cursors

### DIFF
--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -12,8 +12,6 @@
 #include <uint256.h>
 #include <util/log.h>
 
-#include <mutex>
-#include <shared_mutex>
 #include <utility>
 #include <vector>
 
@@ -50,13 +48,13 @@ void SignatureCache::ComputeEntrySchnorr(uint256& entry, const uint256& hash, st
 
 bool SignatureCache::Get(const uint256& entry, const bool erase)
 {
-    std::shared_lock<std::shared_mutex> lock(cs_sigcache);
+    READ_LOCK(cs_sigcache);
     return setValid.contains(entry, erase);
 }
 
 void SignatureCache::Set(const uint256& entry)
 {
-    std::unique_lock<std::shared_mutex> lock(cs_sigcache);
+    LOCK(cs_sigcache);
     setValid.insert(entry);
 }
 

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -10,6 +10,7 @@
 #include <crypto/sha256.h>
 #include <cuckoocache.h>
 #include <script/interpreter.h>
+#include <sync.h>
 #include <uint256.h>
 // IWYU incorrectly suggests removing this header.
 // See https://github.com/include-what-you-use/include-what-you-use/issues/2014.
@@ -17,7 +18,6 @@
 #include <util/hasher.h>
 
 #include <cstddef>
-#include <shared_mutex>
 #include <span>
 #include <vector>
 
@@ -45,8 +45,8 @@ private:
     CSHA256 m_salted_hasher_ecdsa;
     CSHA256 m_salted_hasher_schnorr;
     typedef CuckooCache::cache<uint256, SignatureCacheHasher> map_type;
-    map_type setValid;
-    std::shared_mutex cs_sigcache;
+    SharedMutex cs_sigcache;
+    map_type setValid GUARDED_BY(cs_sigcache);
 
 public:
     SignatureCache(size_t max_size_bytes);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <mutex>
 #include <set>
+#include <shared_mutex>
 #include <system_error>
 #include <thread>
 #include <type_traits>
@@ -31,6 +32,8 @@ void ContendedLock(std::string_view name, std::string_view file, int nLine, Lock
 }
 template void ContendedLock(std::string_view name, std::string_view file, int nLine, std::unique_lock<std::mutex>& lock);
 template void ContendedLock(std::string_view name, std::string_view file, int nLine, std::unique_lock<std::recursive_mutex>& lock);
+template void ContendedLock(std::string_view name, std::string_view file, int line, std::unique_lock<std::shared_mutex>& lock);
+template void ContendedLock(std::string_view name, std::string_view file, int line, std::shared_lock<std::shared_mutex>& lock);
 
 #endif
 
@@ -223,6 +226,7 @@ void EnterCritical(const char* pszName, const char* pszFile, int nLine, MutexTyp
 }
 template void EnterCritical(const char*, const char*, int, std::mutex*, bool);
 template void EnterCritical(const char*, const char*, int, std::recursive_mutex*, bool);
+template void EnterCritical(const char*, const char*, int, std::shared_mutex*, bool);
 
 void CheckLastCritical(void* cs, std::string& lockname, const char* guardname, const char* file, int line)
 {
@@ -289,6 +293,7 @@ void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine,
 }
 template void AssertLockHeldInternal(const char*, const char*, int, Mutex*);
 template void AssertLockHeldInternal(const char*, const char*, int, RecursiveMutex*);
+template void AssertLockHeldInternal(const char*, const char*, int, SharedMutex*);
 
 template <typename MutexType>
 void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs)
@@ -299,6 +304,7 @@ void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLi
 }
 template void AssertLockNotHeldInternal(const char*, const char*, int, Mutex*);
 template void AssertLockNotHeldInternal(const char*, const char*, int, RecursiveMutex*);
+template void AssertLockNotHeldInternal(const char*, const char*, int, SharedMutex*);
 
 void DeleteLock(void* cs)
 {

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -11,6 +11,8 @@
 #include <util/strencodings.h>
 #include <util/threadnames.h>
 
+#include <algorithm>
+#include <iterator>
 #include <map>
 #include <mutex>
 #include <set>
@@ -78,11 +80,12 @@ private:
     bool fTry;
     std::string mutexName;
     std::string sourceFile;
-    const std::string m_thread_name;
+    std::string m_thread_name;
     int sourceLine;
 };
 
 using LockStackItem = std::pair<void*, CLockLocation>;
+static_assert(std::is_move_assignable_v<LockStackItem>);
 using LockStack = std::vector<LockStackItem>;
 using LockStacks = std::unordered_map<std::thread::id, LockStack>;
 
@@ -207,13 +210,16 @@ static void push_lock(MutexType* c, const CLockLocation& locklocation)
     }
 }
 
-static void pop_lock()
+static void pop_lock(void* mutex)
 {
     LockData& lockdata = GetLockData();
     STDLOCK(lockdata.dd_mutex);
 
     LockStack& lock_stack = lockdata.m_lock_stacks[std::this_thread::get_id()];
-    lock_stack.pop_back();
+    // Shared locks may be released out of LIFO order, so erase the newest match.
+    const auto lock_it{std::ranges::find(lock_stack.rbegin(), lock_stack.rend(), mutex, &LockStackItem::first)};
+    assert(lock_it != lock_stack.rend());
+    lock_stack.erase(std::prev(lock_it.base()));
     if (lock_stack.empty()) {
         lockdata.m_lock_stacks.erase(std::this_thread::get_id());
     }
@@ -254,9 +260,9 @@ void CheckLastCritical(void* cs, std::string& lockname, const char* guardname, c
     throw std::logic_error(strprintf("%s was not most recent critical section locked", guardname));
 }
 
-void LeaveCritical()
+void LeaveCritical(void* mutex)
 {
-    pop_lock();
+    pop_lock(mutex);
 }
 
 static std::string LocksHeld()

--- a/src/sync.h
+++ b/src/sync.h
@@ -48,7 +48,7 @@ TRY_LOCK(mutex, name);
 #ifdef DEBUG_LOCKORDER
 template <typename MutexType>
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, MutexType* cs, bool fTry = false);
-void LeaveCritical();
+void LeaveCritical(void* mutex);
 void CheckLastCritical(void* cs, std::string& lockname, const char* guardname, const char* file, int line);
 template <typename MutexType>
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -66,7 +66,7 @@ extern bool g_debug_lockorder_abort;
 #else
 template <typename MutexType>
 inline void EnterCritical(const char* pszName, const char* pszFile, int nLine, MutexType* cs, bool fTry = false) {}
-inline void LeaveCritical() {}
+inline void LeaveCritical(void* mutex) {}
 inline void CheckLastCritical(void* cs, std::string& lockname, const char* guardname, const char* file, int line) {}
 template <typename MutexType>
 inline void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(cs) {}
@@ -190,7 +190,7 @@ private:
         if (Base::try_lock()) {
             return true;
         }
-        LeaveCritical();
+        LeaveCritical(Base::mutex());
         return false;
     }
 
@@ -217,7 +217,7 @@ public:
     ~UniqueLock() UNLOCK_FUNCTION()
     {
         if (Base::owns_lock())
-            LeaveCritical();
+            LeaveCritical(Base::mutex());
     }
 
     operator bool()
@@ -241,7 +241,7 @@ public:
 
             CheckLastCritical((void*)lock.mutex(), lockname, _guardname, _file, _line);
             lock.unlock();
-            LeaveCritical();
+            LeaveCritical(lock.mutex());
             lock.swap(templock);
         }
 
@@ -281,7 +281,7 @@ struct SCOPED_LOCKABLE SharedLock : private std::shared_lock<std::shared_mutex> 
 
     ~SharedLock() UNLOCK_FUNCTION()
     {
-        if (owns_lock()) LeaveCritical();
+        if (owns_lock()) LeaveCritical(mutex());
     }
 
 private:

--- a/src/sync.h
+++ b/src/sync.h
@@ -148,6 +148,20 @@ inline void AssertLockNotHeldInline(const char* name, const char* file, int line
 inline void AssertLockNotHeldInline(const char* name, const char* file, int line, GlobalMutex* cs) LOCKS_EXCLUDED(cs) { AssertLockNotHeldInternal(name, file, line, cs); }
 #define AssertLockNotHeld(cs) AssertLockNotHeldInline(#cs, __FILE__, __LINE__, &cs)
 
+//! Register and acquire a lock, logging contention if enabled.
+template <typename LockType>
+void EnterLock(LockType& lock, const char* name, const char* file, int line)
+{
+    EnterCritical(name, file, line, lock.mutex());
+#ifdef DEBUG_LOCKCONTENTION
+    if (!lock.try_lock()) {
+        ContendedLock(name, file, line, lock);
+    }
+#else
+    lock.lock();
+#endif
+}
+
 /** Wrapper around std::unique_lock style lock for MutexType. */
 template <typename MutexType>
 class SCOPED_LOCKABLE UniqueLock : public MutexType::unique_lock
@@ -155,16 +169,9 @@ class SCOPED_LOCKABLE UniqueLock : public MutexType::unique_lock
 private:
     using Base = typename MutexType::unique_lock;
 
-    void Enter(const char* pszName, const char* pszFile, int nLine)
+    void Enter(const char* name, const char* file, int line)
     {
-        EnterCritical(pszName, pszFile, nLine, Base::mutex());
-#ifdef DEBUG_LOCKCONTENTION
-        if (!Base::try_lock()) {
-            ContendedLock(pszName, pszFile, nLine, static_cast<Base&>(*this));
-        }
-#else
-        Base::lock();
-#endif
+        EnterLock(static_cast<Base&>(*this), name, file, line);
     }
 
     bool TryEnter(const char* pszName, const char* pszFile, int nLine)

--- a/src/sync.h
+++ b/src/sync.h
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <condition_variable>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 
@@ -130,6 +131,14 @@ using RecursiveMutex = AnnotatedMixin<std::recursive_mutex>;
 /** Wrapped mutex: supports waiting but not recursive locking */
 using Mutex = AnnotatedMixin<std::mutex>;
 
+/** Wrapped mutex: supports shared and exclusive locking */
+class SharedMutex : public AnnotatedMixin<std::shared_mutex>
+{
+    using std::shared_mutex::lock_shared;
+    using std::shared_mutex::try_lock_shared;
+    using std::shared_mutex::unlock_shared;
+};
+
 /** Different type to mark Mutex at global scope
  *
  * Thread safety analysis can't handle negative assertions about mutexes
@@ -145,6 +154,7 @@ class GlobalMutex : public Mutex { };
 
 inline void AssertLockNotHeldInline(const char* name, const char* file, int line, Mutex* cs) EXCLUSIVE_LOCKS_REQUIRED(!cs) { AssertLockNotHeldInternal(name, file, line, cs); }
 inline void AssertLockNotHeldInline(const char* name, const char* file, int line, RecursiveMutex* cs) LOCKS_EXCLUDED(cs) { AssertLockNotHeldInternal(name, file, line, cs); }
+inline void AssertLockNotHeldInline(const char* name, const char* file, int line, SharedMutex* cs) LOCKS_EXCLUDED(cs) { AssertLockNotHeldInternal(name, file, line, cs); }
 inline void AssertLockNotHeldInline(const char* name, const char* file, int line, GlobalMutex* cs) LOCKS_EXCLUDED(cs) { AssertLockNotHeldInternal(name, file, line, cs); }
 #define AssertLockNotHeld(cs) AssertLockNotHeldInline(#cs, __FILE__, __LINE__, &cs)
 
@@ -260,12 +270,30 @@ public:
 // the sake of thread-safety analysis, but it is not actually used otherwise.
 #define REVERSE_LOCK(g, cs) typename std::decay<decltype(g)>::type::reverse_lock BITCOIN_UNIQUE_NAME(revlock)(g, cs, #cs, __FILE__, __LINE__)
 
+/** A SharedMutex read lock tracked by DEBUG_LOCKORDER that may outlive its scope but must be destroyed on its creating thread. */
+struct SCOPED_LOCKABLE SharedLock : private std::shared_lock<std::shared_mutex> {
+    SharedLock(SharedMutex& mutex, const char* name, const char* file, int line) SHARED_LOCK_FUNCTION(mutex) : Base{mutex, std::defer_lock}
+    {
+        EnterLock(static_cast<Base&>(*this), name, file, line);
+    }
+
+    SharedLock(SharedLock&&) noexcept = default;
+
+    ~SharedLock() UNLOCK_FUNCTION()
+    {
+        if (owns_lock()) LeaveCritical();
+    }
+
+private:
+    using Base = std::shared_lock<std::shared_mutex>;
+};
+
 // When locking a Mutex, require negative capability to ensure the lock
 // is not already held
 inline Mutex& MaybeCheckNotHeld(Mutex& cs) EXCLUSIVE_LOCKS_REQUIRED(!cs) LOCK_RETURNED(cs) { return cs; }
 inline Mutex* MaybeCheckNotHeld(Mutex* cs) EXCLUSIVE_LOCKS_REQUIRED(!cs) LOCK_RETURNED(cs) { return cs; }
 
-// When locking a GlobalMutex or RecursiveMutex, just check it is not
+// When locking a SharedMutex, GlobalMutex, or RecursiveMutex, just check it is not
 // locked in the surrounding scope.
 template <typename MutexType>
 inline MutexType& MaybeCheckNotHeld(MutexType& m) LOCKS_EXCLUDED(m) LOCK_RETURNED(m) { return m; }
@@ -279,6 +307,7 @@ inline MutexType* MaybeCheckNotHeld(MutexType* m) LOCKS_EXCLUDED(m) LOCK_RETURNE
 #define LOCK_ARGS(cs) MaybeCheckNotHeld(cs), #cs, __FILE__, __LINE__
 #define TRY_LOCK(cs, name) UniqueLock name(LOCK_ARGS(cs), true)
 #define WAIT_LOCK(cs, name) UniqueLock name(LOCK_ARGS(cs))
+#define READ_LOCK(cs) SharedLock BITCOIN_UNIQUE_NAME(shared_lock)(LOCK_ARGS(cs))
 
 //! Run code while locking a mutex.
 //!

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1088,7 +1088,7 @@ BOOST_FIXTURE_TEST_CASE(coins_db_cursor_resize, BasicTestingSetup)
 {
     CCoinsViewDB db{{.path = m_args.GetDataDirBase() / "coins_db_cursor_resize", .cache_bytes = 1_MiB, .wipe_data = true}, {}};
     auto cursor{WITH_LOCK(::cs_main, return db.Cursor())};
-    BOOST_CHECK( CoinsViewDBTestAccess::TryExclusiveLock(db)); // TODO: Cursor does not hold the DB mutex
+    BOOST_CHECK(!CoinsViewDBTestAccess::TryExclusiveLock(db));
     // Keep the cursor's DB alive to observe the resize without a LevelDB abort
     auto old_db{CoinsViewDBTestAccess::RetainOldDB(db, m_args.GetDataDirBase() / "coins_db_cursor_resize_new")};
 
@@ -1100,7 +1100,7 @@ BOOST_FIXTURE_TEST_CASE(coins_db_cursor_resize, BasicTestingSetup)
     auto status{resize.wait_for(100ms)};
     cursor.reset(); // Let ResizeCache() finish
     resize.get();
-    BOOST_CHECK_EQUAL(status, std::future_status::ready); // TODO: ResizeCache() replaces m_db while a cursor is live
+    BOOST_CHECK_EQUAL(status, std::future_status::timeout);
 }
 
 BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
@@ -1122,12 +1122,12 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     BOOST_CHECK_EQUAL(level2_files(base), 0);
     auto cursor{WITH_LOCK(::cs_main, return base.Cursor())};
     auto compaction{std::async(std::launch::async, [&] {
-        return WITH_LOCK(::cs_main, return base.CompactFullAsync());
+        return WITH_LOCK(::cs_main, return base.CompactFullAsync()); // Cursor thread cannot reacquire cs_main while holding m_db_mutex
     }).get()};
     auto status{compaction.wait_for(5s)};
     cursor.reset();
     compaction.wait();
-    BOOST_CHECK_EQUAL(status, std::future_status::ready); // TODO: Compaction is not synchronized with live cursors
+    BOOST_CHECK_EQUAL(status, std::future_status::timeout); // TODO: Compaction unnecessarily waits for live cursors
     BOOST_CHECK_EQUAL(level2_files(base), 1);
 
     BOOST_CHECK(*Assert(base.GetCoin(outpoint)) == coin);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1127,7 +1127,7 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     auto status{compaction.wait_for(5s)};
     cursor.reset();
     compaction.wait();
-    BOOST_CHECK_EQUAL(status, std::future_status::timeout); // TODO: Compaction unnecessarily waits for live cursors
+    BOOST_CHECK_EQUAL(status, std::future_status::ready);
     BOOST_CHECK_EQUAL(level2_files(base), 1);
 
     BOOST_CHECK(*Assert(base.GetCoin(outpoint)) == coin);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -17,17 +17,40 @@
 #include <util/check.h>
 #include <util/strencodings.h>
 
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <future>
+#include <latch>
 #include <map>
 #include <string>
 #include <variant>
 #include <vector>
 
-#include <boost/test/unit_test.hpp>
-
+using namespace std::chrono_literals;
 using namespace util::hex_literals;
 
 int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out);
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txundo, int nHeight);
+
+//! Test access for cursor lifetime checks
+struct CoinsViewDBTestAccess {
+    static std::unique_ptr<CDBWrapper> RetainOldDB(CCoinsViewDB& db, const fs::path& new_path)
+    {
+        db.m_db_params.path = new_path;
+        return std::move(db.m_db);
+    }
+
+    static bool TryExclusiveLock(CCoinsViewDB& db)
+    {
+        // Same-thread try_lock is UB once cursors hold a shared lock
+        const auto try_lock{[&] {
+            TRY_LOCK(db.m_db_mutex, db_lock);
+            return !!db_lock;
+        }};
+        return std::async(std::launch::async, try_lock).get();
+    }
+};
 
 namespace
 {
@@ -1061,6 +1084,25 @@ BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(coins_db_cursor_resize, BasicTestingSetup)
+{
+    CCoinsViewDB db{{.path = m_args.GetDataDirBase() / "coins_db_cursor_resize", .cache_bytes = 1_MiB, .wipe_data = true}, {}};
+    auto cursor{WITH_LOCK(::cs_main, return db.Cursor())};
+    BOOST_CHECK( CoinsViewDBTestAccess::TryExclusiveLock(db)); // TODO: Cursor does not hold the DB mutex
+    // Keep the cursor's DB alive to observe the resize without a LevelDB abort
+    auto old_db{CoinsViewDBTestAccess::RetainOldDB(db, m_args.GetDataDirBase() / "coins_db_cursor_resize_new")};
+
+    // Wait until the resize holds `cs_main` before checking whether it blocks
+    std::latch resize_started{1};
+    auto resize{std::async(std::launch::async, [&] { WITH_LOCK(::cs_main, resize_started.count_down(); db.ResizeCache(2_MiB)); })};
+    resize_started.wait();
+
+    auto status{resize.wait_for(100ms)};
+    cursor.reset(); // Let ResizeCache() finish
+    resize.get();
+    BOOST_CHECK_EQUAL(status, std::future_status::ready); // TODO: ResizeCache() replaces m_db while a cursor is live
+}
+
 BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
 {
     auto level2_files{[](CCoinsViewDB& base) {
@@ -1078,7 +1120,14 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     cache.Sync();
 
     BOOST_CHECK_EQUAL(level2_files(base), 0);
-    WITH_LOCK(::cs_main, return base.CompactFullAsync()).wait();
+    auto cursor{WITH_LOCK(::cs_main, return base.Cursor())};
+    auto compaction{std::async(std::launch::async, [&] {
+        return WITH_LOCK(::cs_main, return base.CompactFullAsync());
+    }).get()};
+    auto status{compaction.wait_for(5s)};
+    cursor.reset();
+    compaction.wait();
+    BOOST_CHECK_EQUAL(status, std::future_status::ready); // TODO: Compaction is not synchronized with live cursors
     BOOST_CHECK_EQUAL(level2_files(base), 1);
 
     BOOST_CHECK(*Assert(base.GetCoin(outpoint)) == coin);

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -5,6 +5,7 @@
 #include <cuckoocache.h>
 #include <random.h>
 #include <script/sigcache.h>
+#include <sync.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/byte_units.h>
@@ -12,8 +13,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <deque>
-#include <mutex>
-#include <shared_mutex>
 #include <thread>
 #include <vector>
 
@@ -206,11 +205,11 @@ void test_cache_erase_parallel(size_t bytes)
      * "future proofed".
      */
     std::vector<uint256> hashes_insert_copy = hashes;
-    std::shared_mutex mtx;
+    SharedMutex mtx;
 
     {
         /** Grab lock to make sure we release inserts */
-        std::unique_lock<std::shared_mutex> l(mtx);
+        LOCK(mtx);
         /** Insert the first half */
         for (uint32_t i = 0; i < (n_insert / 2); ++i)
             set.insert(hashes_insert_copy[i]);
@@ -225,7 +224,7 @@ void test_cache_erase_parallel(size_t bytes)
         /** Each thread is emplaced with x copy-by-value
         */
         threads.emplace_back([&, x] {
-            std::shared_lock<std::shared_mutex> l(mtx);
+            READ_LOCK(mtx);
             size_t ntodo = (n_insert/4)/3;
             size_t start = ntodo*x;
             size_t end = ntodo*(x+1);
@@ -240,7 +239,7 @@ void test_cache_erase_parallel(size_t bytes)
     for (std::thread& t : threads)
         t.join();
     /** Grab lock to make sure we observe erases */
-    std::unique_lock<std::shared_mutex> l(mtx);
+    LOCK(mtx);
     /** Insert the second half */
     for (uint32_t i = (n_insert / 2); i < n_insert; ++i)
         set.insert(hashes_insert_copy[i]);

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 
@@ -157,6 +158,33 @@ BOOST_AUTO_TEST_CASE(shared_mutex)
     }
     AssertLockNotHeld(shared.mutex);
     BOOST_CHECK(LockStackEmpty());
+}
+
+BOOST_AUTO_TEST_CASE(shared_lock_outlives_outer_lock)
+{
+#ifdef DEBUG_LOCKORDER
+    const bool prev{g_debug_lockorder_abort};
+    g_debug_lockorder_abort = false;
+#endif
+
+    {
+        Mutex outer_mutex;
+        auto outer_lock{std::make_unique<UniqueLock<Mutex>>(LOCK_ARGS(outer_mutex))};
+        SharedMutex shared_mutex;
+        SharedLock shared_lock{LOCK_ARGS(shared_mutex)};
+        outer_lock.reset();
+        const auto relock{[&] { LOCK(outer_mutex); }};
+#ifdef DEBUG_LOCKORDER
+        BOOST_CHECK_EXCEPTION(relock(), std::logic_error, HasReason("potential deadlock detected"));
+#else
+        BOOST_CHECK_NO_THROW(relock());
+#endif
+    }
+    BOOST_CHECK(LockStackEmpty());
+
+#ifdef DEBUG_LOCKORDER
+    g_debug_lockorder_abort = prev;
+#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -139,4 +139,24 @@ BOOST_AUTO_TEST_CASE(inconsistent_lock_order_detected)
 #endif // DEBUG_LOCKORDER
 }
 
+BOOST_AUTO_TEST_CASE(shared_mutex)
+{
+    struct {
+        SharedMutex mutex;
+        int value GUARDED_BY(mutex){0};
+    } shared;
+
+    AssertLockNotHeld(shared.mutex);
+    WITH_LOCK(shared.mutex, AssertLockHeld(shared.mutex); shared.value = 1); // Exclusive lock permits guarded writes
+    {
+        READ_LOCK(shared.mutex); // Shared lock permits the guarded read below
+#ifdef DEBUG_LOCKORDER
+        BOOST_CHECK(!LockStackEmpty());
+#endif
+        BOOST_CHECK_EQUAL(shared.value, 1);
+    }
+    AssertLockNotHeld(shared.mutex);
+    BOOST_CHECK(LockStackEmpty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -72,10 +72,11 @@ CCoinsViewDB::~CCoinsViewDB()
 
 void CCoinsViewDB::ResizeCache(size_t new_cache_size)
 {
+    AssertLockHeld(::cs_main);
     // We can't do this operation with an in-memory DB since we'll lose all the coins upon
     // reset.
     if (!m_db_params.memory_only) {
-        LOCK(m_db_mutex);
+        LOCK(m_db_mutex); // Wait for cursors and compaction
         // Have to do a reset first to get the original `m_db` state to release its
         // filesystem lock.
         m_db.reset();
@@ -220,9 +221,9 @@ class CCoinsViewDBCursor: public CCoinsViewCursor
 public:
     // Prefer using CCoinsViewDB::Cursor() since we want to perform some
     // cache warmup on instantiation.
-    CCoinsViewDBCursor(CDBIterator* pcursorIn, const uint256& in_block_hash):
-        CCoinsViewCursor(in_block_hash), pcursor(pcursorIn) {}
-    ~CCoinsViewDBCursor() = default;
+    CCoinsViewDBCursor(CDBIterator* cursor, const uint256& block_hash, SharedLock db_lock)
+        : CCoinsViewCursor{block_hash}, m_db_lock{std::move(db_lock)}, pcursor{cursor} {}
+    ~CCoinsViewDBCursor() override { pcursor.reset(); } // Destroy iterator before releasing m_db_lock
 
     bool GetKey(COutPoint &key) const override;
     bool GetValue(Coin &coin) const override;
@@ -231,6 +232,7 @@ public:
     void Next() override;
 
 private:
+    SharedLock m_db_lock;
     std::unique_ptr<CDBIterator> pcursor;
     std::pair<char, COutPoint> keyTmp;
 
@@ -239,8 +241,9 @@ private:
 
 std::unique_ptr<CCoinsViewCursor> CCoinsViewDB::Cursor() const
 {
+    SharedLock db_lock{LOCK_ARGS(m_db_mutex)};
     auto i = std::make_unique<CCoinsViewDBCursor>(
-        const_cast<CDBWrapper&>(*m_db).NewIterator(), GetBestBlock());
+        const_cast<CDBWrapper&>(*m_db).NewIterator(), GetBestBlock(), std::move(db_lock));
     /* It seems that there are no "const iterators" for LevelDB.  Since we
        only need read operations on it, use a const-cast to get around
        that restriction.  */

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -203,8 +203,7 @@ std::shared_future<void> CCoinsViewDB::CompactFullAsync()
     m_compaction = std::async(std::launch::async, [this] {
         try {
             util::ThreadRename("utxocompact");
-            LOCK(m_db_mutex);
-
+            SharedLock db_lock{LOCK_ARGS(m_db_mutex)}; // Coexists with cursors and protects m_db lifetime
             LogDebug(BCLog::COINDB, "Starting chainstate compaction of %s", fs::PathToString(m_db_params.path));
             m_db->CompactFull();
             LogDebug(BCLog::COINDB, "Finished chainstate compaction of %s", fs::PathToString(m_db_params.path));

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -40,9 +40,9 @@ class CCoinsViewDB final : public CCoinsView
 protected:
     DBParams m_db_params;
     CoinsViewOptions m_options;
-    mutable SharedMutex m_db_mutex; //!< Shared by cursors, exclusive for resize or compaction
+    mutable SharedMutex m_db_mutex; //!< Shared by cursors and compaction, exclusive for resize
     std::unique_ptr<CDBWrapper> m_db;
-    std::shared_future<void> m_compaction;
+    std::shared_future<void> m_compaction GUARDED_BY(::cs_main); //!< Destructor has exclusive access
 public:
     explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
     ~CCoinsViewDB() override;
@@ -60,7 +60,7 @@ public:
     bool NeedsUpgrade();
     size_t EstimateSize() const override;
 
-    //! Resize the LevelDB cache after live cursors finish.
+    //! Resize the LevelDB cache after live cursors and compaction finish.
     void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
 
     //! Perform a full compaction of the underlying LevelDB on a one-shot background thread.

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -40,8 +40,7 @@ class CCoinsViewDB final : public CCoinsView
 protected:
     DBParams m_db_params;
     CoinsViewOptions m_options;
-    //! Prevents CompactFull() from using m_db while ResizeCache() replaces it.
-    Mutex m_db_mutex;
+    mutable SharedMutex m_db_mutex; //!< Shared by cursors, exclusive for resize or compaction
     std::unique_ptr<CDBWrapper> m_db;
     std::shared_future<void> m_compaction;
 public:
@@ -54,14 +53,14 @@ public:
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override;
-    //! Get a cursor to iterate over the whole state.
-    std::unique_ptr<CCoinsViewCursor> Cursor() const;
+    //! A cursor must not outlive its DB or leave its creating thread. That thread cannot lock cs_main or open another cursor for this DB.
+    std::unique_ptr<CCoinsViewCursor> Cursor() const EXCLUSIVE_LOCKS_REQUIRED(!m_db_mutex);
 
     //! Whether an unsupported database format is used.
     bool NeedsUpgrade();
     size_t EstimateSize() const override;
 
-    //! Dynamically alter the underlying leveldb cache size.
+    //! Resize the LevelDB cache after live cursors finish.
     void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
 
     //! Perform a full compaction of the underlying LevelDB on a one-shot background thread.

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -35,6 +35,8 @@ struct CoinsViewOptions {
 /** CCoinsView backed by the coin database (chainstate/) */
 class CCoinsViewDB final : public CCoinsView
 {
+    friend struct CoinsViewDBTestAccess;
+
 protected:
     DBParams m_db_params;
     CoinsViewOptions m_options;


### PR DESCRIPTION
**Problem:** `gettxoutsetinfo`, `scantxoutset`, and `dumptxoutset` retain LevelDB iterators after releasing `cs_main`.
While those iterators are live, AssumeUTXO cache rebalancing can call `ResizeCache()`, replace `m_db`, and cause LevelDB to abort.
The issue was [reported during review of #35465](https://github.com/bitcoin/bitcoin/pull/35465#discussion_r3428902672).

**Fix:** Each cursor holds a shared lock on `m_db_mutex` for its lifetime.
Compaction takes the same shared lock, allowing it to run alongside cursors.
`ResizeCache()` takes `m_db_mutex` exclusively, so it waits for their shared locks to be released before replacing `m_db`.
`ResizeCache()` holds `cs_main` while it waits, so a long-running UTXO scan can stall validation during cache rebalancing.

<details>
<summary>Historical test failures without the fix</summary>

```text
test/coins_tests.cpp:1090: error: in "coins_tests/coins_db_cursor_resize": check !CCoinsViewDBTestAccess::TryExclusiveLock(db) has failed
test/coins_tests.cpp:1102: error: in "coins_tests/coins_db_cursor_resize": check status == std::future_status::timeout has failed [0 != 1]
```
</details>