### PR TITLE
depends: Update `boost` package to 1.92.0

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version = 1.91.0-1
+$(package)_version = 1.92.0
 $(package)_download_path = https://github.com/boostorg/boost/releases/download/boost-$($(package)_version)
 $(package)_file_name = boost-$($(package)_version)-cmake.tar.gz
-$(package)_sha256_hash = 8a82bd11a720c70923806c36ee5c26dbd2d630c1eaa1d8fad9a7bd5529908a26
+$(package)_sha256_hash = f51707c27359a0df0cac1beada86de31bb5eed5e8285592dadec384df99c2984
 $(package)_build_subdir = build
 
 define $(package)_set_vars


### PR DESCRIPTION
From the Boost.MultiIndex library [Release Notes](https://www.boost.org/doc/libs/latest/libs/multi_index/doc/release_notes.html#boost_1_92):
> Fixed a performance issue with hashed indices when rehashing at very large container sizes.
