### PR TITLE
fuzz: don't connman.ReceiveMsgFrom oversized msg

### DIFF
--- a/src/test/fuzz/p2p_private_broadcast.cpp
+++ b/src/test/fuzz/p2p_private_broadcast.cpp
@@ -232,6 +232,11 @@ FUZZ_TARGET(p2p_private_broadcast, .init = ::initialize)
                 net_msg->data = ConsumeRandomLengthByteVector(fuzzed_data_provider, MAX_PROTOCOL_MESSAGE_LENGTH);
             }
             connman.FlushSendBuffer(p2p_node);
+
+            // ConsumeTransaction() can produce messages larger than the
+            // maximum payload accepted by the P2P transport.
+            if (net_msg->data.size() > MAX_PROTOCOL_MESSAGE_LENGTH) continue;
+
             (void)connman.ReceiveMsgFrom(p2p_node, std::move(*net_msg));
 
             bool more_work{true};


### PR DESCRIPTION
Got a report that tripped it. As this will never happen in p2p, avoid it.

```
INFO: Running with entropic power schedule (0xFF, 100).
	INFO: Seed: 4207564465
	INFO: Loaded 1 modules   (531453 inline 8-bit counters): 531453 [0x5ae1af7ab4c0, 0x5ae1af82d0bd),
	INFO: Loaded 1 PC tables (531453 PCs): 531453 [0x5ae1af82d0c0,0x5ae1b0049090),
	/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_bitcoin-core_fcaf00df4dbc83b967efedfb94c0da52db5f507f/revisions/p2p_private_broadcast: Running 1 inputs 100 time(s) each.
	Running: /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-7374a74f5b473b761282ebac8029bef22b32b1cd
	p2p_private_broadcast: test/util/net.cpp:93: void ConnmanTestMsg::NodeReceiveMsgBytes(CNode &, std::span<const uint8_t>, bool &) const: Assertion `node.ReceiveMsgBytes(msg_bytes, complete)' failed.
	==251== ERROR: libFuzzer: deadly signal
	    #0 0x5ae1adc5adf4 in __sanitizer_print_stack_trace /src/llvm-project/compiler-rt/lib/ubsan/ubsan_diag_standalone.cpp:31:3
	    #1 0x5ae1adbceff8 in fuzzer::PrintStackTrace() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerUtil.cpp:210:5
	    #2 0x5ae1adbb1b45 in fuzzer::Fuzzer::CrashCallback() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:231:3
	    #3 0x7e8bc7ef741f in libpthread.so.0
	    #4 0x7e8bc7ceb00a in __libc_signal_restore_set /build/glibc-B3wQXB/glibc-2.31/sysdeps/unix/sysv/linux/internal-signals.h:86:3
	    #5 0x7e8bc7ceb00a in raise /build/glibc-B3wQXB/glibc-2.31/sysdeps/unix/sysv/linux/raise.c:48:3
	    #6 0x7e8bc7cca858 in abort /build/glibc-B3wQXB/glibc-2.31/stdlib/abort.c:79:7
	    #7 0x7e8bc7cca728 in __assert_fail_base /build/glibc-B3wQXB/glibc-2.31/assert/assert.c:94:3
	    #8 0x7e8bc7cdbfd5 in __assert_fail /build/glibc-B3wQXB/glibc-2.31/assert/assert.c:103:3
	    #9 0x5ae1ae9bd015 in NodeReceiveMsgBytes bitcoin-core/src/test/util/net.cpp:93:5
	    #10 0x5ae1ae9bd015 in ConnmanTestMsg::ReceiveMsgFrom(CNode&, CSerializedNetMsg&&) const bitcoin-core/src/test/util/net.cpp:119:9
	    #11 0x5ae1adfff8f7 in p2p_private_broadcast_fuzz_target(std::__1::span<unsigned char const, 18446744073709551615ul>) bitcoin-core/src/test/fuzz/p2p_private_broadcast.cpp:235:27
	    #12 0x5ae1ae263e23 in operator() /usr/local/include/c++/v1/__functional/function.h:274:12
	    #13 0x5ae1ae263e23 in operator() /usr/local/include/c++/v1/__functional/function.h:772:10
	    #14 0x5ae1ae263e23 in test_one_input bitcoin-core/src/test/fuzz/fuzz.cpp:86:5
	    #15 0x5ae1ae263e23 in LLVMFuzzerTestOneInput bitcoin-core/src/test/fuzz/fuzz.cpp:214:5
	    #16 0x5ae1adbb322d in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:619:13
	    #17 0x5ae1adb9cf42 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:329:6
	    #18 0x5ae1adba2e10 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:865:9
	    #19 0x5ae1adbcf9a2 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
	    #20 0x7e8bc7ccc082 in __libc_start_main /build/glibc-B3wQXB/glibc-2.31/csu/libc-start.c:308:16
	    #21 0x5ae1adb9602d in _start
```
