### PR TITLE
refactor: keep duration calculations typed

### DIFF
--- a/src/banman.h
+++ b/src/banman.h
@@ -10,13 +10,14 @@
 #include <net_types.h>
 #include <sync.h>
 #include <util/fs.h>
+#include <util/time.h>
 
 #include <chrono>
 #include <cstdint>
 #include <memory>
 
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
-inline constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24; // Default 24-hour ban
+inline constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME{std::chrono::days{1} / 1s};
 
 /// How often to dump banned addresses/subnets to disk.
 inline constexpr std::chrono::minutes DUMP_BANS_INTERVAL{15};

--- a/src/banman.h
+++ b/src/banman.h
@@ -10,13 +10,14 @@
 #include <net_types.h>
 #include <sync.h>
 #include <util/fs.h>
+#include <util/time.h>
 
 #include <chrono>
 #include <cstdint>
 #include <memory>
 
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
-static constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24; // Default 24-hour ban
+static constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME{std::chrono::days{1} / 1s};
 
 /// How often to dump banned addresses/subnets to disk.
 static constexpr std::chrono::minutes DUMP_BANS_INTERVAL{15};

--- a/src/chain.h
+++ b/src/chain.h
@@ -26,7 +26,7 @@
  * Maximum amount of time that a block timestamp is allowed to exceed the
  * current time before the block will be accepted.
  */
-inline constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
+inline constexpr auto MAX_FUTURE_BLOCK_TIME{2h};
 
 /**
  * Timestamp window used as a grace period by code that compares external
@@ -34,7 +34,7 @@ inline constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
  * to block timestamps. This should be set at least as high as
  * MAX_FUTURE_BLOCK_TIME.
  */
-inline constexpr int64_t TIMESTAMP_WINDOW = MAX_FUTURE_BLOCK_TIME;
+inline constexpr int64_t TIMESTAMP_WINDOW{MAX_FUTURE_BLOCK_TIME / 1s};
 //! Init values for CBlockIndex nSequenceId when loaded from disk
 inline constexpr int32_t SEQ_ID_BEST_CHAIN_FROM_DISK = 0;
 inline constexpr int32_t SEQ_ID_INIT_FROM_DISK = 1;

--- a/src/chain.h
+++ b/src/chain.h
@@ -26,7 +26,7 @@
  * Maximum amount of time that a block timestamp is allowed to exceed the
  * current time before the block will be accepted.
  */
-static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
+static constexpr auto MAX_FUTURE_BLOCK_TIME{2h};
 
 /**
  * Timestamp window used as a grace period by code that compares external
@@ -34,7 +34,7 @@ static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
  * to block timestamps. This should be set at least as high as
  * MAX_FUTURE_BLOCK_TIME.
  */
-static constexpr int64_t TIMESTAMP_WINDOW = MAX_FUTURE_BLOCK_TIME;
+static constexpr int64_t TIMESTAMP_WINDOW{MAX_FUTURE_BLOCK_TIME / 1s};
 //! Init values for CBlockIndex nSequenceId when loaded from disk
 static constexpr int32_t SEQ_ID_BEST_CHAIN_FROM_DISK = 0;
 static constexpr int32_t SEQ_ID_INIT_FROM_DISK = 1;

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -39,7 +39,7 @@ HeadersSyncState::HeadersSyncState(NodeId id,
     // chain to be longer than this (at the current time -- in the future we
     // could try again, if necessary, to sync a longer chain).
     const auto max_seconds_since_start{(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start.GetMedianTimePast()}}))
-                                       + MAX_FUTURE_BLOCK_TIME};
+                                       + (MAX_FUTURE_BLOCK_TIME / 1s)};
     m_max_commitments = 6 * max_seconds_since_start / m_params.commitment_period;
 
     LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s\n", m_id, m_current_height, m_max_commitments, m_minimum_required_work.ToString());

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -21,6 +21,7 @@
 #include <util/chaintype.h>
 #include <util/log.h>
 #include <util/strencodings.h>
+#include <util/time.h>
 
 #include <algorithm>
 #include <array>
@@ -124,8 +125,8 @@ public:
         consensus.SegwitHeight = 481824; // 0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893
         consensus.MinBIP9WarningHeight = 711648; // taproot activation height + miner confirmation window
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = std::chrono::weeks{2} / 1s;
+        consensus.nPowTargetSpacing = 10min / 1s;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -248,8 +249,8 @@ public:
         consensus.SegwitHeight = 834624; // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
         consensus.MinBIP9WarningHeight = 2013984; // taproot activation height + miner confirmation window
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = std::chrono::weeks{2} / 1s;
+        consensus.nPowTargetSpacing = 10min / 1s;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -348,8 +349,8 @@ public:
         consensus.SegwitHeight = 1;
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = std::chrono::weeks{2} / 1s;
+        consensus.nPowTargetSpacing = 10min / 1s;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
@@ -492,8 +493,8 @@ public:
         consensus.BIP66Height = 1;
         consensus.CSVHeight = 1;
         consensus.SegwitHeight = 1;
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = std::chrono::weeks{2} / 1s;
+        consensus.nPowTargetSpacing = 10min / 1s;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -577,8 +578,8 @@ public:
         consensus.SegwitHeight = 0; // Always active unless overridden
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256{"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 24 * 60 * 60; // one day
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = std::chrono::days{1} / 1s;
+        consensus.nPowTargetSpacing = 10min / 1s;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = opts.enforce_bip94;
         consensus.fPowNoRetargeting = true;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -82,8 +82,8 @@ static constexpr std::chrono::seconds DNSSEEDS_DELAY_FEW_PEERS{11};
 static constexpr std::chrono::minutes DNSSEEDS_DELAY_MANY_PEERS{5};
 static constexpr int DNSSEEDS_DELAY_PEER_THRESHOLD = 1000; // "many" vs "few" peers
 
-/** The default timeframe for -maxuploadtarget. 1 day. */
-static constexpr std::chrono::seconds MAX_UPLOAD_TIMEFRAME{60 * 60 * 24};
+/** The default timeframe for -maxuploadtarget. */
+static constexpr std::chrono::seconds MAX_UPLOAD_TIMEFRAME{std::chrono::days{1}};
 
 // A random time period (0 to 1 seconds) is added to feeler connections to prevent synchronization.
 static constexpr auto FEELER_SLEEP_WINDOW{1s};

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4509,8 +4509,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 break;
             }
             // If pruning, don't inv blocks unless we have on disk and are likely to still have
