### PR TITLE
doc: fix dead link in txrequest.h

### DIFF
--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -56,7 +56,7 @@
  *              cap on the number of tracked announcements per peer. As failed requests in response to announcements
  *              from honest peers should be rare, this almost solely hinders attackers.
  *              Transaction censoring attacks can be done by announcing transactions quickly while not answering
- *              requests for them. See https://allquantor.at/blockchainbib/pdf/miller2015topology.pdf for more
+ *              requests for them. See https://www.cs.umd.edu/projects/coinscope/coinscope.pdf for more
  *              information.
  *
  * - Transactions are not requested from a peer until its reqtime has passed.


### PR DESCRIPTION
The link is dead. Both the file and the whole `blockchainbib/` section return 404. The host certificate expired on 2026-08-07, so the site looks abandoned rather than moved.

It was a local copy of Miller et al. 2015, *Discovering Bitcoin's Public Topology and Influential Nodes*. The [`blockchainbib` bibliography](https://github.com/kernoelpanic/blockchainbib) that distributed it points to `cs.umd.edu/projects/coinscope/coinscope.pdf`, where the original is still accessible.

No other occurrences in the tree.
