### PR TITLE
doc: remove mention of `::wsystem`

### DIFF
--- a/cmake/bitcoin-build-config.h.in
+++ b/cmake/bitcoin-build-config.h.in
@@ -88,7 +88,7 @@
 /* Define this symbol if the BSD sysctl(KERN_ARND) is available */
 #cmakedefine HAVE_SYSCTL_ARND 1
 
-/* Define to 1 if std::system or ::wsystem is available. */
+/* Define to 1 if std::system is available. */
 #cmakedefine HAVE_SYSTEM 1
 
 /* Define to the address where bug reports for this package should be sent. */


### PR DESCRIPTION
Followup to #35704.