### PR TITLE
refactor: Remove unused newFeeRate var in ReplacementChecks

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -995,8 +995,6 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     const Txid& hash = ws.m_hash;
     TxValidationState& state = ws.m_state;
 
-    CFeeRate newFeeRate(ws.m_modified_fees, ws.m_vsize);
-
     CTxMemPool::setEntries all_conflicts;
 
     // Calculate all conflicting entries and enforce Rule #5.


### PR DESCRIPTION
This is unused since cluster-mempool, so it seems confusing to keep around. See the commit that forgot to remove it:

```sh
$ git show 216e6937290338950215795291dbf0a533e234cf -U99999 | grep newFeeRate
     CFeeRate newFeeRate(ws.m_modified_fees, ws.m_vsize);
-    if (const auto err_string{PaysMoreThanConflicts(ws.m_iters_conflicting, newFeeRate, hash)}) {
```