### PR TITLE
init: don't suggest -reindex-chainstate for recovery on a pruned node

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1894,7 +1894,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
             uiInterface.ThreadSafeQuestion(
             error + Untranslated(".\n\n") + _("Do you want to rebuild the databases now?"),
-            error.original + ".\nPlease restart with -reindex or -reindex-chainstate to recover.",
+            error.original + (args.GetIntArg("-prune", 0) ? ".\nPlease restart with -reindex to recover." : ".\nPlease restart with -reindex or -reindex-chainstate to recover."),
             CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT)};
         if (!do_retry) {
             return false;


### PR DESCRIPTION
When chainstate loading fails, init offers to rebuild the databases and, if declined, suggests restarting with `-reindex` or `-reindex-chainstate`.

On a pruned node `-reindex-chainstate` cannot recover: it rebuilds the chainstate by replaying existing block data, which has been pruned, and the node already rejects it with "Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead." Only a full `-reindex` recovers a pruned node.

Omit `-reindex-chainstate` from the suggestion when pruning is enabled.
