### PR TITLE
wallet: Fix ScanForWalletTransactions missing tx when look-ahead pool expands mid-block

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1963,8 +1963,41 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                     result.status = ScanResult::FAILURE;
                     break;
                 }
-                for (size_t posInBlock = 0; posInBlock < block.vtx.size(); ++posInBlock) {
-                    SyncTransaction(block.vtx[posInBlock], TxStateConfirmed{block_hash, block_height, static_cast<int>(posInBlock)}, /*rescanning_old_block=*/true);
+                // Collect range_end per HD descriptor so we can detect a mid-block
+                // look-ahead pool expansion (TopUp called from MarkUnusedAddresses).
+                auto collect_range_ends = [this]() {
+                    std::map<uint256, int32_t> ends;
+                    for (const auto* spkm : GetAllScriptPubKeyMans()) {
+                        if (const auto* desc = dynamic_cast<const DescriptorScriptPubKeyMan*>(spkm)) {
+                            if (desc->IsHDEnabled()) ends[desc->GetID()] = desc->GetEndRange();
+                        }
+                    }
+                    return ends;
+                };
+                // Process transactions in vtx order. If a pool-expanding tx appears
+                // after a tx paying to a not-yet-derived key in the same block, the
+                // earlier tx is missed. Track the last vtx position where the pool
+                // expands and re-scan only the prefix before it [0, scan_end) on the
+                // next pass, to recover missed txs without re-processing ones that
+                // came after the final expansion (which would double-fire
+                // walletnotify for those). The prefix shrinks each pass, guaranteeing
+                // termination.
+                auto range_ends = collect_range_ends();
+                size_t scan_end = block.vtx.size();
+                while (scan_end > 0) {
+                    std::optional<size_t> next_scan_end;
+                    for (size_t pos_in_block = 0; pos_in_block < scan_end; ++pos_in_block) {
+                        if (!SyncTransaction(block.vtx[pos_in_block], TxStateConfirmed{block_hash, block_height, static_cast<int>(pos_in_block)}, /*rescanning_old_block=*/true)) {
+                            continue; // Not wallet-relevant; the pool cannot have expanded.
+                        }
+                        auto cur = collect_range_ends();
+                        if (cur != range_ends) {
+                            next_scan_end = pos_in_block;
+                            range_ends = std::move(cur);
+                        }
+                    }
+                    if (!next_scan_end.has_value()) break;
+                    scan_end = *next_scan_end;
                 }
                 // scan succeeded, record block as most recent successfully scanned
                 result.last_scanned_block = block_hash;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1963,8 +1963,35 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                     result.status = ScanResult::FAILURE;
                     break;
                 }
