### PR TITLE
p2p: prevent BIP35 requesters from bypassing inbound tx-relay capacity

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -883,8 +883,10 @@ public:
     /** Whether this peer provides all services that we want. Used for eviction decisions */
     std::atomic_bool m_has_all_wanted_services{false};
 
-    /** Whether we should relay transactions to this peer. This only changes
-     * from false to true. It will never change back to false. */
+    /** When inbound, whether this peer consumes transaction-relay capacity, is
+     * eligible for transaction-relay eviction, and forgoes the block-relay-only
+     * eviction protection. Set by VERSION `fRelay`, bloom filter messages, or
+     * BIP35 `mempool` requests, and never reset. */
     std::atomic_bool m_relays_txs{false};
 
     /** Whether this peer has loaded a bloom filter. Used only in inbound

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5198,6 +5198,9 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
+            // Ignore BIP35 requests while the peer has transaction relay disabled, unless the operator permitted it.
+            if (!pfrom.HasPermission(NetPermissionFlags::Mempool) &&
+                !WITH_LOCK(tx_relay->m_bloom_filter_mutex, return tx_relay->m_relay_txs)) return;
             LOCK(tx_relay->m_tx_inventory_mutex);
             tx_relay->m_send_mempool = true;
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -666,11 +666,11 @@ private:
      */
     bool MaybeDiscourageAndDisconnect(CNode& pnode, Peer& peer);
 
