### PR TITLE
rpc: fail scanblocks when block filter range is unavailable

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2671,6 +2671,10 @@ static RPCMethod scanblocks()
         g_scanfilter_progress_height = start_block_height;
         bool completed = true;
 
+        // Only used to classify a failed range lookup below; the requested range
+        // may be available even while the index is behind the tip.
+        const bool index_ready = index->BlockUntilSyncedToCurrentChain();
+
         const CBlockIndex* end_range = nullptr;
         do {
             node.rpc_interruption_point(); // allow a clean shutdown
@@ -2685,21 +2689,26 @@ static RPCMethod scanblocks()
                     WITH_LOCK(::cs_main, return chainman.ActiveChain()[start_block + amount_per_chunk]) :
                     stop_block;
 
-            if (index->LookupFilterRange(start_block, end_range, filters)) {
-                for (const BlockFilter& filter : filters) {
-                    // compare the elements-set with each filter
-                    if (filter.GetFilter().MatchAny(needle_set)) {
-                        if (filter_false_positives) {
-                            // Double check the filter matches by scanning the block
-                            const CBlockIndex& blockindex = *CHECK_NONFATAL(WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(filter.GetBlockHash())));
+            if (!index->LookupFilterRange(start_block, end_range, filters)) {
+                // Report the failure like getblockfilter: still indexing vs. corruption.
+                if (!index_ready) {
+                    throw JSONRPCError(RPC_MISC_ERROR, "Block filters are still in the process of being indexed.");
+                }
+                throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to read block filter range. This error is unexpected and indicates index corruption.");
+            }
+            for (const BlockFilter& filter : filters) {
+                // compare the elements-set with each filter
+                if (filter.GetFilter().MatchAny(needle_set)) {
+                    if (filter_false_positives) {
+                        // Double check the filter matches by scanning the block
+                        const CBlockIndex& blockindex = *CHECK_NONFATAL(WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(filter.GetBlockHash())));
 
-                            if (!CheckBlockFilterMatches(chainman.m_blockman, blockindex, needle_set)) {
-                                continue;
-                            }
+                        if (!CheckBlockFilterMatches(chainman.m_blockman, blockindex, needle_set)) {
+                            continue;
                         }
-
-                        blocks.push_back(filter.GetBlockHash().GetHex());
                     }
+
+                    blocks.push_back(filter.GetBlockHash().GetHex());
                 }
             }
             start_index = end_range;

--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -13,6 +13,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    JSONRPCException,
 )
 from test_framework.wallet import (
     MiniWallet,
@@ -136,6 +137,64 @@ class ScanblocksTest(BitcoinTestFramework):
 
         # test that null scanobjects is rejected for start
         assert_raises_rpc_error(-1, "scanobjects argument is required for the start action", node.scanblocks, "start", None)
+
+        self.test_scanblocks_unindexed_range()
+
+    def test_scanblocks_unindexed_range(self):
+        """scanblocks must not silently skip ranges the filter index has not written yet.
+
+        Like getblockfilter, a scan succeeds when the requested range is already
+        available even if the index is still behind the tip, and it errors (instead
+        of silently skipping the range and still reporting completed=true) when the
+        requested range is not yet available.
+        """
+        node = self.nodes[0]
+        wallet = MiniWallet(node)
+
+        def bfi():
+            return node.getindexinfo()["basic block filter index"]
+
+        _, spk, addr = getnewdestination()
+        wallet.send_to(from_node=node, scriptPubKey=spk, amount=1 * COIN)
+        match_hash = self.generate(node, 1, sync_fun=self.no_op)[0]
+        # A large enough chain that rebuilding the wiped index after a restart
+        # leaves the node briefly behind the tip. Missing that window is harmless.
+        self.generate(node, 3000, sync_fun=self.no_op)
+        self.wait_until(lambda: bfi()["synced"])
+
+        self.stop_node(0)
+        self.cleanup_folder(node.chain_path / "indexes" / "blockfilter")
+        self.start_node(0, extra_args=["-blockfilterindex=1"])
+        tip = node.getblockcount()
+
+        if not bfi()["synced"]:
+            self.log.info("scanning to the not-yet-indexed tip errors instead of skipping silently")
+            try:
+                out = node.scanblocks("start", [f"addr({addr})"], 0, tip)
+            except JSONRPCException as e:
+                assert "still in the process of being indexed" in e.error["message"]
+            else:
+                # A returning scan must be complete: the match must be present.
+                assert_equal(out["completed"], True)
+                assert match_hash in out["relevant_blocks"]
+
+            self.log.info("scanning an already-indexed prefix succeeds while still behind the tip")
+            # Genesis is indexed first, so it is available while the tip is not.
+            while not bfi()["synced"]:
+                try:
+                    out = node.scanblocks("start", [f"addr({addr})"], 0, 0)
+                except JSONRPCException as e:
+                    assert "still in the process of being indexed" in e.error["message"]
+                    continue
+                assert_equal(out["completed"], True)
+                assert_equal(out["to_height"], 0)
+                break
+
+        self.log.info("once the index is synced the same scan completes and finds the match")
+        self.wait_until(lambda: bfi()["synced"])
+        out = node.scanblocks("start", [f"addr({addr})"])
+        assert_equal(out["completed"], True)
+        assert match_hash in out["relevant_blocks"]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### The issue

`scanblocks` reads block filters over a range via `LookupFilterRange`. When the
block filter index is behind the active chain (e.g. right after startup, while
it is still syncing in the background), the lookup for the not yet indexed range
fails. The old code ignored that failure, advanced `start_index` to the end of
the chunk, and kept going - so the scan skipped every unindexed block and still
returned `"completed": true`.

The result is a silent gap: a caller gets a `relevant_blocks` list that looks
fine but is missing any match in the unindexed range, with no way to
distinguish "no matches" from "range was never scanned".

Note that `"completed"` only means the scan was not aborted - it does not mean
every filter in the requested range was actually read.

### Steps to reproduce

1. Start a node with `-blockfilterindex=1` and let it mine/receive some blocks.
2. Stop the node, delete `<datadir>/<chain>/indexes/blockfilter`, restart with
   `-blockfilterindex=1`.
3. Immediately (before the index finishes rebuilding) call
   `scanblocks start '["addr(<addr>)"]'`.

Before this change the call returns `"completed": true` with an empty/partial
`relevant_blocks`, silently skipping the range the index had not rebuilt yet.

### How it is fixed and why

Mirror `getblockfilter`'s error classification:

- Call `BlockUntilSyncedToCurrentChain()` only to obtain an `index_ready` flag.
  Do **not** fail unconditionally when the index is still behind the tip - the
  requested range may already be available.
- If `LookupFilterRange` fails and the index is not ready, throw the same
  "still in the process of being indexed" `RPC_MISC_ERROR` that
  `getblockfilter` uses.
- If `LookupFilterRange` fails after the index is ready, throw
  `RPC_INTERNAL_ERROR` (unexpected / corruption), instead of skipping the chunk.

This closes the silent gap without rejecting scans whose range is already
covered while the index catches up to the tip.

The diff also reindents the match loop: inverting `if (LookupFilterRange(...))`
into an early `throw` removes one nesting level from the existing body. That
reindentation is a consequence of the bug fix, not a standalone style change.

### Tests

- `test/functional/rpc_scanblocks.py` - new `test_scanblocks_unindexed_range`
  covers the modified code: it pads the chain, wipes the filter index, restarts,
  and while the index is behind the tip asserts that a scan to the tip returns
  the indexing error, that a scan over an already-written prefix (genesis)
  still succeeds, and that after sync the match is found.
- The existing `run_test` cases (which `wait_until(... synced ...)` before
  scanning) continue to exercise the normal synced path.

### AI / tooling note

I found this regression while reviewing the RPC with an AI-assisted tool.
I reproduced the unsynced-index behavior myself, chose to mirror
`getblockfilter`'s existing guard, and verified the fix with the
functional test above. This PR text and any review replies are my own.
