### PR TITLE
bench: add  index  benchmarks

### DIFF
--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -71,6 +71,40 @@ restricted to the same input set (introducing bias). [Fuzz
 tests](/doc/fuzzing.md) are better suited for this purpose, as they are
 specifically aimed at exploring the possible input space.
 
+Measuring I/O and memory cost
+-----------------------------
+
+The framework reports time and, where hardware counters are available, cycles
+and instructions. It does not report syscalls, bytes written or peak memory. For
+a change aimed at I/O or memory rather than CPU, measure those with standard
+tools around `bench_bitcoin`.
+
+The data directory defaults to a temporary directory, often a RAM-backed
+`tmpfs` where nothing reaches a real disk. Point it elsewhere first:
+
+    build/bin/bench_bitcoin -filter='<benchmark>' -testdatadir=/path/on/disk
+
+Write syscalls. A run covers several iterations, so compare between builds
+rather than reading the absolute count:
+
+    strace -f -c -e trace=write,pwrite64,fsync,fdatasync \
+        build/bin/bench_bitcoin -filter='<benchmark>'
+
+Peak resident memory:
+
+    /usr/bin/time -v build/bin/bench_bitcoin -filter='<benchmark>' 2>&1 \
+        | grep 'Maximum resident set size'
+
+On-disk size. Each benchmark gets its own datadir, named after it:
+
+    du -sb '<testdatadir>/test_common bitcoin/<benchmark>/datadir/regtest/<dir>'
+
+The test setups keep the chainstate and the block index in memory, so `<dir>` is
+`blocks` or `indexes/<name>`.
+
+To profile where time is spent, use `perf` as described in [Performance
+profiling with perf](/doc/developer-notes.md#performance-profiling-with-perf).
+
 Going Further
 --------------------
 

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -71,6 +71,44 @@ restricted to the same input set (introducing bias). [Fuzz
 tests](/doc/fuzzing.md) are better suited for this purpose, as they are
 specifically aimed at exploring the possible input space.
 
+Measuring I/O and memory cost
+-----------------------------
+
+The framework reports time and, where hardware counters are available, cycles
+and instructions. It does not report syscalls, bytes written or peak memory. For
+a change aimed at I/O or memory rather than CPU, measure those with standard
+tools around `bench_bitcoin`. The commands below are Linux/GNU specific.
+
+The data directory defaults to a temporary directory, often a RAM-backed
+`tmpfs` where nothing reaches a real disk. Point it elsewhere first:
+
+    build/bin/bench_bitcoin -filter='<benchmark>' -testdatadir=/path/on/disk
+
+Write syscalls. A run covers several iterations, so compare between builds
+rather than reading the absolute count:
+
+    strace -f -c -e trace=write,pwrite64,fsync,fdatasync \
+        build/bin/bench_bitcoin -filter='<benchmark>' -testdatadir=/path/on/disk
+
+Peak resident memory:
+
+    /usr/bin/time -v build/bin/bench_bitcoin -filter='<benchmark>' \
+        -testdatadir=/path/on/disk 2>&1 | grep 'Maximum resident set size'
+
+On-disk size. This one needs `-testdatadir`: without it the setup deletes the
+data directory on teardown, leaving nothing to measure. Each benchmark gets its
+own directory, named after it:
+
+    du -sb '<testdatadir>/test_common bitcoin/<benchmark>/datadir/regtest/<dir>'
+
+The test setups keep the chainstate and the block index in memory, so `<dir>` is
+`blocks` or `indexes/<name>`. Beware that `blocks` and the block filter index
+preallocate their flat files, so `du` there reports the reservation rather than
+the data; it only tracks content for plain LevelDB directories.
+
+To profile where time is spent, use `perf` as described in [Performance
+profiling with perf](/doc/developer-notes.md#performance-profiling-with-perf).
+
 Going Further
 --------------------
 

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -30,6 +30,8 @@ add_executable(bench_bitcoin
   hashpadding.cpp
   index_blockfilter.cpp
   index_sync_util.cpp
+  index_txindex.cpp
+  index_txospender.cpp
   load_external.cpp
   lockedpool.cpp
   logging.cpp

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(bench_bitcoin
   gcs_filter.cpp
   hashpadding.cpp
   index_blockfilter.cpp
+  index_sync_util.cpp
   load_external.cpp
   lockedpool.cpp
   logging.cpp

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -4,6 +4,7 @@
 
 #include <addresstype.h>
 #include <bench/bench.h>
+#include <bench/index_sync_util.h>
 #include <blockfilter.h>
 #include <chain.h>
 #include <index/base.h>
@@ -60,3 +61,27 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
 }
 
 BENCHMARK(BlockFilterIndexSync);
+
+// Returns a fresh, not-yet-initialized BASIC BlockFilterIndex. `f_memory=false`
+// exercises the real disk write path, true isolates CPU cost from I/O.
+static std::unique_ptr<BlockFilterIndex> MakeBlockFilterIndex(TestChain100Setup& test_setup, bool f_memory)
+{
+    return std::make_unique<BlockFilterIndex>(interfaces::MakeChain(test_setup.m_node), BlockFilterType::BASIC,
+                                              /*n_cache_size=*/1 << 20, f_memory, /*f_wipe=*/true);
+}
+
+// Same sync as BlockFilterIndexSync above, but over blocks that carry
+// transactions paying to distinct scripts, so the filters hold elements
+// proportional to the number of transactions rather than a handful per block.
+static void BlockFilterIndexSyncRealistic(benchmark::Bench& bench, bool f_memory)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK);
+
+    BenchIndexSync(bench, *test_setup, [&] { return MakeBlockFilterIndex(*test_setup, f_memory); });
+}
+
+static void BlockFilterIndexSyncRealisticDisk(benchmark::Bench& bench) { BlockFilterIndexSyncRealistic(bench, /*f_memory=*/false); }
+static void BlockFilterIndexSyncRealisticMem(benchmark::Bench& bench) { BlockFilterIndexSyncRealistic(bench, /*f_memory=*/true); }
+BENCHMARK(BlockFilterIndexSyncRealisticDisk);
+BENCHMARK(BlockFilterIndexSyncRealisticMem);

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -18,6 +18,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
+#include <util/byte_units.h> // IWYU pragma: keep
 #include <util/check.h>
 #include <util/strencodings.h>
 #include <validation.h>
@@ -60,14 +61,12 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
     });
 }
 
