### PR TITLE
rpc: avoid quadratic `gettxspendingprevout` work and preserve order

### DIFF
--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -1020,32 +1020,32 @@ static RPCMethod gettxspendingprevout()
             std::vector<UniValue> results(output_params.size());
 
             // Search the mempool first
+            std::vector<Entry> unresolved;
+            unresolved.reserve(prevouts_to_process.size());
             {
                 const CTxMemPool& mempool = EnsureAnyMemPool(request.context);
                 LOCK(mempool.cs);
 
                 // Make the result if the spending tx appears in the mempool or this is a mempool_only request
-                for (auto it = prevouts_to_process.begin(); it != prevouts_to_process.end(); ) {
-                    const CTransaction* spending_tx{mempool.GetConflictTx(it->outpoint)};
+                for (const auto& prevout : prevouts_to_process) {
+                    const auto* spending_tx{mempool.GetConflictTx(prevout.outpoint)};
 
                     // If the outpoint is not spent in the mempool and this is not a mempool-only
                     // request, we cannot answer it yet.
                     if (!spending_tx && !mempool_only) {
-                        ++it;
-                        continue;
+                        unresolved.push_back(prevout);
+                    } else {
+                        results[prevout.request_index] = make_output(prevout, spending_tx);
                     }
-
-                    results[it->request_index] = make_output(*it, spending_tx);
-                    it = prevouts_to_process.erase(it);
                 }
             }
 
             // mempool_only requests resolve every outpoint above, so only other requests reach the index.
-            if (!prevouts_to_process.empty() && (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain())) {
+            if (!unresolved.empty() && (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain())) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Mempool lacks a relevant spend, and txospenderindex is unavailable.");
             }
 
-            for (const auto& prevout : prevouts_to_process) {
+            for (const auto& prevout : unresolved) {
                 const auto spender{g_txospenderindex->FindSpender(prevout.outpoint)};
                 if (!spender) {
                     throw JSONRPCError(RPC_MISC_ERROR, spender.error());

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -32,6 +32,7 @@
 #include <util/vector.h>
 
 #include <map>
+#include <ranges>
 #include <string_view>
 #include <utility>
 
@@ -984,11 +985,11 @@ static RPCMethod gettxspendingprevout()
             // Worklist of outpoints to resolve
             struct Entry {
                 COutPoint outpoint;
-                const UniValue* raw;
+                size_t request_index;
             };
             std::vector<Entry> prevouts_to_process;
             prevouts_to_process.reserve(output_params.size());
-            for (unsigned int idx = 0; idx < output_params.size(); idx++) {
+            for (const size_t idx : std::views::iota(size_t{0}, output_params.size())) {
                 const UniValue& o = output_params[idx].get_obj();
 
                 RPCTypeCheckObj(o,
@@ -1002,11 +1003,11 @@ static RPCMethod gettxspendingprevout()
                 if (nOutput < 0) {
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout cannot be negative");
                 }
-                prevouts_to_process.emplace_back(COutPoint{txid, static_cast<uint32_t>(nOutput)}, &o);
+                prevouts_to_process.emplace_back(COutPoint{txid, static_cast<uint32_t>(nOutput)}, idx);
             }
 
-            auto make_output = [return_spending_tx](const Entry& prevout, const CTransaction* spending_tx = nullptr) {
-                UniValue o{*prevout.raw};
+            auto make_output = [&output_params, return_spending_tx](const Entry& prevout, const CTransaction* spending_tx = nullptr) {
+                UniValue o{output_params[prevout.request_index]};
                 if (spending_tx) {
                     o.pushKV("spendingtxid", spending_tx->GetHash().ToString());
                     if (return_spending_tx) {

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -1017,7 +1017,7 @@ static RPCMethod gettxspendingprevout()
                 return o;
             };
 
-            UniValue result{UniValue::VARR};
+            std::vector<UniValue> results(output_params.size());
 
             // Search the mempool first
             {
@@ -1035,19 +1035,13 @@ static RPCMethod gettxspendingprevout()
                         continue;
                     }
 
-                    result.push_back(make_output(*it, spending_tx));
+                    results[it->request_index] = make_output(*it, spending_tx);
                     it = prevouts_to_process.erase(it);
                 }
             }
 
-            // Return early if all requests have been handled by the mempool search
-            if (prevouts_to_process.empty()) {
-                return result;
-            }
-
-            // At this point the request was not limited to the mempool and some outpoints remain
-            // unresolved. We now rely on the index to determine whether they were spent or not.
-            if (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain()) {
+            // mempool_only requests resolve every outpoint above, so only other requests reach the index.
+            if (!prevouts_to_process.empty() && (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain())) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Mempool lacks a relevant spend, and txospenderindex is unavailable.");
             }
 
@@ -1060,13 +1054,16 @@ static RPCMethod gettxspendingprevout()
                 if (const auto& spender_opt{spender.value()}) {
                     UniValue o{make_output(prevout, spender_opt->tx.get())};
                     o.pushKV("blockhash", spender_opt->block_hash.GetHex());
-                    result.push_back(std::move(o));
+                    results[prevout.request_index] = std::move(o);
                 } else {
                     // Only return the input outpoint itself, which indicates it is unspent.
-                    result.push_back(make_output(prevout));
+                    results[prevout.request_index] = make_output(prevout);
                 }
             }
 
+            UniValue result{UniValue::VARR};
+            result.reserve(results.size());
+            for (auto& output : results) result.push_back(std::move(output));
             return result;
         },
     };

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -32,6 +32,7 @@
 #include <util/vector.h>
 
 #include <map>
+#include <ranges>
 #include <string_view>
 #include <utility>
 
@@ -984,11 +985,11 @@ static RPCMethod gettxspendingprevout()
             // Worklist of outpoints to resolve
             struct Entry {
                 COutPoint outpoint;
-                const UniValue* raw;
+                size_t request_index;
             };
             std::vector<Entry> prevouts_to_process;
             prevouts_to_process.reserve(output_params.size());
-            for (unsigned int idx = 0; idx < output_params.size(); idx++) {
+            for (size_t idx : std::views::iota(size_t{0}, output_params.size())) {
                 const UniValue& o = output_params[idx].get_obj();
 
                 RPCTypeCheckObj(o,
@@ -1002,11 +1003,11 @@ static RPCMethod gettxspendingprevout()
                 if (nOutput < 0) {
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout cannot be negative");
                 }
-                prevouts_to_process.emplace_back(COutPoint{txid, static_cast<uint32_t>(nOutput)}, &o);
+                prevouts_to_process.emplace_back(COutPoint{txid, static_cast<uint32_t>(nOutput)}, idx);
             }
 
-            auto make_output = [return_spending_tx](const Entry& prevout, const CTransaction* spending_tx = nullptr) {
-                UniValue o{*prevout.raw};
+            auto make_output = [&output_params, return_spending_tx](const Entry& prevout, const CTransaction* spending_tx = nullptr) {
+                UniValue o{output_params[prevout.request_index]};
                 if (spending_tx) {
                     o.pushKV("spendingtxid", spending_tx->GetHash().ToString());
                     if (return_spending_tx) {

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -1017,7 +1017,7 @@ static RPCMethod gettxspendingprevout()
                 return o;
             };
 
-            UniValue result{UniValue::VARR};
+            std::vector<UniValue> results(output_params.size());
 
             // Search the mempool first
             {
@@ -1035,19 +1035,13 @@ static RPCMethod gettxspendingprevout()
                         continue;
                     }
 
-                    result.push_back(make_output(*it, spending_tx));
+                    results[it->request_index] = make_output(*it, spending_tx);
                     it = prevouts_to_process.erase(it);
                 }
             }
 
-            // Return early if all requests have been handled by the mempool search
-            if (prevouts_to_process.empty()) {
-                return result;
-            }
-
-            // At this point the request was not limited to the mempool and some outpoints remain
-            // unresolved. We now rely on the index to determine whether they were spent or not.
-            if (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain()) {
+            // mempool_only requests resolve every outpoint above, so only other requests reach the index.
+            if (!prevouts_to_process.empty() && (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain())) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Mempool lacks a relevant spend, and txospenderindex is unavailable.");
             }
 
@@ -1060,13 +1054,15 @@ static RPCMethod gettxspendingprevout()
                 if (const auto& spender_opt{spender.value()}) {
                     UniValue o{make_output(prevout, spender_opt->tx.get())};
                     o.pushKV("blockhash", spender_opt->block_hash.GetHex());
-                    result.push_back(std::move(o));
+                    results[prevout.request_index] = std::move(o);
                 } else {
                     // Only return the input outpoint itself, which indicates it is unspent.
-                    result.push_back(make_output(prevout));
+                    results[prevout.request_index] = make_output(prevout);
                 }
             }
 
+            UniValue result{UniValue::VARR};
+            for (auto& output : results) result.push_back(std::move(output));
             return result;
         },
     };

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -1020,32 +1020,32 @@ static RPCMethod gettxspendingprevout()
             std::vector<UniValue> results(output_params.size());
 
             // Search the mempool first
+            std::vector<Entry> unresolved;
+            unresolved.reserve(prevouts_to_process.size());
             {
                 const CTxMemPool& mempool = EnsureAnyMemPool(request.context);
                 LOCK(mempool.cs);
 
                 // Make the result if the spending tx appears in the mempool or this is a mempool_only request
-                for (auto it = prevouts_to_process.begin(); it != prevouts_to_process.end(); ) {
-                    const CTransaction* spending_tx{mempool.GetConflictTx(it->outpoint)};
+                for (auto& prevout : prevouts_to_process) {
+                    auto* spending_tx{mempool.GetConflictTx(prevout.outpoint)};
 
                     // If the outpoint is not spent in the mempool and this is not a mempool-only
                     // request, we cannot answer it yet.
                     if (!spending_tx && !mempool_only) {
-                        ++it;
-                        continue;
+                        unresolved.push_back(prevout);
+                    } else {
+                        results[prevout.request_index] = make_output(prevout, spending_tx);
                     }
-
-                    results[it->request_index] = make_output(*it, spending_tx);
-                    it = prevouts_to_process.erase(it);
                 }
             }
 
             // mempool_only requests resolve every outpoint above, so only other requests reach the index.
-            if (!prevouts_to_process.empty() && (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain())) {
+            if (unresolved.size() && (!g_txospenderindex || !g_txospenderindex->BlockUntilSyncedToCurrentChain())) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Mempool lacks a relevant spend, and txospenderindex is unavailable.");
             }
 
-            for (const auto& prevout : prevouts_to_process) {
+            for (auto& prevout : unresolved) {
                 const auto spender{g_txospenderindex->FindSpender(prevout.outpoint)};
                 if (!spender) {
                     throw JSONRPCError(RPC_MISC_ERROR, spender.error());

--- a/test/functional/rpc_gettxspendingprevout.py
+++ b/test/functional/rpc_gettxspendingprevout.py
@@ -215,7 +215,6 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         self.log.info("Check mixed mempool and index result order")
         tx4 = create_tx(utxos_to_spend=[txH["new_utxos"][0]], num_outputs=1)
         result = node0.gettxspendingprevout([prevout(txid_reorg_cancel_utxo, vout=0), prevout(txidH, vout=0)])
-        result.reverse()  # TODO: Return results in request order
         assert_equal(result, [
             spent_out(txid_reorg_cancel_utxo, vout=0, spending_tx_id=tx3["txid"]) | {"blockhash": blockhash},
             spent_out(txidH, vout=0, spending_tx_id=tx4["txid"]),

--- a/test/functional/rpc_gettxspendingprevout.py
+++ b/test/functional/rpc_gettxspendingprevout.py
@@ -212,6 +212,15 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         result = node0.gettxspendingprevout([prevout(tx1['txid'], vout=0)], return_spending_tx=True)
         assert_equal(result, [unspent_out(tx1['txid'], vout=0)])
 
+        self.log.info("Check mixed mempool and index result order")
+        tx4 = create_tx(utxos_to_spend=[txH["new_utxos"][0]], num_outputs=1)
+        result = node0.gettxspendingprevout([prevout(txid_reorg_cancel_utxo, vout=0), prevout(txidH, vout=0)])
+        result.reverse()  # TODO: Return results in request order
+        assert_equal(result, [
+            spent_out(txid_reorg_cancel_utxo, vout=0, spending_tx_id=tx3["txid"]) | {"blockhash": blockhash},
+            spent_out(txidH, vout=0, spending_tx_id=tx4["txid"]),
+        ])
+
 
 if __name__ == '__main__':
     GetTxSpendingPrevoutTest(__file__).main()


### PR DESCRIPTION
**Problem:** `gettxspendingprevout` erases each mempool result from a vector while holding `mempool.cs`, shifting the remaining requests every time and making large calls quadratic in the critical section.
For 10,000 mempool matches, an [operation-count model](https://godbolt.org/z/nzch7McPG) reaches nearly 50 million moves.
For mixed requests, the RPC returns mempool results before `txospenderindex` results instead of following request order.
#34749 introduced both regressions.

**Fix:** `gettxspendingprevout` stores each result at its request position and collects unresolved requests in a reserved worklist for the `txospenderindex` lookup.
The mempool pass is linear, the response follows request order, and Clang can verify the lock requirement on `GetConflictTx`.

**Benchmark:** The [functional benchmark](https://gist.github.com/l0rinc/c3231e287cacfdefd100dbf95cd0c3ad) sends mempool-only requests ranging from 8,000 to 128,000 entries ten times per size.
Using the same settings for the unfixed and fixed commits:

```text
AMD Ryzen 7 3700X (8 cores)
unfixed  ██████████████████████████████  90 s
fixed    ███▒░░░░░░░░░░░░░░░░░░░░░░░░░░  10 s  (-80 s, 9.0x faster)

Raspberry Pi 5 (4 cores)
unfixed  ██████████████████████████████  685 s
fixed    ▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  22 s  (-663 s, 31.1x faster)
```

The unfixed run timed out after ~9 minutes on a Raspberry Pi 4 with 1 GB RAM.

<details><summary>Benchmark command</summary>

```bash
for commit in 963b061358b489b2ff4ff64895f2b895b3b89844 46e7173550a93cbe9d4e8ea28cfe7216286d8197; do \
  git fetch origin "$commit" && git checkout --detach "$commit" && \
  rm -rfd build && cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF -DENABLE_WALLET=OFF >/dev/null 2>&1 && \
  ninja -C build -j1 bitcoind >/dev/null 2>&1 && \
  build/test/functional/test_runner.py rpc_gettxspendingprevout_quadratic.py --repeats=10 || break; \
done
```
</details>
