### PR TITLE
fuzz: improve ipc fuzz coverage

### DIFF
--- a/src/ipc/test/fuzz/ipc.cpp
+++ b/src/ipc/test/fuzz/ipc.cpp
@@ -30,7 +30,7 @@ public:
     {
         std::promise<std::unique_ptr<mp::ProxyClient<test::fuzz::messages::IpcFuzzInterface>>> client_promise;
         auto client_future{client_promise.get_future()};
-        m_loop_thread = std::thread([&client_promise] {
+        m_loop_thread = std::thread([&client_promise, impl = m_impl] {
             mp::EventLoop loop("ipc-fuzz", [](mp::LogMessage message) {
                 if (message.level == mp::Log::Raise) throw std::runtime_error(message.message);
             });
@@ -40,8 +40,7 @@ public:
                 loop,
                 kj::mv(pipe.ends[0]),
                 [&](mp::Connection& connection) {
-                    auto server_proxy = kj::heap<mp::ProxyServer<test::fuzz::messages::IpcFuzzInterface>>(
-                        std::make_shared<IpcFuzzImplementation>(), connection);
+                    auto server_proxy = kj::heap<mp::ProxyServer<test::fuzz::messages::IpcFuzzInterface>>(impl, connection);
                     return capnp::Capability::Client(kj::mv(server_proxy));
                 });
             server_connection->onDisconnect([&] { server_connection.reset(); });
@@ -66,6 +65,7 @@ public:
         if (m_loop_thread.joinable()) m_loop_thread.join();
     }
 
+    std::shared_ptr<IpcFuzzImplementation> m_impl{std::make_shared<IpcFuzzImplementation>()};
     std::unique_ptr<mp::ProxyClient<test::fuzz::messages::IpcFuzzInterface>> m_client;
 
 private:
@@ -100,34 +100,41 @@ FUZZ_TARGET(ipc, .init = initialize_ipc)
                 static constexpr int MAX_ADD{1'000'000};
                 const int a = fuzzed_data_provider.ConsumeIntegralInRange<int>(MIN_ADD, MAX_ADD);
                 const int b = fuzzed_data_provider.ConsumeIntegralInRange<int>(MIN_ADD, MAX_ADD);
+                ipc.m_impl->m_expected_a = a;
+                ipc.m_impl->m_expected_b = b;
                 assert(ipc.m_client->add(a, b) == a + b);
             },
             [&] {
                 COutPoint outpoint{Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider)),
                                    fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
                 COutPoint expected{outpoint.hash, outpoint.n ^ 0xFFFFFFFFu};
+                ipc.m_impl->m_expected_outpoint = outpoint;
                 assert(ipc.m_client->passOutPoint(outpoint) == expected);
             },
             [&] {
                 std::vector<uint8_t> value = ConsumeRandomLengthByteVector<uint8_t>(fuzzed_data_provider, 512);
                 std::vector<uint8_t> expected{value.rbegin(), value.rend()};
+                ipc.m_impl->m_expected_vector = value;
                 assert(ipc.m_client->passVectorUint8(value) == expected);
             },
             [&] {
                 CScript script{ConsumeScript(fuzzed_data_provider)};
                 CScript expected{script};
                 expected << OP_NOP;
+                ipc.m_impl->m_expected_script = script;
                 assert(ipc.m_client->passScript(script) == expected);
             },
             [&] {
                 UniValue value;
                 if (!value.read(fuzzed_data_provider.ConsumeRandomLengthString(512))) return;
+                ipc.m_impl->m_expected_univalue = value.write();
                 assert(ipc.m_client->passUniValue(value).write() == value.write());
             },
             [&] {
                 const CMutableTransaction mutable_tx = ConsumeTransaction(fuzzed_data_provider, std::nullopt);
                 if (mutable_tx.vin.empty()) return;
                 const CTransactionRef tx = MakeTransactionRef(mutable_tx);
+                ipc.m_impl->m_expected_transaction = tx;
                 assert(*ipc.m_client->passTransaction(tx) == *tx);
             });
     }

--- a/src/ipc/test/fuzz/ipc.cpp
+++ b/src/ipc/test/fuzz/ipc.cpp
@@ -2,24 +2,26 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <primitives/transaction.h>
 #include <capnp/capability.h>
 #include <capnp/rpc.h>
+#include <ipc/test/fuzz/ipc_fuzz.capnp.h>
+#include <ipc/test/fuzz/ipc_fuzz.capnp.proxy.h>
+#include <ipc/test/fuzz/ipc_fuzz.h>
 #include <ipc/util.h>
 #include <kj/memory.h>
 #include <mp/proxy-io.h>
 #include <mp/proxy.h>
