### PR TITLE
First steps towards a stateless, side-effect free validation library

### DIFF
--- a/src/deploymentstatus.h
+++ b/src/deploymentstatus.h
@@ -11,6 +11,12 @@
 #include <limits>
 
 /** Determine if a deployment is active for the next block */
+inline bool DeploymentActiveAfter(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::BuriedDeployment dep)
+{
+    assert(Consensus::ValidDeployment(dep));
+    return (pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1) >= params.DeploymentHeight(dep);
+}
+
 inline bool DeploymentActiveAfter(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::BuriedDeployment dep, [[maybe_unused]] VersionBitsCache& versionbitscache)
 {
     assert(Consensus::ValidDeployment(dep));

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -135,6 +135,7 @@ add_executable(test_bitcoin
   validation_chainstate_tests.cpp
   validation_chainstatemanager_tests.cpp
   validation_flush_tests.cpp
+  validation_header_tests.cpp
   validation_tests.cpp
   validationinterface_tests.cpp
   versionbits_tests.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -134,6 +134,7 @@ add_executable(test_bitcoin
   validation_block_tests.cpp
   validation_chainstate_tests.cpp
   validation_chainstatemanager_tests.cpp
+  validation_check_header_tests.cpp
   validation_flush_tests.cpp
   validation_tests.cpp
   validationinterface_tests.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -134,6 +134,7 @@ add_executable(test_bitcoin
   validation_block_tests.cpp
   validation_chainstate_tests.cpp
   validation_chainstatemanager_tests.cpp
+  validation_check_block_tests.cpp
   validation_check_header_tests.cpp
   validation_flush_tests.cpp
   validation_tests.cpp

--- a/src/test/validation_check_block_tests.cpp
+++ b/src/test/validation_check_block_tests.cpp
@@ -1,0 +1,290 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chain.h>
+#include <consensus/consensus.h>
+#include <consensus/merkle.h>
+#include <consensus/params.h>
+#include <consensus/validation.h>
+#include <kernel/chainparams.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
+#include <uint256.h>
+#include <util/time.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(validation_check_block_tests)
+
+BOOST_AUTO_TEST_CASE(block_valid)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    const CBlock block{chainparams->GenesisBlock()};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(CheckBlock(block, state, consensusParams));
+    BOOST_CHECK(state.IsValid());
+    BOOST_CHECK(block.fChecked);
+}
+
+BOOST_AUTO_TEST_CASE(block_valid_multiple_transactions)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // Append a transaction with a non-null prevout, so that it is not a
+    // coinbase and the loop over the non-coinbase transactions completes an
+    // iteration instead of returning on the first one.
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vin[0].prevout.n = 0;
+    block.vtx.push_back(MakeTransactionRef(std::move(mtx)));
+    BOOST_REQUIRE(!block.vtx[1]->IsCoinBase());
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+
+    BlockValidationState state;
+
+    BOOST_CHECK(CheckBlock(block, state, consensusParams, /*fCheckPOW=*/false));
+    BOOST_CHECK(state.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(block_valid_signet)
+{
+    const auto chainparams{CChainParams::SigNet()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    const CBlock block{chainparams->GenesisBlock()};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(CheckBlock(block, state, consensusParams));
+    BOOST_CHECK(state.IsValid());
+    BOOST_CHECK(block.fChecked);
+}
+
+BOOST_AUTO_TEST_CASE(block_cached)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    BlockValidationState state;
+
+    BOOST_REQUIRE(CheckBlock(block, state, consensusParams));
+    BOOST_REQUIRE(block.fChecked);
+
+    // Invalidate the proof of work. The block is still accepted and valid, which
+    // is only possible if the cached result is returned without re-running the checks.
+    block.nNonce = 0;
+    BOOST_CHECK(CheckBlock(block, state, consensusParams));
+    BOOST_CHECK(state.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(block_not_cached_on_partial_check)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    const CBlock block{chainparams->GenesisBlock()};
+
+    BlockValidationState state;
+
+    // Skipping either check must not mark the block as fully checked.
+    BOOST_CHECK(CheckBlock(block, state, consensusParams, /*fCheckPOW=*/false));
+    BOOST_CHECK(!block.fChecked);
+    BOOST_CHECK(CheckBlock(block, state, consensusParams, /*fCheckPOW=*/true, /*fCheckMerkleRoot=*/false));
+    BOOST_CHECK(!block.fChecked);
+}
+
+BOOST_AUTO_TEST_CASE(block_bad_header)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+    block.nNonce = 0;
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!CheckBlock(block, state, consensusParams));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "high-hash");
+}
+
+BOOST_AUTO_TEST_CASE(block_bad_signet_blksig)
+{
+    const auto chainparams{CChainParams::SigNet()};
+    Consensus::Params consensusParams{chainparams->GetConsensus()};
+
+    // The signet solution of the genesis block is never checked, so the params
+    // are pointed at a different block to get it checked like any other.
+    consensusParams.hashGenesisBlock = uint256{};
+
+    const CBlock block{chainparams->GenesisBlock()};
+
+    BlockValidationState state;
+
+    // The coinbase carries no witness commitment, so no signet solution can be
+    // extracted from it.
+    BOOST_CHECK(!CheckBlock(block, state, consensusParams));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-signet-blksig");
+}
+
+BOOST_AUTO_TEST_CASE(block_bad_txnmrklroot)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+    block.hashMerkleRoot = uint256{};
+
+    BlockValidationState state;
+
+    // The header commits to the merkle root, so the proof of work no longer
+    // matches once it is changed.
+    BOOST_CHECK(!CheckBlock(block, state, consensusParams, /*fCheckPOW=*/false));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-txnmrklroot");
+
+    // The same block passes when the merkle root is not checked.
+    BlockValidationState state_unchecked;
+    BOOST_CHECK(CheckBlock(block, state_unchecked, consensusParams, /*fCheckPOW=*/false, /*fCheckMerkleRoot=*/false));
+    BOOST_CHECK(state_unchecked.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(block_bad_blk_length_empty)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // Drop all transactions. The merkle root of an empty block is the null
+    // hash, so it is updated to match and the size check is reached.
+    block.vtx.clear();
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!CheckBlock(block, state, consensusParams, /*fCheckPOW=*/false));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-blk-length");
+}
+
+BOOST_AUTO_TEST_CASE(block_bad_blk_length_oversized)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // Pad the coinbase with the maximum base size worth of data, so that the
+    // block exceeds the weight limit by at least the size of its header.
+    const std::vector<unsigned char> padding(MAX_BLOCK_WEIGHT / WITNESS_SCALE_FACTOR, OP_RETURN);
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vout[0].scriptPubKey = CScript(padding.begin(), padding.end());
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!CheckBlock(block, state, consensusParams, /*fCheckPOW=*/false));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-blk-length");
+}
+
+BOOST_AUTO_TEST_CASE(block_bad_cb_missing)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // Give the first transaction a non-null prevout so that it is no longer a
+    // coinbase, and update the merkle root to match.
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vin[0].prevout.n = 0;
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+    BOOST_REQUIRE(!block.vtx[0]->IsCoinBase());
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!CheckBlock(block, state, consensusParams, /*fCheckPOW=*/false));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-cb-missing");
+}
+
+BOOST_AUTO_TEST_CASE(block_bad_cb_multiple)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // Append a second coinbase. It must not be identical to the first one, or
+    // the merkle root check would reject the block as "bad-txns-duplicate"
+    // before the coinbase count is looked at.
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.nLockTime = 1;
+    block.vtx.push_back(MakeTransactionRef(std::move(mtx)));
+    BOOST_REQUIRE(block.vtx[1]->IsCoinBase());
+    BOOST_REQUIRE(block.vtx[0]->GetHash() != block.vtx[1]->GetHash());
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!CheckBlock(block, state, consensusParams, /*fCheckPOW=*/false));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-cb-multiple");
+}
+
+BOOST_AUTO_TEST_CASE(block_bad_txns_vout_negative)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // Give the coinbase a negative output value. The transaction stays a
+    // coinbase, so the block is only rejected once its transactions are
+    // checked, and the reason is the one reported by CheckTransaction().
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vout[0].nValue = -1;
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+    BOOST_REQUIRE(block.vtx[0]->IsCoinBase());
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!CheckBlock(block, state, consensusParams, /*fCheckPOW=*/false));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-txns-vout-negative");
+}
+
+BOOST_AUTO_TEST_CASE(block_bad_blk_sigops)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // Fill the coinbase output script with one more OP_CHECKSIG than the
+    // block is allowed to have.
+    const std::vector<unsigned char> checksigs(MAX_BLOCK_SIGOPS_COST / WITNESS_SCALE_FACTOR + 1, OP_CHECKSIG);
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vout[0].scriptPubKey = CScript(checksigs.begin(), checksigs.end());
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!CheckBlock(block, state, consensusParams, /*fCheckPOW=*/false));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-blk-sigops");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/validation_check_block_tests.cpp
+++ b/src/test/validation_check_block_tests.cpp
@@ -287,4 +287,176 @@ BOOST_AUTO_TEST_CASE(block_bad_blk_sigops)
     BOOST_CHECK(state.GetRejectReason() == "bad-blk-sigops");
 }
 
