### PR TITLE
cmake: Add `-Wunused-template` to `warn_interface`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,6 +502,7 @@ else()
   try_append_cxx_flags("-Wundef" TARGET warn_interface SKIP_LINK)
   try_append_cxx_flags("-Wleading-whitespace=spaces" TARGET warn_interface SKIP_LINK)
   try_append_cxx_flags("-Wtrailing-whitespace=any" TARGET warn_interface SKIP_LINK)
+  try_append_cxx_flags("-Wunused-template" TARGET warn_interface SKIP_LINK)
 
   # Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
   # unknown options if any other warning is produced. Test the -Wfoo case, and

--- a/cmake/minisketch.cmake
+++ b/cmake/minisketch.cmake
@@ -27,9 +27,9 @@ check_cxx_source_compiles_with_flags("
   CXXFLAGS ${CLMUL_CXXFLAGS}
 )
 
-add_library(minisketch_common INTERFACE)
+add_library(nowarn_minisketch_interface INTERFACE)
 if(MSVC)
-  target_compile_options(minisketch_common INTERFACE
+  target_compile_options(nowarn_minisketch_interface INTERFACE
     /wd4060
     /wd4065
     /wd4146
@@ -64,7 +64,7 @@ target_include_directories(minisketch
 target_link_libraries(minisketch
   PRIVATE
     core_interface
-    minisketch_common
+    nowarn_minisketch_interface
 )
 
 set_target_properties(minisketch PROPERTIES

--- a/cmake/minisketch.cmake
+++ b/cmake/minisketch.cmake
@@ -36,6 +36,12 @@ if(MSVC)
     /wd4244
     /wd4267
   )
+else()
+  # This exemption can be removed once the minisketch subtree
+  # includes https://github.com/bitcoin-core/minisketch/pull/102.
+  try_append_cxx_flags("-Wunused-template" TARGET nowarn_minisketch_interface SKIP_LINK
+    IF_CHECK_PASSED "-Wno-unused-template"
+  )
 endif()
 
 add_library(minisketch STATIC EXCLUDE_FROM_ALL


### PR DESCRIPTION
Clang recently enabled `-Wunused-template` under `-Wall` (see https://github.com/llvm/llvm-project/pull/208001). This change enables the diagnostic for older Clang versions as well, notably those used in the CI.

The minisketch subtree is exempted until it includes the upstream fix from https://github.com/bitcoin-core/minisketch/pull/102.