-            // for some reasonable time window (1 hour) that block relay might require.
-            const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 3600 / m_chainparams.GetConsensus().nPowTargetSpacing;
+            // for some reasonable time window that block relay might require.
+            const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 1h / m_chainparams.GetConsensus().PowTargetSpacing();
             if (m_chainman.m_blockman.IsPruneMode() && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= m_chainman.ActiveChain().Tip()->nHeight - nPrunedBlocksLikelyToHave)) {
                 LogDebug(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -116,11 +116,11 @@ static constexpr auto MINIMUM_CONNECT_TIME{30s};
 /** SHA256("main address relay")[0:8] */
 static constexpr uint64_t RANDOMIZER_ID_ADDRESS_RELAY = 0x3cac0035b5866b90ULL;
 /// Age after which a stale block will no longer be served if requested as
-/// protection against fingerprinting. Set to one month, denominated in seconds.
-static constexpr int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
+/// protection against fingerprinting.
+static constexpr auto STALE_RELAY_AGE_LIMIT{std::chrono::days{30}};
 /// Age after which a block is considered historical for purposes of rate
-/// limiting block relay. Set to one week, denominated in seconds.
-static constexpr int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
+/// limiting block relay.
+static constexpr auto HISTORICAL_BLOCK_AGE{std::chrono::weeks{1}};
 /** Time between pings automatically sent out for latency probing and keepalive */
 static constexpr auto PING_INTERVAL{2min};
 /** The maximum number of entries in a locator */
@@ -2075,8 +2075,8 @@ bool PeerManagerImpl::BlockRequestAllowed(const CBlockIndex& block_index)
     AssertLockHeld(cs_main);
     if (m_chainman.ActiveChain().Contains(block_index)) return true;
     return block_index.IsValid(BLOCK_VALID_SCRIPTS) && (m_chainman.m_best_header != nullptr) &&
-           (m_chainman.m_best_header->GetBlockTime() - block_index.GetBlockTime() < STALE_RELAY_AGE_LIMIT) &&
-           (GetBlockProofEquivalentTime(*m_chainman.m_best_header, block_index, *m_chainman.m_best_header, m_chainparams.GetConsensus()) < STALE_RELAY_AGE_LIMIT);
+           (m_chainman.m_best_header->Time() - block_index.Time() < STALE_RELAY_AGE_LIMIT) &&
+           (GetBlockProofEquivalentTime(*m_chainman.m_best_header, block_index, *m_chainman.m_best_header, m_chainparams.GetConsensus()) < (STALE_RELAY_AGE_LIMIT / 1s));
 }
 
 util::Expected<void, std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, const CBlockIndex& block_index)
@@ -2614,7 +2614,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         }
         // disconnect node in case we have reached the outbound limit for serving historical blocks
         if (m_connman.OutboundTargetReached(true) &&
-            (((m_chainman.m_best_header != nullptr) && (m_chainman.m_best_header->GetBlockTime() - pindex->GetBlockTime() > HISTORICAL_BLOCK_AGE)) || inv.IsMsgFilteredBlk()) &&
+            (((m_chainman.m_best_header != nullptr) && (m_chainman.m_best_header->Time() - pindex->Time() > HISTORICAL_BLOCK_AGE)) || inv.IsMsgFilteredBlk()) &&
             !pfrom.HasPermission(NetPermissionFlags::Download) // nodes with the download permission may exceed target
         ) {
             LogDebug(BCLog::NET, "historical block serving limit reached, %s", pfrom.DisconnectMsg());

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4524,8 +4524,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 break;
             }
             // If pruning, don't inv blocks unless we have on disk and are likely to still have