-BENCHMARK(BlockFilterIndexSync);
-
 // Returns a fresh, not-yet-initialized BASIC BlockFilterIndex. `f_memory=false`
 // exercises the real disk write path, true isolates CPU cost from I/O.
 static std::unique_ptr<BlockFilterIndex> MakeBlockFilterIndex(TestChain100Setup& test_setup, bool f_memory)
 {
     return std::make_unique<BlockFilterIndex>(interfaces::MakeChain(test_setup.m_node), BlockFilterType::BASIC,
-                                              /*n_cache_size=*/1 << 20, f_memory, /*f_wipe=*/true);
+                                              /*n_cache_size=*/1_MiB, f_memory, /*f_wipe=*/true);
 }
 
 // Same sync as BlockFilterIndexSync above, but over blocks that carry
@@ -83,5 +82,7 @@ static void BlockFilterIndexSyncRealistic(benchmark::Bench& bench, bool f_memory
 
 static void BlockFilterIndexSyncRealisticDisk(benchmark::Bench& bench) { BlockFilterIndexSyncRealistic(bench, /*f_memory=*/false); }
 static void BlockFilterIndexSyncRealisticMem(benchmark::Bench& bench) { BlockFilterIndexSyncRealistic(bench, /*f_memory=*/true); }
+
+BENCHMARK(BlockFilterIndexSync);
 BENCHMARK(BlockFilterIndexSyncRealisticDisk);
 BENCHMARK(BlockFilterIndexSyncRealisticMem);

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -4,6 +4,7 @@
 
 #include <addresstype.h>
 #include <bench/bench.h>
+#include <bench/index_sync_util.h>
 #include <blockfilter.h>
 #include <chain.h>
 #include <index/base.h>
@@ -17,6 +18,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
+#include <util/byte_units.h> // IWYU pragma: keep
 #include <util/check.h>
 #include <util/strencodings.h>
 #include <validation.h>
@@ -59,4 +61,35 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
     });
 }
 
+// Returns a fresh, not-yet-initialized BASIC BlockFilterIndex. f_memory only
+// covers the index database: the filters always go through m_filter_fileseq
+// into the data directory, so both variants pay that I/O.
+static std::unique_ptr<BlockFilterIndex> MakeBlockFilterIndex(TestChain100Setup& test_setup, bool f_memory)
+{
+    return std::make_unique<BlockFilterIndex>(interfaces::MakeChain(test_setup.m_node), BlockFilterType::BASIC,
+                                              /*n_cache_size=*/1_MiB, f_memory, /*f_wipe=*/true);
+}
+
+// Same sync as BlockFilterIndexSync above, but over blocks carrying
+// transactions paying to distinct scripts, so the filters scale with what a
+// block contains rather than with the number of blocks.
+static void BlockFilterIndexSyncRealistic(benchmark::Bench& bench, bool f_memory)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK);
+
+    BenchIndexSync(bench, *test_setup, [&] { return MakeBlockFilterIndex(*test_setup, f_memory); });
+}
+
+static void BlockFilterIndexSyncRealisticDisk(benchmark::Bench& bench)
+{
+    BlockFilterIndexSyncRealistic(bench, /*f_memory=*/false);
+}
+static void BlockFilterIndexSyncRealisticMem(benchmark::Bench& bench)
+{
+    BlockFilterIndexSyncRealistic(bench, /*f_memory=*/true);
+}
+
 BENCHMARK(BlockFilterIndexSync);
+BENCHMARK(BlockFilterIndexSyncRealisticDisk);
+BENCHMARK(BlockFilterIndexSyncRealisticMem);

--- a/src/bench/index_sync_util.cpp
+++ b/src/bench/index_sync_util.cpp
@@ -19,11 +19,12 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <utility>
 #include <vector>
 
