### PR TITLE
wallet: harden the read-only BDB parser against crafted files

### DIFF
--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -380,10 +380,11 @@ public:
 class RecordsPage
 {
 public:
-    RecordsPage(const PageHeader& header) : m_header(header) {}
+    RecordsPage(const PageHeader& header, uint32_t page_size) : m_header(header), m_page_size(page_size) {}
     RecordsPage() = delete;
 
     PageHeader m_header;
+    uint32_t m_page_size;
 
     std::vector<uint16_t> indexes;
     std::vector<std::variant<DataRecord, OverflowRecord>> records;
@@ -393,6 +394,11 @@ public:
     {
         // Current position within the page
         int64_t pos = PageHeader::SIZE;
+
+        // In a valid page the records do not overlap, so their total size cannot
+        // exceed the page. Track it to reject a page whose entries point at the same
+        // record, which would otherwise be read and kept once per entry.
+        int64_t records_size{0};
 
         // Get the items
         for (uint32_t i = 0; i < m_header.entries; ++i) {
@@ -423,6 +429,7 @@ public:
                 s >> record;
                 records.emplace_back(record);
                 to_jump += rec_hdr.len;
+                records_size += RecordHeader::SIZE + rec_hdr.len;
                 break;
             }
             case RecordType::OVERFLOW_DATA: {
@@ -430,10 +437,15 @@ public:
                 s >> record;
                 records.emplace_back(record);
                 to_jump += OverflowRecord::SIZE;
+                records_size += RecordHeader::SIZE + OverflowRecord::SIZE;
                 break;
             }
             default:
                 throw std::runtime_error("Unknown record type in records page");
+            }
+
+            if (records_size > m_page_size) {
+                throw std::runtime_error("Data records exceed page size");
             }
 
             // Go back to the indexes
@@ -470,10 +482,11 @@ public:
 class InternalPage
 {
 public:
-    InternalPage(const PageHeader& header) : m_header(header) {}
+    InternalPage(const PageHeader& header, uint32_t page_size) : m_header(header), m_page_size(page_size) {}
     InternalPage() = delete;
 
     PageHeader m_header;
+    uint32_t m_page_size;
 
     std::vector<uint16_t> indexes;
     std::vector<InternalRecord> records;
@@ -483,6 +496,11 @@ public:
     {
         // Current position within the page
         int64_t pos = PageHeader::SIZE;
+
+        // In a valid page the records do not overlap, so their total size cannot
+        // exceed the page. Track it to reject a page whose entries point at the same
+        // record, which would otherwise be read and kept once per entry.
+        int64_t records_size{0};
 
         // Get the items
         for (uint32_t i = 0; i < m_header.entries; ++i) {
@@ -514,6 +532,11 @@ public:
             s >> record;
             records.emplace_back(record);
             to_jump += InternalRecord::FIXED_SIZE + rec_hdr.len;
+
+            records_size += RecordHeader::SIZE + InternalRecord::FIXED_SIZE + rec_hdr.len;
+            if (records_size > m_page_size) {
+                throw std::runtime_error("Internal records exceed page size");
+            }
 
             // Go back to the indexes
             s.seek(-to_jump, SEEK_CUR);
@@ -594,7 +617,7 @@ void BerkeleyRODatabase::Open()
     if (header.entries != 2) {
         throw std::runtime_error("Unexpected number of entries in outer database root page");
     }
-    RecordsPage page(header);
+    RecordsPage page(header, page_size);
     db_file >> page;
 
     // First record should be the string "main"
@@ -669,7 +692,7 @@ void BerkeleyRODatabase::Open()
         }
         switch (header.type) {
         case PageType::BTREE_INTERNAL: {
-            InternalPage int_page(header);
+            InternalPage int_page(header, page_size);
             db_file >> int_page;
             for (const InternalRecord& rec : int_page.records) {
                 if (rec.m_header.deleted) continue;
@@ -681,7 +704,7 @@ void BerkeleyRODatabase::Open()
             if (header.level != 1) {
                 throw std::runtime_error("BTree Leaf page is not at level 1");
             }
-            RecordsPage rec_page(header);
+            RecordsPage rec_page(header, page_size);
             db_file >> rec_page;
             if (rec_page.records.size() % 2 != 0) {
                 // BDB stores key value pairs in consecutive records, thus an odd number of records is unexpected

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <optional>
 #include <stdexcept>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -639,9 +640,15 @@ void BerkeleyRODatabase::Open()
     PageHeader root_header(inner_meta.root, inner_meta.other_endian);
     db_file >> root_header;
 
-    // Do a DFS through the BTree, starting at root
-    // We track the expected level of each page in order to avoid loops
+    // Do a DFS through the BTree, starting at root.
+    // The expected level of each page is tracked to reject cycles, but that is not
+    // sufficient on its own: a page reachable through more than one parent is
+    // level-consistent, passes the level check, and would be re-parsed once per path
+    // to it, so a small file can describe an exponential amount of work. Track the
+    // visited pages and reject any seen more than once, as a valid BTree references
+    // each page exactly once.
     std::vector<std::pair<uint32_t, uint32_t>> pages{{inner_meta.root, root_header.level}};
+    std::unordered_set<uint32_t> visited_pages;
     while (pages.size() > 0) {
         auto [curr_page, expected_level] = pages.back();
         // It turns out BDB completely ignores this last_page field and doesn't actually update it to the correct
@@ -651,6 +658,9 @@ void BerkeleyRODatabase::Open()
         //     throw std::runtime_error("Page number is greater than subdatabase last page");
         // }
         pages.pop_back();
+        if (!visited_pages.insert(curr_page).second) {
+            throw std::runtime_error("BTree page referenced more than once");
+        }
         SeekToPage(db_file, curr_page, page_size);
         PageHeader header(curr_page, inner_meta.other_endian);
         db_file >> header;

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -700,7 +700,14 @@ void BerkeleyRODatabase::Open()
                     if (orec->item_len > max_data_size) {
                         throw std::runtime_error("Overflow record has an impossible length");
                     }
+                    // Overflow pages that carry no data do not grow the accumulated
+                    // size, so the length check above cannot bound a chain of them.
+                    // Track visited pages to reject a chain that references one twice.
+                    std::unordered_set<uint32_t> visited_overflow;
                     while (next_page != 0) {
+                        if (!visited_overflow.insert(next_page).second) {
+                            throw std::runtime_error("Overflow page referenced more than once");
+                        }
                         SeekToPage(db_file, next_page, page_size);
                         PageHeader opage_header(next_page, inner_meta.other_endian);
                         db_file >> opage_header;

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -15,6 +15,8 @@
 #include <wallet/walletutil.h>
 
 #include <cstddef>
+#include <cstdint>
+#include <fstream>
 #include <memory>
 #include <span>
 #include <string>
@@ -304,6 +306,102 @@ BOOST_AUTO_TEST_CASE(in_memory_database_cannot_reopen)
     InMemoryWalletDatabase database;
     database.Close();
     BOOST_CHECK_THROW(database.Open(), std::runtime_error);
+}
+
+namespace {
+//! Hand-crafts a legacy BDB file. Core has no BDB write support, so the read-only
+//! parser can only be tested against bytes laid out here in the format it reads.
+class BDBFileBuilder
+{
+    static constexpr uint32_t PAGE_BYTES{512};
+    std::vector<std::byte> m_bytes;
+
+    size_t Offset(uint32_t page, size_t off) const { return size_t{page} * PAGE_BYTES + off; }
+
+public:
+    explicit BDBFileBuilder(uint32_t num_pages) : m_bytes(size_t{num_pages} * PAGE_BYTES, std::byte{0}) {}
+
+    void W8(uint32_t page, size_t off, uint8_t v) { m_bytes.at(Offset(page, off)) = std::byte{v}; }
+    void WLE(uint32_t page, size_t off, uint32_t v, size_t n) { for (size_t i = 0; i < n; ++i) W8(page, off + i, static_cast<uint8_t>(v >> (8 * i))); }
+    void WBE(uint32_t page, size_t off, uint32_t v, size_t n) { for (size_t i = 0; i < n; ++i) W8(page, off + i, static_cast<uint8_t>(v >> (8 * (n - 1 - i)))); }
+    void WStr(uint32_t page, size_t off, std::string_view s) { for (char c : s) W8(page, off++, static_cast<uint8_t>(c)); }
+
+    //! A BTREE_META page (type 9) pointing at a subdatabase root.
+    void MetaPage(uint32_t page, uint32_t last_page, uint32_t root)
+    {
+        WLE(page, 4, 1, 4);            // lsn_offset = 1 (LSNs must read as reset)
+        WLE(page, 8, page, 4);         // page_num
+        WLE(page, 12, 0x00053162, 4);  // btree magic
+        WLE(page, 16, 9, 4);           // version
+        WLE(page, 20, PAGE_BYTES, 4);   // pagesize
+        W8(page, 25, 9);               // type = BTREE_META
+        WLE(page, 32, last_page, 4);   // last_page
+        WLE(page, 48, 0x20, 4);        // flags = SUBDB
+        WLE(page, 88, root, 4);        // root
+    }
+
+    //! The outer root leaf that names the "main" subdatabase and its meta page.
+    void OuterLeaf(uint32_t page, uint32_t inner_meta_page)
+    {
+        WLE(page, 4, 1, 4);            // lsn_offset = 1
+        WLE(page, 8, page, 4);         // page_num
+        WLE(page, 20, 2, 2);           // entries = 2
+        W8(page, 24, 1);               // level = 1
+        W8(page, 25, 5);               // type = BTREE_LEAF
+        WLE(page, 26, 30, 2);          // index[0] -> "main" record
+        WLE(page, 28, 37, 2);          // index[1] -> inner meta page record
+        WLE(page, 30, 4, 2); W8(page, 32, 1); WStr(page, 33, "main");
+        WLE(page, 37, 4, 2); W8(page, 39, 1); WBE(page, 40, inner_meta_page, 4);
+    }
+
+    fs::path WriteTo(const fs::path& dir, const std::string& name) const
+    {
+        const fs::path path{dir / fs::PathFromString(name)};
+        std::ofstream file{path.std_path(), std::ios::binary};
+        file.write(reinterpret_cast<const char*>(m_bytes.data()), static_cast<std::streamsize>(m_bytes.size()));
+        return path;
+    }
+};
+} // namespace
+
+BOOST_AUTO_TEST_CASE(bdbro_btree_page_referenced_twice)
+{
+    // An internal page with two entries pointing at the same child stays level
+    // consistent, so the level check passes, but the child (and its subtree) would
+    // be parsed once per parent edge. Check the parser rejects the second visit.
+    BDBFileBuilder builder(/*num_pages=*/5);
+    builder.MetaPage(/*page=*/0, /*last_page=*/4, /*root=*/1);
+    builder.OuterLeaf(/*page=*/1, /*inner_meta_page=*/2);
+    builder.MetaPage(/*page=*/2, /*last_page=*/4, /*root=*/3);
+
+    // Page 3: an internal page (level 2) whose two entries point at one record
+    // whose child page is 4.
+    builder.WLE(3, 4, 1, 4);          // lsn_offset = 1
+    builder.WLE(3, 8, 3, 4);          // page_num
+    builder.WLE(3, 20, 2, 2);         // entries = 2
+    builder.W8(3, 24, 2);             // level = 2
+    builder.W8(3, 25, 3);             // type = BTREE_INTERNAL
+    builder.WLE(3, 26, 30, 2);        // index[0] -> record
+    builder.WLE(3, 28, 30, 2);        // index[1] -> same record
+    builder.WLE(3, 30, 1, 2);         // RecordHeader.len = 1
+    builder.W8(3, 32, 1);             // RecordHeader.type = KEYDATA
+    builder.WLE(3, 34, 4, 4);         // InternalRecord.page_num = 4
+
+    // Page 4: an empty leaf, parsed once and then reached a second time.
+    builder.WLE(4, 4, 1, 4);          // lsn_offset = 1
+    builder.WLE(4, 8, 4, 4);          // page_num
+    builder.W8(4, 24, 1);             // level = 1
+    builder.W8(4, 25, 5);             // type = BTREE_LEAF
+
+    const fs::path path{builder.WriteTo(m_path_root, "bdbro_btree.dat")};
+
+    DatabaseOptions options;
+    DatabaseStatus status;
+    bilingual_str error;
+    auto db{MakeBerkeleyRODatabase(path, options, status, error)};
+    BOOST_CHECK(!db);
+    BOOST_CHECK_EQUAL(status, DatabaseStatus::FAILED_LOAD);
+    BOOST_CHECK_EQUAL(error.original, "BTree page referenced more than once");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -404,5 +404,45 @@ BOOST_AUTO_TEST_CASE(bdbro_btree_page_referenced_twice)
     BOOST_CHECK_EQUAL(error.original, "BTree page referenced more than once");
 }
 
+BOOST_AUTO_TEST_CASE(bdbro_overflow_page_referenced_twice)
+{
+    // A record's overflow page points back at itself. It carries no data, so the
+    // length check cannot bound the chain; check the repeated page is rejected.
+    BDBFileBuilder builder(/*num_pages=*/5);
+    builder.MetaPage(/*page=*/0, /*last_page=*/4, /*root=*/1);
+    builder.OuterLeaf(/*page=*/1, /*inner_meta_page=*/2);
+    builder.MetaPage(/*page=*/2, /*last_page=*/4, /*root=*/3);
+
+    // Page 3: a leaf whose two records are a key and an overflow record -> page 4.
+    builder.WLE(3, 4, 1, 4);          // lsn_offset = 1
+    builder.WLE(3, 8, 3, 4);          // page_num
+    builder.WLE(3, 20, 2, 2);         // entries = 2
+    builder.W8(3, 24, 1);             // level = 1
+    builder.W8(3, 25, 5);             // type = BTREE_LEAF
+    builder.WLE(3, 26, 30, 2);        // index[0] -> key record
+    builder.WLE(3, 28, 34, 2);        // index[1] -> overflow record
+    builder.WLE(3, 30, 1, 2); builder.W8(3, 32, 1); builder.WStr(3, 33, "k");
+    builder.WLE(3, 34, 0, 2);         // RecordHeader.len = 0
+    builder.W8(3, 36, 3);             // RecordHeader.type = OVERFLOW_DATA
+    builder.WLE(3, 38, 4, 4);         // OverflowRecord.page_number = 4
+    builder.WLE(3, 42, 1, 4);         // OverflowRecord.item_len = 1
+
+    // Page 4: an overflow page with no data whose next page is itself.
+    builder.WLE(4, 4, 1, 4);          // lsn_offset = 1
+    builder.WLE(4, 8, 4, 4);          // page_num
+    builder.WLE(4, 16, 4, 4);         // next_page = 4
+    builder.W8(4, 25, 7);             // type = OVERFLOW_DATA
+
+    const fs::path path{builder.WriteTo(m_path_root, "bdbro_overflow.dat")};
+
+    DatabaseOptions options;
+    DatabaseStatus status;
+    bilingual_str error;
+    auto db{MakeBerkeleyRODatabase(path, options, status, error)};
+    BOOST_CHECK(!db);
+    BOOST_CHECK_EQUAL(status, DatabaseStatus::FAILED_LOAD);
+    BOOST_CHECK_EQUAL(error.original, "Overflow page referenced more than once");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -444,5 +444,42 @@ BOOST_AUTO_TEST_CASE(bdbro_overflow_page_referenced_twice)
     BOOST_CHECK_EQUAL(error.original, "Overflow page referenced more than once");
 }
 
+BOOST_AUTO_TEST_CASE(bdbro_page_records_do_not_fit)
+{
+    // A page whose index entries all point at the same record makes the parser read
+    // and keep that record once per entry. Craft one and check the parser rejects it
+    // rather than reading a single page into entries * record_len bytes of memory.
+    const uint32_t entries{40};
+    const uint32_t record_off{26 + 2 * entries}; // just past the index array
+    const uint32_t record_len{20};
+
+    BDBFileBuilder builder(/*num_pages=*/4);
+    builder.MetaPage(/*page=*/0, /*last_page=*/3, /*root=*/1);
+    builder.OuterLeaf(/*page=*/1, /*inner_meta_page=*/2);
+    builder.MetaPage(/*page=*/2, /*last_page=*/3, /*root=*/3);
+
+    // Page 3: the inner root leaf, with every index pointing at one record.
+    builder.WLE(3, 4, 1, 4);          // lsn_offset = 1
+    builder.WLE(3, 8, 3, 4);          // page_num
+    builder.WLE(3, 20, entries, 2);   // entries
+    builder.W8(3, 24, 1);             // level = 1
+    builder.W8(3, 25, 5);             // type = BTREE_LEAF
+    for (uint32_t i = 0; i < entries; ++i) {
+        builder.WLE(3, 26 + 2 * i, record_off, 2);
+    }
+    builder.WLE(3, record_off, record_len, 2); // RecordHeader.len
+    builder.W8(3, record_off + 2, 1);          // RecordHeader.type = KEYDATA
+
+    const fs::path path{builder.WriteTo(m_path_root, "bdbro_records.dat")};
+
+    DatabaseOptions options;
+    DatabaseStatus status;
+    bilingual_str error;
+    auto db{MakeBerkeleyRODatabase(path, options, status, error)};
+    BOOST_CHECK(!db);
+    BOOST_CHECK_EQUAL(status, DatabaseStatus::FAILED_LOAD);
+    BOOST_CHECK_EQUAL(error.original, "Data records exceed page size");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -78,6 +78,7 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
             error.original == "BTree page has an unexpected level" ||
             error.original == "BTree page referenced more than once" ||
             error.original == "BTree Leaf page is not at level 1" ||
+            error.original == "Overflow page referenced more than once" ||
             error.original == "Subdatabase last page is greater than database last page" ||
             error.original == "Page number is greater than database last page" ||
             error.original == "Last page number could not fit in file" ||

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -71,7 +71,9 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
             error.original == "Bad page size" ||
             error.original == "Meta page number mismatch" ||
             error.original == "Data record position not in page" ||
+            error.original == "Data records exceed page size" ||
             error.original == "Internal record position not in page" ||
+            error.original == "Internal records exceed page size" ||
             error.original == "LSNs are not reset, this database is not completely flushed. Please reopen then close the database with a version that has BDB support" ||
             error.original == "Records page has odd number of records" ||
             error.original == "Bad overflow record page type" ||

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -76,6 +76,7 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
             error.original == "Records page has odd number of records" ||
             error.original == "Bad overflow record page type" ||
             error.original == "BTree page has an unexpected level" ||
+            error.original == "BTree page referenced more than once" ||
             error.original == "BTree Leaf page is not at level 1" ||
             error.original == "Subdatabase last page is greater than database last page" ||
             error.original == "Page number is greater than database last page" ||


### PR DESCRIPTION
The read-only BDB parser (`BerkeleyRODatabase::Open()` in migrate.cpp) is fed an
attacker-supplied file whenever a user runs `migratewallet`, loads a legacy
`.dat` wallet, or runs `bitcoin-wallet`. #34959 hardened it against circular
references, but three crafted-file cases still get through and turn a small file
into unbounded CPU or memory.

**Revisited btree page.** The level check rejects a page that is its own
ancestor, but a page reachable from more than one parent stays level consistent,
passes the check, and is parsed once per path to it. An ~8 KB file of shared
subtrees does not finish.

**Overflow chain of empty pages.** #34959 bounds an overflow chain by the stated
data length, but pages that carry no data never advance it, so two empty
overflow pages pointing at each other loop forever.

**Page records that do not fit.** A page's index entries can all point at the
same record, which is then read and kept once per entry. `entries` and the
record length are both 16-bit, so a single ~64 KB page can be read into
`entries * len` bytes. A 256 KB file takes a node from 54 MB to ~800 MB during
`migratewallet`, and distinct such pages add up to an OOM.

None of these corrupt memory; they are CPU/memory exhaustion from a crafted or
corrupted wallet file, the same threat model #34959 addressed.

The first two are fixed by tracking visited pages in each traversal (the
approach from #34946 / #35150, closed as superseded by #34959, which turns out
not to cover these level-consistent and empty-page cases). The third is fixed by
bounding a page's total record size to the page. A valid BDB database references
each page once and its records fit within the page, so none of this rejects a
file that parses today.

Each fix is a separate commit with a regression test in db_tests.cpp that
hand-crafts the relevant file (Core cannot write a BDB database, so the bytes are
laid out directly) and checks the parser rejects it. The three new error strings
are also added to the `wallet_bdb_parser` fuzz allow-list.

Supersedes #35992, which proposed the record-size bound on its own.