+#include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
-#include <ipc/test/fuzz/ipc_fuzz.capnp.h>
-#include <ipc/test/fuzz/ipc_fuzz.capnp.proxy.h>
-#include <ipc/test/fuzz/ipc_fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 
+#include <exception>
 #include <future>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <thread>
 
 namespace {
@@ -77,6 +79,57 @@ public:
         m_client = client_future.get();
         // Exchange thread maps so the server can invoke callbacks on the fuzzing thread.
         m_client->initThreadMap();
+    }
+
+    // Bypass ProxyClient serialization to send arbitrary data directly to the server.
+    void sendTransactionPayload(std::vector<uint8_t> payload)
+    {
+        std::promise<void> done;
+        auto future{done.get_future()};
+
+        m_client->m_context.loop->sync([&] {
+            auto request{m_client->m_client.consumeTransactionRequest()};
+            request.setArg(kj::arrayPtr(payload.data(), payload.size()));
+
+            m_client->m_context.loop->m_task_set->add(request.send().then(
+                [&](auto&&) {
+                    done.set_value();
+                },
+                [&](kj::Exception&& exception) {
+                    // Arbitrary transaction bytes may fail deserialization.
+                    if (exception.getType() == kj::Exception::Type::FAILED) {
+                        done.set_value();
+                        return;
+                    }
+                    done.set_exception(std::make_exception_ptr(
+                        std::runtime_error{exception.getDescription().cStr()}));
+                }));
+        });
+
+        future.get();
+    }
+
+    // Bypass ProxyClient serialization to send arbitrary text directly to the server.
+    void sendUniValuePayload(std::string payload)
+    {
+        std::promise<void> done;
+        auto future{done.get_future()};
+
+        m_client->m_context.loop->sync([&] {
+            auto request{m_client->m_client.consumeUniValueRequest()};
+            request.setArg(kj::StringPtr{payload.data(), payload.size()});
+
+            m_client->m_context.loop->m_task_set->add(request.send().then(
+                [&](auto&&) {
+                    done.set_value();
+                },
+                [&](kj::Exception&& exception) {
+                    done.set_exception(std::make_exception_ptr(
+                        std::runtime_error{exception.getDescription().cStr()}));
+                }));
+        });
+
+        future.get();
     }
 
     ~IpcFuzzSetup()
@@ -166,6 +219,14 @@ FUZZ_TARGET(ipc, .init = initialize_ipc)
 
                 FuzzCallback callback{arg, result};
                 assert(ipc.m_client->callCallback(callback, arg) == result);
+            },
+            [&] {
+                ipc.sendTransactionPayload(
+                    ConsumeRandomLengthByteVector<uint8_t>(fuzzed_data_provider, 512));
+            },
+            [&] {
+                ipc.sendUniValuePayload(
+                    fuzzed_data_provider.ConsumeRandomLengthString(512));
             });
     }
 }

--- a/src/ipc/test/fuzz/ipc.cpp
+++ b/src/ipc/test/fuzz/ipc.cpp
@@ -23,6 +23,24 @@
 #include <thread>
 
 namespace {
+// Callback invoked by the server to exercise IPC communication in the
+// server to client direction.
+class FuzzCallback final : public IpcFuzzCallback
+{
+public:
+    FuzzCallback(int expected_arg, int result) : m_expected_arg{expected_arg}, m_result{result} {}
+
+    int call(int arg) override
+    {
+        assert(arg == m_expected_arg);
+        return m_result;
+    }
+
+private:
+    const int m_expected_arg;
+    const int m_result;
+};
+
 class IpcFuzzSetup
 {
 public:
@@ -57,6 +75,8 @@ public:
             loop.loop();
         });
         m_client = client_future.get();
+        // Exchange thread maps so the server can invoke callbacks on the fuzzing thread.
+        m_client->initThreadMap();
     }
 
     ~IpcFuzzSetup()
@@ -136,6 +156,16 @@ FUZZ_TARGET(ipc, .init = initialize_ipc)
                 const CTransactionRef tx = MakeTransactionRef(mutable_tx);
                 ipc.m_impl->m_expected_transaction = tx;
                 assert(*ipc.m_client->passTransaction(tx) == *tx);
+            },
+            [&] {
+                const int arg = fuzzed_data_provider.ConsumeIntegral<int>();
+                const int result = fuzzed_data_provider.ConsumeIntegral<int>();
+
+                ipc.m_impl->m_expected_callback_arg = arg;
+                ipc.m_impl->m_expected_callback_result = result;
+
+                FuzzCallback callback{arg, result};
+                assert(ipc.m_client->callCallback(callback, arg) == result);
             });
     }
 }

