### PR TITLE
ipc: use std::optional for checkSpawned(), add tests and rename arg -ipcfd to -ipcchild

### DIFF
--- a/src/bitcoin.cpp
+++ b/src/bitcoin.cpp
@@ -169,7 +169,7 @@ bool UseMultiprocess(const CommandLine& cmd)
 
     // If any -ipc* options are set these need to be processed by a
     // multiprocess-capable binary.
-    return args.IsArgSet("-ipcbind") || args.IsArgSet("-ipcconnect") || args.IsArgSet("-ipcfd");
+    return args.IsArgSet("-ipcbind") || args.IsArgSet("-ipcconnect") || args.IsArgSet("-ipcchild");
 }
 
 //! Execute the specified bitcoind, bitcoin-qt or other command line in `args`

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -74,12 +75,12 @@ public:
     bool startSpawnedProcess(int argc, char* argv[], int& exit_status) override
     {
         exit_status = EXIT_FAILURE;
-        mp::SocketId socket{mp::SocketError};
-        if (!m_process->checkSpawned(argc, argv, socket)) {
+        std::optional<mp::SocketId> socket{m_process->checkSpawned(argc, argv)};
+        if (!socket) {
             return false;
         }
         IgnoreCtrlC(strprintf("[%s] SIGINT received — waiting for parent to shut down.\n", m_exe_name));
-        m_protocol->serve(m_init, [&] { return m_protocol->makeStream(socket); } );
+        m_protocol->serve(m_init, [&] { return m_protocol->makeStream(*socket); } );
         exit_status = EXIT_SUCCESS;
         return true;
     }

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -17,6 +17,7 @@
 #include <cerrno>
 #include <exception>
 #include <iostream>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -42,26 +43,25 @@ public:
         });
     }
     int waitSpawned(mp::ProcessId pid) override { return mp::WaitProcess(pid); }