-                for (size_t posInBlock = 0; posInBlock < block.vtx.size(); ++posInBlock) {
-                    SyncTransaction(block.vtx[posInBlock], TxStateConfirmed{block_hash, block_height, static_cast<int>(posInBlock)}, /*rescanning_old_block=*/true);
+                // Collect range_end per HD descriptor so we can detect a mid-block
+                // look-ahead pool expansion (TopUp called from MarkUnusedAddresses).
+                auto collect_range_ends = [this]() {
+                    std::map<uint256, int32_t> ends;
+                    for (const auto* spkm : GetAllScriptPubKeyMans()) {
+                        if (const auto* desc = dynamic_cast<const DescriptorScriptPubKeyMan*>(spkm)) {
+                            if (desc->IsHDEnabled()) ends[desc->GetID()] = desc->GetEndRange();
+                        }
+                    }
+                    return ends;
+                };
+                // Process transactions in vtx order. If a pool-expanding tx (which
+                // triggers TopUp and derives new keys) appears after a tx sending to
+                // one of those not-yet-derived keys in the same block, the earlier tx
+                // is missed. Re-process the block until the pool is stable so that
+                // transactions to newly-derived keys at earlier vtx positions are found.
+                // Each extra pass requires at least one newly pool-expanded tx, so the
+                // number of passes is bounded by block size. The pass cap is a safety
+                // net against adversarially crafted blocks where many txs cascade
+                // successive pool expansions; in normal operation the loop runs once.
+                auto range_ends = collect_range_ends();
+                for (size_t pass = 0; ; ++pass) {
+                    for (size_t posInBlock = 0; posInBlock < block.vtx.size(); ++posInBlock) {
+                        SyncTransaction(block.vtx[posInBlock], TxStateConfirmed{block_hash, block_height, static_cast<int>(posInBlock)}, /*rescanning_old_block=*/true);
+                    }
+                    auto new_range_ends = collect_range_ends();
+                    if (new_range_ends == range_ends) break;
+                    if (pass >= block.vtx.size()) break; // safety cap
+                    range_ends = std::move(new_range_ends);
                 }
                 // scan succeeded, record block as most recent successfully scanned
                 result.last_scanned_block = block_hash;

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -327,6 +327,7 @@ BASE_SCRIPTS = [
     'wallet_sendmany.py',
     'wallet_spend_unconfirmed.py',
     'wallet_rescan_unconfirmed.py',
+    'wallet_rescan_intrablock_ordering.py',
     'p2p_fingerprint.py',
     'feature_uacomment.py',
     'feature_init.py',

--- a/test/functional/wallet_rescan_intrablock_ordering.py
+++ b/test/functional/wallet_rescan_intrablock_ordering.py
@@ -31,12 +31,9 @@ Background:
    before the block arrives, so the pool is already extended when blockConnected
    processes the block in vtx order.
 
-   This test demonstrates the incorrect behaviour. Parts 1 and 2 assert that
-   Tx_lookahead is missed on the first scan; Part 3 confirms that a second
-   rescanblockchain does recover it (pool was extended as a side effect of finding
-   Tx_expand).
-
-   TODO: Parts 1 and 2 assertions will be flipped once the fix lands.
+   This test verifies the fix: after re-processing the vtx prefix up to the last
+   pool expansion, Tx_lookahead is found on the first scan. Part 3 confirms that
+   a second rescanblockchain is no longer needed to recover the missed transaction.
 
    Reference: https://github.com/bitcoin/bitcoin/pull/31629#issuecomment-2657775368
 """
@@ -130,9 +127,8 @@ class WalletRescanIntraBlockOrderingTest(BitcoinTestFramework):
         txids = {tx['txid'] for tx in w.listtransactions('*', 1000)}
         assert tx_expand['txid'] in txids, \
             "tx_expand must always be found (it was within the initial pool)"
-        # TODO: flip to `in` once the fix lands — currently missed due to vtx-order bug
-        assert tx_lookahead['txid'] not in txids, \
-            "pre-fix: tx_lookahead is missed when pool-expanding tx appears later in vtx order"
+        assert tx_lookahead['txid'] in txids, \
+            "tx_lookahead must be found after fix: block is re-processed when pool expands mid-block"
 
         # -----------------------------------------------------------------------
         # Part 2: ScanForWalletTransactions via importdescriptors (timestamp=0)
@@ -148,9 +144,8 @@ class WalletRescanIntraBlockOrderingTest(BitcoinTestFramework):
         txids_rescan = {tx['txid'] for tx in w_rescan.listtransactions('*', 1000)}
         assert tx_expand['txid'] in txids_rescan, \
             "tx_expand must be found after full rescan"
-        # TODO: flip to `in` once the fix lands — currently missed due to vtx-order bug
-        assert tx_lookahead['txid'] not in txids_rescan, \
-            "pre-fix: tx_lookahead is missed on full rescan"
+        assert tx_lookahead['txid'] in txids_rescan, \
+            "tx_lookahead must be found after fix: block re-processed when pool expands mid-block"
 
         # -----------------------------------------------------------------------
         # Part 3: a second rescanblockchain recovers tx_lookahead.
@@ -167,6 +162,88 @@ class WalletRescanIntraBlockOrderingTest(BitcoinTestFramework):
         assert tx_lookahead['txid'] in txids_after_second_scan, \
             "tx_lookahead must be recovered on a second rescan (pool was already extended)"
         assert tx_expand['txid'] in txids_after_second_scan
+
+        # -----------------------------------------------------------------------
+        # Part 4: cascading pool expansions — two levels in one block, interleaved.
+        #
+        # vtx order: [lookahead_1, expand_1, lookahead_2, expand_2]
+        #   pos 0: lookahead_1 — outside pool → missed without fix
+        #   pos 1: expand_1   — in pool → found, TopUp fires (pool grows to [0, e2])
+        #   pos 2: lookahead_2 — outside expanded pool → missed without fix
+        #   pos 3: expand_2   — in expanded pool → found, TopUp fires again
+        #
+        # With first_expansion_pos=1, re-scanning [0,1) finds lookahead_1 but misses
+        # lookahead_2. last_expansion_pos=3 re-scans [0,3) and finds both.
+        #
+        # A probe wallet triggers the first TopUp via the mempool path and reads the
+        # resulting boundary dynamically — no hardcoded keypool size assumptions.
+        # -----------------------------------------------------------------------
+        self.log.info("Part 4: cascading pool expansions — two TopUp levels in one block")
+
+        node.createwallet(wallet_name='w_probe', disable_private_keys=True, blank=True)
+        w_probe = node.get_wallet_rpc('w_probe')
+        w_probe.importdescriptors([{"desc": recv_desc['desc'], "timestamp": "now"}])
+        probe_descs = w_probe.listdescriptors()['descriptors']
+        probe_recv = next(d for d in probe_descs if 'range' in d and not d.get('internal', False))
+        _, e1 = probe_recv['range']
+        addr_expand_1 = w_probe.deriveaddresses(probe_recv['desc'], [e1, e1])[0]
+        addr_lookahead_1 = w_probe.deriveaddresses(probe_recv['desc'], [e1 + 1, e1 + 1])[0]
+
+        probe_tx = funding_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(addr_expand_1),
+            amount=10_000,
+        )
+        node.syncwithvalidationinterfacequeue()
+
+        probe_descs = w_probe.listdescriptors()['descriptors']
+        probe_recv = next(d for d in probe_descs if 'range' in d and not d.get('internal', False))
+        _, e2 = probe_recv['range']
+        addr_expand_2 = w_probe.deriveaddresses(probe_recv['desc'], [e2, e2])[0]
+        addr_lookahead_2 = w_probe.deriveaddresses(probe_recv['desc'], [e2 + 1, e2 + 1])[0]
+        node.unloadwallet('w_probe')
+
+        self.log.info(f"First boundary:  e1={e1}, expand_1={addr_expand_1}, lookahead_1={addr_lookahead_1}")
+        self.log.info(f"Second boundary: e2={e2}, expand_2={addr_expand_2}, lookahead_2={addr_lookahead_2}")
+
+        self.generateblock(node, output="raw(51)", transactions=[probe_tx['txid']])
+
+        # Mine an extra block so the probe block is strictly before w_cascade's scan
+        # start. Without this, importdescriptors(timestamp="now") may include the probe
+        # block in the rescan, triggering TopUp early and making lookahead_1 visible
+        # before the cascade block is processed — hiding the bug this test targets.
+        self.generate(node, 1)
+
+        node.createwallet(wallet_name='w_cascade', disable_private_keys=True, blank=True)
+        w_cascade = node.get_wallet_rpc('w_cascade')
+        w_cascade.importdescriptors([{"desc": recv_desc['desc'], "timestamp": "now"}])
+        node.unloadwallet('w_cascade')
+
+        tx_c_expand_1 = funding_wallet.send_to(from_node=node, scriptPubKey=address_to_scriptpubkey(addr_expand_1), amount=10_000)
+        tx_c_expand_2 = funding_wallet.send_to(from_node=node, scriptPubKey=address_to_scriptpubkey(addr_expand_2), amount=10_000)
+        tx_c_lookahead_1 = funding_wallet.send_to(from_node=node, scriptPubKey=address_to_scriptpubkey(addr_lookahead_1), amount=10_000)
+        tx_c_lookahead_2 = funding_wallet.send_to(from_node=node, scriptPubKey=address_to_scriptpubkey(addr_lookahead_2), amount=10_000)
+
+        self.generateblock(node, output="raw(51)", transactions=[
+            tx_c_lookahead_1['txid'],
+            tx_c_expand_1['txid'],
+            tx_c_lookahead_2['txid'],
+            tx_c_expand_2['txid'],
+        ])
+
+        node.loadwallet('w_cascade')
+        w_cascade = node.get_wallet_rpc('w_cascade')
+        node.syncwithvalidationinterfacequeue()
+
+        txids_cascade = {tx['txid'] for tx in w_cascade.listtransactions('*', 1000)}
+        assert tx_c_expand_1['txid'] in txids_cascade, \
+            "expand_1 must be found (it was within the initial pool)"
+        assert tx_c_expand_2['txid'] in txids_cascade, \
+            "expand_2 must be found (it enters pool after expand_1 fires TopUp)"
+        assert tx_c_lookahead_1['txid'] in txids_cascade, \
+            "lookahead_1 must be found after fix: visible after first TopUp re-scan"
+        assert tx_c_lookahead_2['txid'] in txids_cascade, \
+            "lookahead_2 must be found after fix: visible after second TopUp re-scan"
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_rescan_intrablock_ordering.py
+++ b/test/functional/wallet_rescan_intrablock_ordering.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that ScanForWalletTransactions misses a transaction when a look-ahead key
+   tx and a pool-expanding tx appear in the same block with the look-ahead tx first.
+
+Background:
+   A descriptor wallet pre-derives a batch of N keys ahead of actual use (the
+   look-ahead pool, [next_index, next_index + keypool_size - 1]). When a payment
+   is received to a key near the pool boundary, MarkUnusedAddresses() calls TopUp()
+   to extend the pool by another keypool_size keys.
+
+   ScanForWalletTransactions iterates over a block's transactions in the order the
+   miner placed them (vtx order). If within one block:
+     - Tx_lookahead sends to key at index end_range+1 (just outside the pool), AND
+     - Tx_expand   sends to key at index end_range   (last in pool, triggers TopUp)
+   and Tx_lookahead comes before Tx_expand in vtx order, then:
+     - Tx_lookahead is processed while pool=[0, end_range]: IsMine returns false, missed.
+     - Tx_expand is processed next: IsMine returns true, TopUp extends pool.
+   FastWalletRescanFilter::UpdateIfNeeded() fires only at the start of the NEXT block
+   iteration, so within the same block there is no mechanism to re-process Tx_lookahead.
+
+   Result: Tx_lookahead is missed on the first scan and the wallet shows a wrong
+   balance. However, because Tx_expand was found and extended the pool as a side
+   effect, a subsequent explicit rescanblockchain call recovers Tx_lookahead.
+   The user has no indication that a second rescan is needed.
+
+   Note: this bug does NOT appear when both transactions go through the mempool
+   with the wallet loaded. transactionAddedToMempool(Tx_expand) triggers TopUp
+   before the block arrives, so the pool is already extended when blockConnected
+   processes the block in vtx order.
+
+   This test verifies the fix: after re-processing the block when the pool expands
+   mid-block, Tx_lookahead is found on the first scan. Part 3 confirms that a second
+   rescanblockchain is no longer needed to recover the missed transaction.
+
+   Reference: https://github.com/bitcoin/bitcoin/pull/31629#issuecomment-2657775368
+"""
+from test_framework.address import address_to_scriptpubkey
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+
+
+KEYPOOL_SIZE = 5   # small keypool for faster test execution
+
+
+class WalletRescanIntraBlockOrderingTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [[f'-keypool={KEYPOOL_SIZE}']]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+        funding_wallet = MiniWallet(node)
+
+        self.generate(funding_wallet, COINBASE_MATURITY + 1)
+
+        # -----------------------------------------------------------------------
+        # Setup: derive the two addresses that will trigger the bug.
+        #
+        # Unload the wallet before submitting transactions so that
+        # transactionAddedToMempool(Tx_expand) cannot pre-emptively extend the
+        # pool — which would hide the bug in blockConnected.
+        # -----------------------------------------------------------------------
+        self.log.info("Create wallet, derive boundary addresses, then unload it")
+        node.createwallet(wallet_name='w')
+        w = node.get_wallet_rpc('w')
+
+        descs = w.listdescriptors()['descriptors']
+        recv_desc = next(d for d in descs if 'range' in d and not d['internal'])
+        _, end_range = recv_desc['range']   # end_range == KEYPOOL_SIZE - 1
+
+        # addr_expand: the last key in the pool. A payment here triggers TopUp,
+        # extending the pool by another KEYPOOL_SIZE keys.
+        addr_expand    = w.deriveaddresses(recv_desc['desc'], [end_range,     end_range    ])[0]
+        # addr_lookahead: the first key just outside the pool. It enters the pool
+        # only after addr_expand's TopUp fires.
+        addr_lookahead = w.deriveaddresses(recv_desc['desc'], [end_range + 1, end_range + 1])[0]
+
+        self.log.info(f"Initial pool:  [0, {end_range}]")
+        self.log.info(f"addr_expand    (index {end_range}):     {addr_expand}")
+        self.log.info(f"addr_lookahead (index {end_range + 1}): {addr_lookahead}")
+
+        node.unloadwallet('w')
+
+        # -----------------------------------------------------------------------
+        # Submit both transactions and mine them in the bug-triggering order:
+        #   vtx position 0: Tx_lookahead (addr outside pool)
+        #   vtx position 1: Tx_expand   (addr inside pool, triggers TopUp)
+        #
+        # Tx_expand spends Tx_lookahead's change, so the dependency chain forces
+        # Tx_lookahead into position 0 without any artificial arrangement.
+        # -----------------------------------------------------------------------
+        self.log.info("Submit txs and mine with Tx_lookahead before Tx_expand")
+        tx_lookahead = funding_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(addr_lookahead),
+            amount=10_000,
+        )
+        tx_expand = funding_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(addr_expand),
+            amount=10_000,
+        )
+        assert_equal(sorted(node.getrawmempool()), sorted([tx_lookahead['txid'], tx_expand['txid']]))
+
+        self.generateblock(node, output="raw(51)", transactions=[
+            tx_lookahead['txid'],
+            tx_expand['txid'],
+        ])
+        assert_equal(node.getrawmempool(), [])
+
+        # -----------------------------------------------------------------------
+        # Part 1: rescan triggered by loadwallet
+        #
+        # The wallet stored best-block = height COINBASE_MATURITY+1 when unloaded.
+        # Loading it now triggers ScanForWalletTransactions over the one new block.
+        # Pool starts at [0, end_range]; Tx_lookahead is processed first and missed;
+        # Tx_expand is processed second, found, and extends the pool as a side effect.
+        # -----------------------------------------------------------------------
+        self.log.info("Part 1: reload wallet (rescan of the missed block)")
+        node.loadwallet('w')
+        w = node.get_wallet_rpc('w')
+        node.syncwithvalidationinterfacequeue()
+
+        txids = {tx['txid'] for tx in w.listtransactions('*', 1000)}
+        assert tx_expand['txid'] in txids, \
+            "tx_expand must always be found (it was within the initial pool)"
+        assert tx_lookahead['txid'] not in txids, \
+            "tx_lookahead is missed without fix: pool-expanding tx appears after it in vtx order"
+
+        # -----------------------------------------------------------------------
+        # Part 2: ScanForWalletTransactions via importdescriptors (timestamp=0)
+        #
+        # A fresh blank wallet imports the same descriptor and rescans from genesis.
+        # It has no prior transaction history, so the pool starts at [0, end_range].
+        # The same vtx-order miss applies: Tx_lookahead missed, Tx_expand found.
+        # -----------------------------------------------------------------------
+        self.log.info("Part 2: importdescriptors on fresh wallet (full rescan from genesis)")
+        node.createwallet(wallet_name='w_rescan', disable_private_keys=True, blank=True)
+        w_rescan = node.get_wallet_rpc('w_rescan')
+        w_rescan.importdescriptors([{
+            "desc": recv_desc['desc'],
+            "timestamp": 0,
+        }])
+
+        txids_rescan = {tx['txid'] for tx in w_rescan.listtransactions('*', 1000)}
+        assert tx_expand['txid'] in txids_rescan, \
+            "tx_expand must be found after full rescan"
+        assert tx_lookahead['txid'] not in txids_rescan, \
+            "tx_lookahead is missed without fix: pool-expanding tx appears after it in vtx order"
+
+        # -----------------------------------------------------------------------
+        # Part 3: verify that a second rescanblockchain recovers tx_lookahead.
+        #
+        # Part 2's importdescriptors scan found tx_expand and extended the pool
+        # as a side effect. A second pass now sees tx_lookahead's key in the pool.
+        # This matches furszy's description: "the user might need to rescan those
+        # blocks too" — i.e. the tx is not permanently lost, just missed on the
+        # first scan with no indication a second scan is needed.
+        # -----------------------------------------------------------------------
+        self.log.info("Part 3: second rescanblockchain recovers tx_lookahead")
+        w_rescan.rescanblockchain()
+
+        txids_after_second_scan = {tx['txid'] for tx in w_rescan.listtransactions('*', 1000)}
+        assert tx_lookahead['txid'] in txids_after_second_scan, \
+            "tx_lookahead must be recovered on a second rescan (pool was already extended)"
+        assert tx_expand['txid'] in txids_after_second_scan
+
+
+if __name__ == '__main__':
+    WalletRescanIntraBlockOrderingTest(__file__).main()