--- a/src/ipc/test/fuzz/ipc.cpp
+++ b/src/ipc/test/fuzz/ipc.cpp
@@ -8,6 +8,7 @@
 #include <ipc/test/fuzz/ipc_fuzz.capnp.proxy.h>
 #include <ipc/test/fuzz/ipc_fuzz.h>
 #include <ipc/util.h>
+#include <kj/async.h>
 #include <kj/memory.h>
 #include <mp/proxy-io.h>
 #include <mp/proxy.h>
@@ -19,10 +20,12 @@
 
 #include <exception>
 #include <future>
+#include <ios>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 
 namespace {
 // Callback invoked by the server to exercise IPC communication in the
@@ -43,14 +46,44 @@ private:
     const int m_result;
 };
 
+struct MalformedResponseState
+{
+    std::vector<uint8_t> transaction;
+    std::string univalue;
+};
+
+// Return arbitrary payloads to exercise deserialization by ProxyClient.
+class MalformedResponseServer final : public test::fuzz::messages::IpcFuzzInterface::Server
+{
+public:
+    explicit MalformedResponseServer(std::shared_ptr<MalformedResponseState> state) : m_state{std::move(state)} {}
+
+    kj::Promise<void> passTransaction(PassTransactionContext context) override
+    {
+        context.getResults().setResult(kj::arrayPtr(m_state->transaction.data(), m_state->transaction.size()));
+        return kj::READY_NOW;
+    }
+
+    kj::Promise<void> passUniValue(PassUniValueContext context) override
+    {
+        context.getResults().setResult(kj::StringPtr(m_state->univalue.data(), m_state->univalue.size()));
+        return kj::READY_NOW;
+    }
+
+private:
+    std::shared_ptr<MalformedResponseState> m_state;
+};
+
 class IpcFuzzSetup
 {
 public:
     IpcFuzzSetup()
     {
         std::promise<std::unique_ptr<mp::ProxyClient<test::fuzz::messages::IpcFuzzInterface>>> client_promise;
+        std::promise<std::unique_ptr<mp::ProxyClient<test::fuzz::messages::IpcFuzzInterface>>> response_client_promise;
         auto client_future{client_promise.get_future()};
-        m_loop_thread = std::thread([&client_promise, impl = m_impl] {
+        auto response_client_future{response_client_promise.get_future()};
+        m_loop_thread = std::thread([&client_promise, &response_client_promise, impl = m_impl, response_state = m_response_state] {
             mp::EventLoop loop("ipc-fuzz", [](mp::LogMessage message) {
                 if (message.level == mp::Log::Raise) throw std::runtime_error(message.message);
             });
@@ -74,9 +107,29 @@ public:
             (void)client_connection.release();
 
             client_promise.set_value(std::move(client_proxy));
+
+            auto response_pipe = loop.m_io_context.provider->newTwoWayPipe();
+            auto response_server_connection = std::make_unique<mp::Connection>(
+                loop,
+                kj::mv(response_pipe.ends[0]),
+                [response_state](mp::Connection&) {
+                    auto response_proxy = kj::heap<MalformedResponseServer>(response_state);
+                    return capnp::Capability::Client(kj::mv(response_proxy));
+                });
+            response_server_connection->onDisconnect([&] { response_server_connection.reset(); });
+
+            auto response_client_connection = std::make_unique<mp::Connection>(loop, kj::mv(response_pipe.ends[1]));
+            auto response_client = std::make_unique<mp::ProxyClient<test::fuzz::messages::IpcFuzzInterface>>(
+                response_client_connection->m_rpc_system->bootstrap(mp::ServerVatId().vat_id).castAs<test::fuzz::messages::IpcFuzzInterface>(),
+                response_client_connection.get(),
+                /* destroy_connection= */ true);
+            (void)response_client_connection.release();
+            response_client_promise.set_value(std::move(response_client));
             loop.loop();
         });
         m_client = client_future.get();
+        m_response_client = response_client_future.get();
+
         // Exchange thread maps so the server can invoke callbacks on the fuzzing thread.
         m_client->initThreadMap();
     }
@@ -132,14 +185,39 @@ public:
         future.get();
     }
 
+    // Return arbitrary transaction data from the raw server to ProxyClient.
+    void receiveTransactionPayload(std::vector<uint8_t> payload)
+    {
+        m_response_state->transaction = std::move(payload);
+
+        try {
+            const auto request{MakeTransactionRef(CMutableTransaction{})};
+            (void)m_response_client->passTransaction(request);
+        } catch (const std::ios_base::failure&) {
+            // Arbitrary transaction bytes may fail deserialization.
+        }
+    }
+
+    // Return arbitrary text data from the raw server to ProxyClient.
+    void receiveUniValuePayload(std::string payload)
+    {
+        m_response_state->univalue = std::move(payload);
+
+        UniValue request;
+        (void)m_response_client->passUniValue(request);
+    }
+
     ~IpcFuzzSetup()
     {
         m_client.reset();
+        m_response_client.reset();
         if (m_loop_thread.joinable()) m_loop_thread.join();
     }
 
     std::shared_ptr<IpcFuzzImplementation> m_impl{std::make_shared<IpcFuzzImplementation>()};
     std::unique_ptr<mp::ProxyClient<test::fuzz::messages::IpcFuzzInterface>> m_client;
+    std::shared_ptr<MalformedResponseState> m_response_state{std::make_shared<MalformedResponseState>()};
+    std::unique_ptr<mp::ProxyClient<test::fuzz::messages::IpcFuzzInterface>> m_response_client;
 
 private:
     std::thread m_loop_thread;
@@ -227,6 +305,12 @@ FUZZ_TARGET(ipc, .init = initialize_ipc)
             [&] {
                 ipc.sendUniValuePayload(
                     fuzzed_data_provider.ConsumeRandomLengthString(512));
+            },
+            [&] {
+                ipc.receiveTransactionPayload(ConsumeRandomLengthByteVector<uint8_t>(fuzzed_data_provider, 512));
+            },
+            [&] {
+                ipc.receiveUniValuePayload(fuzzed_data_provider.ConsumeRandomLengthString(512));
             });
     }
 }

