### PR TITLE
wallet, rpc: Add listrawtransactions RPC

### DIFF
--- a/doc/release-notes-35813.md
+++ b/doc/release-notes-35813.md
@@ -1,0 +1,11 @@
+New RPCs
+--------
+
+- A new `listrawtransactions` RPC has been added to the wallet. Unlike
+  `listtransactions`, which only lists transactions with a logical economic
+  category (sends to external addresses, receives from external addresses), this
+  RPC returns every transaction the wallet knows about, including consolidations
+  and self-transfers that would otherwise be invisible. Each transaction appears
+  exactly once with its net wallet balance change (`amount`) and, when the wallet
+  funded the transaction, the fee paid (`fee`). The results support the same
+  `count` and `skip` pagination as `listtransactions`. (#35813)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -105,6 +105,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listtransactions", 1, "count" },
     { "listtransactions", 2, "skip" },
     { "listtransactions", 3, "include_watchonly" },
+    { "listrawtransactions", 0, "count" },
+    { "listrawtransactions", 1, "skip" },
     { "walletpassphrase", 0, "passphrase", ParamFormat::STRING },
     { "walletpassphrase", 1, "timeout" },
     { "getblocktemplate", 0, "template_request" },

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -379,6 +379,35 @@ static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nM
     }
 }
 