-void ExtendChainWithSpends(TestChain100Setup& test_setup, size_t num_blocks, size_t num_txs_per_block)
+void ExtendChainWithSpends(TestChain100Setup& test_setup, uint32_t num_blocks, uint32_t num_txs_per_block)
 {
     assert(num_txs_per_block > 0);
 
@@ -49,18 +50,25 @@ void ExtendChainWithSpends(TestChain100Setup& test_setup, size_t num_blocks, siz
     auto& coinbase_to_spend{test_setup.m_coinbase_txns[0]};
     size_t k0{0};
     size_t k1{1};
-    const CMutableTransaction first_tx{test_setup.CreateValidTransaction({coinbase_to_spend}, {COutPoint(coinbase_to_spend->GetHash(), 0)},
-                                                                        next_height, {test_setup.coinbaseKey}, {outs[k0], outs[k1]}, {}, {})
-                                           .first};
+    const CMutableTransaction first_tx{
+        test_setup.CreateValidTransaction(
+            /*input_transactions=*/{coinbase_to_spend},
+            /*inputs=*/{COutPoint(coinbase_to_spend->GetHash(), 0)},
+            /*input_height=*/next_height,
+            /*input_signing_keys=*/{test_setup.coinbaseKey},
+            /*outputs=*/{outs[k0], outs[k1]},
+            /*feerate=*/{},
+            /*fee_output=*/{})
+            .first};
     test_setup.CreateAndProcessBlock({first_tx}, coinbase_spk);
     ++next_height;
 
     CTransactionRef tx_to_spend{MakeTransactionRef(first_tx)};
     size_t next_key{2 % num_keys};
-    for (size_t b{0}; b < num_blocks; ++b) {
+    for (uint32_t b{0}; b < num_blocks; ++b) {
         std::vector<CMutableTransaction> txs;
         txs.reserve(num_txs_per_block);
-        for (size_t i{0}; i < num_txs_per_block; ++i) {
+        for (uint32_t i{0}; i < num_txs_per_block; ++i) {
             const std::vector<COutPoint> inputs{
                 COutPoint(tx_to_spend->GetHash(), 0),
                 COutPoint(tx_to_spend->GetHash(), 1),
@@ -70,9 +78,16 @@ void ExtendChainWithSpends(TestChain100Setup& test_setup, size_t num_blocks, siz
             next_key = (next_key + 1) % num_keys;
             k1 = next_key;
             next_key = (next_key + 1) % num_keys;
-            const CMutableTransaction tx{test_setup.CreateValidTransaction({tx_to_spend}, inputs, next_height,
-                                                                          signing_keys, {outs[k0], outs[k1]}, {}, {})
-                                             .first};
+            const CMutableTransaction tx{
+                test_setup.CreateValidTransaction(
+                    /*input_transactions=*/{tx_to_spend},
+                    /*inputs=*/inputs,
+                    /*input_height=*/next_height,
+                    /*input_signing_keys=*/signing_keys,
+                    /*outputs=*/{outs[k0], outs[k1]},
+                    /*feerate=*/{},
+                    /*fee_output=*/{})
+                    .first};
             txs.emplace_back(tx);
             tx_to_spend = MakeTransactionRef(tx);
         }

--- a/src/bench/index_sync_util.cpp
+++ b/src/bench/index_sync_util.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/index_sync_util.h>
+
+#include <addresstype.h>
+#include <chain.h>
+#include <consensus/amount.h>
+#include <key.h>
+#include <node/blockstorage.h>
+#include <policy/feerate.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+#include <cassert>
+#include <cstddef>
+#include <optional>
+#include <utility>
+#include <vector>
+
+void ExtendChainWithSpends(TestChain100Setup& test_setup, size_t num_blocks, size_t num_txs_per_block)
+{
+    assert(num_txs_per_block > 0);
+
+    // Pay every output to a different key: block filter elements are
+    // deduplicated, so shared scripts would keep filters small regardless of
+    // how many transactions a block holds. Only the keys within one block need
+    // to be distinct.
+    const size_t num_keys{2 * num_txs_per_block};
+    std::vector<CKey> keys;
+    std::vector<CTxOut> outs;
+    keys.reserve(num_keys);
+    outs.reserve(num_keys);
+    for (size_t i{0}; i < num_keys; ++i) {
+        keys.push_back(GenerateRandomKey());
+        outs.emplace_back(COIN, GetScriptForDestination(WitnessV0KeyHash{keys.back().GetPubKey()}));
+    }
+
+    const CScript coinbase_spk{GetScriptForDestination(WitnessV0KeyHash{test_setup.coinbaseKey.GetPubKey()})};
+    const int start_height{WITH_LOCK(::cs_main, return test_setup.m_node.chainman->ActiveHeight())};
+    int next_height{start_height + 1};
+
+    // Coinbase from block 1 matures at height 101, the first height added here.
+    auto& coinbase_to_spend{test_setup.m_coinbase_txns[0]};
+    size_t k0{0};
+    size_t k1{1};
+    const CMutableTransaction first_tx{test_setup.CreateValidTransaction({coinbase_to_spend}, {COutPoint(coinbase_to_spend->GetHash(), 0)},
+                                                                        next_height, {test_setup.coinbaseKey}, {outs[k0], outs[k1]}, {}, {})
+                                           .first};
+    test_setup.CreateAndProcessBlock({first_tx}, coinbase_spk);
+    ++next_height;
+
+    CTransactionRef tx_to_spend{MakeTransactionRef(first_tx)};
+    size_t next_key{2 % num_keys};
+    for (size_t b{0}; b < num_blocks; ++b) {
+        std::vector<CMutableTransaction> txs;
+        txs.reserve(num_txs_per_block);
+        for (size_t i{0}; i < num_txs_per_block; ++i) {
+            const std::vector<COutPoint> inputs{
+                COutPoint(tx_to_spend->GetHash(), 0),
+                COutPoint(tx_to_spend->GetHash(), 1),
+            };
+            const std::vector<CKey> signing_keys{keys[k0], keys[k1]};
+            k0 = next_key;
+            next_key = (next_key + 1) % num_keys;
+            k1 = next_key;
+            next_key = (next_key + 1) % num_keys;
+            const CMutableTransaction tx{test_setup.CreateValidTransaction({tx_to_spend}, inputs, next_height,
+                                                                          signing_keys, {outs[k0], outs[k1]}, {}, {})
+                                             .first};
+            txs.emplace_back(tx);
+            tx_to_spend = MakeTransactionRef(tx);
+        }
+        test_setup.CreateAndProcessBlock(txs, coinbase_spk);
+        ++next_height;
+    }
+
+    // CreateAndProcessBlock ignores the result of ProcessNewBlock, so without
+    // this a rejected block would silently shrink the chain.
+    assert(WITH_LOCK(::cs_main, return test_setup.m_node.chainman->ActiveHeight()) == next_height - 1);
+}
+
+std::vector<Txid> CollectChainTxids(TestChain100Setup& test_setup, int from_height)
+{
+    std::vector<Txid> txids;
+    LOCK(::cs_main);
+    const CChain& chain{test_setup.m_node.chainman->ActiveChain()};
+    for (int h{from_height}; h <= chain.Height(); ++h) {
+        CBlock block;
+        assert(test_setup.m_node.chainman->m_blockman.ReadBlock(block, *chain[h]));
+        for (const auto& tx : block.vtx) txids.push_back(tx->GetHash());
+    }
+    return txids;
+}
+
+std::vector<COutPoint> CollectChainSpentOutpoints(TestChain100Setup& test_setup, int from_height)
+{
+    std::vector<COutPoint> outpoints;
+    LOCK(::cs_main);
+    const CChain& chain{test_setup.m_node.chainman->ActiveChain()};
+    for (int h{from_height}; h <= chain.Height(); ++h) {
+        CBlock block;
+        assert(test_setup.m_node.chainman->m_blockman.ReadBlock(block, *chain[h]));
+        for (const auto& tx : block.vtx) {
+            if (tx->IsCoinBase()) continue;
+            for (const auto& in : tx->vin) outpoints.push_back(in.prevout);
+        }
+    }
+    return outpoints;
+}

--- a/src/bench/index_sync_util.cpp
+++ b/src/bench/index_sync_util.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/index_sync_util.h>
+
+#include <addresstype.h>
+#include <chain.h>
+#include <consensus/amount.h>
+#include <key.h>
+#include <node/blockstorage.h>
+#include <policy/feerate.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <util/check.h>
+#include <validation.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+int ExtendChainWithSpends(TestChain100Setup& test_setup, uint32_t num_blocks, uint32_t num_txs_per_block)
+{
+    Assert(num_txs_per_block > 0);
+
+    // Block filter elements are deduplicated, so only distinct scripts add to a
+    // filter. Keys are reused across blocks, distinct within one.
+    const size_t num_keys{2 * num_txs_per_block};
+    std::vector<CKey> keys;
+    std::vector<CTxOut> outs;
+    keys.reserve(num_keys);
+    outs.reserve(num_keys);
+    for (size_t i{0}; i < num_keys; ++i) {
+        keys.push_back(GenerateRandomKey());
+        outs.emplace_back(COIN, GetScriptForDestination(WitnessV0KeyHash{keys.back().GetPubKey()}));
+    }
+
+    const CScript coinbase_spk{GetScriptForDestination(WitnessV0KeyHash{test_setup.coinbaseKey.GetPubKey()})};
+    const int start_height{WITH_LOCK(::cs_main, return test_setup.m_node.chainman->ActiveHeight())};
+
+    // The coinbase of block 1 matures exactly at the first height added here.
+    auto& coinbase_to_spend{test_setup.m_coinbase_txns[0]};
+    size_t k0{0};
+    size_t k1{1};
+    const CMutableTransaction first_tx{
+        test_setup.CreateValidTransaction(
+            /*input_transactions=*/{coinbase_to_spend},
+            /*inputs=*/{COutPoint(coinbase_to_spend->GetHash(), 0)},
+            /*input_height=*/1,
+            /*input_signing_keys=*/{test_setup.coinbaseKey},
+            /*outputs=*/{outs[k0], outs[k1]},
+            /*feerate=*/{},
+            /*fee_output=*/{})
+            .first};
+    test_setup.CreateAndProcessBlock({first_tx}, coinbase_spk);
+    test_setup.m_clock += 1s;
+
+    // first_tx went into start_height + 1, so the loop starts one above that.
+    int next_height{start_height + 2};
+    CTransactionRef tx_to_spend{MakeTransactionRef(first_tx)};
+    size_t next_key{2 % num_keys};
+    for (uint32_t b{0}; b < num_blocks; ++b) {
+        std::vector<CMutableTransaction> txs;
+        txs.reserve(num_txs_per_block);
+        for (uint32_t i{0}; i < num_txs_per_block; ++i) {
+            const std::vector<COutPoint> inputs{
+                COutPoint(tx_to_spend->GetHash(), 0),
+                COutPoint(tx_to_spend->GetHash(), 1),
+            };
+            const std::vector<CKey> signing_keys{keys[k0], keys[k1]};
+            // The first transaction of a block spends the last one of the
+            // previous block; the rest spend within this one.
+            const int input_height{i == 0 ? next_height - 1 : next_height};
+            k0 = next_key;
+            next_key = (next_key + 1) % num_keys;
+            k1 = next_key;
+            next_key = (next_key + 1) % num_keys;
+            const CMutableTransaction tx{
+                test_setup.CreateValidTransaction(
+                    /*input_transactions=*/{tx_to_spend},
+                    /*inputs=*/inputs,
+                    /*input_height=*/input_height,
+                    /*input_signing_keys=*/signing_keys,
+                    /*outputs=*/{outs[k0], outs[k1]},
+                    /*feerate=*/{},
+                    /*fee_output=*/{})
+                    .first};
+            txs.emplace_back(tx);
+            tx_to_spend = MakeTransactionRef(tx);
+        }
+        test_setup.CreateAndProcessBlock(txs, coinbase_spk);
+        // UpdateTime() clamps a block's time to at least MTP+1, so a frozen
+        // clock drifts a second per block and eventually trips
+        // MAX_FUTURE_BLOCK_TIME.
+        test_setup.m_clock += 1s;
+        ++next_height;
+    }
+
+    // CreateAndProcessBlock ignores the result of ProcessNewBlock.
+    Assert(WITH_LOCK(::cs_main, return test_setup.m_node.chainman->ActiveHeight()) == next_height - 1);
+
+    // BaseIndex::Commit() writes nothing until the index tip is an ancestor of
+    // the last flushed block, and a test setup never flushes on its own.
+    test_setup.m_node.chainman->ActiveChainstate().ForceFlushStateToDisk();
+
+    return start_height + 1;
+}
+
+std::vector<Txid> CollectChainTxids(TestChain100Setup& test_setup, int from_height)
+{
+    Assert(from_height >= 0);
+    std::vector<Txid> txids;
+    LOCK(::cs_main);
+    const CChain& chain{test_setup.m_node.chainman->ActiveChain()};
+    for (int h{from_height}; h <= chain.Height(); ++h) {
+        CBlock block;
+        Assert(test_setup.m_node.chainman->m_blockman.ReadBlock(block, *chain[h]));
+        for (const auto& tx : block.vtx) txids.push_back(tx->GetHash());
+    }
+    return txids;
+}
+
+std::vector<COutPoint> CollectChainSpentOutpoints(TestChain100Setup& test_setup, int from_height)
+{
+    Assert(from_height >= 0);
+    std::vector<COutPoint> outpoints;
+    LOCK(::cs_main);
+    const CChain& chain{test_setup.m_node.chainman->ActiveChain()};
+    for (int h{from_height}; h <= chain.Height(); ++h) {
+        CBlock block;
+        Assert(test_setup.m_node.chainman->m_blockman.ReadBlock(block, *chain[h]));
+        for (const auto& tx : block.vtx) {
+            if (tx->IsCoinBase()) continue;
+            for (const auto& in : tx->vin) outpoints.push_back(in.prevout);
+        }
+    }
+    return outpoints;
+}

--- a/src/bench/index_sync_util.h
+++ b/src/bench/index_sync_util.h
@@ -1,0 +1,88 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BENCH_INDEX_SYNC_UTIL_H
+#define BITCOIN_BENCH_INDEX_SYNC_UTIL_H
+
+#include <bench/bench.h>
+#include <chain.h>
+#include <index/base.h>
+#include <primitives/transaction.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+/** Size of the chain the index benchmarks build. Building it is not timed, but it is most of a run. */
+static constexpr size_t BENCH_INDEX_NUM_BLOCKS{50};
+static constexpr size_t BENCH_INDEX_TXS_PER_BLOCK{50};
+/** First height added by ExtendChainWithSpends to a fresh TestChain100Setup. */
+static constexpr int BENCH_INDEX_FIRST_SPEND_HEIGHT{101};
+
+/**
+ * Extends the active chain with `num_blocks` blocks of `num_txs_per_block`
+ * chained, validly-signed transactions. Each spends the two outputs of the
+ * transaction before it in the same block and creates two new ones, each paying
+ * a distinct key.
+ */
+void ExtendChainWithSpends(TestChain100Setup& test_setup, size_t num_blocks, size_t num_txs_per_block);
+
+/**
+ * Times `make_index()` plus a full Init -> BlockUntilSyncedToCurrentChain ->
+ * Sync -> Stop cycle over the chain in `test_setup`. `make_index` runs once per
+ * iteration and must return a fresh, not-yet-initialized index, since an index
+ * cannot be re-synced after Stop(). Constructing one opens and wipes its
+ * database, inside the timed region.
+ */
+template <typename MakeIndex>
+void BenchIndexSync(benchmark::Bench& bench, TestChain100Setup& test_setup, MakeIndex make_index)
+{
+    bench.minEpochIterations(5).run([&] {
+        std::unique_ptr<BaseIndex> index{make_index()};
+        assert(index->Init());
+        assert(!index->BlockUntilSyncedToCurrentChain());
+        index->Sync();
+
+        IndexSummary summary{index->GetSummary()};
+        assert(summary.synced);
+        assert(summary.best_block_hash == WITH_LOCK(::cs_main, return test_setup.m_node.chainman->ActiveTip()->GetBlockHash()));
+
+        // Shutdown sequence (c.f. Shutdown() in init.cpp)
+        index->Stop();
+    });
+}
+
+/** All txids in the active chain from `from_height` to the tip, in block/tx order. */
+std::vector<Txid> CollectChainTxids(TestChain100Setup& test_setup, int from_height);
+
+/** All outpoints spent by non-coinbase transactions from `from_height` to the tip. */
+std::vector<COutPoint> CollectChainSpentOutpoints(TestChain100Setup& test_setup, int from_height);
+
+/**
+ * Times `lookup_one(key)` over every key in `keys` on an already synced index,
+ * reporting time per lookup via `bench.batch()`. `lookup_one` runs one query
+ * and returns whether it hit, which is asserted.
+ *
+ * Two things the number includes: the caches are warm, since the lookups run in
+ * the process that just wrote the index, and the lookup APIs do not stop at the
+ * database, they also read and deserialize the transaction from the block file.
+ */
+template <typename Key, typename LookupOne>
+void BenchIndexLookup(benchmark::Bench& bench, const std::vector<Key>& keys, LookupOne lookup_one)
+{
+    assert(!keys.empty());
+    bench.batch(keys.size()).unit("lookup").run([&] {
+        for (const Key& key : keys) {
+            const bool ok{lookup_one(key)};
+            assert(ok);
+            ankerl::nanobench::doNotOptimizeAway(ok);
+        }
+    });
+}
+
+#endif // BITCOIN_BENCH_INDEX_SYNC_UTIL_H

--- a/src/bench/index_sync_util.h
+++ b/src/bench/index_sync_util.h
@@ -14,13 +14,13 @@
 #include <validation.h>
 
 #include <cassert>
-#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
 /** Size of the chain the index benchmarks build. Building it is not timed, but it is most of a run. */
-static constexpr size_t BENCH_INDEX_NUM_BLOCKS{50};
-static constexpr size_t BENCH_INDEX_TXS_PER_BLOCK{50};
+static constexpr uint32_t BENCH_INDEX_NUM_BLOCKS{50};
+static constexpr uint32_t BENCH_INDEX_TXS_PER_BLOCK{50};
 /** First height added by ExtendChainWithSpends to a fresh TestChain100Setup. */
 static constexpr int BENCH_INDEX_FIRST_SPEND_HEIGHT{101};
 
@@ -30,7 +30,7 @@ static constexpr int BENCH_INDEX_FIRST_SPEND_HEIGHT{101};
  * transaction before it in the same block and creates two new ones, each paying
  * a distinct key.
  */
-void ExtendChainWithSpends(TestChain100Setup& test_setup, size_t num_blocks, size_t num_txs_per_block);
+void ExtendChainWithSpends(TestChain100Setup& test_setup, uint32_t num_blocks, uint32_t num_txs_per_block);
 
 /**
  * Times `make_index()` plus a full Init -> BlockUntilSyncedToCurrentChain ->
@@ -42,15 +42,19 @@ void ExtendChainWithSpends(TestChain100Setup& test_setup, size_t num_blocks, siz
 template <typename MakeIndex>
 void BenchIndexSync(benchmark::Bench& bench, TestChain100Setup& test_setup, MakeIndex make_index)
 {
+    // The tip doesn't change during the run, so take it once here to keep the
+    // lock out of the measurement.
+    const auto expected_tip{WITH_LOCK(::cs_main, return test_setup.m_node.chainman->ActiveTip()->GetBlockHash())};
+
     bench.minEpochIterations(5).run([&] {
         std::unique_ptr<BaseIndex> index{make_index()};
         assert(index->Init());
         assert(!index->BlockUntilSyncedToCurrentChain());
         index->Sync();
 
-        IndexSummary summary{index->GetSummary()};
+        const IndexSummary summary{index->GetSummary()};
         assert(summary.synced);
-        assert(summary.best_block_hash == WITH_LOCK(::cs_main, return test_setup.m_node.chainman->ActiveTip()->GetBlockHash()));
+        assert(summary.best_block_hash == expected_tip);
 
         // Shutdown sequence (c.f. Shutdown() in init.cpp)
         index->Stop();
@@ -77,11 +81,11 @@ void BenchIndexLookup(benchmark::Bench& bench, const std::vector<Key>& keys, Loo
 {
     assert(!keys.empty());
     bench.batch(keys.size()).unit("lookup").run([&] {
-        for (const Key& key : keys) {
-            const bool ok{lookup_one(key)};
-            assert(ok);
-            ankerl::nanobench::doNotOptimizeAway(ok);
-        }
+        // Accumulated without short-circuiting, so every key is queried and the
+        // reported per-lookup time really divides by keys.size().
+        bool all_found{true};
+        for (const Key& key : keys) all_found &= lookup_one(key);
+        assert(all_found);
     });
 }
 

--- a/src/bench/index_sync_util.h
+++ b/src/bench/index_sync_util.h
@@ -1,0 +1,98 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BENCH_INDEX_SYNC_UTIL_H
+#define BITCOIN_BENCH_INDEX_SYNC_UTIL_H
+
+#include <bench/bench.h>
+#include <index/base.h>
+#include <primitives/transaction.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <util/check.h>
+#include <validation.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+/** Blocks of chained spends the benchmarks build. ExtendChainWithSpends() mines
+ *  one more on top of these to spend a coinbase, over TestChain100Setup's 100.
+ *  Building the chain is not timed, but it is most of the wall time of a run. */
+static constexpr uint32_t BENCH_INDEX_NUM_BLOCKS{50};
+/** Chained transactions in each of those blocks. */
+static constexpr uint32_t BENCH_INDEX_TXS_PER_BLOCK{50};
+
+/**
+ * Extends the active chain with `num_blocks + 1` blocks: one spending a mature
+ * coinbase, then `num_blocks` of `num_txs_per_block` chained transactions, each
+ * spending the two outputs of the previous one. Returns the first height added.
+ *
+ * Only callable once per setup: it always spends m_coinbase_txns[0]. Flushes
+ * the chainstate, without which BaseIndex::Commit() writes nothing.
+ */
+int ExtendChainWithSpends(TestChain100Setup& test_setup, uint32_t num_blocks, uint32_t num_txs_per_block);
+
+/**
+ * Times `make_index()` plus a full Init -> Sync -> Stop cycle over the chain in
+ * `test_setup`. `make_index` must return a fresh index, wiped and constructed
+ * inside the timed region: a second Sync() on a synced index is a no-op.
+ *
+ * Disk vs Mem: f_memory=false keeps the index database on the filesystem, true
+ * keeps it in memory. The data directory defaults to fs::temp_directory_path(),
+ * a tmpfs on many Linux systems where Disk writes to RAM too, so the Disk
+ * figure only means what its name says when the directory is on real storage:
+ *
+ *     build/bin/bench_bitcoin -filter='<benchmark>' -testdatadir=/path/on/disk
+ *
+ * The chain is small enough that the index never leaves LevelDB's write buffer,
+ * so what Disk adds over Mem is page cache traffic. See doc/benchmarking.md.
+ */
+template <typename MakeIndex>
+void BenchIndexSync(benchmark::Bench& bench, TestChain100Setup& test_setup, MakeIndex make_index)
+{
+    // The tip is fixed for the whole run, and cs_main stays out of the loop.
+    const auto expected_tip{WITH_LOCK(::cs_main, return test_setup.m_node.chainman->ActiveTip()->GetBlockHash())};
+
+    bench.minEpochIterations(5).run([&] {
+        std::unique_ptr<BaseIndex> index{make_index()};
+        Assert(index->Init());
+        index->Sync();
+
+        const IndexSummary summary{index->GetSummary()};
+        Assert(summary.synced);
+        Assert(summary.best_block_hash == expected_tip);
+
+        // Shutdown sequence (c.f. Shutdown() in init.cpp)
+        index->Stop();
+    });
+}
+
+/** All txids in the active chain from `from_height` (>= 0) to the tip, in block/tx order. */
+std::vector<Txid> CollectChainTxids(TestChain100Setup& test_setup, int from_height);
+
+/** All outpoints spent by non-coinbase transactions from `from_height` (>= 0) to the tip. */
+std::vector<COutPoint> CollectChainSpentOutpoints(TestChain100Setup& test_setup, int from_height);
+
+/**
+ * Times `lookup_one(key)` over every key in `keys` on an already synced index,
+ * reporting time per lookup via `bench.batch()`. `lookup_one` runs one query
+ * and returns whether it hit, which is asserted. What the number measures is
+ * mostly the block file read and deserialization the lookup APIs do on top of
+ * the database query, which at this chain size is answered from memory.
+ */
+template <typename Key, typename LookupOne>
+void BenchIndexLookup(benchmark::Bench& bench, const std::vector<Key>& keys, LookupOne lookup_one)
+{
+    Assert(!keys.empty());
+    bench.batch(keys.size()).minEpochIterations(5).unit("lookup").run([&] {
+        // Accumulated without short-circuiting, so every key is queried and the
+        // reported per-lookup time really divides by keys.size().
+        bool all_found{true};
+        for (const Key& key : keys) all_found &= lookup_one(key);
+        Assert(all_found);
+    });
+}
+
+#endif // BITCOIN_BENCH_INDEX_SYNC_UTIL_H

--- a/src/bench/index_txindex.cpp
+++ b/src/bench/index_txindex.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <bench/index_sync_util.h>
+#include <index/base.h>
+#include <index/txindex.h>
+#include <interfaces/chain.h>
+#include <primitives/transaction.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+
+#include <cassert>
+#include <memory>
+#include <vector>
+
+// Returns a fresh, not-yet-initialized TxIndex. `f_memory=false` exercises the
+// real disk write path, true isolates CPU cost from I/O.
+static std::unique_ptr<TxIndex> MakeTxIndex(TestChain100Setup& test_setup, bool f_memory)
+{
+    return std::make_unique<TxIndex>(interfaces::MakeChain(test_setup.m_node),
+                                     /*n_cache_size=*/1 << 20, f_memory, /*f_wipe=*/true);
+}
+
+// End-to-end sync of a TxIndex: BaseIndex::Sync -> TxIndex::CustomAppend ->
+// TxIndex::DB::WriteTxs.
+static void TxIndexSync(benchmark::Bench& bench, bool f_memory)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK);
+
+    BenchIndexSync(bench, *test_setup, [&] { return MakeTxIndex(*test_setup, f_memory); });
+}
+
+static void TxIndexSyncDisk(benchmark::Bench& bench) { TxIndexSync(bench, /*f_memory=*/false); }
+static void TxIndexSyncMem(benchmark::Bench& bench) { TxIndexSync(bench, /*f_memory=*/true); }
+BENCHMARK(TxIndexSyncDisk);
+BENCHMARK(TxIndexSyncMem);
+
+// After a full sync, time FindTx() over every txid in the chain. See
+// BenchIndexLookup() for what the number covers.
+static void TxIndexLookup(benchmark::Bench& bench)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK);
+
+    // Build and fully sync a persistent txindex, kept alive for the lookups.
+    auto index{MakeTxIndex(*test_setup, /*f_memory=*/false)};
+    assert(index->Init());
+    assert(!index->BlockUntilSyncedToCurrentChain());
+    index->Sync();
+    assert(index->GetSummary().synced);
+
+    const std::vector<Txid> txids{CollectChainTxids(*test_setup, BENCH_INDEX_FIRST_SPEND_HEIGHT)};
+
+    BenchIndexLookup(bench, txids, [&](const Txid& id) {
+        uint256 block_hash;
+        CTransactionRef tx;
+        return index->FindTx(id, block_hash, tx);
+    });
+
+    index->Stop();
+}
+BENCHMARK(TxIndexLookup);

--- a/src/bench/index_txindex.cpp
+++ b/src/bench/index_txindex.cpp
@@ -10,6 +10,7 @@
 #include <primitives/transaction.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/byte_units.h> // IWYU pragma: keep
 
 #include <cassert>
 #include <memory>
@@ -20,7 +21,7 @@
 static std::unique_ptr<TxIndex> MakeTxIndex(TestChain100Setup& test_setup, bool f_memory)
 {
     return std::make_unique<TxIndex>(interfaces::MakeChain(test_setup.m_node),
-                                     /*n_cache_size=*/1 << 20, f_memory, /*f_wipe=*/true);
+                                     /*n_cache_size=*/1_MiB, f_memory, /*f_wipe=*/true);
 }
 
 // End-to-end sync of a TxIndex: BaseIndex::Sync -> TxIndex::CustomAppend ->
@@ -35,8 +36,6 @@ static void TxIndexSync(benchmark::Bench& bench, bool f_memory)
 
 static void TxIndexSyncDisk(benchmark::Bench& bench) { TxIndexSync(bench, /*f_memory=*/false); }
 static void TxIndexSyncMem(benchmark::Bench& bench) { TxIndexSync(bench, /*f_memory=*/true); }
-BENCHMARK(TxIndexSyncDisk);
-BENCHMARK(TxIndexSyncMem);
 
 // After a full sync, time FindTx() over every txid in the chain. See
 // BenchIndexLookup() for what the number covers.
@@ -62,4 +61,7 @@ static void TxIndexLookup(benchmark::Bench& bench)
 
     index->Stop();
 }
+
+BENCHMARK(TxIndexSyncDisk);
+BENCHMARK(TxIndexSyncMem);
 BENCHMARK(TxIndexLookup);

--- a/src/bench/index_txindex.cpp
+++ b/src/bench/index_txindex.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <bench/index_sync_util.h>
+#include <index/base.h>
+#include <index/txindex.h>
+#include <interfaces/chain.h>
+#include <primitives/transaction.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/byte_units.h> // IWYU pragma: keep
+#include <util/check.h>
+
+#include <memory>
+#include <vector>
+
+// Returns a fresh, not-yet-initialized TxIndex. See BenchIndexSync() for what
+// f_memory changes.
+static std::unique_ptr<TxIndex> MakeTxIndex(TestChain100Setup& test_setup, bool f_memory)
+{
+    return std::make_unique<TxIndex>(interfaces::MakeChain(test_setup.m_node),
+                                     /*n_cache_size=*/1_MiB, f_memory, /*f_wipe=*/true);
+}
+
+// End-to-end sync of a TxIndex: BaseIndex::Sync -> TxIndex::CustomAppend ->
+// TxIndex::DB::WriteTxs.
+static void TxIndexSync(benchmark::Bench& bench, bool f_memory)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK);
+
+    BenchIndexSync(bench, *test_setup, [&] { return MakeTxIndex(*test_setup, f_memory); });
+}
+
+static void TxIndexSyncDisk(benchmark::Bench& bench) { TxIndexSync(bench, /*f_memory=*/false); }
+static void TxIndexSyncMem(benchmark::Bench& bench) { TxIndexSync(bench, /*f_memory=*/true); }
+
+// After a full sync, time FindTx() over every txid in the chain. See
+// BenchIndexLookup() for what the number covers.
+static void TxIndexLookup(benchmark::Bench& bench)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    const int first_spend_height{
+        ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK)};
+
+    auto index{MakeTxIndex(*test_setup, /*f_memory=*/false)};
+    Assert(index->Init());
+    index->Sync();
+    Assert(index->GetSummary().synced);
+
+    const std::vector<Txid> txids{CollectChainTxids(*test_setup, first_spend_height)};
+
+    BenchIndexLookup(bench, txids, [&](const Txid& id) {
+        uint256 block_hash;
+        CTransactionRef tx;
+        return index->FindTx(id, block_hash, tx);
+    });
+
+    index->Stop();
+}
+
+BENCHMARK(TxIndexSyncDisk);
+BENCHMARK(TxIndexSyncMem);
+BENCHMARK(TxIndexLookup);

