### PR TITLE
doc: mention -DWITH_ZMQ=ON in macOS build guide

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -106,7 +106,7 @@ Otherwise, if you don't need QR encoding support, you can pass `-DWITH_QRENCODE=
 
 #### ZMQ Dependencies
 
-Support for ZMQ notifications requires the following dependency.
+Bitcoin Core can provide notifications via ZeroMQ. To compile ZMQ support, install the following dependency and pass `-DWITH_ZMQ=ON` when configuring.
 Skip if you do not need ZMQ functionality.
 
 ``` bash


### PR DESCRIPTION
`doc/build-osx.md` currently says:

> Support for ZMQ notifications requires the following dependency.

The `zeromq` dependency is covered, but the `-DWITH_ZMQ=ON` CMake option is not
mentioned anywhere in that section. `WITH_ZMQ` defaults to `OFF`, so following the
guide as written results in a build with ZMQ disabled, even though the user completed
the ZMQ section. I verified this at the configure step on macOS: with `zeromq`
installed and no flag, CMake reports `ZeroMQ ... OFF`; with `-DWITH_ZMQ=ON` it
reports `ON`.

The same wording was added to the BSD build guides in #35283, but `doc/build-osx.md`
was not included.

Docs-only change. No tests run.