### PR TITLE
refactor: Default uint256::operator==, add operator<=>

### DIFF
--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(bench_bitcoin
   strencodings.cpp
   txgraph.cpp
   txorphanage.cpp
+  uint256_blob.cpp
   util_time.cpp
   verify_script.cpp
 )

--- a/src/bench/uint256_blob.cpp
+++ b/src/bench/uint256_blob.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
+#include <bench/bench.h>
+#include <random.h>
+#include <uint256.h>
+
+#include <compare>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace {
+
+enum class Difference {
+    NONE,
+    FIRST_BYTE,
+    LAST_BYTE,
+};
+
+constexpr size_t NUM_PAIRS{4'096};
+
+std::vector<std::pair<uint256, uint256>> MakePairs(Difference difference)
+{
+    FastRandomContext rng{/*fDeterministic=*/true};
+    std::vector<std::pair<uint256, uint256>> pairs;
+    pairs.reserve(NUM_PAIRS);
+
+    for (size_t i{0}; i < NUM_PAIRS; ++i) {
+        uint256 lhs{rng.rand256()};
+        uint256 rhs{lhs};
+        if (difference != Difference::NONE) {
+            const size_t position{difference == Difference::FIRST_BYTE ? 0 : uint256::size() - 1};
+            lhs.begin()[position] = i % 2 == 0 ? 0 : 255;
+            rhs.begin()[position] = i % 2 == 0 ? 255 : 0;
+        }
+        pairs.emplace_back(lhs, rhs);
+    }
+    return pairs;
+}
+
+template <typename Comparator>
+void Comparison(benchmark::Bench& bench, Difference difference, Comparator comparator)
+{
+    const auto pairs{MakePairs(difference)};
+    bench.batch(pairs.size()).unit("comparison").run([&] {
+        for (const auto& [lhs, rhs] : pairs) {
+            ankerl::nanobench::doNotOptimizeAway(comparator(lhs, rhs));
+        }
+    });
+}
+
+void Uint256EqualIdentical(benchmark::Bench& bench)
+{
+    Comparison(bench, Difference::NONE, [](const uint256& lhs, const uint256& rhs) { return lhs == rhs; });
+}
+
+void Uint256EqualFirstByteDifferent(benchmark::Bench& bench)
+{
+    Comparison(bench, Difference::FIRST_BYTE, [](const uint256& lhs, const uint256& rhs) { return lhs == rhs; });
+}
+
+void Uint256EqualLastByteDifferent(benchmark::Bench& bench)
+{
+    Comparison(bench, Difference::LAST_BYTE, [](const uint256& lhs, const uint256& rhs) { return lhs == rhs; });
+}
+
+void Uint256LessIdentical(benchmark::Bench& bench)
+{
+    Comparison(bench, Difference::NONE, [](const uint256& lhs, const uint256& rhs) { return lhs < rhs; });
+}
+
+void Uint256LessFirstByteDifferent(benchmark::Bench& bench)
+{
+    Comparison(bench, Difference::FIRST_BYTE, [](const uint256& lhs, const uint256& rhs) { return lhs < rhs; });
+}
+
+void Uint256LessLastByteDifferent(benchmark::Bench& bench)
+{
+    Comparison(bench, Difference::LAST_BYTE, [](const uint256& lhs, const uint256& rhs) { return lhs < rhs; });
+}
+
+} // namespace
+
+BENCHMARK(Uint256EqualIdentical);
+BENCHMARK(Uint256EqualFirstByteDifferent);
+BENCHMARK(Uint256EqualLastByteDifferent);
+BENCHMARK(Uint256LessIdentical);
+BENCHMARK(Uint256LessFirstByteDifferent);
+BENCHMARK(Uint256LessLastByteDifferent);

--- a/src/primitives/transaction_identifier.h
+++ b/src/primitives/transaction_identifier.h
@@ -7,7 +7,6 @@
 
 #include <attributes.h>
 #include <uint256.h>
-#include <util/types.h>
 
 #include <compare>
 #include <cstddef>
@@ -28,22 +27,12 @@ class transaction_identifier
     // Note: Use FromUint256 externally instead.
     transaction_identifier(const uint256& wrapped) : m_wrapped{wrapped} {}
 
-    constexpr int Compare(const transaction_identifier<has_witness>& other) const { return m_wrapped.Compare(other.m_wrapped); }
-    template <typename Other>
-    constexpr int Compare(const Other& other) const
-    {
-        static_assert(ALWAYS_FALSE<Other>, "Forbidden comparison type");
-        return 0;
-    }
-
 public:
     transaction_identifier() : m_wrapped{} {}
     consteval explicit transaction_identifier(std::string_view hex_str) : m_wrapped{uint256{hex_str}} {}
 
-    template <typename Other>
-    bool operator==(const Other& other) const { return Compare(other) == 0; }
-    template <typename Other>
-    std::strong_ordering operator<=>(const Other& other) const { return Compare(other) <=> 0; }
+    constexpr bool operator==(const transaction_identifier&) const = default;
+    constexpr auto operator<=>(const transaction_identifier&) const = default;
 
     const uint256& ToUint256() const LIFETIMEBOUND { return m_wrapped; }
     static transaction_identifier FromUint256(const uint256& id) { return {id}; }

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -59,6 +59,8 @@ public:
         std::fill(m_data.begin(), m_data.end(), 0);
     }
 
+    constexpr bool operator==(const base_blob&) const = default;
+
     /** Lexicographic ordering
      * @note Does NOT match the ordering on the corresponding \ref
      *       base_uint::CompareTo, which starts comparing from the end.
@@ -70,7 +72,6 @@ public:
         return 0;
     }
 
-    friend constexpr bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
     friend constexpr bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
 
     /** @name Hex representation

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -65,14 +65,7 @@ public:
      * @note Does NOT match the ordering on the corresponding \ref
      *       base_uint::CompareTo, which starts comparing from the end.
      */
-    constexpr int Compare(const base_blob& other) const {
-        auto cmp = m_data <=> other.m_data;
-        if (cmp < 0) return -1;
-        if (cmp > 0) return 1;
-        return 0;
-    }
-
-    friend constexpr bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
+    constexpr std::strong_ordering operator<=>(const base_blob& other) const = default;
 
     /** @name Hex representation
      *

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -64,8 +64,8 @@ public:
     NonFatalCheckError(std::string_view msg, const std::source_location& loc);
 };
 
-/** Internal helper */
-void assertion_fail(const std::source_location& loc, std::string_view assertion);
+/// Internal helper. The noreturn enables optimizers to discard invalid paths.
+[[noreturn]] void assertion_fail(const std::source_location& loc, std::string_view assertion);
 
 /** Helper for CHECK_NONFATAL() */
 template <typename T>


### PR DESCRIPTION
Some refactors with rationale:

* Default the `uint256` base blob equals operator, because this is standard C++20 practise.
* Add the `uint256` base blob `<=>` operator, because this is standard C++20 practise. Also, `transaction_identifier` already offers such an operator. This allows to remove the non-standard `Compare()` function.
* Add a `[[noreturn]]` to the assertion failure helper that does not return. This is standard C++11 practise.
