### PR TITLE
refactor: remove unused <vector> header

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -17,7 +17,6 @@
 #include <uint256.h>
 
 #include <string>
-#include <vector>
 
 /** A BIP32 chain code. Cleansed on destruction. */
 class ChainCode : public base_blob<256> {


### PR DESCRIPTION
remove <vector> header after a refactor from `const std::vector<unsigned char>&` to `Span<const unsigned char>`

This PR is related to #19326
