### PR TITLE
doc: Add privacy.md consolidating network privacy recommendations

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -82,6 +82,7 @@ The Bitcoin repo's [root README](/README.md) contains relevant information on th
 - [Multisig Tutorial](multisig-tutorial.md)
 - [Offline Signing Tutorial](offline-signing-tutorial.md)
 - [P2P bad ports definition and list](p2p-bad-ports.md)
+- [Privacy](privacy.md)
 - [PSBT support](psbt.md)
 - [Reduce Memory](reduce-memory.md)
 - [Reduce Traffic](reduce-traffic.md)

--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -170,4 +170,5 @@ if you are developing a downstream application that may be bundling I2P with Bit
 ## Privacy recommendations
 
 See [doc/privacy.md](privacy.md) for privacy recommendations, including
-guidance on node identity across multiple networks.
+guidance on node identity across multiple networks and private transaction
+broadcasting.

--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -169,10 +169,5 @@ if you are developing a downstream application that may be bundling I2P with Bit
 
 ## Privacy recommendations
 
-- Operating a node that listens on multiple networks (e.g. IPv4 and I2P) can help
-  strengthen the Bitcoin network, as nodes in this configuration (i.e. bridge nodes) increase
-  the cost and complexity of launching eclipse and partition attacks. However, under certain
-  conditions, an adversary that can connect to your node on multiple networks may be
-  able to correlate those identities by observing shared runtime characteristics. It
-  is not recommended to expose your node over multiple networks if you require
-  unlinkability across those identities.
+See [doc/privacy.md](privacy.md) for privacy recommendations, including
+guidance on node identity across multiple networks.

--- a/doc/privacy.md
+++ b/doc/privacy.md
@@ -1,5 +1,47 @@
 # Privacy in Bitcoin Core
 
+## Transaction broadcasting privacy
+
+By default, when Bitcoin Core submits a transaction to the network it announces
+it to all connected peers. This allows any peer to correlate the transaction
+with the announcing node's IP address and identify it as the likely origin.
+
+### Private broadcast (`-privatebroadcast`)
+
+Transactions submitted via the `sendrawtransaction` RPC can be broadcast
+privately through a short-lived Tor or I2P connection, without putting them
+in the local mempool first. The transaction reaches the wider network only
+once a recipient relays it, which prevents linking the submission to the
+node's IP address.
+
+To enable:
+
+```
+-privatebroadcast=1
+```
+
+This option is disabled by default.
+
+**Prerequisites:** Tor (via `-proxy` or `-onion`) or I2P (via `-i2psam`) must
+be configured and reachable. See [doc/tor.md](tor.md) and [doc/i2p.md](i2p.md)
+for setup instructions. If neither network is reachable when a transaction is
+submitted, `sendrawtransaction` returns an error.
+
+**Scope:** Only `sendrawtransaction` is affected. Wallet RPCs (`sendtoaddress`,
+`send`, `sendmany`, `sendall`, etc.) broadcast transactions through the standard method
+regardless of this setting. Wallet-level private broadcast is not yet supported;
+see the [private broadcast tracking issue](https://github.com/bitcoin/bitcoin/issues/34476)
+for planned extensions.
+
+**Related RPCs:**
+
+- `getprivatebroadcastinfo` — returns transactions currently in the private
+  broadcast queue with per-peer send timestamps and acknowledgment times where available.
+- `abortprivatebroadcast <id>` — removes a transaction from the private
+  broadcast queue by txid or wtxid.
+
+Both RPCs are only available when `-privatebroadcast=1` is set.
+
 ## Network connectivity privacy
 
 ### Node identity across multiple networks
@@ -27,4 +69,4 @@ always have only one port open.
 - [doc/tor.md](tor.md) — Tor proxy setup, onion service creation and configuration
 - [doc/i2p.md](i2p.md) — I2P setup, configuration, and address types
 - [doc/cjdns.md](cjdns.md) — CJDNS setup (note: CJDNS encrypts traffic but
-  does not hide the sender from intermediate routers)
+  does not hide the sender or recipient from intermediate routers)

