### PR TITLE
common: remove `::runtime_error` from `RunCommandParseJSON`

### DIFF
--- a/src/common/run_command.cpp
+++ b/src/common/run_command.cpp
@@ -2,17 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
-
 #include <common/run_command.h>
 
 #include <tinyformat.h>
 #include <univalue.h>
 #include <util/string.h>
-
-#ifdef ENABLE_EXTERNAL_SIGNER
 #include <util/subprocess.h>
-#endif // ENABLE_EXTERNAL_SIGNER
 
 #include <sstream>
 #include <stdexcept>
@@ -20,7 +15,6 @@
 
 UniValue RunCommandParseJSON(const std::vector<std::string>& cmd_args, const std::string& str_std_in)
 {
-#ifdef ENABLE_EXTERNAL_SIGNER
     namespace sp = subprocess;
 
     UniValue result_json;
@@ -47,7 +41,4 @@ UniValue RunCommandParseJSON(const std::vector<std::string>& cmd_args, const std
     if (!result_json.read(result)) throw std::runtime_error("Unable to parse JSON: " + result);
 
     return result_json;
-#else
-    throw std::runtime_error("Compiled without external signing support (required for external signing).");
-#endif // ENABLE_EXTERNAL_SIGNER
 }

--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -3,8 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
-
 #include <common/run_command.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
@@ -15,9 +13,7 @@
 #include <iostream>
 #include <string_view>
 
-#ifdef ENABLE_EXTERNAL_SIGNER
 #include <util/subprocess.h>
-#endif // ENABLE_EXTERNAL_SIGNER
 
 #include <boost/test/unit_test.hpp>
 
@@ -59,8 +55,6 @@ const bool g_maybe_run_mock_dispatcher_before_main{[]() {
 } // namespace
 
 BOOST_FIXTURE_TEST_SUITE(system_tests, BasicTestingSetup)
-
-#ifdef ENABLE_EXTERNAL_SIGNER
 
 static std::vector<std::string> mock_executable(const std::string& name)
 {
@@ -127,6 +121,5 @@ BOOST_AUTO_TEST_CASE(run_command)
         BOOST_CHECK_EQUAL(success.get_bool(), true);
     }
 }
-#endif // ENABLE_EXTERNAL_SIGNER
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I don't think there's a code path that can reach `RunCommandParseJSON` if we compile with `ENABLE_EXTERNAL_SIGNER=OFF`. If there is a reason for having the code this way, it could  be good to document.

This also requires more workarounds in #35911.