### PR TITLE
wallet: Reject whitespace-only wallet names

### DIFF
--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -17,6 +17,8 @@
 #include <utility>
 #include <vector>
 
+using util::TrimStringView;
+
 namespace wallet {
 static const std::string DUMP_MAGIC = "BITCOIN_CORE_WALLET_DUMP";
 uint32_t DUMP_VERSION = 1;
@@ -121,7 +123,7 @@ static void WalletToolReleaseWallet(CWallet* wallet)
 
 bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error, std::vector<bilingual_str>& warnings)
 {
-    if (name.empty()) {
+    if (TrimStringView(name).empty()) {
         tfm::format(std::cerr, "Wallet name cannot be empty\n");
         return false;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -91,6 +91,7 @@ using interfaces::FoundBlock;
 using kernel::ChainstateRole;
 using util::ReplaceAll;
 using util::ToString;
+using util::TrimStringView;
 
 namespace wallet {
 
@@ -385,7 +386,7 @@ std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& n
 std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings)
 {
     // Wallet must have a non-empty name
-    if (name.empty()) {
+    if (TrimStringView(name).empty()) {
         error = Untranslated("Wallet name cannot be empty");
         status = DatabaseStatus::FAILED_NEW_UNNAMED;
         return nullptr;

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -12,6 +12,8 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
+using util::TrimStringView;
+
 namespace wallet {
 namespace WalletTool {
 
@@ -113,7 +115,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
     const fs::path& path = *path_res;
 
     if (command == "create") {
-        if (name.empty()) {
+        if (TrimStringView(name).empty()) {
             tfm::format(std::cerr, "Wallet name cannot be empty\n");
             return false;
         }

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -432,6 +432,12 @@ class ToolWalletTest(BitcoinTestFramework):
         self.assert_raises_tool_error("Wallet name cannot be empty", "-wallet=", "-dumpfile=wallet.dump", "createfromdump")
         assert not (self.nodes[0].wallets_path / "wallet.dat").exists()
 
+        self.assert_raises_tool_error("Wallet name cannot be empty", "-wallet=    ", "create")
+        assert not (self.nodes[0].wallets_path / "wallet.dat").exists()
+
+        self.assert_raises_tool_error("Wallet name cannot be empty", "-wallet=    ", "-dumpfile=wallet.dump", "createfromdump")
+        assert not (self.nodes[0].wallets_path / "wallet.dat").exists()
+
     def run_test(self):
         self.wallet_path = self.nodes[0].wallets_path / self.default_wallet_name / self.wallet_data_filename
         self.test_invalid_tool_commands_and_args()

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -55,6 +55,7 @@ class CreateWalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-4, "Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.",
             self.nodes[0].createwallet, wallet_name='w0', disable_private_keys=True, passphrase="passphrase")
         assert_raises_rpc_error(-8, "Wallet name cannot be empty", self.nodes[0].createwallet, "")
+        assert_raises_rpc_error(-8, "Wallet name cannot be empty", self.nodes[0].createwallet, "    ")
 
         self.nodes[0].createwallet(wallet_name='w0')
         w0 = node.get_wallet_rpc('w0')


### PR DESCRIPTION
### Summary
This PR trims wallet names using util::TrimStringView before the empty check, across all call sites that currently guard against empty wallet names

**Motivation:** Although there is a check against empty wallet names, it does not reject wallet names consisting solely of whitespace. As a result, the RPC command below succeeds and creates a wallet with a whitespace-only name. Such names are not meaningful and are effectively indistinguishable from nameless directories to users, so they should be rejected in the same way as empty wallet names. 

```sh
bitcoin-cli createwallet "    "
```
`util::TrimStringView;` has been preferred as opposed to `util::TrimString;` to prevent mutating the user input but guarding against space-only names. This means that the wallet name can have leading and trailing white space unless requested otherwise.

### Testing
**Before:**
```sh
ratedg@0xratedg:~/projects/contributions/bitcoin/build/bin$ ./bitcoin-cli createwallet "                            "
{
  "name": "                            "
}
ratedg@0xratedg:~/projects/contributions/bitcoin/build/bin$ ls ~/.bitcoin/regtest/wallets/
 '                        '   '                           '   '                            '
ratedg@0xratedg:~/projects/contributions/bitcoin/build/bin$ 
```

**After:**
```sh
ratedg@0xratedg:~/Desktop/bitcoin/build/bin$ ./bitcoin-cli createwallet "                    "
error code: -8
error message:
Wallet name cannot be empty
ratedg@0xratedg:~/Desktop/bitcoin/build/bin$
```

