### PR TITLE
net_processing: Ignore MSG_WITNESS_TX entries from INV messages

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4341,8 +4341,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         const bool reject_tx_invs{RejectIncomingTxs(pfrom)};
-        std::unordered_set<uint256, SaltedUint256Hasher> seen_txids{0, m_txhash_hasher};
-        std::unordered_set<uint256, SaltedUint256Hasher> seen_wtxids{0, m_txhash_hasher};
+        std::unordered_set<uint256, SaltedUint256Hasher> seen_tx_hashes{0, m_txhash_hasher};
 
         LOCK2(cs_main, m_tx_download_mutex);
 
@@ -4383,8 +4382,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                     // BIP 144) for compatibility with neutrino
                     if (inv.IsMsgWtx()) continue;
                 }
-                auto& seen_hashes{inv.IsMsgWtx() ? seen_wtxids : seen_txids};
-                if (!seen_hashes.insert(inv.hash).second) continue;
+                // Due to the check above, we're only adding hashes of one particular type here
+                if (!seen_tx_hashes.insert(inv.hash).second) continue;
                 const GenTxid gtxid = ToGenTxid(inv);
                 AddKnownTx(peer, inv.hash);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4341,8 +4341,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         const bool reject_tx_invs{RejectIncomingTxs(pfrom)};
-        std::unordered_set<uint256, SaltedUint256Hasher> seen_txids{0, m_txhash_hasher};
-        std::unordered_set<uint256, SaltedUint256Hasher> seen_wtxids{0, m_txhash_hasher};
+        std::unordered_set<uint256, SaltedUint256Hasher> seen_tx_hashes{0, m_txhash_hasher};
 
         LOCK2(cs_main, m_tx_download_mutex);
 
@@ -4383,8 +4382,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 } else {
                     if (!inv.IsMsgTx()) continue;
                 }
