### PR TITLE
chainparams: remove my testnet3 seed

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -284,7 +284,6 @@ public:
         // nodes with support for servicebits filtering should be at the top
         vSeeds.emplace_back("testnet-seed.bitcoin.jonasschnelli.ch.");
         vSeeds.emplace_back("seed.tbtc.petertodd.net.");
-        vSeeds.emplace_back("seed.testnet.bitcoin.sprovoost.nl.");
         vSeeds.emplace_back("testnet-seed.bluematt.me."); // Just a static list of stable node(s), only supports x9
         vSeeds.emplace_back("seed.testnet.achownodes.xyz."); // Ava Chow, only supports x1, x5, x9, x49, x809, x849, xd, x400, x404, x408, x448, xc08, xc48, x40c
 

--- a/test/functional/data/util/getchainparams-testnet.json
+++ b/test/functional/data/util/getchainparams-testnet.json
@@ -15,7 +15,6 @@
     "dns_seeds": [
       "testnet-seed.bitcoin.jonasschnelli.ch.",
       "seed.tbtc.petertodd.net.",
-      "seed.testnet.bitcoin.sprovoost.nl.",
       "testnet-seed.bluematt.me.",
       "seed.testnet.achownodes.xyz."
     ]


### PR DESCRIPTION
With testnet3 long deprecated, albeit still not dropped #31975, and [testnet5](https://groups.google.com/g/bitcoindev/c/kGUMTxOvdJA) on the horizon, this seems like a good time. I plan to keep it up and running until v31 is end-of-life, so no need to backport.