### PR TITLE
argsman, cli: Allow options after non-option arguments (GNU-style)

### DIFF
--- a/doc/release-notes-35831.md
+++ b/doc/release-notes-35831.md
@@ -1,0 +1,14 @@
+### Tools and Utilities
+
+Command-line tools
+------------------
+
+- A dash-prefixed argument after a command is now parsed as an option (or an
+  error if unrecognized) rather than silently collected as a positional
+  argument (backwards compatibility). `bitcoin-cli` now supports GNU-style
+  option parsing: options (such as `-rpcwallet=<wallet>`) may be specified
+  after the command and its positional arguments, not only before. The `--`
+  separator can be used to explicitly end option processing; all subsequent
+  tokens are treated as positional arguments. `bitcoin-wallet` also benefits:
+  options such as `-wallet=<name>` may now be placed after the subcommand
+  (e.g. `bitcoin-wallet create -wallet=foo`).

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -220,6 +220,7 @@ static int AppInitRPC(int argc, char* argv[])
                 "\nIt can be used to query network information, manage wallets, create or broadcast transactions, and control the " CLIENT_NAME " server.\n"
                 "\nUse the \"help\" command to list all commands. Use \"help <command>\" to show help for that command.\n"
                 "The -named option allows you to specify parameters using the key=value format, eliminating the need to pass unused positional parameters.\n"
+                "[options] can be specified before or after <command>.\n"
                 "\n"
                 "Usage: bitcoin-cli [options] <command> [params]\n"
                 "or:    bitcoin-cli [options] -named <command> [name=value]...\n"