+BOOST_AUTO_TEST_CASE(contextual_block_valid)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    const CBlock block{chainparams->GenesisBlock()};
+
+    BlockValidationState state;
+
+    // Without a previous block the height is zero, so none of the deployments
+    // this depends on are active yet.
+    BOOST_CHECK(ContextualCheckBlock(block, state, consensusParams, /*pindexPrev=*/nullptr));
+    BOOST_CHECK(state.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(contextual_block_bad_txns_nonfinal)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // A locktime that has not passed yet is ignored as long as every input is
+    // final, so the sequence number has to be lowered as well.
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.nLockTime = block.nTime;
+    mtx.vin[0].nSequence = CTxIn::SEQUENCE_FINAL - 1;
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlock(block, state, consensusParams, /*pindexPrev=*/nullptr));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-txns-nonfinal");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_block_cb_height)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    CBlockIndex prev;
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_HEIGHTINCB);
+    const int height{prev.nHeight + 1};
+
+    BlockValidationState state;
+
+    // The genesis coinbase does not start with the serialized block height.
+    BOOST_CHECK(!ContextualCheckBlock(block, state, consensusParams, &prev));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-cb-height");
+
+    // A scriptSig that is too short to hold the height is rejected on its
+    // length alone, before a comparison that would read past the end of it.
+    CMutableTransaction truncated{*block.vtx[0]};
+    truncated.vin[0].scriptSig = CScript();
+    block.vtx[0] = MakeTransactionRef(std::move(truncated));
+
+    BlockValidationState state_truncated;
+    BOOST_CHECK(!ContextualCheckBlock(block, state_truncated, consensusParams, &prev));
+    BOOST_CHECK(state_truncated.IsInvalid());
+    BOOST_CHECK(state_truncated.GetRejectReason() == "bad-cb-height");
+
+    // Prefixing the coinbase with the height of this block makes it acceptable.
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vin[0].scriptSig = CScript() << height;
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+
+    BlockValidationState state_with_height;
+    BOOST_CHECK(ContextualCheckBlock(block, state_with_height, consensusParams, &prev));
+    BOOST_CHECK(state_with_height.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(contextual_block_unexpected_witness)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // Segwit is not active at height zero, so the block is not allowed to
+    // carry any witness data at all.
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vin[0].scriptWitness.stack.emplace_back(32, 0);
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+    BOOST_REQUIRE(block.vtx[0]->HasWitness());
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlock(block, state, consensusParams, /*pindexPrev=*/nullptr));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "unexpected-witness");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_block_bad_witness_nonce_size)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    CBlockIndex prev;
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_SEGWIT);
+    prev.nTime = block.nTime;
+    const int height{prev.nHeight + 1};
+
+    // Give the coinbase a witness commitment, so that the witness reserved
+    // value is looked at. The output script is OP_RETURN followed by a
+    // 36 byte push: the four byte header and a 32 byte commitment hash. The
+    // height prefix is needed because BIP34 is active by this height as well.
+    std::vector<unsigned char> commitment{0xaa, 0x21, 0xa9, 0xed};
+    commitment.resize(36);
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vin[0].scriptSig = CScript() << height;
+    mtx.vout.emplace_back(0, CScript() << OP_RETURN << commitment);
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+
+    BlockValidationState state;
+
+    // The coinbase commits to witness data but carries no reserved value.
+    BOOST_CHECK(!ContextualCheckBlock(block, state, consensusParams, &prev));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-witness-nonce-size");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_block_bad_witness_merkle_match)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    CBlockIndex prev;
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_SEGWIT);
+    prev.nTime = block.nTime;
+    const int height{prev.nHeight + 1};
+
+    // As above, but with a reserved value of the expected size, so that the
+    // commitment itself is compared against the witness merkle root.
+    std::vector<unsigned char> commitment{0xaa, 0x21, 0xa9, 0xed};
+    commitment.resize(36);
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vin[0].scriptSig = CScript() << height;
+    mtx.vin[0].scriptWitness.stack.emplace_back(32, 0);
+    mtx.vout.emplace_back(0, CScript() << OP_RETURN << commitment);
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+
+    BlockValidationState state;
+
+    // The commitment is all zeroes, which is not the witness merkle root.
+    BOOST_CHECK(!ContextualCheckBlock(block, state, consensusParams, &prev));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-witness-merkle-match");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_block_bad_blk_weight)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+    CBlock block{chainparams->GenesisBlock()};
+
+    // Pad the coinbase with the maximum base size worth of data. There is no
+    // witness data, so the weight is four times the base size and the block
+    // ends up just over the limit.
+    const std::vector<unsigned char> padding(MAX_BLOCK_WEIGHT / WITNESS_SCALE_FACTOR, OP_RETURN);
+    CMutableTransaction mtx{*block.vtx[0]};
+    mtx.vout[0].scriptPubKey = CScript(padding.begin(), padding.end());
+    block.vtx[0] = MakeTransactionRef(std::move(mtx));
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlock(block, state, consensusParams, /*pindexPrev=*/nullptr));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-blk-weight");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/validation_check_header_tests.cpp
+++ b/src/test/validation_check_header_tests.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/params.h>
+#include <consensus/validation.h>
+#include <kernel/chainparams.h>
+#include <primitives/block.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <string>
+
+BOOST_AUTO_TEST_SUITE(validation_check_header_tests)
+
+BOOST_AUTO_TEST_CASE(intrinsic_valid)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    // The genesis header has valid proof of work.
+    const CBlockHeader header{chainparams->GenesisBlock()};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(CheckBlockHeader(header, state, consensusParams));
+    BOOST_CHECK(state.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(intrinsic_high_hash)
+{
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    // Decrementing the nonce invalidates the proof of work.
+    header.nNonce--;
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!CheckBlockHeader(header, state, consensusParams));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "high-hash");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/validation_check_header_tests.cpp
+++ b/src/test/validation_check_header_tests.cpp
@@ -2,16 +2,21 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <chain.h>
+#include <consensus/consensus.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
 #include <kernel/chainparams.h>
 #include <primitives/block.h>
