### PR TITLE
net: reject oversized locators before allocating

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1250,6 +1250,18 @@ static void AddKnownTx(Peer& peer, const uint256& hash)
     tx_relay->m_tx_inventory_known_filter.insert(hash);
 }
 
+/** Read a locator and stop hash, disconnecting if the locator is oversized. */
+bool ReadBlockLocator(DataStream& stream, CBlockLocator& locator, uint256& hash_stop, CNode& node, const std::string& msg_type)
+{
+    stream >> locator >> hash_stop;
+    if (locator.vHave.size() > MAX_LOCATOR_SZ) {
+        LogDebug(BCLog::NET, "%s locator size %lld > %d, %s", msg_type, locator.vHave.size(), MAX_LOCATOR_SZ, node.DisconnectMsg());
+        node.fDisconnect = true;
+        return false;
+    }
+    return true;
+}
+
 /** Whether this peer can serve us blocks. */
 static bool CanServeBlocks(const Peer& peer)
 {
@@ -4490,13 +4502,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     if (msg_type == NetMsgType::GETBLOCKS) {
         CBlockLocator locator;
         uint256 hashStop;
-        vRecv >> locator >> hashStop;
-
-        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-            LogDebug(BCLog::NET, "getblocks locator size %lld > %d, %s", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom.DisconnectMsg());
-            pfrom.fDisconnect = true;
-            return;
-        }
+        if (!ReadBlockLocator(vRecv, locator, hashStop, pfrom, msg_type)) return;
 
         // We might have announced the currently-being-connected tip using a
         // compact block, which resulted in the peer sending a getblocks
@@ -4625,13 +4631,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     if (msg_type == NetMsgType::GETHEADERS) {
         CBlockLocator locator;
         uint256 hashStop;
-        vRecv >> locator >> hashStop;
-
-        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-            LogDebug(BCLog::NET, "getheaders locator size %lld > %d, %s", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom.DisconnectMsg());
-            pfrom.fDisconnect = true;
-            return;
-        }
+        if (!ReadBlockLocator(vRecv, locator, hashStop, pfrom, msg_type)) return;
 
         if (m_chainman.m_blockman.LoadingBlocks()) {
             LogDebug(BCLog::NET, "Ignoring getheaders from peer=%d while importing/reindexing\n", pfrom.GetId());

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1253,13 +1253,15 @@ static void AddKnownTx(Peer& peer, const uint256& hash)
 /** Read a locator and stop hash, disconnecting if the locator is oversized. */
 bool ReadBlockLocator(DataStream& stream, CBlockLocator& locator, uint256& hash_stop, CNode& node, const std::string& msg_type)
 {
-    stream >> locator >> hash_stop;
-    if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-        LogDebug(BCLog::NET, "%s locator size %lld > %d, %s", msg_type, locator.vHave.size(), MAX_LOCATOR_SZ, node.DisconnectMsg());
+    try {
+        locator.LimitedRead<MAX_LOCATOR_SZ>(stream);
+        stream >> hash_stop;
+        return true;
+    } catch (const LimitedVectorExceededError& e) {
+        LogDebug(BCLog::NET, "%s locator size %u > %u, %s", msg_type, e.m_size, MAX_LOCATOR_SZ, node.DisconnectMsg());
         node.fDisconnect = true;
         return false;
     }
-    return true;
 }
 
 /** Whether this peer can serve us blocks. */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1253,13 +1253,15 @@ static void AddKnownTx(Peer& peer, const uint256& hash)
 /** Read a locator and stop hash, disconnecting if the locator is oversized. */
 bool ReadBlockLocator(DataStream& stream, CBlockLocator& locator, uint256& hash_stop, CNode& node, const std::string& msg_type)
 {
-    stream >> locator >> hash_stop;
-    if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-        LogDebug(BCLog::NET, "%s locator size %lld > %d, %s", msg_type, locator.vHave.size(), MAX_LOCATOR_SZ, node.DisconnectMsg());
+    try {
+        locator.LimitedRead<MAX_LOCATOR_SZ>(stream);
+        stream >> hash_stop;
+        return true;
+    } catch (LimitedVectorExceededError& e) {
+        LogDebug(BCLog::NET, "%s locator size %u > %u, %s", msg_type, e.m_size, MAX_LOCATOR_SZ, node.DisconnectMsg());
         node.fDisconnect = true;
         return false;
     }
-    return true;
 }
 
 /** Whether this peer can serve us blocks. */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1250,6 +1250,18 @@ static void AddKnownTx(Peer& peer, const uint256& hash)
     tx_relay->m_tx_inventory_known_filter.insert(hash);
 }
 
+/** Read a locator and stop hash, disconnecting if the locator is oversized. */
+bool ReadBlockLocator(DataStream& stream, CBlockLocator& locator, uint256& hash_stop, CNode& node, const std::string& msg_type)
+{
+    stream >> locator >> hash_stop;
+    if (locator.vHave.size() > MAX_LOCATOR_SZ) {
+        LogDebug(BCLog::NET, "%s locator size %lld > %d, %s", msg_type, locator.vHave.size(), MAX_LOCATOR_SZ, node.DisconnectMsg());
+        node.fDisconnect = true;
+        return false;
+    }
+    return true;
+}
+
 /** Whether this peer can serve us blocks. */
 static bool CanServeBlocks(const Peer& peer)
 {
@@ -4481,13 +4493,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     if (msg_type == NetMsgType::GETBLOCKS) {
         CBlockLocator locator;
         uint256 hashStop;
-        vRecv >> locator >> hashStop;
-
-        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-            LogDebug(BCLog::NET, "getblocks locator size %lld > %d, %s", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom.DisconnectMsg());
-            pfrom.fDisconnect = true;
-            return;
-        }
+        if (!ReadBlockLocator(vRecv, locator, hashStop, pfrom, msg_type)) return;
 
         // We might have announced the currently-being-connected tip using a
         // compact block, which resulted in the peer sending a getblocks
@@ -4616,13 +4622,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     if (msg_type == NetMsgType::GETHEADERS) {
         CBlockLocator locator;
         uint256 hashStop;
-        vRecv >> locator >> hashStop;
-
-        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-            LogDebug(BCLog::NET, "getheaders locator size %lld > %d, %s", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom.DisconnectMsg());
-            pfrom.fDisconnect = true;
-            return;
-        }
+        if (!ReadBlockLocator(vRecv, locator, hashStop, pfrom, msg_type)) return;
 
         if (m_chainman.m_blockman.LoadingBlocks()) {
             LogDebug(BCLog::NET, "Ignoring getheaders from peer=%d while importing/reindexing\n", pfrom.GetId());

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -11,6 +11,7 @@
 #include <uint256.h>
 #include <util/time.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -135,6 +136,13 @@ struct CBlockLocator
         int nVersion = DUMMY_VERSION;
         READWRITE(nVersion);
         READWRITE(obj.vHave);
+    }
+
+    template <size_t Limit, typename Stream>
+    void LimitedRead(Stream& s)
+    {
+        s.ignore(sizeof(DUMMY_VERSION));
+        s >> LIMITED_VECTOR(vHave, Limit);
     }
 
     void SetNull()

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -791,10 +791,16 @@ struct DefaultFormatter
     static void Unser(Stream& s, T& t) { Unserialize(s, t); }
 };
 
-/**
- * Limited vector formatter. Throws an error if a vector is oversized.
- */
+class LimitedVectorExceededError : public std::ios_base::failure
+{
+public:
+    explicit LimitedVectorExceededError(size_t size)
+        : std::ios_base::failure{"Vector length limit exceeded"}, m_size{size} {}
 
+    size_t m_size;
+};
+
+/** Limited vector formatter. Throws an error if a vector is oversized. */
 template<size_t Limit, class Formatter = DefaultFormatter>
 struct LimitedVectorFormatter
 {
@@ -805,7 +811,7 @@ struct LimitedVectorFormatter
         v.clear();
         size_t size = ReadCompactSize(s);
         if (size > Limit) {
-            throw std::ios_base::failure("Vector length limit exceeded");
+            throw LimitedVectorExceededError{size};
         }
         v.reserve(size);
         for (size_t i = 0; i < size; ++i) {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -791,10 +791,16 @@ struct DefaultFormatter
     static void Unser(Stream& s, T& t) { Unserialize(s, t); }
 };
 
-/**
- * Limited vector formatter. Throws an error if a vector is oversized.
- */
+class LimitedVectorExceededError : public std::ios_base::failure
+{
+public:
+    explicit LimitedVectorExceededError(uint64_t size)
+        : std::ios_base::failure{"Vector length limit exceeded"}, m_size{size} {}
 
+    uint64_t m_size;
+};
+
+/** Limited vector formatter. Throws an error if a vector is oversized. */
 template<size_t Limit, class Formatter = DefaultFormatter>
 struct LimitedVectorFormatter
 {
@@ -803,11 +809,11 @@ struct LimitedVectorFormatter
     {
         Formatter formatter;
         v.clear();
-        size_t size = ReadCompactSize(s);
+        const uint64_t size{ReadCompactSize(s, /*range_check=*/false)};
         if (size > Limit) {
-            throw std::ios_base::failure("Vector length limit exceeded");
+            throw LimitedVectorExceededError{size};
         }
-        v.reserve(size);
+        v.reserve(static_cast<size_t>(size));
         for (size_t i = 0; i < size; ++i) {
             v.emplace_back();
             formatter.Unser(s, v.back());

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1726,7 +1726,7 @@ BOOST_AUTO_TEST_CASE(oversized_locator_handling)
             BOOST_REQUIRE(connman.ReceiveMsgFrom(node, std::move(oversized_locator)));
             node.fPauseSend = false;
             BOOST_CHECK(!connman.ProcessMessagesOnce(node));
-            BOOST_CHECK(!node.fDisconnect); // TODO: reject oversized locators before allocating
+            BOOST_CHECK(node.fDisconnect);
 
             m_node.peerman->FinalizeNode(node);
         }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1707,4 +1707,30 @@ BOOST_AUTO_TEST_CASE(addlocal_onlynet_externalip)
     fDiscover = discover_orig;
 }
 
+BOOST_AUTO_TEST_CASE(oversized_locator_handling)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+    auto& connman{static_cast<ConnmanTestMsg&>(*m_node.connman)};
+    const CAddress addr{Lookup("1.2.3.4", 8333, /*fAllowLookup=*/false).value(), NODE_NETWORK};
+
+    // Exercise advertised counts below and above ReadCompactSize's default MAX_SIZE limit
+    for (const uint64_t locator_count : {MAX_SIZE / sizeof(uint256), MAX_SIZE + 1}) {
+        for (auto msg_type : {NetMsgType::GETBLOCKS, NetMsgType::GETHEADERS}) {
+            CNode node{/*id=*/0, /*sock=*/nullptr, addr, /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, /*addrBindIn=*/CService{}, /*addrNameIn=*/"", ConnectionType::INBOUND, /*inbound_onion=*/false, /*network_key=*/0};
+
+            connman.Handshake(node, /*successfully_connected=*/true, /*remote_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS), /*local_services=*/NODE_NETWORK, PROTOCOL_VERSION, /*relay_txs=*/true);
+            connman.FlushSendBuffer(node);
+
+            auto oversized_locator{NetMsg::Make(msg_type, CBlockLocator::DUMMY_VERSION, COMPACTSIZE(locator_count))};
+
+            BOOST_REQUIRE(connman.ReceiveMsgFrom(node, std::move(oversized_locator)));
+            node.fPauseSend = false;
+            BOOST_CHECK(!connman.ProcessMessagesOnce(node));
+            BOOST_CHECK(!node.fDisconnect); // TODO: reject oversized locators before allocating
+
+            m_node.peerman->FinalizeNode(node);
+        }
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1686,7 +1686,7 @@ BOOST_AUTO_TEST_CASE(oversized_locator_handling)
         BOOST_REQUIRE(connman.ReceiveMsgFrom(node, std::move(oversized_locator)));
         node.fPauseSend = false;
         BOOST_CHECK(!connman.ProcessMessagesOnce(node));
-        BOOST_CHECK(!node.fDisconnect); // TODO: reject oversized locators before allocating
+        BOOST_CHECK(node.fDisconnect);
 
         m_node.peerman->FinalizeNode(node);
     }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1668,4 +1668,28 @@ BOOST_AUTO_TEST_CASE(addlocal_onlynet_externalip)
     fDiscover = discover_orig;
 }
 
+BOOST_AUTO_TEST_CASE(oversized_locator_handling)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+    auto& connman{static_cast<ConnmanTestMsg&>(*m_node.connman)};
+    const CAddress addr{Lookup("1.2.3.4", 8333, /*fAllowLookup=*/false).value(), NODE_NETWORK};
+
+    for (auto msg_type : {NetMsgType::GETBLOCKS, NetMsgType::GETHEADERS}) {
+        CNode node{/*id=*/0, /*sock=*/nullptr, addr, /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, /*addrBindIn=*/CService{}, /*addrNameIn=*/"", ConnectionType::INBOUND, /*inbound_onion=*/false, /*network_key=*/0};
+
+        connman.Handshake(node, /*successfully_connected=*/true, /*remote_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS), /*local_services=*/NODE_NETWORK, PROTOCOL_VERSION, /*relay_txs=*/true);
+        connman.FlushSendBuffer(node);
+
+        // Advertise MAX_SIZE bytes of hashes but omit them.
+        auto oversized_locator{NetMsg::Make(msg_type, CBlockLocator::DUMMY_VERSION, COMPACTSIZE(MAX_SIZE / sizeof(uint256)))};
+
+        BOOST_REQUIRE(connman.ReceiveMsgFrom(node, std::move(oversized_locator)));
+        node.fPauseSend = false;
+        BOOST_CHECK(!connman.ProcessMessagesOnce(node));
+        BOOST_CHECK(!node.fDisconnect); // TODO: reject oversized locators before allocating
+
+        m_node.peerman->FinalizeNode(node);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Problem:** `getblocks` and `getheaders` enforce `MAX_LOCATOR_SZ` only after deserializing locator hashes.
A truncated locator advertising an oversized count makes generic vector deserialization fail before the disconnect check, leaving the peer connected.

**Fix:** Read the advertised count before allocating hashes and disconnect when it exceeds the existing limit.
Catch only the size-limit error so other deserialization failures remain non-disconnecting.
Complete oversized locators continue to disconnect without discouragement, and `p2p_invalid_locator.py` verifies that both messages accept 101 hashes and disconnect at 102.
