### PR TITLE
util: set os-level thread names on Windows

### DIFF
--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -18,6 +18,10 @@
 #include <sys/prctl.h>
 #endif
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 //! Set the thread's name at the process level. Does not affect the
 //! internal name.
 static void SetThreadName(const char* name)
@@ -29,6 +33,11 @@ static void SetThreadName(const char* name)
     pthread_set_name_np(pthread_self(), name);
 #elif defined(__APPLE__)
     pthread_setname_np(name);
+#elif defined(WIN32)
+    // Thread names are ASCII-only, so widening each character is sufficient as
+    // a conversion to UTF-16.
+    const std::wstring wname{name, name + std::strlen(name)};
+    ::SetThreadDescription(::GetCurrentThread(), wname.c_str());
 #else
     // Prevent warnings for unused parameters...
     (void)name;

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -18,6 +18,10 @@
 #include <sys/prctl.h>
 #endif
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 //! Set the thread's name at the process level. Does not affect the
 //! internal name.
 static void SetThreadName(const char* name)
@@ -29,6 +33,10 @@ static void SetThreadName(const char* name)
     pthread_set_name_np(pthread_self(), name);
 #elif defined(__APPLE__)
     pthread_setname_np(name);
+#elif defined(WIN32)
+    // Thread names are ASCII-only, so widening each character is sufficient.
+    const std::wstring wname{name, name + std::strlen(name)};
+    ::SetThreadDescription(::GetCurrentThread(), wname.c_str());
 #else
     // Prevent warnings for unused parameters...
     (void)name;


### PR DESCRIPTION
Update SetThreadName to set os-level thread names on Windows too.

This is useful for debugging-ergonomics on Windows. Threads currently show up unnamed in debuggers, crash dumps on Windows and mismatch what's documented under https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#threads.

Tested with the mingw cross build running on Windows 11, print from WinDbg:

<img width="713" height="631" alt="image" src="https://github.com/user-attachments/assets/05e03383-c9b1-4e6b-91f3-9088b2fc7e90" />