+#include <sync.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
 #include <memory>
 #include <string>
+#include <vector>
 
 BOOST_AUTO_TEST_SUITE(validation_check_header_tests)
 
@@ -43,6 +48,298 @@ BOOST_AUTO_TEST_CASE(intrinsic_high_hash)
     BOOST_CHECK(!CheckBlockHeader(header, state, consensusParams));
     BOOST_CHECK(state.IsInvalid());
     BOOST_CHECK(state.GetRejectReason() == "high-hash");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_valid)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nTime = prev.GetMedianTimePast() + 1;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(contextual_bad_diffbits)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nTime = prev.GetMedianTimePast() + 1;
+    header.nBits = 0x1dffffff;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-diffbits");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_time_too_old)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nTime = prev.GetMedianTimePast();
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "time-too-old");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_time_timewarp_attack)
+{
+    LOCK(::cs_main);
+
+    // The timewarp check is only enforced on chains with BIP94.
+    CChainParams::RegTestOptions opts{.enforce_bip94 = true};
+    const auto chainparams{CChainParams::RegTest(opts)};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    const int interval{static_cast<int>(consensusParams.DifficultyAdjustmentInterval())};
+    std::vector<CBlockIndex> chain(interval);
+    for (int i = 0; i < interval; ++i) {
+        chain[i].nHeight = i;
+        chain[i].nTime = 1231006505 + i * 600;
+        chain[i].nBits = 0x207fffff;
+        chain[i].pprev = i > 0 ? &chain[i - 1] : nullptr;
+    }
+
+    CBlockIndex& prev{chain.back()};
+    prev.nTime += 10000;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nVersion = 4;
+    header.nTime = prev.nTime - MAX_TIMEWARP - 1;
+    header.nBits = prev.nBits;
+    BOOST_REQUIRE(header.GetBlockTime() > prev.GetMedianTimePast());
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "time-timewarp-attack");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_time_too_new)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nTime = prev.nTime + MAX_FUTURE_BLOCK_TIME + 1;
+
+    // Keep the clock at the previous block's time, so the header is more than
+    // MAX_FUTURE_BLOCK_TIME ahead of it.
+    const NodeClock::time_point now{std::chrono::seconds{prev.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "time-too-new");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_version_1_after_heightincb)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    // The deployment height is mid difficulty-period; at a retarget boundary
+    // GetNextWorkRequired() would walk the (absent) pprev chain.
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_HEIGHTINCB);
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nVersion = 1;
+    header.nTime = prev.GetMedianTimePast() + 1;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-version(0x00000001)");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_version_2_after_dersig)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    // The deployment height is mid difficulty-period; at a retarget boundary
+    // GetNextWorkRequired() would walk the (absent) pprev chain.
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_DERSIG);
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nVersion = 2;
+    header.nTime = prev.GetMedianTimePast() + 1;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-version(0x00000002)");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_version_3_after_cltv)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    // The deployment height is mid difficulty-period; at a retarget boundary
+    // GetNextWorkRequired() would walk the (absent) pprev chain.
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_CLTV);
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nVersion = 3;
+    header.nTime = prev.GetMedianTimePast() + 1;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-version(0x00000003)");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_version_2_before_dersig)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nVersion = 2;
+    header.nTime = prev.GetMedianTimePast() + 1;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    // Version 2 is only outdated once DERSIG requires version 3.
+    BOOST_CHECK(ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(contextual_version_3_before_cltv)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nVersion = 3;
+    header.nTime = prev.GetMedianTimePast() + 1;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    // Version 3 is only outdated once CLTV requires version 4.
+    BOOST_CHECK(ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(contextual_version_4_after_cltv)
+{
+    LOCK(::cs_main);
+
+    const auto chainparams{CChainParams::Main()};
+    const Consensus::Params& consensusParams{chainparams->GetConsensus()};
+
+    CBlockIndex prev;
+    // The deployment height is mid difficulty-period; at a retarget boundary
+    // GetNextWorkRequired() would walk the (absent) pprev chain.
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_CLTV);
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header{chainparams->GenesisBlock()};
+    header.nVersion = 4;
+    header.nTime = prev.GetMedianTimePast() + 1;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    // Version 4 is accepted with every version deployment active.
+    BOOST_CHECK(ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsValid());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/validation_header_tests.cpp
+++ b/src/test/validation_header_tests.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(validation_header_tests)
+
+BOOST_AUTO_TEST_CASE(valid_intrinsic)
+{
+    CBlockHeader header;
+    header.nVersion = 1;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = 1231006505;
+    header.nBits = 0x1d00ffff;
+    header.nNonce = 2083236893;
+
+    BlockValidationState state;
+    Consensus::Params consensusParams = CChainParams::Main()->GetConsensus();
+
+    BOOST_CHECK(CheckBlockHeader(header, state, consensusParams));
+    BOOST_CHECK(state.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(invalid_proof_of_work)
+{
+    CBlockHeader header;
+    header.nVersion = 1;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = 1231006505;
+    header.nBits = 0x1d00ffff;
+    header.nNonce = 2083236892;
+
+    BlockValidationState state;
+    Consensus::Params consensusParams = CChainParams::Main()->GetConsensus();
+
+    BOOST_CHECK(!CheckBlockHeader(header, state, consensusParams));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "high-hash");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/validation_header_tests.cpp
+++ b/src/test/validation_header_tests.cpp
@@ -43,4 +43,233 @@ BOOST_AUTO_TEST_CASE(invalid_proof_of_work)
     BOOST_CHECK(state.GetRejectReason() == "high-hash");
 }
 
+BOOST_AUTO_TEST_CASE(contextual_valid)
+{
+    LOCK(::cs_main);
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header;
+    header.nVersion = 1;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = prev.GetMedianTimePast() + 1;
+    header.nBits = 0x1d00ffff;
+    header.nNonce = 2083236893;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+    Consensus::Params consensusParams = CChainParams::Main()->GetConsensus();
+
+    BOOST_CHECK(ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(contextual_bad_diffbits)
+{
+    LOCK(::cs_main);
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header;
+    header.nVersion = 1;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = prev.GetMedianTimePast() + 1;
+    header.nBits = 0x1dffffff;
+    header.nNonce = 2083236893;
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+    Consensus::Params consensusParams = CChainParams::Main()->GetConsensus();
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-diffbits");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_time_too_old)
+{
+    LOCK(::cs_main);
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header;
+    header.nVersion = 1;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = prev.GetMedianTimePast();
+    header.nBits = 0x1d00ffff;
+    header.nNonce = 2083236893;
+
+    const NodeClock::time_point now{std::chrono::seconds{prev.nTime}};
+
+    BlockValidationState state;
+    Consensus::Params consensusParams = CChainParams::Main()->GetConsensus();
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "time-too-old");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_time_timewarp_attack)
+{
+    LOCK(::cs_main);
+
+    // The timewarp check is only enforced on chains with BIP94.
+    CChainParams::RegTestOptions opts{.enforce_bip94 = true};
+    Consensus::Params consensusParams = CChainParams::RegTest(opts)->GetConsensus();
+
+    const int interval{static_cast<int>(consensusParams.DifficultyAdjustmentInterval())};
+    std::vector<CBlockIndex> chain(interval);
+    for (int i = 0; i < interval; ++i) {
+        chain[i].nHeight = i;
+        chain[i].nTime = 1231006505 + i * 600;
+        chain[i].nBits = 0x207fffff;
+        chain[i].pprev = i > 0 ? &chain[i - 1] : nullptr;
+    }
+
+    CBlockIndex& prev{chain.back()};
+    prev.nTime += 10000;
+
+    CBlockHeader header;
+    header.nVersion = 4;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = prev.nTime - MAX_TIMEWARP - 1;
+    header.nBits = prev.nBits;
+    header.nNonce = 2083236893;
+    BOOST_REQUIRE(header.GetBlockTime() > prev.GetMedianTimePast());
+
+    const NodeClock::time_point now{std::chrono::seconds{header.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "time-timewarp-attack");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_time_too_new)
+{
+    LOCK(::cs_main);
+
+    CBlockIndex prev;
+    prev.nHeight = 100;
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header;
+    header.nVersion = 1;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = prev.nTime + MAX_FUTURE_BLOCK_TIME + 1;
+    header.nBits = 0x1d00ffff;
+    header.nNonce = 2083236893;
+
+    const NodeClock::time_point now{std::chrono::seconds{prev.nTime}};
+
+    BlockValidationState state;
+    Consensus::Params consensusParams = CChainParams::Main()->GetConsensus();
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "time-too-new");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_bad_version_1)
+{
+    LOCK(::cs_main);
+
+    Consensus::Params consensusParams = CChainParams::Main()->GetConsensus();
+
+    CBlockIndex prev;
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_HEIGHTINCB);
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header;
+    header.nVersion = 1;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = prev.GetMedianTimePast() + 1;
+    header.nBits = 0x1d00ffff;
+    header.nNonce = 2083236893;
+
+    const NodeClock::time_point now{std::chrono::seconds{prev.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-version(0x00000001)");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_bad_version_2)
+{
+    LOCK(::cs_main);
+
+    Consensus::Params consensusParams = CChainParams::Main()->GetConsensus();
+
+    CBlockIndex prev;
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_DERSIG);
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header;
+    header.nVersion = 2;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = prev.GetMedianTimePast() + 1;
+    header.nBits = 0x1d00ffff;
+    header.nNonce = 2083236893;
+
+    const NodeClock::time_point now{std::chrono::seconds{prev.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-version(0x00000002)");
+}
+
+BOOST_AUTO_TEST_CASE(contextual_bad_version_3)
+{
+    LOCK(::cs_main);
+
+    Consensus::Params consensusParams = CChainParams::Main()->GetConsensus();
+
+    CBlockIndex prev;
+    prev.nHeight = consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_CLTV);
+    prev.nTime = 1231006505;
+    prev.nBits = 0x1d00ffff;
+
+    CBlockHeader header;
+    header.nVersion = 3;
+    header.hashPrevBlock = uint256{};
+    header.hashMerkleRoot = uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"};
+    header.nTime = prev.GetMedianTimePast() + 1;
+    header.nBits = 0x1d00ffff;
+    header.nNonce = 2083236893;
+
+    const NodeClock::time_point now{std::chrono::seconds{prev.nTime}};
+
+    BlockValidationState state;
+
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &prev, now));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetRejectReason() == "bad-version(0x00000003)");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4091,14 +4091,13 @@ arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers)
  *  v0.12 and v0.15 (when no additional protection was in place) whereby an attacker could unboundedly
  *  grow our in-memory block index. See https://bitcoincore.org/en/2024/07/03/disclose-header-spam.
  */
-bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     AssertLockHeld(::cs_main);
     assert(pindexPrev != nullptr);
     const int nHeight = pindexPrev->nHeight + 1;
 
     // Check proof of work
-    const Consensus::Params& consensusParams = chainman.GetConsensus();
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-diffbits", "incorrect proof of work");
 
@@ -4124,9 +4123,9 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState&
     }
 
     // Reject blocks with outdated version
-    if ((block.nVersion < 2 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
-        (block.nVersion < 3 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_DERSIG)) ||
-        (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CLTV))) {
+    if ((block.nVersion < 2 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
+        (block.nVersion < 3 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DERSIG)) ||
+        (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CLTV))) {
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
     }
@@ -4140,13 +4139,13 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState&
  *  in ConnectBlock().
  *  Note that -reindex-chainstate skips the validation that happens here!
  */
-bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
+bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
 
     // Enforce BIP113 (Median Time Past).
     bool enforce_locktime_median_time_past{false};
-    if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CSV)) {
+    if (DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CSV)) {
         assert(pindexPrev != nullptr);
         enforce_locktime_median_time_past = true;
     }