--- a/src/ipc/test/fuzz/ipc_fuzz.capnp
+++ b/src/ipc/test/fuzz/ipc_fuzz.capnp
@@ -20,6 +20,8 @@ interface IpcFuzzInterface $Proxy.wrap("IpcFuzzImplementation") {
     passTransaction @5 (arg :Data) -> (result :Data);
     initThreadMap @6 (threadMap :Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
     callCallback @7 (context :Proxy.Context, callback :IpcFuzzCallback, arg :Int32) -> (result :Int32);
+    consumeTransaction @8 (arg :Data) -> ();
+    consumeUniValue @9 (arg :Text) -> ();
 }
 
 interface IpcFuzzCallback $Proxy.wrap("IpcFuzzCallback") {

--- a/src/ipc/test/fuzz/ipc_fuzz.capnp
+++ b/src/ipc/test/fuzz/ipc_fuzz.capnp
@@ -18,4 +18,11 @@ interface IpcFuzzInterface $Proxy.wrap("IpcFuzzImplementation") {
     passScript @3 (arg :Data) -> (result :Data);
     passUniValue @4 (arg :Text) -> (result :Text);
     passTransaction @5 (arg :Data) -> (result :Data);
+    initThreadMap @6 (threadMap :Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
+    callCallback @7 (context :Proxy.Context, callback :IpcFuzzCallback, arg :Int32) -> (result :Int32);
+}
+
+interface IpcFuzzCallback $Proxy.wrap("IpcFuzzCallback") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, arg :Int32) -> (result :Int32);
 }

--- a/src/ipc/test/fuzz/ipc_fuzz.h
+++ b/src/ipc/test/fuzz/ipc_fuzz.h
@@ -65,6 +65,11 @@ public:
         return tx;
     }
 
+    // These methods intentionally do nothing. Calling them through raw capnp
+    // requests exercises deserialization of arbitrary payloads.
+    void consumeTransaction(CTransactionRef) {}
+    void consumeUniValue(UniValue) {}
+
     // Enables libmultiprocess to exchange the thread capabilities used for callbacks.
     void initThreadMap() {}
 

--- a/src/ipc/test/fuzz/ipc_fuzz.h
+++ b/src/ipc/test/fuzz/ipc_fuzz.h
@@ -10,17 +10,63 @@
 #include <univalue.h>
 
 #include <algorithm>
