### PR TITLE
refactor: modernize typedef to using alias in test code

### DIFF
--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -145,12 +145,12 @@ std::atomic<size_t> FakeCheckCheckCompletion::n_calls{0};
 std::atomic<size_t> MemoryCheck::fake_allocated_memory{0};
 
 // Queue Typedefs
-typedef CCheckQueue<FakeCheckCheckCompletion> Correct_Queue;
-typedef CCheckQueue<FakeCheck> Standard_Queue;
-typedef CCheckQueue<FixedCheck> Fixed_Queue;
-typedef CCheckQueue<UniqueCheck> Unique_Queue;
-typedef CCheckQueue<MemoryCheck> Memory_Queue;
-typedef CCheckQueue<FrozenCleanupCheck> FrozenCleanup_Queue;
+using Correct_Queue = CCheckQueue<FakeCheckCheckCompletion>;
+using Standard_Queue = CCheckQueue<FakeCheck>;
+using Fixed_Queue = CCheckQueue<FixedCheck>;
+using Unique_Queue = CCheckQueue<UniqueCheck>;
+using Memory_Queue = CCheckQueue<MemoryCheck>;
+using FrozenCleanup_Queue = CCheckQueue<FrozenCleanupCheck>;
 
 
 /** This test case checks that the CCheckQueue works properly

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -308,7 +308,7 @@ BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
 
 struct UpdateTest : BasicTestingSetup {
 // Store of all necessary tx and undo data for next test
-typedef std::map<COutPoint, std::tuple<CTransaction,CTxUndo,Coin>> UtxoData;
+using UtxoData = std::map<COutPoint, std::tuple<CTransaction,CTxUndo,Coin>>;
 UtxoData utxoData;
 
 UtxoData::iterator FindRandomFrom(const std::set<COutPoint> &utxoSet) {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -47,7 +47,7 @@ using namespace util::hex_literals;
 using util::SplitString;
 using util::ToString;
 
-typedef std::vector<unsigned char> valtype;
+using valtype = std::vector<unsigned char>;
 
 static CFeeRate g_dust{DUST_RELAY_TX_FEE};
 static bool g_bare_multi{DEFAULT_PERMIT_BAREMULTISIG};


### PR DESCRIPTION
This PR modernizes legacy `typedef` declarations to `using` aliases in the test suite (`src/test/checkqueue_tests.cpp`, `src/test/transaction_tests.cpp`, `src/test/coins_tests.cpp`).

This brings the test code in line with the modernization efforts applied to the rest of the codebase, adhering to modern C++ guidelines.
