### PR TITLE
refactor: modernize typedef to using alias in txmempool, torcontrol, versionbits

### DIFF
--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -55,7 +55,7 @@ public:
 class TorControlConnection
 {
 public:
-    typedef std::function<void(TorControlConnection &,const TorControlReply &)> ReplyHandlerCB;
+    using ReplyHandlerCB = std::function<void(TorControlConnection &,const TorControlReply &)>;
 
     /** Create a new TorControlConnection.
      */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -65,7 +65,7 @@ bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp) EXCLUSIVE
 // extracts a transaction hash from CTxMemPoolEntry or CTransactionRef
 struct mempoolentry_txid
 {
-    typedef Txid result_type;
+    using result_type = Txid;
     result_type operator() (const CTxMemPoolEntry &entry) const
     {
         return entry.GetTx().GetHash();
@@ -80,7 +80,7 @@ struct mempoolentry_txid
 // extracts a transaction witness-hash from CTxMemPoolEntry or CTransactionRef
 struct mempoolentry_wtxid
 {
-    typedef Wtxid result_type;
+    using result_type = Wtxid;
     result_type operator() (const CTxMemPoolEntry &entry) const
     {
         return entry.GetTx().GetWitnessHash();
@@ -263,7 +263,7 @@ public:
     using txiter = indexed_transaction_set::nth_index<0>::type::const_iterator;
     std::vector<std::pair<Wtxid, txiter>> txns_randomized GUARDED_BY(cs); //!< All transactions in mapTx with their wtxids, in arbitrary order
 
-    typedef std::set<txiter, CompareIteratorByHash> setEntries;
+    using setEntries = std::set<txiter, CompareIteratorByHash>;
 
     using Limits = kernel::MemPoolLimits;
 

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -30,7 +30,7 @@ enum class ThresholdState : uint8_t;
 // A map that gives the state for blocks whose height is a multiple of Period().
 // The map is indexed by the block's parent, however, so all keys in the map
 // will either be nullptr or a block with (height + 1) % Period() == 0.
-typedef std::map<const CBlockIndex*, ThresholdState> ThresholdConditionCache;
+using ThresholdConditionCache = std::map<const CBlockIndex*, ThresholdState>;
 
 /** Display status of an in-progress BIP9 softfork */
 struct BIP9Stats {


### PR DESCRIPTION
This PR modernizes legacy `typedef` declarations to `using` aliases in `src/txmempool.h`, `src/torcontrol.h`, and `src/versionbits.h`.

This change follows the C++ Core Guidelines recommendation to use `using` declarations instead of `typedef` for type aliases, improving code readability. 

There are no functional changes in this PR.
