### PR TITLE
blockstorage: fail instead of storing a null XOR key over a lost one

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1145,6 +1145,34 @@ FlatFilePos BlockManager::SaveBlockToDisk(const CBlock& block, int nHeight)
     return blockPos;
 }
 
+//! Determine whether existing block data in the blocksdir was written with an
+//! XOR key applied, by checking whether the block files still start with the
+//! network magic. A single file that does proves the data is unobfuscated,
+//! while concluding the opposite takes every file disagreeing, so that one
+//! damaged file can't make an unobfuscated blocksdir look obfuscated.
+static bool BlocksdirDataIsObfuscated(const fs::path& blocks_dir, const MessageStartChars& magic)
+{
+    bool obfuscated{false};
+    for (const auto& entry : fs::directory_iterator{blocks_dir}) {
+        const std::string filename{fs::PathToString(entry.path().filename())};
+        if (filename.length() != 12 || !filename.starts_with("blk") || !filename.ends_with(".dat")) continue;
+        if (!entry.is_regular_file()) continue;
+
+        MessageStartChars blk_start{};
+        try {
+            AutoFile blk_file{fsbridge::fopen(entry.path(), "rb")};
+            blk_file >> blk_start;
+        } catch (const std::exception&) {
+            continue; // Unreadable or too short, try the next file
+        }
+        // Skip a block file that was preallocated but never written to.
+        if (blk_start == MessageStartChars{}) continue;
+        if (blk_start == magic) return false;
+        obfuscated = true;
+    }
+    return obfuscated;
+}
+
 static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
 {
     // Bytes are serialized without length indicator, so this is also the exact
@@ -1163,6 +1191,19 @@ static auto InitBlocksdirXorKey(const BlockManager::Options& opts)
         AutoFile xor_key_file{fsbridge::fopen(xor_key_path, "rb")};
         xor_key_file >> xor_key;
     } else {
+        // A missing key file means either a fresh blocksdir, or one written
+        // before the XOR key was introduced, where the data is unobfuscated
+        // and the null key below is the correct one. If existing block data is
+        // obfuscated, the key file was lost instead, and storing a null key
+        // would silently render all of that data unreadable.
+        if (BlocksdirDataIsObfuscated(opts.blocks_dir, opts.chainparams.MessageStart())) {
+            throw std::runtime_error{
+                strprintf("The XOR-key file '%s' is missing, but the block files in '%s' are obfuscated with a key. "
+                          "Restore the key file from a backup, or delete the blocks and chainstate directories to sync from scratch. "
+                          "(This can also mean the blocks directory belongs to a different network.)",
+                          fs::PathToString(xor_key_path), fs::PathToString(opts.blocks_dir)),
+            };
+        }
         // Create initial or missing xor key file
         AutoFile xor_key_file{fsbridge::fopen(xor_key_path,
 #ifdef __MINGW64__

--- a/test/functional/feature_blocksxor.py
+++ b/test/functional/feature_blocksxor.py
@@ -42,6 +42,15 @@ class BlocksXORTest(BitcoinTestFramework):
         self.log.info("Shut down node and un-XOR block/undo files manually")
         self.stop_node(0)
         xor_key = node.read_xor_key()
+
+        self.log.info("Check that a lost XOR key is detected while block data is still obfuscated")
+        node.blocks_key_path.unlink()
+        node.assert_start_raises_init_error(
+            expected_msg='The XOR-key file .* is missing, but the block files in .* are obfuscated with a key',
+            match=ErrorMatch.PARTIAL_REGEX)
+        assert not node.blocks_key_path.exists()  # no null key was stored over the lost one
+        node.blocks_key_path.write_bytes(xor_key)
+
         for data_file in sorted(block_files + undo_files):
             self.log.debug(f"Rewriting file {data_file}...")
             with open(data_file, 'rb+') as f:
@@ -61,6 +70,19 @@ class BlocksXORTest(BitcoinTestFramework):
         # nblocks=0    -> verify all blocks
         node.verifychain(checklevel=2, nblocks=0)
         self.log.info("Check that blocks XOR key is recreated")
+        assert_equal(node.read_xor_key(), NULL_BLK_XOR_KEY)
+
+        self.log.info("Check that an unobfuscated blocksdir without a key starts with XOR enabled")
+        self.stop_node(0)
+        node.blocks_key_path.unlink()
+        self.start_node(0)
+        assert_equal(node.read_xor_key(), NULL_BLK_XOR_KEY)
+
+        self.log.info("Check that a single unreadable block file is not mistaken for a lost XOR key")
+        self.stop_node(0)
+        (node.blocks_path / 'blk99999.dat').write_bytes(b'\xde\xad\xbe\xef')
+        node.blocks_key_path.unlink()
+        self.start_node(0)
         assert_equal(node.read_xor_key(), NULL_BLK_XOR_KEY)
 
 


### PR DESCRIPTION
`blocks/xor.dat` holds the 8-byte key that block and undo data is obfuscated with. If the file goes missing, `InitBlocksdirXorKey` silently stores an all-zero key, every read of the existing data then fails, and the node reports:

```
Corrupted block database detected.
Please restart with -reindex or -reindex-chainstate to recover.
```

The data is not corrupt, only the key was lost. Restoring the key at that point brings the chain back untouched.

Following the suggested recovery instead makes things worse. `-reindex` reports no error at all: it completes, leaves the node at height 0 having silently discarded the chain, and rewrites the start of the block file with a null-key genesis. Restoring the key afterwards then still loads 0 blocks on the first reindex, and only recovers on a second one. A user who sees an empty chain twice concludes the data is gone and resyncs from scratch.

A missing key file is legitimate for a fresh blocksdir, and for one written before v28 where the data is unobfuscated and the null key is correct. Both are distinguishable from a lost key by whether the block files still start with the network magic, so check that and fail with an actionable error instead. The null key is not written in that case, so the original key can still be restored.

One file matching the magic proves the data is unobfuscated. Concluding the opposite takes every file disagreeing, so a single damaged file cannot misfire the check.

This guards the moment the key goes missing. It cannot help a node that already stored a null key on an earlier version, since `xor.dat` then exists and is read as-is.

### Reproduce on master

Build a chain and keep a copy of the key:

```
bitcoind -regtest -daemonwait
bitcoin-cli -regtest createwallet w
bitcoin-cli -regtest generatetoaddress 20 $(bitcoin-cli -regtest -rpcwallet=w getnewaddress)
bitcoin-cli -regtest stop
cp <datadir>/regtest/blocks/xor.dat /tmp/xor.bak
```

The data is intact and the key alone recovers it:

```
rm <datadir>/regtest/blocks/xor.dat
bitcoind -regtest                       # "Corrupted block database detected."
cp /tmp/xor.bak <datadir>/regtest/blocks/xor.dat
bitcoind -regtest -daemonwait
bitcoin-cli -regtest getblockcount      # 20
bitcoin-cli -regtest verifychain 4 20   # true
```

Following the error message instead:

```
rm <datadir>/regtest/blocks/xor.dat
bitcoind -regtest -reindex -daemonwait
bitcoin-cli -regtest getblockcount      # 0, and no error was reported
```

With this change the node refuses to start on both paths, leaves the block file untouched, and does not write a null key.

### Testing

Three cases added to `feature_blocksxor.py`: a lost key is detected and no null key is written over it; an unobfuscated blocksdir with no key still starts with XOR enabled (the pre-v28 upgrade path); and a single unreadable block file is not mistaken for a lost key. The first fails on master with the output above. The pre-existing steps still pass, and the full functional suite passes.
