### PR TITLE
fuzz: populate wallet TXO index in wallet_create_transaction

### DIFF
--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -72,6 +72,7 @@ FUZZ_TARGET(wallet_create_transaction, .init = initialize_setup)
         auto txid{tx.GetHash()};
         auto ret{fuzzed_wallet.wallet->mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateConfirmed{chainstate.m_chain.Tip()->GetBlockHash(), chainstate.m_chain.Height(), /*index=*/0}))};
         assert(ret.second);
+        fuzzed_wallet.wallet->RefreshTXOsFromTx(ret.first->second);
     }
 
     std::vector<CRecipient> recipients;


### PR DESCRIPTION
A refactor in #27286 seemingly caused a regression in this harness. Rewiring to `m_txos` from `mapWallet` makes the setup loop in `wallet_create_transaction`, which uses raw `mapWallet.emplace()`, to no longer see coins. Therefore, `GetTXO`/`GetTXOs` probably return empty. To make coin selection possible, this fix calls `RefreshTXOsFromTx` after each insertion.

<details>
<summary>Coverage diff on select functions</summary>

`diff spend_cov_before.txt spend_cov_after.txt` on `src/wallet/spend.cpp`:

```diff
-  748|      0|  if (auto bnb_result{SelectCoinsBnB(...)}) {
+  748|  2.14k|  if (auto bnb_result{SelectCoinsBnB(...)}) {

-  761|      0|  if (auto knapsack_result{KnapsackSolver(...)}) {
+  761|  4.46k|  if (auto knapsack_result{KnapsackSolver(...)}) {

-  766|      0|  if (auto cg_result{CoinGrinder(...)}) {
+  766|  2.88k|  if (auto cg_result{CoinGrinder(...)}) {

-  774|      0|  if (auto srd_result{SelectCoinsSRD(...)}) {
+  774|  4.46k|  if (auto srd_result{SelectCoinsSRD(...)}) {

-  845|      0|  auto op_selection_result = AutomaticCoinSelection(...);
+  845|  1.27k|  auto op_selection_result = AutomaticCoinSelection(...);

-  960|      0|  if (auto res{AttemptSelection(...)}) {
+  960|  1.36k|  if (auto res{AttemptSelection(...)}) {

- 1484|      0|  auto txr_grouped = CreateTransactionInternal(...);
+ 1484|    380|  auto txr_grouped = CreateTransactionInternal(...);
```

</details>