### PR TITLE
net: reject oversized outbound messages

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -848,7 +848,7 @@ CNetMessage V1Transport::GetReceivedMessage(NodeClock::time_point time, bool& re
 bool V1Transport::SetMessageToSend(CSerializedNetMsg& msg) noexcept
 {
     AssertLockNotHeld(m_send_mutex);
-    if (!Assume(msg.m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE)) return false;
+    if (!Assume(msg.IsWithinLimits())) return false;
     // Determine whether a new message can be set.
     LOCK(m_send_mutex);
     if (m_sending_header || m_bytes_sent < m_message_to_send.data.size()) return false;
@@ -1490,7 +1490,7 @@ CNetMessage V2Transport::GetReceivedMessage(NodeClock::time_point time, bool& re
 bool V2Transport::SetMessageToSend(CSerializedNetMsg& msg) noexcept
 {
     AssertLockNotHeld(m_send_mutex);
-    if (!Assume(msg.m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE)) return false;
+    if (!Assume(msg.IsWithinLimits())) return false;
     LOCK(m_send_mutex);
     if (m_send_state == SendState::V1) return m_v1_fallback.SetMessageToSend(msg);
     // We only allow adding a new message to be sent when in the READY state (so the packet cipher
@@ -4165,7 +4165,10 @@ static bool IsOutboundMessageAllowedInPrivateBroadcast(std::string_view type) no
 void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);
-    if (!Assume(msg.m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE)) return;
+    if (!Assume(msg.IsWithinLimits())) {
+        LogDebug(BCLog::NET, "Dropping oversized message (%u-byte type, %u-byte payload), %s", msg.m_type.size(), msg.data.size(), pnode->LogPeer());
+        return;
+    }
 
     if (pnode->IsPrivateBroadcastConn() && !IsOutboundMessageAllowedInPrivateBroadcast(msg.m_type)) {
         LogDebug(BCLog::PRIVBROADCAST, "Omitting send of message '%s', %s", msg.m_type, pnode->LogPeer());

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -848,6 +848,7 @@ CNetMessage V1Transport::GetReceivedMessage(NodeClock::time_point time, bool& re
 bool V1Transport::SetMessageToSend(CSerializedNetMsg& msg) noexcept
 {
     AssertLockNotHeld(m_send_mutex);
+    if (!Assume(msg.m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE)) return false;
     // Determine whether a new message can be set.
     LOCK(m_send_mutex);
     if (m_sending_header || m_bytes_sent < m_message_to_send.data.size()) return false;
@@ -1489,6 +1490,7 @@ CNetMessage V2Transport::GetReceivedMessage(NodeClock::time_point time, bool& re
 bool V2Transport::SetMessageToSend(CSerializedNetMsg& msg) noexcept
 {
     AssertLockNotHeld(m_send_mutex);
+    if (!Assume(msg.m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE)) return false;
     LOCK(m_send_mutex);
     if (m_send_state == SendState::V1) return m_v1_fallback.SetMessageToSend(msg);
     // We only allow adding a new message to be sent when in the READY state (so the packet cipher
@@ -4163,6 +4165,7 @@ static bool IsOutboundMessageAllowedInPrivateBroadcast(std::string_view type) no
 void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);
+    if (!Assume(msg.m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE)) return;
 
     if (pnode->IsPrivateBroadcastConn() && !IsOutboundMessageAllowedInPrivateBroadcast(msg.m_type)) {
         LogDebug(BCLog::PRIVBROADCAST, "Omitting send of message '%s', %s", msg.m_type, pnode->LogPeer());

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -4164,7 +4164,10 @@ static bool IsOutboundMessageAllowedInPrivateBroadcast(std::string_view type) no
 void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);
-    if (!Assume(msg.m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE)) return;
+    if (!Assume(msg.IsWithinLimits())) {
+        LogDebug(BCLog::NET, "Dropping oversized message (%u-byte type, %u-byte payload), %s", msg.m_type.size(), msg.data.size(), pnode->LogPeer());
+        return;
+    }
 
     if (pnode->IsPrivateBroadcastConn() && !IsOutboundMessageAllowedInPrivateBroadcast(msg.m_type)) {
         LogDebug(BCLog::PRIVBROADCAST, "Omitting send of message '%s', %s", msg.m_type, pnode->LogPeer());

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -4164,6 +4164,7 @@ static bool IsOutboundMessageAllowedInPrivateBroadcast(std::string_view type) no
 void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);
+    if (!Assume(msg.m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE)) return;
 
     if (pnode->IsPrivateBroadcastConn() && !IsOutboundMessageAllowedInPrivateBroadcast(msg.m_type)) {
         LogDebug(BCLog::PRIVBROADCAST, "Omitting send of message '%s', %s", msg.m_type, pnode->LogPeer());

--- a/src/net.h
+++ b/src/net.h
@@ -61,7 +61,7 @@ inline constexpr std::chrono::minutes TIMEOUT_INTERVAL{20};
 inline constexpr auto FEELER_INTERVAL = 2min;
 /** Run the extra block-relay-only connection loop once every 5 minutes. **/
 inline constexpr auto EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL = 5min;
-/** Maximum length of incoming protocol messages (no message over 4 MB is currently acceptable). */
+/** Maximum length of protocol message payloads (no message over 4 MB is currently acceptable). */
 inline constexpr unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
 /** Maximum length of the user agent string in `version` message */
 inline constexpr unsigned int MAX_SUBVERSION_LENGTH = 256;
@@ -119,6 +119,10 @@ struct AddedNodeInfo {
 class CNodeStats;
 class CClientUIInterface;
 
+/**
+ * A serialized message ready to be passed to the outbound send path.
+ * Callers must ensure the message is within the protocol's type and payload limits.
+ */
 struct CSerializedNetMsg {
     CSerializedNetMsg() = default;
     CSerializedNetMsg(CSerializedNetMsg&&) = default;
@@ -137,6 +141,11 @@ struct CSerializedNetMsg {
 
     std::vector<unsigned char> data;
     std::string m_type;
+
+    bool IsWithinLimits() const noexcept
+    {
+        return m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE && data.size() <= MAX_PROTOCOL_MESSAGE_LENGTH;
+    }
 
     /** Compute total memory usage of this object (own memory + any dynamic memory). */
     size_t GetMemoryUsage() const noexcept;

--- a/src/net.h
+++ b/src/net.h
@@ -61,7 +61,7 @@ static constexpr std::chrono::minutes TIMEOUT_INTERVAL{20};
 static constexpr auto FEELER_INTERVAL = 2min;
 /** Run the extra block-relay-only connection loop once every 5 minutes. **/
 static constexpr auto EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL = 5min;
-/** Maximum length of incoming protocol messages (no message over 4 MB is currently acceptable). */
+/** Maximum length of protocol message payloads (no message over 4 MB is currently acceptable). */
 static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
 /** Maximum length of the user agent string in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
@@ -119,6 +119,10 @@ struct AddedNodeInfo {
 class CNodeStats;
 class CClientUIInterface;
 
+/**
+ * A serialized message ready to be passed to an outbound transport.
+ * Callers must ensure the message is within the transport's type and payload limits.
+ */
 struct CSerializedNetMsg {
     CSerializedNetMsg() = default;
     CSerializedNetMsg(CSerializedNetMsg&&) = default;
@@ -137,6 +141,11 @@ struct CSerializedNetMsg {
 
     std::vector<unsigned char> data;
     std::string m_type;
+
+    bool IsWithinLimits() const noexcept
+    {
+        return m_type.size() <= CMessageHeader::MESSAGE_TYPE_SIZE && data.size() <= MAX_PROTOCOL_MESSAGE_LENGTH;
+    }
 
     /** Compute total memory usage of this object (own memory + any dynamic memory). */
     size_t GetMemoryUsage() const noexcept;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1079,7 +1079,7 @@ static RPCMethod sendmsgtopeer()
         {
             {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::NO, "The peer to send the message to."},
             {"msg_type", RPCArg::Type::STR, RPCArg::Optional::NO, strprintf("The message type (maximum length %i)", CMessageHeader::MESSAGE_TYPE_SIZE)},
-            {"msg", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The serialized message body to send, in hex, without a message header"},
+            {"msg", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, strprintf("The serialized message body to send, in hex, without a message header (maximum %u bytes)", MAX_PROTOCOL_MESSAGE_LENGTH)},
         },
         RPCResult{RPCResult::Type::OBJ, "", "", std::vector<RPCResult>{}},
         RPCExamples{
@@ -1093,6 +1093,9 @@ static RPCMethod sendmsgtopeer()
             auto msg{TryParseHex<unsigned char>(self.Arg<std::string_view>("msg"))};
             if (!msg.has_value()) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Error parsing input for msg");
+            }
+            if (msg->size() > MAX_PROTOCOL_MESSAGE_LENGTH) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Error: msg too large, max size is %u bytes", MAX_PROTOCOL_MESSAGE_LENGTH));
             }
 
             NodeContext& node = EnsureAnyNodeContext(request.context);

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -34,6 +34,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 using namespace std::literals;
 using namespace util::hex_literals;
@@ -1093,8 +1094,9 @@ public:
 
     /** Send/receive scheduled/available bytes and messages.
      *
-     * This is the only function that interacts with the transport being tested; everything else is
-     * scheduling things done by Interact(), or processing things learned by it.
+     * Aside from GetTransport(), this is the only function that interacts with the transport being
+     * tested; everything else is scheduling things done by Interact(), or processing things learned
+     * by it.
      */
     InteractResult Interact()
     {
@@ -1146,6 +1148,9 @@ public:
 
     /** Expose the cipher. */
     BIP324Cipher& GetCipher() { return m_cipher; }
+
+    /** Expose the transport being tested. */
+    Transport& GetTransport() { return m_transport; }
 
     /** Schedule bytes to be sent to the transport. */
     void Send(std::span<const uint8_t> data)
@@ -1374,10 +1379,45 @@ public:
     }
 };
 
+constexpr std::string_view MAX_MESSAGE_TYPE{"xxxxxxxxxxxx"};
+static_assert(MAX_MESSAGE_TYPE.size() == CMessageHeader::MESSAGE_TYPE_SIZE);
+
+CSerializedNetMsg MakeNetMessage(std::string_view type, size_t payload_size)
+{
+    auto msg{NetMsg::Make(std::string{type})};
+    msg.data.resize(payload_size, uint8_t{0x01});
+    return msg;
+}
+
 } // namespace
+
+BOOST_AUTO_TEST_CASE(v1transport_message_limits)
+{
+    V1Transport max_type_transport{NodeId{0}};
+    auto max_type_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1)};
+    BOOST_REQUIRE(max_type_transport.SetMessageToSend(max_type_msg));
+
+    auto [header, more, message_type]{max_type_transport.GetBytesToSend(/*have_next_message=*/false)};
+    BOOST_CHECK_EQUAL(header.size(), CMessageHeader::HEADER_SIZE);
+    BOOST_CHECK(more);
+    BOOST_CHECK_EQUAL(message_type, MAX_MESSAGE_TYPE);
+
+    V1Transport max_payload_transport{NodeId{0}};
+    auto max_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH)};
+    BOOST_REQUIRE(max_payload_transport.SetMessageToSend(max_payload_msg));
+
+    V1Transport oversized_payload_transport{NodeId{0}};
+    auto oversized_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH + 1)};
+    BOOST_REQUIRE(oversized_payload_transport.SetMessageToSend(oversized_payload_msg)); // TODO: Oversized payloads should be rejected before encoding
+}
 
 BOOST_AUTO_TEST_CASE(v2transport_test)
 {
+    auto max_type_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1)};
+    auto oversized_type_msg{MakeNetMessage(/*type=*/std::string{MAX_MESSAGE_TYPE} + 'x', /*payload_size=*/1)};
+    auto max_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH)};
+    auto oversized_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH + 1)};
+
     // A mostly normal scenario, testing a transport in initiator mode.
     for (int i = 0; i < 10; ++i) {
         V2TransportTester tester(m_rng, true);
@@ -1511,6 +1551,11 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         BOOST_CHECK(!(*ret)[2]);
         BOOST_CHECK((*ret)[3] && (*ret)[3]->m_type == "foobar" && (*ret)[3]->m_recv.empty());
         tester.ReceiveMessage("barfoo", {});
+        // Accepted messages occupy the send buffer, so use a separate ready transport for each case.
+        BOOST_REQUIRE(i != 0 || tester.GetTransport().SetMessageToSend(max_type_msg));
+        BOOST_REQUIRE(i != 1 || tester.GetTransport().SetMessageToSend(oversized_type_msg)); // TODO: Oversized message types should be rejected before encoding
+        BOOST_REQUIRE(i != 2 || tester.GetTransport().SetMessageToSend(max_payload_msg));
+        BOOST_REQUIRE(i != 3 || tester.GetTransport().SetMessageToSend(oversized_payload_msg)); // TODO: Oversized payloads should be rejected before encoding
     }
 
     // Too long garbage (initiator).

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1414,7 +1414,6 @@ BOOST_AUTO_TEST_CASE(v1transport_message_limits)
 BOOST_AUTO_TEST_CASE(v2transport_test)
 {
     auto max_type_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1)};
