### PR TITLE
net_proc: use a single set to deduplicate tx INVs

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4341,8 +4341,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         const bool reject_tx_invs{RejectIncomingTxs(pfrom)};
-        std::unordered_set<uint256, SaltedUint256Hasher> seen_txids{0, m_txhash_hasher};
-        std::unordered_set<uint256, SaltedUint256Hasher> seen_wtxids{0, m_txhash_hasher};
+        std::unordered_set<uint256, SaltedUint256Hasher> seen_tx_hashes{0, m_txhash_hasher};
 
         LOCK2(cs_main, m_tx_download_mutex);
 
@@ -4381,9 +4380,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                     pfrom.fDisconnect = true;
                     return;
                 }
-                // MSG_WITNESS_TX is treated as a txid, despite only being specified for getdata.
-                auto& seen_hashes{inv.IsMsgWtx() ? seen_wtxids : seen_txids};
-                if (!seen_hashes.insert(inv.hash).second) continue;
+                if (!seen_tx_hashes.insert(inv.hash).second) continue;
                 const GenTxid gtxid = ToGenTxid(inv);
                 AddKnownTx(peer, inv.hash);
 

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -378,7 +378,7 @@ class TxDownloadTest(BitcoinTestFramework):
             assert_equal(log.count(f"got inv: {first_name} {hash_a:064x}"), 1)
             assert_equal(log.count(f"got inv: {second_name} {hash_a:064x}"), 0)
 
-        self.log.info('Check that txids and wtxids are deduplicated separately')
+        self.log.info('Check that txids and wtxids are deduplicated together')
         peer = node.add_p2p_connection(TestP2PConn(wtxidrelay=True))
         for first_type, second_type, hash_a in [
             (MSG_WITNESS_TX, MSG_WTX, 0x8899aa),
@@ -388,8 +388,9 @@ class TxDownloadTest(BitcoinTestFramework):
                 CInv(t=first_type, h=hash_a),
                 CInv(t=second_type, h=hash_a),
             ])
-            assert_equal(log.count(f"got inv: witness-tx {hash_a:064x}"), 1)
-            assert_equal(log.count(f"got inv: wtx {hash_a:064x}"), 1)
+            wit_tx_count = log.count(f"got inv: witness-tx {hash_a:064x}")
+            wtx_count = log.count(f"got inv: wtx {hash_a:064x}")
+            assert_equal(wit_tx_count + wtx_count, 1)
 
     def test_spurious_notfound(self):
         self.log.info('Check that spurious notfound is ignored')


### PR DESCRIPTION
If we get a hit across wtxid and txid relay, then it just means this is a legacy transaction and deduping is fine.

Therefore using two sets for the purpose of deduplication is overkill and we can simplify this code.