### PR TITLE
http: linger-close after parse errors so clients can read the reply

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -47,6 +47,16 @@
 //! the sleep time needs to be small to avoid new sockets stalling.
 static constexpr auto SELECT_TIMEOUT{50ms};
 
+/**
+ * Maximum time to drain input after flushing an error reply and half-closing
+ * the send side. This bounds clients that do not close their side.
+ *
+ * Closing with unread input can reset the connection and hide the reply on
+ * Windows (https://github.com/bitcoin/bitcoin/issues/35632). For oversized
+ * requests the client may still be uploading when this timeout expires.
+ */
+static constexpr auto LINGERING_CLOSE_TIMEOUT{1s};
+
 //! Explicit alias for setting socket option methods.
 static constexpr int SOCKET_OPTION_TRUE{1};
 
@@ -182,9 +192,8 @@ static void MaybeDispatchRequestToWorker(std::shared_ptr<HTTPRequest> hreq)
                 err_msg = "unknown error";
             }
             // Reply so the client doesn't hang waiting for the response.
-            req->WriteHeader("Connection", "close");
             // TODO: Implement specific error formatting for the REST and JSON-RPC servers responses.
-            req->WriteReply(HTTP_INTERNAL_SERVER_ERROR, err_msg);
+            req->WriteReply(HTTP_INTERNAL_SERVER_ERROR, err_msg, /*force_close=*/true);
         };
 
         if (auto res = g_threadpool_http.Submit(std::move(item)); !res.has_value()) {
@@ -262,6 +271,25 @@ void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)
 
 namespace http_bitcoin {
 using util::Split;
+
+/**
+ * Queue an error reply for a rejected request and enable a lingering close.
+ *
+ * Covers requests rejected while parsing: malformed syntax as well as an
+ * oversized body. Runs only on the HTTP I/O thread. The send path starts the
+ * timeout and half-closes after flushing the reply; the receive path then
+ * drains to EOF.
+ */
+static void SendErrorReplyAndLingerClose(HTTPRequest& req, HTTPRemoteClient& client, HTTPStatusCode status)
+{
+    client.m_lingering_close = true;
+    // Keep the connection alive until the reply is flushed.
+    client.m_connection_busy = true;
+    // Further input is drained directly from the socket.
+    client.m_recv_buffer.clear();
+
+    req.WriteReply(status, std::span<const std::byte>{}, /*force_close=*/true);
+}
 
 std::optional<std::string> HTTPHeaders::FindFirst(const std::string_view key) const
 {
@@ -512,7 +540,7 @@ bool HTTPRequest::LoadBody(LineReader& reader)
     }
 }
 
-void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body)
+void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body, bool force_close)
 {
     HTTPResponse res;
 
@@ -570,7 +598,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
     }
 
     auto connection_header{m_headers.FindFirst("Connection")};
-    if (connection_header && ToLower(connection_header.value()) == "close") {
+    if (force_close || (connection_header && ToLower(connection_header.value()) == "close")) {
         // Might not exist already but we need to replace it, not append to it
         res.m_headers.RemoveAll("Connection");
 
@@ -847,6 +875,8 @@ void HTTPServer::SocketHandlerConnected(const IOReadiness& io_readiness) const
         }
         const std::shared_ptr<HTTPRemoteClient>& client{it->second};
 
+        const bool lingering_close{client->m_lingering_close};
+
         bool send_ready = events.occurred & Sock::SendEvent;
         bool recv_ready = events.occurred & Sock::RecvEvent;
         bool err_ready = events.occurred & Sock::ErrorEvent;
@@ -892,18 +922,23 @@ void HTTPServer::SocketHandlerConnected(const IOReadiness& io_readiness) const
                 // Prevent disconnect until all requests are completely handled.
                 client->m_connection_busy = true;
 
-                // Copy data from socket buffer to client receive buffer
-                client->m_recv_buffer.insert(
-                    client->m_recv_buffer.end(),
-                    buf,
-                    buf + nrecv);
+                // While lingering, input is drained without parsing another request.
+                if (!lingering_close) {
+                    // Copy data from socket buffer to client receive buffer
+                    client->m_recv_buffer.insert(
+                        client->m_recv_buffer.end(),
+                        buf,
+                        buf + nrecv);
+                }
             }
         }
         // Process as much received data as we can.
         // This executes for every client whether or not reading or writing
         // took place because it also (might) parse a request we have already
         // received and pass it to a worker thread.