-    /** If an inbound peer wants tx relay and we are at capacity for those, attempt to
+    /** If an inbound peer consumes tx-relay capacity and the limit is exceeded, attempt to
      *  evict a tx-relaying inbound peer - possibly node itself, unless it is protected.
      *  Only if no peer can be evicted, disconnect node.
      *
-     * @param[in]   node          The node that wants to relay txs to us.
+     * @param[in]   node          The node to check after setting `m_relays_txs`.
      * @param[in]   msg_type      The message that triggered this check, for logging.
      * @param[in]   protect_peer  Peer that is exempt from being evicted.
      * @return                    True if the node was disconnected because no eviction candidate
@@ -5191,6 +5191,12 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
+            if (pfrom.IsInboundConn() && !pfrom.m_relays_txs) {
+                // Keep tx_relay->m_relay_txs unchanged so fRelay=false still
+                // disables ongoing announcements.
+                pfrom.m_relays_txs = true;
+                if (MaybeDisconnectForTxRelayCapacity(pfrom, msg_type) || pfrom.fDisconnect) return;
+            }
             LOCK(tx_relay->m_tx_inventory_mutex);
             tx_relay->m_send_mempool = true;
         }

--- a/test/functional/p2p_connection_limits.py
+++ b/test/functional/p2p_connection_limits.py
@@ -25,22 +25,21 @@ class P2PConnectionLimits(BitcoinTestFramework):
     def run_test(self):
         self.test_inbound_limits()
 
-    def create_blocks_only_version(self):
-        no_txrelay_version_msg = msg_version()
-        no_txrelay_version_msg.nVersion = P2P_VERSION
-        no_txrelay_version_msg.strSubVer = P2P_SUBVERSION
-        no_txrelay_version_msg.nServices = P2P_SERVICES
-        no_txrelay_version_msg.relay = 0
-        return no_txrelay_version_msg
-
-    def create_no_services_blocks_only_version(self):
-        """VERSION with relay=0 and nServices=0 to avoid block-relay eviction protection."""
+    def add_relay_disabled_peers(self, p2ps, *, services=P2P_SERVICES):
         version_msg = msg_version()
         version_msg.nVersion = P2P_VERSION
         version_msg.strSubVer = P2P_SUBVERSION
-        version_msg.nServices = 0
+        version_msg.nServices = services
         version_msg.relay = 0
-        return version_msg
+        peers = [self.nodes[0].add_p2p_connection(p2p, send_version=False, wait_for_verack=False) for p2p in p2ps]
+        for peer in peers:
+            peer.send_without_ping(version_msg)
+        for peer in peers:
+            peer.wait_for_verack()
+        return peers
+
+    def add_relay_disabled_peer(self, p2p, *, services=P2P_SERVICES):
+        return self.add_relay_disabled_peers([p2p], services=services)[0]
 
     def test_inbound_limits(self):
         node = self.nodes[0]
@@ -56,9 +55,7 @@ class P2PConnectionLimits(BitcoinTestFramework):
         node.disconnect_p2ps()
 
         self.log.info('Connect a block-relay inbound peer - test that second full relay peer is accepted')
-        peer1 = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
-        peer1.send_without_ping(self.create_blocks_only_version())
-        peer1.wait_for_verack()
+        self.add_relay_disabled_peer(P2PInterface())
 
         node.add_p2p_connection(P2PInterface())
         self.wait_until(lambda: len(node.getpeerinfo()) == 2)
@@ -70,9 +67,7 @@ class P2PConnectionLimits(BitcoinTestFramework):
 
         self.log.info('Run with bloom filter support and check that a switch to tx relay during runtime can trigger eviction')
         self.restart_node(0, ['-maxconnections=13', '-peerbloomfilters'])
-        peer1 = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
-        peer1.send_without_ping(self.create_blocks_only_version())
-        peer1.wait_for_verack()
+        peer1 = self.add_relay_disabled_peer(P2PInterface())
 
         node.add_p2p_connection(P2PInterface())
         self.wait_until(lambda: len(node.getpeerinfo()) == 2)
@@ -93,10 +88,8 @@ class P2PConnectionLimits(BitcoinTestFramework):
         self.log.info('Test that EvictTxPeerIfFull only evicts tx-relaying peers')
         NUM_BLOCK_RELAY_PEERS = 21
         self.restart_node(0, ['-maxconnections=33', '-inboundrelaypercent=0'])
-        for _ in range(NUM_BLOCK_RELAY_PEERS):
-            p = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
-            p.send_without_ping(self.create_no_services_blocks_only_version())
-            p.wait_for_verack()
+        # Avoid block-relay eviction protection.
+        self.add_relay_disabled_peers([P2PInterface() for _ in range(NUM_BLOCK_RELAY_PEERS)], services=0)
         self.wait_until(lambda: len(node.getpeerinfo()) == NUM_BLOCK_RELAY_PEERS)
 
         with node.assert_debug_log(['failed to find a tx-relaying eviction candidate - connection dropped'], timeout=5):

--- a/test/functional/p2p_connection_limits.py
+++ b/test/functional/p2p_connection_limits.py
@@ -3,17 +3,22 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import (
     msg_version,
-    msg_filterload
+    msg_filterload,
+    msg_mempool,
 )
 from test_framework.p2p import (
     P2PInterface,
+    P2PTxInvStore,
     P2P_SERVICES,
     P2P_SUBVERSION,
     P2P_VERSION,
 )
+from test_framework.wallet import MiniWallet
 
 
 class P2PConnectionLimits(BitcoinTestFramework):
@@ -74,6 +79,24 @@ class P2PConnectionLimits(BitcoinTestFramework):
         with node.assert_debug_log(['connection dropped after filterload message'], timeout=2):
             peer1.send_without_ping(msg_filterload(data=b'\xbb'*(100)))
         self.wait_until(lambda: len(node.getpeerinfo()) == 1)
+
+        self.log.info('Check BIP35 requests do not enable ongoing transaction relay')
+        self.restart_node(0, ['-maxconnections=13', '-peerbloomfilters', '-inboundrelaypercent=100'])
+        node.setmocktime(int(time.time()))
+        wallet = MiniWallet(node)
+        # Complete the requested snapshot before creating the transaction tested for ongoing relay.
+        snapshot_tx = wallet.send_self_transfer(from_node=node)
+        bip35_peer = self.add_relay_disabled_peer(P2PTxInvStore())
+        bip35_peer.send_and_ping(msg_mempool())
+        node.bumpmocktime(60)
+        bip35_peer.wait_for_broadcast([snapshot_tx['wtxid']])
+
+        relay_peer = node.add_p2p_connection(P2PTxInvStore())
+        tx = wallet.send_self_transfer(from_node=node)
+        node.bumpmocktime(60)
+        relay_peer.wait_for_broadcast([tx['wtxid']])
+        bip35_peer.sync_with_ping()
+        assert int(tx['wtxid'], 16) not in bip35_peer.get_invs()
 
         self.log.info('Test different values of inboundrelaypercent')
         self.restart_node(0, ['-maxconnections=13', '-inboundrelaypercent=0'])

--- a/test/functional/p2p_connection_limits.py
+++ b/test/functional/p2p_connection_limits.py
@@ -94,7 +94,7 @@ class P2PConnectionLimits(BitcoinTestFramework):
         peer1.send_and_ping(msg_mempool())
         node.setmocktime(int(time.time()) + 60)  # jump past the inv trickle interval
         peer1.sync_with_ping()
-        assert peer1.get_invs()  # TODO: Ignore BIP35 requests while transaction relay is disabled
+        assert not peer1.get_invs()
 
         self.log.info('Test different values of inboundrelaypercent')
         self.restart_node(0, ['-maxconnections=13', '-inboundrelaypercent=0'])

--- a/test/functional/p2p_connection_limits.py
+++ b/test/functional/p2p_connection_limits.py
@@ -98,6 +98,14 @@ class P2PConnectionLimits(BitcoinTestFramework):
         bip35_peer.sync_with_ping()
         assert int(tx['wtxid'], 16) not in bip35_peer.get_invs()
 
+        self.log.info('Check BIP35 requests against inbound transaction-relay capacity')
+        # NODE_BLOOM permits BIP35, while zero capacity makes any counted requester exceed the limit.
+        self.restart_node(0, ['-maxconnections=13', '-peerbloomfilters', '-inboundrelaypercent=0'])
+        peer1 = self.add_relay_disabled_peer(P2PInterface())
+        with node.assert_debug_log(['received: mempool'], timeout=2):
+            peer1.send_without_ping(msg_mempool())
+            peer1.sync_with_ping()  # TODO: Account BIP35 service against inbound tx-relay capacity
+
         self.log.info('Test different values of inboundrelaypercent')
         self.restart_node(0, ['-maxconnections=13', '-inboundrelaypercent=0'])
         with node.assert_debug_log(['failed to find a tx-relaying eviction candidate - connection dropped'], timeout=2):

--- a/test/functional/p2p_connection_limits.py
+++ b/test/functional/p2p_connection_limits.py
@@ -3,17 +3,22 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import (
     msg_version,
-    msg_filterload
+    msg_filterload,
+    msg_mempool,
 )
 from test_framework.p2p import (
     P2PInterface,
+    P2PTxInvStore,
     P2P_SERVICES,
     P2P_SUBVERSION,
     P2P_VERSION,
 )
+from test_framework.wallet import MiniWallet
 
 
 class P2PConnectionLimits(BitcoinTestFramework):
@@ -79,6 +84,17 @@ class P2PConnectionLimits(BitcoinTestFramework):
         with node.assert_debug_log(['connection dropped after filterload message'], timeout=2):
             peer1.send_without_ping(msg_filterload(data=b'\xbb'*(100)))
         self.wait_until(lambda: len(node.getpeerinfo()) == 1)
+
+        self.log.info('Check BIP35 requests require transaction relay')
+        node.disconnect_p2ps()
+        MiniWallet(node).send_self_transfer(from_node=node)
+        peer1 = node.add_p2p_connection(P2PTxInvStore(), send_version=False, wait_for_verack=False)
+        peer1.send_without_ping(self.create_blocks_only_version())
+        peer1.wait_for_verack()
+        peer1.send_and_ping(msg_mempool())
+        node.setmocktime(int(time.time()) + 60)  # jump past the inv trickle interval
+        peer1.sync_with_ping()
+        assert peer1.get_invs()  # TODO: Ignore BIP35 requests while transaction relay is disabled
 
         self.log.info('Test different values of inboundrelaypercent')
         self.restart_node(0, ['-maxconnections=13', '-inboundrelaypercent=0'])

--- a/test/functional/p2p_connection_limits.py
+++ b/test/functional/p2p_connection_limits.py
@@ -102,9 +102,9 @@ class P2PConnectionLimits(BitcoinTestFramework):
         # NODE_BLOOM permits BIP35, while zero capacity makes any counted requester exceed the limit.
         self.restart_node(0, ['-maxconnections=13', '-peerbloomfilters', '-inboundrelaypercent=0'])
         peer1 = self.add_relay_disabled_peer(P2PInterface())
-        with node.assert_debug_log(['received: mempool'], timeout=2):
+        with node.assert_debug_log(['connection dropped after mempool message'], timeout=2):
             peer1.send_without_ping(msg_mempool())
-            peer1.sync_with_ping()  # TODO: Account BIP35 service against inbound tx-relay capacity
+            peer1.wait_for_disconnect()
 
         self.log.info('Test different values of inboundrelaypercent')
         self.restart_node(0, ['-maxconnections=13', '-inboundrelaypercent=0'])

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -157,10 +157,15 @@ class FilterTest(BitcoinTestFramework):
     def test_frelay_false(self, filter_peer):
         self.log.info("Check that a node with fRelay set to false does not receive invs until the filter is set")
         filter_peer.tx_received = False
-        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
+        txid = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)["txid"]
         # Sync to make sure the reason filter_peer doesn't receive the tx is not p2p delays
         filter_peer.sync_with_ping()
         assert not filter_peer.tx_received
+
+        # Preserve bitcoinj's filterload-then-mempool sequence for fRelay=false peers.
+        filter_peer.send_and_ping(filter_peer.watch_filter_init)
+        filter_peer.send_without_ping(msg_mempool())
+        filter_peer.wait_for_tx(txid)
 
         # Clear the mempool so that this transaction does not impact subsequent tests
         self.generate(self.nodes[0], 1)


### PR DESCRIPTION
**Problem:** When a node offers `NODE_BLOOM`, an inbound peer can advertise `fRelay=false` and request BIP35 mempool inventory while remaining outside the inbound transaction-relay capacity introduced in [#28463](https://github.com/bitcoin/bitcoin/pull/28463).

**Fix:** Ignore `mempool` requests while the peer has transaction relay disabled, unless the connection has the `mempool` permission.
A BIP37 `filterload` message enables transaction relay and applies the existing capacity limit, preserving bitcoinj's [SPV `filterload`-then-`mempool` sequence](https://github.com/bitcoin/bitcoin/pull/35874#issuecomment-5278621654).
Targeted `getdata` requests remain unchanged.