-            // for some reasonable time window (1 hour) that block relay might require.
-            const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 3600 / m_chainparams.GetConsensus().nPowTargetSpacing;
+            // for some reasonable time window that block relay might require.
+            const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 1h / m_chainparams.GetConsensus().PowTargetSpacing();
             if (m_chainman.m_blockman.IsPruneMode() && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= m_chainman.ActiveChain().Tip()->nHeight - nPrunedBlocksLikelyToHave)) {
                 LogDebug(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -114,11 +114,11 @@ static constexpr auto MINIMUM_CONNECT_TIME{30s};
 /** SHA256("main address relay")[0:8] */
 static constexpr uint64_t RANDOMIZER_ID_ADDRESS_RELAY = 0x3cac0035b5866b90ULL;
 /// Age after which a stale block will no longer be served if requested as
-/// protection against fingerprinting. Set to one month, denominated in seconds.
-static constexpr int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
+/// protection against fingerprinting.
+static constexpr auto STALE_RELAY_AGE_LIMIT{std::chrono::days{30}};
 /// Age after which a block is considered historical for purposes of rate
-/// limiting block relay. Set to one week, denominated in seconds.
-static constexpr int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
+/// limiting block relay.
+static constexpr auto HISTORICAL_BLOCK_AGE{std::chrono::weeks{1}};
 /** Time between pings automatically sent out for latency probing and keepalive */
 static constexpr auto PING_INTERVAL{2min};
 /** The maximum number of entries in a locator */
@@ -2071,8 +2071,8 @@ bool PeerManagerImpl::BlockRequestAllowed(const CBlockIndex& block_index)
     AssertLockHeld(cs_main);
     if (m_chainman.ActiveChain().Contains(block_index)) return true;
     return block_index.IsValid(BLOCK_VALID_SCRIPTS) && (m_chainman.m_best_header != nullptr) &&
-           (m_chainman.m_best_header->GetBlockTime() - block_index.GetBlockTime() < STALE_RELAY_AGE_LIMIT) &&
-           (GetBlockProofEquivalentTime(*m_chainman.m_best_header, block_index, *m_chainman.m_best_header, m_chainparams.GetConsensus()) < STALE_RELAY_AGE_LIMIT);
+           (m_chainman.m_best_header->Time() - block_index.Time() < STALE_RELAY_AGE_LIMIT) &&
+           (GetBlockProofEquivalentTime(*m_chainman.m_best_header, block_index, *m_chainman.m_best_header, m_chainparams.GetConsensus()) < (STALE_RELAY_AGE_LIMIT / 1s));
 }
 
 util::Expected<void, std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, const CBlockIndex& block_index)
