### PR TITLE
ci: Fix GHA ipv6 setup

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -8,6 +8,33 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Debug and enable IPv6
+      shell: bash
+      run: |
+        echo 'IPv6 state before enabling:'
+        uname -a
+        echo 'Kernel command line:'
+        cat /proc/cmdline || true
+        echo 'IPv6 module state before loading:'
+        lsmod | grep '^ipv6' || true
+        modinfo ipv6 2>&1 || true
+        echo 'IPv6-related kernel messages before loading:'
+        sudo dmesg | grep -i ipv6 || true
+        sysctl net.ipv6.conf.all.disable_ipv6 net.ipv6.conf.default.disable_ipv6 || true
+        ls -la /proc/sys/net/ipv6/conf 2>&1 || true
+
+        sudo modprobe ipv6 || true
+        sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 || true
+        sudo sysctl -w net.ipv6.conf.default.disable_ipv6=0 || true
+
+        echo 'IPv6 state after enabling:'
+        echo 'IPv6 module state after loading:'
+        lsmod | grep '^ipv6' || true
+        sysctl net.ipv6.conf.all.disable_ipv6 net.ipv6.conf.default.disable_ipv6 || true
+        ls -la /proc/sys/net/ipv6/conf 2>&1 || true
+        echo 'IPv6-related kernel messages after loading:'
+        sudo dmesg | grep -i ipv6 || true
+
     - name: Set up Docker Buildx for Warp cache
       if: ${{ inputs.provider == 'warp' }}
       uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Looks like CI started failing for some reason: https://github.com/bitcoin/bitcoin/actions/runs/32003166302/job/95307313400#step:11:233:

```
Error response from daemon: Cannot read IPv6 setup for bridge br-5b85391ca17e: open /proc/sys/net/ipv6/conf/br-5b85391ca17e/disable_ipv6: no such file or directory