### PR TITLE
build, msvc: Update vcpkg manifest baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -39,7 +39,10 @@
     "wallet": {
       "description": "Enable wallet (SQLite)",
       "dependencies": [
-        "sqlite3"
+        {
+          "name": "sqlite3",
+          "default-features": false
+        }
       ]
     },
     "zeromq": {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
-  "$comment": "The builtin-baseline corresponds to 2025.08.27 Release",
+  "$comment": "The builtin-baseline corresponds to 2026-07-29 Release",
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-  "builtin-baseline": "120deac3062162151622ca4860575a33844ba10b",
+  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "dependencies": [
     "boost-multi-index"
   ],


### PR DESCRIPTION
This change updates the vcpkg manifest baseline from the ["2025.08.27 Release"](https://github.com/microsoft/vcpkg/releases/tag/2025.08.27) to the ["2026-07-29 Release"](https://github.com/microsoft/vcpkg/releases/tag/2026.07.29), with the following package changes:
 - boost: 1.88.0 --> 1.91.0
 - sqlite3: 3.50.4 --> 3.53.4
 - zeromq: 4.3.5#2 --> 4.3.5#3
 - qtbase: 6.9.1 --> 6.11.1#1
 - qttools: 6.9.1 --> 6.11.1
 - libqrencode: 4.1.1#2 --> 4.1.1#3

The previous update was made in https://github.com/bitcoin/bitcoin/pull/33408.

---

Additionally, the default features of the `sqlite3` package have been disabled. See the commit message for more details.