### PR TITLE
bitcoin-util: Add evalscript subcommand

### DIFF
--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -14,10 +14,16 @@
 #include <common/system.h>
 #include <compat/compat.h>
 #include <core_io.h>
+#include <policy/policy.h>
+#include <script/interpreter.h>
+#include <script/sign.h>
 #include <streams.h>
 #include <univalue.h>
+#include <util/check.h>
 #include <util/exception.h>
+#include <util/expected.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/translation.h>
 
 #include <atomic>
@@ -36,8 +42,25 @@ static void SetupBitcoinUtilArgs(ArgsManager &argsman)
 
     argsman.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 
+    // evalscript options
+    auto get_scriptflags = []() -> std::string {
+        std::string r;
+        for (const auto& [k, v] : ScriptFlagNamesToEnum()) {
+            if (!r.empty()) r += ",";
+            r += k;
+        }
+        return r;
+    };
+
+    argsman.AddArg("-sigversion", "Specify a script sigversion (base, witness_v0, tapscript; default: witness_v0).", ArgsManager::ALLOW_ANY, OptionsCategory::COMMAND_OPTIONS);
+    argsman.AddArg("-scriptflags", strprintf("Specify SCRIPT_VERIFY flags (NONE, MANDATORY, STANDARD, or a selection from %s; default: MANDATORY).", get_scriptflags()), ArgsManager::ALLOW_ANY, OptionsCategory::COMMAND_OPTIONS);
+    argsman.AddArg("-tx", "The tx (hex encoded). Required for meaningful validation of CHECKSIG, CHECKLOCKTIMEVERIFY and CHECKSEQUENCEVERIFY.", ArgsManager::ALLOW_ANY, OptionsCategory::COMMAND_OPTIONS);
+    argsman.AddArg("-input", "The index of the input being spent", ArgsManager::ALLOW_ANY, OptionsCategory::COMMAND_OPTIONS);
+    argsman.AddArg("-spentoutput", "The spent prevouts (hex encoded TxOut, ie nValue, scriptPubKey). May be specified multiple times.", ArgsManager::ALLOW_ANY, OptionsCategory::COMMAND_OPTIONS);
+
     argsman.AddCommand("grind", "Perform proof of work on hex header string");
     argsman.AddCommand("getchainparams", "Get hardcoded parameters for the selected chain");
+    argsman.AddCommand("evalscript", "Interpret a bitcoin script", {"-sigversion", "-scriptflags", "-tx", "-input", "-spentoutput"});
 
     SetupChainParamsBaseOptions(argsman);
 }
@@ -209,6 +232,271 @@ static int GetChainParams(const std::vector<std::string>& args, std::string& str
     return EXIT_SUCCESS;
 }
 
