### PR TITLE
wallet: Fix FillPSBT failing to sign owned inputs when UTXOs disagree

### DIFF
--- a/src/psbt.h
+++ b/src/psbt.h
@@ -330,6 +330,11 @@ public:
     /**
      * Retrieves the UTXO for this input
      *
+     * Prefers non_witness_utxo when present and usable. Falls back to
+     * witness_utxo only if non_witness_utxo is absent. Returns false if
+     * neither can be used (including when non_witness_utxo is present but
+     * does not match this input).
+     *
      * @param[out] utxo The UTXO of this input
      * @return Whether the UTXO could be retrieved
      */

--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -216,4 +216,48 @@ BOOST_AUTO_TEST_CASE(merge_proprietary_fields)
     BOOST_CHECK(output_it->value == right_prop.value);
 }
 
+BOOST_AUTO_TEST_CASE(psbt2_getutxo)
+{
+    CMutableTransaction mtx;
+    mtx.vout = {CTxOut{100, CScript()}};
+    const auto tx{MakeTransactionRef(mtx)};
+
+    PSBTInput psbt_in(/*psbt_version=*/2, tx->GetHash(), /*prev_out=*/0);
+    psbt_in.non_witness_utxo = tx;
+    CTxOut utxo;
+
+    // Reject OOB prev_out
+    psbt_in.prev_out = 1;
+    BOOST_CHECK(!psbt_in.GetUTXO(utxo));
+
+    // Reject mismatched prev_txid
+    psbt_in.prev_out = 0;
+    psbt_in.prev_txid = Txid::FromUint256(uint256::ONE);
+    BOOST_CHECK(!psbt_in.GetUTXO(utxo));
+
+    // Accept valid non_witness_utxo
+    psbt_in.prev_txid = tx->GetHash();
+    BOOST_CHECK(psbt_in.GetUTXO(utxo));
+    BOOST_CHECK_EQUAL(utxo.nValue, 100);
+
+    // Fall back to witness_utxo when non_witness_utxo is absent
+    psbt_in.non_witness_utxo.reset();
+    psbt_in.witness_utxo = CTxOut{50, CScript()};
+    BOOST_CHECK(psbt_in.GetUTXO(utxo));
+    BOOST_CHECK_EQUAL(utxo.nValue, 50);
+
+    // Reject when both utxo types are absent
+    psbt_in.witness_utxo.SetNull();
+    BOOST_CHECK(!psbt_in.GetUTXO(utxo));
+
+    // Prefer verified non_witness_utxo when both are present
+    psbt_in.non_witness_utxo = tx;
+    psbt_in.witness_utxo = CTxOut{50, CScript()};
+    BOOST_CHECK(psbt_in.GetUTXO(utxo));
+    BOOST_CHECK_EQUAL(utxo.nValue, 100);
+
+    // Do not fall through to witness_utxo when non_witness_utxo is invalid
+    psbt_in.prev_txid = Txid::FromUint256(uint256::ONE);
+    BOOST_CHECK(!psbt_in.GetUTXO(utxo));
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1369,18 +1369,15 @@ std::optional<PSBTError> DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTran
         }
 
         // Get the scriptPubKey to know which SigningProvider to use