@@ -4163,7 +4162,7 @@ bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, cons
     }
 
     // Enforce rule that the coinbase starts with serialized block height
-    if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB))
+    if (DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_HEIGHTINCB))
     {
         CScript expect = CScript() << nHeight;
         if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
@@ -4180,7 +4179,7 @@ bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, cons
     // * There must be at least one output whose scriptPubKey is a single 36-byte push, the first 4 bytes of which are
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness reserved value). In case there are
     //   multiple, the last one is used.
-    if (!CheckWitnessMalleation(block, DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT), state)) {
+    if (!CheckWitnessMalleation(block, DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT), state)) {
         return false;
     }
 
@@ -4235,7 +4234,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             LogDebug(BCLog::VALIDATION, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
         }
-        if (!ContextualCheckBlockHeader(block, state, *this, pindexPrev)) {
+        if (!ContextualCheckBlockHeader(block, state, GetConsensus(), pindexPrev)) {
             LogDebug(BCLog::VALIDATION, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
@@ -4362,7 +4361,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     const CChainParams& params{GetParams()};
 
     if (!CheckBlock(block, state, params.GetConsensus()) ||
-        !ContextualCheckBlock(block, state, *this, pindex->pprev)) {
+        !ContextualCheckBlock(block, state, GetConsensus(), pindex->pprev)) {
         if (Assume(state.IsInvalid())) {
             ActiveChainstate().InvalidBlockFound(pindex, state);
         }
@@ -4523,12 +4522,12 @@ BlockValidationState TestBlockValidity(
      * - do run ContextualCheckBlock()
      */
 
-    if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman, tip)) {
+    if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman.GetConsensus(), tip)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
     }
 
-    if (!ContextualCheckBlock(block, state, chainstate.m_chainman, tip)) {
+    if (!ContextualCheckBlock(block, state, chainstate.m_chainman.GetConsensus(), tip)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4091,7 +4091,7 @@ arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers)
  *  v0.12 and v0.15 (when no additional protection was in place) whereby an attacker could unboundedly
  *  grow our in-memory block index. See https://bitcoincore.org/en/2024/07/03/disclose-header-spam.
  */
-bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, NodeClock::time_point now)
 {
     AssertLockHeld(::cs_main);
     assert(pindexPrev != nullptr);
@@ -4118,7 +4118,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState&
     }
 
     // Check timestamp
-    if (block.Time() > NodeClock::now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
+    if (block.Time() > now + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
     }
 
@@ -4234,7 +4234,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             LogDebug(BCLog::VALIDATION, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
         }
-        if (!ContextualCheckBlockHeader(block, state, GetConsensus(), pindexPrev)) {
+        if (!ContextualCheckBlockHeader(block, state, GetConsensus(), pindexPrev, NodeClock::now())) {
             LogDebug(BCLog::VALIDATION, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
@@ -4522,7 +4522,7 @@ BlockValidationState TestBlockValidity(
      * - do run ContextualCheckBlock()
      */
 
-    if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman.GetConsensus(), tip)) {
+    if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman.GetConsensus(), tip, NodeClock::now())) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4078,14 +4078,13 @@ arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers)
     return total_work;
 }
 
-bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     AssertLockHeld(::cs_main);
     assert(pindexPrev != nullptr);
     const int nHeight = pindexPrev->nHeight + 1;
 
     // Check proof of work
-    const Consensus::Params& consensusParams = chainman.GetConsensus();
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-diffbits", "incorrect proof of work");
 
@@ -4111,9 +4110,9 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState&
     }
 
     // Reject blocks with outdated version
-    if ((block.nVersion < 2 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
-        (block.nVersion < 3 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_DERSIG)) ||
-        (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CLTV))) {
+    if ((block.nVersion < 2 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
+        (block.nVersion < 3 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DERSIG)) ||
+        (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CLTV))) {
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
     }
