### PR TITLE
Warn on and add missing [[noreturn]]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,7 @@ else()
   try_append_cxx_flags("-Wundef" TARGET warn_interface SKIP_LINK)
   try_append_cxx_flags("-Wleading-whitespace=spaces" TARGET warn_interface SKIP_LINK)
   try_append_cxx_flags("-Wtrailing-whitespace=any" TARGET warn_interface SKIP_LINK)
+  try_append_cxx_flags("-Wmissing-noreturn" TARGET warn_interface SKIP_LINK)
 
   # Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
   # unknown options if any other warning is produced. Test the -Wfoo case, and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,12 +497,17 @@ else()
   try_append_cxx_flags("-Wundef" TARGET warn_interface SKIP_LINK)
   try_append_cxx_flags("-Wleading-whitespace=spaces" TARGET warn_interface SKIP_LINK)
   try_append_cxx_flags("-Wtrailing-whitespace=any" TARGET warn_interface SKIP_LINK)
+  try_append_cxx_flags("-Wmissing-noreturn" TARGET warn_interface SKIP_LINK)
 
   # Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
   # unknown options if any other warning is produced. Test the -Wfoo case, and
   # set the -Wno-foo case if it works.
   try_append_cxx_flags("-Wunused-parameter" TARGET warn_interface SKIP_LINK
     IF_CHECK_PASSED "-Wno-unused-parameter"
+  )
+
+  try_append_cxx_flags("-Wc++23-lambda-attributes" TARGET warn_interface SKIP_LINK
+    IF_CHECK_PASSED "-Wno-c++23-lambda-attributes"
   )
 endif()
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -31,6 +31,7 @@
 #include <util/translation.h>
 
 #include <any>
+#include <cstdlib>
 #include <functional>
 #include <optional>
 
@@ -227,7 +228,7 @@ static bool AppInit(NodeContext& node)
                     exit(EXIT_SUCCESS);
                 } else { // fRet = false or token read error (premature exit).
                     tfm::format(std::cerr, "Error during initialization - check %s for details\n", fs::PathToString(LogInstance().m_file_path.filename()));
-                    exit(EXIT_FAILURE);
+                    std::exit(EXIT_FAILURE);
                 }
             }
             }

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -41,7 +41,7 @@ public:
     virtual Ipc* ipc() { return nullptr; }
     virtual bool canListenIpc() { return false; }
     virtual const char* exeName() { return nullptr; }
-    virtual void makeMiningOld2() { throw std::runtime_error("Old mining interface (@2) not supported. Please update your client!"); }
+    [[noreturn]] virtual void makeMiningOld2() { throw std::runtime_error("Old mining interface (@2) not supported. Please update your client!"); }
 };
 
 //! Return implementation of Init interface for the node process. If the argv

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -48,7 +48,7 @@ public:
     virtual Ipc* ipc() { return nullptr; }
     virtual bool canListenIpc() { return false; }
     virtual const char* exeName() { return nullptr; }
-    virtual void makeMiningOld2() { throw std::runtime_error("Old mining interface (@2) not supported. Please update your client!"); }
+    [[noreturn]] virtual void makeMiningOld2() { throw std::runtime_error("Old mining interface (@2) not supported. Please update your client!"); }
 };
 
 //! Return implementation of Init interface for the node process. If the argv

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -78,7 +78,7 @@ public:
 
     //! Deprecated older method preserved to return an explicit error for IPC
     //! clients using mining.capnp @7.
-    virtual bool submitSolutionOld7(uint32_t, uint32_t, uint32_t, CTransactionRef)
+    [[noreturn]] virtual bool submitSolutionOld7(uint32_t, uint32_t, uint32_t, CTransactionRef)
     {
         throw std::runtime_error("Old submitSolution (@7) not supported. Please update your client!");
     }

--- a/src/ipc/libmultiprocess/include/mp/proxy-types.h
+++ b/src/ipc/libmultiprocess/include/mp/proxy-types.h
@@ -220,7 +220,7 @@ void ThrowField(TypeList<LocalType>, InvokeContext& invoke_context, Input&& inpu
 {
     ReadField(
         TypeList<LocalType>(), invoke_context, input, ReadDestEmplace(TypeList<LocalType>(),
-            [](auto&& ...args) -> const LocalType& { throw LocalType{std::forward<decltype(args)>(args)...}; }));
+            [] [[noreturn]] (auto&& ...args) -> const LocalType& { throw LocalType{std::forward<decltype(args)>(args)...}; }));
 }
 
 //! Special case for generic std::exception. It's an abstract type so it can't