-        CScript script;
-        if (!input.witness_utxo.IsNull()) {
-            script = input.witness_utxo.scriptPubKey;
-        } else if (input.non_witness_utxo) {
-            if (input.prev_out >= input.non_witness_utxo->vout.size()) {
+        CTxOut utxo;
+        if (!input.GetUTXO(utxo)) {
+            if (input.non_witness_utxo) {
                 return PSBTError::MISSING_INPUTS;
             }
-            script = input.non_witness_utxo->vout[input.prev_out].scriptPubKey;
-        } else {
             // There's no UTXO so we can just skip this now
             continue;
         }
+        const CScript& script = utxo.scriptPubKey;
 
         std::unique_ptr<FlatSigningProvider> keys = std::make_unique<FlatSigningProvider>();
         std::unique_ptr<FlatSigningProvider> script_keys = GetSigningProvider(script, /*include_private=*/options.sign);

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -2,14 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <key.h>
 #include <key_io.h>
 #include <node/types.h>
+#include <psbt.h>
+#include <script/script.h>
 #include <util/bip32.h>
 #include <util/strencodings.h>
 #include <wallet/wallet.h>
 
 #include <boost/test/unit_test.hpp>
 #include <test/util/setup_common.h>
+#include <wallet/test/util.h>
 #include <wallet/test/wallet_test_fixture.h>
 
 using namespace util::hex_literals;
@@ -77,6 +81,42 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
     // Try to sign the mutated input
     SignatureData sigdata;
     BOOST_CHECK(m_wallet.FillPSBT(psbtx, {.sign = true, .bip32_derivs = true}, complete));
+}
+
+BOOST_AUTO_TEST_CASE(fillpsbt_signs_despite_conflicting_witness_utxo)
+{
+    LOCK(m_wallet.cs_wallet);
+
+    // Import descriptor for the signing key
+    CKey key{GenerateRandomKey()};
+    CKey bad_key{GenerateRandomKey()};
+    CreateDescriptor(m_wallet, /*desc_str=*/"wpkh(" + EncodeSecret(key) + ")", /*success=*/true);
+
+    // Create wallet UTXO and a bad witness_utxo for the input
+    const CScript spk{GetScriptForDestination(WitnessV0KeyHash(key.GetPubKey()))};
+    const CScript bad_spk{GetScriptForDestination(WitnessV0KeyHash(bad_key.GetPubKey()))};
+    const CTxOut non_witness_utxo{100, spk};
+    const CTxOut witness_utxo{100, bad_spk};
+
+    // Create prev_tx with the matching output
+    CMutableTransaction prev;
+    prev.vout = {non_witness_utxo};
+    const CTransactionRef prev_tx{MakeTransactionRef(prev)};
+
+    // Build a spend transaction
+    CMutableTransaction spend;
+    spend.vin = {CTxIn{prev_tx->GetHash(), /*nOut=*/0}};
+    spend.vout = {CTxOut{50, CScript()}};
+
+    // Attach both UTXOs to the PSBT
+    PartiallySignedTransaction psbt(spend, /*version=*/2);
+    psbt.inputs[0].non_witness_utxo = prev_tx;
+    psbt.inputs[0].witness_utxo = witness_utxo;
+
+    // Sign should succeed using non_witness_utxo despite the conflict
+    bool complete{false};
+    BOOST_REQUIRE(!m_wallet.FillPSBT(psbt, /*options=*/{.sign = true}, /*complete=*/complete));
+    BOOST_CHECK(complete);
 }
 
 BOOST_AUTO_TEST_CASE(parse_hd_keypath)

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -2,13 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <key.h>
 #include <key_io.h>
 #include <node/types.h>
+#include <psbt.h>
+#include <script/script.h>
 #include <util/strencodings.h>
 #include <wallet/wallet.h>
 
 #include <boost/test/unit_test.hpp>
 #include <test/util/setup_common.h>
+#include <wallet/test/util.h>
 #include <wallet/test/wallet_test_fixture.h>
 
 using namespace util::hex_literals;
@@ -76,6 +80,42 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
     // Try to sign the mutated input
     SignatureData sigdata;
     BOOST_CHECK(m_wallet.FillPSBT(psbtx, {.sign = true, .bip32_derivs = true}, complete));
+}
+
+BOOST_AUTO_TEST_CASE(fillpsbt_signs_despite_conflicting_witness_utxo)
+{
+    LOCK(m_wallet.cs_wallet);
+
+    // Import descriptor for the signing key
+    const CKey key{GenerateRandomKey()};
+    const CKey bad_key{GenerateRandomKey()};
+    CreateDescriptor(m_wallet, /*desc_str=*/"wpkh(" + EncodeSecret(key) + ")", /*success=*/true);
+
+    // Create wallet UTXO and a bad witness_utxo for the input
+    const CScript spk{GetScriptForDestination(WitnessV0KeyHash(key.GetPubKey()))};
+    const CScript bad_spk{GetScriptForDestination(WitnessV0KeyHash(bad_key.GetPubKey()))};
+    const CTxOut non_witness_utxo{100, spk};
+    const CTxOut witness_utxo{100, bad_spk};
+
+    // Create prev_tx with the matching output
+    CMutableTransaction prev;
+    prev.vout = {non_witness_utxo};
+    const CTransactionRef prev_tx{MakeTransactionRef(prev)};
+
+    // Build a spend transaction
+    CMutableTransaction spend;
+    spend.vin = {CTxIn{prev_tx->GetHash(), /*nOut=*/0}};
+    spend.vout = {CTxOut{50, CScript()}};
+
+    // Attach both UTXOs to the PSBT
+    PartiallySignedTransaction psbt(spend, /*version=*/2);
+    psbt.inputs[0].non_witness_utxo = prev_tx;
+    psbt.inputs[0].witness_utxo = witness_utxo;
+
+    // Sign should succeed using non_witness_utxo despite the conflict
+    bool complete{false};
+    BOOST_REQUIRE(!m_wallet.FillPSBT(psbt, /*options=*/{.sign = true}, complete));
+    BOOST_CHECK(complete);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### tl;dr

Previously, the wallet could fail to sign an intended spend when an input's `non_witness_utxo` and `witness_utxo` disagreed.
This PR fixes `FillPSBT` by routing its UTXO-selection logic through `GetUTXO`.

### Problem

A PSBT input can carry both a `non_witness_utxo` and a `witness_utxo`. `GetUTXO` prefers a verified `non_witness_utxo` and does **not** fall back to `witness_utxo` when the `non_witness_utxo` is present but unusable.

Previously, `FillPSBT` selected the `SigningProvider` from the `witness_utxo` whenever it was set. When the two disagreed, `FillPSBT` loaded keys for the `witness_utxo` script while `SignPSBTInput` signed the `non_witness_utxo` spend. This could lead to an incomplete input even though the wallet owns the appropriate `non_witness_utxo` script. 

### Fix

Route `FillPSBT` through `GetUTXO` so it shares `SignPSBTInput`'s prefer/reject rule.

### Behavior change

`FillPSBT` now uses `GetUTXO` for script selection, so an input whose `non_witness_utxo` is present but unusable (out-of-range or txid-mismatched) returns `MISSING_INPUTS` instead of first selecting a script from `witness_utxo`.

`SignPSBTInput` rejects the same input with `MISSING_INPUTS`, and `FillPSBT` already propagates any non-`INCOMPLETE` error for the remaining `ScriptPubKeyMan`s and inputs. The change is that the failure is detected at script selection rather than after a mistaken key lookup.

Well-formed PSBTs are unaffected, since `witness_utxo` and `non_witness_utxo` resolve to the same script. Txid handling is also tightened in the selection path. A txid-mismatched `non_witness_utxo` is now rejected by `GetUTXO` rather than used for script selection when no `witness_utxo` is present.

### Testing

`fillpsbt_signs_despite_conflicting_witness_utxo` covers the regression. `psbt2_getutxo` pins the `GetUTXO` prefer/reject rules the fix relies on.

### Follow-up

`SignPSBTInput`, `PSBTInputSignedAndVerified`, and `decodepsbt` fee totaling still reimplement `GetUTXO`'s logic and risk the same divergence. Refactoring them is left for a follow-up.