@@ -1342,7 +1343,7 @@ static void ParseError(const UniValue& error, std::string& strPrint, int& nRet)
             strPrint += ("error message:\n" + err_msg.get_str());
         }
         if (err_code.isNum() && err_code.getInt<int>() == RPC_WALLET_NOT_SPECIFIED) {
-            strPrint += " Or for the CLI, specify the \"-rpcwallet=<walletname>\" option before the command";
+            strPrint += " Or for the CLI, specify the \"-rpcwallet=<walletname>\" option before or after the command";
             strPrint += " (run \"bitcoin-cli -h\" for help or \"bitcoin-cli listwallets\" to see which wallets are currently loaded).";
         }
     } else {
@@ -1553,11 +1554,6 @@ static int CommandLineRPC(int argc, char *argv[])
     std::string strPrint;
     int nRet = 0;
     try {
-        // Skip switches
-        while (argc > 1 && IsSwitchChar(argv[1][0])) {
-            argc--;
-            argv++;
-        }
         std::string rpcPass;
         if (gArgs.GetBoolArg("-stdinrpcpass", false)) {
             NO_STDIN_ECHO();
@@ -1573,7 +1569,8 @@ static int CommandLineRPC(int argc, char *argv[])
             }
             gArgs.ForceSetArg("-rpcpassword", rpcPass);
         }
-        std::vector<std::string> args = std::vector<std::string>(&argv[1], &argv[argc]);
+        const auto cmd = gArgs.GetCommand();
+        std::vector<std::string> args = cmd ? cmd->args : std::vector<std::string>{};
         if (gArgs.GetBoolArg("-stdinwalletpassphrase", false)) {
             NO_STDIN_ECHO();
             std::string walletPass;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -797,35 +797,40 @@ static int CommandLineRawTx(int argc, char* argv[])
     std::string strPrint;
     int nRet = 0;
     try {
-        // Skip switches; Permit common stdin convention "-"
-        while (argc > 1 && IsSwitchChar(argv[1][0]) &&
-               (argv[1][1] != 0)) {
-            argc--;
-            argv++;
+        std::vector<std::string> args;
+        if (const auto command{gArgs.GetCommand()}) {
+            args = command->args;
+        } else {
+            // Parsing stops at "-", so fall back to argv to preserve stdin handling.
+            while (argc > 1 && IsSwitchChar(argv[1][0]) && argv[1][1] != 0) {
+                argc--;
+                argv++;
+            }
+            args.assign(argv + 1, argv + argc);
         }
 
         CMutableTransaction tx;
-        int startArg;
+        size_t startArg;
 
         if (!fCreateBlank) {
             // require at least one param
-            if (argc < 2)
+            if (args.empty())
                 throw std::runtime_error("too few parameters");
 
             // param: hex-encoded bitcoin transaction
-            std::string strHexTx(argv[1]);
+            std::string strHexTx(args[0]);
             if (strHexTx == "-")                 // "-" implies standard input
                 strHexTx = readStdin();
 
             if (!DecodeHexTx(tx, strHexTx, true))
                 throw std::runtime_error("invalid transaction encoding");
 
-            startArg = 2;
-        } else
             startArg = 1;
+        } else
+            startArg = 0;
 
-        for (int i = startArg; i < argc; i++) {
-            std::string arg = argv[i];
+        for (size_t i{startArg}; i < args.size(); ++i) {
+            const std::string& arg = args[i];
             std::string key, value;
             size_t eqpos = arg.find('=');
             if (eqpos == std::string::npos)

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -214,8 +214,51 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
             }
             m_command.push_back(key);
             while (++i < argc) {
-                // The remaining args are command args
-                m_command.emplace_back(argv[i]);
+                std::string cmd_arg(argv[i]);
+                // "--" ends option processing; all subsequent args are positional
+                if (cmd_arg == "--") {
+                    while (++i < argc) m_command.emplace_back(argv[i]);
+                    break;
+                }
+                // cmd_key is used only for option-name matching; cmd_arg preserves
+                // the original case so positional args are not corrupted on Windows.
+                std::string cmd_key = cmd_arg;
+#ifdef WIN32
+                cmd_key = ToLower(cmd_key);
+                // Unlike pre-command args (options only), post-command args can be
+                // file paths. Only treat /foo as -foo when there is no embedded
+                // slash, which distinguishes Windows options (/rpcwallet=foo) from
+                // paths (/bad/./path). Bare '/' is excluded by the size > 1 check.
+                if (cmd_key.size() > 1 && cmd_key[0] == '/' && cmd_key.find('/', 1) == std::string::npos)
+                    cmd_key[0] = '-';
+#endif
+                // Negative integers (e.g. -10, -3) are positional args, not options.
+                bool is_number = cmd_key.size() > 1 && cmd_key[1] != '-' &&
+                                 std::all_of(cmd_key.begin() + 1, cmd_key.end(), IsDigit);
+                bool is_option = !cmd_key.empty() && cmd_key[0] == '-' && !is_number;
+                if (is_option) {
+                    // Options after a command are parsed the same way as options
+                    // before a command — unrecognized options are always errors.
+                    std::optional<std::string> cmd_val;
+                    size_t eq = cmd_key.find('=');
+                    if (eq != std::string::npos) {
+                        cmd_val = cmd_arg.substr(eq + 1);
+                        cmd_key.erase(eq);
+                    }
+                    if (cmd_key.length() > 1 && cmd_key[1] == '-') cmd_key.erase(0, 1);
+                    cmd_key.erase(0, 1);
+                    KeyInfo keyinfo = InterpretKey(cmd_key);
+                    std::optional<unsigned int> flags = GetArgFlags_('-' + keyinfo.name);
+                    if (!flags || !keyinfo.section.empty()) {
+                        error = strprintf("Invalid parameter %s", argv[i]);
+                        return false;
+                    }
+                    std::optional<common::SettingsValue> value = InterpretValue(keyinfo, cmd_val ? &*cmd_val : nullptr, *flags, error);
+                    if (!value) return false;
+                    m_settings.command_line_options[keyinfo.name].push_back(*value);
+                } else {
+                    m_command.emplace_back(cmd_arg);
+                }
             }
             break;
         }

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -210,10 +210,56 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
                     return false;
                 }
             }
-            m_command.push_back(key);
+            // Preserve unregistered commands verbatim; key may have been normalized above.
+            m_command.push_back(m_accept_any_command ? std::string{argv[i]} : key);
             while (++i < argc) {
-                // The remaining args are command args
-                m_command.emplace_back(argv[i]);
+                std::string cmd_arg(argv[i]);
+                // "--" ends option processing; all subsequent args are positional
+                if (cmd_arg == "--") {
+                    while (++i < argc) m_command.emplace_back(argv[i]);
+                    break;
+                }
+                // cmd_key is used only for option-name matching; cmd_arg preserves
+                // the original case so positional args are not corrupted on Windows.
+                std::string cmd_key = cmd_arg;
+#ifdef WIN32
+                cmd_key = ToLower(cmd_key);
+                // Unlike pre-command args (options only), post-command args can be
+                // file paths. Only check the option name for embedded slashes, as
+                // the option value itself may be a path. This distinguishes Windows
+                // options (/rpcwallet=dir/wallet) from paths (/bad/./path). Bare '/'
+                // is excluded by the size > 1 check.
+                const auto option_name{cmd_key.substr(0, cmd_key.find('='))};
+                if (option_name.size() > 1 && option_name[0] == '/' && option_name.find('/', 1) == std::string::npos)
+                    cmd_key[0] = '-';
+#endif
+                // Negative integers (e.g. -10, -3) are positional args, not options.
+                bool is_number = cmd_key.size() > 1 && cmd_key[1] != '-' &&
+                                 std::all_of(cmd_key.begin() + 1, cmd_key.end(), IsDigit);
+                bool is_option = cmd_key.size() > 1 && cmd_key[0] == '-' && !is_number;
+                if (is_option) {
+                    // Options after a command are parsed the same way as options
+                    // before a command — unrecognized options are always errors.
+                    std::optional<std::string> cmd_val;
+                    size_t eq = cmd_key.find('=');
+                    if (eq != std::string::npos) {
+                        cmd_val = cmd_arg.substr(eq + 1);
+                        cmd_key.erase(eq);
+                    }
+                    if (cmd_key.length() > 1 && cmd_key[1] == '-') cmd_key.erase(0, 1);
+                    cmd_key.erase(0, 1);
+                    KeyInfo keyinfo = InterpretKey(cmd_key);
+                    std::optional<unsigned int> flags = GetArgFlags_('-' + keyinfo.name);
+                    if (!flags || !keyinfo.section.empty()) {
+                        error = strprintf("Invalid parameter %s", argv[i]);
+                        return false;
+                    }
+                    std::optional<common::SettingsValue> value = InterpretValue(keyinfo, cmd_val ? &*cmd_val : nullptr, *flags, error);
+                    if (!value) return false;
+                    m_settings.command_line_options[keyinfo.name].push_back(*value);
+                } else {
+                    m_command.emplace_back(cmd_arg);
+                }
             }
             break;
         }

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -188,20 +188,28 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
         if (key.starts_with("-psn_")) continue;
 #endif
 
