### PR TITLE
doc: Document initial setup storage cost and node startup in macOS build guide

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -212,6 +212,13 @@ touch "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
 chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
 ```
 
+To start the node:
+
+```shell
+./build/bin/bitcoind           # Runs in the foreground.
+./build/bin/bitcoind -daemon   # Runs in the background.
+```
+
 If you do not need to run on the main network, you can use a test network instead, which
 requires far less time and disk space:
 
@@ -229,7 +236,6 @@ tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
 ## Other commands:
 
 ```shell
-./build/bin/bitcoind -daemon      # Starts the bitcoin daemon.
 ./build/bin/bitcoin-cli --help    # Outputs a list of command-line options.
 ./build/bin/bitcoin-cli help      # Outputs a list of RPC commands when the daemon is running.
 ./build/bin/bitcoin-qt -server # Starts the bitcoin-qt server mode, allows bitcoin-cli control

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -193,7 +193,8 @@ supporting subcommands like `bitcoin node`, `bitcoin gui`, `bitcoin rpc`, and
 others that can be listed with `bitcoin help`.
 
 The first time you run `bitcoind` or `bitcoin-qt`, it will start downloading the blockchain.
-This process could take many hours, or even days on slower than average systems.
+This process could take many hours, or even days on slower than average systems, and will
+download and store several hundred gigabytes of data.
 
 By default, blockchain and wallet data files will be stored in:
 
@@ -209,6 +210,14 @@ mkdir -p "/Users/${USER}/Library/Application Support/Bitcoin"
 touch "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
 
 chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+```
+
+If you do not need to run on the main network, you can use a test network instead, which
+requires far less time and disk space:
+
+```shell
+./build/bin/bitcoind -signet   # Public test network.
+./build/bin/bitcoind -regtest  # Private local network, requires no download.
 ```
 
 You can monitor the download process by looking at the debug.log file:


### PR DESCRIPTION
 The "Running Bitcoin Core" section tells the reader how long the initial blockchain sync takes, but not what it costs in disk space or bandwidth. Following this guide end to end, one can start an initial block download without ever being told it will consume several hundred gigabytes of storage. `bitcoind` does warn about this at startup, but `init.cpp` only emits it when `CheckDiskSpace` fails so a user with a large drive is never told, and the warning arrives after the build and configuration steps are already done.

170e37353d6008d1675a6e063ab72e482f1b64f3 adds the storage and bandwidth cost to the existing sentence. It also shows the signet and regtest alternatives, following the pattern used elsewhere in this guide of pairing a cost with a way to opt out of it (`-DENABLE_WALLET=OFF`, `-DWITH_QRENCODE=OFF`, and so on).The exact figure is left as "several hundred gigabytes" rather than the current value. `m_assumed_blockchain_size` is already regularly updated per release in `chainparams.cpp`; a second copy here would have no update process attached to it.

0a85eab2228d6dffb8a8b44e09d206fb2fc26230 moves the command that starts the node out of "Other commands:" and into the running flow. A section titled "Running Bitcoin Core" previously never showed how to run it. The start command sat at the bottom of the page under a heading implying it was secondary.

Tested by running `bitcoind -signet` and `bitcoind -regtest` as documented.