### PR TITLE
net: Simplify `AddressPosition` comparitor

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -16,7 +16,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <tuple>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -73,10 +72,7 @@ struct AddressPosition {
     const int bucket;
     const int position;
 
-    bool operator==(AddressPosition other) {
-        return std::tie(tried, multiplicity, bucket, position) ==
-               std::tie(other.tried, other.multiplicity, other.bucket, other.position);
-    }
+    bool operator==(const AddressPosition&) const = default;
     explicit AddressPosition(bool tried_in, int multiplicity_in, int bucket_in, int position_in)
         : tried{tried_in}, multiplicity{multiplicity_in}, bucket{bucket_in}, position{position_in} {}
 };


### PR DESCRIPTION
Picked from #35713 because this appears unintentional. There were no cases where the source attempted to compare `AddressPosition` by const reference, but such a comparison is valid. This may be fixed by simplifying the comparison operator here, which also avoids copying the value.

Found in #35713:
```
<AddressPosition>' requested here
  817 |     BOOST_CHECK(addr_pos1 == addr_pos2);
      |                           ^
/bitcoin-core/bitcoin/src/addrman.h:76:10: note: candidate function not viable: 'this' argument has type 'const AddressPosition', but method is not marked const
   76 |     bool operator==(AddressPosition other) {
```