### PR TITLE
init, rpc: ignore empty addnode values

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -169,6 +169,7 @@ using node::VerifyLoadedChainstate;
 using util::Join;
 using util::ReplaceAll;
 using util::ToString;
+using util::TrimStringView;
 
 static constexpr bool DEFAULT_PROXYRANDOMIZE{true};
 static constexpr bool DEFAULT_REST_ENABLE{false};
@@ -2133,7 +2134,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.m_msgproc = node.peerman.get();
     connOptions.nSendBufferMaxSize = 1000 * args.GetIntArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER);
     connOptions.nReceiveFloodSize = 1000 * args.GetIntArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER);
-    connOptions.m_added_nodes = args.GetArgs("-addnode");
+    for (const std::string& added_node : args.GetArgs("-addnode")) {
+        // Such a value is not a valid connection target, but would otherwise be
+        // treated as one and retried indefinitely.
+        if (TrimStringView(added_node).empty()) {
+            LogWarning("Ignoring empty -addnode value");
+            continue;
+        }
+        connOptions.m_added_nodes.push_back(added_node);
+    }
     connOptions.nMaxOutboundLimit = *opt_max_upload;
     connOptions.m_peer_connect_timeout = peer_connect_timeout;
     connOptions.whitelist_forcerelay = args.GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -47,6 +47,7 @@
 
 using node::NodeContext;
 using util::Join;
+using util::TrimStringView;
 
 const std::vector<std::string> CONNECTION_TYPE_DOC{
         "outbound-full-relay (default automatic connections)",
@@ -348,6 +349,11 @@ static RPCMethod addnode()
     CConnman& connman = EnsureConnman(node);
 
     const auto node_arg{self.Arg<std::string_view>("node")};
+    if (TrimStringView(node_arg).empty()) {
+        // Such a node would never resolve, but would be retried indefinitely.
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: Node address cannot be empty");
+    }
+
     bool node_v2transport = connman.GetLocalServices() & NODE_P2P_V2;
     bool use_v2transport = self.MaybeArg<bool>("v2transport").value_or(node_v2transport);
 

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -265,6 +265,21 @@ class ConfArgsTest(BitcoinTestFramework):
             ])
         self.stop_node(0)
 
+    def test_empty_addnode(self):
+        self.log.info("Test empty addnode configuration values are ignored")
+        node = self.nodes[0]
+        util.append_config(node.datadir_path, ["addnode="])
+
+        with node.assert_debug_log(expected_msgs=["Ignoring empty -addnode value"]):
+            # Values consisting of whitespace only are trimmed away by the
+            # config file parser, so they can only be passed on the command
+            # line. Non-empty values are unaffected.
+            self.start_node(0, extra_args=["-addnode= ", "-addnode=some.node"])
+        util.assert_equal([added["addednode"] for added in node.getaddednodeinfo()], ["some.node"])
+        self.stop_node(0)
+
+        node.replace_in_config([("addnode=\n", "")])
+
     def test_networkactive(self):
         self.log.info('Test -networkactive option')
         with self.nodes[0].assert_debug_log(expected_msgs=['SetNetworkActive: true\n']):
@@ -325,13 +340,15 @@ class ConfArgsTest(BitcoinTestFramework):
 
         # No peers.dat exists and -dnsseed=0
         # We expect the node will fallback immediately to fixed seeds
+        # An empty -addnode value is ignored, so it must not delay the fallback
+        # either.
         assert not peer_dat.exists()
         with self.nodes[0].assert_debug_log(expected_msgs=[
                 "Loaded 0 addresses from peers.dat",
                 "DNS seeding disabled",
                 "Adding fixed seeds as -dnsseed=0 (or IPv4/IPv6 connections are disabled via -onlynet) and neither -addnode nor -seednode are provided\n",
         ], timeout=2):
-            self.start_node(0, extra_args=['-dnsseed=0', '-fixedseeds=1'])
+            self.start_node(0, extra_args=['-dnsseed=0', '-fixedseeds=1', '-addnode='])
         self.stop_node(0)
         self.nodes[0].assert_start_raises_init_error(['-dnsseed=1', '-onlynet=i2p', '-i2psam=127.0.0.1:7656'], "Error: Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6")
 
@@ -516,6 +533,7 @@ class ConfArgsTest(BitcoinTestFramework):
     def run_test(self):
         self.test_log_buffer()
         self.test_args_log()
+        self.test_empty_addnode()
         self.test_seed_peers()
         self.test_networkactive()
         self.test_connect_with_seednode()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -272,6 +272,11 @@ class NetTest(BitcoinTestFramework):
         assert_equal(added_nodes[0]['addednode'], "11.22.33.44")
         self.log.info("Check that an invalid command returns an error")
         assert_raises_rpc_error(-1, 'addnode "node" "command"', self.nodes[0].addnode, node=ip_port, command='abc')
+        self.log.info("Check that an empty node address returns an error")
+        for command in ['add', 'remove', 'onetry']:
+            assert_raises_rpc_error(-8, "Node address cannot be empty", self.nodes[0].addnode, node="", command=command)
+            assert_raises_rpc_error(-8, "Node address cannot be empty", self.nodes[0].addnode, node=" ", command=command)
+        assert_equal(len(self.nodes[0].getaddednodeinfo()), 1)
         self.log.info("Check that trying to remove the node again returns an error")
         assert_raises_rpc_error(-24, "Node could not be removed", self.nodes[0].addnode, node=ip_port, command='remove')
         self.log.info("Check that a non-existent node returns an error")


### PR DESCRIPTION
An empty `addnode=` entry currently creates an empty added-node record. The node then repeatedly attempts to connect to the empty destination:

```text
2026-07-23T19:22:33Z [net] trying v2 connection (manual) to , lastseen=0.0hrs
2026-07-23T19:23:33Z [net] trying v2 connection (manual) to , lastseen=0.0hrs
2026-07-23T19:24:34Z [net] trying v2 connection (manual) to , lastseen=0.0hrs
```

With this change, the node ignores empty `-addnode` values when initializing the connection manager. This preserves the existing startup behavior while avoiding useless connection attempts. Non-empty values are unaffected. Values consisting only of whitespace are ignored as well, and every ignored value is logged.

The `addnode` RPC has the same issue, so it now returns `Error: Node address cannot be empty` instead of adding such a record.

Functional tests verify that the node starts with `addnode=`, that no added-node record is created while non-empty values are still added, and that the RPC rejects empty values.