-    bool checkSpawned(int argc, char* argv[], mp::SocketId& socket) override
+    std::optional<mp::SocketId> checkSpawned(int argc, char* argv[]) override
     {
-        // If this process was not started with a single -ipcfd argument, it is
-        // not a process spawned by the spawn() call above, so return false and
-        // do not try to serve requests.
+        // If this process was not started with a single -ipcfd argument, it
+        // is not a process spawned by the spawn() call above, so return
+        // std::nullopt and do not try to serve requests.
         if (argc != 3 || strcmp(argv[1], "-ipcfd") != 0) {
-            return false;
+            return std::nullopt;
         }
-        // If a single -ipcfd argument was provided, return true and get the
-        // file descriptor so Protocol::serve() can be called to handle
-        // requests from the parent process. The -ipcfd argument is not valid
-        // in combination with other arguments because the parent process
-        // should be able to control the child process through the IPC protocol
-        // without passing information out of band.
+        // If a single -ipcfd argument was provided, return the socket id so
+        // Protocol::serve() can be called to handle requests from the parent
+        // process. The -ipcfd argument is not valid in combination with
+        // other arguments because the parent process should be able to control
+        // the child process through the IPC protocol without passing
+        // information out of band.
         try {
-           socket = mp::StartSpawned(argv[2]);
+            return mp::StartSpawned(argv[2]);
         } catch (const std::exception& e) {
            throw std::runtime_error(strprintf("Invalid -ipcfd number '%s' (%s)", argv[2], e.what()));
         }
-        return true;
     }
     mp::SocketId connect(const fs::path& data_dir,
                 const std::string& dest_exe_name,

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -39,28 +39,28 @@ public:
             fs::path path = argv0_path;
             path.remove_filename();
             path /= fs::PathFromString(new_exe_name);
-            return std::vector<std::string>{fs::PathToString(path), "-ipcfd", std::move(connect_info)};
+            return std::vector<std::string>{fs::PathToString(path), "-ipcchild", std::move(connect_info)};
         });
     }
     int waitSpawned(mp::ProcessId pid) override { return mp::WaitProcess(pid); }
     std::optional<mp::SocketId> checkSpawned(int argc, char* argv[]) override
     {
-        // If this process was not started with a single -ipcfd argument, it
+        // If this process was not started with a single -ipcchild argument, it
         // is not a process spawned by the spawn() call above, so return
         // std::nullopt and do not try to serve requests.
-        if (argc != 3 || strcmp(argv[1], "-ipcfd") != 0) {
+        if (argc != 3 || strcmp(argv[1], "-ipcchild") != 0) {
             return std::nullopt;
         }
-        // If a single -ipcfd argument was provided, return the socket id so
+        // If a single -ipcchild argument was provided, return the socket id so
         // Protocol::serve() can be called to handle requests from the parent
-        // process. The -ipcfd argument is not valid in combination with
+        // process. The -ipcchild argument is not valid in combination with
         // other arguments because the parent process should be able to control
         // the child process through the IPC protocol without passing
         // information out of band.
         try {
             return mp::StartSpawned(argv[2]);
         } catch (const std::exception& e) {
-           throw std::runtime_error(strprintf("Invalid -ipcfd number '%s' (%s)", argv[2], e.what()));
+            throw std::runtime_error(strprintf("Invalid -ipcchild value '%s' (%s)", argv[2], e.what()));
         }
     }
     mp::SocketId connect(const fs::path& data_dir,

--- a/src/ipc/process.h
+++ b/src/ipc/process.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <ipc/util.h>
+#include <optional>
 #include <string>
 
 namespace ipc {
@@ -31,9 +32,9 @@ public:
     virtual int waitSpawned(mp::ProcessId pid) = 0;
 
     //! Parse command line and determine if current process is a spawned child
-    //! process. If so, return true and a socket id for communicating
-    //! with the parent process.
-    virtual bool checkSpawned(int argc, char* argv[], mp::SocketId& socket) = 0;
+    //! process. If so, return a socket id for communicating with the parent
+    //! process, otherwise return std::nullopt.
+    virtual std::optional<mp::SocketId> checkSpawned(int argc, char* argv[]) = 0;
 
     //! Canonicalize and connect to address, returning socket id.
     virtual mp::SocketId connect(const fs::path& data_dir,

--- a/src/ipc/test/ipc_tests.cpp
+++ b/src/ipc/test/ipc_tests.cpp
@@ -18,6 +18,7 @@
 #include <validation.h>
 
 #include <future>
+#include <optional>
 #include <thread>
 #include <kj/common.h>
 #include <kj/memory.h>
@@ -228,6 +229,46 @@ BOOST_AUTO_TEST_CASE(parse_address_test)
                   "unix:" + prefix + "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.sock",
                   "Unix address path \"" + prefix + "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.sock\" exceeded maximum socket path length");
     check_address("invalid", "invalid", "Unrecognized address 'invalid'");
+}
+
+// Test command line parsing in ipc::Process::checkSpawned().
+BOOST_AUTO_TEST_CASE(check_spawned_test)
+{
+    std::unique_ptr<ipc::Process> process{ipc::MakeProcess()};
+    char arg0[]{"bitcoin-node"};
+    char arg_spawn[]{"-ipcchild"};
+    char arg_invalid[]{"invalid"};
+    char arg_other[]{"-ipcbind=unix"};
+
+    // no -ipcchild arg.
+    {
+        char* argv[]{arg0};
+        BOOST_CHECK(!process->checkSpawned(1, argv));
+    }
+    {
+        char* argv[]{arg0, arg_other};
+        BOOST_CHECK(!process->checkSpawned(2, argv));
+    }
+    {
+        char* argv[]{arg0, arg_other, arg_invalid};
+        BOOST_CHECK(!process->checkSpawned(3, argv));
+    }
+    // -ipcchild without a value.
+    {
+        char* argv[]{arg0, arg_spawn};
+        BOOST_CHECK(!process->checkSpawned(2, argv));
+    }
+    // -ipcchild combined with other arguments.
+    {
+        char* argv[]{arg0, arg_spawn, arg_invalid, arg_other};
+        BOOST_CHECK(!process->checkSpawned(4, argv));
+    }
+    // -ipcchild with a value that is not a valid way of connecting to the
+    // parent process.
+    {
+        char* argv[]{arg0, arg_spawn, arg_invalid};
+        BOOST_CHECK_THROW(process->checkSpawned(3, argv), std::runtime_error);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/ipc/test/ipc_tests.cpp
+++ b/src/ipc/test/ipc_tests.cpp
@@ -18,6 +18,7 @@
 #include <validation.h>
 
 #include <future>
+#include <optional>
 #include <thread>
 #include <kj/common.h>
 #include <kj/memory.h>
@@ -228,6 +229,42 @@ BOOST_AUTO_TEST_CASE(parse_address_test)
                   "unix:" + prefix + "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.sock",
                   "Unix address path \"" + prefix + "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.sock\" exceeded maximum socket path length");
     check_address("invalid", "invalid", "Unrecognized address 'invalid'");
+}
+
+// Test command line parsing in ipc::Process::checkSpawned().
+BOOST_AUTO_TEST_CASE(check_spawned_test)
+{
+    std::unique_ptr<ipc::Process> process{ipc::MakeProcess()};
+    char arg0[]{"bitcoin-node"};
+    char arg_spawn[]{"-ipcchild"};
+    char arg_invalid[]{"invalid"};
+    char arg_other[]{"-ipcbind=unix"};
+
+    // no -ipcchild arg.
+    {
+        char* argv[]{arg0};
+        BOOST_CHECK(!process->checkSpawned(1, argv));
+    }
+    {
+        char* argv[]{arg0, arg_other};
+        BOOST_CHECK(!process->checkSpawned(2, argv));
+    }
+    // -ipcchild without a value.
+    {
+        char* argv[]{arg0, arg_spawn};
+        BOOST_CHECK(!process->checkSpawned(2, argv));
+    }
+    // -ipcchild combined with other arguments.
+    {
+        char* argv[]{arg0, arg_spawn, arg_invalid, arg_other};
+        BOOST_CHECK(!process->checkSpawned(4, argv));
+    }
+    // -ipcchild with a value that is not a valid way of connecting to the
+    // parent process.
+    {
+        char* argv[]{arg0, arg_spawn, arg_invalid};
+        BOOST_CHECK_THROW(process->checkSpawned(3, argv), std::runtime_error);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -21,7 +21,7 @@ CMD_GREP_WALLET_ARGS = r"git grep --function-context 'void WalletInit::AddWallet
 CMD_GREP_WALLET_HIDDEN_ARGS = r"git grep --function-context 'void DummyWalletInit::AddWalletOptions' -- {}".format(CMD_ROOT_DIR)
 CMD_GREP_DOCS = r"git grep --perl-regexp '{}' {}".format(REGEX_DOC, CMD_ROOT_DIR)
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set(['-h', '-?', '-dbcrashratio', '-forcecompactdb', '-ipcconnect', '-ipcfd'])
+SET_DOC_OPTIONAL = set(['-h', '-?', '-dbcrashratio', '-forcecompactdb', '-ipcconnect', '-ipcchild'])
 
 
 def lint_missing_argument_documentation():


### PR DESCRIPTION
Implement proposed follow-ups on dicussion https://github.com/bitcoin/bitcoin/pull/35084#discussion_r3664894660:

<details>

<summary>Discussion</summary>

[Sjors](https://github.com/Sjors):

In https://github.com/bitcoin/bitcoin/commit/2d3f72fd3fa45ab4e399094c39bfa93bb5a87323 ipc, refactor: Update mp::SpawnProcess call: suggested test coverage:

BOOST_AUTO_TEST_CASE(check_spawned_test)
{
    std::unique_ptr<ipc::Process> process{ipc::MakeProcess()};
    mp::SocketId socket{mp::SocketError};
    char arg0[]{"bitcoin-node"};
    char arg1[]{"-ipcfd"};
    char arg2[]{"invalid"};
    char* argv[]{arg0, arg1, arg2};
    auto check_error{[](const std::runtime_error& e) {
        return std::string_view{e.what()}.starts_with("Invalid -ipcfd number 'invalid'");
    }};
    BOOST_CHECK_EXCEPTION(process->checkSpawned(3, argv, socket), std::runtime_error, check_error);
    BOOST_CHECK_EQUAL(socket, mp::SocketError);
}

[ryanofsky](https://github.com/ryanofsky):

re: https://github.com/bitcoin/bitcoin/pull/35084#discussion_r3664894660

This is a good test suggestion that would be a nice followup. Note that after https://github.com/bitcoin-core/libmultiprocess/pull/274, the exception will be a little different and look more like "StartSpawned: invalid connect_info" and after https://github.com/bitcoin-core/libmultiprocess/pull/231 the exception on windows will be "CreateFile(pipe) failed" so it could make sense to just check that an exception is thrown and not try to match the text.

Also:

It would be nice to change checkSpawned signature to return optional<SocketId> instead of using bool and an output parameter. (I believe this code is from before C++17 which added std::optional)
Could be good to add another test case that doesn't pass an -ipcfd and ensures checkSpawned returns false without throwing an exception.
Could be good to add another test case that just passes -ipcfd as the last argument.
Could be nice to rename -ipcfd to something more generic like -ipcspawn or -ipcchild since a named pipe path instead of a file descriptor is passed on windows.
</details>

- Add unit test for checkSpawned().
- Make checkSpawned() return std::optional<mp::SocketId>.
- Rename -ipcfd to -ipcchild.