-    auto oversized_type_msg{MakeNetMessage(/*type=*/std::string{MAX_MESSAGE_TYPE} + 'x', /*payload_size=*/1)};
     auto max_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH)};
     auto oversized_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH + 1)};
 
@@ -1553,7 +1552,6 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.ReceiveMessage("barfoo", {});
         // Accepted messages occupy the send buffer, so use a separate ready transport for each case.
         BOOST_REQUIRE(i != 0 || tester.GetTransport().SetMessageToSend(max_type_msg));
-        BOOST_REQUIRE(i != 1 || tester.GetTransport().SetMessageToSend(oversized_type_msg)); // TODO: Oversized message types should be rejected before encoding
         BOOST_REQUIRE(i != 2 || tester.GetTransport().SetMessageToSend(max_payload_msg));
         BOOST_REQUIRE(i != 3 || tester.GetTransport().SetMessageToSend(oversized_payload_msg)); // TODO: Oversized payloads should be rejected before encoding
     }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1405,17 +1405,12 @@ BOOST_AUTO_TEST_CASE(v1transport_message_limits)
     V1Transport max_payload_transport{NodeId{0}};
     auto max_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH)};
     BOOST_REQUIRE(max_payload_transport.SetMessageToSend(max_payload_msg));
-
-    V1Transport oversized_payload_transport{NodeId{0}};
-    auto oversized_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH + 1)};
-    BOOST_REQUIRE(oversized_payload_transport.SetMessageToSend(oversized_payload_msg)); // TODO: Oversized payloads should be rejected before encoding
 }
 
 BOOST_AUTO_TEST_CASE(v2transport_test)
 {
     auto max_type_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1)};
     auto max_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH)};
