### PR TITLE
iwyu: Fix warnings in `src/interfaces` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -249,6 +249,7 @@ if [[ "${RUN_IWYU}" == true ]]; then
              -Xiwyu --max_line_length=160 \
              -Xiwyu --check_also='*/common/types\.h' \
              -Xiwyu --check_also='*/consensus/*\.h' \
+             -Xiwyu --check_also='*/interfaces/*\.h' \
              -Xiwyu --check_also='*/primitives/transaction_identifier\.h' \
              2>&1 || true
     } | tee /tmp/iwyu_ci.out

--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -5,4 +5,8 @@
   { "include": [ "<mmintrin.h>", "private", "<immintrin.h>", "public" ] },
   { "include": [ "<smmintrin.h>", "private", "<immintrin.h>", "public" ] },
   { "include": [ "<tmmintrin.h>", "private", "<immintrin.h>", "public" ] },
+
+  # Workaround for IWYU issue.
+  # See: https://github.com/include-what-you-use/include-what-you-use/issues/2084.
+  { "symbol": ["std::tuple", "private", "<tuple>", "public"] },
 ]

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -7,10 +7,11 @@
 
 #include <blockfilter.h>
 #include <common/settings.h>
+#include <consensus/amount.h>
 #include <kernel/chain.h> // IWYU pragma: export
-#include <node/types.h>
 #include <primitives/transaction.h>
 #include <util/result.h>
+#include <util/time.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -21,9 +22,7 @@
 #include <string>
 #include <vector>
 
-class ArgsManager;
 class CBlock;
-class CBlockUndo;
 class CFeeRate;
 class CRPCCommand;
 class CScheduler;
@@ -39,12 +38,11 @@ struct ChainstateRole;
 } // namespace kernel
 namespace node {
 struct NodeContext;
+enum class TxBroadcast : uint8_t;
 } // namespace node
 
 namespace interfaces {
-
 class Handler;
-class Wallet;
 
 //! Helper for findBlock to selectively return pieces of block data. If block is
 //! found, data will be returned by setting specified output variables. If block

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -7,12 +7,13 @@
 
 #include <blockfilter.h>
 #include <common/settings.h>
+#include <consensus/amount.h>
 #include <kernel/chain.h> // IWYU pragma: export
-#include <node/types.h>
 #include <primitives/transaction.h>
 #include <util/expected.h>
 #include <util/fees.h>
 #include <util/result.h>
+#include <util/time.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -23,9 +24,7 @@
 #include <string>
 #include <vector>
 
-class ArgsManager;
 class CBlock;
-class CBlockUndo;
 class CFeeRate;
 class CRPCCommand;
 class CScheduler;
@@ -40,12 +39,11 @@ struct ChainstateRole;
 } // namespace kernel
 namespace node {
 struct NodeContext;
+enum class TxBroadcast : uint8_t;
 } // namespace node
 
 namespace interfaces {
-
 class Handler;
-class Wallet;
 
 //! Helper for findBlock to selectively return pieces of block data. If block is
 //! found, data will be returned by setting specified output variables. If block

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -11,35 +11,30 @@
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
-#include <support/allocators/secure.h>
+#include <primitives/transaction.h>
+#include <uint256.h>
 #include <util/log.h>
 #include <util/translation.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
 
-class BanMan;
 class CFeeRate;
-class CNodeStats;
 class Coin;
 class UniValue;
-class Proxy;
 enum class SynchronizationState;
 struct CNodeStateStats;
-struct bilingual_str;
 namespace node {
 enum class TransactionError;
 struct NodeContext;
 } // namespace node
-namespace wallet {
-class CCoinControl;
-} // namespace wallet
 
 namespace interfaces {
 class Handler;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -10,36 +10,34 @@
 #include <common/types.h>
 #include <consensus/amount.h>
 #include <interfaces/chain.h>
-#include <primitives/transaction_identifier.h>
-#include <pubkey.h>
-#include <script/script.h>
+#include <primitives/transaction.h>
 #include <support/allocators/secure.h>
 #include <util/fs.h>
 #include <util/result.h>
 #include <util/ui_change_type.h>
 
+#include <compare>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
+#include <set>
 #include <string>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
-class CFeeRate;
-class CKey;
+class ArgsManager;
+class CKeyID;
+class CPubKey;
+class CScript;
+class PartiallySignedTransaction;
+class uint256;
 enum class FeeReason;
 enum class OutputType;
-class PartiallySignedTransaction;
 struct bilingual_str;
-namespace common {
-enum class PSBTError;
-} // namespace common
-namespace node {
-enum class TransactionError;
-} // namespace node
 namespace wallet {
 struct CreatedTransactionResult;
 class CCoinControl;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -10,37 +10,34 @@
 #include <common/types.h>
 #include <consensus/amount.h>
 #include <interfaces/chain.h>
-#include <primitives/transaction_identifier.h>
-#include <pubkey.h>
-#include <script/script.h>
+#include <primitives/transaction.h>
 #include <support/allocators/secure.h>
 #include <util/fs.h>
 #include <util/result.h>
 #include <util/ui_change_type.h>
 
+#include <compare>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
-class CFeeRate;
-class CKey;
+class ArgsManager;
+class CKeyID;
+class CPubKey;
+class CScript;
+class PartiallySignedTransaction;
+class uint256;
 enum class FeeReason;
 enum class OutputType;
-class PartiallySignedTransaction;
 struct bilingual_str;
-namespace common {
-enum class PSBTError;
-} // namespace common
-namespace node {
-enum class TransactionError;
-} // namespace node
 namespace wallet {
 struct CreatedTransactionResult;
 class CCoinControl;

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <variant>
 
 const SigningProvider& DUMMY_SIGNING_PROVIDER = SigningProvider();
 

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -25,7 +25,6 @@
 #include <span>
 #include <tuple>
 #include <utility>
-#include <variant>
 #include <vector>
 
 class MuSig2SecNonce;


### PR DESCRIPTION
This PR continues the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).