### PR TITLE
bloom: avoid undefined sizing calculations

### DIFF
--- a/src/common/bloom.cpp
+++ b/src/common/bloom.cpp
@@ -11,6 +11,7 @@
 #include <script/solver.h>
 #include <span.h>
 #include <streams.h>
+#include <util/check.h>
 #include <util/fastrange.h>
 #include <util/overflow.h>
 
@@ -23,19 +24,27 @@
 static constexpr double LN2SQUARED = 0.4804530139182014246671025263266649717305529515945455;
 static constexpr double LN2 = 0.6931471805599453094172321214581765680755001343602552;
 
+static unsigned int BloomFilterSize(const unsigned int elements, const double false_positive_rate)
+{
+    Assert(std::isfinite(false_positive_rate) && false_positive_rate >= 0 && false_positive_rate <= 1);
+    if (elements == 0) return 0; // Must precede the zero-rate case to preserve empty-filter semantics.
+    if (false_positive_rate == 0) return MAX_BLOOM_FILTER_SIZE; // Avoid log(0) raising FE_DIVBYZERO.
+    return std::min(-1 / LN2SQUARED * elements * log(false_positive_rate), MAX_BLOOM_FILTER_SIZE * 8.0) / 8;
+}
+
 CBloomFilter::CBloomFilter(const unsigned int nElements, const double nFPRate, const unsigned int nTweakIn, unsigned char nFlagsIn) :
     /**
      * The ideal size for a bloom filter with a given number of elements and false positive rate is:
      * - nElements * log(fp rate) / ln(2)^2
      * We ignore filter parameters which will create a bloom filter larger than the protocol limits
      */
-    vData(std::min((unsigned int)(-1  / LN2SQUARED * nElements * log(nFPRate)), MAX_BLOOM_FILTER_SIZE * 8) / 8),
+    vData(BloomFilterSize(nElements, nFPRate)),
     /**
      * The ideal number of hash functions is filter size * ln(2) / number of elements
      * Again, we ignore filter parameters which will create a bloom filter with more hash functions than the protocol limits
      * See https://en.wikipedia.org/wiki/Bloom_filter for an explanation of these formulas
      */
-    nHashFuncs(std::min((unsigned int)(vData.size() * 8 / nElements * LN2), MAX_HASH_FUNCS)),
+    nHashFuncs(nElements == 0 ? 0 : std::min((unsigned int)(vData.size() * 8 / nElements * LN2), MAX_HASH_FUNCS)),
     nTweak(nTweakIn),
     nFlags(nFlagsIn)
 {

--- a/src/common/bloom.h
+++ b/src/common/bloom.h
@@ -54,6 +54,8 @@ private:
 public:
     /**
      * Creates a new bloom filter which will provide the given fp rate when filled with the given number of elements
+     * nFPRate must be in [0, 1].
+     * An nElements of 0 creates an empty filter which ignores inserts and matches everything.
      * Note that if the given parameters will result in a filter outside the bounds of the protocol limits,
      * the filter created will be as close to the given parameters as possible within the protocol limits.
      * This will apply if nFPRate is very low or nElements is unreasonably high.

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -17,9 +17,11 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <cfenv>
+#include <cmath>
 #include <limits>
 #include <vector>
 
@@ -73,6 +75,11 @@ BOOST_AUTO_TEST_CASE(bloom_create_filter_size)
     BOOST_CHECK_EQUAL(filter_size(/*elements=*/1, /*false_positive_rate=*/1), 0);
 
     std::feclearexcept(FE_ALL_EXCEPT);
+    BOOST_CHECK_EQUAL(filter_size(/*elements=*/0, /*false_positive_rate=*/0), 0);
+    // Negative zero compares equal to zero, so it is a valid zero rate.
+    BOOST_CHECK_EQUAL(filter_size(/*elements=*/1, /*false_positive_rate=*/-0.0), MAX_BLOOM_FILTER_SIZE);
+    BOOST_CHECK_EQUAL(filter_size(/*elements=*/1, /*false_positive_rate=*/0), MAX_BLOOM_FILTER_SIZE);
+    BOOST_CHECK_EQUAL(filter_size(std::numeric_limits<unsigned int>::max(), /*false_positive_rate=*/0.01), MAX_BLOOM_FILTER_SIZE);
     for (double rate : {std::numeric_limits<double>::denorm_min(), std::numeric_limits<double>::min(), std::numeric_limits<double>::epsilon()}) {
         const auto size{filter_size(/*elements=*/1, rate)};
         BOOST_CHECK_GT(size, 0);
@@ -88,6 +95,18 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_empty)
     filter.insert("beef"_hex_u8);
     BOOST_CHECK(filter.contains("beef"_hex_u8));
     BOOST_CHECK(filter.contains("deadbeef"_hex_u8)); // An empty filter holds no bits, so it matches everything
