### PR TITLE
kernel: handle null mempool on chainstate deletion

### DIFF
--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -117,6 +117,15 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager, TestChain100Setup)
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
 }
 
+BOOST_FIXTURE_TEST_CASE(chainstatemanager_delete_chainstate_no_mempool, ChainTestingSetup)
+{
+    auto& manager{*Assert(m_node.chainman)};
+    auto& validated{WITH_LOCK(::cs_main, return manager.InitializeChainstate(/*mempool=*/nullptr))};
+    auto& snapshot{WITH_LOCK(::cs_main, return manager.AddChainstate(std::make_unique<Chainstate>(nullptr, manager.m_blockman, manager, uint256::ONE)))};
+    WITH_LOCK(::cs_main, validated.SetTargetBlock(nullptr));
+    BOOST_CHECK(WITH_LOCK(::cs_main, return manager.DeleteChainstate(snapshot))); // Accept Kernel's null mempool
+}
+
 //! Test rebalancing the caches associated with each chainstate.
 BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -6268,7 +6268,7 @@ bool ChainstateManager::DeleteChainstate(Chainstate& chainstate)
     }
     std::unique_ptr<Chainstate> prev_chainstate{Assert(RemoveChainstate(chainstate))};
     Chainstate& curr_chainstate{CurrentChainstate()};
-    assert(prev_chainstate->m_mempool->size() == 0);
+    assert(!prev_chainstate->m_mempool || prev_chainstate->m_mempool->size() == 0);
     assert(!curr_chainstate.m_mempool);
     std::swap(curr_chainstate.m_mempool, prev_chainstate->m_mempool);
     return true;


### PR DESCRIPTION
**Problem:** Kernel creates a `ChainstateManager` without a mempool, while `AppInitMain()` supplies one for node applications.
If chainstate wiping is enabled and the data directory contains a saved AssumeUTXO snapshot, `LoadChainstate()` calls `DeleteChainstate()`, which dereferences the snapshot's null mempool pointer.

**Fix:** Accept a missing mempool when deleting the snapshot, matching the existing check in `AddChainstate()`.

<details>
<summary>Failure without the fix</summary>

```
unknown location:0: fatal error: in "validation_chainstatemanager_tests/chainstatemanager_delete_chainstate_no_mempool": memory access violation at address: 0x48: invalid permissions
```
</details>
