### PR TITLE
guix: followups to #35537

### DIFF
--- a/contrib/guix/libexec/build_linux.sh
+++ b/contrib/guix/libexec/build_linux.sh
@@ -65,6 +65,12 @@ esac
 # LDFLAGS
 HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$(glibc_dynamic_linker "$HOST") -Wl,-O2"
 
+# Use LINK_WARNING_AS_ERROR when using CMake 4.x
+case "$HOST" in
+    riscv64-linux-gnu) ;; # https://github.com/boostorg/test/issues/345
+    *) HOST_LDFLAGS="${HOST_LDFLAGS} -Wl,--fatal-warnings" ;;
+esac
+
 mkdir -p "$DISTSRC"
 (
     cd "$DISTSRC"

--- a/contrib/guix/libexec/build_linux.sh
+++ b/contrib/guix/libexec/build_linux.sh
@@ -58,15 +58,16 @@ mkdir -p "$DISTSRC"
     env CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}" \
     cmake -S . -B build \
           --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
-          -Werror=dev \
           -DBUILD_BENCH=OFF \
           -DBUILD_FUZZ_BINARY=OFF \
           -DBUILD_GUI=OFF \
+          -DBUILD_GUI_TESTS=OFF \
+          -DCMAKE_EXE_LINKER_FLAGS="${HOST_LDFLAGS} -static-libstdc++ -static-libgcc" \
           -DCMAKE_INSTALL_PREFIX="${INSTALLPATH}" \
           -DCMAKE_SKIP_RPATH=TRUE \
           -DREDUCE_EXPORTS=ON \
-          -DCMAKE_EXE_LINKER_FLAGS="${HOST_LDFLAGS} -static-libstdc++ -static-libgcc" \
-          -DWITH_CCACHE=OFF
+          -DWITH_CCACHE=OFF \
+          -Werror=dev
 
     # Build Bitcoin Core
     cmake --build build -j "$JOBS"

--- a/contrib/guix/libexec/build_linux.sh
+++ b/contrib/guix/libexec/build_linux.sh
@@ -8,32 +8,8 @@ set -o errexit -o pipefail
 # shellcheck source=setup.sh
 source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 
-# Set environment variables to point the NATIVE toolchain to the right
-# includes/libs
-NATIVE_GCC="$(store_path gcc-toolchain)"
-
-# Set native toolchain
-build_CC="${NATIVE_GCC}/bin/gcc -isystem ${NATIVE_GCC}/include"
-build_CXX="${NATIVE_GCC}/bin/g++ -isystem ${NATIVE_GCC}/include/c++ -isystem ${NATIVE_GCC}/include"
-
-NATIVE_GCC_STATIC="$(store_path gcc-toolchain static)"
-export LIBRARY_PATH="${NATIVE_GCC}/lib:${NATIVE_GCC_STATIC}/lib"
-
-# Set environment variables to point the CROSS toolchain to the right
-# includes/libs for $HOST
-CROSS_GLIBC="$(store_path "glibc-cross-${HOST}")"
-CROSS_GLIBC_STATIC="$(store_path "glibc-cross-${HOST}" static)"
-CROSS_KERNEL="$(store_path "linux-libre-headers-cross-${HOST}")"
-CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
-CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
-CROSS_GCC_LIBS=( "${CROSS_GCC_LIB_STORE}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
-CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
-
-export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
-export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
-
-check_cross_paths "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
+# setup gcc toolchain
+gcc_toolchain
 
 # Build the depends tree, overriding variables that assume multilib gcc
 make -C depends --jobs="$JOBS" HOST="$HOST" \

--- a/contrib/guix/libexec/build_linux_gui.sh
+++ b/contrib/guix/libexec/build_linux_gui.sh
@@ -51,8 +51,8 @@ mkdir -p "$DISTSRC"
     env CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}" \
     cmake -S . -B build \
           --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
-          -Werror=dev \
           -DBUILD_BENCH=OFF \
+          -DBUILD_BITCOIN_BIN=OFF \
           -DBUILD_CLI=OFF \
           -DBUILD_DAEMON=OFF \
           -DBUILD_FUZZ_BINARY=OFF \
@@ -65,7 +65,8 @@ mkdir -p "$DISTSRC"
           -DCMAKE_INSTALL_PREFIX="${INSTALLPATH}" \
           -DCMAKE_SKIP_RPATH=TRUE \
           -DREDUCE_EXPORTS=ON \
