### PR TITLE
fuzz: reset connman state in p2p targets

### DIFF
--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -503,6 +503,7 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
     setup->m_node.validation_signals->SyncWithValidationInterfaceQueue();
     setup->m_node.validation_signals->UnregisterAllValidationInterfaces();
     connman.StopNodes();
+    connman.Reset();
 
     const size_t end_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
     const uint64_t end_sequence{WITH_LOCK(mempool.cs, return mempool.GetSequence())};

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -167,6 +167,8 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
     FakeSteadyClock steady_clock;
 
     auto setup = g_setup;
+    auto& connman = *static_cast<ConnmanTestMsg*>(setup->m_node.connman.get());
+    connman.Reset();
     auto& mempool = *setup->m_node.mempool;
     auto& chainman = static_cast<TestChainstateManager&>(*setup->m_node.chainman);
     chainman.ResetIbd();
@@ -174,7 +176,6 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
     const size_t initial_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
 
     AddrMan addrman{*setup->m_node.netgroupman, /*deterministic=*/true, /*consistency_check_ratio=*/0};
-    auto& connman = *static_cast<ConnmanTestMsg*>(setup->m_node.connman.get());
     auto peerman = PeerManager::make(connman, addrman,
                                      /*banman=*/nullptr, chainman,
                                      mempool, *setup->m_node.warnings,

--- a/src/test/fuzz/p2p_handshake.cpp
+++ b/src/test/fuzz/p2p_handshake.cpp
@@ -106,4 +106,5 @@ FUZZ_TARGET(p2p_handshake, .init = ::initialize)
     }
 
     node.connman->StopNodes();
+    connman.Reset();
 }

--- a/src/test/fuzz/p2p_handshake.cpp
+++ b/src/test/fuzz/p2p_handshake.cpp
@@ -40,6 +40,7 @@ FUZZ_TARGET(p2p_handshake, .init = ::initialize)
 
     auto& node{g_setup->m_node};
     auto& connman{static_cast<ConnmanTestMsg&>(*node.connman)};
+    connman.Reset();
     auto& chainman{static_cast<TestChainstateManager&>(*node.chainman)};
     FakeNodeClock clock{1610000000s}; // any time to successfully reset ibd
     FakeSteadyClock steady_clock;


### PR DESCRIPTION
Resets `ConnmanTestMsg` at the start of each input in `cmpctblock` and `p2p_handshake`, matching the other reused-connman fuzz targets and preventing sticky `CConnman` state from leaking between corpus inputs.

Before this, deterministic-fuzz-coverage showed single inputs were stable, but all-input directory runs were not:

```diff
cmpctblock, src/net.cpp:4172
- Branch (4172:9): [True: 1.21k, False: 33.0k]
+ Branch (4172:9): [True: 613, False: 33.6k]
- Branch (4172:72): [True: 901, False: 311]
+ Branch (4172:72): [True: 497, False: 116]
```

```diff
p2p_handshake, src/net.cpp:4172
- Branch (4172:9): [True: 98, False: 1.67k]
+ Branch (4172:9): [True: 743, False: 1.03k]
- Branch (4172:72): [True: 90, False: 8]
+ Branch (4172:72): [True: 612, False: 131]
```

With the resets, `deterministic-fuzz-coverage` passed for both `cmpctblock` and `p2p_handshake`.
