### PR TITLE
net: allow selecting BIP152 high-bandwidth peers with `-addnode`

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -121,6 +121,7 @@
 #include <set>
 #include <span>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <thread>
 #include <tuple>
@@ -175,6 +176,7 @@ static constexpr bool DEFAULT_PROXYRANDOMIZE{true};
 static constexpr bool DEFAULT_REST_ENABLE{false};
 static constexpr bool DEFAULT_I2P_ACCEPT_INCOMING{true};
 static constexpr bool DEFAULT_STOPAFTERBLOCKIMPORT{false};
+static constexpr std::string_view ADDNODE_BIP152_HB_SUFFIX{"=bip152-hb"};
 
 #ifdef WIN32
 // Win32 LevelDB doesn't use filedescriptors, and the ones used for
@@ -564,7 +566,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                  " If <type> is not supplied or if <type> = 1, indexes for all known types are enabled.",
                  ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 
-    argsman.AddArg("-addnode=<ip>", strprintf("Add a node to connect to and attempt to keep the connection open (see the addnode RPC help for more info). This option can be specified multiple times to add multiple nodes; connections are limited to %u at a time and are counted separately from the -maxconnections limit.", MAX_ADDNODE_CONNECTIONS), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-addnode=<ip>[:<port>][=bip152-hb]", strprintf("Add a node to connect to and attempt to keep the connection open (see the addnode RPC help for more info). Append =bip152-hb to request BIP152 high-bandwidth compact block announcements. This is incompatible with -blocksonly and is additional to the automatically selected high-bandwidth peers. This option can be specified multiple times to add multiple nodes; connections are limited to %u at a time and are counted separately from the -maxconnections limit.", MAX_ADDNODE_CONNECTIONS), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-asmap=<file>", strprintf("Specify asn mapping used for bucketing of the peers. Relative paths will be prefixed by the net-specific datadir location.%s",
                 #ifdef ENABLE_EMBEDDED_ASMAP
                     " If a bool arg is given (-asmap or -asmap=1), the embedded mapping data in the binary will be used."
@@ -985,6 +987,17 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     if (!errors.empty()) {
         return InitError(errors);
+    }
+
+    if (args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)) {
+        for (const std::string& value : args.GetArgs("-addnode")) {
+            std::string_view added_node{value};
+            if (!added_node.ends_with(ADDNODE_BIP152_HB_SUFFIX)) continue;
+            added_node.remove_suffix(ADDNODE_BIP152_HB_SUFFIX.size());
+            if (TrimStringView(added_node).empty()) continue;
+            return InitError(Untranslated(strprintf(
+                "Invalid -addnode value '%s': the bip152-hb suffix is incompatible with -blocksonly", value)));
+        }
     }
 
     // Testnet3 deprecation warning
@@ -2147,14 +2160,18 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // Attempt v2 connection if we support v2 - we'll reconnect with v1 if our
     // peer doesn't support it or immediately disconnects us for another reason.
     const bool use_v2transport{static_cast<bool>(g_local_services & NODE_P2P_V2)};
-    for (const std::string& added_node : args.GetArgs("-addnode")) {
+    for (const std::string& value : args.GetArgs("-addnode")) {
+        std::string added_node{value};
+        const bool bip152_highbandwidth{added_node.ends_with(ADDNODE_BIP152_HB_SUFFIX)};
+        if (bip152_highbandwidth) added_node.resize(added_node.size() - ADDNODE_BIP152_HB_SUFFIX.size());
+
         // Such a value is not a valid connection target, but would otherwise be
         // treated as one and retried indefinitely.
         if (TrimStringView(added_node).empty()) {
             LogWarning("Ignoring empty -addnode value");
             continue;
         }
-        connOptions.m_added_nodes.push_back({added_node, use_v2transport});
+        connOptions.m_added_nodes.push_back({std::move(added_node), use_v2transport, bip152_highbandwidth});
     }
     connOptions.nMaxOutboundLimit = *opt_max_upload;
     connOptions.m_peer_connect_timeout = peer_connect_timeout;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2144,6 +2144,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.m_msgproc = node.peerman.get();
     connOptions.nSendBufferMaxSize = 1000 * args.GetIntArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER);
     connOptions.nReceiveFloodSize = 1000 * args.GetIntArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER);