@@ -2602,7 +2602,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         }
         // disconnect node in case we have reached the outbound limit for serving historical blocks
         if (m_connman.OutboundTargetReached(true) &&
-            (((m_chainman.m_best_header != nullptr) && (m_chainman.m_best_header->GetBlockTime() - pindex->GetBlockTime() > HISTORICAL_BLOCK_AGE)) || inv.IsMsgFilteredBlk()) &&
+            (((m_chainman.m_best_header != nullptr) && (m_chainman.m_best_header->Time() - pindex->Time() > HISTORICAL_BLOCK_AGE)) || inv.IsMsgFilteredBlk()) &&
             !pfrom.HasPermission(NetPermissionFlags::Download) // nodes with the download permission may exceed target
         ) {
             LogDebug(BCLog::NET, "historical block serving limit reached, %s", pfrom.DisconnectMsg());

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -248,7 +248,7 @@ ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const C
     for (auto& chainstate : chainman.m_chainstates) {
         if (!is_coinsview_empty(*chainstate)) {
             const CBlockIndex* tip = chainstate->m_chain.Tip();
-            if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
+            if (tip && tip->Time() > Now<NodeSeconds>() + MAX_FUTURE_BLOCK_TIME) {
                 return {ChainstateLoadStatus::FAILURE, _("The block database contains a block which appears to be from the future. "
                                                          "This may be due to your computer's date and time being set incorrectly. "
                                                          "Only rebuild the block database if you are sure that your computer's date and time are correct")};

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -38,6 +38,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <node/interface_ui.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -76,7 +77,7 @@
  *
  * Ref: https://github.com/bitcoin/bitcoin/pull/1026
  */
-static constexpr int64_t MAX_BLOCK_TIME_GAP = 90 * 60;
+static constexpr auto MAX_BLOCK_TIME_GAP{90min};
 
 const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #if defined(Q_OS_MACOS)
@@ -1211,7 +1212,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     QString tooltip;
 
     QDateTime currentDate = QDateTime::currentDateTime();
-    qint64 secs = blockDate.secsTo(currentDate);
+    std::chrono::seconds secs{blockDate.secsTo(currentDate)};
 
     tooltip = tr("Processed %n block(s) of transaction history.", "", count);
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -38,6 +38,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <node/interface_ui.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -76,7 +77,7 @@
  *
  * Ref: https://github.com/bitcoin/bitcoin/pull/1026
  */
-static constexpr int64_t MAX_BLOCK_TIME_GAP = 90 * 60;
+static constexpr auto MAX_BLOCK_TIME_GAP{90min};
 
 const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #if defined(Q_OS_MACOS)
@@ -1188,7 +1189,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     QString tooltip;
 
     QDateTime currentDate = QDateTime::currentDateTime();
-    qint64 secs = blockDate.secsTo(currentDate);
+    std::chrono::seconds secs{blockDate.secsTo(currentDate)};
 
     tooltip = tr("Processed %n block(s) of transaction history.", "", count);
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -780,39 +780,24 @@ QString formatTimeOffset(int64_t time_offset)
   return QObject::tr("%1 s").arg(QString::number((int)time_offset, 10));
 }
 
-QString formatNiceTimeOffset(qint64 secs)
+QString formatNiceTimeOffset(std::chrono::seconds secs)
 {
     // Represent time from last generated block in human readable text
     QString timeBehindText;
-    const int HOUR_IN_SECONDS = 60*60;
-    const int DAY_IN_SECONDS = 24*60*60;
-    const int WEEK_IN_SECONDS = 7*24*60*60;
-    const int YEAR_IN_SECONDS = 31556952; // Average length of year in Gregorian calendar
-    if(secs < 60)
-    {
-        timeBehindText = QObject::tr("%n second(s)","",secs);
-    }
-    else if(secs < 2*HOUR_IN_SECONDS)
-    {
-        timeBehindText = QObject::tr("%n minute(s)","",secs/60);
-    }
-    else if(secs < 2*DAY_IN_SECONDS)
-    {
-        timeBehindText = QObject::tr("%n hour(s)","",secs/HOUR_IN_SECONDS);
-    }
-    else if(secs < 2*WEEK_IN_SECONDS)
-    {
-        timeBehindText = QObject::tr("%n day(s)","",secs/DAY_IN_SECONDS);
-    }
-    else if(secs < YEAR_IN_SECONDS)
-    {
-        timeBehindText = QObject::tr("%n week(s)","",secs/WEEK_IN_SECONDS);
-    }
-    else
-    {
-        qint64 years = secs / YEAR_IN_SECONDS;
-        qint64 remainder = secs % YEAR_IN_SECONDS;
-        timeBehindText = QObject::tr("%1 and %2").arg(QObject::tr("%n year(s)", "", years)).arg(QObject::tr("%n week(s)","", remainder/WEEK_IN_SECONDS));
+    if (secs < 1min) {
+        timeBehindText = QObject::tr("%n second(s)", "", secs / 1s);
+    } else if (secs < 2h) {
+        timeBehindText = QObject::tr("%n minute(s)", "", secs / 1min);
+    } else if (secs < std::chrono::days{2}) {
+        timeBehindText = QObject::tr("%n hour(s)", "", secs / 1h);
+    } else if (secs < std::chrono::weeks{2}) {
+        timeBehindText = QObject::tr("%n day(s)", "", secs / std::chrono::days{1});
+    } else if (secs < std::chrono::years{1}) {
+        timeBehindText = QObject::tr("%n week(s)", "", secs / std::chrono::weeks{1});
+    } else {
+        auto years{secs / std::chrono::years{1}};
+        auto remainder{secs % std::chrono::years{1}};
+        timeBehindText = QObject::tr("%1 and %2").arg(QObject::tr("%n year(s)", "", years)).arg(QObject::tr("%n week(s)", "", remainder / std::chrono::weeks{1}));
     }
     return timeBehindText;
 }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -778,39 +778,24 @@ QString formatTimeOffset(int64_t time_offset)
   return QObject::tr("%1 s").arg(QString::number((int)time_offset, 10));
 }
 
-QString formatNiceTimeOffset(qint64 secs)
+QString formatNiceTimeOffset(std::chrono::seconds secs)
 {
     // Represent time from last generated block in human readable text
     QString timeBehindText;
-    const int HOUR_IN_SECONDS = 60*60;
-    const int DAY_IN_SECONDS = 24*60*60;
-    const int WEEK_IN_SECONDS = 7*24*60*60;
-    const int YEAR_IN_SECONDS = 31556952; // Average length of year in Gregorian calendar
-    if(secs < 60)
-    {
-        timeBehindText = QObject::tr("%n second(s)","",secs);
-    }
-    else if(secs < 2*HOUR_IN_SECONDS)
-    {
-        timeBehindText = QObject::tr("%n minute(s)","",secs/60);
-    }
-    else if(secs < 2*DAY_IN_SECONDS)
-    {
-        timeBehindText = QObject::tr("%n hour(s)","",secs/HOUR_IN_SECONDS);
-    }
-    else if(secs < 2*WEEK_IN_SECONDS)
-    {
-        timeBehindText = QObject::tr("%n day(s)","",secs/DAY_IN_SECONDS);
-    }
-    else if(secs < YEAR_IN_SECONDS)
-    {
-        timeBehindText = QObject::tr("%n week(s)","",secs/WEEK_IN_SECONDS);
-    }
-    else
-    {
-        qint64 years = secs / YEAR_IN_SECONDS;
-        qint64 remainder = secs % YEAR_IN_SECONDS;
-        timeBehindText = QObject::tr("%1 and %2").arg(QObject::tr("%n year(s)", "", years)).arg(QObject::tr("%n week(s)","", remainder/WEEK_IN_SECONDS));
+    if (secs < 1min) {
+        timeBehindText = QObject::tr("%n second(s)", "", secs / 1s);
+    } else if (secs < 2h) {
+        timeBehindText = QObject::tr("%n minute(s)", "", secs / 1min);
+    } else if (secs < std::chrono::days{2}) {
+        timeBehindText = QObject::tr("%n hour(s)", "", secs / 1h);
+    } else if (secs < std::chrono::weeks{2}) {
+        timeBehindText = QObject::tr("%n day(s)", "", secs / std::chrono::days{1});
+    } else if (secs < std::chrono::years{1}) {
+        timeBehindText = QObject::tr("%n week(s)", "", secs / std::chrono::weeks{1});
+    } else {
+        auto years{secs / std::chrono::years{1}};
+        auto remainder{secs % std::chrono::years{1}};
+        timeBehindText = QObject::tr("%1 and %2").arg(QObject::tr("%n year(s)", "", years)).arg(QObject::tr("%n week(s)", "", remainder / std::chrono::weeks{1}));
     }
     return timeBehindText;
 }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -243,7 +243,7 @@ namespace GUIUtil
     /** Format a CNodeStateStats.time_offset into a user-readable string */
     QString formatTimeOffset(int64_t time_offset);
 
-    QString formatNiceTimeOffset(qint64 secs);
+    QString formatNiceTimeOffset(std::chrono::seconds secs);
 
     QString formatBytes(uint64_t bytes);
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -9,6 +9,7 @@
 #include <qt/forms/ui_intro.h>
 #include <util/chaintype.h>
 #include <util/fs.h>
+#include <util/time.h>
 
 #include <qt/freespacechecker.h>
 #include <qt/guiconstants.h>
@@ -304,9 +305,9 @@ void Intro::UpdatePruneLabels(bool prune_checked)
     }
     ui->lblExplanation3->setVisible(prune_checked);
     ui->pruneGB->setEnabled(prune_checked);
-    static constexpr uint64_t nPowTargetSpacing = 10 * 60;  // from chainparams, which we don't have at this stage
+    static constexpr uint64_t BLOCKS_PER_DAY{std::chrono::days{1} / 10min}; // spacing from chainparams, which we don't have at this stage
     static constexpr uint32_t expected_block_data_size = 2250000;  // includes undo data
-    const uint64_t expected_backup_days = m_prune_target_gb * 1e9 / (uint64_t(expected_block_data_size) * 86400 / nPowTargetSpacing);
+    const uint64_t expected_backup_days = m_prune_target_gb * 1e9 / (uint64_t(expected_block_data_size) * BLOCKS_PER_DAY);
     ui->lblPruneSuffix->setText(
         //: Explanatory text on the capability of the current prune target.
         tr("(sufficient to restore backups %n day(s) old)", "", expected_backup_days));

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -126,7 +126,7 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
 
         // show expected remaining time
         if(remainingMSecs >= 0) {
-            ui->expectedTimeLeft->setText(GUIUtil::formatNiceTimeOffset(remainingMSecs / 1000.0));
+            ui->expectedTimeLeft->setText(GUIUtil::formatNiceTimeOffset(std::chrono::seconds{remainingMSecs / 1000}));
         } else {
             ui->expectedTimeLeft->setText(QObject::tr("unknown"));
         }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -675,10 +675,10 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
         });
         peersTableContextMenu->addSeparator();
         peersTableContextMenu->addAction(tr("&Disconnect"), this, &RPCConsole::disconnectSelectedNode);
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &hour"), [this] { banSelectedNode(60 * 60); });
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 d&ay"), [this] { banSelectedNode(60 * 60 * 24); });
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &week"), [this] { banSelectedNode(60 * 60 * 24 * 7); });
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &year"), [this] { banSelectedNode(60 * 60 * 24 * 365); });
+        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &hour"), [this] { banSelectedNode(std::chrono::hours{1}); });
+        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 d&ay"), [this] { banSelectedNode(std::chrono::days{1}); });
+        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &week"), [this] { banSelectedNode(std::chrono::weeks{1}); });
+        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &year"), [this] { banSelectedNode(std::chrono::days{365}); }); // Not an average year.
         connect(ui->peerWidget, &QTableView::customContextMenuRequested, this, &RPCConsole::showPeersTableContextMenu);
 
         // peer table signal handling - update peer details when selecting new node
@@ -1289,7 +1289,7 @@ void RPCConsole::disconnectSelectedNode()
     }
 }
 