-                auto& seen_hashes{inv.IsMsgWtx() ? seen_wtxids : seen_txids};
-                if (!seen_hashes.insert(inv.hash).second) continue;
+                // Due to the check above, we're only adding hashes of one particular type here
+                if (!seen_tx_hashes.insert(inv.hash).second) continue;
                 const GenTxid gtxid = ToGenTxid(inv);
                 AddKnownTx(peer, inv.hash);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4352,15 +4352,6 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         for (CInv& inv : vInv) {
             if (interruptMsgProc) return;
 
-            // Ignore INVs that don't match wtxidrelay setting.
-            // Note that orphan parent fetching always uses MSG_TX GETDATAs regardless of the wtxidrelay setting.
-            // This is fine as no INV messages are involved in that process.
-            if (peer.m_wtxid_relay) {
-                if (inv.IsMsgTx()) continue;
-            } else {
-                if (inv.IsMsgWtx()) continue;
-            }
-
             if (inv.IsMsgBlk()) {
                 const bool fAlreadyHave = AlreadyHaveBlock(inv.hash);
                 LogDebug(BCLog::NET, "got inv: %s %s peer=%d", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
@@ -4381,7 +4372,17 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                     pfrom.fDisconnect = true;
                     return;
                 }
-                // MSG_WITNESS_TX is treated as a txid, despite only being specified for getdata.
+
+                // Ignore INVs that don't match wtxidrelay setting.
+                // Note that orphan parent fetching always uses MSG_TX GETDATAs regardless of the wtxidrelay setting.
+                // This is fine as no INV messages are involved in that process.
+                if (peer.m_wtxid_relay) {
+                    if (!inv.IsMsgWtx()) continue;
+                } else {
+                    // Allows MSG_WITNESS_TX entries (in violation of
+                    // BIP 144) for compatibility with neutrino
+                    if (inv.IsMsgWtx()) continue;
+                }
                 auto& seen_hashes{inv.IsMsgWtx() ? seen_wtxids : seen_txids};
                 if (!seen_hashes.insert(inv.hash).second) continue;
                 const GenTxid gtxid = ToGenTxid(inv);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4352,15 +4352,6 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         for (CInv& inv : vInv) {
             if (interruptMsgProc) return;
 
-            // Ignore INVs that don't match wtxidrelay setting.
-            // Note that orphan parent fetching always uses MSG_TX GETDATAs regardless of the wtxidrelay setting.
-            // This is fine as no INV messages are involved in that process.
-            if (peer.m_wtxid_relay) {
-                if (inv.IsMsgTx()) continue;
-            } else {
-                if (inv.IsMsgWtx()) continue;
-            }
-
             if (inv.IsMsgBlk()) {
                 const bool fAlreadyHave = AlreadyHaveBlock(inv.hash);
                 LogDebug(BCLog::NET, "got inv: %s %s peer=%d", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
@@ -4381,7 +4372,17 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                     pfrom.fDisconnect = true;
                     return;
                 }
-                // MSG_WITNESS_TX is treated as a txid, despite only being specified for getdata.
+
+                // Ignore INVs that don't match wtxidrelay setting.
+                // Note that orphan parent fetching always uses MSG_TX GETDATAs regardless of the wtxidrelay setting.
+                // This is fine as no INV messages are involved in that process.
+                // This ignores any MSG_WITNESS_TX entries, as that inv
+                // type is only for use with GETDATA (per BIP 144).
+                if (peer.m_wtxid_relay) {
+                    if (!inv.IsMsgWtx()) continue;
+                } else {
+                    if (!inv.IsMsgTx()) continue;
+                }
                 auto& seen_hashes{inv.IsMsgWtx() ? seen_wtxids : seen_txids};
                 if (!seen_hashes.insert(inv.hash).second) continue;
                 const GenTxid gtxid = ToGenTxid(inv);

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -6,7 +6,7 @@
 
 import time
 
-from test_framework.messages import msg_getdata, msg_tx, msg_inv, CInv, MSG_WTX
+from test_framework.messages import msg_getdata, msg_tx, msg_inv, CInv, MSG_TX, MSG_WITNESS_TX, MSG_WTX
 from test_framework.p2p import P2PInterface, P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -89,9 +89,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
         _, txid, _, tx_hex = self.check_p2p_tx_violation()
 
         self.log.info("Tests with node in normal mode with block-relay-only connection, sending an inv")
-        conn = self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=0, connection_type="block-relay-only")
-        assert_equal(self.nodes[0].getpeerinfo()[0]['relaytxes'], False)
-        self.check_p2p_inv_violation(conn)
+        self.check_p2p_inv_violation()
 
         self.log.info(
             "Check that getdata(tx) from a block-relay-only connection is ignored"
@@ -114,12 +112,17 @@ class P2PBlocksOnly(BitcoinTestFramework):
         conn.sync_with_ping()
         assert int(txid, 16) not in conn.get_invs()
 
-    def check_p2p_inv_violation(self, peer):
+    def check_p2p_inv_violation(self):
         self.log.info("Check that tx-invs from P2P are rejected and result in disconnect")
-        with self.nodes[0].assert_debug_log(["inv sent in violation of protocol, disconnecting peer"]):
-            peer.send_without_ping(msg_inv([CInv(t=MSG_WTX, h=0x12345)]))
-            peer.wait_for_disconnect()
-        self.nodes[0].disconnect_p2ps()
+        h = 0x12345
+        for msg_type in [MSG_WTX, MSG_TX, MSG_WITNESS_TX]:
+            h += 1
+            peer = self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=0, connection_type="block-relay-only")
+            assert_equal(self.nodes[0].getpeerinfo()[0]['relaytxes'], False)
+            with self.nodes[0].assert_debug_log(["inv sent in violation of protocol, disconnecting peer"]):
+                peer.send_without_ping(msg_inv([CInv(t=msg_type, h=h)]))
+                peer.wait_for_disconnect()
+            self.nodes[0].disconnect_p2ps()
 
     def check_p2p_tx_violation(self):
         self.log.info('Check that txs from P2P are rejected and result in disconnect')

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -378,7 +378,7 @@ class TxDownloadTest(BitcoinTestFramework):
             assert_equal(log.count(f"got inv: {first_name} {hash_a:064x}"), 1)
             assert_equal(log.count(f"got inv: {second_name} {hash_a:064x}"), 0)
 
-        self.log.info('Check that txids and wtxids are deduplicated separately')
+        self.log.info('Check that MSG_WITNESS_TX inv is ignored with wtxid relay')
         peer = node.add_p2p_connection(TestP2PConn(wtxidrelay=True))
         for first_type, second_type, hash_a in [
             (MSG_WITNESS_TX, MSG_WTX, 0x8899aa),
@@ -388,7 +388,7 @@ class TxDownloadTest(BitcoinTestFramework):
                 CInv(t=first_type, h=hash_a),
                 CInv(t=second_type, h=hash_a),
             ])
-            assert_equal(log.count(f"got inv: witness-tx {hash_a:064x}"), 1)
+            assert_equal(log.count(f"got inv: witness-tx {hash_a:064x}"), 0)
             assert_equal(log.count(f"got inv: wtx {hash_a:064x}"), 1)
 
     def test_spurious_notfound(self):

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -365,20 +365,20 @@ class TxDownloadTest(BitcoinTestFramework):
             assert_equal(log.count(inv_a_log), 1)
             assert_equal(log.count(inv_b_log), 0)
 
-        self.log.info('Check that MSG_TX and MSG_WITNESS_TX are deduplicated as txids')
+        self.log.info('Check that MSG_WITNESS_TX inv is ignored with txid relay')
         peer = node.add_p2p_connection(TestP2PConn(wtxidrelay=False))
-        for first_type, first_name, second_type, second_name, hash_a in [
-            (MSG_TX, 'tx', MSG_WITNESS_TX, 'witness-tx', 0x667788),
-            (MSG_WITNESS_TX, 'witness-tx', MSG_TX, 'tx', 0x778899),
+        for first_type, second_type, hash_a in [
+            (MSG_TX, MSG_WITNESS_TX, 0x667788),
+            (MSG_WITNESS_TX, MSG_TX, 0x778899),
         ]:
             log = send_invs_and_read_log(peer, [
                 CInv(t=first_type, h=hash_a),
                 CInv(t=second_type, h=hash_a),
             ])
-            assert_equal(log.count(f"got inv: {first_name} {hash_a:064x}"), 1)
-            assert_equal(log.count(f"got inv: {second_name} {hash_a:064x}"), 0)
+            assert_equal(log.count(f"got inv: witness-tx {hash_a:064x}"), 0)
+            assert_equal(log.count(f"got inv: tx {hash_a:064x}"), 1)
 
-        self.log.info('Check that txids and wtxids are deduplicated separately')
+        self.log.info('Check that MSG_WITNESS_TX inv is ignored with wtxid relay')
         peer = node.add_p2p_connection(TestP2PConn(wtxidrelay=True))
         for first_type, second_type, hash_a in [
             (MSG_WITNESS_TX, MSG_WTX, 0x8899aa),
@@ -388,7 +388,7 @@ class TxDownloadTest(BitcoinTestFramework):
                 CInv(t=first_type, h=hash_a),
                 CInv(t=second_type, h=hash_a),
             ])
-            assert_equal(log.count(f"got inv: witness-tx {hash_a:064x}"), 1)
+            assert_equal(log.count(f"got inv: witness-tx {hash_a:064x}"), 0)
             assert_equal(log.count(f"got inv: wtx {hash_a:064x}"), 1)
 
     def test_spurious_notfound(self):


### PR DESCRIPTION
When introducing wtxidrelay we added checks to skip attempts to announce txs with the wrong hash (https://github.com/bitcoin/bitcoin/pull/18044#discussion_r403953004), but didn't similarly ignore `MSG_WITNESS_TX` entries in announcements, which have never been valid (see [BIP-144](https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki#relay)).

This PR corrects that oversight, skipping such announcements. It also moves the check to be after the disconnect code, so that attempting to announce txs on `fRelay=false` doesn't get treated as okay just because you're doing it wrong. As a result this allows deduping the `seen_tx_hashes` set.