### PR TITLE
test: add CONST_SCRIPTCODE failure-path vectors to script_tests.json

### DIFF
--- a/src/test/data/script_tests.json
+++ b/src/test/data/script_tests.json
@@ -2757,5 +2757,16 @@
 ["0 0x09 0x300602010102010101 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", "0x01 0x14 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0x01 0x14 CHECKMULTISIG NOT", "DERSIG", "OK", "BIP66-compliant but not NULLFAIL-compliant"],
 ["0 0x09 0x300602010102010101 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", "0x01 0x14 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0x01 0x14 CHECKMULTISIG NOT", "DERSIG,NULLFAIL", "NULLFAIL", "BIP66-compliant but not NULLFAIL-compliant"],
 
+["CONST_SCRIPTCODE tests"],
+["OP_CODESEPARATOR in a pre-segwit script and a signature push found in the scriptCode"],
+["are rejected with their own error codes when the CONST_SCRIPTCODE flag is set. Both"],
+["checks run before any signature verification, so the signatures never have to be valid."],
+["1", "CODESEPARATOR", "CONST_SCRIPTCODE", "OP_CODESEPARATOR", "OP_CODESEPARATOR in an executed pre-segwit script"],
+["0", "IF CODESEPARATOR ENDIF 1", "CONST_SCRIPTCODE", "OP_CODESEPARATOR", "OP_CODESEPARATOR is rejected even in an unexecuted branch"],
+["0", "IF CODESEPARATOR ENDIF 1", "", "OK", "Without CONST_SCRIPTCODE, OP_CODESEPARATOR in an unexecuted branch is allowed"],
+["0x02 0x0001", "0x02 0x0001 DROP 0x21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 CHECKSIG", "CONST_SCRIPTCODE", "SIG_FINDANDDELETE", "CHECKSIG fails when the signature push is found in the scriptCode"],
+["0 0x02 0x0001", "0x02 0x0001 DROP 1 0x21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 1 CHECKMULTISIG", "CONST_SCRIPTCODE", "SIG_FINDANDDELETE", "CHECKMULTISIG fails when a signature push is found in the scriptCode"],
+["0x02 0x0001", "0x02 0x0001 DROP 0x21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 CHECKSIG NOT", "", "OK", "Without CONST_SCRIPTCODE, FindAndDelete silently drops the signature push from the scriptCode"],
+
 ["The End"]
 ]


### PR DESCRIPTION
Follow-up to #35664.

Going through which script error codes `script_tests.json` covers, I found that neither error gated behind `SCRIPT_VERIFY_CONST_SCRIPTCODE` is asserted anywhere. `SCRIPT_ERR_SIG_FINDANDDELETE` is not asserted by any test; `SCRIPT_ERR_OP_CODESEPARATOR` appears only as a mempool reject string in `invalid_txs.py`, never at the script level. `tx_invalid.json` does have a `CONST_SCRIPTCODE` section, but those vectors can only say a transaction is invalid, not which error made it fail; `script_tests.json` is the harness that pins error codes, and it has no vector using the flag.

This adds six vectors. Four fail with the flag set:

- `OP_CODESEPARATOR` in an executed pre-segwit script.
- `OP_CODESEPARATOR` in an unexecuted `IF` branch. The check in `EvalScript` runs ahead of the `fExec` guard, so the opcode is rejected even though it never executes — the rule with no error-level coverage before.
- A signature push that also appears in the scriptPubKey, against `CHECKSIG`.
- The same against `CHECKMULTISIG`, which calls `FindAndDelete` in a separate loop.

The other two are controls with the flag off, one per error. Both checks run before signature verification, so the vectors can use a dummy signature.

To confirm the expected errors are the ones that fire, I added the vectors expecting `OK` first and let the harness report the actual error for each.

Tested with:

```
build/bin/test_bitcoin --run_test=script_tests/script_json_test
```
