### PR TITLE
scripted-diff: Use C.UTF-8 locale in Guix scripts

### DIFF
--- a/contrib/guix/guix-attest
+++ b/contrib/guix/guix-attest
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -e -o pipefail
 
 # Source the common prelude, which:

--- a/contrib/guix/guix-attest
+++ b/contrib/guix/guix-attest
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
-set -e -o pipefail
+set -o errexit -o pipefail
 
 # Source the common prelude, which:
 #   1. Checks if we're at the top directory of the Bitcoin Core repository

--- a/contrib/guix/guix-attest
+++ b/contrib/guix/guix-attest
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
 set -e -o pipefail
 

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 
 # Source the common prelude, which:

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 

--- a/contrib/guix/guix-clean
+++ b/contrib/guix/guix-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -e -o pipefail
 
 # Source the common prelude, which:

--- a/contrib/guix/guix-clean
+++ b/contrib/guix/guix-clean
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
-set -e -o pipefail
+set -o errexit -o pipefail
 
 # Source the common prelude, which:
 #   1. Checks if we're at the top directory of the Bitcoin Core repository

--- a/contrib/guix/guix-clean
+++ b/contrib/guix/guix-clean
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
 set -e -o pipefail
 

--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -e -o pipefail
 
 # Source the common prelude, which:

--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
-set -e -o pipefail
+set -o errexit -o pipefail
 
 # Source the common prelude, which:
 #   1. Checks if we're at the top directory of the Bitcoin Core repository

--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
 set -e -o pipefail
 

--- a/contrib/guix/guix-verify
+++ b/contrib/guix/guix-verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -e -o pipefail
 
 # Source the common prelude, which:

--- a/contrib/guix/guix-verify
+++ b/contrib/guix/guix-verify
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
-set -e -o pipefail
+set -o errexit -o pipefail
 
 # Source the common prelude, which:
 #   1. Checks if we're at the top directory of the Bitcoin Core repository

--- a/contrib/guix/guix-verify
+++ b/contrib/guix/guix-verify
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
 set -e -o pipefail
 

--- a/contrib/guix/libexec/build_linux.sh
+++ b/contrib/guix/libexec/build_linux.sh
@@ -2,7 +2,7 @@
 # Copyright (c) The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 
 # shellcheck source=setup.sh

--- a/contrib/guix/libexec/build_linux_gui.sh
+++ b/contrib/guix/libexec/build_linux_gui.sh
@@ -2,7 +2,7 @@
 # Copyright (c) The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 
 # shellcheck source=setup.sh

--- a/contrib/guix/libexec/build_macos.sh
+++ b/contrib/guix/libexec/build_macos.sh
@@ -2,7 +2,7 @@
 # Copyright (c) The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 
 # shellcheck source=setup.sh

--- a/contrib/guix/libexec/build_macos_gui.sh
+++ b/contrib/guix/libexec/build_macos_gui.sh
@@ -2,7 +2,7 @@
 # Copyright (c) The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 
 # shellcheck source=setup.sh

--- a/contrib/guix/libexec/build_win.sh
+++ b/contrib/guix/libexec/build_win.sh
@@ -2,7 +2,7 @@
 # Copyright (c) The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 
 # shellcheck source=setup.sh

--- a/contrib/guix/libexec/build_win_gui.sh
+++ b/contrib/guix/libexec/build_win_gui.sh
@@ -2,7 +2,7 @@
 # Copyright (c) The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 
 # shellcheck source=setup.sh

--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -2,7 +2,7 @@
 # Copyright (c) 2021-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -e -o pipefail
 
 # Environment variables for determinism

--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Copyright (c) 2021-present The Bitcoin Core developers
+# Copyright (c) The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
 set -e -o pipefail
 

--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
-set -e -o pipefail
+set -o errexit -o pipefail
 
 # Environment variables for determinism
 export TAR_OPTIONS="--owner=0 --group=0 --numeric-owner --mtime='@${SOURCE_DATE_EPOCH}' --sort=name"

--- a/contrib/guix/libexec/package.sh
+++ b/contrib/guix/libexec/package.sh
@@ -2,7 +2,7 @@
 # Copyright (c) The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -e -o pipefail
 
 (

--- a/contrib/guix/libexec/package.sh
+++ b/contrib/guix/libexec/package.sh
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
-set -e -o pipefail
+set -o errexit -o pipefail
 
 (
     cd "$DISTSRC"

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 
 source contrib/shell/realpath.bash

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
 export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 

--- a/contrib/guix/libexec/setup.sh
+++ b/contrib/guix/libexec/setup.sh
@@ -2,7 +2,7 @@
 # Copyright (c) The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit.
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -o errexit -o pipefail
 
 # Environment variables for determinism

--- a/contrib/guix/manifest_build.scm
+++ b/contrib/guix/manifest_build.scm
@@ -209,7 +209,7 @@ chain for " target " development."))
 (define-public glibc-2.31
   (let ((commit "28eb5caf895ced5d895cb02757e109004a2d33e5"))
   (package
-    (inherit glibc) ;; 2.39
+    (inherit glibc) ;; 2.41
     (version "2.31")
     (source (origin
               (method git-fetch)


### PR DESCRIPTION
The C.UTF-8 locale is set by default in `guix shell`, and there is no reason to avoid it nowadays. This PR also silences superfluous warnings from Qt tools, making build logs cleaner and other issues easier to spot. For example:
```
Detected locale "C" with character encoding "ANSI_X3.4-1968", which is not UTF-8.
Qt depends on a UTF-8 locale, and has switched to "C.UTF-8" instead.
If this causes problems, reconfigure your locale. See the locale(1) manual
for more information.
```

Locales in the `guix-*` launch scripts have been updated as well for consistency with the rest of the codebase.

Additionally, the headers of the Guix scripts have been adjusted for [uniformity](https://github.com/bitcoin/bitcoin/pull/35775#discussion_r3636959268).