-        if (key == "-") break; //bitcoin-tx using stdin
+        bool options_ended{false};
+        if (key == "--") {
+            options_ended = true;
+            if (++i >= argc) break;
+            key = argv[i];
+        }
+        if (!options_ended && key == "-") break; //bitcoin-tx using stdin
         std::optional<std::string> val;
-        size_t is_index = key.find('=');
-        if (is_index != std::string::npos) {
-            val = key.substr(is_index + 1);
-            key.erase(is_index);
+        if (!options_ended) {
+            size_t is_index = key.find('=');
+            if (is_index != std::string::npos) {
+                val = key.substr(is_index + 1);
+                key.erase(is_index);
+            }
         }
 #ifdef WIN32
         key = ToLower(key);
-        if (key[0] == '/')
+        if (!options_ended && key[0] == '/')
             key[0] = '-';
 #endif
 
-        if (key[0] != '-') {
+        if (options_ended || key[0] != '-') {
             if (!m_accept_any_command && m_command.empty()) {
                 // The first non-dash arg is a registered command
                 std::optional<unsigned int> flags = GetArgFlags_(key);
@@ -212,6 +220,10 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
             }
             // Preserve unregistered commands verbatim; key may have been normalized above.
             m_command.push_back(m_accept_any_command ? std::string{argv[i]} : key);
+            if (options_ended) {
+                while (++i < argc) m_command.emplace_back(argv[i]);
+                break;
+            }
             while (++i < argc) {
                 std::string cmd_arg(argv[i]);
                 // "--" ends option processing; all subsequent args are positional

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -826,6 +826,38 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters_gnu_style)
     }
 #endif
 
+    // "--" also ends option processing before the command.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "--", "cmd", "-not-an-option", "arg2"};
+        BOOST_CHECK(test.ParseParameters(5, argv, error));
+        BOOST_CHECK(!test.IsArgSet("-opt"));
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_CHECK_EQUAL(cmd->command, "cmd");
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 2U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "-not-an-option");
+        BOOST_CHECK_EQUAL(cmd->args[1], "arg2");
+    }
+
+    // Options before "--" are parsed; the first positional argument after
+    // it may begin with a dash.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        std::string error;
+        const char* argv[] = {"x", "-opt", "--", "-1"};
+        BOOST_CHECK(test.ParseParameters(4, argv, error));
+        BOOST_CHECK(test.IsArgSet("-opt"));
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_CHECK(cmd->command.empty());
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 1U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "-1");
+    }
 }
 
 BOOST_AUTO_TEST_CASE(util_AddCommand_clearargs_replaces_command_options)

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -214,14 +214,14 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
 
     BOOST_CHECK(testArgs.ParseParameters(7, argv_test, error));
     // expectation: -ignored is ignored (program name argument),
