### PR TITLE
mempool: count unbroadcast txids in memory usage

### DIFF
--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -526,4 +526,21 @@ BOOST_AUTO_TEST_CASE(MempoolAncestryTestsDiamond)
     BOOST_CHECK_EQUAL(descendants, 4ULL);
 }
 
+BOOST_AUTO_TEST_CASE(MempoolUnbroadcastMemoryUsage)
+{
+    CTxMemPool& pool{*Assert(m_node.mempool)};
+    LOCK2(cs_main, pool.cs);
+
+    auto tx{make_tx({10 * COIN})};
+    auto txid{tx->GetHash()};
+    TryAddToMempool(pool, TestMemPoolEntryHelper{}.Fee(1000).FromTx(tx));
+
+    auto usage_before{pool.DynamicMemoryUsage()};
+    pool.AddUnbroadcastTx(txid);
+    BOOST_CHECK_EQUAL(pool.DynamicMemoryUsage(), usage_before); // TODO: Include the retained set node in reported usage
+
+    pool.RemoveUnbroadcastTx(txid);
+    BOOST_CHECK_EQUAL(pool.DynamicMemoryUsage(), usage_before);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(MempoolUnbroadcastMemoryUsage)
 
     auto usage_before{pool.DynamicMemoryUsage()};
     pool.AddUnbroadcastTx(txid);
-    BOOST_CHECK_EQUAL(pool.DynamicMemoryUsage(), usage_before); // TODO: Include the retained set node in reported usage
+    BOOST_CHECK_GT(pool.DynamicMemoryUsage(), usage_before);
 
     pool.RemoveUnbroadcastTx(txid);
     BOOST_CHECK_EQUAL(pool.DynamicMemoryUsage(), usage_before);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -828,7 +828,7 @@ void CCoinsViewMemPool::Reset()
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
     // Estimate the overhead of mapTx to be 9 pointers (3 pointers per index) + an allocation, as no exact formula for boost::multi_index_contained is implemented.
-    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 9 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(txns_randomized) + m_txgraph->GetMainMemoryUsage() + cachedInnerUsage;
+    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 9 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(txns_randomized) + memusage::DynamicUsage(m_unbroadcast_txids) + m_txgraph->GetMainMemoryUsage() + cachedInnerUsage;
 }
 
 void CTxMemPool::RemoveUnbroadcastTx(const Txid& txid, const bool unchecked) {


### PR DESCRIPTION
**Problem:** The mempool memory estimate omits the txid set used to retry the initial broadcast of locally submitted transactions, so `getmempoolinfo` and `-maxmempool` undercount retained memory.

**Fix:** Count this set when calculating mempool memory usage.
