### PR TITLE
build: set CMAKE_VISIBILITY_INLINES_HIDDEN in REDUCE_EXPORTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,6 +601,7 @@ endif()
 
 if(REDUCE_EXPORTS)
   set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
   try_append_linker_flag("-Wl,--exclude-libs,ALL" TARGET core_interface)
   try_append_linker_flag("-Wl,-no_exported_symbols" VAR CMAKE_EXE_LINKER_FLAGS)
 endif()


### PR DESCRIPTION
This was originally part of the CMake switchover, but was removed because it was an addition, rather than a port. Add it now.

See https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-fvisibility-inlines-hidden:

> This switch declares that the user does not attempt to compare pointers
> to inline functions or methods where the addresses of the two functions
> are taken in different shared objects.

> The effect of this is that GCC may, effectively, mark inline methods
> with __attribute__ ((visibility ("hidden"))) so that they do not appear
> in the export table of a DSO

See also https://cmake.org/cmake/help/latest/prop_tgt/VISIBILITY_INLINES_HIDDEN.html.

When building for macOS, this will also enable [`-fvisibility-inlines-hidden-static-local-var`](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fvisibility-inlines-hidden-static-local-var).