### PR TITLE
fuzz: Avoid dangling prevoutfetch threads after AFL fork

### DIFF
--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -231,7 +231,7 @@ int main(int argc, char** argv)
     // Enable AFL persistent mode. Requires compilation using afl-clang-fast++.
     // See fuzzing.md for details.
     const uint8_t* buffer = __AFL_FUZZ_TESTCASE_BUF;
-    while (__AFL_LOOP(100000)) {
+    while (__AFL_LOOP(100'000)) {
         size_t buffer_len = __AFL_FUZZ_TESTCASE_LEN;
         test_one_input({buffer, buffer_len});
     }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -307,8 +307,10 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
             .check_block_index = 1,
             .notifications = *m_node.notifications,
             .signals = m_node.validation_signals.get(),
-            // Use no worker threads while fuzzing to avoid non-determinism
+            // Use no worker threads while fuzzing to avoid racy non-determinism
+            // and dangling thread handles if AFL forks after initialization.
             .worker_threads_num = EnableFuzzDeterminism() ? 0 : 2,
+            .prevoutfetch_threads_num = EnableFuzzDeterminism() ? 0 : 2,
         };
         if (opts.min_validation_cache) {
             chainman_opts.script_execution_cache_bytes = 0;


### PR DESCRIPTION
Presumably fixes https://issues.oss-fuzz.com/issues/536943806

This is a bit confusing, because the issue was already fixed in commit f608a409f7591b4f5cf170898bee58b9d9dcf1b6, by removing the AFL forkserver.

However, OSS-Fuzz doesn't go through the AFL_LOOP, but through the AFL libFuzzer driver:

```
          #0 0x7e055245baab in __pthread_clockjoin_ex /build/glibc-B3wQXB/glibc-2.31/nptl/pthread_join_common.c:89:6
	    #1 0x5a27e904dcdd in operator() /src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:293:14
	    #2 0x5a27e904dcdd in Join<(lambda at /src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:292:44)> /src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_thread_arg_retval.h:75:9
	    #3 0x5a27e904dcdd in ___interceptor_pthread_join /src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:292:25
	    #4 0x5a27e90f4044 in std::__1::thread::join()
	    #5 0x5a27e9366277 in ThreadPool::Stop() [bitcoin-core/src/util/threadpool.h:146](https://github.com/bitcoin/bitcoin/blob/7d8137c1417b61589949b3e8b081e5310fe335f3/src/util/threadpool.h#L146):53
	    #6 0x5a27e9365db9 in ThreadPool::~ThreadPool() [bitcoin-core/src/util/threadpool.h:94](https://github.com/bitcoin/bitcoin/blob/7d8137c1417b61589949b3e8b081e5310fe335f3/src/util/threadpool.h#L94):9
...
          #32 0x5a27e95a9506 in (anonymous namespace)::ResetChainman(TestingSetup&) (.12669) [bitcoin-core/src/test/fuzz/process_messages.cpp:44](https://github.com/bitcoin/bitcoin/blob/7d8137c1417b61589949b3e8b081e5310fe335f3/src/test/fuzz/process_messages.cpp#L44):27
	    #33 0x5a27e95a8c60 in process_messages_fuzz_target(std::__1::span<unsigned char const, 18446744073709551615ul>) [bitcoin-core/src/test/fuzz/process_messages.cpp:141](https://github.com/bitcoin/bitcoin/blob/7d8137c1417b61589949b3e8b081e5310fe335f3/src/test/fuzz/process_messages.cpp#L141):9
...
            #36 0x5a27e97b7190 in test_one_input(std::__1::span<unsigned char const, 18446744073709551615ul>) bitcoin-core/src/test/fuzz/fuzz.cpp:86:5
            #37 0x5a27e97b7190 in LLVMFuzzerTestOneInput bitcoin-core/src/test/fuzz/fuzz.cpp:214:5
            #38 0x5a27e90ada19 in LLVMFuzzerRunDriver /src/aflplusplus/utils/aflpp_driver/aflpp_driver.c:427:13
            #39 0x5a27e90ad69b in main /src/aflplusplus/utils/aflpp_driver/aflpp_driver.c:323:10
            #40 0x7e055223b082 in __libc_start_main /build/glibc-B3wQXB/glibc-2.31/csu/libc-start.c:308:16
            #41 0x5a27e8fc602d in _start
```

So the correct fix would be to set `AFL_DRIVER_DONT_DEFER=1`. Ref: https://github.com/AFLplusplus/AFLplusplus/blob/ad5304010ae3be9d5cdc1ba51b09e14169c5cb87/utils/aflpp_driver/aflpp_driver.c#L161


However, I don't know how to do this on OSS-Fuzz, so just drop the threads for now, because there are dedicated fuzz targets to test the multi-threaded case anyway.