@@ -4121,13 +4120,13 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState&
     return true;
 }
 
-bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
+bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
 
     // Enforce BIP113 (Median Time Past).
     bool enforce_locktime_median_time_past{false};
-    if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CSV)) {
+    if (DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CSV)) {
         assert(pindexPrev != nullptr);
         enforce_locktime_median_time_past = true;
     }
@@ -4144,7 +4143,7 @@ bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, cons
     }
 
     // Enforce rule that the coinbase starts with serialized block height
-    if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB))
+    if (DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_HEIGHTINCB))
     {
         CScript expect = CScript() << nHeight;
         if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
@@ -4161,7 +4160,7 @@ bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, cons
     // * There must be at least one output whose scriptPubKey is a single 36-byte push, the first 4 bytes of which are
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness reserved value). In case there are
     //   multiple, the last one is used.
-    if (!CheckWitnessMalleation(block, DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT), state)) {
+    if (!CheckWitnessMalleation(block, DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT), state)) {
         return false;
     }
 
@@ -4216,7 +4215,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             LogDebug(BCLog::VALIDATION, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
         }
-        if (!ContextualCheckBlockHeader(block, state, *this, pindexPrev)) {
+        if (!ContextualCheckBlockHeader(block, state, GetConsensus(), pindexPrev)) {
             LogDebug(BCLog::VALIDATION, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
@@ -4340,10 +4339,8 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
         if (pindex->nChainWork < MinimumChainWork()) return true;
     }
 
-    const CChainParams& params{GetParams()};
-
-    if (!CheckBlock(block, state, params.GetConsensus()) ||
-        !ContextualCheckBlock(block, state, *this, pindex->pprev)) {
+    if (!CheckBlock(block, state, GetConsensus()) ||
+        !ContextualCheckBlock(block, state, GetConsensus(), pindex->pprev)) {
         if (Assume(state.IsInvalid())) {
             ActiveChainstate().InvalidBlockFound(pindex, state);
         }
@@ -4504,12 +4501,12 @@ BlockValidationState TestBlockValidity(
      * - do run ContextualCheckBlock()
      */
 
-    if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman, tip)) {
+    if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman.GetConsensus(), tip)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
     }
 
-    if (!ContextualCheckBlock(block, state, chainstate.m_chainman, tip)) {
+    if (!ContextualCheckBlock(block, state, chainstate.m_chainman.GetConsensus(), tip)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4078,7 +4078,7 @@ arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers)
     return total_work;
 }
 
-bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, NodeClock::time_point now)
 {
     AssertLockHeld(::cs_main);
     assert(pindexPrev != nullptr);
@@ -4105,7 +4105,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState&
     }
 
     // Check timestamp
-    if (block.Time() > NodeClock::now() + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
+    if (block.Time() > now + std::chrono::seconds{MAX_FUTURE_BLOCK_TIME}) {
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
     }
 
@@ -4215,7 +4215,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             LogDebug(BCLog::VALIDATION, "header %s has prev block invalid: %s\n", hash.ToString(), block.hashPrevBlock.ToString());
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_PREV, "bad-prevblk");
         }
