### PR TITLE
p2p: avoid block disk reads on unnecessary requests

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4345,6 +4345,14 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     if (msg_type == NetMsgType::GETBLOCKTXN) {
         BlockTransactionsRequest req;
         vRecv >> req;
+
+        // No legitimate reason to send indexes empty
+        if (req.indexes.empty()) {
+            LogDebug(BCLog::NET, "getblocktxn received with no transaction indexes, %s", pfrom.DisconnectMsg());
+            pfrom.fDisconnect = true;
+            return;
+        }
+
         // Verify differential encoding invariant: indexes must be strictly increasing
         // DifferenceFormatter should guarantee this property during deserialization
         for (size_t i = 1; i < req.indexes.size(); ++i) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2365,6 +2365,14 @@ void PeerManagerImpl::RelayAddress(NodeId originator,
 
 void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& inv)
 {
+    // First perform the stateless checks:
+    // A filtered-block can only ever be requested if we offer NODE_BLOOM
+    if (inv.IsMsgFilteredBlk() && !(peer.m_our_services & NODE_BLOOM)) {
+        LogDebug(BCLog::NET, "filtered block request received when NODE_BLOOM service disabled, %s", pfrom.DisconnectMsg());
+        pfrom.fDisconnect = true;
+        return;
+    }
+
     std::shared_ptr<const CBlock> a_recent_block;
     std::shared_ptr<const CBlockHeaderAndShortTxIDs> a_recent_compact_block;
     {

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -843,6 +843,17 @@ class CompactBlocksTest(BitcoinTestFramework):
         msg = msg_cmpctblock(comp_block.to_p2p())
         test_node.send_await_disconnect(msg)
 
+    def test_empty_getblocktxn_disconnects(self):
+        self.log.info("Testing empty getblocktxn disconnects the peer...")
+        node = self.nodes[0]
+        block_hash = int(node.getbestblockhash(), 16)
+        peer = node.add_p2p_connection(P2PInterface())
+        msg = msg_getblocktxn()
+        msg.block_txn_request = BlockTransactionsRequest(blockhash=block_hash, indexes=[])
+        with node.assert_debug_log(['getblocktxn received with no transaction indexes']):
+            peer.send_without_ping(msg)
+            peer.wait_for_disconnect()
+
     # peer generates a block and sends it to node, which makes the peer a
     # candidate for high-bandwidth 'to' (up to 3 peers according to BIP 152)
     def make_peer_hb_to_candidate(self, node, peer):
@@ -1097,6 +1108,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         self.log.info("Testing handling of invalid compact blocks...")
         self.test_invalid_tx_in_compactblock(self.segwit_node)
+        self.test_empty_getblocktxn_disconnects()
 
         # The previous test will lead to a disconnection. Reconnect before continuing.
         self.segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn())

--- a/test/functional/p2p_getdata.py
+++ b/test/functional/p2p_getdata.py
@@ -26,7 +26,7 @@ class GetdataTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
 
-    def run_test(self):
+    def test_invalid_getdata(self):
         p2p_block_store = self.nodes[0].add_p2p_connection(P2PStoreBlock())
 
         self.log.info("test that an invalid GETDATA doesn't prevent processing of future messages")
@@ -42,6 +42,10 @@ class GetdataTest(BitcoinTestFramework):
         good_getdata.inv.append(CInv(t=2, h=best_block))
         p2p_block_store.send_and_ping(good_getdata)
         p2p_block_store.wait_until(lambda: p2p_block_store.blocks[best_block] == 1)
+
+
+    def run_test(self):
+        self.test_invalid_getdata()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_nobloomfilter_messages.py
+++ b/test/functional/p2p_nobloomfilter_messages.py
@@ -11,7 +11,7 @@ Test that, when bloom filters are not enabled, peers are disconnected if:
 4. They send a p2p filterclear message
 """
 
-from test_framework.messages import msg_mempool, msg_filteradd, msg_filterload, msg_filterclear
+from test_framework.messages import msg_mempool, msg_filteradd, msg_filterload, msg_filterclear, CInv, MSG_FILTERED_BLOCK, msg_getdata
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -42,6 +42,10 @@ class P2PNoBloomFilterMessages(BitcoinTestFramework):
 
         self.log.info("Test that peer is disconnected if it sends a filterclear message")
         self.test_message_causes_disconnect(msg_filterclear())
+
+        self.log.info("Test that peer is disconnected if it requests a filtered block")
+        with self.nodes[0].assert_debug_log(['filtered block request received when NODE_BLOOM service disabled']):
+            self.test_message_causes_disconnect(msg_getdata([CInv(MSG_FILTERED_BLOCK, int(self.nodes[0].getbestblockhash(), 16))]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reject requests that make the node read blocks from disk unnecessarily:

* `getblocktxn` is meant to request the txs a peer is missing. When a
  peer sends a `getblocktxn` with an empty index vector, it isn't missing
  anything, so it shouldn't have sent the message in the first place.

* The peer should not request a filtered block when the node does not
  advertise the `NODE_BLOOM` service. Filtered blocks are built from
  the bloom filter, which can be loaded only when the `NODE_BLOOM`
  service is offered.

Both are disconnected now.

Note: can be split in two PRs if preferred.