### PR TITLE
ci: Test build directory path with spaces

### DIFF
--- a/.github/actions/configure-environment/action.yml
+++ b/.github/actions/configure-environment/action.yml
@@ -7,7 +7,9 @@ runs:
       shell: bash
       run: |
         echo "BASE_ROOT_DIR=${{ runner.temp }}" >> "$GITHUB_ENV"
-        echo "BASE_BUILD_DIR=${{ runner.temp }}/build" >> "$GITHUB_ENV"
+        # Space and non-ASCII symbols mimic BASE_SCRATCH_DIR in ci/test/00_setup_env.sh,
+        # to test word-splitting and UTF-8 path handling on CI.
+        echo "BASE_BUILD_DIR=${{ runner.temp }}/build_ ₿🧪_" >> "$GITHUB_ENV"
         echo "CCACHE_DIR=${{ runner.temp }}/ccache_dir" >> $GITHUB_ENV
         echo "DEPENDS_DIR=${{ runner.temp }}/depends" >> "$GITHUB_ENV"
         echo "BASE_CACHE=${{ runner.temp }}/depends/built" >> $GITHUB_ENV

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -72,19 +72,19 @@ ShowUninstDetails show
 Section -Main SEC0000
     SetOutPath $INSTDIR
     SetOverwrite on
-    File @BIN_DIR@/@BITCOIN_GUI_NAME@@EXEEXT@
-    File @BIN_DIR@/@BITCOIN_WRAPPER_NAME@@EXEEXT@
-    File /oname=COPYING.txt @abs_top_srcdir@/COPYING
-    File /oname=readme.txt @abs_top_srcdir@/doc/README_windows.txt
-    File @abs_top_srcdir@/share/examples/bitcoin.conf
+    File "@BIN_DIR@/@BITCOIN_GUI_NAME@@EXEEXT@"
+    File "@BIN_DIR@/@BITCOIN_WRAPPER_NAME@@EXEEXT@"
+    File /oname=COPYING.txt "@abs_top_srcdir@/COPYING"
+    File /oname=readme.txt "@abs_top_srcdir@/doc/README_windows.txt"
+    File "@abs_top_srcdir@/share/examples/bitcoin.conf"
     SetOutPath $INSTDIR\share\rpcauth
-    File @abs_top_srcdir@/share/rpcauth/*.*
+    File "@abs_top_srcdir@/share/rpcauth/*.*"
     SetOutPath $INSTDIR\daemon
-    File @BIN_DIR@/@BITCOIN_DAEMON_NAME@@EXEEXT@
-    File @BIN_DIR@/@BITCOIN_CLI_NAME@@EXEEXT@
-    File @BIN_DIR@/@BITCOIN_TX_NAME@@EXEEXT@
-    File @BIN_DIR@/@BITCOIN_WALLET_TOOL_NAME@@EXEEXT@
-    File @LIBEXEC_DIR@/@BITCOIN_TEST_NAME@@EXEEXT@
+    File "@BIN_DIR@/@BITCOIN_DAEMON_NAME@@EXEEXT@"
+    File "@BIN_DIR@/@BITCOIN_CLI_NAME@@EXEEXT@"
+    File "@BIN_DIR@/@BITCOIN_TX_NAME@@EXEEXT@"
+    File "@BIN_DIR@/@BITCOIN_WALLET_TOOL_NAME@@EXEEXT@"
+    File "@LIBEXEC_DIR@/@BITCOIN_TEST_NAME@@EXEEXT@"
     SetOutPath $INSTDIR
     WriteRegStr HKCU "${REGKEY}\Components" Main 1
 SectionEnd


### PR DESCRIPTION
The CI scratch directory contains a space and non-ASCII symbols to test path handling (see #34614). However, the GHA workflows [override](https://github.com/bitcoin/bitcoin/blob/18c05d93016b28a9afd4c716dfe00b6e0accb30b/.github/actions/configure-environment/action.yml#L10) `BASE_BUILD_DIR` to `${{ runner.temp }}/build` via the `configure-environment` action, bypassing the `$BASE_SCRATCH_DIR/build-$HOST` [default](https://github.com/bitcoin/bitcoin/blob/18c05d93016b28a9afd4c716dfe00b6e0accb30b/ci/test/03_test_script.sh#L109-L110) from `03_test_script.sh`.

The first commit fixes the NSIS template, which otherwise breaks the `deploy` target when paths contain spaces.

Related to #35356.