### PR TITLE
init: reject -noconnect double-negatives that become -connect=1

### DIFF
--- a/doc/release-notes-35939.md
+++ b/doc/release-notes-35939.md
@@ -1,0 +1,8 @@
+Updated settings
+----------------
+
+- Invalid `-noconnect` values such as `-noconnect=0` (double-negatives that
+  previously became `-connect=1` and attempted a connection to `0.0.0.1`)
+  now cause startup to fail with an error instead of silently connecting.
+  `-noconnect` and `-noconnect=1` still disable automatic outbound
+  connections. (#35939)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -83,6 +83,7 @@
 #include <txgraph.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <univalue.h>
 #include <util/asmap.h>
 #include <util/batchpriority.h>
 #include <util/btcsignals.h>
@@ -2277,6 +2278,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     connOptions.vSeedNodes = args.GetArgs("-seednode");
+
+    for (const auto& value : args.GetSettingsList("-connect")) {
+        if (!value.isStr()) {
+            return InitError(_("Invalid value detected for '-connect' or '-noconnect'. "
+                               "'-connect' requires a string value (hostname or IP), while "
+                               "'-noconnect' accepts only '1' to disable automatic connections"));
+        }
+    }
 
     const auto connect = args.GetArgs("-connect");
     if (!connect.empty() || args.IsArgNegated("-connect")) {

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -227,6 +227,12 @@ class ConfArgsTest(BitcoinTestFramework):
                     expected_msg="Error: Invalid value detected for '-wallet' or '-nowallet'. '-wallet' requires a string value, while '-nowallet' accepts only '1' to disable all wallets",
                     extra_args=[f'-nowallet={value}'],
                 )
+        # Provide a value different from 1 to the -connect negated option
+        for value in [0, 'not_a_boolean']:
+            self.nodes[0].assert_start_raises_init_error(
+                expected_msg="Error: Invalid value detected for '-connect' or '-noconnect'. '-connect' requires a string value (hostname or IP), while '-noconnect' accepts only '1' to disable automatic connections",
+                extra_args=[f'-noconnect={value}'],
+            )
 
     def test_log_buffer(self):
         with self.nodes[0].assert_debug_log(expected_msgs=["[warning] Parsed potentially confusing double-negative -listen=0\n"]):


### PR DESCRIPTION
Fixes #31426.

### Motivation

-noconnect=0 is interpreted as -connect=1, which is interpreted as -connect=0.0.0.1

```
bitcoind -noconnect=0 -debug=net
```

before this change that leads to a connection attempt to 0.0.0.1 (and the usual -connect parameter interactions that disable listen/dnsseed). bitcoind should not try to connect to 0.0.0.1 from that permutation.

### Change

Fail init for invalid -noconnect values, same pattern as -wallet / -nowallet: -connect must be a string host/IP -noconnect / -noconnect=1 still disable automatic connections 

Double-negatives like -noconnect=0 are stored as boolean true, which GetArgs stringifies as "1" and Lookup resolves as 0.0.0.1 

those now error instead.
