### PR TITLE
guix: Drop unused `(guix licenses)` import from `manifest_build.scm`

### DIFF
--- a/contrib/guix/manifest_build.scm
+++ b/contrib/guix/manifest_build.scm
@@ -14,7 +14,6 @@
              (guix download)
              (guix gexp)
              (guix git-download)
-             ((guix licenses) #:prefix license:)
              (guix packages)
              ((guix utils) #:select (substitute-keyword-arguments)))
 


### PR DESCRIPTION
This was overlooked in bitcoin/bitcoin#34948.