### PR TITLE
ci: test cross-built macos arm64 binaries

### DIFF
--- a/.github/actions/cache/restore/internal/action.yml
+++ b/.github/actions/cache/restore/internal/action.yml
@@ -14,6 +14,14 @@ inputs:
   provider:
     description: 'The cache provider to use'
     required: true
+  enable-cross-os-archive:
+    description: 'Allow the cache to be restored from another operating system'
+    required: false
+    default: 'false'
+  enable-cross-arch-archive:
+    description: 'Allow the WarpBuild cache to be restored from another architecture'
+    required: false
+    default: 'false'
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
@@ -32,6 +40,8 @@ runs:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}
         restore-keys: ${{ inputs.restore-keys }}
+        enableCrossOsArchive: ${{ inputs.enable-cross-os-archive }}
+        enableCrossArchArchive: ${{ inputs.enable-cross-arch-archive }}
 
     - name: Restore cache with GitHub Actions
       id: gha
@@ -41,3 +51,4 @@ runs:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}
         restore-keys: ${{ inputs.restore-keys }}
+        enableCrossOsArchive: ${{ inputs.enable-cross-os-archive }}

--- a/.github/actions/cache/save/internal/action.yml
+++ b/.github/actions/cache/save/internal/action.yml
@@ -10,6 +10,14 @@ inputs:
   provider:
     description: 'The cache provider to use'
     required: true
+  enable-cross-os-archive:
+    description: 'Allow the cache to be restored on another operating system'
+    required: false
+    default: 'false'
+  enable-cross-arch-archive:
+    description: 'Allow the WarpBuild cache to be restored on another architecture'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -19,6 +27,8 @@ runs:
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}
+        enableCrossOsArchive: ${{ inputs.enable-cross-os-archive }}
+        enableCrossArchArchive: ${{ inputs.enable-cross-arch-archive }}
 
     - name: Save cache with GitHub Actions
       if: ${{ inputs.provider == 'gha' }}