+}
+
+BOOST_AUTO_TEST_CASE(bloom_create_invalid_false_positive_rate)
+{
+    test_only_CheckFailuresAreExceptionsNotAborts mock_checks{};
+
+    BOOST_CHECK_EXCEPTION((CBloomFilter{1, std::numeric_limits<double>::signaling_NaN(), /*nTweak=*/0, BLOOM_UPDATE_ALL}), NonFatalCheckError, HasReason{"Internal bug detected"}); // Classifying a signaling NaN may raise FE_INVALID
+    std::feclearexcept(FE_ALL_EXCEPT);
+    for (double rate : {-std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::denorm_min(), std::nextafter(1.0, 2.0), std::numeric_limits<double>::infinity(), std::numeric_limits<double>::quiet_NaN()}) {
+        BOOST_CHECK_EXCEPTION((CBloomFilter{1, rate, /*nTweak=*/0, BLOOM_UPDATE_ALL}), NonFatalCheckError, HasReason{"Internal bug detected"});
+    }
+    BOOST_REQUIRE_EQUAL(std::fetestexcept(FE_DIVBYZERO | FE_INVALID), 0);
 }
 
 BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -19,6 +19,8 @@
 #include <uint256.h>
 #include <util/strencodings.h>
 
+#include <cfenv>
+#include <limits>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -56,6 +58,36 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize)
     BOOST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
 
     BOOST_CHECK_MESSAGE( filter.contains("99108ad8ed9bb6274d3980bab5a85c048f0950c8"_hex_u8), "Bloom filter doesn't contain just-inserted object!");
+}
+
+BOOST_AUTO_TEST_CASE(bloom_create_filter_size)
+{
+    auto filter_size{[](unsigned int elements, double false_positive_rate) {
+        DataStream stream{};
+        stream << CBloomFilter{elements, false_positive_rate, /*nTweak=*/0, BLOOM_UPDATE_ALL};
+        return ReadCompactSize(stream);
+    }};
+
+    BOOST_CHECK_EQUAL(filter_size(/*elements=*/10, /*false_positive_rate=*/0.01), 11);
+    BOOST_CHECK_EQUAL(filter_size(/*elements=*/10'000'000, /*false_positive_rate=*/0.01), MAX_BLOOM_FILTER_SIZE);
+    BOOST_CHECK_EQUAL(filter_size(/*elements=*/1, /*false_positive_rate=*/1), 0);
+
+    std::feclearexcept(FE_ALL_EXCEPT);
+    for (double rate : {std::numeric_limits<double>::denorm_min(), std::numeric_limits<double>::min(), std::numeric_limits<double>::epsilon()}) {
+        const auto size{filter_size(/*elements=*/1, rate)};
+        BOOST_CHECK_GT(size, 0);
+        BOOST_CHECK_LE(size, MAX_BLOOM_FILTER_SIZE);
+    }
+    BOOST_REQUIRE_EQUAL(std::fetestexcept(FE_DIVBYZERO | FE_INVALID), 0);
+}
+
+BOOST_AUTO_TEST_CASE(bloom_create_insert_empty)
+{
+    CBloomFilter filter{/*nElements=*/1, /*nFPRate=*/1, /*nTweak=*/0, BLOOM_UPDATE_ALL};
+    BOOST_CHECK(filter.IsWithinSizeConstraints());
+    filter.insert("beef"_hex_u8);
+    BOOST_CHECK(filter.contains("beef"_hex_u8));
+    BOOST_CHECK(filter.contains("deadbeef"_hex_u8)); // An empty filter holds no bits, so it matches everything
 }
 
 BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)

--- a/src/test/fuzz/bloom_filter.cpp
+++ b/src/test/fuzz/bloom_filter.cpp
@@ -19,9 +19,18 @@ FUZZ_TARGET(bloom_filter)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     bool good_data{true};
 
+    const auto false_positive_rate{fuzzed_data_provider.ConsumeBool() ?
+        fuzzed_data_provider.ConsumeProbability<double>() :
+        fuzzed_data_provider.PickValueInArray({
+            0.0,
+            std::numeric_limits<double>::denorm_min(),
+            std::numeric_limits<double>::min(),
+            std::numeric_limits<double>::epsilon(),
+            1.0,
+        })};
     CBloomFilter bloom_filter{
-        fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(1, 10000000),
-        1.0 / fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(1, std::numeric_limits<unsigned int>::max()),
+        fuzzed_data_provider.ConsumeIntegral<unsigned int>(),
+        false_positive_rate,
         fuzzed_data_provider.ConsumeIntegral<unsigned int>(),
         static_cast<unsigned char>(fuzzed_data_provider.PickValueInArray({BLOOM_UPDATE_NONE, BLOOM_UPDATE_ALL, BLOOM_UPDATE_P2PUBKEY_ONLY, BLOOM_UPDATE_MASK}))};
     LIMITED_WHILE (good_data && fuzzed_data_provider.remaining_bytes() > 0, 10'000) {


### PR DESCRIPTION
**Problem:** The four-argument `CBloomFilter` constructor is used by unit tests and the fuzz target to exercise Bloom filter sizing directly.
Zero elements make the hash-function calculation divide by zero.
The size calculation converts its floating-point result to `unsigned int` before applying the protocol limit, which is undefined for zero or invalid false-positive rates and for valid parameters whose calculated size exceeds the integer range.

**Fix:** Require false-positive rates in `[0, 1]`, construct the existing empty match-all state for zero elements, and use the largest permitted filter for a zero rate with positive elements.
Clamp the calculated size before its integer conversion so large valid inputs remain within the protocol limit.