### PR TITLE
guix: build glibc with `--enable-kernel=3.17.0`

### DIFF
--- a/contrib/guix/manifest_build.scm
+++ b/contrib/guix/manifest_build.scm
@@ -232,12 +232,13 @@ chain for " target " development."))
         ((#:configure-flags flags)
           `(append ,flags
             ;; https://www.gnu.org/software/libc/manual/html_node/Configuring-and-compiling.html
-            (list "--enable-stack-protector=all",
+            (list "--enable-bind-now",
                   "--enable-cet",
-                  "--enable-bind-now",
-                  "--disable-werror",
-                  "--disable-timezone-tools",
+                  "--enable-kernel=3.17.0",
+                  "--enable-stack-protector=all",
                   "--disable-profile",
+                  "--disable-timezone-tools",
+                  "--disable-werror",
                   building-on)))
     ((#:phases phases)
         `(modify-phases ,phases

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -72,17 +72,17 @@ ELF_INTERPRETER_NAMES: dict[lief.ELF.ARCH, dict[lief.Header.ENDIANNESS, str]] = 
 
 ELF_ABIS: dict[lief.ELF.ARCH, dict[lief.Header.ENDIANNESS, list[int]]] = {
     lief.ELF.ARCH.X86_64: {
-        lief.Header.ENDIANNESS.LITTLE: [3,2,0],
+        lief.Header.ENDIANNESS.LITTLE: [3,17,0],
     },
     lief.ELF.ARCH.ARM: {
-        lief.Header.ENDIANNESS.LITTLE: [3,2,0],
+        lief.Header.ENDIANNESS.LITTLE: [3,17,0],
     },
     lief.ELF.ARCH.AARCH64: {
-        lief.Header.ENDIANNESS.LITTLE: [3,7,0],
+        lief.Header.ENDIANNESS.LITTLE: [3,17,0],
     },
     lief.ELF.ARCH.PPC64: {
-        lief.Header.ENDIANNESS.LITTLE: [3,10,0],
-        lief.Header.ENDIANNESS.BIG: [3,2,0],
+        lief.Header.ENDIANNESS.LITTLE: [3,17,0],
+        lief.Header.ENDIANNESS.BIG: [3,17,0],
     },
     lief.ELF.ARCH.RISCV: {
         lief.Header.ENDIANNESS.LITTLE: [4,15,0],


### PR DESCRIPTION
Our minimum required kernel version is documented as `3.17.0`. Pass `--enable-kernel=3.17.0` when building glibc, so that version is reflected in the binary, and the version checked in the symbol-check script, aligns with the expected minimum.