### PR TITLE
addrman: make `m_last_good` network-specific

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -610,7 +610,7 @@ bool AddrManImpl::Good_(const CService& addr, bool test_before_evict, NodeSecond
 
     nid_type nId;
 
-    m_last_good = time;
+    m_last_good[addr.GetNetwork()] = time;
 
     AddrInfo* pinfo = Find(addr, &nId);
 
@@ -685,7 +685,7 @@ void AddrManImpl::Attempt_(const CService& addr, bool fCountFailure, NodeSeconds
 
     // update info
     info.m_last_try = time;
-    if (fCountFailure && info.m_last_count_attempt < m_last_good) {
+    if (fCountFailure && info.m_last_count_attempt < m_last_good[info.GetNetwork()]) {
         info.m_last_count_attempt = time;
         info.nAttempts++;
     }

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -14,6 +14,7 @@
 #include <util/log.h>
 #include <util/time.h>
 
+#include <array>
 #include <cstdint>
 #include <optional>
 #include <set>
@@ -211,10 +212,10 @@ private:
     //! list of "new" buckets
     nid_type vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE] GUARDED_BY(cs);
 
-    //! last time Good was called (memory only). While unset, no connection failures
+    //! last time Good was called, per network (memory only). While unset, no connection failures
     //! are counted, because we have no evidence that it is due to them instead of
-    //! our connectivity.
-    NodeSeconds m_last_good GUARDED_BY(cs){0s};
+    //! our connectivity for that network.
+    std::array<NodeSeconds, NET_MAX> m_last_good GUARDED_BY(cs){};
 
     //! Holds addrs inserted into tried table that collide with existing entries. Test-before-evict discipline used to resolve these collisions.
     std::set<nid_type> m_tried_collisions;

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -211,8 +211,10 @@ private:
     //! list of "new" buckets
     nid_type vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE] GUARDED_BY(cs);
 
-    //! last time Good was called (memory only). Initially set to 1 so that "never" is strictly worse.
-    NodeSeconds m_last_good GUARDED_BY(cs){1s};
+    //! last time Good was called (memory only). While unset, no connection failures
+    //! are counted, because we have no evidence that it is due to them instead of
+    //! our connectivity.
+    NodeSeconds m_last_good GUARDED_BY(cs){0s};
 
     //! Holds addrs inserted into tried table that collide with existing entries. Test-before-evict discipline used to resolve these collisions.
     std::set<nid_type> m_tried_collisions;

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -129,6 +130,59 @@ BOOST_AUTO_TEST_CASE(addrman_terrible_many_failures)
     BOOST_CHECK_EQUAL(unfiltered.size(), 2U);
 }
 
+BOOST_AUTO_TEST_CASE(addrman_failures_counted_per_network)
+{
+    // Failed attempts are only counted against an address once we have proof that we are
+    // able to reach its network at all.
+    FakeNodeClock clock{};
+
+    auto addrman{std::make_unique<AddrMan>(EMPTY_NETGROUPMAN, DETERMINISTIC, GetCheckRatio(m_node))};
+
+    CNetAddr source{ResolveIP("250.1.2.1")};
+
+    CAddress addr_ipv6{CAddress(ResolveService("2a01::1", 8333), NODE_NONE)};
+    addr_ipv6.nTime = Now<NodeSeconds>();
+    BOOST_CHECK(addrman->Add({addr_ipv6}, source));
+    BOOST_CHECK(addrman->Good(addr_ipv6));
+
+    // Helpers used to keep recording successful connections on either network
+    CAddress addr_ipv4_helper{CAddress(ResolveService("250.250.2.1", 8333), NODE_NONE)};
+    addr_ipv4_helper.nTime = Now<NodeSeconds>();
+    BOOST_CHECK(addrman->Add({addr_ipv4_helper}, source));
+
+    CAddress addr_ipv6_helper{CAddress(ResolveService("2a01::2", 8333), NODE_NONE)};
+    addr_ipv6_helper.nTime = Now<NodeSeconds>();
+    BOOST_CHECK(addrman->Add({addr_ipv6_helper}, source));
+
+    // Advance time so that only the number of attempts decides
+    // whether addr_ipv6 is terrible.
+    clock += ADDRMAN_MIN_FAIL + 24h;
+
+    // IPv6 is now unreachable, while IPv4 keeps working.
+    for (int i = 0; i < ADDRMAN_MAX_FAILURES; ++i) {
+        addrman->Good(addr_ipv4_helper);
+        addrman->Attempt(addr_ipv6, /*fCountFailure=*/true);
+        // Let more than a minute pass between attempts, so that the
+        //"tried in the last minute" check doesn't strike.
+        clock += 61s;
+    }
+
+    // The IPv4 successes do not count towards the failures against addr_ipv6:
+    // it is not terrible and is still relayed.
+    BOOST_CHECK_EQUAL(addrman->GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/std::nullopt).size(), 3U);
+
+    // Once we can reach IPv6 again, failures on it are counted as before.
+    for (int i = 0; i < ADDRMAN_MAX_FAILURES; ++i) {
+        addrman->Good(addr_ipv6_helper);
+        addrman->Attempt(addr_ipv6, /*fCountFailure=*/true);
+        clock += 61s;
+    }
+
+    std::vector<CAddress> filtered{addrman->GetAddr(/*max_addresses=*/0, /*max_pct=*/0, /*network=*/std::nullopt)};
+    BOOST_CHECK_EQUAL(filtered.size(), 2U);
+    BOOST_CHECK(std::none_of(filtered.begin(), filtered.end(),
+                             [&](const CAddress& a) { return a == addr_ipv6; }));
+}
 
 BOOST_AUTO_TEST_CASE(addrman_penalty_self_announcement)
 {


### PR DESCRIPTION
`m_last_good` is used to prevent recording failed attempts for addresses when it is our connectivity that is at fault.
However, it is quite common that only some networks are unreachable - e.g. I have encountered it frequently that `IPv6` is unreachable, while `IPv4` works fine. In this case it is not correct to increase the failed counter for an `IPv6` address  and ultimately making it `Terrible`, just because we are making `IPv4` connections.

Fix this by making `m_last_good` network-specific. 
Also change the initial value from 1 to 0, so that in a situation when there was no previous attempt for an address, but also no previous successful connection to its network, the failed count is not increased. The intial value was not a major issue previously because we would [only count failures](https://github.com/bitcoin/bitcoin/blob/18c05d93016b28a9afd4c716dfe00b6e0accb30b/src/net.cpp#L2935-L2939) after having at least two outbound connections (in which case `m_last_good` would have been set).