-        if (!ContextualCheckBlockHeader(block, state, GetConsensus(), pindexPrev)) {
+        if (!ContextualCheckBlockHeader(block, state, GetConsensus(), pindexPrev, NodeClock::now())) {
             LogDebug(BCLog::VALIDATION, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
@@ -4501,7 +4501,7 @@ BlockValidationState TestBlockValidity(
      * - do run ContextualCheckBlock()
      */
 
-    if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman.GetConsensus(), tip)) {
+    if (!ContextualCheckBlockHeader(block, state, chainstate.m_chainman.GetConsensus(), tip, NodeClock::now())) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3839,7 +3839,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     }
 }
 
-static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
+bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW)
 {
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
@@ -4091,7 +4091,7 @@ arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers)
  *  v0.12 and v0.15 (when no additional protection was in place) whereby an attacker could unboundedly
  *  grow our in-memory block index. See https://bitcoincore.org/en/2024/07/03/disclose-header-spam.
  */
-static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
 {
     AssertLockHeld(::cs_main);
     assert(pindexPrev != nullptr);
@@ -4140,7 +4140,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
  *  in ConnectBlock().
  *  Note that -reindex-chainstate skips the validation that happens here!
  */
-static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
+bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
 {
     const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3839,7 +3839,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     }
 }
 
