### PR TITLE
doc: fix header guard placement in net_permissions.h

### DIFF
--- a/src/net_permissions.h
+++ b/src/net_permissions.h
@@ -2,6 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#ifndef BITCOIN_NET_PERMISSIONS_H
+#define BITCOIN_NET_PERMISSIONS_H
+
 #include <netaddress.h>
 #include <netbase.h>
 
@@ -9,8 +12,6 @@
 #include <type_traits>
 #include <vector>
 
-#ifndef BITCOIN_NET_PERMISSIONS_H
-#define BITCOIN_NET_PERMISSIONS_H
 
 struct bilingual_str;
 


### PR DESCRIPTION
This PR fixes an unconventional header guard placement in `src/net_permissions.h`. Previously, the `#include` directives were placed *before* the `#ifndef BITCOIN_NET_PERMISSIONS_H` header guard. 

This change moves the `#include` directives inside the header guard, aligning with standard C++ practices and the rest of the Bitcoin Core codebase.
