### PR TITLE
scripted-diff: Use C.UTF-8 locale in all shell scripts

### DIFF
--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 
 set -o errexit -o pipefail -o xtrace
 

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 
 set -o errexit -o pipefail -o xtrace
 

--- a/cmake/script/macos_zip.sh
+++ b/cmake/script/macos_zip.sh
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 
 if [ -n "$SOURCE_DATE_EPOCH" ]; then
   find . -exec touch -d "@$SOURCE_DATE_EPOCH" {} +

--- a/contrib/devtools/check-deps.sh
+++ b/contrib/devtools/check-deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -Eeuo pipefail
 
 # Declare paths to libraries

--- a/contrib/devtools/gen-bitcoin-conf.sh
+++ b/contrib/devtools/gen-bitcoin-conf.sh
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 TOPDIR=${TOPDIR:-$(git rev-parse --show-toplevel)}
 BUILDDIR=${BUILDDIR:-$TOPDIR/build}
 BINDIR=${BINDIR:-$BUILDDIR/bin}

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 set -e
 
 SIGNAPPLE=signapple

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 #network interface on which to limit traffic
 IF="eth0"
 #limit of the network interface in question

--- a/contrib/verify-commits/gpg.sh
+++ b/contrib/verify-commits/gpg.sh
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 INPUT=$(cat /dev/stdin)
 if [ "$BITCOIN_VERIFY_COMMITS_ALLOW_SHA1" = 1 ]; then
     printf '%s\n' "$INPUT" | gpg --trust-model always "$@" 2>/dev/null

--- a/contrib/windeploy/detached-sig-create.sh
+++ b/contrib/windeploy/detached-sig-create.sh
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 if [ -z "$OSSLSIGNCODE" ]; then
   OSSLSIGNCODE=osslsigncode
 fi

--- a/src/qt/res/animation/makespinner.sh
+++ b/src/qt/res/animation/makespinner.sh
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 FRAMEDIR=$(dirname "$0")
 for i in {0..35}
 do

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -11,7 +11,7 @@
 # The resulting script should exactly transform the previous commit into the current
 # one. Any remaining diff signals an error.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 if test -z "$1"; then
     echo "Usage: $0 <commit>..."
     exit 1

--- a/test/lint/git-subtree-check.sh
+++ b/test/lint/git-subtree-check.sh
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+export LC_ALL=C.UTF-8
 
 check_remote=0
 while getopts "?hr" opt; do

--- a/test/lint/lint-shell-locale.py
+++ b/test/lint/lint-shell-locale.py
@@ -38,7 +38,7 @@ def main():
     exit_code = 0
     shell_files = get_shell_files_list()
     for file_path in shell_files:
-        if re.search('src/(secp256k1|minisketch)/', file_path):
+        if re.search('src/(ipc/libmultiprocess|secp256k1|minisketch)/', file_path):
             continue
 
         with open(file_path, 'r') as file_obj:

--- a/test/lint/lint-shell-locale.py
+++ b/test/lint/lint-shell-locale.py
@@ -15,7 +15,6 @@ import sys
 import re
 
 OPT_OUT_LINES = [
-    'export LC_ALL=C',
     'export LC_ALL=C.UTF-8',
 ]
 
@@ -51,7 +50,7 @@ def main():
 
         first_non_comment_line = non_comment_lines[0]
         if first_non_comment_line not in OPT_OUT_LINES:
-            print(f'Missing "export LC_ALL=C" (to avoid locale dependence) as first non-comment non-empty line in {file_path}')
+            print(f'Missing "export LC_ALL=C.UTF-8" (to avoid locale dependence) as first non-comment non-empty line in {file_path}')
             exit_code = 1
 
     return sys.exit(exit_code)

--- a/test/lint/lint-shell-locale.py
+++ b/test/lint/lint-shell-locale.py
@@ -5,8 +5,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 """
-Make sure all shell scripts explicitly opt out of locale dependence using
-"export LC_ALL=C" or "export LC_ALL=C.UTF-8", which also enables UTF-8 mode in
+Make sure all shell scripts explicitly opt out of locale dependence
+using "export LC_ALL=C.UTF-8", which also enables UTF-8 mode in
 Python. See: https://docs.python.org/3/library/os.html#python-utf-8-mode
 """
 
@@ -15,7 +15,6 @@ import sys
 import re
 
 OPT_OUT_LINES = [
-    'export LC_ALL=C',
     'export LC_ALL=C.UTF-8',
 ]
 
@@ -51,7 +50,7 @@ def main():
 
         first_non_comment_line = non_comment_lines[0]
         if first_non_comment_line not in OPT_OUT_LINES:
-            print(f'Missing "export LC_ALL=C" (to avoid locale dependence) as first non-comment non-empty line in {file_path}')
+            print(f'Missing "export LC_ALL=C.UTF-8" (to avoid locale dependence) as first non-comment non-empty line in {file_path}')
             exit_code = 1
 
     return sys.exit(exit_code)


### PR DESCRIPTION
This unifies the used locales across the entire codebase.

Additionally, the `test/lint/lint-shell-locale.py` linter has been adjusted accordingly.

Also see https://github.com/bitcoin/bitcoin/pull/35775#issuecomment-5047323736.