-    auto oversized_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH + 1)};
 
     // A mostly normal scenario, testing a transport in initiator mode.
     for (int i = 0; i < 10; ++i) {
@@ -1552,8 +1547,7 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.ReceiveMessage("barfoo", {});
         // Accepted messages occupy the send buffer, so use a separate ready transport for each case.
         BOOST_REQUIRE(i != 0 || tester.GetTransport().SetMessageToSend(max_type_msg));
-        BOOST_REQUIRE(i != 2 || tester.GetTransport().SetMessageToSend(max_payload_msg));
-        BOOST_REQUIRE(i != 3 || tester.GetTransport().SetMessageToSend(oversized_payload_msg)); // TODO: Oversized payloads should be rejected before encoding
+        BOOST_REQUIRE(i != 1 || tester.GetTransport().SetMessageToSend(max_payload_msg));
     }
 
     // Too long garbage (initiator).

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1406,11 +1406,15 @@ BOOST_AUTO_TEST_CASE(outbound_message_limits)
     BOOST_CHECK(more);
     BOOST_CHECK_EQUAL(message_type, MAX_MESSAGE_TYPE);
 
+    V1Transport max_payload_transport{NodeId{0}};
+    auto max_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH)};
+
     // The pending type-limit message keeps messages passed through PushMessage() in the queue
     auto queued{0U};
     for (auto& [msg, reject] : std::array{
              std::pair{MakeNetMessage(std::string{MAX_MESSAGE_TYPE} + 'x', /*payload_size=*/1), true},
-             std::pair{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1), false}}) {
+             std::pair{MakeNetMessage(MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH + 1), false}, // TODO: Reject payloads above the protocol limit
+             std::pair{max_payload_msg.Copy(), false}}) {
         test_only_CheckFailuresAreExceptionsNotAborts mock_checks;
         try {
             m_node.connman->PushMessage(&node, std::move(msg));
@@ -1421,11 +1425,13 @@ BOOST_AUTO_TEST_CASE(outbound_message_limits)
         LOCK(node.cs_vSend);
         BOOST_CHECK_EQUAL(node.vSendMsg.size(), queued);
     }
+    BOOST_REQUIRE(max_payload_transport.SetMessageToSend(max_payload_msg));
 }
 
 BOOST_AUTO_TEST_CASE(v2transport_test)
 {
     auto max_type_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1)};
