### PR TITLE
wallet: make corrupted transaction records fail wallet loading instead of forcing a rescan

### DIFF
--- a/doc/managing-wallets.md
+++ b/doc/managing-wallets.md
@@ -124,6 +124,25 @@ $ bitcoin-cli -rpcwallet="restored-wallet" getwalletinfo
 
 The restored wallet can also be loaded in the GUI via `File` ->`Open wallet`.
 
+### 1.7 Recovering from a Corrupted Wallet
+
+A wallet database can become corrupted due to hardware failure, a power loss or OS crash during a write, or disk-level errors. When corruption is detected at load time, Bitcoin Core will report an error and log details to `debug.log`.
+
+**The only supported recovery mechanism is to restore from a backup** (see [section 1.4](#14-backing-up-the-wallet) and [section 1.6](#16-restoring-the-wallet-from-a-backup)).
+
+There is no safe way to repair a corrupted wallet database in place. Attempting to manually remove, modify, or reconstruct records risks inconsistent state, incorrect balances, or permanent fund loss.
+
+To recover from a corrupted wallet:
+
+1. Ensure the wallet is not loaded by using the `unloadwallet` RPC, or `File` -> `Close Wallet` in the GUI, or stopping Bitcoin Core.
+2. Move the corrupted wallet directory aside — do not delete it until recovery is confirmed.
+3. Restore the most recent backup as described in [section 1.6](#16-restoring-the-wallet-from-a-backup).
+4. Verify the restored wallet loads correctly and shows the expected balance before resuming normal use.
+
+If no backup is available, there is no supported recovery path for the corrupted wallet.
+
+Regular backups as described in [section 1.5](#15-backup-frequency) are the only reliable protection against unrecoverable corruption.
+
 ## Wallet Passphrase
 
 Understanding wallet security is crucial for safely storing your Bitcoin. A key aspect is the wallet passphrase, used for encryption. Let's explore its nuances, role, encryption process, and limitations.

--- a/doc/release-notes-35760.md
+++ b/doc/release-notes-35760.md
@@ -1,0 +1,6 @@
+Wallet
+------
+
+- Wallets with corrupted transactions will no longer force a rescan on loading.
+These wallets will instead be reported as being corrupted and not be loaded.
+The only method to recover from corruption is to restore a backup.

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
+#include <wallet/walletdb.h>
 #include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
@@ -89,6 +90,28 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_descriptors, TestingSetup)
         const std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", std::move(database)));
         BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB(_error, _warnings), DBErrors::CORRUPT);
         BOOST_CHECK(found); // The error must be logged
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(wallet_load_corrupt_tx_hash, TestingSetup)
+{
+    // Write a tx record whose DB key (hash) does not match the hash of the
+    // serialised transaction. Loading must fail with CORRUPT rather than
+    // silently accepting broken data or scheduling a rescan.
+    auto database = CreateMockableWalletDatabase();
+    {
+        CMutableTransaction mtx;
+        mtx.vin.emplace_back();
+        mtx.vout.emplace_back(COIN, CScript() << OP_TRUE);
+        CWalletTx wtx{MakeTransactionRef(std::move(mtx)), TxStateInactive{}};
+        auto batch = database->MakeBatch();
+        BOOST_CHECK(batch->Write(std::make_pair(DBKeys::TX, Txid{}), wtx));
+    }
+    {
+        const std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", std::move(database)));
+        bilingual_str error;
+        std::vector<bilingual_str> warnings;
+        BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB(error, warnings), DBErrors::CORRUPT);
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2389,10 +2389,6 @@ DBErrors CWallet::PopulateWalletFromDB(bilingual_str& error, std::vector<bilingu
                                        " or address metadata may be missing or incorrect."),
             wallet_file));
         break;
-    case DBErrors::NEED_RESCAN:
-        warnings.push_back(strprintf(_("Error reading %s! Transaction data may be missing or incorrect."
-                                       " Rescanning wallet."), wallet_file));
-        break;
     case DBErrors::CORRUPT:
         error = strprintf(_("Error loading %s: Wallet corrupted"), wallet_file);
         break;
@@ -3143,7 +3139,7 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 
-    if (chain && !AttachChain(walletInstance, *chain, /*rescan_required=*/false, error, warnings)) {
+    if (chain && !AttachChain(walletInstance, *chain, error, warnings)) {
         walletInstance->DisconnectChainNotifications();
         return nullptr;
     }
@@ -3165,8 +3161,7 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
 
     // Load wallet
     auto nLoadWalletRet = walletInstance->PopulateWalletFromDB(error, warnings);
-    bool rescan_required = nLoadWalletRet == DBErrors::NEED_RESCAN;
-    if (nLoadWalletRet != DBErrors::LOAD_OK && nLoadWalletRet != DBErrors::NONCRITICAL_ERROR && !rescan_required) {
+    if (nLoadWalletRet != DBErrors::LOAD_OK && nLoadWalletRet != DBErrors::NONCRITICAL_ERROR) {
         return nullptr;
     }
 
@@ -3184,7 +3179,7 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 
-    if (chain && !AttachChain(walletInstance, *chain, rescan_required, error, warnings)) {
+    if (chain && !AttachChain(walletInstance, *chain, error, warnings)) {
         walletInstance->DisconnectChainNotifications();
         return nullptr;
     }
@@ -3195,7 +3190,7 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
 }
 
 
-bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interfaces::Chain& chain, const bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings)
+bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interfaces::Chain& chain, bilingual_str& error, std::vector<bilingual_str>& warnings)
 {
     LOCK(walletInstance->cs_wallet);
     // allow setting the chain if it hasn't been set already but prevent changing it
@@ -3224,16 +3219,12 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
     // so the wallet will only be completeley synced after the notifications delivery.
     walletInstance->m_chain_notifications_handler = walletInstance->chain().handleNotifications(walletInstance);
 
-    // If rescan_required = true, rescan_height remains equal to 0
     int rescan_height = 0;
-    if (!rescan_required)
-    {
-        WalletBatch batch(walletInstance->GetDatabase());
-        CBlockLocator locator;
-        if (batch.ReadBestBlock(locator)) {
-            if (const std::optional<int> fork_height = chain.findLocatorFork(locator)) {
-                rescan_height = *fork_height;
-            }
+    WalletBatch batch(walletInstance->GetDatabase());
+    CBlockLocator locator;
+    if (batch.ReadBestBlock(locator)) {
+        if (const std::optional<int> fork_height = chain.findLocatorFork(locator)) {
+            rescan_height = *fork_height;
         }
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,7 +441,7 @@ private:
      * block locator and m_last_block_processed, and registering for
      * notifications about new blocks and transactions.
      */
-    static bool AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    static bool AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, bilingual_str& error, std::vector<bilingual_str>& warnings);
 
     static NodeClock::time_point GetDefaultNextResend();
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1039,7 +1039,7 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
         try {
             CWalletTx wtx{deserialize, value, ReadWtxVariants(batch, hash)};
             if (wtx.GetHash() != hash) {
-                result = std::max(result, DBErrors::NEED_RESCAN);
+                return DBErrors::CORRUPT;
             }
 
             if (wtx.nOrderPos == -1) {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1039,7 +1039,8 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
         try {
             CWalletTx wtx{deserialize, value, ReadWtxVariants(batch, hash)};
             if (wtx.GetHash() != hash) {
-                result = std::max(result, DBErrors::NEED_RESCAN);
+                err = strprintf("Error: Corrupt transaction. Stored hash of %s but an actual hash of %s", wtx.GetHash().ToString(), hash.ToString());
+                return DBErrors::CORRUPT;
             }
 
             if (wtx.nOrderPos == -1) {
@@ -1047,7 +1048,7 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
             }
 
             if (!pwallet->LoadToWallet(std::move(wtx))) {
-                err = "Error: Corrupt transaction found. This can be fixed by removing transactions from wallet and rescanning.";
+                err = "Error: Corrupt transaction found";
                 return DBErrors::CORRUPT;
             }
         } catch (const std::exception& e) {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -45,7 +45,6 @@ void LogDBInfo();
 enum class DBErrors : int
 {
     LOAD_OK = 0,
-    NEED_RESCAN = 1,
     EXTERNAL_SIGNER_SUPPORT_REQUIRED = 3,
     NONCRITICAL_ERROR = 4,
     TOO_NEW = 5,

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -67,7 +67,7 @@ static std::shared_ptr<CWallet> MakeWallet(const std::string& name, const fs::pa
         tfm::format(std::cerr, "%s", warning.original);
     }
 
-    if (load_wallet_ret != DBErrors::LOAD_OK && load_wallet_ret != DBErrors::NONCRITICAL_ERROR && load_wallet_ret != DBErrors::NEED_RESCAN) {
+    if (load_wallet_ret != DBErrors::LOAD_OK && load_wallet_ret != DBErrors::NONCRITICAL_ERROR) {
         return nullptr;
     }
 


### PR DESCRIPTION
In wallet loading, the `NEED_RESCAN` enum was only ever returned if the stored hash of a transaction did not match the calculated hash of the transaction. This would then trigger a rescan from genesis during loading, and then allow the wallet to be operational as if it were normal.

However, it seems incorrect to be treating such corruption as acceptable. That transaction would be inserted to `mapWallet`, but not be added to `mapTxSpends` or any of the conflict tracking or to TXO caching. Furthermore, the rescan doesn't actually fix the problem, the incorrect record would persist, which means that the wallet would be rescanning the entire chain every time it is loaded. The only situation this could occur is if the wallet actually experienced corruption, so it's reasonable to return `CORRUPT` instead and force the user to load a backup or otherwise un-corrupt the wallet before it can be used.

Implements the idea from https://github.com/bitcoin/bitcoin/pull/35501#discussion_r3617803101