+/**
+ * Build a raw transaction entry for the given wallet transaction.
+ *
+ * @param  wallet         The wallet.
+ * @param  wtx            The wallet transaction.
+ * @return                A JSON object with the net wallet balance change and
+ *                        transaction metadata, without logical interpretation
+ *                        (no category assignment, no change suppression).
+ */
+static UniValue ListRawTransaction(const CWallet& wallet, const CWalletTx& wtx)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    UniValue entry(UniValue::VOBJ);
+
+    CAmount nCredit = CachedTxGetCredit(wallet, wtx, /*avoid_reuse=*/false);
+    CAmount nDebit = CachedTxGetDebit(wallet, wtx, /*avoid_reuse=*/false);
+    CAmount nNet = nCredit - nDebit;
+    bool is_from_me = CachedTxIsFromMe(wallet, wtx);
+    CAmount nFee = (is_from_me ? wtx.tx->GetValueOut() - nDebit : 0);
+
+    entry.pushKV("amount", ValueFromAmount(nNet - nFee));
+    if (is_from_me)
+        entry.pushKV("fee", ValueFromAmount(nFee));
+
+    WalletTxToJSON(wallet, wtx, entry);
+    entry.pushKV("abandoned", wtx.isAbandoned());
+
+    return entry;
+}
 
 static std::vector<RPCResult> TransactionDescriptionString()
 {
@@ -518,6 +547,89 @@ RPCMethod listtransactions()
     auto txs_rev_it{std::make_move_iterator(ret.rend())};
     UniValue result{UniValue::VARR};
     result.push_backV(txs_rev_it - nFrom - nCount, txs_rev_it - nFrom); // Return oldest to newest
+    return result;
+},
+    };
+}
+
+RPCMethod listrawtransactions()
+{
+    return RPCMethod{
+        "listrawtransactions",
+        "Returns up to 'count' most recent wallet transactions ordered from oldest to newest, "
+        "skipping the first 'skip' transactions. Unlike `listtransactions`, each wallet transaction "
+        "appears exactly once with its net wallet balance change, without logical interpretation "
+        "(no category assignment, no change suppression). This means consolidation and self-transfer "
+        "transactions that are invisible in `listtransactions` are included here.\n",
+        {
+            {"count", RPCArg::Type::NUM, RPCArg::Default{10}, "The number of transactions to return."},
+            {"skip",  RPCArg::Type::NUM, RPCArg::Default{0},  "The number of transactions to skip."},
+        },
+        RPCResult{
+            RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::OBJ, "", "", Cat<std::vector<RPCResult>>(
+                {
+                    {RPCResult::Type::STR_AMOUNT, "amount", "The net change to the wallet balance caused by this transaction "
+                        "(excluding fee). Positive means the wallet gained funds, negative means it lost funds, "
+                        "zero means a pure self-transfer (e.g. consolidation)."},
+                    {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The fee paid in " + CURRENCY_UNIT + ". "
+                        "Only present when the wallet funded the transaction."},
+                },
+                Cat(TransactionDescriptionString(),
+                {
+                    {RPCResult::Type::BOOL, "abandoned", "'true' if the transaction has been abandoned (inputs are respendable)."},
+                }))},
+            }
+        },
+        RPCExamples{
+            "\nList the most recent 10 transactions\n"
+            + HelpExampleCli("listrawtransactions", "") +
+            "\nList transactions 100 to 120\n"
+            + HelpExampleCli("listrawtransactions", "20 100") +
+            "\nAs a JSON-RPC call\n"
+            + HelpExampleRpc("listrawtransactions", "20, 100")
+        },
+        [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
+{
+    const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
+    if (!pwallet) return UniValue::VNULL;
+
+    pwallet->BlockUntilSyncedToCurrentChain();
+
+    int nCount = 10;
+    if (!request.params[0].isNull())
+        nCount = request.params[0].getInt<int>();
+    int nFrom = 0;
+    if (!request.params[1].isNull())
+        nFrom = request.params[1].getInt<int>();
+
+    if (nCount < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
+    if (nFrom < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative from");
+
+    std::vector<UniValue> ret;
+    {
+        LOCK(pwallet->cs_wallet);
+
+        const CWallet::TxItems& txOrdered = pwallet->wtxOrdered;
+
+        for (CWallet::TxItems::const_reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it) {
+            CWalletTx* const pwtx = (*it).second;
+            ret.push_back(ListRawTransaction(*pwallet, *pwtx));
+            if ((int)ret.size() >= (nCount + nFrom)) break;
+        }
+    }
+
+    if (nFrom > (int)ret.size())
+        nFrom = ret.size();
+    if ((nFrom + nCount) > (int)ret.size())
+        nCount = ret.size() - nFrom;
+
+    auto txs_rev_it{std::make_move_iterator(ret.rend())};
+    UniValue result{UniValue::VARR};
+    result.push_backV(txs_rev_it - nFrom - nCount, txs_rev_it - nFrom);
     return result;
 },
     };

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -1020,6 +1020,7 @@ RPCMethod signmessage();
 RPCMethod listreceivedbyaddress();
 RPCMethod listreceivedbylabel();
 RPCMethod listtransactions();
+RPCMethod listrawtransactions();
 RPCMethod listsinceblock();
 RPCMethod gettransaction();
 RPCMethod abandontransaction();
@@ -1063,6 +1064,7 @@ std::span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &listreceivedbylabel},
         {"wallet", &listsinceblock},
         {"wallet", &listtransactions},
+        {"wallet", &listrawtransactions},
         {"wallet", &listunspent},
         {"wallet", &listwalletdir},
         {"wallet", &listwallets},

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -149,6 +149,7 @@ BASE_SCRIPTS = [
     'p2p_sendheaders.py',
     'feature_config_args.py',
     'wallet_listtransactions.py',
+    'wallet_listrawtransactions.py',
     'wallet_miniscript.py',
     # vv Tests less than 30s vv
     'wallet_deprecated_rbf.py',

--- a/test/functional/wallet_listrawtransactions.py
+++ b/test/functional/wallet_listrawtransactions.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the listrawtransactions RPC."""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+
+class ListRawTransactionsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.test_invalid_parameters()
+        self.test_one_entry_per_tx()
+        self.test_coinbase_tx()
+        self.test_consolidation_tx_visible()
+        self.test_count_and_skip()
+
+    def test_invalid_parameters(self):
+        self.log.info("Test listrawtransactions RPC parameter validity")
+        assert_raises_rpc_error(-8, "Negative count", self.nodes[0].listrawtransactions, -1)
+        assert_raises_rpc_error(-8, "Negative from", self.nodes[0].listrawtransactions, 10, -1)
+
+    def test_one_entry_per_tx(self):
+        self.log.info("Test that each tx appears exactly once, unlike listtransactions which shows one entry per output")
+        self.generate(self.nodes[0], 101)
+
+        # Send-to-self to a wallet receiving address (not change). listtransactions
+        # produces two entries for this txid — one "send", one "receive" — because
+        # it works per-output. listrawtransactions must produce exactly one.
+        addr = self.nodes[0].getnewaddress()
+        txid = self.nodes[0].sendtoaddress(addr, 0.5)
+
+        lt_matching = [tx for tx in self.nodes[0].listtransactions("*", 20) if tx["txid"] == txid]
+        assert_equal(len(lt_matching), 2)
+        assert_equal({tx["category"] for tx in lt_matching}, {"send", "receive"})
+
+        lrt_matching = [tx for tx in self.nodes[0].listrawtransactions(20) if tx["txid"] == txid]
+        assert_equal(len(lrt_matching), 1)
+
+    def test_coinbase_tx(self):
+        self.log.info("Test that coinbase transactions appear in listrawtransactions with generated=True and no category")
+        node = self.nodes[0]
+
+        # Block 1's coinbase is mature (101 blocks generated in test_one_entry_per_tx).
+        coinbase_txid = node.getblock(node.getblockhash(1))["tx"][0]
+
+        results = node.listrawtransactions(9999)
+        matching = [tx for tx in results if tx["txid"] == coinbase_txid]
+
+        # Appears exactly once — same as any other tx.
+        assert_equal(len(matching), 1)
+        entry = matching[0]
+
+        # Coinbase is flagged via "generated", not via a "category" field —
+        # listrawtransactions intentionally omits category assignment.
+        assert_equal(entry["generated"], True)
+        assert "category" not in entry
+
+        # Wallet received the block reward (positive amount, no fee).
+        assert entry["amount"] > 0
+        assert "fee" not in entry
+
+    def test_consolidation_tx_visible(self):
+        self.log.info("Test that consolidation tx (all inputs/outputs owned by wallet) appears in listrawtransactions")
+
+        # Fund wallet with two UTXOs at distinct fresh addresses so listunspent
+        # can retrieve each one unambiguously.
+        addr1 = self.nodes[0].getnewaddress()
+        addr2 = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(addr1, 1.0)
+        self.nodes[0].sendtoaddress(addr2, 1.0)
+        self.generate(self.nodes[0], 1)
+
+        utxo1 = self.nodes[0].listunspent(1, 9999, [addr1])[0]
+        utxo2 = self.nodes[0].listunspent(1, 9999, [addr2])[0]
+
+        # Build consolidation tx: two inputs → one output, all wallet-owned.
+        # The output must go to a change-keychain address so that listtransactions
+        # omits it (outputs on the receiving keychain would appear as "receive").
+        inputs = [{"txid": utxo1["txid"], "vout": utxo1["vout"]},
+                  {"txid": utxo2["txid"], "vout": utxo2["vout"]}]
+        total = utxo1["amount"] + utxo2["amount"]
+        fee = Decimal("0.0001")
+        outputs = {self.nodes[0].getrawchangeaddress(): float(total - fee)}
+
+        raw_hex = self.nodes[0].createrawtransaction(inputs, outputs)
+        signed = self.nodes[0].signrawtransactionwithwallet(raw_hex)
+        assert_equal(signed["complete"], True)
+        consolidation_txid = self.nodes[0].sendrawtransaction(signed["hex"])
+        self.generate(self.nodes[0], 1)
+
+        # listtransactions omits it — no logical category (neither send to an
+        # external address nor receive from outside).
+        lt_txids = [tx["txid"] for tx in self.nodes[0].listtransactions("*", 100)]
+        assert consolidation_txid not in lt_txids, \
+            f"consolidation txid {consolidation_txid} unexpectedly appeared in listtransactions"
+
+        # listrawtransactions shows it exactly once.
+        lrt_results = self.nodes[0].listrawtransactions(100)
+        matching = [tx for tx in lrt_results if tx["txid"] == consolidation_txid]
+        assert_equal(len(matching), 1)
+
+        # amount = 0: no external flow (all funds stayed in the wallet).
+        # fee is negative: reflects the miner fee paid.
+        entry = matching[0]
+        assert_equal(entry["amount"], Decimal("0"))
+        assert_equal(entry["fee"], -fee)
+
+    def test_count_and_skip(self):
+        self.log.info("Test count and skip")
+        node = self.nodes[0]
+
+        all_txs = node.listrawtransactions(9999)
+        total = len(all_txs)
+        assert total >= 3, f"Need at least 3 txs for pagination test, got {total}"
+
+        # count=2 returns the 2 newest txs ordered oldest-first within the result.
+        page = node.listrawtransactions(2)
+        assert_equal(len(page), 2)
+        assert_equal(page[0]["txid"], all_txs[-2]["txid"])
+        assert_equal(page[1]["txid"], all_txs[-1]["txid"])
+
+        # skip=1 skips the newest tx; the next 2 are returned.
+        page_skipped = node.listrawtransactions(2, 1)
+        assert_equal(len(page_skipped), 2)
+        assert_equal(page_skipped[0]["txid"], all_txs[-3]["txid"])
+        assert_equal(page_skipped[1]["txid"], all_txs[-2]["txid"])
+
+        # skip beyond total returns empty.
+        assert_equal(len(node.listrawtransactions(10, total + 10)), 0)
+
+
+if __name__ == "__main__":
+    ListRawTransactionsTest(__file__).main()


### PR DESCRIPTION
Add a new `listrawtransactions` RPC that returns wallet transactions without logical interpretation. Unlike `listtransactions`, which only lists transactions with an economic category (sends to external addresses, receives from outside), this RPC returns every transaction the wallet knows about — including consolidations and self-transfers that would otherwise be invisible.

Each transaction appears exactly once with its net wallet balance change (`amount`) and, when the wallet funded the transaction, the fee paid (`fee`). Pagination is supported via `count` and `skip` parameters, matching the interface of `listtransactions`.

Next possible follow-ups:
- A filter parameter (`"all"` / `"received"` / `"sent"` / `"self"`) once per-tx semantics are agreed on
- Some fields inherited from `TransactionDescriptionString()` carry references to `category` (e.g. `replaced_by_txid`, `parent_descs`) which don't apply here — could be cleaned up in a separate pass

Closes #34632.

Previous attempt: #35009 (by alfonsoromanz), closed in favour of a separate RPC as suggested by achow101.