-static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
+bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW)
 {
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
@@ -4078,20 +4078,7 @@ arith_uint256 CalculateClaimedHeadersWork(std::span<const CBlockHeader> headers)
     return total_work;
 }
 
-/** Context-dependent validity checks.
- *  By "context", we mean only the previous block headers, but not the UTXO
- *  set; UTXO-related validity checks are done in ConnectBlock().
- *  NOTE: This function is not currently invoked by ConnectBlock(), so we
- *  should consider upgrade issues if we change which consensus rules are
- *  enforced in this function (eg by adding a new consensus rule). See comment
- *  in ConnectBlock().
- *  Note that -reindex-chainstate skips the validation that happens here!
- *
- *  NOTE: failing to check the header's height against the last checkpoint's opened a DoS vector between
- *  v0.12 and v0.15 (when no additional protection was in place) whereby an attacker could unboundedly
- *  grow our in-memory block index. See https://bitcoincore.org/en/2024/07/03/disclose-header-spam.
- */
-static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
 {
     AssertLockHeld(::cs_main);
     assert(pindexPrev != nullptr);
@@ -4134,13 +4121,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     return true;
 }
 
-/** NOTE: This function is not currently invoked by ConnectBlock(), so we
- *  should consider upgrade issues if we change which consensus rules are
- *  enforced in this function (eg by adding a new consensus rule). See comment
- *  in ConnectBlock().
- *  Note that -reindex-chainstate skips the validation that happens here!
- */
-static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
+bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
 {
     const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -395,8 +395,8 @@ public:
 bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
-bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev);
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 /**
  * Verify a block, including transactions.

--- a/src/validation.h
+++ b/src/validation.h
@@ -408,7 +408,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
  *  v0.12 and v0.15 (when no additional protection was in place) whereby an attacker could unboundedly
  *  grow our in-memory block index. See https://bitcoincore.org/en/2024/07/03/disclose-header-spam.
  */
-bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, NodeClock::time_point now) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 
 /** NOTE: This function is not currently invoked by ConnectBlock(), so we

--- a/src/validation.h
+++ b/src/validation.h
@@ -408,7 +408,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
  *  v0.12 and v0.15 (when no additional protection was in place) whereby an attacker could unboundedly
  *  grow our in-memory block index. See https://bitcoincore.org/en/2024/07/03/disclose-header-spam.
  */
-bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 
 /** NOTE: This function is not currently invoked by ConnectBlock(), so we
@@ -417,7 +417,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState&
  *  in ConnectBlock().
  *  Note that -reindex-chainstate skips the validation that happens here!
  */
-bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev);
+bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 /**
  * Verify a block, including transactions.

--- a/src/validation.h
+++ b/src/validation.h
@@ -392,7 +392,32 @@ public:
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
+bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
+
+/** Context-dependent validity checks.
+ *  By "context", we mean only the previous block headers, but not the UTXO
+ *  set; UTXO-related validity checks are done in ConnectBlock().
+ *  NOTE: This function is not currently invoked by ConnectBlock(), so we
+ *  should consider upgrade issues if we change which consensus rules are
+ *  enforced in this function (eg by adding a new consensus rule). See comment
+ *  in ConnectBlock().
+ *  Note that -reindex-chainstate skips the validation that happens here!
+ *
+ *  NOTE: failing to check the header's height against the last checkpoint's opened a DoS vector between
+ *  v0.12 and v0.15 (when no additional protection was in place) whereby an attacker could unboundedly
+ *  grow our in-memory block index. See https://bitcoincore.org/en/2024/07/03/disclose-header-spam.
+ */
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+
+/** NOTE: This function is not currently invoked by ConnectBlock(), so we
+ *  should consider upgrade issues if we change which consensus rules are
+ *  enforced in this function (eg by adding a new consensus rule). See comment
+ *  in ConnectBlock().
+ *  Note that -reindex-chainstate skips the validation that happens here!
+ */
+bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev);
 
 /**
  * Verify a block, including transactions.

--- a/src/validation.h
+++ b/src/validation.h
@@ -392,7 +392,11 @@ public:
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
+bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
+
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev);
 
 /**
  * Verify a block, including transactions.

--- a/src/validation.h
+++ b/src/validation.h
@@ -395,7 +395,7 @@ public:
 bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
-bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, NodeClock::time_point now) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 /**


### PR DESCRIPTION
This implements the following actions from #35904:

1. **Expose the validation interface**

   Make the existing `CheckBlockHeader`, `ContextualCheckBlockHeader`, and `ContextualCheckBlock` functions part of the public validation interface by declaring them in `validation.h`.

2. **Interface Segregation: Remove dependency on `ChainstateManager`**

   `ContextualCheck*` functions need a  `ChainstateManager` only to access the
  consensus parameters. Pass `Consensus::Params` instead and access them at the call site.

3. **Make environmental dependencies explicit**

   Pass the validation time explicitly to `ContextualCheckBlockHeader` instead of reading the system clock internally.
