### PR TITLE
refactor: remove unused GetCScripts function

### DIFF
--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -245,16 +245,6 @@ bool FillableSigningProvider::HaveCScript(const CScriptID& hash) const
     return mapScripts.contains(hash);
 }
 
-std::set<CScriptID> FillableSigningProvider::GetCScripts() const
-{
-    LOCK(cs_KeyStore);
-    std::set<CScriptID> set_script;
-    for (const auto& mi : mapScripts) {
-        set_script.insert(mi.first);
-    }
-    return set_script;
-}
-
 bool FillableSigningProvider::GetCScript(const CScriptID &hash, CScript& redeemScriptOut) const
 {
     LOCK(cs_KeyStore);

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -327,7 +327,6 @@ public:
     virtual bool GetKey(const CKeyID &address, CKey &keyOut) const override;
     virtual bool AddCScript(const CScript& redeemScript);
     virtual bool HaveCScript(const CScriptID &hash) const override;
-    virtual std::set<CScriptID> GetCScripts() const;
     virtual bool GetCScript(const CScriptID &hash, CScript& redeemScriptOut) const override;
 };
 


### PR DESCRIPTION
The function `FillableSigningProvider::GetCScripts() const` is not being used anywhere in the codebase