### PR TITLE
wallet: drop spent parents redundant cache invalidation and notification

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -753,5 +753,105 @@ BOOST_FIXTURE_TEST_CASE(RemoveTxs, TestChain100Setup)
     TestUnloadWallet(std::move(wallet));
 }
 
+struct TxValues
+{
+    CAmount credit, debit, change;
+    bool from_me;
+};
+
+static TxValues CachedValuesOf(const CWallet& wallet, const Txid& txid) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    const CWalletTx& wtx = wallet.mapWallet.at(txid);
+    return {CachedTxGetCredit(wallet, wtx, /*avoid_reuse=*/false),
+            CachedTxGetDebit(wallet, wtx, /*avoid_reuse=*/false),
+            CachedTxGetChange(wallet, wtx),
+            CachedTxIsFromMe(wallet, wtx)};
+}
+
+static void CheckValues(const CWallet& wallet, const Txid& txid, const TxValues& before) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    // Computed from the transaction, without the cache.
+    const CWalletTx& wtx = wallet.mapWallet.at(txid);
+    BOOST_CHECK_EQUAL(TxGetCredit(wallet, *wtx.tx), before.credit);
+    BOOST_CHECK_EQUAL(wallet.GetDebit(*wtx.tx), before.debit);
+    BOOST_CHECK_EQUAL(TxGetChange(wallet, *wtx.tx), before.change);
+    BOOST_CHECK_EQUAL(wallet.IsFromMe(*wtx.tx), before.from_me);
+
+    // And through the cache, which is what callers actually read.
+    const TxValues cached = CachedValuesOf(wallet, txid);
+    BOOST_CHECK_EQUAL(cached.credit, before.credit);
+    BOOST_CHECK_EQUAL(cached.debit, before.debit);
+    BOOST_CHECK_EQUAL(cached.change, before.change);
+    BOOST_CHECK_EQUAL(cached.from_me, before.from_me);
+}
+
+static std::vector<COutPoint> AvailableCoinsOf(const CWallet& wallet, const Txid& txid) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    std::vector<COutPoint> coins;
+    for (const COutput& coin : AvailableCoins(wallet).All()) {
+        if (coin.outpoint.hash == txid) coins.push_back(coin.outpoint);
+    }
+    return coins;
+}
+
+// A transaction spending only the specified outpoint, paying an address outside the wallet.
+static CTransactionRef CreateSpendOf(CWallet& wallet, const COutPoint& outpoint)
+{
+    CCoinControl coin_control;
+    coin_control.m_allow_other_inputs = false;
+    coin_control.Select(outpoint);
+    const CRecipient recipient{PubKeyDestination{GenerateRandomKey().GetPubKey()}, 5 * COIN, /*subtract_fee=*/false};
+    const auto res = Assert(CreateTransaction(wallet, {recipient}, /*change_pos=*/std::nullopt, coin_control));
+    return res->tx;
+}
+
+// Check that a transaction's cached values do not change when one of its outputs is spent,
+// or when that spend is abandoned. They represent the incoming and outgoing amounts of that
+// transaction alone, not the wallet's available balance (see wallet/transaction.h).
+// Abandoning takes the same path as marking a spend conflicted.
+BOOST_FIXTURE_TEST_CASE(cached_values_unchanged_by_spend, ListCoinsTestingSetup)
+{
+    // Pay to ourselves, so the wallet owns two of the transaction's outputs: the payment
+    // and the change.
+    const CTxDestination dest = getNewDestination(*wallet, OutputType::BECH32);
+    const Txid parent_tx = AddTx({dest, 20 * COIN, /*subtract_fee=*/false}).GetHash();
+
+    LOCK(wallet->cs_wallet);
+    const TxValues before = CachedValuesOf(*wallet, parent_tx);
+    const std::vector<COutPoint> coins = AvailableCoinsOf(*wallet, parent_tx);
+    BOOST_REQUIRE_EQUAL(coins.size(), 2U);
+
+    const CTransactionRef spend = CreateSpendOf(*wallet, coins[0]);
+    wallet->CommitTransaction(spend);
+    BOOST_CHECK(wallet->IsSpent(coins[0]));
+    BOOST_CHECK(!wallet->IsSpent(coins[1]));
+    BOOST_CHECK_EQUAL(AvailableCoinsOf(*wallet, parent_tx).size(), 1U);
+    CheckValues(*wallet, parent_tx, before);
+
+    // Now check that abandoning the spending tx does not change the parent cached values either.
+    BOOST_REQUIRE(wallet->AbandonTransaction(spend->GetHash()));
+    BOOST_CHECK(!wallet->IsSpent(coins[0]));
+    BOOST_CHECK_EQUAL(AvailableCoinsOf(*wallet, parent_tx).size(), 2U);
+    CheckValues(*wallet, parent_tx, before);
+}
+
+// Check that a tx's cached values do not change when a spend of one of its
+// outputs reaches the wallet via a mempool event (same path as a block event).
+BOOST_FIXTURE_TEST_CASE(cached_values_unchanged_by_mempool_spend, ListCoinsTestingSetup)
+{
+    const CTxDestination dest = getNewDestination(*wallet, OutputType::BECH32);
+    const Txid parent_tx = AddTx({dest, 20 * COIN, /*subtract_fee=*/false}).GetHash();
+
+    LOCK(wallet->cs_wallet);
+    const TxValues before = CachedValuesOf(*wallet, parent_tx);
+    const std::vector<COutPoint> coins = AvailableCoinsOf(*wallet, parent_tx);
+    BOOST_REQUIRE_EQUAL(coins.size(), 2U);
+
+    wallet->transactionAddedToMempool(CreateSpendOf(*wallet, coins[0]));
+    BOOST_CHECK(wallet->IsSpent(coins[0]));
+    BOOST_CHECK_EQUAL(AvailableCoinsOf(*wallet, parent_tx).size(), 1U);
+    CheckValues(*wallet, parent_tx, before);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -216,14 +216,18 @@ public:
      * CWallet::ComputeTimeSmart().
      */
     unsigned int nTimeSmart;
-    // Cached value for whether the transaction spends any inputs known to the wallet
-    mutable std::optional<bool> m_cached_from_me{std::nullopt};
     int64_t nOrderPos; //!< position in ordered transaction list
     std::multimap<int64_t, CWalletTx*>::const_iterator m_it_wtxOrdered;
 
-    // memory only
+    // Memory only
+    //
+    // Represents the incoming and outgoing amounts of this specific tx.
+    // Not the final wallet balance. Only importing a descriptor could make values change.
     enum AmountType { DEBIT, CREDIT, AMOUNTTYPE_ENUM_ELEMENTS };
     mutable CachableAmount m_amounts[AMOUNTTYPE_ENUM_ELEMENTS];
+    // Cached value for whether the transaction spends any inputs known to the wallet
+    mutable std::optional<bool> m_cached_from_me{std::nullopt};
+
     /**
      * This flag is true if all m_amounts caches are empty. This is particularly
      * useful in places where MarkDirty is conditionally called and the

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2346,12 +2346,6 @@ void CWallet::CommitTransaction(
         throw std::runtime_error(std::string(__func__) + ": Wallet db error, transaction commit failed");
     }
 
-    // Notify that old coins are spent
-    for (const CTxIn& txin : tx->vin) {
-        CWalletTx &coin = mapWallet.at(txin.prevout.hash);
-        NotifyTransactionChanged(coin.GetHash(), CT_UPDATED);
-    }
-
     if (!fBroadcastTransactions) {
         // Don't submit tx to the mempool
         return;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1115,7 +1115,6 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
             // Break caches since we have changed the state
             desc_tx->MarkDirty();
             batch.WriteTx(*desc_tx);
-            MarkInputsDirty(desc_tx->tx);
             for (unsigned int i = 0; i < desc_tx->tx->vout.size(); ++i) {
                 COutPoint outpoint(desc_tx->GetHash(), i);
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(outpoint);
@@ -1304,16 +1303,6 @@ void CWallet::UpdateTrucSiblingConflicts(const CWalletTx& parent_wtx, const Txid
     }
 }
 
-void CWallet::MarkInputsDirty(const CTransactionRef& tx)
-{
-    for (const CTxIn& txin : tx->vin) {
-        auto it = mapWallet.find(txin.prevout.hash);
-        if (it != mapWallet.end()) {
-            it->second.MarkDirty();
-        }
-    }
-}
-
 bool CWallet::AbandonTransaction(const Txid& hashTx)
 {
     LOCK(cs_wallet);
@@ -1418,10 +1407,6 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
             if (update_state == TxUpdate::NOTIFY_CHANGED) {
                 NotifyTransactionChanged(wtx.GetHash(), CT_UPDATED);
             }
-
-            // If a transaction changes its tx state, that usually changes the balance
-            // available of the outputs it spends. So force those to be recomputed
-            MarkInputsDirty(wtx.tx);
         }
     }
 }
@@ -1431,10 +1416,6 @@ bool CWallet::SyncTransaction(const CTransactionRef& ptx, const SyncTxState& sta
     if (!AddToWalletIfInvolvingMe(ptx, state, rescanning_old_block))
         return false; // Not one of ours
 
-    // If a transaction changes 'conflicted' state, that changes the balance
-    // available of the outputs it spends. So force those to be
-    // recomputed, also:
-    MarkInputsDirty(ptx);
     return true;
 }
 
@@ -2368,7 +2349,6 @@ void CWallet::CommitTransaction(
     // Notify that old coins are spent
     for (const CTxIn& txin : tx->vin) {
         CWalletTx &coin = mapWallet.at(txin.prevout.hash);
-        coin.MarkDirty();
         NotifyTransactionChanged(coin.GetHash(), CT_UPDATED);
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -370,9 +370,6 @@ private:
     void RecursiveUpdateTxState(const Txid& tx_hash, const TryUpdatingStateFn& try_updating_state) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, const TryUpdatingStateFn& try_updating_state) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    /** Mark a transaction's inputs dirty, thus forcing the outputs to be recomputed */
-    void MarkInputsDirty(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool SyncTransaction(const CTransactionRef& tx, const SyncTxState& state, bool rescanning_old_block = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
When a transaction spends outputs owned by the wallet, the wallet invalidates
the cached amounts of the transactions those outputs came from, and
`CommitTransaction` also notifies them. Neither is needed.

Both date back to pre-#27286, when a `CWalletTx` also cached the available
amount. Now the balance is read live from `m_txos` and `mapTxSpends`, and
`CWalletTx` cache only its own, tx specific, incoming and outgoing amounts,
and whether the tx is from the wallet. None of this changes after one of its
outputs is spent. So the cache invalidation recomputes the same values, and
the notification makes the GUI refresh a status that has not changed.