--- a/src/ipc/libmultiprocess/include/mp/proxy-types.h
+++ b/src/ipc/libmultiprocess/include/mp/proxy-types.h
@@ -220,7 +220,7 @@ void ThrowField(TypeList<LocalType>, InvokeContext& invoke_context, Input&& inpu
 {
     ReadField(
         TypeList<LocalType>(), invoke_context, input, ReadDestEmplace(TypeList<LocalType>(),
-            [](auto&& ...args) -> const LocalType& { throw LocalType{std::forward<decltype(args)>(args)...}; }));
+            [](auto&& ...args) __attribute__((noreturn)) -> const LocalType& { throw LocalType{std::forward<decltype(args)>(args)...}; }));
 }
 
 //! Special case for generic std::exception. It's an abstract type so it can't

--- a/src/ipc/libmultiprocess/test/mp/test/foo.h
+++ b/src/ipc/libmultiprocess/test/mp/test/foo.h
@@ -74,7 +74,7 @@ public:
     void addInOut(int x, int& sum) { sum += x; }
     int mapSize(const std::map<std::string, std::string>& map) { return map.size(); }
     FooStruct pass(FooStruct foo) { return foo; }
-    void raise(FooStruct foo) { throw foo; }
+    [[noreturn]] void raise(FooStruct foo) { throw foo; }
     void initThreadMap() {}
     int callback(FooCallback& callback, int arg) { return callback.call(arg); }
     int callbackUnique(std::unique_ptr<FooCallback> callback, int arg) { return callback->call(arg); }

--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -730,9 +730,9 @@ class PosixEnv : public Env {
   }
 
  private:
-  void BackgroundThreadMain();
+  [[noreturn]] void BackgroundThreadMain();
 
-  static void BackgroundThreadEntryPoint(PosixEnv* env) {
+  [[noreturn]] static void BackgroundThreadEntryPoint(PosixEnv* env) {
     env->BackgroundThreadMain();
   }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -46,6 +46,7 @@
 #endif // ENABLE_WALLET
 
 #include <chrono>
+#include <cstdlib>
 #include <memory>
 
 #include <QApplication>
@@ -436,7 +437,7 @@ void BitcoinApplication::handleRunawayException(const QString &message)
         nullptr, tr("Runaway exception"),
         tr("A fatal error occurred. %1 can no longer continue safely and will quit.").arg(CLIENT_NAME) +
         QLatin1String("<br><br>") + GUIUtil::MakeHtmlLink(message, CLIENT_BUGREPORT));
-    ::exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
 }
 
 void BitcoinApplication::handleNonFatalException(const QString& message)

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -73,7 +73,7 @@ public Q_SLOTS:
     /// Request core shutdown
     void requestShutdown();
     /// Handle runaway exceptions. Shows a message box with the problem and quits the program.
