### PR TITLE
rest: Allow fetching stale header

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -53,10 +53,15 @@ Given a block hash: returns a block part, in binary or hex-encoded binary format
 Responds with 404 if the block or the byte range doesn't exist.
 
 #### Blockheaders
-`GET /rest/headers/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
+`GET /rest/headers/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>&activechainonly=<ACTIVECHAINONLY=TRUE>`
 
 Given a block hash: returns <COUNT> amount of blockheaders in upward direction.
-Returns empty if the block doesn't exist or it isn't in the active chain.
+
+Returns empty if the block doesn't exist or it isn't in the active chain by
+default.
+
+Single stale block headers can be retrieved with <COUNT> set to 1, and
+<ACTIVECHAINONLY> set to false.
 
 *Deprecated (but not removed) since 24.0:*
 `GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`

--- a/doc/release-notes-reststaleheader.md
+++ b/doc/release-notes-reststaleheader.md
@@ -1,0 +1,5 @@
+REST
+---
+
+- /rest/headers now supports retrieving single stale block headers with
+`/rest/headers/<BLOCK-HASH>.json?count=1&activechainonly=false`.

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -28,6 +28,7 @@
 #include <undo.h>
 #include <util/any.h>
 #include <util/check.h>
+#include <util/expected.h>
 #include <util/overflow.h>
 #include <util/strencodings.h>
 #include <validation.h>
@@ -167,6 +168,28 @@ static std::string AvailableDataFormatsString()
         return formats.substr(0, formats.length() - 2);
 
     return formats;
+}
+
+util::Expected<bool, std::string> RESTParseBoolParam(HTTPRequest* req, const std::string_view& param_name, bool default_val)
+{
+    std::optional<std::string> param_val{std::nullopt};
+    try {
+        param_val = req->GetQueryParameter(param_name);
+    } catch (const std::runtime_error& e) {
+        return util::Unexpected{e.what()};
+    }
+
+    if (param_val.has_value()) {
+        if (param_val == "true") {
+            return true;
+        } else if (param_val == "false") {
+            return false;
+        } else {
+            return util::Unexpected{strprintf("The \"%s\" query parameter must be either \"true\" or \"false\".", param_name)};
+        }
+    } else {
+        return default_val;
+    }
 }
 
 static bool CheckWarmup(HTTPRequest* req)
@@ -798,26 +821,21 @@ static bool rest_mempool(const std::any& context, HTTPRequest* req, const std::s
     case RESTResponseFormat::JSON: {
         std::string str_json;
         if (param == "contents") {
-            std::string raw_verbose;
-            try {
-                raw_verbose = req->GetQueryParameter("verbose").value_or("true");
-            } catch (const std::runtime_error& e) {
-                return RESTERR(req, HTTP_BAD_REQUEST, e.what());
+            bool verbose, mempool_sequence;
+            const auto verbose_parse = RESTParseBoolParam(req, "verbose", /*default_val=*/true);
+            if (verbose_parse.has_value()) {
+                verbose = verbose_parse.value();
+            } else {
+                return RESTERR(req, HTTP_BAD_REQUEST, verbose_parse.error());
             }
-            if (raw_verbose != "true" && raw_verbose != "false") {
-                return RESTERR(req, HTTP_BAD_REQUEST, "The \"verbose\" query parameter must be either \"true\" or \"false\".");
+
+            const auto mempool_sequence_parse = RESTParseBoolParam(req, "mempool_sequence", /*default_val=*/false);
+            if (mempool_sequence_parse.has_value()) {
+                mempool_sequence = mempool_sequence_parse.value();
+            } else {
+                return RESTERR(req, HTTP_BAD_REQUEST, mempool_sequence_parse.error());
             }
-            std::string raw_mempool_sequence;
-            try {
-                raw_mempool_sequence = req->GetQueryParameter("mempool_sequence").value_or("false");
-            } catch (const std::runtime_error& e) {
-                return RESTERR(req, HTTP_BAD_REQUEST, e.what());
-            }
-            if (raw_mempool_sequence != "true" && raw_mempool_sequence != "false") {
-                return RESTERR(req, HTTP_BAD_REQUEST, "The \"mempool_sequence\" query parameter must be either \"true\" or \"false\".");
-            }
-            const bool verbose{raw_verbose == "true"};
-            const bool mempool_sequence{raw_mempool_sequence == "true"};
+
             if (verbose && mempool_sequence) {
                 return RESTERR(req, HTTP_BAD_REQUEST, "Verbose results cannot contain mempool sequence values. (hint: set \"verbose=false\")");
             }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -170,7 +170,7 @@ static std::string AvailableDataFormatsString()
     return formats;
 }
 
-util::Expected<bool, std::string> RESTParseBoolParam(HTTPRequest* req, const std::string_view& param_name, bool default_val)
+util::Expected<bool, std::string> RESTParseBoolParam(HTTPRequest* req, std::string_view param_name, bool default_val)
 {
     std::optional<std::string> param_val{std::nullopt};
     try {
@@ -212,17 +212,24 @@ static bool rest_headers(const std::any& context,
 
     std::string raw_count;
     std::string hashStr;
+    bool active_chain_only{true};
     if (path.size() == 2) {
         // deprecated path: /rest/headers/<count>/<hash>
         hashStr = path[1];
         raw_count = path[0];
     } else if (path.size() == 1) {
-        // new path with query parameter: /rest/headers/<hash>?count=<count>
+        // new path with query parameter: /rest/headers/<hash>?count=<count>&activechainonly=<activechainonly>
         hashStr = path[0];
         try {
             raw_count = req->GetQueryParameter("count").value_or("5");
         } catch (const std::runtime_error& e) {
             return RESTERR(req, HTTP_BAD_REQUEST, e.what());
+        }
+        const auto activechainonly_parse = RESTParseBoolParam(req, "activechainonly", /*default_val=*/true);
+        if (activechainonly_parse.has_value()) {
+            active_chain_only = activechainonly_parse.value();
+        } else {
+            return RESTERR(req, HTTP_BAD_REQUEST, activechainonly_parse.error());
         }
     } else {
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid URI format. Expected /rest/headers/<hash>.<ext>?count=<count>");
@@ -231,6 +238,10 @@ static bool rest_headers(const std::any& context,
     const auto parsed_count{ToIntegral<size_t>(raw_count)};
     if (!parsed_count.has_value() || *parsed_count < 1 || *parsed_count > MAX_REST_HEADERS_RESULTS) {
         return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Header count is invalid or out of acceptable range (1-%u): %s", MAX_REST_HEADERS_RESULTS, raw_count));
+    }
+
+    if (active_chain_only == false && parsed_count.value() != 1) {
+        return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Header count must be set to 1 when activechainonly=false, it was set to %s", raw_count));
     }
 
     auto hash{uint256::FromHex(hashStr)};
@@ -246,15 +257,20 @@ static bool rest_headers(const std::any& context,
     ChainstateManager& chainman = *maybe_chainman;
     {
         LOCK(cs_main);
+        const CBlockIndex* pindex{chainman.m_blockman.LookupBlockIndex(*hash)};
         CChain& active_chain = chainman.ActiveChain();
         tip = active_chain.Tip();
-        const CBlockIndex* pindex{chainman.m_blockman.LookupBlockIndex(*hash)};
-        while (pindex != nullptr && active_chain.Contains(*pindex)) {
-            headers.push_back(pindex);
-            if (headers.size() == *parsed_count) {
-                break;
+
+        if (active_chain_only) {
+            while (pindex != nullptr && active_chain.Contains(*pindex)) {
+                headers.push_back(pindex);
+                if (headers.size() == *parsed_count) {
+                    break;
+                }
+                pindex = active_chain.Next(*pindex);
             }
-            pindex = active_chain.Next(*pindex);
+        } else if (pindex != nullptr) {
+            headers.push_back(pindex);
         }
     }
 

--- a/src/rest.h
+++ b/src/rest.h
@@ -5,6 +5,9 @@
 #ifndef BITCOIN_REST_H
 #define BITCOIN_REST_H
 
+#include <httpserver.h>
+#include <util/expected.h>
+
 #include <string>
 
 enum class RESTResponseFormat {
@@ -24,5 +27,7 @@ enum class RESTResponseFormat {
  * @return      RESTResponseFormat that was parsed from the URI.
  */
 RESTResponseFormat ParseDataFormat(std::string& param, const std::string& strReq);
+
+util::Expected<bool, std::string> RESTParseBoolParam(http_bitcoin::HTTPRequest* req, const std::string_view& param_name, bool default_val);
 
 #endif // BITCOIN_REST_H

--- a/src/rest.h
+++ b/src/rest.h
@@ -28,6 +28,6 @@ enum class RESTResponseFormat {
  */
 RESTResponseFormat ParseDataFormat(std::string& param, const std::string& strReq);
 
-util::Expected<bool, std::string> RESTParseBoolParam(http_bitcoin::HTTPRequest* req, const std::string_view& param_name, bool default_val);
+util::Expected<bool, std::string> RESTParseBoolParam(http_bitcoin::HTTPRequest* req, std::string_view param_name, bool default_val);
 
 #endif // BITCOIN_REST_H

--- a/src/test/rest_tests.cpp
+++ b/src/test/rest_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <httpserver.h>
 #include <rest.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
@@ -9,6 +10,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <string>
+
+using http_bitcoin::HTTPRequest;
 
 BOOST_FIXTURE_TEST_SUITE(rest_tests, BasicTestingSetup)
 
@@ -46,4 +49,45 @@ BOOST_AUTO_TEST_CASE(test_query_string)
     BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource");
     BOOST_CHECK_EQUAL(rf, RESTResponseFormat::UNDEF);
 }
+
+BOOST_AUTO_TEST_CASE(test_bool_parsing)
+{
+    HTTPRequest req;
+    util::Expected<bool, std::string> ret;
+    constexpr auto param = "verbose";
+
+    // If no value is set, the default is used.
+    req.m_target = "/rest/endpoint/resource?someotherparam=false";
+    ret = RESTParseBoolParam(&req, param, /*default_val=*/true);
+    BOOST_CHECK(ret.has_value());
+    BOOST_CHECK_EQUAL(*ret, true);
+
+    ret = RESTParseBoolParam(&req, param, /*default_val=*/false);
+    BOOST_CHECK(ret.has_value());
+    BOOST_CHECK_EQUAL(*ret, false);
+
+    // All the checks will use this format string strprintf'ing in the param
+    // and val.
+    static constexpr char fmt_str[] = "/rest/endpoint/resource?%s=%s";
+
+    // Happy case, true
+    req.m_target = strprintf(fmt_str, param, "true");
+    ret = RESTParseBoolParam(&req, param, /*default_val=*/true);
+    BOOST_CHECK(ret.has_value());
+    BOOST_CHECK_EQUAL(*ret, true);
+
+    // Happy case, false
+    req.m_target = strprintf(fmt_str, param, "false");
+    ret = RESTParseBoolParam(&req, param, /*default_val=*/true);
+    BOOST_CHECK(ret.has_value());
+    BOOST_CHECK_EQUAL(*ret, false);
+
+    // Error when some other value is used
+    req.m_target = strprintf(fmt_str, param, "happiness");
+    ret = RESTParseBoolParam(&req, param, /*default_val=*/true);
+    BOOST_CHECK(!ret.has_value());
+    auto err_str = strprintf("The \"%s\" query parameter must be either \"true\" or \"false\".", param);
+    BOOST_CHECK_EQUAL(ret.error(), err_str);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -230,10 +230,23 @@ class RESTTest (BitcoinTestFramework):
         assert_equal(self.test_rest_request(f"/headers/{UNKNOWN_PARAM}", query_params={"count": 1}), [])
         self.test_rest_request(f"/block/{UNKNOWN_PARAM}", status=404, ret_type=RetType.OBJ)
 
-        # Check result if block is not in the active chain
+        self.log.info("Check that result is blank if block is not in the active chain")
         self.nodes[0].invalidateblock(bb_hash)
         assert_equal(self.test_rest_request(f'/headers/{bb_hash}', query_params={'count': 1}), [])
+
+        # But the block request works
         self.test_rest_request(f'/block/{bb_hash}')
+
+        self.log.info("Check result has header block is not in the active chain but activechainonly=false")
+        response = self.test_rest_request(f'/headers/{bb_hash}', query_params={'count': 1, 'activechainonly': "false"})
+        assert_equal(len(response), 1)
+        assert_equal(response[0]['hash'], bb_hash)
+
+        self.log.info("Check for an error when using activechainonly=false with count != 1")
+        resp = self.test_rest_request(f'/headers/{bb_hash}', ret_type=RetType.OBJ, status=400, query_params={'count': 2, 'activechainonly': "false"})
+        assert_equal(resp.read().decode('utf-8').strip(), 'Header count must be set to 1 when activechainonly=false, it was set to 2')
+
+        # Undo our invalidateblock above
         self.nodes[0].reconsiderblock(bb_hash)
 
         # Check binary format


### PR DESCRIPTION
This is one approach that would resolve #35897.

Being able to request stale block headers is useful for clients that want to learn the ancestors of a blockhash e.g. when following a re-org up and matches the functionality of the getblockheader RPC.

This branch takes the approach that a user has to set `count=1` and opt-in to non-active-chain blocks with `activechainonly=false`.

Alternative approaches:

### Fetching stale blocks when `count=1` without a new param

Hyrum's Law suggests that a client out there relies on the property that `/headers/` returns `[]` for non-active-chain blocks, so this is probably dangerous.

### A separate `/header/` interface

This is nice because it avoids the parameter matrix, and we can have a REST path that matches the semantics of `getblockheader`, but I am not sure if this is worth the additional implementation complexity, but I could rework towards this approach if others feel strongly.

### Another rest endpoint that supports negative ranges

e.g. see https://github.com/bitcoin/bitcoin/pull/33752

---

_LLM Disclosure: Used as a research tool and rubber ducky while making this PR, but all code and text came from some indeterminate place inside my body._