### PR TITLE
net: use `__has_include` to narrow `__APPLE__` guards

### DIFF
--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -18,7 +18,7 @@
 #include <netlink/netlink_route.h>
 #elif defined(WIN32)
 #include <iphlpapi.h>
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && __has_include(<net/route.h>)
 #include <net/route.h>
 #include <sys/sysctl.h>
 #endif
@@ -217,7 +217,7 @@ std::optional<CNetAddr> QueryDefaultGatewayImpl(sa_family_t family)
     return std::nullopt;
 }
 
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && __has_include(<net/route.h>)
 
 #define ROUNDUP32(a) \
     ((a) > 0 ? (1 + (((a) - 1) | (sizeof(uint32_t) - 1))) : sizeof(uint32_t))


### PR DESCRIPTION
The `__APPLE__` macro is defined on all Apple platforms, but only the macOS SDK ships `<net/route.h>`. Use `__has_include(<net/route.h>)` to compile the route-table code only where its header exists, the same idiom `randomenv.cpp` and `util/threadnames.cpp` use for system headers, so unsupported platforms use the existing dummy implementation (`return std::nullopt`).

No behavior change on any currently built platform; no CI changes are requested.

**This PR does not add support for iOS or any other Apple platform.** SDKs without `<net/route.h>` remain unsupported; they now reach the file's existing [dummy implementation](https://github.com/bitcoin/bitcoin/blob/44e7750b3e43bda48622092ca422f4dece1253ae/src/common/netif.cpp#L277-L285) instead of failing on an include their SDK does not ship.

## Reproduction (any Mac with Xcode installed)

### unsupported platform

```bash
echo '#include <net/route.h>' | xcrun --sdk iphoneos clang -x c++ -fsyntax-only -
# <stdin>:1:10: fatal error: 'net/route.h' file not found
```

### macOS

```bash
echo '#include <net/route.h>' | xcrun --sdk macosx clang -x c++ -fsyntax-only -
# no output == success
```

## What I tested

```bash
# fresh configure, Xcode 26.6, Boost 1.90; builds cleanly
cmake --build build -j
# 100% tests passed out of 351
ctest --test-dir build -j
```