-    void handleRunawayException(const QString &message);
+    [[noreturn]] void handleRunawayException(const QString &message);
 
     /**
      * A helper function that shows a message box

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -287,7 +287,7 @@ static RPCMethod generatetodescriptor()
 
 static RPCMethod generate()
 {
-    return RPCMethod{"generate", "has been replaced by the -generate cli option. Refer to -help for more information.", {}, {}, RPCExamples{""}, [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue {
+    return RPCMethod{"generate", "has been replaced by the -generate cli option. Refer to -help for more information.", {}, {}, RPCExamples{""}, [](const RPCMethod& self, const JSONRPCRequest& request) __attribute__((noreturn)) -> UniValue {
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, self.ToString());
     }};
 }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -286,7 +286,7 @@ static RPCMethod generatetodescriptor()
 
 static RPCMethod generate()
 {
-    return RPCMethod{"generate", "has been replaced by the -generate cli option. Refer to -help for more information.", {}, {}, RPCExamples{""}, [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue {
+    return RPCMethod{"generate", "has been replaced by the -generate cli option. Refer to -help for more information.", {}, {}, RPCExamples{""}, [] [[noreturn]] (const RPCMethod& self, const JSONRPCRequest& request) -> UniValue {
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, self.ToString());
     }};
 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -103,7 +103,7 @@ LockData& GetLockData() {
     return lock_data;
 }
 
-static void potential_deadlock_detected(const LockPair& mismatch, const LockStack& s1, const LockStack& s2)
+[[noreturn]] static void potential_deadlock_detected(const LockPair& mismatch, const LockStack& s1, const LockStack& s2)
 {
     LogError("POTENTIAL DEADLOCK DETECTED");
     LogError("Previous lock order was:");
@@ -139,7 +139,7 @@ static void potential_deadlock_detected(const LockPair& mismatch, const LockStac
     throw std::logic_error(strprintf("potential deadlock detected: %s -> %s -> %s", mutex_b, mutex_a, mutex_b));
 }
 
-static void double_lock_detected(const void* mutex, const LockStack& lock_stack)
+[[noreturn]] static void double_lock_detected(const void* mutex, const LockStack& lock_stack)
 {
     LogError("DOUBLE LOCK DETECTED");
     LogError("Lock order:");

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -126,7 +126,7 @@ using Oracle = std::map<uint16_t, uint32_t, LevelDBBytewiseU16Cmp>;
 
 struct FailUnserialize {
     template <typename Stream>
-    void Unserialize(Stream&) { throw std::ios_base::failure{"always fail"}; }
+    [[noreturn]] void Unserialize(Stream&) { throw std::ios_base::failure{"always fail"}; }
 };
 
 uint16_t ConsumeKey(FuzzedDataProvider& provider) { return provider.ConsumeIntegral<uint16_t>(); }

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -90,6 +90,9 @@ const std::function<std::string()> G_TEST_GET_FULL_NAME{[]{
     return std::string{g_fuzz_target};
 }};
 
+// Whether or not this returns depends on the build config.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-noreturn"
 static void initialize()
 {
     CheckGlobals check{};
@@ -166,6 +169,7 @@ static void initialize()
 
     ResetCoverageCounters();
 }
+#pragma GCC diagnostic pop
 
 #if defined(PROVIDE_FUZZ_MAIN_FUNCTION)
 static bool read_stdin(std::vector<uint8_t>& data)
@@ -208,6 +212,9 @@ static fs::path g_input_path;
 }
 #endif
 
+// Whether or not these return depends on the build config.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-noreturn"
 // This function is used by libFuzzer
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -222,6 +229,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
     initialize();
     return 0;
 }
+#pragma GCC diagnostic pop
 
 #if defined(PROVIDE_FUZZ_MAIN_FUNCTION)
 int main(int argc, char** argv)

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -197,7 +197,7 @@ static bool read_file(fs::path p, std::vector<uint8_t>& data)
 
 #if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && !defined(__AFL_LOOP)
 static fs::path g_input_path;
-void signal_handler(int signal)
+[[noreturn]] void signal_handler(int signal)
 {
     if (signal == SIGABRT) {
         std::cerr << "Error processing input " << g_input_path << std::endl;

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -90,6 +90,53 @@ const std::function<std::string()> G_TEST_GET_FULL_NAME{[]{
     return std::string{g_fuzz_target};
 }};
 
+#if defined(PROVIDE_FUZZ_MAIN_FUNCTION)
+static bool read_stdin(std::vector<uint8_t>& data)
+{
+    std::istream::char_type buffer[1024];
+    std::streamsize length;
+    while ((std::cin.read(buffer, 1024), length = std::cin.gcount()) > 0) {
+        data.insert(data.end(), buffer, buffer + length);
+    }
+    return length == 0;
+}
+#endif
+
+#if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && !defined(__AFL_LOOP)
+static bool read_file(fs::path p, std::vector<uint8_t>& data)
+{
+    uint8_t buffer[1024];
+    FILE* f = fsbridge::fopen(p, "rb");
+    if (f == nullptr) return false;
+    do {
+        const size_t length = fread(buffer, sizeof(uint8_t), sizeof(buffer), f);
+        if (ferror(f)) return false;
+        data.insert(data.end(), buffer, buffer + length);
+    } while (!feof(f));
+    fclose(f);
+    return true;
+}
+#endif
+
+#if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && !defined(__AFL_LOOP)
+static fs::path g_input_path;
+[[noreturn]] void signal_handler(int signal)
+{
+    if (signal == SIGABRT) {
+        std::cerr << "Error processing input " << g_input_path << std::endl;
+    } else {
+        std::cerr << "Unexpected signal " << signal << " received\n";
+    }
+    std::_Exit(EXIT_FAILURE);
+}
+#endif
+
+// Whether or not these return depends on the build config.
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-noreturn"
+#endif
+
 static void initialize()
 {
     CheckGlobals check{};
@@ -167,47 +214,6 @@ static void initialize()
     ResetCoverageCounters();
 }
 
-#if defined(PROVIDE_FUZZ_MAIN_FUNCTION)
-static bool read_stdin(std::vector<uint8_t>& data)
-{
-    std::istream::char_type buffer[1024];
-    std::streamsize length;
-    while ((std::cin.read(buffer, 1024), length = std::cin.gcount()) > 0) {
-        data.insert(data.end(), buffer, buffer + length);
-    }
-    return length == 0;
-}
-#endif
-
-#if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && !defined(__AFL_LOOP)
-static bool read_file(fs::path p, std::vector<uint8_t>& data)
-{
-    uint8_t buffer[1024];
-    FILE* f = fsbridge::fopen(p, "rb");
-    if (f == nullptr) return false;
-    do {
-        const size_t length = fread(buffer, sizeof(uint8_t), sizeof(buffer), f);
-        if (ferror(f)) return false;
-        data.insert(data.end(), buffer, buffer + length);
-    } while (!feof(f));
-    fclose(f);
-    return true;
-}
-#endif
-
-#if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && !defined(__AFL_LOOP)
-static fs::path g_input_path;
-[[noreturn]] void signal_handler(int signal)
-{
-    if (signal == SIGABRT) {
-        std::cerr << "Error processing input " << g_input_path << std::endl;
-    } else {
-        std::cerr << "Unexpected signal " << signal << " received\n";
-    }
-    std::_Exit(EXIT_FAILURE);
-}
-#endif
-
 // This function is used by libFuzzer
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -222,6 +228,9 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
     initialize();
     return 0;
 }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #if defined(PROVIDE_FUZZ_MAIN_FUNCTION)
 int main(int argc, char** argv)

--- a/src/test/fuzz/threadpool.cpp
+++ b/src/test/fuzz/threadpool.cpp
@@ -17,7 +17,7 @@ struct ExpectedException : std::runtime_error {
 };
 
 struct ThrowTask {
-    void operator()() const { throw ExpectedException("fail"); }
+    [[noreturn]] void operator()() const { throw ExpectedException("fail"); }
 };
 
 struct CounterTask {

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -131,7 +131,6 @@ FuzzedSock::~FuzzedSock()
 FuzzedSock& FuzzedSock::operator=(Sock&& other)
 {
     assert(false && "Move of Sock into FuzzedSock not allowed.");
-    return *this;
 }
 
 ssize_t FuzzedSock::Send(const void* data, size_t len, int flags) const

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -192,7 +192,7 @@ public:
 
     ~FuzzedSock() override;
 
-    FuzzedSock& operator=(Sock&& other) override;
+    [[noreturn]] FuzzedSock& operator=(Sock&& other) override;
 
     ssize_t Send(const void* data, size_t len, int flags) const override;
 

--- a/src/test/threadpool_tests.cpp
+++ b/src/test/threadpool_tests.cpp
@@ -209,7 +209,9 @@ BOOST_AUTO_TEST_CASE(task_exception_propagates_to_future)
     std::vector<std::future<void>> futures;
     futures.reserve(num_tasks);
     for (int i = 0; i < num_tasks; i++) {
-        futures.emplace_back(Submit(threadPool, [&make_err, i] { throw std::runtime_error(make_err(i)); }));
+        futures.emplace_back(Submit(threadPool, [&make_err, i] [[noreturn]] () {
+          throw std::runtime_error(make_err(i));
+        }));
     }
 
     for (int i = 0; i < num_tasks; i++) {

--- a/src/test/threadpool_tests.cpp
+++ b/src/test/threadpool_tests.cpp
@@ -209,7 +209,9 @@ BOOST_AUTO_TEST_CASE(task_exception_propagates_to_future)
     std::vector<std::future<void>> futures;
     futures.reserve(num_tasks);
     for (int i = 0; i < num_tasks; i++) {
-        futures.emplace_back(Submit(threadPool, [&make_err, i] { throw std::runtime_error(make_err(i)); }));
+        futures.emplace_back(Submit(threadPool, [&make_err, i]() __attribute__((noreturn)) {
+          throw std::runtime_error(make_err(i));
+        }));
     }
 
     for (int i = 0; i < num_tasks; i++) {

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -237,7 +237,6 @@ bool ZeroSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events
 ZeroSock& ZeroSock::operator=(Sock&& other)
 {
     assert(false && "Move of Sock into ZeroSock not allowed.");
-    return *this;
 }
 
 StaticContentsSock::StaticContentsSock(const std::string& contents)
@@ -258,7 +257,6 @@ ssize_t StaticContentsSock::Recv(void* buf, size_t len, int flags) const
 StaticContentsSock& StaticContentsSock::operator=(Sock&& other)
 {
     assert(false && "Move of Sock into StaticContentsSock not allowed.");
-    return *this;
 }
 
 ssize_t DynSock::Pipe::GetBytes(void* buf, size_t len, int flags)
@@ -429,5 +427,4 @@ bool DynSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_
 DynSock& DynSock::operator=(Sock&&)
 {
     assert(false && "Move of Sock into DynSock not allowed.");
-    return *this;
 }

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -201,7 +201,7 @@ public:
     bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock) const override;
 
 private:
-    ZeroSock& operator=(Sock&& other) override;
+    [[noreturn]] ZeroSock& operator=(Sock&& other) override;
 };
 
 /**
@@ -226,7 +226,7 @@ public:
     }
 
 private:
-    StaticContentsSock& operator=(Sock&& other) override;
+    [[noreturn]] StaticContentsSock& operator=(Sock&& other) override;
 
     const std::string m_contents;
     mutable size_t m_consumed{0};
@@ -362,7 +362,7 @@ public:
     bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock) const override;
 
 private:
-    DynSock& operator=(Sock&&) override;
+    [[noreturn]] DynSock& operator=(Sock&&) override;
 
     std::shared_ptr<Pipes> m_pipes;
     Queue* const m_accept_sockets;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -133,7 +133,7 @@ void SetupCommonTestArgs(ArgsManager& argsman)
 }
 
 /** Test setup failure */