+#include <cassert>
+#include <string>
 #include <vector>
 
 class IpcFuzzImplementation
 {
 public:
-    int add(int a, int b) { return a + b; }
-    COutPoint passOutPoint(COutPoint o) { return COutPoint{o.hash, o.n ^ 0xFFFFFFFFu}; }
-    std::vector<uint8_t> passVectorUint8(std::vector<uint8_t> v) { std::reverse(v.begin(), v.end()); return v; }
-    CScript passScript(CScript s) { s << OP_NOP; return s; }
-    UniValue passUniValue(UniValue v) { return v; }
-    CTransactionRef passTransaction(CTransactionRef t) { return t; }
+    int add(int a, int b)
+    {
+        assert(a == m_expected_a);
+        assert(b == m_expected_b);
+        return a + b;
+    }
+
+    COutPoint passOutPoint(COutPoint o)
+    {
+        assert(o == m_expected_outpoint);
+        return COutPoint{o.hash, o.n ^ 0xFFFFFFFFu};
+    }
+
+    std::vector<uint8_t> passVectorUint8(std::vector<uint8_t> v)
+    {
+        assert(v == m_expected_vector);
+        std::reverse(v.begin(), v.end());
+        return v;
+    }
+
+    CScript passScript(CScript s)
+    {
+        assert(s == m_expected_script);
+        s << OP_NOP;
+        return s;
+    }
+
+    UniValue passUniValue(UniValue v)
+    {
+        assert(v.write() == m_expected_univalue);
+        return v;
+    }
+
+    CTransactionRef passTransaction(CTransactionRef tx)
+    {
+        assert(tx);
+        assert(m_expected_transaction);
+        assert(*tx == *m_expected_transaction);
+        return tx;
+    }
+
+    // Calls are synchronous, so expected values are not modified while the
+    // server is checking them.
+    int m_expected_a{0};
+    int m_expected_b{0};
+    COutPoint m_expected_outpoint;
+    std::vector<uint8_t> m_expected_vector;
+    CScript m_expected_script;
+    std::string m_expected_univalue;
+    CTransactionRef m_expected_transaction;
 };
 
 #endif // BITCOIN_IPC_TEST_FUZZ_IPC_FUZZ_H

--- a/src/ipc/test/fuzz/ipc_fuzz.h
+++ b/src/ipc/test/fuzz/ipc_fuzz.h
@@ -14,6 +14,13 @@
 #include <string>
 #include <vector>
 
+class IpcFuzzCallback
+{
+public:
+    virtual ~IpcFuzzCallback() = default;
+    virtual int call(int arg) = 0;
+};
+
 class IpcFuzzImplementation
 {
 public:
@@ -58,6 +65,18 @@ public:
         return tx;
     }
 
+    // Enables libmultiprocess to exchange the thread capabilities used for callbacks.
+    void initThreadMap() {}
+
+    // Invoke the client callback and verify its argument and return value on the server.
+    int callCallback(IpcFuzzCallback& callback, int arg)
+    {
+        assert(arg == m_expected_callback_arg);
+        const int result{callback.call(arg)};
+        assert(result == m_expected_callback_result);
+        return result;
+    }
+
     // Calls are synchronous, so expected values are not modified while the
     // server is checking them.
     int m_expected_a{0};
@@ -67,6 +86,8 @@ public:
     CScript m_expected_script;
     std::string m_expected_univalue;
     CTransactionRef m_expected_transaction;
+    int m_expected_callback_arg{0};
+    int m_expected_callback_result{0};
 };
 
 #endif // BITCOIN_IPC_TEST_FUZZ_IPC_FUZZ_H


### PR DESCRIPTION
This PR follows up on #35118 and continues the IPC fuzzing work proposed in #23015.

The initial ipc fuzz target exercised normal calls through a libmultiprocess client and server. This PR extends the target with

 - Server side assertions that verify arguments arrive unchanged (https://github.com/bitcoin/bitcoin/pull/35118#issuecomment-4452992198 and https://github.com/bitcoin/bitcoin/pull/35118#pullrequestreview-4539477599)
 - A callback call that exercises ipc communication in both directions.
 - Raw capnp requests containing arbitrary transaction and `UniValue` payloads, which are deserialized by a normal libmultiprocess server.
  - Raw capnp responses containing arbitrary transaction and `UniValue` payloads, which are deserialized by a normal libmultiprocess client.

The raw request and response cases allow the fuzz target to exercise deserialization with data that was not first produced by libmultiprocess serialization.

The ipc setup and callback handling closely follow the existing [`libmultiprocess` tests](https://github.com/bitcoin/bitcoin/blob/master/src/ipc/libmultiprocess/test/mp/test/test.cpp), particularly their use of `EventLoop`, `ProxyClient`, `ProxyServer`, two-way pipes, and `initThreadMap`. 

The transaction and UniValue payload cases exercise the serialization hooks defined in [`common-types.h`](https://github.com/bitcoin/bitcoin/blob/master/src/ipc/capnp/common-types.h). 

These files may provide useful background when reviewing the changes.

Generated [coverage report](https://enirox001.github.io/coverage/ipc/) after fuzzing the IPC target for a while using the qa-assets corpus.
