### PR TITLE
doc: Discourage adding AI agents as commit (co)-authors

### DIFF
--- a/doc/AI_POLICY.md
+++ b/doc/AI_POLICY.md
@@ -23,6 +23,7 @@ This includes the pull request body and responses to questions.
 This project requires a human author in the loop who understands the work produced by AI.
 **Pull requests should not be opened or driven by autonomous agents**.
 A human author must choose the work, understand the change, and be responsible for the contribution.
+Do not include agents as authors or co-authors of your commits for these reasons.
 Pull requests that appear in violation of this can be closed without notice.
 
 If you wish to include context from an interaction with AI in your comments, it must be disclosed as such.


### PR DESCRIPTION
The goal of the AI policy is to ensure that contributors maintain the responsibility of understanding the change they are contributing. Adding AI agents as co-authors undermines this. I believe this philosophy should extend to commit co-authors in general: They should only be added if they themselves are capable of fully understanding the commit.

This contribution was sparked by maflcko's comment here: https://github.com/bitcoin/bitcoin/pull/35551#pullrequestreview-4642682025 .