### PR TITLE
test: sync funding block before isolating nodes

### DIFF
--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -283,7 +283,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         desc = descsum_create(f"tr({xpubs[0].to_string()}/*,pk({xprvs[1].to_string()}/*))")
         assert_equal(wallet.importdescriptors([{"desc": desc, "active": True, "timestamp": "now"}])[0]["success"], True)
         default_wallet.sendtoaddress(wallet.getnewaddress(address_type="bech32m"), 1)
-        self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+        self.generate(self.nodes[0], 1)
         # Isolate node0 for later reorg coverage
         self.disconnect_nodes(0, 1)
         self.disconnect_nodes(0, 2)


### PR DESCRIPTION
Fixes #35967

test_alternate_witness_tx mines the taproot funding output on node0 with
sync_fun=self.no_op and immediately disconnects. node1 later includes the
script-path spend via generateblock. If the funding block has not reached
node1, that call fails with bad-txns-inputs-missingorspent.

Drop the no_op so generate() uses the default sync_all before the partition.
Later generate* calls keep no_op because the nodes are then disconnected.

Seen twice this week in hebasto bitcoin-core-nightly NetBSD jobs:
https://github.com/hebasto/bitcoin-core-nightly/actions/runs/31350308484/job/93339698854
https://github.com/hebasto/bitcoin-core-nightly/actions/runs/31765546925/job/94660585799

The modified test is test/functional/wallet_listtransactions.py. I ran it
locally three times with build/test/functional/wallet_listtransactions.py.