-static void ExitFailure(std::string_view str_err)
+[[noreturn]] static void ExitFailure(std::string_view str_err)
 {
     std::cerr << str_err << std::endl;
     exit(EXIT_FAILURE);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -136,7 +136,7 @@ void SetupCommonTestArgs(ArgsManager& argsman)
 [[noreturn]] static void ExitFailure(std::string_view str_err)
 {
     std::cerr << str_err << std::endl;
-    exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
 }
 
 BasicTestingSetup::BasicTestingSetup(const ChainType chainType, TestOpts opts)

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -745,7 +745,7 @@ public:
     err_wr_pipe_(err_wr_pipe)
   {}
 
-  void execute_child();
+  [[noreturn]] void execute_child();
 
 private:
   // Lets call it parent even though


### PR DESCRIPTION
Missing `[[noreturn]]` attributes can cause compiler false positives and other issues; see discussion in https://github.com/bitcoin/bitcoin/pull/35896#discussion_r3726612556. Add missing attributes, and turn on compiler warnings.

This produces C++23 related warnings under Clang:
```bash
[819/1115] Building CXX object src/test/CMakeFiles/test_bitcoin.dir/threadpool_tests.cpp.o
../src/test/threadpool_tests.cpp:212:64: warning: an attribute specifier sequence in this position is a C++23 extension [-Wc++23-lambda-attributes]
  212 |         futures.emplace_back(Submit(threadPool, [&make_err, i] [[noreturn]] () {
      |                                                                ^
1 warning generated.
```

Related:
https://github.com/bitcoin-core/libmultiprocess/pull/339.
https://github.com/bitcoin-core/leveldb-subtree/pull/64.
https://github.com/arun11299/cpp-subprocess/pull/132.