-    // -a, -b and -ccc end up in map, -d ignored because it is after
-    // a non-option argument (non-GNU option parsing)
+    // -a, -b, -ccc and -d end up in map (GNU-style: options are parsed
+    // even after non-option argument "f")
     BOOST_CHECK(testArgs.IsArgSet("-a") && testArgs.IsArgSet("-b") && testArgs.IsArgSet("-ccc")
-                && !testArgs.IsArgSet("f") && !testArgs.IsArgSet("-d"));
+                && !testArgs.IsArgSet("f") && testArgs.IsArgSet("-d"));
     testArgs.LockSettings([&](const common::Settings& s) {
-        BOOST_CHECK(s.command_line_options.size() == 3 && s.ro_config.empty());
+        BOOST_CHECK(s.command_line_options.size() == 4 && s.ro_config.empty());
         BOOST_CHECK(s.command_line_options.contains("a") && s.command_line_options.contains("b") && s.command_line_options.contains("ccc")
-                    && !s.command_line_options.contains("f") && !s.command_line_options.contains("d"));
+                    && !s.command_line_options.contains("f") && s.command_line_options.contains("d"));
 
         BOOST_CHECK(s.command_line_options.at("a").size() == 1);
         BOOST_CHECK(s.command_line_options.at("a").front().get_str() == "");
@@ -669,9 +669,10 @@ BOOST_AUTO_TEST_CASE(util_AddCommand)
     };
 
     BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "-opt1=foo", "cmd1"}));
-    BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "cmd1", "-opt1=foo"})); // things after the command are "args" and left unparsed, not options
+    BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "cmd1", "-opt1=foo"})); // parsed as option after command; -opt1 is invalid for cmd1
 
     BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "-opt1=foo", "cmd2"}));
+    BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "cmd2", "-opt1=foo"})); // opt1 after command; valid for cmd2
     BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "-opt1=foo", "cmd3"}));
     BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "-opt2=foo", "cmd1"}));
     BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "-opt2=foo", "cmd2"}));
@@ -687,6 +688,104 @@ BOOST_AUTO_TEST_CASE(util_AddCommand)
     BOOST_CHECK_EQUAL(PARSE_FAIL, testfn(std::array{"x", "cmd4"}));
     BOOST_CHECK_EQUAL(NO_COMMAND, testfn(std::array{"x", "-opt3=foo"}));
     BOOST_CHECK_EQUAL(PARSE_FAIL, testfn(std::array{"x", "-opt4=foo"}));
