### PR TITLE
build: respect CMAKE_INSTALL_LIBEXECDIR in bitcoin launcher

### DIFF
--- a/cmake/bitcoin-build-config.h.in
+++ b/cmake/bitcoin-build-config.h.in
@@ -100,6 +100,9 @@
 /* Define to the home page for this package. */
 #define CLIENT_URL "@PROJECT_HOMEPAGE_URL@"
 
+/* Define the install directory used for internal executables. */
+#define BITCOIN_LIBEXECDIR "@CMAKE_INSTALL_LIBEXECDIR@"
+
 /* Define to the version of this package. */
 #define CLIENT_VERSION_STRING "@CLIENT_VERSION_STRING@"
 

--- a/src/bitcoin.cpp
+++ b/src/bitcoin.cpp
@@ -205,6 +205,12 @@ static void ExecCommand(const std::vector<const char*>& args, std::string_view w
         }
         throw std::runtime_error("execvp returned unexpectedly");
     };
+    auto build_exec_path = [](const fs::path& base, const fs::path& subdir, const fs::path& filename) {
+        fs::path exe_path{base};
+        exe_path /= subdir;
+        exe_path /= filename;
+        return exe_path;
+    };
 
     // Get the wrapper executable path.
     const fs::path wrapper_path{util::GetExePath(wrapper_argv0)};
@@ -217,6 +223,7 @@ static void ExecCommand(const std::vector<const char*>& args, std::string_view w
 
     // Get path of the executable to be invoked.
     const fs::path arg0{fs::PathFromString(args[0])};
+    const fs::path internal_bindir{fs::PathFromString(BITCOIN_LIBEXECDIR)};
 
     // Decide whether to fall back to the operating system to search for the
     // specified executable. Avoid doing this if it looks like the wrapper
@@ -226,8 +233,8 @@ static void ExecCommand(const std::vector<const char*>& args, std::string_view w
     const bool fallback_os_search{!fs::PathFromString(std::string{wrapper_argv0}).has_parent_path()};
 
     // If wrapper is installed in a bin/ directory, look for target executable
-    // in libexec/
-    (wrapper_dir.filename() == "bin" && try_exec(wrapper_dir.parent_path() / "libexec" / arg0.filename())) ||
+    // in the configured install directory for internal executables.
+    (wrapper_dir.filename() == "bin" && try_exec(build_exec_path(wrapper_dir.parent_path(), internal_bindir, arg0.filename()))) ||
 #ifdef WIN32
     // Otherwise check the "daemon" subdirectory in a windows install.
     (!wrapper_dir.empty() && try_exec(wrapper_dir / "daemon" / arg0.filename())) ||

--- a/test/config.ini.in
+++ b/test/config.ini.in
@@ -11,6 +11,7 @@ CLIENT_BUGREPORT=@CLIENT_BUGREPORT@
 SRCDIR=@abs_top_srcdir@
 BUILDDIR=@abs_top_builddir@
 EXEEXT=@EXEEXT@
+CMAKE_INSTALL_LIBEXECDIR=@CMAKE_INSTALL_LIBEXECDIR@
 RPCAUTH=@abs_top_srcdir@/share/rpcauth/rpcauth.py
 
 [components]

--- a/test/functional/tool_bitcoin.py
+++ b/test/functional/tool_bitcoin.py
@@ -94,8 +94,8 @@ class ToolBitcoinTest(BitcoinTestFramework):
         install_root = self.nodes[0].datadir_path / "installed-wrapper"
         bin_dir = install_root / "bin"
         internal_dir = install_root / self.config["environment"]["CMAKE_INSTALL_LIBEXECDIR"]
-        bin_dir.mkdir(parents=True)
-        internal_dir.mkdir(parents=True)
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        internal_dir.mkdir(parents=True, exist_ok=True)
 
         exeext = self.config["environment"]["EXEEXT"]
         build_dir = self.config["environment"]["BUILDDIR"]

--- a/test/functional/tool_bitcoin.py
+++ b/test/functional/tool_bitcoin.py
@@ -13,6 +13,8 @@ from test_framework.util import (
 )
 
 import platform
+import shutil
+import subprocess
 import re
 
 
@@ -84,6 +86,35 @@ class ToolBitcoinTest(BitcoinTestFramework):
             self.log.info("Ensure bitcoin recognizes -ipcbind in config file")
             append_config(node.datadir_path, ["ipcbind=unix"])
             self.test_args([], [], expect_exe="bitcoin-node")
+
+        self.log.info("Ensure installed bitcoin wrapper respects configured internal binary dir")
+        self.test_installed_internal_binary_dir()
+
+    def test_installed_internal_binary_dir(self):
+        install_root = self.nodes[0].datadir_path / "installed-wrapper"
+        bin_dir = install_root / "bin"
+        internal_dir = install_root / self.config["environment"]["CMAKE_INSTALL_LIBEXECDIR"]
+        bin_dir.mkdir(parents=True)
+        internal_dir.mkdir(parents=True)
+
+        exeext = self.config["environment"]["EXEEXT"]
+        build_dir = self.config["environment"]["BUILDDIR"]
+        bitcoin_src = self.get_binaries().paths.bitcoin_bin
+        test_src = f"{build_dir}/bin/test_bitcoin{exeext}"
+        bitcoin_dest = bin_dir / f"bitcoin{exeext}"
+        test_dest = internal_dir / f"test_bitcoin{exeext}"
+
+        shutil.copy2(bitcoin_src, bitcoin_dest)
+        shutil.copy2(test_src, test_dest)
+
+        result = subprocess.run(
+            [bitcoin_dest, "test", "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert_equal(result.returncode, 0)
+        assert "test_bitcoin" in result.stderr
 
 
 def get_node_output(node):


### PR DESCRIPTION
This updates the `bitcoin` launcher to use the configured `CMAKE_INSTALL_LIBEXECDIR` when resolving internal executables from an installed `bin/` layout.

The issue report showed distro builds that install internal binaries into `lib/` instead of `libexec/`, which currently breaks commands like `bitcoin -m node` and `bitcoin chainstate` after installation. The wrapper already receives the configured install destination in CMake, so this threads the same value into `bitcoin-build-config.h` and uses it in the installed-wrapper lookup path.

The functional test coverage adds an installed-layout regression to `tool_bitcoin.py` by copying `bitcoin` into a temporary `bin/` directory, placing `test_bitcoin` only in the configured internal install directory, and verifying that invoking the wrapper by explicit path succeeds. That keeps the test from falling back to `$PATH` while exercising the same installed-layout logic as the bug report.

Tested:
- `cmake -S . -B build-wsl-libdir -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_LIBEXECDIR=lib -DBUILD_GUI=OFF -DENABLE_WALLET=OFF -DBUILD_BENCH=OFF -DBUILD_TX=OFF -DBUILD_UTIL=OFF -DBUILD_UTIL_CHAINSTATE=OFF -DBUILD_CLI=OFF -DBUILD_TESTS=ON -DBUILD_DAEMON=ON -DENABLE_IPC=OFF`
- `cmake --build build-wsl-libdir --target bitcoin bitcoind test_bitcoin -j4`
- `python3 build-wsl-libdir/test/functional/tool_bitcoin.py --configfile build-wsl-libdir/test/config.ini`

refs #35785
