### PR TITLE
depends, qt: Add patch for missing headers

### DIFF
--- a/depends/packages/native_qt.mk
+++ b/depends/packages/native_qt.mk
@@ -10,6 +10,7 @@ $(package)_patches += qtbase_skip_tools.patch
 $(package)_patches += rcc_hardcode_timestamp.patch
 $(package)_patches += qttools_skip_dependencies.patch
 $(package)_patches += fix-macos26-qyield.patch
+$(package)_patches += fix_missed_headers.patch
 
 $(package)_qttranslations_file_name=$(qt_details_qttranslations_file_name)
 $(package)_qttranslations_sha256_hash=$(qt_details_qttranslations_sha256_hash)
@@ -140,7 +141,8 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/qtbase_skip_tools.patch && \
   patch -p1 -i $($(package)_patch_dir)/rcc_hardcode_timestamp.patch && \
   patch -p1 -i $($(package)_patch_dir)/qttools_skip_dependencies.patch && \
-  patch -p1 -i $($(package)_patch_dir)/fix-macos26-qyield.patch
+  patch -p1 -i $($(package)_patch_dir)/fix-macos26-qyield.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix_missed_headers.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -28,6 +28,7 @@ $(package)_patches += fix-macos26-qyield.patch
 $(package)_patches += fix-qbytearray-include.patch
 $(package)_patches += fix_openbsd_network_kernel.patch
 $(package)_patches += fix_openbsd_plugin_qelfparser.patch
+$(package)_patches += fix_missed_headers.patch
 
 $(package)_qttranslations_file_name=$(qt_details_qttranslations_file_name)
 $(package)_qttranslations_sha256_hash=$(qt_details_qttranslations_sha256_hash)
@@ -293,7 +294,8 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix-macos26-qyield.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix-qbytearray-include.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_openbsd_network_kernel.patch && \
-  patch -p1 -i $($(package)_patch_dir)/fix_openbsd_plugin_qelfparser.patch
+  patch -p1 -i $($(package)_patch_dir)/fix_openbsd_plugin_qelfparser.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix_missed_headers.patch
 endef
 ifeq ($(host),$(build))
   $(package)_preprocess_cmds += && patch -p1 -i $($(package)_patch_dir)/qttools_skip_dependencies.patch