+}
+
+BOOST_AUTO_TEST_CASE(util_ParseParameters_gnu_style)
+{
+    // GNU-style parsing: options are recognized after non-option arguments.
+    // Unrecognized options are always errors; use "--" to pass positional
+    // arguments that begin with a dash.
+
+    // Valid option after command is stored normally.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "-opt=val"};
+        BOOST_CHECK(test.ParseParameters(3, argv, error));
+        BOOST_CHECK_EQUAL(test.GetArg("-opt", ""), "val");
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_CHECK_EQUAL(cmd->command, "cmd");
+        BOOST_CHECK(cmd->args.empty());
+    }
+
+    // Unrecognized option after command is an error (not silently treated as positional).
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "-unknown"};
+        BOOST_CHECK(!test.ParseParameters(3, argv, error));
+        BOOST_CHECK_EQUAL(error, "Invalid parameter -unknown");
+    }
+
+    // "--" ends option processing; everything after is a positional arg,
+    // even arguments beginning with a dash.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "--", "-not-an-option", "arg2"};
+        BOOST_CHECK(test.ParseParameters(5, argv, error));
+        BOOST_CHECK(!test.IsArgSet("-opt"));
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_CHECK_EQUAL(cmd->command, "cmd");
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 2U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "-not-an-option");
+        BOOST_CHECK_EQUAL(cmd->args[1], "arg2");
+    }
+
+    // Options and positional args can be freely mixed after a command.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "arg1", "-opt=val", "arg2"};
+        BOOST_CHECK(test.ParseParameters(5, argv, error));
+        BOOST_CHECK_EQUAL(test.GetArg("-opt", ""), "val");
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 2U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "arg1");
+        BOOST_CHECK_EQUAL(cmd->args[1], "arg2");
+    }
+
+    // Negative numbers after a command are positional args, not options.
+    {
+        TestArgsManager test;
+        test.SetupArgs({});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "-10", "-3"};
+        BOOST_CHECK(test.ParseParameters(4, argv, error));
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 2U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "-10");
+        BOOST_CHECK_EQUAL(cmd->args[1], "-3");
+    }
+
+#ifdef WIN32
+    // On Windows, /option and -OPTION are equivalent to -option after a command.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "/OPT=val"};
+        BOOST_CHECK(test.ParseParameters(3, argv, error));
+        BOOST_CHECK_EQUAL(test.GetArg("-opt", ""), "val");
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_CHECK(cmd->args.empty());
+    }
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(util_AddCommand_clearargs_replaces_command_options)

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -216,21 +216,21 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
 
     BOOST_CHECK(testArgs.ParseParameters(7, argv_test, error));
     // expectation: -ignored is ignored (program name argument),
-    // -a, -b and -ccc end up in map, -d ignored because it is after
-    // a non-option argument (non-GNU option parsing)
+    // -a, -b, -ccc and -d end up in map (GNU-style: options are parsed
+    // even after non-option argument "f")
     BOOST_CHECK(testArgs.IsArgSet("-a"));
     BOOST_CHECK(testArgs.IsArgSet("-b"));
     BOOST_CHECK(testArgs.IsArgSet("-ccc"));
     BOOST_CHECK(!testArgs.IsArgSet("f"));
-    BOOST_CHECK(!testArgs.IsArgSet("-d"));
+    BOOST_CHECK(testArgs.IsArgSet("-d"));
     testArgs.LockSettings([&](const common::Settings& s) {
-        BOOST_CHECK(s.command_line_options.size() == 3);
+        BOOST_CHECK(s.command_line_options.size() == 4);
         BOOST_CHECK(s.ro_config.empty());
         BOOST_CHECK(s.command_line_options.contains("a"));
         BOOST_CHECK(s.command_line_options.contains("b"));
         BOOST_CHECK(s.command_line_options.contains("ccc"));
         BOOST_CHECK(!s.command_line_options.contains("f"));
-        BOOST_CHECK(!s.command_line_options.contains("d"));
+        BOOST_CHECK(s.command_line_options.contains("d"));
 
         BOOST_CHECK(s.command_line_options.at("a").size() == 1);
         BOOST_CHECK(s.command_line_options.at("a").front().get_str() == "");
@@ -679,9 +679,10 @@ BOOST_AUTO_TEST_CASE(util_AddCommand)
     };
 
     BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "-opt1=foo", "cmd1"}));
-    BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "cmd1", "-opt1=foo"})); // things after the command are "args" and left unparsed, not options
+    BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "cmd1", "-opt1=foo"})); // parsed as option after command; -opt1 is invalid for cmd1
 
     BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "-opt1=foo", "cmd2"}));
+    BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "cmd2", "-opt1=foo"})); // opt1 after command; valid for cmd2
     BOOST_CHECK_EQUAL(SUCCESS, testfn(std::array{"x", "-opt1=foo", "cmd3"}));
     BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "-opt2=foo", "cmd1"}));
     BOOST_CHECK_EQUAL(COMMAND_OPTS, testfn(std::array{"x", "-opt2=foo", "cmd2"}));
@@ -697,6 +698,134 @@ BOOST_AUTO_TEST_CASE(util_AddCommand)
     BOOST_CHECK_EQUAL(PARSE_FAIL, testfn(std::array{"x", "cmd4"}));
     BOOST_CHECK_EQUAL(NO_COMMAND, testfn(std::array{"x", "-opt3=foo"}));
     BOOST_CHECK_EQUAL(PARSE_FAIL, testfn(std::array{"x", "-opt4=foo"}));