-void RPCConsole::banSelectedNode(int bantime)
+void RPCConsole::banSelectedNode(std::chrono::seconds bantime)
 {
     if (!clientModel)
         return;
@@ -1298,7 +1298,7 @@ void RPCConsole::banSelectedNode(int bantime)
         // Find possible nodes, ban it and clear the selected node
         const auto stats = peer.data(PeerTableModel::StatsRole).value<CNodeCombinedStats*>();
         if (stats) {
-            m_node.ban(stats->nodeStats.addr, bantime);
+            m_node.ban(stats->nodeStats.addr, bantime / 1s);
             m_node.disconnectByAddress(stats->nodeStats.addr);
         }
     }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -21,6 +21,8 @@
 #include <QThread>
 #include <QWidget>
 
+#include <chrono>
+
 class PlatformStyle;
 class RPCExecutor;
 class WalletModel;
@@ -131,7 +133,7 @@ public Q_SLOTS:
     /** Disconnect a selected node on the Peers tab */
     void disconnectSelectedNode();
     /** Ban a selected node on the Peers tab */
-    void banSelectedNode(int bantime);
+    void banSelectedNode(std::chrono::seconds bantime);
     /** Unban a selected node on the Bans tab */
     void unbanSelectedNode();
     /** set which tab has the focus (is visible) */

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -170,7 +170,7 @@ void SendCoinsDialog::setModel(WalletModel *_model)
 
         // fee section
         for (const int n : confTargets) {
-            ui->confTargetSelector->addItem(tr("%1 (%2 blocks)").arg(GUIUtil::formatNiceTimeOffset(n*Params().GetConsensus().nPowTargetSpacing)).arg(n));
+            ui->confTargetSelector->addItem(tr("%1 (%2 blocks)").arg(GUIUtil::formatNiceTimeOffset(n * Params().GetConsensus().PowTargetSpacing())).arg(n));
         }
         connect(ui->confTargetSelector, qOverload<int>(&QComboBox::currentIndexChanged), this, &SendCoinsDialog::updateSmartFeeLabel);
         connect(ui->confTargetSelector, qOverload<int>(&QComboBox::currentIndexChanged), this, &SendCoinsDialog::coinControlUpdateLabels);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -50,6 +50,7 @@
 #include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/syserror.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -1847,7 +1848,7 @@ static RPCMethod getchaintxstats()
 {
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     const CBlockIndex* pindex;
-    int blockcount = 30 * 24 * 60 * 60 / chainman.GetParams().GetConsensus().nPowTargetSpacing; // By default: 1 month
+    int blockcount = std::chrono::days{30} / chainman.GetParams().GetConsensus().PowTargetSpacing();
 
     if (request.params[1].isNull()) {
         LOCK(cs_main);

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -96,16 +96,16 @@ static RPCMethod mockscheduler()
         throw std::runtime_error("mockscheduler is for regression testing (-regtest mode) only");
     }
 
-    int64_t delta_seconds = request.params[0].getInt<int64_t>();
-    if (delta_seconds <= 0 || delta_seconds > 3600) {
+    std::chrono::seconds delta_time{request.params[0].getInt<int64_t>()};
+    if (delta_time <= 0s || delta_time > 1h) {
         throw std::runtime_error("delta_time must be between 1 and 3600 seconds (1 hr)");
     }
 
     const NodeContext& node_context{EnsureAnyNodeContext(request.context)};
-    CHECK_NONFATAL(node_context.scheduler)->MockForward(std::chrono::seconds{delta_seconds});
+    CHECK_NONFATAL(node_context.scheduler)->MockForward(delta_time);
     CHECK_NONFATAL(node_context.validation_signals)->SyncWithValidationInterfaceQueue();
     for (const auto& chain_client : node_context.chain_clients) {
-        chain_client->schedulerMockForward(std::chrono::seconds(delta_seconds));
+        chain_client->schedulerMockForward(delta_time);
     }
 
     return UniValue::VNULL;

--- a/src/test/chain_tests.cpp
+++ b/src/test/chain_tests.cpp
@@ -44,6 +44,8 @@ const CBlockIndex* NaiveLastCommonAncestor(const CBlockIndex* a, const CBlockInd
 
 BOOST_AUTO_TEST_CASE(basic_tests)
 {
+    BOOST_CHECK_EQUAL(MAX_FUTURE_BLOCK_TIME / 1s, 2 * 60 * 60);
+
     // An empty chain
     const CChain chain_0;
     // A chain with 2 blocks

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -280,6 +280,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     std::vector<CTransactionRef> vtx;
     FakeNodeClock clock{42s};
     constexpr std::chrono::seconds HALFLIFE{CTxMemPool::ROLLING_FEE_HALFLIFE};
+    BOOST_CHECK_EQUAL(HALFLIFE.count(), 12 * 60 * 60);
     clock += HALFLIFE;
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + DEFAULT_INCREMENTAL_RELAY_FEE);
     // ... we should keep the same min fee until we get a block

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -157,13 +157,17 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
     }
 }
 
-void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type)
+void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type, int64_t target_timespan, int64_t target_spacing)
 {
     const auto chainParams = CreateChainParams(args, chain_type);
     const auto consensus = chainParams->GetConsensus();
 
     // hash genesis is correct
     BOOST_CHECK_EQUAL(consensus.hashGenesisBlock, chainParams->GenesisBlock().GetHash());
+
+    // retarget period and block spacing are wired up as expected
+    BOOST_CHECK_EQUAL(consensus.nPowTargetTimespan, target_timespan);
+    BOOST_CHECK_EQUAL(consensus.nPowTargetSpacing, target_spacing);
 
     // target timespan is an even multiple of spacing
     BOOST_CHECK_EQUAL(consensus.nPowTargetTimespan % consensus.nPowTargetSpacing, 0);
@@ -186,27 +190,27 @@ void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type)
 
 BOOST_AUTO_TEST_CASE(ChainParams_MAIN_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::MAIN);
