### PR TITLE
refactor: Annotate `MakeAndPushFeature` with `[[maybe_unused]]`

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -804,7 +804,7 @@ private:
         m_connman.PushMessage(&node, NetMsg::Make(std::move(msg_type), std::forward<Args>(args)...));
     }
     template <typename... Args>
-    void MakeAndPushFeature(CNode& node, std::string_view feature_id, Args&&... args) const
+    [[maybe_unused]] void MakeAndPushFeature(CNode& node, std::string_view feature_id, Args&&... args) const
     {
         if (!Assume(feature_id.size() >= 4 && feature_id.size() <= MAX_FEATUREID_LENGTH)) return;
         std::vector<unsigned char> feature_data;


### PR DESCRIPTION
This is a follow-up to bitcoin/bitcoin#35221. The `MakeAndPushFeature` member function template has no callers yet, which [triggers](https://my.cdash.org/builds/3851810/build) `-Wunused-template` now that Clang 23 [enables](https://github.com/llvm/llvm-project/pull/208001) it as part of `-Wall`.

Related PRs:
 - https://github.com/bitcoin/bitcoin/pull/35679
 - https://github.com/bitcoin/bitcoin/pull/35737
 - https://github.com/bitcoin-core/minisketch/pull/102