### PR TITLE
test: Cover `IsNull()` for PSBT, PSBTInput, PSBTOutput

### DIFF
--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -216,4 +216,74 @@ BOOST_AUTO_TEST_CASE(merge_proprietary_fields)
     BOOST_CHECK(output_it->value == right_prop.value);
 }
 
+BOOST_AUTO_TEST_CASE(psbt_isnull)
+{
+    // PartiallySignedTransaction::IsNull()
+    CMutableTransaction mtx;
+    PartiallySignedTransaction psbt(mtx, /*version=*/2);
+    BOOST_CHECK(psbt.IsNull());
+
+    psbt.inputs.emplace_back(/*psbt_version=*/2, Txid::FromUint256(uint256::ZERO), /*prev_out=*/0);
+    BOOST_CHECK(!psbt.IsNull());
+    psbt.inputs.clear();
+
+    psbt.outputs.emplace_back(/*psbt_version=*/2, /*amount=*/0, CScript());
+    BOOST_CHECK(!psbt.IsNull());
+    psbt.outputs.clear();
+
+    psbt.unknown[{0x01}] = {0x02};
+    BOOST_CHECK(!psbt.IsNull());
+
+    // PSBTInput::IsNull()
+    PSBTInput psbtin(/*psbt_version=*/2, Txid::FromUint256(uint256::ZERO), /*prev_out=*/0);
+    BOOST_CHECK(psbtin.IsNull());
+
+    psbtin.non_witness_utxo = MakeTransactionRef(CMutableTransaction{});
+    BOOST_CHECK(!psbtin.IsNull());
+    psbtin.non_witness_utxo.reset();
+
+    psbtin.witness_utxo = CTxOut(/*nValueIn=*/0, CScript());
+    BOOST_CHECK(!psbtin.IsNull());
+    psbtin.witness_utxo.SetNull();
+
+    psbtin.partial_sigs[{CKeyID()}] = SigPair{CPubKey{}, std::vector<unsigned char>{}};
+    BOOST_CHECK(!psbtin.IsNull());
+    psbtin.partial_sigs.clear();
+
+    psbtin.unknown[{0x01}] = {0x02};
+    BOOST_CHECK(!psbtin.IsNull());
+    psbtin.unknown.clear();
+
+    psbtin.hd_keypaths[{CPubKey()}] = KeyOriginInfo{};
+    BOOST_CHECK(!psbtin.IsNull());
+    psbtin.hd_keypaths.clear();
+
+    psbtin.redeem_script = CScript() << OP_TRUE;
+    BOOST_CHECK(!psbtin.IsNull());
+    psbtin.redeem_script.clear();
+
+    psbtin.witness_script = CScript() << OP_TRUE;
+    BOOST_CHECK(!psbtin.IsNull());
+    psbtin.witness_script.clear();
+
+    // PSBTOutput::IsNull()
+    PSBTOutput psbtout(/*psbt_version=*/2, /*amount=*/0, CScript());
+    BOOST_CHECK(psbtout.IsNull());
+
+    psbtout.redeem_script = CScript() << OP_TRUE;
+    BOOST_CHECK(!psbtout.IsNull());
+    psbtout.redeem_script.clear();
+
+    psbtout.witness_script = CScript() << OP_TRUE;
+    BOOST_CHECK(!psbtout.IsNull());
+    psbtout.witness_script.clear();
+
+    psbtout.hd_keypaths[{CPubKey()}] = KeyOriginInfo{};
+    BOOST_CHECK(!psbtout.IsNull());
+    psbtout.hd_keypaths.clear();
+
+    psbtout.unknown[{0x01}] = {0x02};
+    BOOST_CHECK(!psbtout.IsNull());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The motivation for this PR came while reviewing  [PR#35553](https://github.com/bitcoin/bitcoin/pull/35553), I noticed on [corecheck](https://corecheck.dev/) that the `IsNull()` functions of `PartiallySignedTransaction`, `PSBTInput`, `PSBTOutput` weren't covered by any test.

This PR adds coverage for all of them.

This cases can be tested with the next diffs that don't cause test failure prior to this PR, but with this new test do:
<details>
<summary>Diff for <code>PartiallySignedTransaction</code></summary>

```diff
diff --git a/src/psbt.cpp b/src/psbt.cpp
index 8f2e9ab16f..59bb05822d 100644
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -33,7 +33,7 @@ PartiallySignedTransaction::PartiallySignedTransaction(const CMutableTransaction
 
 bool PartiallySignedTransaction::IsNull() const
 {
-    return inputs.empty() && outputs.empty() && unknown.empty();
+    return inputs.empty() && outputs.empty() && !unknown.empty();
 }
```
</details>

<details>
<summary>Diff for <code>PSBTInput</code></summary>

```diff
diff --git a/src/psbt.cpp b/src/psbt.cpp
index 8f2e9ab16f..20c745f7a4 100644
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -291,7 +291,7 @@ COutPoint PSBTInput::GetOutPoint() const
 
 bool PSBTInput::IsNull() const
 {
-    return !non_witness_utxo && witness_utxo.IsNull() && partial_sigs.empty() && unknown.empty() && hd_keypaths.empty() && redeem_script.empty() && witness_script.empty();
+    return non_witness_utxo && witness_utxo.IsNull() && partial_sigs.empty() && unknown.empty() && hd_keypaths.empty() && redeem_script.empty() && witness_script.empty();
 }
```
</details>

<details>
<summary>Diff for <code>PSBTOutput</code></summary>

```diff
diff --git a/src/psbt.cpp b/src/psbt.cpp
index 8f2e9ab16f..fdfdfe903f 100644
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -530,7 +530,7 @@ void PSBTOutput::FromSignatureData(const SignatureData& sigdata)
 
 bool PSBTOutput::IsNull() const
 {
-    return redeem_script.empty() && witness_script.empty() && hd_keypaths.empty() && unknown.empty();
+    return !redeem_script.empty() && witness_script.empty() && hd_keypaths.empty() && unknown.empty();
 }
```
</details>