### PR TITLE
wallet: Bound the records read from a BDB page to the page size

### DIFF
--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -379,10 +379,11 @@ public:
 class RecordsPage
 {
 public:
-    RecordsPage(const PageHeader& header) : m_header(header) {}
+    RecordsPage(const PageHeader& header, uint32_t page_size) : m_header(header), m_page_size(page_size) {}
     RecordsPage() = delete;
 
     PageHeader m_header;
+    uint32_t m_page_size;
 
     std::vector<uint16_t> indexes;
     std::vector<std::variant<DataRecord, OverflowRecord>> records;
@@ -392,6 +393,11 @@ public:
     {
         // Current position within the page
         int64_t pos = PageHeader::SIZE;
+
+        // In a valid page the records do not overlap, so their total size cannot
+        // exceed the page. Track it to reject a page whose entries point at the same
+        // record, which would otherwise be read and kept once per entry.
+        int64_t records_size{0};
 
         // Get the items
         for (uint32_t i = 0; i < m_header.entries; ++i) {
@@ -422,6 +428,7 @@ public:
                 s >> record;
                 records.emplace_back(record);
                 to_jump += rec_hdr.len;
+                records_size += RecordHeader::SIZE + rec_hdr.len;
                 break;
             }
             case RecordType::OVERFLOW_DATA: {
@@ -429,10 +436,15 @@ public:
                 s >> record;
                 records.emplace_back(record);
                 to_jump += OverflowRecord::SIZE;
+                records_size += RecordHeader::SIZE + OverflowRecord::SIZE;
                 break;
             }
             default:
                 throw std::runtime_error("Unknown record type in records page");
+            }
+
+            if (records_size > m_page_size) {
+                throw std::runtime_error("Data records exceed page size");
             }
 
             // Go back to the indexes
@@ -469,10 +481,11 @@ public:
 class InternalPage
 {
 public:
-    InternalPage(const PageHeader& header) : m_header(header) {}
+    InternalPage(const PageHeader& header, uint32_t page_size) : m_header(header), m_page_size(page_size) {}
     InternalPage() = delete;
 
     PageHeader m_header;
+    uint32_t m_page_size;
 
     std::vector<uint16_t> indexes;
     std::vector<InternalRecord> records;
@@ -482,6 +495,11 @@ public:
     {
         // Current position within the page
         int64_t pos = PageHeader::SIZE;
+
+        // In a valid page the records do not overlap, so their total size cannot
+        // exceed the page. Track it to reject a page whose entries point at the same
+        // record, which would otherwise be read and kept once per entry.
+        int64_t records_size{0};
 
         // Get the items
         for (uint32_t i = 0; i < m_header.entries; ++i) {
@@ -513,6 +531,11 @@ public:
             s >> record;
             records.emplace_back(record);
             to_jump += InternalRecord::FIXED_SIZE + rec_hdr.len;
+
+            records_size += RecordHeader::SIZE + InternalRecord::FIXED_SIZE + rec_hdr.len;
+            if (records_size > m_page_size) {
+                throw std::runtime_error("Internal records exceed page size");
+            }
 
             // Go back to the indexes
             s.seek(-to_jump, SEEK_CUR);
@@ -593,7 +616,7 @@ void BerkeleyRODatabase::Open()
     if (header.entries != 2) {
         throw std::runtime_error("Unexpected number of entries in outer database root page");
     }
-    RecordsPage page(header);
+    RecordsPage page(header, page_size);
     db_file >> page;
 
     // First record should be the string "main"
@@ -659,7 +682,7 @@ void BerkeleyRODatabase::Open()
         }
         switch (header.type) {
         case PageType::BTREE_INTERNAL: {
-            InternalPage int_page(header);
+            InternalPage int_page(header, page_size);
             db_file >> int_page;
             for (const InternalRecord& rec : int_page.records) {
                 if (rec.m_header.deleted) continue;
@@ -671,7 +694,7 @@ void BerkeleyRODatabase::Open()
             if (header.level != 1) {
                 throw std::runtime_error("BTree Leaf page is not at level 1");
             }
-            RecordsPage rec_page(header);
+            RecordsPage rec_page(header, page_size);
             db_file >> rec_page;
             if (rec_page.records.size() % 2 != 0) {
                 // BDB stores key value pairs in consecutive records, thus an odd number of records is unexpected

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -15,6 +15,8 @@
 #include <wallet/walletutil.h>
 
 #include <cstddef>
+#include <cstdint>
+#include <fstream>
 #include <memory>
 #include <span>
 #include <string>
@@ -304,6 +306,99 @@ BOOST_AUTO_TEST_CASE(in_memory_database_cannot_reopen)
     InMemoryWalletDatabase database;
     database.Close();
     BOOST_CHECK_THROW(database.Open(), std::runtime_error);
+}
+
+namespace {
+//! Hand-crafts a legacy BDB file. Core has no BDB write support, so the read-only
+//! parser can only be tested against bytes laid out here in the format it reads.
+class BDBFileBuilder
+{
+    static constexpr size_t PAGE_SIZE{512};
+    std::vector<std::byte> m_bytes;
+
+    size_t Offset(uint32_t page, size_t off) const { return size_t{page} * PAGE_SIZE + off; }
+
+public:
+    explicit BDBFileBuilder(uint32_t num_pages) : m_bytes(size_t{num_pages} * PAGE_SIZE, std::byte{0}) {}
+
+    void W8(uint32_t page, size_t off, uint8_t v) { m_bytes.at(Offset(page, off)) = std::byte{v}; }
+    void WLE(uint32_t page, size_t off, uint32_t v, size_t n) { for (size_t i = 0; i < n; ++i) W8(page, off + i, v >> (8 * i)); }
+    void WBE(uint32_t page, size_t off, uint32_t v, size_t n) { for (size_t i = 0; i < n; ++i) W8(page, off + i, v >> (8 * (n - 1 - i))); }
+    void WStr(uint32_t page, size_t off, std::string_view s) { for (size_t i = 0; i < s.size(); ++i) W8(page, off + i, s[i]); }
+
+    //! A BTREE_META page (type 9) pointing at a subdatabase root.
+    void MetaPage(uint32_t page, uint32_t last_page, uint32_t root)
+    {
+        WLE(page, 4, 1, 4);            // lsn_offset = 1 (LSNs must read as reset)
+        WLE(page, 8, page, 4);         // page_num
+        WLE(page, 12, 0x00053162, 4);  // btree magic
+        WLE(page, 16, 9, 4);           // version
+        WLE(page, 20, PAGE_SIZE, 4);   // pagesize
+        W8(page, 25, 9);               // type = BTREE_META
+        WLE(page, 32, last_page, 4);   // last_page
+        WLE(page, 48, 0x20, 4);        // flags = SUBDB
+        WLE(page, 88, root, 4);        // root
+    }
+
+    //! The outer root leaf that names the "main" subdatabase and its meta page.
+    void OuterLeaf(uint32_t page, uint32_t inner_meta_page)
+    {
+        WLE(page, 4, 1, 4);            // lsn_offset = 1
+        WLE(page, 8, page, 4);         // page_num
+        WLE(page, 20, 2, 2);           // entries = 2
+        W8(page, 24, 1);               // level = 1
+        W8(page, 25, 5);               // type = BTREE_LEAF
+        WLE(page, 26, 30, 2);          // index[0] -> "main" record
+        WLE(page, 28, 37, 2);          // index[1] -> inner meta page record
+        WLE(page, 30, 4, 2); W8(page, 32, 1); WStr(page, 33, "main");
+        WLE(page, 37, 4, 2); W8(page, 39, 1); WBE(page, 40, inner_meta_page, 4);
+    }
+
+    fs::path WriteTo(const fs::path& dir, const std::string& name) const
+    {
+        const fs::path path{dir / fs::PathFromString(name)};
+        std::ofstream file{path.std_path(), std::ios::binary};
+        file.write(reinterpret_cast<const char*>(m_bytes.data()), m_bytes.size());
+        return path;
+    }
+};
+} // namespace
+
+BOOST_AUTO_TEST_CASE(bdbro_page_records_do_not_fit)
+{
+    // A page whose index entries all point at the same record makes the parser read
+    // and keep that record once per entry. Craft one and check the parser rejects it
+    // rather than reading a single page into entries * record_len bytes of memory.
+    const uint32_t entries{40};
+    const uint16_t record_off{26 + 2 * entries}; // just past the index array
+    const uint16_t record_len{20};
+
+    BDBFileBuilder builder(/*num_pages=*/4);
+    builder.MetaPage(/*page=*/0, /*last_page=*/3, /*root=*/1);
+    builder.OuterLeaf(/*page=*/1, /*inner_meta_page=*/2);
+    builder.MetaPage(/*page=*/2, /*last_page=*/3, /*root=*/3);
+
+    // Page 3: the inner root leaf, with every index pointing at one record.
+    builder.WLE(3, 4, 1, 4);          // lsn_offset = 1
+    builder.WLE(3, 8, 3, 4);          // page_num
+    builder.WLE(3, 20, entries, 2);   // entries
+    builder.W8(3, 24, 1);             // level = 1
+    builder.W8(3, 25, 5);             // type = BTREE_LEAF
+    for (uint32_t i = 0; i < entries; ++i) {
+        builder.WLE(3, 26 + 2 * i, record_off, 2);
+    }
+    builder.WLE(3, record_off, record_len, 2); // RecordHeader.len
+    builder.W8(3, record_off + 2, 1);          // RecordHeader.type = KEYDATA
+
+    const fs::path path{builder.WriteTo(m_path_root, "bdbro_records.dat")};
+
+    DatabaseOptions options;
+    DatabaseStatus status;
+    bilingual_str error;
+    auto db{MakeBerkeleyRODatabase(path, options, status, error)};
+    BOOST_CHECK(!db);
+    BOOST_CHECK_EQUAL(status, DatabaseStatus::FAILED_LOAD);
+    BOOST_CHECK_EQUAL(error.original, "Data records exceed page size");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -71,7 +71,9 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
             error.original == "Bad page size" ||
             error.original == "Meta page number mismatch" ||
             error.original == "Data record position not in page" ||
+            error.original == "Data records exceed page size" ||
             error.original == "Internal record position not in page" ||
+            error.original == "Internal records exceed page size" ||
             error.original == "LSNs are not reset, this database is not completely flushed. Please reopen then close the database with a version that has BDB support" ||
             error.original == "Records page has odd number of records" ||
             error.original == "Bad overflow record page type" ||


### PR DESCRIPTION
The read-only BDB parser reads a btree page by walking its index array and
reading the record each entry points at, keeping a copy of every one
(`RecordsPage::Unserialize` and `InternalPage::Unserialize` in migrate.cpp).
The only thing checked about an index is that it does not point before the
running cursor. Nothing stops several entries from pointing at the same record.

The cursor only advances by the two bytes of the index just read, so all of a
page's entries can hold the same offset, and the parser reads that one record
once per entry and keeps every copy. `entries` and the record length are both
16-bit fields, so a single ~64 KB page can be read into `entries * len` bytes.
A 256 KB file takes a node from 54 MB to ~800 MB during `migratewallet`, and it
succeeds rather than erroring. Distinct such pages add up, so a few-MB file
OOMs the process.

This is not caught by #34959 (btree levels and overflow lengths) or #35990
(revisited pages), because it happens within a single page, with no cycle or
repeated page. It is the same hostile-wallet-file case #34959 set out to
harden: `migratewallet`, `loadwallet` of a legacy `.dat`, and `bitcoin-wallet`.

In a valid page the records do not overlap and so cannot be larger than the
page. This tracks their total size while reading and rejects a page whose
records do not fit, which bounds what one page can allocate to its own size.
Nothing that parses today is affected. The two rejections are:

```
Data records exceed page size       # leaf page
Internal records exceed page size   # internal page
```

### Testing

A regression test in db_tests.cpp hand-crafts such a page and checks the parser
rejects it; it fails without this change. Core cannot write a BDB file, so the
page bytes are laid out directly, the same reason #34959 was only fuzz-tested.
The two new error strings are also added to the `wallet_bdb_parser` fuzz
allow-list, and a page packed with many distinct records still parses, so the
bound does not reject a legitimately full page.