-        MaybeDispatchRequestsFromClient(client);
+        if (!lingering_close) {
+            MaybeDispatchRequestsFromClient(client);
+        }
     }
 }
 
@@ -998,8 +1033,8 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
                 client->m_id,
                 e.what());
 
-            req->WriteReply(HTTP_CONTENT_TOO_LARGE);
-            client->m_disconnect = true;
+            // The client may still be uploading when the linger timeout expires.
+            SendErrorReplyAndLingerClose(*req, *client, HTTP_CONTENT_TOO_LARGE);
             return;
         } catch (const std::runtime_error& e) {
             LogDebug(
@@ -1009,9 +1044,7 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
                 client->m_id,
                 e.what());
 
-            // We failed to read a complete request from the buffer
-            req->WriteReply(HTTP_BAD_REQUEST);
-            client->m_disconnect = true;
+            SendErrorReplyAndLingerClose(*req, *client, HTTP_BAD_REQUEST);
             return;
         }
 
@@ -1045,6 +1078,7 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
 void HTTPServer::DisconnectClients()
 {
     const auto now{Now<SteadySeconds>()};
+    const auto now_ms{Now<SteadyMilliseconds>()};
     size_t erased = std::erase_if(m_connected,
                                   [&](auto& client) {
                                         // First check for idle timeout. We reset the timer when we send and receive data,
@@ -1055,13 +1089,21 @@ void HTTPServer::DisconnectClients()
                                         const bool is_idle{m_rpcservertimeout.count() > 0 &&
                                                            now - client->m_idle_since.load() > m_rpcservertimeout &&
                                                            !client->m_req_busy};
+                                        const bool lingering_close_expired{
+                                            client->m_lingering_half_closed &&
+                                            now_ms >= client->m_lingering_close_deadline.load()};
 
-                                        // Disconnect this client due to error, end of communication, or idle timeout.
+                                        // Disconnect on error, EOF, idle timeout, or a stalled lingering close.
                                         // May drop unsent data if we are closing due to error.
-                                        if (client->m_disconnect || is_idle) {
+                                        if (client->m_disconnect || is_idle || lingering_close_expired) {
                                             if (is_idle) {
                                                 LogDebug(BCLog::HTTP,
                                                          "HTTP client idle timeout %s (id=%llu)",
+                                                         client->m_origin,
+                                                         client->m_id);
+                                            } else if (lingering_close_expired && !client->m_disconnect) {
+                                                LogDebug(BCLog::HTTP,
+                                                         "HTTP client lingering-close fallback timeout %s (id=%llu)",
                                                          client->m_origin,
                                                          client->m_id);
                                             }
@@ -1189,6 +1231,27 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
         // on an already-empty m_send_buffer because the connection might have just been opened.
         if (m_send_buffer.empty()) {
             m_send_ready = false;
+
+            if (m_lingering_close) {
+                // The reply is flushed. Half-close once, then drain to EOF.
+                m_connection_busy = true;
+                if (!m_lingering_half_closed) {
+                    // Arm the deadline before publishing the flag.
+                    m_lingering_close_deadline = Now<SteadyMilliseconds>() + LINGERING_CLOSE_TIMEOUT;
+                    m_lingering_half_closed = true;
+                    const int shut_ret{WITH_LOCK(m_sock_mutex, return m_sock->ShutdownSend();)};
+                    if (shut_ret != 0) {
+                        LogDebug(
+                            BCLog::HTTP,
+                            "shutdown(send) failed for client %s (id=%llu): %s; continuing drain",
+                            m_origin,
+                            m_id,
+                            NetworkErrorString(WSAGetLastError()));
+                    }
+                }
+                return true;
+            }
+
             m_connection_busy = false;
 
             // Our work is done here

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -46,6 +46,16 @@
 //! the sleep time needs to be small to avoid new sockets stalling.
 static constexpr auto SELECT_TIMEOUT{50ms};
 
+/**
+ * Maximum time to drain input after flushing an error reply and half-closing
+ * the send side. This bounds clients that do not close their side.
+ *
+ * Closing with unread input can reset the connection and hide the reply on
+ * Windows (https://github.com/bitcoin/bitcoin/issues/35632). For oversized
+ * requests the client may still be uploading when this timeout expires.
+ */
+static constexpr auto LINGERING_CLOSE_TIMEOUT{1s};
+
 //! Explicit alias for setting socket option methods.
 static constexpr int SOCKET_OPTION_TRUE{1};
 
@@ -183,7 +193,6 @@ static void MaybeDispatchRequestToWorker(std::shared_ptr<HTTPRequest> hreq)
                 err_msg = "unknown error";
             }
             // Reply so the client doesn't hang waiting for the response.
-            req->WriteHeader("Connection", "close");
             // TODO: Implement specific error formatting for the REST and JSON-RPC servers responses.
             WriteNoStoreErrorReply(*req, HTTP_INTERNAL_SERVER_ERROR, err_msg);
         };
@@ -263,6 +272,26 @@ void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)
 
 namespace http_bitcoin {
 using util::Split;
+
+/**
+ * Queue an error reply for a rejected request and enable a lingering close.
+ *
+ * Covers requests rejected while parsing: malformed syntax as well as an
+ * oversized body. Runs only on the HTTP I/O thread. The send path starts the
+ * timeout and half-closes after flushing the reply; the receive path then
+ * drains to EOF.
+ */
+static void SendErrorReplyAndLingerClose(HTTPRequest& req, HTTPRemoteClient& client, HTTPStatusCode status)
+{
+    client.m_lingering_close = true;
+    // Keep the connection alive until the reply is flushed.
+    client.m_connection_busy = true;
+    // Further input is drained directly from the socket.
+    client.m_recv_buffer.clear();
+
+    req.WriteHeader("Cache-Control", "no-store");
+    req.WriteReply(status, std::span<const std::byte>{}, /*force_close=*/true);
+}
 
 std::optional<std::string> HTTPHeaders::FindFirst(const std::string_view key) const
 {
@@ -534,7 +563,7 @@ bool HTTPRequest::LoadBody(LineReader& reader)
     }
 }
 
-void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body)
+void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body, bool force_close)
 {
     HTTPResponse res;
 
@@ -592,7 +621,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
     }
 
     auto connection_header{m_headers.FindFirst("Connection")};
-    if (connection_header && ToLower(connection_header.value()) == "close") {
+    if (force_close || (connection_header && ToLower(connection_header.value()) == "close")) {
         // Might not exist already but we need to replace it, not append to it
         res.m_headers.RemoveAll("Connection");
 
@@ -887,6 +916,8 @@ void HTTPServer::SocketHandlerConnected(const IOReadiness& io_readiness) const
         }
         const std::shared_ptr<HTTPRemoteClient>& client{it->second};
 
+        const bool lingering_close{client->m_lingering_close};
+
         bool send_ready = events.occurred & Sock::SendEvent;
         bool recv_ready = events.occurred & Sock::RecvEvent;
         bool err_ready = events.occurred & Sock::ErrorEvent;
@@ -932,18 +963,23 @@ void HTTPServer::SocketHandlerConnected(const IOReadiness& io_readiness) const
                 // Prevent disconnect until all requests are completely handled.
                 client->m_connection_busy = true;
 
-                // Copy data from socket buffer to client receive buffer
-                client->m_recv_buffer.insert(
-                    client->m_recv_buffer.end(),
-                    buf,
-                    buf + nrecv);
+                // While lingering, input is drained without parsing another request.
+                if (!lingering_close) {
+                    // Copy data from socket buffer to client receive buffer
+                    client->m_recv_buffer.insert(
+                        client->m_recv_buffer.end(),
+                        buf,
+                        buf + nrecv);
+                }
             }
         }
         // Process as much received data as we can.
         // This executes for every client whether or not reading or writing
         // took place because it also (might) parse a request we have already
         // received and pass it to a worker thread.
