### PR TITLE
doc: use overwrite (>) instead of append (>>) for one-shot PSBT files in offline-signing-tutorial.md

### DIFF
--- a/doc/offline-signing-tutorial.md
+++ b/doc/offline-signing-tutorial.md
@@ -112,7 +112,7 @@ tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh
 [online]$ ./build/bin/bitcoin-cli -signet -rpcwallet="watch_only_wallet" send \
               '{"tb1q9k5w0nhnhyeh78snpxh0t5t7c3lxdeg3erez32": 0.009}' \
               | jq -r '.psbt' \
-              >> /path/to/funded_psbt.txt
+              > /path/to/funded_psbt.txt
 
 [online]$ cat /path/to/funded_psbt.txt
 
@@ -170,7 +170,7 @@ Use the walletpassphrase command to unlock the `offline_wallet` with the passphr
 [offline]$ ./build/bin/bitcoin-cli -signet -rpcwallet="offline_wallet" walletprocesspsbt \
                 $(cat /path/to/funded_psbt.txt) \
                 | jq -r .hex \
-                >> /path/to/final_psbt.txt
+                > /path/to/final_psbt.txt
  ```
 
 ### Broadcast the Signed and Finalized PSBT


### PR DESCRIPTION
`funded_psbt.txt` and `final_psbt.txt` should only ever have one line in them, since later steps just do `$(cat ...)` to read them back. but the tutorial uses `>>` (append) instead of `>` (overwrite), so if you run the `send` or `walletprocesspsbt` step twice without deleting the file, it adds a second line instead of replacing the first one. then `$(cat ...)` picks up both lines as separate args and the next command fails with too many arguments.

Fixes #35862.
