### PR TITLE
ci: Fix $BASE_ROOT_DIR installation

### DIFF
--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -14,7 +14,9 @@ BASE_READ_ONLY_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../ >/dev/null 2>
 export BASE_READ_ONLY_DIR
 # The destination root dir inside the container.
 # This folder will also hold any SDKs.
-# This folder only exists on the ci guest and will be a copy of BASE_READ_ONLY_DIR
+# This folder only exists on the ci guest and will be a copy of BASE_READ_ONLY_DIR.
+# This value is embedded in the CI image at build time; changing it requires
+# rebuilding the image.
 export BASE_ROOT_DIR="${BASE_ROOT_DIR:-/ci_container_base}"
 # The depends dir.
 # This folder exists only on the ci guest, and on the ci host as a volume.

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -106,8 +106,8 @@ fi
 if [[ "${RUN_IWYU}" == true ]]; then
   ${CI_RETRY_EXE} git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_"${IWYU_LLVM_V}" /include-what-you-use
   pushd /include-what-you-use
-  patch -p1 < /ci_container_base/ci/test/01_iwyu.patch
-  patch -p1 < /ci_container_base/ci/test/02_iwyu_hash.patch
+  patch -p1 < "${BASE_ROOT_DIR}/ci/test/01_iwyu.patch"
+  patch -p1 < "${BASE_ROOT_DIR}/ci/test/02_iwyu_hash.patch"
   popd
   cmake -B /iwyu-build/ -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-"${IWYU_LLVM_V}" -S /include-what-you-use
   make -C /iwyu-build/ install "$MAKEJOBS"

--- a/ci/test_imagefile
+++ b/ci/test_imagefile
@@ -16,10 +16,10 @@ ENV BASE_ROOT_DIR=${BASE_ROOT_DIR}
 
 # Make retry available in PATH, needed for CI_RETRY_EXE
 COPY ./ci/retry/retry /usr/bin/retry
-COPY ./ci/test/00_setup_env.sh ./${FILE_ENV} ./ci/test/01_base_install.sh /ci_container_base/ci/test/
-COPY ./ci/test/*.patch /ci_container_base/ci/test/
+COPY ./ci/test/00_setup_env.sh ./${FILE_ENV} ./ci/test/01_base_install.sh ${BASE_ROOT_DIR}/ci/test/
+COPY ./ci/test/*.patch ${BASE_ROOT_DIR}/ci/test/
 
 # Bash is required, so install it when missing
 RUN sh -c "bash -c 'true' || ( apk update && apk add --no-cache bash )"
 
-RUN ["bash", "-c", "cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && DANGER_RUN_CI_ON_HOST=1 ./ci/test/01_base_install.sh"]
+RUN ["bash", "-c", "cd ${BASE_ROOT_DIR}/ && set -o errexit && source ./ci/test/00_setup_env.sh && DANGER_RUN_CI_ON_HOST=1 ./ci/test/01_base_install.sh"]


### PR DESCRIPTION
In the ci system, `BASE_ROOT_DIR` has a default value that can be changed. This has problems:

* The docs do not mention that changing the value requires re-building the image, as the value is embedded.
* Many places hard-code the default value, which is confusing and brittle.

Fix all issues by adding docs and replacing the hard-coded default values with `$BASE_ROOT_DIR`.