### PR TITLE
refactor: modernize typedef to using alias in wallet code

### DIFF
--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -291,7 +291,7 @@ struct OutputGroupTypeMap
     size_t TypesCount() { return groups_by_type.size(); }
 };
 
-typedef std::map<CoinEligibilityFilter, OutputGroupTypeMap> FilteredOutputGroups;
+using FilteredOutputGroups = std::map<CoinEligibilityFilter, OutputGroupTypeMap>;
 
 /** Choose a random change target for each transaction to make it harder to fingerprint the Core
  * wallet based on the change output values of transactions it creates.

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -60,7 +60,7 @@ public:
     }
 };
 
-typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
+using CKeyingMaterial = std::vector<unsigned char, secure_allocator<unsigned char> >;
 
 namespace wallet_crypto_tests
 {

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -28,7 +28,7 @@ using util::ToString;
 
 namespace wallet {
 
-typedef std::vector<unsigned char> valtype;
+using valtype = std::vector<unsigned char>;
 
 // Legacy wallet IsMine(). Used only in migration
 // DO NOT USE ANYTHING IN THIS NAMESPACE OUTSIDE OF MIGRATION

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -605,7 +605,7 @@ FilteredOutputGroups GroupOutputs(const CWallet& wallet,
     // For each COutput, we check if the scriptPubKey is in the map, and if it is, the COutput is added
     // to the last OutputGroup in the vector for the scriptPubKey. When the last OutputGroup has
     // OUTPUT_GROUP_MAX_ENTRIES COutputs, a new OutputGroup is added to the end of the vector.
-    typedef std::map<std::pair<CScript, OutputType>, std::vector<OutputGroup>> ScriptPubKeyToOutgroup;
+    using ScriptPubKeyToOutgroup = std::map<std::pair<CScript, OutputType>, std::vector<OutputGroup>>;
     const auto& insert_output = [&](
             const std::shared_ptr<COutput>& output, OutputType type, size_t ancestors, size_t cluster_count,
             ScriptPubKeyToOutgroup& groups_map) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -913,7 +913,7 @@ DBErrors CWallet::ReorderTransactions()
     // Probably a bad idea to change the output of this
 
     // First: get all CWalletTx into a sorted-by-time multimap.
-    typedef std::multimap<int64_t, CWalletTx*> TxItems;
+    using TxItems = std::multimap<int64_t, CWalletTx*>;
     TxItems txByTime;
 
     for (auto& entry : mapWallet)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -337,7 +337,7 @@ private:
      * detect and report conflicts (double-spends or
      * mutated transactions where the mutant gets mined).
      */
-    typedef std::unordered_multimap<COutPoint, Txid, SaltedOutpointHasher> TxSpends;
+    using TxSpends = std::unordered_multimap<COutPoint, Txid, SaltedOutpointHasher>;
     TxSpends mapTxSpends GUARDED_BY(cs_wallet);
     void AddToSpends(const COutPoint& outpoint, const Txid& txid) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void AddToSpends(const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -468,7 +468,7 @@ public:
      */
     const std::string& GetName() const { return m_name; }
 
-    typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
+    using MasterKeyMap = std::map<unsigned int, CMasterKey>;
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID = 0;
 
@@ -496,7 +496,7 @@ public:
      * interested in, including received and sent transactions. */
     std::unordered_map<Txid, CWalletTx, SaltedTxidHasher> mapWallet GUARDED_BY(cs_wallet);
 
-    typedef std::multimap<int64_t, CWalletTx*> TxItems;
+    using TxItems = std::multimap<int64_t, CWalletTx*>;
     TxItems wtxOrdered;
 
     int64_t nOrderPosNext GUARDED_BY(cs_wallet) = 0;


### PR DESCRIPTION
This PR modernizes legacy `typedef` declarations to `using` aliases across several wallet files (`wallet.h`, `wallet.cpp`, `spend.cpp`, `scriptpubkeyman.cpp`, `coinselection.h`, `crypter.h`).

This is a continuation of the codebase modernization effort to adhere to C++ Core Guidelines preferring `using` syntax over `typedef`.

This is a purely structural refactor and does not change any behavior.
