### PR TITLE
fuzz: reset SOCKS5 interrupt between inputs

### DIFF
--- a/src/test/fuzz/socks5.cpp
+++ b/src/test/fuzz/socks5.cpp
@@ -30,6 +30,7 @@ void initialize_socks5()
 
 FUZZ_TARGET(socks5, .init = initialize_socks5)
 {
+    g_socks5_interrupt.reset();
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     FakeSteadyClock steady_clock;


### PR DESCRIPTION
Reset `g_socks5_interrupt` before each `socks5` fuzz input.

`CThreadInterrupt` remains interrupted until explicitly reset. Previously,
inputs executed after the first input setting the interrupt flag inherited its
state. As corpus inputs are shuffled between all-input coverage runs, the
number of affected inputs and the resulting coverage counts could differ.

Tested with the complete 91-input `socks5` corpus. The all-input deterministic
coverage check passes.