+static UniValue stack2uv(const std::vector<std::vector<unsigned char>>& stack)
+{
+    UniValue result{UniValue::VARR};
+    for (const auto& v : stack) {
+        result.push_back(HexStr(v));
+    }
+    return result;
+}
+
+static std::string sigver2str(SigVersion sigver)
+{
+    switch (sigver) {
+    case SigVersion::BASE: return "base";
+    case SigVersion::WITNESS_V0: return "witness_v0";
+    case SigVersion::TAPROOT: return "taproot";
+    case SigVersion::TAPSCRIPT: return "tapscript";
+    }
+    return "unknown";
+}
+
+static util::Expected<script_verify_flags, std::string> parse_verify_flags(const std::string& strFlags)
+{
+    if (strFlags.empty() || strFlags == "MANDATORY") return MANDATORY_SCRIPT_VERIFY_FLAGS;
+    if (strFlags == "STANDARD") return STANDARD_SCRIPT_VERIFY_FLAGS;
+    if (strFlags == "NONE") return SCRIPT_VERIFY_NONE;
+
+    script_verify_flags flags{0};
+    std::vector<std::string> words = util::SplitString(strFlags, ',');
+
+    const auto& flag_names = ScriptFlagNamesToEnum();
+    for (const std::string& word : words) {
+        auto it = flag_names.find(word);
+        if (it == flag_names.end()) {
+            return util::Unexpected{strprintf("Unknown script flag: %s", word)};
+        }
+        flags |= it->second;
+    }
+    return flags;
+}
+
+static int EvalScript(const ArgsManager& argsman, const std::vector<std::string>& args, std::string& strPrint)
+{
+    UniValue result{UniValue::VOBJ};
+
+    std::unique_ptr<const CTransaction> txTo;
+    PrecomputedTransactionData txdata;
+    ScriptExecutionData execdata;
+
+    std::unique_ptr<BaseSignatureChecker> tx_checker; // for cleanup of checker if needed
+    const BaseSignatureChecker* checker = &DUMMY_CHECKER;
+
+    SigVersion sigversion = SigVersion::WITNESS_V0;
+
+    if (const auto verstr = argsman.GetArg("-sigversion"); verstr.has_value()) {
+        if (*verstr == "base") {
+            sigversion = SigVersion::BASE;
+        } else if (*verstr == "witness_v0") {
+            sigversion = SigVersion::WITNESS_V0;
+        } else if (*verstr == "tapscript") {
+            sigversion = SigVersion::TAPSCRIPT;
+        } else {
+            strPrint = strprintf("Unknown -sigversion=%s", *verstr);
+            return EXIT_FAILURE;
+        }
+    }
+
+    auto exp_flags = parse_verify_flags(argsman.GetArg("-scriptflags", ""));
+    if (!exp_flags) {
+        strPrint = std::move(exp_flags).error();
+        return EXIT_FAILURE;
+    }
+    const script_verify_flags flags = *exp_flags;
+
+    CScript script{};
+    std::vector<std::vector<unsigned char>> stack{};
+    if (!args.empty()) {
+        if (IsHex(args[0])) {
+            auto h = ParseHex(args[0]);
+            script = CScript(h.begin(), h.end());
+        } else {
+            script = ParseScript(args[0]);
+        }
+
+        for (size_t i = 1; i < args.size(); ++i) {
+            if (args[i].empty()) {
+                stack.emplace_back();
+            } else if (IsHex(args[i])) {
+                stack.push_back(ParseHex(args[i]));
+            } else {
+                strPrint = strprintf("Initial stack element not valid hex: %s", args[i]);
+                return EXIT_FAILURE;
+            }
+        }
+    }
+
+    if (const auto txhex = argsman.GetArg("-tx"); txhex.has_value()) {
+        const int64_t input{argsman.GetIntArg("-input", 0)};
+        const auto spent_outputs_hex{argsman.GetArgs("-spentoutput")};
+
+        CMutableTransaction mut_tx;
+        if (!DecodeHexTx(mut_tx, *txhex)) {
+            strPrint = "Could not decode transaction from -tx argument";
+            return EXIT_FAILURE;
+        }
+        txTo = std::make_unique<CTransaction>(mut_tx);
+
+        if (spent_outputs_hex.size() != txTo->vin.size()) {
+            strPrint = "When -tx is specified, must specify exactly one -spentoutput for each input";
+            return EXIT_FAILURE;
+        }
+
+        std::vector<CTxOut> spent_outputs;
+        for (const auto& outhex : spent_outputs_hex) {
+            bool ok = false;
+            if (IsHex(outhex)) {
+                CTxOut txout;
+                std::vector<unsigned char> out(ParseHex(outhex));
+                DataStream ss(out);
+                try {
+                    ss >> txout;
+                    if (ss.empty()) {
+                        spent_outputs.push_back(txout);
+                        ok = true;
+                    }
+                } catch (const std::exception&) {
+                    // fall through
+                }
+            }
+            if (!ok) {
+                strPrint = strprintf("Could not parse -spentoutput=%s", outhex);
+                return EXIT_FAILURE;
+            }
+        }
+
+        const bool input_in_range = input >= 0 && static_cast<size_t>(input) < spent_outputs.size();
+        if (!input_in_range) {
+            strPrint = strprintf("Invalid -input=%d", input);
+            return EXIT_FAILURE;
+        }
+
+        CAmount amount = spent_outputs.at(input).nValue;
+        txdata.Init(*txTo, std::move(spent_outputs), /*force=*/true);
+        tx_checker = std::make_unique<TransactionSignatureChecker>(txTo.get(), input, amount, txdata, MissingDataBehavior::ASSERT_FAIL);
+        checker = tx_checker.get();
+
+        if (sigversion == SigVersion::TAPSCRIPT) {
+            const CTxIn& txin = txTo->vin.at(input);
+            execdata.m_annex_present = false;
+            if (txin.scriptWitness.stack.size() <= 1) {
+                // either key path spend or no witness, so nothing to do here
+            } else {
+                const auto& top = txin.scriptWitness.stack.back();
+                if (!top.empty() && top.at(0) == ANNEX_TAG) {
+                    execdata.m_annex_hash = (HashWriter{} << top).GetSHA256();
+                    execdata.m_annex_present = true;
+                }
+            }
+            execdata.m_annex_init = true;
+            execdata.m_tapleaf_hash = ComputeTapleafHash(TAPROOT_LEAF_TAPSCRIPT, script);
+            execdata.m_tapleaf_hash_init = true;
+            // we do not set execdata.m_validation_weight_left from the
+            // tx here, because the provided tx data may be incomplete and
+            // not actually match the script that we've been provided
+
+        }
+    }
+
+    if (sigversion == SigVersion::TAPSCRIPT) {
+        if (!execdata.m_annex_init) {
+            execdata.m_annex_present = false;
+            execdata.m_annex_init = true;
+        }
+        if (!execdata.m_tapleaf_hash_init) {
+            execdata.m_tapleaf_hash = uint256::ZERO;
+            execdata.m_tapleaf_hash_init = true;
+        }
+        assert(!execdata.m_validation_weight_left_init);
+        // approximation of the consensus value; should include control block and annex
+        execdata.m_validation_weight_left = ::GetSerializeSize(stack) + ::GetSerializeSize(script) + VALIDATION_WEIGHT_OFFSET;
+        execdata.m_validation_weight_left_init = true;
+    }
+
+    ScriptError serror{};
+
+    UniValue uv_flags{UniValue::VARR};
+    for (const auto& el : GetScriptFlagNames(flags)) {
+        uv_flags.push_back(el);
+    }
+    UniValue uv_script{UniValue::VOBJ};
+    ScriptToUniv(script, uv_script);
+    result.pushKV("script", uv_script);
+    result.pushKV("sigversion", sigver2str(sigversion));
+    result.pushKV("script_flags", uv_flags);
+    result.pushKV("dummy_sig_checker", (checker == &DUMMY_CHECKER));
+
+    std::optional<bool> opsuccess_check;
+    if (sigversion == SigVersion::TAPSCRIPT) {
+        opsuccess_check = CheckTapscriptOpSuccess(script, flags, &serror);
+
+        bool opsuccess_found = opsuccess_check.has_value() && (*opsuccess_check || serror == SCRIPT_ERR_DISCOURAGE_OP_SUCCESS);
+        result.pushKV("opsuccess_found", opsuccess_found);
+    }
+
+    bool success{true};
+    if (opsuccess_check.has_value()) {
+        success = *opsuccess_check;
+    } else {
+        if (sigversion == SigVersion::TAPSCRIPT && stack.size() > MAX_STACK_SIZE) {
+            // Tapscript enforces initial stack size limits
+            serror = SCRIPT_ERR_STACK_SIZE;
+            success = false;
+        } else if (sigversion == SigVersion::WITNESS_V0 || sigversion == SigVersion::TAPSCRIPT) {
+            // Disallow stack item size > MAX_SCRIPT_ELEMENT_SIZE in witness stack
+            for (const auto& elem : stack) {
+                if (elem.size() > MAX_SCRIPT_ELEMENT_SIZE) {
+                    serror = SCRIPT_ERR_PUSH_SIZE;
+                    success = false;
+                    break;
+                }
+            }
+        }
+        if (success) {
+            success = EvalScript(stack, script, flags, *Assert(checker), sigversion, execdata, &serror);
+        }
+        if (success) {
+            if (stack.size() != 1 && (sigversion == SigVersion::WITNESS_V0 || sigversion == SigVersion::TAPSCRIPT)) {
+                serror = SCRIPT_ERR_CLEANSTACK;
+                success = false;
+            } else if (stack.empty() || !CastToBool(stack.back())) {
+                serror = SCRIPT_ERR_EVAL_FALSE;
+                success = false;
+            } else if (stack.size() > 1 && (flags & SCRIPT_VERIFY_CLEANSTACK) != 0) {
+                serror = SCRIPT_ERR_CLEANSTACK;
+                success = false;
+            }
+        }
+    }
+
+    result.pushKV("stack_after", stack2uv(stack));
+
+    auto get_sigop_cost = [&]() -> int64_t {
+        switch (sigversion) {
+        case SigVersion::TAPROOT:
+        case SigVersion::TAPSCRIPT:
+            return 0;
+        case SigVersion::WITNESS_V0:
+            return script.GetSigOpCount(true);
+        case SigVersion::BASE:
+            return script.GetSigOpCount(false) * WITNESS_SCALE_FACTOR;
+        }
+        Assume(false); // unreachable
+        return 0;
+    };
+    result.pushKV("sigop_cost", get_sigop_cost());
+
+    result.pushKV("success", success);
+    if (!success) {
+        result.pushKV("error", ScriptErrorString(serror));
+    }
+
+    strPrint = result.write(2);
+
+    return EXIT_SUCCESS;
+}
+
 MAIN_FUNCTION
 {
     ArgsManager& args = gArgs;
@@ -240,6 +528,8 @@ MAIN_FUNCTION
             ret = Grind(cmd->args, strPrint);
         } else if (cmd->command == "getchainparams") {
             ret = GetChainParams(cmd->args, strPrint);
+        } else if (cmd->command == "evalscript") {
+            ret = EvalScript(args, cmd->args, strPrint);
         } else {
             assert(false); // unknown command should be caught earlier
         }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1839,26 +1839,35 @@ bool GenericTransactionSignatureChecker<T>::CheckSequence(const CScriptNum& nSeq
 template class GenericTransactionSignatureChecker<CTransaction>;
 template class GenericTransactionSignatureChecker<CMutableTransaction>;
 
+std::optional<bool> CheckTapscriptOpSuccess(const CScript& exec_script, script_verify_flags flags, ScriptError* serror)
+{
+    // OP_SUCCESSx processing overrides everything, including stack element size limits
+    CScript::const_iterator pc = exec_script.begin();
+    while (pc < exec_script.end()) {
+        opcodetype opcode;
+        if (!exec_script.GetOp(pc, opcode)) {
+            // Note how this condition would not be reached if an unknown OP_SUCCESSx was found
+            return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+        }
+        // New opcodes will be listed here. May use a different sigversion to modify existing opcodes.
+        if (IsOpSuccess(opcode)) {
+            if (flags & SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS) {
+                return set_error(serror, SCRIPT_ERR_DISCOURAGE_OP_SUCCESS);
+            }
+            return set_success(serror);
+        }
+    }
+
+    return std::nullopt;
+}
+
 static bool ExecuteWitnessScript(const std::span<const valtype>& stack_span, const CScript& exec_script, script_verify_flags flags, SigVersion sigversion, const BaseSignatureChecker& checker, ScriptExecutionData& execdata, ScriptError* serror)
 {
     std::vector<valtype> stack{stack_span.begin(), stack_span.end()};
 
     if (sigversion == SigVersion::TAPSCRIPT) {
-        // OP_SUCCESSx processing overrides everything, including stack element size limits
-        CScript::const_iterator pc = exec_script.begin();
-        while (pc < exec_script.end()) {
-            opcodetype opcode;
-            if (!exec_script.GetOp(pc, opcode)) {
-                // Note how this condition would not be reached if an unknown OP_SUCCESSx was found
-                return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
-            }
-            // New opcodes will be listed here. May use a different sigversion to modify existing opcodes.
-            if (IsOpSuccess(opcode)) {
-                if (flags & SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS) {
-                    return set_error(serror, SCRIPT_ERR_DISCOURAGE_OP_SUCCESS);
-                }
-                return set_success(serror);
-            }
+        if (auto r = CheckTapscriptOpSuccess(exec_script, flags, serror); r.has_value()) {
+            return *r;
         }
 
         // Tapscript enforces initial stack size limits (altstack is empty here)

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -386,4 +386,6 @@ const std::map<std::string, script_verify_flag_name>& ScriptFlagNamesToEnum();
 
 std::vector<std::string> GetScriptFlagNames(script_verify_flags flags);
 
+bool CastToBool(const std::vector<unsigned char>& vch);
+
 #endif // BITCOIN_SCRIPT_INTERPRETER_H

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -388,4 +388,13 @@ std::vector<std::string> GetScriptFlagNames(script_verify_flags flags);
 
 bool CastToBool(const std::vector<unsigned char>& vch);
 
+/** Parses the script for OP_SUCCESS opcodes.
+ *  On parse failure, returns false and sets serror.
+ *  If an OP_SUCCESS opcode is found, then either:
+ *    returns false and sets serror if flags contain DISCOURAGE_OP_SUCCESS
+ *    returns true
+ *  Otherwise returns std::nullopt.
+ */
+std::optional<bool> CheckTapscriptOpSuccess(const CScript& exec_script, script_verify_flags flags, ScriptError* serror);
+
 #endif // BITCOIN_SCRIPT_INTERPRETER_H

--- a/src/test/fuzz/script_interpreter.cpp
+++ b/src/test/fuzz/script_interpreter.cpp
@@ -14,8 +14,6 @@
 #include <string>
 #include <vector>
 
-bool CastToBool(const std::vector<unsigned char>& vch);
-
 FUZZ_TARGET(script_interpreter)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());

--- a/test/functional/data/util/bitcoin-util-test.json
+++ b/test/functional/data/util/bitcoin-util-test.json
@@ -820,5 +820,71 @@
     "return_code": 1,
     "error_txt": "error: Uncompressed pubkeys are not useable for SegWit outputs",
     "description": "Ensure adding witness outputs with uncompressed pubkeys fails"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["evalscript", "1"],
+    "return_code": 0,
+    "output_cmp": "evalscript-op1.json",
+    "description": "evalscript: OP_1 succeeds (default witness_v0, mandatory flags)"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["evalscript"],
+    "return_code": 0,
+    "output_cmp": "evalscript-empty.json",
+    "description": "evalscript: empty script fails with EVAL_FALSE"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["evalscript", "93", "03", "05"],
+    "return_code": 0,
+    "output_cmp": "evalscript-add.json",
+    "description": "evalscript: OP_ADD with initial stack 3+5=8"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["-sigversion=tapscript", "evalscript", "51"],
+    "return_code": 0,
+    "output_cmp": "evalscript-tapscript.json",
+    "description": "evalscript: tapscript sigversion, OP_1"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["-sigversion=tapscript", "evalscript", "bb"],
+    "return_code": 0,
+    "output_cmp": "evalscript-opsuccess.json",
+    "description": "evalscript: tapscript OP_SUCCESS opcode (0xbb) succeeds"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["-sigversion=tapscript", "-scriptflags=DISCOURAGE_OP_SUCCESS", "evalscript", "bb"],
+    "return_code": 0,
+    "output_cmp": "evalscript-opsuccess-discouraged.json",
+    "description": "evalscript: tapscript OP_SUCCESS with DISCOURAGE_OP_SUCCESS fails"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["-sigversion=base", "-scriptflags=NONE", "evalscript", "1", "01"],
+    "return_code": 0,
+    "output_cmp": "evalscript-base-noflags.json",
+    "description": "evalscript: base sigversion, no flags, extra stack item allowed"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["-scriptflags=P2SH,WITNESS", "evalscript", "1"],
+    "return_code": 0,
+    "output_cmp": "evalscript-customflags.json",
+    "description": "evalscript: custom script flags"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["-sigversion=foo", "evalscript", "1"],
+    "return_code": 1,
+    "error_txt": "Unknown -sigversion=foo",
+    "description": "evalscript: unknown sigversion is an error"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["-scriptflags=BOGUS", "evalscript", "1"],
+    "return_code": 1,
+    "error_txt": "Unknown script flag: BOGUS",
+    "description": "evalscript: unknown script flag is an error"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["evalscript", "1", "notahex"],
+    "return_code": 1,
+    "error_txt": "Initial stack element not valid hex: notahex",
+    "description": "evalscript: non-hex stack element is an error"
   }
 ]

--- a/test/functional/data/util/evalscript-add.json
+++ b/test/functional/data/util/evalscript-add.json
@@ -1,0 +1,23 @@
+{
+  "script": {
+    "asm": "OP_ADD",
+    "hex": "93",
+    "type": "nonstandard"
+  },
+  "sigversion": "witness_v0",
+  "script_flags": [
+    "CHECKLOCKTIMEVERIFY",
+    "CHECKSEQUENCEVERIFY",
+    "DERSIG",
+    "NULLDUMMY",
+    "P2SH",
+    "TAPROOT",
+    "WITNESS"
+  ],
+  "dummy_sig_checker": true,
+  "stack_after": [
+    "08"
+  ],
+  "sigop_cost": 0,
+  "success": true
+}

--- a/test/functional/data/util/evalscript-base-noflags.json
+++ b/test/functional/data/util/evalscript-base-noflags.json
@@ -1,0 +1,17 @@
+{
+  "script": {
+    "asm": "1",
+    "hex": "51",
+    "type": "nonstandard"
+  },
+  "sigversion": "base",
+  "script_flags": [
+  ],
+  "dummy_sig_checker": true,
+  "stack_after": [
+    "01",
+    "01"
+  ],
+  "sigop_cost": 0,
+  "success": true
+}

--- a/test/functional/data/util/evalscript-customflags.json
+++ b/test/functional/data/util/evalscript-customflags.json
@@ -1,0 +1,18 @@
+{
+  "script": {
+    "asm": "1",
+    "hex": "51",
+    "type": "nonstandard"
+  },
+  "sigversion": "witness_v0",
+  "script_flags": [
+    "P2SH",
+    "WITNESS"
+  ],
+  "dummy_sig_checker": true,
+  "stack_after": [
+    "01"
+  ],
+  "sigop_cost": 0,
+  "success": true
+}

--- a/test/functional/data/util/evalscript-empty.json
+++ b/test/functional/data/util/evalscript-empty.json
@@ -1,0 +1,23 @@
+{
+  "script": {
+    "asm": "",
+    "hex": "",
+    "type": "nonstandard"
+  },
+  "sigversion": "witness_v0",
+  "script_flags": [
+    "CHECKLOCKTIMEVERIFY",
+    "CHECKSEQUENCEVERIFY",
+    "DERSIG",
+    "NULLDUMMY",
+    "P2SH",
+    "TAPROOT",
+    "WITNESS"
+  ],
+  "dummy_sig_checker": true,
+  "stack_after": [
+  ],
+  "sigop_cost": 0,
+  "success": false,
+  "error": "Stack size must be exactly one after execution"
+}

--- a/test/functional/data/util/evalscript-op1.json
+++ b/test/functional/data/util/evalscript-op1.json
@@ -1,0 +1,23 @@
+{
+  "script": {
+    "asm": "1",
+    "hex": "51",
+    "type": "nonstandard"
+  },
+  "sigversion": "witness_v0",
+  "script_flags": [
+    "CHECKLOCKTIMEVERIFY",
+    "CHECKSEQUENCEVERIFY",
+    "DERSIG",
+    "NULLDUMMY",
+    "P2SH",
+    "TAPROOT",
+    "WITNESS"
+  ],
+  "dummy_sig_checker": true,
+  "stack_after": [
+    "01"
+  ],
+  "sigop_cost": 0,
+  "success": true
+}

--- a/test/functional/data/util/evalscript-opsuccess-discouraged.json
+++ b/test/functional/data/util/evalscript-opsuccess-discouraged.json
@@ -1,0 +1,18 @@
+{
+  "script": {
+    "asm": "OP_UNKNOWN",
+    "hex": "bb",
+    "type": "nonstandard"
+  },
+  "sigversion": "tapscript",
+  "script_flags": [
+    "DISCOURAGE_OP_SUCCESS"
+  ],
+  "dummy_sig_checker": true,
+  "opsuccess_found": true,
+  "stack_after": [
+  ],
+  "sigop_cost": 0,
+  "success": false,
+  "error": "OP_SUCCESSx reserved for soft-fork upgrades"
+}

--- a/test/functional/data/util/evalscript-opsuccess.json
+++ b/test/functional/data/util/evalscript-opsuccess.json
@@ -1,0 +1,23 @@
+{
+  "script": {
+    "asm": "OP_UNKNOWN",
+    "hex": "bb",
+    "type": "nonstandard"
+  },
+  "sigversion": "tapscript",
+  "script_flags": [
+    "CHECKLOCKTIMEVERIFY",
+    "CHECKSEQUENCEVERIFY",
+    "DERSIG",
+    "NULLDUMMY",
+    "P2SH",
+    "TAPROOT",
+    "WITNESS"
+  ],
+  "dummy_sig_checker": true,
+  "opsuccess_found": true,
+  "stack_after": [
+  ],
+  "sigop_cost": 0,
+  "success": true
+}

--- a/test/functional/data/util/evalscript-tapscript.json
+++ b/test/functional/data/util/evalscript-tapscript.json
@@ -1,0 +1,24 @@
+{
+  "script": {
+    "asm": "1",
+    "hex": "51",
+    "type": "nonstandard"
+  },
+  "sigversion": "tapscript",
+  "script_flags": [
+    "CHECKLOCKTIMEVERIFY",
+    "CHECKSEQUENCEVERIFY",
+    "DERSIG",
+    "NULLDUMMY",
+    "P2SH",
+    "TAPROOT",
+    "WITNESS"
+  ],
+  "dummy_sig_checker": true,
+  "opsuccess_found": false,
+  "stack_after": [
+    "01"
+  ],
+  "sigop_cost": 0,
+  "success": true
+}


### PR DESCRIPTION
Adds an `evalscript` subcommand for using bitcoin's consensus logic to evaluate script fragments. Intended for debugging and development.

Examples:

```
# check a script fragment's behaviour
$ bitcoin-util evalscript '1 2 ADD'
{
  "script": {
    "asm": "1 2 OP_ADD",
    "hex": "515293",
    "type": "nonstandard"
  },
  "sigversion": "witness_v0",
  "script_flags": [
    "CHECKLOCKTIMEVERIFY",
    "CHECKSEQUENCEVERIFY",
    "DERSIG",
    "NULLDUMMY",
    "P2SH",
    "TAPROOT",
    "WITNESS"
  ],
  "dummy_sig_checker": true,
  "stack_after": [
    "03"
  ],
  "sigop_cost": 0,
  "success": true
}

# validate a real signature
$ bitcoin-util -sigversion=base \
    -spentoutput=00f2052a0100000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac \
    -tx=0100000001c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd3704000000004847304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901ffffffff0200ca9a3b00000000434104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac00286bee0000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac00000000 \
    evalscript '0x410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3 CHECKSIG' \
    '304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901'
{
  "script": {
    "asm": "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3 OP_CHECKSIG",
    "hex": "410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac",
    "type": "pubkey"
  },
  "sigversion": "base",
  "script_flags": [
    "CHECKLOCKTIMEVERIFY",
    "CHECKSEQUENCEVERIFY",
    "DERSIG",
    "NULLDUMMY",
    "P2SH",
    "TAPROOT",
    "WITNESS"
  ],
  "dummy_sig_checker": false,
  "stack_after": [
    "01"
  ],
  "sigop_cost": 4,
  "success": true
}
```