--- a/src/bench/index_txospender.cpp
+++ b/src/bench/index_txospender.cpp
@@ -10,6 +10,7 @@
 #include <primitives/transaction.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/byte_units.h> // IWYU pragma: keep
 #include <util/expected.h>
 
 #include <cassert>
@@ -23,7 +24,7 @@
 static std::unique_ptr<TxoSpenderIndex> MakeTxoSpenderIndex(TestChain100Setup& test_setup, bool f_memory)
 {
     return std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(test_setup.m_node),
-                                             /*n_cache_size=*/1 << 20, f_memory, /*f_wipe=*/true);
+                                             /*n_cache_size=*/1_MiB, f_memory, /*f_wipe=*/true);
 }
 
 // End-to-end sync of a TxoSpenderIndex: BaseIndex::Sync -> CustomAppend ->
@@ -38,8 +39,6 @@ static void TxoSpenderIndexSync(benchmark::Bench& bench, bool f_memory)
 
 static void TxoSpenderIndexSyncDisk(benchmark::Bench& bench) { TxoSpenderIndexSync(bench, /*f_memory=*/false); }
 static void TxoSpenderIndexSyncMem(benchmark::Bench& bench) { TxoSpenderIndexSync(bench, /*f_memory=*/true); }
-BENCHMARK(TxoSpenderIndexSyncDisk);
-BENCHMARK(TxoSpenderIndexSyncMem);
 
 // After a full sync, time FindSpender() over every spent outpoint in the chain.
 // See BenchIndexLookup() for what the number covers.