--- a/depends/patches/qt/fix_missed_headers.patch
+++ b/depends/patches/qt/fix_missed_headers.patch
@@ -1,0 +1,32 @@
+QXcbAtom: add missing <cstdlib> #include
+
+Clang 21 complained about free() being an undefined identifier.
+
+See: https://codereview.qt-project.org/c/qt/qtbase/+/686891
+
+--- a/qtbase/src/plugins/platforms/xcb/qxcbatom.cpp
++++ b/qtbase/src/plugins/platforms/xcb/qxcbatom.cpp
+@@ -7,6 +7,7 @@
+ #include <string.h>
+ 
+ #include <algorithm>
++#include <cstdlib>
+ 
+ static const char *xcb_atomnames = {
+     // window-manager <-> client protocols
+
+
+syncqt.cpp: Include <algorithm> for std::transform
+
+See: https://codereview.qt-project.org/c/qt/qtbase/+/673183
+
+--- a/qtbase/src/tools/syncqt/main.cpp
++++ b/qtbase/src/tools/syncqt/main.cpp
+@@ -15,6 +15,7 @@
+  * pre-defined list of header files.
+  */
+ 
++#include <algorithm>
+ #include <iostream>
+ #include <fstream>
+ #include <string>


### PR DESCRIPTION
This PR fixes the build when using recent Clang releases and libc++.

From https://github.com/hebasto/bitcoin-core-nightly/actions/runs/31400107892/job/93492660951:
```
[27/1645] Building CXX object qtbase/src/tools/syncqt/CMakeFiles/syncqt.dir/main.cpp.o
FAILED: [code=1] qtbase/src/tools/syncqt/CMakeFiles/syncqt.dir/main.cpp.o 
/usr/bin/clang++-24  -stdlib=libc++ -DQT_EXPLICIT_QFILE_CONSTRUCTION_FROM_PATH -DQT_LEAN_HEADERS=1 -DQT_NAMESPACE=\"\" -DQT_NO_DEBUG -DQT_NO_FOREACH -DQT_NO_JAVA_STYLE_ITERATORS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_NO_QASCONST -DQT_NO_QEXCHANGE -DQT_NO_QSNPRINTF -DQT_USE_QSTRINGBUILDER -DQT_VERSION_MAJOR=6 -DQT_VERSION_MINOR=8 -DQT_VERSION_PATCH=4 -DQT_VERSION_STR=\"6.8.4\" -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-e34d706caeb/qtbase/src/tools/syncqt -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-e34d706caeb/qtbase/mkspecs/linux-clang -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-e34d706caeb/qtbase/include -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/x86_64-pc-linux-gnu/include  -ffile-prefi
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-e34d706caeb/qtbase/src/tools/syncqt/main.cpp:82:10: error: no member named 'transform' in namespace 'std'
   82 |     std::transform(s.begin(), s.end(), s.begin(),
      |          ^~~~~~~~~
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-e34d706caeb/qtbase/src/tools/syncqt/main.cpp:89:10: error: no member named 'transform' in namespace 'std'
   89 |     std::transform(s.begin(), s.end(), s.begin(),
      |          ^~~~~~~~~
2 errors generated.
[28/1645] Building C object qtbase/src/3rdparty/pcre2/CMakeFiles/BundledPcre2.dir/src/pcre2_ucd.c.o
[29/1645] Building C object qtbase/src/3rdparty/pcre2/CMakeFiles/BundledPcre2.dir/src/pcre2_match.c.o
[30/1645] Building C object qtbase/src/3rdparty/pcre2/CMakeFiles/BundledPcre2.dir/src/pcre2_jit_compile.c.o
ninja: build stopped: subcommand failed.
gmake: *** [funcs.mk:343: /home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-e34d706caeb/./.stamp_built] Error 1
gmake: Leaving directory '/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends'
```

From https://github.com/hebasto/bitcoin-core-nightly/actions/runs/31403593334/job/93504547098:
```
[892/1645] Building CXX object qtbase/src/plugins/platforms/xcb/CMakeFiles/XcbQpaPrivate.dir/qxcbatom.cpp.o
FAILED: [code=1] qtbase/src/plugins/platforms/xcb/CMakeFiles/XcbQpaPrivate.dir/qxcbatom.cpp.o 
/usr/bin/clang++-24  -stdlib=libc++ -DQT_ASCII_CAST_WARNINGS -DQT_BUILDING_QT -DQT_BUILD_XCB_PLUGIN -DQT_BUILD_XCB_QPA_LIB_LIB -DQT_CORE_LIB -DQT_DEPRECATED_WARNINGS -DQT_EXPLICIT_QFILE_CONSTRUCTION_FROM_PATH -DQT_GUI_LIB -DQT_LEAN_HEADERS=1 -DQT_MOC_COMPAT -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_EXCEPTIONS -DQT_NO_FOREACH -DQT_NO_JAVA_STYLE_ITERATORS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_NO_QASCONST -DQT_NO_QEXCHANGE -DQT_NO_QSNPRINTF -DQT_USE_QSTRINGBUILDER -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/src/plugins/platforms/xcb/XcbQpaPrivate_autogen/include -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/src/plugins/platforms/xcb -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/src/plugins/platforms/xcb/gl_integrations -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/src/3rdparty/xcb/include -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/src/corelib -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/include/QtCore/6.8.4 -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/include/QtCore/6.8.4/QtCore -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/include -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/include/QtCore -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/mkspecs/linux-clang -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/src/gui -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/include/QtGui/6.8.4 -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/include/QtGui/6.8.4/QtGui -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/include/QtGui -I/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/x86_64-pc-linux-gnu/include  -ffile-prefix-map=/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777=/usr -O2 -std=gnu++20 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -fno-exceptions -ftemplate-depth=1024 -ffunction-sections -fdata-sections -U_FORTIFY_SOURCE -fcf-protection=full -D_FORTIFY_SOURCE=3 -ftrivial-auto-var-init=pattern -fstack-protector-strong -MD -MT qtbase/src/plugins/platforms/xcb/CMakeFiles/XcbQpaPrivate.dir/qxcbatom.cpp.o -MF qtbase/src/plugins/platforms/xcb/CMakeFiles/XcbQpaPrivate.dir/qxcbatom.cpp.o.d -o qtbase/src/plugins/platforms/xcb/CMakeFiles/XcbQpaPrivate.dir/qxcbatom.cpp.o -c /home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/src/plugins/platforms/xcb/qxcbatom.cpp
/home/runner/work/bitcoin-core-nightly/bitcoin-core-nightly/depends/work/build/x86_64-pc-linux-gnu/qt/6.8.4-d5ec21e4777/qtbase/src/plugins/platforms/xcb/qxcbatom.cpp:237:13: error: use of undeclared identifier 'free'
  237 |             free(reply);
      |             ^~~~
1 error generated.
```