### PR TITLE
guix, depends: Drop `GUIX_ENVIRONMENT` from `gen_id` calculations

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -436,6 +436,8 @@ EOF
                 ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"}
                 ${BASE_CACHE:+BASE_CACHE="$BASE_CACHE"}
                 ${SDK_PATH:+SDK_PATH="$SDK_PATH"}
+                BUILD_ID_SALT="$ADDITIONAL_GUIX_COMMON_FLAGS $ADDITIONAL_GUIX_TIMEMACHINE_FLAGS $ADDITIONAL_GUIX_ENVIRONMENT_FLAGS"
+                HOST_ID_SALT="$ADDITIONAL_GUIX_COMMON_FLAGS $ADDITIONAL_GUIX_TIMEMACHINE_FLAGS $ADDITIONAL_GUIX_ENVIRONMENT_FLAGS"
                 DISTSRC="$(distsrc_for_host "$HOST" "" /distsrc-base)"
                 OUTDIR="$(outdir_for_host "$HOST" "" /outdir-base)"
                 DIST_ARCHIVE_BASE=/outdir-base/dist-archive

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -409,6 +409,19 @@ EOF
         read -ra _guix_common_flags <<< "$ADDITIONAL_GUIX_COMMON_FLAGS"
         read -ra _guix_env_flags <<< "$ADDITIONAL_GUIX_ENVIRONMENT_FLAGS"
 
+        guix_files_hash="$( {
+            cat "${PWD}/contrib/guix/manifest_build.scm" "${PWD}/contrib/guix/manifest_gui.scm"
+            find "${PWD}/contrib/guix/patches" -type f -print0 | sort -z | xargs -0 cat
+        } | sha256sum | cut -d' ' -f1 )"
+
+        # We want to reuse the depends build cache whenever possible.
+        # However, salting hash ids with the GUIX_ENVIRONMENT value
+        # does not work when manifests are split.
+        # The following value, used for BUILD_ID_SALT and HOST_ID_SALT, ensures
+        # that the cache is invalidated whenever the Guix environment changes.
+        depends_id_salt="$GUIX_TIMEMACHINE_COMMIT $ADDITIONAL_GUIX_TIMEMACHINE_FLAGS \
+                         $guix_files_hash $ADDITIONAL_GUIX_COMMON_FLAGS $ADDITIONAL_GUIX_ENVIRONMENT_FLAGS"
+
         shell_opts=(
             --manifest="${PWD}/contrib/guix/manifest_build.scm"
             --container
@@ -436,6 +449,8 @@ EOF
                 ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"}
                 ${BASE_CACHE:+BASE_CACHE="$BASE_CACHE"}
                 ${SDK_PATH:+SDK_PATH="$SDK_PATH"}
+                BUILD_ID_SALT="$depends_id_salt"
+                HOST_ID_SALT="$depends_id_salt"
                 DISTSRC="$(distsrc_for_host "$HOST" "" /distsrc-base)"
                 OUTDIR="$(outdir_for_host "$HOST" "" /outdir-base)"
                 DIST_ARCHIVE_BASE=/outdir-base/dist-archive

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -68,10 +68,13 @@ fi
 ################
 # Execute "$@" in a pinned, possibly older version of Guix, for reproducibility
 # across time.
+export GUIX_TIMEMACHINE_URL=https://codeberg.org/guix/guix.git
+export GUIX_TIMEMACHINE_COMMIT=c5eee3336cc1d10a3cc1c97fde2809c3451624d3
+
 time-machine() {
     # shellcheck disable=SC2086
-    guix time-machine --url=https://codeberg.org/guix/guix.git \
-                      --commit=c5eee3336cc1d10a3cc1c97fde2809c3451624d3 \
+    guix time-machine --url="$GUIX_TIMEMACHINE_URL" \
+                      --commit="$GUIX_TIMEMACHINE_COMMIT" \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -143,13 +143,13 @@ include packages/packages.mk
 build_id:=$(shell env CC='$(build_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(build_CXX)' CXX_STANDARD='$(CXX_STANDARD)' \
                       AR='$(build_AR)' NM='$(build_NM)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' \
                       DEBUG='$(DEBUG)' \
-                      ./gen_id '$(BUILD_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
+                      ./gen_id '$(BUILD_ID_SALT)')
 
 $(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' C_STANDARD='$(C_STANDARD)' CXX='$(host_CXX)' CXX_STANDARD='$(CXX_STANDARD)' \
                                         CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' CXXFLAGS='$(CXXFLAGS)' LDFLAGS='$(LDFLAGS)' \
                                         AR='$(host_AR)' NM='$(host_NM)' RANLIB='$(host_RANLIB)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' \
                                         DEBUG='$(DEBUG)' LTO='$(LTO)' \
-                                        ./gen_id '$(HOST_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
+                                        ./gen_id '$(HOST_ID_SALT)')
 
 boost_packages_$(NO_BOOST) = $(boost_packages)
 


### PR DESCRIPTION
This PR fixes a performance regression [noticed](https://github.com/bitcoin/bitcoin/pull/35537#pullrequestreview-4735094380) during the review of https://github.com/bitcoin/bitcoin/pull/35537.

Since commit 008a3e29c8844c0be4457279f5c27c1bc57401c7 ("guix: split builds into Linux(gui) and macOS/Windows"), each host is built in two containers: one instantiated from `manifest_build.scm` and the other from the union of `manifest_build.scm` and `manifest_gui.scm`. The resulting Guix profiles necessarily differ, and because `$(realpath $(GUIX_ENVIRONMENT))` is hashed into every depends package id, the built-package cache is invalidated whenever the profile changes:

1. Depends are rebuilt when switching to another branch with identical Guix scripts and the depends subdirectory.

2. All non-GUI packages are built twice per host, as the GUI container cannot reuse the packages just cached by the base container (this is mostly relevant for non-Linux hosts, as we move towards static builds on Linux).

Drop `GUIX_ENVIRONMENT` from the `gen_id` inputs, and salt the depends ids in `guix-build` with the inputs that define the containers instead: the pinned time-machine commit, the contents of `manifest_build.scm`,  `manifest_gui.scm` and of every patch in `contrib/guix/patches`, and the user-supplied `ADDITIONAL_GUIX_*_FLAGS`.

Unlike the profile path, this salt is identical for both containers of a given host, so the GUI container reuses the packages built by the base container, and it stays stable across branches whose Guix and depends inputs are unchanged, while any change to the pinned Guix revision, to the manifests, or to the patches still invalidates the cache.


Related: https://github.com/bitcoin/bitcoin/pull/34228.