### PR TITLE
zmq: Log bind error at Error level, abort startup on init error

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1841,7 +1841,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
 #ifdef ENABLE_ZMQ
-    g_zmq_notification_interface = CZMQNotificationInterface::Create(
+    auto notifiers{CZMQNotificationInterface::GetNotifiers(
+        gArgs,
         [&chainman = node.chainman](std::vector<std::byte>& block, const CBlockIndex& index) {
             assert(chainman);
             if (auto ret{chainman->m_blockman.ReadRawBlock(WITH_LOCK(cs_main, return index.GetBlockPos()))}) {
@@ -1849,7 +1850,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 return true;
             }
             return false;
-        });
+        })};
+    if (!notifiers.empty()) {
+        if (auto zmq_notification_interface{CZMQNotificationInterface::Create(std::move(notifiers))}) {
+            g_zmq_notification_interface = std::move(*zmq_notification_interface);
+        } else {
+            return InitError(util::ErrorString(zmq_notification_interface));
+        }
+    }
 
     if (g_zmq_notification_interface) {
         validation_signals.RegisterValidationInterface(g_zmq_notification_interface.get());

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
 #define BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
 
+#include <util/result.h>
+
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -40,7 +42,7 @@ public:
         }
     }
 
-    virtual bool Initialize(void *pcontext) = 0;
+    virtual util::Result<void> Initialize(void *pcontext) = 0;
     virtual void Shutdown() = 0;
 
     // Notifies of ConnectTip result, i.e., new active tip only

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -10,14 +10,17 @@
 #include <netbase.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <tinyformat.h>
 #include <util/check.h>
 #include <util/log.h>
+#include <util/translation.h>
 #include <zmq/zmqabstractnotifier.h>
 #include <zmq/zmqpublishnotifier.h>
 #include <zmq/zmqutil.h>
 
 #include <zmq.h>
 
+#include <cerrno>
 #include <map>
 #include <string>
 #include <utility>
@@ -41,7 +44,9 @@ std::list<const CZMQAbstractNotifier*> CZMQNotificationInterface::GetActiveNotif
     return result;
 }
 