+    sanity_check_chainparams(*m_node.args, ChainType::MAIN, /*target_timespan=*/1'209'600, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_REGTEST_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::REGTEST);
+    sanity_check_chainparams(*m_node.args, ChainType::REGTEST, /*target_timespan=*/86'400, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_TESTNET_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::TESTNET);
+    sanity_check_chainparams(*m_node.args, ChainType::TESTNET, /*target_timespan=*/1'209'600, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_TESTNET4_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::TESTNET4);
+    sanity_check_chainparams(*m_node.args, ChainType::TESTNET4, /*target_timespan=*/1'209'600, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::SIGNET);
+    sanity_check_chainparams(*m_node.args, ChainType::SIGNET, /*target_timespan=*/1'209'600, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -157,13 +157,17 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
     }
 }
 
-void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type)
+void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type, int64_t target_timespan, int64_t target_spacing)
 {
     const auto chainParams = CreateChainParams(args, chain_type);
     const auto consensus = chainParams->GetConsensus();
 
     // hash genesis is correct
     BOOST_CHECK_EQUAL(consensus.hashGenesisBlock, chainParams->GenesisBlock().GetHash());
+
+    // retarget period and block spacing are wired up as expected
+    BOOST_CHECK_EQUAL(consensus.nPowTargetTimespan, target_timespan);
+    BOOST_CHECK_EQUAL(consensus.nPowTargetSpacing, target_spacing);
 
     // target timespan is an even multiple of spacing
     BOOST_CHECK_EQUAL(consensus.nPowTargetTimespan % consensus.nPowTargetSpacing, 0);
@@ -187,27 +191,27 @@ void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type)
 
 BOOST_AUTO_TEST_CASE(ChainParams_MAIN_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::MAIN);