@@ -63,4 +62,7 @@ static void TxoSpenderIndexLookup(benchmark::Bench& bench)
 
     index->Stop();
 }
+
+BENCHMARK(TxoSpenderIndexSyncDisk);
+BENCHMARK(TxoSpenderIndexSyncMem);
 BENCHMARK(TxoSpenderIndexLookup);

--- a/src/bench/index_txospender.cpp
+++ b/src/bench/index_txospender.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <bench/index_sync_util.h>
+#include <index/base.h>
+#include <index/txospenderindex.h>
+#include <interfaces/chain.h>
+#include <primitives/transaction.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/expected.h>
+
+#include <cassert>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Returns a fresh, not-yet-initialized TxoSpenderIndex. `f_memory=false`
+// exercises the real disk write path, true isolates CPU cost from I/O.
+static std::unique_ptr<TxoSpenderIndex> MakeTxoSpenderIndex(TestChain100Setup& test_setup, bool f_memory)
+{
+    return std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(test_setup.m_node),
+                                             /*n_cache_size=*/1 << 20, f_memory, /*f_wipe=*/true);
+}
+
+// End-to-end sync of a TxoSpenderIndex: BaseIndex::Sync -> CustomAppend ->
+// BuildSpenderPositions.
+static void TxoSpenderIndexSync(benchmark::Bench& bench, bool f_memory)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK);
+
+    BenchIndexSync(bench, *test_setup, [&] { return MakeTxoSpenderIndex(*test_setup, f_memory); });
+}
+
+static void TxoSpenderIndexSyncDisk(benchmark::Bench& bench) { TxoSpenderIndexSync(bench, /*f_memory=*/false); }
+static void TxoSpenderIndexSyncMem(benchmark::Bench& bench) { TxoSpenderIndexSync(bench, /*f_memory=*/true); }
+BENCHMARK(TxoSpenderIndexSyncDisk);
+BENCHMARK(TxoSpenderIndexSyncMem);
+
+// After a full sync, time FindSpender() over every spent outpoint in the chain.
+// See BenchIndexLookup() for what the number covers.
+static void TxoSpenderIndexLookup(benchmark::Bench& bench)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK);
+
+    auto index{MakeTxoSpenderIndex(*test_setup, /*f_memory=*/false)};
+    assert(index->Init());
+    assert(!index->BlockUntilSyncedToCurrentChain());
+    index->Sync();
+    assert(index->GetSummary().synced);
+
+    const std::vector<COutPoint> outpoints{CollectChainSpentOutpoints(*test_setup, BENCH_INDEX_FIRST_SPEND_HEIGHT)};
+
+    BenchIndexLookup(bench, outpoints, [&](const COutPoint& txo) {
+        const auto result{index->FindSpender(txo)};
+        return result && result->has_value();
+    });
+
+    index->Stop();
+}
+BENCHMARK(TxoSpenderIndexLookup);