@@ -26,3 +36,4 @@ runs:
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}
+        enableCrossOsArchive: ${{ inputs.enable-cross-os-archive }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,6 +642,46 @@ jobs:
         with:
           provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
 
+  macos-cross-arm64-native:
+    name: 'macOS arm64, run cross-built'
+    needs: [macos-cross-arm64, record-frozen-commit]
+    runs-on: ${{ github.repository == 'bitcoin/bitcoin' && 'warp-macos-26-arm64-6x' || 'macos-26' }}
+
+    steps:
+      - *ANNOTATION_PR_NUMBER
+
+      - *CHECKOUT
+
+      - name: Restore macOS arm64 binaries
+        id: restore-binaries
+        uses: ./.github/actions/cache/restore/internal
+        with:
+          path: macos-arm64-binaries.tar
+          key: macos-arm64-binaries-${{ github.run_id }}
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
+          enable-cross-os-archive: true
+          enable-cross-arch-archive: true
+
+      - name: Check cache hit
+        if: ${{ steps.restore-binaries.outputs.cache-hit != 'true' }}
+        run: |
+          echo '::error::Cross-built macOS arm64 binaries were not found in the cache'
+          false
+
+      - name: Unpack cross-built binaries
+        run: |
+          mkdir macos-arm64-binaries
+          tar -xf macos-arm64-binaries.tar -C macos-arm64-binaries
+          macos-arm64-binaries/dist/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt -version
+
+      - name: Run cross-built test_bitcoin
+        env:
+          DIR_UNIT_TEST_DATA: ${{ github.workspace }}/macos-arm64-binaries/unit_test_data
+        run: macos-arm64-binaries/bin/test_bitcoin -l test_suite
+
+      - name: Run cross-built test_bitcoin-qt
+        run: macos-arm64-binaries/bin/test_bitcoin-qt
+
   lint:
     name: 'lint'
     runs-on: ${{ github.repository == 'bitcoin/bitcoin' && 'warp-ubuntu-latest-x64-2x' || 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,12 +451,6 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_asan.sh'
 
-          - name: 'macOS-cross to arm64'
-            warp-runner: 'warp-ubuntu-latest-x64-4x'
-            fallback-runner: 'ubuntu-latest'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_mac_cross.sh'
-
           - name: 'macOS-cross to x86_64'
             warp-runner: 'warp-ubuntu-latest-x64-4x'
             fallback-runner: 'ubuntu-latest'
@@ -582,6 +576,71 @@ jobs:
         uses: ./.github/actions/cache/save
         with:
           provider: ${{ matrix.provider || (github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha') }}
+
+  macos-cross-arm64:
+    name: 'macOS-cross to arm64'
+    needs: record-frozen-commit
+    runs-on: ${{ github.repository == 'bitcoin/bitcoin' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
+    if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
+    timeout-minutes: 120
+
+    env:
+      DANGER_CI_ON_HOST_FOLDERS: 1
+      FILE_ENV: './ci/test/00_setup_env_mac_cross.sh'
+
+    steps:
+      - *ANNOTATION_PR_NUMBER
+
+      - *CHECKOUT
+
+      - name: Configure environment
+        uses: ./.github/actions/configure-environment
+
+      - name: Restore caches
+        id: restore-cache
+        uses: ./.github/actions/cache/restore
+        with:
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
+
+      - name: Configure Docker
+        uses: ./.github/actions/configure-docker
+        with:
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
+
+      - name: Clear unnecessary files
+        if: ${{ github.repository != 'bitcoin/bitcoin' }} # Only needed on GHA runners
+        uses: ./.github/actions/clear-files
+
+      - name: CI script
+        run: ./ci/test_run_all.sh
+
+      - name: Prepare macOS arm64 tests
+        run: |
+          mkdir unit_test_data
+          ./ci/retry/retry curl --location --fail \
+            https://github.com/bitcoin-core/qa-assets/raw/main/unit_test_data/script_assets_test.json \
+            -o unit_test_data/script_assets_test.json
+          tar -cf macos-arm64-binaries.tar \
+            -C "${BASE_BUILD_DIR}" \
+            bin/test_bitcoin \
+            bin/test_bitcoin-qt \
+            dist/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt \
+            -C "${GITHUB_WORKSPACE}" \
+            unit_test_data/script_assets_test.json
+
+      - name: Save macOS arm64 binaries
+        uses: ./.github/actions/cache/save/internal
+        with:
+          path: macos-arm64-binaries.tar
+          key: macos-arm64-binaries-${{ github.run_id }}
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
+          enable-cross-os-archive: true
+          enable-cross-arch-archive: true
+
+      - name: Save caches
+        uses: ./.github/actions/cache/save
+        with:
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
 
   lint:
     name: 'lint'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,6 +647,46 @@ jobs:
         with:
           provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
 
+  macos-cross-arm64-native:
+    name: 'macOS arm64, run cross-built'
+    needs: [macos-cross-arm64, record-frozen-commit]
+    runs-on: ${{ github.repository == 'bitcoin/bitcoin' && 'warp-macos-26-arm64-6x' || 'macos-26' }}
+
+    steps:
+      - *ANNOTATION_PR_NUMBER
+
+      - *CHECKOUT
+
+      - name: Restore macOS arm64 binaries
+        id: restore-binaries
+        uses: ./.github/actions/cache/restore/internal
+        with:
+          path: macos-arm64-binaries.tar
+          key: macos-arm64-binaries-${{ github.run_id }}
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
+          enable-cross-os-archive: true
+          enable-cross-arch-archive: true
+
+      - name: Check cache hit
+        if: ${{ steps.restore-binaries.outputs.cache-hit != 'true' }}
+        run: |
+          echo '::error::Cross-built macOS arm64 binaries were not found in the cache'
+          false
+
+      - name: Unpack cross-built binaries
+        run: |
+          mkdir macos-arm64-binaries
+          tar -xf macos-arm64-binaries.tar -C macos-arm64-binaries
+          macos-arm64-binaries/dist/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt -version
+
+      - name: Run cross-built test_bitcoin
+        env:
+          DIR_UNIT_TEST_DATA: ${{ github.workspace }}/macos-arm64-binaries/unit_test_data
+        run: macos-arm64-binaries/bin/test_bitcoin -l test_suite
+
+      - name: Run cross-built test_bitcoin-qt
+        run: macos-arm64-binaries/bin/test_bitcoin-qt
+
   lint:
     name: 'lint'
     runs-on: ${{ github.repository == 'bitcoin/bitcoin' && 'warp-ubuntu-latest-x64-2x' || 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,12 +456,6 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_native_asan.sh'
 
-          - name: 'macOS-cross to arm64'
-            warp-runner: 'warp-ubuntu-latest-x64-4x'
-            fallback-runner: 'ubuntu-latest'
-            timeout-minutes: 120
-            file-env: './ci/test/00_setup_env_mac_cross.sh'
-
           - name: 'macOS-cross to x86_64'
             warp-runner: 'warp-ubuntu-latest-x64-4x'
             fallback-runner: 'ubuntu-latest'
@@ -587,6 +581,71 @@ jobs:
         uses: ./.github/actions/cache/save
         with:
           provider: ${{ matrix.provider || (github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha') }}
+
+  macos-cross-arm64:
+    name: 'macOS-cross to arm64'
+    needs: record-frozen-commit
+    runs-on: ${{ github.repository == 'bitcoin/bitcoin' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
+    if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
+    timeout-minutes: 120
+
+    env:
+      DANGER_CI_ON_HOST_FOLDERS: 1
+      FILE_ENV: './ci/test/00_setup_env_mac_cross.sh'
+
+    steps:
+      - *ANNOTATION_PR_NUMBER
+
+      - *CHECKOUT
+
+      - name: Configure environment
+        uses: ./.github/actions/configure-environment
+
+      - name: Restore caches
+        id: restore-cache
+        uses: ./.github/actions/cache/restore
+        with:
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
+
+      - name: Configure Docker
+        uses: ./.github/actions/configure-docker
+        with:
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
+
+      - name: Clear unnecessary files
+        if: ${{ github.repository != 'bitcoin/bitcoin' }} # Only needed on GHA runners
+        uses: ./.github/actions/clear-files
+
+      - name: CI script
+        run: ./ci/test_run_all.sh
+
+      - name: Prepare macOS arm64 tests
+        run: |
+          mkdir unit_test_data
+          ./ci/retry/retry curl --location --fail \
+            https://github.com/bitcoin-core/qa-assets/raw/main/unit_test_data/script_assets_test.json \
+            -o unit_test_data/script_assets_test.json
+          tar -cf macos-arm64-binaries.tar \
+            -C "${BASE_BUILD_DIR}" \
+            bin/test_bitcoin \
+            bin/test_bitcoin-qt \
+            dist/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt \
+            -C "${GITHUB_WORKSPACE}" \
+            unit_test_data/script_assets_test.json
+
+      - name: Save macOS arm64 binaries
+        uses: ./.github/actions/cache/save/internal
+        with:
+          path: macos-arm64-binaries.tar
+          key: macos-arm64-binaries-${{ github.run_id }}
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
+          enable-cross-os-archive: true
+          enable-cross-arch-archive: true
+
+      - name: Save caches
+        uses: ./.github/actions/cache/save
+        with:
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
 
   lint:
     name: 'lint'


### PR DESCRIPTION
Currently we have some macos cross-built binaries, which are using depends as opposed to brew in the native macos builds, but these binaries are not being tested, culminating in silent breakages like #35771

Build `test_bitcoin-qt` in `macos_cross`, and test the binaries in a subsequent job.

the macos_cross job is removed from `ci-matrix` as otherwise the new `macos-cross-arm64` test job has to wait for all matrix jobs to finish (successfully) before running. This includes some of our slow jobs, and will needlessly inflate CI runtimes.

Doing this does add some more boilerplate into ci.yml, but IMO this is acceptable (and the best option currently).