+}
+
+BOOST_AUTO_TEST_CASE(util_ParseParameters_gnu_style)
+{
+    // GNU-style parsing: options are recognized after non-option arguments.
+    // Unrecognized options are always errors; use "--" to pass positional
+    // arguments that begin with a dash.
+
+    // Valid option after command is stored normally.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "-opt=val"};
+        BOOST_CHECK(test.ParseParameters(3, argv, error));
+        BOOST_CHECK_EQUAL(test.GetArg("-opt", ""), "val");
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_CHECK_EQUAL(cmd->command, "cmd");
+        BOOST_CHECK(cmd->args.empty());
+    }
+
+    // The first positional argument is preserved exactly.
+    {
+        TestArgsManager test;
+        test.SetupArgs({});
+        std::string error;
+        const char* argv[] = {"x", "cmd=val"};
+        BOOST_CHECK(test.ParseParameters(2, argv, error));
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 1U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "cmd=val");
+    }
+
+    // Unrecognized option after command is an error (not silently treated as positional).
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "-unknown"};
+        BOOST_CHECK(!test.ParseParameters(3, argv, error));
+        BOOST_CHECK_EQUAL(error, "Invalid parameter -unknown");
+    }
+
+    // "--" ends option processing; everything after is a positional arg,
+    // even arguments beginning with a dash.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "--", "-not-an-option", "arg2"};
+        BOOST_CHECK(test.ParseParameters(5, argv, error));
+        BOOST_CHECK(!test.IsArgSet("-opt"));
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_CHECK_EQUAL(cmd->command, "cmd");
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 2U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "-not-an-option");
+        BOOST_CHECK_EQUAL(cmd->args[1], "arg2");
+    }
+
+    // Options and positional args can be freely mixed after a command.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "arg1", "-opt=val", "arg2"};
+        BOOST_CHECK(test.ParseParameters(5, argv, error));
+        BOOST_CHECK_EQUAL(test.GetArg("-opt", ""), "val");
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 2U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "arg1");
+        BOOST_CHECK_EQUAL(cmd->args[1], "arg2");
+    }
+
+    // A lone hyphen after a command is a positional argument, not an option.
+    {
+        TestArgsManager test;
+        test.SetupArgs({});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "-"};
+        BOOST_CHECK(test.ParseParameters(3, argv, error));
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 1U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "-");
+    }
+
+    // Negative numbers after a command are positional args, not options.
+    {
+        TestArgsManager test;
+        test.SetupArgs({});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "-10", "-3"};
+        BOOST_CHECK(test.ParseParameters(4, argv, error));
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 2U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "-10");
+        BOOST_CHECK_EQUAL(cmd->args[1], "-3");
+    }
+
+#ifdef WIN32
+    // On Windows, slash options may have path values, while slash-prefixed paths
+    // remain positional arguments.
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-opt", ArgsManager::ALLOW_ANY}});
+        test.AddCommand("cmd", "test command");
+        std::string error;
+        const char* argv[] = {"x", "cmd", "/OPT=C:/bitcoin", "/bad/./path"};
+        BOOST_CHECK(test.ParseParameters(4, argv, error));
+        BOOST_CHECK_EQUAL(test.GetArg("-opt", ""), "C:/bitcoin");
+        const auto cmd = test.GetCommand();
+        BOOST_REQUIRE(cmd);
+        BOOST_REQUIRE_EQUAL(cmd->args.size(), 1U);
+        BOOST_CHECK_EQUAL(cmd->args[0], "/bad/./path");
+    }
+#endif
+
 }
 
 BOOST_AUTO_TEST_CASE(util_AddCommand_clearargs_replaces_command_options)

