### PR TITLE
wallet, migration: Warn and skip unidentified transactions

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4053,8 +4053,11 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
             }
         }
         if (!is_mine) {
-            // Both not ours and not in the watchonly wallet
-            return util::Error{strprintf(_("Error: Transaction %s in wallet cannot be identified to belong to migrated wallets"), wtx->GetHash().GetHex())};
+            // Transaction belongs to no migrated wallet — likely a BDB log file cross-contamination
+            // artifact from manual wallet.dat swaps. Warn and drop it rather than aborting migration.
+            WalletLogPrintf("Warning: Transaction %s in wallet cannot be identified to belong to migrated wallets; dropping it\n", wtx->GetHash().GetHex());
+            txids_to_delete.push_back(wtx->GetHash());
+            continue;
         }
         // Rewrite the transaction so that anything that may have changed about it in memory also persists to disk
         local_wallet_batch.WriteTx(*wtx);

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -1720,6 +1720,56 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         self.clear_default_wallet(backup_path)
 
+    def test_unidentified_tx(self):
+        """Test migratewallet behaviour when a wallet contains a transaction it doesn't own.
+
+        Simulates BDB log file cross-contamination (issue #35626): a tx is present in
+        mapWallet but belongs to no migrated wallet.  Before the fix this caused
+        migratewallet to abort; after the fix it warns and drops the tx.
+        """
+        self.log.info("Test migration with unidentified (cross-contaminated) transaction")
+        wallet_name = "unidentified_tx"
+        wallet = self.create_legacy_wallet(wallet_name)
+        master_wallet = self.master_node.get_wallet_rpc(self.default_wallet_name)
+
+        # Import a master wallet address as watchonly — this is the mechanism by which
+        # the wallet records a transaction it doesn't own keys for.
+        foreign_addr = master_wallet.getnewaddress()
+        wallet.importaddress(foreign_addr)
+
+        # Fund the watched address so the legacy wallet picks up the transaction.
+        txid = master_wallet.sendtoaddress(foreign_addr, 1.0)
+        self.generate(self.master_node, 1)
+
+        # Confirm the tx appears in the legacy wallet (as watchonly receive).
+        lt = wallet.listtransactions("*", 100, 0, True)  # include_watchonly=True
+        assert any(tx["txid"] == txid for tx in lt)
+
+        wallet.unloadwallet()
+
+        # Erase all importaddress-written records from the BDB file except the tx
+        # record itself. This simulates BDB log file cross-contamination: the tx
+        # data was written into the wallet via log replay, but without the
+        # corresponding key/script material or address book entries. After erasure
+        # the wallet has the tx record but nothing that would let migration identify
+        # or transfer it.
+        wallet_dat = self.old_node.wallets_path / wallet_name / "wallet.dat"
+        addr_bytes = foreign_addr.encode()
+        addr_encoded = bytes([len(addr_bytes)]) + addr_bytes  # compact_size prefix + address
+        self.erase_bdb_record(wallet_dat, b"watchs")
+        self.erase_bdb_record(wallet_dat, b"watchmeta")
+        self.erase_bdb_record(wallet_dat, b"purpose" + addr_encoded)
+        self.erase_bdb_record(wallet_dat, b"name" + addr_encoded)
+
+        # Copy to master node for migration.
+        master_wallet_path = self.master_node.wallets_path / wallet_name
+        os.makedirs(master_wallet_path, exist_ok=True)
+        shutil.copyfile(wallet_dat, master_wallet_path / "wallet.dat")
+
+        # Before the fix migratewallet aborted with this error.
+        assert_raises_rpc_error(-4, "cannot be identified to belong to migrated wallets",
+                                self.master_node.migratewallet, wallet_name)
+
     @staticmethod
     def erase_bdb_record(wallet_dat_path, key):
         data = bytearray(wallet_dat_path.read_bytes())
@@ -1799,6 +1849,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.test_no_load_reports_auxiliary_wallet_names()
         self.test_solvable_no_privs()
         self.test_loading_failure_after_migration()
+        self.test_unidentified_tx()
         self.test_missing_bestblock()
 
         # Note: After this test the first 250 blocks of 'master_node' are pruned

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -1766,9 +1766,20 @@ class WalletMigrationTest(BitcoinTestFramework):
         os.makedirs(master_wallet_path, exist_ok=True)
         shutil.copyfile(wallet_dat, master_wallet_path / "wallet.dat")
 
-        # Before the fix migratewallet aborted with this error.
-        assert_raises_rpc_error(-4, "cannot be identified to belong to migrated wallets",
-                                self.master_node.migratewallet, wallet_name)
+        # Migration must succeed (not abort) and log a warning for the dropped tx.
+        with self.master_node.assert_debug_log(
+            expected_msgs=["cannot be identified to belong to migrated wallets; dropping it"],
+        ):
+            self.master_node.migratewallet(wallet_name)
+
+        migrated = self.master_node.get_wallet_rpc(wallet_name)
+        assert_equal(migrated.getwalletinfo()["descriptors"], True)
+
+        # The unidentified transaction must have been removed from the migrated wallet.
+        txids_after = {tx["txid"] for tx in migrated.listtransactions("*", 100)}
+        assert txid not in txids_after
+
+        migrated.unloadwallet()
 
     @staticmethod
     def erase_bdb_record(wallet_dat_path, key):


### PR DESCRIPTION
Fixes #35626.

<details>
<summary>Legacy wallets can contain transactions they don't own, due to BDB log file cross-contamination.</summary>

This happened when users swapped `wallet.dat` files manually (stopping the node and renaming files) without first flushing the BDB log files. BDB writes data to log files before checkpointing them into `wallet.dat`; if only the `.dat` was swapped but the log files remained, a subsequent node start replayed those logs into the new wallet, writing in transactions from a completely different wallet. The affected wallet has no keys or scripts for those transactions — `gettransaction` shows an empty `details` array.

</details>

Before this fix, `migratewallet` aborted with a fatal error when it encountered such a transaction in `mapWallet` that belonged to no migrated wallet:

      Error: Transaction <txid> in wallet cannot be identified to belong to migrated wallets

<details>
<summary>This change downgrades the fatal error to a warning and removes the unidentified transaction from the migrated wallet instead of aborting (as <a href="https://github.com/bitcoin/bitcoin/issues/35626#issuecomment-4846118013">suggested</a> by achow101).</summary>

The txid is logged so the user can inspect it. The existing `txids_to_delete` / `RemoveTxs` mechanism (already used for watchonly transactions) handles the removal.  

</details>

This fix applies to both the `migratewallet` RPC and the equivalent GUI option, as both go through the same migration code path.

<details>
<summary>A test is added to <code>wallet_migration.py</code> that simulates the cross-contamination scenario...</summary>

a watchonly address is imported so the wallet records a foreign transaction, then the watchonly script and address book BDB records are erased, leaving a transaction in `mapWallet` with no wallet claiming it.
</details>