### PR TITLE
cmake: De-duplicate libraries where possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(FATAL_ERROR "In-source builds are not allowed.")
 endif()
 
+if(POLICY CMP0156)
+  # De-duplicate libraries on link lines based on linker capabilities.
+  # See: https://cmake.org/cmake/help/latest/policy/CMP0156.html
+  cmake_policy(SET CMP0156 NEW)
+endif()
+
 if(POLICY CMP0171)
   # `codegen` is a reserved target name.
   # See: https://cmake.org/cmake/help/latest/policy/CMP0171.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,19 @@ if(POLICY CMP0171)
   cmake_policy(SET CMP0171 NEW)
 endif()
 
+if(POLICY CMP0179)
+  # Set both closely related policies together to avoid the
+  # intermediate behaviour of CMake 3.29/3.30, where only CMP0156
+  # is available.
+
+  # De-duplicate libraries on link lines based on linker capabilities.
+  # See: https://cmake.org/cmake/help/latest/policy/CMP0156.html
+  cmake_policy(SET CMP0156 NEW)
+  # De-duplication of static libraries on link lines keeps first occurrence.
+  # See: https://cmake.org/cmake/help/latest/policy/CMP0179.html
+  cmake_policy(SET CMP0179 NEW)
+endif()
+
 # When adjusting CMake flag variables, we must not override those explicitly
 # set by the user. These are a subset of the CACHE_VARIABLES property.
 get_directory_property(precious_variables CACHE_VARIABLES)

--- a/contrib/guix/libexec/build_macos.sh
+++ b/contrib/guix/libexec/build_macos.sh
@@ -27,6 +27,9 @@ make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${build_STRIP+build_STRIP="$build_STRIP"} \
                                    NO_QT=1
 
+# LDFLAGS
+HOST_LDFLAGS="-Wl,-fatal_warnings"
+
 mkdir -p "$DISTSRC"
 (
     cd "$DISTSRC"
@@ -35,7 +38,8 @@ mkdir -p "$DISTSRC"
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
     # Configure this DISTSRC for $HOST
-    env cmake -S . -B build \
+    env LDFLAGS="${HOST_LDFLAGS}" \
+    cmake -S . -B build \
           --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
           -DBUILD_BENCH=OFF \
           -DBUILD_FUZZ_BINARY=OFF \

--- a/contrib/guix/libexec/build_macos_gui.sh
+++ b/contrib/guix/libexec/build_macos_gui.sh
@@ -26,6 +26,9 @@ make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${build_NM+build_NM="$build_NM"} \
                                    ${build_STRIP+build_STRIP="$build_STRIP"}
 
+# LDFLAGS
+HOST_LDFLAGS="-Wl,-fatal_warnings"
+
 mkdir -p "$DISTSRC"
 (
     cd "$DISTSRC"
@@ -34,7 +37,8 @@ mkdir -p "$DISTSRC"
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
     # Configure this DISTSRC for $HOST
-    env cmake -S . -B build \
+    env LDFLAGS="${HOST_LDFLAGS}" \
+    cmake -S . -B build \
           --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
           -DBUILD_BENCH=OFF \
           -DBUILD_BITCOIN_BIN=OFF \


### PR DESCRIPTION
Set the [CMP0156](https://cmake.org/cmake/help/latest/policy/CMP0156.html) and [CMP0179](https://cmake.org/cmake/help/latest/policy/CMP0179.html) policies to NEW. CMP0156 de-duplicates libraries on link lines based on linker capabilities; CMP0179 makes this de-duplication keep the first occurrence of static libraries. This silences Apple linker "ignoring duplicate libraries" warnings.

Both policies are gated on CMP0179, which requires CMake >=3.31, to avoid the intermediate CMake 3.29/3.30 behaviour where only CMP0156 is available. This requirement is satisfied by the current Homebrew package and the Guix build environment. On older versions, the policy guard makes this a no-op.

The Guix scripts for macOS have been updated to turn linker warnings into errors, as is [done](https://github.com/fanquake/bitcoin/commit/1714953eff0544d6085c4c1cc4270a891dd995c0) for other targets.