--- a/test/functional/data/util/bitcoin-util-test.json
+++ b/test/functional/data/util/bitcoin-util-test.json
@@ -89,6 +89,11 @@
     "description": "Creates a blank v1 transaction (output in json)"
   },
   { "exec": "./bitcoin-tx",
+    "args": ["01000000000000000000", "-json"],
+    "output_cmp": "blanktxv1.json",
+    "description": "Parses an option after a transaction hex"
+  },
+  { "exec": "./bitcoin-tx",
     "args": ["-"],
     "input": "blanktxv2.hex",
     "output_cmp": "blanktxv2.hex",

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -34,7 +34,7 @@ WALLET_NOT_LOADED = 'Requested wallet does not exist or is not loaded'
 WALLET_NOT_SPECIFIED = (
     "Multiple wallets are loaded. Please select which wallet to use by requesting the RPC "
     "through the /wallet/<walletname> URI path. Or for the CLI, specify the \"-rpcwallet=<walletname>\" "
-    "option before the command (run \"bitcoin-cli -h\" for help or \"bitcoin-cli listwallets\" to see "
+    "option before or after the command (run \"bitcoin-cli -h\" for help or \"bitcoin-cli listwallets\" to see "
     "which wallets are currently loaded)."
 )
 
@@ -381,6 +381,7 @@ class TestBitcoinCli(BitcoinTestFramework):
             self.nodes[0].loadwallet(wallets[2])
             n3 = 4
             n4 = 10
+            n5 = 5
             blocks = self.nodes[0].getblockcount()
 
             self.log.info('Test -generate -rpcwallet=<filename> raise RPC error')
@@ -415,9 +416,15 @@ class TestBitcoinCli(BitcoinTestFramework):
             assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 'foo').echo)
             assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 0).echo)
             assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 1, 2, 3).echo)
+
+            self.log.info('Test -rpcwallet specified after the command and its arguments (GNU-style)')
+            generate = self.nodes[0].cli('-generate', n5, 1000000, rpcwallet2).send_cli()
+            assert_equal(set(generate.keys()), {'address', 'blocks'})
+            assert_equal(len(generate["blocks"]), n5)
+            assert_equal(self.nodes[0].getblockcount(), blocks + 1 + n3 + n4 + n5)
         else:
             self.log.info("*** Wallet not compiled; cli getwalletinfo and -getinfo wallet tests skipped")
-            self.generate(self.nodes[0], 25)  # maintain block parity with the wallet_compiled conditional branch
+            self.generate(self.nodes[0], 30)  # maintain block parity with the wallet_compiled conditional branch
 
         self.test_netinfo()
 
@@ -443,7 +450,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         self.nodes[0].wait_for_cookie_credentials()  # ensure cookie file is available to avoid race condition
         blocks = self.nodes[0].cli('-rpcwait').send_cli('getblockcount')
         self.nodes[0].wait_for_rpc_connection()
-        assert_equal(blocks, BLOCKS + 25)
+        assert_equal(blocks, BLOCKS + 30)
 
         self.log.info("Test -rpcwait option waits at most -rpcwaittimeout seconds for startup")
         self.stop_node(0)  # stop the node so we time out


### PR DESCRIPTION
Allow options to be specified after non-option arguments in `ParseParameters`, matching GNU option parsing conventions (`getopt_long` style).                                                                            
                                                                                                                                                               
Currently in `master`, once the first non-dash argument was encountered, all subsequent arguments were collected verbatim into `m_command`. This meant `-rpcwallet` and similar options were silently ignored when placed after a command or its positional args. The same misspelled option before the command  would be a clear error; after the command, it was silently treated as a positional argument — potentially triggering unintended RPC behaviour.
                                                                                                
**_With this change_**:
- Valid options after a command are stored in `command_line_options` exactly as if they appeared before the command.
- Unrecognized options after a command are always errors (no silent fallback to positional).
- A `--` separator stops option processing; all subsequent arguments are treated as positional regardless of leading dashes.
- `bitcoin-cli`'s `CommandLineRPC` is updated to derive its args vector from `gArgs.GetCommand()` rather than re-scanning raw `argv`.
- `bitcoin-wallet` benefits automatically: options such as `-wallet` placed after a command are now parsed correctly instead of being rejected as unexpected positional arguments.
                                                                                                                                                               
<details>
<summary><i><ins>Before and after:</ins></i> options after a command are now recognized...</summary>                                                       

<br>

**`-rpcwallet` after the command and its positional args:**

- Before (`master`) — `-rpcwallet` is silently ignored; request goes to the wrong wallet:                                                                    

    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc listtransactions -rpcwallet=nonExistent                                                                           
    [                                                                                                                                                          
    ]                                                                                                                                                          
    ```                                                                                                                                                        
                                                                                                                                                               
- After — correctly routes to the named wallet and fails with the expected error:                                                                            
    
    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc listtransactions -rpcwallet=nonExistent                                                                           
    error code: -18                                                                                                                                            
    error message:                                                                                                                                             
    Requested wallet does not exist or is not loaded                                                                                                           
    ```

---                                                                                                                                                        

**`getaddressinfo` with `-rpcwallet` appended:**                                                                                        
  