--- a/test/functional/wallet_rescan_intrablock_ordering.py
+++ b/test/functional/wallet_rescan_intrablock_ordering.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that ScanForWalletTransactions misses a transaction when a look-ahead key
+   tx and a pool-expanding tx appear in the same block with the look-ahead tx first.
+
+Background:
+   A descriptor wallet pre-derives a batch of N keys ahead of actual use (the
+   look-ahead pool, [next_index, next_index + keypool_size - 1]). When a payment
+   is received to a key near the pool boundary, MarkUnusedAddresses() calls TopUp()
+   to extend the pool by another keypool_size keys.
+
+   ScanForWalletTransactions iterates over a block's transactions in the order the
+   miner placed them (vtx order). If within one block:
+     - Tx_lookahead sends to key at index end_range+1 (just outside the pool), AND
+     - Tx_expand   sends to key at index end_range   (last in pool, triggers TopUp)
+   and Tx_lookahead comes before Tx_expand in vtx order, then:
+     - Tx_lookahead is processed while pool=[0, end_range]: IsMine returns false, missed.
+     - Tx_expand is processed next: IsMine returns true, TopUp extends pool.
+   FastWalletRescanFilter::UpdateIfNeeded() fires only at the start of the NEXT block
+   iteration, so within the same block there is no mechanism to re-process Tx_lookahead.
+
+   Result: Tx_lookahead is missed on the first scan and the wallet shows a wrong
+   balance. However, because Tx_expand was found and extended the pool as a side
+   effect, a subsequent explicit rescanblockchain call recovers Tx_lookahead.
+   The user has no indication that a second rescan is needed.
+
+   Note: this bug does NOT appear when both transactions go through the mempool
+   with the wallet loaded. transactionAddedToMempool(Tx_expand) triggers TopUp
+   before the block arrives, so the pool is already extended when blockConnected
+   processes the block in vtx order.
+
+   This test demonstrates the incorrect behaviour. Parts 1 and 2 assert that
+   Tx_lookahead is missed on the first scan; Part 3 confirms that a second
+   rescanblockchain does recover it (pool was extended as a side effect of finding
+   Tx_expand).
+
+   TODO: Parts 1 and 2 assertions will be flipped once the fix lands.
+
+   Reference: https://github.com/bitcoin/bitcoin/pull/31629#issuecomment-2657775368
+"""
+from test_framework.address import address_to_scriptpubkey
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+
+
+KEYPOOL_SIZE = 5   # small keypool for faster test execution
+
+
+class WalletRescanIntraBlockOrderingTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [[f'-keypool={KEYPOOL_SIZE}']]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+        funding_wallet = MiniWallet(node)
+
+        self.generate(funding_wallet, COINBASE_MATURITY + 1)
+
+        # -----------------------------------------------------------------------
+        # Setup: derive the two addresses that will trigger the bug.
+        #
+        # Unload the wallet before submitting transactions so that
+        # transactionAddedToMempool(Tx_expand) cannot pre-emptively extend the
+        # pool — which would hide the bug in blockConnected.
+        # -----------------------------------------------------------------------
+        self.log.info("Create wallet, derive boundary addresses, then unload it")
+        node.createwallet(wallet_name='w')
+        w = node.get_wallet_rpc('w')
+
+        descs = w.listdescriptors()['descriptors']
+        recv_desc = next(d for d in descs if 'range' in d and not d['internal'])
+        _, end_range = recv_desc['range']   # end_range == KEYPOOL_SIZE - 1
+
+        # addr_expand: the last key in the pool. A payment here triggers TopUp,
+        # extending the pool by another KEYPOOL_SIZE keys.
+        addr_expand = w.deriveaddresses(recv_desc['desc'], [end_range, end_range])[0]
+        # addr_lookahead: the first key just outside the pool. It enters the pool
+        # only after addr_expand's TopUp fires.
+        addr_lookahead = w.deriveaddresses(recv_desc['desc'], [end_range + 1, end_range + 1])[0]
+
+        self.log.info(f"Initial pool:  [0, {end_range}]")
+        self.log.info(f"addr_expand    (index {end_range}):     {addr_expand}")
+        self.log.info(f"addr_lookahead (index {end_range + 1}): {addr_lookahead}")
+
+        node.unloadwallet('w')
+
+        # -----------------------------------------------------------------------
+        # Submit both transactions and mine them in the bug-triggering order:
+        #   vtx position 0: Tx_lookahead (addr outside pool)
+        #   vtx position 1: Tx_expand   (addr inside pool, triggers TopUp)
+        # -----------------------------------------------------------------------
+        self.log.info("Submit txs and mine with Tx_lookahead before Tx_expand")
+        tx_lookahead = funding_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(addr_lookahead),
+            amount=10_000,
+        )
+        tx_expand = funding_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(addr_expand),
+            amount=10_000,
+        )
+        assert_equal(sorted(node.getrawmempool()), sorted([tx_lookahead['txid'], tx_expand['txid']]))
+
+        self.generateblock(node, output="raw(51)", transactions=[
+            tx_lookahead['txid'],
+            tx_expand['txid'],
+        ])
+        assert_equal(node.getrawmempool(), [])
+
+        # -----------------------------------------------------------------------
+        # Part 1: rescan triggered by loadwallet
+        #
+        # Pool starts at [0, end_range]; Tx_lookahead is processed first and missed;
+        # Tx_expand is processed second, found, and extends the pool as a side effect.
+        # -----------------------------------------------------------------------
+        self.log.info("Part 1: reload wallet (rescan of the missed block)")
+        node.loadwallet('w')
+        w = node.get_wallet_rpc('w')
+        node.syncwithvalidationinterfacequeue()
+
+        txids = {tx['txid'] for tx in w.listtransactions('*', 1000)}
+        assert tx_expand['txid'] in txids, \
+            "tx_expand must always be found (it was within the initial pool)"
+        # TODO: flip to `in` once the fix lands — currently missed due to vtx-order bug
+        assert tx_lookahead['txid'] not in txids, \
+            "pre-fix: tx_lookahead is missed when pool-expanding tx appears later in vtx order"
+
+        # -----------------------------------------------------------------------
+        # Part 2: ScanForWalletTransactions via importdescriptors (timestamp=0)
+        # -----------------------------------------------------------------------
+        self.log.info("Part 2: importdescriptors on fresh wallet (full rescan from genesis)")
+        node.createwallet(wallet_name='w_rescan', disable_private_keys=True, blank=True)
+        w_rescan = node.get_wallet_rpc('w_rescan')
+        w_rescan.importdescriptors([{
+            "desc": recv_desc['desc'],
+            "timestamp": 0,
+        }])
+
+        txids_rescan = {tx['txid'] for tx in w_rescan.listtransactions('*', 1000)}
+        assert tx_expand['txid'] in txids_rescan, \
+            "tx_expand must be found after full rescan"
+        # TODO: flip to `in` once the fix lands — currently missed due to vtx-order bug
+        assert tx_lookahead['txid'] not in txids_rescan, \
+            "pre-fix: tx_lookahead is missed on full rescan"
+
+        # -----------------------------------------------------------------------
+        # Part 3: a second rescanblockchain recovers tx_lookahead.
+        #
+        # Part 2's scan found tx_expand and extended the pool as a side effect.
+        # A second pass now sees tx_lookahead's key in the pool and recovers it.
+        # This is the behaviour described by furszy: "the user might need to rescan
+        # those blocks too" — the tx is not permanently lost, just silently missed.
+        # -----------------------------------------------------------------------
+        self.log.info("Part 3: second rescanblockchain recovers tx_lookahead")
+        w_rescan.rescanblockchain()
+
+        txids_after_second_scan = {tx['txid'] for tx in w_rescan.listtransactions('*', 1000)}
+        assert tx_lookahead['txid'] in txids_after_second_scan, \
+            "tx_lookahead must be recovered on a second rescan (pool was already extended)"
+        assert tx_expand['txid'] in txids_after_second_scan
+
+
+if __name__ == '__main__':
+    WalletRescanIntraBlockOrderingTest(__file__).main()

--- a/test/functional/wallet_rescan_intrablock_ordering.py
+++ b/test/functional/wallet_rescan_intrablock_ordering.py
@@ -132,8 +132,8 @@ class WalletRescanIntraBlockOrderingTest(BitcoinTestFramework):
         txids = {tx['txid'] for tx in w.listtransactions('*', 1000)}
         assert tx_expand['txid'] in txids, \
             "tx_expand must always be found (it was within the initial pool)"
-        assert tx_lookahead['txid'] not in txids, \
-            "tx_lookahead is missed without fix: pool-expanding tx appears after it in vtx order"
+        assert tx_lookahead['txid'] in txids, \
+            "tx_lookahead must be found after fix: block is re-processed when pool expands mid-block"
 
         # -----------------------------------------------------------------------
         # Part 2: ScanForWalletTransactions via importdescriptors (timestamp=0)
@@ -153,8 +153,8 @@ class WalletRescanIntraBlockOrderingTest(BitcoinTestFramework):
         txids_rescan = {tx['txid'] for tx in w_rescan.listtransactions('*', 1000)}
         assert tx_expand['txid'] in txids_rescan, \
             "tx_expand must be found after full rescan"
-        assert tx_lookahead['txid'] not in txids_rescan, \
-            "tx_lookahead is missed without fix: pool-expanding tx appears after it in vtx order"
+        assert tx_lookahead['txid'] in txids_rescan, \
+            "tx_lookahead must be found after fix: block re-processed when pool expands mid-block"
 
         # -----------------------------------------------------------------------
         # Part 3: verify that a second rescanblockchain recovers tx_lookahead.
@@ -172,6 +172,101 @@ class WalletRescanIntraBlockOrderingTest(BitcoinTestFramework):
         assert tx_lookahead['txid'] in txids_after_second_scan, \
             "tx_lookahead must be recovered on a second rescan (pool was already extended)"
         assert tx_expand['txid'] in txids_after_second_scan
+
+        # -----------------------------------------------------------------------
+        # Part 4: cascading pool expansions — two levels in one block.
+        #
+        # This validates that the re-process loop handles multiple successive
+        # TopUp events within a single block, and that the pass cap provides a
+        # bounded safety net against adversarially crafted blocks.
+        #
+        # Setup (pool starts at [0, end_range]):
+        #   addr_expand_1  (key end_range)              triggers TopUp → pool doubles
+        #   addr_expand_2  (key end_range + KEYPOOL_SIZE) triggers TopUp → pool doubles again
+        #   addr_lookahead_1 (key end_range + 1)        visible only after first TopUp
+        #   addr_lookahead_2 (key end_range + KEYPOOL_SIZE + 1) visible only after second TopUp
+        #
+        # vtx order: [lookahead_2, lookahead_1, expand_1, expand_2]
+        #   Pass 1: lookahead_2 and lookahead_1 missed; expand_1 and expand_2 found;
+        #           pool expands twice during this single pass.
+        #   Pass 2: both lookaheads now in pool → found.
+        # -----------------------------------------------------------------------
+        self.log.info("Part 4: cascading pool expansions — two TopUp levels in one block")
+        node.createwallet(wallet_name='w_cascade', disable_private_keys=True, blank=True)
+        w_cascade = node.get_wallet_rpc('w_cascade')
+
+        # Import the same descriptor into a blank wallet so pool starts at [0, end_range].
+        # Use timestamp=now so the rescan only covers blocks from this point forward;
+        # mine the cascade block after import.
+        w_cascade.importdescriptors([{
+            "desc": recv_desc['desc'],
+            "timestamp": "now",
+        }])
+
+        _, cascade_end = w_cascade.listdescriptors()['descriptors'][0]['range']
+
+        i_e1 = cascade_end
+        i_e2 = cascade_end + KEYPOOL_SIZE
+        i_l1 = cascade_end + 1
+        i_l2 = cascade_end + KEYPOOL_SIZE + 1
+        addr_expand_1    = w_cascade.deriveaddresses(recv_desc['desc'], [i_e1, i_e1])[0]
+        addr_expand_2    = w_cascade.deriveaddresses(recv_desc['desc'], [i_e2, i_e2])[0]
+        addr_lookahead_1 = w_cascade.deriveaddresses(recv_desc['desc'], [i_l1, i_l1])[0]
+        addr_lookahead_2 = w_cascade.deriveaddresses(recv_desc['desc'], [i_l2, i_l2])[0]
+
+        self.log.info(f"Cascade pool:      [0, {cascade_end}]")
+        self.log.info(f"addr_expand_1      (index {cascade_end}):                  {addr_expand_1}")
+        self.log.info(f"addr_expand_2      (index {cascade_end + KEYPOOL_SIZE}):   {addr_expand_2}")
+        self.log.info(f"addr_lookahead_1   (index {cascade_end + 1}):              {addr_lookahead_1}")
+        self.log.info(f"addr_lookahead_2   (index {cascade_end + KEYPOOL_SIZE + 1}): {addr_lookahead_2}")
+
+        node.unloadwallet('w_cascade')
+
+        tx_c_lookahead_2 = funding_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(addr_lookahead_2),
+            amount=10_000,
+        )
+        tx_c_lookahead_1 = funding_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(addr_lookahead_1),
+            amount=10_000,
+        )
+        tx_c_expand_1 = funding_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(addr_expand_1),
+            amount=10_000,
+        )
+        tx_c_expand_2 = funding_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(addr_expand_2),
+            amount=10_000,
+        )
+
+        # Mine with both lookaheads before both expanders.
+        # expand_1 fires TopUp (pool level 1); expand_2 is then in pool and fires
+        # TopUp again (pool level 2). Both lookaheads are only coverable after
+        # the second expansion — requiring at least two scan passes.
+        self.generateblock(node, output="raw(51)", transactions=[
+            tx_c_lookahead_2['txid'],
+            tx_c_lookahead_1['txid'],
+            tx_c_expand_1['txid'],
+            tx_c_expand_2['txid'],
+        ])
+
+        node.loadwallet('w_cascade')
+        w_cascade = node.get_wallet_rpc('w_cascade')
+        node.syncwithvalidationinterfacequeue()
+
+        txids_cascade = {tx['txid'] for tx in w_cascade.listtransactions('*', 1000)}
+        assert tx_c_expand_1['txid'] in txids_cascade, \
+            "expand_1 must be found (it was within the initial pool)"
+        assert tx_c_expand_2['txid'] in txids_cascade, \
+            "expand_2 must be found (it enters pool after expand_1 fires TopUp)"
+        assert tx_c_lookahead_1['txid'] in txids_cascade, \
+            "lookahead_1 must be found after fix: visible after first TopUp"
+        assert tx_c_lookahead_2['txid'] in txids_cascade, \
+            "lookahead_2 must be found after fix: visible after second TopUp"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When `ScanForWalletTransactions` processes a block containing both a transaction to a key just outside the look-ahead pool and a pool-expanding transaction that triggers `TopUp`, and the former appears first in vtx order, the wallet misses the earlier transaction — leaving the balance wrong with no indication a second scan is needed. The fix tracks the last vtx position where the pool expanded and re-scans only the prefix [0, `last_expansion_pos`) — every transaction processed before the pool reached its final state.


The first commit demonstrates the incorrect behaviour; the second contains the fix.

<details>
<summary>Bug details...</summary>
<br>

`ScanForWalletTransactions` iterates over a block's transactions in the order the miner placed them (vtx order). A descriptor wallet maintains a look-ahead pool of pre-derived keys so it can recognise incoming payments. When a payment arrives at a key near the pool boundary, `MarkUnusedAddresses` → `TopUp`
extends the pool.

If within a single block:
- **Tx_lookahead** pays to key index `N` (just outside the current pool `[0, N-1]`), AND
- **Tx_expand** pays to key index `N-1` (last in pool — triggers TopUp, extending pool to `[0, 2N-1]`)

and Tx_lookahead appears at an earlier vtx position than Tx_expand, the scan misses Tx_lookahead:

1. Tx_lookahead processed: pool = `[0, N-1]` → `IsMine` returns false → missed
2. Tx_expand processed: key `N-1` found → TopUp fires → pool = `[0, 2N-1]`

`FastWalletRescanFilter::UpdateIfNeeded()` fires only at the **start of the next block** iteration — there is no mechanism to re-examine Tx_lookahead within the same scan pass.

The transaction is not permanently lost — because Tx_expand extended the pool as a side effect, a second explicit `rescanblockchain` call recovers Tx_lookahead. But the wallet shows a wrong balance with no indication a second scan is needed.

This bug does not affect live `blockConnected` when both transactions pass through the mempool first: `transactionAddedToMempool(Tx_expand)` pre-extends the pool before the block arrives, so vtx ordering does not matter. It only manifests in `ScanForWalletTransactions` (rescan paths) for descriptor wallets.

</details>

<details>
<summary>Affected callers...</summary>
<br>

**Callers affected** (all use `ScanForWalletTransactions`):
- `rescanblockchain`
- `importdescriptors` (via `RescanFromTime`)
- `restorewallet` and wallet migration watchonly/solvable wallets (via `AttachChain`)

</details>

<details>
<summary>Fix details and performance...</summary>
<br>

**Fix:** during the per-block vtx loop, snapshot `range_end` per HD descriptor after every transaction. Track the last vtx position where any descriptor's `range_end` increased (`last_expansion_pos`). After the full pass, re-scan only the prefix [0, `last_expansion_pos`) — transactions processed before the pool reached its final state. Transactions at `last_expansion_pos` and beyond were already seen with the fully-expanded pool and are not re-visited.

Using the last (not first) expansion position matters when multiple TopUp events occur in one block. With interleaved vtx order [lookahead_1, expand_1, lookahead_2, expand_2], stopping at the first expansion position (1) re-scans only [0, 1) and misses lookahead_2 at position 2. Stopping at the last (3) re-scans [0, 3) and finds both.

The re-scan repeats with the new `last_expansion_pos` if a transaction within the prefix itself causes a further pool expansion. The prefix strictly shrinks each iteration, guaranteeing termination without a safety cap.

**Performance:** the prefix re-scan fires for any block where TopUp fires during the vtx loop — effectively, any block containing a wallet-relevant transaction during a rescan. The re-visited prefix is [0, `last_expansion_pos`), proportional to where the last pool-expanding transaction sits within the block. Transactions at that position and beyond are visited exactly once.

</details>

<details>
<summary>Test coverage...</summary>
<br>

**Regression test:** `test/functional/wallet_rescan_intrablock_ordering.py`
- Part 1: loadwallet rescan — Tx_lookahead found after fix
- Part 2: importdescriptors full rescan from genesis — Tx_lookahead found after fix
- Part 3: second rescanblockchain recovers Tx_lookahead (pre-fix behaviour, kept as sanity check)
- Part 4: two-level cascade — two successive TopUp events fire in one block, both lookahead txs found, validating the bounded multi-pass loop

</details>

<details>
<summary>Manual reproduction (<code>regtest</code>)</summary>

```bash
bitcoind -regtest -keypool=5 -fallbackfee=0.0001 -daemon

bitcoin-cli -regtest -named createwallet wallet_name=funding
bitcoin-cli -regtest generatetoaddress 102 $(bitcoin-cli -regtest -rpcwallet=funding getnewaddress)

bitcoin-cli -regtest -named createwallet wallet_name=test
RECV_DESC=$(bitcoin-cli -regtest -rpcwallet=test listdescriptors \
  | jq -r '[.descriptors[] | select(.internal==false and .range!=null)][0].desc')
END_RANGE=$(bitcoin-cli -regtest -rpcwallet=test listdescriptors \
  | jq '[.descriptors[] | select(.internal==false and .range!=null)][0].range[1]')
ADDR_EXPAND=$(bitcoin-cli -regtest deriveaddresses "$RECV_DESC" "[$END_RANGE,$END_RANGE]" | jq -r '.[0]')
ADDR_LOOKAHEAD=$(bitcoin-cli -regtest deriveaddresses "$RECV_DESC" "[$((END_RANGE+1)),$((END_RANGE+1))]" | jq -r '.[0]')

bitcoin-cli -regtest unloadwallet test

TXID1=$(bitcoin-cli -regtest -rpcwallet=funding sendtoaddress "$ADDR_LOOKAHEAD" 0.001)
TXID2=$(bitcoin-cli -regtest -rpcwallet=funding sendtoaddress "$ADDR_EXPAND" 0.001)
bitcoin-cli -regtest generateblock "raw(51)" "[\"$TXID1\",\"$TXID2\"]"

# First scan — TXID1 missing, wrong balance
bitcoin-cli -regtest loadwallet test
bitcoin-cli -regtest -rpcwallet=test listtransactions

# Second scan — TXID1 recovered
bitcoin-cli -regtest -rpcwallet=test rescanblockchain
bitcoin-cli -regtest -rpcwallet=test listtransactions
```

</details>

_**Notes**_:

* Originally noted by furszy in https://github.com/bitcoin/bitcoin/pull/31629#issuecomment-2657775368; his "case 2" describes a related but harder inter-block variant: new blocks arriving via `blockConnected` during an active rescan with a not-yet-expanded pool. That problem remains a potential follow-up. This PR fixes the simpler intra-block sub-case where the miss happens entirely within a single block's vtx loop, with no concurrent block arrivals required.

* Perhaps the issue is related to the symptom was previously reported in #19808 but could not be reproduced at the time and was closed without a fix.

* #34681 refactors `ScanForWalletTransactions` into a `ChainScanner` class and touches the same code. If that PR merges first, this fix would need to move into `ChainScanner::ScanBlock`.

* molnard [found](https://github.com/bitcoin/bitcoin/pull/35901#pullrequestreview-5041935034) a related gap this PR doesn't close: if a parent tx pays a look-ahead key and a later tx in the same block spends that parent's output, and the spend sits at or after the block's last pool expansion, the prefix rescan recovers the parent but never revisits the spend — the parent output can remain classified as unspent. Fixing this properly needs a different approach (retry based on each tx's `SyncTransaction()` result until a full pass causes no change, rather than a shrinking-prefix rescan), which is a separate piece of work from this fix. Tracked as a follow-up, same as the furszy case above.