+    sanity_check_chainparams(*m_node.args, ChainType::MAIN, /*target_timespan=*/1'209'600, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_REGTEST_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::REGTEST);
+    sanity_check_chainparams(*m_node.args, ChainType::REGTEST, /*target_timespan=*/86'400, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_TESTNET_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::TESTNET);
+    sanity_check_chainparams(*m_node.args, ChainType::TESTNET, /*target_timespan=*/1'209'600, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_TESTNET4_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::TESTNET4);
+    sanity_check_chainparams(*m_node.args, ChainType::TESTNET4, /*target_timespan=*/1'209'600, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
 {
-    sanity_check_chainparams(*m_node.args, ChainType::SIGNET);
+    sanity_check_chainparams(*m_node.args, ChainType::SIGNET, /*target_timespan=*/1'209'600, /*target_spacing=*/600);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -883,7 +883,7 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
 
     int64_t time = GetTime();
     if (time > lastRollingFeeUpdate + 10) {
-        double halflife = ROLLING_FEE_HALFLIFE;
+        double halflife = ROLLING_FEE_HALFLIFE / 1s;
         if (DynamicMemoryUsage() < sizelimit / 4)
             halflife /= 4;
         else if (DynamicMemoryUsage() < sizelimit / 2)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -23,6 +23,7 @@
 #include <util/feefrac.h>
 #include <util/hasher.h>
 #include <util/result.h>
+#include <util/time.h>
 
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/identity.hpp>
@@ -209,7 +210,7 @@ protected:
 
 public:
 
-    static constexpr int ROLLING_FEE_HALFLIFE{60 * 60 * 12}; // public only for testing
+    static constexpr std::chrono::seconds ROLLING_FEE_HALFLIFE{12h}; // public only for testing
 
     using indexed_transaction_set = boost::multi_index_container<
         CTxMemPoolEntry,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2356,7 +2356,6 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     if (m_chainman.AssumedValidBlock().IsNull()) {
         script_check_reason = "assumevalid=0 (always verify)";
     } else {
-        constexpr int64_t TWO_WEEKS_IN_SECONDS{60 * 60 * 24 * 7 * 2};
         // We've been configured with the hash of a block which has been externally verified to have a valid history.
         // A suitable default value is included with the software and updated from time to time.  Because validity
         //  relative to a piece of software is an objective fact these defaults can be easily reviewed.
@@ -2371,7 +2370,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             script_check_reason = "block not in best header chain";
         } else if (m_chainman.m_best_header->nChainWork < m_chainman.MinimumChainWork()) {
             script_check_reason = "best header chainwork below minimumchainwork";
-        } else if (GetBlockProofEquivalentTime(*m_chainman.m_best_header, *pindex, *m_chainman.m_best_header, params.GetConsensus()) <= TWO_WEEKS_IN_SECONDS) {
+        } else if (GetBlockProofEquivalentTime(*m_chainman.m_best_header, *pindex, *m_chainman.m_best_header, params.GetConsensus()) <= (std::chrono::weeks{2} / 1s)) {
             script_check_reason = "block too recent relative to best header";
         } else {
             // This block is a member of the assumed verified chain and an ancestor of the best header.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4119,7 +4119,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     }
 
     // Check timestamp
-    if (block.Time() > NodeClock::now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
+    if (block.Time() > NodeClock::now() + MAX_FUTURE_BLOCK_TIME) {
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4121,7 +4121,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     }
 
     // Check timestamp
-    if (block.Time() > NodeClock::now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
+    if (block.Time() > NodeClock::now() + MAX_FUTURE_BLOCK_TIME) {
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2358,7 +2358,6 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     if (m_chainman.AssumedValidBlock().IsNull()) {
         script_check_reason = "assumevalid=0 (always verify)";
     } else {
-        constexpr int64_t TWO_WEEKS_IN_SECONDS{60 * 60 * 24 * 7 * 2};
         // We've been configured with the hash of a block which has been externally verified to have a valid history.
         // A suitable default value is included with the software and updated from time to time.  Because validity
         //  relative to a piece of software is an objective fact these defaults can be easily reviewed.
@@ -2373,7 +2372,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             script_check_reason = "block not in best header chain";
         } else if (m_chainman.m_best_header->nChainWork < m_chainman.MinimumChainWork()) {
             script_check_reason = "best header chainwork below minimumchainwork";
-        } else if (GetBlockProofEquivalentTime(*m_chainman.m_best_header, *pindex, *m_chainman.m_best_header, params.GetConsensus()) <= TWO_WEEKS_IN_SECONDS) {
+        } else if (GetBlockProofEquivalentTime(*m_chainman.m_best_header, *pindex, *m_chainman.m_best_header, params.GetConsensus()) <= (std::chrono::weeks{2} / 1s)) {
             script_check_reason = "block too recent relative to best header";
         } else {
             // This block is a member of the assumed verified chain and an ancestor of the best header.

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -21,6 +21,7 @@
 #include <util/check.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
+#include <util/time.h>
 #include <util/trace.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
@@ -982,7 +983,7 @@ static bool IsCurrentForAntiFeeSniping(interfaces::Chain& chain, const uint256& 
     if (chain.isInitialBlockDownload()) {
         return false;
     }
-    constexpr int64_t MAX_ANTI_FEE_SNIPING_TIP_AGE = 8 * 60 * 60; // in seconds
+    constexpr int64_t MAX_ANTI_FEE_SNIPING_TIP_AGE{8h / 1s};
     int64_t block_time;
     CHECK_NONFATAL(chain.findBlock(block_hash, FoundBlock().time(block_time)));
     if (block_time < (GetTime() - MAX_ANTI_FEE_SNIPING_TIP_AGE)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2147,7 +2147,7 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
 
             // Attempt to rebroadcast all txes more than 5 minutes older than
             // the last block, or all txs if forcing.
-            if (!force && wtx.nTimeReceived > m_best_block_time - 5 * 60) continue;
+            if (!force && wtx.nTimeReceived > m_best_block_time - (5min / 1s)) continue;
             to_submit.insert(&wtx);
         }
         // Now try submitting the transactions to the memory pool and (optionally) relay them.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2130,7 +2130,7 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
 
             // Attempt to rebroadcast all txes more than 5 minutes older than
             // the last block, or all txs if forcing.
-            if (!force && wtx.nTimeReceived > m_best_block_time - 5 * 60) continue;
+            if (!force && wtx.nTimeReceived > m_best_block_time - (5min / 1s)) continue;
             to_submit.insert(&wtx);
         }
         // Now try submitting the transactions to the memory pool and (optionally) relay them.

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -24,9 +24,9 @@ Start a few nodes:
       reject block 102 and only sync as far as block 101
     - node1 has -assumevalid set to the hash of block 102. Try to sync to
       block 2202. node1 will sync all the way to block 2202.
-    - node2 has -assumevalid set to the hash of block 102. Try to sync to
-      block 200. node2 will reject block 102 since it's assumed valid, but it
-      isn't buried by at least two weeks' work.
+    - node2 has -assumevalid set to the hash of block 102. Send BURIED_HEADER_COUNT
+      headers, leaving block 1 exactly two weeks of work behind the best header.
+      node2 will reject block 102 because scripts remain checked at the threshold.
     - node3 has -assumevalid set to the hash of block 102. Feed a longer
       competing headers-only branch so block #1 is not on the best header chain.
     - node4 has -assumevalid set to the hash of block 102. Submit an alternative
@@ -46,6 +46,7 @@ from test_framework.messages import (
     CTransaction,
     CTxIn,
     CTxOut,
+    MAX_HEADERS_RESULTS,
     msg_block,
     msg_headers,
 )
@@ -59,11 +60,22 @@ from test_framework.util import assert_equal
 from test_framework.wallet_util import generate_keypair
 
 
+# Scripts remain checked when block 1 is exactly two weeks of work behind the best header.
+TWO_WEEKS = 14 * 24 * 60 * 60
+TARGET_SPACING = 10 * 60
+BURIED_HEADER_COUNT = 1 + TWO_WEEKS // TARGET_SPACING
+
+
 class BaseNode(P2PInterface):
     def send_header_for_blocks(self, new_blocks):
         headers_message = msg_headers()
         headers_message.headers = [CBlockHeader(b) for b in new_blocks]
         self.send_without_ping(headers_message)
+
+    def send_headers_in_batches(self, new_blocks):
+        """Headers must be split: a peer sending more than MAX_HEADERS_RESULTS at once is disconnected."""
+        for i in range(0, len(new_blocks), MAX_HEADERS_RESULTS):
+            self.send_header_for_blocks(new_blocks[i:i + MAX_HEADERS_RESULTS])
 
 
 class AssumeValidTest(BitcoinTestFramework):
@@ -141,8 +153,7 @@ class AssumeValidTest(BitcoinTestFramework):
         # nodes[0]
         self.log.info("Send blocks to node0. Block 102 will be rejected.")
         p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
-        p2p0.send_header_for_blocks(self.blocks[0:2000])
-        p2p0.send_header_for_blocks(self.blocks[2000:])
+        p2p0.send_headers_in_batches(self.blocks)
         with self.nodes[0].assert_debug_log(expected_msgs=[
             f"Enabling script verification at block #1 ({block_1_hash}): assumevalid=0 (always verify).",
         ]):
@@ -159,8 +170,7 @@ class AssumeValidTest(BitcoinTestFramework):
         # nodes[1]
         self.log.info("Send all blocks to node1. All blocks will be accepted.")
         p2p1 = self.nodes[1].add_p2p_connection(BaseNode())
-        p2p1.send_header_for_blocks(self.blocks[0:2000])
-        p2p1.send_header_for_blocks(self.blocks[2000:])
+        p2p1.send_headers_in_batches(self.blocks)
         with self.nodes[1].assert_debug_log(expected_msgs=[
             f"Disabling script verification at block #1 ({self.blocks[0].hash_hex}).",
         ]):
@@ -177,7 +187,7 @@ class AssumeValidTest(BitcoinTestFramework):
         # nodes[2]
         self.log.info("Send blocks to node2. Block 102 will be rejected.")
         p2p2 = self.nodes[2].add_p2p_connection(BaseNode())
-        p2p2.send_header_for_blocks(self.blocks[0:200])
+        p2p2.send_headers_in_batches(self.blocks[:BURIED_HEADER_COUNT])
         with self.nodes[2].assert_debug_log(expected_msgs=[
             f"Enabling script verification at block #1 ({block_1_hash}): block too recent relative to best header.",
         ]):
@@ -189,7 +199,7 @@ class AssumeValidTest(BitcoinTestFramework):
                 p2p2.send_without_ping(msg_block(self.blocks[i]))
             p2p2.wait_for_disconnect()
             assert_equal(self.nodes[2].getblockcount(), COINBASE_MATURITY + 1)
-            assert_equal(next(filter(lambda x: x["hash"] == self.blocks[199].hash_hex, self.nodes[2].getchaintips()))["status"], "invalid")
+            assert_equal(next(filter(lambda x: x["hash"] == self.blocks[BURIED_HEADER_COUNT - 1].hash_hex, self.nodes[2].getchaintips()))["status"], "invalid")
 
         # nodes[3]
         self.log.info("Send two header chains, and a block not in the best header chain to node3.")


### PR DESCRIPTION
**Problem:** Several fixed-duration calculations use raw integer time counts, leaving their units implicit and allowing unrelated integer values to be mixed.

**Fix:** Use `std::chrono` types through calculations where the surrounding APIs already support them, including GUI formatting, peer bans, scheduler forwarding, block timestamps, and target-spacing arithmetic.
Where carrying chrono through an integer interface would broaden the change or make the result harder to read, this PR leaves the expression unchanged or keeps the conversion simply `duration / 1s`.
The remaining integer interfaces receive the same values, and characterization tests pin the PoW timing and inclusive assumevalid threshold.