--- a/src/bench/index_txospender.cpp
+++ b/src/bench/index_txospender.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <bench/index_sync_util.h>
+#include <index/base.h>
+#include <index/txospenderindex.h>
+#include <interfaces/chain.h>
+#include <primitives/transaction.h>
+#include <test/util/setup_common.h>
+#include <util/byte_units.h> // IWYU pragma: keep
+#include <util/check.h>
+#include <util/expected.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Returns a fresh, not-yet-initialized TxoSpenderIndex. See BenchIndexSync()
+// for what f_memory changes. f_wipe empties the database, so the constructor
+// regenerates and writes the siphash key on every iteration.
+static std::unique_ptr<TxoSpenderIndex> MakeTxoSpenderIndex(TestChain100Setup& test_setup, bool f_memory)
+{
+    return std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(test_setup.m_node),
+                                             /*n_cache_size=*/1_MiB, f_memory, /*f_wipe=*/true);
+}
+
+// End-to-end sync of a TxoSpenderIndex: BaseIndex::Sync -> CustomAppend ->
+// WriteSpenderInfos.
+static void TxoSpenderIndexSync(benchmark::Bench& bench, bool f_memory)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK);
+
+    BenchIndexSync(bench, *test_setup, [&] { return MakeTxoSpenderIndex(*test_setup, f_memory); });
+}
+
+static void TxoSpenderIndexSyncDisk(benchmark::Bench& bench) { TxoSpenderIndexSync(bench, /*f_memory=*/false); }
+static void TxoSpenderIndexSyncMem(benchmark::Bench& bench) { TxoSpenderIndexSync(bench, /*f_memory=*/true); }
+
+// After a full sync, time FindSpender() over every spent outpoint in the chain.
+// See BenchIndexLookup() for what the number covers.
+static void TxoSpenderIndexLookup(benchmark::Bench& bench)
+{
+    const auto test_setup = MakeNoLogFileContext<TestChain100Setup>();
+    const int first_spend_height{
+        ExtendChainWithSpends(*test_setup, BENCH_INDEX_NUM_BLOCKS, BENCH_INDEX_TXS_PER_BLOCK)};
+
+    auto index{MakeTxoSpenderIndex(*test_setup, /*f_memory=*/false)};
+    Assert(index->Init());
+    index->Sync();
+    Assert(index->GetSummary().synced);
+
+    const std::vector<COutPoint> outpoints{CollectChainSpentOutpoints(*test_setup, first_spend_height)};
+
+    BenchIndexLookup(bench, outpoints, [&](const COutPoint& txo) {
+        const auto result{index->FindSpender(txo)};
+        return result && result->has_value();
+    });
+
+    index->Stop();
+}
+
+BENCHMARK(TxoSpenderIndexSyncDisk);
+BENCHMARK(TxoSpenderIndexSyncMem);
+BENCHMARK(TxoSpenderIndexLookup);