-        MaybeDispatchRequestsFromClient(client);
+        if (!lingering_close) {
+            MaybeDispatchRequestsFromClient(client);
+        }
     }
 }
 
@@ -1043,8 +1079,8 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
             client->m_id,
             e.what());
 
-        WriteNoStoreErrorReply(*client->m_req, HTTP_CONTENT_TOO_LARGE);
-        client->m_disconnect = true;
+        // The client may still be uploading when the linger timeout expires.
+        SendErrorReplyAndLingerClose(*client->m_req, *client, HTTP_CONTENT_TOO_LARGE);
         return;
     } catch (const std::runtime_error& e) {
         LogDebug(
@@ -1054,9 +1090,7 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
             client->m_id,
             e.what());
 
-        // We failed to read a complete request from the buffer
-        WriteNoStoreErrorReply(*client->m_req, HTTP_BAD_REQUEST);
-        client->m_disconnect = true;
+        SendErrorReplyAndLingerClose(*client->m_req, *client, HTTP_BAD_REQUEST);
         return;
     }
 
@@ -1079,6 +1113,7 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
 void HTTPServer::DisconnectClients()
 {
     const auto now{Now<SteadySeconds>()};
+    const auto now_ms{Now<SteadyMilliseconds>()};
     size_t erased = std::erase_if(m_connected,
                                   [&](auto& client) {
                                         // First check for idle timeout. We reset the timer when we send and receive data,
@@ -1089,14 +1124,23 @@ void HTTPServer::DisconnectClients()
                                         // client on a worker thread - it would keep the socket open even after "disconnecting".
                                         const bool is_idle{m_rpcservertimeout.count() > 0 &&
                                                            now - client->m_idle_since.load() > m_rpcservertimeout &&
-                                                           !client->m_req_busy};
+                                                           !client->m_req_busy &&
+                                                           !client->m_lingering_close};
+                                        const bool lingering_close_expired{
+                                            client->m_lingering_half_closed &&
+                                            now_ms >= client->m_lingering_close_deadline.load()};
 
-                                        // Disconnect this client due to error, end of communication, or idle timeout.
+                                        // Disconnect on error, EOF, idle timeout, or a stalled lingering close.
                                         // May drop unsent data if we are closing due to error.
-                                        if (client->m_disconnect || is_idle) {
+                                        if (client->m_disconnect || is_idle || lingering_close_expired) {
                                             if (is_idle) {
                                                 LogDebug(BCLog::HTTP,
                                                          "HTTP client idle timeout %s (id=%llu)",
+                                                         client->m_origin,
+                                                         client->m_id);
+                                            } else if (lingering_close_expired && !client->m_disconnect) {
+                                                LogDebug(BCLog::HTTP,
+                                                         "HTTP client lingering-close fallback timeout %s (id=%llu)",
                                                          client->m_origin,
                                                          client->m_id);
                                             }
@@ -1249,6 +1293,29 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
         // on an already-empty m_send_buffer because the connection might have just been opened.
         if (m_send_buffer.empty()) {
             m_send_ready = false;
+
+            if (m_lingering_close) {
+                // The reply is flushed. Half-close once, then drain to EOF.
+                m_connection_busy = true;
+                if (!m_lingering_half_closed) {
+                    // Arm the deadline before publishing the flag.
+                    m_lingering_close_deadline = Now<SteadyMilliseconds>() + LINGERING_CLOSE_TIMEOUT;
+                    m_lingering_half_closed = true;
+                    const int shut_ret{WITH_LOCK(m_sock_mutex, return m_sock->ShutdownSend();)};
+                    if (shut_ret != 0) {
+                        LogDebug(
+                            BCLog::HTTP,
+                            "shutdown(send) failed for client %s (id=%llu): %s; continuing drain",
+                            m_origin,
+                            m_id,
+                            NetworkErrorString(WSAGetLastError()));
+                    }
+                }
+                // Teardown is governed by m_lingering_close_deadline from here,
+                // so return without refreshing the idle timer below.
+                return true;
+            }
+
             m_connection_busy = false;
 
             // Our work is done here

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -184,10 +184,16 @@ public:
     bool LoadBody(LineReader& reader);
     /// @}
 
-    void WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body = {});
-    void WriteReply(HTTPStatusCode status, std::string_view reply_body_view)
+    /**
+     * Queue an HTTP response for this request's client.
+     * @param[in] force_close If true, send Connection: close and mark the client
+     *                        non-keep-alive so the connection is closed after the
+     *                        response is flushed (or after a lingering close drain).
+     */
+    void WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body = {}, bool force_close = false);
+    void WriteReply(HTTPStatusCode status, std::string_view reply_body_view, bool force_close = false)
     {
-        WriteReply(status, std::as_bytes(std::span{reply_body_view}));
+        WriteReply(status, std::as_bytes(std::span{reply_body_view}), force_close);
     }
 
     // These methods reimplement the API from http_libevent::HTTPRequest
@@ -517,6 +523,7 @@ public:
      * Written to by http worker threads, read and erased by HTTPServer I/O thread
      */
     /// @{
+    //! Lock order: always acquire m_send_mutex before m_sock_mutex (never the reverse).
     Mutex m_send_mutex;
     std::vector<std::byte> m_send_buffer GUARDED_BY(m_send_mutex);
     /// @}
@@ -535,6 +542,7 @@ public:
      * Mutex that serializes the Send() and Recv() calls on `m_sock`. Reading
      * from the client occurs in the I/O thread but writing back to a client
      * may occur in a worker thread.
+     * Must be acquired after m_send_mutex when both are needed.
      */
     Mutex m_sock_mutex;
 
@@ -548,7 +556,8 @@ public:
     std::shared_ptr<Sock> m_sock GUARDED_BY(m_sock_mutex);
 
     //! Initialized to true while server waits for first request from client.
-    //! Set to false after data is written to m_send_buffer and then that buffer is flushed to client.
+    //! Set to false after m_send_buffer is flushed, unless a lingering close is in progress
+    //! (then kept true so DisconnectAllClients() waits for the drain).
     //! Reset to true when we receive new request data from client.
     //! Checked during DisconnectClients() and set by read/write operations
     //! called in either the HTTPServer I/O loop or by a worker thread during an "optimistic send".
@@ -566,6 +575,25 @@ public:
     //! Might be set in a worker thread or in the I/O thread. When set to `true` we disconnect,
     //! possibly overriding all other disconnect flags.
     std::atomic_bool m_disconnect{false};
+
+    /**
+     * Linger after a parse error so unread request bytes can be drained.
+     *
+     * Set by the I/O thread and read by the send path, which may run on a worker.
+     */
+    std::atomic_bool m_lingering_close{false};
+
+    /**
+     * True after the error reply is flushed and the send side is half-closed.
+     * Set by the send path and read by the I/O thread.
+     */
+    std::atomic_bool m_lingering_half_closed{false};
+
+    /**
+     * Fallback deadline while waiting for peer EOF after the half-close.
+     * Set by the send path once the send side is half-closed.
+     */
+    std::atomic<SteadyMilliseconds> m_lingering_close_deadline{SteadyMilliseconds::max()};
 
     //! Timestamp of last send or receive activity, used for -rpcservertimeout.
     //! Due to optimistic sends it may be updated in either a worker thread or in the

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -180,10 +180,16 @@ public:
     bool LoadBody(LineReader& reader);
     /// @}
 
-    void WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body = {});
-    void WriteReply(HTTPStatusCode status, std::string_view reply_body_view)
+    /**
+     * Queue an HTTP response for this request's client.
+     * @param[in] force_close If true, send Connection: close and mark the client
+     *                        non-keep-alive so the connection is closed after the
+     *                        response is flushed (or after a lingering close drain).
+     */
+    void WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body = {}, bool force_close = false);
+    void WriteReply(HTTPStatusCode status, std::string_view reply_body_view, bool force_close = false)
     {
-        WriteReply(status, std::as_bytes(std::span{reply_body_view}));
+        WriteReply(status, std::as_bytes(std::span{reply_body_view}), force_close);
     }
 
     // These methods reimplement the API from http_libevent::HTTPRequest
@@ -478,6 +484,7 @@ public:
      * Written to by http worker threads, read and erased by HTTPServer I/O thread
      */
     /// @{
+    //! Lock order: always acquire m_send_mutex before m_sock_mutex (never the reverse).
     Mutex m_send_mutex;
     std::vector<std::byte> m_send_buffer GUARDED_BY(m_send_mutex);
     /// @}
@@ -496,6 +503,7 @@ public:
      * Mutex that serializes the Send() and Recv() calls on `m_sock`. Reading
      * from the client occurs in the I/O thread but writing back to a client
      * may occur in a worker thread.
+     * Must be acquired after m_send_mutex when both are needed.
      */
     Mutex m_sock_mutex;
 
@@ -509,7 +517,8 @@ public:
     std::shared_ptr<Sock> m_sock GUARDED_BY(m_sock_mutex);
 
     //! Initialized to true while server waits for first request from client.
-    //! Set to false after data is written to m_send_buffer and then that buffer is flushed to client.
+    //! Set to false after m_send_buffer is flushed, unless a lingering close is in progress
+    //! (then kept true so DisconnectAllClients() waits for the drain).
     //! Reset to true when we receive new request data from client.
     //! Checked during DisconnectClients() and set by read/write operations
     //! called in either the HTTPServer I/O loop or by a worker thread during an "optimistic send".
@@ -527,6 +536,25 @@ public:
     //! Might be set in a worker thread or in the I/O thread. When set to `true` we disconnect,
     //! possibly overriding all other disconnect flags.
     std::atomic_bool m_disconnect{false};
+
+    /**
+     * Linger after a parse error so unread request bytes can be drained.
+     *
+     * Set by the I/O thread and read by the send path, which may run on a worker.
+     */
+    std::atomic_bool m_lingering_close{false};
+
+    /**
+     * True after the error reply is flushed and the send side is half-closed.
+     * Set by the send path and read by the I/O thread.
+     */
+    std::atomic_bool m_lingering_half_closed{false};
+
+    /**
+     * Fallback deadline while waiting for peer EOF after the half-close.
+     * Set by the send path once the send side is half-closed.
+     */
+    std::atomic<SteadyMilliseconds> m_lingering_close_deadline{SteadyMilliseconds::max()};
 
     //! Timestamp of last send or receive activity, used for -rpcservertimeout.
     //! Due to optimistic sends it may be updated in either a worker thread or in the

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -234,6 +234,8 @@ ssize_t FuzzedSock::Recv(void* buf, size_t len, int flags) const
     return len;
 }
 
