### PR TITLE
iwyu: Fix warnings in `src/consensus` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -234,7 +234,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU='/src/((bench|common|crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\.cpp'
+  FILES_WITH_ENFORCED_IWYU='/src/((bench|common|consensus|crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\.cpp'
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 
@@ -248,6 +248,7 @@ if [[ "${RUN_IWYU}" == true ]]; then
              -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
              -Xiwyu --max_line_length=160 \
              -Xiwyu --check_also='*/common/types\.h' \
+             -Xiwyu --check_also='*/consensus/*\.h' \
              -Xiwyu --check_also='*/primitives/transaction_identifier\.h' \
              2>&1 || true
     } | tee /tmp/iwyu_ci.out

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,8 +6,8 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
+#include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
 static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -3,8 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/merkle.h>
+
+#include <crypto/sha256.h>
 #include <hash.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
 #include <util/check.h>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
 
 /*     WARNING! If you're reading this because you're learning about crypto
        and/or designing a new system that will use merkle trees, keep in mind

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -5,10 +5,12 @@
 #ifndef BITCOIN_CONSENSUS_MERKLE_H
 #define BITCOIN_CONSENSUS_MERKLE_H
 
+#include <uint256.h>
+
+#include <cstdint>
 #include <vector>
 
-#include <primitives/block.h>
-#include <uint256.h>
+class CBlock;
 
 uint256 ComputeMerkleRoot(std::vector<uint256> hashes, bool* mutated = nullptr);
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <vector>

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -5,8 +5,16 @@
 #include <consensus/tx_check.h>
 
 #include <consensus/amount.h>
-#include <primitives/transaction.h>
+#include <consensus/consensus.h>
 #include <consensus/validation.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <serialize.h>
+
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
 {

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -11,8 +11,14 @@
 #include <consensus/validation.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
+#include <script/script.h>
+#include <tinyformat.h>
 #include <util/check.h>
 #include <util/moneystr.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
 
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
 {

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -9,6 +9,7 @@
 #include <script/verify_flags.h>
 
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 class CBlockIndex;

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -6,10 +6,18 @@
 #ifndef BITCOIN_CONSENSUS_VALIDATION_H
 #define BITCOIN_CONSENSUS_VALIDATION_H
 
-#include <string>
 #include <consensus/consensus.h>
-#include <primitives/transaction.h>
 #include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <serialize.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 
 /** Index marker for when no witness commitment is present in a coinbase transaction. */
 static constexpr int NO_WITNESS_COMMITMENT{-1};


### PR DESCRIPTION
This PR continues the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).