--- a/doc/privacy.md
+++ b/doc/privacy.md
@@ -1,0 +1,30 @@
+# Privacy in Bitcoin Core
+
+## Network connectivity privacy
+
+### Node identity across multiple networks
+
+Operating a node that listens on multiple networks simultaneously (e.g. IPv4
+and Tor, or IPv4 and I2P) can help strengthen the Bitcoin network, as nodes in
+this configuration (i.e. bridge nodes) increase the cost and complexity of
+launching eclipse and partition attacks. However, under certain conditions, an
+adversary that can connect to your node on multiple networks may be able to
+correlate those identities by observing shared runtime characteristics. It is
+not recommended to expose your node over multiple networks if you require
+unlinkability across those identities.
+
+### Onion service port isolation
+
+Do not add anything but Bitcoin Core ports to the onion service created in
+[doc/tor.md § 3](tor.md#3-manually-create-a-bitcoin-core-onion-service). If
+you run a web service too, create a new onion service for that. Otherwise it is
+trivial to link them, which may reduce privacy. Onion services created
+automatically (as in [§ 2](tor.md#2-automatically-create-a-bitcoin-core-onion-service))
+always have only one port open.
+
+## See also
+
+- [doc/tor.md](tor.md) — Tor proxy setup, onion service creation and configuration
+- [doc/i2p.md](i2p.md) — I2P setup, configuration, and address types
+- [doc/cjdns.md](cjdns.md) — CJDNS setup (note: CJDNS encrypts traffic but
+  does not hide the sender from intermediate routers)

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -238,5 +238,5 @@ for normal IPv4/IPv6 communication, use:
 ## 4. Privacy recommendations
 
 See [doc/privacy.md](privacy.md) for privacy recommendations, including
-guidance on onion service port isolation and node identity across multiple
-networks.
+guidance on onion service port isolation, node identity across multiple
+networks, and private transaction broadcasting.

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -237,15 +237,6 @@ for normal IPv4/IPv6 communication, use:
 
 ## 4. Privacy recommendations
 
-- Do not add anything but Bitcoin Core ports to the onion service created in section 3.
-  If you run a web service too, create a new onion service for that.
-  Otherwise it is trivial to link them, which may reduce privacy. Onion
-  services created automatically (as in section 2) always have only one port
-  open.
-- Operating a node that listens on multiple networks (e.g. IPv4 and Tor) can help
-  strengthen the Bitcoin network, as nodes in this configuration (i.e. bridge nodes) increase
-  the cost and complexity of launching eclipse and partition attacks. However, under certain
-  conditions, an adversary that can connect to your node on multiple networks may be
-  able to correlate those identities by observing shared runtime characteristics. It
-  is not recommended to expose your node over multiple networks if you require
-  unlinkability across those identities.
+See [doc/privacy.md](privacy.md) for privacy recommendations, including
+guidance on onion service port isolation and node identity across multiple
+networks.


### PR DESCRIPTION
[Suggested](https://github.com/bitcoin/bitcoin/pull/29415/changes#r2190771746) by ismaelsadeeq in #29415.

Creates `doc/privacy.md` as a single home for Bitcoin Core's privacy tools for transaction broadcasting and network connectivity.

- Commit 1: Move the "Privacy recommendations" sections from `doc/tor.md` and `doc/i2p.md` into `privacy.md`, replacing them with pointers. The two files contained the same multi-network unlinkability warning duplicated verbatim; this consolidation removes the duplication. No content changes.

- Commit 2: Add a "Transaction broadcasting privacy" section documenting `-privatebroadcast`, its prerequisites (Tor or I2P), current scope (`sendrawtransaction` only, with a link to the tracking issue for planned wallet-level support), and the related RPCs (`getprivatebroadcastinfo`, `abortprivatebroadcast`).