+int FuzzedSock::ShutdownSend() const { return 0; }
+
 int FuzzedSock::Connect(const sockaddr*, socklen_t) const
 {
     // Have a permanent error at connect_errnos[0] because when the fuzzed data is exhausted

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -198,6 +198,8 @@ public:
 
     ssize_t Recv(void* buf, size_t len, int flags) const override;
 
+    int ShutdownSend() const override;
+
     int Connect(const sockaddr*, socklen_t) const override;
 
     int Bind(const sockaddr*, socklen_t) const override;

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -176,6 +176,8 @@ ssize_t ZeroSock::Recv(void* buf, size_t len, int flags) const
     return len;
 }
 
+int ZeroSock::ShutdownSend() const { return 0; }
+
 int ZeroSock::Connect(const sockaddr*, socklen_t) const { return 0; }
 
 int ZeroSock::Bind(const sockaddr*, socklen_t) const { return 0; }

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -176,6 +176,8 @@ public:
 
     ssize_t Recv(void* buf, size_t len, int flags) const override;
 
+    int ShutdownSend() const override;
+
     int Connect(const sockaddr*, socklen_t) const override;
 
     int Bind(const sockaddr*, socklen_t) const override;

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -54,6 +54,15 @@ ssize_t Sock::Recv(void* buf, size_t len, int flags) const
     return recv(m_socket, static_cast<char*>(buf), len, flags);
 }
 
