### PR TITLE
validation: warn on undersized -dbcache

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2825,6 +2825,13 @@ bool Chainstate::FlushStateToDisk(
                 empty_cache ? CoinsTip().Flush() : CoinsTip().Sync();
                 m_last_flushed_block = m_blockman.LookupBlockIndex(CoinsTip().GetBestBlock());
                 full_flush_completed = true;
+                if ((fCacheLarge || fCacheCritical) && !m_undersized_cache_warned &&
+                    !m_chainman.IsInitialBlockDownload() && !GetRole().historical) {
+                    m_undersized_cache_warned = true;
+                    LogWarning("The in-memory UTXO cache was emptied because it reached its size limit (%d MiB). "
+                               "If this happens regularly, consider raising -dbcache to keep more of the UTXO set in memory.",
+                               m_coinstip_cache_size_bytes >> 20);
+                }
                 TRACEPOINT(utxocache, flush,
                     int64_t{Ticks<std::chrono::microseconds>(NodeClock::now() - nNow)},
                     (uint32_t)mode,

--- a/src/validation.h
+++ b/src/validation.h
@@ -895,6 +895,10 @@ protected:
     NodeClock::time_point m_next_write{NodeClock::time_point::max()};
     const CBlockIndex* m_last_flushed_block GUARDED_BY(::cs_main){nullptr};
 
+    //! Whether a warning about the coins cache being emptied due to size
+    //! pressure outside of initial block download has already been logged.
+    bool m_undersized_cache_warned GUARDED_BY(::cs_main){false};
+
     /**
      * In case of an invalid snapshot, rename the coins leveldb directory so
      * that it can be examined for issue diagnosis.

--- a/test/functional/feature_dbcache_warning.py
+++ b/test/functional/feature_dbcache_warning.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the warning for an undersized coins cache.
+
+When the in-memory UTXO cache reaches its size limit outside of initial
+block download, it is emptied and a one-time warning suggesting to raise
+-dbcache is logged.
+"""
+
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.wallet import MiniWallet
+
+# Transactions per block batch and outputs per transaction. Sized so that
+# the cumulative number of new coins comfortably exceeds the ~4 MiB coins
+# cache (plus unused mempool space) configured below.
+NUM_BATCHES = 3
+TXS_PER_BATCH = 30
+OUTPUTS_PER_TX = 1500
+
+
+class DbcacheWarningTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-dbcache=4", "-maxmempool=5"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+
+        # Mature enough coinbase outputs to fund all spends. Generating
+        # recent blocks also takes the node out of IBD, which the warning
+        # requires.
+        self.generate(self.wallet, COINBASE_MATURITY + NUM_BATCHES * TXS_PER_BATCH)
+
+        self.log.info("Fill the coins cache beyond its limit and check for the warning")
+        with node.assert_debug_log(["consider raising -dbcache"]):
+            for _ in range(NUM_BATCHES):
+                for _ in range(TXS_PER_BATCH):
+                    self.wallet.send_self_transfer_multi(
+                        from_node=node,
+                        num_outputs=OUTPUTS_PER_TX,
+                    )
+                self.generate(node, 1)
+
+
+if __name__ == "__main__":
+    DbcacheWarningTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -307,6 +307,7 @@ BASE_SCRIPTS = [
     'p2p_bip434_feature.py --v2transport',
     'wallet_encryption.py',
     'feature_dersig.py',
+    'feature_dbcache_warning.py',
     'feature_reindex_init.py',
     'feature_cltv.py',
     'rpc_uptime.py',


### PR DESCRIPTION
Since #33333 we warn at startup when `-dbcache` is likely too large for the system's memory. This adds the symmetric runtime hint for the opposite misconfiguration: a `-dbcache` too small for the node's working set.

When the coins cache grows past its size limit outside of IBD (`CoinsCacheSizeState::LARGE` on a periodic flush, or `CRITICAL` during block connection), it is fully emptied rather than synced. On a long-running node this is easy to hit with a small `-dbcache`, and it has a real cost: the cache never stays warm, block connection slows down, and every eviction cycle rewrites a large part of the UTXO set into LevelDB, causing compaction churn and sustained write amplification on the underlying disk.

Today this situation is invisible unless the user runs with `-debug=coindb` or attaches to the Linux-only `utxocache:flush` tracepoint. I recently diagnosed a stock Umbrel node (dbcache=450 with txindex and blockfilterindex enabled) whose container had averaged roughly 2 MB/s of disk writes over three weeks while fully synced at tip. The only clue in default logs was the `cache=` value in `UpdateTip` lines sitting pinned at the same number for hours. A one-line hint would have made that diagnosis trivial, and would point the many node-in-a-box users running overridden defaults at the actual fix.

The warning:
- only fires for a size-pressure eviction (not `FORCE_FLUSH`, not periodic syncs, not prune flushes),
- is suppressed during IBD, where filling the cache is expected,
- is suppressed for historical (assumeutxo background) chainstates, and
- is logged at most once per run to avoid log spam.

The new functional test fills a 4 MiB coins cache past its limit with MiniWallet transactions and checks that the warning appears.