+    auto max_payload_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH)};
 
     // A mostly normal scenario, testing a transport in initiator mode.
     for (int i = 0; i < 10; ++i) {
@@ -1594,6 +1600,7 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.ReceiveMessage("barfoo", {});
         // Accepted messages occupy the send buffer, so use a separate ready transport for each case.
         BOOST_REQUIRE(i != 0 || tester.GetTransport().SetMessageToSend(max_type_msg));
+        BOOST_REQUIRE(i != 1 || tester.GetTransport().SetMessageToSend(max_payload_msg));
     }
 
     // Too long garbage (initiator).

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1409,7 +1409,7 @@ BOOST_AUTO_TEST_CASE(outbound_message_limits)
     // The pending type-limit message keeps messages passed through PushMessage() in the queue
     auto queued{0U};
     for (auto& [msg, reject] : std::array{
-             std::pair{MakeNetMessage(std::string{MAX_MESSAGE_TYPE} + 'x', /*payload_size=*/1), false}, // TODO: Reject types longer than the wire field
+             std::pair{MakeNetMessage(std::string{MAX_MESSAGE_TYPE} + 'x', /*payload_size=*/1), true},
              std::pair{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1), false}}) {
         test_only_CheckFailuresAreExceptionsNotAborts mock_checks;
         try {

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -22,6 +22,7 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <validation.h>
@@ -29,11 +30,14 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <ios>
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <utility>
 
 using namespace std::literals;
 using namespace util::hex_literals;
@@ -1093,8 +1097,9 @@ public:
 
     /** Send/receive scheduled/available bytes and messages.
      *
-     * This is the only function that interacts with the transport being tested; everything else is
-     * scheduling things done by Interact(), or processing things learned by it.
+     * Aside from GetTransport(), this is the only function that interacts with the transport being
+     * tested; everything else is scheduling things done by Interact(), or processing things learned
+     * by it.
      */
     InteractResult Interact()
     {
@@ -1146,6 +1151,9 @@ public:
 
     /** Expose the cipher. */
     BIP324Cipher& GetCipher() { return m_cipher; }
+
+    /** Expose the transport being tested. */
+    Transport& GetTransport() { return m_transport; }
 
     /** Schedule bytes to be sent to the transport. */
     void Send(std::span<const uint8_t> data)
@@ -1374,10 +1382,51 @@ public:
     }
 };
 
+constexpr std::string_view MAX_MESSAGE_TYPE{"xxxxxxxxxxxx"};
+static_assert(MAX_MESSAGE_TYPE.size() == CMessageHeader::MESSAGE_TYPE_SIZE);
+
+CSerializedNetMsg MakeNetMessage(std::string_view type, size_t payload_size)
+{
+    auto msg{NetMsg::Make(std::string{type})};
+    msg.data.resize(payload_size, uint8_t{0x01});
+    return msg;
+}
+
 } // namespace
