### PR TITLE
fuzz: add coverage for GetQueryParameterFromUri

### DIFF
--- a/src/test/fuzz/http_request.cpp
+++ b/src/test/fuzz/http_request.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/url.h>
 #include <httpserver.h>
 #include <netaddress.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -65,4 +66,30 @@ FUZZ_TARGET(http_request)
         // Absent both framing headers there is no body.
         assert(body.empty());
     }
+}
+
+FUZZ_TARGET(http_query_parameter)
+{
+    using http_bitcoin::GetQueryParameterFromUri;
+
+    // GetQueryParameterFromUri() parses the query string of a request target
+    // supplied by a remote client. It is reached from the REST interface
+    // (see rest.cpp) for parameters such as "count", "offset" and "verbose".
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    const std::string uri{fuzzed_data_provider.ConsumeRandomLengthString(1024)};
+    const std::string key{fuzzed_data_provider.ConsumeRandomLengthString(64)};
+    const std::string value{fuzzed_data_provider.ConsumeRandomLengthString(1024)};
+    (void)GetQueryParameterFromUri(uri, key);
+
+    const std::string encoded_key{UrlEncode(key)};
+    const std::string encoded_value{UrlEncode(value)};
+    const std::string query_uri{"/endpoint?" + encoded_key + "=" + encoded_value};
+    assert(GetQueryParameterFromUri(query_uri, key) == value);
+    assert(GetQueryParameterFromUri("/endpoint?" + encoded_key, key) == "");
+    assert(GetQueryParameterFromUri(query_uri + "&" + encoded_key + "=ignored", key) == value);
+    assert(GetQueryParameterFromUri(query_uri + "#?" + encoded_key + "=ignored", key) == value);
+
+    // First '?' must precede '#', and this name must not be key.
+    const std::string dummy{key == "n" ? "m" : "n"};
+    assert(!GetQueryParameterFromUri("/endpoint?" + dummy + "=1#?" + encoded_key + "=" + encoded_value, key));
 }


### PR DESCRIPTION
`GetQueryParameterFromUri()` parses the query string of a request target
supplied by a remote client. It is reached from the REST interface for the
`count`, `offset`, `size`, `verbose` and `mempool_sequence` parameters, but had
no fuzz coverage.

This adds an `http_query_parameter` target. Besides running the parser on
arbitrary input, it round-trips a URL-encoded key/value pair back through it and
checks the cases that are easy to get wrong:

- a parameter with no `=`, which is an empty value rather than a missing one
- a repeated key, where the first occurrence wins
- a key that occurs both before and after a `#`, where the parser must return
  the value found before the `#` and ignore the later occurrence, since
  everything from the fragment separator onwards is not part of the query
  string

## Testing

Built the fuzz binary and ran the new target against a temporary corpus
directory, capped at 10,000 executions:

    FUZZ=http_query_parameter build_fuzz/bin/fuzz /tmp/corpus_http_query_parameter -runs=10000