### PR TITLE
http: drop connections from RPC clients that are not allowed to connect

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -131,6 +131,10 @@ static void MaybeDispatchRequestToWorker(std::shared_ptr<HTTPRequest> hreq)
     if (!ClientAllowed(hreq->GetPeer())) {
         LogDebug(BCLog::HTTP, "HTTP request from %s rejected: Client network is not allowed RPC access\n",
                  hreq->GetPeer().ToStringAddrPort());
+        // Drop a rejected peer instead of leaving it to decide whether to keep
+        // the connection open. The client is disconnected once the reply has
+        // been flushed
+        hreq->WriteHeader("Connection", "close");
         hreq->WriteReply(HTTP_FORBIDDEN);
         return;
     }
@@ -569,8 +573,14 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
         res.m_headers.Write("Content-Type", "text/html; charset=ISO-8859-1");
     }
 
-    auto connection_header{m_headers.FindFirst("Connection")};
-    if (connection_header && ToLower(connection_header.value()) == "close") {
+    // The connection is closed after this response if either side asked for it:
+    // the client via its request header, or serverside via WriteHeader()
+    // Relying on the client's choice alone would let a rejected client
+    // keep the connection open by asking for keep-alive.
+    const auto wants_close{[](const std::optional<std::string>& header) {
+        return header && ToLower(header.value()) == "close";
+    }};
+    if (wants_close(m_headers.FindFirst("Connection")) || wants_close(res.m_headers.FindFirst("Connection"))) {
         // Might not exist already but we need to replace it, not append to it
         res.m_headers.RemoveAll("Connection");
 

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -4,10 +4,14 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test running bitcoind with the -rpcbind and -rpcallowip options."""
 
+import socket
+
 from test_framework.netutil import all_interfaces, addr_to_hex, get_bind_addrs, test_ipv6_local
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
 from test_framework.test_node import ErrorMatch
 from test_framework.util import assert_equal, assert_raises_rpc_error, rpc_port
+
+DISCONNECT_TIMEOUT = 10
 
 class RPCBindTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -73,6 +77,50 @@ class RPCBindTest(BitcoinTestFramework):
         # connect to node through non-loopback interface
         node = self.nodes[0].create_new_rpc_connection()
         node.getnetworkinfo()
+        self.stop_nodes()
+
+    def run_allowip_disconnect_test(self, allow_ips, rpchost, rpcport):
+        '''
+        Start a node which does not allow rpchost, then check that a rejected
+        client is disconnected by the server rather than waiting for the client
+        to disconnect.
+        '''
+        self.log.info("Allow IP disconnect test for %s:%d" % (rpchost, rpcport))
+        node_args = \
+            ['-disablewallet', '-nolisten'] + \
+            ['-rpcallowip='+x for x in allow_ips] + \
+            ['-rpcbind='+addr for addr in ['127.0.0.1', "%s:%d" % (rpchost, rpcport)]] # Bind to localhost as well so start_nodes doesn't hang
+        self.nodes[0].rpchost = None
+        self.start_nodes([node_args])
+
+        # Ask for the connection to be kept alive (also the HTTP/1.1 default),
+        # which the server must override because we are not allowed to connect
+        # in the first place.
+        request = (
+            "POST / HTTP/1.1\r\n"
+            f"Host: {rpchost}:{rpcport}\r\n"
+            "Connection: keep-alive\r\n"
+            "Content-Length: 0\r\n"
+            "\r\n"
+        ).encode("ascii")
+
+        response = b""
+        with socket.create_connection((rpchost, rpcport), timeout=DISCONNECT_TIMEOUT) as sock:
+            sock.sendall(request)
+            # Read until the server sends EOF. A server that ignored its own
+            # rejection would keep the connection open and time out here.
+            try:
+                while True:
+                    data = sock.recv(1024)
+                    if not data:
+                        break
+                    response += data
+            except TimeoutError:
+                raise AssertionError(
+                    f"Server did not disconnect rejected client within {DISCONNECT_TIMEOUT}s, got: {response}")
+
+        assert response.startswith(b"HTTP/1.1 403 Forbidden"), response
+        assert b"Connection: close\r\n" in response, response
         self.stop_nodes()
 
     def run_invalid_allowip_test(self):
@@ -164,6 +212,10 @@ class RPCBindTest(BitcoinTestFramework):
 
         # Check that with invalid rpcallowip, we are denied
         self.run_allowip_test([self.non_loopback_ip], self.non_loopback_ip, self.defaultport)
+
+        # A rejected client is dropped, not just told "no".
+        self.run_allowip_disconnect_test(['1.1.1.1'], self.non_loopback_ip, self.defaultport)
+
         if self.options.usecli:
             self.log.info("Skip negative IP test with CLI, because the CLI can not throw the tested exception type")
             return


### PR DESCRIPTION
This PR changes the way how a ClientAllowed rejection is handled.  

Currently whether to drop the connection to a refused client is the client's choice instead of the server.
A client whose address is not covered by `-rpcallowip` gets a `403 Forbidden`, but the connection is not actively closed. This PR changes that by setting a `Connection` close header on reject and a change in the `WriteReply()` function makes that now the connection is closed based on a close requested by either side. The client is disconnected once the reply has been flushed.
 
So a rejected client asking for `keep-alive` (the HTTP/1.1 default) does not hold a slot until `-rpcservertimeout`
expires anymore. Whether to drop a refused connection should not be that peer's choice. This fixes a DDOS vector that will increase severity if #35730 is merged (due to the limited number of connections)

How to reproduce:

<details>

Start a bitcoin node with `-rpcallowip=1.1.1.1 -rpcbind=<ip> -rpcservertimeout=30 -debug=http` eg:

```bash
 ./build/bin/bitcoind --regtest -rpcallowip=1.1.1.1 -rpcbind=10.0.6.30 -rpcservertimeout=30 -debug=http
```

Run a timed netcat connection:

```bash
time { printf 'POST / HTTP/1.1\r\nHost: <ip>:18443\r\nConnection: keep-alive\r\nContent-Length: 0\r\n\r\n'; sleep 35; } | nc <ip> 18443
```

On master:

nc output:

```terminal
HTTP/1.1 403 Forbidden
Date: Wed, 22 Jul 2026 11:45:51 GMT
Content-Length: 0
Content-Type: text/html; charset=ISO-8859-1


real    0m35.026s
user    0m0.009s
sys     0m0.012s
```

bitcoind log:

```terminal
2026-07-22T11:45:51Z [http] HTTP Connection accepted from 10.0.6.30:56618 (id=1)
2026-07-22T11:45:51Z [http] Received a POST request for / from 10.0.6.30:56618 (id=1)
2026-07-22T11:45:51Z [http] HTTP request from 10.0.6.30:56618 rejected: Client network is not allowed RPC access
2026-07-22T11:45:51Z [http] HTTPResponse (status code: 403 size: 127) added to send buffer for client 10.0.6.30:56618 (id=1)
2026-07-22T11:45:51Z [http] Sent 127 bytes to client 10.0.6.30:56618 (id=1)
2026-07-22T11:46:21Z [http] HTTP client idle timeout 10.0.6.30:56618 (id=1)
2026-07-22T11:46:21Z [http] Disconnecting HTTP client 10.0.6.30:56618 (id=1)
```


This PR:

nc output:

```terminal
HTTP/1.1 403 Forbidden
Date: Wed, 22 Jul 2026 11:48:09 GMT
Content-Length: 0
Content-Type: text/html; charset=ISO-8859-1
Connection: close


real    0m35.020s
user    0m0.012s
sys     0m0.011s
```

bitcoind log:

```terminal
2026-07-22T11:48:09Z [http] HTTP Connection accepted from 10.0.6.30:56626 (id=0)
2026-07-22T11:48:09Z [http] Received a POST request for / from 10.0.6.30:56626 (id=0)
2026-07-22T11:48:09Z [http] HTTP request from 10.0.6.30:56626 rejected: Client network is not allowed RPC access
2026-07-22T11:48:09Z [http] HTTPResponse (status code: 403 size: 146) added to send buffer for client 10.0.6.30:56626 (id=0)
2026-07-22T11:48:09Z [http] Sent 146 bytes to client 10.0.6.30:56626 (id=0)
2026-07-22T11:48:09Z [http] Disconnecting HTTP client 10.0.6.30:56626 (id=0)
```

</details>