### PR DESCRIPTION
There is a fair amount of work going into the indices at the moment, and no cheap way to tell whether a change actually improves what it set out to improve: checking end to end means a full IBD. The only index benchmark in the tree, `BlockFilterIndexSync`, syncs coinbase-only blocks, so it cannot show anything that scales with what a block contains, and there is none at all for `TxIndex` or `TxoSpenderIndex`.

This adds shared helpers in `src/bench/index_sync_util.{h,cpp}` that build a chain of blocks with chained, validly-signed transactions (~2 inputs and ~2 outputs each, every output paying a distinct key), and on top of them, for txindex, txospenderindex and blockfilterindex:

- `<Index>SyncDisk` / `<Index>SyncMem` — full sync with the index database on the filesystem, and in memory.
- `<Index>Lookup` — one query per indexed key (`FindTx`, `FindSpender`).



How far apart Disk and Mem land depends on the data directory, which defaults to a tmpfs on many Linux systems. Pointing `-testdatadir` at real storage is what makes the difference the cost of the write path:

| Benchmark                           | tmpfs (default) | ext4 via `-testdatadir` |
| ----------------------------------- | --------------: | ----------------------: |
| `TxIndexSyncDisk`                   |          7.0 ms |                 18.1 ms |
| `TxIndexSyncMem`                    |          6.5 ms |                  6.8 ms |
| `TxIndexLookup`                     |         13.4 us |                 13.7 us |
| `TxoSpenderIndexSyncDisk`           |          8.3 ms |                 23.8 ms |
| `TxoSpenderIndexSyncMem`            |          7.8 ms |                  8.1 ms |
| `TxoSpenderIndexLookup`             |         13.8 us |                 14.1 us |
| `BlockFilterIndexSyncRealisticDisk` |         14.7 ms |                 31.0 ms |
| `BlockFilterIndexSyncRealisticMem`  |         13.8 ms |                 17.8 ms |

(this table has data from the old txindex implementation) 

The existing coinbase-only `BlockFilterIndexSync` is left untouched. The whole suite runs in well under a minute.

I have used this on those two pull requests, and in both the interesting number was one the existing benchmark could not produce: #35531 (5-byte siphash keys) trades a 49% smaller index on disk for a lookup regression that grows with index size, and #34489 (batch db writes) cuts `write` syscalls by 91% with CPU unchanged. The numbers are in those threads.




Disclosure: I used claude to help me in some parts, however all code has been verified by me and I ran the bench manually on the scenarios mentioned