- Before (`master`) — `-rpcwallet` becomes an extra positional arg; `getaddressinfo` errors with its usage string:
    
    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc getaddressinfo bcrt1q... -rpcwallet=nonExistent                                                                   
    error message:                                                                                                                                             
    getaddressinfo "address"                                                                                                                                   
    ...                                                                                                                                                        
    ```                                                                                                                                                        
    
- After — wallet is correctly selected:
    
    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc getaddressinfo bcrt1q... -rpcwallet=nonExistent                                                                   
    error code: -18                                                                                                                                            
    error message:                                                                                                                                             
    Requested wallet does not exist or is not loaded                                                                                                           
    ```

---                                                                                                                                                        
                                                                                                                                                               
**Multi-wallet: `-rpcwallet` no longer needs to come before the command:**                                                                                 
                                                                                                                                                               
- Before (`master`):                                                                                                                                         

    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc listtransactions                                                                                                  
    error code: -19                                                                                                                                            
    error message:                                                                                                                                             
    ...specify the "-rpcwallet=<walletname>" option before the command...                                                                                      
    ```                                                                                                                                                        

    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc listtransactions -rpcwallet=mywallet                                                                              
    error code: -19   ← still fails; option after command was ignored                                                                                          
    error message:                                                                                                                                             
    ...specify the "-rpcwallet=<walletname>" option before the command...                                                                                      
    ```                                                                                                                                                        
                                                                                                                                                               
- After:                                                                                                                                                     
    
    — error message updated:
    ```
    $ bitcoin-cli -regtest -datadir=/tmp/btc listtransactions
    error code: -19
    error message:  
    ...specify the "-rpcwallet=<walletname>" option before or after the command...
    ```
    
    — command executed successfully:
    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc listtransactions -rpcwallet=mywallet                                                                              
    [                                                                                                                                                          
      { "address": "bcrt1q...", "category": "immature", "amount": 50.00000000, ... }                                                                                 
    ]                                                                                                                                                          
    ```

</details>                                                                                                                                                 

<details>                                                                                                                                                  
<summary><i><ins>Before and after:</ins></i> misspelled options and the <code>--</code> separator...</summary>                                             
                                                                                                                                                               
<br>

**Misspelled option is now an error rather than a silent positional arg:**                                                                                 

Before (`master`) — `-rpcwalllet ` (note triple-l) silently absorbed as the `label` positional arg:                                                                        
    
    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc listtransactions <hash> -rpcwalllet=foo                                                                                   
    { ... }   ← result returned, -rpcwallet went unnoticed                                                                                                     
    ```                                                                                                                                                        
                                                                                                                                                               
After:                                                                                                                                                     
    
    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc getblock <hash> -rpcwalllet=foo                                                                                   
    error: Invalid parameter -rpcwalllet                                                                                                                       
    ```                                                                                                                                                        
                                                                                                                                                               
---

**`--` separator: pass a dash-prefixed string as a positional RPC argument:**                                                                              
                                                                                                                                                               
    ```                                                                                                                                                        
    $ bitcoin-cli -regtest -datadir=/tmp/btc somecommand -- -not-an-option                                                                                     
    ```

    Everything after `--` is treated as a positional argument, so `-not-an-option` is passed to the RPC unchanged.

</details>

<details>
<summary><i><ins>Before and after:</ins></i> <code>bitcoin-wallet</code> commands...</summary>

<br>

**`-wallet` option placed after the command:**

Before (`master`) — option treated as an unexpected positional arg:

```
    $ bitcoin-wallet -regtest -datadir=/tmp/btc create -wallet=myWallet
    Error: Additional arguments provided (-wallet=myWallet). Methods do not take arguments. Please refer to -help.
```

After:

```
    $ bitcoin-wallet -regtest -datadir=/tmp/btc create -wallet=myWallet
    Topping up keypool...
    Wallet info

    Name: myWallet
    Format: sqlite
    Descriptors: yes
    Encrypted: no
    HD (hd seed available): yes
    Keypool Size: 8000
    Transactions: 0
    Address Book: 0
```

</details>

---

**Backwards compatibility**: command lines where a dash-prefixed argument follows a non-dash argument will now be parsed as an option (if recognized) or an error (if not). Previously such arguments were silently collected as positional args. The `--` separator can be used to pass arguments that begin with a dash as positional args.