-          -DWITH_CCACHE=OFF
+          -DWITH_CCACHE=OFF \
+          -Werror=dev
 
     # Build Bitcoin Core
     cmake --build build -j "$JOBS" --target bitcoin-gui bitcoin-qt

--- a/contrib/guix/libexec/build_linux_gui.sh
+++ b/contrib/guix/libexec/build_linux_gui.sh
@@ -8,32 +8,8 @@ set -o errexit -o pipefail
 # shellcheck source=setup.sh
 source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 
-# Set environment variables to point the NATIVE toolchain to the right
-# includes/libs
-NATIVE_GCC="$(store_path gcc-toolchain)"
-
-# Set native toolchain
-build_CC="${NATIVE_GCC}/bin/gcc -isystem ${NATIVE_GCC}/include"
-build_CXX="${NATIVE_GCC}/bin/g++ -isystem ${NATIVE_GCC}/include/c++ -isystem ${NATIVE_GCC}/include"
-
-NATIVE_GCC_STATIC="$(store_path gcc-toolchain static)"
-export LIBRARY_PATH="${NATIVE_GCC}/lib:${NATIVE_GCC_STATIC}/lib"
-
-# Set environment variables to point the CROSS toolchain to the right
-# includes/libs for $HOST
-CROSS_GLIBC="$(store_path "glibc-cross-${HOST}")"
-CROSS_GLIBC_STATIC="$(store_path "glibc-cross-${HOST}" static)"
-CROSS_KERNEL="$(store_path "linux-libre-headers-cross-${HOST}")"
-CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
-CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
-CROSS_GCC_LIBS=( "${CROSS_GCC_LIB_STORE}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
-CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
-
-export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
-export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
-
-check_cross_paths "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
+# setup gcc toolchain
+gcc_toolchain
 
 # Build the depends tree, overriding variables that assume multilib gcc
 make -C depends --jobs="$JOBS" HOST="$HOST" \

--- a/contrib/guix/libexec/build_macos.sh
+++ b/contrib/guix/libexec/build_macos.sh
@@ -37,7 +37,6 @@ mkdir -p "$DISTSRC"
     # Configure this DISTSRC for $HOST
     env cmake -S . -B build \
           --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
-          -Werror=dev \
           -DBUILD_BENCH=OFF \
           -DBUILD_FUZZ_BINARY=OFF \
           -DBUILD_GUI=OFF \
@@ -45,7 +44,8 @@ mkdir -p "$DISTSRC"
           -DCMAKE_INSTALL_PREFIX="${INSTALLPATH}" \
           -DCMAKE_SKIP_RPATH=TRUE \
           -DREDUCE_EXPORTS=ON \
-          -DWITH_CCACHE=OFF
+          -DWITH_CCACHE=OFF \
+          -Werror=dev
 
     # Build Bitcoin Core
     cmake --build build -j "$JOBS"

--- a/contrib/guix/libexec/build_macos.sh
+++ b/contrib/guix/libexec/build_macos.sh
@@ -8,21 +8,8 @@ set -o errexit -o pipefail
 # shellcheck source=setup.sh
 source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 
-# Set toolchain
-CLANG_TOOLCHAIN="$(store_path clang-toolchain)"
-LIBCXX="$(store_path libcxx)"
-build_CC="${CLANG_TOOLCHAIN}/bin/clang \
-    -isystem ${CLANG_TOOLCHAIN}/include"
-build_CXX="${CLANG_TOOLCHAIN}/bin/clang++ \
-    -stdlib=libc++ \
-    -isystem ${LIBCXX}/include/c++/v1 \
-    -isystem ${CLANG_TOOLCHAIN}/include"
-build_LDFLAGS="-fuse-ld=lld -rtlib=compiler-rt -unwindlib=libunwind -L${LIBCXX}/lib -Wl,-rpath,${LIBCXX}/lib"
-build_AR="${CLANG_TOOLCHAIN}/bin/llvm-ar"
-build_RANLIB="${CLANG_TOOLCHAIN}/bin/llvm-ranlib"
-build_OBJDUMP="${CLANG_TOOLCHAIN}/bin/llvm-objdump"
-build_NM="${CLANG_TOOLCHAIN}/bin/llvm-nm"
-build_STRIP="${CLANG_TOOLCHAIN}/bin/llvm-strip"
+# Setup toolchain
+llvm_toolchain
 
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \

--- a/contrib/guix/libexec/build_macos_gui.sh
+++ b/contrib/guix/libexec/build_macos_gui.sh
@@ -8,21 +8,8 @@ set -o errexit -o pipefail
 # shellcheck source=setup.sh
 source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 
-# Set toolchain
-CLANG_TOOLCHAIN="$(store_path clang-toolchain)"
-LIBCXX="$(store_path libcxx)"
-build_CC="${CLANG_TOOLCHAIN}/bin/clang \
-    -isystem ${CLANG_TOOLCHAIN}/include"
-build_CXX="${CLANG_TOOLCHAIN}/bin/clang++ \
-    -stdlib=libc++ \
-    -isystem ${LIBCXX}/include/c++/v1 \
-    -isystem ${CLANG_TOOLCHAIN}/include"
-build_LDFLAGS="-fuse-ld=lld -rtlib=compiler-rt -unwindlib=libunwind -L${LIBCXX}/lib -Wl,-rpath,${LIBCXX}/lib"
-build_AR="${CLANG_TOOLCHAIN}/bin/llvm-ar"
-build_RANLIB="${CLANG_TOOLCHAIN}/bin/llvm-ranlib"
-build_OBJDUMP="${CLANG_TOOLCHAIN}/bin/llvm-objdump"
-build_NM="${CLANG_TOOLCHAIN}/bin/llvm-nm"
-build_STRIP="${CLANG_TOOLCHAIN}/bin/llvm-strip"
+# Setup toolchain
+llvm_toolchain
 
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \

--- a/contrib/guix/libexec/build_macos_gui.sh
+++ b/contrib/guix/libexec/build_macos_gui.sh
@@ -36,8 +36,6 @@ mkdir -p "$DISTSRC"
     # Configure this DISTSRC for $HOST
     env cmake -S . -B build \
           --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
-          -DWITH_CCACHE=OFF \
-          -Werror=dev \
           -DBUILD_BENCH=OFF \
           -DBUILD_BITCOIN_BIN=OFF \
           -DBUILD_CLI=OFF \
@@ -50,7 +48,9 @@ mkdir -p "$DISTSRC"
           -DBUILD_WALLET_TOOL=OFF \
           -DCMAKE_INSTALL_PREFIX="${INSTALLPATH}" \
           -DCMAKE_SKIP_RPATH=TRUE \
-          -DREDUCE_EXPORTS=ON
+          -DREDUCE_EXPORTS=ON \
+          -DWITH_CCACHE=OFF \
+          -Werror=dev
 
     # Build Bitcoin Core
     cmake --build build -j "$JOBS" --target bitcoin-gui bitcoin-qt

--- a/contrib/guix/libexec/build_win.sh
+++ b/contrib/guix/libexec/build_win.sh
@@ -54,7 +54,7 @@ HOST_CFLAGS+=" -fno-ident"
 HOST_CXXFLAGS="$HOST_CFLAGS"
 
 # LDFLAGS
-HOST_LDFLAGS="-Wl,--no-insert-timestamp"
+HOST_LDFLAGS="-Wl,--no-insert-timestamp -Wl,--fatal-warnings"
 
 mkdir -p "$DISTSRC"
 (

--- a/contrib/guix/libexec/build_win.sh
+++ b/contrib/guix/libexec/build_win.sh
@@ -8,32 +8,8 @@ set -o errexit -o pipefail
 # shellcheck source=setup.sh
 source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 
-# Set environment variables to point the NATIVE toolchain to the right
-# includes/libs
-NATIVE_GCC="$(store_path gcc-toolchain)"
-
-# Set native toolchain
-build_CC="${NATIVE_GCC}/bin/gcc -isystem ${NATIVE_GCC}/include"
-build_CXX="${NATIVE_GCC}/bin/g++ -isystem ${NATIVE_GCC}/include/c++ -isystem ${NATIVE_GCC}/include"
-
-# Set environment variables to point the CROSS toolchain to the right
-# includes/libs for $HOST
-# Determine output paths to use in CROSS_* environment variables
-CROSS_GLIBC="$(store_path "mingw-w64-x86_64-winpthreads")"
-CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
-CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
-CROSS_GCC_LIBS=( "${CROSS_GCC_LIB_STORE}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
-CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
-
-# The search path ordering is generally:
-#    1. gcc-related search paths
-#    2. libc-related search paths
-#    2. kernel-header-related search paths (not applicable to mingw-w64 hosts)
-export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include"
-export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
-
-check_cross_paths "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
+# setup mingw-w64 toolchain
+mingw_w64_toolchain
 
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \

--- a/contrib/guix/libexec/build_win.sh
+++ b/contrib/guix/libexec/build_win.sh
@@ -43,14 +43,14 @@ mkdir -p "$DISTSRC"
     env CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}" \
     cmake -S . -B build \
           --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
-          -Werror=dev \
           -DBUILD_BENCH=OFF \
           -DBUILD_FUZZ_BINARY=OFF \
           -DBUILD_GUI=OFF \
           -DBUILD_GUI_TESTS=OFF \
           -DCMAKE_INSTALL_PREFIX="${INSTALLPATH}" \
           -DREDUCE_EXPORTS=ON \
-          -DWITH_CCACHE=OFF
+          -DWITH_CCACHE=OFF \
+          -Werror=dev
 
     # Build Bitcoin Core
     cmake --build build -j "$JOBS"

--- a/contrib/guix/libexec/build_win_gui.sh
+++ b/contrib/guix/libexec/build_win_gui.sh
@@ -53,7 +53,7 @@ HOST_CFLAGS+=" -fno-ident"
 HOST_CXXFLAGS="$HOST_CFLAGS"
 
 # LDFLAGS
-HOST_LDFLAGS="-Wl,--no-insert-timestamp"
+HOST_LDFLAGS="-Wl,--no-insert-timestamp -Wl,--fatal-warnings"
 
 mkdir -p "$DISTSRC"
 (

--- a/contrib/guix/libexec/build_win_gui.sh
+++ b/contrib/guix/libexec/build_win_gui.sh
@@ -8,32 +8,8 @@ set -o errexit -o pipefail
 # shellcheck source=setup.sh
 source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 
-# Set environment variables to point the NATIVE toolchain to the right
-# includes/libs
-NATIVE_GCC="$(store_path gcc-toolchain)"
-
-# Set native toolchain
-build_CC="${NATIVE_GCC}/bin/gcc -isystem ${NATIVE_GCC}/include"
-build_CXX="${NATIVE_GCC}/bin/g++ -isystem ${NATIVE_GCC}/include/c++ -isystem ${NATIVE_GCC}/include"
-
-# Set environment variables to point the CROSS toolchain to the right
-# includes/libs for $HOST
-# Determine output paths to use in CROSS_* environment variables
-CROSS_GLIBC="$(store_path "mingw-w64-x86_64-winpthreads")"
-CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
-CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
-CROSS_GCC_LIBS=( "${CROSS_GCC_LIB_STORE}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
-CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
-
-# The search path ordering is generally:
-#    1. gcc-related search paths
-#    2. libc-related search paths
-#    2. kernel-header-related search paths (not applicable to mingw-w64 hosts)
-export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include"
-export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
-
-check_cross_paths "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
+# setup mingw-w64 toolchain
+mingw_w64_toolchain
 
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \

--- a/contrib/guix/libexec/build_win_gui.sh
+++ b/contrib/guix/libexec/build_win_gui.sh
@@ -42,7 +42,6 @@ mkdir -p "$DISTSRC"
     env CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}" \
     cmake -S . -B build \
           --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
-          -Werror=dev \
           -DBUILD_BENCH=OFF \
           -DBUILD_BITCOIN_BIN=OFF \
           -DBUILD_CLI=OFF \
@@ -55,7 +54,8 @@ mkdir -p "$DISTSRC"
           -DBUILD_WALLET_TOOL=OFF \
           -DCMAKE_INSTALL_PREFIX="${INSTALLPATH}" \
           -DREDUCE_EXPORTS=ON \
-          -DWITH_CCACHE=OFF
+          -DWITH_CCACHE=OFF \
+          -Werror=dev
 
     # Build Bitcoin Core
     cmake --build build -j "$JOBS" --target bitcoin-qt

--- a/contrib/guix/libexec/setup.sh
+++ b/contrib/guix/libexec/setup.sh
@@ -86,6 +86,22 @@ glibc_dynamic_linker() {
     esac
 }
 
+llvm_toolchain() {
+    local CLANG_TOOLCHAIN LIB_CXX
+
+    CLANG_TOOLCHAIN="$(store_path clang-toolchain)"
+    LIB_CXX="$(store_path libcxx)"
+
+    export build_CC="${CLANG_TOOLCHAIN}/bin/clang -isystem ${CLANG_TOOLCHAIN}/include"
+    export build_CXX="${CLANG_TOOLCHAIN}/bin/clang++ -stdlib=libc++ -isystem ${LIB_CXX}/include/c++/v1 -isystem ${CLANG_TOOLCHAIN}/include"
+    export build_LDFLAGS="-fuse-ld=lld -rtlib=compiler-rt -unwindlib=libunwind -L${LIB_CXX}/lib -Wl,-rpath,${LIB_CXX}/lib"
+    export build_AR="${CLANG_TOOLCHAIN}/bin/llvm-ar"
+    export build_RANLIB="${CLANG_TOOLCHAIN}/bin/llvm-ranlib"
+    export build_OBJDUMP="${CLANG_TOOLCHAIN}/bin/llvm-objdump"
+    export build_NM="${CLANG_TOOLCHAIN}/bin/llvm-nm"
+    export build_STRIP="${CLANG_TOOLCHAIN}/bin/llvm-strip"
+}
+
 # Disable Guix ld auto-rpath behavior
 export GUIX_LD_WRAPPER_DISABLE_RPATH=yes
 

--- a/contrib/guix/libexec/setup.sh
+++ b/contrib/guix/libexec/setup.sh
@@ -102,6 +102,37 @@ llvm_toolchain() {
     export build_STRIP="${CLANG_TOOLCHAIN}/bin/llvm-strip"
 }
 
+mingw_w64_toolchain() {
+    # Set environment variables to point the NATIVE toolchain to the right
+    # includes/libs
+    local NATIVE_GCC CROSS_GLIBC CROSS_GCC CROSS_GCC_LIB_STORE CROSS_GCC_LIBS CROSS_GCC_LIB
+
+    NATIVE_GCC="$(store_path gcc-toolchain)"
+
+    # Set native toolchain
+    export build_CC="${NATIVE_GCC}/bin/gcc -isystem ${NATIVE_GCC}/include"
+    export build_CXX="${NATIVE_GCC}/bin/g++ -isystem ${NATIVE_GCC}/include/c++ -isystem ${NATIVE_GCC}/include"
+
+    # Set environment variables to point the CROSS toolchain to the right
+    # includes/libs for $HOST
+    # Determine output paths to use in CROSS_* environment variables
+    CROSS_GLIBC="$(store_path "mingw-w64-x86_64-winpthreads")"
+    CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
+    CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
+    CROSS_GCC_LIBS=( "${CROSS_GCC_LIB_STORE}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
+    CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
+
+    # The search path ordering is generally:
+    #    1. gcc-related search paths
+    #    2. libc-related search paths
+    #    2. kernel-header-related search paths (not applicable to mingw-w64 hosts)
+    export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include"
+    export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
+    export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
+
+    check_cross_paths "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
+}
+
 # Disable Guix ld auto-rpath behavior
 export GUIX_LD_WRAPPER_DISABLE_RPATH=yes
 

--- a/contrib/guix/libexec/setup.sh
+++ b/contrib/guix/libexec/setup.sh
@@ -86,6 +86,37 @@ glibc_dynamic_linker() {
     esac
 }
 
+gcc_toolchain() {
+    # Set environment variables to point the NATIVE toolchain to the right
+    # includes/libs
+    local NATIVE_GCC NATIVE_GCC_STATIC CROSS_GLIBC CROSS_GLIBC_STATIC CROSS_KERNEL CROSS_GCC CROSS_GCC_LIB_STORE CROSS_GCC_LIBS CROSS_GCC_LIB
+
+    NATIVE_GCC="$(store_path gcc-toolchain)"
+
+    # Set native toolchain
+    export build_CC="${NATIVE_GCC}/bin/gcc -isystem ${NATIVE_GCC}/include"
+    export build_CXX="${NATIVE_GCC}/bin/g++ -isystem ${NATIVE_GCC}/include/c++ -isystem ${NATIVE_GCC}/include"
+
+    NATIVE_GCC_STATIC="$(store_path gcc-toolchain static)"
+    export LIBRARY_PATH="${NATIVE_GCC}/lib:${NATIVE_GCC_STATIC}/lib"
+
+    # Set environment variables to point the CROSS toolchain to the right
+    # includes/libs for $HOST
+    CROSS_GLIBC="$(store_path "glibc-cross-${HOST}")"
+    CROSS_GLIBC_STATIC="$(store_path "glibc-cross-${HOST}" static)"
+    CROSS_KERNEL="$(store_path "linux-libre-headers-cross-${HOST}")"
+    CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
+    CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
+    CROSS_GCC_LIBS=( "${CROSS_GCC_LIB_STORE}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
+    CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
+
+    export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
+    export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
+    export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
+
+    check_cross_paths "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
+}
+
 llvm_toolchain() {
     local CLANG_TOOLCHAIN LIB_CXX
 


### PR DESCRIPTION
This deduplicates setup code, as well as adds flags to turn linker warnings into errors, which is easier now that the GUI build has been split out (the gui link warns about shared libs during linking).