### PR TITLE
validation: use parallel input prevout fetching in TestBlockValidity

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -17,7 +17,9 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <ranges>
 #include <vector>
 
 using node::BlockCreateOptions;
@@ -32,14 +34,15 @@ static void AssembleBlock(benchmark::Bench& bench)
         .coinbase_output_script = P2WSH_OP_TRUE,
     };
 
-    // Collect some loose transactions that spend the coinbases of our mined blocks
+    // Collect fan-out transactions that split the coinbases of our mined blocks
     constexpr size_t NUM_BLOCKS{200};
+    constexpr uint32_t FAN_OUT{100};
     std::array<CTransactionRef, NUM_BLOCKS - COINBASE_MATURITY + 1> txs;
     for (size_t b{0}; b < NUM_BLOCKS; ++b) {
         CMutableTransaction tx;
         tx.vin.emplace_back(MineBlock(test_setup->m_node, options));
         tx.vin.back().scriptWitness = witness;
-        tx.vout.emplace_back(1337, P2WSH_OP_TRUE);
+        tx.vout.assign(FAN_OUT, CTxOut{100'000, P2WSH_OP_TRUE});
         if (NUM_BLOCKS - b >= COINBASE_MATURITY)
             txs.at(b) = MakeTransactionRef(tx);
     }
@@ -49,6 +52,26 @@ static void AssembleBlock(benchmark::Bench& bench)
         for (const auto& txr : txs) {
             const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(txr);
             assert(res.m_result_type == MempoolAcceptResult::ResultType::VALID);
+        }
+    }
+
+    // Mine a block confirming the fan-out transactions, so the loose transactions
+    // below spend coins that already exist in the UTXO set
+    MineBlock(test_setup->m_node, options);
+
+    // Collect loose transactions spending the fan-out outputs to fill the assembled block
+    {
+        LOCK(::cs_main);
+
+        for (const auto& txr : txs) {
+            for (const uint32_t o : std::views::iota(uint32_t{0}, FAN_OUT)) {
+                CMutableTransaction tx;
+                tx.vin.emplace_back(COutPoint{txr->GetHash(), o});
+                tx.vin.back().scriptWitness = witness;
+                tx.vout.emplace_back(1337, P2WSH_OP_TRUE);
+                const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(MakeTransactionRef(tx));
+                assert(res.m_result_type == MempoolAcceptResult::ResultType::VALID);
+            }
         }
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3052,7 +3052,7 @@ bool Chainstate::ConnectTip(
     LogDebug(BCLog::BENCH, "  - Load block from disk: %.2fms\n",
              Ticks<MillisecondsDouble>(time_2 - time_1));
     {
-        CoinsViewOverlay& view{*m_coins_views->m_connect_block_view};
+        CoinsViewOverlay& view{ConnectBlockView()};
         const auto reset_guard{view.StartFetching(*block_to_connect)};
         bool rv = ConnectBlock(*block_to_connect, state, pindexNew, view);
         if (m_chainman.m_options.signals) {
@@ -4535,17 +4535,18 @@ BlockValidationState TestBlockValidity(
         return state;
     }
 
-    // We don't want ConnectBlock to update the actual chainstate, so create
-    // a cache on top of it, along with a dummy block index.
+    // We don't want ConnectBlock to update the actual chainstate, so use the
+    // reusable overlay view on top of it, along with a dummy block index.
     CBlockIndex index_dummy{block};
     uint256 block_hash(block.GetHash());
     index_dummy.pprev = tip;
     index_dummy.nHeight = tip->nHeight + 1;
     index_dummy.phashBlock = &block_hash;
-    CCoinsViewCache view_dummy(&chainstate.CoinsTip());
+    CoinsViewOverlay& overlay_view{chainstate.ConnectBlockView()};
+    const auto reset_guard{overlay_view.StartFetching(block)};
 
     // Set fJustCheck to true in order to update, and not clear, validation caches.
-    if(!chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true)) {
+    if(!chainstate.ConnectBlock(block, state, &index_dummy, overlay_view, /*fJustCheck=*/true)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -693,6 +693,14 @@ public:
         return *Assert(m_coins_views->m_cacheview);
     }
 
+    //! @returns A reference to the reusable overlay view passed to ConnectBlock().
+    CoinsViewOverlay& ConnectBlockView() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    {
+        AssertLockHeld(::cs_main);
+        Assert(m_coins_views);
+        return *Assert(m_coins_views->m_connect_block_view);
+    }
+
     //! @returns A reference to the on-disk UTXO set database.
     CCoinsViewDB& CoinsDB() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {


### PR DESCRIPTION
Use CoinsViewOverlay to speed up ConnectBlock in TestBlockValidity. This also has the benefit of not inserting entries fetched from db into the main cache.

cs_main must be held for each place where the overlay is being used, and the reset guard ensures it will be reset for the next caller.
