### PR TITLE
doc, wallet: Add wallet corruption recovery guidance to managing-wallets.md

### DIFF
--- a/doc/managing-wallets.md
+++ b/doc/managing-wallets.md
@@ -124,6 +124,25 @@ $ bitcoin-cli -rpcwallet="restored-wallet" getwalletinfo
 
 The restored wallet can also be loaded in the GUI via `File` ->`Open wallet`.
 
+### 1.7 Recovering from a Corrupted Wallet
+
+A wallet database can become corrupted due to hardware failure, a power loss or OS crash during a write, or disk-level errors. When corruption is detected at load time, Bitcoin Core will report an error and log details to `debug.log`.
+
+**The only supported recovery mechanism is to restore from a backup** (see [section 1.4](#14-backing-up-the-wallet) and [section 1.6](#16-restoring-the-wallet-from-a-backup)).
+
+There is no safe way to repair a corrupted wallet database in place. Attempting to manually remove, modify, or reconstruct records risks inconsistent state, incorrect balances, or permanent fund loss.
+
+To recover from a corrupted wallet:
+
+1. Stop Bitcoin Core.
+2. Move the corrupted wallet directory aside — do not delete it until recovery is confirmed.
+3. Restore the most recent backup as described in [section 1.6](#16-restoring-the-wallet-from-a-backup).
+4. Verify the restored wallet loads correctly and shows the expected balance before resuming normal use.
+
+If no backup is available, there is no supported recovery path for the corrupted wallet.
+
+Regular backups as described in [section 1.5](#15-backup-frequency) are the only reliable protection against unrecoverable corruption.
+
 ## Wallet Passphrase
 
 Understanding wallet security is crucial for safely storing your Bitcoin. A key aspect is the wallet passphrase, used for encryption. Let's explore its nuances, role, encryption process, and limitations.


### PR DESCRIPTION
Adds section 1.7 "**Recovering from a Corrupted Wallet**" to `doc/managing-wallets.md`. Documents that restoring from a known-good backup is the only supported recovery path for corrupted wallet databases, and that there is no safe in-place repair mechanism.

Motivated by achow101's conclusion in #35605:
> we should make the only supported corruption recovery mechanism be to
> restore a backup and not do any of this stuff with maybe being able
> to recover.

Note: the error message at `walletdb.cpp:1050` currently says "This can be fixed by removing transactions from wallet and rescanning." — that message is inconsistent with this guidance and should be updated as a follow-up (or in #35605 or #35760, both of which are touching the related code paths).