+    // Attempt v2 connection if we support v2 - we'll reconnect with v1 if our
+    // peer doesn't support it or immediately disconnects us for another reason.
+    const bool use_v2transport{static_cast<bool>(g_local_services & NODE_P2P_V2)};
     for (const std::string& added_node : args.GetArgs("-addnode")) {
         // Such a value is not a valid connection target, but would otherwise be
         // treated as one and retried indefinitely.
@@ -2151,7 +2154,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             LogWarning("Ignoring empty -addnode value");
             continue;
         }
-        connOptions.m_added_nodes.push_back(added_node);
+        connOptions.m_added_nodes.push_back({added_node, use_v2transport});
     }
     connOptions.nMaxOutboundLimit = *opt_max_upload;
     connOptions.m_peer_connect_timeout = peer_connect_timeout;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3866,6 +3866,31 @@ bool CConnman::AddedNodesContain(const CAddress& addr) const
                            [&](const auto& p) { return p.m_added_node == addr_str || p.m_added_node == addr_port_str; }));
 }
 
+bool CConnman::IsBip152HighBandwidthAddedNode(const CNode& node) const
+{
+    AssertLockNotHeld(m_added_nodes_mutex);
+    if (!node.IsManualConn() && !node.IsOutboundOrBlockRelayConn()) return false;
+
+    std::vector<std::string> configured_nodes;
+    {
+        LOCK(m_added_nodes_mutex);
+        for (const auto& params : m_added_node_params) {
+            if (params.m_bip152_highbandwidth && !params.m_added_node.empty()) {
+                configured_nodes.push_back(params.m_added_node);
+            }
+        }
+    }
+
+    for (const auto& endpoint : configured_nodes) {
+        if (node.m_addr_name == endpoint) return true;
+
+        const CService service{MaybeFlipIPv6toCJDNS(
+            LookupNumeric(endpoint, GetDefaultPort(endpoint)))};
+        if (service.IsValid() && service == node.addr) return true;
+    }
+    return false;
+}
+
 size_t CConnman::GetNodeCount(ConnectionDirection flags) const
 {
     LOCK(m_nodes_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -107,6 +107,7 @@ typedef int64_t NodeId;
 struct AddedNodeParams {
     std::string m_added_node;
     bool m_use_v2transport;
+    bool m_bip152_highbandwidth{false};
 };
 
 struct AddedNodeInfo {
@@ -1357,6 +1358,9 @@ public:
     bool AddNode(const AddedNodeParams& add) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
     bool RemoveAddedNode(std::string_view node) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
     bool AddedNodesContain(const CAddress& addr) const EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
+    /** Whether an outbound peer matches an added node configured for BIP152 high-bandwidth announcements. */
+    bool IsBip152HighBandwidthAddedNode(const CNode& node) const
+        EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
     std::vector<AddedNodeInfo> GetAddedNodeInfo(bool include_connected) const
         EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex, !m_nodes_mutex);
 

--- a/src/net.h
+++ b/src/net.h
@@ -1108,7 +1108,7 @@ public:
         bool bind_on_any;
         bool m_use_addrman_outgoing = true;
         std::vector<std::string> m_specified_outgoing;
-        std::vector<std::string> m_added_nodes;
+        std::vector<AddedNodeParams> m_added_nodes;
         bool m_i2p_accept_incoming;
         bool whitelist_forcerelay = DEFAULT_WHITELISTFORCERELAY;
         bool whitelist_relay = DEFAULT_WHITELISTRELAY;
@@ -1141,12 +1141,8 @@ public:
         vWhitelistedRangeOutgoing = connOptions.vWhitelistedRangeOutgoing;
         {
             LOCK(m_added_nodes_mutex);
-            // Attempt v2 connection if we support v2 - we'll reconnect with v1 if our
-            // peer doesn't support it or immediately disconnects us for another reason.
-            const bool use_v2transport(GetLocalServices() & NODE_P2P_V2);
-            for (const std::string& added_node : connOptions.m_added_nodes) {
-                m_added_node_params.push_back({added_node, use_v2transport});
-            }
+            m_added_node_params.insert(
+                m_added_node_params.end(), connOptions.m_added_nodes.begin(), connOptions.m_added_nodes.end());
         }
         m_onion_binds = connOptions.onion_binds;
         whitelist_forcerelay = connOptions.whitelist_forcerelay;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -249,6 +249,8 @@ struct Peer {
 
     //! Whether this peer is an inbound connection
     const bool m_is_inbound;
+    //! Whether this peer matches a persistent addnode configured for BIP152 high bandwidth.
+    const bool m_bip152_highbandwidth_configured;
 
     /** Protects misbehavior data members */
     Mutex m_misbehavior_mutex;
@@ -417,10 +419,11 @@ struct Peer {
      * timestamp the peer sent in the version message. */
     std::atomic<std::chrono::seconds> m_time_offset{0s};
 
-    explicit Peer(NodeId id, ServiceFlags our_services, bool is_inbound)
+    explicit Peer(NodeId id, ServiceFlags our_services, bool is_inbound, bool bip152_highbandwidth_configured)
         : m_id{id}
         , m_our_services{our_services}
         , m_is_inbound{is_inbound}
+        , m_bip152_highbandwidth_configured{bip152_highbandwidth_configured}
     {}
 
 private:
@@ -1386,6 +1389,9 @@ void PeerManagerImpl::MaybeSetPeerAsAnnouncingHeaderAndIDs(NodeId nodeid)
         // Don't request compact blocks if the peer has not signalled support
         return;
     }
+    // Configured peers are additional to the automatic peers and must not
+    // enter or reorder the automatic selection list.
+    if (peer && peer->m_bip152_highbandwidth_configured) return;
 
     int num_outbound_hb_peers = 0;
     for (std::list<NodeId>::iterator it = lNodesAnnouncingHeaderAndIDs.begin(); it != lNodesAnnouncingHeaderAndIDs.end(); it++) {
@@ -1705,6 +1711,7 @@ void PeerManagerImpl::UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_s
 
 void PeerManagerImpl::InitializeNode(const CNode& node, ServiceFlags our_services)
 {
+    const bool bip152_highbandwidth_configured{m_connman.IsBip152HighBandwidthAddedNode(node)};
     NodeId nodeid = node.GetId();
     {
         LOCK(cs_main); // For m_node_states
@@ -1716,7 +1723,8 @@ void PeerManagerImpl::InitializeNode(const CNode& node, ServiceFlags our_service
         our_services = static_cast<ServiceFlags>(our_services | NODE_BLOOM);
     }
 
-    PeerRef peer = std::make_shared<Peer>(nodeid, our_services, node.IsInboundConn());
+    PeerRef peer = std::make_shared<Peer>(
+        nodeid, our_services, node.IsInboundConn(), bip152_highbandwidth_configured);
     {
         LOCK(m_peer_mutex);
         m_peer_map.emplace_hint(m_peer_map.end(), nodeid, peer);
@@ -4114,11 +4122,12 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
         if (pfrom.GetCommonVersion() >= SHORT_IDS_BLOCKS_VERSION) {
             // Tell our peer we are willing to provide version 2 cmpctblocks.
-            // However, we do not request new block announcements using
-            // cmpctblock messages.
             // We send this to non-NODE NETWORK peers as well, because
             // they may wish to request compact blocks from us
-            MakeAndPushMessage(pfrom, NetMsgType::SENDCMPCT, /*high_bandwidth=*/false, /*version=*/CMPCTBLOCKS_VERSION);
+            const bool high_bandwidth{
+                peer.m_bip152_highbandwidth_configured && !m_opts.ignore_incoming_txs};
+            MakeAndPushMessage(pfrom, NetMsgType::SENDCMPCT, high_bandwidth, /*version=*/CMPCTBLOCKS_VERSION);
+            pfrom.m_bip152_highbandwidth_to = high_bandwidth;
         }
 
         if (m_txreconciliation) {

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -163,4 +163,52 @@ BOOST_FIXTURE_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection, 
     connman->ClearTestNodes();
 }
 
+BOOST_FIXTURE_TEST_CASE(bip152_high_bandwidth_added_node_matching, PeerTest)
+{
+    const CService manual_address{LookupNumeric("127.0.0.1", Params().GetDefaultPort())};
+    const CService numeric_target{LookupNumeric("127.0.0.2", Params().GetDefaultPort())};
+    const CService plain{LookupNumeric("127.0.0.3", Params().GetDefaultPort())};
+    BOOST_REQUIRE(manual_address.IsValid());
+    BOOST_REQUIRE(numeric_target.IsValid());
+    BOOST_REQUIRE(plain.IsValid());
+
+    auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params());
+    CConnman::Options options;
+    options.m_added_nodes = {
+        {.m_added_node = "example.test", .m_use_v2transport = false, .m_bip152_highbandwidth = true},
+        {.m_added_node = numeric_target.ToStringAddr(), .m_use_v2transport = false, .m_bip152_highbandwidth = true},
+        {.m_added_node = plain.ToStringAddrPort(), .m_use_v2transport = false},
+    };
+    connman->Init(options);
+
+    const auto make_node = [](NodeId id, const CService& service, std::string name, ConnectionType type) {
+        return std::make_unique<CNode>(id,
+                                       /*sock=*/nullptr,
+                                       CAddress{service, NODE_NONE},
+                                       /*nKeyedNetGroupIn=*/0,
+                                       /*nLocalHostNonceIn=*/0,
+                                       CAddress{},
+                                       std::move(name),
+                                       type,
+                                       /*inbound_onion=*/false,
+                                       /*network_key=*/0);
+    };
+
+    // Exact destination matching works without local DNS, including through a name proxy.
+    const auto manual{make_node(1, manual_address, "example.test", ConnectionType::MANUAL)};
+    BOOST_CHECK(connman->IsBip152HighBandwidthAddedNode(*manual));
+
+    // Numeric aliases also match durable outbound connections by service. Omitting
+    // the default port ensures this cannot pass through exact string matching.
+    const auto addrman{make_node(2, numeric_target, /*name=*/{}, ConnectionType::OUTBOUND_FULL_RELAY)};
+    BOOST_REQUIRE_NE(addrman->m_addr_name, numeric_target.ToStringAddr());
+    BOOST_CHECK(connman->IsBip152HighBandwidthAddedNode(*addrman));
+
+    const auto unconfigured{make_node(3, plain, /*name=*/{}, ConnectionType::OUTBOUND_FULL_RELAY)};
+    BOOST_CHECK(!connman->IsBip152HighBandwidthAddedNode(*unconfigured));
+
+    const auto inbound{make_node(4, numeric_target, /*name=*/{}, ConnectionType::INBOUND)};
+    BOOST_CHECK(!connman->IsBip152HighBandwidthAddedNode(*inbound));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -280,6 +280,26 @@ class ConfArgsTest(BitcoinTestFramework):
 
         node.replace_in_config([("addnode=\n", "")])
 
+    def test_bip152_high_bandwidth_addnode(self):
+        self.log.info("Test the BIP152 high-bandwidth addnode suffix")
+        node = self.nodes[0]
+
+        self.start_node(0, extra_args=[
+            "-addnode=tagged.example=bip152-hb",
+            "-addnode=opaque.example=x",
+            UNREACHABLE_PROXY_ARG,
+        ])
+        util.assert_equal(
+            [entry["addednode"] for entry in node.getaddednodeinfo()],
+            ["tagged.example", "opaque.example=x"],
+        )
+        self.stop_node(0)
+
+        node.assert_start_raises_init_error(
+            extra_args=["-blocksonly", "-addnode=127.0.0.1:18444=bip152-hb"],
+            expected_msg="Error: Invalid -addnode value '127.0.0.1:18444=bip152-hb': the bip152-hb suffix is incompatible with -blocksonly",
+        )
+
     def test_networkactive(self):
         self.log.info('Test -networkactive option')
         with self.nodes[0].assert_debug_log(expected_msgs=['SetNetworkActive: true\n']):
@@ -534,6 +554,7 @@ class ConfArgsTest(BitcoinTestFramework):
         self.test_log_buffer()
         self.test_args_log()
         self.test_empty_addnode()
+        self.test_bip152_high_bandwidth_addnode()
         self.test_seed_peers()
         self.test_networkactive()
         self.test_connect_with_seednode()

--- a/test/functional/p2p_compactblocks_hb.py
+++ b/test/functional/p2p_compactblocks_hb.py
@@ -5,7 +5,11 @@
 """Test compact blocks HB selection logic."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    append_config,
+    assert_equal,
+    p2p_port,
+)
 
 
 class CompactBlocksConnectionTest(BitcoinTestFramework):
@@ -94,6 +98,40 @@ class CompactBlocksConnectionTest(BitcoinTestFramework):
             assert not status[0]
             assert status[nodeid - 2]
         assert_equal(status, [False, True, True, True])
+
+        self.log.info("Testing a configured peer alongside automatic selection...")
+        self.stop_node(1)
+        append_config(self.nodes[1].datadir_path, [f"addnode=127.0.0.1:{p2p_port(2)}=bip152-hb"])
+        self.start_node(1)
+
+        def configured_peer_connected():
+            info_to = self.peer_info(1, 2)
+            info_from = self.peer_info(2, 1)
+            return (
+                info_to is not None
+                and info_from is not None
+                and info_to["bip152_hb_to"]
+                and info_from["bip152_hb_from"]
+            )
+
+        self.wait_until(configured_peer_connected)
+        self.connect_nodes(3, 1)
+        self.connect_nodes(4, 1)
+        self.connect_nodes(5, 1)
+
+        # The configured peer is additional to the three peers selected after
+        # they announce blocks.
+        for nodeid in range(3, 6):
+            status = self.relay_block_through(nodeid)
+            assert_equal(status, [True, nodeid >= 3, nodeid >= 4, nodeid >= 5])
+
+        # Receiving another block from the configured peer must not insert it
+        # into the automatic list or displace one of those three peers.
+        assert_equal(self.relay_block_through(2), [True, True, True, True])
+
+        # Peer initialization re-reads persistent intent after reconnecting.
+        self.restart_node(1)
+        self.wait_until(configured_peer_connected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bitcoin Core automatically selects up to three BIP152 high-bandwidth peers after they deliver useful blocks. This works for ordinary connections, but it cannot use topology information known by the operator.

For example, an operator may run nodes in multiple locations or maintain a stable, low-latency peering link and want that connection to announce compact blocks immediately and consistently, including after reconnects, instead of waiting for automatic selection.

This PR adds an opt-in suffix:

```
-addnode=<host>[:port]=bip152-hb
```
A matching outbound peer receives the existing `SENDCMPCT(1)` request after the handshake. The policy is reapplied on reconnect and requires no new P2P protocol messages.

Configured peers are additional to the three automatically selected peers and are not included in automatic rotation. This intentionally allows explicit configuration to exceed BIP152’s current three-peer limit and may increase redundant bandwidth. If accepted, BIP152 can be updated separately.

The option is incompatible with `-blocksonly`. Untagged addnodes, inbound connections, and the addnode RPC retain their existing behavior; RPC support can be considered separately.