### PR TITLE
doc: fix outdated i2p URLs in comments

### DIFF
--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -4,20 +4,20 @@ It is possible to run Bitcoin Core as an
 [I2P (Invisible Internet Project)](https://en.wikipedia.org/wiki/I2P)
 service and connect to such services.
 
-This [glossary](https://geti2p.net/en/about/glossary) may be useful to get
+This [glossary](https://i2p.net/en/docs/overview/glossary) may be useful to get
 started with I2P terminology.
 
 ## Run Bitcoin Core with an I2P router (proxy)
 
-A running I2P router (proxy) is required with the [SAM](https://geti2p.net/en/docs/api/samv3)
+A running I2P router (proxy) is required with the [SAM](https://i2p.net/en/docs/api/samv3)
 application bridge enabled. The following routers are recommended for use with Bitcoin Core:
 
-- [i2prouter (I2P Router)](https://geti2p.net), the official implementation in
+- [i2prouter (I2P Router)](https://i2p.net), the official implementation in
   Java. The SAM bridge is not enabled by default; it must be started manually,
   or configured to start automatically, in the Clients page in the
   router console (`http://127.0.0.1:7657/configclients`) or in the `clients.config` file.
 - [i2pd (I2P Daemon)](https://github.com/PurpleI2P/i2pd)
-  ([documentation](https://i2pd.readthedocs.io/en/latest)), a lighter
+  ([documentation](https://docs.i2pd.website/en/latest)), a lighter
   alternative in C++. It enables the SAM bridge by default.
 
 Note the IP address and port the SAM proxy is listening to; usually, it is
@@ -113,7 +113,7 @@ You can use the `getnodeaddresses` RPC to fetch a number of I2P peers known to y
 
 ## Compatibility
 
-Bitcoin Core uses the [SAM v3.1](https://geti2p.net/en/docs/api/samv3) protocol
+Bitcoin Core uses the [SAM v3.1](https://i2p.net/en/docs/api/samv3) protocol
 to connect to the I2P network. Any I2P router that supports it can be used.
 
 ## Ports in I2P and Bitcoin Core
@@ -158,13 +158,13 @@ Similar bandwidth configuration options for the Java I2P router can be found in
 `http://127.0.0.1:7657/config` under the "Bandwidth" tab.
 
 Before doing this, please see the "Participating Traffic Considerations" section
-in [Embedding I2P in your Application](https://geti2p.net/en/docs/applications/embedding).
+in [Embedding I2P in your Application](https://i2p.net/en/docs/applications/embedding).
 
 In most cases, the default router settings should work fine.
 
 ## Bundling I2P in a Bitcoin application
 
-Please see the "General Guidance for Developers" section in https://geti2p.net/en/docs/api/samv3
+Please see the "General Guidance for Developers" section in https://i2p.net/en/docs/api/samv3
 if you are developing a downstream application that may be bundling I2P with Bitcoin.
 
 ## Privacy recommendations

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -352,7 +352,7 @@ void Session::CheckControlSock()
 
 void Session::DestGenerate(const Sock& sock)
 {
-    // https://geti2p.net/spec/common-structures#key-certificates
+    // https://i2p.net/en/docs/specs/common-structures/#key-certificates
     // "7" or "EdDSA_SHA512_Ed25519" - "Recent Router Identities and Destinations".
     // Use "7" because i2pd <2.24.0 does not recognize the textual form.
     // If SIGNATURE_TYPE is not specified, then the default one is DSA_SHA1.
@@ -375,7 +375,7 @@ void Session::GenerateAndSavePrivateKey(const Sock& sock)
 
 Binary Session::MyDestination() const
 {
-    // From https://geti2p.net/spec/common-structures#destination:
+    // From https://i2p.net/en/docs/specs/common-structures/#destination:
     // "They are 387 bytes plus the certificate length specified at bytes 385-386, which may be
     // non-zero"
     static constexpr size_t DEST_LEN_BASE = 387;

--- a/src/i2p.h
+++ b/src/i2p.h
@@ -193,7 +193,7 @@ private:
 
     /**
      * Derive own destination from `m_private_key`.
-     * @see https://geti2p.net/spec/common-structures#destination
+     * @see https://i2p.net/en/docs/specs/common-structures/#destination
      * @return an I2P destination
      */
     Binary MyDestination() const EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
@@ -240,7 +240,7 @@ private:
 
     /**
      * The private key of this peer.
-     * @see The reply to the "DEST GENERATE" command in https://geti2p.net/en/docs/api/samv3
+     * @see The reply to the "DEST GENERATE" command in https://i2p.net/en/docs/api/samv3
      */
     Binary m_private_key GUARDED_BY(m_mutex);
 
@@ -251,7 +251,7 @@ private:
      * other connections to the SAM service to accept incoming I2P
      * connections and make outgoing ones.
      * If not connected then this unique_ptr will be empty.
-     * See https://geti2p.net/en/docs/api/samv3
+     * See https://i2p.net/en/docs/api/samv3
      */
     std::unique_ptr<Sock> m_control_sock GUARDED_BY(m_mutex);
 

--- a/src/test/i2p_tests.cpp
+++ b/src/test/i2p_tests.cpp
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(listen_ok_accept_fail)
                 // reply to STREAM ACCEPT
                 "STREAM STATUS RESULT=OK\n"
                 // continued reply to STREAM ACCEPT, violating the protocol described at
-                // https://geti2p.net/en/docs/api/samv3#Accept%20Response
+                // https://i2p.net/en/docs/api/samv3/#accept-response
                 // should be base64, something like
                 // "IchV608baDoXbqzQKSqFDmTXPVgoDbPAhZJvNRXXxi4hyFXrTxtoOhdurNApKoUOZNc9WCgNs8CFkm81FdfGLiHIVetPG2g6F26s0CkqhQ5k1z1YKA2zwIWSbzUV18YuIchV608baDoXbqzQKSqFDmTXPVgoDbPAhZJvNRXXxi4hyFXrTxtoOhdurNApKoUOZNc9WCgNs8CFkm81FdfGLiHIVetPG2g6F26s0CkqhQ5k1z1YKA2zwIWSbzUV18YuIchV608baDoXbqzQKSqFDmTXPVgoDbPAhZJvNRXXxi4hyFXrTxtoOhdurNApKoUOZNc9WCgNs8CFkm81FdfGLiHIVetPG2g6F26s0CkqhQ5k1z1YKA2zwIWSbzUV18YuIchV608baDoXbqzQKSqFDmTXPVgoDbPAhZJvNRXXxi4hyFXrTxtoOhdurNApKoUOZNc9WCgNs8CFkm81FdfGLlSreVaCuCS5sdb-8ToWULWP7kt~lRPDeUNxQMq3cRSBBQAEAAcAAA==\n"
                 "STREAM STATUS RESULT=I2P_ERROR MESSAGE=\"Session was closed\"\n"

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -253,8 +253,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_CHECK(!addr.SetSpecial("udhdrtrcetjm5sxzskjyr5ztpeszydbh4dpl3pl4utgqqw2v\0wtf.b32.i2p"s));
 
     // I2P, valid but unsupported (56 Base32 characters)
-    // See "Encrypted LS with Base 32 Addresses" in
-    // https://geti2p.net/spec/encryptedleaseset.txt
+    // See https://i2p.net/en/docs/specs/b32encrypted
     BOOST_CHECK(
         !addr.SetSpecial("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscsad.b32.i2p"));
 


### PR DESCRIPTION
This PR only updates URLs in comments, no functional changes.
**Motivation**: While reviewing [PR\#35696](https://github.com/bitcoin/bitcoin/pull/35696) I discovered that some I2P related URLs needed a fix.

For context I2P project transitioned from **geti2p.net** to **i2p.net** and **i2pd.readthedocs.io** now uses **docs.i2pd.website**.
- One of the URLs is broken and returns [404](https://i2p.net/spec/encryptedleaseset.txt), fixed with this [one](https://i2p.net/en/docs/specs/b32encrypted).
- Another URL redirects from [this](https://geti2p.net/en/docs/api/samv3#Accept%20Response) to [this](https://i2p.net/en/docs/api/samv3/#Accept%20Response) and should be [this one](https://i2p.net/en/docs/api/samv3/#accept-response).
- The rest of changed URLs are basically the new URLs without the redirection, so in case the projects stop redirecting the old URLs we will have the updated ones.