### PR TITLE
doc: Update NetBSD Build Guide

### DIFF
--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -26,7 +26,7 @@ To build Bitcoin Core without the wallet, use `-DENABLE_WALLET=OFF`.
 Cap'n Proto is needed for IPC functionality (see [multiprocess.md](multiprocess.md)):
 
 ```bash
-pkgin install capnproto
+pkgin install capnproto pkgconf
 ```
 
 Compile with `-DENABLE_IPC=OFF` if you do not need IPC functionality.

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -15,22 +15,6 @@ The example commands below use `pkgin`.
 pkgin install git cmake boost
 ```
 
-NetBSD currently ships with an older version of `gcc` than is needed to build. You should upgrade your `gcc` and then pass this new version to the CMake configuration.
-
-For example, grab `gcc12`:
-```
-pkgin install gcc12
-```
-
-Then, when configuring, pass the following:
-```bash
-cmake -B build
-    ...
-    -DCMAKE_C_COMPILER="/usr/pkg/gcc12/bin/gcc" \
-    -DCMAKE_CXX_COMPILER="/usr/pkg/gcc12/bin/g++" \
-    ...
-```
-
 SQLite is required for the wallet:
 
 ```bash

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -68,7 +68,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 
 Bitcoin Core can provide notifications via ZeroMQ. To compile ZMQ support, install the following dependency and pass `-DWITH_ZMQ=ON` when configuring.
 ```bash
-pkgin install zeromq pkg-config
+pkgin install zeromq pkgconf
 ```
 
 #### Test Suite Dependencies


### PR DESCRIPTION
This PR updates the "NetBSD Build Guide" following the latest release 11.0. See commit messages for more details.