+int Sock::ShutdownSend() const
+{
+#ifdef WIN32
+    return shutdown(m_socket, SD_SEND);
+#else
+    return shutdown(m_socket, SHUT_WR);
+#endif
+}
+
 int Sock::Connect(const sockaddr* addr, socklen_t addr_len) const
 {
     return connect(m_socket, addr, addr_len);

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -79,6 +79,12 @@ public:
     [[nodiscard]] virtual ssize_t Recv(void* buf, size_t len, int flags) const;
 
     /**
+     * Half-close the send side while leaving the receive side open.
+     * Equivalent to `shutdown(m_socket, SHUT_WR)` or `shutdown(m_socket, SD_SEND)`.
+     */
+    [[nodiscard]] virtual int ShutdownSend() const;
+
+    /**
      * connect(2) wrapper. Equivalent to `connect(m_socket, addr, addrlen)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */


### PR DESCRIPTION
Based on this issue #35632 raised i believe the issue is not with whitespace header validation since the logic works fine coz the server detects the malformed request and queues a 400 reply as expected.

The problem is how the server closes the connection afterwards. It queues the reply and closes the socket right away sometimes before it has finished reading everything the client had sent. 
So when socket is closed while there's still unread data sitting in the kernel's receive buffer, Windows responds with a TCP RST. That reset just throws away the reply that was already on its way out, so the client never gets to read the 400 and instead sees the connection aborted.

So my LLM Buddie and I realized that we should change how the server closes a connection after a parse/size error so the client always gets a chance to read the response first by queuing the `400/413 response` with `Connection: close`. 
Then, waits until the response has actually left the send buffer. Then, Half-close only the write side (shutdown(SHUT_WR/SD_SEND)) so the client can still finish reading while the server stops sending. Afterwards, Keep draining whatever the client is still sending until it hits EOF or a socket error and only force the connection closed after a 1s fallback timeout, for a client that never finishes.