### PR TITLE
test: cover Taproot standardness rules in mempool_accept

### DIFF
--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -29,6 +29,7 @@ from test_framework.messages import (
     tx_from_hex,
 )
 from test_framework.script import (
+    ANNEX_TAG,
     CScript,
     OP_0,
     OP_HASH160,
@@ -357,6 +358,29 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             result_expected=[{'txid': tx.txid_hex, 'allowed': True, 'vsize_adjusted': tx.get_vsize(), 'vsize': tx.get_vsize(), 'vsize_bip141': tx.get_vsize(), 'fees': {'base': Decimal('0.05')}}],
             rawtxs=[tx.serialize().hex()],
             maxfeerate=0
+        )
+
+        self.log.info('Some nonstandard Taproot spends')
+        # The reference tx spends a P2TR output through the script path, so its
+        # witness stack is [script, control_block].
+        tx = tx_from_hex(raw_tx_reference)
+        tx.wit.vtxinwit[0].scriptWitness.stack.append(bytes([ANNEX_TAG]))  # Annexes are nonstandard
+        self.check_mempool_result(
+            result_expected=[{'txid': tx.txid_hex, 'allowed': False, 'reject-reason': 'bad-witness-nonstandard'}],
+            rawtxs=[tx.serialize().hex()],
+        )
+        tx = tx_from_hex(raw_tx_reference)
+        # Tapscript stack element size over 80 bytes is nonstandard
+        tx.wit.vtxinwit[0].scriptWitness.stack.insert(0, b'\xff' * 81)
+        self.check_mempool_result(
+            result_expected=[{'txid': tx.txid_hex, 'allowed': False, 'reject-reason': 'bad-witness-nonstandard'}],
+            rawtxs=[tx.serialize().hex()],
+        )
+        tx = tx_from_hex(raw_tx_reference)
+        tx.wit.vtxinwit[0].scriptWitness.stack[-1] = b''  # An empty control block is also invalid by consensus
+        self.check_mempool_result(
+            result_expected=[{'txid': tx.txid_hex, 'allowed': False, 'reject-reason': 'bad-witness-nonstandard'}],
+            rawtxs=[tx.serialize().hex()],
         )
 
         self.log.info("A transaction with several OP_RETURN outputs.")


### PR DESCRIPTION
`IsWitnessStandard` has three policy rules for Taproot spends: annexes are nonstandard, tapscript stack items are limited to 80 bytes, and an empty control block is rejected. No test ties `bad-witness-nonstandard` to any of them. Every existing assertion of that reject reason is for another output type. `feature_taproot.py` does exercise annexes and oversized stack items, but it checks standardness with `assert_raises_rpc_error(-26, None, ...)`, so it never asserts which rule rejected the spend.

This adds a case per rule to `mempool_accept.py`. The file already builds a P2TR script-path spend, so each case only mutates its witness stack; the oversized item is one byte over the limit.

To check that each case hits the rule it claims to cover, I disabled the three branches in `policy.cpp` one at a time: each case fails with its branch disabled and passes with it restored.