+
+BOOST_AUTO_TEST_CASE(outbound_message_limits)
+{
+    CNode node{/*id=*/0, /*sock=*/nullptr, /*addrIn=*/CAddress{}, /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, /*addrBindIn=*/CAddress{}, /*addrNameIn=*/"", ConnectionType::INBOUND, /*inbound_onion=*/false, /*network_key=*/0};
+    auto& max_type_transport{*node.m_transport};
+    auto max_type_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1)};
+    BOOST_REQUIRE(max_type_transport.SetMessageToSend(max_type_msg));
+
+    auto [header, more, message_type]{max_type_transport.GetBytesToSend(/*have_next_message=*/false)};
+    BOOST_CHECK_EQUAL(header.size(), CMessageHeader::HEADER_SIZE);
+    BOOST_CHECK(more);
+    BOOST_CHECK_EQUAL(message_type, MAX_MESSAGE_TYPE);
+
+    // The pending type-limit message keeps messages passed through PushMessage() in the queue
+    auto queued{0U};
+    for (auto& [msg, reject] : std::array{
+             std::pair{MakeNetMessage(std::string{MAX_MESSAGE_TYPE} + 'x', /*payload_size=*/1), false}, // TODO: Reject types longer than the wire field
+             std::pair{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1), false}}) {
+        test_only_CheckFailuresAreExceptionsNotAborts mock_checks;
+        try {
+            m_node.connman->PushMessage(&node, std::move(msg));
+        } catch (const NonFatalCheckError&) {
+            BOOST_CHECK(reject);
+        }
+        queued += !reject;
+        LOCK(node.cs_vSend);
+        BOOST_CHECK_EQUAL(node.vSendMsg.size(), queued);
+    }
+}
 
 BOOST_AUTO_TEST_CASE(v2transport_test)
 {
+    auto max_type_msg{MakeNetMessage(/*type=*/MAX_MESSAGE_TYPE, /*payload_size=*/1)};
+
     // A mostly normal scenario, testing a transport in initiator mode.
     for (int i = 0; i < 10; ++i) {
         V2TransportTester tester(m_rng, true);
@@ -1543,6 +1592,8 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         BOOST_CHECK((*ret)[3]->m_type == "foobar");
         BOOST_CHECK((*ret)[3]->m_recv.empty());
         tester.ReceiveMessage("barfoo", {});
+        // Accepted messages occupy the send buffer, so use a separate ready transport for each case.
+        BOOST_REQUIRE(i != 0 || tester.GetTransport().SetMessageToSend(max_type_msg));
     }
 
     // Too long garbage (initiator).

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1413,7 +1413,7 @@ BOOST_AUTO_TEST_CASE(outbound_message_limits)
     auto queued{0U};
     for (auto& [msg, reject] : std::array{
              std::pair{MakeNetMessage(std::string{MAX_MESSAGE_TYPE} + 'x', /*payload_size=*/1), true},
-             std::pair{MakeNetMessage(MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH + 1), false}, // TODO: Reject payloads above the protocol limit
+             std::pair{MakeNetMessage(MAX_MESSAGE_TYPE, MAX_PROTOCOL_MESSAGE_LENGTH + 1), true},
              std::pair{max_payload_msg.Copy(), false}}) {
         test_only_CheckFailuresAreExceptionsNotAborts mock_checks;
         try {

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -454,8 +454,7 @@ class NetTest(BitcoinTestFramework):
 
         self.log.debug("Test oversized message handling")
         oversized_msg = b'\x00' * (test_framework.messages.MAX_PROTOCOL_MESSAGE_LENGTH + 1)
-        node.sendmsgtopeer(peer_id=0, msg_type="addr", msg=oversized_msg.hex())
-        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)  # TODO: Oversized payloads should be rejected before being sent
+        assert_raises_rpc_error(-8, "Error: msg too large", node.sendmsgtopeer, peer_id=0, msg_type="addr", msg=oversized_msg.hex())
 
     def test_getaddrmaninfo(self):
         self.log.info("Test getaddrmaninfo")

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -446,10 +446,16 @@ class NetTest(BitcoinTestFramework):
         self.log.debug("Test that empty msg is allowed")
         node.sendmsgtopeer(peer_id=0, msg_type="addr", msg="FF")
 
-        self.log.debug("Test that oversized messages are allowed, but get us disconnected")
-        zero_byte_string = b'\x00' * 4000001
-        node.sendmsgtopeer(peer_id=0, msg_type="addr", msg=zero_byte_string.hex())
-        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)
+        self.log.debug("Test that a msg at the size limit is relayed without disconnecting")
+        max_msg = b'\x00' * test_framework.messages.MAX_PROTOCOL_MESSAGE_LENGTH
+        with self.nodes[1].assert_debug_log(expected_msgs=[f"received: unknown ({len(max_msg)} bytes)"], timeout=10):
+            node.sendmsgtopeer(peer_id=0, msg_type="unknown", msg=max_msg.hex())
+        assert_equal(len(node.getpeerinfo()), 1)
+
+        self.log.debug("Test oversized message handling")
+        oversized_msg = b'\x00' * (test_framework.messages.MAX_PROTOCOL_MESSAGE_LENGTH + 1)
+        node.sendmsgtopeer(peer_id=0, msg_type="addr", msg=oversized_msg.hex())
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)  # TODO: Oversized payloads should be rejected before being sent
 
     def test_getaddrmaninfo(self):
         self.log.info("Test getaddrmaninfo")


### PR DESCRIPTION
**Problem:** Outbound transports encode message types in a fixed 12-byte field, but `CConnman` did not ensure internal callers respected this limit before queuing messages.
An oversized type aborts V1 encoding, while V2 can overwrite the first payload byte or write past its encoding buffer.
Normal outbound payloads are also expected to stay within the 4 MB protocol limit, but the send path did not enforce this invariant.

**Fix:** Treat oversized types and payloads as failed assumptions in `CConnman::PushMessage()` before they enter the send queue.
Debug and fuzz builds expose invalid internal callers, while release builds log and drop the messages.
 The testing-only `sendmsgtopeer` RPC rejects oversized payloads before calling `PushMessage()`, while `p2p_invalid_messages.py` continues to cover inbound handling.
