### PR TITLE
util: write JSON atomically in WriteJson

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -142,14 +142,13 @@ CBanDB::CBanDB(fs::path ban_list_path)
 bool CBanDB::Write(const banmap_t& banSet)
 {
     std::vector<std::string> errors;
-    if (common::WriteSettings(m_banlist_json, {{JSON_KEY, BanMapToJson(banSet)}}, errors)) {
-        return true;
+    if (!common::WriteJson(m_banlist_json, {{JSON_KEY, BanMapToJson(banSet)}}, errors)) {
+        for (const auto& err : errors) {
+            LogError("%s\n", err);
+        }
+        return false;
     }
-
-    for (const auto& err : errors) {
-        LogError("%s\n", err);
-    }
-    return false;
+    return true;
 }
 
 bool CBanDB::Read(banmap_t& banSet)

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -142,14 +142,13 @@ CBanDB::CBanDB(fs::path ban_list_path)
 bool CBanDB::Write(const banmap_t& banSet)
 {
     std::vector<std::string> errors;
-    if (common::WriteSettings(m_banlist_json, {{JSON_KEY, BanMapToJson(banSet)}}, errors)) {
-        return true;
+    if (!common::WriteSettings(m_banlist_json, {{JSON_KEY, BanMapToJson(banSet)}}, errors)) {
+        for (const auto& err : errors) {
+            LogError("%s\n", err);
+        }
+        return false;
     }
-
-    for (const auto& err : errors) {
-        LogError("%s\n", err);
-    }
-    return false;
+    return true;
 }
 
 bool CBanDB::Read(banmap_t& banSet)

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -486,19 +486,15 @@ bool ArgsManager::ReadSettingsFile(std::vector<std::string>* errors)
 
 bool ArgsManager::WriteSettingsFile(std::vector<std::string>* errors, bool backup) const
 {
-    fs::path path, path_tmp;
-    if (!GetSettingsPath(&path, /*temp=*/false, backup) || !GetSettingsPath(&path_tmp, /*temp=*/true, backup)) {
+    fs::path path;
+    if (!GetSettingsPath(&path, /*temp=*/false, backup)) {
         throw std::logic_error("Attempt to write settings file when dynamic settings are disabled.");
     }
 
     LOCK(cs_args);
     std::vector<std::string> write_errors;
-    if (!common::WriteSettings(path_tmp, m_settings.rw_settings, write_errors)) {
+    if (!common::WriteJson(path, m_settings.rw_settings, write_errors)) {
         SaveErrors(write_errors, errors);
-        return false;
-    }
-    if (!RenameOver(path_tmp, path)) {
-        SaveErrors({strprintf("Failed renaming settings file %s to %s\n", fs::PathToString(path_tmp), fs::PathToString(path))}, errors);
         return false;
     }
     return true;

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -435,7 +435,7 @@ bool ArgsManager::IsArgSet(const std::string& strArg) const
     return !GetSetting(strArg).isNull();
 }
 
-bool ArgsManager::GetSettingsPath(fs::path* filepath, bool temp, bool backup) const
+bool ArgsManager::GetSettingsPath(fs::path* filepath, bool backup) const
 {
     fs::path settings = GetPathArg("-settings", BITCOIN_SETTINGS_FILENAME);
     if (settings.empty()) {
@@ -445,7 +445,7 @@ bool ArgsManager::GetSettingsPath(fs::path* filepath, bool temp, bool backup) co
         settings += ".bak";
     }
     if (filepath) {
-        *filepath = fsbridge::AbsPathJoin(GetDataDirNet(), temp ? settings + ".tmp" : settings);
+        *filepath = fsbridge::AbsPathJoin(GetDataDirNet(), settings);
     }
     return true;
 }
@@ -464,7 +464,7 @@ static void SaveErrors(const std::vector<std::string> errors, std::vector<std::s
 bool ArgsManager::ReadSettingsFile(std::vector<std::string>* errors)
 {
     fs::path path;
-    if (!GetSettingsPath(&path, /* temp= */ false)) {
+    if (!GetSettingsPath(&path)) {
         return true; // Do nothing if settings file disabled.
     }
 
@@ -486,19 +486,15 @@ bool ArgsManager::ReadSettingsFile(std::vector<std::string>* errors)
 
 bool ArgsManager::WriteSettingsFile(std::vector<std::string>* errors, bool backup) const
 {
-    fs::path path, path_tmp;
-    if (!GetSettingsPath(&path, /*temp=*/false, backup) || !GetSettingsPath(&path_tmp, /*temp=*/true, backup)) {
+    fs::path path;
+    if (!GetSettingsPath(&path, backup)) {
         throw std::logic_error("Attempt to write settings file when dynamic settings are disabled.");
     }
 
     LOCK(cs_args);
     std::vector<std::string> write_errors;
-    if (!common::WriteSettings(path_tmp, m_settings.rw_settings, write_errors)) {
+    if (!common::WriteSettings(path, m_settings.rw_settings, write_errors)) {
         SaveErrors(write_errors, errors);
-        return false;
-    }
-    if (!RenameOver(path_tmp, path)) {
-        SaveErrors({strprintf("Failed renaming settings file %s to %s\n", fs::PathToString(path_tmp), fs::PathToString(path))}, errors);
         return false;
     }
     return true;

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -417,7 +417,7 @@ public:
      * Get settings file path, or return false if read-write settings were
      * disabled with -nosettings.
      */
-    bool GetSettingsPath(fs::path* filepath = nullptr, bool temp = false, bool backup = false) const EXCLUSIVE_LOCKS_REQUIRED(!cs_args);
+    bool GetSettingsPath(fs::path* filepath = nullptr, bool backup = false) const EXCLUSIVE_LOCKS_REQUIRED(!cs_args);
 
     /**
      * Read settings file. Push errors to vector, or log them if null.

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -9,6 +9,7 @@
 #include <tinyformat.h>
 #include <univalue.h>
 #include <util/fs.h>
+#include <util/fs_helpers.h>
 
 #include <algorithm>
 #include <fstream>
@@ -120,7 +121,7 @@ bool ReadSettings(const fs::path& path, std::map<std::string, SettingsValue>& va
     return errors.empty();
 }
 
-bool WriteSettings(const fs::path& path,
+bool WriteJson(const fs::path& path,
     const std::map<std::string, SettingsValue>& values,
     std::vector<std::string>& errors)
 {
@@ -132,20 +133,25 @@ bool WriteSettings(const fs::path& path,
     for (const auto& value : values) {
         out.pushKVEnd(value.first, value.second);
     }
+    const fs::path path_tmp{path + ".tmp"};
     std::ofstream file;
-    file.open(path.std_path());
+    file.open(path_tmp.std_path());
     if (file.fail()) {
-        errors.emplace_back(strprintf("Error: Unable to open settings file %s for writing", fs::PathToString(path)));
+        errors.emplace_back(strprintf("Error: Unable to open JSON file %s for writing", fs::PathToString(path_tmp)));
         return false;
     }
     file << out.write(/* prettyIndent= */ 4, /* indentLevel= */ 1) << std::endl;
     if (file.fail()) {
-        errors.emplace_back(strprintf("Error: Unable to write settings file %s", fs::PathToString(path)));
+        errors.emplace_back(strprintf("Error: Unable to write JSON file %s", fs::PathToString(path_tmp)));
         return false;
     }
     file.close();
     if (file.fail()) {
-        errors.emplace_back(strprintf("Error: Unable to close settings file %s", fs::PathToString(path)));
+        errors.emplace_back(strprintf("Error: Unable to close JSON file %s", fs::PathToString(path_tmp)));
+        return false;
+    }
+    if (!RenameOver(path_tmp, path)) {
+        errors.emplace_back(strprintf("Failed renaming JSON file %s to %s", fs::PathToString(path_tmp), fs::PathToString(path)));
         return false;
     }
     return true;

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -9,6 +9,7 @@
 #include <tinyformat.h>
 #include <univalue.h>
 #include <util/fs.h>
+#include <util/fs_helpers.h>
 
 #include <algorithm>
 #include <fstream>
@@ -132,20 +133,25 @@ bool WriteSettings(const fs::path& path,
     for (const auto& value : values) {
         out.pushKVEnd(value.first, value.second);
     }
+    const fs::path path_tmp{path + ".tmp"};
     std::ofstream file;
-    file.open(path.std_path());
+    file.open(path_tmp.std_path());
     if (file.fail()) {
-        errors.emplace_back(strprintf("Error: Unable to open settings file %s for writing", fs::PathToString(path)));
+        errors.emplace_back(strprintf("Error: Unable to open JSON file %s for writing", fs::PathToString(path_tmp)));
         return false;
     }
     file << out.write(/* prettyIndent= */ 4, /* indentLevel= */ 1) << std::endl;
     if (file.fail()) {
-        errors.emplace_back(strprintf("Error: Unable to write settings file %s", fs::PathToString(path)));
+        errors.emplace_back(strprintf("Error: Unable to write JSON file %s", fs::PathToString(path_tmp)));
         return false;
     }
     file.close();
     if (file.fail()) {
-        errors.emplace_back(strprintf("Error: Unable to close settings file %s", fs::PathToString(path)));
+        errors.emplace_back(strprintf("Error: Unable to close JSON file %s", fs::PathToString(path_tmp)));
+        return false;
+    }
+    if (!RenameOver(path_tmp, path)) {
+        errors.emplace_back(strprintf("Failed renaming JSON file %s to %s", fs::PathToString(path_tmp), fs::PathToString(path)));
         return false;
     }
     return true;

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -45,8 +45,12 @@ bool ReadSettings(const fs::path& path,
     std::map<std::string, SettingsValue>& values,
     std::vector<std::string>& errors);
 
-//! Write settings file.
-bool WriteSettings(const fs::path& path,
+//! Atomically write a JSON object to a file.
+//!
+//! Writes to a temporary `.tmp` file next to `path`, then uses RenameOver()
+//! to replace the destination. This avoids leaving a truncated or empty file
+//! if the write is interrupted.
+bool WriteJson(const fs::path& path,
     const std::map<std::string, SettingsValue>& values,
     std::vector<std::string>& errors);
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -45,7 +45,11 @@ bool ReadSettings(const fs::path& path,
     std::map<std::string, SettingsValue>& values,
     std::vector<std::string>& errors);
 
-//! Write settings file.
+//! Atomically write a settings file.
+//!
+//! Writes to a temporary `.tmp` file next to `path`, then uses RenameOver()
+//! to replace the destination. This avoids leaving a truncated or empty file
+//! if the write is interrupted.
 bool WriteSettings(const fs::path& path,
     const std::map<std::string, SettingsValue>& values,
     std::vector<std::string>& errors);

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -1107,7 +1107,7 @@ BOOST_AUTO_TEST_CASE(util_ReadWriteSettings)
 
     // Test error logging, and remove previously written setting.
     {
-        ASSERT_DEBUG_LOG("Failed renaming settings file");
+        ASSERT_DEBUG_LOG("Failed renaming JSON file");
         fs::remove(args1.GetDataDirBase() / "settings.json");
         fs::create_directory(args1.GetDataDirBase() / "settings.json");
         args2.WriteSettingsFile();

--- a/src/test/banman_tests.cpp
+++ b/src/test/banman_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <addrdb.h>
 #include <banman.h>
 #include <chainparams.h>
 #include <netbase.h>
@@ -37,6 +38,39 @@ BOOST_AUTO_TEST_CASE(file)
             banman.GetBanned(entries_read);
             BOOST_CHECK_EQUAL(entries_read.size(), 1);
         }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(write_uses_rename)
+{
+    const fs::path banlist_path{m_args.GetDataDirBase() / "banlist_atomic"};
+    CBanDB bandb{banlist_path};
+
+    banmap_t bans_write;
+    CBanEntry entry{/*nCreateTimeIn=*/100};
+    entry.nBanUntil = 200;
+    bans_write.emplace(LookupSubNet("203.0.113.1/32"), entry);
+
+    BOOST_REQUIRE(bandb.Write(bans_write));
+    BOOST_CHECK(fs::exists(banlist_path + ".json"));
+    BOOST_CHECK(!fs::exists(banlist_path + ".json.tmp"));
+
+    banmap_t bans_read;
+    BOOST_REQUIRE(bandb.Read(bans_read));
+    BOOST_REQUIRE_EQUAL(bans_read.size(), 1);
+    BOOST_CHECK(bans_read.begin()->first == LookupSubNet("203.0.113.1/32"));
+    BOOST_CHECK_EQUAL(bans_read.begin()->second.nCreateTime, 100);
+    BOOST_CHECK_EQUAL(bans_read.begin()->second.nBanUntil, 200);
+
+    // Make the destination a directory so RenameOver fails. Direct writes to
+    // banlist.json would fail earlier with an open/write error instead.
+    {
+        ASSERT_DEBUG_LOG("Failed renaming JSON file");
+        fs::remove(banlist_path + ".json");
+        fs::create_directory(banlist_path + ".json");
+        BOOST_CHECK(!bandb.Write(bans_write));
+        fs::remove(banlist_path + ".json");
+        fs::remove(banlist_path + ".json.tmp");
     }
 }
 

--- a/src/test/banman_tests.cpp
+++ b/src/test/banman_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <addrdb.h>
 #include <banman.h>
 #include <chainparams.h>
 #include <netbase.h>
@@ -37,6 +38,49 @@ BOOST_AUTO_TEST_CASE(file)
             banman.GetBanned(entries_read);
             BOOST_CHECK_EQUAL(entries_read.size(), 1);
         }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(write_uses_rename)
+{
+    const fs::path banlist_path{m_args.GetDataDirBase() / "banlist_atomic"};
+    CBanDB bandb{banlist_path};
+
+    banmap_t bans_write;
+    CBanEntry entry{/*nCreateTimeIn=*/100};
+    entry.nBanUntil = 200;
+    bans_write.emplace(LookupSubNet("203.0.113.1/32"), entry);
+
+    BOOST_REQUIRE(bandb.Write(bans_write));
+    BOOST_CHECK(fs::exists(banlist_path + ".json"));
+    BOOST_CHECK(!fs::exists(banlist_path + ".json.tmp"));
+
+    banmap_t bans_read;
+    BOOST_REQUIRE(bandb.Read(bans_read));
+    BOOST_REQUIRE_EQUAL(bans_read.size(), 1);
+    BOOST_CHECK(bans_read.begin()->first == LookupSubNet("203.0.113.1/32"));
+    BOOST_CHECK_EQUAL(bans_read.begin()->second.nCreateTime, 100);
+    BOOST_CHECK_EQUAL(bans_read.begin()->second.nBanUntil, 200);
+
+    // Make the destination a directory so RenameOver fails. Direct writes to
+    // banlist.json would fail earlier with an open/write error instead.
+    {
+        ASSERT_DEBUG_LOG("Failed renaming JSON file");
+        fs::remove(banlist_path + ".json");
+        fs::create_directory(banlist_path + ".json");
+        BOOST_CHECK(!bandb.Write(bans_write));
+        BOOST_CHECK(!bandb.Write(bans_write));
+        BOOST_CHECK(fs::exists(banlist_path + ".json.tmp"));
+        int tmp_count{0};
+        for (const auto& entry : fs::directory_iterator(banlist_path.parent_path())) {
+            const std::string name{fs::PathToString(entry.path().filename())};
+            if (name.starts_with("banlist_atomic") && name.ends_with(".tmp")) {
+                ++tmp_count;
+            }
+        }
+        BOOST_CHECK_EQUAL(tmp_count, 1);
+        fs::remove(banlist_path + ".json");
+        fs::remove(banlist_path + ".json.tmp");
     }
 }
 


### PR DESCRIPTION
## Summary
Follow-up to https://github.com/bitcoin/bitcoin/pull/35384#issuecomment-4750866299

- Renamed `common::WriteSettings` to `common::WriteJson`.
- `WriteJson` writes to `path + ".tmp"` and `RenameOver()`s into place, so a failed or interrupted write cannot leave a truncated destination. Both `settings.json` and `banlist.json` use this helper.
- Added a unit test for the write/read roundtrip, that the `.tmp` is gone after success, that rename failure is detected, and that a second failed write overwrites the same `.tmp` rather than creating another.