### PR TITLE
refactor: modernize typedef to using alias in streams.h

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -169,15 +169,15 @@ protected:
     vector_type::size_type m_read_pos{0};
 
 public:
-    typedef vector_type::allocator_type   allocator_type;
-    typedef vector_type::size_type        size_type;
-    typedef vector_type::difference_type  difference_type;
-    typedef vector_type::reference        reference;
-    typedef vector_type::const_reference  const_reference;
-    typedef vector_type::value_type       value_type;
-    typedef vector_type::iterator         iterator;
-    typedef vector_type::const_iterator   const_iterator;
-    typedef vector_type::reverse_iterator reverse_iterator;
+    using allocator_type   = vector_type::allocator_type;
+    using size_type        = vector_type::size_type;
+    using difference_type  = vector_type::difference_type;
+    using reference        = vector_type::reference;
+    using const_reference  = vector_type::const_reference;
+    using value_type       = vector_type::value_type;
+    using iterator         = vector_type::iterator;
+    using const_iterator   = vector_type::const_iterator;
+    using reverse_iterator = vector_type::reverse_iterator;
 
     explicit DataStream() = default;
     explicit DataStream(std::span<const uint8_t> sp) : DataStream{std::as_bytes(sp)} {}


### PR DESCRIPTION
This PR modernizes legacy `typedef` declarations to `using` aliases in `src/streams.h`. 

This is part of an ongoing effort to modernize the codebase to C++11/C++14/C++17 standards, following the C++ Core Guidelines which recommend `using` over `typedef` for readability and consistency. 

This change does not alter any behavior.
