### PR TITLE
net: only count connections in AddConnection when the type has a limit

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1291,12 +1291,13 @@ bool CConnman::AddConnection(const std::string& address, ConnectionType conn_typ
         break;
     } // no default case, so the compiler can warn about missing cases
 
-    // Count existing connections
-    int existing_connections = WITH_LOCK(m_nodes_mutex,
-                                         return std::count_if(m_nodes.begin(), m_nodes.end(), [conn_type](CNode* node) { return node->m_conn_type == conn_type; }););
-
-    // Max connections of specified type already exist
-    if (max_connections != std::nullopt && existing_connections >= max_connections) return false;
+    // Only lock and count when this connection type has a limit to enforce.
+    if (max_connections != std::nullopt) {
+        const int existing_connections = WITH_LOCK(m_nodes_mutex,
+                                                   return std::count_if(m_nodes.begin(), m_nodes.end(), [conn_type](CNode* node) { return node->m_conn_type == conn_type; }););
+        // Max connections of specified type already exist
+        if (existing_connections >= *max_connections) return false;
+    }
 
     // Max total outbound connections already exist
     CSemaphoreGrant grant(*semOutbound, true);


### PR DESCRIPTION
`CConnman::AddConnection` locks `m_nodes_mutex` and counts existing connections of the requested type even for types that have no limit (`ADDR_FETCH` and `FEELER`), then discards the count. Move the count inside the `max_connections != std::nullopt` check so we only take the lock and walk the node list when there is a limit to enforce.

No behavior change: when `max_connections` is `std::nullopt` the old code computed a count it never used.