-std::unique_ptr<CZMQNotificationInterface> CZMQNotificationInterface::Create(std::function<bool(std::vector<std::byte>&, const CBlockIndex&)> get_block_by_index)
+std::list<std::unique_ptr<CZMQAbstractNotifier>> CZMQNotificationInterface::GetNotifiers(
+    const ArgsManager& args,
+    std::function<bool(std::vector<std::byte>&, const CBlockIndex&)> get_block_by_index)
 {
     std::map<std::string, CZMQNotifierFactory> factories;
     factories["pubhashblock"] = CZMQAbstractNotifier::Create<CZMQPublishHashBlockNotifier>;
@@ -57,7 +62,7 @@ std::unique_ptr<CZMQNotificationInterface> CZMQNotificationInterface::Create(std
     {
         std::string arg("-zmq" + entry.first);
         const auto& factory = entry.second;
-        for (std::string& address : gArgs.GetArgs(arg)) {
+        for (std::string& address : args.GetArgs(arg)) {
             // libzmq uses prefix "ipc://" for UNIX domain sockets
             if (address.starts_with(ADDR_PREFIX_UNIX)) {
                 address.replace(0, ADDR_PREFIX_UNIX.length(), ADDR_PREFIX_IPC);
@@ -66,26 +71,29 @@ std::unique_ptr<CZMQNotificationInterface> CZMQNotificationInterface::Create(std
             std::unique_ptr<CZMQAbstractNotifier> notifier = factory();
             notifier->SetType(entry.first);
             notifier->SetAddress(address);
-            notifier->SetOutboundMessageHighWaterMark(static_cast<int>(gArgs.GetIntArg(arg + "hwm", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM)));
+            notifier->SetOutboundMessageHighWaterMark(static_cast<int>(args.GetIntArg(arg + "hwm", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM)));
             notifiers.push_back(std::move(notifier));
         }
     }
+    return notifiers;
+}
 
-    if (!notifiers.empty())
-    {
-        std::unique_ptr<CZMQNotificationInterface> notificationInterface(new CZMQNotificationInterface());
-        notificationInterface->notifiers = std::move(notifiers);
+util::Result<std::unique_ptr<CZMQNotificationInterface>> CZMQNotificationInterface::Create(
+    std::list<std::unique_ptr<CZMQAbstractNotifier>>&& notifiers)
+{
+    if (notifiers.empty()) return util::Error{Untranslated("No ZMQ notifiers provided")};
 
-        if (notificationInterface->Initialize()) {
-            return notificationInterface;
-        }
+    std::unique_ptr<CZMQNotificationInterface> notificationInterface(new CZMQNotificationInterface());
+    notificationInterface->notifiers = std::move(notifiers);
+
+    if (auto result{notificationInterface->Initialize()}; !result) {
+        return util::Error{util::ErrorString(result)};
     }
-
-    return nullptr;
+    return notificationInterface;
 }
 
 // Called at startup to conditionally set up ZMQ socket(s)
-bool CZMQNotificationInterface::Initialize()
+util::Result<void> CZMQNotificationInterface::Initialize()
 {
     int major = 0, minor = 0, patch = 0;
     zmq_version(&major, &minor, &patch);
@@ -98,20 +106,19 @@ bool CZMQNotificationInterface::Initialize()
 
     if (!pcontext)
     {
-        zmqError("Unable to initialize context");
-        return false;
+        return util::Error{Untranslated(strprintf("Unable to initialize ZMQ context: %s", zmq_strerror(errno)))};
     }
 
     for (auto& notifier : notifiers) {
-        if (notifier->Initialize(pcontext)) {
+        if (auto result{notifier->Initialize(pcontext)}) {
             LogDebug(BCLog::ZMQ, "Notifier %s ready (address = %s)\n", notifier->GetType(), notifier->GetAddress());
         } else {
             LogDebug(BCLog::ZMQ, "Notifier %s failed (address = %s)\n", notifier->GetType(), notifier->GetAddress());
-            return false;
+            return util::Error{util::ErrorString(result)};
         }
     }
 
-    return true;
+    return {};
 }
 
 // Called during shutdown sequence

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -6,6 +6,7 @@
 #define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
 #include <primitives/transaction.h>
+#include <util/result.h>
 #include <validationinterface.h>
 
 #include <cstddef>
@@ -15,6 +16,7 @@
 #include <memory>
 #include <vector>
 
+class ArgsManager;
 class CBlockIndex;
 class CZMQAbstractNotifier;
 
@@ -25,10 +27,14 @@ public:
 
     std::list<const CZMQAbstractNotifier*> GetActiveNotifiers() const;
 
-    static std::unique_ptr<CZMQNotificationInterface> Create(std::function<bool(std::vector<std::byte>&, const CBlockIndex&)> get_block_by_index);
+    static std::list<std::unique_ptr<CZMQAbstractNotifier>> GetNotifiers(
+        const ArgsManager& args,
+        std::function<bool(std::vector<std::byte>&, const CBlockIndex&)> get_block_by_index);
+    // error with the failure reason if initialization fails
+    static util::Result<std::unique_ptr<CZMQNotificationInterface>> Create(std::list<std::unique_ptr<CZMQAbstractNotifier>>&& notifiers);
 
 protected:
-    bool Initialize();
+    util::Result<void> Initialize();
     void Shutdown();
 
     // CValidationInterface

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -11,13 +11,17 @@
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <streams.h>
+#include <tinyformat.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/log.h>
+#include <util/result.h>
+#include <util/translation.h>
 #include <zmq/zmqutil.h>
 
 #include <zmq.h>
 
+#include <cerrno>
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
@@ -49,7 +53,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
         int rc = zmq_msg_init_size(&msg, size);
         if (rc != 0)
         {
-            zmqError("Unable to initialize ZMQ msg");
+            zmqDebug("Unable to initialize ZMQ msg");
             va_end(args);
             return -1;
         }
@@ -62,7 +66,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
         rc = zmq_msg_send(&msg, sock, data ? ZMQ_SNDMORE : 0);
         if (rc == -1)
         {
-            zmqError("Unable to send ZMQ msg");
+            zmqDebug("Unable to send ZMQ msg");
             zmq_msg_close(&msg);
             va_end(args);
             return -1;
@@ -92,7 +96,7 @@ static bool IsZMQAddressIPV6(const std::string &zmq_address)
     return false;
 }
 
-bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
+util::Result<void> CZMQAbstractPublishNotifier::Initialize(void *pcontext)
 {
     assert(!psocket);
 
@@ -104,8 +108,7 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         psocket = zmq_socket(pcontext, ZMQ_PUB);
         if (!psocket)
         {
-            zmqError("Failed to create socket");
-            return false;
+            return util::Error{Untranslated(strprintf("Failed to create socket for %s (address %s): %s", type, address, zmq_strerror(errno)))};
         }
 
         LogDebug(BCLog::ZMQ, "Outbound message high water mark for %s at %s is %d\n", type, address, outbound_message_high_water_mark);
@@ -113,39 +116,40 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         int rc = zmq_setsockopt(psocket, ZMQ_SNDHWM, &outbound_message_high_water_mark, sizeof(outbound_message_high_water_mark));
         if (rc != 0)
         {
-            zmqError("Failed to set outbound message high water mark");
+            // compose the message before zmq_close, which may overwrite errno
+            auto msg{strprintf("Failed to set outbound message high water mark for %s (address %s): %s", type, address, zmq_strerror(errno))};
             zmq_close(psocket);
-            return false;
+            return util::Error{Untranslated(msg)};
         }
 
         const int so_keepalive_option {1};
         rc = zmq_setsockopt(psocket, ZMQ_TCP_KEEPALIVE, &so_keepalive_option, sizeof(so_keepalive_option));
         if (rc != 0) {
-            zmqError("Failed to set SO_KEEPALIVE");
+            auto msg{strprintf("Failed to set SO_KEEPALIVE for %s (address %s): %s", type, address, zmq_strerror(errno))};
             zmq_close(psocket);
-            return false;
+            return util::Error{Untranslated(msg)};
         }
 
         // On some systems (e.g. OpenBSD) the ZMQ_IPV6 must not be enabled, if the address to bind isn't IPv6
         const int enable_ipv6 { IsZMQAddressIPV6(address) ? 1 : 0};
         rc = zmq_setsockopt(psocket, ZMQ_IPV6, &enable_ipv6, sizeof(enable_ipv6));
         if (rc != 0) {
-            zmqError("Failed to set ZMQ_IPV6");
+            auto msg{strprintf("Failed to set ZMQ_IPV6 for %s (address %s): %s", type, address, zmq_strerror(errno))};
             zmq_close(psocket);
-            return false;
+            return util::Error{Untranslated(msg)};
         }
 
         rc = zmq_bind(psocket, address.c_str());
         if (rc != 0)
         {
-            zmqError("Failed to bind address");
+            auto msg{strprintf("Failed to bind address %s for %s: %s", address, type, zmq_strerror(errno))};
             zmq_close(psocket);
-            return false;
+            return util::Error{Untranslated(msg)};
         }
 
         // register this notifier for the address, so it can be reused for other publish notifier
         mapPublishNotifiers.insert(std::make_pair(address, this));
-        return true;
+        return {};
     }
     else
     {
@@ -155,7 +159,7 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         psocket = i->second->psocket;
         mapPublishNotifiers.insert(std::make_pair(address, this));
 
-        return true;
+        return {};
     }
 }
 
@@ -235,7 +239,7 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 
     std::vector<std::byte> block{};
     if (!m_get_block_by_index(block, *pindex)) {
-        zmqError("Can't read block from disk");
+        zmqDebug("Can't read block from disk");
         return false;
     }
 

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -11,13 +11,16 @@
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <streams.h>
+#include <tinyformat.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/log.h>
+#include <util/translation.h>
 #include <zmq/zmqutil.h>
 
 #include <zmq.h>
 
+#include <cerrno>
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
@@ -49,7 +52,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
         int rc = zmq_msg_init_size(&msg, size);
         if (rc != 0)
         {
-            zmqError("Unable to initialize ZMQ msg");
+            zmqDebug("Unable to initialize ZMQ msg");
             va_end(args);
             return -1;
         }
@@ -62,7 +65,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
         rc = zmq_msg_send(&msg, sock, data ? ZMQ_SNDMORE : 0);
         if (rc == -1)
         {
-            zmqError("Unable to send ZMQ msg");
+            zmqDebug("Unable to send ZMQ msg");
             zmq_msg_close(&msg);
             va_end(args);
             return -1;
@@ -92,7 +95,7 @@ static bool IsZMQAddressIPV6(const std::string &zmq_address)
     return false;
 }
 
-bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
+util::Result<void> CZMQAbstractPublishNotifier::Initialize(void *pcontext)
 {
     assert(!psocket);
 
@@ -104,8 +107,7 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         psocket = zmq_socket(pcontext, ZMQ_PUB);
         if (!psocket)
         {
-            zmqError("Failed to create socket");
-            return false;
+            return util::Error{Untranslated(strprintf("Failed to create socket for %s (address %s): %s", type, address, zmq_strerror(errno)))};
         }
 
         LogDebug(BCLog::ZMQ, "Outbound message high water mark for %s at %s is %d\n", type, address, outbound_message_high_water_mark);
@@ -113,39 +115,40 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         int rc = zmq_setsockopt(psocket, ZMQ_SNDHWM, &outbound_message_high_water_mark, sizeof(outbound_message_high_water_mark));
         if (rc != 0)
         {
-            zmqError("Failed to set outbound message high water mark");
+            // compose the message before zmq_close, which may overwrite errno
+            auto msg{strprintf("Failed to set outbound message high water mark for %s (address %s): %s", type, address, zmq_strerror(errno))};
             zmq_close(psocket);
-            return false;
+            return util::Error{Untranslated(msg)};
         }
 
         const int so_keepalive_option {1};
         rc = zmq_setsockopt(psocket, ZMQ_TCP_KEEPALIVE, &so_keepalive_option, sizeof(so_keepalive_option));
         if (rc != 0) {
-            zmqError("Failed to set SO_KEEPALIVE");
+            auto msg{strprintf("Failed to set SO_KEEPALIVE for %s (address %s): %s", type, address, zmq_strerror(errno))};
             zmq_close(psocket);
-            return false;
+            return util::Error{Untranslated(msg)};
         }
 
         // On some systems (e.g. OpenBSD) the ZMQ_IPV6 must not be enabled, if the address to bind isn't IPv6
         const int enable_ipv6 { IsZMQAddressIPV6(address) ? 1 : 0};
         rc = zmq_setsockopt(psocket, ZMQ_IPV6, &enable_ipv6, sizeof(enable_ipv6));
         if (rc != 0) {
-            zmqError("Failed to set ZMQ_IPV6");
+            auto msg{strprintf("Failed to set ZMQ_IPV6 for %s (address %s): %s", type, address, zmq_strerror(errno))};
             zmq_close(psocket);
-            return false;
+            return util::Error{Untranslated(msg)};
         }
 
         rc = zmq_bind(psocket, address.c_str());
         if (rc != 0)
         {
-            zmqError("Failed to bind address");
+            auto msg{strprintf("Failed to bind address %s for %s: %s", address, type, zmq_strerror(errno))};
             zmq_close(psocket);
-            return false;
+            return util::Error{Untranslated(msg)};
         }
 
         // register this notifier for the address, so it can be reused for other publish notifier
         mapPublishNotifiers.insert(std::make_pair(address, this));
-        return true;
+        return {};
     }
     else
     {
@@ -155,7 +158,7 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         psocket = i->second->psocket;
         mapPublishNotifiers.insert(std::make_pair(address, this));
 
-        return true;
+        return {};
     }
 }
 
@@ -235,7 +238,7 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 
     std::vector<std::byte> block{};
     if (!m_get_block_by_index(block, *pindex)) {
-        zmqError("Can't read block from disk");
+        zmqDebug("Can't read block from disk");
         return false;
     }
 

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -30,7 +30,7 @@ public:
     */
     bool SendZmqMessage(const char *command, const void* data, size_t size);
 
-    bool Initialize(void *pcontext) override;
+    util::Result<void> Initialize(void *pcontext) override;
     void Shutdown() override;
 };
 

--- a/src/zmq/zmqutil.cpp
+++ b/src/zmq/zmqutil.cpp
@@ -11,7 +11,7 @@
 #include <cerrno>
 #include <string>
 
-void zmqError(const std::string& str)
+void zmqDebug(const std::string& str)
 {
     LogDebug(BCLog::ZMQ, "Error: %s, msg: %s\n", str, zmq_strerror(errno));
 }

--- a/src/zmq/zmqutil.h
+++ b/src/zmq/zmqutil.h
@@ -7,7 +7,8 @@
 
 #include <string>
 
-void zmqError(const std::string& str);
+/** Log ZMQ error at Debug level */
+void zmqDebug(const std::string& str);
 
 /** Prefix for unix domain socket addresses (which are local filesystem paths) */
 inline const std::string ADDR_PREFIX_IPC = "ipc://"; // used by libzmq, example "ipc:///root/path/to/file"

--- a/src/zmq/zmqutil.h
+++ b/src/zmq/zmqutil.h
@@ -7,7 +7,8 @@
 
 #include <string>
 
-void zmqError(const std::string& str);
+/** Log ZMQ error at Debug level */
+void zmqDebug(const std::string& str);
 
 /** Prefix for unix domain socket addresses (which are local filesystem paths) */
 const std::string ADDR_PREFIX_IPC = "ipc://"; // used by libzmq, example "ipc:///root/path/to/file"

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -184,8 +184,10 @@ class ZMQTest (BitcoinTestFramework):
     def test_basic(self, unix = False):
         self.log.info(f"Running basic test with {'ipc' if unix else 'tcp'} protocol")
 
-        # Invalid zmq arguments don't take down the node, see #17185.
-        self.restart_node(0, ["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"])
+        # Invalid zmq arguments should cause exit with an error
+        self.stop_node(0)
+        self.nodes[0].assert_start_raises_init_error(extra_args=["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"])
+        self.start_node(0)
 
         address = f"tcp://127.0.0.1:{self.zmq_port_base}"
 

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -3,8 +3,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the ZMQ notification interface."""
+import errno
 import os
 import struct
+import sys
 import tempfile
 from io import BytesIO
 
@@ -27,6 +29,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     ensure_for,
     p2p_port,
+    rpc_port,
 )
 from test_framework.wallet import (
     MiniWallet,
@@ -184,8 +187,46 @@ class ZMQTest (BitcoinTestFramework):
     def test_basic(self, unix = False):
         self.log.info(f"Running basic test with {'ipc' if unix else 'tcp'} protocol")
 
-        # Invalid zmq arguments don't take down the node, see #17185.
-        self.restart_node(0, ["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"])
+        # Invalid zmq arguments should cause exit with an error naming the notifier and address.
+        # The errno text after the last ":" comes from zmq_strerror: on Windows libzmq
+        # returns its own hardcoded strings, elsewhere it falls through to the platform
+        # strerror, which os.strerror also consults.
+        if sys.platform == "win32":
+            eaddrnotavail = "Address not available"
+            eaddrinuse = "Address in use"
+        else:
+            eaddrnotavail = os.strerror(errno.EADDRNOTAVAIL)
+            eaddrinuse = os.strerror(errno.EADDRINUSE)
+
+        self.stop_node(0)
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"],
+            expected_msg=f"Error: Failed to bind address bar for pubhashtx: {os.strerror(errno.EINVAL)}",
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=["-zmqpubsequence=baz"],
+            expected_msg=f"Error: Failed to bind address baz for pubsequence: {os.strerror(errno.EINVAL)}",
+        )
+        # A notifier that binds successfully must not mask a later notifier's failure
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=[f"-zmqpubhashblock=tcp://127.0.0.1:{self.zmq_port_base}", "-zmqpubrawblock=foo"],
+            expected_msg=f"Error: Failed to bind address foo for pubrawblock: {os.strerror(errno.EINVAL)}",
+        )
+        # Binding an address this host doesn't own fails with EADDRNOTAVAIL. Use an
+        # unprivileged port so the error cannot be EACCES instead.
+        address = f"tcp://1.2.3.4:{self.zmq_port_base}"
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=[f"-zmqpubrawblock={address}"],
+            expected_msg=f"Error: Failed to bind address {address} for pubrawblock: {eaddrnotavail}",
+        )
+        # Binding the node's own RPC port fails with EADDRINUSE, as the RPC server
+        # binds before the ZMQ notifiers initialize
+        address = f"tcp://127.0.0.1:{rpc_port(self.nodes[0].index)}"
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=[f"-zmqpubrawblock={address}"],
+            expected_msg=f"Error: Failed to bind address {address} for pubrawblock: {eaddrinuse}",
+        )
+        self.start_node(0)
 
         address = f"tcp://127.0.0.1:{self.zmq_port_base}"
 


### PR DESCRIPTION
## History

This picks up #33727, which was closed for inactivity

## Problem

Currently when a user configures -zmqpub* and the socket can't be bound, the program proceeds normally. The only trace is a debug-level log line that's invisible in a default configuration.

#33715 hit this when their port was already taken.

## What this PR does
The node refuses to start if ZMQ is configured and setup failed. This failure is now logged at error level. 

Code path: 
GetNotifiers builds the notifier objects from the config; Create initializes them — starts the ZMQ engine and binds each socket. When initialization fails, Initialize() returns a util::Result carrying an error that names the notifier, the address and the OS error. Create() propagates it and init.cpp returns InitError with that message. On a node with no -zmqpub* option, the notifier list is empty.

## Why abort?
#17445 fixed bitcoind crash from bad assert due to ZMQ config (issue #17185). 
Issue #33715 reports that when ZMQ port was already taken, bitcoind started but user could not see anything with getzmqnotifications. Maintainers at the time agreed it should log louder and abort at startup. Which is what this PR fixes. 

## Testing

bitcoind -regtest -zmqpubhashblock=foo
Result: exits with code 1, and prints:

```
[error] Failed to bind address foo for pubhashblock: Invalid argument
Error: Failed to bind address foo for pubhashblock: Invalid argument
```

interface_zmq.py asserts the exact full error message for five startup-failure cases: invalid address, invalid address on a later notifier after an earlier one bound successfully (partial success must still abort), unreachable IP (EADDRNOTAVAIL), and a port already taken by the node's own RPC server (EADDRINUSE, via rpc_port()). The expected errno text is derived with os.strerror on the platform running the test, since the string after the last ":" differs per platform; on Windows the two strings libzmq hardcodes are pinned instead.

Verified locally on Windows; the full CI matrix is green on my fork.

A node with no -zmqpub* options starts exactly as before — nothing changes for nodes that don't use ZMQ.
