### PR TITLE
test: Suppress implicit-unsigned-integer-truncation:SaltedCoinsCacheHasher::operator()

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -61,6 +61,7 @@ implicit-integer-sign-change:crypto/
 implicit-integer-sign-change:TxConfirmStats::removeTx
 implicit-integer-sign-change:EvalScript
 implicit-signed-integer-truncation:crypto/
+implicit-unsigned-integer-truncation:SaltedCoinsCacheHasher::operator()
 implicit-unsigned-integer-truncation:crypto/
 shift-base:arith_uint256.cpp
 shift-base:crypto/


### PR DESCRIPTION
The truncation of u64 to size_t is intentional here, but it would be nice to document that for ubsan.

Otherwise, ubsan will print warnings about this. E.g. on 32-bit platforms:

```
/ci_container_base/src/coins.h:255:16: runtime error: implicit conversion from type 'uint64_t' (aka 'unsigned long long') of value 18400304222395891501 (64-bit, unsigned) to type 'size_t' (aka 'unsigned int') changed the value to 2265382701 (32-bit, unsigned)
```

This is a bit tedious to test on 64-bit platforms, but one can use a diff like:

```diff
diff --git a/src/coins.h b/src/coins.h
index c854893bcb..906be9efae 100644
--- a/src/coins.h
+++ b/src/coins.h
@@ -246,3 +246,3 @@ public:
     /** Hash a transaction ID, itself a cryptographic hash, as one jumbo block. */
-    size_t operator()(const Txid& id) const noexcept
+    uint32_t operator()(const Txid& id) const noexcept
     {
@@ -252,3 +252,3 @@ public:
     /** Hash an outpoint as its txid jumbo block followed by the zero-extended index as one normal block. */
-    size_t operator()(const COutPoint& id) const noexcept
+    uint32_t operator()(const COutPoint& id) const noexcept
     {
```

and:

```
$ UBSAN_OPTIONS="suppressions=$(pwd)/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1" ./bld-cmake/bin/test_bitcoin 

./src/coins.h:255:16: runtime error: implicit conversion from type 'uint64_t' (aka 'unsigned long') of value 17092028281225243117 (64-bit, unsigned) to type 'uint32_t' (aka 'unsigned int') changed the value to 291269101 (32-bit, unsigned)
