### PR TITLE
refactor: modernize typedef to using alias in zmq and support code

### DIFF
--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -89,11 +89,11 @@ public:
      */
     bool addressInArena(void *ptr) const { return ptr >= base && ptr < end; }
 private:
-    typedef std::multimap<size_t, void*> SizeToChunkSortedMap;
+    using SizeToChunkSortedMap = std::multimap<size_t, void*>;
     /** Map to enable O(log(n)) best-fit allocation, as it's sorted by size */
     SizeToChunkSortedMap size_to_free_chunk;
 
-    typedef std::unordered_map<void*, SizeToChunkSortedMap::const_iterator> ChunkToSizeMap;
+    using ChunkToSizeMap = std::unordered_map<void*, SizeToChunkSortedMap::const_iterator>;
     /** Map from begin of free chunk to its node in size_to_free_chunk */
     ChunkToSizeMap chunks_free;
     /** Map from end of free chunk to its node in size_to_free_chunk */
@@ -139,7 +139,7 @@ public:
 
     /** Callback when allocation succeeds but locking fails.
      */
-    typedef bool (*LockingFailed_Callback)();
+    using LockingFailed_Callback = bool (*)();
 
     /** Memory statistics. */
     struct Stats

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -167,7 +167,7 @@ void CZMQAbstractPublishNotifier::Shutdown()
     int count = mapPublishNotifiers.count(address);
 
     // remove this notifier from the list of publishers using this address
-    typedef std::multimap<std::string, CZMQAbstractPublishNotifier*>::iterator iterator;
+    using iterator = std::multimap<std::string, CZMQAbstractPublishNotifier*>::iterator;
     std::pair<iterator, iterator> iterpair = mapPublishNotifiers.equal_range(address);
 
     for (iterator it = iterpair.first; it != iterpair.second; ++it)


### PR DESCRIPTION
This PR modernizes legacy `typedef` declarations to `using` aliases in `src/zmq/zmqpublishnotifier.cpp` and `src/support/lockedpool.h`.

This completes another step in replacing older C-style typedefs with modern C++ `using` syntax across the codebase.
