### PR TITLE
lint: (re-)add contrib/guix for Python linting

### DIFF
--- a/ci/lint/requirements.txt
+++ b/ci/lint/requirements.txt
@@ -1,3 +1,4 @@
+# lief version should match the version used in Guix
 lief==0.17.5
 mypy==2.3.0
 pyzmq==27.1.0

--- a/contrib/guix/security-check.py
+++ b/contrib/guix/security-check.py
@@ -280,8 +280,8 @@ if __name__ == '__main__':
     for filename in sys.argv[1:]:
         binary = lief.parse(filename)
 
-        etype = binary.format
-        arch = binary.abstract.header.architecture
+        etype = binary.format # type: ignore[union-attr]
+        arch = binary.abstract.header.architecture # type: ignore[union-attr]
 
         failed: list[str] = []
         for (name, func) in CHECKS[etype][arch]:

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -306,7 +306,7 @@ if __name__ == '__main__':
     for filename in sys.argv[1:]:
         binary = lief.parse(filename)
 
-        etype = binary.format
+        etype = binary.format # type: ignore[union-attr]
 
         failed: list[str] = []
         for (name, func) in CHECKS[etype]:

--- a/test/lint/lint-python.py
+++ b/test/lint/lint-python.py
@@ -20,9 +20,9 @@ os.environ["MYPY_CACHE_DIR"] = str(cache_dir)
 
 DEPS = ['lief', 'mypy', 'pyzmq']
 
-# Only .py files in test/functional and contrib/devtools have type annotations
+# Only .py files in test/functional and contrib/(devtools|guix) have type annotations
 # enforced.
-MYPY_FILES_ARGS = ['git', 'ls-files', 'test/functional/*.py', 'contrib/devtools/*.py']
+MYPY_FILES_ARGS = ['git', 'ls-files', 'test/functional/*.py', 'contrib/devtools/*.py', 'contrib/guix/*.py']
 
 
 def check_dependencies():


### PR DESCRIPTION
These were no-longer being linted after https://github.com/bitcoin/bitcoin/pull/32458.

suppress `[union-attr]` warning. i.e:
```bash
contrib/guix/symbol-check.py:309: error: Item "None" of "lief.PE.Binary | lief.ELF.Binary | lief.MachO.Binary | lief.COFF.Binary | None" has no attribute "format"  [union-attr]
contrib/guix/security-check.py:284: error: Item "lief.COFF.Binary" of "lief.PE.Binary | lief.ELF.Binary | lief.MachO.Binary | lief.COFF.Binary | None" has no attribute "abstract"  [union-attr]
```

Add the comment suggested in [#35855.](https://github.com/bitcoin/bitcoin/pull/35855#discussion_r3694954625).